### PR TITLE
fix(a11y): journal editor — ⌘/Ctrl+Enter to save + restore focus on exit

### DIFF
--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -92,6 +92,15 @@ export function JournalEntries({
     return () => { mountedRef.current = false; };
   }, []);
 
+  // Return focus to the Edit button when leaving the inline editor (save/cancel),
+  // so a keyboard/SR user doesn't get dropped to <body>.
+  const editBtnRef = useRef<HTMLButtonElement>(null);
+  const wasEditingRef = useRef(editing);
+  useEffect(() => {
+    if (wasEditingRef.current && !editing) editBtnRef.current?.focus();
+    wasEditingRef.current = editing;
+  }, [editing]);
+
   const familiarName = useCallback(
     (id: string | null) => (id ? familiars.find((f) => f.id === id)?.display_name ?? id : null),
     [familiars],
@@ -226,6 +235,15 @@ export function JournalEntries({
       cancelEdit();
       await loadDay(day.date);
       await loadDays();
+      // The reload's setState re-renders the detail AFTER this point and steals
+      // focus from the Edit button the editing→false effect restored. Re-assert
+      // it on the next frame, once that re-render has committed and painted, so
+      // a keyboard/SR user lands back on a real control instead of <body>.
+      if (mountedRef.current) {
+        requestAnimationFrame(() => {
+          if (mountedRef.current) editBtnRef.current?.focus();
+        });
+      }
     } catch (err) {
       if (mountedRef.current) setError(err instanceof Error ? err.message : "Could not save journal entry.");
     } finally {
@@ -404,6 +422,7 @@ export function JournalEntries({
                     </>
                   ) : (
                     <button
+                      ref={editBtnRef}
                       type="button"
                       className="journal-entry__action"
                       onClick={startEdit}
@@ -436,8 +455,12 @@ export function JournalEntries({
                     onChange={(e) => setDraftReflection(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === "Escape") cancelEdit();
+                      else if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                        e.preventDefault();
+                        if (!saving && draftReflection.trim()) void saveEdit();
+                      }
                     }}
-                    aria-label="Journal reflection"
+                    aria-label="Journal reflection (⌘↵ to save, Esc to cancel)"
                     autoFocus
                   />
                 ) : (

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -77,6 +77,24 @@ assert.match(entries, /<UndoToast/, "JournalEntries renders an UndoToast for del
 assert.match(entries, /aria-label="Edit journal entry"/, "JournalEntries renders an edit affordance");
 assert.match(entries, /aria-label="Delete journal entry"/, "JournalEntries renders a delete affordance");
 assert.match(entries, /onKeyDown=\{\(e\) => \{[\s\S]*?e\.key === "Escape"[\s\S]*?cancelEdit/, "Journal edit textarea cancels on Escape");
+// ⌘/Ctrl+Enter saves the reflection editor (was: Save reachable only by tabbing
+// to the ✓ button), and focus returns to the Edit button when leaving the editor.
+assert.match(
+  entries,
+  /e\.key === "Enter" && \(e\.metaKey \|\| e\.ctrlKey\)[\s\S]*?void saveEdit\(\)/,
+  "Journal edit textarea saves on ⌘/Ctrl+Enter",
+);
+assert.match(
+  entries,
+  /if \(wasEditingRef\.current && !editing\) editBtnRef\.current\?\.focus\(\)/,
+  "Leaving the journal editor restores focus to the Edit button",
+);
+assert.match(entries, /ref=\{editBtnRef\}/, "the Edit button is the focus-restore target");
+assert.match(
+  entries,
+  /await loadDays\(\);[\s\S]*?requestAnimationFrame\(\(\) => \{[\s\S]*?editBtnRef\.current\?\.focus\(\)/,
+  "save re-asserts focus on the next frame, after the reload's re-render commits",
+);
 
 // JournalEntries is scoped to the selected familiar and its memory coverage.
 assert.match(entries, /const selectedFamiliarId = activeFamiliarId \?\? familiars\[0\]\?\.id \?\? null/, "JournalEntries derives one selected familiar scope");


### PR DESCRIPTION
## Journal entry detail audit (`JournalEntries`)

This surface is already very clean — the day loaders **and** the generate/save/delete mutations are all `mountedRef`-guarded (#1788), the detail is a labelled region, every action is a real `<button>` with an aria-label, errors are `role="alert"`, and the reflection renders through the shared sanitized `MarkdownBlock`. The only real gaps were inline-editor keyboard ergonomics:

1. **⌘/Ctrl+Enter to save** — the reflection editor only handled `Escape` (cancel); a keyboard user had to tab out to the ✓ button to commit. Now `⌘/Ctrl+Enter` saves (Escape + the Save button still work).
2. **Focus restore on exit** — leaving the editor dropped focus to `<body>`. An `editing→false` effect restores focus to the Edit button for Escape/Cancel. The **save path needed more**: the slow `/api/journal` reload re-renders *after* the effect fires and steals the focus, so the save path re-asserts focus via `requestAnimationFrame` once that re-render commits.

## Verification
- `journal-view.test.ts` extended (save shortcut + both focus-restore paths) · `tsc` clean · `pnpm build` exit 0
- Live (Playwright, seeded entry): `⌘/Ctrl+Enter` closes the editor (saves), and `document.activeElement` is the **Edit button** after both the **save** and **cancel** paths. The save-path focus only worked once the rAF was added — the earlier direct/effect focus was reliably stolen by the slow reload (caught by measuring `activeElement` after the reload settled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)