### PR TITLE
fix(board): re-sync on window focus (desktop app stale-after-action fix)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -178,6 +178,7 @@ export const SUITES = {
     "src/components/task-chat-cwd.test.ts",
     "src/lib/board-search.test.ts",
     "src/lib/board-wip.test.ts",
+    "src/lib/use-refresh-on-focus.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",
     "src/lib/code-lang.test.ts",
@@ -606,6 +607,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/use-refresh-on-focus.test.ts",
   "src/lib/flow/flow-progress.test.ts",
   "src/lib/familiar-card-data.test.ts",
   "src/lib/dashboard-model.test.ts",

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -7,6 +7,7 @@ import { DEMO_BOARD_CARDS } from "@/lib/demo-seed";
 import { DEMO_MODE_EVENT, isDemoModeEnabled } from "@/lib/demo-mode";
 import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { type WipLimits, readWipLimits, writeWipLimits, setWipLimit } from "@/lib/board-wip";
+import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
 import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus, STATUSES } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
@@ -181,6 +182,13 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     window.addEventListener("cave:board:reload", onReload);
     return () => window.removeEventListener("cave:board:reload", onReload);
   }, [load]);
+
+  // Re-sync when the app regains focus. The board has no poll and no daemon
+  // subscription, so a familiar finishing a task (or any change made while the
+  // window was in the background) would otherwise sit stale until a manual
+  // reload — most visibly in the installed desktop app, where the OS window
+  // manager doesn't fire the web visibility events that browser tabs do.
+  useRefreshOnFocus(load);
 
   // Honour `#card-<id>` in the URL: workspace's `focus-card` palette intent
   // (e.g. the Task chip in chat-view) routes to /?…#card-<id>; we pick that

--- a/src/lib/use-refresh-on-focus.test.ts
+++ b/src/lib/use-refresh-on-focus.test.ts
@@ -1,0 +1,20 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { shouldRefresh } from "./use-refresh-on-focus.ts";
+
+// ── shouldRefresh: throttle gate ──
+assert.equal(shouldRefresh(0, 1500, 1500), true, "fires once the interval has elapsed");
+assert.equal(shouldRefresh(0, 1499, 1500), false, "suppressed inside the interval");
+assert.equal(shouldRefresh(1000, 3000, 1500), true, "fires when enough time has passed since last");
+assert.equal(shouldRefresh(1000, 1200, 1500), false, "suppressed for a rapid re-focus flurry");
+
+// ── source wiring: all three foreground signals + Tauri focus ──
+const src = readFileSync(new URL("./use-refresh-on-focus.ts", import.meta.url), "utf8");
+assert.match(src, /window\.addEventListener\("focus", run\)/, "wires window focus");
+assert.match(src, /document\.addEventListener\("visibilitychange", onVisible\)/, "wires visibilitychange");
+assert.match(src, /getCurrentWindow\(\)\.onFocusChanged/, "wires the Tauri native focus event (the desktop fix)");
+assert.match(src, /if \(isTauri\(\)\)/, "the Tauri path is guarded behind isTauri()");
+assert.match(src, /removeEventListener\("focus", run\)[\s\S]*?removeEventListener\("visibilitychange"/, "cleans up the web listeners");
+
+console.log("use-refresh-on-focus.test.ts: ok");

--- a/src/lib/use-refresh-on-focus.ts
+++ b/src/lib/use-refresh-on-focus.ts
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { isTauri } from "@/lib/tauri-platform";
+
+/** Pure throttle gate — exported for testing. */
+export function shouldRefresh(lastMs: number, nowMs: number, minIntervalMs: number): boolean {
+  return nowMs - lastMs >= minIntervalMs;
+}
+
+/**
+ * Re-run `refresh` whenever the app regains the foreground, so a surface that
+ * only fetches on mount doesn't sit on stale data after the user switches away
+ * and back — or after the daemon changes data while the window was unfocused.
+ *
+ * Wires every available foreground signal so it works in both the browser and
+ * the installed desktop app:
+ *   - `window` "focus" + `document` "visibilitychange" — browser tabs and most
+ *     webviews.
+ *   - Tauri `onFocusChanged` — the desktop window manager does NOT reliably emit
+ *     the web events when you switch between OS windows, so the native focus
+ *     event is the dependable signal in the Tauri build. This is the actual fix
+ *     for "stale data after an action in the installed app".
+ *
+ * Calls are throttled (default 1.5s) so a focus/blur flurry, or one regain that
+ * fires on several channels at once, only refetches a single time. The initial
+ * mount load is the caller's job — this hook only fires on RE-focus.
+ */
+export function useRefreshOnFocus(
+  refresh: () => void | Promise<void>,
+  opts?: { minIntervalMs?: number; enabled?: boolean },
+): void {
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  const lastRef = useRef(0);
+  const minIntervalMs = opts?.minIntervalMs ?? 1500;
+  const enabled = opts?.enabled ?? true;
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") return;
+    let disposed = false;
+
+    const run = () => {
+      const now = Date.now();
+      if (!shouldRefresh(lastRef.current, now, minIntervalMs)) return;
+      lastRef.current = now;
+      void refreshRef.current();
+    };
+    const onVisible = () => {
+      if (document.visibilityState === "visible") run();
+    };
+
+    window.addEventListener("focus", run);
+    document.addEventListener("visibilitychange", onVisible);
+
+    let unlisten: (() => void) | undefined;
+    if (isTauri()) {
+      void (async () => {
+        try {
+          const { getCurrentWindow } = await import("@tauri-apps/api/window");
+          const un = await getCurrentWindow().onFocusChanged((e: { payload: boolean }) => {
+            if (e.payload) run();
+          });
+          if (disposed) un();
+          else unlisten = un;
+        } catch {
+          /* Tauri window API unavailable — the web listeners still cover most cases. */
+        }
+      })();
+    }
+
+    return () => {
+      disposed = true;
+      window.removeEventListener("focus", run);
+      document.removeEventListener("visibilitychange", onVisible);
+      unlisten?.();
+    };
+  }, [enabled, minIntervalMs]);
+}


### PR DESCRIPTION
## Problem
You reported the refresh isn't meaningful in the installed desktop app — data goes **stale after an action**. Root cause: the Board fetches on mount and on the `cave:board:reload` event, but has **no poll and no daemon subscription**. So when a familiar finishes a task (or anything changes while the window is backgrounded), the Board sits on old data until a manual reload.

It's worst in the **Tauri desktop build**: the OS window manager doesn't fire the `visibilitychange`/`focus` web events that a browser tab does, so switching back to the app never triggers a re-sync.

## Fix
New **`useRefreshOnFocus`** hook re-runs a refresh when the app regains the foreground, wiring **every** available signal:
- web `window` "focus" + `document` "visibilitychange" — browser tabs / most webviews
- **Tauri `getCurrentWindow().onFocusChanged`** — the dependable foreground signal in the desktop build (guarded behind the existing `isTauri()`)

Throttled (1.5s) so one regain doesn't refetch several times. Wired into `board-view`; the hook is reusable for other load-once surfaces.

## Verification
- Pure throttle gate (`shouldRefresh`) unit-tested; source wiring asserted (focus + visibilitychange + onFocusChanged + isTauri guard + cleanup).
- Real app (Playwright): a card added to `/api/board` while the window was "backgrounded" is **not** visible until a `focus` event fires, after which the board refetches and the new card renders. GET count 3→4 on focus.

Scoped to the Board for this PR (the surface where daemon-driven staleness is most visible). The hook can be adopted by projects/library/workflows/calendar in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)