### PR TITLE
feat(board): extend bulk-edit with set-priority and add-label

### DIFF
--- a/src/components/board-bulk-select.test.ts
+++ b/src/components/board-bulk-select.test.ts
@@ -35,4 +35,13 @@ assert.match(kanban, /aria-checked=\{selectMode \? isSelected : undefined\}/, "k
 assert.match(table, /onClick=\{\(\) => \(selectMode \? onToggleSelect\?\.\(card\.id\) : onSelect\(card\.id\)\)\}/, "table rows toggle selection in select mode");
 assert.match(table, /aria-checked=\{selectMode \? rowChecked : undefined\}/, "table checkbox rows expose aria-checked");
 
+// ── Extended bulk-edit: priority + label (#4) ──
+assert.match(view, /const bulkSetPriority = async \(priority: CardPriority\)/, "bulk set-priority handler");
+assert.match(view, /const bulkAddLabel = async \(raw: string\)/, "bulk add-label handler");
+assert.match(view, /\.filter\(\(c\) => !c\.labels\.includes\(label\)\)/, "bulk label skips cards that already have it");
+assert.match(view, /id="board-bulk-priority"/, "toolbar exposes a priority control");
+assert.match(view, /void bulkSetPriority\(e\.target\.value as CardPriority\)/, "priority select wires bulkSetPriority");
+assert.match(view, /list="board-bulk-label-options"/, "label input is backed by a datalist of existing labels");
+assert.match(view, /void bulkAddLabel\(labelDraft\)/, "label form submits bulkAddLabel");
+
 console.log("board-bulk-select.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -389,8 +389,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const [bulkBusy, setBulkBusy] = useState(false);
   const [labelDraft, setLabelDraft] = useState("");
   const selectedCards = () => cardSelect.selectedFrom(filtered);
-  // Existing labels across the board → datalist autocomplete for bulk add.
-  const allLabels = useMemo(
+  // Existing labels across the board → datalist autocomplete for the bulk
+  // add-label control (NOT a filter row — label filtering is search syntax).
+  const bulkLabelOptions = useMemo(
     () => [...new Set(cards.flatMap((c) => c.labels))].sort(),
     [cards],
   );
@@ -899,7 +900,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                   className="focus-ring w-24 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] disabled:opacity-50"
                 />
                 <datalist id="board-bulk-label-options">
-                  {allLabels.map((l) => <option key={l} value={l} />)}
+                  {bulkLabelOptions.map((l) => <option key={l} value={l} />)}
                 </datalist>
                 <button
                   type="submit"

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -9,7 +9,7 @@ import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { type WipLimits, readWipLimits, writeWipLimits, setWipLimit } from "@/lib/board-wip";
 import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
 import { Icon } from "@/lib/icon";
-import { type Card, type CardStatus, STATUSES } from "@/lib/cave-board-types";
+import { type Card, type CardStatus, type CardPriority, STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
@@ -387,7 +387,13 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   // ── Bulk select (kanban + table) ────────────────────────────────────────────
   const cardSelect = useMultiSelect(filtered, (c) => c.id);
   const [bulkBusy, setBulkBusy] = useState(false);
+  const [labelDraft, setLabelDraft] = useState("");
   const selectedCards = () => cardSelect.selectedFrom(filtered);
+  // Existing labels across the board → datalist autocomplete for bulk add.
+  const allLabels = useMemo(
+    () => [...new Set(cards.flatMap((c) => c.labels))].sort(),
+    [cards],
+  );
 
   const bulkMove = async (status: CardStatus) => {
     const ids = selectedCards().map((c) => c.id);
@@ -407,6 +413,31 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     cardSelect.exit();
   };
 
+  const bulkSetPriority = async (priority: CardPriority) => {
+    const ids = selectedCards().map((c) => c.id);
+    if (ids.length === 0) { cardSelect.exit(); return; }
+    setBulkBusy(true);
+    await Promise.all(ids.map((id) => patchCard(id, { priority })));
+    setBulkBusy(false);
+    cardSelect.exit();
+  };
+
+  // Add one label to every selected card (skip cards that already have it).
+  const bulkAddLabel = async (raw: string) => {
+    const label = raw.trim();
+    const sel = selectedCards();
+    if (!label || sel.length === 0) { if (sel.length === 0) cardSelect.exit(); return; }
+    setBulkBusy(true);
+    await Promise.all(
+      sel
+        .filter((c) => !c.labels.includes(label))
+        .map((c) => patchCard(c.id, { labels: [...c.labels, label] })),
+    );
+    setBulkBusy(false);
+    setLabelDraft("");
+    cardSelect.exit();
+  };
+
   const bulkDelete = () => {
     const sel = selectedCards();
     if (sel.length === 0) { cardSelect.exit(); return; }
@@ -418,6 +449,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const STATUS_LABELS: Record<CardStatus, string> = {
     backlog: "Backlog", inbox: "Inbox", running: "Running",
     review: "Review", blocked: "Blocked", done: "Done",
+  };
+  const PRIORITY_LABELS: Record<CardPriority, string> = {
+    urgent: "Urgent", high: "High", medium: "Medium", low: "Low",
   };
 
   const handleClearDone = async () => {
@@ -840,6 +874,43 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 <option value="">Assign to…</option>
                 {familiars.map((f) => <option key={f.id} value={f.id}>{f.display_name}</option>)}
               </select>
+              <label className="sr-only" htmlFor="board-bulk-priority">Set priority of selected tasks</label>
+              <select
+                id="board-bulk-priority"
+                disabled={bulkBusy || cardSelect.selectedCount === 0}
+                value=""
+                onChange={(e) => { if (e.target.value) void bulkSetPriority(e.target.value as CardPriority); }}
+                className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
+              >
+                <option value="">Priority…</option>
+                {PRIORITIES.map((p) => <option key={p} value={p}>{PRIORITY_LABELS[p]}</option>)}
+              </select>
+              <form
+                className="inline-flex items-center gap-1"
+                onSubmit={(e) => { e.preventDefault(); void bulkAddLabel(labelDraft); }}
+              >
+                <input
+                  list="board-bulk-label-options"
+                  value={labelDraft}
+                  onChange={(e) => setLabelDraft(e.target.value)}
+                  placeholder="Add label…"
+                  aria-label="Add a label to selected tasks"
+                  disabled={bulkBusy || cardSelect.selectedCount === 0}
+                  className="focus-ring w-24 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] disabled:opacity-50"
+                />
+                <datalist id="board-bulk-label-options">
+                  {allLabels.map((l) => <option key={l} value={l} />)}
+                </datalist>
+                <button
+                  type="submit"
+                  disabled={bulkBusy || cardSelect.selectedCount === 0 || !labelDraft.trim()}
+                  title="Add this label to the selected tasks"
+                  className="focus-ring inline-flex items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+                >
+                  <Icon name="ph:tag-bold" width={11} aria-hidden />
+                  Label
+                </button>
+              </form>
               <button
                 type="button"
                 disabled={bulkBusy || cardSelect.selectedCount === 0}


### PR DESCRIPTION
Last of the Board UX pitch — the bulk-select toolbar gains the two most common backlog-triage edits beyond move/assign/delete.

## What
- **Set priority** — a `Priority…` select (urgent/high/medium/low) PATCHes every selected card.
- **Add label** — a small input (datalist-backed by the board's existing labels, so you can pick or type) adds one label to each selected card, **skipping cards that already carry it**.

Both reuse the existing optimistic `patchCard` path and exit select mode on apply, mirroring `bulkAssign`.

## Verification (real app, Playwright)
- Select all → Priority `Urgent` → all 3 cards PATCHed `priority: urgent`
- Select all → Add label `triage` → only the 2 cards lacking it were PATCHed; the card that already had `triage` was skipped (dedup)
- Toolbar fits one line: Move · Assign · Priority · Add-label · Label · Delete · Cancel

Source-text assertions added to `board-bulk-select.test.ts`; `tsc` + `check:tests-wired` green.

This completes the 4-item Board UX pitch: #1859 overdue+quick-add · #1864 WIP limits · #1873 desktop refresh · this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)