### PR TITLE
chore(nav): rename the Board surface to "Tasks"

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -109,8 +109,8 @@ assert.match(
 
 assert.match(
   source,
-  /\{ id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description:/,
-  "Board should move to the ⌘3 Work shortcut after removing Familiars",
+  /\{ id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description:/,
+  "the Tasks surface (mode id 'board') sits on the ⌘3 Work shortcut",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -92,7 +92,7 @@ const FOLDER_MODES: Array<{
   { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
   { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
   { id: "groupchat", label: "Group", iconName: "ph:users-three", group: "work", description: "Group chat — broadcast to a coven of familiars at once" },
-  { id: "board", label: "Board", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
+  { id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-bold", group: "work", kbd: "⌘5", description: "Reminders and recurring agent automations", badge: (p) => badgeText(p.scheduleNeedsCount) },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -87,7 +87,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   home: "Home",
   chat: "Familiars",
   groupchat: "Group Chat",
-  board: "Board",
+  board: "Tasks",
   calendar: "Calendar",
   inbox: "Schedules",
   library: "Library",


### PR DESCRIPTION
Renames the kanban surface's display label from **Board** to **Tasks** — it's about tasks, and the iOS app already calls it Tasks.

- `sidebar-minimal.tsx`: nav label `Board` → `Tasks`.
- `workspace.tsx`: `WORKSPACE_MODE_TITLES.board` → `Tasks`.
- Updated the source-text test that pinned the old label.

The mode id stays `board`, so routes, deep links, the `board-*` components, badges, and the ⌘3 shortcut are all unchanged — display-label only. The command palette picks up the new label automatically (it reads `fm.label`).

## Verified
`tsc --noEmit` clean; app source-text suite green (421).

🤖 Generated with [Claude Code](https://claude.com/claude-code)