### PR TITLE
feat(desktop): seamless macOS title bar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1090,6 +1090,19 @@ pub fn run() {
             // handler intercepts dragenter/dragover/drop before the DOM sees
             // them.
             .disable_drag_drop_handler();
+            // macOS: dissolve the seam between the native title bar and the
+            // app's top toolbar. `Overlay` lets the webview content fill to the
+            // very top (the traffic-light buttons float over it) and
+            // `hidden_title` drops the centered "CovenCave" label, so the
+            // toolbar reads as one continuous strip. The web side reserves room
+            // for the traffic lights and makes the bar draggable (see
+            // `[data-tauri-titlebar]` in globals.css). No-op on Windows/Linux.
+            #[cfg(target_os = "macos")]
+            {
+                main_window = main_window
+                    .title_bar_style(tauri::TitleBarStyle::Overlay)
+                    .hidden_title(true);
+            }
             // Dev-only automation hook: WKWebView has no external driver
             // protocol, so dev tooling (terminal e2e checks, screenshots)
             // can inject a script that runs before the page loads. No-op in

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3968,6 +3968,37 @@ button:active > .edge-rail-chip {
   background: transparent;
 }
 
+/* ────────────────────────────────────────────────
+   Seamless macOS title bar (Tauri desktop)
+   The native title bar is set to `Overlay` (see src-tauri/src/lib.rs), so the
+   webview fills to the very top and the traffic-light buttons float over this
+   bar — there's no separate native title strip and no seam. We:
+     1. reserve room on the left so the toggle doesn't sit under the lights,
+     2. give the bar a touch more height to comfortably frame the lights,
+     3. make the empty bar background a window-drag handle, while keeping every
+        interactive control clickable (no-drag).
+   `[data-tauri-titlebar]` is set on <html> only in the macOS desktop shell
+   (see shell.tsx), so browser/Windows/Linux are untouched. Scoped to the
+   desktop layout (≥1024px) to match where `.menu-bar` renders.
+   ──────────────────────────────────────────────── */
+@media (min-width: 1024px) {
+  :root[data-tauri-titlebar] .shell-top {
+    /* ~78px clears the three traffic lights + their left inset. */
+    padding-left: 78px;
+    min-height: 52px;
+    -webkit-app-region: drag;
+    app-region: drag;
+  }
+
+  :root[data-tauri-titlebar] .shell-top :is(
+    button, a, input, select, textarea, kbd, label,
+    [role="button"], [role="textbox"], [contenteditable], .menu-bar__search
+  ) {
+    -webkit-app-region: no-drag;
+    app-region: no-drag;
+  }
+}
+
 .shell-top-toggle {
   display: inline-flex;
   align-items: center;

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -166,6 +166,23 @@ function ShellInner({
   useEffect(() => {
     if (!isMobile) setMobileDrawer(null);
   }, [isMobile]);
+
+  // Seamless macOS title bar: only the macOS desktop Tauri shell overlays the
+  // native title bar (lib.rs sets TitleBarStyle::Overlay), so only there do we
+  // mark <html> to reserve room for the traffic lights and make the top bar a
+  // drag handle (see [data-tauri-titlebar] in globals.css). Browser, Windows,
+  // Linux, and Tauri-mobile keep their normal chrome.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const isTauri = "__TAURI_INTERNALS__" in window;
+    const isMac = /Mac/i.test(navigator.platform || navigator.userAgent || "");
+    if (!isTauri || !isMac) return;
+    const root = document.documentElement;
+    root.dataset.tauriTitlebar = "";
+    return () => {
+      delete root.dataset.tauriTitlebar;
+    };
+  }, []);
   const mobileChromeState: ShellMobileChromeState = {
     navDrawerOpen: isMobile && mobileDrawer === "nav",
     listDrawerOpen: isMobile && mobileDrawer === "list",


### PR DESCRIPTION
## What

Dissolve the seam between the native macOS title bar (centered "CovenCave" + traffic lights) and the app's top toolbar so the top reads as one continuous strip — the VS Code / Linear pattern.

![before: native title strip sits above the toolbar with a visible seam]

## How

- **`src-tauri/src/lib.rs`** — the macOS window now uses `TitleBarStyle::Overlay` + `hidden_title(true)`, so the webview content fills to the very top and the traffic-light buttons float over the toolbar. The centered title label is dropped. Both builder methods are `#[cfg(target_os = "macos")]`, so this is a no-op on Windows/Linux.
- **`src/components/shell.tsx`** — sets `data-tauri-titlebar` on `<html>` **only** in the macOS desktop Tauri build (`__TAURI_INTERNALS__` present + macOS UA).
- **`src/app/globals.css`** — gated on `[data-tauri-titlebar]` and `≥1024px`: reserves ~78px on the left of `.shell-top` for the traffic lights, bumps the bar to 52px, and makes the empty bar a window-drag region (`-webkit-app-region: drag`) while every interactive control stays clickable (`no-drag`).

Browser, Windows, Linux, and Tauri-mobile chrome are untouched.

## Verification

- `tsc --noEmit` clean; `shell-edge-rails` / `right-panel-expand` / `misc-aria-fixes` source-text tests pass (the `.shell-top` base rule + JSX they pin are unchanged — the new styles are additive).
- Tauri builder API verified against `tauri-2.11` (`title_bar_style`, `hidden_title`, `TitleBarStyle::Overlay`).
- **Note:** the overlay title bar only renders in the native macOS desktop build, which the web E2E harness can't show — the Rust compile is validated by the **Rust check** CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)