### PR TITLE
fix(harness): canonicalize harness ids — dedup duplicate Hermes + fix spurious chat 403

### DIFF
--- a/src/app/api/capabilities/route.test.ts
+++ b/src/app/api/capabilities/route.test.ts
@@ -52,6 +52,18 @@ assert.match(
 
 assert.match(
   source,
+  /const id = canonicalHarnessId\(m\.harness_id\);\s*if \(!byId\.has\(id\)\) byId\.set\(id, m\);/,
+  "Manifests must be deduped by canonical harness id so a duplicate/aliased harness (e.g. Hermes) renders only once",
+);
+
+assert.match(
+  source,
+  /const present = new Set\(manifests\.map\(\(m\) => canonicalHarnessId\(m\.harness_id\)\)\)/,
+  "Presence is computed on the canonical id so an aliased aggregate manifest isn't double-counted by the backfill",
+);
+
+assert.match(
+  source,
   /supplementClaudeSkills/,
   "Claude manifests are supplemented with the local ~/.claude/skills scan",
 );

--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
-import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
+import { COMPATIBILITY_ADAPTERS, canonicalHarnessId } from "@/lib/harness-adapters";
 import {
   openClawBridgeCapabilities,
   type OpenClawBridgeCapabilities,
@@ -173,13 +173,24 @@ async function ensureAdapterCoverage(
   manifests: HarnessCapabilityManifest[],
   refresh: string,
 ): Promise<HarnessCapabilityManifest[]> {
-  const present = new Set(manifests.map((m) => m.harness_id));
+  const present = new Set(manifests.map((m) => canonicalHarnessId(m.harness_id)));
   const missing = COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id).filter((id) => !present.has(id));
-  if (missing.length === 0) return manifests;
-  const backfilled = (await Promise.all(missing.map((id) => fetchHarnessManifest(id, refresh)))).filter(
-    (m): m is HarnessCapabilityManifest => m !== null,
-  );
-  return [...manifests, ...backfilled];
+  const backfilled = missing.length
+    ? (await Promise.all(missing.map((id) => fetchHarnessManifest(id, refresh)))).filter(
+        (m): m is HarnessCapabilityManifest => m !== null,
+      )
+    : [];
+  // Dedup by CANONICAL harness id, first occurrence wins. The daemon can report
+  // the same harness twice — or under an alias (e.g. "hermes-agent") that the
+  // missing-calc no longer treats as absent — and a backfilled adapter must
+  // never re-add an id already covered. Aggregate-reported manifests come
+  // first, so they always beat the synthetic backfill, matching the contract.
+  const byId = new Map<string, HarnessCapabilityManifest>();
+  for (const m of [...manifests, ...backfilled]) {
+    const id = canonicalHarnessId(m.harness_id);
+    if (!byId.has(id)) byId.set(id, m);
+  }
+  return [...byId.values()];
 }
 
 export async function GET(req: Request) {

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -36,6 +36,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /binding\.harness = canonicalHarnessId\(binding\.harness\)/,
+  "Native chat must canonicalize the bound harness id (e.g. hermes-agent → hermes) before the trust gate, so an aliased familiar isn't 403'd",
+);
+
+assert.match(
+  chatRoute,
   /const adapter = COMPATIBILITY_ADAPTERS\.find\(\(h\) => h\.id === binding\.harness\);/,
   "Native chat should consult bundled adapter metadata before spawning a harness",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -50,7 +50,7 @@ import {
   resolveOpenClawAgentBinding,
   type OpenClawAgentJson,
 } from "@/lib/openclaw-bridge";
-import { isTrustedChatHarness, covenRunSupportsModelFlag } from "@/lib/harness-adapters";
+import { isTrustedChatHarness, covenRunSupportsModelFlag, canonicalHarnessId } from "@/lib/harness-adapters";
 import {
   type ConversationFile,
   type ChatTurn,
@@ -837,6 +837,12 @@ export async function POST(req: Request) {
 
   const config = await loadConfig();
   const binding = bindingFor(config, body.familiarId);
+  // Canonicalize the bound harness id up front so a familiar carrying a
+  // package/alias id (e.g. "hermes-agent" for Hermes) is recognized as the
+  // trusted "hermes" adapter — otherwise the trust gate below 403s and `coven
+  // run` is invoked with an unknown harness name. Every downstream check and
+  // the spawn use this canonical id.
+  binding.harness = canonicalHarnessId(binding.harness);
   const sshRuntime = isSshRuntime(binding.runtime) ? binding.runtime : null;
   const existingConversation = body.sessionId
     ? await loadConversation(body.sessionId).catch(() => null)

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -11,6 +11,7 @@ import {
   isTrustedChatHarness,
   isTrustedOnboardingHarness,
   openClawAdapterReport,
+  canonicalHarnessId,
 } from "./harness-adapters.ts";
 
 // Model-parity gating probe: forwarding `--model` must stay off until the
@@ -152,6 +153,18 @@ assert.equal(isTrustedChatHarness("openclaw"), true);
 assert.equal(isTrustedChatHarness("attacker-adapter"), false);
 assert.equal(isTrustedOnboardingHarness("openclaw"), true);
 assert.equal(isTrustedOnboardingHarness("attacker-adapter"), false);
+
+// canonicalHarnessId collapses package/alias ids and bare binary names back to
+// the adapter id, so a familiar bound to "hermes-agent" (the NousResearch repo
+// name) is recognized as the trusted "hermes" adapter instead of 403-ing.
+assert.equal(canonicalHarnessId("hermes-agent"), "hermes");
+assert.equal(canonicalHarnessId("Hermes-Agent"), "hermes", "alias match is case-insensitive");
+assert.equal(canonicalHarnessId("claude-code"), "claude");
+assert.equal(canonicalHarnessId("hermes"), "hermes", "canonical id passes through");
+assert.equal(canonicalHarnessId("HERMES"), "hermes", "id match is case-insensitive");
+assert.equal(canonicalHarnessId("attacker-adapter"), "attacker-adapter", "unknown ids are unchanged (still untrusted)");
+assert.equal(isTrustedChatHarness("hermes-agent"), true, "the Hermes package alias must clear the chat trust gate");
+assert.equal(isTrustedChatHarness("attacker-adapter"), false, "canonicalization must not trust an unknown harness");
 
 assert.deepEqual(adapterSetupState(merged), {
   ok: true,

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -101,8 +101,32 @@ export function isTrustedOnboardingHarness(harness: string): boolean {
   return TRUSTED_ONBOARDING_HARNESSES.has(harness);
 }
 
+// The daemon and older familiar configs sometimes carry a project/package
+// alias instead of the canonical adapter id — e.g. "hermes-agent" (the repo +
+// package is NousResearch/hermes-agent, even though its binary is `hermes`).
+// A familiar bound to such an alias fails the chat trust gate (a spurious 403)
+// and shows up as a SECOND runtime row next to the canonical backfill. Mapping
+// aliases (and bare binary names) back to the adapter id fixes both.
+const HARNESS_ALIASES: Record<string, string> = {
+  "hermes-agent": "hermes",
+  "claude-code": "claude",
+  "openai-codex": "codex",
+};
+
+export function canonicalHarnessId(harness: string): string {
+  if (typeof harness !== "string") return harness;
+  const key = harness.trim().toLowerCase();
+  if (!key) return harness;
+  if (HARNESS_ALIASES[key]) return HARNESS_ALIASES[key];
+  const byId = COMPATIBILITY_ADAPTERS.find((a) => a.id.toLowerCase() === key);
+  if (byId) return byId.id;
+  const byBinary = COMPATIBILITY_ADAPTERS.find((a) => a.binary.toLowerCase() === key);
+  if (byBinary) return byBinary.id;
+  return harness;
+}
+
 export function isTrustedChatHarness(harness: string): boolean {
-  return TRUSTED_CHAT_HARNESSES.has(harness);
+  return TRUSTED_CHAT_HARNESSES.has(canonicalHarnessId(harness));
 }
 
 export function openClawAdapterReport(openclawAgentCount: number): AdapterReport {


### PR DESCRIPTION
## What

Fixes three linked Hermes symptoms that all trace to a **non-canonical harness id** (e.g. `hermes-agent` — the NousResearch repo/package name, whose binary is actually `hermes`) being stored on a familiar or reported by the daemon:

1. **Chat bridge denies the request (403).** `isTrustedChatHarness("hermes-agent")` returned `false` even though Hermes is a trusted, chat-supported adapter, so `POST /api/chat/send` returned **403** and the UI rendered "Chat bridge rejected the request" (`chat-view.tsx`).
2. **Hermes populates twice** in the runtimes/capabilities list. The daemon's aliased manifest didn't satisfy the backfill presence check in `ensureAdapterCoverage`, so the canonical `hermes` manifest was appended alongside it — and neither the route nor `normalizeCapabilities` deduped (also a React `key={harness.id}` collision).
3. **"Two model lines" for one runtime** — a side effect of #2: the duplicated Hermes row carried its own model/version.

## How

New `canonicalHarnessId()` in `harness-adapters.ts` — an alias map (`hermes-agent → hermes`, `claude-code → claude`, `openai-codex → codex`) plus bare-binary / id matching, case-insensitive. Unknown ids pass through unchanged, so untrusted adapters **stay** untrusted (the `attacker-adapter` security test still holds). Applied in:

- `isTrustedChatHarness` — an aliased id clears the trust gate.
- `/api/chat/send` — `binding.harness` is canonicalized up front, so the trust check **and** the `coven run <harness>` spawn use the canonical id.
- `ensureAdapterCoverage` — dedup manifests by canonical id (aggregate-reported wins), which also collapses daemon-side duplicate manifests.

## Verify

- New unit assertions: `canonicalHarnessId` alias/binary/case behavior + `isTrustedChatHarness("hermes-agent") === true` while `attacker-adapter` stays untrusted.
- New source-text assertions for the chat/send canonicalization and the capabilities dedup.
- Full `pnpm test:app` green; `pnpm build` clean.

> Note: if your familiar's stored harness value is something other than `hermes-agent`, tell me the exact string and I'll add it to the alias map — the mechanism is in place either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)