### PR TITLE
feat(chat): minimal chat + power-mode chat↔code split; drop memory from chat

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -377,6 +377,7 @@ export const SUITES = {
     "src/lib/code-layout-preset.test.ts",
     "src/lib/use-changes-summary.test.ts",
     "src/components/chat-surface-projects-tab.test.ts",
+    "src/components/chat-surface-power-mode.test.ts",
     "src/components/composer-density.test.ts",
     "src/lib/memory-rows.test.ts",
     "src/lib/memory-file-scope.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4004,11 +4004,11 @@ button:active > .edge-rail-chip {
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  /* Match the collapsed nav-rail button hit target (.shell-nav--rail
-     .sidebar-action-row is a 40px square) so the top toggles line up in
-     width with the sidepanel's icon buttons. */
-  width: 40px;
-  height: 40px;
+  /* Match the height of the adjacent top-bar controls (the familiar switcher
+     and search box sit at 28px) so the sidepanel toggles line up with the rest
+     of the bar rather than towering over it. */
+  width: 28px;
+  height: 28px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
@@ -7557,6 +7557,57 @@ a.mobile-handoff__link:hover {
 
 .chat-scope-tabs--minimal [role="tab"] {
   padding-block: 8px;
+}
+
+/* Power-mode toggle — sits at the right edge of the standalone chat's scope-tab
+   row. Off = quiet ghost button; on = lit accent pill, signalling the inline
+   chat↔code split is active. */
+.chat-power-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  height: 26px;
+  padding-inline: 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.chat-power-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.chat-power-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--ring-focus);
+}
+
+.chat-power-toggle--on {
+  /* Alias the theme accent once so the lit state reads in a single place. */
+  --power-accent: var(--accent);
+  border-color: color-mix(in oklch, var(--power-accent) 55%, transparent);
+  background: color-mix(in oklch, var(--power-accent) 18%, transparent);
+  color: var(--power-accent);
+}
+
+.chat-power-toggle--on:hover {
+  background: color-mix(in oklch, var(--power-accent) 26%, transparent);
+  color: var(--power-accent);
+}
+
+/* Collapse the label to an icon-only chip on narrow screens. */
+@media (max-width: 640px) {
+  .chat-power-toggle__label {
+    display: none;
+  }
 }
 
 /* Dynamic viewport units for layout shell + modals — `100vh` on iOS

--- a/src/components/chat-surface-mobile-command-center.test.ts
+++ b/src/components/chat-surface-mobile-command-center.test.ts
@@ -71,9 +71,11 @@ assert.match(
 
 // Gate the inline desktop sidebar on !isMobile so only one RightPanel mounts per
 // breakpoint — otherwise InspectorPane double-fetches and duplicates DOM ids.
+// The gate now folds into showRightSidebar (= !showPowerPanel && rightPanel !==
+// null && !isMobile), which keeps the !isMobile guarantee.
 assert.match(
   source,
-  /rightPanel !== null && !isMobile && \(/,
+  /const showRightSidebar = !showPowerPanel && rightPanel !== null && !isMobile/,
   "Inline desktop right sidebar should not also mount on mobile (avoids duplicate RightPanel)",
 );
 

--- a/src/components/chat-surface-power-mode.test.ts
+++ b/src/components/chat-surface-power-mode.test.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+// Power mode: the standalone chat transforms its side area into an inline
+// chat↔code split (the comux coding surface beside the conversation), toggled
+// from the scope-tab row. Memory is removed from the chat surface entirely —
+// it's not part of a conversation, so it lives in the Familiars surface.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const inspector = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── Power-mode toggle + state ───────────────────────────────────────────────
+assert.match(surface, /import \{ ComuxView \} from "@\/components\/comux-view"/, "chat-surface embeds the comux coding surface");
+assert.match(surface, /POWER_MODE_KEY = "cave:chat-power-mode:v1"/, "power-mode preference has a stable storage key");
+assert.match(surface, /const \[powerMode, setPowerMode\] = useState\(false\)/, "power mode is off by default");
+assert.match(
+  surface,
+  /window\.localStorage\.setItem\(POWER_MODE_KEY, next \? "1" : "0"\)/,
+  "toggling power mode persists across reloads",
+);
+assert.match(
+  surface,
+  /className=\{`chat-power-toggle\$\{powerMode \? " chat-power-toggle--on" : ""\}`\}/,
+  "the toggle reflects its on/off state via a modifier class",
+);
+assert.match(surface, /aria-pressed=\{powerMode\}/, "the toggle exposes pressed state to assistive tech");
+
+// Power mode is standalone-chat only — the Code workspace already is a split.
+assert.match(
+  surface,
+  /const showPowerPanel = powerMode && !isCodeSurface && !isMobile/,
+  "power mode only mounts the code panel on the standalone desktop chat",
+);
+assert.match(
+  surface,
+  /const showRightSidebar = !showPowerPanel && rightPanel !== null && !isMobile/,
+  "the inspector sidebar and the power panel are mutually exclusive",
+);
+
+// ── The inline code panel ───────────────────────────────────────────────────
+assert.match(surface, /id="code-power"/, "power mode renders a dedicated code panel");
+assert.match(
+  surface,
+  /<ComuxView[\s\S]*?storageNamespace=":chat-power"/,
+  "the power-mode comux instance keeps its own isolated terminal/layout namespace",
+);
+assert.match(surface, /POWER_GROUP_ID = "cave.chat.power.widths.v1"/, "the power split width persists separately from the inspector layout");
+
+// ── Memory is not part of chat ──────────────────────────────────────────────
+assert.match(inspector, /hideMemory\?: boolean/, "InspectorPane accepts a hideMemory flag");
+assert.match(
+  inspector,
+  /useState<Tab>\(hideMemory \? "familiar" : "memory"\)/,
+  "InspectorPane defaults off the Memory tab when memory is hidden",
+);
+assert.match(
+  inspector,
+  /tab === "memory" && !hideMemory \? <MemoryTab/,
+  "the Memory tab body never renders when memory is hidden",
+);
+// chat-surface passes hideMemory to every inspector it mounts.
+assert.match(surface, /onInboxItemChanged=\{onInboxItemChanged\}\s*\n\s*hideMemory/, "chat-surface hides memory in its inspector");
+
+// ── Toggle styling matches the bar ──────────────────────────────────────────
+assert.match(css, /\.chat-power-toggle \{[\s\S]*?border-radius: 999px;/, "the power toggle is a pill chip");
+assert.match(css, /\.chat-power-toggle--on \{[\s\S]*?--power-accent: var\(--accent\);/, "the active toggle lights up in the theme accent");
+
+console.log("chat-surface-power-mode.test.ts: ok");

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -9,11 +9,19 @@ assert.match(events, /CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects"/, "ev
 
 assert.match(surface, /import \{ ProjectsView \} from "@\/components\/projects-view"/, "chat-surface imports ProjectsView");
 assert.match(surface, /CHAT_OPEN_PROJECTS_EVENT/, "chat-surface references the reroute event");
-assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union includes projects");
+assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union still includes memory (Code surface) + projects");
+// Standalone chat is intentionally minimal: Sessions then Projects, no Memory —
+// memory is not part of a conversation (it lives in the Familiars surface). The
+// standalone branch is the ` : [ … ]` arm after the isCodeSurface ternary.
 assert.match(
   surface,
-  /\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\}[\s\S]*?\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\}[\s\S]*?\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
-  "shared Tabs items list all three scopes ending with the projects tab",
+  /:\s*\[\s*\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\},?\s*\]/,
+  "standalone chat tab list is Sessions then Projects (Memory dropped)",
+);
+assert.doesNotMatch(
+  surface,
+  /:\s*\[\s*\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"memory"/,
+  "standalone chat tab list must not include a Memory tab",
 );
 assert.match(surface, /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/, "projects tab is labeled");
 assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects scope renders its own panel (standalone chat only)");

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -163,8 +163,8 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /<ChatRouter[\s\S]*?compact=\{isCodeSurface\}/,
-  "ChatSurface should suppress the in-chat project sidebar in Code mode via compact",
+  /<ChatRouter[\s\S]*?compact=\{isCodeSurface \|\| showPowerPanel\}/,
+  "ChatSurface should suppress the in-chat project sidebar in Code mode and power mode via compact",
 );
 assert.match(
   chatSurface,

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -5,6 +5,7 @@ import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panel
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
 import { ProjectsView } from "@/components/projects-view";
+import { ComuxView } from "@/components/comux-view";
 import { InspectorPane } from "@/components/inspector-pane";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { DebugPane } from "@/components/debug-pane";
@@ -25,6 +26,11 @@ import type { PendingChatAction } from "@/lib/pending-chat-action";
 // the set of mounted panel ids, so the no-sidebar layout doesn't clobber the
 // with-sidebar one. localStorage-backed, fails soft under strict privacy modes.
 const CHAT_GROUP_ID = "cave.chat.widths.v1";
+// Power mode = the standalone chat transforms its side area into an inline
+// chat↔code split (the comux coding surface beside the conversation). Toggle
+// state and the split width persist independently of the inspector layout.
+const POWER_MODE_KEY = "cave:chat-power-mode:v1";
+const POWER_GROUP_ID = "cave.chat.power.widths.v1";
 const chatStorage = {
   getItem(key: string): string | null {
     if (typeof window === "undefined") return null;
@@ -172,6 +178,7 @@ function RightPanel({
               onCreateReminder={onCreateReminder}
               onOpenInboxItem={onOpenInboxItem}
               onInboxItemChanged={onInboxItemChanged}
+              hideMemory
             />
           )}
           {active === "debug" && <DebugPane />}
@@ -229,6 +236,7 @@ function RightPanel({
                 onCreateReminder={onCreateReminder}
                 onOpenInboxItem={onOpenInboxItem}
                 onInboxItemChanged={onInboxItemChanged}
+                hideMemory
               />
             )}
             {primaryPanel === "debug" && <DebugPane />}
@@ -288,6 +296,29 @@ export function ChatSurface({
   const isCodeSurface = surface === "code";
   const [scope, setScope] = useState<FamiliarsScope>("conversation");
   const [rightExpanded, setRightExpanded] = useState(false);
+  // Power mode applies only to the standalone chat surface (the Code workspace
+  // already *is* a chat↔code split). Hydrated from localStorage after mount to
+  // stay SSR-safe.
+  const [powerMode, setPowerMode] = useState(false);
+  useEffect(() => {
+    if (isCodeSurface) return;
+    try {
+      setPowerMode(window.localStorage.getItem(POWER_MODE_KEY) === "1");
+    } catch {
+      /* ignore — strict privacy mode */
+    }
+  }, [isCodeSurface]);
+  function togglePowerMode() {
+    setPowerMode((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(POWER_MODE_KEY, next ? "1" : "0");
+      } catch {
+        /* ignore */
+      }
+      return next;
+    });
+  }
   // Below the desktop shell breakpoint the inline 230px right sidebar is hidden
   // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
   // be unreachable. On mobile we render them in a right-edge sheet overlay instead.
