### PR TITLE
Enforce curated typography pairs

### DIFF
--- a/src/components/font-boot.test.ts
+++ b/src/components/font-boot.test.ts
@@ -12,6 +12,9 @@ assert.match(src, /"jetbrains-mono"/, "boot skips the mono default");
 assert.match(src, /setProperty\(\s*["']--font-sans["']/, "boot sets --font-sans");
 assert.match(src, /setProperty\(\s*["']--font-mono["']/, "boot sets --font-mono");
 assert.match(src, /\^\[a-z0-9-\]\+\$/, "boot validates id is kebab-case");
+assert.match(src, /APPROVED_FONT_PAIRS/, "boot gates saved fonts through approved font pairs");
+assert.match(src, /manrope-space-mono/, "boot includes curated pair ids");
+assert.match(src, /fontPairId/, "boot derives a pair id from saved slot ids");
 assert.ok(src.includes(SANS_FALLBACK), "inlined sans fallback matches catalog SANS_FALLBACK");
 assert.ok(src.includes(MONO_FALLBACK), "inlined mono fallback matches catalog MONO_FALLBACK");
 

--- a/src/components/settings-fonts.test.ts
+++ b/src/components/settings-fonts.test.ts
@@ -5,15 +5,19 @@ import { readFileSync } from "node:fs";
 const src = readFileSync(new URL("./settings-fonts.tsx", import.meta.url), "utf8");
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 
-assert.match(src, /FONT_OPTIONS/, "FontSettings reads FONT_OPTIONS");
-assert.match(src, /slot === "sans"/, "filters the sans slot");
-assert.match(src, /slot === "mono"/, "filters the mono slot");
+assert.match(src, /FONT_PAIRS/, "FontSettings reads curated FONT_PAIRS");
+assert.doesNotMatch(src, /SANS_OPTIONS/, "does not expose an independent sans picker");
+assert.doesNotMatch(src, /MONO_OPTIONS/, "does not expose an independent mono picker");
+assert.match(src, /readFontPairPref/, "loads the saved curated font pair");
+assert.match(src, /writeFontPairPref/, "persists font pairs as a unit");
+assert.match(src, /applyFontPair/, "applies font pairs as a unit");
 assert.match(src, /<select/, "renders selects");
-assert.match(src, /writeFontPref/, "persists the choice");
-assert.match(src, /applyFont/, "applies the choice live");
 assert.match(src, /fontStack\(/, "preview rendered with fontStack");
-assert.match(src, /DEFAULT_FONT_ID/, "reset targets the defaults");
+assert.match(src, /DEFAULT_FONT_PAIR_ID/, "reset targets the default pair");
 assert.match(src, /Reset/, "exposes a reset control");
+assert.match(src, /Typography pair/, "renders a single pair selector");
+assert.match(src, /Interface/, "keeps the interface preview");
+assert.match(src, /Code &amp; terminal/, "keeps the code and terminal preview");
 
 assert.match(shell, /import \{ FontSettings \} from "\.\/settings-fonts"/, "shell imports FontSettings");
 assert.match(shell, /<FontSettings\s*\/>/, "AppearanceSection renders <FontSettings />");
@@ -23,8 +27,8 @@ assert.match(shell, /<FontSettings\s*\/>/, "AppearanceSection renders <FontSetti
 // persisted selection after a reload — not just after a user change.
 assert.match(
   src,
-  /useEffect\(\(\) => \{[\s\S]*?applyFont\("sans"[\s\S]*?applyFont\("mono"[\s\S]*?\}, \[\]\)/,
-  "mount effect applies both saved fonts",
+  /useEffect\(\(\) => \{[\s\S]*?readFontPairPref\([\s\S]*?writeFontPairPref\([\s\S]*?applyFontPair\([\s\S]*?\}, \[\]\)/,
+  "mount effect normalizes and applies the saved font pair",
 );
 
 // Text size control (reframed Screen magnification) lives in Typography.

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -3,14 +3,14 @@
 import { type ReactNode, useEffect, useState } from "react";
 import { SettingsGroup } from "@/components/ui/settings-group";
 import {
-  DEFAULT_FONT_ID,
-  FONT_OPTIONS,
+  DEFAULT_FONT_PAIR_ID,
+  FONT_PAIRS,
+  fontPairById,
   fontOptionById,
   fontStack,
   type FontSlot,
-  type FontOption,
 } from "@/lib/font-catalog";
-import { applyFont, readFontPref, writeFontPref } from "@/lib/font-storage";
+import { applyFontPair, readFontPairPref, writeFontPairPref } from "@/lib/font-storage";
 import {
   DEFAULT_SCREEN_SCALE,
   SCREEN_SCALE_EVENT,
@@ -120,9 +120,6 @@ const ALIGN_LABEL: Record<ReadingAlign, string> = {
   justify: "Justify",
 };
 
-const SANS_OPTIONS = FONT_OPTIONS.filter((o) => o.slot === "sans");
-const MONO_OPTIONS = FONT_OPTIONS.filter((o) => o.slot === "mono");
-
 const PREVIEW: Record<FontSlot, string> = {
   sans: "The quick brown fox jumps over 0123",
   mono: "const x = 42; // 0123",
@@ -162,36 +159,20 @@ function ReadingRow({
   );
 }
 
-function FontField({
+function FontPreview({
   slot,
   label,
-  options,
-  value,
-  onChange,
+  fontId,
 }: {
   slot: FontSlot;
-  label: string;
-  options: FontOption[];
-  value: string;
-  onChange: (id: string) => void;
+  label: ReactNode;
+  fontId: string;
 }) {
-  const opt = fontOptionById(value) ?? fontOptionById(DEFAULT_FONT_ID[slot]);
+  const opt = fontOptionById(fontId);
   return (
     <div className="flex flex-col gap-1.5">
-      <label className="text-[12px] font-medium text-[var(--text-secondary)]">{label}</label>
-      <select
-        className="gh-select"
-        style={{ maxWidth: "260px" }}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        aria-label={`${label} font`}
-      >
-        {options.map((o) => (
-          <option key={o.id} value={o.id}>
-            {o.label}
-          </option>
-        ))}
-      </select>
+      <div className="text-[12px] font-medium text-[var(--text-secondary)]">{label}</div>
+      <div className="truncate text-[11px] text-[var(--text-muted)]">{opt?.label}</div>
       <p
         className="text-[15px] text-[var(--text-primary)] truncate"
         style={{ fontFamily: opt ? fontStack(opt) : undefined }}
@@ -203,8 +184,7 @@ function FontField({
 }
 
 export function FontSettings() {
-  const [sansId, setSansId] = useState<string>(DEFAULT_FONT_ID.sans);
-  const [monoId, setMonoId] = useState<string>(DEFAULT_FONT_ID.mono);
+  const [pairId, setPairId] = useState<string>(DEFAULT_FONT_PAIR_ID);
   const [scale, setScale] = useState<ScreenScale>(DEFAULT_SCREEN_SCALE);
   const [leading, setLeading] = useState<ReadingLeading>(DEFAULT_READING_LEADING);
   const [tracking, setTracking] = useState<ReadingTracking>(DEFAULT_READING_TRACKING);
@@ -218,12 +198,10 @@ export function FontSettings() {
   const dtPrefs = useDateTimePrefs();
 
   useEffect(() => {
-    const sans = readFontPref("sans");
-    const mono = readFontPref("mono");
-    setSansId(sans);
-    setMonoId(mono);
-    applyFont("sans", sans);
-    applyFont("mono", mono);
+    const pair = readFontPairPref();
+    setPairId(pair.id);
+    writeFontPairPref(pair.id);
+    applyFontPair(pair.id);
     // The mounted Screen/Reading controllers already applied these on load;
     // we only mirror them into local UI state.
     setScale(readScreenScale());
@@ -247,11 +225,11 @@ export function FontSettings() {
     return () => window.removeEventListener(SCREEN_SCALE_EVENT, onScaleChange);
   }, []);
 
-  const select = (slot: FontSlot, id: string) => {
-    if (slot === "sans") setSansId(id);
-    else setMonoId(id);
-    writeFontPref(slot, id);
-    applyFont(slot, id);
+  const selectPair = (id: string) => {
+    const pair = fontPairById(id) ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
+    setPairId(pair.id);
+    writeFontPairPref(pair.id);
+    applyFontPair(pair.id);
   };
 
   const setTextSize = (next: ScreenScale) => {
@@ -295,8 +273,7 @@ export function FontSettings() {
   };
 
   const reset = () => {
-    select("sans", DEFAULT_FONT_ID.sans);
-    select("mono", DEFAULT_FONT_ID.mono);
+    selectPair(DEFAULT_FONT_PAIR_ID);
     setTextSize(DEFAULT_SCREEN_SCALE);
     setLineSpacing(DEFAULT_READING_LEADING);
     setLetterSpacing(DEFAULT_READING_TRACKING);
@@ -308,8 +285,7 @@ export function FontSettings() {
   };
 
   const isDefault =
-    sansId === DEFAULT_FONT_ID.sans &&
-    monoId === DEFAULT_FONT_ID.mono &&
+    pairId === DEFAULT_FONT_PAIR_ID &&
     scale === DEFAULT_SCREEN_SCALE &&
     leading === DEFAULT_READING_LEADING &&
     tracking === DEFAULT_READING_TRACKING &&
@@ -318,6 +294,7 @@ export function FontSettings() {
     weight === DEFAULT_READING_WEIGHT &&
     hyphens === DEFAULT_READING_HYPHENS &&
     dropcap === DEFAULT_READING_DROPCAP;
+  const selectedPair = fontPairById(pairId) ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
 
   return (
     <section className="flex flex-col gap-5">
@@ -325,10 +302,29 @@ export function FontSettings() {
         label="Typography"
         description="Choose the interface and code fonts and how text is sized. Changes apply immediately."
       >
-        {/* Fonts — paired side by side, each with a live preview. */}
+        {/* Fonts — one approved pair selector, then read-only previews. */}
         <div className="grid grid-cols-1 gap-4 px-4 py-3 sm:grid-cols-2">
-          <FontField slot="sans" label="Interface" options={SANS_OPTIONS} value={sansId} onChange={(id) => select("sans", id)} />
-          <FontField slot="mono" label="Code &amp; terminal" options={MONO_OPTIONS} value={monoId} onChange={(id) => select("mono", id)} />
+          <div className="flex flex-col gap-1.5 sm:col-span-2">
+            <label className="text-[12px] font-medium text-[var(--text-secondary)]" htmlFor="typography-pair">
+              Typography pair
+            </label>
+            <select
+              id="typography-pair"
+              className="gh-select"
+              style={{ maxWidth: "360px" }}
+              value={pairId}
+              onChange={(e) => selectPair(e.target.value)}
+              aria-label="Typography pair"
+            >
+              {FONT_PAIRS.map((pair) => (
+                <option key={pair.id} value={pair.id}>
+                  {pair.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <FontPreview slot="sans" label="Interface" fontId={selectedPair.sansId} />
+          <FontPreview slot="mono" label={<>Code &amp; terminal</>} fontId={selectedPair.monoId} />
         </div>
 
         {/* Text size — the one control that scales the whole UI, not just prose. */}

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -11,8 +11,9 @@
  *  4. Always set BOTH `data-theme` and `data-mode` on <html>.
  *  5. If theme === "custom", apply `cssVars.theme` (mode-agnostic) +
  *     `cssVars[mode]` (mode-specific) from localStorage["coven-custom-theme"].
- *  6. Read localStorage["cave:font:sans"] / localStorage["cave:font:mono"] and
- *     apply --font-sans / --font-mono CSS vars for non-default selections.
+ *  6. Read localStorage["cave:font:sans"] / localStorage["cave:font:mono"],
+ *     accept only approved font pairs, and apply --font-sans / --font-mono CSS
+ *     vars for non-default selections.
  *
  * NOTE: The storage key strings ("coven-theme", "coven-mode",
  * "coven-custom-theme") and the legacy rename map are duplicated from
@@ -22,9 +23,10 @@
  * renames.
  *
  * NOTE: The font keys ("cave:font:sans", "cave:font:mono"), default ids
- * ("geist", "jetbrains-mono"), and the SANS_FALLBACK / MONO_FALLBACK strings
- * are duplicated from src/lib/font-catalog.ts and src/lib/font-storage.ts.
- * Keep in sync when adding new fonts or changing fallback chains.
+ * ("geist", "jetbrains-mono"), approved pairs, and the SANS_FALLBACK /
+ * MONO_FALLBACK strings are duplicated from src/lib/font-catalog.ts and
+ * src/lib/font-storage.ts. Keep in sync when adding new fonts, changing
+ * fallback chains, or editing pair choices.
  */
 
 const THEME_SCRIPT = `
@@ -73,15 +75,43 @@ const THEME_SCRIPT = `
     }
     // ── Fonts ── apply saved non-default families before paint (no flash).
     // Inlined from src/lib/font-catalog.ts (SANS_FALLBACK / MONO_FALLBACK) and
-    // src/lib/font-storage.ts (keys + stack shape) — keep in sync.
+    // src/lib/font-storage.ts (keys + approved pairs + stack shape) — keep in sync.
     var SANS_FB = 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
     var MONO_FB = 'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
-    var fontSansId = localStorage.getItem("cave:font:sans");
-    if (fontSansId && fontSansId !== "geist" && /^[a-z0-9-]+$/.test(fontSansId)) {
+    var fontSansId = localStorage.getItem("cave:font:sans") || "geist";
+    var fontMonoId = localStorage.getItem("cave:font:mono") || "jetbrains-mono";
+    var APPROVED_FONT_PAIRS = {
+      "geist-jetbrains": ["geist", "jetbrains-mono"],
+      "inter-geist-mono": ["inter", "geist-mono"],
+      "manrope-space-mono": ["manrope", "space-mono"],
+      "public-sans-roboto-mono": ["public-sans", "roboto-mono"],
+      "ibm-plex-pair": ["ibm-plex-sans", "ibm-plex-mono"],
+      "source-pair": ["source-sans-3", "source-code-pro"],
+      "dm-sans-fira-code": ["dm-sans", "fira-code"]
+    };
+    var fontPairId = null;
+    if (/^[a-z0-9-]+$/.test(fontSansId) && /^[a-z0-9-]+$/.test(fontMonoId)) {
+      for (var pairId in APPROVED_FONT_PAIRS) {
+        if (!Object.prototype.hasOwnProperty.call(APPROVED_FONT_PAIRS, pairId)) continue;
+        var pair = APPROVED_FONT_PAIRS[pairId];
+        if (pair[0] === fontSansId && pair[1] === fontMonoId) {
+          fontPairId = pairId;
+          break;
+        }
+      }
+    }
+    if (!fontPairId) {
+      fontSansId = "geist";
+      fontMonoId = "jetbrains-mono";
+      try {
+        localStorage.setItem("cave:font:sans", fontSansId);
+        localStorage.setItem("cave:font:mono", fontMonoId);
+      } catch (e) {}
+    }
+    if (fontSansId !== "geist") {
       try { html.style.setProperty("--font-sans", "var(--font-" + fontSansId + "), " + SANS_FB); } catch (e) {}
     }
-    var fontMonoId = localStorage.getItem("cave:font:mono");
-    if (fontMonoId && fontMonoId !== "jetbrains-mono" && /^[a-z0-9-]+$/.test(fontMonoId)) {
+    if (fontMonoId !== "jetbrains-mono") {
       try { html.style.setProperty("--font-mono", "var(--font-" + fontMonoId + "), " + MONO_FB); } catch (e) {}
     }
     // ── UI corner radius ── override the base radius tokens before paint so the

--- a/src/lib/font-catalog.ts
+++ b/src/lib/font-catalog.ts
@@ -15,6 +15,13 @@ export type FontOption = {
   cssVar: string;
 };
 
+export type FontPair = {
+  id: string;
+  label: string;
+  sansId: string;
+  monoId: string;
+};
+
 export const SANS_FALLBACK =
   'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
 export const MONO_FALLBACK =
@@ -54,8 +61,63 @@ export const DEFAULT_FONT_ID: Record<FontSlot, string> = {
   mono: "jetbrains-mono",
 };
 
+export const FONT_PAIRS: FontPair[] = [
+  {
+    id: "geist-jetbrains",
+    label: "Geist + JetBrains Mono",
+    sansId: "geist",
+    monoId: "jetbrains-mono",
+  },
+  {
+    id: "inter-geist-mono",
+    label: "Inter + Geist Mono",
+    sansId: "inter",
+    monoId: "geist-mono",
+  },
+  {
+    id: "manrope-space-mono",
+    label: "Manrope + Space Mono",
+    sansId: "manrope",
+    monoId: "space-mono",
+  },
+  {
+    id: "public-sans-roboto-mono",
+    label: "Public Sans + Roboto Mono",
+    sansId: "public-sans",
+    monoId: "roboto-mono",
+  },
+  {
+    id: "ibm-plex-pair",
+    label: "IBM Plex Sans + IBM Plex Mono",
+    sansId: "ibm-plex-sans",
+    monoId: "ibm-plex-mono",
+  },
+  {
+    id: "source-pair",
+    label: "Source Sans 3 + Source Code Pro",
+    sansId: "source-sans-3",
+    monoId: "source-code-pro",
+  },
+  {
+    id: "dm-sans-fira-code",
+    label: "DM Sans + Fira Code",
+    sansId: "dm-sans",
+    monoId: "fira-code",
+  },
+];
+
+export const DEFAULT_FONT_PAIR_ID = "geist-jetbrains";
+
 export function fontOptionById(id: string): FontOption | undefined {
   return FONT_OPTIONS.find((o) => o.id === id);
+}
+
+export function fontPairById(id: string): FontPair | undefined {
+  return FONT_PAIRS.find((pair) => pair.id === id);
+}
+
+export function fontPairForFonts(sansId: string, monoId: string): FontPair | undefined {
+  return FONT_PAIRS.find((pair) => pair.sansId === sansId && pair.monoId === monoId);
 }
 
 export function slotFallback(slot: FontSlot): string {

--- a/src/lib/font-settings.test.ts
+++ b/src/lib/font-settings.test.ts
@@ -2,9 +2,13 @@
 import assert from "node:assert/strict";
 import {
   FONT_OPTIONS,
+  FONT_PAIRS,
+  DEFAULT_FONT_PAIR_ID,
   DEFAULT_FONT_ID,
   SANS_FALLBACK,
   MONO_FALLBACK,
+  fontPairById,
+  fontPairForFonts,
   fontOptionById,
   fontStack,
 } from "./font-catalog.ts";
@@ -34,6 +38,27 @@ assert.equal(DEFAULT_FONT_ID.mono, "jetbrains-mono");
 assert.equal(fontOptionById("geist")?.cssVar, "--font-geist-sans");
 assert.equal(fontOptionById("geist-mono")?.cssVar, "--font-geist-mono");
 assert.equal(fontOptionById("nope"), undefined);
+
+// Font choices are curated pairs, not arbitrary sans/mono cross-products.
+assert.ok(FONT_PAIRS.length >= 5, "catalog exposes a useful set of curated font pairs");
+const pairIds = new Set(FONT_PAIRS.map((pair) => pair.id));
+assert.equal(pairIds.size, FONT_PAIRS.length, "font pair ids must be unique");
+for (const pair of FONT_PAIRS) {
+  assert.match(pair.id, /^[a-z0-9-]+$/, `pair id ${pair.id} must be kebab-case`);
+  assert.ok(pair.label.length > 0, `label for pair ${pair.id}`);
+  assert.equal(fontOptionById(pair.sansId)?.slot, "sans", `${pair.id} sans id must resolve to a sans font`);
+  assert.equal(fontOptionById(pair.monoId)?.slot, "mono", `${pair.id} mono id must resolve to a mono font`);
+}
+assert.equal(DEFAULT_FONT_PAIR_ID, "geist-jetbrains");
+assert.deepEqual(fontPairById(DEFAULT_FONT_PAIR_ID), {
+  id: "geist-jetbrains",
+  label: "Geist + JetBrains Mono",
+  sansId: DEFAULT_FONT_ID.sans,
+  monoId: DEFAULT_FONT_ID.mono,
+});
+assert.equal(fontPairForFonts(DEFAULT_FONT_ID.sans, DEFAULT_FONT_ID.mono)?.id, DEFAULT_FONT_PAIR_ID);
+assert.equal(fontPairForFonts("manrope", "space-mono")?.id, "manrope-space-mono");
+assert.equal(fontPairForFonts("manrope", "jetbrains-mono"), undefined, "unapproved mixes are not accepted");
 
 // Stacks chain the font var onto the slot fallback.
 assert.equal(

--- a/src/lib/font-storage.test.ts
+++ b/src/lib/font-storage.test.ts
@@ -8,6 +8,9 @@ import {
   readFontPref,
   writeFontPref,
   applyFont,
+  readFontPairPref,
+  writeFontPairPref,
+  applyFontPair,
 } from "./font-storage.ts";
 
 function setupDom() {
@@ -71,4 +74,30 @@ test("mono slot uses the mono key and --font-mono var", () => {
   applyFont("mono", "geist-mono");
   assert.equal(readFontPref("mono"), "geist-mono");
   assert.equal(props.get("--font-mono"), fontStack(fontOptionById("geist-mono")));
+});
+
+test("readFontPairPref accepts only curated sans/mono pairs", () => {
+  const { store } = setupDom();
+  store.set(FONT_SANS_KEY, "manrope");
+  store.set(FONT_MONO_KEY, "space-mono");
+  assert.equal(readFontPairPref().id, "manrope-space-mono");
+
+  store.set(FONT_MONO_KEY, "jetbrains-mono");
+  assert.equal(readFontPairPref().id, "geist-jetbrains");
+});
+
+test("writeFontPairPref stores both paired slots together", () => {
+  setupDom();
+  writeFontPairPref("manrope-space-mono");
+  assert.equal(readFontPref("sans"), "manrope");
+  assert.equal(readFontPref("mono"), "space-mono");
+  assert.equal(globalThis.window.localStorage.getItem(FONT_SANS_KEY), "manrope");
+  assert.equal(globalThis.window.localStorage.getItem(FONT_MONO_KEY), "space-mono");
+});
+
+test("applyFontPair applies the curated sans and mono stacks together", () => {
+  const { props } = setupDom();
+  applyFontPair("manrope-space-mono");
+  assert.equal(props.get("--font-sans"), fontStack(fontOptionById("manrope")));
+  assert.equal(props.get("--font-mono"), fontStack(fontOptionById("space-mono")));
 });

--- a/src/lib/font-storage.ts
+++ b/src/lib/font-storage.ts
@@ -11,9 +11,13 @@
  * the key strings and the stack shape in sync with this file.
  */
 import {
+  DEFAULT_FONT_PAIR_ID,
   DEFAULT_FONT_ID,
+  fontPairById,
+  fontPairForFonts,
   fontOptionById,
   fontStack,
+  type FontPair,
   type FontSlot,
 } from "./font-catalog.ts";
 
@@ -54,6 +58,17 @@ export function writeFontPref(slot: FontSlot, id: string): void {
   }
 }
 
+export function readFontPairPref(): FontPair {
+  const pair = fontPairForFonts(readFontPref("sans"), readFontPref("mono"));
+  return pair ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
+}
+
+export function writeFontPairPref(id: string): void {
+  const pair = fontPairById(id) ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
+  writeFontPref("sans", pair.sansId);
+  writeFontPref("mono", pair.monoId);
+}
+
 /** Point the slot's CSS var at the chosen family's stack. The default id (or an
  *  unknown id) removes the override so the :root Geist alias applies. */
 export function applyFont(slot: FontSlot, id: string): void {
@@ -66,4 +81,10 @@ export function applyFont(slot: FontSlot, id: string): void {
     return;
   }
   root.style.setProperty(cssVar, fontStack(opt));
+}
+
+export function applyFontPair(id: string): void {
+  const pair = fontPairById(id) ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
+  applyFont("sans", pair.sansId);
+  applyFont("mono", pair.monoId);
 }


### PR DESCRIPTION
## Summary
- replace independent typography font dropdowns with one curated pair selector
- add approved font pair catalog helpers and pair-level storage/apply helpers
- gate the pre-paint font boot script through approved pairs and reset invalid mixes

## Verification
- node --experimental-strip-types src/lib/font-settings.test.ts && node --experimental-strip-types src/lib/font-storage.test.ts && node --experimental-strip-types src/components/settings-fonts.test.ts && node --experimental-strip-types src/components/font-boot.test.ts
- node --experimental-strip-types src/components/settings-appearance.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:app
- git diff --check --cached && git diff --check