### PR TITLE
feat(marketplace): expand MCP catalog to 44 plugins across 13 categories

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -476,6 +476,933 @@
         "useCases": ["Convert time zones", "Resolve today/tomorrow/yesterday", "Prepare dated status updates"],
         "guardrails": ["Use absolute dates when the user may be confused", "Preserve the user's timezone preference", "Do not schedule external events without approval"]
       }
+    },
+    {
+      "name": "serena",
+      "displayName": "Serena",
+      "version": "0.1.0",
+      "description": "Semantic code retrieval and editing toolkit purpose-built for coding agents and harnesses.",
+      "category": "Agents & Harnesses",
+      "keywords": ["coding-agent", "semantic-code", "lsp", "refactor", "harness"],
+      "capabilities": ["read_files", "write_files", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/oraios/serena", "https://github.com/mcp-use/mcp-use"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "serena": {
+          "command": "uvx",
+          "args": ["--from", "git+https://github.com/oraios/serena", "serena", "start-mcp-server", "--context", "ide-assistant"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "code-reviewer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher", "librarian"]}
+      ],
+      "skill": {
+        "description": "Use Serena for symbol-level code navigation and edits instead of dumping whole files into context.",
+        "useCases": ["Find symbols and references", "Plan precise multi-file edits", "Read project structure semantically"],
+        "guardrails": ["Confirm the project root before indexing", "Do not apply edits without approval", "Prefer targeted symbol reads over whole-file dumps"]
+      }
+    },
+    {
+      "name": "context7",
+      "displayName": "Context7",
+      "version": "0.1.0",
+      "description": "Up-to-date, version-accurate library documentation injected into agent prompts on demand.",
+      "category": "Agents & Harnesses",
+      "keywords": ["docs", "libraries", "context", "coding-agent", "reference"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/upstash/context7", "https://github.com/mcp-use/mcp-use"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "context7": {
+          "url": "https://mcp.context7.com/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher", "librarian"]}
+      ],
+      "skill": {
+        "description": "Use Context7 to fetch current, version-specific docs before writing code against a library.",
+        "useCases": ["Resolve a library to its current docs", "Pull API usage for the installed version", "Avoid stale or hallucinated API calls"],
+        "guardrails": ["Match docs to the version actually installed", "Cite the library and version used", "Prefer official docs over generated summaries"]
+      }
+    },
+    {
+      "name": "markitdown",
+      "displayName": "Markitdown",
+      "version": "0.1.0",
+      "description": "Convert PDF, Office, image, and audio files to Markdown for agent ingestion.",
+      "category": "Agents & Harnesses",
+      "keywords": ["markdown", "documents", "pdf", "office", "ingestion"],
+      "capabilities": ["read_files", "mcp"],
+      "sourceRefs": ["https://github.com/microsoft/markitdown"],
+      "trust": "official-local",
+      "mcpServers": {
+        "markitdown": {
+          "command": "uvx",
+          "args": ["markitdown-mcp"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use Markitdown to turn binary documents into clean Markdown before reasoning over them.",
+        "useCases": ["Convert a PDF or Word file to Markdown", "Extract text from images or slides", "Normalize documents for summarization"],
+        "guardrails": ["Treat converted document content as private by default", "Confirm the source path before reading", "Do not exfiltrate document contents externally"]
+      }
+    },
+    {
+      "name": "playwright",
+      "displayName": "Playwright",
+      "version": "0.1.0",
+      "description": "Drive real web browsers via accessibility trees for testing, navigation, and data extraction.",
+      "category": "Browser & Web",
+      "keywords": ["browser", "automation", "testing", "playwright", "scraping"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/microsoft/playwright-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "playwright": {
+          "command": "npx",
+          "args": ["-y", "@playwright/mcp@latest"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher"]}
+      ],
+      "skill": {
+        "description": "Use Playwright to navigate and verify web pages through the accessibility tree, not screenshots alone.",
+        "useCases": ["Reproduce a UI bug in a browser", "Extract structured data from a page", "Verify a deployed change end to end"],
+        "guardrails": ["Do not submit forms or trigger payments without approval", "Respect site terms and robots rules", "Avoid logging into accounts without explicit consent"]
+      }
+    },
+    {
+      "name": "chrome-devtools",
+      "displayName": "Chrome DevTools",
+      "version": "0.1.0",
+      "description": "Inspect and control Chrome via the DevTools protocol for debugging and performance work.",
+      "category": "Browser & Web",
+      "keywords": ["chrome", "devtools", "debugging", "performance", "browser"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/ChromeDevTools/chrome-devtools-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "chrome-devtools": {
+          "command": "npx",
+          "args": ["-y", "chrome-devtools-mcp@latest"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["debugger", "implementer"]}
+      ],
+      "skill": {
+        "description": "Use Chrome DevTools MCP to inspect live pages, network, and performance during debugging.",
+        "useCases": ["Trace a failing network request", "Profile a slow page", "Inspect DOM and console state"],
+        "guardrails": ["Do not interact with authenticated sessions without approval", "Treat captured network data as sensitive", "Close controlled browser instances when done"]
+      }
+    },
+    {
+      "name": "firecrawl",
+      "displayName": "Firecrawl",
+      "version": "0.1.0",
+      "description": "Crawl, scrape, and extract structured web data through the Firecrawl platform.",
+      "category": "Browser & Web",
+      "keywords": ["scraping", "crawl", "web", "extract", "research"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/firecrawl/firecrawl-mcp-server"],
+      "trust": "official-local",
+      "mcpServers": {
+        "firecrawl": {
+          "command": "npx",
+          "args": ["-y", "firecrawl-mcp"],
+          "type": "stdio",
+          "env": {
+            "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+          }
+        }
+      },
+      "userConfig": {
+        "firecrawl_api_key": {
+          "type": "string",
+          "title": "Firecrawl API Key",
+          "description": "API key for the Firecrawl scraping platform.",
+          "required": true,
+          "sensitive": true,
+          "env": "FIRECRAWL_API_KEY"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "charm", "roles": ["copywriter", "devrel-liaison"]}
+      ],
+      "skill": {
+        "description": "Use Firecrawl for bounded, structured web extraction with primary-source preference.",
+        "useCases": ["Scrape a documentation site", "Extract structured fields from pages", "Gather cited research sources"],
+        "guardrails": ["Respect site terms and rate limits", "Do not over-quote copyrighted text", "Record source URLs in summaries"]
+      }
+    },
+    {
+      "name": "tavily",
+      "displayName": "Tavily",
+      "version": "0.1.0",
+      "description": "Advanced web search and answer extraction tuned for AI agents.",
+      "category": "Browser & Web",
+      "keywords": ["search", "web", "research", "answers", "tavily"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/tavily-ai/tavily-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "tavily": {
+          "command": "npx",
+          "args": ["-y", "tavily-mcp@latest"],
+          "type": "stdio",
+          "env": {
+            "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+          }
+        }
+      },
+      "userConfig": {
+        "tavily_api_key": {
+          "type": "string",
+          "title": "Tavily API Key",
+          "description": "API key for the Tavily search API.",
+          "required": true,
+          "sensitive": true,
+          "env": "TAVILY_API_KEY"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Tavily for fast, agent-friendly web search with concise sourced answers.",
+        "useCases": ["Answer a current-events question", "Find primary sources fast", "Gather citations for synthesis"],
+        "guardrails": ["Prefer primary sources", "Record URLs used", "Flag uncertainty when sources conflict"]
+      }
+    },
+    {
+      "name": "brightdata",
+      "displayName": "Bright Data",
+      "version": "0.1.0",
+      "description": "Search, extract, and navigate the public web at scale through Bright Data's Web MCP.",
+      "category": "Browser & Web",
+      "keywords": ["scraping", "web-data", "proxy", "extract", "search"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/brightdata/brightdata-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "brightdata": {
+          "command": "npx",
+          "args": ["-y", "@brightdata/mcp"],
+          "type": "stdio",
+          "env": {
+            "API_TOKEN": "${BRIGHTDATA_API_TOKEN}"
+          }
+        }
+      },
+      "userConfig": {
+        "brightdata_api_token": {
+          "type": "string",
+          "title": "Bright Data API Token",
+          "description": "API token for the Bright Data Web MCP.",
+          "required": true,
+          "sensitive": true,
+          "env": "BRIGHTDATA_API_TOKEN"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Bright Data for resilient large-scale web extraction with respect for source policies.",
+        "useCases": ["Search and extract web data", "Navigate sites that block naive scrapers", "Collect market or competitive data"],
+        "guardrails": ["Respect site terms and legal limits", "Do not collect personal data without basis", "Record sources and extraction scope"]
+      }
+    },
+    {
+      "name": "apify",
+      "displayName": "Apify",
+      "version": "0.1.0",
+      "description": "Run thousands of scrapers, crawlers, and automations from the Apify Store over MCP.",
+      "category": "Browser & Web",
+      "keywords": ["actors", "scraping", "automation", "apify", "store"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/apify/actors-mcp-server"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "apify": {
+          "url": "https://mcp.apify.com",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Apify Actors for prebuilt scraping and automation tasks instead of hand-rolling crawlers.",
+        "useCases": ["Run a Store actor to extract data", "Automate a repetitive web task", "Collect structured datasets"],
+        "guardrails": ["Confirm actor cost and scope before running", "Respect target site terms", "Do not run actors that mutate external state without approval"]
+      }
+    },
+    {
+      "name": "searxng",
+      "displayName": "SearXNG Search",
+      "version": "0.1.0",
+      "description": "Privacy-respecting metasearch with pagination and URL reading through a SearXNG instance.",
+      "category": "Browser & Web",
+      "keywords": ["search", "privacy", "metasearch", "searxng", "web"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/ihor-sokoliuk/mcp-searxng"],
+      "trust": "local-tool",
+      "mcpServers": {
+        "searxng": {
+          "command": "npx",
+          "args": ["-y", "mcp-searxng"],
+          "type": "stdio",
+          "env": {
+            "SEARXNG_URL": "${SEARXNG_URL}"
+          }
+        }
+      },
+      "userConfig": {
+        "searxng_url": {
+          "type": "string",
+          "title": "SearXNG Instance URL",
+          "description": "Base URL of the SearXNG instance to query.",
+          "required": true,
+          "sensitive": false,
+          "env": "SEARXNG_URL"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]}
+      ],
+      "skill": {
+        "description": "Use SearXNG for privacy-respecting web search against a self-chosen instance.",
+        "useCases": ["Search without tracking", "Page through results", "Read a result URL's content"],
+        "guardrails": ["Use a trusted SearXNG instance", "Record source URLs", "Prefer primary sources"]
+      }
+    },
+    {
+      "name": "dbhub",
+      "displayName": "DBHub",
+      "version": "0.1.0",
+      "description": "Token-efficient universal database MCP for PostgreSQL, MySQL, SQL Server, SQLite, and MariaDB.",
+      "category": "Databases",
+      "keywords": ["database", "sql", "postgres", "mysql", "sqlite"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/bytebase/dbhub"],
+      "trust": "official-local",
+      "mcpServers": {
+        "dbhub": {
+          "command": "npx",
+          "args": ["-y", "@bytebase/dbhub", "--transport", "stdio", "--dsn", "${DBHUB_DSN}"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "dbhub_dsn": {
+          "type": "string",
+          "title": "Database DSN",
+          "description": "Connection string for the target database (e.g. postgres://user:pass@host:5432/db).",
+          "required": true,
+          "sensitive": true,
+          "env": "DBHUB_DSN"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher"]}
+      ],
+      "skill": {
+        "description": "Use DBHub for read-first database inspection with intentional, approved writes.",
+        "useCases": ["Inspect schema", "Run read-only queries", "Prepare migrations for review"],
+        "guardrails": ["Default to read-only; confirm before any write or DDL", "Never expose credentials from the DSN", "Scope queries to the smallest dataset needed"]
+      }
+    },
+    {
+      "name": "supabase",
+      "displayName": "Supabase",
+      "version": "0.1.0",
+      "description": "Manage and query Supabase projects — database, auth, storage, and edge functions.",
+      "category": "Databases",
+      "keywords": ["supabase", "postgres", "backend", "auth", "storage"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/supabase-community/supabase-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "supabase": {
+          "command": "npx",
+          "args": ["-y", "@supabase/mcp-server-supabase@latest"],
+          "type": "stdio",
+          "env": {
+            "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+          }
+        }
+      },
+      "userConfig": {
+        "supabase_access_token": {
+          "type": "string",
+          "title": "Supabase Access Token",
+          "description": "Personal access token for the Supabase Management API.",
+          "required": true,
+          "sensitive": true,
+          "env": "SUPABASE_ACCESS_TOKEN"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Supabase MCP for project inspection and approved changes, preferring read-only first.",
+        "useCases": ["Inspect tables and policies", "Run read-only queries", "Prepare schema or function changes for review"],
+        "guardrails": ["Prefer read-only mode; confirm writes and migrations", "Scope to a single project", "Never reveal the access token"]
+      }
+    },
+    {
+      "name": "mongodb",
+      "displayName": "MongoDB",
+      "version": "0.1.0",
+      "description": "Inspect and query MongoDB databases and collections through the official MCP server.",
+      "category": "Databases",
+      "keywords": ["mongodb", "database", "nosql", "collections", "query"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/mongodb-js/mongodb-mcp-server"],
+      "trust": "official-local",
+      "mcpServers": {
+        "mongodb": {
+          "command": "npx",
+          "args": ["-y", "mongodb-mcp-server"],
+          "type": "stdio",
+          "env": {
+            "MDB_MCP_CONNECTION_STRING": "${MDB_MCP_CONNECTION_STRING}"
+          }
+        }
+      },
+      "userConfig": {
+        "mongodb_connection_string": {
+          "type": "string",
+          "title": "MongoDB Connection String",
+          "description": "Connection string for the target MongoDB deployment.",
+          "required": true,
+          "sensitive": true,
+          "env": "MDB_MCP_CONNECTION_STRING"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "sage", "roles": ["researcher"]}
+      ],
+      "skill": {
+        "description": "Use MongoDB MCP for read-first data inspection with approved, scoped writes.",
+        "useCases": ["List collections and indexes", "Run read-only find/aggregate queries", "Prepare data changes for review"],
+        "guardrails": ["Default to read-only; confirm writes and deletes", "Never reveal the connection string", "Scope queries to the smallest dataset needed"]
+      }
+    },
+    {
+      "name": "azure",
+      "displayName": "Azure MCP Server",
+      "version": "0.1.0",
+      "description": "Connect agents to Azure services across storage, databases, monitoring, and more.",
+      "category": "Cloud & Infrastructure",
+      "keywords": ["azure", "cloud", "infrastructure", "microsoft", "devops"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/Azure/azure-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "azure": {
+          "command": "npx",
+          "args": ["-y", "@azure/mcp@latest", "server", "start"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]}
+      ],
+      "skill": {
+        "description": "Use Azure MCP for cloud resource inspection and approved operations via your signed-in Azure context.",
+        "useCases": ["List resources and configs", "Read logs and metrics", "Prepare infrastructure changes for review"],
+        "guardrails": ["Do not provision, delete, or change resources without approval", "Treat resource configs as sensitive", "Prefer scoped, subscription-aware queries"]
+      }
+    },
+    {
+      "name": "azure-devops",
+      "displayName": "Azure DevOps",
+      "version": "0.1.0",
+      "description": "Work with Azure DevOps repos, work items, builds, releases, test plans, and code search.",
+      "category": "Cloud & Infrastructure",
+      "keywords": ["azure-devops", "work-items", "pipelines", "repos", "boards"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/microsoft/azure-devops-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "azure-devops": {
+          "command": "npx",
+          "args": ["-y", "@azure-devops/mcp", "${AZURE_DEVOPS_ORG}"],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "azure_devops_org": {
+          "type": "string",
+          "title": "Azure DevOps Organization",
+          "description": "Azure DevOps organization name the MCP server should target.",
+          "required": true,
+          "sensitive": false,
+          "env": "AZURE_DEVOPS_ORG"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "code-reviewer"]},
+        {"familiar": "astra", "roles": ["coordination-layer"]}
+      ],
+      "skill": {
+        "description": "Use Azure DevOps MCP for planning and review context without silently changing work state.",
+        "useCases": ["Read work items and pipelines", "Summarize build or release status", "Draft work-item updates"],
+        "guardrails": ["Do not create, complete, or reassign work without approval", "Keep status reports dated and concrete", "Respect project-level access boundaries"]
+      }
+    },
+    {
+      "name": "terraform",
+      "displayName": "Terraform",
+      "version": "0.1.0",
+      "description": "Generate accurate Terraform and automate HCP Terraform and Terraform Enterprise workflows.",
+      "category": "Cloud & Infrastructure",
+      "keywords": ["terraform", "iac", "hashicorp", "infrastructure", "providers"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/hashicorp/terraform-mcp-server"],
+      "trust": "official-local",
+      "mcpServers": {
+        "terraform": {
+          "command": "docker",
+          "args": ["run", "-i", "--rm", "hashicorp/terraform-mcp-server"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Terraform MCP for provider-accurate IaC authoring and read-first workspace inspection.",
+        "useCases": ["Look up provider/resource schemas", "Draft accurate Terraform config", "Inspect workspace and run status"],
+        "guardrails": ["Do not apply, destroy, or change state without approval", "Treat state and variables as sensitive", "Show plans before any apply"]
+      }
+    },
+    {
+      "name": "notion",
+      "displayName": "Notion",
+      "version": "0.1.0",
+      "description": "Read, search, and draft Notion pages and databases through Notion's official MCP server.",
+      "category": "Productivity",
+      "keywords": ["notion", "docs", "wiki", "knowledge-base", "notes"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/makenotion/notion-mcp-server", "https://developers.notion.com/docs/mcp"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "notion": {
+          "url": "https://mcp.notion.com/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "echo", "roles": ["archivist"]},
+        {"familiar": "charm", "roles": ["copywriter"]},
+        {"familiar": "astra", "roles": ["coordination-layer"]}
+      ],
+      "skill": {
+        "description": "Use Notion for knowledge lookup and drafting while keeping page edits behind approval.",
+        "useCases": ["Search the workspace", "Summarize pages and databases", "Draft new content for review"],
+        "guardrails": ["Do not create, edit, or move pages without approval", "Respect workspace permissions", "Keep private content private by default"]
+      }
+    },
+    {
+      "name": "atlassian",
+      "displayName": "Atlassian Rovo",
+      "version": "0.1.0",
+      "description": "Search, create, and manage Jira, Confluence, and Compass work via Atlassian's official MCP.",
+      "category": "Project Management",
+      "keywords": ["jira", "confluence", "atlassian", "issues", "wiki"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/atlassian/atlassian-mcp-server", "https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassian-remote-mcp-server/"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "atlassian": {
+          "url": "https://mcp.atlassian.com/v1/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "cody", "roles": ["implementer"]},
+        {"familiar": "echo", "roles": ["archivist"]}
+      ],
+      "skill": {
+        "description": "Use Atlassian Rovo for Jira/Confluence context while keeping writes intentional and approved.",
+        "useCases": ["Read issues and pages", "Summarize project status", "Draft issue or page updates"],
+        "guardrails": ["Do not create, transition, or comment without approval", "Keep status reports dated and concrete", "Respect space and project permissions"]
+      }
+    },
+    {
+      "name": "figma",
+      "displayName": "Figma",
+      "version": "0.1.0",
+      "description": "Bring Figma design context — frames, components, and variables — into agent workflows.",
+      "category": "Design",
+      "keywords": ["figma", "design", "components", "dev-mode", "ui"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "figma": {
+          "url": "https://mcp.figma.com/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer"]},
+        {"familiar": "charm", "roles": ["copywriter", "social-voice"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Figma MCP to pull design context and specs into implementation without guessing values.",
+        "useCases": ["Read frame and component structure", "Pull spacing, color, and type tokens", "Translate a design into code"],
+        "guardrails": ["Do not edit or publish designs without approval", "Respect file and team permissions", "Confirm the target node before extracting"]
+      }
+    },
+    {
+      "name": "stripe",
+      "displayName": "Stripe",
+      "version": "0.1.0",
+      "description": "Work with Stripe customers, products, payments, and billing through the official MCP server.",
+      "category": "Commerce",
+      "keywords": ["stripe", "payments", "billing", "customers", "subscriptions"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/stripe/agent-toolkit", "https://docs.stripe.com/mcp"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "stripe": {
+          "url": "https://mcp.stripe.com",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]},
+        {"familiar": "astra", "roles": ["strategic-navigator"]}
+      ],
+      "skill": {
+        "description": "Use Stripe MCP for read-first billing inspection; treat money-moving actions as approval-gated.",
+        "useCases": ["Look up customers and subscriptions", "Inspect payments and invoices", "Draft product or price changes for review"],
+        "guardrails": ["Never create charges, refunds, or payouts without explicit approval", "Treat financial and PII data as highly sensitive", "Prefer test mode until production is approved"]
+      }
+    },
+    {
+      "name": "microsoft-learn",
+      "displayName": "Microsoft Learn",
+      "version": "0.1.0",
+      "description": "Pull trusted Microsoft Learn documentation directly into agent workflows.",
+      "category": "Knowledge & Docs",
+      "keywords": ["docs", "microsoft", "learn", "reference", "azure"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://learn.microsoft.com/en-us/training/support/mcp", "https://github.com/MicrosoftDocs/mcp"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "microsoft-learn": {
+          "url": "https://learn.microsoft.com/api/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "sage", "roles": ["researcher", "librarian"]},
+        {"familiar": "cody", "roles": ["implementer"]}
+      ],
+      "skill": {
+        "description": "Use Microsoft Learn MCP for authoritative, current Microsoft/Azure documentation.",
+        "useCases": ["Look up Azure or .NET docs", "Confirm current API guidance", "Cite official Microsoft sources"],
+        "guardrails": ["Prefer official docs over generated summaries", "Cite the page used", "Match guidance to the relevant product version"]
+      }
+    },
+    {
+      "name": "activepieces",
+      "displayName": "Activepieces",
+      "version": "0.1.0",
+      "description": "Reach 280+ open-source integrations (\"pieces\") as tools through a self-hosted Activepieces MCP server.",
+      "category": "Automation",
+      "keywords": ["automation", "workflows", "integrations", "zapier-alternative", "no-code"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/activepieces/activepieces", "https://www.activepieces.com/docs/mcp/overview"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "activepieces": {
+          "url": "${ACTIVEPIECES_MCP_URL}",
+          "type": "sse"
+        }
+      },
+      "userConfig": {
+        "activepieces_mcp_url": {
+          "type": "string",
+          "title": "Activepieces MCP URL",
+          "description": "Per-project MCP server URL (with token) from your Activepieces instance.",
+          "required": true,
+          "sensitive": true,
+          "env": "ACTIVEPIECES_MCP_URL"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator", "coordination-layer"]},
+        {"familiar": "charm", "roles": ["devrel-liaison"]},
+        {"familiar": "kitty", "roles": ["general-helper"]}
+      ],
+      "skill": {
+        "description": "Use Activepieces to invoke prebuilt integrations and flows instead of wiring each API by hand.",
+        "useCases": ["Trigger an automation flow", "Use a Store piece as a tool", "Connect SaaS apps through one MCP endpoint"],
+        "guardrails": ["Confirm scope and side effects before running a flow", "Do not move data between systems without approval", "Keep the tokenized MCP URL secret"]
+      }
+    },
+    {
+      "name": "desktop-commander",
+      "displayName": "Desktop Commander",
+      "version": "0.1.0",
+      "description": "Terminal commands, file operations, and process management on the local machine over MCP.",
+      "category": "Developer Tools",
+      "keywords": ["terminal", "shell", "files", "process", "local"],
+      "capabilities": ["read_files", "write_files", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/wonderwhy-er/DesktopCommanderMCP"],
+      "trust": "local-tool",
+      "mcpServers": {
+        "desktop-commander": {
+          "command": "npx",
+          "args": ["-y", "@wonderwhy-er/desktop-commander@latest"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]}
+      ],
+      "skill": {
+        "description": "Use Desktop Commander for local shell and file work with explicit, narrow intent.",
+        "useCases": ["Run scoped local commands", "Edit or move local files", "Inspect running processes"],
+        "guardrails": ["Confirm before destructive commands or deletes", "Use the narrowest path scope", "Never run commands that exfiltrate secrets"]
+      }
+    },
+    {
+      "name": "netdata",
+      "displayName": "Netdata",
+      "version": "0.1.0",
+      "description": "Real-time infrastructure metrics, logs, alerts, and anomaly detection for AI troubleshooting.",
+      "category": "Cloud & Infrastructure",
+      "keywords": ["monitoring", "metrics", "observability", "logs", "alerts"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://learn.netdata.cloud/docs/netdata-ai/mcp"],
+      "trust": "official-remote",
+      "mcpServers": {
+        "netdata": {
+          "url": "${NETDATA_MCP_URL}",
+          "type": "http"
+        }
+      },
+      "userConfig": {
+        "netdata_mcp_url": {
+          "type": "string",
+          "title": "Netdata MCP URL",
+          "description": "MCP endpoint of your Netdata agent (e.g. http://localhost:19999/mcp). Requires Netdata v2.6.0+.",
+          "required": true,
+          "sensitive": false,
+          "env": "NETDATA_MCP_URL"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["debugger"]},
+        {"familiar": "astra", "roles": ["coordination-layer"]}
+      ],
+      "skill": {
+        "description": "Use Netdata to investigate live infrastructure health before drawing conclusions about incidents.",
+        "useCases": ["Inspect real-time metrics", "Correlate alerts with logs", "Spot anomalies during an incident"],
+        "guardrails": ["Treat telemetry as sensitive", "Do not change agent config without approval", "Cite the time window and node inspected"]
+      }
+    },
+    {
+      "name": "fabric",
+      "displayName": "Microsoft Fabric",
+      "version": "0.1.0",
+      "description": "Microsoft Fabric REST/OpenAPI context for AI-assisted Fabric development, served locally.",
+      "category": "Cloud & Infrastructure",
+      "keywords": ["fabric", "microsoft", "data", "analytics", "openapi"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"],
+      "trust": "official-local",
+      "mcpServers": {
+        "fabric": {
+          "command": "npx",
+          "args": ["-y", "@microsoft/fabric-mcp@latest", "server", "start", "--mode", "all"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer"]},
+        {"familiar": "sage", "roles": ["researcher"]}
+      ],
+      "skill": {
+        "description": "Use Microsoft Fabric MCP for accurate Fabric API context when building against the platform.",
+        "useCases": ["Look up Fabric REST API shapes", "Draft Fabric automation accurately", "Confirm current Fabric capabilities"],
+        "guardrails": ["Do not change Fabric workspaces without approval", "Treat workspace data as sensitive", "Prefer official API context over guesses"]
+      }
+    },
+    {
+      "name": "unity",
+      "displayName": "Unity",
+      "version": "0.1.0",
+      "description": "Bridge AI assistants to the Unity Editor — assets, scenes, scripts, and task automation.",
+      "category": "Developer Tools",
+      "keywords": ["unity", "game-dev", "editor", "assets", "scenes"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/CoplayDev/unity-mcp"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "unity": {
+          "command": "uvx",
+          "args": ["--from", "mcpforunityserver", "mcp-for-unity", "--transport", "stdio"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]}
+      ],
+      "skill": {
+        "description": "Use the Unity MCP bridge to inspect and modify a running Unity project with explicit intent.",
+        "useCases": ["Inspect scene and asset structure", "Apply approved editor changes", "Automate repetitive editor tasks"],
+        "guardrails": ["Confirm a running Editor and correct project before acting", "Do not delete assets without approval", "Keep edits scoped to the current task"]
+      }
+    },
+    {
+      "name": "nuget",
+      "displayName": "NuGet",
+      "version": "0.1.0",
+      "description": "Real-time NuGet package info, vulnerability remediation, and upgrade planning for .NET.",
+      "category": "Developer Tools",
+      "keywords": ["nuget", "dotnet", "packages", "dependencies", "security"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://learn.microsoft.com/en-us/nuget/concepts/nuget-mcp-server"],
+      "trust": "official-local",
+      "mcpServers": {
+        "nuget": {
+          "command": "dnx",
+          "args": ["NuGet.Mcp.Server", "--source", "https://api.nuget.org/v3/index.json", "--yes"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "code-reviewer"]}
+      ],
+      "skill": {
+        "description": "Use NuGet MCP for current package versions and vulnerability-aware dependency choices.",
+        "useCases": ["Check latest package versions", "Plan dependency upgrades", "Review packages for known vulnerabilities"],
+        "guardrails": ["Confirm before changing project dependencies", "Prefer fixed, current versions", "Flag supply-chain risks explicitly"]
+      }
+    },
+    {
+      "name": "nuxt-dev",
+      "displayName": "Nuxt Dev",
+      "version": "0.1.0",
+      "description": "Lets models understand your running Vite/Nuxt app via an MCP endpoint on the dev server.",
+      "category": "Developer Tools",
+      "keywords": ["nuxt", "vite", "frontend", "dev-server", "vue"],
+      "capabilities": ["network", "mcp"],
+      "sourceRefs": ["https://github.com/antfu/nuxt-mcp-dev"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "nuxt-dev": {
+          "url": "${NUXT_MCP_URL}",
+          "type": "sse"
+        }
+      },
+      "userConfig": {
+        "nuxt_mcp_url": {
+          "type": "string",
+          "title": "Nuxt Dev MCP URL",
+          "description": "SSE endpoint exposed by the nuxt-mcp-dev module or vite-plugin-mcp (e.g. http://localhost:3000/__mcp/sse).",
+          "required": true,
+          "sensitive": false,
+          "env": "NUXT_MCP_URL"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]}
+      ],
+      "skill": {
+        "description": "Use Nuxt Dev MCP to ground frontend work in your actual running app structure.",
+        "useCases": ["Inspect app routes and components", "Understand local project structure", "Debug a running Nuxt/Vite app"],
+        "guardrails": ["Requires the dev-server MCP plugin to be enabled", "Treat the endpoint as local-only", "Confirm the running app before relying on its state"]
+      }
+    },
+    {
+      "name": "stackql",
+      "displayName": "StackQL",
+      "version": "0.1.0",
+      "description": "Query, provision, and operate cloud, SaaS, and API resources using SQL, over MCP.",
+      "category": "Cloud & Infrastructure",
+      "keywords": ["stackql", "sql", "cloud", "provisioning", "infrastructure"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://stackql.io/", "https://github.com/stackql/stackql"],
+      "trust": "reference-local",
+      "mcpServers": {
+        "stackql": {
+          "command": "npx",
+          "args": ["-y", "@stackql/mcp-server"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "astra", "roles": ["strategic-navigator"]},
+        {"familiar": "cody", "roles": ["implementer", "debugger"]}
+      ],
+      "skill": {
+        "description": "Use StackQL for SQL-native cloud inspection, preferring read-only queries before provisioning.",
+        "useCases": ["Query cloud resources with SQL", "Audit configuration across providers", "Prepare provisioning for review"],
+        "guardrails": ["Default to read-only SELECTs; confirm any provisioning or mutation", "Never expose provider credentials", "Scope queries to the smallest provider/account needed"]
+      }
+    },
+    {
+      "name": "next-devtools",
+      "displayName": "Next.js DevTools",
+      "version": "0.1.0",
+      "description": "Bridge agents to a running Next.js 16+ dev server — errors, logs, routes, and server actions.",
+      "category": "Developer Tools",
+      "keywords": ["nextjs", "vercel", "frontend", "dev-server", "react"],
+      "capabilities": ["network", "shell", "mcp"],
+      "sourceRefs": ["https://github.com/vercel/next-devtools-mcp"],
+      "trust": "official-local",
+      "mcpServers": {
+        "next-devtools": {
+          "command": "npx",
+          "args": ["-y", "next-devtools-mcp@latest"],
+          "type": "stdio"
+        }
+      },
+      "roleAffinity": [
+        {"familiar": "cody", "roles": ["implementer", "debugger"]}
+      ],
+      "skill": {
+        "description": "Use Next.js DevTools MCP to debug a running Next.js app against its real runtime state.",
+        "useCases": ["Read build and runtime errors", "Inspect routes and server actions", "Trace logs from the dev server"],
+        "guardrails": ["Requires a running Next.js 16+ dev server", "Treat the endpoint as local-only", "Confirm the target project before acting"]
+      }
     }
   ]
 }

--- a/marketplace/exports/codex/marketplace.json
+++ b/marketplace/exports/codex/marketplace.json
@@ -171,6 +171,366 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Core MCP"
+    },
+    {
+      "name": "serena",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/serena"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Agents & Harnesses"
+    },
+    {
+      "name": "context7",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/context7"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Agents & Harnesses"
+    },
+    {
+      "name": "markitdown",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/markitdown"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Agents & Harnesses"
+    },
+    {
+      "name": "playwright",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/playwright"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "chrome-devtools",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/chrome-devtools"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "firecrawl",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/firecrawl"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "tavily",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/tavily"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "brightdata",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/brightdata"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "apify",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/apify"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "searxng",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/searxng"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "dbhub",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/dbhub"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
+    },
+    {
+      "name": "supabase",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/supabase"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
+    },
+    {
+      "name": "mongodb",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/mongodb"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
+    },
+    {
+      "name": "azure",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/azure"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "azure-devops",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/azure-devops"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "terraform",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/terraform"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "notion",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/notion"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "atlassian",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/atlassian"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Project Management"
+    },
+    {
+      "name": "figma",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/figma"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Design"
+    },
+    {
+      "name": "stripe",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/stripe"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Commerce"
+    },
+    {
+      "name": "microsoft-learn",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/microsoft-learn"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Knowledge & Docs"
+    },
+    {
+      "name": "activepieces",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/activepieces"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Automation"
+    },
+    {
+      "name": "desktop-commander",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/desktop-commander"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "netdata",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/netdata"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "fabric",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/fabric"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "unity",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/unity"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "nuget",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/nuget"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "nuxt-dev",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/nuxt-dev"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "stackql",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/stackql"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "next-devtools",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/next-devtools"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/marketplace/exports/mcp/mcp.json
+++ b/marketplace/exports/mcp/mcp.json
@@ -94,6 +94,245 @@
         "${COVEN_MCP_LOCAL_TIMEZONE}"
       ],
       "type": "stdio"
+    },
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide-assistant"
+      ],
+      "type": "stdio"
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "type": "http"
+    },
+    "markitdown": {
+      "command": "uvx",
+      "args": [
+        "markitdown-mcp"
+      ],
+      "type": "stdio"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest"
+      ],
+      "type": "stdio"
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ],
+      "type": "stdio"
+    },
+    "firecrawl": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "firecrawl-mcp"
+      ],
+      "type": "stdio",
+      "env": {
+        "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+      }
+    },
+    "tavily": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "tavily-mcp@latest"
+      ],
+      "type": "stdio",
+      "env": {
+        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+      }
+    },
+    "brightdata": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@brightdata/mcp"
+      ],
+      "type": "stdio",
+      "env": {
+        "API_TOKEN": "${BRIGHTDATA_API_TOKEN}"
+      }
+    },
+    "apify": {
+      "url": "https://mcp.apify.com",
+      "type": "http"
+    },
+    "searxng": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-searxng"
+      ],
+      "type": "stdio",
+      "env": {
+        "SEARXNG_URL": "${SEARXNG_URL}"
+      }
+    },
+    "dbhub": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@bytebase/dbhub",
+        "--transport",
+        "stdio",
+        "--dsn",
+        "${DBHUB_DSN}"
+      ],
+      "type": "stdio"
+    },
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest"
+      ],
+      "type": "stdio",
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
+    },
+    "mongodb": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mongodb-mcp-server"
+      ],
+      "type": "stdio",
+      "env": {
+        "MDB_MCP_CONNECTION_STRING": "${MDB_MCP_CONNECTION_STRING}"
+      }
+    },
+    "azure": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure/mcp@latest",
+        "server",
+        "start"
+      ],
+      "type": "stdio"
+    },
+    "azure-devops": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure-devops/mcp",
+        "${AZURE_DEVOPS_ORG}"
+      ],
+      "type": "stdio"
+    },
+    "terraform": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "hashicorp/terraform-mcp-server"
+      ],
+      "type": "stdio"
+    },
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "type": "http"
+    },
+    "atlassian": {
+      "url": "https://mcp.atlassian.com/v1/mcp",
+      "type": "http"
+    },
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "type": "http"
+    },
+    "stripe": {
+      "url": "https://mcp.stripe.com",
+      "type": "http"
+    },
+    "microsoft-learn": {
+      "url": "https://learn.microsoft.com/api/mcp",
+      "type": "http"
+    },
+    "activepieces": {
+      "url": "${ACTIVEPIECES_MCP_URL}",
+      "type": "sse"
+    },
+    "desktop-commander": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@wonderwhy-er/desktop-commander@latest"
+      ],
+      "type": "stdio"
+    },
+    "netdata": {
+      "url": "${NETDATA_MCP_URL}",
+      "type": "http"
+    },
+    "fabric": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@microsoft/fabric-mcp@latest",
+        "server",
+        "start",
+        "--mode",
+        "all"
+      ],
+      "type": "stdio"
+    },
+    "unity": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "mcpforunityserver",
+        "mcp-for-unity",
+        "--transport",
+        "stdio"
+      ],
+      "type": "stdio"
+    },
+    "nuget": {
+      "command": "dnx",
+      "args": [
+        "NuGet.Mcp.Server",
+        "--source",
+        "https://api.nuget.org/v3/index.json",
+        "--yes"
+      ],
+      "type": "stdio"
+    },
+    "nuxt-dev": {
+      "url": "${NUXT_MCP_URL}",
+      "type": "sse"
+    },
+    "stackql": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@stackql/mcp-server"
+      ],
+      "type": "stdio"
+    },
+    "next-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "next-devtools-mcp@latest"
+      ],
+      "type": "stdio"
     }
   }
 }

