### PR TITLE
refactor(lib): add usePausablePoll + adopt canonical reduced-motion hook

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -184,6 +184,7 @@ export const SUITES = {
     "src/lib/library-doc-sort.test.ts",
     "src/lib/github-search.test.ts",
     "src/lib/use-refresh-on-focus.test.ts",
+    "src/lib/use-pausable-poll.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",
     "src/lib/code-lang.test.ts",

--- a/src/components/board-inspector-a11y.test.ts
+++ b/src/components/board-inspector-a11y.test.ts
@@ -4,14 +4,13 @@ import { readFileSync } from "node:fs";
 
 const src = readFileSync(new URL("./board-inspector.tsx", import.meta.url), "utf8");
 
-// ── TimeoutBadge poll pauses when the tab is hidden ──────────────────────────
+// ── TimeoutBadge poll pauses when hidden — via the shared usePausablePoll hook ─
 assert.match(
   src,
-  /setInterval\(\(\) => \{ if \(!document\.hidden\) setTick/,
-  "TimeoutBadge stops ticking while the tab is hidden",
+  /usePausablePoll\(\(\) => setTick\(\(n\) => n \+ 1\), 60_000\)/,
+  "TimeoutBadge re-renders once a minute through the shared pausable-poll hook",
 );
-assert.match(src, /addEventListener\("visibilitychange", onVisible\)/, "TimeoutBadge refreshes on re-show");
-assert.match(src, /removeEventListener\("visibilitychange", onVisible\)/, "TimeoutBadge cleans up its visibility listener");
+assert.match(src, /import \{ usePausablePoll \} from "@\/lib\/use-pausable-poll"/, "TimeoutBadge uses the centralized hidden-pause poll");
 
 // ── GitHub-attach fetch drops stale / post-close responses ───────────────────
 assert.match(
@@ -34,8 +33,9 @@ assert.match(
   "the step toggle exposes checkbox semantics with the step text as its name",
 );
 
-// ── Inline-style motion respects prefers-reduced-motion ──────────────────────
-assert.match(src, /function usePrefersReducedMotion\(\): boolean/, "a reduced-motion subscription exists");
+// ── Inline-style motion respects prefers-reduced-motion (shared hook) ────────
+assert.match(src, /import \{ usePrefersReducedMotion \} from "@\/lib\/use-prefers-reduced-motion"/, "reduced-motion uses the canonical shared hook, not a local copy");
+assert.doesNotMatch(src, /function usePrefersReducedMotion\(\): boolean/, "the local reduced-motion duplicate is removed");
 assert.match(src, /transition: reducedMotion \? "none" : "width 0\.2s/, "the progress bar drops its transition under reduced motion");
 assert.match(src, /transition: reducedMotion \? "none" : "background 0\.15s"/, "the step checkbox drops its transition under reduced motion");
 assert.match(src, /@media \(prefers-reduced-motion: reduce\) \{ \.step-actions \{ transition: none; \} \}/, "the step-actions hover reveal honors reduced motion");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -8,6 +8,8 @@ import { STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge, formatTimeoutBadge } from "@/components/ui/lifecycle-badge";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import type { CardStep } from "@/lib/cave-board-types";
 import type { GitHubItem } from "@/lib/github-tasks";
 import {
@@ -66,14 +68,9 @@ type Props = {
 
 function TimeoutBadge({ runningSince, timeoutMs }: { runningSince?: string; timeoutMs?: number }) {
   const [, setTick] = useState(0);
-  // Re-render once a minute so the relative "running for…" text advances — but
-  // not while the tab is hidden (no point ticking a badge nobody can see).
-  useEffect(() => {
-    const id = setInterval(() => { if (!document.hidden) setTick((n) => n + 1); }, 60_000);
-    const onVisible = () => { if (!document.hidden) setTick((n) => n + 1); };
-    document.addEventListener("visibilitychange", onVisible);
-    return () => { clearInterval(id); document.removeEventListener("visibilitychange", onVisible); };
-  }, []);
+  // Re-render once a minute so the relative "running for…" text advances — paused
+  // while the tab is hidden, refreshed on return (see usePausablePoll).
+  usePausablePoll(() => setTick((n) => n + 1), 60_000);
   const text = formatTimeoutBadge(runningSince, timeoutMs, DEFAULT_TIMEOUT_MS);
   if (!text) return null;
   const over = runningSince ? Date.now() - new Date(runningSince).getTime() > (timeoutMs ?? DEFAULT_TIMEOUT_MS) : false;
@@ -621,21 +618,6 @@ function LinksSection({
       <style>{".link-item-anchor:hover { text-decoration: underline; } .step-actions { opacity: 0; transition: opacity 0.1s; } li:hover .step-actions, li:focus-within .step-actions { opacity: 1; } @media (prefers-reduced-motion: reduce) { .step-actions { transition: none; } }"}</style>
     </div>
   );
-}
-
-// SSR-safe prefers-reduced-motion subscription, so inline-style transitions
-// can opt out for users who ask for reduced motion.
-function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduced(mq.matches);
-    const onChange = () => setReduced(mq.matches);
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-  return reduced;
 }
 
 // ── Steps ─────────────────────────────────────────────────────────────────────

--- a/src/lib/use-pausable-poll.test.ts
+++ b/src/lib/use-pausable-poll.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./use-pausable-poll.ts", import.meta.url), "utf8");
+
+// ── Signature ────────────────────────────────────────────────────────────────
+assert.match(
+  src,
+  /export function usePausablePoll\(\s*callback: \(\) => void,\s*intervalMs: number,\s*opts\?: \{ enabled\?: boolean \},\s*\): void/,
+  "usePausablePoll(callback, intervalMs, { enabled }) returns void",
+);
+
+// ── Recurring poll pauses while the tab is hidden ────────────────────────────
+assert.match(
+  src,
+  /const id = setInterval\(\(\) => \{[\s\S]*?if \(typeof document !== "undefined" && document\.hidden\) return;[\s\S]*?cbRef\.current\(\);[\s\S]*?\}, intervalMs\)/,
+  "the interval skips the callback while the tab is hidden",
+);
+assert.match(src, /return \(\) => clearInterval\(id\)/, "the interval is cleared on cleanup");
+
+// ── Disabled stops polling entirely ──────────────────────────────────────────
+assert.match(src, /if \(!enabled\) return;/, "passing { enabled: false } suspends the poll");
+
+// ── Resume reuses the existing foreground hook (no re-rolled visibilitychange) ─
+assert.match(src, /import \{ useRefreshOnFocus \} from "@\/lib\/use-refresh-on-focus"/, "composes the existing useRefreshOnFocus");
+assert.match(src, /useRefreshOnFocus\(\(\) => cbRef\.current\(\), \{ enabled \}\)/, "an immediate refresh fires when the app regains the foreground");
+assert.doesNotMatch(src, /addEventListener\("visibilitychange"/, "no hand-rolled visibilitychange listener — that lives in useRefreshOnFocus");
+
+// ── Stable interval across callback identity changes ─────────────────────────
+assert.match(src, /const cbRef = useRef\(callback\);\s*cbRef\.current = callback;/, "the callback is read via a ref so the interval isn't torn down each render");
+assert.match(src, /\}, \[enabled, intervalMs\]\)/, "the poll effect depends only on enabled + intervalMs");
+
+console.log("use-pausable-poll.test.ts: ok");

--- a/src/lib/use-pausable-poll.ts
+++ b/src/lib/use-pausable-poll.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
+
+/**
+ * Poll `callback` every `intervalMs` — but only while the tab is visible — and
+ * fire an immediate `callback` when the app regains the foreground, so the user
+ * never waits a whole interval after switching back.
+ *
+ * Why this exists: surfaces kept hand-rolling the same trio of
+ * `setInterval` + `if (!document.hidden)` + a `visibilitychange` listener, each
+ * one slightly different and each one a place to forget the hidden-tab pause.
+ * This centralises it, and the on-return refresh reuses {@link useRefreshOnFocus}
+ * so it works in both the browser and the Tauri desktop window.
+ *
+ * The recurring poll is suspended while `document.hidden`, so a backgrounded tab
+ * stops hitting the network. Pass `{ enabled: false }` to stop polling entirely
+ * (e.g. only poll while a run is active). The initial mount load stays the
+ * caller's job — this hook only schedules the recurring poll + the on-return
+ * refresh.
+ */
+export function usePausablePoll(
+  callback: () => void,
+  intervalMs: number,
+  opts?: { enabled?: boolean },
+): void {
+  const enabled = opts?.enabled ?? true;
+  // Read the latest callback via a ref so a changing callback identity doesn't
+  // tear down and recreate the interval on every render.
+  const cbRef = useRef(callback);
+  cbRef.current = callback;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const id = setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      cbRef.current();
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [enabled, intervalMs]);
+
+  // Immediate refresh on regaining the foreground (browser focus/visibility +
+  // Tauri native focus), so returning to the tab doesn't wait out the interval.
+  useRefreshOnFocus(() => cbRef.current(), { enabled });
+}


### PR DESCRIPTION
## Consolidation: stop hand-rolling hidden-pause polling

Across the recent a11y sweep, surface after surface hand-rolled the same trio — `setInterval` + `if (!document.hidden)` + a `visibilitychange` listener — each slightly different and each a place to forget the hidden-tab pause. This extracts it.

### New `src/lib/use-pausable-poll.ts`
`usePausablePoll(callback, intervalMs, { enabled })`:
- recurring poll that **pauses while `document.hidden`**,
- **immediate refresh when the app regains the foreground** — and that part **reuses the existing `useRefreshOnFocus`**, so it covers browser focus/visibility **and** the Tauri desktop window's native focus event (the hand-rolled `visibilitychange` listeners didn't),
- `{ enabled: false }` suspends it entirely (for "only poll while a run is active").

### Adoptions in `board-inspector.tsx`
- `TimeoutBadge` replaces its hand-rolled `setInterval`+`visibilitychange` with `usePausablePoll(...)`.
- The **local `usePrefersReducedMotion` copy is removed** in favor of the canonical `@/lib/use-prefers-reduced-motion` (it had become a duplicate). Net −30 lines in board-inspector.

### Scope (deliberately narrow — see the note below)
`automations-view` and `github-view` use the same poll pattern but are **actively developed on main**, so I left them as follow-up adoptions rather than risk concurrent-edit churn. `calls-view`/`coven-floor`, which also used it, were **removed from main** (commit 7f2beed2) and are moot.

> Pre-flight finding: while scoping this I discovered **three** surfaces I'd recently audited (Calls #1853, Coven-floor #1856, Workflows-run #1899) were deleted on main by an active legacy-removal effort. Checking each target file still exists on fresh `origin/main` before touching it is now a standing pre-flight step.

## Verification
- New `use-pausable-poll.test.ts` (source-text wiring; wired into `run-tests.mjs`, `check:tests-wired` ✓) + updated `board-inspector-a11y.test.ts` pass · `tsc` clean · `pnpm build` exit 0 · board loads with **0 page errors** after the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)