### PR TITLE
fix(familiar-studio): Open Brain Studio actually opens the Brain surface

### DIFF
--- a/src/components/familiar-studio-inline.test.ts
+++ b/src/components/familiar-studio-inline.test.ts
@@ -34,10 +34,12 @@ assert.match(source, /<FamiliarStudioMemoryTab familiar=\{familiar\} allFamiliar
 assert.match(source, /VaultPanel/, "Wires the Vault settings panel inside familiar settings");
 assert.match(source, /id: "vault", label: "Vault"/, "Exposes Vault as a familiar settings tab");
 
-// Detail pane is never empty on entry: auto-selects the first familiar and
-// recovers when the current selection disappears.
+// Detail pane is never empty on entry: auto-selects a familiar (the one-shot
+// "Open Brain Studio" handoff id when present, else the first) and recovers when
+// the current selection disappears.
 assert.match(source, /resolved\.some\(\(f\) => f\.id === activeFamiliarId\)/, "Recovers when the selected familiar vanishes");
-assert.match(source, /openFamiliarStudio\(resolved\[0\]\.id\)/, "Auto-selects the first familiar");
+assert.match(source, /openFamiliarStudio\(handoff \?\? resolved\[0\]\.id\)/, "Auto-selects the Brain Studio handoff familiar, falling back to the first");
+assert.match(source, /BRAIN_STUDIO_FAMILIAR_KEY/, "Reads the one-shot Brain Studio handoff key");
 
 // Autosave footer carries over from the drawer.
 assert.match(source, /Changes save automatically/, "Shows the autosave footer");

--- a/src/components/familiar-studio-inline.tsx
+++ b/src/components/familiar-studio-inline.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, type CSSProperties } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { Tabs } from "@/components/ui/tabs";
-import { useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
+import { useFamiliarStudio, BRAIN_STUDIO_FAMILIAR_KEY, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
 import { useDaemonSyncStatus } from "@/lib/daemon-sync-status";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { FamiliarStudioIdentityTab } from "./familiar-studio-identity-tab";
@@ -54,12 +54,24 @@ export function FamiliarStudioInlinePanel({ familiars, resolved }: Props) {
     [resolved, activeFamiliarId],
   );
 
-  // Auto-select the first familiar so the detail pane is never empty on entry,
-  // and recover if the current selection vanishes (archived/removed) while open.
+  // Auto-select a familiar so the detail pane is never empty on entry, and
+  // recover if the current selection vanishes (archived/removed) while open.
+  // Prefer the one-shot handoff id written by "Open Brain Studio" so the right
+  // familiar opens (not just the first), then fall back to the first.
   useEffect(() => {
     if (resolved.length === 0) return;
     if (!activeFamiliarId || !resolved.some((f) => f.id === activeFamiliarId)) {
-      openFamiliarStudio(resolved[0].id);
+      let handoff: string | null = null;
+      try {
+        const stored = window.localStorage.getItem(BRAIN_STUDIO_FAMILIAR_KEY);
+        if (stored) {
+          window.localStorage.removeItem(BRAIN_STUDIO_FAMILIAR_KEY);
+          if (resolved.some((f) => f.id === stored)) handoff = stored;
+        }
+      } catch {
+        /* ignore storage failures */
+      }
+      openFamiliarStudio(handoff ?? resolved[0].id);
     }
   }, [resolved, activeFamiliarId, openFamiliarStudio]);
 

--- a/src/components/familiar-studio.test.ts
+++ b/src/components/familiar-studio.test.ts
@@ -72,8 +72,8 @@ assert.match(
 );
 assert.match(
   source,
-  /setActiveTab\("brain"\)[\s\S]*window\.location\.assign\("\/settings"\)/,
-  "Open Brain Studio should persist the Brain tab and leave the side panel for the full Settings surface",
+  /setActiveTab\("brain"\)[\s\S]*window\.location\.assign\("\/settings#familiars"\)/,
+  "Open Brain Studio should persist the Brain tab and deep-link to the Familiars section (the full Brain Studio surface), not the General settings page",
 );
 
 // The drawer traps focus, focuses on open, wires Escape, and restores focus on

--- a/src/components/familiar-studio.tsx
+++ b/src/components/familiar-studio.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties }
 import { Icon, type IconName } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useFamiliarImageUpload, FAMILIAR_IMAGE_ACCEPT } from "@/lib/familiar-image-upload";