--- a/marketplace/exports/roles/role-affinity.json
+++ b/marketplace/exports/roles/role-affinity.json
@@ -381,5 +381,450 @@
         "devrel-liaison"
       ]
     }
+  ],
+  "serena": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "code-reviewer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    }
+  ],
+  "context7": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    }
+  ],
+  "markitdown": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist"
+      ]
+    },
+    {
+      "familiar": "kitty",
+      "roles": [
+        "general-helper"
+      ]
+    }
+  ],
+  "playwright": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "chrome-devtools": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "debugger",
+        "implementer"
+      ]
+    }
+  ],
+  "firecrawl": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "charm",
+      "roles": [
+        "copywriter",
+        "devrel-liaison"
+      ]
+    }
+  ],
+  "tavily": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "brightdata": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "apify": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "searxng": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    }
+  ],
+  "dbhub": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "supabase": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "mongodb": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "azure": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator",
+        "coordination-layer"
+      ]
+    }
+  ],
+  "azure-devops": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "code-reviewer"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "coordination-layer"
+      ]
+    }
+  ],
+  "terraform": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "notion": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist"
+      ]
+    },
+    {
+      "familiar": "charm",
+      "roles": [
+        "copywriter"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "coordination-layer"
+      ]
+    }
+  ],
+  "atlassian": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator",
+        "coordination-layer"
+      ]
+    },
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist"
+      ]
+    }
+  ],
+  "figma": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    },
+    {
+      "familiar": "charm",
+      "roles": [
+        "copywriter",
+        "social-voice"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "stripe": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    }
+  ],
+  "microsoft-learn": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    }
+  ],
+  "activepieces": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator",
+        "coordination-layer"
+      ]
+    },
+    {
+      "familiar": "charm",
+      "roles": [
+        "devrel-liaison"
+      ]
+    },
+    {
+      "familiar": "kitty",
+      "roles": [
+        "general-helper"
+      ]
+    }
+  ],
+  "desktop-commander": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    }
+  ],
+  "netdata": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "coordination-layer"
+      ]
+    }
+  ],
+  "fabric": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "unity": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    }
+  ],
+  "nuget": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "code-reviewer"
+      ]
+    }
+  ],
+  "nuxt-dev": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    }
+  ],
+  "stackql": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    },
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    }
+  ],
+  "next-devtools": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    }
   ]
 }

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -584,6 +584,871 @@
           ]
         }
       ]
