### PR TITLE
fix(home): don't keep showing "Start daemon" after the daemon is started

### DIFF
--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -269,7 +269,7 @@ export function Workspace() {
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
 
-  const refreshDaemonStatus = useCallback(async () => {
+  const refreshDaemonStatus = useCallback(async (opts?: { trusted?: boolean }) => {
     let running = false;
     try {
       const res = await fetch("/api/daemon/status", { cache: "no-store" });
@@ -280,10 +280,16 @@ export function Workspace() {
       setDaemonRunning(false);
     } finally {
       // Drive the sticky offline signal: any failed poll marks the daemon
-      // offline immediately, but it takes two *consecutive* healthy polls to
-      // clear — otherwise a flapping zombie daemon keeps dismissing the banner.
+      // offline immediately, but a background poll takes two *consecutive*
+      // healthy polls to clear — otherwise a flapping zombie daemon keeps
+      // dismissing the banner.
       if (running) {
         daemonHealthyStreakRef.current += 1;
+        // A `trusted` refresh follows an explicit user-initiated start, so a
+        // healthy answer is enough to clear the banner immediately — without it
+        // the "Start daemon" banner lingered for a poll cycle (~5s) after the
+        // daemon was already up.
+        if (opts?.trusted) daemonHealthyStreakRef.current = 2;
         if (daemonHealthyStreakRef.current >= 2) setDaemonOffline(false);
       } else {
         daemonHealthyStreakRef.current = 0;
@@ -303,7 +309,9 @@ export function Workspace() {
         throw new Error(json?.error || json?.stderr || "daemon did not start");
       }
       dismissBanner("daemon-start-error");
-      await refreshDaemonStatus();
+      // Trusted: the user just started it and the API reported success, so a
+      // single healthy status poll is enough to dismiss the offline banner now.
+      await refreshDaemonStatus({ trusted: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : "daemon did not start";
       pushBanner({


### PR DESCRIPTION
## Problem

On the home (and every) surface, the **"Daemon offline — Start daemon"** banner kept showing for a few seconds *after* the daemon was already running — most visibly right after clicking the banner's own **Start daemon** button.

## Cause

The banner keys off a sticky `daemonOffline` flag that only clears after **two consecutive healthy status polls**. That guard exists so a crash-looping / codesigning-zombie daemon (which briefly answers `running:true` then dies) can't flicker the banner away. But it also meant a genuine start took a full ~5s poll cycle before the single post-start poll was "confirmed" by a second one — so the banner lingered.

## Fix

`refreshDaemonStatus` now takes a `{ trusted }` option. `startDaemon()` passes `trusted: true` on the post-start status poll, so an explicit user-initiated start that comes back healthy clears the banner immediately. The background 5s poll still requires two consecutive healthy answers, so a flapping daemon can't dismiss the banner on its own.

One file, `src/components/workspace.tsx` (+12 / −4). The `else if (daemonStatusResolved)` banner gate is unchanged (still pinned by `workspace-sessions-navigation.test.ts`).

## Verification
- `tsc --noEmit` clean
- `workspace-sessions-navigation`, `daemon-start-button`, `chat-surface` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)