### PR TITLE
feat(ios): interactive widget buttons + deep links

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -33,6 +33,10 @@ struct CovenCaveApp: App {
                           app.connectionState != .checking else { return }
                     Task { await app.connectWithRetry() }
                 }
+                // Deep links from the home-screen widget (covencave://…) route to
+                // the matching tab/sheet. Handled even before connect — the tab is
+                // set so the right surface shows once the desktop is reached.
+                .onOpenURL { app.handleDeepLink($0) }
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Info.plist
+++ b/apps/ios/CovenCave/CovenCave/Info.plist
@@ -62,5 +62,16 @@
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>ai.opencoven.cave</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>covencave</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/apps/ios/CovenCave/CovenCave/Intents/WidgetReminderIntents.swift
+++ b/apps/ios/CovenCave/CovenCave/Intents/WidgetReminderIntents.swift
@@ -1,0 +1,59 @@
+import AppIntents
+import WidgetKit
+import Foundation
+
+/// Mark the widget's "next reminder" done, straight from the home-screen widget.
+/// Self-contained (no app-model dependency) so it compiles into the widget
+/// extension too: it reads the API base the app published to the shared snapshot
+/// and POSTs to the inbox endpoint, then refreshes the widget.
+struct CompleteReminderIntent: AppIntent {
+    static var title: LocalizedStringResource = "Complete Reminder"
+
+    @Parameter(title: "Reminder ID")
+    var reminderId: String
+
+    init() {}
+    init(reminderId: String) { self.reminderId = reminderId }
+
+    func perform() async throws -> some IntentResult {
+        await WidgetInboxAction.post(reminderId: reminderId, action: "done")
+        return .result()
+    }
+}
+
+/// Snooze the widget's "next reminder" by 15 minutes.
+struct SnoozeReminderIntent: AppIntent {
+    static var title: LocalizedStringResource = "Snooze Reminder"
+
+    @Parameter(title: "Reminder ID")
+    var reminderId: String
+
+    init() {}
+    init(reminderId: String) { self.reminderId = reminderId }
+
+    func perform() async throws -> some IntentResult {
+        let body = try? JSONSerialization.data(withJSONObject: ["minutes": 15])
+        await WidgetInboxAction.post(reminderId: reminderId, action: "snooze", body: body)
+        return .result()
+    }
+}
+
+enum WidgetInboxAction {
+    /// `POST /api/inbox/{id}/{action}` using the API base the app published to the
+    /// shared snapshot. Best-effort: a failure leaves the reminder untouched and
+    /// the next app refresh re-publishes the truth.
+    static func post(reminderId: String, action: String, body: Data? = nil) async {
+        guard let base = WidgetSnapshotStore.read()?.apiBaseURL else { return }
+        let trimmed = base.hasSuffix("/") ? String(base.dropLast()) : base
+        let escaped = reminderId.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? reminderId
+        guard let url = URL(string: "\(trimmed)/api/inbox/\(escaped)/\(action)") else { return }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        if let body {
+            req.httpBody = body
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        _ = try? await URLSession.shared.data(for: req)
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/LiveActivity/WidgetSnapshot.swift
+++ b/apps/ios/CovenCave/CovenCave/LiveActivity/WidgetSnapshot.swift
@@ -4,10 +4,14 @@ import Foundation
 /// widget can render without its own network access. Written after reminders /
 /// tasks load; read by the widget's timeline provider.
 struct WidgetSnapshot: Codable, Hashable {
+    var nextReminderId: String?
     var nextReminderTitle: String?
     var nextReminderDate: Date?
     var dueTaskCount: Int
     var runningTaskCount: Int
+    /// Resolved API base URL (e.g. `https://host.ts.net:8443`) so the widget's
+    /// Complete / Snooze intents can hit the inbox endpoints directly.
+    var apiBaseURL: String?
     var updatedAt: Date
 }
 

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -387,13 +387,33 @@ final class AppModel {
         }.count
         let running = tasks.filter { $0.status == .running }.count
         WidgetSnapshotStore.write(WidgetSnapshot(
+            nextReminderId: next?.0.id,
             nextReminderTitle: next?.0.title,
             nextReminderDate: next?.1,
             dueTaskCount: due,
             runningTaskCount: running,
+            apiBaseURL: connection?.baseURL?.absoluteString,
             updatedAt: now
         ))
         WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    // MARK: - Deep links (home-screen widget)
+
+    /// Surface a widget tap targets. The widget body deep-links to `.reminders`
+    /// (tap the reminder) / `.tasks` (tap the counts) via the `covencave://` URL
+    /// scheme; `TasksView` opens the reminders sheet when it sees `.reminders`.
+    enum DeepLink: String { case tasks, reminders, calendar }
+
+    var deepLink: DeepLink?
+
+    func handleDeepLink(_ url: URL) {
+        guard url.scheme == "covencave", let target = DeepLink(rawValue: url.host ?? "") else { return }
+        switch target {
+        case .tasks, .reminders: selectedTab = .tasks
+        case .calendar: selectedTab = .calendar
+        }
+        deepLink = target
     }
 
     func loadJournal() async {

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -117,6 +117,10 @@ struct TasksView: View {
                 .sheet(item: $boardDetail) { card in
                     NavigationStack { TaskDetailView(card: card) }
                 }
+                // A widget deep link (covencave://reminders) lands on this tab;
+                // open the reminders sheet, then clear the pending link.
+                .onChange(of: app.deepLink) { _, link in consumeDeepLink(link) }
+                .onAppear { consumeDeepLink(app.deepLink) }
         } detail: {
             if let selection {
                 NavigationStack { TaskDetailView(card: selection) }
@@ -221,6 +225,12 @@ struct TasksView: View {
         guard let card = app.cardToOpen else { return }
         if selection?.id != card.id { selection = card }
         app.cardToOpen = nil
+    }
+
+    private func consumeDeepLink(_ link: AppModel.DeepLink?) {
+        guard let link else { return }
+        if link == .reminders { showReminders = true }
+        app.deepLink = nil
     }
 
     private var groupBar: some View {

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -1,4 +1,5 @@
 import ActivityKit
+import AppIntents
 import WidgetKit
 import SwiftUI
 
@@ -94,6 +95,8 @@ struct UpNextWidgetView: View {
     var entry: UpNextEntry
     @Environment(\.widgetFamily) private var family
 
+    private var reminderId: String? { entry.snapshot?.nextReminderId }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 5) {
@@ -119,20 +122,49 @@ struct UpNextWidgetView: View {
 
             Spacer(minLength: 0)
 
-            HStack(spacing: 12) {
-                if let s = entry.snapshot, s.runningTaskCount > 0 {
-                    Label("\(s.runningTaskCount) running", systemImage: "play.fill")
-                        .foregroundStyle(.tint)
-                }
-                if let s = entry.snapshot, s.dueTaskCount > 0 {
-                    Label("\(s.dueTaskCount) due", systemImage: "checklist")
-                        .foregroundStyle(.secondary)
-                }
+            // When there's a reminder, offer one-tap Complete / Snooze (interactive
+            // widget buttons). Otherwise fall back to the running / due counts.
+            if let id = reminderId {
+                actionButtons(id: id)
+            } else {
+                counts
             }
-            .font(.caption2)
-            .lineLimit(1)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        // Tapping anywhere outside the buttons opens the reminders list.
+        .widgetURL(URL(string: "covencave://reminders"))
+    }
+
+    private func actionButtons(id: String) -> some View {
+        HStack(spacing: 8) {
+            Button(intent: CompleteReminderIntent(reminderId: id)) {
+                Label("Done", systemImage: "checkmark")
+            }
+            .tint(.green)
+            Button(intent: SnoozeReminderIntent(reminderId: id)) {
+                Label("15m", systemImage: "clock.arrow.circlepath")
+            }
+            .tint(.orange)
+        }
+        .font(.caption2.weight(.semibold))
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .lineLimit(1)
+    }
+
+    private var counts: some View {
+        HStack(spacing: 12) {
+            if let s = entry.snapshot, s.runningTaskCount > 0 {
+                Label("\(s.runningTaskCount) running", systemImage: "play.fill")
+                    .foregroundStyle(.tint)
+            }
+            if let s = entry.snapshot, s.dueTaskCount > 0 {
+                Label("\(s.dueTaskCount) due", systemImage: "checklist")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .font(.caption2)
+        .lineLimit(1)
     }
 }
 

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -67,6 +67,7 @@ targets:
       - path: CovenCaveWidgets
       - path: CovenCave/LiveActivity/TaskActivityAttributes.swift
       - path: CovenCave/LiveActivity/WidgetSnapshot.swift
+      - path: CovenCave/Intents/WidgetReminderIntents.swift
     settings:
       base:
         INFOPLIST_FILE: CovenCaveWidgets/Info.plist


### PR DESCRIPTION
Makes the home-screen **"Up Next" widget actionable** — the follow-up to #1884.

## Deep links
- Registers a `covencave://` URL scheme. The app's `onOpenURL` routes:
  - `covencave://reminders` → **Tasks tab + reminders sheet**
  - `covencave://tasks` / `covencave://calendar` → their tabs
- Tapping the widget opens the reminders list (`.widgetURL`).

## Interactive buttons
When the widget is showing a reminder, it offers one-tap **Complete** / **Snooze (15m)** via `Button(intent:)`, reusing the inbox `done` / `snooze` endpoints. The intents are self-contained (read the resolved API base from the shared App Group snapshot and POST directly), so they compile into the widget extension. The snapshot now carries the next reminder's `id` + the resolved `apiBaseURL`.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED** (app + widget extension).
- Mobile source-text suite green (65); `covencave://` scheme registers (`simctl openurl` succeeds).
- **Deep-link navigation confirmed at runtime**: pointed the simulator at a stub server, fired `covencave://reminders`, and the app switched to the Tasks tab and presented the Reminders sheet (screenshot captured during review).
- **Caveat:** placing a widget on the home screen and tapping its buttons isn't `simctl`-automatable, so the Complete/Snooze button taps are verified at the build/compile + endpoint level, not via a placed-widget tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)