+    },
+    {
+      "name": "serena",
+      "displayName": "Serena",
+      "category": "Agents & Harnesses",
+      "source": {
+        "source": "local",
+        "path": "./plugins/serena"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "code-reviewer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "context7",
+      "displayName": "Context7",
+      "category": "Agents & Harnesses",
+      "source": {
+        "source": "local",
+        "path": "./plugins/context7"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "markitdown",
+      "displayName": "Markitdown",
+      "category": "Agents & Harnesses",
+      "source": {
+        "source": "local",
+        "path": "./plugins/markitdown"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "playwright",
+      "displayName": "Playwright",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/playwright"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "chrome-devtools",
+      "displayName": "Chrome DevTools",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/chrome-devtools"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger",
+            "implementer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "firecrawl",
+      "displayName": "Firecrawl",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/firecrawl"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "copywriter",
+            "devrel-liaison"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "tavily",
+      "displayName": "Tavily",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/tavily"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "brightdata",
+      "displayName": "Bright Data",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/brightdata"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "apify",
+      "displayName": "Apify",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/apify"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "searxng",
+      "displayName": "SearXNG Search",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/searxng"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "local-tool",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "dbhub",
+      "displayName": "DBHub",
+      "category": "Databases",
+      "source": {
+        "source": "local",
+        "path": "./plugins/dbhub"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "supabase",
+      "displayName": "Supabase",
+      "category": "Databases",
+      "source": {
+        "source": "local",
+        "path": "./plugins/supabase"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "mongodb",
+      "displayName": "MongoDB",
+      "category": "Databases",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mongodb"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "azure",
+      "displayName": "Azure MCP Server",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/azure"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "azure-devops",
+      "displayName": "Azure DevOps",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/azure-devops"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "code-reviewer"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "terraform",
+      "displayName": "Terraform",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/terraform"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "notion",
+      "displayName": "Notion",
+      "category": "Productivity",
+      "source": {
+        "source": "local",
+        "path": "./plugins/notion"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "copywriter"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "atlassian",
+      "displayName": "Atlassian Rovo",
+      "category": "Project Management",
+      "source": {
+        "source": "local",
+        "path": "./plugins/atlassian"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "figma",
+      "displayName": "Figma",
+      "category": "Design",
+      "source": {
+        "source": "local",
+        "path": "./plugins/figma"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "copywriter",
+            "social-voice"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "stripe",
+      "displayName": "Stripe",
+      "category": "Commerce",
+      "source": {
+        "source": "local",
+        "path": "./plugins/stripe"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "microsoft-learn",
+      "displayName": "Microsoft Learn",
+      "category": "Knowledge & Docs",
+      "source": {
+        "source": "local",
+        "path": "./plugins/microsoft-learn"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "activepieces",
+      "displayName": "Activepieces",
+      "category": "Automation",
+      "source": {
+        "source": "local",
+        "path": "./plugins/activepieces"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "desktop-commander",
+      "displayName": "Desktop Commander",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/desktop-commander"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "local-tool",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "netdata",
+      "displayName": "Netdata",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/netdata"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "fabric",
+      "displayName": "Microsoft Fabric",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/fabric"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "unity",
+      "displayName": "Unity",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/unity"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "nuget",
+      "displayName": "NuGet",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/nuget"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "code-reviewer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "nuxt-dev",
+      "displayName": "Nuxt Dev",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/nuxt-dev"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "stackql",
+      "displayName": "StackQL",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/stackql"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "next-devtools",
+      "displayName": "Next.js DevTools",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/next-devtools"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/marketplace/plugins/activepieces/.codex-plugin/plugin.json
+++ b/marketplace/plugins/activepieces/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "activepieces",
+  "version": "0.1.0",
+  "description": "Reach 280+ open-source integrations (\"pieces\") as tools through a self-hosted Activepieces MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Activepieces",
+    "shortDescription": "Reach 280+ open-source integrations (\"pieces\") as tools through a self-hosted Activepieces MCP server.",
+    "longDescription": "Use Activepieces to invoke prebuilt integrations and flows instead of wiring each API by hand.",
+    "developerName": "OpenCoven",
+    "category": "Automation",
+    "capabilities": [
+      "automation",
+      "workflows",
+      "integrations",
+      "zapier-alternative",
+      "no-code"
+    ],
+    "defaultPrompt": "Help me use Activepieces safely."
+  }
+}

--- a/marketplace/plugins/activepieces/plugin.json
+++ b/marketplace/plugins/activepieces/plugin.json
@@ -1,0 +1,76 @@
+{
+  "name": "activepieces",
+  "version": "0.1.0",
+  "description": "Reach 280+ open-source integrations (\"pieces\") as tools through a self-hosted Activepieces MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "automation",
+    "workflows",
+    "integrations",
+    "zapier-alternative",
+    "no-code"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/activepieces",
+  "x-coven": {
+    "displayName": "Activepieces",
+    "category": "Automation",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://github.com/activepieces/activepieces",
+      "https://www.activepieces.com/docs/mcp/overview"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator",
+          "coordination-layer"
+        ]
+      },
+      {
+        "familiar": "charm",
+        "roles": [
+          "devrel-liaison"
+        ]
+      },
+      {
+        "familiar": "kitty",
+        "roles": [
+          "general-helper"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "activepieces": {
+      "url": "${ACTIVEPIECES_MCP_URL}",
+      "type": "sse"
+    }
+  },
+  "userConfig": {
+    "activepieces_mcp_url": {
+      "type": "string",
+      "title": "Activepieces MCP URL",
+      "description": "Per-project MCP server URL (with token) from your Activepieces instance.",
+      "required": true,
+      "sensitive": true,
+      "env": "ACTIVEPIECES_MCP_URL"
+    }
+  }
+}

--- a/marketplace/plugins/activepieces/skills/activepieces/SKILL.md
+++ b/marketplace/plugins/activepieces/skills/activepieces/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: activepieces
+description: Use Activepieces to invoke prebuilt integrations and flows instead of wiring each API by hand.
+---
+
+# Activepieces
+
+Use Activepieces to invoke prebuilt integrations and flows instead of wiring each API by hand.
+
+## Use When
+- Trigger an automation flow
+- Use a Store piece as a tool
+- Connect SaaS apps through one MCP endpoint
+
+## Guardrails
+- Confirm scope and side effects before running a flow
+- Do not move data between systems without approval
+- Keep the tokenized MCP URL secret
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/apify/.codex-plugin/plugin.json
+++ b/marketplace/plugins/apify/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "apify",
+  "version": "0.1.0",
+  "description": "Run thousands of scrapers, crawlers, and automations from the Apify Store over MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Apify",
+    "shortDescription": "Run thousands of scrapers, crawlers, and automations from the Apify Store over MCP.",
+    "longDescription": "Use Apify Actors for prebuilt scraping and automation tasks instead of hand-rolling crawlers.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "actors",
+      "scraping",
+      "automation",
+      "apify",
+      "store"
+    ],
+    "defaultPrompt": "Help me use Apify safely."
+  }
+}

--- a/marketplace/plugins/apify/plugin.json
+++ b/marketplace/plugins/apify/plugin.json
@@ -1,0 +1,58 @@
+{
+  "name": "apify",
+  "version": "0.1.0",
+  "description": "Run thousands of scrapers, crawlers, and automations from the Apify Store over MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "actors",
+    "scraping",
+    "automation",
+    "apify",
+    "store"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/apify",
+  "x-coven": {
+    "displayName": "Apify",
+    "category": "Browser & Web",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://github.com/apify/actors-mcp-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "apify": {
+      "url": "https://mcp.apify.com",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/apify/skills/apify/SKILL.md
+++ b/marketplace/plugins/apify/skills/apify/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: apify
+description: Use Apify Actors for prebuilt scraping and automation tasks instead of hand-rolling crawlers.
+---
+
+# Apify
+
+Use Apify Actors for prebuilt scraping and automation tasks instead of hand-rolling crawlers.
+
+## Use When
+- Run a Store actor to extract data
+- Automate a repetitive web task
+- Collect structured datasets
+
+## Guardrails
+- Confirm actor cost and scope before running
+- Respect target site terms
+- Do not run actors that mutate external state without approval
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/atlassian/.codex-plugin/plugin.json
+++ b/marketplace/plugins/atlassian/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "atlassian",
+  "version": "0.1.0",
+  "description": "Search, create, and manage Jira, Confluence, and Compass work via Atlassian's official MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Atlassian Rovo",
+    "shortDescription": "Search, create, and manage Jira, Confluence, and Compass work via Atlassian's official MCP.",
+    "longDescription": "Use Atlassian Rovo for Jira/Confluence context while keeping writes intentional and approved.",
+    "developerName": "OpenCoven",
+    "category": "Project Management",
+    "capabilities": [
+      "jira",
+      "confluence",
+      "atlassian",
+      "issues",
+      "wiki"
+    ],
+    "defaultPrompt": "Help me use Atlassian Rovo safely."
+  }
+}

--- a/marketplace/plugins/atlassian/plugin.json
+++ b/marketplace/plugins/atlassian/plugin.json
@@ -1,0 +1,66 @@
+{
+  "name": "atlassian",
+  "version": "0.1.0",
+  "description": "Search, create, and manage Jira, Confluence, and Compass work via Atlassian's official MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "jira",
+    "confluence",
+    "atlassian",
+    "issues",
+    "wiki"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/atlassian",
+  "x-coven": {
+    "displayName": "Atlassian Rovo",
+    "category": "Project Management",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://github.com/atlassian/atlassian-mcp-server",
+      "https://support.atlassian.com/rovo/docs/getting-started-with-the-atlassian-remote-mcp-server/"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator",
+          "coordination-layer"
+        ]
+      },
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "atlassian": {
+      "url": "https://mcp.atlassian.com/v1/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/atlassian/skills/atlassian/SKILL.md
+++ b/marketplace/plugins/atlassian/skills/atlassian/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: atlassian
+description: Use Atlassian Rovo for Jira/Confluence context while keeping writes intentional and approved.
+---
+
+# Atlassian Rovo
+
+Use Atlassian Rovo for Jira/Confluence context while keeping writes intentional and approved.
+
+## Use When
+- Read issues and pages
+- Summarize project status
+- Draft issue or page updates
+
+## Guardrails
+- Do not create, transition, or comment without approval
+- Keep status reports dated and concrete
+- Respect space and project permissions
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/azure-devops/.codex-plugin/plugin.json
+++ b/marketplace/plugins/azure-devops/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "azure-devops",
+  "version": "0.1.0",
+  "description": "Work with Azure DevOps repos, work items, builds, releases, test plans, and code search.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Azure DevOps",
+    "shortDescription": "Work with Azure DevOps repos, work items, builds, releases, test plans, and code search.",
+    "longDescription": "Use Azure DevOps MCP for planning and review context without silently changing work state.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "azure-devops",
+      "work-items",
+      "pipelines",
+      "repos",
+      "boards"
+    ],
+    "defaultPrompt": "Help me use Azure DevOps safely."
+  }
+}

--- a/marketplace/plugins/azure-devops/plugin.json
+++ b/marketplace/plugins/azure-devops/plugin.json
@@ -1,0 +1,74 @@
+{
+  "name": "azure-devops",
+  "version": "0.1.0",
+  "description": "Work with Azure DevOps repos, work items, builds, releases, test plans, and code search.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "azure-devops",
+    "work-items",
+    "pipelines",
+    "repos",
+    "boards"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/azure-devops",
+  "x-coven": {
+    "displayName": "Azure DevOps",
+    "category": "Cloud & Infrastructure",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/microsoft/azure-devops-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "code-reviewer"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "coordination-layer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "azure-devops": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure-devops/mcp",
+        "${AZURE_DEVOPS_ORG}"
+      ],
+      "type": "stdio"
+    }
+  },
+  "userConfig": {
+    "azure_devops_org": {
+      "type": "string",
+      "title": "Azure DevOps Organization",
+      "description": "Azure DevOps organization name the MCP server should target.",
+      "required": true,
+      "sensitive": false,
+      "env": "AZURE_DEVOPS_ORG"
+    }
+  }
+}

--- a/marketplace/plugins/azure-devops/skills/azure-devops/SKILL.md
+++ b/marketplace/plugins/azure-devops/skills/azure-devops/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: azure-devops
+description: Use Azure DevOps MCP for planning and review context without silently changing work state.
+---
+
+# Azure DevOps
+
+Use Azure DevOps MCP for planning and review context without silently changing work state.
+
+## Use When
+- Read work items and pipelines
+- Summarize build or release status
+- Draft work-item updates
+
+## Guardrails
+- Do not create, complete, or reassign work without approval
+- Keep status reports dated and concrete
+- Respect project-level access boundaries
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/azure/.codex-plugin/plugin.json
+++ b/marketplace/plugins/azure/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "azure",
+  "version": "0.1.0",
+  "description": "Connect agents to Azure services across storage, databases, monitoring, and more.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Azure MCP Server",
+    "shortDescription": "Connect agents to Azure services across storage, databases, monitoring, and more.",
+    "longDescription": "Use Azure MCP for cloud resource inspection and approved operations via your signed-in Azure context.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "azure",
+      "cloud",
+      "infrastructure",
+      "microsoft",
+      "devops"
+    ],
+    "defaultPrompt": "Help me use Azure MCP Server safely."
+  }
+}

