### PR TITLE
feat(ios): Lock Screen + StandBy widgets for the next reminder

### DIFF
--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -67,7 +67,8 @@ struct UpNextEntry: TimelineEntry {
 
 struct UpNextProvider: TimelineProvider {
     private var sample: WidgetSnapshot {
-        WidgetSnapshot(nextReminderTitle: "Stand-up sync",
+        WidgetSnapshot(nextReminderId: "preview",
+                       nextReminderTitle: "Stand-up sync",
                        nextReminderDate: Date().addingTimeInterval(3600),
                        dueTaskCount: 2, runningTaskCount: 1, updatedAt: Date())
     }
@@ -98,6 +99,30 @@ struct UpNextWidgetView: View {
     private var reminderId: String? { entry.snapshot?.nextReminderId }
 
     var body: some View {
+        content
+            // Tapping (outside the home-screen buttons) opens the reminders list.
+            .widgetURL(URL(string: "covencave://reminders"))
+            .containerBackground(for: .widget) {
+                switch family {
+                case .accessoryCircular: AccessoryWidgetBackground()
+                case .accessoryRectangular, .accessoryInline: Color.clear
+                default: Rectangle().fill(.fill.tertiary)
+                }
+            }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch family {
+        case .accessoryInline: inlineView
+        case .accessoryCircular: circularView
+        case .accessoryRectangular: rectangularView
+        default: homeScreenView
+        }
+    }
+
+    // MARK: Home Screen (small / medium)
+
+    private var homeScreenView: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 5) {
                 Image(systemName: "sparkles")
@@ -131,8 +156,53 @@ struct UpNextWidgetView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-        // Tapping anywhere outside the buttons opens the reminders list.
-        .widgetURL(URL(string: "covencave://reminders"))
+    }
+
+    // MARK: Lock Screen / StandBy (accessory families)
+
+    @ViewBuilder private var inlineView: some View {
+        if let s = entry.snapshot, let title = s.nextReminderTitle {
+            if let when = s.nextReminderDate {
+                Label("\(title) · \(when.formatted(.dateTime.hour().minute()))",
+                      systemImage: "bell.fill")
+            } else {
+                Label(title, systemImage: "bell.fill")
+            }
+        } else {
+            Label("No reminders", systemImage: "bell")
+        }
+    }
+
+    @ViewBuilder private var circularView: some View {
+        VStack(spacing: 1) {
+            Image(systemName: "bell.fill").font(.system(size: 12))
+            if let when = entry.snapshot?.nextReminderDate {
+                Text(when, format: .dateTime.hour().minute())
+                    .font(.system(size: 11, weight: .semibold))
+                    .minimumScaleFactor(0.6)
+            }
+        }
+        .widgetAccentable()
+    }
+
+    @ViewBuilder private var rectangularView: some View {
+        if let s = entry.snapshot, let title = s.nextReminderTitle {
+            VStack(alignment: .leading, spacing: 1) {
+                Label("Up Next", systemImage: "sparkles")
+                    .font(.caption2.weight(.semibold))
+                    .widgetAccentable()
+                Text(title).font(.headline).lineLimit(1)
+                if let when = s.nextReminderDate {
+                    Text(when, format: .dateTime.weekday().hour().minute())
+                        .font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        } else {
+            Label("No upcoming reminders", systemImage: "bell")
+                .font(.caption)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        }
     }
 
     private func actionButtons(id: String) -> some View {
@@ -172,11 +242,13 @@ struct UpNextWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: "CovenCaveUpNext", provider: UpNextProvider()) { entry in
             UpNextWidgetView(entry: entry)
-                .containerBackground(.fill.tertiary, for: .widget)
         }
         .configurationDisplayName("Up Next")
-        .description("Your next reminder and how many tasks are running or due.")
-        .supportedFamilies([.systemSmall, .systemMedium])
+        .description("Your next reminder — on the Home Screen, Lock Screen, or StandBy.")
+        .supportedFamilies([
+            .systemSmall, .systemMedium,
+            .accessoryRectangular, .accessoryCircular, .accessoryInline,
+        ])
     }
 }
 


### PR DESCRIPTION
Extends the "Up Next" widget (#1884) to the **accessory families**, so your next reminder shows on the **Lock Screen** and in **StandBy** (nightstand) mode:

- `.accessoryRectangular` — "Up Next" + reminder title + day/time.
- `.accessoryCircular` — a bell glyph + the reminder time (widget-accentable).
- `.accessoryInline` — bell + "Title · HH:MM" above the clock.

All three reuse the App Group snapshot the app already publishes (no new data path) and deep-link to the reminders list on tap (`covencave://reminders`). Per-family `containerBackground`: `AccessoryWidgetBackground` for circular, clear for inline/rectangular, the existing fill for Home Screen.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED** (app + widget extension).
- Mobile source-text suite green (65); app launches with no crash.
- **Caveat:** adding an accessory widget to the Lock Screen / StandBy isn't `simctl`-automatable, so the placed rendering is verified at the build/compile level only — not via a runtime screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)