### PR TITLE
fix(marketplace): make the Netdata MCP entry actually connect (+ NuGet .NET 10 note)

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -1210,21 +1210,30 @@
       "keywords": ["monitoring", "metrics", "observability", "logs", "alerts"],
       "capabilities": ["network", "mcp"],
       "sourceRefs": ["https://learn.netdata.cloud/docs/netdata-ai/mcp"],
-      "trust": "official-remote",
+      "trust": "official-local",
       "mcpServers": {
         "netdata": {
-          "url": "${NETDATA_MCP_URL}",
-          "type": "http"
+          "command": "npx",
+          "args": ["-y", "mcp-remote@latest", "--http", "${NETDATA_MCP_URL}", "--header", "Authorization: Bearer ${NETDATA_API_KEY}"],
+          "type": "stdio"
         }
       },
       "userConfig": {
         "netdata_mcp_url": {
           "type": "string",
           "title": "Netdata MCP URL",
-          "description": "MCP endpoint of your Netdata agent (e.g. http://localhost:19999/mcp). Requires Netdata v2.6.0+.",
+          "description": "MCP endpoint: a local agent/parent (http://YOUR_IP:19999/mcp, Netdata v2.7.2+) or Netdata Cloud (https://app.netdata.cloud/api/v1/mcp).",
           "required": true,
           "sensitive": false,
           "env": "NETDATA_MCP_URL"
+        },
+        "netdata_api_key": {
+          "type": "string",
+          "title": "Netdata API Key",
+          "description": "Bearer token. For a local agent it is the dev-preview key at /var/lib/netdata/mcp_dev_preview_api_key; for Cloud, a token with scope:mcp.",
+          "required": true,
+          "sensitive": true,
+          "env": "NETDATA_API_KEY"
         }
       },
       "roleAffinity": [
@@ -1313,7 +1322,7 @@
       "skill": {
         "description": "Use NuGet MCP for current package versions and vulnerability-aware dependency choices.",
         "useCases": ["Check latest package versions", "Plan dependency upgrades", "Review packages for known vulnerabilities"],
-        "guardrails": ["Confirm before changing project dependencies", "Prefer fixed, current versions", "Flag supply-chain risks explicitly"]
+        "guardrails": ["Requires the .NET 10 SDK (provides the dnx command)", "Confirm before changing project dependencies", "Prefer fixed, current versions", "Flag supply-chain risks explicitly"]
       }
     },
     {

--- a/marketplace/exports/mcp/mcp.json
+++ b/marketplace/exports/mcp/mcp.json
@@ -278,8 +278,16 @@
       "type": "stdio"
     },
     "netdata": {
-      "url": "${NETDATA_MCP_URL}",
-      "type": "http"
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "--http",
+        "${NETDATA_MCP_URL}",
+        "--header",
+        "Authorization: Bearer ${NETDATA_API_KEY}"
+      ],
+      "type": "stdio"
     },
     "fabric": {
       "command": "npx",

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -1285,7 +1285,7 @@
         "installation": "AVAILABLE",
         "authentication": "ON_INSTALL"
       },
-      "trust": "official-remote",
+      "trust": "official-local",
       "roleAffinity": [
         {
           "familiar": "cody",

--- a/marketplace/plugins/netdata/plugin.json
+++ b/marketplace/plugins/netdata/plugin.json
@@ -23,7 +23,7 @@
   "x-coven": {
     "displayName": "Netdata",
     "category": "Cloud & Infrastructure",
-    "trust": "official-remote",
+    "trust": "official-local",
     "sourceRefs": [
       "https://learn.netdata.cloud/docs/netdata-ai/mcp"
     ],
@@ -51,18 +51,34 @@
   },
   "mcpServers": {
     "netdata": {
-      "url": "${NETDATA_MCP_URL}",
-      "type": "http"
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "--http",
+        "${NETDATA_MCP_URL}",
+        "--header",
+        "Authorization: Bearer ${NETDATA_API_KEY}"
+      ],
+      "type": "stdio"
     }
   },
   "userConfig": {
     "netdata_mcp_url": {
       "type": "string",
       "title": "Netdata MCP URL",
-      "description": "MCP endpoint of your Netdata agent (e.g. http://localhost:19999/mcp). Requires Netdata v2.6.0+.",
+      "description": "MCP endpoint: a local agent/parent (http://YOUR_IP:19999/mcp, Netdata v2.7.2+) or Netdata Cloud (https://app.netdata.cloud/api/v1/mcp).",
       "required": true,
       "sensitive": false,
       "env": "NETDATA_MCP_URL"
+    },
+    "netdata_api_key": {
+      "type": "string",
+      "title": "Netdata API Key",
+      "description": "Bearer token. For a local agent it is the dev-preview key at /var/lib/netdata/mcp_dev_preview_api_key; for Cloud, a token with scope:mcp.",
+      "required": true,
+      "sensitive": true,
+      "env": "NETDATA_API_KEY"
     }
   }
 }

--- a/marketplace/plugins/nuget/skills/nuget/SKILL.md
+++ b/marketplace/plugins/nuget/skills/nuget/SKILL.md
@@ -13,6 +13,7 @@ Use NuGet MCP for current package versions and vulnerability-aware dependency ch
 - Review packages for known vulnerabilities
 
 ## Guardrails
+- Requires the .NET 10 SDK (provides the dnx command)
 - Confirm before changing project dependencies
 - Prefer fixed, current versions
 - Flag supply-chain risks explicitly


### PR DESCRIPTION
## What
Follow-up hardening of the newly-added MCP catalog entries. I verified all five shakier ones against current official docs:

| Entry | Result |
|-------|--------|
| **Fabric** | `npx -y @microsoft/fabric-mcp@latest server start --mode all` — **matches the official readme verbatim** ✓ |
| **StackQL** | `npx -y @stackql/mcp-server` — package exists (bin `stackql-mcp`) ✓ |
| **NuGet** | `dnx NuGet.Mcp.Server --source … --yes` — **matches the official VS2022 docs** ✓ (added a guardrail noting the **.NET 10 SDK** prereq for `dnx`) |
| **Nuxt Dev** | dev-server plugin (no bin) — remote-SSE-URL modeling is the correct shape ✓ |
| **Netdata** | **was broken — fixed here** ⬇ |

### Netdata fix
Netdata's MCP endpoint **always requires a Bearer token** (local dev-preview key or a Cloud `scope:mcp` token), but the entry modeled it as a bare `{ url, type: http }` — and the catalog schema has no `headers` field, so it could never authenticate. Switched to the official **`mcp-remote` npx bridge**:

```json
"netdata": {
  "command": "npx",
  "args": ["-y", "mcp-remote@latest", "--http", "${NETDATA_MCP_URL}", "--header", "Authorization: Bearer ${NETDATA_API_KEY}"],
  "type": "stdio"
}
```

with `NETDATA_MCP_URL` + `NETDATA_API_KEY` config fields (covers both a local agent `http://IP:19999/mcp` and Cloud `https://app.netdata.cloud/api/v1/mcp`). Trust downgraded to `official-local` since it's now a local bridge.

## Test
`scripts/sync-marketplace.py --check` clean; `marketplace-catalog.test` passes. Verified npm package existence for every config (`@microsoft/fabric-mcp` 1.1.0, `@stackql/mcp-server` 0.10.500, `coven-code` 0.0.22, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)