### PR TITLE
test(sessions/prune): regression guard for dry-run wouldPrune contract

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -523,6 +523,7 @@ export const SUITES = {
     "src/app/api/library/pdf/route.test.ts",
     "scripts/sidecar-bundle-deps.test.mjs",
     "src/app/api/sessions/[id]/events/route.test.ts",
+    "src/app/api/sessions/prune/prune-response.test.ts",
     "src/lib/server/familiar-contract-files.test.ts",
     "src/lib/server/project-paths.test.ts",
     "src/lib/server/session-project-roots.test.ts",

--- a/src/app/api/sessions/prune/prune-response.test.ts
+++ b/src/app/api/sessions/prune/prune-response.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { prunePayload, type PruneResponseBody } from "./prune-response.ts";
+
+// Regression guard for the Maintenance "Check" → Delete flow (onboarding
+// overlay). The panel reads the dry-run count from `wouldPrune`; the
+// daemon-native path used to return it under `pruned`, leaving `wouldPrune`
+// undefined → "Nothing to prune" → the Delete button never appeared, so a
+// prune could never run. Both response paths now funnel through prunePayload,
+// so this exercises the exact contract the UI depends on.
+
+function has(body: PruneResponseBody, key: string): unknown {
+  return (body as Record<string, unknown>)[key];
+}
+
+for (const method of ["daemon", "client"] as const) {
+  // Dry run: count under wouldPrune, pruned pinned to 0 — for BOTH paths.
+  const dry = prunePayload({ dryRun: true, count: 7, method });
+  assert.equal(dry.wouldPrune, 7, `${method}: dry run surfaces the count under wouldPrune`);
+  assert.equal(dry.pruned, 0, `${method}: dry run reports pruned 0`);
+  assert.equal(has(dry, "dryRun"), true, `${method}: dry run flagged`);
+  assert.equal(dry.method, method);
+  assert.equal(dry.ok, true);
+  // The specific pre-fix bug: the count must NOT leak into `pruned` (which is
+  // what made wouldPrune undefined for the UI).
+  assert.notEqual(dry.pruned, 7, `${method}: dry-run count must not land in pruned`);
+
+  // Real run: deletions under pruned, no wouldPrune.
+  const real = prunePayload({ dryRun: false, count: 7, method });
+  assert.equal(real.pruned, 7, `${method}: real run reports deletions under pruned`);
+  assert.equal(has(real, "wouldPrune"), undefined, `${method}: real run has no wouldPrune`);
+  assert.equal(has(real, "dryRun"), undefined, `${method}: real run is not flagged dry`);
+  assert.equal(real.method, method);
+  assert.equal(real.ok, true);
+}
+
+// Zero candidates on a dry run is still a valid count (0), not a missing field —
+// the UI shows "Nothing to prune" from wouldPrune === 0, not from undefined.
+const none = prunePayload({ dryRun: true, count: 0, method: "daemon" });
+assert.equal(none.wouldPrune, 0);
+assert.equal(none.pruned, 0);
+
+console.log("prune-response: all assertions passed");

--- a/src/app/api/sessions/prune/prune-response.test.ts
+++ b/src/app/api/sessions/prune/prune-response.test.ts
@@ -15,7 +15,7 @@ function has(body: PruneResponseBody, key: string): unknown {
 for (const method of ["daemon", "client"] as const) {
   // Dry run: count under wouldPrune, pruned pinned to 0 — for BOTH paths.
   const dry = prunePayload({ dryRun: true, count: 7, method });
-  assert.equal(dry.wouldPrune, 7, `${method}: dry run surfaces the count under wouldPrune`);
+  assert.equal(has(dry, "wouldPrune"), 7, `${method}: dry run surfaces the count under wouldPrune`);
   assert.equal(dry.pruned, 0, `${method}: dry run reports pruned 0`);
   assert.equal(has(dry, "dryRun"), true, `${method}: dry run flagged`);
   assert.equal(dry.method, method);
@@ -36,7 +36,7 @@ for (const method of ["daemon", "client"] as const) {
 // Zero candidates on a dry run is still a valid count (0), not a missing field —
 // the UI shows "Nothing to prune" from wouldPrune === 0, not from undefined.
 const none = prunePayload({ dryRun: true, count: 0, method: "daemon" });
-assert.equal(none.wouldPrune, 0);
+assert.equal(has(none, "wouldPrune"), 0);
 assert.equal(none.pruned, 0);
 
 console.log("prune-response: all assertions passed");

--- a/src/app/api/sessions/prune/prune-response.ts
+++ b/src/app/api/sessions/prune/prune-response.ts
@@ -1,0 +1,31 @@
+/**
+ * Shapes the `/api/sessions/prune` success response body. Both the
+ * daemon-native path and the client-side fallback funnel through here so the
+ * dry-run-vs-real contract is single-sourced:
+ *
+ *   - dry run  → the count goes under `wouldPrune`, with `pruned: 0`
+ *   - real run → deletions go under `pruned`
+ *
+ * The Maintenance "Check" UI (onboarding overlay) reads `wouldPrune` to decide
+ * whether to offer the Delete button. Returning the dry-run count under
+ * `pruned` instead silently left `wouldPrune` undefined → "Nothing to prune" →
+ * no Delete button, so a prune could never run. That regression (the
+ * daemon-native branch) shipped before this helper existed; keeping the shape
+ * in one place is what stops it recurring on the next path that's added.
+ */
+export type PruneMethod = "daemon" | "client";
+
+export type PruneResponseBody =
+  | { ok: true; pruned: 0; wouldPrune: number; dryRun: true; method: PruneMethod }
+  | { ok: true; pruned: number; method: PruneMethod };
+
+export function prunePayload(opts: {
+  dryRun: boolean;
+  count: number;
+  method: PruneMethod;
+}): PruneResponseBody {
+  const { dryRun, count, method } = opts;
+  return dryRun
+    ? { ok: true, pruned: 0, wouldPrune: count, dryRun: true, method }
+    : { ok: true, pruned: count, method };
+}

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
+import { prunePayload } from "./prune-response";
 
 export const dynamic = "force-dynamic";
 
@@ -39,21 +40,12 @@ export async function POST(req: Request) {
   });
 
   if (native.ok && native.data) {
-    // For a dry run the daemon reports how many sessions *would* be pruned in
-    // `pruned`; surface it under `wouldPrune` (and keep `pruned: 0`) so the
-    // client reads the count the same way it does for the fallback path below.
-    // Without this the Maintenance "Check" action always saw `wouldPrune`
-    // undefined → count 0 → "Nothing to prune", and the Delete button never
-    // appeared, so a prune could never actually run.
-    return dryRun
-      ? NextResponse.json({
-          ok: true,
-          pruned: 0,
-          wouldPrune: native.data.pruned,
-          dryRun: true,
-          method: "daemon",
-        })
-      : NextResponse.json({ ok: true, pruned: native.data.pruned, method: "daemon" });
+    // On a dry run the daemon reports how many sessions *would* be pruned; the
+    // shared payload helper routes that to `wouldPrune` so the Maintenance
+    // "Check" UI reads it the same way it does for the client path below.
+    return NextResponse.json(
+      prunePayload({ dryRun, count: native.data.pruned, method: "daemon" }),
+    );
   }
 
   // Daemon doesn't support prune natively — do client-side pruning.
@@ -84,13 +76,9 @@ export async function POST(req: Request) {
   });
 
   if (dryRun) {
-    return NextResponse.json({
-      ok: true,
-      pruned: 0,
-      wouldPrune: candidates.length,
-      dryRun: true,
-      method: "client",
-    });
+    return NextResponse.json(
+      prunePayload({ dryRun: true, count: candidates.length, method: "client" }),
+    );
   }
 
   let pruned = 0;
@@ -103,5 +91,5 @@ export async function POST(req: Request) {
     if (del.ok) pruned++;
   }
 
-  return NextResponse.json({ ok: true, pruned, method: "client" });
+  return NextResponse.json(prunePayload({ dryRun: false, count: pruned, method: "client" }));
 }


### PR DESCRIPTION
## Why

[#1865](https://github.com/OpenCoven/coven-cave/pull/1865) fixed the Maintenance **Check → Delete** flow on the setup page: the daemon-native dry-run path returned the count under `pruned` instead of `wouldPrune`, so the panel saw `wouldPrune ?? 0` → `0` → *"Nothing to prune"* and never offered the Delete button. Nothing tested that contract, so it could silently regress again on the next code path added.

## What

- **Extract `prunePayload`** (`prune-response.ts`) — a pure helper that shapes the success body. Both the daemon-native and client-fallback paths now funnel through it, so the dry-run-vs-real contract is single-sourced:
  - dry run → count under `wouldPrune`, `pruned: 0`
  - real run → deletions under `pruned`, no `wouldPrune`
- **`prune-response.test.ts`** — executable unit test asserting the contract for both `daemon` and `client` methods, including the specific failure mode (count must not leak into `pruned` on a dry run) and the zero-candidates case. Reintroducing the bug fails the test (verified locally).
- Wired into the `api` suite in `run-tests.mjs`; `check:tests-wired` passes.

No behavior change — the four response shapes are identical to before; they're just produced in one place now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)