-import { useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
+import { useFamiliarStudio, BRAIN_STUDIO_FAMILIAR_KEY, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Tabs } from "@/components/ui/tabs";
@@ -54,8 +54,19 @@ export function FamiliarStudio({ familiars }: Props) {
   const drawerActiveTab = activeTab === "brain" || activeTab === "vault" ? "identity" : activeTab;
   const openBrainStudio = useCallback(() => {
     setActiveTab("brain");
-    window.location.assign("/settings");
-  }, [setActiveTab]);
+    // Carry the current familiar across the full-page navigation (the Settings
+    // provider is a separate instance, so activeFamiliarId would otherwise
+    // reset), and deep-link straight to the Familiars section where the Brain
+    // editor lives — a bare "/settings" lands on General instead.
+    if (activeFamiliarId) {
+      try {
+        window.localStorage.setItem(BRAIN_STUDIO_FAMILIAR_KEY, activeFamiliarId);
+      } catch {
+        /* ignore storage failures */
+      }
+    }
+    window.location.assign("/settings#familiars");
+  }, [setActiveTab, activeFamiliarId]);
 
   // Trap keyboard focus inside the open drawer, focus it on open, wire Escape,
   // and restore focus to the trigger on close — matching every other modal

--- a/src/lib/familiar-studio-context.tsx
+++ b/src/lib/familiar-studio-context.tsx
@@ -15,6 +15,15 @@ export type FamiliarStudioTab = "identity" | "look" | "brain" | "lifecycle" | "m
 const TAB_STORAGE_KEY = "cave:familiar-studio-tab:v1";
 const DEFAULT_TAB: FamiliarStudioTab = "identity";
 
+/**
+ * One-shot handoff for "Open Brain Studio": the right-side drawer (Workspace
+ * provider) writes the familiar id here before a full navigation to
+ * `/settings#familiars`, and the Settings inline panel (a separate, isolated
+ * provider — so `activeFamiliarId` does not carry over) reads it once to select
+ * the same familiar, then clears it.
+ */
+export const BRAIN_STUDIO_FAMILIAR_KEY = "cave:brain-studio-familiar:v1";
+
 type Ctx = {
   /** `null` means closed; a string id means open for a specific familiar. */
   activeFamiliarId: string | null;


### PR DESCRIPTION
## Problem
Clicking **Open Brain Studio** (in the familiar side-panel drawer) set the Brain tab then navigated to a bare `/settings` — which lands on the **General** section. The Brain editor never appeared, so the action effectively did nothing useful.

## Fix
- Deep-link to **`/settings#familiars`** (the section whose inline panel hosts the Brain editor), instead of bare `/settings`.
- Carry the **current familiar** across the full-page navigation via a one-shot `localStorage` handoff key (`cave:brain-studio-familiar:v1`). The Settings page uses a *separate* `FamiliarStudioProvider` instance, so `activeFamiliarId` would otherwise reset and open the *first* familiar instead of the one you were editing. The inline panel reads the handoff id during auto-select, then clears it. The Brain tab itself already persists via the existing tab-storage key.

## Verification
Built and loaded `/settings#familiars` with the Brain tab persisted — confirmed the Familiars section opens with the **Brain panel active** (`familiar-studio-inline-panel-brain`) showing the Runtime/model + system-prompt + voice editor. Screenshot reviewed.

`familiar-studio` + `familiar-studio-inline` tests updated and passing; full `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)