### PR TITLE
chore(release): stamp v0.0.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.114] - 2026-06-25
+
+Patch release on top of v0.0.113 with the next iOS utility sweep, a broader
+marketplace catalog, and desktop polish for Home, Tasks, GitHub, and Flow.
+
+### Added
+
+- **iOS controls and notifications** - Control Center controls for reminders
+  and running tasks (#1906), on-device notifications for upcoming reminders
+  (#1892), and Lock Screen / StandBy widgets for the next reminder (#1897).
+- **Marketplace catalog expansion** - 44 MCP plugins across 13 categories
+  (#1902).
+- **Home surface** - Codex-style composer + connector cards (#1907) and a
+  "Jump back in" recent-chats strip (#1910).
+- **Board table** - spreadsheet-grade task table striping, reorder, resize, and
+  autofit (#1905).
+- **GitHub view** - free-text search over the activity list (#1900).
+- **Group chat targeting** - @-tag familiars to target a message at a subset of
+  the coven (#1896).
+- **Flow** - template gallery (#1893).
+
+### Changed
+
+- Removed the legacy Workflows page (#1898).
+- Added `usePausablePoll` and adopted the canonical reduced-motion hook
+  (#1909).
+
+### Fixed
+
+- **iOS navigation** - remove the empty nav-bar band atop Developer GitHub and
+  Library (#1912).
+- **Shell and sidebar** - align top sidepanel toggles to nav-rail button width
+  (#1904) and size the New-chat icon to match the collapsed rail (#1911).
+- **Chat progress** - make truncated progress-step details expandable (#1903).
+- **Canvas accessibility** - fullscreen dialog, tab arrow navigation, and
+  selected `aria-current` (#1895).
+- **Journal accessibility** - save with Cmd/Ctrl+Enter and restore focus on exit
+  (#1891).
+- **Schedules** - per-row quick actions for run-now and pause/resume (#1894).
+- **Eval loop panel** - guard undefined iterations (#1908).
+
 ## [0.0.113] - 2026-06-24
 
 Another huge release: **120 PRs** building on the v0.0.112 push. The iOS app gains a real **Calendar tab**, **Library/Bookmarks**, **Journal**, **Live Activities**, **Siri Shortcuts / App Intents**, **iPad split-view** across Chats/Tasks/Developer, a **Board (kanban) view**, and an actionable **home-screen widget**. The desktop gets a new visual **Flow editor** (n8n-style), a **Marketplace** surface with credential & config collection, a redesigned **Code Projects explorer**, broad **undo** support, and a wide **accessibility sweep**. Group Chat (broadcast one prompt to many familiars) ships as the foundation for the v1 group-chat work tracked in opencoven/coven#258.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.113"
+version = "0.0.114"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.113"
+version = "0.0.114"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.113</string>
+	<string>0.0.114</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.113</string>
+	<string>0.0.114</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.113</string>
+	<string>0.0.114</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.113</string>
+	<string>0.0.114</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.113",
+  "version": "0.0.114",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump Coven Cave release metadata to v0.0.114 across package, Tauri, Cargo, and iOS plists
- add the v0.0.114 changelog entry from the merged PRs since v0.0.113

## Verification
- node --experimental-strip-types src/lib/app-version.test.ts
- node scripts/release-notes.test.mjs
- bash scripts/release-notes.sh v0.0.114 > /tmp/coven-cave-v0.0.114-release-notes.md
- git diff --check
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:api
- pnpm test:app
- pnpm test:mobile
- pnpm build
- cargo check --locked