### PR TITLE
feat(knowledge): cross-harness Knowledge Vault, separate from memory

### DIFF
--- a/docs/knowledge-vault.md
+++ b/docs/knowledge-vault.md
@@ -1,0 +1,58 @@
+# Knowledge Vault
+
+The **Knowledge Vault** is curated, human-authored reference knowledge that is
+injected into **every harness** (claude, codex, hermes, openclaw) at chat time.
+It is deliberately **separate from memory**:
+
+| | Memory | Knowledge Vault |
+|---|---|---|
+| Author | the familiar (auto-written as it works) | you (curated) |
+| Lifetime | evolves / drifts per day | durable, stable |
+| Scope | per-familiar, per-day | global or an explicit familiar allow-list |
+| Storage | `~/.coven/.../memory/<date>.md` | `~/.coven/knowledge/<id>.md` |
+| Intent | the agent's notebook | authoritative background facts |
+
+Use it for style guides, glossaries, domain facts, API contracts, "house rules"
+— anything you want *every* harness to treat as authoritative context without
+copy-pasting it into each prompt.
+
+## How the cross-harness tie-in works
+
+Every harness is spawned from a single constructed prompt in
+`src/app/api/chat/send/route.ts`. The vault is wrapped onto that prompt via
+`buildPromptWithKnowledgeVault(...)`, so the same curated knowledge reaches all
+harnesses with no per-harness plumbing. Entries land inside a `<KNOWLEDGE_VAULT>`
+block, clearly labelled as durable reference material (not memory).
+
+## Storage format
+
+One Markdown file per entry under `~/.coven/knowledge/` (override with
+`COVEN_KNOWLEDGE_DIR`). Each file has a small YAML frontmatter:
+
+```markdown
+---
+title: API Style Guide
+tags: [api, conventions]
+scope: global            # or a list/space-separated set of familiar ids, e.g. "sage echo"
+enabled: true
+---
+Routes are kebab-case. Every change ships through a PR.
+```
+
+- `scope: global` (or omitted) → reaches every familiar.
+- `scope: sage echo` → only those familiars' prompts.
+- `enabled: false` → kept on disk but never injected.
+
+## Managing entries — `/api/knowledge`
+
+```
+GET    /api/knowledge                  → { ok, entries }   (full list)
+GET    /api/knowledge?familiarId=sage  → { ok, entries }   (what sage would receive)
+POST   /api/knowledge                  body { title, body, tags?, scope?, enabled?, id? } → { ok, entry }
+DELETE /api/knowledge?id=<id>          → { ok, deleted }
+```
+
+The entry `id` is the only user input that touches the filesystem and is gated on
+a strict slug allow-list (`isValidKnowledgeId`) before any path is built — the
+route can't escape the vault directory. When `id` is omitted on POST, it is
+slugified from the title.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -493,6 +493,7 @@ export const SUITES = {
     "src/lib/session-list-merge.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",
+    "src/lib/server/knowledge-vault.test.ts",
     "src/lib/server/memory-file-paths.test.ts",
     "src/lib/server/skill-file-paths.test.ts",
     "src/lib/server/automation-log-paths.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -72,6 +72,7 @@ const contracts: RouteContract[] = [
   { route: "/inbox", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/inbox/stream", methods: ["GET"], kind: "stream" },
   { route: "/journal", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/knowledge", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/launch", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/library/all", methods: ["GET"], kind: "json" },
   { route: "/library/bookmarks", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true },

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -33,6 +33,10 @@ import {
 } from "@/lib/chat-tool-events";
 import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
+import {
+  buildPromptWithKnowledgeVault,
+  readKnowledgeVaultForPrompt,
+} from "@/lib/server/knowledge-vault";
 import { buildNextPathsDirective } from "@/lib/next-paths";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects, projectForRoot } from "@/lib/cave-projects";
@@ -998,23 +1002,30 @@ export async function POST(req: Request) {
   const dailyMemoryContext = await readFamiliarDailyMemoryStartupContext(
     resolvedFamiliarWorkspace,
   );
+  // Knowledge Vault — curated, cross-harness reference knowledge, separate from
+  // memory. Injected here so every harness (claude/codex/hermes/openclaw) that
+  // consumes `harnessPrompt` below receives the same authoritative context.
+  const knowledgeVaultEntries = await readKnowledgeVaultForPrompt(body.familiarId);
 
   const taskContext = await taskContextForSession(body.sessionId);
   const harnessPrompt = buildPromptWithRuntimeScope(
     buildPromptWithCovenIdentityCanon(
       buildTaskAwarePrompt(
-        buildPromptWithFamiliarStartupContext(
-          appendMentionedFilesBlock(
-            buildPromptWithResponseControls(
-              buildPromptWithAttachments(promptText, attachments, {
-                imagesSupported,
-                imageFilePaths,
-              }),
-              body,
+        buildPromptWithKnowledgeVault(
+          buildPromptWithFamiliarStartupContext(
+            appendMentionedFilesBlock(
+              buildPromptWithResponseControls(
+                buildPromptWithAttachments(promptText, attachments, {
+                  imagesSupported,
+                  imageFilePaths,
+                }),
+                body,
+              ),
+              mentionedFiles,
             ),
-            mentionedFiles,
+            [dailyMemoryContext],
           ),
-          [dailyMemoryContext],
+          knowledgeVaultEntries,
         ),
         taskContext,
       ),

--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import {
+  deleteKnowledgeEntry,
+  isValidKnowledgeId,
+  listKnowledgeEntries,
+  normalizeScope,
+  selectKnowledgeForFamiliar,
+  slugifyKnowledgeId,
+  writeKnowledgeEntry,
+  type KnowledgeEntry,
+} from "@/lib/server/knowledge-vault";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Knowledge Vault — curated, cross-harness reference knowledge (NOT memory).
+ *
+ *   GET    /api/knowledge                  → { ok, entries }            (full list)
+ *   GET    /api/knowledge?familiarId=<id>  → { ok, entries }            (scoped)
+ *   POST   /api/knowledge  body { id?, title, body, tags?, scope?, enabled? } → { ok, entry }
+ *   DELETE /api/knowledge?id=<id>          → { ok, deleted }
+ *
+ * The entry `id` is the only user input that reaches the filesystem and is gated
+ * on a strict slug allow-list (`isValidKnowledgeId`) before any path is built,
+ * so the route can never escape the vault directory.
+ */
+export async function GET(req: Request) {
+  const familiarId = new URL(req.url).searchParams.get("familiarId")?.trim() || undefined;
+  const all = await listKnowledgeEntries();
+  const entries = familiarId ? selectKnowledgeForFamiliar(all, familiarId) : all;
+  return NextResponse.json({ ok: true, entries });
+}
+
+export async function POST(req: Request) {
+  let body: {
+    id?: unknown;
+    title?: unknown;
+    body?: unknown;
+    tags?: unknown;
+    scope?: unknown;
+    enabled?: unknown;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const content = typeof body.body === "string" ? body.body : "";
+  if (!title && !content.trim()) {
+    return NextResponse.json({ ok: false, error: "title or body required" }, { status: 400 });
+  }
+
+  const requestedId = typeof body.id === "string" && body.id.trim() ? body.id.trim() : slugifyKnowledgeId(title);
+  if (!isValidKnowledgeId(requestedId)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+
+  const tags = Array.isArray(body.tags)
+    ? body.tags.map((t) => String(t).trim()).filter(Boolean)
+    : typeof body.tags === "string"
+      ? body.tags.split(/[,\s]+/).map((t) => t.trim()).filter(Boolean)
+      : [];
+
+  const entry: KnowledgeEntry = {
+    id: requestedId,
+    title: title || requestedId,
+    tags,
+    scope: normalizeScope(body.scope),
+    enabled: body.enabled !== false,
+    body: content,
+  };
+
+  const saved = await writeKnowledgeEntry(entry);
+  return NextResponse.json({ ok: true, entry: saved });
+}
+
+export async function DELETE(req: Request) {
+  const id = new URL(req.url).searchParams.get("id")?.trim() ?? "";
+  if (!isValidKnowledgeId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+  const deleted = await deleteKnowledgeEntry(id);
+  return NextResponse.json({ ok: true, deleted });
+}

--- a/src/components/board-chat-link.test.ts
+++ b/src/components/board-chat-link.test.ts
@@ -64,6 +64,6 @@ assert.match(
 );
 assert.match(
   chatSendRoute,
-  /buildTaskAwarePrompt\(\s*(?:buildPromptWithFamiliarStartupContext\([\s\S]{0,120})?(?:appendMentionedFilesBlock\(\s*)?buildPromptWithAttachments/,
+  /buildTaskAwarePrompt\(\s*(?:buildPromptWithKnowledgeVault\(\s*)?(?:buildPromptWithFamiliarStartupContext\([\s\S]{0,120})?(?:appendMentionedFilesBlock\(\s*)?buildPromptWithAttachments/,
   "Chat send should include task context in the harness prompt only",
 );

--- a/src/lib/server/knowledge-vault.test.ts
+++ b/src/lib/server/knowledge-vault.test.ts
@@ -1,0 +1,149 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  buildPromptWithKnowledgeVault,
+  deleteKnowledgeEntry,
+  isValidKnowledgeId,
+  listKnowledgeEntries,
+  normalizeScope,
+  parseKnowledgeFile,
+  readKnowledgeVaultForPrompt,
+  selectKnowledgeForFamiliar,
+  serializeKnowledgeEntry,
+  slugifyKnowledgeId,
+  writeKnowledgeEntry,
+} from "./knowledge-vault.ts";
+
+// ── id guard ─────────────────────────────────────────────────────────────────
+assert.equal(isValidKnowledgeId("api-style_guide1"), true);
+assert.equal(isValidKnowledgeId("UPPER"), false, "ids are lowercase-only");
+assert.equal(isValidKnowledgeId("../escape"), false, "no traversal");
+assert.equal(isValidKnowledgeId("has/slash"), false);
+assert.equal(isValidKnowledgeId("has.dot"), false);
+assert.equal(isValidKnowledgeId(""), false);
+assert.equal(isValidKnowledgeId(42), false);
+assert.equal(slugifyKnowledgeId("API Style Guide!"), "api-style-guide");
+
+// ── scope normalization ──────────────────────────────────────────────────────
+assert.equal(normalizeScope(undefined), "global");
+assert.equal(normalizeScope("global"), "global");
+assert.equal(normalizeScope("  "), "global");
+assert.equal(normalizeScope("all"), "global");
+assert.equal(normalizeScope(["*"]), "global");
+assert.deepEqual(normalizeScope("sage echo"), ["sage", "echo"]);
+assert.deepEqual(normalizeScope("sage, echo"), ["sage", "echo"]);
+assert.deepEqual(normalizeScope(["sage", "echo"]), ["sage", "echo"]);
+
+// ── parse round-trips with serialize ─────────────────────────────────────────
+{
+  const entry = {
+    id: "guide",
+    title: "Style Guide",
+    tags: ["api", "conventions"],
+    scope: ["sage"],
+    enabled: true,
+    body: "Use kebab-case for routes.",
+  };
+  const parsed = parseKnowledgeFile("guide", serializeKnowledgeEntry(entry));
+  assert.deepEqual(parsed, entry, "serialize → parse is lossless");
+}
+
+// frontmatter-less file → whole thing is body, title falls back to id
+{
+  const parsed = parseKnowledgeFile("notes", "just some text\n");
+  assert.equal(parsed.title, "notes");
+  assert.equal(parsed.scope, "global");
+  assert.equal(parsed.enabled, true);
+  assert.equal(parsed.body, "just some text");
+}
+
+// enabled:false is honored; malformed frontmatter degrades gracefully
+{
+  const off = parseKnowledgeFile("x", "---\ntitle: X\nenabled: false\n---\nbody");
+  assert.equal(off.enabled, false);
+  const bad = parseKnowledgeFile("y", "---\n: : not yaml :\n---\nbody");
+  assert.equal(bad.title, "y");
+}
+
+// ── scope selection ──────────────────────────────────────────────────────────
+{
+  const entries = [
+    { id: "g", title: "G", tags: [], scope: "global", enabled: true, body: "g" },
+    { id: "s", title: "S", tags: [], scope: ["sage"], enabled: true, body: "s" },
+    { id: "off", title: "Off", tags: [], scope: "global", enabled: false, body: "off" },
+  ];
+  assert.deepEqual(
+    selectKnowledgeForFamiliar(entries, "sage").map((e) => e.id),
+    ["g", "s"],
+    "sage sees global + sage-scoped, never disabled",
+  );
+  assert.deepEqual(
+    selectKnowledgeForFamiliar(entries, "echo").map((e) => e.id),
+    ["g"],
+    "echo sees only global",
+  );
+  assert.deepEqual(
+    selectKnowledgeForFamiliar(entries, undefined).map((e) => e.id),
+    ["g"],
+    "no familiar → only global",
+  );
+}
+
+// ── prompt block ─────────────────────────────────────────────────────────────
+assert.equal(
+  buildPromptWithKnowledgeVault("hello", []),
+  "hello",
+  "no entries → prompt unchanged",
+);
+{
+  const out = buildPromptWithKnowledgeVault("USER PROMPT", [
+    { id: "g", title: "Glossary", tags: ["domain"], scope: "global", enabled: true, body: "Coven = a set of familiars." },
+    { id: "empty", title: "Empty", tags: [], scope: "global", enabled: true, body: "   " },
+  ]);
+  assert.match(out, /<KNOWLEDGE_VAULT>/);
+  assert.match(out, /<\/KNOWLEDGE_VAULT>/);
+  assert.match(out, /## Glossary {2}\[tags: domain\]/);
+  assert.match(out, /Coven = a set of familiars\./);
+  assert.doesNotMatch(out, /## Empty/, "empty-body entries are dropped");
+  assert.ok(out.trimEnd().endsWith("USER PROMPT"), "user prompt stays at the end");
+}
+
+// ── filesystem round-trip (temp dir via COVEN_KNOWLEDGE_DIR) ──────────────────
+{
+  const dir = mkdtempSync(path.join(tmpdir(), "kv-test-"));
+  const prev = process.env.COVEN_KNOWLEDGE_DIR;
+  process.env.COVEN_KNOWLEDGE_DIR = dir;
+  try {
+    assert.deepEqual(await listKnowledgeEntries(), [], "absent/empty dir → []");
+    await writeKnowledgeEntry({
+      id: "ship-rules",
+      title: "Ship Rules",
+      tags: ["process"],
+      scope: ["sage"],
+      enabled: true,
+      body: "All changes go through a PR.",
+    });
+    const all = await listKnowledgeEntries();
+    assert.equal(all.length, 1);
+    assert.equal(all[0].id, "ship-rules");
+    assert.deepEqual(all[0].scope, ["sage"]);
+
+    const forSage = await readKnowledgeVaultForPrompt("sage");
+    assert.equal(forSage.length, 1);
+    const forEcho = await readKnowledgeVaultForPrompt("echo");
+    assert.equal(forEcho.length, 0, "sage-scoped entry hidden from echo");
+
+    assert.equal(await deleteKnowledgeEntry("ship-rules"), true);
+    assert.equal(await deleteKnowledgeEntry("ship-rules"), false, "second delete → false");
+    assert.deepEqual(await listKnowledgeEntries(), []);
+  } finally {
+    if (prev === undefined) delete process.env.COVEN_KNOWLEDGE_DIR;
+    else process.env.COVEN_KNOWLEDGE_DIR = prev;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+console.log("knowledge-vault.test.ts: ok");

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -1,0 +1,261 @@
+/**
+ * Knowledge Vault — curated, cross-harness reference knowledge.
+ *
+ * The Knowledge Vault is deliberately SEPARATE from the memory system:
+ *
+ *   - Memory (`~/.coven/.../memory/*.md`) is the agent's own evolving notebook —
+ *     written by familiars as they work, scoped per-familiar-per-day, and meant
+ *     to drift over time.
+ *   - The Knowledge Vault (`~/.coven/knowledge/*.md`) is durable, human-curated
+ *     reference material — style guides, glossaries, domain facts, API contracts
+ *     — that the user wants every harness to treat as authoritative background.
+ *
+ * The "tie-in" is the prompt-construction layer in `/api/chat/send`: every
+ * harness (claude, codex, hermes, openclaw) is spawned with a single
+ * constructed prompt, so wrapping that prompt with the vault block delivers the
+ * same curated knowledge to all of them — no per-harness plumbing required.
+ *
+ * Storage: one Markdown file per entry under `~/.coven/knowledge/`, each with a
+ * small YAML frontmatter block:
+ *
+ *     ---
+ *     title: API Style Guide
+ *     tags: [api, conventions]
+ *     scope: global            # or a list/space-separated set of familiar ids
+ *     enabled: true
+ *     ---
+ *     Body markdown…
+ */
+
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { parse as parseYaml } from "yaml";
+import { covenHome } from "../coven-paths.ts";
+
+// ── Paths & id guard ────────────────────────────────────────────────────────
+
+/** Root directory for vault entries. Overridable for tests/bundles. */
+export function covenKnowledgeRoot(): string {
+  return process.env.COVEN_KNOWLEDGE_DIR || path.join(covenHome(), "knowledge");
+}
+
+const KNOWLEDGE_ID_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+/** Strict slug guard — the id is the only user input that hits the filesystem,
+ *  so it must never contain separators, dots, or anything path-traversing. */
+export function isValidKnowledgeId(id: unknown): id is string {
+  return typeof id === "string" && KNOWLEDGE_ID_RE.test(id);
+}
+
+/** Derive a safe id from a free-form title (best-effort; may be empty). */
+export function slugifyKnowledgeId(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export type KnowledgeScope = "global" | string[];
+
+export type KnowledgeEntry = {
+  id: string;
+  title: string;
+  tags: string[];
+  /** "global" → every familiar; otherwise an explicit familiar-id allow-list. */
+  scope: KnowledgeScope;
+  enabled: boolean;
+  body: string;
+};
+
+// ── Parse / serialize (pure) ─────────────────────────────────────────────────
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+function normalizeTags(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map((t) => String(t).trim()).filter(Boolean);
+  if (typeof value === "string") {
+    return value
+      .split(/[,\s]+/)
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+/** Normalize an arbitrary `scope` field into "global" or a familiar-id list. */
+export function normalizeScope(value: unknown): KnowledgeScope {
+  if (value == null) return "global";
+  const list = Array.isArray(value)
+    ? value.map((v) => String(v).trim())
+    : String(value)
+        .split(/[,\s]+/)
+        .map((v) => v.trim());
+  const ids = list.filter(Boolean);
+  if (ids.length === 0) return "global";
+  if (ids.some((id) => id.toLowerCase() === "global" || id === "*" || id.toLowerCase() === "all")) {
+    return "global";
+  }
+  return ids;
+}
+
+/** Parse one entry file's contents (frontmatter + body) into an entry. */
+export function parseKnowledgeFile(id: string, raw: string): KnowledgeEntry {
+  const match = raw.match(FRONTMATTER_RE);
+  let front: Record<string, unknown> = {};
+  let body = raw;
+  if (match) {
+    body = match[2] ?? "";
+    try {
+      const parsed = parseYaml(match[1]);
+      if (parsed && typeof parsed === "object") front = parsed as Record<string, unknown>;
+    } catch {
+      // Malformed frontmatter → treat the whole file as body, keep title from id.
+      front = {};
+      body = raw;
+    }
+  }
+  return {
+    id,
+    title: typeof front.title === "string" && front.title.trim() ? front.title.trim() : id,
+    tags: normalizeTags(front.tags),
+    scope: normalizeScope(front.scope),
+    enabled: front.enabled !== false,
+    body: body.trim(),
+  };
+}
+
+/** Serialize an entry back to its on-disk Markdown-with-frontmatter form. */
+export function serializeKnowledgeEntry(entry: KnowledgeEntry): string {
+  const scope = entry.scope === "global" ? "global" : entry.scope.join(", ");
+  const lines = [
+    "---",
+    `title: ${JSON.stringify(entry.title)}`,
+    `tags: [${entry.tags.map((t) => JSON.stringify(t)).join(", ")}]`,
+    `scope: ${JSON.stringify(scope)}`,
+    `enabled: ${entry.enabled}`,
+    "---",
+    "",
+    entry.body.trim(),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+// ── Selection & prompt block (pure) ──────────────────────────────────────────
+
+/** Pick the entries that should reach a given familiar's harness prompt:
+ *  enabled, and either global or explicitly scoped to that familiar. */
+export function selectKnowledgeForFamiliar(
+  entries: readonly KnowledgeEntry[],
+  familiarId?: string,
+): KnowledgeEntry[] {
+  return entries.filter((entry) => {
+    if (!entry.enabled) return false;
+    if (entry.scope === "global") return true;
+    return Boolean(familiarId) && entry.scope.includes(familiarId as string);
+  });
+}
+
+/** Wrap a harness prompt with the Knowledge Vault block. Pure: same prompt back
+ *  when there are no entries, so it's safe to call unconditionally. */
+export function buildPromptWithKnowledgeVault(
+  prompt: string,
+  entries: readonly KnowledgeEntry[],
+): string {
+  const text = prompt.trim();
+  const usable = entries.filter((e) => e.enabled && e.body.trim());
+  if (usable.length === 0) return text;
+
+  const blocks = usable.map((entry) => {
+    const heading = entry.tags.length
+      ? `## ${entry.title}  [tags: ${entry.tags.join(", ")}]`
+      : `## ${entry.title}`;
+    return [heading, entry.body.trim()].join("\n");
+  });
+
+  const context = [
+    "<KNOWLEDGE_VAULT>",
+    "Shared Knowledge Vault — curated reference knowledge available to every harness.",
+    "This is durable, human-curated background material, NOT your evolving memory.",
+    "Treat it as authoritative context for this conversation; do not edit it.",
+    "",
+    ...blocks,
+    "</KNOWLEDGE_VAULT>",
+  ].join("\n\n");
+
+  return text ? `${context}\n\n${text}` : context;
+}
+
+// ── Filesystem store ─────────────────────────────────────────────────────────
+
+function entryPath(id: string): string {
+  return path.join(covenKnowledgeRoot(), `${id}.md`);
+}
+
+/** List every vault entry on disk. Returns [] when the directory is absent or
+ *  unreadable — the vault is an optional add-on, never a hard dependency. */
+export async function listKnowledgeEntries(): Promise<KnowledgeEntry[]> {
+  const root = covenKnowledgeRoot();
+  let names: string[];
+  try {
+    names = await readdir(root);
+  } catch {
+    return [];
+  }
+  const entries: KnowledgeEntry[] = [];
+  for (const name of names.sort()) {
+    if (!name.endsWith(".md")) continue;
+    const id = name.slice(0, -3);
+    if (!isValidKnowledgeId(id)) continue;
+    try {
+      const raw = await readFile(path.join(root, name), "utf8");
+      entries.push(parseKnowledgeFile(id, raw));
+    } catch {
+      // Skip unreadable entries rather than failing the whole list.
+    }
+  }
+  return entries;
+}
+
+export async function readKnowledgeEntry(id: string): Promise<KnowledgeEntry | null> {
+  if (!isValidKnowledgeId(id)) return null;
+  try {
+    const raw = await readFile(entryPath(id), "utf8");
+    return parseKnowledgeFile(id, raw);
+  } catch {
+    return null;
+  }
+}
+
+export async function writeKnowledgeEntry(entry: KnowledgeEntry): Promise<KnowledgeEntry> {
+  if (!isValidKnowledgeId(entry.id)) throw new Error("invalid knowledge id");
+  const root = covenKnowledgeRoot();
+  await mkdir(root, { recursive: true });
+  await writeFile(entryPath(entry.id), serializeKnowledgeEntry(entry), "utf8");
+  return entry;
+}
+
+export async function deleteKnowledgeEntry(id: string): Promise<boolean> {
+  if (!isValidKnowledgeId(id)) return false;
+  try {
+    await stat(entryPath(id));
+  } catch {
+    return false;
+  }
+  await rm(entryPath(id), { force: true });
+  return true;
+}
+
+/** Convenience for the prompt-construction layer: load the vault and select the
+ *  entries that apply to this familiar. Never throws. */
+export async function readKnowledgeVaultForPrompt(familiarId?: string): Promise<KnowledgeEntry[]> {
+  try {
+    const entries = await listKnowledgeEntries();
+    return selectKnowledgeForFamiliar(entries, familiarId);
+  } catch {
+    return [];
+  }
+}

--- a/src/lib/server/knowledge-vault.ts
+++ b/src/lib/server/knowledge-vault.ts
@@ -49,11 +49,15 @@ export function isValidKnowledgeId(id: unknown): id is string {
 
 /** Derive a safe id from a free-form title (best-effort; may be empty). */
 export function slugifyKnowledgeId(title: string): string {
-  return title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64);
+  // Cap length first, then collapse non-slug runs. The leading/trailing dashes
+  // are trimmed with index walks rather than an anchored `/-+$/` regex, which
+  // backtracks quadratically on long dash runs (ReDoS).
+  const collapsed = title.slice(0, 200).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  let end = collapsed.length;
+  while (start < end && collapsed[start] === "-") start += 1;
+  while (end > start && collapsed[end - 1] === "-") end -= 1;
+  return collapsed.slice(start, end).slice(0, 64);
 }
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -192,7 +196,15 @@ export function buildPromptWithKnowledgeVault(
 // ── Filesystem store ─────────────────────────────────────────────────────────
 
 function entryPath(id: string): string {
-  return path.join(covenKnowledgeRoot(), `${id}.md`);
+  // Single chokepoint where a vault path is built from the (slug-validated) id.
+  // Resolve and assert containment directly under the vault root so a path can
+  // never escape it, even if a caller forgets the id guard.
+  const root = path.resolve(covenKnowledgeRoot());
+  const resolved = path.resolve(root, `${id}.md`);
+  if (!resolved.startsWith(root + path.sep) || path.dirname(resolved) !== root) {
+    throw new Error("invalid knowledge id");
+  }
+  return resolved;
 }
 
 /** List every vault entry on disk. Returns [] when the directory is absent or


### PR DESCRIPTION
## What

Adds a **Knowledge Vault** — curated, human-authored reference knowledge that is injected into **every harness** (claude / codex / hermes / openclaw) at chat time, and is deliberately **separate from the memory system**.

| | Memory | Knowledge Vault |
|---|---|---|
| Author | familiar (auto-written) | you (curated) |
| Lifetime | drifts per day | durable |
| Scope | per-familiar/day | global or familiar allow-list |
| Storage | `~/.coven/.../memory/<date>.md` | `~/.coven/knowledge/<id>.md` |

## The cross-harness tie-in

Every harness is spawned from a single constructed `harnessPrompt` in `src/app/api/chat/send/route.ts` (the OpenClaw bridge and the `coven run` path both consume it). The vault is wrapped onto that prompt via `buildPromptWithKnowledgeVault(...)`, so all harnesses receive the same authoritative `<KNOWLEDGE_VAULT>` block with no per-harness plumbing. The block is clearly labelled as durable reference material, distinct from memory.

## Pieces

- **`src/lib/server/knowledge-vault.ts`** — file-backed store under `~/.coven/knowledge` (override `COVEN_KNOWLEDGE_DIR`); YAML-frontmatter entries with `global`/familiar `scope` + `enabled`; pure `parse`/`serialize`/`select`/`buildPromptWithKnowledgeVault`.
- **`/api/knowledge`** — `GET` (list / `?familiarId=` scoped) · `POST` (upsert) · `DELETE`. The `id` is slug-guarded (`isValidKnowledgeId`) before any path is built → path-injection safe (mirrors the existing memory/notes routes; returns `path not allowed` / 403).
- **chat/send** — loads scoped entries and wraps the constructed prompt.
- **Tests** — `knowledge-vault.test.ts` (unit + temp-dir fs round-trip), `api-contracts` entry, `run-tests.mjs` wiring.
- **Docs** — `docs/knowledge-vault.md`.

## Verification

- `node … src/lib/server/knowledge-vault.test.ts` → ok
- `node … src/app/api/api-contracts.test.ts` → 126 route contracts passed
- `check:tests-wired` → all 576 test files wired
- `tsc --noEmit` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)