### PR TITLE
feat(home): Codex-style composer + connector cards on the home surface

### DIFF
--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -11,26 +11,29 @@ const globals = await readFile(
   "utf8",
 );
 
-// ───── Suggestion chips ellipsis cleanly inside their max-width ─────
-// Without these, long chip titles ("Continue: Task context: Title: …") spill
-// past the suggestion-row edge and clip at the viewport on phones.
-const chipMatch = css.match(/\.hc-suggestion\s*\{([^}]*)\}/);
-assert.ok(chipMatch, ".hc-suggestion rule must exist");
+// ───── Connector cards lay out 3-up and don't overflow their column ─────
+// The cards replaced the suggestion chips; they grid 3-up on desktop and stack
+// to a single column on narrow viewports so titles/subtitles never clip.
+const connectorsMatch = css.match(/\.home-composer-connectors\s*\{([^}]*)\}/);
+assert.ok(connectorsMatch, ".home-composer-connectors grid rule must exist");
 assert.match(
-  chipMatch[1],
-  /max-width:\s*min\(100%, 360px\);/,
-  ".hc-suggestion caps chip width at 360px",
+  connectorsMatch[1],
+  /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\);/,
+  ".home-composer-connectors is a 3-up grid with min-width:0 tracks (cards can shrink)",
 );