@@ -303,12 +334,22 @@ export function ChatSurface({
     onSetInspectorOpen(next === "inspector");
   }
 
-  // Persist the chat / right-sidebar split. panelIds tracks which panels are
-  // actually mounted so the with-sidebar and no-sidebar layouts persist separately.
-  const showRightSidebar = rightPanel !== null && !isMobile;
+  // Power mode owns the side area when on (standalone, desktop); otherwise the
+  // inspector/debug/changes sidebar does. They are mutually exclusive so the
+  // chat thread never has to share its row with both.
+  const showPowerPanel = powerMode && !isCodeSurface && !isMobile;
+  const showRightSidebar = !showPowerPanel && rightPanel !== null && !isMobile;
+
+  // Persist the chat / right-area split. panelIds tracks which panels are
+  // actually mounted so the power-split, with-sidebar, and bare layouts persist
+  // separately (the power split is much wider than the 230px inspector rail).
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: CHAT_GROUP_ID,
-    panelIds: showRightSidebar ? ["chat-main", "right-sidebar"] : ["chat-main"],
+    id: showPowerPanel ? POWER_GROUP_ID : CHAT_GROUP_ID,
+    panelIds: showPowerPanel
+      ? ["chat-main", "code-power"]
+      : showRightSidebar
+        ? ["chat-main", "right-sidebar"]
+        : ["chat-main"],
     storage: chatStorage,
   });
 