--- a/marketplace/plugins/azure/plugin.json
+++ b/marketplace/plugins/azure/plugin.json
@@ -1,0 +1,67 @@
+{
+  "name": "azure",
+  "version": "0.1.0",
+  "description": "Connect agents to Azure services across storage, databases, monitoring, and more.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "azure",
+    "cloud",
+    "infrastructure",
+    "microsoft",
+    "devops"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/azure",
+  "x-coven": {
+    "displayName": "Azure MCP Server",
+    "category": "Cloud & Infrastructure",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/Azure/azure-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator",
+          "coordination-layer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "azure": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@azure/mcp@latest",
+        "server",
+        "start"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/azure/skills/azure/SKILL.md
+++ b/marketplace/plugins/azure/skills/azure/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: azure
+description: Use Azure MCP for cloud resource inspection and approved operations via your signed-in Azure context.
+---
+
+# Azure MCP Server
+
+Use Azure MCP for cloud resource inspection and approved operations via your signed-in Azure context.
+
+## Use When
+- List resources and configs
+- Read logs and metrics
+- Prepare infrastructure changes for review
+
+## Guardrails
+- Do not provision, delete, or change resources without approval
+- Treat resource configs as sensitive
+- Prefer scoped, subscription-aware queries
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/brightdata/.codex-plugin/plugin.json
+++ b/marketplace/plugins/brightdata/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "brightdata",
+  "version": "0.1.0",
+  "description": "Search, extract, and navigate the public web at scale through Bright Data's Web MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Bright Data",
+    "shortDescription": "Search, extract, and navigate the public web at scale through Bright Data's Web MCP.",
+    "longDescription": "Use Bright Data for resilient large-scale web extraction with respect for source policies.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "scraping",
+      "web-data",
+      "proxy",
+      "extract",
+      "search"
+    ],
+    "defaultPrompt": "Help me use Bright Data safely."
+  }
+}

