### PR TITLE
feat(board): spreadsheet-grade tasks table — striping, reorder, resize, autofit

### DIFF
--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Familiar } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import type { CaveProject } from "@/lib/cave-projects";
@@ -95,6 +95,13 @@ const COLS: ColDef[] = [
   { key: "updatedAt", label: "Updated",   width: "80px" },
 ];
 
+// Persisted, user-arrangeable column layout (order + per-column widths). Kept in
+// localStorage so a reorder/resize survives reloads, like a spreadsheet.
+const ORDER_KEY = "cave:board-table:order";
+const WIDTHS_KEY = "cave:board-table:widths";
+const MIN_COL_PX = 48;
+const MAX_COL_PX = 680;
+
 type Props = {
   cards: Card[];
   familiars: Familiar[];
@@ -114,6 +121,16 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set(["done"]));
 
+  // Column arrangement state (reorder + resize). Defaults match COLS for SSR;
+  // the persisted layout is hydrated after mount to avoid a hydration mismatch.
+  const [colOrder, setColOrder] = useState<SortKey[]>(() => COLS.map((c) => c.key));
+  const [colWidths, setColWidths] = useState<Partial<Record<SortKey, number>>>({});
+  const [dragOverKey, setDragOverKey] = useState<SortKey | null>(null);
+  const hydratedRef = useRef(false);
+  const dragKeyRef = useRef<SortKey | null>(null);
+  const tableRef = useRef<HTMLTableElement | null>(null);
+  const resizeRef = useRef<{ key: SortKey; startX: number; startW: number } | null>(null);
+
   const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
   const resolvedByIdMap = useMemo(() => {
     const m = new Map(resolvedFamiliars.map((f) => [f.id, f]));
@@ -128,6 +145,49 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
     () => familiars.map((f) => <option key={f.id} value={f.id}>{f.display_name}</option>),
     [familiars],
   );
+
+  // Columns rendered in the user's saved order; any unknown/new key is dropped
+  // and any column missing from the saved order is appended so the table is
+  // always complete even if COLS changes between releases.
+  const orderedCols = useMemo(() => {
+    const byKey = new Map(COLS.map((c) => [c.key, c]));
+    const seen = new Set<SortKey>();
+    const out: ColDef[] = [];
+    for (const k of colOrder) {
+      const col = byKey.get(k);
+      if (col && !seen.has(k)) { out.push(col); seen.add(k); }
+    }
+    for (const col of COLS) if (!seen.has(col.key)) out.push(col);
+    return out;
+  }, [colOrder]);
+
+  // Hydrate the persisted layout once, after mount.
+  useEffect(() => {
+    try {
+      const o = localStorage.getItem(ORDER_KEY);
+      if (o) {
+        const arr = JSON.parse(o);
+        if (Array.isArray(arr) && arr.length) setColOrder(arr as SortKey[]);
+      }
+      const w = localStorage.getItem(WIDTHS_KEY);
+      if (w) {
+        const obj = JSON.parse(w);
+        if (obj && typeof obj === "object") setColWidths(obj as Partial<Record<SortKey, number>>);
+      }
+    } catch {
+      /* ignore malformed prefs */
+    }
+    hydratedRef.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    try { localStorage.setItem(ORDER_KEY, JSON.stringify(colOrder)); } catch { /* ignore */ }
+  }, [colOrder]);
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    try { localStorage.setItem(WIDTHS_KEY, JSON.stringify(colWidths)); } catch { /* ignore */ }
+  }, [colWidths]);
 
   const tbodyRef = useRef<HTMLTableSectionElement | null>(null);
   useRovingTabIndex({
@@ -165,6 +225,75 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
   const toggleGroup = (key: string) =>
     setCollapsed((prev) => { const n = new Set(prev); if (n.has(key)) n.delete(key); else n.add(key); return n; });
 
+  // ── Column reorder (drag a header onto another) ─────────────────────────────
+  const onColDrop = (key: SortKey) => {
+    const from = dragKeyRef.current;
+    dragKeyRef.current = null;
+    setDragOverKey(null);
+    if (!from || from === key) return;
+    setColOrder((prev) => {
+      const arr = prev.filter((k): k is SortKey => COLS.some((c) => c.key === k));
+      // Ensure completeness before splicing.
+      for (const c of COLS) if (!arr.includes(c.key)) arr.push(c.key);
+      const fi = arr.indexOf(from);
+      const ti = arr.indexOf(key);
+      if (fi < 0 || ti < 0) return prev;
+      const next = [...arr];
+      next.splice(fi, 1);
+      next.splice(ti, 0, from);
+      return next;
+    });
+  };
+
+  // ── Column resize (drag the right edge) + autofit (double-click) ────────────
+  const onResizeMove = useCallback((e: MouseEvent) => {
+    const r = resizeRef.current;
+    if (!r) return;
+    const next = Math.max(MIN_COL_PX, Math.min(MAX_COL_PX, Math.round(r.startW + (e.clientX - r.startX))));
+    setColWidths((prev) => ({ ...prev, [r.key]: next }));
+  }, []);
+  const onResizeUp = useCallback(() => {
+    resizeRef.current = null;
+    window.removeEventListener("mousemove", onResizeMove);
+    window.removeEventListener("mouseup", onResizeUp);
+    document.body.style.userSelect = "";
+  }, [onResizeMove]);
+  const startResize = useCallback((e: React.MouseEvent, key: SortKey) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const th = (e.currentTarget as HTMLElement).closest("th");
+    const startW = th ? Math.round(th.getBoundingClientRect().width) : (colWidths[key] ?? 120);
+    resizeRef.current = { key, startX: e.clientX, startW };
+    window.addEventListener("mousemove", onResizeMove);
+    window.addEventListener("mouseup", onResizeUp);
+    document.body.style.userSelect = "none";
+  }, [onResizeMove, onResizeUp, colWidths]);
+
+  // Autofit: size the column to its widest content, like double-clicking an
+  // Excel column border. Measures the inner element's scrollWidth (the natural
+  // text width, even when the cell is currently clipping it).
+  const autofitCol = (key: SortKey) => {
+    const table = tableRef.current;
+    if (!table) return;
+    const idx = orderedCols.findIndex((c) => c.key === key);
+    if (idx < 0) return;
+    let max = 0;
+    const head = table.querySelectorAll("thead th")[idx] as HTMLElement | undefined;
+    if (head) {
+      const btn = head.querySelector(".board-table-sort-btn") as HTMLElement | null;
+      max = Math.max(max, (btn?.scrollWidth ?? head.scrollWidth) + 14);
+    }
+    table.querySelectorAll("tbody tr").forEach((tr) => {
+      const cells = tr.children;
+      if (cells.length !== orderedCols.length) return; // skip the single-cell group rows
+      const cell = cells[idx] as HTMLElement;
+      const inner = cell.firstElementChild as HTMLElement | null;
+      max = Math.max(max, inner?.scrollWidth ?? cell.scrollWidth);
+    });
+    const next = Math.min(MAX_COL_PX, Math.max(MIN_COL_PX, max + 22));
+    setColWidths((prev) => ({ ...prev, [key]: next }));
+  };
+
   if (cards.length === 0) {
     return (
       <div className="board-empty">
@@ -176,21 +305,46 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
 
   return (
     <div className="board-table-wrap">
-      <table className="board-table">
+      <table className="board-table board-table--grid" ref={tableRef}>
+        <colgroup>
+          {orderedCols.map((col) => {
+            const w = colWidths[col.key] ?? (col.width ? parseInt(col.width, 10) : undefined);
+            return <col key={col.key} style={w ? { width: `${w}px` } : undefined} />;
+          })}
+        </colgroup>
         <thead>
           <tr>
-            {COLS.map((col) => (
-              <th key={col.key} style={col.width ? { width: col.width } : undefined}
-                className={sortKey === col.key ? "sorted" : ""}
-                aria-sort={sortKey === col.key ? (sortDir === "asc" ? "ascending" : "descending") : "none"}>
-                <button type="button" className="board-table-sort-btn focus-ring" onClick={() => handleCol(col.key)}>
-                  {col.label}
-                  <span className="board-table-sort-icon">
-                    {sortKey === col.key
-                      ? <Icon name={sortDir === "asc" ? "ph:caret-up" : "ph:caret-down-fill"} width={9} />
-                      : <Icon name="ph:caret-up-down" width={9} />}
-                  </span>
-                </button>
+            {orderedCols.map((col) => (
+              <th key={col.key}
+                className={`${sortKey === col.key ? "sorted" : ""}${dragOverKey === col.key ? " board-table-col--dragover" : ""}`.trim()}
+                aria-sort={sortKey === col.key ? (sortDir === "asc" ? "ascending" : "descending") : "none"}
+                onDragOver={(e) => { e.preventDefault(); if (dragOverKey !== col.key) setDragOverKey(col.key); }}
+                onDrop={() => onColDrop(col.key)}>
+                <span
+                  className="board-table-col-head"
+                  draggable
+                  onDragStart={(e) => { dragKeyRef.current = col.key; e.dataTransfer.effectAllowed = "move"; }}
+                  onDragEnd={() => { dragKeyRef.current = null; setDragOverKey(null); }}
+                  title="Drag to reorder column"
+                >
+                  <button type="button" className="board-table-sort-btn focus-ring" onClick={() => handleCol(col.key)}>
+                    {col.label}
+                    <span className="board-table-sort-icon">
+                      {sortKey === col.key
+                        ? <Icon name={sortDir === "asc" ? "ph:caret-up" : "ph:caret-down-fill"} width={9} />
+                        : <Icon name="ph:caret-up-down" width={9} />}
+                    </span>
+                  </button>
+                </span>
+                <span
+                  className="board-table-col-resize"
+                  role="separator"
+                  aria-orientation="vertical"
+                  aria-label={`Resize ${col.label} column — double-click to autofit`}
+                  title="Drag to resize · double-click to autofit"
+                  onMouseDown={(e) => startResize(e, col.key)}
+                  onDoubleClick={(e) => { e.preventDefault(); e.stopPropagation(); autofitCol(col.key); }}
+                />
               </th>
             ))}
           </tr>
@@ -213,68 +367,95 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                   <span className="board-table-group-badge">{gc.length}</span>
                 </td>
               </tr>
-              {!collapsed.has(key) && gc.map((card) => {
+              {!collapsed.has(key) && gc.map((card, rowIdx) => {
                 const resolvedFamiliar = card.familiarId ? resolvedByIdMap.get(card.familiarId) ?? null : null;
                 const rowChecked = selectMode && !!isSelected?.(card.id);
+                const isSel = selectMode ? rowChecked : selectedCardId === card.id;
                 return (
                   <tr key={card.id}
                     data-board-row="true"
                     data-card-id={card.id}
                     role={selectMode ? "checkbox" : undefined}
                     aria-checked={selectMode ? rowChecked : undefined}
-                    className={(selectMode ? rowChecked : selectedCardId === card.id) ? "selected" : ""}
+                    className={`${isSel ? "selected" : ""}${rowIdx % 2 === 1 ? " board-table-row--alt" : ""}`.trim()}
                     onClick={() => (selectMode ? onToggleSelect?.(card.id) : onSelect(card.id))}>
-                    <td>
-                      <span className="board-table-title-cell" style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                        {selectMode && (
-                          <span
-                            aria-hidden
-                            style={{
-                              display: "inline-flex", alignItems: "center", justifyContent: "center",
-                              height: 16, width: 16, flexShrink: 0, borderRadius: 4,
-                              border: `1px solid ${rowChecked ? "var(--accent-presence)" : "var(--border-strong)"}`,
-                              background: rowChecked ? "var(--accent-presence)" : "transparent",
-                            }}
-                          >
-                            {rowChecked && <Icon name="ph:check-bold" width={11} className="text-white" />}
-                          </span>
-                        )}
-                        <span className="board-table-title" title={card.title}>{card.title}</span>
-                      </span>
-                    </td>
-                    <td>
-                      <span className="board-table-cell-status">
-                        <span className={`board-table-status-dot board-table-status-dot--${card.status}`} aria-hidden />
-                        <span>{card.status.charAt(0).toUpperCase() + card.status.slice(1)}</span>
-                      </span>
-                    </td>
-                    <td>
-                      <span className="board-table-cell-priority">
-                        <span className={`board-table-priority-flag board-table-priority-flag--${card.priority}`} aria-hidden />
-                        <span>{card.priority.charAt(0).toUpperCase() + card.priority.slice(1)}</span>
-                      </span>
-                    </td>
-                    <td>
-                      <span className="board-table-cell-familiar">
-                        <span className={`board-table-familiar-avatar${resolvedFamiliar ? "" : " board-table-familiar-avatar--empty"}`} aria-hidden>
-                          {resolvedFamiliar ? <FamiliarAvatar familiar={resolvedFamiliar} size="sm" /> : <Icon name="ph:user" width={9} />}
-                        </span>
-                        <select
-                          className="board-table-familiar-select"
-                          value={card.familiarId ?? ""}
-                          aria-label={`Assign familiar for ${card.title}`}
-                          onClick={(e) => e.stopPropagation()}
-                          onChange={(e) => onPatch(card.id, { familiarId: e.target.value || null })}
-                        >
-                          <option value="">Unassigned</option>
-                          {familiarOptions}
-                        </select>
-                      </span>
-                    </td>
-                    <td><LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} /></td>
-                    <td><span className="board-table-cell-date">{formatBoardDate(card.startDate)}</span></td>
-                    <td><span className="board-table-cell-date">{formatBoardDate(card.endDate)}</span></td>
-                    <td style={{ textAlign: "right" }}><RelativeTime iso={card.updatedAt} className="board-table-cell-time" /></td>
+                    {orderedCols.map((col) => {
+                      let content: React.ReactNode = null;
+                      switch (col.key) {
+                        case "title":
+                          content = (
+                            <span className="board-table-title-cell" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                              {selectMode && (
+                                <span
+                                  aria-hidden
+                                  style={{
+                                    display: "inline-flex", alignItems: "center", justifyContent: "center",
+                                    height: 16, width: 16, flexShrink: 0, borderRadius: 4,
+                                    border: `1px solid ${rowChecked ? "var(--accent-presence)" : "var(--border-strong)"}`,
+                                    background: rowChecked ? "var(--accent-presence)" : "transparent",
+                                  }}
+                                >
+                                  {rowChecked && <Icon name="ph:check-bold" width={11} className="text-white" />}
+                                </span>
+                              )}
+                              <span className="board-table-title" title={card.title}>{card.title}</span>
+                            </span>
+                          );
+                          break;
+                        case "status":
+                          content = (
+                            <span className="board-table-cell-status">
+                              <span className={`board-table-status-dot board-table-status-dot--${card.status}`} aria-hidden />
+                              <span>{card.status.charAt(0).toUpperCase() + card.status.slice(1)}</span>
+                            </span>
+                          );
+                          break;
+                        case "priority":
+                          content = (
+                            <span className="board-table-cell-priority">
+                              <span className={`board-table-priority-flag board-table-priority-flag--${card.priority}`} aria-hidden />
+                              <span>{card.priority.charAt(0).toUpperCase() + card.priority.slice(1)}</span>
+                            </span>
+                          );
+                          break;
+                        case "familiar":
+                          content = (
+                            <span className="board-table-cell-familiar">
+                              <span className={`board-table-familiar-avatar${resolvedFamiliar ? "" : " board-table-familiar-avatar--empty"}`} aria-hidden>
+                                {resolvedFamiliar ? <FamiliarAvatar familiar={resolvedFamiliar} size="sm" /> : <Icon name="ph:user" width={9} />}
+                              </span>
+                              <select
+                                className="board-table-familiar-select"
+                                value={card.familiarId ?? ""}
+                                aria-label={`Assign familiar for ${card.title}`}
+                                onClick={(e) => e.stopPropagation()}
+                                onChange={(e) => onPatch(card.id, { familiarId: e.target.value || null })}
+                              >
+                                <option value="">Unassigned</option>
+                                {familiarOptions}
+                              </select>
+                            </span>
+                          );
+                          break;
+                        case "lifecycle":
+                          content = <LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} />;
+                          break;
+                        case "startDate":
+                          content = <span className="board-table-cell-date">{formatBoardDate(card.startDate)}</span>;
+                          break;
+                        case "endDate":
+                          content = <span className="board-table-cell-date">{formatBoardDate(card.endDate)}</span>;
+                          break;
+                        case "updatedAt":
+                          content = <RelativeTime iso={card.updatedAt} className="board-table-cell-time" />;
+                          break;
+                      }
+                      return (
+                        <td key={col.key} style={col.key === "updatedAt" ? { textAlign: "right" } : undefined}>
+                          {content}
+                        </td>
+                      );
+                    })}
                   </tr>
                 );
               })}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -223,6 +223,43 @@
 .board-table-cell-date { color:var(--text-secondary); font-size:11px; font-variant-numeric:tabular-nums; white-space:nowrap; }
 .board-table-cell-time { color:var(--text-muted); font-size:11px; font-variant-numeric:tabular-nums; }
 
+/* ── Spreadsheet-grade tasks table (board-table--grid only; the library list
+   reuses .board-table and must stay untouched) ─────────────────────────────
+   Larger/more legible type, zebra striping, fixed layout so columns honour the
+   user's drag-to-resize widths, draggable headers, and resize/autofit handles. */
+.board-table--grid { table-layout:fixed; font-size:13px; }
+.board-table--grid td { padding:9px 10px; overflow:hidden; }
+.board-table--grid thead th { font-size:12px; padding:8px 10px; }
+.board-table--grid .board-table-title { max-width:none; font-size:13px; color:var(--text-primary); }
+.board-table--grid .board-table-cell-status,
+.board-table--grid .board-table-cell-priority,
+.board-table--grid .board-table-cell-familiar { font-size:12.5px; }
+.board-table--grid .board-table-cell-date,
+.board-table--grid .board-table-cell-time { font-size:12.5px; }
+.board-table--grid .board-table-familiar-select { font-size:12.5px; max-width:none; }
+
+/* Slight zebra striping; hover + selected always win (hence :not()). */
+.board-table--grid tbody tr.board-table-row--alt:not(:hover):not(.selected) td {
+  background:color-mix(in oklch,var(--foreground) 3.5%,transparent);
+}
+
+/* Header is a flex row: draggable label + a resize gutter pinned right. */
+.board-table--grid thead th { position:relative; }
+.board-table-col-head { display:flex; align-items:center; min-width:0; width:100%; cursor:grab; }
+.board-table-col-head:active { cursor:grabbing; }
+.board-table--grid thead th.board-table-col--dragover { box-shadow:inset 2px 0 0 var(--accent-presence); }
+.board-table--grid thead th.board-table-col--dragover .board-table-col-head { opacity:0.7; }
+.board-table-col-resize {
+  position:absolute; top:0; right:0; height:100%; width:8px; z-index:11;
+  cursor:col-resize; user-select:none; touch-action:none;
+}
+.board-table-col-resize::after {
+  content:""; position:absolute; right:3px; top:5px; bottom:5px; width:2px; border-radius:2px;
+  background:var(--border-strong); opacity:0; transition:opacity .12s ease;
+}
+.board-table--grid thead th:hover .board-table-col-resize::after,
+.board-table-col-resize:hover::after { opacity:1; }
+
 .board-swimlane { flex-shrink:0; border-bottom:1px solid var(--border-hairline); }
 .board-swimlane-header { display:flex; align-items:center; gap:8px; padding:8px 16px 6px; font-size:11px; font-weight:600; color:var(--text-secondary); letter-spacing:.05em; text-transform:uppercase; user-select:none; }
 .board-swimlane-toggle { display:inline-flex; align-items:center; gap:8px; background:none; border:none; padding:0; margin:0; font:inherit; color:inherit; letter-spacing:inherit; text-transform:inherit; cursor:pointer; }


### PR DESCRIPTION
## What
Upgrades the Tasks table (`BoardTable`, used only in `board-view.tsx`). All new styling is scoped to a new `board-table--grid` class so the Library list that reuses `.board-table` is untouched.

1. **Alternating row striping** — subtle zebra (`:not(:hover):not(.selected)` so hover/selection win).
2. **Larger, more visible font** — 12→13px body, 11.5→12.5px sub-cells, 11→12px headers.
3. **Reorder columns** — drag a header onto another; body cells render in the saved order so headers/data stay in sync.
4. **Resize width** — drag a header's right-edge gutter (`table-layout: fixed` + `<colgroup>`); horizontal scroll when total width exceeds the pane.
5. **Excel-style autofit** — double-click the gutter to size a column to its widest content.

Order + widths persist to `localStorage` (`cave:board-table:order` / `:widths`), hydrated after mount to avoid SSR mismatch.

## Test
Board tests pass (`board-table-keyboard`, `board-grouping`, `board-bulk-select`, `board-schedule-window`, `board-table-familiar-select`, `a11y-audit-fixes`, `board-view-familiar-scope`) + `library-polish` (confirms Library list unaffected); full `tsc --noEmit` clean; rendered screenshot reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)