### PR TITLE
fix(inspector): guard memory loaders against stale/post-unmount responses

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -278,6 +278,7 @@ export const SUITES = {
     "src/components/inbox-calendar-familiar-scope.test.ts",
     "src/components/inspector-inbox.test.ts",
     "src/components/inspector-pane-polish.test.ts",
+    "src/components/inspector-pane-load-guards.test.ts",
     "src/components/inspector-pane-surface.test.ts",
     "src/components/library-error-retry.test.ts",
     "src/components/library-reader-keyboard.test.ts",

--- a/src/components/inspector-pane-load-guards.test.ts
+++ b/src/components/inspector-pane-load-guards.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+
+// The inspector's three memory loaders (coven-memory, the per-familiar file
+// list, and the open-file contents) all set state from an async fetch. Each
+// must guard against stale / post-unmount responses with a cancelled flag, or:
+//   - a response could call setState after the pane unmounts, and
+//   - switching familiars / files could let an older request's response
+//     overwrite the newer selection (a cross-familiar list leak for /api/memory).
+
+// Every effect that awaits a fetch declares a cancelled flag and a cleanup.
+const cancelledDecls = src.match(/let cancelled = false;/g) ?? [];
+assert.ok(cancelledDecls.length >= 3, "all three memory loaders declare a cancelled guard");
+const cleanups = src.match(/return \(\) => \{ cancelled = true; \};/g) ?? [];
+assert.ok(cleanups.length >= 3, "each guarded loader cleans up by cancelling in-flight work");
+
+// coven-memory: guards the setState and the loaded flag.
+assert.match(
+  src,
+  /fetch\("\/api\/coven-memory"[\s\S]*?if \(cancelled\) return;[\s\S]*?setCovenEntries/,
+  "the coven-memory loader drops stale/post-unmount responses",
+);
+assert.match(src, /if \(!cancelled\) setCovenLoaded\(true\);/, "the coven-memory loaded flag is only set while mounted");
+
+// per-familiar file list: guards before applying entries so a previous
+// familiar's response can't overwrite the current one.
+assert.match(
+  src,
+  /\/api\/memory\?familiarId[\s\S]*?if \(cancelled\) return;[\s\S]*?setEntries/,
+  "the per-familiar memory list drops a superseded response (no cross-familiar leak)",
+);
+
+// open-file contents: guards before setOpenFile.
+assert.match(
+  src,
+  /\/api\/memory\/file\?path[\s\S]*?if \(cancelled\) return;[\s\S]*?setOpenFile\(json\)/,
+  "the open-file loader drops a stale response when the selection changes",
+);
+
+console.log("inspector-pane-load-guards.test.ts: ok");

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -587,10 +587,12 @@ function MemoryTab({
   const [reveal, setReveal] = useState(false);
 
   useEffect(() => {
+    let cancelled = false;
     void (async () => {
       try {
         const res = await fetch("/api/coven-memory", { cache: "no-store" });
         const json = await res.json();
+        if (cancelled) return;
         if (json.ok) {
           const fetched: CovenMemoryEntry[] = json.entries ?? [];
           setCovenEntries(fetched);
@@ -600,9 +602,10 @@ function MemoryTab({
       } catch {
         /* Inspector remains the default; the legacy Coven tab can stay empty. */
       } finally {
-        setCovenLoaded(true);
+        if (!cancelled) setCovenLoaded(true);
       }
     })();
+    return () => { cancelled = true; };
   }, []);
 
   // Scope the file inventory to the active familiar AT THE SOURCE so another
@@ -610,6 +613,7 @@ function MemoryTab({
   // this familiar's files + ownerless/global pools and drops every other
   // familiar's. Re-fetch when the active familiar changes.
   useEffect(() => {
+    let cancelled = false;
     void (async () => {
       try {
         const url = familiar
@@ -617,15 +621,20 @@ function MemoryTab({
           : "/api/memory";
         const res = await fetch(url, { cache: "no-store" });
         const json = await res.json();
+        // Drop a stale response: switching familiars must not let the previous
+        // familiar's file list overwrite the current one.
+        if (cancelled) return;
         if (!json.ok) {
           setError(json.error ?? "memory list failed");
           return;
         }
         setEntries(json.entries ?? []);
       } catch (err) {
+        if (cancelled) return;
         setError(err instanceof Error ? err.message : "fetch failed");
       }
     })();
+    return () => { cancelled = true; };
   }, [familiar?.id]);
 
   useEffect(() => {
@@ -633,6 +642,7 @@ function MemoryTab({
       setOpenFile(null);
       return;
     }
+    let cancelled = false;
     void (async () => {
       try {
         const res = await fetch(
@@ -640,8 +650,12 @@ function MemoryTab({
           { cache: "no-store" },
         );
         const json = (await res.json()) as MemoryFile;
+        // Drop a stale response: switching files quickly must not let an earlier
+        // file's contents overwrite the newer selection.
+        if (cancelled) return;
         setOpenFile(json);
       } catch (err) {
+        if (cancelled) return;
         setOpenFile({
           ok: false,
           path: openPath,
@@ -653,6 +667,7 @@ function MemoryTab({
         });
       }
     })();
+    return () => { cancelled = true; };
   }, [openPath, reveal]);
 
   // Strict per-familiar scoping (defense in depth alongside the server filter):


### PR DESCRIPTION
## Inspector view audit (`inspector-pane.tsx`)

The inspector pane is otherwise clean — its tabs use the accessible shared `ui/tabs`, there's no polling, no mouse-only rows, and no reduced-motion or visual-only-selection gaps. The one real issue class: **three async memory loaders that set state with no cancelled/request-id guard.**

- **`/api/coven-memory`** (mount-only) — a response resolving after unmount called `setCovenEntries`/`setCovenLoaded` on a gone component.
- **`/api/memory` file list** (re-fetches on `familiar?.id`) — switching familiars let the *previous* familiar's response overwrite the current list: a **cross-familiar leak** into the rendered file inventory.
- **`/api/memory/file` contents** (re-fetches on `openPath`/`reveal`) — switching files quickly let an earlier file's contents overwrite the newer selection.

Each effect now declares a `cancelled` flag, drops the response when cancelled, and cleans up on unmount / before the next run.

## Scope note
`board-inspector.tsx` (the Board *card* detail panel — a separate surface) has its own findings from the scan: a 60s `TimeoutBadge` poll that doesn't pause when hidden, an unguarded GitHub-attach fetch, visual-only selection on GitHub rows + step-done state, and a non-`motion-reduce` transition. Left for a separate audit.

## Verification
- New `inspector-pane-load-guards.test.ts` (wired; `check:tests-wired` ✓) + existing `inspector-pane-polish.test.ts` pass · `tsc` clean · `pnpm build` exit 0
- No live Playwright: the cross-familiar/stale-response races need rapid familiar/file switching against a live memory backend that demo mode can't drive deterministically; the guards are pinned by the source test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)