### PR TITLE
fix(sidebar): unify the collapsed-rail icon buttons

### DIFF
--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -1058,8 +1058,10 @@
   align-items: center;
 }
 
-/* Each row becomes a centered 40px square hit target — comfortable for the
-   icon, still a wide-enough click area. */
+/* Every rail control is the same centered 40px rounded square — one shared
+   hit-area box so the compose, nav, and footer icons read as a single family
+   (previously: compose had a 2px accent outline, the active row a tinted box
+   with a left bar, and the rest were bare icons). */
 .shell-nav--rail .sidebar-folder-row,
 .shell-nav--rail .sidebar-action-row,
 .shell-nav--rail .sidebar-foot-btn,
@@ -1068,8 +1070,49 @@
   flex: none;
   gap: 0;
   width: 40px;
+  height: 40px;
+  min-height: 0;
   padding: 0;
   margin: 0 auto;
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+
+/* Uniform hover box for every rail control (the active row keeps its own fill
+   below, so it's excluded here). */
+.shell-nav--rail .sidebar-folder-row:not(.sidebar-folder-row--active):hover,
+.shell-nav--rail .sidebar-foot-btn:hover,
+.shell-nav--rail .sidebar-foot-icon-btn:hover {
+  background: color-mix(in oklch, var(--text-primary) 8%, transparent);
+  border-color: var(--border-hairline);
+  color: var(--text-primary);
+}
+
+/* Compose ("new chat") shares the exact same square — drop its loud 2px accent
+   outline — and stays recognisable purely through its accent glyph. */
+.shell-nav--rail .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--accent-presence);
+  font-weight: 500;
+}
+.shell-nav--rail .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
+}
+
+/* The active destination is the one persistent fill: a single accent-tinted
+   square (no left bar, which looks off-centre under a centred icon). */
+.shell-nav--rail .sidebar-folder-row--active {
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+  box-shadow: none;
+  color: var(--text-primary);
+}
+.shell-nav--rail .sidebar-folder-row--active:hover {
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
 }
 
 /* Nav icon sizing follows the global icon scale in globals.css. */


### PR DESCRIPTION
## Problem

In the collapsed left rail, the icon buttons had three different treatments side by side:
- the compose ("new chat") button had a loud **2px accent outline**,
- the active destination had a **tinted box with a left accent bar**,
- every other nav/footer icon was a **bare icon** with no shared hit-area box.

## Fix

Every rail control now shares one **40px rounded square**:
- transparent by default,
- a uniform neutral **hover** box (subtle bg + hairline border),
- a single accent-tinted **active** fill (no off-centre left bar under a centred icon).

Compose drops its outline and stays recognisable purely through its accent glyph — so the only persistent fill in the rail is the active destination, and color (not a competing box) marks "new chat".

CSS-only, one file (`src/styles/sidebar-minimal.css`, +45/−2). No tests pin the rail markup; `font-css-vars` (the only test that reads this file) passes.

## Verification
Built + ran the app, collapsed the nav to its rail, and screenshotted: compose is a clean accent glyph, Home is the lone accent-filled active square, all other icons share the same muted treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)