### PR TITLE
feat(ios): Live Activity for a running task (Lock Screen + Dynamic Island)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Info.plist
+++ b/apps/ios/CovenCave/CovenCave/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIColorName</key>

--- a/apps/ios/CovenCave/CovenCave/LiveActivity/LiveActivityManager.swift
+++ b/apps/ios/CovenCave/CovenCave/LiveActivity/LiveActivityManager.swift
@@ -1,0 +1,53 @@
+import ActivityKit
+import Foundation
+
+/// Owns the single "task running" Live Activity. The app starts one for a
+/// running task (from the task detail), and it ends automatically once that
+/// task leaves the running state — or when the user stops it.
+@MainActor
+@Observable
+final class LiveActivityManager {
+    static let shared = LiveActivityManager()
+    private init() {}
+
+    private var current: Activity<TaskActivityAttributes>?
+    /// The task currently tracked on the Lock Screen, if any (observed by views).
+    private(set) var currentTaskId: String?
+
+    var isSupported: Bool { ActivityAuthorizationInfo().areActivitiesEnabled }
+
+    /// Start (or replace) the Live Activity for a running task.
+    func start(for card: BoardCard) async {
+        guard isSupported else { return }
+        await endCurrent()
+        let attributes = TaskActivityAttributes(taskId: card.id, title: card.title, startedAt: Date())
+        let state = TaskActivityAttributes.ContentState(statusLabel: card.status.label)
+        do {
+            current = try Activity.request(attributes: attributes,
+                                           content: .init(state: state, staleDate: nil))
+            currentTaskId = card.id
+        } catch {
+            current = nil
+            currentTaskId = nil
+        }
+    }
+
+    /// Stop tracking (user-initiated).
+    func stop() async { await endCurrent() }
+
+    /// End the activity if the tracked task is gone or no longer running. Called
+    /// after task mutations / refreshes so completion auto-dismisses the card.
+    func reconcile(_ tasks: [BoardCard]) async {
+        guard let id = currentTaskId else { return }
+        let stillRunning = tasks.first { $0.id == id }?.status == .running
+        if !stillRunning { await endCurrent() }
+    }
+
+    private func endCurrent() async {
+        guard let activity = current else { currentTaskId = nil; return }
+        await activity.end(.init(state: activity.content.state, staleDate: nil),
+                           dismissalPolicy: .immediate)
+        current = nil
+        currentTaskId = nil
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/LiveActivity/TaskActivityAttributes.swift
+++ b/apps/ios/CovenCave/CovenCave/LiveActivity/TaskActivityAttributes.swift
@@ -1,0 +1,14 @@
+import ActivityKit
+import Foundation
+
+/// Shared between the app (which starts/ends the activity) and the widget
+/// extension (which renders it). The title + start time are fixed for the life
+/// of the activity; only the status label changes.
+struct TaskActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var statusLabel: String
+    }
+    var taskId: String
+    var title: String
+    var startedAt: Date
+}

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -171,6 +171,8 @@ final class AppModel {
             tasksError = error.localizedDescription
         }
         tasksLoaded = true
+        // A task that finished on the desktop should drop its Lock Screen activity.
+        await LiveActivityManager.shared.reconcile(tasks)
     }
 
     // MARK: - Task actions
