### PR TITLE
fix(shell): match top sidepanel toggles to nav-rail button width

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3973,8 +3973,11 @@ button:active > .edge-rail-chip {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  width: 28px;
-  height: 28px;
+  /* Match the collapsed nav-rail button hit target (.shell-nav--rail
+     .sidebar-action-row is a 40px square) so the top toggles line up in
+     width with the sidepanel's icon buttons. */
+  width: 40px;
+  height: 40px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -7954,9 +7957,9 @@ a.mobile-handoff__link:hover {
   position: absolute;
   inset: 0;
   margin: auto;
-  width: 28px;
-  height: 28px;
-  border-radius: 10px;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-control);
   pointer-events: none;
   z-index: 1;
   /* White-hot violet core + a 4-point sparkle star (two crossed bright lines),


### PR DESCRIPTION
## What
The top nav-collapse and right-panel toggles (`.shell-top-toggle`) were **28×28px** while the collapsed nav-rail's icon buttons are **40px** squares — so the toggles read as smaller/mismatched.

Bumps `.shell-top-toggle` to **40×40** (fits the 44px `.shell-top` bar) and scales the `magic-cast` click-ripple overlay to match. The familiar-switcher avatar (pinned to 28px by its own tests) is intentionally left as-is — only the toggles changed.

## Test
`misc-aria-fixes`, `shell-edge-rails`, `right-panel-expand` pass; full `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)