### PR TITLE
fix(eval-loop-panel): guard undefined iterations

### DIFF
--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -151,7 +151,7 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
   }
 
   const visibleIterations = state?.iterations
-    .filter((i) => activeTrack === "all" || i.track === activeTrack)
+    ?.filter((i) => activeTrack === "all" || i.track === activeTrack)
     .slice(0, 20) ?? [];
 
   return (


### PR DESCRIPTION
## Summary

Fixes a runtime `TypeError: Cannot read properties of undefined (reading 'filter')` in `EvalLoopPanel`.

`state.iterations` could be `undefined` even when `state` is defined. The optional chain stopped at `state?`, so `.filter` was called on `undefined` and threw. Changed `.filter` to `?.filter` so the expression short-circuits to `[]` via the trailing `?? []`.

Verified all other `state.` accesses in the file are inside `state?`/`state ?` guards — this was the only unguarded spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)