--- a/marketplace/plugins/brightdata/plugin.json
+++ b/marketplace/plugins/brightdata/plugin.json
@@ -1,0 +1,75 @@
+{
+  "name": "brightdata",
+  "version": "0.1.0",
+  "description": "Search, extract, and navigate the public web at scale through Bright Data's Web MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "scraping",
+    "web-data",
+    "proxy",
+    "extract",
+    "search"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/brightdata",
+  "x-coven": {
+    "displayName": "Bright Data",
+    "category": "Browser & Web",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/brightdata/brightdata-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "brightdata": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@brightdata/mcp"
+      ],
+      "type": "stdio",
+      "env": {
+        "API_TOKEN": "${BRIGHTDATA_API_TOKEN}"
+      }
+    }
+  },
+  "userConfig": {
+    "brightdata_api_token": {
+      "type": "string",
+      "title": "Bright Data API Token",
+      "description": "API token for the Bright Data Web MCP.",
+      "required": true,
+      "sensitive": true,
+      "env": "BRIGHTDATA_API_TOKEN"
+    }
+  }
+}

--- a/marketplace/plugins/brightdata/skills/brightdata/SKILL.md
+++ b/marketplace/plugins/brightdata/skills/brightdata/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: brightdata
+description: Use Bright Data for resilient large-scale web extraction with respect for source policies.
+---
+
+# Bright Data
+
+Use Bright Data for resilient large-scale web extraction with respect for source policies.
+
+## Use When
+- Search and extract web data
+- Navigate sites that block naive scrapers
+- Collect market or competitive data
+
+## Guardrails
+- Respect site terms and legal limits
+- Do not collect personal data without basis
+- Record sources and extraction scope
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/chrome-devtools/.codex-plugin/plugin.json
+++ b/marketplace/plugins/chrome-devtools/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "chrome-devtools",
+  "version": "0.1.0",
+  "description": "Inspect and control Chrome via the DevTools protocol for debugging and performance work.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Chrome DevTools",
+    "shortDescription": "Inspect and control Chrome via the DevTools protocol for debugging and performance work.",
+    "longDescription": "Use Chrome DevTools MCP to inspect live pages, network, and performance during debugging.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "chrome",
+      "devtools",
+      "debugging",
+      "performance",
+      "browser"
+    ],
+    "defaultPrompt": "Help me use Chrome DevTools safely."
+  }
+}

--- a/marketplace/plugins/chrome-devtools/plugin.json
+++ b/marketplace/plugins/chrome-devtools/plugin.json
@@ -1,0 +1,58 @@
+{
+  "name": "chrome-devtools",
+  "version": "0.1.0",
+  "description": "Inspect and control Chrome via the DevTools protocol for debugging and performance work.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "chrome",
+    "devtools",
+    "debugging",
+    "performance",
+    "browser"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/chrome-devtools",
+  "x-coven": {
+    "displayName": "Chrome DevTools",
+    "category": "Browser & Web",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/ChromeDevTools/chrome-devtools-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "debugger",
+          "implementer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/chrome-devtools/skills/chrome-devtools/SKILL.md
+++ b/marketplace/plugins/chrome-devtools/skills/chrome-devtools/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: chrome-devtools
+description: Use Chrome DevTools MCP to inspect live pages, network, and performance during debugging.
+---
+
+# Chrome DevTools
+
+Use Chrome DevTools MCP to inspect live pages, network, and performance during debugging.
+
+## Use When
+- Trace a failing network request
+- Profile a slow page
+- Inspect DOM and console state
+
+## Guardrails
+- Do not interact with authenticated sessions without approval
+- Treat captured network data as sensitive
+- Close controlled browser instances when done
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/context7/.codex-plugin/plugin.json
+++ b/marketplace/plugins/context7/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "context7",
+  "version": "0.1.0",
+  "description": "Up-to-date, version-accurate library documentation injected into agent prompts on demand.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Context7",
+    "shortDescription": "Up-to-date, version-accurate library documentation injected into agent prompts on demand.",
+    "longDescription": "Use Context7 to fetch current, version-specific docs before writing code against a library.",
+    "developerName": "OpenCoven",
+    "category": "Agents & Harnesses",
+    "capabilities": [
+      "docs",
+      "libraries",
+      "context",
+      "coding-agent",
+      "reference"
+    ],
+    "defaultPrompt": "Help me use Context7 safely."
+  }
+}

--- a/marketplace/plugins/context7/plugin.json
+++ b/marketplace/plugins/context7/plugin.json
@@ -1,0 +1,61 @@
+{
+  "name": "context7",
+  "version": "0.1.0",
+  "description": "Up-to-date, version-accurate library documentation injected into agent prompts on demand.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "docs",
+    "libraries",
+    "context",
+    "coding-agent",
+    "reference"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/context7",
+  "x-coven": {
+    "displayName": "Context7",
+    "category": "Agents & Harnesses",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://github.com/upstash/context7",
+      "https://github.com/mcp-use/mcp-use"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/context7/skills/context7/SKILL.md
+++ b/marketplace/plugins/context7/skills/context7/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: context7
+description: Use Context7 to fetch current, version-specific docs before writing code against a library.
+---
+
+# Context7
+
+Use Context7 to fetch current, version-specific docs before writing code against a library.
+
+## Use When
+- Resolve a library to its current docs
+- Pull API usage for the installed version
+- Avoid stale or hallucinated API calls
+
+## Guardrails
+- Match docs to the version actually installed
+- Cite the library and version used
+- Prefer official docs over generated summaries
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/dbhub/.codex-plugin/plugin.json
+++ b/marketplace/plugins/dbhub/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "dbhub",
+  "version": "0.1.0",
+  "description": "Token-efficient universal database MCP for PostgreSQL, MySQL, SQL Server, SQLite, and MariaDB.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "DBHub",
+    "shortDescription": "Token-efficient universal database MCP for PostgreSQL, MySQL, SQL Server, SQLite, and MariaDB.",
+    "longDescription": "Use DBHub for read-first database inspection with intentional, approved writes.",
+    "developerName": "OpenCoven",
+    "category": "Databases",
+    "capabilities": [
+      "database",
+      "sql",
+      "postgres",
+      "mysql",
+      "sqlite"
+    ],
+    "defaultPrompt": "Help me use DBHub safely."
+  }
+}

--- a/marketplace/plugins/dbhub/plugin.json
+++ b/marketplace/plugins/dbhub/plugin.json
@@ -1,0 +1,77 @@
+{
+  "name": "dbhub",
+  "version": "0.1.0",
+  "description": "Token-efficient universal database MCP for PostgreSQL, MySQL, SQL Server, SQLite, and MariaDB.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "database",
+    "sql",
+    "postgres",
+    "mysql",
+    "sqlite"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/dbhub",
+  "x-coven": {
+    "displayName": "DBHub",
+    "category": "Databases",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/bytebase/dbhub"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "dbhub": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@bytebase/dbhub",
+        "--transport",
+        "stdio",
+        "--dsn",
+        "${DBHUB_DSN}"
+      ],
+      "type": "stdio"
+    }
+  },
+  "userConfig": {
+    "dbhub_dsn": {
+      "type": "string",
+      "title": "Database DSN",
+      "description": "Connection string for the target database (e.g. postgres://user:pass@host:5432/db).",
+      "required": true,
+      "sensitive": true,
+      "env": "DBHUB_DSN"
+    }
+  }
+}

--- a/marketplace/plugins/dbhub/skills/dbhub/SKILL.md
+++ b/marketplace/plugins/dbhub/skills/dbhub/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: dbhub
+description: Use DBHub for read-first database inspection with intentional, approved writes.
+---
+
+# DBHub
+
+Use DBHub for read-first database inspection with intentional, approved writes.
+
+## Use When
+- Inspect schema
+- Run read-only queries
+- Prepare migrations for review
+
+## Guardrails
+- Default to read-only; confirm before any write or DDL
+- Never expose credentials from the DSN
+- Scope queries to the smallest dataset needed
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/desktop-commander/.codex-plugin/plugin.json
+++ b/marketplace/plugins/desktop-commander/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "desktop-commander",
+  "version": "0.1.0",
+  "description": "Terminal commands, file operations, and process management on the local machine over MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Desktop Commander",
+    "shortDescription": "Terminal commands, file operations, and process management on the local machine over MCP.",
+    "longDescription": "Use Desktop Commander for local shell and file work with explicit, narrow intent.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "terminal",
+      "shell",
+      "files",
+      "process",
+      "local"
+    ],
+    "defaultPrompt": "Help me use Desktop Commander safely."
+  }
+}

--- a/marketplace/plugins/desktop-commander/plugin.json
+++ b/marketplace/plugins/desktop-commander/plugin.json
@@ -1,0 +1,59 @@
+{
+  "name": "desktop-commander",
+  "version": "0.1.0",
+  "description": "Terminal commands, file operations, and process management on the local machine over MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "terminal",
+    "shell",
+    "files",
+    "process",
+    "local"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/desktop-commander",
+  "x-coven": {
+    "displayName": "Desktop Commander",
+    "category": "Developer Tools",
+    "trust": "local-tool",
+    "sourceRefs": [
+      "https://github.com/wonderwhy-er/DesktopCommanderMCP"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "desktop-commander": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@wonderwhy-er/desktop-commander@latest"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/desktop-commander/skills/desktop-commander/SKILL.md
+++ b/marketplace/plugins/desktop-commander/skills/desktop-commander/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: desktop-commander
+description: Use Desktop Commander for local shell and file work with explicit, narrow intent.
+---
+
+# Desktop Commander
+
+Use Desktop Commander for local shell and file work with explicit, narrow intent.
+
+## Use When
+- Run scoped local commands
+- Edit or move local files
+- Inspect running processes
+
+## Guardrails
+- Confirm before destructive commands or deletes
+- Use the narrowest path scope
+- Never run commands that exfiltrate secrets
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/fabric/.codex-plugin/plugin.json
+++ b/marketplace/plugins/fabric/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "fabric",
+  "version": "0.1.0",
+  "description": "Microsoft Fabric REST/OpenAPI context for AI-assisted Fabric development, served locally.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Microsoft Fabric",
+    "shortDescription": "Microsoft Fabric REST/OpenAPI context for AI-assisted Fabric development, served locally.",
+    "longDescription": "Use Microsoft Fabric MCP for accurate Fabric API context when building against the platform.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "fabric",
+      "microsoft",
+      "data",
+      "analytics",
+      "openapi"
+    ],
+    "defaultPrompt": "Help me use Microsoft Fabric safely."
+  }
+}

--- a/marketplace/plugins/fabric/plugin.json
+++ b/marketplace/plugins/fabric/plugin.json
@@ -1,0 +1,66 @@
+{
+  "name": "fabric",
+  "version": "0.1.0",
+  "description": "Microsoft Fabric REST/OpenAPI context for AI-assisted Fabric development, served locally.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "fabric",
+    "microsoft",
+    "data",
+    "analytics",
+    "openapi"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/fabric",
+  "x-coven": {
+    "displayName": "Microsoft Fabric",
+    "category": "Cloud & Infrastructure",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/microsoft/mcp/tree/main/servers/Fabric.Mcp.Server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "fabric": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@microsoft/fabric-mcp@latest",
+        "server",
+        "start",
+        "--mode",
+        "all"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/fabric/skills/fabric/SKILL.md
+++ b/marketplace/plugins/fabric/skills/fabric/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: fabric
+description: Use Microsoft Fabric MCP for accurate Fabric API context when building against the platform.
+---
+
+# Microsoft Fabric
+
+Use Microsoft Fabric MCP for accurate Fabric API context when building against the platform.
+
+## Use When
+- Look up Fabric REST API shapes
+- Draft Fabric automation accurately
+- Confirm current Fabric capabilities
+
+## Guardrails
+- Do not change Fabric workspaces without approval
+- Treat workspace data as sensitive
+- Prefer official API context over guesses
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/figma/.codex-plugin/plugin.json
+++ b/marketplace/plugins/figma/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "figma",
+  "version": "0.1.0",
+  "description": "Bring Figma design context \u2014 frames, components, and variables \u2014 into agent workflows.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Figma",
+    "shortDescription": "Bring Figma design context \u2014 frames, components, and variables \u2014 into agent workflows.",
+    "longDescription": "Use Figma MCP to pull design context and specs into implementation without guessing values.",
+    "developerName": "OpenCoven",
+    "category": "Design",
+    "capabilities": [
+      "figma",
+      "design",
+      "components",
+      "dev-mode",
+      "ui"
+    ],
+    "defaultPrompt": "Help me use Figma safely."
+  }
+}

