### PR TITLE
feat(home): live RSS feed widget (replaces the connector cards)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -45,6 +45,7 @@ export const SUITES = {
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/session-project-scope.test.ts",
     "src/lib/marketplace-catalog.test.ts",
+    "src/lib/rss.test.ts",
     "src/lib/secret-validators.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/lib/workflows.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -115,6 +115,7 @@ const contracts: RouteContract[] = [
   { route: "/roles", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/roles/workflows", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/retro-runs", methods: ["GET"], kind: "json" },
+  { route: "/rss", methods: ["GET"], kind: "json" },
   { route: "/salem", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/salem/pathfinder", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/salem/pathfinder/feedback", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/rss/route.ts
+++ b/src/app/api/rss/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { canonicalLink, mergeFeedItems, parseFeed, type FeedItem } from "@/lib/rss";
+import { resolveFeeds, type FeedSource } from "@/lib/server/rss-feeds";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/rss → { ok, items, sources, fetchedAt }
+ *
+ * Fetches the configured RSS/Atom feeds server-side (the browser can't, due to
+ * CORS), merges + sorts them newest-first, and returns a flat item list plus
+ * the source list for the widget's filter chips. Pass `?refresh=1` to bypass
+ * the short server cache.
+ *
+ * The fetched URLs come exclusively from `resolveFeeds()` (built-in defaults or
+ * the user's local `~/.coven/rss-feeds.json`) — never from the request — so
+ * there is no request-driven SSRF surface here.
+ */
+
+const TTL_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 6000;
+const MAX_ITEMS = 40;
+const PER_FEED_ITEMS = 12;
+
+type RssPayload = {
+  ok: true;
+  items: FeedItem[];
+  sources: Array<{ id: string; title: string; category: string; ok: boolean }>;
+  fetchedAt: string;
+};
+
+let cache: { at: number; body: RssPayload } | null = null;
+
+async function fetchOne(feed: FeedSource): Promise<{ source: FeedSource; items: FeedItem[]; ok: boolean }> {
+  try {
+    const res = await fetch(feed.url, {
+      headers: {
+        // Some hosts reject the default fetch agent or non-feed Accept headers.
+        "User-Agent": "coven-cave/rss (+https://github.com/OpenCoven/coven-cave)",
+        Accept: "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
+      },
+      cache: "no-store",
+      redirect: "follow",
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return { source: feed, items: [], ok: false };
+    const xml = await res.text();
+    const parsed = parseFeed(xml);
+    const items: FeedItem[] = parsed.items.slice(0, PER_FEED_ITEMS).map((it, i) => ({
+      ...it,
+      id: it.link ? `${feed.id}:${canonicalLink(it.link)}` : `${feed.id}-${i}`,
+      source: feed.title,
+      category: feed.category,
+    }));
+    return { source: feed, items, ok: true };
+  } catch {
+    return { source: feed, items: [], ok: false };
+  }
+}
+
+export async function GET(req: Request) {
+  const refresh = new URL(req.url).searchParams.get("refresh") === "1";
+  const now = Date.now();
+  if (!refresh && cache && now - cache.at < TTL_MS) {
+    return NextResponse.json(cache.body);
+  }
+
+  const feeds = await resolveFeeds();
+  const results = await Promise.all(feeds.map(fetchOne));
+
+  const items = mergeFeedItems(
+    results.map((r) => r.items),
+    MAX_ITEMS,
+  );
+  const sources = results.map((r) => ({
+    id: r.source.id,
+    title: r.source.title,
+    category: r.source.category,
+    ok: r.ok,
+  }));
+
+  const body: RssPayload = { ok: true, items, sources, fetchedAt: new Date(now).toISOString() };
+  cache = { at: now, body };
+  return NextResponse.json(body);
+}

--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -11,29 +11,36 @@ const globals = await readFile(
   "utf8",
 );
 
-// ───── Connector cards lay out 3-up and don't overflow their column ─────
-// The cards replaced the suggestion chips; they grid 3-up on desktop and stack
-// to a single column on narrow viewports so titles/subtitles never clip.
-const connectorsMatch = css.match(/\.home-composer-connectors\s*\{([^}]*)\}/);
-assert.ok(connectorsMatch, ".home-composer-connectors grid rule must exist");
+// ───── RSS widget rows ellipsis cleanly and scroll within a bounded card ─────
+// The live RSS widget replaced the connector cards. Its rows must clamp long
+// titles (so they never overflow the card) and the list must cap its height and
+// scroll rather than pushing the page.
+const titleMatch = css.match(/\.home-rss__item-title\s*\{([^}]*)\}/);
+assert.ok(titleMatch, ".home-rss__item-title rule must exist");
 assert.match(
-  connectorsMatch[1],
-  /grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\);/,
-  ".home-composer-connectors is a 3-up grid with min-width:0 tracks (cards can shrink)",
+  titleMatch[1],
+  /-webkit-line-clamp:\s*2;/,
+  ".home-rss__item-title clamps to 2 lines so long headlines don't overflow",
 );
 
-const connectorMatch = css.match(/\.hc-connector\s*\{([^}]*)\}/);
-assert.ok(connectorMatch, ".hc-connector rule must exist");
+const listMatch = css.match(/\.home-rss__list\s*\{([^}]*)\}/);
+assert.ok(listMatch, ".home-rss__list rule must exist");
 assert.match(
-  connectorMatch[1],
-  /min-width:\s*0;/,
-  ".hc-connector has min-width: 0 so the card can shrink inside its grid track",
+  listMatch[1],
+  /max-height:\s*\d+px;/,
+  ".home-rss__list caps its height",
+);
+assert.match(
+  listMatch[1],
+  /overflow-y:\s*auto;/,
+  ".home-rss__list scrolls instead of pushing the page",
 );
 
