### PR TITLE
fix(ios): reader view 404 — preserve query strings in CaveClient.request

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -20,7 +20,23 @@ struct CaveClient {
     }
 
     private func request(_ path: String, method: String = "GET", body: Data? = nil) throws -> URLRequest {
-        let url = try base.appendingPathComponent(path)
+        // `appendingPathComponent` percent-encodes "?" to "%3F", which turns a
+        // path like "api/journal?date=…" into a bogus path segment the server
+        // 404s on. Split the query off, append only the path, then reattach the
+        // query as a real query string. Callers already percent-encode values
+        // (urlQuery), so set `percentEncodedQuery` to avoid double-encoding.
+        let parts = path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+        let pathPart = String(parts[0])
+        let queryPart = parts.count > 1 ? String(parts[1]) : nil
+        var url = try base.appendingPathComponent(pathPart)
+        if let queryPart, !queryPart.isEmpty {
+            guard var comps = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+                throw CaveError.notConfigured
+            }
+            comps.percentEncodedQuery = queryPart
+            guard let composed = comps.url else { throw CaveError.notConfigured }
+            url = composed
+        }
         var req = URLRequest(url: url)
         req.httpMethod = method
         req.setValue("application/json", forHTTPHeaderField: "Accept")

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -109,6 +109,7 @@ export const SUITES = {
     "src/components/home-composer.test.ts",
     "src/components/home-composer-centering.test.ts",
     "src/components/ios-theme-api.test.ts",
+    "src/components/ios-query-url.test.ts",
     "src/components/chat-all-familiars-project-list.test.ts",
     "src/components/chat-list-delete.test.ts",
     "src/components/chat-list-collapse.test.ts",

--- a/src/components/ios-query-url.test.ts
+++ b/src/components/ios-query-url.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+// Regression guard for the iOS reader-view 404 ("Couldn't load this entry —
+// Server returned status 404"). CaveClient.request() used
+// `base.appendingPathComponent(path)`, which percent-encodes "?" to "%3F" — so
+// "api/journal?date=…" became the bogus path "/api/journal%3Fdate=…" that the
+// server 404s on. The builder must split the query off the path and reattach it
+// as a real query string. iOS isn't compiled in CI, so this source-text test is
+// the guard.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const client = readFileSync(
+  new URL("../../apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift", import.meta.url),
+  "utf8",
+);
+
+const requestFn = client.match(/private func request\([\s\S]*?\n    \}/)?.[0] ?? "";
+assert.ok(requestFn, "CaveClient.request(_:) must exist");
+
+// The query must be split off the path before path-appending…
+assert.match(
+  requestFn,
+  /split\(separator:\s*"\?",\s*maxSplits:\s*1/,
+  "request() must split the query string off the path",
+);
+// …only the path part is appended as a path component…
+assert.match(
+  requestFn,
+  /appendingPathComponent\(pathPart\)/,
+  "request() must append only the path part (not the raw query-bearing path)",
+);
+// …and the query is reattached without double-encoding.
+assert.match(
+  requestFn,
+  /percentEncodedQuery\s*=\s*queryPart/,
+  "request() must reattach the query via percentEncodedQuery",
+);
+// The old bug — appending the whole raw `path` (with its "?") — must be gone.
+assert.doesNotMatch(
+  requestFn,
+  /appendingPathComponent\(path\)/,
+  "request() must not append the raw query-bearing path (the 404 cause)",
+);
+
+// The journal reader still requests the query-string form that this fix repairs.
+assert.match(
+  client,
+  /request\("api\/journal\?date=\\\(urlQuery\(date\)\)"\)/,
+  "journalDay still builds api/journal?date=…",
+);
+
+console.log("ios-query-url.test.ts: ok");


### PR DESCRIPTION
## Problem

Opening a dated entry in the iOS app (e.g. **"Saturday, June 20"**) failed with **"Couldn't load this entry — Server returned status 404."**

## Cause

`CaveClient.request(_:)` built URLs with `base.appendingPathComponent(path)`, which percent-encodes `?` → `%3F`. So `"api/journal?date=2026-06-20"` became the path **`/api/journal%3Fdate=2026-06-20`** — which matches no route, so Next.js returns **404**. The same bug hit any client call with a query string (`sessions(includeArchived:)`, `chatModelState(...)`).

## Fix

At the shared `request()` chokepoint: split the query off the path, append only the path component, then reattach the query via `URLComponents.percentEncodedQuery`. Callers already percent-encode values (`urlQuery`), so this avoids double-encoding. One change fixes `journalDay`, `sessions`, and `chatModelState`.

## Verification
- `xcodegen generate && xcodebuild -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED** (the SourceKit "cannot find type" noise is single-file false-positive analysis).
- iOS isn't compiled in CI, so **`ios-query-url.test.ts`** guards the request builder as a source-text test (wired into the `app` suite); full `test:app` green.

3 files, +70 / −1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)