### PR TITLE
fix(a11y): canvas detail — fullscreen dialog + tab arrow-nav + selected aria-current

### DIFF
--- a/src/components/journal/canvas-list.tsx
+++ b/src/components/journal/canvas-list.tsx
@@ -7,6 +7,7 @@ import { copyText } from "@/lib/clipboard";
 import { isDemoModeEnabled } from "@/lib/demo-mode";
 import { relativeTime } from "@/lib/daily-report";
 import { useDateTimePrefs } from "@/lib/datetime-format";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DEFAULT_REFINE_SUGGESTIONS, generateRefineSuggestions } from "@/lib/refine-suggestions";
 import {
   buildPreviewSrcDoc,
@@ -69,6 +70,8 @@ export function CanvasList({
   // Transient "Copied" confirmation for the Code tab's copy button.
   const [copied, setCopied] = useState(false);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const detailRef = useRef<HTMLElement | null>(null);
+  const tablistRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => () => { if (copiedTimer.current) clearTimeout(copiedTimer.current); }, []);
   // Guards async setState after the tab unmounts — generation is a slow LLM
   // call, so leaving Canvas mid-generate would otherwise setState on a dead tree.
@@ -240,14 +243,21 @@ export function CanvasList({
     setCodeDraft(selected?.code ?? "");
   }, [selected?.id, selected?.code]);
 
-  // Escape exits full-screen; deselecting/closing the pane also exits it.
+  // In full screen the detail is a portaled modal: trap focus inside it and
+  // close on Escape. (useFocusTrap's own focus-restore can't be relied on here —
+  // MaybePortal remounts the subtree on toggle, so the previously-focused node
+  // is gone before the trap captures it; we restore focus explicitly below.)
+  useFocusTrap(fullscreen, detailRef, { onEscape: () => setFullscreen(false) });
+
+  // Restore focus to the full-screen toggle when leaving full screen, on the
+  // next frame so it lands after the un-portal remount has committed.
+  const fsBtnRef = useRef<HTMLButtonElement>(null);
+  const wasFullscreenRef = useRef(fullscreen);
   useEffect(() => {
-    if (!fullscreen) return;
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setFullscreen(false);
+    if (wasFullscreenRef.current && !fullscreen) {
+      requestAnimationFrame(() => fsBtnRef.current?.focus());
     }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    wasFullscreenRef.current = fullscreen;
   }, [fullscreen]);
 
   useEffect(() => {
@@ -369,6 +379,7 @@ export function CanvasList({
                     <button
                       type="button"
                       className="journal-art__select"
+                      aria-current={a.id === selectedId ? "true" : undefined}
                       onClick={() => {
                         setSelectedId(a.id);
                         setView("preview");
@@ -397,15 +408,38 @@ export function CanvasList({
         )}
       </aside>
       <MaybePortal active={fullscreen}>
-      <section className={`journal-detail${fullscreen ? " journal-detail--fullscreen" : ""}`} aria-label="Sketch preview">
+      <section
+        ref={detailRef}
+        className={`journal-detail${fullscreen ? " journal-detail--fullscreen" : ""}`}
+        aria-label="Sketch preview"
+        role={fullscreen ? "dialog" : undefined}
+        aria-modal={fullscreen ? true : undefined}
+        tabIndex={fullscreen ? -1 : undefined}
+      >
         {selected ? (
           <>
             <div className="journal-detail__bar">
-              <div className="journal-seg" role="tablist" aria-label="Preview or code">
+              <div
+                className="journal-seg"
+                role="tablist"
+                aria-label="Preview or code"
+                ref={tablistRef}
+                onKeyDown={(e) => {
+                  if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"].includes(e.key)) return;
+                  e.preventDefault();
+                  const next =
+                    e.key === "Home" ? "preview"
+                    : e.key === "End" ? "code"
+                    : view === "preview" ? "code" : "preview";
+                  setView(next);
+                  tablistRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]')[next === "preview" ? 0 : 1]?.focus();
+                }}
+              >
                 <button
                   type="button"
                   role="tab"
                   aria-selected={view === "preview"}
+                  tabIndex={view === "preview" ? 0 : -1}
                   className={view === "preview" ? "on" : ""}
                   onClick={() => setView("preview")}
                 >
@@ -415,6 +449,7 @@ export function CanvasList({
                   type="button"
                   role="tab"
                   aria-selected={view === "code"}
+                  tabIndex={view === "code" ? 0 : -1}
                   className={view === "code" ? "on" : ""}
                   onClick={() => setView("code")}
                 >
@@ -423,6 +458,7 @@ export function CanvasList({
               </div>
               <div className="journal-detail__actions">
                 <button
+                  ref={fsBtnRef}
                   type="button"
                   className={`journal-act${fullscreen ? " journal-act--on" : ""}`}
                   aria-label={fullscreen ? "Exit full screen" : "View full screen"}

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -57,6 +57,44 @@ assert.match(list, /aria-label="Save canvas code"/, "Canvas Code tab renders a s
 assert.match(list, /aria-label="Revert canvas code edits"/, "Canvas Code tab renders a revert action");
 assert.match(list, /e\.key === "s"[\s\S]*?saveCodeEdit/, "Canvas Code tab supports Cmd/Ctrl+S save");
 assert.match(list, /e\.key === "Escape"[\s\S]*?revertCodeEdit/, "Canvas Code tab supports Escape to revert unsaved edits");
+
+// ── Fullscreen detail is a real modal dialog (focus trap + Escape + restore) ──
+// Was: a portaled <section> with a manual Escape handler, no focus trap/restore.
+assert.match(
+  list,
+  /useFocusTrap\(fullscreen, detailRef, \{ onEscape: \(\) => setFullscreen\(false\) \}\)/,
+  "Fullscreen canvas detail traps focus, closes on Escape, and restores focus on exit",
+);
+assert.match(
+  list,
+  /role=\{fullscreen \? "dialog" : undefined\}[\s\S]*?aria-modal=\{fullscreen \? true : undefined\}/,
+  "Fullscreen canvas detail exposes dialog semantics only while full screen",
+);
+assert.doesNotMatch(
+  list,
+  /window\.addEventListener\("keydown", onKeyDown\)/,
+  "the hand-rolled fullscreen Escape listener is replaced by the focus trap",
+);
+// The portal remount defeats useFocusTrap's own restore, so focus is returned to
+// the full-screen toggle explicitly on the next frame after exiting full screen.
+assert.match(
+  list,
+  /if \(wasFullscreenRef\.current && !fullscreen\) \{\s*requestAnimationFrame\(\(\) => fsBtnRef\.current\?\.focus\(\)\)/,
+  "leaving full screen restores focus to the toggle (after the un-portal remount)",
+);
+assert.match(list, /ref=\{fsBtnRef\}/, "the full-screen toggle is the focus-restore target");
+
+// ── Selected canvas item is aria-current (was visual .is-selected only) ──────
+assert.match(list, /aria-current=\{a\.id === selectedId \? "true" : undefined\}/, "the selected canvas item announces itself");
+
+// ── Preview/Code tabs are arrow-navigable with a roving tab stop ─────────────
+assert.match(list, /tabIndex=\{view === "preview" \? 0 : -1\}/, "the preview tab roves the tab stop");
+assert.match(list, /tabIndex=\{view === "code" \? 0 : -1\}/, "the code tab roves the tab stop");
+assert.match(
+  list,
+  /\["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown", "Home", "End"\]\.includes\(e\.key\)/,
+  "the Preview/Code tablist supports arrow/Home/End navigation",
+);
 assert.match(css, /\.journal-list \{[\s\S]*?min-width:\s*0;/, "Journal master-detail shell can shrink inside the workspace");
 assert.match(css, /\.journal-detail \{[\s\S]*?overflow:\s*hidden;/, "Journal detail pane contains overflowing code surfaces");
 assert.match(css, /\.journal-detail__code \{[\s\S]*?overflow-x:\s*hidden;[\s\S]*?white-space:\s*pre-wrap;[\s\S]*?overflow-wrap:\s*anywhere;/, "Canvas Code tab wraps long source lines instead of overflowing horizontally");


### PR DESCRIPTION
## Canvas item detail audit (`journal/canvas-list.tsx` detail pane)

Mostly solid — async loaders/mutations are `mountedRef`-guarded (#1825), the preview iframe is safely sandboxed (`allow-scripts`, **no** `allow-same-origin`, `srcDoc`), the preview/code toggle already uses `role="tablist"`/`tab`/`aria-selected`, and reduced-motion is handled globally. Three a11y fixes:

### 1. Fullscreen is now a real modal dialog
Full screen portals the detail to `<body>` — but it was a plain `<section>` with a hand-rolled Escape listener: no focus trap, no `role="dialog"`/`aria-modal`, no focus restore. Now `useFocusTrap` (trap + Escape) + `role="dialog"`/`aria-modal` **only while full screen**.

**Subtlety caught in live verification:** `MaybePortal` remounts the subtree on toggle, which destroys the focused node *before* `useFocusTrap` can capture it for restore (focus landed on `<body>` on exit). So focus is returned to the full-screen toggle **explicitly via `requestAnimationFrame`** after the un-portal remount commits.

### 2. Selected sketch is `aria-current`
Was conveyed only by an `.is-selected` class.

### 3. Preview/Code tabs are arrow-navigable
Added a roving tab stop (`tabIndex` 0/-1) + Arrow/Home/End nav (were click-only).

## Verification
- `journal-view.test.ts` extended (all three + the rAF restore) · `tsc` clean · `pnpm build` exit 0
- Live (Playwright, seeded artifact): full screen reports `role=dialog`/`aria-modal` with focus **trapped inside**; Escape exits and `document.activeElement` is the **"View full screen"** toggle; `aria-current` tracks the selected item; ArrowRight moves Preview→Code with the roving tab stop + focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)