### PR TITLE
feat(group-chat): @-tag familiars to target a message at a subset

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -22,6 +22,22 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
 });
 
+test("@mentions target a subset of the coven", () => {
+  // Send routes to mentioned familiars only, falling back to the full roster.
+  assert.match(view, /const mentioned = parseMentions\(text, mentionable\)/, "parses @mentions on send");
+  assert.match(
+    view,
+    /mentioned\.length > 0 \? group\.familiarIds\.filter/,
+    "targets only mentioned familiars, else broadcasts to all",
+  );
+  assert.match(view, /targetFamiliarIds: mentioned\.length > 0/, "records the targeted ids on the user turn");
+  assert.match(view, /replies: GroupReply\[\] = targetIds\.map/, "only the targets reply");
+  // Composer autocomplete reuses the tested pure helpers.
+  assert.match(view, /findActiveMention\(el\.value/, "detects the active mention token");
+  assert.match(view, /matchMentions\(mention\.query, mentionable\)/, "filters the roster by the query");
+  assert.match(view, /applyMention\(draft, mention\.start, mention\.query/, "inserts the chosen familiar");
+});
+
 test("Group Chat is wired into navigation", () => {
   assert.match(mode, /\| "groupchat"/, "groupchat is a valid WorkspaceMode");
   assert.match(sidebar, /id: "groupchat", label: "Group"/, "sidebar exposes the Group surface");

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -35,6 +35,10 @@ import {
   removeGroup,
   setGroupSession,
   setGroupParticipants,
+  parseMentions,
+  findActiveMention,
+  matchMentions,
+  applyMention,
   loadGroups,
   saveGroups,
   loadTranscript,
@@ -43,6 +47,7 @@ import {
   type GroupTurn,
   type GroupUserTurn,
   type GroupReply,
+  type MentionableFamiliar,
 } from "@/lib/group-chat";
 
 type Props = {
@@ -71,10 +76,17 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   const [busy, setBusy] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
+  // @mention autocomplete in the composer.
+  const [mention, setMention] = useState<{ start: number; query: string } | null>(null);
+  const [mentionIndex, setMentionIndex] = useState(0);
 
   const addBtnRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const composerRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Caret to restore after we programmatically rewrite the draft (mention insert).
+  const pendingCaretRef = useRef<number | null>(null);
   const groupsRef = useRef<CovenGroup[]>(groups);
   const transcriptRef = useRef<GroupTurn[]>(transcript);
   groupsRef.current = groups;
@@ -119,6 +131,18 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [transcript]);
+
+  // --- restore caret after a programmatic draft rewrite (mention insert) ---
+  useEffect(() => {
+    const caret = pendingCaretRef.current;
+    if (caret == null) return;
+    pendingCaretRef.current = null;
+    const el = textareaRef.current;
+    if (el) {
+      el.focus();
+      el.setSelectionRange(caret, caret);
+    }
+  }, [draft]);
 
   const persistGroups = useCallback((next: CovenGroup[]) => {
     setGroups(next);
@@ -265,9 +289,23 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     const group = activeGroupRef.current;
     const text = draft.trim();
     if (!group || group.familiarIds.length === 0 || !text || busy) return;
+    // Tagging a subset of familiars with `@mentions` targets the message at just
+    // those participants; with no mention it broadcasts to the whole coven.
+    const mentionable: MentionableFamiliar[] = group.familiarIds.map((id) => ({
+      id,
+      name: byId.get(id)?.display_name ?? "",
+    }));
+    const mentioned = parseMentions(text, mentionable);
+    const targetIds = mentioned.length > 0 ? group.familiarIds.filter((id) => mentioned.includes(id)) : group.familiarIds;
     const at = nowIso();
-    const userTurn: GroupUserTurn = { id: newId(), role: "user", text, createdAt: at };
-    const replies: GroupReply[] = group.familiarIds.map((fid) => ({
+    const userTurn: GroupUserTurn = {
+      id: newId(),
+      role: "user",
+      text,
+      targetFamiliarIds: mentioned.length > 0 ? targetIds : undefined,
+      createdAt: at,
+    };
+    const replies: GroupReply[] = targetIds.map((fid) => ({
       id: newId(),
       role: "assistant",
       familiarId: fid,
@@ -279,17 +317,52 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     }));
     setTranscript((prev) => [...prev, userTurn, ...replies]);
     setDraft("");
+    setMention(null);
     setBusy(true);
     const controller = new AbortController();
     abortRef.current = controller;
     await Promise.all(replies.map((r) => streamOne(group, r, text, controller.signal)));
     abortRef.current = null;
     setBusy(false);
-  }, [draft, busy, streamOne]);
+  }, [draft, busy, streamOne, byId]);
 
   const stop = useCallback(() => {
     abortRef.current?.abort();
   }, []);
+
+  // --- @mention autocomplete ----------------------------------------------
+  const mentionable = useMemo<MentionableFamiliar[]>(() => {
+    if (!activeGroup) return [];
+    return activeGroup.familiarIds
+      .map((id) => byId.get(id))
+      .filter((f): f is ResolvedFamiliar => Boolean(f))
+      .map((f) => ({ id: f.id, name: f.display_name }));
+  }, [activeGroup, byId]);
+  const mentionMatches = useMemo(
+    () => (mention ? matchMentions(mention.query, mentionable) : []),
+    [mention, mentionable],
+  );
+  const mentionOpen = mention !== null && mentionMatches.length > 0;
+
+  // Recompute the active mention token from the textarea's current caret.
+  const syncMention = useCallback(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    const next = findActiveMention(el.value, el.selectionStart ?? el.value.length);
+    setMention(next);
+    setMentionIndex(0);
+  }, []);
+
+  const chooseMention = useCallback(
+    (f: MentionableFamiliar) => {
+      if (!mention) return;
+      const { text, caret } = applyMention(draft, mention.start, mention.query, f.name);
+      pendingCaretRef.current = caret;
+      setDraft(text);
+      setMention(null);
+    },
+    [mention, draft],
+  );
 
   // --- derived transcript view --------------------------------------------
   // Group replies under the user turn they answer for a clean threaded layout.
@@ -505,8 +578,20 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                 </div>
               ) : (
                 <div className="mx-auto flex max-w-3xl flex-col gap-5">
-                  {threads.map(({ user, replies }) => (
+                  {threads.map(({ user, replies }) => {
+                    const targets = user.targetFamiliarIds
+                      ?.map((id) => byId.get(id))
+                      .filter((f): f is ResolvedFamiliar => Boolean(f));
+                    return (
                     <div key={user.id} className="flex flex-col gap-2">
+                      {targets && targets.length > 0 && (
+                        <div className="flex items-center gap-1.5 self-end text-[11px]" style={{ color: "var(--text-muted)" }}>
+                          <Icon name="ph:at" width={12} height={12} />
+                          <span>
+                            to {targets.map((f) => f.display_name).join(", ")}
+                          </span>
+                        </div>
+                      )}
                       <MessageBubble role="user" content={user.text} timestamp={user.createdAt} onOpenUrl={onOpenUrl} />
                       <div className="flex flex-col gap-3 pl-1">
                         {replies.map((r) => {
@@ -541,18 +626,48 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                         })}
                       </div>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               )}
             </div>
 
             {/* Composer */}
             <div className="border-t px-4 py-3" style={{ borderColor: "var(--border-hairline)" }}>
-              <div className="mx-auto flex max-w-3xl items-end gap-2">
+              <div ref={composerRef} className="mx-auto flex max-w-3xl items-end gap-2">
                 <textarea
+                  ref={textareaRef}
                   value={draft}
-                  onChange={(e) => setDraft(e.target.value)}
+                  onChange={(e) => {
+                    setDraft(e.target.value);
+                    syncMention();
+                  }}
+                  onKeyUp={syncMention}
+                  onClick={syncMention}
+                  onBlur={() => setMention(null)}
                   onKeyDown={(e) => {
+                    if (mentionOpen) {
+                      if (e.key === "ArrowDown") {
+                        e.preventDefault();
+                        setMentionIndex((i) => (i + 1) % mentionMatches.length);
+                        return;
+                      }
+                      if (e.key === "ArrowUp") {
+                        e.preventDefault();
+                        setMentionIndex((i) => (i - 1 + mentionMatches.length) % mentionMatches.length);
+                        return;
+                      }
+                      if (e.key === "Enter" || e.key === "Tab") {
+                        e.preventDefault();
+                        chooseMention(mentionMatches[mentionIndex] ?? mentionMatches[0]);
+                        return;
+                      }
+                      if (e.key === "Escape") {
+                        e.preventDefault();
+                        setMention(null);
+                        return;
+                      }
+                    }
                     if (e.key === "Enter" && !e.shiftKey) {
                       e.preventDefault();
                       void send();
@@ -562,12 +677,57 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   placeholder={
                     participants.length === 0
                       ? "Add familiars to this coven first…"
-                      : `Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}…`
+                      : `Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}… (@ to tag one)`
                   }
                   disabled={participants.length === 0}
                   className="max-h-40 min-h-[40px] flex-1 resize-none rounded-lg border px-3 py-2 text-[14px] outline-none disabled:opacity-50"
                   style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)", color: "var(--text-primary)" }}
                 />
+                <Popover
+                  open={mentionOpen}
+                  onOpenChange={(next) => {
+                    if (!next) setMention(null);
+                  }}
+                  anchorRef={composerRef}
+                  placement="top-start"
+                  ariaLabel="Tag a familiar"
+                  minWidth={220}
+                >
+                  <div className="max-h-64 overflow-y-auto p-1">
+                    {mentionMatches.map((f, i) => {
+                      const resolved = byId.get(f.id);
+                      return (
+                        <button
+                          key={f.id}
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left"
+                          style={i === mentionIndex ? { background: "var(--bg-raised)" } : undefined}
+                          // Use mousedown so the textarea's onBlur doesn't fire first and close us.
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            chooseMention(f);
+                          }}
+                          onMouseEnter={() => setMentionIndex(i)}
+                        >
+                          {resolved && (
+                            <FamiliarAvatar familiar={resolved} size="md" className="rounded-full object-cover" />
+                          )}
+                          <div className="min-w-0 flex-1">
+                            <div className="truncate text-[13px]" style={{ color: "var(--text-primary)" }}>
+                              {f.name}
+                            </div>
+                            {resolved?.role && (
+                              <div className="truncate text-[11px]" style={{ color: "var(--text-muted)" }}>
+                                {resolved.role}
+                              </div>
+                            )}
+                          </div>
+                          <Icon name="ph:at" width={14} height={14} className="text-[var(--text-muted)]" />
+                        </button>
+                      );
+                    })}
+                  </div>
+                </Popover>
                 {busy ? (
                   <Button variant="danger-ghost" leadingIcon="ph:stop-fill" onClick={stop}>
                     Stop

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -9,8 +9,19 @@ import {
   removeGroup,
   setGroupSession,
   setGroupParticipants,
+  parseMentions,
+  findActiveMention,
+  matchMentions,
+  applyMention,
   type GroupReply,
+  type MentionableFamiliar,
 } from "./group-chat.ts";
+
+const ROSTER: MentionableFamiliar[] = [
+  { id: "nova", name: "Nova" },
+  { id: "nova-star", name: "Nova Star" },
+  { id: "sage", name: "Sage" },
+];
 
 function baseReply(overrides: Partial<GroupReply> = {}): GroupReply {
   return {
@@ -140,4 +151,79 @@ test("setGroupParticipants: drops session pins for removed familiars", () => {
   assert.deepEqual(g.familiarIds, ["a", "c"]);
   assert.equal(g.sessions.a, "sess-a");
   assert.equal(g.sessions.b, undefined);
+});
+
+// --- @mentions -------------------------------------------------------------
+
+test("parseMentions: no mention ⇒ empty (broadcast to all)", () => {
+  assert.deepEqual(parseMentions("what does everyone think?", ROSTER), []);
+});
+
+test("parseMentions: single tag targets just that familiar", () => {
+  assert.deepEqual(parseMentions("@Nova can you double-check?", ROSTER), ["nova"]);
+});
+
+test("parseMentions: is case-insensitive", () => {
+  assert.deepEqual(parseMentions("hey @sage", ROSTER), ["sage"]);
+});
+
+test("parseMentions: multiple tags, deduped in first-seen order", () => {
+  assert.deepEqual(parseMentions("@Sage and @Nova and @Sage again", ROSTER), ["sage", "nova"]);
+});
+
+test("parseMentions: prefers the longest matching name", () => {
+  assert.deepEqual(parseMentions("@Nova Star ship it", ROSTER), ["nova-star"]);
+});
+
+test("parseMentions: trailing word char is not a match (@Novak ≠ @Nova)", () => {
+  assert.deepEqual(parseMentions("@Novak hi", ROSTER), []);
+});
+
+test("parseMentions: @ mid-word (email) is not a mention", () => {
+  assert.deepEqual(parseMentions("mail me at me@Nova.dev", ROSTER), []);
+});
+
+test("parseMentions: punctuation after a name still matches", () => {
+  assert.deepEqual(parseMentions("@Nova, thoughts?", ROSTER), ["nova"]);
+});
+
+test("findActiveMention: caret inside a fresh token returns start + query", () => {
+  const text = "hey @Nov";
+  assert.deepEqual(findActiveMention(text, text.length), { start: 4, query: "Nov" });
+});
+
+test("findActiveMention: bare @ has an empty query", () => {
+  const text = "ask @";
+  assert.deepEqual(findActiveMention(text, text.length), { start: 4, query: "" });
+});
+
+test("findActiveMention: not in a token returns null", () => {
+  assert.equal(findActiveMention("plain text", 5), null);
+});
+
+test("findActiveMention: @ glued to a word is not a token start", () => {
+  const text = "me@host";
+  assert.equal(findActiveMention(text, text.length), null);
+});
+
+test("findActiveMention: does not span a newline", () => {
+  const text = "@Nova\nhello";
+  assert.equal(findActiveMention(text, text.length), null);
+});
+
+test("matchMentions: blank query lists everyone", () => {
+  assert.equal(matchMentions("", ROSTER).length, ROSTER.length);
+});
+
+test("matchMentions: prefix filters case-insensitively", () => {
+  assert.deepEqual(
+    matchMentions("nov", ROSTER).map((f) => f.id),
+    ["nova", "nova-star"],
+  );
+});
+
+test("applyMention: replaces the token with '@name ' and moves caret after", () => {
+  const out = applyMention("hey @Nov rest", 4, "Nov", "Nova");
+  assert.equal(out.text, "hey @Nova  rest");
+  assert.equal(out.caret, "hey @Nova ".length);
 });

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -32,6 +32,12 @@ export type GroupUserTurn = {
   id: string;
   role: "user";
   text: string;
+  /**
+   * Familiar ids this prompt was directed at via `@mentions`. When present the
+   * message was *targeted* — only these participants replied. Absent/undefined
+   * means it was broadcast to the whole coven.
+   */
+  targetFamiliarIds?: string[];
   createdAt: string;
 };
 
@@ -145,6 +151,100 @@ export function defaultGroupName(names: string[]): string {
   if (clean.length === 1) return clean[0];
   if (clean.length === 2) return `${clean[0]} & ${clean[1]}`;
   return `${clean[0]}, ${clean[1]} +${clean.length - 2}`;
+}
+
+// ---------------------------------------------------------------------------
+// @mentions — tag specific familiars to target a message at them (pure)
+// ---------------------------------------------------------------------------
+
+/** A coven member as seen by the mention parser/autocomplete. */
+export type MentionableFamiliar = { id: string; name: string };
+
+/** True for a char that may not abut the end of a matched `@name` (a word char,
+ *  so `@Nova` does not greedily match a participant named `Nov`). */
+function isWordChar(ch: string | undefined): boolean {
+  return ch !== undefined && /[a-z0-9_]/i.test(ch);
+}
+
+/** True if char `before` permits an `@` to *start* a mention (start-of-string
+ *  or whitespace — so an email like `a@b` is never read as a mention). */
+function isMentionBoundary(before: string): boolean {
+  return before === "" || /\s/.test(before);
+}
+
+/**
+ * Scan free text for `@mentions` of the given participants and return the ids
+ * of every familiar named (deduped, in first-seen order). Matching is
+ * case-insensitive and prefers the longest participant name, so `@Nova Star`
+ * resolves to "Nova Star" rather than a shorter "Nova". Only ids present in
+ * `participants` are ever returned. Empty result ⇒ no valid mention ⇒ caller
+ * should broadcast to the whole coven.
+ */
+export function parseMentions(text: string, participants: MentionableFamiliar[]): string[] {
+  const byLongest = [...participants]
+    .filter((p) => p.name.trim())
+    .sort((a, b) => b.name.length - a.name.length);
+  if (byLongest.length === 0) return [];
+  const lower = text.toLowerCase();
+  const ids: string[] = [];
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "@") continue;
+    if (!isMentionBoundary(i === 0 ? "" : text[i - 1])) continue;
+    const rest = lower.slice(i + 1);
+    for (const p of byLongest) {
+      const name = p.name.toLowerCase();
+      if (!rest.startsWith(name)) continue;
+      if (isWordChar(rest[name.length])) continue; // `@Novak` ≠ `@Nova`
+      if (!ids.includes(p.id)) ids.push(p.id);
+      break;
+    }
+  }
+  return ids;
+}
+
+/**
+ * Locate the `@mention` token the caret is currently editing, for autocomplete.
+ * Returns the `@`'s index and the partial query typed after it, or `null` when
+ * the caret is not inside a mention. The token starts at an `@` preceded by
+ * whitespace/start and does not span an `@` or newline.
+ */
+export function findActiveMention(
+  text: string,
+  caret: number,
+): { start: number; query: string } | null {
+  let i = caret - 1;
+  while (i >= 0 && text[i] !== "@" && text[i] !== "\n") i--;
+  if (i < 0 || text[i] !== "@") return null;
+  if (!isMentionBoundary(i === 0 ? "" : text[i - 1])) return null;
+  return { start: i, query: text.slice(i + 1, caret) };
+}
+
+/**
+ * Filter participants matching an in-progress mention query (case-insensitive
+ * prefix on the display name). A blank query lists everyone.
+ */
+export function matchMentions(
+  query: string,
+  participants: MentionableFamiliar[],
+): MentionableFamiliar[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return participants;
+  return participants.filter((p) => p.name.toLowerCase().startsWith(q));
+}
+
+/**
+ * Replace the active mention token (`@<query>` at `start`) with the chosen
+ * familiar's full `@name `, returning the new text and caret position.
+ */
+export function applyMention(
+  text: string,
+  start: number,
+  query: string,
+  name: string,
+): { text: string; caret: number } {
+  const insert = `@${name} `;
+  const end = start + 1 + query.length;
+  return { text: text.slice(0, start) + insert + text.slice(end), caret: start + insert.length };
 }
 
 export function makeGroup(


### PR DESCRIPTION
## What

Adds **@-mention tagging** to the Group Chat ("coven") composer. Typing `@` opens an autocomplete of the coven's participants; selecting one inserts `@DisplayName`. On send, a tagged message goes **only** to the mentioned familiars — with no mention it still broadcasts to the whole coven (existing behavior).

The targeted user turn renders a small `@ to <names>` indicator and only those familiars reply in their own threads.

```
@Nova can you double-check that?   → sends to Nova only
What does everyone think?          → broadcasts to all participants
```

## How

- **`src/lib/group-chat.ts`** — new framework-free, unit-tested helpers:
  - `parseMentions(text, participants)` → ids targeted (case-insensitive, longest-name-wins, boundary-aware so `me@host` / `@Novak` don't false-match).
  - `findActiveMention` / `matchMentions` / `applyMention` drive the composer autocomplete.
  - `GroupUserTurn` gains optional `targetFamiliarIds` (absent = broadcast).
- **`src/components/group-chat-view.tsx`** — `@` autocomplete Popover (keyboard nav: ↑/↓/Enter/Tab/Esc; mouse), caret restore after insert, send routes to the mentioned subset, transcript shows the "to …" indicator. Placeholder hints `(@ to tag one)`.

## Tests
- 14 new unit tests for the mention helpers + a source-text wiring assertion (`group-chat-view.test.ts`).
- `pnpm test:app` (421 files) ✅ · `tsc --noEmit` ✅ · `pnpm build` (incl. eslint) ✅ · `check-tests-wired` ✅
- Verified live in the real app: autocomplete popover lists the coven's familiars, selecting inserts `@Nova `, placeholder reads `Message 3 familiars… (@ to tag one)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)