@@ -185,6 +187,7 @@ final class AppModel {
             let updated = try await client.updateTask(cardId: card.id, status: status)
             applyTask(id: card.id) { $0 = updated }
             Haptics.tap()
+            await LiveActivityManager.shared.reconcile(tasks)
         } catch {
             tasks = previous
             tasksError = error.localizedDescription

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -14,6 +14,7 @@ struct TaskDetailView: View {
     @State private var renamingTitle = false
     @State private var titleDraft = ""
     @State private var newStep = ""
+    @State private var liveActivity = LiveActivityManager.shared
 
     /// The current card from the store, so status/priority/step edits made here
     /// reflect immediately; falls back to the passed-in snapshot.
@@ -89,6 +90,18 @@ struct TaskDetailView: View {
 
             Button { editingNotes = true } label: {
                 Label(hasNotes ? "Edit notes" : "Add notes", systemImage: "square.and.pencil")
+            }
+
+            // Live Activity: track a running task on the Lock Screen / Dynamic
+            // Island. It ends automatically once the task leaves the running state.
+            if liveActivity.currentTaskId == live.id {
+                Button { Task { await liveActivity.stop() } } label: {
+                    Label("Stop Lock Screen tracking", systemImage: "stop.circle")
+                }
+            } else if live.status == .running && liveActivity.isSupported {
+                Button { Task { await liveActivity.start(for: live) } } label: {
+                    Label("Track on Lock Screen", systemImage: "bolt.badge.clock")
+                }
             }
 
             Divider()

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -1,0 +1,65 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+/// The "task running" Live Activity — Lock Screen banner + Dynamic Island.
+/// Shows the task title and a live elapsed-time counter from `startedAt`.
+struct TaskLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: TaskActivityAttributes.self) { context in
+            // Lock Screen / banner presentation.
+            HStack(spacing: 12) {
+                Image(systemName: "play.circle.fill")
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Running task")
+                        .font(.caption2).foregroundStyle(.secondary)
+                    Text(context.attributes.title)
+                        .font(.headline).lineLimit(2)
+                }
+                Spacer(minLength: 8)
+                Text(context.attributes.startedAt, style: .timer)
+                    .font(.title3.monospacedDigit())
+                    .frame(maxWidth: 64, alignment: .trailing)
+            }
+            .padding()
+            .activityBackgroundTint(Color.black.opacity(0.35))
+            .activitySystemActionForegroundColor(.primary)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "play.circle.fill").foregroundStyle(.tint)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.attributes.startedAt, style: .timer)
+                        .font(.body.monospacedDigit())
+                        .frame(maxWidth: 64, alignment: .trailing)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.attributes.title)
+                        .font(.subheadline.weight(.medium)).lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.statusLabel)
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+            } compactLeading: {
+                Image(systemName: "play.fill").foregroundStyle(.tint)
+            } compactTrailing: {
+                Text(context.attributes.startedAt, style: .timer)
+                    .font(.caption2.monospacedDigit())
+                    .frame(maxWidth: 44)
+            } minimal: {
+                Image(systemName: "play.fill").foregroundStyle(.tint)
+            }
+        }
+    }
+}
+
+@main
+struct CovenCaveWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        TaskLiveActivity()
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveWidgets/Info.plist
+++ b/apps/ios/CovenCave/CovenCaveWidgets/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Coven Cave</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -52,3 +52,21 @@ targets:
         ENABLE_PREVIEWS: YES
         SWIFT_EMIT_LOC_STRINGS: YES
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+    dependencies:
+      - target: CovenCaveWidgets
+
+  # Widget extension hosting the "task running" Live Activity (Lock Screen +
+  # Dynamic Island). Shares TaskActivityAttributes.swift with the app target.
+  CovenCaveWidgets:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: CovenCaveWidgets
+      - path: CovenCave/LiveActivity/TaskActivityAttributes.swift
+    settings:
+      base:
+        INFOPLIST_FILE: CovenCaveWidgets/Info.plist
+        PRODUCT_BUNDLE_IDENTIFIER: ai.opencoven.cave.widgets
+        PRODUCT_NAME: CovenCaveWidgets
+        IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+        SKIP_INSTALL: YES


### PR DESCRIPTION
Track a running board task on the **Lock Screen** and in the **Dynamic Island** with a live elapsed-time counter — the first iOS-native capability beyond parity.

## What's in it
- **New `CovenCaveWidgets` widget-extension target** (XcodeGen): a `WidgetBundle` with an `ActivityConfiguration` rendering the Lock Screen banner + Dynamic Island (compact play glyph + timer, expanded title/status/timer, minimal glyph).
- **Shared `TaskActivityAttributes.swift`** compiled into both the app and the extension.
- **`LiveActivityManager`** (`@Observable @MainActor`): `start(for:)` / `stop()` / `reconcile(tasks:)`, owning the single activity, guarded on `areActivitiesEnabled`.
- **TaskDetailView**: a "Track on Lock Screen" action on a running task, "Stop Lock Screen tracking" while active.
- **Auto-end**: AppModel ends the activity once the tracked task leaves running (after `setTaskStatus` and after `loadTasks`, so desktop completion dismisses it too).
- **Info.plist**: `NSSupportsLiveActivities`; the app embeds the `.appex`.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED** (both targets; `CovenCaveWidgets.appex` embedded in `PlugIns/`, `NSSupportsLiveActivities=true` in the built Info.plist).
- Ran on the simulator against live `~/.coven` data and **captured the Live Activity live in the Dynamic Island** — compact play glyph + counting timer (screenshot).
- Mobile (65) + app (413) source-text suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)