--- a/marketplace/plugins/figma/plugin.json
+++ b/marketplace/plugins/figma/plugin.json
@@ -1,0 +1,65 @@
+{
+  "name": "figma",
+  "version": "0.1.0",
+  "description": "Bring Figma design context \u2014 frames, components, and variables \u2014 into agent workflows.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "figma",
+    "design",
+    "components",
+    "dev-mode",
+    "ui"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/figma",
+  "x-coven": {
+    "displayName": "Figma",
+    "category": "Design",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://help.figma.com/hc/en-us/articles/32132100833559-Guide-to-the-Figma-MCP-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      },
+      {
+        "familiar": "charm",
+        "roles": [
+          "copywriter",
+          "social-voice"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "figma": {
+      "url": "https://mcp.figma.com/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/figma/skills/figma/SKILL.md
+++ b/marketplace/plugins/figma/skills/figma/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: figma
+description: Use Figma MCP to pull design context and specs into implementation without guessing values.
+---
+
+# Figma
+
+Use Figma MCP to pull design context and specs into implementation without guessing values.
+
+## Use When
+- Read frame and component structure
+- Pull spacing, color, and type tokens
+- Translate a design into code
+
+## Guardrails
+- Do not edit or publish designs without approval
+- Respect file and team permissions
+- Confirm the target node before extracting
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/firecrawl/.codex-plugin/plugin.json
+++ b/marketplace/plugins/firecrawl/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "firecrawl",
+  "version": "0.1.0",
+  "description": "Crawl, scrape, and extract structured web data through the Firecrawl platform.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Firecrawl",
+    "shortDescription": "Crawl, scrape, and extract structured web data through the Firecrawl platform.",
+    "longDescription": "Use Firecrawl for bounded, structured web extraction with primary-source preference.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "scraping",
+      "crawl",
+      "web",
+      "extract",
+      "research"
+    ],
+    "defaultPrompt": "Help me use Firecrawl safely."
+  }
+}

--- a/marketplace/plugins/firecrawl/plugin.json
+++ b/marketplace/plugins/firecrawl/plugin.json
@@ -1,0 +1,77 @@
+{
+  "name": "firecrawl",
+  "version": "0.1.0",
+  "description": "Crawl, scrape, and extract structured web data through the Firecrawl platform.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "scraping",
+    "crawl",
+    "web",
+    "extract",
+    "research"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/firecrawl",
+  "x-coven": {
+    "displayName": "Firecrawl",
+    "category": "Browser & Web",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/firecrawl/firecrawl-mcp-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "charm",
+        "roles": [
+          "copywriter",
+          "devrel-liaison"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "firecrawl": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "firecrawl-mcp"
+      ],
+      "type": "stdio",
+      "env": {
+        "FIRECRAWL_API_KEY": "${FIRECRAWL_API_KEY}"
+      }
+    }
+  },
+  "userConfig": {
+    "firecrawl_api_key": {
+      "type": "string",
+      "title": "Firecrawl API Key",
+      "description": "API key for the Firecrawl scraping platform.",
+      "required": true,
+      "sensitive": true,
+      "env": "FIRECRAWL_API_KEY"
+    }
+  }
+}

--- a/marketplace/plugins/firecrawl/skills/firecrawl/SKILL.md
+++ b/marketplace/plugins/firecrawl/skills/firecrawl/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: firecrawl
+description: Use Firecrawl for bounded, structured web extraction with primary-source preference.
+---
+
+# Firecrawl
+
+Use Firecrawl for bounded, structured web extraction with primary-source preference.
+
+## Use When
+- Scrape a documentation site
+- Extract structured fields from pages
+- Gather cited research sources
+
+## Guardrails
+- Respect site terms and rate limits
+- Do not over-quote copyrighted text
+- Record source URLs in summaries
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/markitdown/.codex-plugin/plugin.json
+++ b/marketplace/plugins/markitdown/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "markitdown",
+  "version": "0.1.0",
+  "description": "Convert PDF, Office, image, and audio files to Markdown for agent ingestion.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Markitdown",
+    "shortDescription": "Convert PDF, Office, image, and audio files to Markdown for agent ingestion.",
+    "longDescription": "Use Markitdown to turn binary documents into clean Markdown before reasoning over them.",
+    "developerName": "OpenCoven",
+    "category": "Agents & Harnesses",
+    "capabilities": [
+      "markdown",
+      "documents",
+      "pdf",
+      "office",
+      "ingestion"
+    ],
+    "defaultPrompt": "Help me use Markitdown safely."
+  }
+}

--- a/marketplace/plugins/markitdown/plugin.json
+++ b/marketplace/plugins/markitdown/plugin.json
@@ -1,0 +1,68 @@
+{
+  "name": "markitdown",
+  "version": "0.1.0",
+  "description": "Convert PDF, Office, image, and audio files to Markdown for agent ingestion.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "markdown",
+    "documents",
+    "pdf",
+    "office",
+    "ingestion"
+  ],
+  "capabilities": [
+    "read_files",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/markitdown",
+  "x-coven": {
+    "displayName": "Markitdown",
+    "category": "Agents & Harnesses",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/microsoft/markitdown"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist"
+        ]
+      },
+      {
+        "familiar": "kitty",
+        "roles": [
+          "general-helper"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "markitdown": {
+      "command": "uvx",
+      "args": [
+        "markitdown-mcp"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/markitdown/skills/markitdown/SKILL.md
+++ b/marketplace/plugins/markitdown/skills/markitdown/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: markitdown
+description: Use Markitdown to turn binary documents into clean Markdown before reasoning over them.
+---
+
+# Markitdown
+
+Use Markitdown to turn binary documents into clean Markdown before reasoning over them.
+
+## Use When
+- Convert a PDF or Word file to Markdown
+- Extract text from images or slides
+- Normalize documents for summarization
+
+## Guardrails
+- Treat converted document content as private by default
+- Confirm the source path before reading
+- Do not exfiltrate document contents externally
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/microsoft-learn/.codex-plugin/plugin.json
+++ b/marketplace/plugins/microsoft-learn/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "microsoft-learn",
+  "version": "0.1.0",
+  "description": "Pull trusted Microsoft Learn documentation directly into agent workflows.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Microsoft Learn",
+    "shortDescription": "Pull trusted Microsoft Learn documentation directly into agent workflows.",
+    "longDescription": "Use Microsoft Learn MCP for authoritative, current Microsoft/Azure documentation.",
+    "developerName": "OpenCoven",
+    "category": "Knowledge & Docs",
+    "capabilities": [
+      "docs",
+      "microsoft",
+      "learn",
+      "reference",
+      "azure"
+    ],
+    "defaultPrompt": "Help me use Microsoft Learn safely."
+  }
+}

--- a/marketplace/plugins/microsoft-learn/plugin.json
+++ b/marketplace/plugins/microsoft-learn/plugin.json
@@ -1,0 +1,60 @@
+{
+  "name": "microsoft-learn",
+  "version": "0.1.0",
+  "description": "Pull trusted Microsoft Learn documentation directly into agent workflows.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "docs",
+    "microsoft",
+    "learn",
+    "reference",
+    "azure"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/microsoft-learn",
+  "x-coven": {
+    "displayName": "Microsoft Learn",
+    "category": "Knowledge & Docs",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://learn.microsoft.com/en-us/training/support/mcp",
+      "https://github.com/MicrosoftDocs/mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "microsoft-learn": {
+      "url": "https://learn.microsoft.com/api/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/microsoft-learn/skills/microsoft-learn/SKILL.md
+++ b/marketplace/plugins/microsoft-learn/skills/microsoft-learn/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: microsoft-learn
+description: Use Microsoft Learn MCP for authoritative, current Microsoft/Azure documentation.
+---
+
+# Microsoft Learn
+
+Use Microsoft Learn MCP for authoritative, current Microsoft/Azure documentation.
+
+## Use When
+- Look up Azure or .NET docs
+- Confirm current API guidance
+- Cite official Microsoft sources
+
+## Guardrails
+- Prefer official docs over generated summaries
+- Cite the page used
+- Match guidance to the relevant product version
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/mongodb/.codex-plugin/plugin.json
+++ b/marketplace/plugins/mongodb/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "mongodb",
+  "version": "0.1.0",
+  "description": "Inspect and query MongoDB databases and collections through the official MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "MongoDB",
+    "shortDescription": "Inspect and query MongoDB databases and collections through the official MCP server.",
+    "longDescription": "Use MongoDB MCP for read-first data inspection with approved, scoped writes.",
+    "developerName": "OpenCoven",
+    "category": "Databases",
+    "capabilities": [
+      "mongodb",
+      "database",
+      "nosql",
+      "collections",
+      "query"
+    ],
+    "defaultPrompt": "Help me use MongoDB safely."
+  }
+}

--- a/marketplace/plugins/mongodb/plugin.json
+++ b/marketplace/plugins/mongodb/plugin.json
@@ -1,0 +1,76 @@
+{
+  "name": "mongodb",
+  "version": "0.1.0",
+  "description": "Inspect and query MongoDB databases and collections through the official MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "mongodb",
+    "database",
+    "nosql",
+    "collections",
+    "query"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/mongodb",
+  "x-coven": {
+    "displayName": "MongoDB",
+    "category": "Databases",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/mongodb-js/mongodb-mcp-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "mongodb": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mongodb-mcp-server"
+      ],
+      "type": "stdio",
+      "env": {
+        "MDB_MCP_CONNECTION_STRING": "${MDB_MCP_CONNECTION_STRING}"
+      }
+    }
+  },
+  "userConfig": {
+    "mongodb_connection_string": {
+      "type": "string",
+      "title": "MongoDB Connection String",
+      "description": "Connection string for the target MongoDB deployment.",
+      "required": true,
+      "sensitive": true,
+      "env": "MDB_MCP_CONNECTION_STRING"
+    }
+  }
+}

--- a/marketplace/plugins/mongodb/skills/mongodb/SKILL.md
+++ b/marketplace/plugins/mongodb/skills/mongodb/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: mongodb
+description: Use MongoDB MCP for read-first data inspection with approved, scoped writes.
+---
+
+# MongoDB
+
+Use MongoDB MCP for read-first data inspection with approved, scoped writes.
+
+## Use When
+- List collections and indexes
+- Run read-only find/aggregate queries
+- Prepare data changes for review
+
+## Guardrails
+- Default to read-only; confirm writes and deletes
+- Never reveal the connection string
+- Scope queries to the smallest dataset needed
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/netdata/.codex-plugin/plugin.json
+++ b/marketplace/plugins/netdata/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "netdata",
+  "version": "0.1.0",
+  "description": "Real-time infrastructure metrics, logs, alerts, and anomaly detection for AI troubleshooting.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Netdata",
+    "shortDescription": "Real-time infrastructure metrics, logs, alerts, and anomaly detection for AI troubleshooting.",
+    "longDescription": "Use Netdata to investigate live infrastructure health before drawing conclusions about incidents.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "monitoring",
+      "metrics",
+      "observability",
+      "logs",
+      "alerts"
+    ],
+    "defaultPrompt": "Help me use Netdata safely."
+  }
+}

--- a/marketplace/plugins/netdata/plugin.json
+++ b/marketplace/plugins/netdata/plugin.json
@@ -1,0 +1,68 @@
+{
+  "name": "netdata",
+  "version": "0.1.0",
+  "description": "Real-time infrastructure metrics, logs, alerts, and anomaly detection for AI troubleshooting.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "monitoring",
+    "metrics",
+    "observability",
+    "logs",
+    "alerts"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/netdata",
+  "x-coven": {
+    "displayName": "Netdata",
+    "category": "Cloud & Infrastructure",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://learn.netdata.cloud/docs/netdata-ai/mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "coordination-layer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "netdata": {
+      "url": "${NETDATA_MCP_URL}",
+      "type": "http"
+    }
+  },
+  "userConfig": {
+    "netdata_mcp_url": {
+      "type": "string",
+      "title": "Netdata MCP URL",
+      "description": "MCP endpoint of your Netdata agent (e.g. http://localhost:19999/mcp). Requires Netdata v2.6.0+.",
+      "required": true,
+      "sensitive": false,
+      "env": "NETDATA_MCP_URL"
+    }
+  }
+}

--- a/marketplace/plugins/netdata/skills/netdata/SKILL.md
+++ b/marketplace/plugins/netdata/skills/netdata/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: netdata
+description: Use Netdata to investigate live infrastructure health before drawing conclusions about incidents.
+---
+
+# Netdata
+
+Use Netdata to investigate live infrastructure health before drawing conclusions about incidents.
+
+## Use When
+- Inspect real-time metrics
+- Correlate alerts with logs
+- Spot anomalies during an incident
+
+## Guardrails
+- Treat telemetry as sensitive
+- Do not change agent config without approval
+- Cite the time window and node inspected
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/next-devtools/.codex-plugin/plugin.json
+++ b/marketplace/plugins/next-devtools/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "next-devtools",
+  "version": "0.1.0",
+  "description": "Bridge agents to a running Next.js 16+ dev server \u2014 errors, logs, routes, and server actions.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Next.js DevTools",
+    "shortDescription": "Bridge agents to a running Next.js 16+ dev server \u2014 errors, logs, routes, and server actions.",
+    "longDescription": "Use Next.js DevTools MCP to debug a running Next.js app against its real runtime state.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "nextjs",
+      "vercel",
+      "frontend",
+      "dev-server",
+      "react"
+    ],
+    "defaultPrompt": "Help me use Next.js DevTools safely."
+  }
+}

