### PR TITLE
fix(a11y): make board card-stack row actions keyboard-accessible

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -153,6 +153,7 @@ export const SUITES = {
     "src/components/board-grouping.test.ts",
     "src/components/board-project-picker.test.ts",
     "src/components/board-ux-polish.test.ts",
+    "src/components/board-card-stack-a11y.test.ts",
     "src/components/board-bulk-select.test.ts",
     "src/components/delete-undo-surfaces.test.ts",
     "src/components/vault-automations-filter.test.ts",

--- a/src/components/board-card-stack-a11y.test.ts
+++ b/src/components/board-card-stack-a11y.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./board-card-stack.tsx", import.meta.url), "utf8");
+
+// The card body is a role=button element (not a real <button>) so it can hold
+// flow content + focusable action buttons without invalid nesting — mirroring
+// KanbanCard. Was: a <button> wrapping <div>/<p> and a tabIndex=-1 role=link.
+assert.match(
+  src,
+  /className="board-card-stack__row-main"\s+role="button"\s+tabIndex=\{0\}\s+aria-pressed=\{isSelected\}/,
+  "the card body is a keyboard-focusable role=button (not a <button> wrapping flow content)",
+);
+assert.match(
+  src,
+  /onKeyDown=\{\(e\) => \{\s*if \(e\.key === "Enter" \|\| e\.key === " "\) \{ e\.preventDefault\(\); onSelect\(\); \}/,
+  "the card body activates on Enter/Space",
+);
+
+// The Open / Start actions are real, focusable <button>s — keyboard and screen
+// reader users can trigger them (they were tabIndex=-1 spans before).
+assert.doesNotMatch(
+  src,
+  /role="link"\s+tabIndex=\{-1\}/,
+  "no keyboard-unreachable role=link spans remain for the row actions",
+);
+assert.match(
+  src,
+  /<button\s+type="button"\s+className="board-card-stack__row-action board-card-stack__row-action--chat"\s+aria-label=\{`Open linked session/,
+  "the Open-session action is a real labelled button",
+);
+assert.match(
+  src,
+  /<button\s+type="button"\s+className="board-card-stack__row-action board-card-stack__row-action--chat"\s+disabled=\{chatLinking\}[\s\S]*?aria-label=\{`Start a chat/,
+  "the Start-chat action is a real labelled button that disables while linking",
+);
+
+console.log("board-card-stack-a11y.test.ts: ok");

--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -187,11 +187,18 @@ function BoardCardStackRow({
         isSelected ? " board-card-stack__row--selected" : ""
       }`}
     >
-      <button
-        type="button"
+      {/* role=button (not a real <button>) so the card body can hold flow
+          content — title/notes/footer — and real, focusable action buttons as
+          descendants, mirroring the accessible KanbanCard idiom. */}
+      <div
         className="board-card-stack__row-main"
-        onClick={onSelect}
+        role="button"
+        tabIndex={0}
         aria-pressed={isSelected}
+        onClick={onSelect}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(); }
+        }}
       >
         <div className="board-card-stack__row-top">
           <span className={`board-card-stack__priority-pill board-card-stack__priority-pill--${card.priority}`}>
@@ -238,10 +245,10 @@ function BoardCardStackRow({
             </span>
           ) : null}
           {session ? (
-            <span
+            <button
+              type="button"
               className="board-card-stack__row-action board-card-stack__row-action--chat"
-              role="link"
-              tabIndex={-1}
+              aria-label={`Open linked session for ${card.title}`}
               onClick={(e) => {
                 e.stopPropagation();
                 onJumpToSession?.(session.id, session.familiarId ?? null);
@@ -249,13 +256,14 @@ function BoardCardStackRow({
             >
               <Icon name="ph:arrow-square-out" width={11} />
               Open
-            </span>
+            </button>
           ) : (
-            <span
+            <button
+              type="button"
               className="board-card-stack__row-action board-card-stack__row-action--chat"
-              role="link"
-              tabIndex={-1}
+              disabled={chatLinking}
               title="Start chat"
+              aria-label={`Start a chat for ${card.title}`}
               onClick={(e) => {
                 e.stopPropagation();
                 if (!chatLinking) void onOpenTaskChat?.(card.id);
@@ -263,10 +271,10 @@ function BoardCardStackRow({
             >
               <Icon name="ph:chat-circle-dots" width={11} />
               {chatLinking ? "Starting…" : "Start"}
-            </span>
+            </button>
           )}
         </div>
-      </button>
+      </div>
       <button
         ref={menuButtonRef}
         type="button"

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1550,15 +1550,23 @@
   align-items: center;
   gap: 4px;
   font-weight: 500;
+  font-size: inherit;
+  font-family: inherit;
   color: var(--text-secondary);
   white-space: nowrap;
   padding: 4px 8px;
+  border: 0;
+  background: none;
   border-radius: 6px;
   cursor: pointer;
 }
-.board-card-stack__row-action:hover {
+.board-card-stack__row-action:hover:not(:disabled) {
   background: var(--bg-hover);
   color: var(--text-primary);
+}
+.board-card-stack__row-action:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 /* Board Gantt */


### PR DESCRIPTION
## Board card view audit

Two card components render board tasks:
- **`KanbanCard`** (desktop kanban) — already exemplary: `role=button`/`checkbox`, rich `aria-label`, `aria-keyshortcuts`, keyboard handlers, real focusable footer buttons. No change.
- **`BoardCardStackRow`** (mobile-first card list) — one real defect, fixed here.

### The defect
The row body was a real `<button>` wrapping flow content (`<div>`/`<p>`) **and** a nested `<span role="link" tabIndex={-1}>` for the Open-session / Start-chat action. That's invalid (a `<button>` may only contain phrasing content) and, because of `tabIndex={-1}`, the Open/Start action was **unreachable by keyboard or screen reader** — you could open the card but never trigger its action from the row.

### The fix — mirror the accessible KanbanCard idiom
- The card body is now a `role="button"` `<div>` (`tabIndex=0`, `aria-pressed`, Enter/Space handler) so it can validly hold flow content + real buttons.
- Open and Start are real, focusable `<button>`s with descriptive `aria-label`s (`Open linked session for <title>` / `Start a chat for <title>`); Start disables while linking.
- CSS: `.board-card-stack__row-action` gains button resets (border/background/font) + a `:disabled` style, so the buttons render identically to the old spans.

## Verification
- New `board-card-stack-a11y.test.ts` (wired; `check:tests-wired` ✓); `a11y-audit-fixes`, `board-ux-polish`, `board-schedule-window`, `library-polish` still pass · `tsc` clean · `pnpm build` exit 0
- Live (Playwright, 390px mobile viewport): the row renders as `div[role=button][tabindex=0]` and **all** row actions are real `<button>`s — both the row and the action receive keyboard focus (focus ring confirmed in screenshot), `aria-label` resolves to the card title, visual parity preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)