### PR TITLE
Add Flow template gallery

### DIFF
--- a/src/components/flow/flow-library.tsx
+++ b/src/components/flow/flow-library.tsx
@@ -14,6 +14,8 @@ export type FlowLibraryProps = {
   onCreateFromPrompt: (prompt: string) => void;
   onDuplicate: (id: string) => void;
   onDelete: (id: string) => void;
+  /** Open the template gallery. */
+  onTemplate: () => void;
 };
 
 export function FlowLibrary(props: FlowLibraryProps) {
@@ -37,9 +39,19 @@ export function FlowLibrary(props: FlowLibraryProps) {
     <aside className="flow-library" aria-label="Flows">
       <div className="flow-library-head">
         <span className="flow-library-title">Flows</span>
-        <button type="button" className="flow-library-new" onClick={props.onCreate} title="New flow">
-          <Icon name="ph:plus" width={14} /> New
-        </button>
+        <div className="flow-library-head-actions">
+          <button
+            type="button"
+            className="flow-library-template-btn"
+            onClick={props.onTemplate}
+            title="Browse templates"
+          >
+            <Icon name="ph:squares-four" width={13} />
+          </button>
+          <button type="button" className="flow-library-new" onClick={props.onCreate} title="New flow">
+            <Icon name="ph:plus" width={14} /> New
+          </button>
+        </div>
       </div>
       <div className="flow-library-search">
         <Icon name="ph:magnifying-glass" width={13} aria-hidden />
@@ -71,7 +83,9 @@ export function FlowLibrary(props: FlowLibraryProps) {
         </ul>
       ) : filtered.length === 0 ? (
         <p className="flow-library-empty">
-          {props.flows.length === 0 ? "No flows yet — create your first one." : "No flows match your search."}
+          {props.flows.length === 0
+            ? "No flows yet — pick a template or start blank."
+            : "No flows match your search."}
         </p>
       ) : (
         <ul className="flow-library-list">

--- a/src/components/flow/flow-run-steps.tsx
+++ b/src/components/flow/flow-run-steps.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+import { catalogNode } from "@/lib/flow/flow-catalog";
+import type { FlowDoc } from "@/lib/flow/flow-doc";
+import type { FlowNodePhase, FlowRunProgress } from "@/lib/flow/flow-progress";
+import type { FlowRunRecord } from "@/lib/flows";
+
+const STATUS_LABEL: Record<FlowRunRecord["status"], string> = {
+  preview: "Preview",
+  running: "Running",
+  succeeded: "Succeeded",
+  failed: "Failed",
+};
+
+const PHASE_ICON: Record<FlowNodePhase, IconName> = {
+  pending: "ph:circle-dashed",
+  running: "ph:circle-notch-bold",
+  succeeded: "ph:check-circle-fill",
+  failed: "ph:x-circle-fill",
+  skipped: "ph:minus-circle",
+};
+
+export type FlowRunStepsProps = {
+  doc: FlowDoc;
+  run: FlowRunRecord;
+  progress: FlowRunProgress;
+  /** True while the run's session is still being polled. */
+  running: boolean;
+  selectedNodeId: string | null;
+  onSelectNode: (id: string) => void;
+  onOpenSession: (sessionId: string) => void;
+  onStop: () => void;
+};
+
+/**
+ * Live step list docked beside the canvas. Walks the run's steps in execution
+ * order, painting each with its live phase parsed from the agent transcript and
+ * surfacing the active step's narration — so the run is legible on the page, not
+ * only as coloured dots scattered across the graph. Click a step to focus its
+ * node.
+ */
+export function FlowRunSteps({
+  doc,
+  run,
+  progress,
+  running,
+  selectedNodeId,
+  onSelectNode,
+  onOpenSession,
+  onStop,
+}: FlowRunStepsProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const nameById = useMemo(
+    () => new Map(doc.nodes.map((node) => [node.id, node.name])),
+    [doc.nodes],
+  );
+  const detailById = useMemo(
+    () => new Map(progress.steps.map((step) => [step.id, step.detail])),
+    [progress.steps],
+  );
+
+  // Prefer the live-parsed phase; fall back to the run's persisted step status
+  // (e.g. a finished run reopened, or before any markers land).
+  const phaseFor = (id: string, persisted: FlowRunStepRecordStatus): FlowNodePhase =>
+    (progress.markersFound ? progress.phases[id] : undefined) ?? persisted;
+
+  const doneCount = run.steps.filter((step) => phaseFor(step.id, step.status) === "succeeded").length;
+
+  return (
+    <aside className={`flow-run-steps${collapsed ? " is-collapsed" : ""}`} aria-label="Flow run steps">
+      <header className="flow-run-steps-head">
+        <button
+          type="button"
+          className="flow-run-steps-toggle"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          title={collapsed ? "Expand steps" : "Collapse steps"}
+        >
+          <Icon name={collapsed ? "ph:caret-right" : "ph:caret-down"} width={13} />
+        </button>
+        <span className={`flow-run-steps-status flow-exec-status-${run.status}`}>
+          {STATUS_LABEL[run.status]}
+        </span>
+        <span className="flow-run-steps-count">
+          {doneCount}/{run.steps.length} steps
+        </span>
+        {running && (
+          <button type="button" className="flow-run-steps-stop" onClick={onStop} title="Stop run">
+            <Icon name="ph:stop-fill" width={12} /> Stop
+          </button>
+        )}
+      </header>
+
+      {!collapsed && (
+        <ol className="flow-run-steps-list">
+          {run.steps.map((step) => {
+            const phase = phaseFor(step.id, step.status);
+            const def = catalogNode(step.type);
+            const name = nameById.get(step.id) ?? def?.label ?? step.type;
+            const detail = detailById.get(step.id) ?? "";
+            const isActive = phase === "running";
+            const isSelected = step.id === selectedNodeId;
+            return (
+              <li
+                key={step.id}
+                className={`flow-run-step flow-run-step-${phase}${isSelected ? " is-selected" : ""}`}
+              >
+                <button
+                  type="button"
+                  className="flow-run-step-row"
+                  onClick={() => onSelectNode(step.id)}
+                  title={`Focus ${name}`}
+                >
+                  <span className={`flow-run-step-icon flow-run-step-icon-${phase}`} aria-hidden>
+                    <Icon
+                      name={PHASE_ICON[phase]}
+                      width={15}
+                      className={isActive ? "flow-run-step-spin" : undefined}
+                    />
+                  </span>
+                  <span className="flow-run-step-body">
+                    <span className="flow-run-step-name">{name}</span>
+                    <span className="flow-run-step-type">{def?.label ?? step.type}</span>
+                  </span>
+                  <span className="flow-run-step-phase" aria-label={phase}>
+                    {phase}
+                  </span>
+                </button>
+                {isActive && detail && (
+                  <p className="flow-run-step-detail">{detail.slice(0, 280)}</p>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+
+      {!collapsed && run.sessionId && (
+        <footer className="flow-run-steps-foot">
+          <button
+            type="button"
+            className="flow-run-steps-open"
+            onClick={() => onOpenSession(run.sessionId as string)}
+          >
+            <Icon name="ph:chat-circle-dots" width={13} /> Open session
+          </button>
+        </footer>
+      )}
+    </aside>
+  );
+}
+
+type FlowRunStepRecordStatus = FlowRunRecord["steps"][number]["status"];

--- a/src/components/flow/flow-template-gallery.tsx
+++ b/src/components/flow/flow-template-gallery.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+// FlowTemplateGallery — a modal/overlay showing pre-built flow templates.
+//
+// Shown in two contexts:
+//   1. Empty-state: when there are no flows yet, replaces the bare "New flow" empty state.
+//   2. On-demand: via the "From template" button in the FlowLibrary header.
+//
+// Each card shows the template name, category badge, description, and a
+// "Use template" button. Clicking creates a new flow from the template,
+// saves it to disk, and calls onSelect with the new flow id.
+
+import { useState } from "react";
+import { Icon } from "@/lib/icon";
+import { FLOW_TEMPLATES, type FlowTemplate } from "@/lib/flow/flow-templates";
+
+const CATEGORY_LABEL: Record<FlowTemplate["category"], string> = {
+  research: "Research",
+  automation: "Automation",
+  review: "Review",
+  notification: "Notification",
+  data: "Data",
+  chat: "Chat",
+};
+
+const CATEGORY_COLOR: Record<FlowTemplate["category"], string> = {
+  research: "var(--color-violet-500, #9a8ecd)",
+  automation: "var(--color-teal-500, #5aa37a)",
+  review: "var(--color-blue-500, #6b8fbf)",
+  notification: "var(--color-amber-500, #d98b3f)",
+  data: "var(--color-green-600, #7c9b70)",
+  chat: "var(--color-violet-400, #b8aee8)",
+};
+
+export type FlowTemplateGalleryProps = {
+  /** Called when the user picks a template and instantiation succeeds. */
+  onUse: (templateId: string) => void | Promise<void>;
+  /** Called when the user closes the gallery without picking. */
+  onClose?: () => void;
+  /** Whether this is the primary empty-state (no close button shown). */
+  isEmpty?: boolean;
+};
+
+export function FlowTemplateGallery({ onUse, onClose, isEmpty }: FlowTemplateGalleryProps) {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FlowTemplate["category"] | "all">("all");
+
+  const categories = Array.from(
+    new Set(FLOW_TEMPLATES.map((t) => t.category)),
+  ) as FlowTemplate["category"][];
+
+  const visible =
+    filter === "all" ? FLOW_TEMPLATES : FLOW_TEMPLATES.filter((t) => t.category === filter);
+
+  async function handleUse(template: FlowTemplate) {
+    if (busy) return;
+    setBusy(template.id);
+    try {
+      await onUse(template.id);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="flow-template-gallery">
+      {/* Header */}
+      <div className="flow-template-gallery-header">
+        <div className="flow-template-gallery-title">
+          <Icon name="ph:squares-four" width={18} aria-hidden />
+          {isEmpty ? "Start from a template" : "Flow templates"}
+        </div>
+        <div className="flow-template-gallery-header-right">
+          {!isEmpty && (
+            <button
+              type="button"
+              className="flow-template-gallery-blank"
+              onClick={onClose}
+              title="Start blank instead"
+            >
+              Start blank
+            </button>
+          )}
+          {onClose && !isEmpty && (
+            <button
+              type="button"
+              className="flow-template-gallery-close"
+              onClick={onClose}
+              aria-label="Close gallery"
+            >
+              <Icon name="ph:x" width={15} />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Category filter pills */}
+      <div className="flow-template-gallery-filters">
+        <button
+          type="button"
+          className={`flow-template-filter-pill${filter === "all" ? " is-active" : ""}`}
+          onClick={() => setFilter("all")}
+        >
+          All
+        </button>
+        {categories.map((cat) => (
+          <button
+            key={cat}
+            type="button"
+            className={`flow-template-filter-pill${filter === cat ? " is-active" : ""}`}
+            onClick={() => setFilter(cat)}
+          >
+            {CATEGORY_LABEL[cat]}
+          </button>
+        ))}
+      </div>
+
+      {/* Template grid */}
+      <div className="flow-template-gallery-grid">
+        {visible.map((template) => (
+          <div key={template.id} className="flow-template-card">
+            {/* Icon tile */}
+            <div
+              className="flow-template-card-icon"
+              style={{ background: `${template.accent}22`, color: template.accent }}
+            >
+              <Icon name={template.icon as any} width={22} />
+            </div>
+
+            {/* Body */}
+            <div className="flow-template-card-body">
+              <div className="flow-template-card-top">
+                <span className="flow-template-card-name">{template.name}</span>
+                <span
+                  className="flow-template-card-badge"
+                  style={{ color: CATEGORY_COLOR[template.category] }}
+                >
+                  {CATEGORY_LABEL[template.category]}
+                </span>
+              </div>
+              <p className="flow-template-card-desc">{template.description}</p>
+              <div className="flow-template-card-meta">
+                <span className="flow-template-card-nodes">
+                  {template.graph.nodes.length} node{template.graph.nodes.length !== 1 ? "s" : ""}
+                </span>
+              </div>
+            </div>
+
+            {/* Action */}
+            <button
+              type="button"
+              className="flow-template-card-use"
+              disabled={busy === template.id}
+              onClick={() => void handleUse(template)}
+            >
+              {busy === template.id ? (
+                <Icon name="ph:circle-notch-bold" width={13} className="flow-template-card-spinner" />
+              ) : (
+                <Icon name="ph:arrow-right-bold" width={13} />
+              )}
+              Use template
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {isEmpty && (
+        <div className="flow-template-gallery-blank-row">
+          <button
+            type="button"
+            className="flow-template-gallery-blank-btn"
+            onClick={onClose}
+          >
+            <Icon name="ph:plus" width={14} />
+            Start with a blank flow instead
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -49,9 +49,12 @@ import {
 import { FlowCanvas, type FlowConnectFrom } from "./flow-canvas";
 import { FlowExecutions } from "./flow-executions";
 import { FlowLibrary } from "./flow-library";
+import { FlowTemplateGallery } from "./flow-template-gallery";
+import { FLOW_TEMPLATES, instantiateTemplate } from "@/lib/flow/flow-templates";
 import { FlowToolbar, type FlowTab } from "./flow-toolbar";
 import { NodeCatalogPanel } from "./node-catalog-panel";
 import { NodeDetailView, type NodeDetailOption } from "./node-detail-view";
+import { FlowRunSteps } from "./flow-run-steps";
 import { useFlowRun } from "./use-flow-run";
 
 type CatalogIntent =
@@ -88,6 +91,7 @@ export function FlowView() {
   const [runsLoading, setRunsLoading] = useState(false);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
+  const [templateGalleryOpen, setTemplateGalleryOpen] = useState(false);
   // The run currently overlaid on the canvas (live session, or a finished run
   // whose final state we keep painted until the user switches flows).
   const [activeRun, setActiveRun] = useState<FlowRunRecord | null>(null);
@@ -273,6 +277,31 @@ export function FlowView() {
       dispatchDraft({ type: "reset", doc: flow });
     },
     [confirmDiscard, dispatchDraft, flows, selectedId],
+  );
+
+  const fromTemplate = useCallback(
+    async (templateId: string) => {
+      if (!(await confirmDiscard())) return;
+      const template = FLOW_TEMPLATES.find((t) => t.id === templateId);
+      if (!template) return;
+      const now = new Date().toISOString();
+      const id = uniqueId(templateId);
+      const flow = instantiateTemplate(template, id, now);
+      const result = await saveFlow(flow);
+      if (!result.ok || !result.flow) {
+        showNotice(result.error ?? "couldn't create from template");
+        return;
+      }
+      await loadFlows();
+      setSelectedId(result.flow.id);
+      setSelectedNodeId(null);
+      setActiveRun(null);
+      setTab("editor");
+      dispatchDraft({ type: "reset", doc: result.flow });
+      setTemplateGalleryOpen(false);
+      showNotice(`Created from template: ${result.flow.name}`);
+    },
+    [confirmDiscard, dispatchDraft, loadFlows, saveFlow, showNotice, uniqueId],
   );
 
   const createFlow = useCallback(async () => {
@@ -592,6 +621,11 @@ export function FlowView() {
             </div>
           }
         />
+        <FlowTemplateGallery
+          isEmpty
+          onUse={(id) => void fromTemplate(id)}
+          onClose={() => void createFlow()}
+        />
       </div>
     );
   }
@@ -607,7 +641,20 @@ export function FlowView() {
         onCreateFromPrompt={(prompt) => void createFlowFromPrompt(prompt)}
         onDuplicate={(id) => void duplicateFlow(id)}
         onDelete={(id) => void removeFlow(id)}
+        onTemplate={() => setTemplateGalleryOpen(true)}
       />
+
+      {templateGalleryOpen && (
+        <div className="flow-template-overlay" role="dialog" aria-modal aria-label="Flow templates">
+          <div className="flow-template-overlay-backdrop" onClick={() => setTemplateGalleryOpen(false)} />
+          <div className="flow-template-overlay-panel">
+            <FlowTemplateGallery
+              onUse={(id) => void fromTemplate(id)}
+              onClose={() => setTemplateGalleryOpen(false)}
+            />
+          </div>
+        </div>
+      )}
 
       <div className="flow-main">
         {doc ? (
@@ -654,6 +701,18 @@ export function FlowView() {
                   onStickyText={(id, text) => onChangeSticky(id, { text })}
                   onStickySize={(id, width, height) => onChangeSticky(id, { width, height })}
                 />
+                {activeRun && activeRun.steps.length > 0 && (
+                  <FlowRunSteps
+                    doc={doc}
+                    run={activeRun}
+                    progress={progress}
+                    running={running}
+                    selectedNodeId={selectedNodeId}
+                    onSelectNode={setSelectedNodeId}
+                    onOpenSession={openSession}
+                    onStop={() => void stop()}
+                  />
+                )}
                 {selectedNode && (
                   <NodeDetailView
                     node={selectedNode}

--- a/src/lib/flow/flow-templates.ts
+++ b/src/lib/flow/flow-templates.ts
@@ -1,0 +1,509 @@
+// Flow templates — pre-built FlowDoc graphs that seed the Flow editor.
+//
+// Each template is a complete FlowDoc (minus id/createdAt/updatedAt, which are
+// stamped at instantiation time). They demonstrate real Coven patterns so
+// builders have a working starting point rather than a blank canvas.
+//
+// Adding a new template: add a FlowTemplate entry to FLOW_TEMPLATES; the
+// gallery in FlowLibrary picks it up automatically.
+
+import type { FlowDoc } from "./flow-doc.ts";
+
+export type FlowTemplate = {
+  /** Short slug — used to seed the flow id. */
+  id: string;
+  name: string;
+  /** One-sentence pitch shown in the gallery card. */
+  description: string;
+  /** Category badge. */
+  category: "research" | "automation" | "review" | "notification" | "data" | "chat";
+  /** Phosphor icon name. */
+  icon: string;
+  /** Warm accent colour for the gallery card. */
+  accent: string;
+  /** The graph. Ids, timestamps, and schema are stamped at instantiation. */
+  graph: Pick<FlowDoc, "nodes" | "edges">;
+};
+
+export const FLOW_TEMPLATES: FlowTemplate[] = [
+  // ── 1. Daily Briefing ─────────────────────────────────────────────────────
+  {
+    id: "daily-briefing",
+    name: "Daily Briefing",
+    description: "Sage reads your calendar and email each morning and sends a summary to your preferred channel.",
+    category: "notification",
+    icon: "ph:sun",
+    accent: "#d98b3f",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger.schedule",
+          name: "Every morning",
+          position: { x: 80, y: 160 },
+          params: { mode: "cron", cron: "0 8 * * *" },
+        },
+        {
+          id: "sage",
+          type: "familiar",
+          name: "Sage — gather briefing",
+          position: { x: 380, y: 160 },
+          params: {
+            familiar: "sage",
+            prompt:
+              "Check today's calendar events and any urgent unread emails. Produce a concise morning briefing: upcoming events with times, action items from email, and one weather note if relevant. Be brief — this is for a morning read.",
+          },
+        },
+        {
+          id: "charm",
+          type: "familiar",
+          name: "Charm — send to channel",
+          position: { x: 680, y: 160 },
+          params: {
+            familiar: "charm",
+            prompt:
+              "Take this briefing text and send it to Val's preferred channel (Telegram direct). Format it cleanly for mobile reading.",
+          },
+        },
+        {
+          id: "out",
+          type: "data.output",
+          name: "Done",
+          position: { x: 960, y: 160 },
+          params: { label: "briefing sent" },
+        },
+      ],
+      edges: [
+        {
+          id: "trigger:main->sage:in",
+          source: "trigger",
+          sourceHandle: "main",
+          target: "sage",
+          targetHandle: "in",
+        },
+        {
+          id: "sage:main->charm:in",
+          source: "sage",
+          sourceHandle: "main",
+          target: "charm",
+          targetHandle: "in",
+        },
+        {
+          id: "charm:main->out:in",
+          source: "charm",
+          sourceHandle: "main",
+          target: "out",
+          targetHandle: "in",
+        },
+      ],
+    },
+  },
+
+  // ── 2. Deep Research Report ───────────────────────────────────────────────
+  {
+    id: "deep-research",
+    name: "Deep Research Report",
+    description: "Given a topic, Sage searches, synthesizes, and drops a structured research brief into your inbox.",
+    category: "research",
+    icon: "ph:magnifying-glass",
+    accent: "#9a8ecd",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger.manual",
+          name: "Start research",
+          position: { x: 80, y: 180 },
+          params: {},
+          notes: "Set the research topic in Sage's prompt below.",
+        },
+        {
+          id: "sage-plan",
+          type: "familiar",
+          name: "Sage — plan queries",
+          position: { x: 360, y: 180 },
+          params: {
+            familiar: "sage",
+            prompt:
+              "You are planning a deep research sweep. Given the topic in the input, produce 4–6 focused web search queries that together would give comprehensive coverage. Return them as a JSON array of strings.",
+          },
+        },
+        {
+          id: "sage-search",
+          type: "familiar",
+          name: "Sage — search & collect",
+          position: { x: 640, y: 180 },
+          params: {
+            familiar: "sage",
+            prompt:
+              "Run each query from the input using web_search. For each result, note the source URL, title, and a 1-2 sentence summary of the relevant content. Return a structured list of all sources found.",
+          },
+        },
+        {
+          id: "sage-synthesize",
+          type: "familiar",
+          name: "Sage — synthesize",
+          position: { x: 920, y: 180 },
+          params: {
+            familiar: "sage",
+            prompt:
+              "Synthesize the collected sources into a structured research brief. Include: executive summary, key findings (with citations), open questions, and recommended next steps. Be precise — distinguish evidence from speculation.",
+          },
+        },
+        {
+          id: "approval",
+          type: "human.gate",
+          name: "Review before sending",
+          position: { x: 1200, y: 180 },
+          params: { prompt: "Review the research brief. Approve to send, or reject to discard." },
+        },
+        {
+          id: "charm",
+          type: "familiar",
+          name: "Charm — deliver",
+          position: { x: 1480, y: 120 },
+          params: {
+            familiar: "charm",
+            prompt: "Send this research brief to Val via Telegram. Use clean formatting suitable for mobile.",
+          },
+        },
+        {
+          id: "out",
+          type: "data.output",
+          name: "Done",
+          position: { x: 1720, y: 120 },
+          params: { label: "brief sent" },
+        },
+        {
+          id: "discarded",
+          type: "data.output",
+          name: "Discarded",
+          position: { x: 1480, y: 280 },
+          params: { label: "discarded" },
+        },
+      ],
+      edges: [
+        { id: "trigger:main->sage-plan:in", source: "trigger", sourceHandle: "main", target: "sage-plan", targetHandle: "in" },
+        { id: "sage-plan:main->sage-search:in", source: "sage-plan", sourceHandle: "main", target: "sage-search", targetHandle: "in" },
+        { id: "sage-search:main->sage-synthesize:in", source: "sage-search", sourceHandle: "main", target: "sage-synthesize", targetHandle: "in" },
+        { id: "sage-synthesize:main->approval:in", source: "sage-synthesize", sourceHandle: "main", target: "approval", targetHandle: "in" },
+        { id: "approval:approved->charm:in", source: "approval", sourceHandle: "approved", target: "charm", targetHandle: "in" },
+        { id: "approval:rejected->discarded:in", source: "approval", sourceHandle: "rejected", target: "discarded", targetHandle: "in" },
+        { id: "charm:main->out:in", source: "charm", sourceHandle: "main", target: "out", targetHandle: "in" },
+      ],
+    },
+  },
+
+  // ── 3. PR Review Notifier ─────────────────────────────────────────────────
+  {
+    id: "pr-review",
+    name: "PR Review Notifier",
+    description: "Watches for new GitHub pull requests, has Cody review them, and pings you with a summary.",
+    category: "review",
+    icon: "ph:git-pull-request",
+    accent: "#6b8fbf",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger.webhook",
+          name: "GitHub webhook",
+          position: { x: 80, y: 180 },
+          params: { method: "POST", path: "/hook/github-pr" },
+          notes: "Point your GitHub repo webhook here (pull_request events).",
+        },
+        {
+          id: "filter",
+          type: "logic.if",
+          name: "Only opened/reopened",
+          position: { x: 360, y: 180 },
+          params: { condition: "{{ $json.action }} == 'opened' || {{ $json.action }} == 'reopened'" },
+        },
+        {
+          id: "cody",
+          type: "familiar",
+          name: "Cody — review PR",
+          position: { x: 640, y: 120 },
+          params: {
+            familiar: "cody",
+            prompt:
+              "A new pull request has been opened. Based on the PR title, description, and diff (from the input), provide a concise code review summary: what the change does, potential issues, and an overall verdict (looks good / needs changes / needs discussion).",
+          },
+        },
+        {
+          id: "charm",
+          type: "familiar",
+          name: "Charm — notify",
+          position: { x: 920, y: 120 },
+          params: {
+            familiar: "charm",
+            prompt:
+              "Send this PR review summary to Val via Telegram. Include the PR title and link from the input. Keep it scannable.",
+          },
+        },
+        {
+          id: "out",
+          type: "data.output",
+          name: "Done",
+          position: { x: 1160, y: 120 },
+          params: { label: "notified" },
+        },
+        {
+          id: "skip",
+          type: "data.output",
+          name: "Skipped",
+          position: { x: 640, y: 280 },
+          params: { label: "skipped" },
+        },
+      ],
+      edges: [
+        { id: "trigger:main->filter:in", source: "trigger", sourceHandle: "main", target: "filter", targetHandle: "in" },
+        { id: "filter:true->cody:in", source: "filter", sourceHandle: "true", target: "cody", targetHandle: "in" },
+        { id: "filter:false->skip:in", source: "filter", sourceHandle: "false", target: "skip", targetHandle: "in" },
+        { id: "cody:main->charm:in", source: "cody", sourceHandle: "main", target: "charm", targetHandle: "in" },
+        { id: "charm:main->out:in", source: "charm", sourceHandle: "main", target: "out", targetHandle: "in" },
+      ],
+    },
+  },
+
+  // ── 4. Familiar Chat Router ───────────────────────────────────────────────
+  {
+    id: "chat-router",
+    name: "Familiar Chat Router",
+    description: "Classifies incoming chat messages and routes them to the right familiar — research, code, or general.",
+    category: "chat",
+    icon: "ph:chats-circle",
+    accent: "#9a8ecd",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger.chat",
+          name: "Incoming message",
+          position: { x: 80, y: 220 },
+          params: { familiar: "nova" },
+        },
+        {
+          id: "classify",
+          type: "ai.classify",
+          name: "Route intent",
+          position: { x: 360, y: 220 },
+          params: {
+            familiar: "nova",
+            categories: "research\ncode\ngeneral",
+          },
+        },
+        {
+          id: "sage",
+          type: "familiar",
+          name: "Sage — research",
+          position: { x: 640, y: 80 },
+          params: {
+            familiar: "sage",
+            prompt: "Handle this research question. Cite your sources.",
+          },
+        },
+        {
+          id: "cody",
+          type: "familiar",
+          name: "Cody — code",
+          position: { x: 640, y: 220 },
+          params: {
+            familiar: "cody",
+            prompt: "Handle this coding question or task.",
+          },
+        },
+        {
+          id: "kitty",
+          type: "familiar",
+          name: "Kitty — general",
+          position: { x: 640, y: 360 },
+          params: {
+            familiar: "kitty",
+            prompt: "Handle this general request helpfully.",
+          },
+        },
+        {
+          id: "merge",
+          type: "logic.merge",
+          name: "Collect reply",
+          position: { x: 920, y: 220 },
+          params: { mode: "append" },
+        },
+        {
+          id: "out",
+          type: "data.output",
+          name: "Reply sent",
+          position: { x: 1160, y: 220 },
+          params: { label: "replied" },
+        },
+      ],
+      edges: [
+        { id: "trigger:main->classify:in", source: "trigger", sourceHandle: "main", target: "classify", targetHandle: "in" },
+        { id: "classify:a->sage:in", source: "classify", sourceHandle: "a", target: "sage", targetHandle: "in" },
+        { id: "classify:b->cody:in", source: "classify", sourceHandle: "b", target: "cody", targetHandle: "in" },
+        { id: "classify:c->kitty:in", source: "classify", sourceHandle: "c", target: "kitty", targetHandle: "in" },
+        { id: "sage:main->merge:in-0", source: "sage", sourceHandle: "main", target: "merge", targetHandle: "in-0" },
+        { id: "cody:main->merge:in-0", source: "cody", sourceHandle: "main", target: "merge", targetHandle: "in-0" },
+        { id: "kitty:main->merge:in-0", source: "kitty", sourceHandle: "main", target: "merge", targetHandle: "in-0" },
+        { id: "merge:main->out:in", source: "merge", sourceHandle: "main", target: "out", targetHandle: "in" },
+      ],
+    },
+  },
+
+  // ── 5. Webhook → Familiar → Slack ─────────────────────────────────────────
+  {
+    id: "webhook-to-familiar",
+    name: "Webhook to Familiar",
+    description: "A minimal webhook receiver that passes the payload to a familiar for processing and posts the result externally.",
+    category: "automation",
+    icon: "ph:link",
+    accent: "#6b8fbf",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger.webhook",
+          name: "Inbound webhook",
+          position: { x: 80, y: 180 },
+          params: { method: "POST", path: "/hook/process" },
+        },
+        {
+          id: "familiar",
+          type: "familiar",
+          name: "Process payload",
+          position: { x: 380, y: 180 },
+          params: {
+            familiar: "",
+            prompt: "Process the incoming webhook payload and produce a structured summary or action.",
+          },
+        },
+        {
+          id: "http",
+          type: "http",
+          name: "POST result",
+          position: { x: 680, y: 180 },
+          params: {
+            method: "POST",
+            url: "https://hooks.slack.com/services/YOUR/WEBHOOK/URL",
+            headers: JSON.stringify({ "Content-Type": "application/json" }),
+            body: JSON.stringify({ text: "{{ $json.result }}" }),
+          },
+          notes: "Replace the URL with your Slack (or any HTTP) endpoint.",
+        },
+        {
+          id: "out",
+          type: "data.output",
+          name: "Done",
+          position: { x: 960, y: 180 },
+          params: { label: "posted" },
+        },
+      ],
+      edges: [
+        { id: "trigger:main->familiar:in", source: "trigger", sourceHandle: "main", target: "familiar", targetHandle: "in" },
+        { id: "familiar:main->http:in", source: "familiar", sourceHandle: "main", target: "http", targetHandle: "in" },
+        { id: "http:main->out:in", source: "http", sourceHandle: "main", target: "out", targetHandle: "in" },
+      ],
+    },
+  },
+
+  // ── 6. Memory Maintenance ─────────────────────────────────────────────────
+  {
+    id: "memory-maintenance",
+    name: "Memory Maintenance",
+    description: "Echo reviews recent daily notes, distills what matters, and updates long-term memory — runs weekly.",
+    category: "automation",
+    icon: "ph:brain",
+    accent: "#7c9b70",
+    graph: {
+      nodes: [
+        {
+          id: "trigger",
+          type: "trigger.schedule",
+          name: "Weekly — Sunday night",
+          position: { x: 80, y: 180 },
+          params: { mode: "cron", cron: "0 22 * * 0" },
+        },
+        {
+          id: "echo-read",
+          type: "familiar",
+          name: "Echo — gather this week",
+          position: { x: 360, y: 180 },
+          params: {
+            familiar: "echo",
+            prompt:
+              "Read the last 7 daily note files from the memory/ directory. List the significant events, decisions, lessons learned, and recurring themes across all familiars this week.",
+          },
+        },
+        {
+          id: "echo-distill",
+          type: "familiar",
+          name: "Echo — distill to MEMORY.md",
+          position: { x: 660, y: 180 },
+          params: {
+            familiar: "echo",
+            prompt:
+              "Given this week's summary from the previous step, update MEMORY.md with distilled long-term memories. Remove outdated entries. Add new learnings. Keep MEMORY.md concise — it's curated wisdom, not a log.",
+          },
+        },
+        {
+          id: "approval",
+          type: "human.gate",
+          name: "Review memory changes",
+          position: { x: 940, y: 180 },
+          params: { prompt: "Echo has proposed memory updates. Review the diff and approve to apply." },
+        },
+        {
+          id: "echo-commit",
+          type: "familiar",
+          name: "Echo — commit changes",
+          position: { x: 1220, y: 120 },
+          params: {
+            familiar: "echo",
+            prompt: "Commit the MEMORY.md changes with a descriptive message: 'memory: weekly distillation YYYY-MM-DD'.",
+          },
+        },
+        {
+          id: "out",
+          type: "data.output",
+          name: "Done",
+          position: { x: 1460, y: 120 },
+          params: { label: "memory updated" },
+        },
+        {
+          id: "skipped",
+          type: "data.output",
+          name: "Skipped",
+          position: { x: 1220, y: 280 },
+          params: { label: "skipped" },
+        },
+      ],
+      edges: [
+        { id: "trigger:main->echo-read:in", source: "trigger", sourceHandle: "main", target: "echo-read", targetHandle: "in" },
+        { id: "echo-read:main->echo-distill:in", source: "echo-read", sourceHandle: "main", target: "echo-distill", targetHandle: "in" },
+        { id: "echo-distill:main->approval:in", source: "echo-distill", sourceHandle: "main", target: "approval", targetHandle: "in" },
+        { id: "approval:approved->echo-commit:in", source: "approval", sourceHandle: "approved", target: "echo-commit", targetHandle: "in" },
+        { id: "approval:rejected->skipped:in", source: "approval", sourceHandle: "rejected", target: "skipped", targetHandle: "in" },
+        { id: "echo-commit:main->out:in", source: "echo-commit", sourceHandle: "main", target: "out", targetHandle: "in" },
+      ],
+    },
+  },
+];
+
+/** Materialise a template as a saveable FlowDoc stub (no id/timestamps yet). */
+export function instantiateTemplate(
+  template: FlowTemplate,
+  id: string,
+  now: string,
+): FlowDoc {
+  return {
+    id,
+    name: template.name,
+    active: false,
+    nodes: template.graph.nodes,
+    edges: template.graph.edges,
+    createdAt: now,
+    updatedAt: now,
+    schema: 1,
+  };
+}

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -241,6 +241,89 @@
 .react-flow__resize-control.flow-sticky-resize-handle { width: 8px; height: 8px; border-radius: 2px; background: var(--accent-presence); border: 1px solid var(--card); }
 .react-flow__resize-control.flow-sticky-resize-line { border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent); }
 
+/* ---- Live run steps panel ---------------------------------------------- */
+.flow-run-steps {
+  position: absolute; top: 54px; left: 12px; z-index: 7;
+  display: flex; flex-direction: column; gap: 0;
+  width: 268px; max-height: calc(100% - 66px);
+  border: 1px solid var(--border-hairline); border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
+  box-shadow: 0 12px 36px rgb(0 0 0 / 32%);
+  backdrop-filter: blur(8px);
+  overflow: hidden;
+}
+.flow-run-steps.is-collapsed { width: auto; }
+.flow-run-steps-head {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px; border-bottom: 1px solid var(--border-hairline);
+}
+.flow-run-steps.is-collapsed .flow-run-steps-head { border-bottom: 0; }
+.flow-run-steps-toggle {
+  display: inline-flex; padding: 2px; border: 0; border-radius: var(--radius-sm);
+  background: transparent; color: var(--text-muted); cursor: pointer;
+}
+.flow-run-steps-toggle:hover { background: var(--bg-elevated); color: var(--text-primary); }
+.flow-run-steps-status { flex: none; padding: 2px 9px; font-size: var(--text-xs); font-weight: 600; border-radius: 999px; }
+.flow-run-steps-count { flex: 1; font-size: var(--text-xs); color: var(--text-muted); }
+.flow-run-steps-stop {
+  display: inline-flex; align-items: center; gap: 4px; padding: 3px 9px;
+  font-size: var(--text-xs); font-weight: 600; cursor: pointer;
+  border: 1px solid color-mix(in oklch, var(--color-danger) 45%, var(--border));
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--color-danger) 14%, var(--bg-elevated));
+  color: var(--color-danger);
+}
+.flow-run-steps-stop:hover { background: color-mix(in oklch, var(--color-danger) 24%, var(--bg-elevated)); }
+
+.flow-run-steps-list {
+  list-style: none; margin: 0; padding: 6px;
+  overflow-y: auto; min-height: 0;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.flow-run-step { border-radius: var(--radius-control); }
+.flow-run-step.is-selected { background: color-mix(in oklch, var(--accent-presence) 16%, transparent); }
+.flow-run-step-row {
+  width: 100%; display: flex; align-items: center; gap: 9px;
+  padding: 7px 8px; border: 0; border-radius: var(--radius-control);
+  background: transparent; text-align: left; cursor: pointer;
+}
+.flow-run-step-row:hover { background: var(--bg-hover); }
+.flow-run-step-icon { flex: none; display: grid; place-items: center; width: 17px; height: 17px; }
+.flow-run-step-icon-pending { color: var(--text-muted); }
+.flow-run-step-icon-running { color: var(--color-warning); }
+.flow-run-step-icon-succeeded { color: var(--color-success); }
+.flow-run-step-icon-failed { color: var(--color-danger); }
+.flow-run-step-icon-skipped { color: var(--text-muted); opacity: 0.6; }
+.flow-run-step-spin { animation: flow-spin 0.9s linear infinite; }
+.flow-run-step-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.flow-run-step-name {
+  font-size: var(--text-sm); font-weight: 600; color: var(--text-primary);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.flow-run-step-type { font-size: var(--text-2xs); color: var(--text-muted); }
+.flow-run-step-phase {
+  flex: none; font-size: var(--text-2xs); text-transform: uppercase;
+  letter-spacing: 0.04em; color: var(--text-muted);
+}
+.flow-run-step-running .flow-run-step-phase { color: var(--color-warning); }
+.flow-run-step-failed .flow-run-step-phase { color: var(--color-danger); }
+.flow-run-step-detail {
+  margin: 0 8px 7px 34px; padding: 6px 8px;
+  font-size: var(--text-2xs); line-height: 1.45; color: var(--text-secondary);
+  background: var(--bg-base); border-radius: var(--radius-sm);
+  max-height: 84px; overflow: hidden;
+  white-space: pre-wrap; word-break: break-word;
+}
+.flow-run-steps-foot { padding: 7px 8px; border-top: 1px solid var(--border-hairline); }
+.flow-run-steps-open {
+  width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 6px 10px; font-size: var(--text-sm); font-weight: 500; cursor: pointer;
+  border: 1px solid var(--border); border-radius: var(--radius-control);
+  background: var(--bg-elevated); color: var(--text-primary);
+}
+.flow-run-steps-open:hover { border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border)); }
+@media (prefers-reduced-motion: reduce) { .flow-run-step-spin { animation: none; } }
+
 /* ---- Node catalog panel ------------------------------------------------- */
 .flow-catalog-scrim { position: absolute; inset: 0; z-index: 20; background: var(--backdrop-scrim); display: flex; justify-content: flex-end; }
 .flow-catalog { width: 340px; max-width: 90%; height: 100%; display: flex; flex-direction: column; background: var(--bg-raised); border-left: 1px solid var(--border-hairline); box-shadow: -12px 0 40px rgb(0 0 0 / 35%); animation: flow-slide-in var(--duration-base) var(--ease-decelerate); }
@@ -345,4 +428,284 @@
 @media (max-width: 640px) {
   .flow-onboarding-actions,
   .flow-onboarding-prompt { display: flex; flex-direction: column; }
+}
+
+/* ---- Template gallery --------------------------------------------------- */
+
+/* Overlay (modal wrapper) */
+.flow-template-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+}
+.flow-template-overlay-backdrop {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in oklch, var(--bg) 40%, transparent);
+  backdrop-filter: blur(4px);
+}
+.flow-template-overlay-panel {
+  position: relative;
+  z-index: 1;
+  width: min(900px, 100%);
+  max-height: min(700px, 90vh);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-panel);
+  box-shadow: 0 24px 64px color-mix(in oklch, #000 45%, transparent);
+  overflow: hidden;
+}
+
+/* Gallery container — used both in the overlay and as the full empty-state */
+.flow-template-gallery {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* Gallery header */
+.flow-template-gallery-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 10px;
+  border-bottom: 1px solid var(--border-hairline);
+  flex: none;
+}
+.flow-template-gallery-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.flow-template-gallery-header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.flow-template-gallery-blank {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-control);
+}
+.flow-template-gallery-blank:hover { background: var(--bg-hover); color: var(--text-primary); }
+.flow-template-gallery-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.flow-template-gallery-close:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* Filter pills */
+.flow-template-gallery-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 18px 8px;
+  border-bottom: 1px solid var(--border-hairline);
+  flex: none;
+}
+.flow-template-filter-pill {
+  padding: 3px 11px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.12s, background 0.12s, border-color 0.12s;
+}
+.flow-template-filter-pill:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.flow-template-filter-pill.is-active {
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border));
+  color: var(--text-primary);
+}
+
+/* Template grid */
+.flow-template-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
+  padding: 14px 18px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+
+/* Template card */
+.flow-template-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--card);
+  transition: border-color 0.15s, background 0.15s;
+}
+.flow-template-card:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border));
+  background: var(--bg-hover);
+}
+
+.flow-template-card-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  flex: none;
+}
+
+.flow-template-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  flex: 1;
+  min-height: 0;
+}
+.flow-template-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 6px;
+}
+.flow-template-card-name {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.3;
+}
+.flow-template-card-badge {
+  flex: none;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.flow-template-card-desc {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.45;
+  margin: 0;
+}
+.flow-template-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.flow-template-card-nodes {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.flow-template-card-use {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+  width: 100%;
+  justify-content: center;
+}
+.flow-template-card-use:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--accent-presence) 15%, var(--bg-elevated));
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border));
+}
+.flow-template-card-use:disabled { opacity: 0.5; cursor: not-allowed; }
+
+@keyframes flow-template-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+.flow-template-card-spinner {
+  animation: flow-template-spin 0.7s linear infinite;
+}
+
+/* Blank-flow row shown at the bottom of the empty-state gallery */
+.flow-template-gallery-blank-row {
+  padding: 12px 18px 16px;
+  border-top: 1px solid var(--border-hairline);
+  flex: none;
+  display: flex;
+  justify-content: center;
+}
+.flow-template-gallery-blank-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.flow-template-gallery-blank-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* FlowLibrary — template button in head */
+.flow-library-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.flow-library-template-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.flow-library-template-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* Empty-state onboarding uses full gallery */
+.flow-view-onboarding {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-4);
 }


### PR DESCRIPTION
## Summary
- Add a Flow template gallery with six prebuilt flow templates.
- Wire template creation into the Flow empty state and library rail.
- Include the live run steps panel component required by the flow view.

## Verification
- pnpm check:tests-wired
- pnpm exec next typegen
- pnpm typecheck
- pnpm test:app
- git diff --check origin/main...HEAD