### PR TITLE
feat(schedules): per-row quick actions (run-now + pause/resume) on hover

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -71,4 +71,18 @@ assert.match(source, /const mountedRef = useRef\(true\)/, "tracks mounted state 
 assert.match(source, /const runsReqRef = useRef\(0\)/, "refreshRuns tracks a request id");
 assert.match(source, /if \(reqId !== runsReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late runs fetch is dropped");
 
+// ── Per-row quick actions (run-now + pause/resume), revealed on hover ──
+assert.match(source, /const ScheduleActionsContext = createContext/, "row actions are provided via context (no prop threading)");
+assert.match(source, /<ScheduleActionsContext\.Provider/, "AutomationsView provides the row actions");
+assert.match(source, /runReminder: runNow/, "reminder run-now is wired");
+assert.match(source, /togglePauseReminder: togglePaused/, "reminder pause/resume is wired");
+assert.match(source, /runAutomation: runCodexNow/, "automation run-now is wired");
+assert.match(source, /togglePauseAutomation: toggleCodex/, "automation pause/resume is wired");
+// Hidden actions must not steal clicks meant for the row's detail panel.
+assert.match(source, /pointer-events-none[\s\S]*?group-hover\/srow:pointer-events-auto/, "hidden row actions keep pointer-events:none until hover/focus");
+assert.match(source, /onClick=\{\(e\) => \{ e\.stopPropagation\(\); onClick\(\); \}\}/, "a row action stops the click from opening the detail panel");
+assert.match(source, /actions\.runAutomation\(auto\)/, "the automation row exposes run-now");
+assert.match(source, /actions\.togglePauseReminder\(item\)/, "the reminder row exposes pause/resume");
+assert.match(source, /item\.kind !== "daily-summary"/, "daily-summary rows get no run/pause actions");
+
 console.log("automations-view.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
@@ -13,6 +13,7 @@ import type {
 } from "@/lib/codex-automations-types";
 import type { AutomationRunRecord } from "@/lib/automation-runs";
 import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
 import { formatTimestamp, formatClock, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { relativeTimeSigned } from "@/lib/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
@@ -361,6 +362,46 @@ function DetailPanel({
   );
 }
 
+// Row quick-actions (run-now, pause/resume) are wired once at the top of the
+// view and read by each leaf row — so the most-used actions are one hover away
+// instead of buried in the detail panel. Avoids threading callbacks through the
+// list/section components.
+type ScheduleActions = {
+  runReminder: (id: string) => void;
+  togglePauseReminder: (item: InboxItem) => void;
+  runAutomation: (auto: CodexAutomation) => void;
+  togglePauseAutomation: (auto: CodexAutomation) => void;
+};
+const ScheduleActionsContext = createContext<ScheduleActions | null>(null);
+
+function RowActionButton({ icon, label, onClick }: { icon: IconName; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      title={label}
+      aria-label={label}
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-white/10 hover:text-[var(--text-primary)]"
+    >
+      <Icon name={icon} width={12} />
+    </button>
+  );
+}
+
+// Hover/focus-revealed action cluster pinned to the right of a schedule row.
+// Hidden rows keep `pointer-events:none` so a non-hover click still opens the
+// row's detail panel rather than landing on an invisible action.
+function RowActions({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="pointer-events-none absolute right-1.5 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md border border-[var(--border-hairline)] px-0.5 py-0.5 opacity-0 transition-opacity group-hover/srow:pointer-events-auto group-hover/srow:opacity-100 group-focus-within/srow:pointer-events-auto group-focus-within/srow:opacity-100 motion-reduce:transition-none"
+      style={{ background: "var(--bg-elevated)" }}
+    >
+      {children}
+    </div>
+  );
+}
+
 function ReminderTaskRow({
   item,
   selected,
@@ -395,9 +436,14 @@ function ReminderTaskRow({
   // selecting, and the detail-panel `selected` highlight otherwise.
   const active = selectMode ? checked : selected;
   const activate = () => (selectMode ? onToggle(item.id) : onSelect(item));
+  const actions = useContext(ScheduleActionsContext);
+  const paused = item.status === "dismissed";
+  // Run-now / pause make sense for actual reminders, not daily summaries, and
+  // never while picking rows in select mode.
+  const showActions = !selectMode && item.kind !== "daily-summary" && !!actions;
 
   return (
-    <li>
+    <li className="group/srow relative">
       <button
         type="button"
         role={selectMode ? "checkbox" : undefined}
@@ -442,6 +488,18 @@ function ReminderTaskRow({
           {schedule}
         </span>
       </button>
+      {showActions && actions && (
+        <RowActions>
+          {!paused && (
+            <RowActionButton icon="ph:lightning-bold" label={`Run ${item.title} now`} onClick={() => actions.runReminder(item.id)} />
+          )}
+          <RowActionButton
+            icon={paused ? "ph:play-fill" : "ph:pause-fill"}
+            label={`${paused ? "Resume" : "Pause"} ${item.title}`}
+            onClick={() => actions.togglePauseReminder(item)}
+          />
+        </RowActions>
+      )}
     </li>
   );
 }
@@ -1050,8 +1108,9 @@ function AutomationScheduleRow({
   onSelect: (auto: CodexAutomation) => void;
 }) {
   const isActive = auto.status === "ACTIVE";
+  const actions = useContext(ScheduleActionsContext);
   return (
-    <li>
+    <li className="group/srow relative">
       <button
         type="button"
         onClick={() => onSelect(auto)}
@@ -1105,6 +1164,16 @@ function AutomationScheduleRow({
           {auto.scheduleHuman}
         </span>
       </button>
+      {actions && (
+        <RowActions>
+          <RowActionButton icon="ph:lightning-bold" label={`Run ${auto.name} now`} onClick={() => actions.runAutomation(auto)} />
+          <RowActionButton
+            icon={isActive ? "ph:pause-fill" : "ph:play-fill"}
+            label={`${isActive ? "Pause" : "Activate"} ${auto.name}`}
+            onClick={() => actions.togglePauseAutomation(auto)}
+          />
+        </RowActions>
+      )}
     </li>
   );
 }
@@ -1750,6 +1819,14 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   };
 
   return (
+    <ScheduleActionsContext.Provider
+      value={{
+        runReminder: runNow,
+        togglePauseReminder: togglePaused,
+        runAutomation: runCodexNow,
+        togglePauseAutomation: toggleCodex,
+      }}
+    >
     <section className="flex h-full" style={{ background: "var(--bg-base)" }}>
       {/* ── Main list ──────────────────────────────────────────────────────── */}
       <div className="flex flex-1 min-w-0 flex-col">
@@ -2032,5 +2109,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
         />
       ) : null}
     </section>
+    </ScheduleActionsContext.Provider>
   );
 }


### PR DESCRIPTION
The top pick from the Schedules UX scan.

## Problem
On the Schedules page, **every action lived in the detail panel** — to run, pause, or resume a reminder or automation you had to select the row → open the panel → click. The most frequent actions were buried.

## Fix
Each **reminder** and **automation** row now reveals a compact **run-now (⚡) + pause/resume (⏸/▶)** cluster on hover/focus — the actions are one hover away.

- Reuses the existing handlers (`runNow`/`togglePaused`, `runCodexNow`/`toggleCodex`), surfaced at the row level via a small `ScheduleActionsContext` (no callback threading through the list/section components).
- Hidden clusters keep `pointer-events:none` so a normal row click still opens the detail panel; action buttons `stopPropagation`.
- Daily-summary rows get no run/pause (matching the detail panel). State-aware icons (Pause when active, Resume when paused). Icons reused from the allowlist.

## Verification (real app, Playwright)
Hovering an automation row shows the run + pause icons; **clicking Pause on the active automation PATCHes `status → PAUSED`**. `tsc` clean; full `test:app` (421 files) + `check:tests-wired` green; source-text assertions added.

Follow-ups from the same scan: bulk pause/resume for automations, familiar filter on Inbox/Reminders, run history for reminders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)