### PR TITLE
fix(a11y): workflow run detail — live status region + hidden-pause poll + aria-controls

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -140,6 +140,7 @@ export const SUITES = {
     "src/components/workflows-view.test.ts",
     "src/components/workflows/workflow-studio.test.ts",
     "src/components/workflows/workflow-step-list.test.ts",
+    "src/components/workflows/workflow-run-detail-a11y.test.ts",
     "src/components/workflows/workflow-capability-attachments.test.ts",
     "src/components/projects-view.test.ts",
     "src/components/dnd-context-stable-ids.test.ts",

--- a/src/components/workflows/workflow-run-detail-a11y.test.ts
+++ b/src/components/workflows/workflow-run-detail-a11y.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const progress = readFileSync(new URL("./workflow-run-progress.tsx", import.meta.url), "utf8");
+const panel = readFileSync(new URL("./workflow-runs-panel.tsx", import.meta.url), "utf8");
+
+// ── Live status is announced to assistive tech ───────────────────────────────
+// The headline updates "Running: <step>" → "All N steps reported" live; without
+// a live region a screen-reader user following a run hears nothing.
+assert.match(
+  progress,
+  /className="workflow-run-progress-head" role="status" aria-live="polite"/,
+  "the live run-status headline is a polite live region",
+);
+assert.match(progress, /<p className="workflow-muted" role="alert">\{error\}<\/p>/, "the transcript-fetch error is announced");
+
+// ── Transcript poll pauses while the tab is hidden ───────────────────────────
+assert.match(progress, /if \(document\.hidden\) return;/, "the tick skips fetching while the tab is hidden");
+assert.match(
+  progress,
+  /const onVisible = \(\) => \{ if \(!document\.hidden && alive && live\) void tick\(\); \};/,
+  "polling resumes with an immediate refresh when the tab becomes visible",
+);
+assert.match(progress, /addEventListener\("visibilitychange", onVisible\)/, "a visibility listener drives resume");
+assert.match(progress, /removeEventListener\("visibilitychange", onVisible\)/, "the visibility listener is cleaned up");
+assert.match(progress, /if \(timer\) \{ clearTimeout\(timer\); timer = null; \}/, "a stale timer is cleared before each tick so resume can't double-poll");
+
+// ── Disclosure toggles pair aria-expanded with aria-controls ─────────────────
+// Step-detail toggle (run-progress)
+assert.match(
+  progress,
+  /aria-controls=\{hasDetail \? `\$\{detailBaseId\}-\$\{step\.id\}` : undefined\}/,
+  "the step-detail toggle controls its detail region",
+);
+assert.match(
+  progress,
+  /<pre id=\{`\$\{detailBaseId\}-\$\{step\.id\}`\} className="workflow-progress-step-detail">/,
+  "the step detail region carries the controlled id",
+);
+// Run-row toggle (runs-panel)
+assert.match(panel, /aria-controls=\{`workflow-run-exp-\$\{run\.id\}`\}/, "the run row controls its expansion region");
+assert.match(panel, /<div className="workflow-run-expansion" id=\{`workflow-run-exp-\$\{run\.id\}`\}>/, "the run expansion region carries the controlled id");
+
+console.log("workflow-run-detail-a11y.test.ts: ok");

--- a/src/components/workflows/workflow-run-progress.tsx
+++ b/src/components/workflows/workflow-run-progress.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import {
   parseWorkflowStepProgress,
@@ -36,6 +36,9 @@ export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
     let alive = true;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const tick = async () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      // Don't poll the transcript while the tab is hidden — resume on re-show.
+      if (document.hidden) return;
       try {
         const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, {
           cache: "no-store",
@@ -58,11 +61,17 @@ export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
       if (alive && live) timer = setTimeout(tick, POLL_MS);
     };
     void tick();
+    // Resume polling (with an immediate refresh) when the tab becomes visible.
+    const onVisible = () => { if (!document.hidden && alive && live) void tick(); };
+    document.addEventListener("visibilitychange", onVisible);
     return () => {
       alive = false;
       if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisible);
     };
   }, [sessionId, live]);
+
+  const detailBaseId = useId();
 
   if (!sessionId) return null;
 
