### PR TITLE
Fix flow transcript polling 404s

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -482,6 +482,7 @@ export const SUITES = {
     "src/app/api/capabilities/route.test.ts",
     "src/app/api/workflows/route.test.ts",
     "src/app/api/workflows/run/route.test.ts",
+    "src/app/api/flows/session-transcript/route.test.ts",
     "src/lib/cave-chat-titles.test.ts",
     "src/lib/session-title-canon.test.ts",
     "src/lib/chat-model-state.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -53,6 +53,7 @@ const contracts: RouteContract[] = [
   { route: "/flows", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/flows/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/flows/runs", methods: ["GET", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/flows/session-transcript", methods: ["GET"], kind: "json" },
   { route: "/github/comment", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/github/comments", methods: ["GET"], kind: "json" },
   { route: "/github/item", methods: ["GET"], kind: "json" },

--- a/src/app/api/flows/session-transcript/route.test.ts
+++ b/src/app/api/flows/session-transcript/route.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+const hook = await readFile(new URL("../../../../components/flow/use-flow-run.ts", import.meta.url), "utf8");
+
+assert.match(route, /export async function GET\(req: Request\)/, "route should expose a GET handler");
+assert.match(
+  route,
+  /isSafeConversationSessionId\(sessionId\)[\s\S]*status: 400/,
+  "route should reject unsafe session ids",
+);
+assert.match(
+  route,
+  /loadConversation\(sessionId\)[\s\S]*assistantTranscript\(conversation\)[\s\S]*found: true/,
+  "route should read persisted Cave conversations",
+);
+assert.match(
+  route,
+  /loadConversationFromJsonl\(sessionId, familiarId\)[\s\S]*assistantTranscript\(jsonlConversation\)[\s\S]*found: true/,
+  "route should fall back to OpenClaw JSONL transcripts",
+);
+assert.match(
+  route,
+  /NextResponse\.json\(\{ ok: true, transcript: "", found: false \}\)/,
+  "missing flow transcripts should return an empty successful payload instead of HTTP 404",
+);
+assert.match(
+  hook,
+  /\/api\/flows\/session-transcript\?\$\{params\.toString\(\)\}/,
+  "flow polling should use the no-404 transcript endpoint",
+);
+assert.doesNotMatch(
+  hook,
+  /\/api\/chat\/conversation\//,
+  "flow polling should not fetch missing chat conversations directly",
+);
+
+console.log("flows session-transcript route.test.ts: ok");

--- a/src/app/api/flows/session-transcript/route.ts
+++ b/src/app/api/flows/session-transcript/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { isSafeConversationSessionId, loadConversation } from "../../../../lib/cave-conversations.ts";
+import { loadState } from "../../../../lib/cave-config.ts";
+import { loadConversationFromJsonl } from "../../../../lib/openclaw-conversation.ts";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function assistantTranscript(conversation: { turns?: Array<{ role?: string; text?: string }> } | null): string {
+  return (conversation?.turns ?? [])
+    .filter((turn) => turn.role === "assistant")
+    .map((turn) => turn.text ?? "")
+    .join("\n");
+}
+
+/**
+ * Flow execution polling endpoint. A live flow run can have a daemon session id
+ * before Cave has a persisted conversation or OpenClaw JSONL transcript for it.
+ * Return an empty 200 in that normal gap so browser polling does not emit 404
+ * resource errors while the session is still coming up.
+ */
+export async function GET(req: Request) {
+  const sessionId = new URL(req.url).searchParams.get("sessionId") ?? "";
+  if (!isSafeConversationSessionId(sessionId)) {
+    return NextResponse.json({ ok: false, error: "invalid session id" }, { status: 400 });
+  }
+
+  const conversation = await loadConversation(sessionId);
+  if (conversation) {
+    return NextResponse.json({ ok: true, transcript: assistantTranscript(conversation), found: true });
+  }
+
+  const state = await loadState();
+  const familiarId = state.sessionFamiliar[sessionId];
+  if (familiarId) {
+    const jsonlConversation = await loadConversationFromJsonl(sessionId, familiarId);
+    if (jsonlConversation) {
+      return NextResponse.json({ ok: true, transcript: assistantTranscript(jsonlConversation), found: true });
+    }
+  }
+
+  return NextResponse.json({ ok: true, transcript: "", found: false });
+}

--- a/src/components/flow/use-flow-run.ts
+++ b/src/components/flow/use-flow-run.ts
@@ -16,8 +16,7 @@ const EMPTY: FlowRunProgress = {
 
 /**
  * Live node-phase progress for an active flow run. Polls the run's agent
- * session transcript (the same `/api/chat/conversation/[id]` endpoint the
- * Workflow Studio uses) and parses the `@@step-…` markers into per-node phases.
+ * session transcript and parses the `@@step-…` markers into per-node phases.
  * Polling stops once the run is no longer `running` or every node has resolved,
  * keeping the last parsed phases so the canvas holds the finished state.
  */
@@ -35,19 +34,16 @@ export function useFlowRun(run: FlowRunRecord | null): FlowRunProgress {
     let timer: ReturnType<typeof setTimeout> | null = null;
     const tick = async () => {
       try {
-        const res = await fetch(`/api/chat/conversation/${encodeURIComponent(sessionId)}`, {
+        const params = new URLSearchParams({ sessionId });
+        const res = await fetch(`/api/flows/session-transcript?${params.toString()}`, {
           cache: "no-store",
         });
         const json = (await res.json().catch(() => null)) as
-          | { ok?: boolean; conversation?: { turns?: Array<{ role?: string; text?: string }> } }
+          | { ok?: boolean; transcript?: string }
           | null;
         if (!alive) return;
-        if (json?.ok && Array.isArray(json.conversation?.turns)) {
-          const text = json.conversation.turns
-            .filter((turn) => turn.role === "assistant")
-            .map((turn) => turn.text ?? "")
-            .join("\n");
-          setTranscript(text);
+        if (json?.ok && typeof json.transcript === "string") {
+          setTranscript(json.transcript);
         }
       } catch {
         // transient — keep the last transcript and retry on the next tick


### PR DESCRIPTION
## Summary
- Add a flow transcript polling endpoint that returns an empty 200 while a session transcript has not materialized yet.
- Point flow run progress polling at that endpoint instead of the chat conversation route.
- Add the endpoint/hook contract test to CI wiring.

## Test Plan
- node --experimental-strip-types src/app/api/flows/session-transcript/route.test.ts
- pnpm check:tests-wired
- git diff --check
- pnpm exec tsc --noEmit --pretty false --incremental false