### PR TITLE
feat(ios): leading swipe to complete a task; trailing for delete

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -308,10 +308,15 @@ struct TasksView: View {
                             .tag(card)
                             .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 12))
                             .contextMenu { taskMenu(card) }
+                            // Trailing = destructive (delete); leading = the
+                            // positive quick-action (done/reopen), full-swipe to
+                            // complete — matching RemindersView + iOS convention.
                             .swipeActions(edge: .trailing, allowsFullSwipe: true) {
                                 Button(role: .destructive) { pendingDelete = card } label: {
                                     Label("Delete", systemImage: "trash")
                                 }
+                            }
+                            .swipeActions(edge: .leading, allowsFullSwipe: true) {
                                 Button { Task { await app.setTaskStatus(card, card.status == .done ? .running : .done) } } label: {
                                     Label(card.status == .done ? "Reopen" : "Done",
                                           systemImage: card.status == .done ? "arrow.uturn.backward" : "checkmark")


### PR DESCRIPTION
Task rows had Delete + Done together on the trailing edge. Splits them to the iOS convention (and to match RemindersView): **leading edge = Done / Reopen** (positive, full-swipe to complete), **trailing = Delete** (destructive). Status changes still buzz + auto-reconcile any Live Activity via the existing AppModel path.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED**; app launches/runs with no regression.
- Mobile (65) source-text suite green (task-action tests unaffected).
- The swipe gesture isn't simctl-automatable, but this is a minimal reshape of the existing, working `swipeActions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)