### PR TITLE
fix(ios): remove empty nav-bar band atop Developer GitHub & Library

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -19,6 +19,9 @@ struct GitHubView: View {
     var body: some View {
         NavigationSplitView {
             content
+                .navigationTitle("")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.hidden, for: .navigationBar)
                 .searchable(text: $query, prompt: "Search issues & PRs")
                 .refreshable { await load() }
                 .task { await load() }

--- a/apps/ios/CovenCave/CovenCave/Views/LibraryView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LibraryView.swift
@@ -20,8 +20,9 @@ struct LibraryView: View {
     var body: some View {
         NavigationStack {
             content
-                .navigationTitle("Library")
+                .navigationTitle("")
                 .navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.hidden, for: .navigationBar)
                 .searchable(text: $query, prompt: "Search library")
                 .safeAreaInset(edge: .top) { kindPicker }
                 .task(id: kind) { await load() }


### PR DESCRIPTION
## Summary

Removes the large empty band between the Developer section picker (Code / Terminal / GitHub / Library) and the search field in the iOS **GitHub** and **Library** sections.

- **GitHub** — the `NavigationSplitView` used the default large-title display, reserving a tall empty title region above the search field. Now uses an empty inline title with a hidden nav-bar background.
- **Library** — dropped the redundant inline "Library" title bar (the section is already labelled by the Developer picker) and hid the nav-bar background.

The `.searchable` field still lives in the nav bar; only the empty title space is gone.

## Test

`xcodebuild -scheme CovenCave -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)