+// On phones the filter chips hide (no room) and the list shrinks.
 assert.match(
   css,
-  /@media \(max-width: 640px\)\s*\{[\s\S]*?\.home-composer-connectors\s*\{[\s\S]*?grid-template-columns:\s*1fr;/,
-  "connector cards collapse to a single column under 640px",
+  /@media \(max-width: 640px\)\s*\{[\s\S]*?\.home-rss__chips\s*\{[\s\S]*?display:\s*none;/,
+  "RSS filter chips hide under 640px",
 );
 
 // ───── Phone composer controls are thumb-sized ─────
@@ -43,11 +50,6 @@ assert.match(
   "phone composer action bar wraps into thumb-sized familiar/send/destination controls",
 );
 
-assert.match(
-  css,
-  /@media \(max-width: 640px\)\s*\{[\s\S]*?\.hc-connector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "stacked connector cards should meet the shared touch target",
-);
 
 // ───── Keyboard hint hides on touch ─────
 // Touch devices have no physical keyboard — hide the desktop-only legend.

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -25,6 +25,7 @@ import { readComposerHistory, writeComposerHistory } from "@/lib/composer-histor
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
+import { HomeRssWidget } from "@/components/home/rss-widget";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -41,36 +42,6 @@ const PLACEHOLDERS: Record<Destination, string> = {
   board: "Describe a new task…",
   reminder: "Remind me about…",
 };
-
-// Connector cards mirror the Codex-style cold start: one-tap entry points into
-// the marketplace for the integrations that give a familiar real context.
-type Connector = {
-  id: string;
-  title: string;
-  subtitle: string;
-  glyph: "slack" | "gmail" | "drive";
-};
-
-const CONNECTORS: Connector[] = [
-  {
-    id: "slack",
-    title: "Connect messaging",
-    subtitle: "Get context from recent team discussions",
-    glyph: "slack",
-  },
-  {
-    id: "gmail",
-    title: "Connect email",
-    subtitle: "Summarize stakeholder asks from email",
-    glyph: "gmail",
-  },
-  {
-    id: "drive",
-    title: "Connect files",
-    subtitle: "Review results, research, and plans",
-    glyph: "drive",
-  },
-];
 
 type Props = {
   familiars: Familiar[];
@@ -89,8 +60,8 @@ type Props = {
   onSlash?: (command: string, args: string) => void;
   /** Resume a recent chat from the "Jump back in" strip. */
   onOpenSession?: (sessionId: string, familiarId: string | null) => void;
-  /** Open the marketplace for a connector card (Slack / Gmail / Drive). */
-  onConnect?: (connectorId: string) => void;
+  /** Open an RSS article in Cave's in-app browser. */
+  onOpenUrl?: (url: string) => void;
 };
 
 // Persist the in-progress prompt so a page reload doesn't eat what you were
@@ -131,7 +102,7 @@ export function HomeComposer({
   onToast,
   onSlash,
   onOpenSession,
-  onConnect,
+  onOpenUrl,
 }: Props) {
   const [text, setText] = useState(() => readHomeDraft());
   const [destination, setDestination] = useState<Destination>("chat");
@@ -710,68 +681,13 @@ export function HomeComposer({
         </div>
       )}
 
-      {/* Connector cards — one-tap entry points into the marketplace. */}
-      <div className="home-composer-suggestions home-composer-connectors">
-        {CONNECTORS.map((c) => (
-          <button
-            key={c.id}
-            type="button"
-            className="hc-connector"
-            onClick={() => {
-              if (onConnect) onConnect(c.id);
-              else onToast("Open the Marketplace to connect integrations.");
-            }}
-          >
-            <span className="hc-connector-glyph" aria-hidden>
-              <BrandGlyph glyph={c.glyph} />
-            </span>
-            <span className="hc-connector-title">{c.title}</span>
-            <span className="hc-connector-sub">{c.subtitle}</span>
-          </button>
-        ))}
-      </div>
+      {/* Live RSS feed — the latest across a curated set of sources. */}
+      <HomeRssWidget
+        onOpenUrl={(url) => {
+          if (onOpenUrl) onOpenUrl(url);
+          else window.open(url, "_blank", "noopener,noreferrer");
+        }}
+      />
     </div>
-  );
-}
-
-// ─── Brand glyphs ───────────────────────────────────────────────────────────
-// Inline, full-colour marks for the connector cards. The shared Icon component
-// only ships the monochrome Phosphor subset, so the multi-colour brand logos
-// live here as small inline SVGs.
-function BrandGlyph({ glyph }: { glyph: Connector["glyph"] }) {
-  if (glyph === "slack") {
-    return (
-      <svg viewBox="0 0 122.8 122.8" width="22" height="22" aria-hidden focusable="false">
-        <path d="M25.8 77.6a12.9 12.9 0 1 1-12.9-12.9h12.9z" fill="#E01E5A" />
-        <path d="M32.3 77.6a12.9 12.9 0 0 1 25.8 0v32.3a12.9 12.9 0 0 1-25.8 0z" fill="#E01E5A" />
-        <path d="M45.2 25.8a12.9 12.9 0 1 1 12.9-12.9v12.9z" fill="#36C5F0" />
-        <path d="M45.2 32.3a12.9 12.9 0 0 1 0 25.8H12.9a12.9 12.9 0 0 1 0-25.8z" fill="#36C5F0" />
-        <path d="M97 45.2a12.9 12.9 0 1 1 12.9 12.9H97z" fill="#2EB67D" />
-        <path d="M90.5 45.2a12.9 12.9 0 0 1-25.8 0V12.9a12.9 12.9 0 0 1 25.8 0z" fill="#2EB67D" />
-        <path d="M77.6 97a12.9 12.9 0 1 1-12.9 12.9V97z" fill="#ECB22E" />
-        <path d="M77.6 90.5a12.9 12.9 0 0 1 0-25.8h32.3a12.9 12.9 0 0 1 0 25.8z" fill="#ECB22E" />
-      </svg>
-    );
-  }
-  if (glyph === "gmail") {
-    return (
-      <svg viewBox="0 0 48 36" width="22" height="22" aria-hidden focusable="false">
-        <path fill="#4285F4" d="M3.27 35.5H10V19L0 11.5v20.73c0 1.8 1.47 3.27 3.27 3.27z" />
-        <path fill="#34A853" d="M38 35.5h6.73c1.8 0 3.27-1.47 3.27-3.27V11.5L38 19z" />
-        <path fill="#FBBC04" d="M38 3.77V19l10-7.5V5.27c0-4.55-5.2-7.14-8.84-4.41z" />
-        <path fill="#EA4335" d="M10 19V3.77L24 14.32 38 3.77V19L24 29.55z" />
-        <path fill="#C5221F" d="M0 5.27V11.5l10 7.5V3.77L8.84.86C5.2-1.87 0 .72 0 5.27z" />
-      </svg>
-    );
-  }
-  return (
-    <svg viewBox="0 0 87.3 78" width="22" height="22" aria-hidden focusable="false">
-      <path d="M6.6 66.85l3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3l13.75-23.8H0c0 1.55.4 3.1 1.2 4.5z" fill="#0066da" />
-      <path d="M43.65 25L29.9 1.2c-1.35.8-2.5 1.9-3.3 3.3L1.2 48.5C.4 49.9 0 51.45 0 53h27.5z" fill="#00ac47" />
-      <path d="M73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75 7.65-13.25c.8-1.4 1.2-2.95 1.2-4.5H59.8l5.85 11.45z" fill="#ea4335" />
-      <path d="M43.65 25L57.4 1.2C56.05.4 54.5 0 52.9 0H34.4c-1.6 0-3.15.45-4.5 1.2z" fill="#00832d" />
-      <path d="M59.8 53H27.5L13.75 76.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z" fill="#2684fc" />
-      <path d="M73.4 26.5L60.65 4.5c-.8-1.4-1.95-2.5-3.3-3.3L43.65 25 59.8 53h27.45c0-1.55-.4-3.1-1.2-4.5z" fill="#ffba00" />
-    </svg>
   );
 }

--- a/src/components/home/rss-widget.tsx
+++ b/src/components/home/rss-widget.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+/**
+ * HomeRssWidget — a compact, live feed reader on the home screen. Pulls the
+ * merged RSS/Atom items from /api/rss (server fetches + parses), shows them
+ * newest-first with source favicons + relative time, and opens an article in
+ * Cave's in-app browser on click. Category chips filter the list; the refresh
+ * button forces a re-fetch.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { faviconUrl, relativeAge, type FeedItem } from "@/lib/rss";
+
+type Source = { id: string; title: string; category: string; ok: boolean };
+
+type Props = {
+  /** Open an article — wired to Cave's browser pane by the workspace. */
+  onOpenUrl: (url: string) => void;
+};
+
+export function HomeRssWidget({ onOpenUrl }: Props) {
+  const [items, setItems] = useState<FeedItem[]>([]);
+  const [sources, setSources] = useState<Source[]>([]);
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+  const [refreshing, setRefreshing] = useState(false);
+  const [activeCat, setActiveCat] = useState<string>("All");
+  // Recomputed each load so relative times don't drift across renders.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  const load = useCallback(async (opts?: { refresh?: boolean }) => {
+    if (opts?.refresh) setRefreshing(true);
+    else setState((s) => (s === "ready" ? s : "loading"));
+    try {
+      const res = await fetch(`/api/rss${opts?.refresh ? "?refresh=1" : ""}`, { cache: "no-store" });
+      const json = (await res.json()) as { ok?: boolean; items?: FeedItem[]; sources?: Source[] };
+      if (!json.ok || !Array.isArray(json.items)) throw new Error("bad payload");
+      setItems(json.items);
+      setSources(Array.isArray(json.sources) ? json.sources : []);
+      setNowMs(Date.now());
+      setState("ready");
+    } catch {
+      setState((s) => (s === "ready" ? s : "error"));
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const categories = useMemo(() => {
+    const cats = new Set<string>();
+    for (const it of items) if (it.category) cats.add(it.category);
+    return ["All", ...[...cats].sort()];
+  }, [items]);
+
+  const visible = useMemo(
+    () => (activeCat === "All" ? items : items.filter((it) => it.category === activeCat)),
+    [items, activeCat],
+  );
+
+  const liveCount = sources.filter((s) => s.ok).length;
+
+  return (
+    <div className="home-composer-suggestions home-rss">
+      <div className="home-rss__head">
+        <span className="home-rss__title">
+          <Icon name="ph:newspaper" width={15} className="home-rss__title-icon" aria-hidden />
+          Latest
+          {state === "ready" && liveCount > 0 ? (
+            <span className="home-rss__live" title={`${liveCount} live sources`}>
+              {liveCount} sources
+            </span>
+          ) : null}
+        </span>
+
+        {categories.length > 2 ? (
+          <div className="home-rss__chips" role="tablist" aria-label="Filter by category">
+            {categories.map((cat) => (
+              <button
+                key={cat}
+                type="button"
+                role="tab"
+                aria-selected={activeCat === cat}
+                className={`home-rss__chip${activeCat === cat ? " is-active" : ""}`}
+                onClick={() => setActiveCat(cat)}
+              >
+                {cat}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <button
+          type="button"
+          className={`home-rss__refresh${refreshing ? " is-spinning" : ""}`}
+          onClick={() => void load({ refresh: true })}
+          disabled={refreshing}
+          title="Refresh feeds"
+          aria-label="Refresh feeds"
+        >
+          <Icon name="ph:arrows-clockwise-bold" width={13} aria-hidden />
+        </button>
+      </div>
+
+      {state === "loading" ? (
+        <ul className="home-rss__list" aria-hidden>
+          {[0, 1, 2, 3, 4].map((i) => (
+            <li key={i} className="home-rss__item home-rss__item--skeleton">
+              <span className="home-rss__fav home-rss__sk-dot" />
+              <span className="home-rss__body">
+                <span className="home-rss__sk-line" />
+                <span className="home-rss__sk-line home-rss__sk-line--short" />
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : state === "error" ? (
+        <div className="home-rss__empty">
+          <Icon name="ph:warning-circle" width={18} aria-hidden />
+          <span>Couldn’t load feeds.</span>
+          <button type="button" className="home-rss__retry" onClick={() => void load({ refresh: true })}>
+            Try again
+          </button>
+        </div>
+      ) : visible.length === 0 ? (
+        <div className="home-rss__empty">
+          <Icon name="ph:newspaper" width={18} aria-hidden />
+          <span>No stories yet.</span>
+        </div>
+      ) : (
+        <ul className="home-rss__list">
+          {visible.map((it) => {
+            const fav = it.link ? faviconUrl(it.link) : null;
+            const age = relativeAge(it.isoDate, nowMs);
+            return (
+              <li key={it.id}>
+                <button
+                  type="button"
+                  className="home-rss__item"
+                  onClick={() => it.link && onOpenUrl(it.link)}
+                  title={it.title}
+                >
+                  {fav ? (
+                    <img
+                      className="home-rss__fav"
+                      src={fav}
+                      alt=""
+                      width={16}
+                      height={16}
+                      loading="lazy"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.currentTarget.style.visibility = "hidden";
+                      }}
+                    />
+                  ) : (
+                    <span className="home-rss__fav" />
+                  )}
+                  <span className="home-rss__body">
+                    <span className="home-rss__item-title">{it.title}</span>
+                    <span className="home-rss__meta">
+                      <span className="home-rss__source">{it.source}</span>
+                      {age ? <span className="home-rss__time">· {age}</span> : null}
+                    </span>
+                  </span>
+                  <Icon name="ph:arrow-square-out" width={13} className="home-rss__open" aria-hidden />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -189,11 +189,6 @@ export function Workspace() {
   const [topSearchQuery, setTopSearchQuery] = useState("");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [mode, setMode] = useState<WorkspaceMode>("home");
-  // Deep-link target for the Roles surface's inner tabs. The home connector
-  // cards open the marketplace tab; cleared once we leave Roles so a later
-  // sidebar visit lands on the default Roles tab.
-  const [pendingPluginsTab, setPendingPluginsTab] =
-    useState<"marketplace" | null>(null);
   // Whether the first daemon status poll has resolved. Until it has, the daemon
   // state is *unknown* (not "offline"), so the offline banner must stay hidden.
   const [daemonStatusResolved, setDaemonStatusResolved] = useState(false);
@@ -426,12 +421,6 @@ export function Workspace() {
     window.addEventListener("cave:navigate-mode", onNavigate as EventListener);
     return () => window.removeEventListener("cave:navigate-mode", onNavigate as EventListener);
   }, []);
-
-  // Once the Roles deep-link has been consumed (PluginsView mounts with the
-  // requested tab), drop it so a later sidebar visit opens the default tab.
-  useEffect(() => {
-    if (mode !== "roles" && pendingPluginsTab) setPendingPluginsTab(null);
-  }, [mode, pendingPluginsTab]);
 
   // Click-to-open a file from chat: the comux pane (Code/Terminal) handles
   // `cave:open-project-file` directly when it's showing. When neither is, switch
@@ -1896,11 +1885,7 @@ export function Workspace() {
       <PluginsView
         key={mode}
         tabs={["roles", "skills", "marketplace", "capabilities"]}
-        initialTab={
-          mode === "capabilities"
-            ? "capabilities"
-            : pendingPluginsTab ?? "roles"
-        }
+        initialTab={mode === "capabilities" ? "capabilities" : "roles"}
         activeHarness={active?.harness ?? null}
         familiars={resolvedFamiliars}
         onOpenChat={(familiarId) => startFamiliarChat(familiarId)}
@@ -1955,9 +1940,9 @@ export function Workspace() {
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
-        onConnect={() => {
-          setPendingPluginsTab("marketplace");
-          setMode("roles");
+        onOpenUrl={(url) => {
+          setMode("browser");
+          requestAnimationFrame(() => browserPaneRef.current?.navigateTo(url));
         }}
       />
     )}

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -1,0 +1,120 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  parseFeed,
+  decodeEntities,
+  cleanText,
+  normalizeDate,
+  hostFromUrl,
+  faviconUrl,
+  canonicalLink,
+  relativeAge,
+  mergeFeedItems,
+} from "./rss.ts";
+
+// ── Entities + text cleanup ──────────────────────────────────────────────────
+assert.equal(decodeEntities("AT&amp;T &lt;b&gt; &#39;x&#39; &#x27;y&#x27;"), "AT&T <b> 'x' 'y'");
+assert.equal(decodeEntities("&unknownentity; stays"), "&unknownentity; stays");
+assert.equal(cleanText("<![CDATA[Hello &amp; <b>world</b>]]>"), "Hello & world");
+assert.equal(cleanText("  multi\n  line   text "), "multi line text");
+
+// ── Date normalization (RFC-822 + ISO) ───────────────────────────────────────
+assert.equal(normalizeDate("Wed, 02 Oct 2024 13:00:00 GMT"), "2024-10-02T13:00:00.000Z");
+assert.equal(normalizeDate("2024-10-02T13:00:00Z"), "2024-10-02T13:00:00.000Z");
+assert.equal(normalizeDate("not a date"), null);
+assert.equal(normalizeDate(null), null);
+
+// ── RSS 2.0 parsing ──────────────────────────────────────────────────────────
+const RSS = `<?xml version="1.0"?>
+<rss version="2.0"><channel>
+  <title>Example Tech</title>
+  <link>https://example.com</link>
+  <item>
+    <title><![CDATA[Rockets &amp; Robots]]></title>
+    <link>https://example.com/a</link>
+    <pubDate>Wed, 02 Oct 2024 13:00:00 GMT</pubDate>
+  </item>
+  <item>
+    <title>Second post</title>
+    <link>https://example.com/b/</link>
+    <pubDate>Tue, 01 Oct 2024 09:00:00 GMT</pubDate>
+  </item>
+</channel></rss>`;
+
+const rss = parseFeed(RSS);
+assert.equal(rss.title, "Example Tech");
+assert.equal(rss.items.length, 2);
+assert.equal(rss.items[0].title, "Rockets & Robots");
+assert.equal(rss.items[0].link, "https://example.com/a");
+assert.equal(rss.items[0].isoDate, "2024-10-02T13:00:00.000Z");
+assert.equal(rss.items[1].title, "Second post");
+
+// ── Atom parsing (link href, published/updated) ──────────────────────────────
+const ATOM = `<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Source</title>
+  <entry>
+    <title>Atom Entry One</title>
+    <link rel="alternate" type="text/html" href="https://atom.example/one"/>
+    <link rel="edit" href="https://atom.example/edit/one"/>
+    <updated>2024-09-30T10:00:00Z</updated>
+  </entry>
+  <entry>
+    <title>Atom Entry Two</title>
+    <link href="https://atom.example/two"/>
+    <published>2024-09-29T08:00:00Z</published>
+  </entry>
+</feed>`;
+
+const atom = parseFeed(ATOM);
+assert.equal(atom.title, "Atom Source");
+assert.equal(atom.items.length, 2);
+// Must pick the alternate/html link, NOT the rel="edit" one.
+assert.equal(atom.items[0].link, "https://atom.example/one");
+assert.equal(atom.items[0].isoDate, "2024-09-30T10:00:00.000Z");
+assert.equal(atom.items[1].link, "https://atom.example/two");
+
+// ── Robustness: garbage / empty ──────────────────────────────────────────────
+assert.deepEqual(parseFeed(""), { title: null, items: [] });
+assert.deepEqual(parseFeed("<html>not a feed</html>").items, []);
+
+// ── URL helpers ──────────────────────────────────────────────────────────────
+assert.equal(hostFromUrl("https://www.theverge.com/rss/index.xml"), "theverge.com");
+assert.equal(hostFromUrl("garbage"), null);
+assert.equal(faviconUrl("https://news.ycombinator.com/x"), "https://icons.duckduckgo.com/ip3/news.ycombinator.com.ico");
+assert.equal(canonicalLink("https://Example.com/A/"), "example.com/a");
+assert.equal(
+  canonicalLink("https://www.example.com/a"),
+  canonicalLink("https://example.com/a/"),
+  "www + trailing slash collapse to the same key",
+);
+
+// ── relativeAge ──────────────────────────────────────────────────────────────
+const now = Date.parse("2024-10-02T13:00:00Z");
+assert.equal(relativeAge("2024-10-02T12:59:40Z", now), "just now");
+assert.equal(relativeAge("2024-10-02T12:30:00Z", now), "30m");
+assert.equal(relativeAge("2024-10-02T09:00:00Z", now), "4h");
+assert.equal(relativeAge("2024-09-30T13:00:00Z", now), "2d");
+assert.equal(relativeAge(null, now), "");
+
+// ── mergeFeedItems: dedupe by canonical link + sort newest first ──────────────
+const merged = mergeFeedItems(
+  [
+    [
+      { id: "1", title: "A", link: "https://x.com/a", isoDate: "2024-10-01T00:00:00Z", source: "X" },
+      { id: "2", title: "B", link: "https://x.com/b", isoDate: "2024-10-03T00:00:00Z", source: "X" },
+    ],
+    [
+      // duplicate of A by canonical link (www + trailing slash) — dropped
+      { id: "3", title: "A dup", link: "https://www.x.com/a/", isoDate: "2024-10-01T00:00:00Z", source: "Y" },
+      { id: "4", title: "C", link: "https://y.com/c", isoDate: null, source: "Y" },
+    ],
+  ],
+  10,
+);
+assert.deepEqual(merged.map((i) => i.title), ["B", "A", "C"], "newest first; undated sinks; dup removed");
+
+const capped = mergeFeedItems([merged.map((i) => ({ ...i }))], 2);
+assert.equal(capped.length, 2, "limit caps the merged list");
+
+console.log("rss.test.ts: ok");

--- a/src/lib/rss.test.ts
+++ b/src/lib/rss.test.ts
@@ -17,6 +17,9 @@ assert.equal(decodeEntities("AT&amp;T &lt;b&gt; &#39;x&#39; &#x27;y&#x27;"), "AT
 assert.equal(decodeEntities("&unknownentity; stays"), "&unknownentity; stays");
 assert.equal(cleanText("<![CDATA[Hello &amp; <b>world</b>]]>"), "Hello & world");
 assert.equal(cleanText("  multi\n  line   text "), "multi line text");
+// Entities are decoded BEFORE tags are stripped, so encoded markup is removed
+// rather than re-exposed as live text.
+assert.equal(cleanText("&lt;b&gt;Bold&lt;/b&gt; &amp; clean"), "Bold & clean");
 
 // ── Date normalization (RFC-822 + ISO) ───────────────────────────────────────
 assert.equal(normalizeDate("Wed, 02 Oct 2024 13:00:00 GMT"), "2024-10-02T13:00:00.000Z");

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -61,12 +61,22 @@ export function decodeEntities(input: string): string {
   });
 }
 
-/** Unwrap CDATA, strip residual markup, decode entities, and collapse runs of
- *  whitespace to single spaces. Safe on plain text too. */
+/** Unwrap CDATA, decode entities, strip residual markup, and collapse runs of
+ *  whitespace to single spaces. Safe on plain text too.
+ *
+ *  Order matters: entities are decoded *before* tags are stripped, so an encoded
+ *  `&lt;script&gt;` can't survive stripping as live markup; and the strip runs to
+ *  a fixed point, since removing one tag can re-expose a nested one
+ *  (`<scr<i>ipt>` → `<script>`). */
 export function cleanText(raw: string): string {
   const withoutCdata = raw.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1");
-  const withoutTags = withoutCdata.replace(/<[^>]+>/g, "");
-  return decodeEntities(withoutTags).replace(/\s+/g, " ").trim();
+  let text = decodeEntities(withoutCdata);
+  let prev: string;
+  do {
+    prev = text;
+    text = text.replace(/<[^>]*>/g, "");
+  } while (text !== prev);
+  return text.replace(/\s+/g, " ").trim();
 }
 
 /** Inner text of the first `<tag>…</tag>` in `block` (attributes allowed),

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,218 @@
+/**
+ * Tiny dependency-free RSS 2.0 / Atom parser + feed helpers.
+ *
+ * The app ships no XML parser, and pulling one in for a single widget isn't
+ * worth the bundle. Feeds are simple and well-formed enough that a focused
+ * regex extractor handles RSS `<item>` and Atom `<entry>` reliably, including
+ * CDATA, HTML entities, and the Atom `<link href>` form. Everything here is
+ * pure so it unit-tests without a network or DOM (see rss.test.ts).
+ */
+
+export type ParsedFeedItem = {
+  title: string;
+  link: string;
+  /** Normalized ISO-8601 timestamp, or null when the feed omitted/garbled it. */
+  isoDate: string | null;
+};
+
+export type ParsedFeed = {
+  title: string | null;
+  items: ParsedFeedItem[];
+};
+
+/** A merged, display-ready item annotated with its source feed. */
+export type FeedItem = ParsedFeedItem & {
+  /** Stable key — the canonicalized link (falls back to the title). */
+  id: string;
+  /** Human source label (the feed's configured title). */
+  source: string;
+  /** Optional grouping label for the filter chips. */
+  category?: string;
+};
+
+// ─── Entity + tag helpers ────────────────────────────────────────────────────
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+/** Decode the handful of XML/HTML entities that show up in feed titles. */
+export function decodeEntities(input: string): string {
+  return input.replace(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (whole, body: string) => {
+    if (body[0] === "#") {
+      const code =
+        body[1] === "x" || body[1] === "X"
+          ? Number.parseInt(body.slice(2), 16)
+          : Number.parseInt(body.slice(1), 10);
+      if (!Number.isFinite(code) || code <= 0) return whole;
+      try {
+        return String.fromCodePoint(code);
+      } catch {
+        return whole;
+      }
+    }
+    const named = NAMED_ENTITIES[body.toLowerCase()];
+    return named ?? whole;
+  });
+}
+
+/** Unwrap CDATA, strip residual markup, decode entities, and collapse runs of
+ *  whitespace to single spaces. Safe on plain text too. */
+export function cleanText(raw: string): string {
+  const withoutCdata = raw.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, "$1");
+  const withoutTags = withoutCdata.replace(/<[^>]+>/g, "");
+  return decodeEntities(withoutTags).replace(/\s+/g, " ").trim();
+}
+
+/** Inner text of the first `<tag>…</tag>` in `block` (attributes allowed),
+ *  cleaned. Namespaced names like `dc:date` are matched literally. */
+function firstTagText(block: string, tag: string): string | null {
+  const re = new RegExp(`<${escapeTag(tag)}(?:\\s[^>]*)?>([\\s\\S]*?)<\\/${escapeTag(tag)}>`, "i");
+  const m = re.exec(block);
+  return m ? cleanText(m[1]) : null;
+}
+
+function escapeTag(tag: string): string {
+  return tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** First non-empty result among several candidate tags. */
+function firstOfTags(block: string, tags: string[]): string | null {
+  for (const tag of tags) {
+    const value = firstTagText(block, tag);
+    if (value) return value;
+  }
+  return null;
+}
+
+/** Resolve an item's link. RSS uses `<link>text</link>`; Atom uses
+ *  `<link href="…" rel="alternate"/>` — prefer rel="alternate" (or no rel),
+ *  and an html type when several links are present. */
+function extractLink(block: string): string {
+  const rssLink = firstTagText(block, "link");
+  if (rssLink && /^https?:\/\//i.test(rssLink)) return rssLink;
+
+  const links = [...block.matchAll(/<link\b([^>]*?)\/?>/gi)].map((m) => parseAttrs(m[1]));
+  if (links.length === 0) return rssLink ?? "";
+  const score = (a: Record<string, string>) =>
+    (a.rel === undefined || a.rel === "alternate" ? 2 : 0) + (/(html)/i.test(a.type ?? "") ? 1 : 0);
+  const best = [...links].sort((a, b) => score(b) - score(a))[0];
+  return best?.href ?? rssLink ?? "";
+}
+
+function parseAttrs(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  for (const m of raw.matchAll(/([\w:-]+)\s*=\s*"([^"]*)"/g)) attrs[m[1].toLowerCase()] = m[2];
+  return attrs;
+}
+
+/** Normalize an RFC-822 (`pubDate`) or ISO-8601 (`updated`) date to ISO, or
+ *  null when unparseable. */
+export function normalizeDate(raw: string | null): string | null {
+  if (!raw) return null;
+  const t = Date.parse(raw.trim());
+  return Number.isNaN(t) ? null : new Date(t).toISOString();
+}
+
+// ─── Feed parsing ────────────────────────────────────────────────────────────
+
+/** Parse a feed document (RSS 2.0 or Atom) into normalized items. Resilient to
+ *  the common shapes; returns an empty item list rather than throwing. */
+export function parseFeed(xml: string): ParsedFeed {
+  if (typeof xml !== "string" || xml.length === 0) return { title: null, items: [] };
+
+  const isAtom = /<feed[\s>]/i.test(xml) && !/<rss[\s>]/i.test(xml);
+  const blockRe = isAtom ? /<entry\b[\s\S]*?<\/entry>/gi : /<item\b[\s\S]*?<\/item>/gi;
+
+  // Feed title lives in the header, before the first item/entry.
+  const headEnd = xml.search(isAtom ? /<entry[\s>]/i : /<item[\s>]/i);
+  const head = headEnd >= 0 ? xml.slice(0, headEnd) : xml;
+  const title = firstTagText(head, "title");
+
+  const items: ParsedFeedItem[] = [];
+  for (const m of xml.matchAll(blockRe)) {
+    const block = m[0];
+    const itemTitle = firstTagText(block, "title") ?? "(untitled)";
+    const link = extractLink(block);
+    const dateRaw = isAtom
+      ? firstOfTags(block, ["published", "updated"])
+      : firstOfTags(block, ["pubDate", "dc:date", "date"]);
+    items.push({ title: itemTitle, link, isoDate: normalizeDate(dateRaw) });
+  }
+  return { title, items };
+}
+
+// ─── Display helpers ─────────────────────────────────────────────────────────
+
+/** Bare hostname (no `www.`) for a URL, or null when it isn't parseable. */
+export function hostFromUrl(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return null;
+  }
+}
+
+/** A favicon URL for a feed item via DuckDuckGo's icon service (no key, https). */
+export function faviconUrl(url: string): string | null {
+  const host = hostFromUrl(url);
+  return host ? `https://icons.duckduckgo.com/ip3/${host}.ico` : null;
+}
+
+/** Canonical key for de-duplication: lowercased host + path, trailing slash
+ *  stripped. Falls back to the raw string when it isn't a URL. */
+export function canonicalLink(url: string): string {
+  try {
+    const u = new URL(url);
+    const path = u.pathname.replace(/\/+$/, "");
+    return `${u.hostname.replace(/^www\./, "").toLowerCase()}${path.toLowerCase()}`;
+  } catch {
+    return url.trim().toLowerCase();
+  }
+}
+
+/** Compact relative age, e.g. "just now", "5m", "3h", "2d", "Apr 3". */
+export function relativeAge(iso: string | null, nowMs: number): string {
+  if (!iso) return "";
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const diff = nowMs - then;
+  if (diff < 0) return "just now";
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d`;
+  const d = new Date(then);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+// ─── Merge ───────────────────────────────────────────────────────────────────
+
+/** Merge per-feed item groups into one list: dedupe by canonical link, sort
+ *  newest-first (undated items sink to the bottom), and cap at `limit`. */
+export function mergeFeedItems(groups: FeedItem[][], limit: number): FeedItem[] {
+  const seen = new Set<string>();
+  const out: FeedItem[] = [];
+  for (const group of groups) {
+    for (const item of group) {
+      const key = item.link ? canonicalLink(item.link) : `t:${item.title}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(item);
+    }
+  }
+  out.sort((a, b) => {
+    const ta = a.isoDate ? Date.parse(a.isoDate) : -Infinity;
+    const tb = b.isoDate ? Date.parse(b.isoDate) : -Infinity;
+    return tb - ta;
+  });
+  return out.slice(0, Math.max(0, limit));
+}

--- a/src/lib/server/rss-feeds.ts
+++ b/src/lib/server/rss-feeds.ts
@@ -1,0 +1,70 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
+import { isSafeHttpUrl } from "@/lib/url-safety";
+
+/** A configured source feed. URLs here are SERVER-controlled — either the
+ *  built-in defaults below or the user's own `~/.coven/rss-feeds.json` — never
+ *  taken from an HTTP request, so the fetch in /api/rss has no SSRF surface. */
+export type FeedSource = {
+  id: string;
+  title: string;
+  url: string;
+  category: string;
+};
+
+/** Curated, reliable defaults across a few categories. Users can fully override
+ *  this set by dropping their own list in `~/.coven/rss-feeds.json`. */
+export const DEFAULT_FEEDS: FeedSource[] = [
+  { id: "hn", title: "Hacker News", url: "https://hnrss.org/frontpage", category: "Tech" },
+  { id: "verge", title: "The Verge", url: "https://www.theverge.com/rss/index.xml", category: "Tech" },
+  { id: "ars", title: "Ars Technica", url: "https://feeds.arstechnica.com/arstechnica/index", category: "Tech" },
+  { id: "hf", title: "Hugging Face", url: "https://huggingface.co/blog/feed.xml", category: "AI" },
+  { id: "mit-tr", title: "MIT Tech Review", url: "https://www.technologyreview.com/feed/", category: "AI" },
+  { id: "gh-blog", title: "GitHub Blog", url: "https://github.blog/feed/", category: "Dev" },
+  { id: "smashing", title: "Smashing Magazine", url: "https://www.smashingmagazine.com/feed/", category: "Design" },
+  { id: "bbc-world", title: "BBC World", url: "https://feeds.bbci.co.uk/news/world/rss.xml", category: "World" },
+];
+
+function feedConfigPath(): string {
+  return path.join(covenHome(), "rss-feeds.json");
+}
+
+/** Validate + normalize a single user-supplied feed entry. */
+function coerceFeed(raw: unknown, index: number): FeedSource | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const url = typeof r.url === "string" ? r.url.trim() : "";
+  if (!isSafeHttpUrl(url)) return null;
+  const title = typeof r.title === "string" && r.title.trim() ? r.title.trim() : url;
+  const category = typeof r.category === "string" && r.category.trim() ? r.category.trim() : "Feeds";
+  const id = typeof r.id === "string" && r.id.trim() ? r.id.trim() : `feed-${index}`;
+  return { id, title, url, category };
+}
+
+/**
+ * Resolve the feed list. When `~/.coven/rss-feeds.json` exists and parses to a
+ * non-empty array of valid feeds, it fully replaces the defaults (so users can
+ * curate). Otherwise the built-in defaults are used. Always returns at least
+ * one feed.
+ */
+export async function resolveFeeds(): Promise<FeedSource[]> {
+  let raw: string;
+  try {
+    raw = await readFile(feedConfigPath(), "utf8");
+  } catch {
+    return DEFAULT_FEEDS;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    const list = Array.isArray(parsed)
+      ? parsed
+      : Array.isArray((parsed as { feeds?: unknown })?.feeds)
+        ? (parsed as { feeds: unknown[] }).feeds
+        : [];
+    const feeds = list.map(coerceFeed).filter((f): f is FeedSource => f !== null);
+    return feeds.length > 0 ? feeds : DEFAULT_FEEDS;
+  } catch {
+    return DEFAULT_FEEDS;
+  }
+}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -393,11 +393,11 @@
   to { transform: rotate(360deg); }
 }
 
-/* ── Connector cards ─────────────────────────────────────────────────────────
- *   Codex-style cold-start cards: one-tap entry points into the marketplace
- *   for the integrations that give a familiar real context. The wrapper keeps
+/* ── Live RSS widget ─────────────────────────────────────────────────────────
+ *   A compact feed reader replacing the old connector cards. The wrapper keeps
  *   the `.home-composer-suggestions` class so it inherits the home layout's
- *   1200px content cap and viewport centering. */
+ *   1200px content cap and viewport centering; `.home-rss` overrides the
+ *   flex-center to a single vertical card. */
 .home-composer-suggestions {
   display: flex;
   flex-wrap: wrap;
@@ -408,79 +408,271 @@
   margin-inline: auto;
 }
 
-.home-composer-connectors {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 14px;
+.home-rss {
+  display: block;
   margin-top: 8px;
-}
-
-.hc-connector {
-  display: grid;
-  grid-template-rows: auto auto auto;
-  gap: 10px;
-  min-width: 0;
-  padding: 18px 18px 20px;
-  border-radius: 16px;
   border: 1px solid var(--border-hairline);
+  border-radius: 16px;
   background: color-mix(in oklch, var(--bg-raised) 55%, var(--bg-base));
+  overflow: hidden;
   text-align: left;
-  cursor: pointer;
-  transition: background 0.14s ease, border-color 0.14s ease, transform 0.14s ease;
 }
 
-.hc-connector:hover {
-  background: color-mix(in oklch, var(--bg-raised) 80%, var(--bg-base));
-  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
-  transform: translateY(-1px);
+.home-rss__head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 11px 12px 11px 14px;
+  border-bottom: 1px solid var(--border-hairline);
 }
 
-.hc-connector-glyph {
+.home-rss__title {
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
-  height: 24px;
-}
-
-.hc-connector-title {
-  font-size: 15px;
+  gap: 7px;
+  font-size: 14px;
   font-weight: 600;
   color: var(--text-primary);
   letter-spacing: -0.01em;
+  white-space: nowrap;
 }
 
-.hc-connector-sub {
-  font-size: 13px;
-  line-height: 1.45;
+.home-rss__title-icon {
+  color: var(--accent-presence);
+}
+
+.home-rss__live {
+  font-size: 11px;
+  font-weight: 500;
   color: var(--text-muted);
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-base);
+}
+
+.home-rss__chips {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.home-rss__chip {
+  font-size: 11px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+  white-space: nowrap;
+}
+.home-rss__chip:hover {
+  background: var(--bg-base);
+  color: var(--text-secondary);
+}
+.home-rss__chip.is-active {
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.home-rss__refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.home-rss__refresh:hover:not(:disabled) {
+  background: var(--bg-base);
+  border-color: var(--border-hairline);
+  color: var(--text-secondary);
+}
+.home-rss__refresh.is-spinning svg {
+  animation: hc-spin 0.8s linear infinite;
+}
+
+.home-rss__list {
+  list-style: none;
+  margin: 0;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  max-height: 320px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-hairline) transparent;
+}
+
+.home-rss__item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.home-rss__item:hover {
+  background: var(--bg-base);
+}
+.home-rss__item:hover .home-rss__open {
+  opacity: 0.6;
+}
+
+.home-rss__fav {
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  object-fit: cover;
+  background: var(--bg-base);
+}
+
+.home-rss__body {
+  min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.home-rss__item-title {
+  font-size: 13px;
+  line-height: 1.35;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.home-rss__meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--text-muted);
+  min-width: 0;
+}
+.home-rss__source {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+.home-rss__time {
+  flex-shrink: 0;
+}
+
+.home-rss__open {
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--text-muted);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+/* Skeleton + empty/error states */
+.home-rss__item--skeleton {
+  cursor: default;
+}
+.home-rss__sk-dot,
+.home-rss__sk-line {
+  background: linear-gradient(
+    90deg,
+    var(--bg-raised) 0%,
+    color-mix(in oklch, var(--bg-raised) 70%, var(--bg-elevated) 30%) 50%,
+    var(--bg-raised) 100%
+  );
+  background-size: 200% 100%;
+  animation: ui-skeleton-shimmer 1.4s ease-in-out infinite;
+  border-radius: 4px;
+}
+.home-rss__sk-dot {
+  width: 16px;
+  height: 16px;
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+.home-rss__sk-line {
+  height: 10px;
+  width: 100%;
+}
+.home-rss__sk-line--short {
+  width: 40%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-rss__sk-dot,
+  .home-rss__sk-line {
+    animation: none;
+    opacity: 0.65;
+  }
+}
+
+.home-rss__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 30px 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.home-rss__retry {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent-presence);
+  background: transparent;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, transparent);
+  border-radius: 8px;
+  padding: 5px 12px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.home-rss__retry:hover {
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
 }
 
 @media (max-width: 640px) {
-  .home-composer-connectors {
-    grid-template-columns: 1fr;
-    gap: 10px;
+  .home-rss__list {
+    max-height: 280px;
   }
-  .hc-connector {
-    min-height: var(--touch-target);
-    grid-template-rows: none;
-    grid-template-columns: auto 1fr;
-    grid-template-areas:
-      "glyph title"
-      "glyph sub";
-    align-items: center;
-    column-gap: 14px;
-    row-gap: 2px;
-    padding: 14px 16px;
+  .home-rss__chips {
+    display: none;
   }
-  .hc-connector-glyph { grid-area: glyph; }
-  .hc-connector-title { grid-area: title; }
-  .hc-connector-sub { grid-area: sub; }
+  .home-rss__item {
+    padding: 10px;
+  }
 }
 
 /* ── Focus rings (keyboard-only) ─────────────────────────────────────────── */
 .hc-dest-pill,
 .hc-send-btn,
-.hc-connector,
+.home-rss__item,
+.home-rss__chip,
+.home-rss__refresh,
+.home-rss__retry,
 .hc-add-btn,
 .hc-model-chip,
 .hc-familiar-select {
@@ -488,7 +680,10 @@
 }
 .hc-dest-pill:focus-visible,
 .hc-send-btn:focus-visible,
-.hc-connector:focus-visible,
+.home-rss__item:focus-visible,
+.home-rss__chip:focus-visible,
+.home-rss__refresh:focus-visible,
+.home-rss__retry:focus-visible,
 .hc-add-btn:focus-visible,
 .hc-model-chip:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);


### PR DESCRIPTION
## What

Replaces the three static **Connect messaging / email / files** cards on the home screen with a live **"Latest"** RSS feed reader.

![widget](latest feed: headline, source favicon, source · relative time, category chips, refresh)

### Pieces
- **`src/lib/rss.ts`** — dependency-free RSS 2.0 / Atom parser + merge/dedupe/relative-age helpers (handles CDATA, HTML entities, Atom `<link href>`, RFC-822 + ISO dates). Pure → unit-tested in `rss.test.ts`.
- **`src/lib/server/rss-feeds.ts`** — curated defaults across Tech / AI / Dev / Design / World, fully overridable via `~/.coven/rss-feeds.json`.
- **`GET /api/rss`** — fetches every feed in parallel (per-feed `AbortSignal.timeout` + try/catch so one dead feed can't sink the response), merges newest-first, dedupes, caches 5 min (`?refresh=1` bypasses). Registered in `api-contracts.test`.
- **`HomeRssWidget`** — favicons, 2-line clamped titles, source · relative time, category filter chips, refresh button, and loading / empty / error states. Clicking an item opens it in Cave's in-app browser via the existing `onOpenUrl` → browser-pane path.

### Security
Fetched URLs come **only** from `resolveFeeds()` (built-in constants or the user's local config file) — never from the HTTP request — so there's no request-driven SSRF surface. The route exposes no `url` param.

### Cleanup
Removes the connector cards + `BrandGlyph`, and the now-dead `pendingPluginsTab` marketplace deep-link plumbing in `Workspace`.

## Verification
- `tsc --noEmit` clean; full `test:app` + `test:mobile` suites green (new `rss.test.ts`, updated `home-composer-mobile-gaps.test.ts`, `api-contracts.test.ts`).
- Built + ran the app: `/api/rss` returns live parsed items, and the widget renders 40 newest stories with working favicons, chips (All / Tech / World), and relative times.

10 files, +956 / −185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)