### PR TITLE
refactor(onboarding): extract + unit-test the install queue

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -324,6 +324,7 @@ export const SUITES = {
     "src/lib/memory-inspector.test.ts",
     "src/lib/memory-source-context.test.ts",
     "src/lib/onboarding-familiars.test.ts",
+    "src/lib/onboarding-install-queue.test.ts",
     "src/lib/openclaw-agents.test.ts",
     "src/lib/openclaw-conversation-tools.test.ts",
     "src/lib/shell-banners.test.ts",

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -3,6 +3,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
+import {
+  shouldQueueInstall,
+  enqueueInstall,
+  nextDrainTarget,
+  shouldRequeueOn409,
+} from "@/lib/onboarding-install-queue";
 import type { IconName } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
@@ -610,8 +616,8 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       if (!res.ok) {
         // Lost the race for the single npm lane — re-queue and let the drain
         // effect retry instead of surfacing a "wait for X to finish" error.
-        if (res.status === 409 && INSTALL_TARGET_KIND[target] === "npm") {
-          setInstallQueue((q) => (q.includes(target) ? q : [...q, target]));
+        if (shouldRequeueOn409(INSTALL_TARGET_KIND[target], res.status)) {
+          setInstallQueue((q) => enqueueInstall(q, target));
           markQueued(target);
           return;
         }
@@ -658,12 +664,14 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   // what makes "install both" work instead of failing the second one.
   const runInstall = (target: InstallTarget) => {
     if (
-      INSTALL_TARGET_KIND[target] === "npm" &&
-      (anyNpmInstallRunning(installJobs) ||
-        installInFlightRef.current ||
-        installQueue.length > 0)
+      shouldQueueInstall({
+        kind: INSTALL_TARGET_KIND[target],
+        npmBusy: anyNpmInstallRunning(installJobs),
+        inFlight: installInFlightRef.current,
+        queuedCount: installQueue.length,
+      })
     ) {
-      setInstallQueue((q) => (q.includes(target) ? q : [...q, target]));
+      setInstallQueue((q) => enqueueInstall(q, target));
       markQueued(target);
       return;
     }
@@ -672,10 +680,11 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
 
   // Drain the npm queue one at a time as the lane frees up.
   useEffect(() => {
-    if (installQueue.length === 0) return;
-    if (installInFlightRef.current) return;
-    if (anyNpmInstallRunning(installJobs)) return;
-    const next = installQueue[0];
+    const next = nextDrainTarget(installQueue, {
+      npmBusy: anyNpmInstallRunning(installJobs),
+      inFlight: installInFlightRef.current,
+    });
+    if (next == null) return;
     setInstallQueue((q) => q.slice(1));
     void postInstall(next);
   }, [installQueue, installJobs, postInstall]);

--- a/src/lib/onboarding-install-queue.test.ts
+++ b/src/lib/onboarding-install-queue.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  shouldQueueInstall,
+  enqueueInstall,
+  nextDrainTarget,
+  shouldRequeueOn409,
+} from "./onboarding-install-queue.ts";
+
+test("shouldQueueInstall: script installs never queue", () => {
+  assert.equal(
+    shouldQueueInstall({ kind: "script", npmBusy: true, inFlight: true, queuedCount: 5 }),
+    false,
+  );
+});
+
+test("shouldQueueInstall: npm runs immediately when the lane is free", () => {
+  assert.equal(
+    shouldQueueInstall({ kind: "npm", npmBusy: false, inFlight: false, queuedCount: 0 }),
+    false,
+  );
+});
+
+test("shouldQueueInstall: npm queues when busy / in-flight / already queued", () => {
+  assert.equal(shouldQueueInstall({ kind: "npm", npmBusy: true, inFlight: false, queuedCount: 0 }), true);
+  assert.equal(shouldQueueInstall({ kind: "npm", npmBusy: false, inFlight: true, queuedCount: 0 }), true);
+  assert.equal(shouldQueueInstall({ kind: "npm", npmBusy: false, inFlight: false, queuedCount: 1 }), true);
+});
+
+test("enqueueInstall: appends, preserves order, dedupes (same ref when unchanged)", () => {
+  assert.deepEqual(enqueueInstall<string>([], "a"), ["a"]);
+  assert.deepEqual(enqueueInstall(["a"], "b"), ["a", "b"]);
+  const q = ["a", "b"];
+  // Duplicate returns the SAME reference so a React setState bails out.
+  assert.equal(enqueueInstall(q, "a"), q);
+});
+
+test("nextDrainTarget: null when empty or lane not free; head otherwise", () => {
+  assert.equal(nextDrainTarget<string>([], { npmBusy: false, inFlight: false }), null);
+  assert.equal(nextDrainTarget(["a", "b"], { npmBusy: true, inFlight: false }), null);
+  assert.equal(nextDrainTarget(["a", "b"], { npmBusy: false, inFlight: true }), null);
+  assert.equal(nextDrainTarget(["a", "b"], { npmBusy: false, inFlight: false }), "a");
+});
+
+test("shouldRequeueOn409: only a 409 on an npm target re-queues", () => {
+  assert.equal(shouldRequeueOn409("npm", 409), true);
+  assert.equal(shouldRequeueOn409("npm", 422), false);
+  assert.equal(shouldRequeueOn409("script", 409), false);
+});
+
+test("integration: 'install both' serializes coven-cli then coven-code", () => {
+  // Click coven-cli (lane free → runs now), then coven-code (lane busy → queued).
+  let queue: string[] = [];
+  const npmBusyAfterFirst = true; // coven-cli job registered
+
+  const firstQueued = shouldQueueInstall({ kind: "npm", npmBusy: false, inFlight: false, queuedCount: 0 });
+  assert.equal(firstQueued, false, "coven-cli starts immediately");
+
+  const secondQueued = shouldQueueInstall({ kind: "npm", npmBusy: npmBusyAfterFirst, inFlight: false, queuedCount: 0 });
+  assert.equal(secondQueued, true, "coven-code waits");
+  queue = enqueueInstall(queue, "coven-code");
+  assert.deepEqual(queue, ["coven-code"]);
+
+  // While coven-cli runs, nothing drains.
+  assert.equal(nextDrainTarget(queue, { npmBusy: true, inFlight: false }), null);
+
+  // coven-cli finishes → the lane frees → coven-code drains.
+  const drain = nextDrainTarget(queue, { npmBusy: false, inFlight: false });
+  assert.equal(drain, "coven-code");
+  queue = queue.slice(1);
+  assert.deepEqual(queue, []);
+});
+
+console.log("onboarding-install-queue.test.ts OK");

--- a/src/lib/onboarding-install-queue.ts
+++ b/src/lib/onboarding-install-queue.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure decision helpers for the onboarding install queue.
+ *
+ * npm global installs share one lane — the install route 409s a second
+ * concurrent npm target — so the onboarding overlay can only run one at a time.
+ * To make "install both" work (rather than failing the second), npm targets are
+ * queued and drained one at a time. Script installs (e.g. Hermes) are
+ * independent and never queue.
+ *
+ * The overlay owns the React state (queue array, in-flight ref, running jobs);
+ * these functions hold only the decision logic so it stays unit-testable.
+ */
+
+export type InstallLaneKind = "npm" | "script";
+
+/**
+ * Should an install for a target be queued (wait) instead of started now?
+ *
+ * npm targets queue when the lane is busy, a dispatch is mid-flight, or anything
+ * is already queued (preserve order). Non-npm (script) targets never queue.
+ */
+export function shouldQueueInstall(opts: {
+  kind: InstallLaneKind;
+  /** An npm install is currently running. */
+  npmBusy: boolean;
+  /** An install POST is dispatched but its job hasn't registered yet. */
+  inFlight: boolean;
+  /** How many targets are already queued. */
+  queuedCount: number;
+}): boolean {
+  if (opts.kind !== "npm") return false;
+  return opts.npmBusy || opts.inFlight || opts.queuedCount > 0;
+}
+
+/**
+ * Append a target to the queue without duplicates. Returns the SAME array
+ * reference when the target is already queued so a React state setter can bail
+ * out of a no-op re-render.
+ */
+export function enqueueInstall<T>(queue: T[], target: T): T[] {
+  return queue.includes(target) ? queue : [...queue, target];
+}
+
+/**
+ * The next target to dispatch from the queue, or null when the queue is empty
+ * or the lane isn't free yet (something running or a dispatch in-flight).
+ */
+export function nextDrainTarget<T>(
+  queue: readonly T[],
+  opts: { npmBusy: boolean; inFlight: boolean },
+): T | null {
+  if (queue.length === 0) return null;
+  if (opts.npmBusy || opts.inFlight) return null;
+  return queue[0];
+}
+
+/**
+ * A 409 for an npm target means it lost the race for the single npm lane —
+ * re-queue and let the drain retry it, rather than surfacing an error.
+ */
+export function shouldRequeueOn409(kind: InstallLaneKind, httpStatus: number): boolean {
+  return httpStatus === 409 && kind === "npm";
+}


### PR DESCRIPTION
## What
The "install both" serialization (queue + drain + 409-requeue) shipped in #1924 lived inline in `onboarding-overlay.tsx` with **no test coverage**. This extracts the decision logic into a pure, fully-tested module and has the overlay consume it.

`src/lib/onboarding-install-queue.ts`:
- `shouldQueueInstall({kind, npmBusy, inFlight, queuedCount})` — npm targets queue when the lane is busy/in-flight/non-empty; script installs never queue.
- `enqueueInstall(queue, target)` — append, dedupe, same-ref-when-unchanged (so a React setter bails on a no-op).
- `nextDrainTarget(queue, {npmBusy, inFlight})` — head of queue when the lane is free, else null.
- `shouldRequeueOn409(kind, status)` — only a 409 on an npm target re-queues.

## Behavior
No change — pure refactor. The overlay's `runInstall`, the 409 path, and the drain effect now call these helpers.

## Test
New `onboarding-install-queue.test.ts` (7 cases incl. the coven-cli→coven-code "install both" serialization integration path). `pnpm typecheck` clean; `onboarding-guided-steps` + `onboarding-polish` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)