### PR TITLE
chore(capabilities): hide the add-a-new-harness/runtime panel for now

### DIFF
--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -11,7 +11,9 @@ import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { MarkdownBlock } from "@/components/message-bubble";
-import { OpenCovenSubmissionPanel } from "@/components/opencoven-submission-panel";
+// Hidden for now — the OpenCoven submissions panel (add a new harness/runtime)
+// is parked until the flow is ready. Re-enable the import + render below to restore.
+// import { OpenCovenSubmissionPanel } from "@/components/opencoven-submission-panel";
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
 import {
   filterCapabilityItems,
@@ -384,7 +386,10 @@ export function CapabilitiesViewSurface({
             </div>
           </div>
 
-          <OpenCovenSubmissionPanel />
+          {/* Hidden for now — add-a-new-harness/runtime (OpenCoven submissions)
+              is parked until the flow is ready. Restore the import above + this
+              line to bring it back. */}
+          {/* <OpenCovenSubmissionPanel /> */}
 
           {!loaded ? (
             <CapabilitiesSkeleton />


### PR DESCRIPTION
Hides the **OpenCoven submissions panel** — the "add a new harness or runtime" surface — from the Capabilities tab, parked until the flow is ready.

- Comments out (doesn't delete) the import + render of `<OpenCovenSubmissionPanel />` in `capabilities-view.tsx`, so it's a one-line restore.
- The panel component, its `/api/opencoven/submissions` route, and the standalone `submissions` workspace mode are left intact. That standalone mode already has **no nav entry or link**, so it's unreachable — the Capabilities tab was the only visible entry point.

## Verified
- `tsc --noEmit` clean (no unused-import fallout — the import is commented too).
- App source-text suite green (420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)