@@ -491,8 +532,10 @@ export function ChatSurface({
                   window.setTimeout(() => routerRef.current?.goToList(), 0);
                 }
               }}
-              // In Code mode the comux pane owns project/file navigation, so the
-              // duplicate Projects tab is dropped — only Sessions + Memory here.
+              // Standalone chat is intentionally minimal: just Sessions + Projects.
+              // Memory is not part of a conversation, so it lives in the Familiars
+              // surface, not the chat header. In Code mode the comux pane owns
+              // project/file navigation, so that surface keeps Sessions + Memory.
               items={
                 isCodeSurface
                   ? [
@@ -501,15 +544,29 @@ export function ChatSurface({
                     ]
                   : [
                       { id: "conversation", label: "Sessions" },
-                      { id: "memory", label: "Memory" },
                       { id: "projects", label: "Projects" },
                     ]
               }
             />
           </div>
           {/* Code workspace: layout presets + companion-panel toggle ride on
-              this row so the Code surface needs no separate toolbar row. */}
-          {isCodeSurface ? <CodeInlineToolbar /> : null}
+              this row so the Code surface needs no separate toolbar row.
+              Standalone chat gets the Power-mode toggle instead — it transforms
+              the side area into an inline chat↔code split. */}
+          {isCodeSurface ? (
+            <CodeInlineToolbar />
+          ) : (
+            <button
+              type="button"
+              className={`chat-power-toggle${powerMode ? " chat-power-toggle--on" : ""}`}
+              aria-pressed={powerMode}
+              onClick={togglePowerMode}
+              title={powerMode ? "Exit power mode" : "Power mode — split chat with code & terminal"}
+            >
+              <Icon name="ph:lightning-fill" width={13} />
+              <span className="chat-power-toggle__label">Power</span>
+            </button>
+          )}
         </div>
 
         {scope === "memory" ? (
@@ -531,7 +588,7 @@ export function ChatSurface({
             defaultLayout={defaultLayout}
             onLayoutChanged={onLayoutChanged}
           >
-            <Panel id="chat-main" className="flex min-h-0 min-w-0" minSize="45%">
+            <Panel id="chat-main" className="flex min-h-0 min-w-0" minSize={showPowerPanel ? "32%" : "45%"}>
               <div className="min-h-0 min-w-0 flex-1" data-surface={surface}>
                 <ChatRouter
                   ref={routerRef}
@@ -540,7 +597,7 @@ export function ChatSurface({
                   sessions={sessions}
                   daemonRunning={daemonRunning}
                   sessionsLoaded={sessionsLoaded}
-                  compact={isCodeSurface}
+                  compact={isCodeSurface || showPowerPanel}
                   onSetActiveFamiliar={onSetActiveFamiliar}
                   onSessionStarted={onSessionStarted}
                   onSessionsChanged={onSessionsChanged}
@@ -553,7 +610,38 @@ export function ChatSurface({
                 />
               </div>
             </Panel>
-            {rightPanel !== null && !isMobile && (
+            {/* Power mode: the side area becomes the comux coding surface — file
+                tree + editable preview + terminal — beside the conversation, a
+                single resizable split. Same component the Code workspace uses,
+                with its own isolated terminal/layout namespace. */}
+            {showPowerPanel && (
+              <>
+                <Separator className="shell-separator hidden lg:flex">
+                  <SeparatorHandle orientation="col" />
+                </Separator>
+                <Panel
+                  id="code-power"
+                  className="hidden min-h-0 min-w-0 lg:flex"
+                  defaultSize="50%"
+                  minSize="35%"
+                >
+                  <div className="chat-power-pane flex min-h-0 min-w-0 flex-1 flex-col">
+                    <ComuxView
+                      view="projects"
+                      active={powerMode}
+                      storageNamespace=":chat-power"
+                      sessions={sessions}
+                      onOpenSession={(sessionId, familiarId) => {
+                        if (familiarId) onSetActiveFamiliar(familiarId);
+                        window.setTimeout(() => routerRef.current?.openSession(sessionId), 0);
+                      }}
+                      onNewChat={startProjectChat}
+                    />
+                  </div>
+                </Panel>
+              </>
+            )}
+            {showRightSidebar && (
               <>
                 {/* Defaults to 230px (mirrors the internal left rail, chat-thread-rail
                     is w-[230px]) but is drag-resizable via the handle below, clamped

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -52,7 +52,8 @@ assert.match(
 );
 assert.match(toolbar, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
 // The toolbar is mounted on the Code surface's tab row + carries the panel toggle.
-assert.match(chatSurface, /isCodeSurface \? <CodeInlineToolbar \/> : null/, "the Code tab row hosts the inline toolbar");
+// (Standalone chat shows the Power-mode toggle on that row instead of null.)
+assert.match(chatSurface, /isCodeSurface \? \(\s*<CodeInlineToolbar \/>\s*\) : \(/, "the Code tab row hosts the inline toolbar");
 assert.match(toolbar, /code-panel-toggle/, "the toolbar includes the companion-panel toggle");
 assert.match(toolbar, /cave:toggle-right-panel/, "the panel toggle asks the shell to toggle the companion panel");
 

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -55,6 +55,10 @@ type Props = {
   compact?: boolean;
   /** When set, the Memory tab shows an "Open full memory →" footer button. */
   onOpenFullView?: () => void;
+  /** Drop the Memory tab entirely. The chat surface uses this — memory is not
+   *  part of a conversation, so it lives in the Familiars surface, not the
+   *  chat-side inspector. Defaults to false (the standalone inspector keeps it). */
+  hideMemory?: boolean;
 };
 
 const TAB_LABEL: Record<Tab, string> = {
@@ -120,8 +124,16 @@ export function InspectorPane({
   onInboxItemChanged,
   compact = false,
   onOpenFullView,
+  hideMemory = false,
 }: Props) {
-  const [tab, setTab] = useState<Tab>("memory");
+  const [tab, setTab] = useState<Tab>(hideMemory ? "familiar" : "memory");
+  // If memory is hidden but the pane somehow lands on it (prop flip), fall back
+  // to the Familiar tab so the panel never renders an empty memory body.
+  useEffect(() => {
+    if (hideMemory && tab === "memory") setTab("familiar");
+  }, [hideMemory, tab]);
+
+  const visibleTabs = hideMemory ? INSPECTOR_TABS.filter((t) => t !== "memory") : INSPECTOR_TABS;
 
   const familiarInbox = useMemo(() => {
     if (!familiar) return [];
@@ -154,7 +166,7 @@ export function InspectorPane({
           ariaLabel="Inspector sections"
           value={tab}
           onChange={setTab}
-          items={INSPECTOR_TABS.map((t) => ({
+          items={visibleTabs.map((t) => ({
             id: t,
             label:
               t === "inbox" && inboxBadge > 0 ? (
@@ -182,7 +194,7 @@ export function InspectorPane({
           tab === "memory" ? "overflow-hidden" : "overflow-y-auto"
         }`}
       >
-        {tab === "memory" ? <MemoryTab familiar={familiar} onOpenFullView={onOpenFullView} /> : null}
+        {tab === "memory" && !hideMemory ? <MemoryTab familiar={familiar} onOpenFullView={onOpenFullView} /> : null}
         {tab === "familiar" ? <FamiliarCapabilityPanel familiar={familiar} /> : null}
         {tab === "inbox" ? (
           <InboxTab

--- a/src/components/right-sidebar-fit.test.ts
+++ b/src/components/right-sidebar-fit.test.ts
@@ -21,11 +21,13 @@ assert.match(
   "The right sidebar should have an outer drag-to-resize separator before it",
 );
 
-// The split width must persist across reloads via useDefaultLayout.
+// The split width must persist across reloads via useDefaultLayout. The id is
+// CHAT_GROUP_ID for the inspector layout and POWER_GROUP_ID for the wider
+// chat↔code power split (persisted separately so they don't clobber each other).
 assert.match(
   chatSurface,
-  /useDefaultLayout\(\{[\s\S]*id: CHAT_GROUP_ID[\s\S]*storage: chatStorage/,
-  "ChatSurface should persist the chat/right-sidebar split width across reloads",
+  /useDefaultLayout\(\{[\s\S]*id: showPowerPanel \? POWER_GROUP_ID : CHAT_GROUP_ID[\s\S]*storage: chatStorage/,
+  "ChatSurface should persist the chat/right-area split width across reloads",
 );
 
 assert.match(


### PR DESCRIPTION
## What

Reworks the standalone chat surface toward a focused, ChatGPT-like experience, per request.

### ⚡ Power mode (the headline)
A toggle on the chat's scope-tab row transforms the side area into an **inline chat↔code split** — the comux coding surface (file tree, editable preview, terminal, project search) beside the conversation, in one resizable pane. It reuses the exact `ComuxView` the Code workspace uses, with its own isolated terminal/layout namespace (`:chat-power`).

- Standalone-desktop only (the Code workspace already *is* a split; mobile gets the existing one-pane treatment).
- Toggle state persists (`cave:chat-power-mode:v1`); split width persists separately from the inspector layout (`cave.chat.power.widths.v1`).
- The chat pane goes **compact** in power mode → a clean thread beside the code panel, not a cramped triple-column.
- The inspector sidebar and the power panel are mutually exclusive.

### Memory removed from chat
Memory isn't part of a conversation, so:
- Dropped the **Memory** scope tab from the standalone chat header (now just **Sessions / Projects**). Memory still lives in the Familiars surface and the Code surface's Memory tab.
- Added a `hideMemory` flag to `InspectorPane`; `chat-surface` passes it so the chat-side inspector never surfaces memory.

### Top-bar polish (follow-up ask)
The sidepanel toggles were 40px, towering over the 28px familiar switcher / search box beside them. Resized to **28px** so the top bar lines up. (Measured via Playwright: nav/right toggles + switcher + search all 28px now.)

## Verification
- Full **app suite: 422 files green**; **mobile suite: 65 green**; `tsc --noEmit` clean; **production build passes**.
- Visually verified in demo mode (Playwright): minimal `Sessions / Projects` + ⚡ Power row; power-mode split renders the comux surface; toggle heights aligned.
- Updated the source-text tests that pinned the old scope-tab list, layout id, sidebar gate, and inline-toolbar row; added `chat-surface-power-mode.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)