--- a/marketplace/plugins/next-devtools/plugin.json
+++ b/marketplace/plugins/next-devtools/plugin.json
@@ -1,0 +1,58 @@
+{
+  "name": "next-devtools",
+  "version": "0.1.0",
+  "description": "Bridge agents to a running Next.js 16+ dev server \u2014 errors, logs, routes, and server actions.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "nextjs",
+    "vercel",
+    "frontend",
+    "dev-server",
+    "react"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/next-devtools",
+  "x-coven": {
+    "displayName": "Next.js DevTools",
+    "category": "Developer Tools",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/vercel/next-devtools-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "next-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "next-devtools-mcp@latest"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/next-devtools/skills/next-devtools/SKILL.md
+++ b/marketplace/plugins/next-devtools/skills/next-devtools/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: next-devtools
+description: Use Next.js DevTools MCP to debug a running Next.js app against its real runtime state.
+---
+
+# Next.js DevTools
+
+Use Next.js DevTools MCP to debug a running Next.js app against its real runtime state.
+
+## Use When
+- Read build and runtime errors
+- Inspect routes and server actions
+- Trace logs from the dev server
+
+## Guardrails
+- Requires a running Next.js 16+ dev server
+- Treat the endpoint as local-only
+- Confirm the target project before acting
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/notion/.codex-plugin/plugin.json
+++ b/marketplace/plugins/notion/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "notion",
+  "version": "0.1.0",
+  "description": "Read, search, and draft Notion pages and databases through Notion's official MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Notion",
+    "shortDescription": "Read, search, and draft Notion pages and databases through Notion's official MCP server.",
+    "longDescription": "Use Notion for knowledge lookup and drafting while keeping page edits behind approval.",
+    "developerName": "OpenCoven",
+    "category": "Productivity",
+    "capabilities": [
+      "notion",
+      "docs",
+      "wiki",
+      "knowledge-base",
+      "notes"
+    ],
+    "defaultPrompt": "Help me use Notion safely."
+  }
+}

--- a/marketplace/plugins/notion/plugin.json
+++ b/marketplace/plugins/notion/plugin.json
@@ -1,0 +1,72 @@
+{
+  "name": "notion",
+  "version": "0.1.0",
+  "description": "Read, search, and draft Notion pages and databases through Notion's official MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "notion",
+    "docs",
+    "wiki",
+    "knowledge-base",
+    "notes"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/notion",
+  "x-coven": {
+    "displayName": "Notion",
+    "category": "Productivity",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://github.com/makenotion/notion-mcp-server",
+      "https://developers.notion.com/docs/mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist"
+        ]
+      },
+      {
+        "familiar": "charm",
+        "roles": [
+          "copywriter"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "coordination-layer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/notion/skills/notion/SKILL.md
+++ b/marketplace/plugins/notion/skills/notion/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: notion
+description: Use Notion for knowledge lookup and drafting while keeping page edits behind approval.
+---
+
+# Notion
+
+Use Notion for knowledge lookup and drafting while keeping page edits behind approval.
+
+## Use When
+- Search the workspace
+- Summarize pages and databases
+- Draft new content for review
+
+## Guardrails
+- Do not create, edit, or move pages without approval
+- Respect workspace permissions
+- Keep private content private by default
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/nuget/.codex-plugin/plugin.json
+++ b/marketplace/plugins/nuget/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "nuget",
+  "version": "0.1.0",
+  "description": "Real-time NuGet package info, vulnerability remediation, and upgrade planning for .NET.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "NuGet",
+    "shortDescription": "Real-time NuGet package info, vulnerability remediation, and upgrade planning for .NET.",
+    "longDescription": "Use NuGet MCP for current package versions and vulnerability-aware dependency choices.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "nuget",
+      "dotnet",
+      "packages",
+      "dependencies",
+      "security"
+    ],
+    "defaultPrompt": "Help me use NuGet safely."
+  }
+}

--- a/marketplace/plugins/nuget/plugin.json
+++ b/marketplace/plugins/nuget/plugin.json
@@ -1,0 +1,59 @@
+{
+  "name": "nuget",
+  "version": "0.1.0",
+  "description": "Real-time NuGet package info, vulnerability remediation, and upgrade planning for .NET.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "nuget",
+    "dotnet",
+    "packages",
+    "dependencies",
+    "security"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/nuget",
+  "x-coven": {
+    "displayName": "NuGet",
+    "category": "Developer Tools",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://learn.microsoft.com/en-us/nuget/concepts/nuget-mcp-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "code-reviewer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "nuget": {
+      "command": "dnx",
+      "args": [
+        "NuGet.Mcp.Server",
+        "--source",
+        "https://api.nuget.org/v3/index.json",
+        "--yes"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/nuget/skills/nuget/SKILL.md
+++ b/marketplace/plugins/nuget/skills/nuget/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: nuget
+description: Use NuGet MCP for current package versions and vulnerability-aware dependency choices.
+---
+
+# NuGet
+
+Use NuGet MCP for current package versions and vulnerability-aware dependency choices.
+
+## Use When
+- Check latest package versions
+- Plan dependency upgrades
+- Review packages for known vulnerabilities
+
+## Guardrails
+- Confirm before changing project dependencies
+- Prefer fixed, current versions
+- Flag supply-chain risks explicitly
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/nuxt-dev/.codex-plugin/plugin.json
+++ b/marketplace/plugins/nuxt-dev/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "nuxt-dev",
+  "version": "0.1.0",
+  "description": "Lets models understand your running Vite/Nuxt app via an MCP endpoint on the dev server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Nuxt Dev",
+    "shortDescription": "Lets models understand your running Vite/Nuxt app via an MCP endpoint on the dev server.",
+    "longDescription": "Use Nuxt Dev MCP to ground frontend work in your actual running app structure.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "nuxt",
+      "vite",
+      "frontend",
+      "dev-server",
+      "vue"
+    ],
+    "defaultPrompt": "Help me use Nuxt Dev safely."
+  }
+}

--- a/marketplace/plugins/nuxt-dev/plugin.json
+++ b/marketplace/plugins/nuxt-dev/plugin.json
@@ -1,0 +1,63 @@
+{
+  "name": "nuxt-dev",
+  "version": "0.1.0",
+  "description": "Lets models understand your running Vite/Nuxt app via an MCP endpoint on the dev server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "nuxt",
+    "vite",
+    "frontend",
+    "dev-server",
+    "vue"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/nuxt-dev",
+  "x-coven": {
+    "displayName": "Nuxt Dev",
+    "category": "Developer Tools",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/antfu/nuxt-mcp-dev"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "nuxt-dev": {
+      "url": "${NUXT_MCP_URL}",
+      "type": "sse"
+    }
+  },
+  "userConfig": {
+    "nuxt_mcp_url": {
+      "type": "string",
+      "title": "Nuxt Dev MCP URL",
+      "description": "SSE endpoint exposed by the nuxt-mcp-dev module or vite-plugin-mcp (e.g. http://localhost:3000/__mcp/sse).",
+      "required": true,
+      "sensitive": false,
+      "env": "NUXT_MCP_URL"
+    }
+  }
+}

--- a/marketplace/plugins/nuxt-dev/skills/nuxt-dev/SKILL.md
+++ b/marketplace/plugins/nuxt-dev/skills/nuxt-dev/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: nuxt-dev
+description: Use Nuxt Dev MCP to ground frontend work in your actual running app structure.
+---
+
+# Nuxt Dev
+
+Use Nuxt Dev MCP to ground frontend work in your actual running app structure.
+
+## Use When
+- Inspect app routes and components
+- Understand local project structure
+- Debug a running Nuxt/Vite app
+
+## Guardrails
+- Requires the dev-server MCP plugin to be enabled
+- Treat the endpoint as local-only
+- Confirm the running app before relying on its state
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/playwright/.codex-plugin/plugin.json
+++ b/marketplace/plugins/playwright/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "playwright",
+  "version": "0.1.0",
+  "description": "Drive real web browsers via accessibility trees for testing, navigation, and data extraction.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Playwright",
+    "shortDescription": "Drive real web browsers via accessibility trees for testing, navigation, and data extraction.",
+    "longDescription": "Use Playwright to navigate and verify web pages through the accessibility tree, not screenshots alone.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "browser",
+      "automation",
+      "testing",
+      "playwright",
+      "scraping"
+    ],
+    "defaultPrompt": "Help me use Playwright safely."
+  }
+}

--- a/marketplace/plugins/playwright/plugin.json
+++ b/marketplace/plugins/playwright/plugin.json
@@ -1,0 +1,64 @@
+{
+  "name": "playwright",
+  "version": "0.1.0",
+  "description": "Drive real web browsers via accessibility trees for testing, navigation, and data extraction.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "browser",
+    "automation",
+    "testing",
+    "playwright",
+    "scraping"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/playwright",
+  "x-coven": {
+    "displayName": "Playwright",
+    "category": "Browser & Web",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/microsoft/playwright-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/playwright/skills/playwright/SKILL.md
+++ b/marketplace/plugins/playwright/skills/playwright/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: playwright
+description: Use Playwright to navigate and verify web pages through the accessibility tree, not screenshots alone.
+---
+
+# Playwright
+
+Use Playwright to navigate and verify web pages through the accessibility tree, not screenshots alone.
+
+## Use When
+- Reproduce a UI bug in a browser
+- Extract structured data from a page
+- Verify a deployed change end to end
+
+## Guardrails
+- Do not submit forms or trigger payments without approval
+- Respect site terms and robots rules
+- Avoid logging into accounts without explicit consent
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/searxng/.codex-plugin/plugin.json
+++ b/marketplace/plugins/searxng/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "searxng",
+  "version": "0.1.0",
+  "description": "Privacy-respecting metasearch with pagination and URL reading through a SearXNG instance.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "SearXNG Search",
+    "shortDescription": "Privacy-respecting metasearch with pagination and URL reading through a SearXNG instance.",
+    "longDescription": "Use SearXNG for privacy-respecting web search against a self-chosen instance.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "search",
+      "privacy",
+      "metasearch",
+      "searxng",
+      "web"
+    ],
+    "defaultPrompt": "Help me use SearXNG Search safely."
+  }
+}

--- a/marketplace/plugins/searxng/plugin.json
+++ b/marketplace/plugins/searxng/plugin.json
@@ -1,0 +1,70 @@
+{
+  "name": "searxng",
+  "version": "0.1.0",
+  "description": "Privacy-respecting metasearch with pagination and URL reading through a SearXNG instance.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "search",
+    "privacy",
+    "metasearch",
+    "searxng",
+    "web"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/searxng",
+  "x-coven": {
+    "displayName": "SearXNG Search",
+    "category": "Browser & Web",
+    "trust": "local-tool",
+    "sourceRefs": [
+      "https://github.com/ihor-sokoliuk/mcp-searxng"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "searxng": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-searxng"
+      ],
+      "type": "stdio",
+      "env": {
+        "SEARXNG_URL": "${SEARXNG_URL}"
+      }
+    }
+  },
+  "userConfig": {
+    "searxng_url": {
+      "type": "string",
+      "title": "SearXNG Instance URL",
+      "description": "Base URL of the SearXNG instance to query.",
+      "required": true,
+      "sensitive": false,
+      "env": "SEARXNG_URL"
+    }
+  }
+}

--- a/marketplace/plugins/searxng/skills/searxng/SKILL.md
+++ b/marketplace/plugins/searxng/skills/searxng/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: searxng
+description: Use SearXNG for privacy-respecting web search against a self-chosen instance.
+---
+
+# SearXNG Search
+
+Use SearXNG for privacy-respecting web search against a self-chosen instance.
+
+## Use When
+- Search without tracking
+- Page through results
+- Read a result URL's content
+
+## Guardrails
+- Use a trusted SearXNG instance
+- Record source URLs
+- Prefer primary sources
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/serena/.codex-plugin/plugin.json
+++ b/marketplace/plugins/serena/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "serena",
+  "version": "0.1.0",
+  "description": "Semantic code retrieval and editing toolkit purpose-built for coding agents and harnesses.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Serena",
+    "shortDescription": "Semantic code retrieval and editing toolkit purpose-built for coding agents and harnesses.",
+    "longDescription": "Use Serena for symbol-level code navigation and edits instead of dumping whole files into context.",
+    "developerName": "OpenCoven",
+    "category": "Agents & Harnesses",
+    "capabilities": [
+      "coding-agent",
+      "semantic-code",
+      "lsp",
+      "refactor",
+      "harness"
+    ],
+    "defaultPrompt": "Help me use Serena safely."
+  }
+}

--- a/marketplace/plugins/serena/plugin.json
+++ b/marketplace/plugins/serena/plugin.json
@@ -1,0 +1,72 @@
+{
+  "name": "serena",
+  "version": "0.1.0",
+  "description": "Semantic code retrieval and editing toolkit purpose-built for coding agents and harnesses.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coding-agent",
+    "semantic-code",
+    "lsp",
+    "refactor",
+    "harness"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/serena",
+  "x-coven": {
+    "displayName": "Serena",
+    "category": "Agents & Harnesses",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/oraios/serena",
+      "https://github.com/mcp-use/mcp-use"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "code-reviewer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "serena": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/oraios/serena",
+        "serena",
+        "start-mcp-server",
+        "--context",
+        "ide-assistant"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/serena/skills/serena/SKILL.md
+++ b/marketplace/plugins/serena/skills/serena/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: serena
+description: Use Serena for symbol-level code navigation and edits instead of dumping whole files into context.
+---
+
+# Serena
+
+Use Serena for symbol-level code navigation and edits instead of dumping whole files into context.
+
+## Use When
+- Find symbols and references
+- Plan precise multi-file edits
+- Read project structure semantically
+
+## Guardrails
+- Confirm the project root before indexing
+- Do not apply edits without approval
+- Prefer targeted symbol reads over whole-file dumps
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/stackql/.codex-plugin/plugin.json
+++ b/marketplace/plugins/stackql/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "stackql",
+  "version": "0.1.0",
+  "description": "Query, provision, and operate cloud, SaaS, and API resources using SQL, over MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "StackQL",
+    "shortDescription": "Query, provision, and operate cloud, SaaS, and API resources using SQL, over MCP.",
+    "longDescription": "Use StackQL for SQL-native cloud inspection, preferring read-only queries before provisioning.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "stackql",
+      "sql",
+      "cloud",
+      "provisioning",
+      "infrastructure"
+    ],
+    "defaultPrompt": "Help me use StackQL safely."
+  }
+}

