### PR TITLE
fix(a11y): complete command-palette combobox + guard corpus loader + scroll active row

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -90,6 +90,7 @@ export const SUITES = {
     "src/components/roles-tools-navigation.test.ts",
     "src/components/top-bar.test.ts",
     "src/components/command-palette.test.ts",
+    "src/components/command-palette-a11y.test.ts",
     "src/components/command-palette-save-link.test.ts",
     "src/lib/command-palette-scope.test.ts",
     "src/lib/fuzzy-match.test.ts",

--- a/src/components/command-palette-a11y.test.ts
+++ b/src/components/command-palette-a11y.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
+
+// ── Input is a complete combobox ─────────────────────────────────────────────
+// It already had aria-label/aria-controls/aria-activedescendant; these complete
+// the pattern so screen readers announce the popup's open state + autocomplete.
+assert.match(src, /role="combobox"/, "the search input declares the combobox role");
+assert.match(src, /aria-expanded=\{rows\.length > 0\}/, "the input reports whether the results popup is open");
+assert.match(src, /aria-autocomplete="list"/, "the input advertises list autocomplete");
+
+// ── Corpus loader drops post-close/unmount responses ─────────────────────────
+// The Promise.all of /api/board + /api/coven-memory + /api/memory previously set
+// state with no guard; closing the palette mid-fetch hit a gone component.
+assert.match(
+  src,
+  /let cancelled = false;[\s\S]*?Promise\.all\(\[[\s\S]*?\/api\/board[\s\S]*?\/api\/coven-memory[\s\S]*?\/api\/memory[\s\S]*?if \(cancelled\) return;[\s\S]*?setCards/,
+  "the corpus loader bails out if the palette closed/unmounted before it resolved",
+);
+assert.match(
+  src,
+  /return \(\) => \{ cancelled = true; clearTimeout\(t\); \};/,
+  "closing the palette cancels the in-flight corpus refresh",
+);
+
+// ── Active option is scrolled into view on keyboard nav ──────────────────────
+assert.match(
+  src,
+  /getElementById\(`command-palette-option-\$\{activeIdx\}`\)\s*\?\.scrollIntoView\(\{ block: "nearest" \}\)/,
+  "the keyboard-highlighted option is scrolled into view as activeIdx changes",
+);
+assert.match(
+  src,
+  /\}, \[activeIdx, open\]\);/,
+  "the scroll-into-view effect tracks the active index",
+);
+
+console.log("command-palette-a11y.test.ts: ok");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -307,6 +307,7 @@ export function CommandPalette({
     setSalemError(null);
     const t = setTimeout(() => inputRef.current?.focus(), 10);
 
+    let cancelled = false;
     void (async () => {
       try {
         const [boardRes, covenRes, fsRes] = await Promise.all([
@@ -317,6 +318,8 @@ export function CommandPalette({
         const board = await boardRes.json();
         const coven = await covenRes.json();
         const fs = await fsRes.json();
+        // Don't apply a corpus refresh after the palette closed/unmounted.
+        if (cancelled) return;
         if (board.ok) setCards(board.cards ?? []);
         if (coven.ok) setCovenMemory(coven.entries ?? []);
         if (fs.ok) setFsMemory(fs.entries ?? []);
@@ -325,8 +328,17 @@ export function CommandPalette({
       }
     })();
 
-    return () => clearTimeout(t);
+    return () => { cancelled = true; clearTimeout(t); };
   }, [open]);
+
+  // Keep the keyboard-highlighted option visible: arrowing past the bottom of
+  // the max-h-[60vh] list must scroll it into view, not just advance the index.
+  useEffect(() => {
+    if (!open) return;
+    document
+      .getElementById(`command-palette-option-${activeIdx}`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx, open]);
 
   useEffect(() => {
     if (!open) return;
@@ -799,7 +811,10 @@ export function CommandPalette({
           }}
           onKeyDown={onComposerKey}
           placeholder="Search familiars · chats · cards · memory · commands… (try @familiar to scope)"
+          role="combobox"
           aria-label="Search and jump to anything"
+          aria-expanded={rows.length > 0}
+          aria-autocomplete="list"
           aria-controls="command-palette-listbox"
           aria-activedescendant={
             rows.length > 0 ? `command-palette-option-${activeIdx}` : undefined


### PR DESCRIPTION
## Command palette audit (`command-palette.tsx`)

Already strong — complete dialog semantics (`role=dialog`/`aria-modal`/label, Escape, backdrop-close), focus trap **with** focus restore (`useFocusTrap`), `role=listbox`/`option`/`aria-selected`, `aria-controls`/`aria-activedescendant`, real `<button>` items, AbortController on the content search, and a global `prefers-reduced-motion` reset (globals.css) that already neutralizes the modal/pulse animations. Three genuine gaps, fixed:

1. **Input is now a complete combobox** — it had `aria-label`/`aria-controls`/`aria-activedescendant` but wasn't declared a combobox. Added `role="combobox"`, `aria-expanded` (true when results are shown), and `aria-autocomplete="list"` so screen readers announce the popup's open state.
2. **Corpus loader guarded** — the `Promise.all` of `/api/board` + `/api/coven-memory` + `/api/memory` set `setCards`/`setCovenMemory`/`setFsMemory` with no guard; closing/unmounting the palette mid-fetch hit a gone component. Added a `cancelled` flag dropped in the effect cleanup.
3. **Active option scrolls into view** — arrowing past the bottom of the `max-h-[60vh]` list advanced `activeIdx` but left the highlight off-screen. Now `scrollIntoView({ block: "nearest" })` on every `activeIdx` change.

## Verification
- New `command-palette-a11y.test.ts` (wired; `check:tests-wired` ✓) + existing `command-palette`, `command-palette-save-link`, `command-palette-scope` pass · `tsc` clean · `pnpm build` exit 0
- Live (Playwright, ⌘K): input reports `role=combobox` + `aria-autocomplete=list` + `aria-expanded` tracking results; after 12× ArrowDown the active option (`option-12`) is confirmed in-view within the listbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)