+
+const connectorMatch = css.match(/\.hc-connector\s*\{([^}]*)\}/);
+assert.ok(connectorMatch, ".hc-connector rule must exist");
 assert.match(
-  chipMatch[1],
+  connectorMatch[1],
   /min-width:\s*0;/,
-  ".hc-suggestion has min-width: 0 so flex children can shrink for ellipsis",
+  ".hc-connector has min-width: 0 so the card can shrink inside its grid track",
 );
 
 assert.match(
   css,
-  /\.hc-suggestion > span\s*\{[\s\S]*?min-width:\s*0;[\s\S]*?overflow:\s*hidden;[\s\S]*?text-overflow:\s*ellipsis;[\s\S]*?white-space:\s*nowrap;/,
-  ".hc-suggestion > span ellipsis chain (min-width: 0 + overflow + text-overflow + nowrap)",
+  /@media \(max-width: 640px\)\s*\{[\s\S]*?\.home-composer-connectors\s*\{[\s\S]*?grid-template-columns:\s*1fr;/,
+  "connector cards collapse to a single column under 640px",
 );
 
 // ───── Phone composer controls are thumb-sized ─────
@@ -42,8 +45,8 @@ assert.match(
 
 assert.match(
   css,
-  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-suggestion\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "phone suggestion chips should meet the shared touch target",
+  /@media \(max-width: 640px\)\s*\{[\s\S]*?\.hc-connector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "stacked connector cards should meet the shared touch target",
 );
 
 // ───── Keyboard hint hides on touch ─────

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -33,11 +33,13 @@ assert.match(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ command
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 assert.match(css, /\.hc-keyboard-hint\s*\{[\s\S]*?color:\s*var\(--text-muted\)/, ".hc-keyboard-hint CSS with --text-muted");
 
-// ───────── Task 3: Visible Send label ─────────
-assert.match(source, /<span className="hc-send-label">Send<\/span>/, "Send label in button body");
-assert.match(source, /aria-label="Send"/, "Button keeps aria-label='Send'");
-assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?gap:\s*5px/, ".hc-send-btn uses gap: 5px");
-assert.doesNotMatch(css, /\.hc-send-btn\s*\{[\s\S]*?width:\s*32px;[\s\S]*?height:\s*32px;[\s\S]*?\}/, "Old fixed 32x32 size removed");
-assert.match(css, /\.hc-send-label\s*\{/, ".hc-send-label rule defined");
+// ───────── Task 3: Circular icon-only Send button ─────────
+// The Codex-style composer uses a round arrow button. The visible "Send" text
+// label is gone, but the button keeps an aria-label so screen readers announce
+// it, and the icon-only disc is a full circle.
+assert.match(source, /aria-label="Send"/, "Send button keeps aria-label='Send'");
+assert.doesNotMatch(source, /className="hc-send-label"/, "visible Send text label removed (button is icon-only)");
+assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule removed");
+assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/, ".hc-send-btn is a circular disc");
 
 console.log("home-composer-polish.test.ts: ok");

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -16,8 +16,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { Familiar, SessionRow } from "@/lib/types";
-import type { InboxItem } from "@/lib/cave-inbox";
+import type { Familiar } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
 import type { ChatModelState } from "@/lib/chat-model-state";
@@ -36,15 +35,44 @@ const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
 ];
 
 const PLACEHOLDERS: Record<Destination, string> = {
-  chat: "Ask a familiar anything…",
+  chat: "Do anything",
   board: "Describe a new task…",
   reminder: "Remind me about…",
 };
 
+// Connector cards mirror the Codex-style cold start: one-tap entry points into
+// the marketplace for the integrations that give a familiar real context.
+type Connector = {
+  id: string;
+  title: string;
+  subtitle: string;
+  glyph: "slack" | "gmail" | "drive";
+};
+
+const CONNECTORS: Connector[] = [
+  {
+    id: "slack",
+    title: "Connect messaging",
+    subtitle: "Get context from recent team discussions",
+    glyph: "slack",
+  },
+  {
+    id: "gmail",
+    title: "Connect email",
+    subtitle: "Summarize stakeholder asks from email",
+    glyph: "gmail",
+  },
+  {
+    id: "drive",
+    title: "Connect files",
+    subtitle: "Review results, research, and plans",
+    glyph: "drive",
+  },
+];
+
 type Props = {
   familiars: Familiar[];
   activeFamiliarId: string | null;
-  sessions: SessionRow[];
   onSetActiveFamiliar: (id: string) => void;
   /** Open a new chat that sends `prompt` through ChatView's streaming path.
    *  Home never talks to the chat API itself — a fire-and-cancel send here
@@ -56,13 +84,9 @@ type Props = {
   /** Submit a slash command. Mirrors the chat composer's escape hatch so
    *  `/inbox`, `/board`, `/remind …` etc. work from the home screen too. */
   onSlash?: (command: string, args: string) => void;
+  /** Open the marketplace for a connector card (Slack / Gmail / Drive). */
+  onConnect?: (connectorId: string) => void;
 };
-
-const SEED_SUGGESTIONS = [
-  "Summarise what my active familiar has been working on today",
-  "Create a board card for the next app polish pass",
-  "Remind me to review PRs tomorrow at 10 AM",
-];
 
 // Persist the in-progress prompt so a page reload doesn't eat what you were
 // typing on the home screen (mirrors the chat composer's draft persistence).
@@ -94,19 +118,17 @@ function writeHomeDraft(text: string) {
 export function HomeComposer({
   familiars,
   activeFamiliarId,
-  sessions,
   onSetActiveFamiliar,
   onStartChat,
   onNavigateToBoard,
   onNavigateToInbox,
   onToast,
   onSlash,
+  onConnect,
 }: Props) {
   const [text, setText] = useState(() => readHomeDraft());
   const [destination, setDestination] = useState<Destination>("chat");
   const [sending, setSending] = useState(false);
-  const [suggestions, setSuggestions] = useState<string[]>([]);
-  const [suggestionsLoading, setSuggestionsLoading] = useState(true);
   const [history, setHistory] = useState<string[]>(() => readComposerHistory(HOME_HISTORY_KEY));
   const [historyIdx, setHistoryIdx] = useState<number>(-1);
   const [slashIdx, setSlashIdx] = useState(0);
@@ -207,36 +229,24 @@ export function HomeComposer({
     setTimeout(() => textareaRef.current?.focus(), 80);
   }, []);
 
-  // Build suggestions from recent sessions + inbox
-  useEffect(() => {
-    let cancelled = false;
-    setSuggestionsLoading(true);
-    void (async () => {
-      const lines: string[] = [];
-      const recentTitles = sessions
-        .filter((s) => !s.archived_at && s.title)
-        .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
-        .slice(0, 2)
-        .map((s) => `Continue: ${s.title}`);
-      lines.push(...recentTitles);
-      try {
-        const res = await fetch("/api/inbox?status=pending", { cache: "no-store" });
-        if (res.ok) {
-          const json = (await res.json()) as { ok: boolean; items: InboxItem[] };
-          if (json.ok) lines.push(...json.items.slice(0, 3 - lines.length).map((i) => i.title));
-        }
-      } catch { /* silent — falls back to seeds below */ }
-      while (lines.length < 3) {
-        const seed = SEED_SUGGESTIONS[lines.length % SEED_SUGGESTIONS.length];
-        if (seed && !lines.includes(seed)) lines.push(seed); else break;
-      }
-      if (!cancelled) {
-        setSuggestions(lines.slice(0, 3));
-        setSuggestionsLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [sessions]);
+  // Short model label for the toolbar chip (e.g. "openai/gpt-5.5" → "gpt-5.5").
+  const modelLabel = useMemo(() => {
+    const m = modelState?.effectiveModel;
+    if (!m || m === "unknown") return null;
+    return m.includes("/") ? m.slice(m.lastIndexOf("/") + 1) : m;
+  }, [modelState]);
+
+  // The "＋" affordance reveals the slash-command menu (board/remind/model/…),
+  // and the model chip jumps straight to the inline /model picker. Both keep the
+  // home composer's single text entry path — no separate dialogs to wire up.
+  const openCommands = useCallback(() => {
+    setText((t) => (t.trim() ? t : "/"));
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, []);
+  const openModelPicker = useCallback(() => {
+    setText("/model ");
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, []);
 
   // Auto-grow textarea
   const autoGrow = useCallback(() => {
@@ -450,7 +460,7 @@ export function HomeComposer({
 
       {/* Headline */}
       <div className="home-composer-hero">
-        <h1 className="home-composer-headline">What can the Coven do?</h1>
+        <h1 className="home-composer-headline">What should we build in coven-cave?</h1>
       </div>
 
       {/* Composer card — wrapped so the slash menu can render above the
@@ -551,6 +561,16 @@ export function HomeComposer({
 
         {/* Action bar */}
         <div className="hc-action-bar">
+          <button
+            type="button"
+            className="hc-add-btn"
+            onClick={openCommands}
+            aria-label="Commands"
+            title="Slash commands"
+          >
+            <Icon name="ph:plus" width={15} aria-hidden />
+          </button>
+
           <label className="hc-familiar-selector">
             <Icon name="ph:sparkle" width={13} className="hc-familiar-glyph" aria-hidden />
             <select
@@ -600,7 +620,20 @@ export function HomeComposer({
             ))}
           </div>
 
-          {/* Right: send */}
+          {/* Right cluster: model chip + circular send */}
+          {modelLabel ? (
+            <button
+              type="button"
+              className="hc-model-chip"
+              onClick={openModelPicker}
+              title="Change model"
+            >
+              <Icon name="ph:lightning-fill" width={12} className="hc-model-bolt" aria-hidden />
+              <span className="hc-model-name">{modelLabel}</span>
+              <Icon name="ph:caret-down-bold" width={9} aria-hidden />
+            </button>
+          ) : null}
+
           <button
             type="button"
             className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() ? " empty" : ""}`}
@@ -611,10 +644,7 @@ export function HomeComposer({
             {sending ? (
               <span className="hc-spinner" />
             ) : (
-              <>
-                <Icon name="ph:arrow-up-bold" width={11} aria-hidden />
-                <span className="hc-send-label">Send</span>
-              </>
+              <Icon name="ph:arrow-up-bold" width={14} aria-hidden />
             )}
           </button>
         </div>
@@ -625,28 +655,68 @@ export function HomeComposer({
         ⏎ send · ⇧⏎ newline · ↑↓ history · / commands
       </div>
 
-      {/* Suggestions */}
-      {suggestionsLoading ? (
-        <div className="home-composer-suggestions" aria-hidden>
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="hc-suggestion-skeleton" />
-          ))}
-        </div>
-      ) : suggestions.length > 0 ? (
-        <div className="home-composer-suggestions">
-          {suggestions.map((s, i) => (
-            <button
-              key={i}
-              type="button"
-              className="hc-suggestion"
-              onClick={() => { setText(s); setTimeout(() => textareaRef.current?.focus(), 0); }}
-            >
-              <Icon name="ph:arrow-bend-up-right" width={11} className="hc-suggestion-icon" aria-hidden />
-              <span>{s}</span>
-            </button>
-          ))}
-        </div>
-      ) : null}
+      {/* Connector cards — one-tap entry points into the marketplace. */}
+      <div className="home-composer-suggestions home-composer-connectors">
+        {CONNECTORS.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            className="hc-connector"
+            onClick={() => {
+              if (onConnect) onConnect(c.id);
+              else onToast("Open the Marketplace to connect integrations.");
+            }}
+          >
+            <span className="hc-connector-glyph" aria-hidden>
+              <BrandGlyph glyph={c.glyph} />
+            </span>
+            <span className="hc-connector-title">{c.title}</span>
+            <span className="hc-connector-sub">{c.subtitle}</span>
+          </button>
+        ))}
+      </div>
     </div>
+  );
+}
+
+// ─── Brand glyphs ───────────────────────────────────────────────────────────
+// Inline, full-colour marks for the connector cards. The shared Icon component
+// only ships the monochrome Phosphor subset, so the multi-colour brand logos
+// live here as small inline SVGs.
+function BrandGlyph({ glyph }: { glyph: Connector["glyph"] }) {
+  if (glyph === "slack") {
+    return (
+      <svg viewBox="0 0 122.8 122.8" width="22" height="22" aria-hidden focusable="false">
+        <path d="M25.8 77.6a12.9 12.9 0 1 1-12.9-12.9h12.9z" fill="#E01E5A" />
+        <path d="M32.3 77.6a12.9 12.9 0 0 1 25.8 0v32.3a12.9 12.9 0 0 1-25.8 0z" fill="#E01E5A" />
+        <path d="M45.2 25.8a12.9 12.9 0 1 1 12.9-12.9v12.9z" fill="#36C5F0" />
+        <path d="M45.2 32.3a12.9 12.9 0 0 1 0 25.8H12.9a12.9 12.9 0 0 1 0-25.8z" fill="#36C5F0" />
+        <path d="M97 45.2a12.9 12.9 0 1 1 12.9 12.9H97z" fill="#2EB67D" />
+        <path d="M90.5 45.2a12.9 12.9 0 0 1-25.8 0V12.9a12.9 12.9 0 0 1 25.8 0z" fill="#2EB67D" />
+        <path d="M77.6 97a12.9 12.9 0 1 1-12.9 12.9V97z" fill="#ECB22E" />
+        <path d="M77.6 90.5a12.9 12.9 0 0 1 0-25.8h32.3a12.9 12.9 0 0 1 0 25.8z" fill="#ECB22E" />
+      </svg>
+    );
+  }
+  if (glyph === "gmail") {
+    return (
+      <svg viewBox="0 0 48 36" width="22" height="22" aria-hidden focusable="false">
+        <path fill="#4285F4" d="M3.27 35.5H10V19L0 11.5v20.73c0 1.8 1.47 3.27 3.27 3.27z" />
+        <path fill="#34A853" d="M38 35.5h6.73c1.8 0 3.27-1.47 3.27-3.27V11.5L38 19z" />
+        <path fill="#FBBC04" d="M38 3.77V19l10-7.5V5.27c0-4.55-5.2-7.14-8.84-4.41z" />
+        <path fill="#EA4335" d="M10 19V3.77L24 14.32 38 3.77V19L24 29.55z" />
+        <path fill="#C5221F" d="M0 5.27V11.5l10 7.5V3.77L8.84.86C5.2-1.87 0 .72 0 5.27z" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 87.3 78" width="22" height="22" aria-hidden focusable="false">
+      <path d="M6.6 66.85l3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3l13.75-23.8H0c0 1.55.4 3.1 1.2 4.5z" fill="#0066da" />
+      <path d="M43.65 25L29.9 1.2c-1.35.8-2.5 1.9-3.3 3.3L1.2 48.5C.4 49.9 0 51.45 0 53h27.5z" fill="#00ac47" />
+      <path d="M73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75 7.65-13.25c.8-1.4 1.2-2.95 1.2-4.5H59.8l5.85 11.45z" fill="#ea4335" />
+      <path d="M43.65 25L57.4 1.2C56.05.4 54.5 0 52.9 0H34.4c-1.6 0-3.15.45-4.5 1.2z" fill="#00832d" />
+      <path d="M59.8 53H27.5L13.75 76.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z" fill="#2684fc" />
+      <path d="M73.4 26.5L60.65 4.5c-.8-1.4-1.95-2.5-3.3-3.3L43.65 25 59.8 53h27.45c0-1.55-.4-3.1-1.2-4.5z" fill="#ffba00" />
+    </svg>
   );
 }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -189,6 +189,11 @@ export function Workspace() {
   const [topSearchQuery, setTopSearchQuery] = useState("");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [mode, setMode] = useState<WorkspaceMode>("home");
+  // Deep-link target for the Roles surface's inner tabs. The home connector
+  // cards open the marketplace tab; cleared once we leave Roles so a later
+  // sidebar visit lands on the default Roles tab.
+  const [pendingPluginsTab, setPendingPluginsTab] =
+    useState<"marketplace" | null>(null);
   // Whether the first daemon status poll has resolved. Until it has, the daemon
   // state is *unknown* (not "offline"), so the offline banner must stay hidden.
   const [daemonStatusResolved, setDaemonStatusResolved] = useState(false);
@@ -413,6 +418,12 @@ export function Workspace() {
     window.addEventListener("cave:navigate-mode", onNavigate as EventListener);
     return () => window.removeEventListener("cave:navigate-mode", onNavigate as EventListener);
   }, []);
+
+  // Once the Roles deep-link has been consumed (PluginsView mounts with the
+  // requested tab), drop it so a later sidebar visit opens the default tab.
+  useEffect(() => {
+    if (mode !== "roles" && pendingPluginsTab) setPendingPluginsTab(null);
+  }, [mode, pendingPluginsTab]);
 
   // Click-to-open a file from chat: the comux pane (Code/Terminal) handles
   // `cave:open-project-file` directly when it's showing. When neither is, switch
@@ -1877,7 +1888,11 @@ export function Workspace() {
       <PluginsView
         key={mode}
         tabs={["roles", "skills", "marketplace", "capabilities"]}
-        initialTab={mode === "capabilities" ? "capabilities" : "roles"}
+        initialTab={
+          mode === "capabilities"
+            ? "capabilities"
+            : pendingPluginsTab ?? "roles"
+        }
         activeHarness={active?.harness ?? null}
         familiars={resolvedFamiliars}
         onOpenChat={(familiarId) => startFamiliarChat(familiarId)}
@@ -1924,13 +1939,16 @@ export function Workspace() {
       <HomeComposer
         familiars={familiars}
         activeFamiliarId={activeId}
-        sessions={sessions}
         onSetActiveFamiliar={setActiveId}
         onStartChat={(prompt, fid) => startFamiliarChat(fid, null, prompt)}
         onNavigateToBoard={() => setMode("board")}
         onNavigateToInbox={() => setMode("inbox")}
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
+        onConnect={() => {
+          setPendingPluginsTab("marketplace");
+          setMode("roles");
+        }}
       />
     )}
     </div>

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -57,15 +57,15 @@
 /* ── Hero ────────────────────────────────────────────────────────────────── */
 .home-composer-hero {
   text-align: center;
-  margin-bottom: 8px;
+  margin-bottom: 18px;
 }
 
 .home-composer-headline {
   font-family: var(--font-fredoka, "Fredoka", system-ui, sans-serif);
-  font-weight: 600;
-  font-size: clamp(24px, 3.5vw, 40px);
+  font-weight: 500;
+  font-size: clamp(26px, 3.8vw, 44px);
   line-height: 1.1;
-  color: var(--text-primary);
+  color: color-mix(in oklch, var(--text-primary) 88%, var(--text-muted));
   letter-spacing: -0.02em;
   margin: 0 0 6px;
 }
@@ -90,11 +90,11 @@
 .home-composer-card {
   width: 100%;
   max-width: 100%;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-strong);
-  border-radius: 16px;
+  background: color-mix(in oklch, var(--bg-raised) 70%, var(--bg-base));
+  border: 1px solid var(--border-hairline);
+  border-radius: 22px;
   overflow: hidden;
-  box-shadow: 0 8px 32px color-mix(in oklch, var(--text-primary) 12%, transparent),
+  box-shadow: 0 12px 40px color-mix(in oklch, var(--text-primary) 14%, transparent),
               0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
@@ -118,9 +118,9 @@
      worth a (pointer: coarse) gate. */
   font-size: 16px;
   line-height: 1.6;
-  padding: 18px 18px 10px;
+  padding: 22px 22px 8px;
   font-family: inherit;
-  min-height: 72px;
+  min-height: 92px;
   max-height: 240px;
   overflow-y: auto;
   scrollbar-width: thin;
@@ -142,8 +142,61 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 8px 10px 10px 12px;
-  border-top: 1px solid var(--border-hairline);
+  padding: 10px 14px 14px;
+}
+
+/* ── "＋" command launcher ───────────────────────────────────────────────── */
+.hc-add-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border-radius: 9px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.hc-add-btn:hover {
+  background: var(--bg-base);
+  border-color: var(--border-hairline);
+  color: var(--text-secondary);
+}
+
+/* ── Model chip ──────────────────────────────────────────────────────────── */
+.hc-model-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  padding: 4px 8px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.hc-model-chip:hover {
+  background: var(--bg-base);
+  border-color: var(--border-hairline);
+  color: var(--text-secondary);
+}
+.hc-model-bolt {
+  color: var(--accent-presence);
+  flex-shrink: 0;
+}
+.hc-model-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ── Familiar selector ───────────────────────────────────────────────────── */
@@ -258,8 +311,9 @@
 
   .hc-send-btn {
     min-height: var(--touch-target);
-    border-radius: 8px;
-    padding-inline: 16px;
+    width: var(--touch-target);
+    border-radius: 999px;
+    padding-inline: 0;
   }
 
   .hc-dest-pills {
@@ -285,28 +339,22 @@
   }
 }
 
-/* ── Send button ─────────────────────────────────────────────────────────── */
+/* ── Send button (circular, icon-only — matches the Codex-style composer) ──── */
 .hc-send-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 5px;
-  min-height: 32px;
-  padding: 0 12px;
-  border-radius: 6px;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 999px;
   border: none;
   background: var(--accent-presence);
   color: #fff;
   cursor: pointer;
   flex-shrink: 0;
-  margin-left: auto;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
-}
-
-.hc-send-label {
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.01em;
 }
 
 .hc-send-btn:hover:not(:disabled) {
@@ -314,9 +362,12 @@
   transform: scale(1.05);
 }
 
+/* Empty/disabled reads as a neutral grey disc (no green) until there's a prompt
+ * to send — mirrors the screenshot's idle send affordance. */
 .hc-send-btn.empty,
 .hc-send-btn:disabled {
-  opacity: 0.3;
+  background: color-mix(in oklch, var(--text-muted) 24%, var(--bg-base));
+  color: var(--text-muted);
   cursor: default;
   transform: none;
 }
@@ -325,14 +376,6 @@
   opacity: 0.75;
   cursor: wait;
   transform: none;
-}
-
-@media (max-width: 520px) {
-  .hc-send-btn {
-    min-height: var(--touch-target);
-    border-radius: 8px;
-    padding-inline: 16px;
-  }
 }
 
 /* Spinner */
@@ -350,7 +393,11 @@
   to { transform: rotate(360deg); }
 }
 
-/* ── Suggestions ─────────────────────────────────────────────────────────── */
+/* ── Connector cards ─────────────────────────────────────────────────────────
+ *   Codex-style cold-start cards: one-tap entry points into the marketplace
+ *   for the integrations that give a familiar real context. The wrapper keeps
+ *   the `.home-composer-suggestions` class so it inherits the home layout's
+ *   1200px content cap and viewport centering. */
 .home-composer-suggestions {
   display: flex;
   flex-wrap: wrap;
@@ -361,69 +408,89 @@
   margin-inline: auto;
 }
 
-.hc-suggestion {
+.home-composer-connectors {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.hc-connector {
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 10px;
+  min-width: 0;
+  padding: 18px 18px 20px;
+  border-radius: 16px;
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 55%, var(--bg-base));
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.14s ease, border-color 0.14s ease, transform 0.14s ease;
+}
+
+.hc-connector:hover {
+  background: color-mix(in oklch, var(--bg-raised) 80%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+  transform: translateY(-1px);
+}
+
+.hc-connector-glyph {
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 12px;
-  border-radius: 20px;
-  border: 1px solid var(--border-hairline);
-  background: var(--bg-raised);
-  color: var(--text-muted);
-  font-size: 12px;
-  cursor: pointer;
-  transition: all 0.12s ease;
-  /* Cap each chip so long suggestions ellipsis inside the chip instead of
-   * extending past the suggestion row's edge — without this the chip stays
-   * one wide line and clips its tail at the viewport on phones. */
-  max-width: min(100%, 360px);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  justify-content: flex-start;
+  height: 24px;
 }
 
-@media (max-width: 520px) {
-  .hc-suggestion {
-    min-height: var(--touch-target);
-    justify-content: flex-start;
-    padding: 10px 14px;
-    border-radius: 999px;
-    font-size: 13px;
-  }
-}
-
-/* The label inside each chip needs its own overflow context with min-width: 0
- * because the chip is `display: inline-flex` — text-overflow on the flex
- * parent doesn't reach individual flex children. */
-.hc-suggestion > span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.hc-suggestion:hover {
-  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
-  border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
+.hc-connector-title {
+  font-size: 15px;
+  font-weight: 600;
   color: var(--text-primary);
+  letter-spacing: -0.01em;
 }
 
-.hc-suggestion-icon {
-  flex-shrink: 0;
-  opacity: 0.5;
+.hc-connector-sub {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
+@media (max-width: 640px) {
+  .home-composer-connectors {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+  .hc-connector {
+    min-height: var(--touch-target);
+    grid-template-rows: none;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      "glyph title"
+      "glyph sub";
+    align-items: center;
+    column-gap: 14px;
+    row-gap: 2px;
+    padding: 14px 16px;
+  }
+  .hc-connector-glyph { grid-area: glyph; }
+  .hc-connector-title { grid-area: title; }
+  .hc-connector-sub { grid-area: sub; }
 }
 
 /* ── Focus rings (keyboard-only) ─────────────────────────────────────────── */
 .hc-dest-pill,
 .hc-send-btn,
-.hc-suggestion,
+.hc-connector,
+.hc-add-btn,
+.hc-model-chip,
 .hc-familiar-select {
   outline: none;
 }
 .hc-dest-pill:focus-visible,
 .hc-send-btn:focus-visible,
-.hc-suggestion:focus-visible {
+.hc-connector:focus-visible,
+.hc-add-btn:focus-visible,
+.hc-model-chip:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: var(--ring-offset);
 }
@@ -432,26 +499,6 @@
 .hc-familiar-selector:focus-within {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: var(--ring-offset);
-}
-
-/* ── Suggestions skeleton (during initial fetch) ─────────────────────────── */
-.hc-suggestion-skeleton {
-  height: 28px;
-  width: 100%;
-  max-width: 280px;
-  border-radius: 999px;
-  background:
-    linear-gradient(
-      90deg,
-      var(--bg-raised) 0%,
-      color-mix(in oklch, var(--bg-raised) 70%, var(--bg-elevated) 30%) 50%,
-      var(--bg-raised) 100%
-    );
-  background-size: 200% 100%;
-  animation: ui-skeleton-shimmer 1.4s ease-in-out infinite;
-}
-@media (prefers-reduced-motion: reduce) {
-  .hc-suggestion-skeleton { animation: none; opacity: 0.65; }
 }
 
 /* ── Slash command menu ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Reworks the home cold-start view (`HomeComposer`) to emulate the Codex-style home screen, adapted to Cave's real controls.

![target](https://github.com/OpenCoven/coven-cave/assets/placeholder)

### Composer
- Headline → **"What should we build in coven-cave?"**, placeholder → **"Do anything"**
- Toolbar rebuilt: a **`＋`** command launcher (opens the slash menu), the **Familiar** selector, the **Familiar / Tasks / Reminder** destinations, a **`⚡ <model> ⌄` chip** that opens the inline `/model` picker, and a **circular icon-only send button** (neutral disc when empty, accent when ready).

### Connector cards
- Replaces the dynamic suggestion chips with three cards — **Connect messaging** (Slack), **Connect email** (Gmail), **Connect files** (Drive) — rendered with inline full-colour brand logos.
- Clicking a card deep-links into the **Marketplace tab** (new `pendingPluginsTab` plumbing in `Workspace`, feeding `PluginsView`'s `initialTab` and cleared on leaving Roles).

Kept Cave's real controls rather than cloning Codex's worktree / environment / branch chrome, so there's **no dead UI**.

## Tests
Source-text tests that pinned the old markup are updated in the same commit:
- `home-composer-polish.test.ts` — Send label → circular button
- `home-composer-mobile-gaps.test.ts` — suggestion chips → connector-card grid

## Verification
- `tsc --noEmit` clean; full `test:app` suite green (home-composer, centering, mobile-gaps, zoom-smoke, font-css, labels)
- Built + ran the app; verified desktop + narrow (stacked) layouts render the headline, composer, model chip, circular send, and the three brand-logo connector cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)