--- a/marketplace/plugins/stackql/plugin.json
+++ b/marketplace/plugins/stackql/plugin.json
@@ -1,0 +1,65 @@
+{
+  "name": "stackql",
+  "version": "0.1.0",
+  "description": "Query, provision, and operate cloud, SaaS, and API resources using SQL, over MCP.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "stackql",
+    "sql",
+    "cloud",
+    "provisioning",
+    "infrastructure"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/stackql",
+  "x-coven": {
+    "displayName": "StackQL",
+    "category": "Cloud & Infrastructure",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://stackql.io/",
+      "https://github.com/stackql/stackql"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      },
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "stackql": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@stackql/mcp-server"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/stackql/skills/stackql/SKILL.md
+++ b/marketplace/plugins/stackql/skills/stackql/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: stackql
+description: Use StackQL for SQL-native cloud inspection, preferring read-only queries before provisioning.
+---
+
+# StackQL
+
+Use StackQL for SQL-native cloud inspection, preferring read-only queries before provisioning.
+
+## Use When
+- Query cloud resources with SQL
+- Audit configuration across providers
+- Prepare provisioning for review
+
+## Guardrails
+- Default to read-only SELECTs; confirm any provisioning or mutation
+- Never expose provider credentials
+- Scope queries to the smallest provider/account needed
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/stripe/.codex-plugin/plugin.json
+++ b/marketplace/plugins/stripe/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "stripe",
+  "version": "0.1.0",
+  "description": "Work with Stripe customers, products, payments, and billing through the official MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Stripe",
+    "shortDescription": "Work with Stripe customers, products, payments, and billing through the official MCP server.",
+    "longDescription": "Use Stripe MCP for read-first billing inspection; treat money-moving actions as approval-gated.",
+    "developerName": "OpenCoven",
+    "category": "Commerce",
+    "capabilities": [
+      "stripe",
+      "payments",
+      "billing",
+      "customers",
+      "subscriptions"
+    ],
+    "defaultPrompt": "Help me use Stripe safely."
+  }
+}

--- a/marketplace/plugins/stripe/plugin.json
+++ b/marketplace/plugins/stripe/plugin.json
@@ -1,0 +1,60 @@
+{
+  "name": "stripe",
+  "version": "0.1.0",
+  "description": "Work with Stripe customers, products, payments, and billing through the official MCP server.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "stripe",
+    "payments",
+    "billing",
+    "customers",
+    "subscriptions"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/stripe",
+  "x-coven": {
+    "displayName": "Stripe",
+    "category": "Commerce",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://github.com/stripe/agent-toolkit",
+      "https://docs.stripe.com/mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "stripe": {
+      "url": "https://mcp.stripe.com",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/stripe/skills/stripe/SKILL.md
+++ b/marketplace/plugins/stripe/skills/stripe/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: stripe
+description: Use Stripe MCP for read-first billing inspection; treat money-moving actions as approval-gated.
+---
+
+# Stripe
+
+Use Stripe MCP for read-first billing inspection; treat money-moving actions as approval-gated.
+
+## Use When
+- Look up customers and subscriptions
+- Inspect payments and invoices
+- Draft product or price changes for review
+
+## Guardrails
+- Never create charges, refunds, or payouts without explicit approval
+- Treat financial and PII data as highly sensitive
+- Prefer test mode until production is approved
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/supabase/.codex-plugin/plugin.json
+++ b/marketplace/plugins/supabase/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "supabase",
+  "version": "0.1.0",
+  "description": "Manage and query Supabase projects \u2014 database, auth, storage, and edge functions.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Supabase",
+    "shortDescription": "Manage and query Supabase projects \u2014 database, auth, storage, and edge functions.",
+    "longDescription": "Use Supabase MCP for project inspection and approved changes, preferring read-only first.",
+    "developerName": "OpenCoven",
+    "category": "Databases",
+    "capabilities": [
+      "supabase",
+      "postgres",
+      "backend",
+      "auth",
+      "storage"
+    ],
+    "defaultPrompt": "Help me use Supabase safely."
+  }
+}

--- a/marketplace/plugins/supabase/plugin.json
+++ b/marketplace/plugins/supabase/plugin.json
@@ -1,0 +1,76 @@
+{
+  "name": "supabase",
+  "version": "0.1.0",
+  "description": "Manage and query Supabase projects \u2014 database, auth, storage, and edge functions.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "supabase",
+    "postgres",
+    "backend",
+    "auth",
+    "storage"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/supabase",
+  "x-coven": {
+    "displayName": "Supabase",
+    "category": "Databases",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/supabase-community/supabase-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest"
+      ],
+      "type": "stdio",
+      "env": {
+        "SUPABASE_ACCESS_TOKEN": "${SUPABASE_ACCESS_TOKEN}"
+      }
+    }
+  },
+  "userConfig": {
+    "supabase_access_token": {
+      "type": "string",
+      "title": "Supabase Access Token",
+      "description": "Personal access token for the Supabase Management API.",
+      "required": true,
+      "sensitive": true,
+      "env": "SUPABASE_ACCESS_TOKEN"
+    }
+  }
+}

--- a/marketplace/plugins/supabase/skills/supabase/SKILL.md
+++ b/marketplace/plugins/supabase/skills/supabase/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: supabase
+description: Use Supabase MCP for project inspection and approved changes, preferring read-only first.
+---
+
+# Supabase
+
+Use Supabase MCP for project inspection and approved changes, preferring read-only first.
+
+## Use When
+- Inspect tables and policies
+- Run read-only queries
+- Prepare schema or function changes for review
+
+## Guardrails
+- Prefer read-only mode; confirm writes and migrations
+- Scope to a single project
+- Never reveal the access token
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/tavily/.codex-plugin/plugin.json
+++ b/marketplace/plugins/tavily/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "tavily",
+  "version": "0.1.0",
+  "description": "Advanced web search and answer extraction tuned for AI agents.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Tavily",
+    "shortDescription": "Advanced web search and answer extraction tuned for AI agents.",
+    "longDescription": "Use Tavily for fast, agent-friendly web search with concise sourced answers.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "search",
+      "web",
+      "research",
+      "answers",
+      "tavily"
+    ],
+    "defaultPrompt": "Help me use Tavily safely."
+  }
+}

--- a/marketplace/plugins/tavily/plugin.json
+++ b/marketplace/plugins/tavily/plugin.json
@@ -1,0 +1,76 @@
+{
+  "name": "tavily",
+  "version": "0.1.0",
+  "description": "Advanced web search and answer extraction tuned for AI agents.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "search",
+    "web",
+    "research",
+    "answers",
+    "tavily"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/tavily",
+  "x-coven": {
+    "displayName": "Tavily",
+    "category": "Browser & Web",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/tavily-ai/tavily-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "tavily": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "tavily-mcp@latest"
+      ],
+      "type": "stdio",
+      "env": {
+        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+      }
+    }
+  },
+  "userConfig": {
+    "tavily_api_key": {
+      "type": "string",
+      "title": "Tavily API Key",
+      "description": "API key for the Tavily search API.",
+      "required": true,
+      "sensitive": true,
+      "env": "TAVILY_API_KEY"
+    }
+  }
+}

--- a/marketplace/plugins/tavily/skills/tavily/SKILL.md
+++ b/marketplace/plugins/tavily/skills/tavily/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: tavily
+description: Use Tavily for fast, agent-friendly web search with concise sourced answers.
+---
+
+# Tavily
+
+Use Tavily for fast, agent-friendly web search with concise sourced answers.
+
+## Use When
+- Answer a current-events question
+- Find primary sources fast
+- Gather citations for synthesis
+
+## Guardrails
+- Prefer primary sources
+- Record URLs used
+- Flag uncertainty when sources conflict
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/terraform/.codex-plugin/plugin.json
+++ b/marketplace/plugins/terraform/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "terraform",
+  "version": "0.1.0",
+  "description": "Generate accurate Terraform and automate HCP Terraform and Terraform Enterprise workflows.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Terraform",
+    "shortDescription": "Generate accurate Terraform and automate HCP Terraform and Terraform Enterprise workflows.",
+    "longDescription": "Use Terraform MCP for provider-accurate IaC authoring and read-first workspace inspection.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "terraform",
+      "iac",
+      "hashicorp",
+      "infrastructure",
+      "providers"
+    ],
+    "defaultPrompt": "Help me use Terraform safely."
+  }
+}

--- a/marketplace/plugins/terraform/plugin.json
+++ b/marketplace/plugins/terraform/plugin.json
@@ -1,0 +1,66 @@
+{
+  "name": "terraform",
+  "version": "0.1.0",
+  "description": "Generate accurate Terraform and automate HCP Terraform and Terraform Enterprise workflows.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "terraform",
+    "iac",
+    "hashicorp",
+    "infrastructure",
+    "providers"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/terraform",
+  "x-coven": {
+    "displayName": "Terraform",
+    "category": "Cloud & Infrastructure",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/hashicorp/terraform-mcp-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "terraform": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "hashicorp/terraform-mcp-server"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/terraform/skills/terraform/SKILL.md
+++ b/marketplace/plugins/terraform/skills/terraform/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: terraform
+description: Use Terraform MCP for provider-accurate IaC authoring and read-first workspace inspection.
+---
+
+# Terraform
+
+Use Terraform MCP for provider-accurate IaC authoring and read-first workspace inspection.
+
+## Use When
+- Look up provider/resource schemas
+- Draft accurate Terraform config
+- Inspect workspace and run status
+
+## Guardrails
+- Do not apply, destroy, or change state without approval
+- Treat state and variables as sensitive
+- Show plans before any apply
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/unity/.codex-plugin/plugin.json
+++ b/marketplace/plugins/unity/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "unity",
+  "version": "0.1.0",
+  "description": "Bridge AI assistants to the Unity Editor \u2014 assets, scenes, scripts, and task automation.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Unity",
+    "shortDescription": "Bridge AI assistants to the Unity Editor \u2014 assets, scenes, scripts, and task automation.",
+    "longDescription": "Use the Unity MCP bridge to inspect and modify a running Unity project with explicit intent.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "unity",
+      "game-dev",
+      "editor",
+      "assets",
+      "scenes"
+    ],
+    "defaultPrompt": "Help me use Unity safely."
+  }
+}

--- a/marketplace/plugins/unity/plugin.json
+++ b/marketplace/plugins/unity/plugin.json
@@ -1,0 +1,61 @@
+{
+  "name": "unity",
+  "version": "0.1.0",
+  "description": "Bridge AI assistants to the Unity Editor \u2014 assets, scenes, scripts, and task automation.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "unity",
+    "game-dev",
+    "editor",
+    "assets",
+    "scenes"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/unity",
+  "x-coven": {
+    "displayName": "Unity",
+    "category": "Developer Tools",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/CoplayDev/unity-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "unity": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "mcpforunityserver",
+        "mcp-for-unity",
+        "--transport",
+        "stdio"
+      ],
+      "type": "stdio"
+    }
+  }
+}

--- a/marketplace/plugins/unity/skills/unity/SKILL.md
+++ b/marketplace/plugins/unity/skills/unity/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: unity
+description: Use the Unity MCP bridge to inspect and modify a running Unity project with explicit intent.
+---
+
+# Unity
+
+Use the Unity MCP bridge to inspect and modify a running Unity project with explicit intent.
+
+## Use When
+- Inspect scene and asset structure
+- Apply approved editor changes
+- Automate repetitive editor tasks
+
+## Guardrails
+- Confirm a running Editor and correct project before acting
+- Do not delete assets without approval
+- Keep edits scoped to the current task
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -6,6 +6,7 @@ import { pluginBadgeState, type MarketplacePlugin } from "@/lib/marketplace-cata
 
 const TRUST_LABEL: Record<string, string> = {
   "official-remote": "Official",
+  "official-local": "Official",
   "reference-local": "Reference",
   "preview-local": "Preview",
   "local-tool": "Local tool",

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -9,6 +9,7 @@ import { pluginBadgeState, type MarketplacePlugin } from "@/lib/marketplace-cata
 
 const TRUST_LABEL: Record<string, string> = {
   "official-remote": "Official remote",
+  "official-local": "Official (local)",
   "reference-local": "Reference (local)",
   "preview-local": "Preview (local)",
   "local-tool": "Local tool",


### PR DESCRIPTION
## What
Expands the familiars MCP marketplace from 14 → **44 plugins** across **13 categories**.

### Sources absorbed
- **All ~30 servers from github.com/mcp** — Notion, Stripe, Figma, Supabase, MongoDB, Playwright, Chrome DevTools, Firecrawl, Tavily, Bright Data, Apify, Azure / Azure DevOps / Fabric, Terraform, DBHub, Atlassian Rovo, Microsoft Learn, Markitdown, Netdata, Serena, Context7, Desktop Commander, SearXNG, Nuxt, StackQL, NuGet, Unity, Next.js DevTools.
- **Agent/harness/skill MCPs** (via mcp-use) → new **Agents & Harnesses** category: Serena, Context7, Markitdown. (mcp-use is a framework, not a single addable server, so its agent-oriented servers are categorized rather than adding the framework as a plugin.)
- **Activepieces** → new **Automation** category.

### New categories
Agents & Harnesses, Browser & Web, Databases, Cloud & Infrastructure, Commerce, Knowledge & Docs, Automation (alongside the existing six).

### Notes
- Connection configs verified against official docs/repos (e.g. Atlassian `/v1/sse` is retired 30 Jun 2026 → uses `/v1/mcp`).
- New `official-local` trust badge for official-vendor stdio servers (Supabase, Azure, Playwright, …), wired into card + detail label maps.
- Regenerated all manifests / SKILL.md / exports via `scripts/sync-marketplace.py`.

## Test
- `marketplace-catalog.test` passes; full `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)