### PR TITLE
fix(update): About-page Download fetches a direct installer, not the release page

### DIFF
--- a/src/app/api/app/latest-release/route.test.ts
+++ b/src/app/api/app/latest-release/route.test.ts
@@ -10,5 +10,7 @@ assert.match(source, /isUpdateAvailable/, "decides availability via the shared s
 assert.match(source, /AbortSignal\.timeout/, "bounds the GitHub fetch with a timeout");
 assert.match(source, /catch\s*\(/, "fails soft on network/error (never surfaces a false update)");
 assert.match(source, /TTL_MS|cache/, "caches the result to avoid GitHub rate limits");
+assert.match(source, /resolveDownloadUrls/, "resolves direct installer downloads from the release assets");
+assert.match(source, /downloads:/, "returns the per-platform installer download map");
 
 console.log("app/latest-release route.test.ts: ok");

--- a/src/app/api/app/latest-release/route.ts
+++ b/src/app/api/app/latest-release/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { APP_VERSION } from "@/lib/app-version";
-import { isUpdateAvailable, type UpdateStatus } from "@/lib/app-update";
+import {
+  isUpdateAvailable,
+  resolveDownloadUrls,
+  type ReleaseAsset,
+  type UpdateStatus,
+} from "@/lib/app-update";
 
 export const dynamic = "force-dynamic";
 
@@ -35,13 +40,18 @@ export async function GET() {
       // Fail soft — never surface an update on an error; don't cache the failure long.
       return NextResponse.json({ ...base, error: `github ${res.status}` });
     }
-    const data = (await res.json()) as { tag_name?: string; html_url?: string };
+    const data = (await res.json()) as {
+      tag_name?: string;
+      html_url?: string;
+      assets?: ReleaseAsset[];
+    };
     const latest = data.tag_name ? data.tag_name.replace(/^v/, "") : null;
     const body: UpdateStatus = {
       ...base,
       latest,
       available: latest ? isUpdateAvailable(latest, APP_VERSION) : false,
       url: data.html_url || RELEASE_PAGE,
+      downloads: resolveDownloadUrls(data.assets ?? []),
     };
     cache = { at: now, body };
     return NextResponse.json(body);

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -15,7 +15,13 @@ assert.match(src, /relaunch\(\)/, "relaunches the app after install");
 
 // Graceful fallback when no updater-enabled release exists yet.
 assert.match(src, /\/api\/app\/latest-release/, "falls back to the server release check");
-assert.match(src, /openExternalUrl/, "fallback opens the release page in the system browser");
+assert.match(src, /openExternalUrl/, "fallback opens the download in the system browser");
+
+// Fallback "Download" resolves a direct platform installer (DMG/MSI/AppImage)
+// via the OS plugin instead of dead-ending on the release page.
+assert.match(src, /pickDownloadUrl/, "fallback resolves a direct platform installer download");
+assert.match(src, /@tauri-apps\/plugin-os/, "resolves the running platform/arch to pick an installer");
+assert.match(src, /resolveDownloadUrl\(fb\)/, "fallback download URL is the resolved installer, not the release page");
 
 // Both surfaces are exported and resolve native-first.
 assert.match(src, /export function UpdateBannerTrigger/, "exports the banner trigger");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -5,7 +5,7 @@ import { Icon } from "@/lib/icon";
 import { isTauri, useIsTauriDesktop } from "@/lib/tauri-platform";
 import { useShellBanners } from "@/lib/shell-banners";
 import { openExternalUrl } from "@/lib/open-external";
-import type { UpdateStatus } from "@/lib/app-update";
+import { pickDownloadUrl, type UpdateStatus } from "@/lib/app-update";
 
 const BANNER_ID = "update-available";
 const RELEASES_PAGE = "https://github.com/OpenCoven/coven-cave/releases/latest";
@@ -91,6 +91,21 @@ async function fetchFallbackStatus(): Promise<UpdateStatus | null> {
   }
 }
 
+/**
+ * Resolve a *direct* installer download for the running desktop platform so the
+ * fallback "Download" actually downloads (DMG / MSI / AppImage) instead of just
+ * opening the release page. Falls back to `status.url` (the release page) when
+ * the OS plugin is unavailable or no matching asset shipped.
+ */
+async function resolveDownloadUrl(status: UpdateStatus): Promise<string> {
+  try {
+    const { platform, arch } = await import("@tauri-apps/plugin-os");
+    return pickDownloadUrl(status, platform(), arch());
+  } catch {
+    return status.url;
+  }
+}
+
 type Resolved =
   | { kind: "current" }
   | { kind: "native"; version: string; update: TauriUpdate }
@@ -101,7 +116,10 @@ async function resolveUpdate(): Promise<Resolved> {
   const native = await checkNativeUpdate();
   if (native) return { kind: "native", version: native.version, update: native };
   const fb = await fetchFallbackStatus();
-  if (fb?.available && fb.latest) return { kind: "fallback", version: fb.latest, url: fb.url };
+  if (fb?.available && fb.latest) {
+    const url = await resolveDownloadUrl(fb);
+    return { kind: "fallback", version: fb.latest, url };
+  }
   return { kind: "current" };
 }
 

--- a/src/lib/app-update.test.ts
+++ b/src/lib/app-update.test.ts
@@ -1,7 +1,29 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { parseSemver, compareSemver, isUpdateAvailable } from "./app-update.ts";
+import {
+  parseSemver,
+  compareSemver,
+  isUpdateAvailable,
+  resolveDownloadUrls,
+  downloadTargetFor,
+  pickDownloadUrl,
+} from "./app-update.ts";
+
+// Mirrors a real release's asset list (see releases/v0.0.114).
+const ASSETS = [
+  { name: "CovenCave-v0.0.114-aarch64.app.tar.gz", browser_download_url: "u/mac-arm-updater" },
+  { name: "CovenCave-v0.0.114-aarch64.app.tar.gz.sig", browser_download_url: "u/mac-arm-sig" },
+  { name: "CovenCave-v0.0.114-aarch64.dmg", browser_download_url: "u/mac-arm-dmg" },
+  { name: "CovenCave-v0.0.114-x86_64.app.tar.gz", browser_download_url: "u/mac-x64-updater" },
+  { name: "CovenCave-v0.0.114-x86_64.dmg", browser_download_url: "u/mac-x64-dmg" },
+  { name: "CovenCave_0.0.114_amd64.AppImage", browser_download_url: "u/linux-appimage" },
+  { name: "CovenCave_0.0.114_amd64.AppImage.sig", browser_download_url: "u/linux-sig" },
+  { name: "CovenCave_0.0.114_x64_en-US.msi", browser_download_url: "u/win-msi" },
+  { name: "CovenCave_0.0.114_x64_en-US.msi.sig", browser_download_url: "u/win-sig" },
+  { name: "latest.json", browser_download_url: "u/latest-json" },
+  { name: "SHA256SUMS", browser_download_url: "u/sums" },
+];
 
 test("parseSemver handles plain and v-prefixed versions", () => {
   assert.deepEqual(parseSemver("0.0.80"), [0, 0, 80]);
@@ -29,6 +51,51 @@ test("isUpdateAvailable is true only when latest is strictly newer", () => {
   assert.equal(isUpdateAvailable("0.0.80", "0.0.80"), false);
   assert.equal(isUpdateAvailable("0.0.79", "0.0.80"), false);
   assert.equal(isUpdateAvailable("garbage", "0.0.80"), false);
+});
+
+test("resolveDownloadUrls picks the end-user installer per platform, skips updater + .sig artifacts", () => {
+  const d = resolveDownloadUrls(ASSETS);
+  assert.equal(d["darwin-aarch64"], "u/mac-arm-dmg"); // DMG, not the .app.tar.gz updater
+  assert.equal(d["darwin-x86_64"], "u/mac-x64-dmg");
+  assert.equal(d["windows-x86_64"], "u/win-msi"); // .msi, not its .sig
+  assert.equal(d["linux-x86_64"], "u/linux-appimage");
+});
+
+test("resolveDownloadUrls returns only the targets it found", () => {
+  const d = resolveDownloadUrls([
+    { name: "CovenCave_0.0.114_x64_en-US.msi", browser_download_url: "u/win-msi" },
+  ]);
+  assert.deepEqual(Object.keys(d), ["windows-x86_64"]);
+  assert.deepEqual(resolveDownloadUrls([]), {});
+});
+
+test("downloadTargetFor maps OS-plugin output to a release target", () => {
+  assert.equal(downloadTargetFor("macos", "aarch64"), "darwin-aarch64");
+  assert.equal(downloadTargetFor("macos", "x86_64"), "darwin-x86_64");
+  assert.equal(downloadTargetFor("windows", "x86_64"), "windows-x86_64");
+  assert.equal(downloadTargetFor("linux", "x86_64"), "linux-x86_64");
+  assert.equal(downloadTargetFor("freebsd", "x86_64"), null);
+});
+
+test("pickDownloadUrl returns the direct installer for the running platform", () => {
+  const status = { downloads: resolveDownloadUrls(ASSETS), url: "u/release-page" };
+  assert.equal(pickDownloadUrl(status, "macos", "aarch64"), "u/mac-arm-dmg");
+  assert.equal(pickDownloadUrl(status, "windows", "x86_64"), "u/win-msi");
+  assert.equal(pickDownloadUrl(status, "linux", "x86_64"), "u/linux-appimage");
+});
+
+test("pickDownloadUrl falls back to the release page when no asset matches", () => {
+  const status = { downloads: {}, url: "u/release-page" };
+  assert.equal(pickDownloadUrl(status, "macos", "aarch64"), "u/release-page");
+  // Unsupported OS → release page even when other assets exist.
+  const macOnly = { downloads: { "darwin-aarch64": "u/mac-arm-dmg" }, url: "u/release-page" };
+  assert.equal(pickDownloadUrl(macOnly, "freebsd", "x86_64"), "u/release-page");
+});
+
+test("pickDownloadUrl offers the other mac build on a macOS arch mismatch", () => {
+  const armOnly = { downloads: { "darwin-aarch64": "u/mac-arm-dmg" }, url: "u/release-page" };
+  // x86_64 report (e.g. under Rosetta) with only an arm build present.
+  assert.equal(pickDownloadUrl(armOnly, "macos", "x86_64"), "u/mac-arm-dmg");
 });
 
 console.log("app-update.test.ts: ok");

--- a/src/lib/app-update.ts
+++ b/src/lib/app-update.ts
@@ -1,6 +1,16 @@
 // Pure version-comparison helpers + shared types for the desktop update check.
 // Server-safe (no window / browser APIs) so the API route and client can both import it.
 
+/**
+ * The platform/arch targets we ship installers for. Keyed the same way as the
+ * Tauri updater manifest (`<os>-<arch>`) so the client can resolve its own
+ * target from the OS plugin and pick a direct installer download.
+ */
+export type DownloadTarget = "darwin-aarch64" | "darwin-x86_64" | "windows-x86_64" | "linux-x86_64";
+
+/** Direct installer download URLs per platform, resolved from a release's assets. */
+export type DownloadUrls = Partial<Record<DownloadTarget, string>>;
+
 export type UpdateStatus = {
   /** The running app's version (from package.json via APP_VERSION). */
   current: string;
@@ -8,8 +18,14 @@ export type UpdateStatus = {
   latest: string | null;
   /** True when `latest` is strictly newer than `current`. */
   available: boolean;
-  /** Where to send the user to download (GitHub release page). */
+  /** Where to send the user to download (GitHub release page) — last-resort fallback. */
   url: string;
+  /**
+   * Direct installer download URLs per platform (DMG / MSI / AppImage). The
+   * client picks its own target so "Download" downloads an installer instead of
+   * just opening the release page. Empty when assets couldn't be resolved.
+   */
+  downloads?: DownloadUrls;
   /** ISO timestamp of when the check ran. */
   checkedAt: string;
   /** Present when the latest version could not be determined (network/rate-limit). */
@@ -37,4 +53,70 @@ export function compareSemver(a: string, b: string): number {
 /** True when `latest` is a strictly newer release than `current`. */
 export function isUpdateAvailable(latest: string, current: string): boolean {
   return compareSemver(latest, current) > 0;
+}
+
+/** A GitHub release asset (subset of the fields we care about). */
+export type ReleaseAsset = { name?: string; browser_download_url?: string };
+
+/**
+ * Map a release's assets to direct, user-installable downloads per platform.
+ * Prefers the end-user installer for each target (DMG on macOS, MSI on Windows,
+ * AppImage on Linux) over the updater artifacts (`.app.tar.gz`) and skips the
+ * detached `.sig` signatures. Returns only the targets we found an asset for.
+ */
+export function resolveDownloadUrls(assets: ReleaseAsset[]): DownloadUrls {
+  const out: DownloadUrls = {};
+  const pick = (test: (name: string) => boolean): string | undefined => {
+    for (const a of assets) {
+      const name = a.name;
+      if (!name || !a.browser_download_url) continue;
+      if (name.endsWith(".sig")) continue;
+      if (test(name)) return a.browser_download_url;
+    }
+    return undefined;
+  };
+
+  const macArm = pick((n) => /aarch64\.dmg$/i.test(n));
+  const macX64 = pick((n) => /x86_64\.dmg$/i.test(n));
+  const win = pick((n) => /\.msi$/i.test(n)) ?? pick((n) => /-setup\.exe$/i.test(n));
+  const linux = pick((n) => /\.AppImage$/i.test(n));
+
+  if (macArm) out["darwin-aarch64"] = macArm;
+  if (macX64) out["darwin-x86_64"] = macX64;
+  if (win) out["windows-x86_64"] = win;
+  if (linux) out["linux-x86_64"] = linux;
+  return out;
+}
+
+/**
+ * Resolve the running platform to a download target key. `os`/`arch` come from
+ * the Tauri OS plugin (`platform()` → "macos"|"windows"|"linux"…, `arch()` →
+ * "aarch64"|"x86_64"…). Returns null when we don't ship for that combination.
+ */
+export function downloadTargetFor(os: string, arch: string): DownloadTarget | null {
+  if (os === "macos") return arch === "aarch64" ? "darwin-aarch64" : "darwin-x86_64";
+  if (os === "windows") return "windows-x86_64";
+  if (os === "linux") return "linux-x86_64";
+  return null;
+}
+
+/**
+ * Pick the best direct download for the running platform, falling back through
+ * the other macOS arch (universal-ish) and finally to the release page so the
+ * Download button always points at *something* downloadable.
+ */
+export function pickDownloadUrl(
+  status: Pick<UpdateStatus, "downloads" | "url">,
+  os: string,
+  arch: string,
+): string {
+  const downloads = status.downloads ?? {};
+  const target = downloadTargetFor(os, arch);
+  if (target && downloads[target]) return downloads[target]!;
+  // macOS arch mismatch (e.g. Rosetta arch report): offer the other mac build.
+  if (os === "macos") {
+    const other = downloads["darwin-aarch64"] ?? downloads["darwin-x86_64"];
+    if (other) return other;
+  }
+  return status.url;
 }


### PR DESCRIPTION
## Problem

Clicking **Download** from Settings ▸ About "fails to download the latest version" — it just opens a web page.

When the native Tauri updater can't run (unsigned/translocated/dev build, or a plugin error), `resolveUpdate()` falls back to a **Download** button that called `openExternalUrl(html_url)` — where `html_url` is GitHub's release **page** (`…/releases/tag/v0.0.114`), not an installer. So nothing downloads; the browser just lands on the release page.

The release itself is healthy (signed `latest.json`, DMG/MSI/AppImage assets all present) — only the *fallback target* was wrong.

## Fix

Resolve a **direct, platform-correct installer** for the fallback Download instead of the release page:

- **`/api/app/latest-release`** now maps the release `assets` → per-platform installer URLs (`downloads`): DMG (macOS), MSI (Windows), AppImage (Linux). It skips the `.app.tar.gz` updater artifacts and `.sig` signatures.
- **Client** resolves its own target via `@tauri-apps/plugin-os` (`platform()`/`arch()`) and points Download at the matching installer — falling back to the other macOS arch (Rosetta mismatch), then the release page when no asset shipped.

Pure helpers `resolveDownloadUrls` / `downloadTargetFor` / `pickDownloadUrl` live in `app-update.ts` (server-safe) and are unit-tested against a real release's asset list. Source-text tests pin the new route + client wiring.

The native "Install & restart" path and the failed-state manual-download escape hatch are unchanged.

## Test
- `node --test src/lib/app-update.test.ts` — 10 pass (new asset-resolution cases)
- `update-available.test.ts`, `latest-release/route.test.ts` — pass
- `tsc --noEmit` clean, `check:tests-wired` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)