### PR TITLE
fix(terminal): don't hang on "Starting terminal…" — watchdog + retry + fail-visible

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -222,6 +222,7 @@ export const SUITES = {
     "src/components/voice-call-overlay.test.ts",
     "src/lib/session-debug.test.ts",
     "src/components/bottom-terminal-ws-bridge.test.ts",
+    "src/components/bottom-terminal-startup-watchdog.test.ts",
     "src/lib/library-metadata.test.ts",
     "src/components/familiars-memory-view-filter-paginate.test.ts",
     "src/components/familiars-memory-view-detail.test.ts",

--- a/src/components/bottom-terminal-startup-watchdog.test.ts
+++ b/src/components/bottom-terminal-startup-watchdog.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./bottom-terminal.tsx", import.meta.url), "utf8");
+
+// The desktop terminal could hang on "Starting terminal…" forever: a native
+// pty_* command that never returns, a transport await that threw, or `platform`
+// stuck at "unknown" so neither transport effect ran — all left the spinner up
+// with no error and no recovery. These pin the fail-visible + retry behavior.
+
+// ── Watchdog surfaces a stall instead of spinning forever ────────────────────
+assert.match(src, /const START_WATCHDOG_MS = \d[\d_]*;/, "a startup watchdog timeout is defined");
+assert.match(
+  src,
+  /if \(ready \|\| unavailable \|\| startError\) return;[\s\S]*?setTimeout\(\(\) => \{[\s\S]*?setStartError\([\s\S]*?\}, START_WATCHDOG_MS\)/,
+  "an unresolved startup flips to a visible error after the watchdog window",
+);
+
+// ── Both transports surface a thrown/rejected startup instead of hanging ─────
+assert.ok(
+  (src.match(/setStartError\(`Terminal failed to start: \$\{String\(err\)\}`\)/g) ?? []).length >= 2,
+  "both the desktop (Tauri IPC) and the WebSocket startup paths catch + surface a thrown await",
+);
+assert.match(src, /log\("desktop terminal startup FAILED", err\)/, "the desktop startup failure is logged (forwarded to Rust)");
+
+// ── Retry re-runs the transport effects ──────────────────────────────────────
+assert.match(src, /const retryStart = useCallback\(\(\) => \{[\s\S]*?setRetryNonce\(\(n\) => n \+ 1\)/, "Retry bumps the nonce that re-runs startup");
+assert.match(src, /\}, \[threadId, platform, openFind, retryNonce\]\)/, "the desktop transport effect re-runs on retry");
+assert.match(src, /\}, \[threadId, platform, pushToMirror, openFind, retryNonce\]\)/, "the WebSocket transport effect re-runs on retry");
+
+// ── The overlay shows the error + a Retry button (not just the spinner) ──────
+assert.match(src, /\{!ready && startError \?/, "the error state replaces the spinner overlay");
+assert.match(src, /onClick=\{retryStart\}[\s\S]*?Retry/, "the error overlay offers a Retry control");
+
+console.log("bottom-terminal-startup-watchdog.test.ts: ok");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -21,6 +21,11 @@ import { Icon } from "@/lib/icon";
 // (e.g. `cargo build`) don't flood SR or thrash React.
 const MIRROR_LINES = 50;
 const MIRROR_DEBOUNCE_MS = 250;
+// The xterm lazy-import + PTY handshake is "a few seconds"; well past that with
+// no connection means startup hung (a wedged native command, a transport await
+// that never settled, or `platform` never resolving off "unknown"). Surface a
+// Retry rather than spinning forever.
+const START_WATCHDOG_MS = 15_000;
 
 function stripAnsi(text: string): string {
   return text
@@ -227,6 +232,12 @@ export function BottomTerminal({
   // Until then the pane shows a "Starting terminal…" overlay instead of looking
   // blank during the lazy xterm import + WebSocket handshake (~a few seconds).
   const [ready, setReady] = useState(false);
+  // Startup never resolved — a thrown/hung transport await, or `platform` stuck
+  // at "unknown" so neither transport effect ran. Surfaced (with Retry) instead
+  // of an indefinite "Starting terminal…" spinner. `retryNonce` re-runs the
+  // transport effects when the user retries.
+  const [startError, setStartError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
   // useTauriPlatform() resolves async and starts at "unknown". Desktop uses
   // Tauri IPC; browser dev/prod AND Tauri-mobile use the WebSocket PTY
   // bridge — the mobile webview is served by a remote Cave server, and the
@@ -300,6 +311,29 @@ export function BottomTerminal({
     }
   }, [active]);
 
+  // Startup watchdog: covers every way the terminal can stall before `ready` —
+  // a native pty_* command that never returns, a transport await that throws/
+  // hangs, or `platform` stuck at "unknown" so neither transport effect runs.
+  // Without this the user just stares at "Starting terminal…" forever.
+  useEffect(() => {
+    if (ready || unavailable || startError) return;
+    const id = setTimeout(() => {
+      setStartError("The terminal didn't finish starting — the shell backend isn't responding.");
+      log("startup watchdog fired", { platform, retryNonce });
+    }, START_WATCHDOG_MS);
+    return () => clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, unavailable, startError, platform, retryNonce]);
+
+  // Re-run the transport effects (retryNonce is in their deps) and reset the
+  // overlay state so the watchdog re-arms.
+  const retryStart = useCallback(() => {
+    setStartError(null);
+    setUnavailable(false);
+    setReady(false);
+    setRetryNonce((n) => n + 1);
+  }, []);
+
   useEffect(() => {
     const wrap = wrapRef.current;
     if (!wrap) return;
@@ -312,6 +346,7 @@ export function BottomTerminal({
     let cleanup: (() => void) | null = null;
 
     void (async () => {
+     try {
       // Skip all logs in browser dev — only log when Tauri is actually present
       const inTauri = typeof window !== "undefined" && !!(window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
       if (inTauri) log("mount: loading tauri bridge");
@@ -476,13 +511,22 @@ export function BottomTerminal({
       };
 
       if (disposed) cleanup();
+     } catch (err) {
+       // A thrown/rejected await (loadTauri, createXterm, listen, a native
+       // command) must not leave the pane stuck on "Starting terminal…" — surface
+       // it (with Retry) instead of hanging silently.
+       if (!disposed) {
+         log("desktop terminal startup FAILED", err);
+         setStartError(`Terminal failed to start: ${String(err)}`);
+       }
+     }
     })();
 
     return () => {
       disposed = true;
       cleanup?.();
     };
-  }, [threadId, platform, openFind]);
+  }, [threadId, platform, openFind, retryNonce]);
 
   useEffect(() => {
     const wrap = wrapRef.current;
@@ -496,6 +540,7 @@ export function BottomTerminal({
     let cleanup: (() => void) | null = null;
 
     void (async () => {
+     try {
       const { term, fit, search } = await createXterm(wrap, {
         onResults: (index, count) => setFindInfo({ index, count }),
         onRequestFind: openFind,
@@ -666,13 +711,19 @@ export function BottomTerminal({
       };
 
       if (disposed) cleanup();
+     } catch (err) {
+       if (!disposed) {
+         log("ws terminal startup FAILED", err);
+         setStartError(`Terminal failed to start: ${String(err)}`);
+       }
+     }
     })();
 
     return () => {
       disposed = true;
       cleanup?.();
     };
-  }, [threadId, platform, pushToMirror, openFind]);
+  }, [threadId, platform, pushToMirror, openFind, retryNonce]);
 
   if (unavailable) {
     return (
@@ -737,8 +788,25 @@ export function BottomTerminal({
         </div>
       ) : null}
       {/* Overlay while the xterm lazy-loads and the PTY (native or WebSocket)
-          connects — without it the pane reads as blank for a few seconds. */}
-      {!ready ? (
+          connects — without it the pane reads as blank for a few seconds. If
+          startup stalls or throws, it flips to a visible error + Retry instead
+          of spinning forever. */}
+      {!ready && startError ? (
+        <div
+          className="absolute inset-0 flex flex-col items-center justify-center gap-3 px-6 text-center text-[11px] text-[var(--text-muted)]"
+          style={{ background: "oklch(0.11 0.022 293)" }}
+          role="alert"
+        >
+          <span className="max-w-[42ch] text-[var(--text-secondary)]">{startError}</span>
+          <button
+            type="button"
+            onClick={retryStart}
+            className="focus-ring rounded-md border border-[var(--border-strong)] bg-[var(--bg-elevated)] px-3 py-1 text-[11px] text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-raised)]"
+          >
+            Retry
+          </button>
+        </div>
+      ) : !ready ? (
         <div
           className="pointer-events-none absolute inset-0 flex items-center justify-center gap-2 text-[11px] text-[var(--text-muted)]"
           style={{ background: "oklch(0.11 0.022 293)" }}


### PR DESCRIPTION
## The bug
The terminal in the **desktop app** gets stuck on the "Starting terminal…" spinner indefinitely (the web app is fine).

## Root-cause analysis
The desktop transport (`bottom-terminal.tsx`) runs an async startup that only clears the overlay at `setReady(true)` *after* the whole flow. Several `await`s before that point are **unguarded**, so any of these leaves the spinner up forever with no error and no recovery:
- `loadTauri()` (dynamic import of the Tauri API), `createXterm()`, the `pty:data`/`pty:exit` listeners — a throw/reject aborts the IIFE silently.
- `bridge.invoke("pty_start")` — `pty_start` is a **synchronous** Tauri command; if it wedges, the `invoke` never resolves.
- `platform` stuck at `"unknown"` (e.g. `@tauri-apps/plugin-os` not resolving) → **neither** transport effect runs → same dead spinner.

I verified the Rust side isn't an obvious culprit (pty commands *are* registered on desktop; no lock-ordering deadlock in the `pty_start` gates), and the web/WS path already self-heals — but I can't run the packaged desktop build to pin the exact upstream await. So the fix makes startup **fail-visible and recoverable** for all of the above.

## The fix
- **Watchdog** (platform-agnostic): if the terminal hasn't connected within `START_WATCHDOG_MS`, flip the overlay to a visible error — covers a wedged native command, an await that never settled, and an unresolved `platform`.
- **Guard both transport IIFEs** (Tauri IPC + WebSocket): a thrown/rejected await now surfaces the error (and `log()`s it back to Rust stderr) instead of aborting silently.
- **Retry** control on the error overlay (`retryNonce` re-runs the transport effects).

## Verification
- New `bottom-terminal-startup-watchdog.test.ts` (wired; `check:tests-wired` ✓) + existing `bottom-terminal-*` tests pass · `tsc` clean · `pnpm build` exit 0.
- **Web happy path unaffected** (Playwright): terminal still connects — xterm rows render, spinner clears, **no** error overlay, 0 page errors.
- I can't run the packaged desktop app here, so the desktop hang isn't directly reproduced — but this guarantees the user is **no longer stuck**, and the now-surfaced error message will pinpoint the exact failing await for any deeper follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)