@@ -81,7 +90,7 @@ export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
 
   return (
     <div className="workflow-run-progress">
-      <div className="workflow-run-progress-head">
+      <div className="workflow-run-progress-head" role="status" aria-live="polite">
         {live && !progress.done && (
           <Icon name="ph:circle-notch-bold" width={12} className="workflow-spin" aria-hidden />
         )}
@@ -104,6 +113,7 @@ export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
                   type="button"
                   className="workflow-progress-step-row"
                   aria-expanded={hasDetail ? open : undefined}
+                  aria-controls={hasDetail ? `${detailBaseId}-${step.id}` : undefined}
                   disabled={!hasDetail}
                   onClick={() => setOpenStep(open ? null : step.id)}
                 >
@@ -116,7 +126,9 @@ export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
                   <span className="workflow-run-step-status">{step.status}</span>
                   {hasDetail && <Icon name={open ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden />}
                 </button>
-                {open && hasDetail && <pre className="workflow-progress-step-detail">{step.detail}</pre>}
+                {open && hasDetail && (
+                  <pre id={`${detailBaseId}-${step.id}`} className="workflow-progress-step-detail">{step.detail}</pre>
+                )}
               </li>
             );
           })}
@@ -128,7 +140,7 @@ export function WorkflowRunProgress({ run }: { run: WorkflowRunRecord }) {
       ) : (
         <p className="workflow-muted">Waiting for the agent's first output…</p>
       )}
-      {error && <p className="workflow-muted">{error}</p>}
+      {error && <p className="workflow-muted" role="alert">{error}</p>}
     </div>
   );
 }

--- a/src/components/workflows/workflow-runs-panel.tsx
+++ b/src/components/workflows/workflow-runs-panel.tsx
@@ -158,6 +158,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                   type="button"
                   className="workflow-run-row"
                   aria-expanded={expanded}
+                  aria-controls={`workflow-run-exp-${run.id}`}
                   onClick={() => setExpandedId(expanded ? null : run.id)}
                 >
                   <Icon
@@ -173,7 +174,7 @@ export function WorkflowRunsPanel({ runs, loading, workflow, playback, onReplayR
                   </span>
                 </button>
                 {expanded && (
-                  <div className="workflow-run-expansion">
+                  <div className="workflow-run-expansion" id={`workflow-run-exp-${run.id}`}>
                     <dl className="workflow-run-meta">
                       <div>
                         <dt>Source</dt>


### PR DESCRIPTION
## Workflow run detail audit (`workflow-run-progress.tsx` + `workflow-runs-panel.tsx`)

Solid foundation: the transcript poll is `alive`-guarded against stale/unmount, status is shown as **text** (not color-only), runs use `RelativeTime`, reduced-motion is global, and the spinner is `aria-hidden`. Four fixes:

1. **Live status is announced** — `WorkflowRunProgress`'s headline updates "Running: `<step>`" → "All N steps reported" live, but was silent to screen readers. Now `role="status"`/`aria-live="polite"`. The transcript-fetch error gains `role="alert"`.
2. **Transcript poll pauses when hidden** — the 2.5s poll kept hitting `/api/chat/conversation/<id>` in a backgrounded tab. Now skips the fetch while `document.hidden` and resumes (with an immediate refresh) on `visibilitychange`; a stale timer is cleared before each tick so resume can't double-poll.
3. **Disclosure toggles get `aria-controls`** — both the run row (→ its expansion region `id`) and the step-detail toggle (→ its `<pre>` `id`, per-instance via `useId`) had `aria-expanded` with no controlled-region link.

## Verification
- New `workflow-run-detail-a11y.test.ts` (wired; `check:tests-wired` ✓) + existing `workflow-studio.test.ts` pass · `tsc` clean · `pnpm build` exit 0
- No live Playwright pass: the runs panel renders deep inside the workflow **studio** (select a workflow → studio → runs), which isn't practically drivable headlessly. The changes are static markup (aria-live / aria-controls / role=alert) plus a hidden-pause poll that mirrors the same pattern shipped+verified on Calls/Schedules/Coven-floor — so source-text + type + build are the verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)