### PR TITLE
feat(github): free-text search over the activity list

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -185,6 +185,7 @@ export const SUITES = {
     "src/lib/board-wip.test.ts",
     "src/lib/familiar-color.test.ts",
     "src/lib/library-doc-sort.test.ts",
+    "src/lib/github-search.test.ts",
     "src/lib/use-refresh-on-focus.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -332,4 +332,13 @@ assert.doesNotMatch(
 );
 assert.match(source, /useCopy/, "GitHub view copies via the shared useCopy hook");
 
+// ── Free-text search over the activity list ──
+assert.match(source, /import \{ githubItemMatchesQuery \} from "@\/lib\/github-search"/, "uses the pure search matcher");
+assert.match(source, /const \[query, setQuery\] = useState\(""\)/, "tracks a search query");
+assert.match(source, /githubItemMatchesQuery\(i, query\)/, "the scoped list filters by the query");
+assert.match(source, /\[filtered, orgFilter, repoFilter, query\]/, "query is a dependency of the scoped memo");
+assert.match(source, /aria-label="Search GitHub items by title, repo, or number"/, "the search input is labelled");
+assert.match(source, /No items match/, "a no-match query gets its own empty state");
+assert.match(boardCss, /\.gh-search \{/, "the search box is styled to match the toolbar controls");
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -12,6 +12,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { GitHubItem } from "@/lib/github-tasks";
+import { githubItemMatchesQuery } from "@/lib/github-search";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { gfmAutolink } from "@/lib/gfm-autolink";
@@ -1349,6 +1350,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
   const [filter, setFilter] = useState<Filter>("all");
   const [orgFilter, setOrgFilter] = useState<string>("all");
   const [repoFilter, setRepoFilter] = useState<string>("all");
+  const [query, setQuery] = useState("");
   const [groupBy, setGroupBy] = useState<GroupBy>("none");
   const [showPatModal, setShowPatModal] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>("updatedAt");
@@ -1495,9 +1497,10 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       filtered.filter(
         (i) =>
           (orgFilter === "all" || orgOf(i.repo) === orgFilter) &&
-          (repoFilter === "all" || i.repo === repoFilter),
+          (repoFilter === "all" || i.repo === repoFilter) &&
+          githubItemMatchesQuery(i, query),
       ),
-    [filtered, orgFilter, repoFilter],
+    [filtered, orgFilter, repoFilter, query],
   );
 
   const linkedMap = useMemo(() => {
@@ -1684,6 +1687,29 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
         />
 
         <div className="gh-compact-filters">
+          <div className="gh-search">
+            <Icon name="ph:magnifying-glass" width={12} className="gh-search-icon" aria-hidden />
+            <input
+              type="search"
+              className="gh-search-input"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Escape" && query) { e.preventDefault(); setQuery(""); } }}
+              placeholder="Search…"
+              aria-label="Search GitHub items by title, repo, or number"
+              spellCheck={false}
+            />
+            {query && (
+              <button
+                type="button"
+                className="gh-search-clear"
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+              >
+                <Icon name="ph:x" width={10} />
+              </button>
+            )}
+          </div>
           <select
             className="gh-select"
             value={orgFilter}
@@ -1801,11 +1827,19 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
 
         ) : sorted.length === 0 ? (
           <div className="flex h-full items-center justify-center px-8">
-            <EmptyState
-              icon="ph:check-circle"
-              headline={filter === "all" ? "Nothing open right now" : `No open ${filter === "review_request" ? "review requests" : filter + "s"}`}
-              subtitle={filter === "all" ? "Pull requests, reviews, and issues that need you will show up here." : undefined}
-            />
+            {query.trim() ? (
+              <EmptyState
+                icon="ph:magnifying-glass"
+                headline={`No items match “${query.trim()}”`}
+                subtitle="Try a shorter query, or clear the search to see everything."
+              />
+            ) : (
+              <EmptyState
+                icon="ph:check-circle"
+                headline={filter === "all" ? "Nothing open right now" : `No open ${filter === "review_request" ? "review requests" : filter + "s"}`}
+                subtitle={filter === "all" ? "Pull requests, reviews, and issues that need you will show up here." : undefined}
+              />
+            )}
           </div>
 
         ) : (

--- a/src/lib/github-search.test.ts
+++ b/src/lib/github-search.test.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { githubItemMatchesQuery } from "./github-search.ts";
+
+const item = (over = {}) => ({
+  kind: "pr", id: "1", title: "Fix auth token refresh", repo: "OpenCoven/coven-cave",
+  number: 1832, url: "", state: "open", updatedAt: "", ...over,
+});
+
+// ── empty query matches everything ──
+assert.equal(githubItemMatchesQuery(item(), ""), true);
+assert.equal(githubItemMatchesQuery(item(), "   "), true);
+
+// ── title / repo / number ──
+assert.equal(githubItemMatchesQuery(item(), "auth"), true, "matches title");
+assert.equal(githubItemMatchesQuery(item(), "coven-cave"), true, "matches repo");
+assert.equal(githubItemMatchesQuery(item(), "1832"), true, "matches number");
+assert.equal(githubItemMatchesQuery(item(), "#1832"), true, "matches #number");
+
+// ── case-insensitive ──
+assert.equal(githubItemMatchesQuery(item(), "AUTH"), true);
+
+// ── multi-term AND (each term must appear) ──
+assert.equal(githubItemMatchesQuery(item(), "auth refresh"), true, "all terms present");
+assert.equal(githubItemMatchesQuery(item(), "auth payment"), false, "one term missing → no match");
+
+// ── no match ──
+assert.equal(githubItemMatchesQuery(item(), "deploy"), false);
+
+// ── missing number doesn't crash ──
+assert.equal(githubItemMatchesQuery(item({ number: undefined }), "auth"), true);
+
+console.log("github-search.test.ts: ok");

--- a/src/lib/github-search.ts
+++ b/src/lib/github-search.ts
@@ -1,0 +1,16 @@
+import type { GitHubItem } from "@/lib/github-tasks";
+
+/**
+ * Free-text match for the GitHub activity list. Searches the item's title,
+ * repo ("owner/name"), and number. Every whitespace-separated term must match
+ * (AND), so "auth pr" narrows progressively. Empty query matches everything.
+ *
+ * (The type-only import above is erased at runtime, so this module is
+ * dependency-free and runs in the plain test runner.)
+ */
+export function githubItemMatchesQuery(item: GitHubItem, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  const hay = `${item.title} ${item.repo} #${item.number ?? ""}`.toLowerCase();
+  return q.split(/\s+/).every((term) => hay.includes(term));
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -707,6 +707,17 @@
 .gh-select:disabled { opacity:.45; cursor:not-allowed; }
 .gh-select-sep { width:1px; height:calc(var(--gh-control-h) - 8px); background:var(--border-hairline); }
 
+/* Free-text search box for the GitHub activity list. */
+.gh-search { display:inline-flex; align-items:center; gap:5px; height:var(--gh-control-h); max-width:200px; padding:0 6px; border:1px solid var(--border-hairline); border-radius:6px; background-color:var(--bg-base); transition:border-color .12s; }
+.gh-search:focus-within { border-color:var(--accent-presence); }
+.gh-search-icon { color:var(--text-muted); flex-shrink:0; }
+.gh-search-input { min-width:0; flex:1; border:none; outline:none; background:transparent; color:var(--text-primary); font-size:11px; }
+.gh-search-input::placeholder { color:var(--text-muted); }
+.gh-search-input::-webkit-search-cancel-button { display:none; }
+.gh-search-clear { display:grid; place-items:center; width:16px; height:16px; flex-shrink:0; border:none; border-radius:4px; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .12s,color .12s; }
+.gh-search-clear:hover { background:var(--bg-hover); color:var(--text-primary); }
+.gh-search-clear:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
+
 /* Group header rows in the GitHub table */
 .gh-table tbody tr.gh-group-row,
 .gh-table tbody tr.gh-group-row:hover { background:color-mix(in oklch,var(--bg-base) 82%,var(--foreground) 18%); }


### PR DESCRIPTION
The top pick from the GitHub UX scan.

## Problem
The GitHub activity list filtered by **kind / org / repo** and sorted, but had **no keyword search** — the only list surface in the app without one (Board, Library, Schedules all have search). With 20+ items there was no way to jump to "that auth PR" by title.

## Fix
A search box in the toolbar (next to the existing filters) that filters rows by **title, repo, or number**, case-insensitive. Every whitespace term must match (so `auth pr` narrows progressively). A no-match query gets its own empty state; **Esc** clears.

## Implementation
- New pure **`github-search.ts`** (`githubItemMatchesQuery`) — unit-tested (title/repo/number, multi-term AND, case-insensitivity, missing-number).
- Folded into the existing `scoped` memo, so **sort and group-by respect it**.
- The row arrow-key nav is scoped to `tbody`, so the toolbar search input doesn't steal keys. Search box styled with the shared `--gh-control-h` token.

## Verification (real app, Playwright)
Mocked activity (5 items): `auth` → 1 matching PR, `coven-cli` → filters by repo, nonsense query → no-match empty state. `tsc` clean; full `test:app` (422 files) + `check:tests-wired` green; source-text assertions added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)