### PR TITLE
feat(nav): simple-by-default sidebar (+ rename Board → Tasks)

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -565,6 +565,14 @@ export function CommandPalette({
       : rank(FOLDER_MODES.filter((fm) => {
           if (fm.id === "github") return addons?.github === true;
           if (fm.id === "library") return addons?.library === true;
+          if (fm.id === "code") return addons?.code === true;
+          if (fm.id === "terminal") return addons?.terminal === true;
+          if (fm.id === "browser") return addons?.browser === true;
+          if (fm.id === "flow") return addons?.flow === true;
+          if (fm.id === "roles") return addons?.roles === true;
+          if (fm.id === "groupchat") return addons?.groupchat === true;
+          if (fm.id === "journal") return addons?.journal === true;
+          if (fm.id === "docs") return addons?.docs === true;
           return true;
         })
           // Fuzzy on the short label/id; substring-only on the long description

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -89,7 +89,7 @@ const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "daemon", group: "Info", keywords: "daemon info version socket pid api" },
   { section: "familiars", keywords: "familiars agents personas avatar name look" },
   { section: "permissions", keywords: "permissions allow deny tools access guard security" },
-  { section: "addons", group: "Integrations", keywords: "add-ons addons integrations plugins github youtube sidebar" },
+  { section: "addons", group: "Integrations", keywords: "add-ons addons integrations plugins github youtube sidebar surfaces code terminal browser flow roles journal coven group chat library" },
   { section: "mobile", group: "Steps", keywords: "phone mobile connect qr pair tailscale" },
   { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
   { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },
@@ -498,45 +498,119 @@ function DaemonSection() {
 
 // ─── Section: Add-ons ─────────────────────────────────────────────────────────────
 
-type AddonKey = "github" | "library";
+type AddonKey =
+  | "github"
+  | "library"
+  | "code"
+  | "terminal"
+  | "browser"
+  | "flow"
+  | "roles"
+  | "groupchat"
+  | "journal"
+  | "docs";
 
 const ADDON_ROWS: Array<{
   key: AddonKey;
   label: string;
   icon: string;
+  group: "integrations" | "surfaces";
   description: string;
 }> = [
+  // Integrations
   {
     key: "github",
     label: "GitHub",
     icon: "ph:github-logo",
+    group: "integrations",
     description: "Browse open issues and pull requests, attach them to tasks, and hand off to a familiar.",
   },
   {
     key: "library",
     label: "Library",
     icon: "ph:books",
+    group: "integrations",
     description: "Save links, notes, and references for your familiars to draw from.",
+  },
+  // Sidebar surfaces — off by default to keep Cave simple; turn on what you need.
+  {
+    key: "code",
+    label: "Code",
+    icon: "ph:code",
+    group: "surfaces",
+    description: "Chat with a familiar beside your files and a terminal.",
+  },
+  {
+    key: "terminal",
+    label: "Terminal",
+    icon: "ph:terminal-window",
+    group: "surfaces",
+    description: "A shell session running in your project.",
+  },
+  {
+    key: "browser",
+    label: "Browser",
+    icon: "ph:globe",
+    group: "surfaces",
+    description: "A built-in web browser.",
+  },
+  {
+    key: "flow",
+    label: "Flow",
+    icon: "ph:flow-arrow",
+    group: "surfaces",
+    description: "Freeform automation editor — wire nodes on a canvas.",
+  },
+  {
+    key: "roles",
+    label: "Roles",
+    icon: "ph:mask-happy",
+    group: "surfaces",
+    description: "Agent personas, workflows, skills, and capabilities.",
+  },
+  {
+    key: "groupchat",
+    label: "Group chat",
+    icon: "ph:users-three",
+    group: "surfaces",
+    description: "Broadcast one prompt to a coven of familiars at once.",
+  },
+  {
+    key: "journal",
+    label: "Journal",
+    icon: "ph:book-open",
+    group: "surfaces",
+    description: "Your daily journal and generated sketches.",
+  },
+  {
+    key: "docs",
+    label: "Coven",
+    icon: "ph:book-bookmark",
+    group: "surfaces",
+    description: "OpenCoven docs, feedback, and social tabs.",
   },
 ];
 
+const DEFAULT_ADDONS = Object.fromEntries(
+  ADDON_ROWS.map((r) => [r.key, false]),
+) as Record<AddonKey, boolean>;
+
 function AddonsSection() {
-  const [addons, setAddons] = useState<Record<AddonKey, boolean>>({
-    github: false,
-    library: false,
-  });
+  const [addons, setAddons] = useState<Record<AddonKey, boolean>>(DEFAULT_ADDONS);
   const [loading, setLoading] = useState(true);
   const [toggleError, setToggleError] = useState<string | null>(null);
 
   useEffect(() => {
     fetch("/api/config", { cache: "no-store" })
       .then((r) => r.json())
-      .then((j: { ok?: boolean; config?: { addons?: { github?: boolean; library?: boolean } } }) => {
+      .then((j: { ok?: boolean; config?: { addons?: Partial<Record<AddonKey, boolean>> } }) => {
         if (j.ok && j.config?.addons) {
-          setAddons({
-            github: j.config.addons.github ?? false,
-            library: j.config.addons.library ?? false,
-          });
+          const cfg = j.config.addons;
+          setAddons(
+            Object.fromEntries(
+              ADDON_ROWS.map((r) => [r.key, cfg[r.key] ?? false]),
+            ) as Record<AddonKey, boolean>,
+          );
         }
       })
       .catch(() => {})
@@ -564,55 +638,60 @@ function AddonsSection() {
     }
   };
 
+  const renderRow = (row: (typeof ADDON_ROWS)[number]) => (
+    <div key={row.key} className="flex items-center justify-between gap-4 px-4 py-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <Icon
+          name={row.icon as Parameters<typeof Icon>[0]["name"]}
+          width={18}
+          className="shrink-0 text-[var(--text-muted)]"
+        />
+        <div className="min-w-0">
+          <p className="text-[13px] text-[var(--text-primary)]">{row.label}</p>
+          <p className="text-[11px] text-[var(--text-muted)]">{row.description}</p>
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={addons[row.key]}
+        onClick={() => void toggle(row.key)}
+        className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
+          addons[row.key]
+            ? "bg-[var(--accent-presence)]"
+            : "bg-[var(--bg-elevated)]"
+        }`}
+      >
+        <span
+          className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-150 ${
+            addons[row.key] ? "translate-x-4" : "translate-x-0.5"
+          } mt-0.5`}
+        />
+      </button>
+    </div>
+  );
+
+  const skeleton = (rows: number) => (
+    <div aria-hidden className="animate-pulse space-y-3 px-4 py-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center justify-between gap-4">
+          <span className="h-3 w-1/3 rounded bg-[var(--bg-hover)]" />
+          <span className="h-5 w-9 rounded-full bg-[var(--bg-hover)] opacity-70" />
+        </div>
+      ))}
+    </div>
+  );
+
   return (
-    <SettingsPage title="Add-ons" description="Optional integrations. Disabled add-ons are hidden from the sidebar.">
+    <SettingsPage title="Add-ons" description="Optional surfaces and integrations. Anything disabled here is hidden from the sidebar — turn on what you need.">
       {toggleError && (
         <p role="alert" className="mb-2 px-1 text-[12px] text-[var(--color-danger)]">{toggleError}</p>
       )}
+      <SettingsGroup label="Sidebar surfaces">
+        {loading ? skeleton(4) : ADDON_ROWS.filter((r) => r.group === "surfaces").map(renderRow)}
+      </SettingsGroup>
       <SettingsGroup label="Integrations">
-        {loading ? (
-          <div aria-hidden className="animate-pulse space-y-3 px-4 py-3">
-            {[0, 1].map((i) => (
-              <div key={i} className="flex items-center justify-between gap-4">
-                <span className="h-3 w-1/3 rounded bg-[var(--bg-hover)]" />
-                <span className="h-5 w-9 rounded-full bg-[var(--bg-hover)] opacity-70" />
-              </div>
-            ))}
-          </div>
-        ) : (
-          ADDON_ROWS.map((row) => (
-            <div key={row.key} className="flex items-center justify-between gap-4 px-4 py-3">
-              <div className="flex min-w-0 items-center gap-3">
-                <Icon
-                  name={row.icon as Parameters<typeof Icon>[0]["name"]}
-                  width={18}
-                  className="shrink-0 text-[var(--text-muted)]"
-                />
-                <div className="min-w-0">
-                  <p className="text-[13px] text-[var(--text-primary)]">{row.label}</p>
-                  <p className="text-[11px] text-[var(--text-muted)]">{row.description}</p>
-                </div>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={addons[row.key]}
-                onClick={() => void toggle(row.key)}
-                className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
-                  addons[row.key]
-                    ? "bg-[var(--accent-presence)]"
-                    : "bg-[var(--bg-elevated)]"
-                }`}
-              >
-                <span
-                  className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-150 ${
-                    addons[row.key] ? "translate-x-4" : "translate-x-0.5"
-                  } mt-0.5`}
-                />
-              </button>
-            </div>
-          ))
-        )}
+        {loading ? skeleton(2) : ADDON_ROWS.filter((r) => r.group === "integrations").map(renderRow)}
       </SettingsGroup>
     </SettingsPage>
   );

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -109,8 +109,8 @@ assert.match(
 
 assert.match(
   source,
-  /\{ id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description:/,
-  "Board should move to the ⌘3 Work shortcut after removing Familiars",
+  /\{ id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description:/,
+  "the Tasks surface (mode id 'board') sits on the ⌘3 Work shortcut",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -43,6 +43,14 @@ export type FolderMode =
 export type AddonsConfig = {
   github?: boolean;
   library?: boolean;
+  code?: boolean;
+  terminal?: boolean;
+  browser?: boolean;
+  flow?: boolean;
+  roles?: boolean;
+  groupchat?: boolean;
+  journal?: boolean;
+  docs?: boolean;
 };
 
 export type SidebarMinimalProps = {
@@ -235,11 +243,20 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onModeChange(id);
   };
 
-  // Filter out disabled add-on items. GitHub and Library are gated add-ons,
-  // hidden from the nav until enabled in Settings → Add-ons (both default off).
+  // Gated surfaces are hidden from the nav until enabled in Settings → Add-ons
+  // (all default off). This keeps the default Cave to a simple core — Home, Chat,
+  // Board, Calendar, Schedules — with everything else opt-in.
   const visibleFolderModes = FOLDER_MODES.filter((fm) => {
     if (fm.id === "github") return addons?.github === true;
     if (fm.id === "library") return addons?.library === true;
+    if (fm.id === "code") return addons?.code === true;
+    if (fm.id === "terminal") return addons?.terminal === true;
+    if (fm.id === "browser") return addons?.browser === true;
+    if (fm.id === "flow") return addons?.flow === true;
+    if (fm.id === "roles") return addons?.roles === true;
+    if (fm.id === "groupchat") return addons?.groupchat === true;
+    if (fm.id === "journal") return addons?.journal === true;
+    if (fm.id === "docs") return addons?.docs === true;
     return true;
   });
 
@@ -288,23 +305,27 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           ))}
         </SidebarSection>
 
-        <SidebarSection label="Tools">
-          {toolsModes.map((fm) => (
-            <FolderRow
-              key={fm.id}
-              id={fm.id}
-              label={fm.label}
-              iconName={fm.iconName}
-              // Capabilities now lives as a tab on the Roles page, so keep the
-              // Roles entry lit when that mode is active.
-              active={mode === fm.id || (fm.id === "roles" && mode === "capabilities")}
-              badge={fm.badge?.(props)}
-              kbd={fm.kbd}
-              description={fm.description}
-              onClick={() => handleModeSelect(fm.id)}
-            />
-          ))}
-        </SidebarSection>
+        {/* Hide the whole Tools section when every tool is gated off — an empty
+            labelled section reads as broken. */}
+        {toolsModes.length > 0 && (
+          <SidebarSection label="Tools">
+            {toolsModes.map((fm) => (
+              <FolderRow
+                key={fm.id}
+                id={fm.id}
+                label={fm.label}
+                iconName={fm.iconName}
+                // Capabilities now lives as a tab on the Roles page, so keep the
+                // Roles entry lit when that mode is active.
+                active={mode === fm.id || (fm.id === "roles" && mode === "capabilities")}
+                badge={fm.badge?.(props)}
+                kbd={fm.kbd}
+                description={fm.description}
+                onClick={() => handleModeSelect(fm.id)}
+              />
+            ))}
+          </SidebarSection>
+        )}
 
         <RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
       </div>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -100,7 +100,7 @@ const FOLDER_MODES: Array<{
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
   { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
   { id: "groupchat", label: "Group", iconName: "ph:users-three", group: "work", description: "Group chat — broadcast to a coven of familiars at once" },
-  { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
+  { id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-bold", group: "work", kbd: "⌘5", description: "Reminders and recurring agent automations", badge: (p) => badgeText(p.scheduleNeedsCount) },

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -76,8 +76,13 @@ assert.doesNotMatch(
 );
 assert.match(
   settings,
-  /\{loading \? \([\s\S]{0,200}animate-pulse/,
-  "Settings integrations shows skeleton rows while the daemon status loads",
+  /loading \? skeleton\(/,
+  "Settings add-ons shows skeleton rows while the config loads",
+);
+assert.match(
+  settings,
+  /const skeleton = [\s\S]{0,160}animate-pulse/,
+  "the add-ons skeleton helper renders animate-pulse placeholder rows",
 );
 
 const vault = read("./vault-panel.tsx");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -87,7 +87,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   home: "Home",
   chat: "Familiars",
   groupchat: "Group Chat",
-  board: "Board",
+  board: "Tasks",
   calendar: "Calendar",
   inbox: "Schedules",
   library: "Library",

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -15,7 +15,18 @@ const DEFAULT_CONFIG: CaveConfig = {
   defaults: { harness: "codex", model: "openai/gpt-5.5" },
   familiars: {},
   roles: [],
-  addons: { github: false, library: false },
+  addons: {
+    github: false,
+    library: false,
+    code: false,
+    terminal: false,
+    browser: false,
+    flow: false,
+    roles: false,
+    groupchat: false,
+    journal: false,
+    docs: false,
+  },
   marketplace: { installed: {} },
 };
 
@@ -93,6 +104,14 @@ export type CaveConfig = {
   addons?: {
     github?: boolean;
     library?: boolean;
+    code?: boolean;
+    terminal?: boolean;
+    browser?: boolean;
+    flow?: boolean;
+    roles?: boolean;
+    groupchat?: boolean;
+    journal?: boolean;
+    docs?: boolean;
   };
   marketplace: {
     installed: Record<string, MarketplaceInstallEntry>;
@@ -124,6 +143,14 @@ export async function loadConfig(): Promise<CaveConfig> {
       addons: {
         github: parsed.addons?.github ?? false,
         library: parsed.addons?.library ?? false,
+        code: parsed.addons?.code ?? false,
+        terminal: parsed.addons?.terminal ?? false,
+        browser: parsed.addons?.browser ?? false,
+        flow: parsed.addons?.flow ?? false,
+        roles: parsed.addons?.roles ?? false,
+        groupchat: parsed.addons?.groupchat ?? false,
+        journal: parsed.addons?.journal ?? false,
+        docs: parsed.addons?.docs ?? false,
       },
       marketplace: {
         installed: parsed.marketplace?.installed ?? {},

--- a/tests/board-touch.spec.ts
+++ b/tests/board-touch.spec.ts
@@ -11,7 +11,7 @@ test("touch long-press drag moves a card between columns", async ({ page }) => {
   // Dismiss the onboarding overlay (covers the shell on a fresh CI profile).
   await page.addInitScript(() => window.localStorage.setItem("cave:onboarding:dismissed", "1"));
   await page.goto("/"); await page.waitForSelector(".shell-frame", { timeout: 60000 });
-  await page.locator(".sidebar-nav-scroll").getByRole("button", { name: /^Board\b/ }).click();
+  await page.locator(".sidebar-nav-scroll").getByRole("button", { name: /^Tasks\b/ }).click();
   await page.waitForSelector(".board-kanban-card", { timeout: 60000 });
 
   const card = page.locator(".board-kanban-card").first();

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -72,13 +72,18 @@ test.describe("mobile foundations", () => {
     await page.goto("/");
     await page.waitForSelector(".shell-frame");
 
-    const surfaces = ["Home", "Chat", "Board", "Calendar", "Browser", "Terminal", "Code"];
-    const sidebar = page.locator(".sidebar-nav-scroll");
+    // Drive by mode id via the navigate-mode event rather than clicking nav
+    // rows: most of these surfaces are now opt-in add-ons (hidden from the nav by
+    // default), but they still render when navigated — so this stays a true
+    // cross-surface chrome check without depending on which rows are visible.
+    const surfaces = ["home", "chat", "board", "calendar", "browser", "terminal", "code"];
 
     for (const surface of surfaces) {
-      if (surface !== "Home") {
-        await sidebar.getByRole("button", { name: new RegExp(`^${surface}\\b`) }).click();
-      }
+      await page.evaluate(
+        (mode) => window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } })),
+        surface,
+      );
+      await page.waitForTimeout(200);
 
       await expect(page.locator(".top-bar"), `desktop top bar should stay hidden on ${surface}`).toBeHidden();
 


### PR DESCRIPTION
Keeps the default Cave to a focused core — **Home, Chat, Tasks, Calendar, Schedules** — and hides everything else behind the existing **Settings → Add-ons** gate (each off by default, with a toggle to restore). Also renames the **Board** surface to **Tasks** (the iOS app already calls it that; mode id stays `board`).

### Hidden by default (now opt-in add-ons)
Code, Terminal, Browser, Flow, Roles, Group chat, Journal, Coven (docs) — joining the already-gated GitHub & Library.

### Changes
- **cave-config**: new addon keys (default `false`) + parsing.
- **sidebar-minimal** + **command-palette**: gate each surface on its add-on, so hidden surfaces drop out of both the nav *and* ⌘K. The whole **Tools** section hides when everything in it is off.
- **settings-shell**: Add-ons → two groups, **Sidebar surfaces** + **Integrations**, sharing one row renderer.
- **Rename**: nav label + `WORKSPACE_MODE_TITLES` Board → Tasks.
- **E2E**: `foundations.spec.ts` now drives surfaces via the `cave:navigate-mode` event (independent of which nav rows are visible, and of the label); `board-touch.spec.ts` targets the "Tasks" row.

Nothing is deleted — every surface's code/routes/mode stay intact and reappear the instant its toggle flips on.

### Verified
- `tsc` clean; **app (421) + api (90) + mobile (65)** suites green.
- Ran the app locally (Playwright): sidebar shows the 5-item core; Settings → Add-ons lists all 8 surfaces off + GitHub/Library.
- Ran the two affected E2E specs locally — **22 passed** across all three viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)