### PR TITLE
fix(a11y): add calendar detail backdrop dismiss

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -21,6 +21,13 @@ assert.match(view, /role="dialog"/, "Detail panel must be a dialog");
 assert.match(view, /aria-modal="true"/, "Detail panel must be aria-modal");
 assert.match(view, /aria-labelledby=\{titleId\}/, "Detail panel must be labelled by its title");
 assert.match(view, /useFocusTrap\(true, panelRef, \{ onEscape: onClose \}\)/, "Detail panel must trap focus + Escape");
+// A backdrop makes aria-modal honest (calendar behind is inert) and gives the
+// drawer the outside-click dismiss it was missing (was: close button/Escape only).
+assert.match(
+  view,
+  /<div className="cave-cal-detail-backdrop" role="presentation" onClick=\{onClose\} \/>/,
+  "Detail panel has a click-to-dismiss backdrop behind it",
+);
 
 // ───────── Dismissed items leave the calendar ─────────
 assert.match(view, /\.filter\(\(it\) => it\.status !== "dismissed"\)/, "Dismissed items must be filtered out of the calendar");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1321,100 +1321,105 @@ function ItemDetailPanel({
   const isDone = item.status === "done";
 
   return (
-    <div
-      ref={panelRef}
-      className="cave-cal-detail-panel"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      tabIndex={-1}
-    >
-      <div className="cave-cal-detail-header">
-        <div className="flex items-center gap-2 min-w-0">
-          <Icon name={platformIcon(item)} className="shrink-0 text-[var(--text-muted)] text-[14px]" />
-          <span id={titleId} className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
-            {item.title}
-          </span>
-        </div>
-        <button
-          onClick={onClose}
-          aria-label="Close"
-          className="focus-ring shrink-0 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-        >
-          <Icon name="ph:x" width={14} />
-        </button>
-      </div>
-
-      <div className="flex flex-col gap-3 px-4 py-3 text-[12px] text-[var(--text-secondary)] overflow-y-auto flex-1">
-        <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
-          <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">{KIND_LABEL[item.kind]}</span>
-          {isDone ? <span className="inline-flex items-center gap-1 rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--color-success,#34d399)]"><Icon name="ph:check" width={9} />Done</span> : null}
-        </div>
-        {meta?.urgency && meta.urgency !== "normal" && (
-          <div className="flex items-center gap-1.5">
-            <span className={`h-2 w-2 rounded-full ${urgencyColor(item)}`} />
-            <span className="capitalize">{meta.urgency.replace("-", " ")}</span>
-          </div>
-        )}
-        {(item.fireAt ?? item.firedAt) && (
-          <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
-            <Icon name="ph:clock" width={12} />
-            <span>
-              {(() => {
-                const at = (item.fireAt ?? item.firedAt)!;
-                // Short weekday isn't a preference; the date order + clock are.
-                const weekday = new Date(at).toLocaleDateString([], { weekday: "short" });
-                return `${weekday}, ${formatDate(at, undefined, { month: "short" })} ${formatClock(at)}`;
-              })()}
+    <>
+      {/* Backdrop makes aria-modal honest (the calendar behind is inert) and
+          adds the outside-click dismiss the drawer was missing. */}
+      <div className="cave-cal-detail-backdrop" role="presentation" onClick={onClose} />
+      <div
+        ref={panelRef}
+        className="cave-cal-detail-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+      >
+        <div className="cave-cal-detail-header">
+          <div className="flex items-center gap-2 min-w-0">
+            <Icon name={platformIcon(item)} className="shrink-0 text-[var(--text-muted)] text-[14px]" />
+            <span id={titleId} className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
+              {item.title}
             </span>
           </div>
-        )}
-        {body && (
-          <p className="text-[var(--text-secondary)] leading-relaxed whitespace-pre-wrap">
-            {body}
-          </p>
-        )}
-      </div>
-
-      <div className="flex flex-col gap-2 border-t border-[var(--border-hairline)] px-4 py-3">
-        {openLabel && onOpen ? (
           <button
-            onClick={() => { onOpen(item); onClose(); }}
-            className="focus-ring inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] text-white transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
+            onClick={onClose}
+            aria-label="Close"
+            className="focus-ring shrink-0 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
           >
-            <Icon name="ph:arrow-square-out" width={12} />
-            {openLabel}
+            <Icon name="ph:x" width={14} />
           </button>
-        ) : null}
-        <div className="flex items-center gap-2">
-          {!isDone && onComplete ? (
+        </div>
+
+        <div className="flex flex-col gap-3 px-4 py-3 text-[12px] text-[var(--text-secondary)] overflow-y-auto flex-1">
+          <div className="flex flex-wrap items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
+            <span className="rounded bg-[var(--bg-elevated)] px-1.5 py-0.5">{KIND_LABEL[item.kind]}</span>
+            {isDone ? <span className="inline-flex items-center gap-1 rounded bg-[var(--bg-elevated)] px-1.5 py-0.5 text-[var(--color-success,#34d399)]"><Icon name="ph:check" width={9} />Done</span> : null}
+          </div>
+          {meta?.urgency && meta.urgency !== "normal" && (
+            <div className="flex items-center gap-1.5">
+              <span className={`h-2 w-2 rounded-full ${urgencyColor(item)}`} />
+              <span className="capitalize">{meta.urgency.replace("-", " ")}</span>
+            </div>
+          )}
+          {(item.fireAt ?? item.firedAt) && (
+            <div className="flex items-center gap-1.5 text-[var(--text-muted)]">
+              <Icon name="ph:clock" width={12} />
+              <span>
+                {(() => {
+                  const at = (item.fireAt ?? item.firedAt)!;
+                  // Short weekday isn't a preference; the date order + clock are.
+                  const weekday = new Date(at).toLocaleDateString([], { weekday: "short" });
+                  return `${weekday}, ${formatDate(at, undefined, { month: "short" })} ${formatClock(at)}`;
+                })()}
+              </span>
+            </div>
+          )}
+          {body && (
+            <p className="text-[var(--text-secondary)] leading-relaxed whitespace-pre-wrap">
+              {body}
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-2 border-t border-[var(--border-hairline)] px-4 py-3">
+          {openLabel && onOpen ? (
             <button
-              onClick={() => { onComplete(item.id); onClose(); }}
-              className="focus-ring inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-1.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              onClick={() => { onOpen(item); onClose(); }}
+              className="focus-ring inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] text-white transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
             >
-              <Icon name="ph:check" width={12} />
-              Done
+              <Icon name="ph:arrow-square-out" width={12} />
+              {openLabel}
             </button>
           ) : null}
-          {onSnooze ? (
-            <SnoozeMenu
-              className="shrink-0"
-              onSnooze={(untilIso) => { onSnooze(item.id, untilIso); onClose(); }}
-            />
-          ) : null}
-          {onDismiss ? (
-            <button
-              onClick={() => { onDismiss(item.id); onClose(); }}
-              aria-label="Dismiss"
-              className="focus-ring inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-              title="Dismiss"
-            >
-              <Icon name="ph:trash" width={12} />
-            </button>
-          ) : null}
+          <div className="flex items-center gap-2">
+            {!isDone && onComplete ? (
+              <button
+                onClick={() => { onComplete(item.id); onClose(); }}
+                className="focus-ring inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-1.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:check" width={12} />
+                Done
+              </button>
+            ) : null}
+            {onSnooze ? (
+              <SnoozeMenu
+                className="shrink-0"
+                onSnooze={(untilIso) => { onSnooze(item.id, untilIso); onClose(); }}
+              />
+            ) : null}
+            {onDismiss ? (
+              <button
+                onClick={() => { onDismiss(item.id); onClose(); }}
+                aria-label="Dismiss"
+                className="focus-ring inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                title="Dismiss"
+              >
+                <Icon name="ph:trash" width={12} />
+              </button>
+            ) : null}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -3424,6 +3424,14 @@ details[open] > .cave-tool-summary::before {
    CALENDAR DETAIL PANEL
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 
+.cave-cal-detail-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 19;
+  background: var(--backdrop-scrim, oklch(0 0 0 / 28%));
+  animation: ui-modal-fade-in var(--duration-fast) var(--ease-decelerate);
+}
+
 .cave-cal-detail-panel {
   position: absolute;
   top: 0;

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -3427,8 +3427,10 @@ details[open] > .cave-tool-summary::before {
 .cave-cal-detail-backdrop {
   position: absolute;
   inset: 0;
-  z-index: 19;
-  background: var(--backdrop-scrim, oklch(0 0 0 / 28%));
+  /* Keep below the detail panel (z-index: 10 in globals.css) while still
+     intercepting clicks to the calendar surface behind it. */
+  z-index: 9;
+  background: var(--backdrop-scrim);
   animation: ui-modal-fade-in var(--duration-fast) var(--ease-decelerate);
 }
 


### PR DESCRIPTION
## Calendar event detail audit (`ItemDetailPanel`, calendar-view.tsx)

The event-detail drawer was already a strong dialog — `role=dialog` + `aria-labelledby`, `useFocusTrap` (Escape + focus restore), real labelled action buttons, and its slide-in is covered by the global `prefers-reduced-motion` reset. The one gap:

It declared **`aria-modal="true"` and trapped focus, but had no backdrop and no outside-click dismiss** — so it announced as modal while the calendar behind stayed visible/clickable, and a mouse user could only close it via the ✕ or Escape. Every other dialog (command palette, voice overlay) pairs `aria-modal` with a click-to-dismiss backdrop.

**Fix:** add a backdrop scrim behind the drawer (click → `onClose`). This makes `aria-modal` honest (calendar inert) and adds the missing outside-click dismiss.

### ⚠️ z-index gotcha (caught in live verification)
`.cave-cal-detail-panel` has **two** rules — `z-index:20` in cave-chat.css and `z-index:10` in globals.css, the latter winning (loaded later). So the panel's *effective* z is **10**. The backdrop must sit at `z-index:9` (under 10), not 19 — otherwise it covers the panel and intercepts every action-button click. Source-text tests pass either way; the bug only surfaced via an `elementFromPoint` / click-the-title probe.

### Verification
- `calendar-actions.test.ts` extended (backdrop assertion) + calendar-view-polish/keyboard pass · `tsc` clean · `pnpm build` exit 0
- Live (Playwright): with the fix, panel z=10 > backdrop z=9, `elementFromPoint` at the panel center returns the panel, clicking the panel's title leaves it **open** (interactive on top), and clicking the backdrop **dismisses** it.

> Note: most of the calendar-view.tsx line count is formatter reindentation from wrapping the panel return in a fragment; the only logic change is the backdrop element (see \`git diff -w\`). The z-index:9 commit was converged on by GitHub Copilot Autofix + this session independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)