### PR TITLE
feat(ios): home-screen "Up Next" widget (next reminder + task counts)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCave.entitlements
+++ b/apps/ios/CovenCave/CovenCave/CovenCave.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ai.opencoven.cave</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/CovenCave/CovenCave/LiveActivity/WidgetSnapshot.swift
+++ b/apps/ios/CovenCave/CovenCave/LiveActivity/WidgetSnapshot.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// A tiny snapshot the app publishes to the shared App Group so the home-screen
+/// widget can render without its own network access. Written after reminders /
+/// tasks load; read by the widget's timeline provider.
+struct WidgetSnapshot: Codable, Hashable {
+    var nextReminderTitle: String?
+    var nextReminderDate: Date?
+    var dueTaskCount: Int
+    var runningTaskCount: Int
+    var updatedAt: Date
+}
+
+enum WidgetSnapshotStore {
+    static let appGroup = "group.ai.opencoven.cave"
+    private static let key = "widget.snapshot.v1"
+
+    private static var defaults: UserDefaults? { UserDefaults(suiteName: appGroup) }
+
+    static func write(_ snapshot: WidgetSnapshot) {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        defaults?.set(data, forKey: key)
+    }
+
+    static func read() -> WidgetSnapshot? {
+        guard let data = defaults?.data(forKey: key) else { return nil }
+        return try? JSONDecoder().decode(WidgetSnapshot.self, from: data)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import WidgetKit
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
@@ -173,6 +174,7 @@ final class AppModel {
         tasksLoaded = true
         // A task that finished on the desktop should drop its Lock Screen activity.
         await LiveActivityManager.shared.reconcile(tasks)
+        publishWidgetSnapshot()
     }
 
     // MARK: - Task actions
@@ -188,6 +190,7 @@ final class AppModel {
             applyTask(id: card.id) { $0 = updated }
             Haptics.tap()
             await LiveActivityManager.shared.reconcile(tasks)
+            publishWidgetSnapshot()
         } catch {
             tasks = previous
             tasksError = error.localizedDescription
@@ -363,6 +366,34 @@ final class AppModel {
             remindersError = error.localizedDescription
         }
         remindersLoaded = true
+        publishWidgetSnapshot()
+    }
+
+    /// Publish a compact snapshot to the shared App Group so the home-screen
+    /// "Up Next" widget renders the next reminder + task counts without its own
+    /// network access. Cheap; called whenever reminders/tasks load or change.
+    func publishWidgetSnapshot() {
+        let now = Date()
+        let next = reminders
+            .filter { $0.status == "pending" || $0.status == "fired" }
+            .compactMap { r -> (Reminder, Date)? in caveParseISO(r.whenISO).map { (r, $0) } }
+            .filter { $0.1 >= now }
+            .min { $0.1 < $1.1 }
+        let cal = Calendar.current
+        let endOfToday = cal.date(byAdding: .day, value: 1, to: cal.startOfDay(for: now)) ?? now
+        let due = tasks.filter { $0.status != .done }.filter { card in
+            guard let d = caveParseISO(card.endDate) else { return false }
+            return d < endOfToday
+        }.count
+        let running = tasks.filter { $0.status == .running }.count
+        WidgetSnapshotStore.write(WidgetSnapshot(
+            nextReminderTitle: next?.0.title,
+            nextReminderDate: next?.1,
+            dueTaskCount: due,
+            runningTaskCount: running,
+            updatedAt: now
+        ))
+        WidgetCenter.shared.reloadAllTimelines()
     }
 
     func loadJournal() async {

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.entitlements
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.ai.opencoven.cave</string>
+	</array>
+</dict>
+</plist>

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -57,9 +57,101 @@ struct TaskLiveActivity: Widget {
     }
 }
 
+// MARK: - Home-screen "Up Next" widget
+
+struct UpNextEntry: TimelineEntry {
+    let date: Date
+    let snapshot: WidgetSnapshot?
+}
+
+struct UpNextProvider: TimelineProvider {
+    private var sample: WidgetSnapshot {
+        WidgetSnapshot(nextReminderTitle: "Stand-up sync",
+                       nextReminderDate: Date().addingTimeInterval(3600),
+                       dueTaskCount: 2, runningTaskCount: 1, updatedAt: Date())
+    }
+
+    func placeholder(in context: Context) -> UpNextEntry {
+        UpNextEntry(date: Date(), snapshot: sample)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (UpNextEntry) -> Void) {
+        let snap = context.isPreview ? sample : (WidgetSnapshotStore.read() ?? sample)
+        completion(UpNextEntry(date: Date(), snapshot: snap))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<UpNextEntry>) -> Void) {
+        let entry = UpNextEntry(date: Date(), snapshot: WidgetSnapshotStore.read())
+        // The app reloads timelines whenever its data changes; this hourly
+        // backstop just keeps the relative time fresh while the app is closed.
+        let next = Calendar.current.date(byAdding: .hour, value: 1, to: Date())
+            ?? Date().addingTimeInterval(3600)
+        completion(Timeline(entries: [entry], policy: .after(next)))
+    }
+}
+
+struct UpNextWidgetView: View {
+    var entry: UpNextEntry
+    @Environment(\.widgetFamily) private var family
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 5) {
+                Image(systemName: "sparkles")
+                Text("Up Next").font(.caption2.weight(.semibold))
+            }
+            .foregroundStyle(.tint)
+
+            if let s = entry.snapshot, let title = s.nextReminderTitle {
+                VStack(alignment: .leading, spacing: 2) {
+                    if let when = s.nextReminderDate {
+                        Text(when, format: .dateTime.weekday().hour().minute())
+                            .font(.caption2).foregroundStyle(.secondary)
+                    }
+                    Text(title)
+                        .font(family == .systemSmall ? .subheadline.weight(.semibold) : .headline)
+                        .lineLimit(family == .systemSmall ? 3 : 2)
+                }
+            } else {
+                Text("No upcoming reminders")
+                    .font(.subheadline).foregroundStyle(.secondary)
+            }
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 12) {
+                if let s = entry.snapshot, s.runningTaskCount > 0 {
+                    Label("\(s.runningTaskCount) running", systemImage: "play.fill")
+                        .foregroundStyle(.tint)
+                }
+                if let s = entry.snapshot, s.dueTaskCount > 0 {
+                    Label("\(s.dueTaskCount) due", systemImage: "checklist")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .font(.caption2)
+            .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+}
+
+struct UpNextWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "CovenCaveUpNext", provider: UpNextProvider()) { entry in
+            UpNextWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Up Next")
+        .description("Your next reminder and how many tasks are running or due.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
 @main
 struct CovenCaveWidgetsBundle: WidgetBundle {
     var body: some Widget {
         TaskLiveActivity()
+        UpNextWidget()
     }
 }

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -52,17 +52,21 @@ targets:
         ENABLE_PREVIEWS: YES
         SWIFT_EMIT_LOC_STRINGS: YES
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+        CODE_SIGN_ENTITLEMENTS: CovenCave/CovenCave.entitlements
     dependencies:
       - target: CovenCaveWidgets
 
   # Widget extension hosting the "task running" Live Activity (Lock Screen +
-  # Dynamic Island). Shares TaskActivityAttributes.swift with the app target.
+  # Dynamic Island) and the home-screen "Up Next" widget. Shares
+  # TaskActivityAttributes.swift + WidgetSnapshot.swift with the app target;
+  # the App Group lets the widget read the snapshot the app publishes.
   CovenCaveWidgets:
     type: app-extension
     platform: iOS
     sources:
       - path: CovenCaveWidgets
       - path: CovenCave/LiveActivity/TaskActivityAttributes.swift
+      - path: CovenCave/LiveActivity/WidgetSnapshot.swift
     settings:
       base:
         INFOPLIST_FILE: CovenCaveWidgets/Info.plist
@@ -70,3 +74,4 @@ targets:
         PRODUCT_NAME: CovenCaveWidgets
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
         SKIP_INSTALL: YES
+        CODE_SIGN_ENTITLEMENTS: CovenCaveWidgets/CovenCaveWidgets.entitlements


### PR DESCRIPTION
Adds a WidgetKit **home-screen widget** (small + medium) to the existing `CovenCaveWidgets` extension, alongside the task Live Activity. It shows your **next upcoming reminder** (title + time) and how many tasks are **running / due**.

## How it gets data
The widget process has no network access of its own, so the app publishes a compact `WidgetSnapshot` to a shared **App Group** (`group.ai.opencoven.cave`) after every reminders/tasks load or task-status change, then reloads the widget timelines. The widget's `TimelineProvider` reads that snapshot; an hourly backstop keeps the relative time fresh while the app is closed.

- `WidgetSnapshot.swift` — shared Codable snapshot + App Group store, compiled into **both** the app and the widget extension.
- `AppModel.publishWidgetSnapshot()` — computes the next reminder + running/due counts; called from `loadTasks` / `loadReminders` / `setTaskStatus`.
- App Group entitlements added to both targets; `project.yml` wires the entitlements + the shared source into the widget target.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED** (app + widget extension compile together).
- Mobile source-text suite green (65); app installs + launches with no crash.
- **Caveat:** placing a widget on the home screen (and screenshotting it) isn't automatable via `simctl`, so the placed-widget rendering is verified at the build/compile level only — not with a runtime screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)