### PR TITLE
fix(sidebar): size the New-chat icon to match the collapsed rail

### DIFF
--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -262,6 +262,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         <button type="button" className="sidebar-action-row focus-ring" onClick={onNewChat} title="New chat">
           <Icon
             name="ph:note-pencil"
+            className="sidebar-action-icon"
             width={CAVE_ICON_SIZE.sidePanelAction}
             height={CAVE_ICON_SIZE.sidePanelAction}
             aria-hidden


### PR DESCRIPTION
## Problem
In the **collapsed icon rail**, the New-chat (pencil) glyph rendered smaller than every other icon — `--icon-md` (16px) vs the `--icon-lg` (20px) used by the nav icons — so it looked off inside its tile.

## Cause
`.shell-nav--rail .sidebar-action-icon` bumps the action icon to `--icon-lg` in the rail, but the compose `<Icon>` was rendered **without** the `sidebar-action-icon` class, so the rule never matched it.

## Fix
Add `className="sidebar-action-icon"` to the New-chat `<Icon>`. One line.
- Expanded mode is unchanged (both action and folder icons are `--icon-md` there).
- Rows were already perfectly centered — measured `rowCenter == iconCenter == 28` for every row — so this was purely an icon-size mismatch, not a position one.

## Verified
Ran the app locally with Playwright and measured the collapsed rail: the action row now reports `iconW=20`, matching all folder rows (screenshot confirmed the pencil now fills its tile like the others). App source-text suite green (419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)