### PR TITLE
chore(release): stamp v0.0.115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.115] - 2026-06-25
+
+Patch release on top of v0.0.114: a harness-identity fix that unblocks native
+chat for aliased runtimes, onboarding/installer clarity, and reliability polish
+for the terminal and chat surfaces.
+
+### Added
+
+- **Browser** - the tab rail opens (pinned) by default and remembers an
+  explicit auto-hide choice across sessions (#1916).
+- **Chat** - an inline debug/error strip below the chat surfaces the latest
+  failure (#1920).
+
+### Fixed
+
+- **Harness identity** - canonicalize harness ids (e.g. `hermes-agent` →
+  `hermes`) so an aliased familiar no longer triggers a spurious chat-bridge
+  403, and dedup duplicate/aliased runtime rows in the capabilities view
+  (#1921).
+- **Terminal** - no longer hangs on "Starting terminal…"; added a watchdog,
+  retry, and fail-visible state (#1919).
+- **Onboarding** - require Coven Code at startup and make "install both" work
+  (#1924); clarify the "Create your familiar" step and re-indent its config
+  form (#1915, #1922).
+- **Updater** - the About-page Download fetches a direct installer instead of
+  the release page (#1923).
+- **Familiar Studio** - "Open Brain Studio" now actually opens the Brain
+  surface (#1917).
+- **Home** - clear the daemon-offline banner immediately after the user starts
+  the daemon (#1914).
+
+### Changed
+
+- Hide the add-a-new-harness/runtime panel in the capabilities view for now
+  (#1918).
+
 ## [0.0.114] - 2026-06-25
 
 Patch release on top of v0.0.113 with the next iOS utility sweep, a broader

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.114",
+  "version": "0.0.115",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.114"
+version = "0.0.115"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.114"
+version = "0.0.115"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.114</string>
+	<string>0.0.115</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.114</string>
+	<string>0.0.115</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.114</string>
+	<string>0.0.115</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.114</string>
+	<string>0.0.115</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.114",
+  "version": "0.0.115",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version stamp for **v0.0.115** — bumps `package.json`, `src-tauri/{Cargo.toml,Cargo.lock,tauri.conf.json}`, and both iOS plists (`Info.ios.plist`, `gen/apple/app_iOS/Info.plist`) from 0.0.114 → 0.0.115, plus a CHANGELOG section. Same file set as the v0.0.114 stamp (#1913), so Rust check stays green (Cargo.lock app version kept in sync).

Once merged, I'll push the signed `v0.0.115` tag to trigger the Release workflow (sign + notarize + publish) so the desktop auto-updater delivers it.

### Headline of v0.0.115
- **Harness identity** — canonicalize harness ids (`hermes-agent` → `hermes`) so an aliased familiar no longer triggers a spurious chat-bridge **403**, and dedup duplicate runtime rows (#1921).
- Browser tab-rail opens by default (#1916); terminal hang watchdog (#1919); onboarding/installer clarity (#1914/#1915/#1922/#1923/#1924); capabilities/chat polish (#1917/#1918/#1920).

🤖 Generated with [Claude Code](https://claude.com/claude-code)