### PR TITLE
feat(browser): open the tab rail by default (persisted)

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -90,6 +90,7 @@ const HOME_URL = "https://opencoven.ai";
 const LOCALHOST_PORTS = [3000, 3001, 5173, 8080, 4000, 4321];
 const NATIVE_BROWSER_LABEL_PREFIX = "cave-browser-";
 const PINNED_STORAGE_KEY = "cave.browser.pinnedTabs.v1";
+const RAIL_PINNED_STORAGE_KEY = "cave.browser.railPinned.v1";
 
 export type BrowserTab = {
   id: string;
@@ -149,6 +150,25 @@ function savePinnedTabs(tabs: BrowserTab[]) {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(tabs));
+  } catch { /* ignore */ }
+}
+
+// The tab rail opens pinned by default so the tabs are visible on first open;
+// the user can auto-hide it and we remember that choice across sessions.
+function loadRailPinned(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    const raw = window.localStorage.getItem(RAIL_PINNED_STORAGE_KEY);
+    if (raw === "0") return false;
+    if (raw === "1") return true;
+  } catch { /* ignore */ }
+  return true;
+}
+
+function saveRailPinned(pinned: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(RAIL_PINNED_STORAGE_KEY, pinned ? "1" : "0");
   } catch { /* ignore */ }
 }
 
@@ -248,10 +268,13 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
   const [addressBar, setAddressBar] = useState<string>(HOME_URL);
   const [quickOpen, setQuickOpen] = useState(false);
   const [railHover, setRailHover] = useState(false);
-  const [railPinned, setRailPinned] = useState(false);
+  const [railPinned, setRailPinned] = useState(loadRailPinned);
   // Rail expands on hover/focus and stays expanded while the quick-open
   // palette is up so users can verify the active tab visually.
   const railExpanded = railPinned || railHover || quickOpen;
+  useEffect(() => {
+    saveRailPinned(railPinned);
+  }, [railPinned]);
 
   // Collapsible toolbar. The native page webview is an OS-level overlay that
   // always renders above the DOM, so the toolbar and the page can never

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -21,6 +21,26 @@ assert.match(
   /setRailPinned\(\(v\) => !v\)/,
   "[ handler must call setRailPinned((v) => !v)",
 );
+
+// ───────── Rail opens pinned by default (persisted) ─────────
+// The tab rail should start open so its tabs are visible on first open, and
+// remember an explicit auto-hide choice across sessions — without ever
+// covering the top menu bar (it stays inside .browser-pane, below .shell-top).
+assert.match(
+  pane,
+  /useState\(loadRailPinned\)/,
+  "railPinned must initialize from the persisted loadRailPinned() helper",
+);
+assert.match(
+  pane,
+  /function loadRailPinned\(\)[\s\S]*?if \(raw === "0"\) return false;[\s\S]*?return true;\n\}/,
+  "loadRailPinned() must default to true (rail open) when no preference is stored",
+);
+assert.match(
+  pane,
+  /useEffect\(\(\) => \{\s*saveRailPinned\(railPinned\);\s*\}, \[railPinned\]\)/,
+  "railPinned changes must be persisted via saveRailPinned",
+);
 assert.match(
   pane,
   /paneRef\.current\?\.contains\(e\.target as Node\)/,


### PR DESCRIPTION
## What

The browser **tab rail** (left vertical strip) defaulted collapsed to a 6px edge handle, so tabs were hidden until you hovered. This defaults it **open (pinned)** so the pinned tabs are visible the moment the Browser surface opens.

- New `cave.browser.railPinned.v1` localStorage key persists the pin state. `loadRailPinned()` defaults to **true** (open); auto-hiding the rail (via the pin button or the `[` shortcut) is remembered across sessions.
- The rail stays inside `.browser-pane` (which lives below `.shell-top` in `.shell-body`), so it **does not cover the top menu bar** — verified geometrically: `.shell-top` is `top:0 h:45`, the rail starts at `top:45`, on the opposite (left) side from the Enhance/Tasks/Inbox controls.

## Verify

Built a prod server and screenshotted the Browser surface: rail renders open (`!w-12`), first control sits ~6px below the menu-bar edge, no overlap.

Source-text assertions added to `browser-polish.test.ts` (default-true `loadRailPinned`, `useState(loadRailPinned)`, persistence effect). Full `pnpm test:app` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)