### PR TITLE
feat(home): "Jump back in" recent-chats strip

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -40,4 +40,13 @@ assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?gap:\s*5px/, ".hc-send-btn uses gap
 assert.doesNotMatch(css, /\.hc-send-btn\s*\{[\s\S]*?width:\s*32px;[\s\S]*?height:\s*32px;[\s\S]*?\}/, "Old fixed 32x32 size removed");
 assert.match(css, /\.hc-send-label\s*\{/, ".hc-send-label rule defined");
 
+// ── "Jump back in" recent-chats strip ──
+assert.match(source, /onOpenSession\?: \(sessionId: string, familiarId: string \| null\) => void/, "HomeComposer accepts a resume handler");
+assert.match(source, /const recentSessions = useMemo/, "derives the recent sessions");
+assert.match(source, /\.filter\(\(s\) => !s\.archived_at && s\.title\)/, "recents exclude archived/untitled chats");
+assert.match(source, /onOpenSession && recentSessions\.length > 0/, "the strip only shows when there are recents and a resume handler");
+assert.match(source, /onClick=\{\(\) => onOpenSession\(s\.id, s\.familiarId \?\? null\)\}/, "clicking a recent resumes that chat");
+assert.match(source, /Jump back in/, "the strip is labelled");
+assert.match(css, /\.home-recent \{/, "the recents strip is styled");
+
 console.log("home-composer-polish.test.ts: ok");

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -23,6 +23,8 @@ import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
 import type { ChatModelState } from "@/lib/chat-model-state";
 import { draftReminderFromText } from "@/lib/reminder-draft";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
+import { sessionRailTitle } from "@/lib/session-rail-title";
+import { relativeTime } from "@/lib/relative-time";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -56,6 +58,8 @@ type Props = {
   /** Submit a slash command. Mirrors the chat composer's escape hatch so
    *  `/inbox`, `/board`, `/remind …` etc. work from the home screen too. */
   onSlash?: (command: string, args: string) => void;
+  /** Resume a recent chat from the "Jump back in" strip. */
+  onOpenSession?: (sessionId: string, familiarId: string | null) => void;
 };
 
 const SEED_SUGGESTIONS = [
@@ -101,6 +105,7 @@ export function HomeComposer({
   onNavigateToInbox,
   onToast,
   onSlash,
+  onOpenSession,
 }: Props) {
   const [text, setText] = useState(() => readHomeDraft());
   const [destination, setDestination] = useState<Destination>("chat");
@@ -237,6 +242,23 @@ export function HomeComposer({
     })();
     return () => { cancelled = true; };
   }, [sessions]);
+
+  // "Jump back in" — the most recent non-archived chats, for one-click resume.
+  const familiarNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const f of familiars) m.set(f.id, f.display_name);
+    return m;
+  }, [familiars]);
+  const recentSessions = useMemo(
+    () =>
+      [...sessions]
+        .filter((s) => !s.archived_at && s.title)
+        .sort((a, b) =>
+          (b.updated_at ?? b.created_at ?? "").localeCompare(a.updated_at ?? a.created_at ?? ""),
+        )
+        .slice(0, 4),
+    [sessions],
+  );
 
   // Auto-grow textarea
   const autoGrow = useCallback(() => {
@@ -647,6 +669,37 @@ export function HomeComposer({
           ))}
         </div>
       ) : null}
+
+      {/* Jump back in — resume a recent chat. The composer above starts new
+          intent; this is the "continue where you left off" path. */}
+      {onOpenSession && recentSessions.length > 0 && (
+        <div className="home-recent">
+          <div className="home-recent-label">Jump back in</div>
+          <div className="home-recent-list" role="list">
+            {recentSessions.map((s) => {
+              const title = sessionRailTitle(s);
+              const famName = s.familiarId ? familiarNameById.get(s.familiarId) : null;
+              const when = relativeTime(s.updated_at ?? s.created_at);
+              return (
+                <button
+                  key={s.id}
+                  type="button"
+                  role="listitem"
+                  className="home-recent-item"
+                  onClick={() => onOpenSession(s.id, s.familiarId ?? null)}
+                  title={`Resume “${title}”`}
+                >
+                  <Icon name="ph:chat-circle-dots" width={13} className="home-recent-icon" aria-hidden />
+                  <span className="home-recent-text">
+                    <span className="home-recent-title">{title}</span>
+                    <span className="home-recent-meta">{[famName, when].filter(Boolean).join(" · ")}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1931,6 +1931,7 @@ export function Workspace() {
         onNavigateToInbox={() => setMode("inbox")}
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
+        onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
       />
     )}
     </div>

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -541,3 +541,75 @@
     display: none;
   }
 }
+
+/* "Jump back in" — recent chats strip, secondary to the composer hero. */
+.home-recent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  max-width: min(1200px, 100%);
+  margin-inline: auto;
+  margin-top: 12px;
+}
+.home-recent-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.home-recent-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+.home-recent-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 260px;
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s, background 0.12s, transform 0.12s;
+}
+.home-recent-item:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  transform: translateY(-1px);
+}
+.home-recent-item:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+}
+.home-recent-icon {
+  color: var(--accent-presence);
+  flex-shrink: 0;
+}
+.home-recent-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 1px;
+}
+.home-recent-title {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.home-recent-meta {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
The top pick from the Home UX scan.

## Problem
The Home surface (`HomeComposer`) is a great cold-start launcher for **new** intent — type, pick a destination (Familiar / Tasks / Reminder), send. But there was **no path to continue** a recent conversation; resuming meant detouring through the sidebar/Chat tab.

## Fix
A compact **"Jump back in"** strip below the composer: the **4 most recent** non-archived chats (`title · familiar · relative time`), each one click to resume.

- The session data was already passed to `HomeComposer` (it powers the prompt suggestions) — this adds an `onOpenSession` prop wired to the workspace's existing **`openFamiliarSession`** (sets the active familiar, opens the chat).
- **Secondary by design** — it sits below the composer hero, so Home keeps its intentional minimalism (the rich cockpit is `/dashboard`). Only renders when there are recents *and* a resume handler.

## Verification (real app, Playwright)
Mocked sessions: the strip lists chats **newest-first** with familiar + relative time ("Nova · 5m ago"), and clicking one **leaves Home and resumes** that chat. `tsc` clean; full `test:app` (419 files) + `check:tests-wired` green; source-text assertions added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)