### PR TITLE
feat(ios): Control Center controls for reminders + running tasks

### DIFF
--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveControls.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveControls.swift
@@ -1,0 +1,46 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+// Control Center / Lock Screen controls (iOS 18). Each is a one-tap shortcut
+// that opens the app at the right surface via the covencave:// deep links the
+// app already routes (see CovenCaveApp.onOpenURL). The Tasks control also shows
+// a live "running" count read from the shared App Group snapshot.
+
+/// Open the reminders list.
+struct RemindersControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "ai.opencoven.cave.control.reminders") {
+            ControlWidgetButton(action: OpenURLIntent(URL(string: "covencave://reminders")!)) {
+                Label("Reminders", systemImage: "bell.fill")
+            }
+        }
+        .displayName("Coven Reminders")
+        .description("Open your reminders in Coven Cave.")
+    }
+}
+
+/// Supplies the current "running tasks" count for the Tasks control.
+struct RunningTasksValueProvider: ControlValueProvider {
+    var previewValue: Int { 1 }
+
+    func currentValue() async throws -> Int {
+        WidgetSnapshotStore.read()?.runningTaskCount ?? 0
+    }
+}
+
+/// Show how many tasks are running and open the Tasks tab.
+struct TasksControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: "ai.opencoven.cave.control.tasks",
+            provider: RunningTasksValueProvider()
+        ) { running in
+            ControlWidgetButton(action: OpenURLIntent(URL(string: "covencave://tasks")!)) {
+                Label(running > 0 ? "\(running) running" : "Tasks", systemImage: "play.circle.fill")
+            }
+        }
+        .displayName("Coven Tasks")
+        .description("See running tasks and open the Tasks tab.")
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
+++ b/apps/ios/CovenCave/CovenCaveWidgets/CovenCaveWidgets.swift
@@ -257,5 +257,7 @@ struct CovenCaveWidgetsBundle: WidgetBundle {
     var body: some Widget {
         TaskLiveActivity()
         UpNextWidget()
+        RemindersControl()
+        TasksControl()
     }
 }


### PR DESCRIPTION
Adds two **iOS 18 Control Center / Lock Screen controls** to the widget extension:

- **Coven Reminders** — one tap opens the reminders list.
- **Coven Tasks** — shows a live "N running" count (read from the shared App Group snapshot) and opens the Tasks tab.

Both are `ControlWidgetButton`s that open the app via the `covencave://` deep links the app already routes (`OpenURLIntent` → `onOpenURL`), so there's no new plumbing — they reuse the deep-link + snapshot work from #1887 / #1884.

## Verified
- `xcodebuild` for the iOS Simulator: **BUILD SUCCEEDED** (app + widget extension; the `ControlWidget` API compiles).
- Mobile source-text suite green (65); app launches with no crash.
- **Caveat:** adding a control to Control Center isn't `simctl`-automatable, so the placed control is verified at the build/compile level only — not via a runtime screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)