### PR TITLE
feat(ios): world-class Settings redesign + push-to-desktop theme override

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -386,9 +386,29 @@ struct CaveClient {
 
     /// `GET /api/theme` — the desktop's active theme + resolved colour tokens, so
     /// the app chrome can match the desktop appearance. Same connection as
-    /// `api/familiars` etc.; one-way (desktop → iOS).
+    /// `api/familiars` etc.
     func fetchTheme() async throws -> ThemeSnapshot {
         let req = try request("api/theme")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(ThemeResponse.self, from: data).theme
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// `PUT /api/theme` — override the desktop's active theme from the phone.
+    /// Sends only `{themeId, mode}`: the phone can't resolve the desktop's
+    /// `oklch` / `color-mix` tokens to hex, so it names the preset and lets the
+    /// desktop adopt it and re-publish the resolved tokens — which the app then
+    /// picks up on its next `fetchTheme` poll for full-fidelity chrome. Returns
+    /// the saved snapshot.
+    @discardableResult
+    func publishTheme(themeId: String, mode: String) async throws -> ThemeSnapshot {
+        struct Body: Encodable { let themeId: String; let mode: String }
+        let payload = try JSONEncoder().encode(Body(themeId: themeId, mode: mode))
+        let req = try request("api/theme", method: "PUT", body: payload)
         let (data, resp) = try await session.data(for: req)
         try Self.check(resp)
         do {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -123,8 +123,19 @@ final class AppModel {
 
     /// App-chrome palette mirrored from the desktop's published theme
     /// (`GET /api/theme`). Starts at the built-in look and is replaced once the
-    /// desktop theme loads. One-way (desktop → iOS), per the design.
+    /// desktop theme loads.
     var chrome: ChromePalette = .fallback
+
+    /// The desktop's currently-published theme id + light/dark mode, mirrored
+    /// from the last `GET /api/theme`. Drives the Settings theme picker's
+    /// selected state so the active card is highlighted. `nil` until a theme
+    /// loads (disconnected / pre-poll).
+    var publishedThemeId: String?
+    var publishedMode: String?
+
+    /// True while a phone-initiated theme override is in flight, so the picker
+    /// can show progress and ignore double-taps.
+    var publishingTheme = false
 
     /// Fetch the desktop theme and adopt its palette. Best-effort: on any
     /// failure the current palette stands, so there's no flash back to the
@@ -132,9 +143,42 @@ final class AppModel {
     func loadTheme() async {
         guard let client else { return }
         if let snapshot = try? await client.fetchTheme() {
-            let next = ChromePalette(snapshot: snapshot)
-            if next != chrome { chrome = next }
+            adopt(snapshot)
         }
+    }
+
+    /// Apply a fetched/published snapshot: refresh the chrome palette and record
+    /// the active theme id + mode for the picker. Only assigns on change so an
+    /// unchanged poll stays a cheap no-op (no needless view invalidation).
+    private func adopt(_ snapshot: ThemeSnapshot) {
+        let next = ChromePalette(snapshot: snapshot)
+        if next != chrome { chrome = next }
+        if publishedThemeId != snapshot.themeId { publishedThemeId = snapshot.themeId }
+        if publishedMode != snapshot.mode { publishedMode = snapshot.mode }
+    }
+
+    /// Override the desktop's active theme from the phone (`PUT /api/theme`).
+    /// The desktop adopts the preset and re-publishes resolved tokens; we adopt
+    /// the returned snapshot immediately so the phone re-themes without waiting
+    /// for the next 20s poll. Best-effort — a failed write leaves the current
+    /// theme untouched and surfaces `false` so the caller can flag it.
+    @discardableResult
+    func setDesktopTheme(themeId: String, mode: String) async -> Bool {
+        guard let client else { return false }
+        publishingTheme = true
+        defer { publishingTheme = false }
+        guard let snapshot = try? await client.publishTheme(themeId: themeId, mode: mode) else {
+            return false
+        }
+        adopt(snapshot)
+        // The desktop resolves the real hex tokens asynchronously after it
+        // adopts; re-poll shortly so the phone upgrades from the preset's
+        // bundled swatch to the desktop's exact palette.
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(1))
+            await self?.loadTheme()
+        }
+        return true
     }
 
     var client: CaveClient? {

--- a/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+/// The desktop's named-theme roster, mirrored on-device so the iOS Settings
+/// theme picker can render a faithful swatch for each preset *before* a token
+/// payload arrives. When the user taps a card we publish `{themeId, mode}` to
+/// the desktop (`PUT /api/theme`); the desktop adopts it and re-publishes the
+/// resolved hex tokens, which the app then adopts in full fidelity on its next
+/// poll. So these swatches only need to be representative, not pixel-exact.
+///
+/// SOURCE OF TRUTH: `src/lib/theme-palettes.ts` (`THEME_IDS` + `THEME_META`).
+/// Names, blurbs, and accent hexes are copied verbatim from there. The two
+/// background hexes per theme are the sRGB resolution of that module's
+/// `bgDark` / `bgLight` (its `oklch(…)` values rasterised to `#RRGGBB`, since
+/// SwiftUI's `Color(hex:)` can't parse `oklch`). Keep this list in lockstep
+/// with the TypeScript roster — `ios-theme-override.test.ts` asserts the ids
+/// here match `THEME_IDS` so a new desktop theme can't silently go missing.
+struct ThemeOption: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let blurb: String
+    private let accentDark: String
+    private let accentLight: String
+    private let bgDark: String
+    private let bgLight: String
+
+    init(_ id: String, _ name: String, _ blurb: String,
+         accentDark: String, accentLight: String, bgDark: String, bgLight: String) {
+        self.id = id
+        self.name = name
+        self.blurb = blurb
+        self.accentDark = accentDark
+        self.accentLight = accentLight
+        self.bgDark = bgDark
+        self.bgLight = bgLight
+    }
+
+    /// The brand accent for the given scheme — used for the swatch ring, the
+    /// selected check, and the mini "Aa" glyph on each card.
+    func accent(_ scheme: ColorScheme) -> Color {
+        Color(hex: scheme == .light ? accentLight : accentDark) ?? .accentColor
+    }
+
+    /// The canvas colour for the given scheme — fills the swatch card so each
+    /// theme reads as its true light/dark surface, not a neutral chip.
+    func background(_ scheme: ColorScheme) -> Color {
+        Color(hex: scheme == .light ? bgLight : bgDark)
+            ?? Color(uiColor: scheme == .light ? .systemBackground : .black)
+    }
+}
+
+enum ThemeRoster {
+    /// All 16 desktop presets, in the desktop's roster order.
+    static let all: [ThemeOption] = [
+        .init("coven", "Coven", "Lavender-inked grimoire. The house default.",
+              accentDark: "#9a8ecd", accentLight: "#6F62A8", bgDark: "#08060f", bgLight: "#f7f5fe"),
+        .init("tide", "Tide", "Moontide blue. Cold, deliberate, underwater.",
+              accentDark: "#5FB0FF", accentLight: "#2E6FC9", bgDark: "#00040d", bgLight: "#eaf7ff"),
+        .init("grove", "Grove", "Hexenwald moss. Damp, patient, full of teeth.",
+              accentDark: "#7FD89F", accentLight: "#2A8050", bgDark: "#000600", bgLight: "#eef9ee"),
+        .init("ember", "Vintage Paper", "Sun-faded folio. Warm tan ink on aged paper.",
+              accentDark: "#c0a080", accentLight: "#a67c52", bgDark: "#2d2621", bgLight: "#f5f1e6"),
+        .init("bloom", "Bloom", "Bewitching-blood rose. Sweet looks; thorned hands.",
+              accentDark: "#F09BB1", accentLight: "#BE506E", bgDark: "#100102", bgLight: "#fff2f2"),
+        .init("dusk", "Dusk", "Witching-hour magenta. The veil thins.",
+              accentDark: "#E175FF", accentLight: "#9930C2", bgDark: "#09000c", bgLight: "#fdf0fd"),
+        .init("mist", "Mist", "Scrying-pool teal. Cold as a question.",
+              accentDark: "#6BD8D3", accentLight: "#1A857F", bgDark: "#000405", bgLight: "#eaf9f8"),
+        .init("hex", "Hex", "Bloodletter's brand. The mark that won't wash off.",
+              accentDark: "#E04848", accentLight: "#A41C24", bgDark: "#0f0000", bgLight: "#fff0ee"),
+        .init("bane", "Bane", "Wolfsbane bloom. Bright; deeply unwise.",
+              accentDark: "#A5F050", accentLight: "#4A7C18", bgDark: "#010300", bgLight: "#f2f8e8"),
+        .init("slate", "Slate", "Ink-and-bone monochrome. No colour. No mercy.",
+              accentDark: "#B8B8C2", accentLight: "#525258", bgDark: "#000000", bgLight: "#fafafa"),
+        .init("ghosty", "Ghosty", "Spectral grayscale. Quiet as a haunt.",
+              accentDark: "#a6a6a6", accentLight: "#808080", bgDark: "#1a1a1a", bgLight: "#fafafa"),
+        .init("claymorphism", "Claymorphism", "Soft-molded stone with indigo glaze.",
+              accentDark: "#818cf8", accentLight: "#6366f1", bgDark: "#1e1b18", bgLight: "#e7e5e4"),
+        .init("claude", "Claude", "Warm parchment, muted ink, burnt-clay primary.",
+              accentDark: "#d97757", accentLight: "#c96442", bgDark: "#262624", bgLight: "#faf9f5"),
+        .init("pastel-dreams", "Pastel Dreams", "Soft violet pastels, lifted surfaces.",
+              accentDark: "#c0aafd", accentLight: "#a78bfa", bgDark: "#1c1917", bgLight: "#f7f3f9"),
+        .init("meatseeks", "Meatseeks", "Supabase green over crisp utility surfaces.",
+              accentDark: "#006239", accentLight: "#72e3ad", bgDark: "#121212", bgLight: "#fcfcfc"),
+        .init("trucker", "Trucker", "Roadside evergreen, blacktop panels, cab lights.",
+              accentDark: "#005735", accentLight: "#005735", bgDark: "#020504", bgLight: "#f5fcf9"),
+    ]
+
+    /// Look up a theme by id, for resolving the published `themeId` to a name.
+    static func option(id: String?) -> ThemeOption? {
+        guard let id else { return nil }
+        return all.first { $0.id == id }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -2,11 +2,16 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @State private var editingHost: String = ""
     @State private var showDisconnectConfirm = false
     @State private var exportArchive: ExportArchive?
     @State private var exportFailed = false
+    @State private var themeError = false
+    /// Light/Dark used both to preview the theme swatches and as the mode pushed
+    /// to the desktop. Seeded from the desktop's published mode on appear.
+    @State private var pushMode: ColorScheme = .dark
 
     /// Marketing version + build, e.g. "1.2.0 (34)", read from the bundle.
     private var appVersion: String {
@@ -19,81 +24,27 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section {
-                    Button {
-                        do {
-                            exportArchive = ExportArchive(url: try app.exportAllThreadsZip())
-                        } catch {
-                            exportFailed = true
-                        }
-                    } label: {
-                        Label("Export all chats", systemImage: "square.and.arrow.up.on.square")
-                            .foregroundStyle(.primary)
-                    }
-                    .disabled(app.threads.isEmpty)
-                } header: {
-                    Text("Chats")
-                } footer: {
-                    Text("Save every conversation as Markdown files in a single .zip.")
-                }
-
-                Section {
-                    Picker(selection: $appearanceRaw) {
-                        ForEach(AppearanceMode.allCases) { mode in
-                            Label(mode.label, systemImage: mode.icon).tag(mode.rawValue)
-                        }
-                    } label: {
-                        Label("Appearance", systemImage: "circle.lefthalf.filled")
-                    }
-                } header: {
-                    Text("Appearance")
-                } footer: {
-                    Text("“Match desktop” follows your Cave desktop's light/dark mode. Light or Dark sets it just on this phone.")
-                }
-
-                Section("Desktop") {
-                    LabeledContent("Address") {
-                        Text(app.connection?.host ?? "—")
-                            .font(.callout.monospaced())
-                            .foregroundStyle(.secondary)
-                    }
-                    LabeledContent("Status") { statusBadge }
-                    Button("Re-check connection") {
-                        Task { await app.refreshConnection() }
-                    }
-                }
-
-                Section("Change host") {
-                    TextField("my-mac.tailnet.ts.net", text: $editingHost)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .keyboardType(.URL)
-                    Button("Save and Reconnect") {
-                        Task { await app.configure(host: editingHost) }
-                    }
-                    .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty)
-                }
-
-                Section {
-                    Button("Disconnect", role: .destructive) {
-                        showDisconnectConfirm = true
-                    }
-                } footer: {
-                    Text("Connection is trusted via your Tailscale network — there is no token or password to manage.")
-                }
-
-                Section("About") {
-                    LabeledContent("Version") {
-                        Text(appVersion)
-                            .font(.callout.monospaced())
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                connectionCard
+                themeSection
+                appearanceSection
+                chatsSection
+                hostSection
+                disconnectSection
+                aboutSection
             }
             .themedListBackground()
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
-            .onAppear { editingHost = app.connection?.host ?? "" }
+            .onAppear {
+                editingHost = app.connection?.host ?? ""
+                pushMode = (app.publishedMode ?? (chrome.colorScheme == .light ? "light" : "dark")) == "light" ? .light : .dark
+            }
+            .onChange(of: app.publishedMode) { _, mode in
+                // Keep the preview/push mode in step when the desktop flips mode
+                // from elsewhere, so the swatches and selection stay truthful.
+                guard let mode else { return }
+                pushMode = mode == "light" ? .light : .dark
+            }
             .confirmationDialog("Disconnect from your desktop?",
                                 isPresented: $showDisconnectConfirm,
                                 titleVisibility: .visible) {
@@ -108,19 +59,281 @@ struct SettingsView: View {
             .alert("Couldn't export chats", isPresented: $exportFailed) {
                 Button("OK", role: .cancel) {}
             }
+            .alert("Couldn't change the theme", isPresented: $themeError) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Your desktop didn't confirm the change. Check the connection and try again.")
+            }
         }
     }
 
-    @ViewBuilder private var statusBadge: some View {
-        switch app.connectionState {
-        case .connected:
-            Label("Connected", systemImage: "checkmark.circle.fill").foregroundStyle(.green)
-        case .checking:
-            Label("Checking…", systemImage: "clock").foregroundStyle(.secondary)
-        case .unreachable:
-            Label("Unreachable", systemImage: "exclamationmark.triangle.fill").foregroundStyle(.orange)
-        case .unconfigured:
-            Label("Not set up", systemImage: "circle").foregroundStyle(.secondary)
+    // MARK: - Connection hero
+
+    /// A glanceable header card: a themed glyph, the desktop host, and a live
+    /// status pill — so the most important state (am I connected?) reads at once
+    /// instead of buried in a labelled row.
+    private var connectionCard: some View {
+        Section {
+            HStack(spacing: 14) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(chrome.accent.opacity(0.18))
+                    Image(systemName: "desktopcomputer")
+                        .font(.title2)
+                        .foregroundStyle(chrome.accent)
+                }
+                .frame(width: 52, height: 52)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Your desktop")
+                        .font(.headline)
+                    Text(app.connection?.host ?? "Not set up")
+                        .font(.footnote.monospaced())
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    statusBadge.padding(.top, 2)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 6)
+            .listRowBackground(chrome.bgRaised.opacity(0.6))
+        } footer: {
+            Text("Connected over your Tailscale network — no token or password to manage.")
         }
+    }
+
+    // MARK: - Theme (overrides the desktop)
+
+    /// The headline feature: pick any of the desktop's named themes from the
+    /// phone. Selecting one publishes it to the desktop (`PUT /api/theme`), which
+    /// adopts it and re-publishes the resolved palette — so both the Mac and this
+    /// phone re-theme together within a couple of seconds.
+    private var themeSection: some View {
+        Section {
+            Picker("Mode", selection: $pushMode) {
+                Label("Light", systemImage: "sun.max.fill").tag(ColorScheme.light)
+                Label("Dark", systemImage: "moon.fill").tag(ColorScheme.dark)
+            }
+            .pickerStyle(.segmented)
+            .listRowBackground(chrome.bgRaised.opacity(0.4))
+            .onChange(of: pushMode) { _, scheme in
+                let mode = scheme == .light ? "light" : "dark"
+                // Only push when this is a genuine flip away from the desktop's
+                // current mode (not the initial sync from `publishedMode`), and
+                // only if a theme is already active to carry into the new mode.
+                guard mode != app.publishedMode, let id = app.publishedThemeId else { return }
+                Haptics.tap()
+                push(themeId: id, mode: mode)
+            }
+
+            ThemeGrid(
+                mode: pushMode,
+                selectedId: app.publishedThemeId,
+                isBusy: app.publishingTheme
+            ) { id in
+                let mode = pushMode == .light ? "light" : "dark"
+                guard id != app.publishedThemeId || mode != app.publishedMode else { return }
+                Haptics.tap()
+                push(themeId: id, mode: mode)
+            }
+            .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+            .listRowBackground(Color.clear)
+        } header: {
+            Text("Theme")
+        } footer: {
+            Text("Sets the palette for your Cave desktop **and** this phone. Your desktop must be open; it updates within a few seconds.")
+        }
+    }
+
+    private func push(themeId: String, mode: String) {
+        Task {
+            let ok = await app.setDesktopTheme(themeId: themeId, mode: mode)
+            if ok { Haptics.success() } else { Haptics.error(); themeError = true }
+        }
+    }
+
+    // MARK: - Appearance (this phone only)
+
+    private var appearanceSection: some View {
+        Section {
+            Picker(selection: $appearanceRaw) {
+                ForEach(AppearanceMode.allCases) { mode in
+                    Label(mode.label, systemImage: mode.icon).tag(mode.rawValue)
+                }
+            } label: {
+                Label("Light / Dark", systemImage: "circle.lefthalf.filled")
+            }
+        } header: {
+            Text("On this phone")
+        } footer: {
+            Text("“Match desktop” follows your Cave desktop's light/dark mode. Light or Dark fixes it on this phone only — handy when you're outdoors and the desktop is dark.")
+        }
+    }
+
+    // MARK: - Chats
+
+    private var chatsSection: some View {
+        Section {
+            Button {
+                do {
+                    exportArchive = ExportArchive(url: try app.exportAllThreadsZip())
+                } catch {
+                    exportFailed = true
+                }
+            } label: {
+                Label("Export all chats", systemImage: "square.and.arrow.up.on.square")
+                    .foregroundStyle(.primary)
+            }
+            .disabled(app.threads.isEmpty)
+        } header: {
+            Text("Chats")
+        } footer: {
+            Text("Save every conversation as Markdown files in a single .zip.")
+        }
+    }
+
+    // MARK: - Change host
+
+    private var hostSection: some View {
+        Section {
+            LabeledContent("Status") { statusBadge }
+            Button("Re-check connection") {
+                Task { await app.refreshConnection() }
+            }
+            TextField("my-mac.tailnet.ts.net", text: $editingHost)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .font(.callout.monospaced())
+            Button("Save and reconnect") {
+                Task { await app.configure(host: editingHost) }
+            }
+            .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
+                      || editingHost == app.connection?.host)
+        } header: {
+            Text("Connection")
+        } footer: {
+            Text("Change this if your desktop's Tailscale name changes.")
+        }
+    }
+
+    private var disconnectSection: some View {
+        Section {
+            Button("Disconnect", role: .destructive) {
+                showDisconnectConfirm = true
+            }
+        }
+    }
+
+    private var aboutSection: some View {
+        Section("About") {
+            LabeledContent("Version") {
+                Text(appVersion)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    private var statusBadge: some View {
+        Group {
+            switch app.connectionState {
+            case .connected:
+                Label("Connected", systemImage: "checkmark.circle.fill").foregroundStyle(.green)
+            case .checking:
+                Label("Checking…", systemImage: "clock").foregroundStyle(.secondary)
+            case .unreachable:
+                Label("Unreachable", systemImage: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+            case .unconfigured:
+                Label("Not set up", systemImage: "circle").foregroundStyle(.secondary)
+            }
+        }
+        .font(.subheadline)
+    }
+}
+
+// MARK: - Theme picker grid
+
+/// A responsive grid of theme swatch cards. Each card paints the theme's true
+/// canvas colour with an accent sample, so the roster reads like a row of real
+/// palettes rather than a list of names. The selected card is ringed in its own
+/// accent and badged with a check.
+private struct ThemeGrid: View {
+    let mode: ColorScheme
+    let selectedId: String?
+    let isBusy: Bool
+    let onSelect: (String) -> Void
+
+    private let columns = [GridItem(.adaptive(minimum: 104), spacing: 12)]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(ThemeRoster.all) { theme in
+                ThemeSwatchCard(
+                    theme: theme,
+                    mode: mode,
+                    isSelected: theme.id == selectedId
+                ) { onSelect(theme.id) }
+                .disabled(isBusy)
+            }
+        }
+    }
+}
+
+private struct ThemeSwatchCard: View {
+    let theme: ThemeOption
+    let mode: ColorScheme
+    let isSelected: Bool
+    let action: () -> Void
+
+    private var accent: Color { theme.accent(mode) }
+    private var background: Color { theme.background(mode) }
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 0) {
+                ZStack(alignment: .topTrailing) {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(background)
+                        .frame(height: 62)
+                        .overlay(alignment: .bottomLeading) {
+                            HStack(spacing: 6) {
+                                Circle().fill(accent).frame(width: 16, height: 16)
+                                Text("Aa")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(accent)
+                            }
+                            .padding(10)
+                        }
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .strokeBorder(isSelected ? accent : Color.primary.opacity(0.12),
+                                              lineWidth: isSelected ? 2.5 : 1)
+                        }
+
+                    if isSelected {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.body)
+                            .foregroundStyle(accent)
+                            .background(Circle().fill(background).padding(1))
+                            .padding(6)
+                            .transition(.scale.combined(with: .opacity))
+                    }
+                }
+
+                Text(theme.name)
+                    .font(.caption.weight(isSelected ? .semibold : .regular))
+                    .foregroundStyle(isSelected ? .primary : .secondary)
+                    .lineLimit(1)
+                    .padding(.top, 6)
+            }
+        }
+        .buttonStyle(.plain)
+        .animation(.easeOut(duration: 0.18), value: isSelected)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(theme.name)
+        .accessibilityHint(theme.blurb)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -110,6 +110,8 @@ export const SUITES = {
     "src/components/home-feed.test.ts",
     "src/components/home-composer-centering.test.ts",
     "src/components/ios-theme-api.test.ts",
+    "src/components/ios-theme-override.test.ts",
+    "src/components/remote-theme-controller.test.ts",
     "src/components/ios-query-url.test.ts",
     "src/components/chat-all-familiars-project-list.test.ts",
     "src/components/chat-list-delete.test.ts",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { ReadingWeightController } from "@/components/reading-weight-controller"
 import { ReadingHyphensController } from "@/components/reading-hyphens-controller";
 import { ReadingDropcapController } from "@/components/reading-dropcap-controller";
 import { CornerRadiusController } from "@/components/corner-radius-controller";
+import { RemoteThemeController } from "@/components/remote-theme-controller";
 import { ThemeScript } from "@/components/theme-script";
 import { ShellBannersProvider } from "@/lib/shell-banners";
 import { LiveRegionProvider } from "@/components/ui/live-region";
@@ -83,6 +84,7 @@ export default function RootLayout({
             <ReadingHyphensController />
             <ReadingDropcapController />
             <CornerRadiusController />
+            <RemoteThemeController />
             <PwaRegister />
             {children}
             </ConfirmProvider>

--- a/src/components/ios-theme-override.test.ts
+++ b/src/components/ios-theme-override.test.ts
@@ -1,0 +1,86 @@
+// @ts-nocheck
+// Pins the iOS "override the desktop theme from your phone" contract: the iOS
+// theme roster mirrors the desktop's THEME_IDS, the client can PUT a theme, the
+// app model publishes + adopts it, and the redesigned Settings page exposes the
+// theme picker. iOS Swift isn't compiled in CI, so these source-text assertions
+// are the guard that keeps the Swift side honest with the web contract.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { THEME_IDS } from "../lib/theme-palettes.ts";
+
+const base = new URL("../../apps/ios/CovenCave/CovenCave/", import.meta.url);
+const read = (p: string) => readFileSync(new URL(p, base), "utf8");
+
+const roster = read("Theme/ThemeRoster.swift");
+const client = read("Networking/CaveClient.swift");
+const appModel = read("State/AppModel.swift");
+const settings = read("Views/SettingsView.swift");
+
+// ── Roster parity ────────────────────────────────────────────────────────────
+// Every desktop preset must have a card (and vice-versa) so a theme the phone
+// pushes is one the desktop actually knows, and no theme silently goes missing.
+const rosterIds = [...roster.matchAll(/\.init\("([a-z-]+)",/g)].map((m) => m[1]);
+assert.deepEqual(
+  rosterIds,
+  [...THEME_IDS],
+  "ThemeRoster.all must list the same theme ids, in the same order, as the desktop THEME_IDS",
+);
+assert.match(
+  roster,
+  /func accent\(_ scheme: ColorScheme\) -> Color[\s\S]*func background\(_ scheme: ColorScheme\) -> Color/,
+  "each ThemeOption exposes accent + background per light/dark scheme for its swatch",
+);
+
+// ── CaveClient can push a theme to the desktop ───────────────────────────────
+assert.match(
+  client,
+  /func publishTheme\(themeId: String, mode: String\) async throws -> ThemeSnapshot[\s\S]*request\("api\/theme", method: "PUT"/,
+  "CaveClient.publishTheme PUTs {themeId, mode} to /api/theme",
+);
+
+// ── AppModel publishes + optimistically adopts ───────────────────────────────
+assert.match(
+  appModel,
+  /var publishedThemeId: String\?/,
+  "AppModel tracks the desktop's published theme id for the picker selection",
+);
+assert.match(
+  appModel,
+  /func setDesktopTheme\(themeId: String, mode: String\) async -> Bool[\s\S]*client\.publishTheme\(themeId: themeId, mode: mode\)[\s\S]*adopt\(snapshot\)/,
+  "AppModel.setDesktopTheme pushes the theme then adopts the returned snapshot",
+);
+
+// ── Settings exposes the theme picker that overrides the desktop ─────────────
+assert.match(
+  settings,
+  /ThemeGrid\(/,
+  "SettingsView renders the theme picker grid",
+);
+assert.match(
+  settings,
+  /ForEach\(ThemeRoster\.all\)/,
+  "the theme grid is driven by the shared roster",
+);
+assert.match(
+  settings,
+  /app\.setDesktopTheme\(themeId: [^,]+, mode: [^)]+\)/,
+  "tapping a theme card pushes it to the desktop",
+);
+assert.match(
+  settings,
+  /selectedId: app\.publishedThemeId/,
+  "the active card reflects the desktop's currently-published theme",
+);
+assert.match(
+  settings,
+  /\.pickerStyle\(\.segmented\)/,
+  "a Light/Dark segmented control drives the previewed + pushed mode",
+);
+assert.match(
+  settings,
+  /accessibilityAddTraits\(isSelected \? \[\.isButton, \.isSelected\] : \.isButton\)/,
+  "theme swatch cards expose their selected state to VoiceOver",
+);
+
+console.log("ios-theme-override.test.ts: ok");

--- a/src/components/remote-theme-controller.test.ts
+++ b/src/components/remote-theme-controller.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+// Pins the desktop side of "override the desktop theme from your phone": the
+// RemoteThemeController polls GET /api/theme, adopts a remote preset that
+// differs from what's applied, guards against clobbering itself / custom themes,
+// and is mounted app-wide in the root layout.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const controller = await readFile(
+  new URL("./remote-theme-controller.tsx", import.meta.url),
+  "utf8",
+);
+const layout = await readFile(new URL("../app/layout.tsx", import.meta.url), "utf8");
+
+// ── Mounted globally (not just on Settings) ──────────────────────────────────
+assert.match(
+  layout,
+  /import \{ RemoteThemeController \} from "@\/components\/remote-theme-controller"/,
+  "root layout imports the remote-theme controller",
+);
+assert.match(
+  layout,
+  /<RemoteThemeController \/>/,
+  "root layout mounts RemoteThemeController so theme overrides apply on every surface",
+);
+
+// ── Polls and adopts ─────────────────────────────────────────────────────────
+assert.match(controller, /"use client"/, "controller runs on the client");
+assert.match(
+  controller,
+  /fetch\("\/api\/theme", \{ cache: "no-store" \}\)/,
+  "controller polls GET /api/theme without caching",
+);
+assert.match(
+  controller,
+  /setInterval\(\(\) => void reconcile\(\), POLL_MS\)/,
+  "controller reconciles on an interval",
+);
+assert.match(
+  controller,
+  /addEventListener\("visibilitychange"/,
+  "controller also reconciles when the tab becomes visible again",
+);
+assert.match(
+  controller,
+  /applyRemoteTheme\(snap\.themeId, mode\)/,
+  "a differing remote preset is applied to the DOM",
+);
+assert.match(
+  controller,
+  /setAttribute\("data-theme", themeId\)[\s\S]*setAttribute\("data-mode", mode\)/,
+  "applying a theme sets both data-theme and data-mode",
+);
+
+// ── Loop / clobber safety ────────────────────────────────────────────────────
+assert.match(
+  controller,
+  /if \(!isPreset\(snap\.themeId\)\) return/,
+  "custom / unknown remote ids are ignored so they can't clobber a custom theme",
+);
+assert.match(
+  controller,
+  /if \(snap\.updatedAt && snap\.updatedAt <= synced\) return/,
+  "already-reconciled publishes are skipped via the persisted updatedAt watermark",
+);
+assert.match(
+  controller,
+  /if \(!synced\) \{[\s\S]*setItem\(SYNCED_KEY, snap\.updatedAt\)[\s\S]*return;/,
+  "the first reconcile takes a baseline instead of adopting, so a stale mirror can't revert a fresh local pick",
+);
+assert.match(
+  controller,
+  /snap\.themeId === html\.getAttribute\("data-theme"\) && mode === html\.getAttribute\("data-mode"\)/,
+  "a publish that already matches the applied theme is a no-op (no ping-pong)",
+);
+
+// ── Re-publishes resolved tokens for phone clients ───────────────────────────
+assert.match(
+  controller,
+  /republishTokens\(snap\.themeId, mode\)/,
+  "after adopting, the controller re-publishes resolved hex tokens",
+);
+assert.match(
+  controller,
+  /rgbaBytesToHex\(r, g, b, a\)/,
+  "token resolution rasterises to plain sRGB hex via the shared helper",
+);
+
+console.log("remote-theme-controller.test.ts: ok");

--- a/src/components/remote-theme-controller.tsx
+++ b/src/components/remote-theme-controller.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { THEME_IDS } from "@/lib/theme-palettes";
+import { COVEN_THEME_KEY, COVEN_MODE_KEY } from "@/lib/theme-storage";
+import { rgbaBytesToHex } from "@/lib/theme-token-hex";
+
+/**
+ * RemoteThemeController — lets a phone (or any other client) override the
+ * desktop's theme.
+ *
+ * The desktop already *publishes* its active theme to `PUT /api/theme` so other
+ * devices can match it. This controller closes the loop the other way: it polls
+ * `GET /api/theme` and, when it sees a preset that differs from what's currently
+ * applied, adopts it — so tapping a theme in the iOS Settings re-themes the Mac
+ * within a few seconds. After adopting it re-publishes the resolved hex tokens,
+ * which is what gives the phone full-fidelity chrome for that preset (the phone
+ * can't resolve `oklch`/`color-mix` itself).
+ *
+ * Loop-safety: a publish only bumps `updatedAt`; we reconcile against the last
+ * `updatedAt` we've already accounted for (persisted) and short-circuit when the
+ * published `(themeId, mode)` already matches the DOM, so the desktop never
+ * ping-pongs with its own writes. `custom` and unknown ids are ignored, so a
+ * stale published preset can't silently clobber a hand-tuned custom theme.
+ *
+ * Mounted in the root layout (alongside the other appearance controllers) since
+ * it must run on every surface, not just Settings.
+ *
+ * NOTE: `THEME_OWNED_APPEARANCE_KEYS` is duplicated from settings-shell.tsx
+ * (`applyPreset`) — keep both in sync. They can't share a module without
+ * tripping the source-text guard that pins that list inside settings-shell.
+ */
+
+const SYNCED_KEY = "cave:theme:remote-synced-at";
+const POLL_MS = 10_000;
+
+// Mirror of settings-shell's THEME_SYNC_KEYS — the eight core tokens phones read.
+const THEME_SYNC_KEYS = [
+  "--bg-base",
+  "--bg-raised",
+  "--bg-elevated",
+  "--text-primary",
+  "--text-secondary",
+  "--text-muted",
+  "--border-hairline",
+  "--accent-presence",
+] as const;
+
+// Mirror of settings-shell's THEME_OWNED_APPEARANCE_KEYS.
+const THEME_OWNED_APPEARANCE_KEYS = [
+  "cave:font:sans",
+  "cave:font:mono",
+  "cave:corner-radius",
+  "cave:reading-leading",
+  "cave:reading-tracking",
+  "cave:reading-weight",
+] as const;
+
+function isPreset(id: unknown): id is string {
+  return typeof id === "string" && (THEME_IDS as readonly string[]).includes(id);
+}
+
+/** Strip any custom inline CSS vars so a preset's own tokens take over cleanly. */
+function clearCustomCssVars(html: HTMLElement) {
+  const style = html.getAttribute("style") ?? "";
+  const cleaned = style.replace(/--[\w-]+\s*:[^;]+;?/g, "").trim();
+  if (cleaned) html.setAttribute("style", cleaned);
+  else html.removeAttribute("style");
+}
+
+/** Apply a preset theme + light/dark mode to the DOM and persist the choice. */
+function applyRemoteTheme(themeId: string, mode: "light" | "dark") {
+  const html = document.documentElement;
+  clearCustomCssVars(html);
+  for (const key of THEME_OWNED_APPEARANCE_KEYS) localStorage.removeItem(key);
+  html.setAttribute("data-theme", themeId);
+  html.setAttribute("data-mode", mode);
+  localStorage.setItem(COVEN_THEME_KEY, themeId);
+  localStorage.setItem(COVEN_MODE_KEY, mode);
+}
+
+/** Resolve the active theme's synced tokens to plain sRGB hex (canvas rasterise). */
+function resolveSyncTokens(): Record<string, string> {
+  const cs = getComputedStyle(document.documentElement);
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  const ctx = canvas.getContext("2d", { willReadFrequently: true });
+  const tokens: Record<string, string> = {};
+  for (const key of THEME_SYNC_KEYS) {
+    const value = cs.getPropertyValue(key).trim();
+    if (!value) continue;
+    if (!ctx) {
+      tokens[key] = value;
+      continue;
+    }
+    try {
+      ctx.clearRect(0, 0, 1, 1);
+      ctx.fillStyle = value;
+      ctx.fillRect(0, 0, 1, 1);
+      const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+      tokens[key] = rgbaBytesToHex(r, g, b, a);
+    } catch {
+      tokens[key] = value;
+    }
+  }
+  return tokens;
+}
+
+/** Re-publish the now-applied preset with resolved hex tokens for phone clients. */
+async function republishTokens(themeId: string, mode: string): Promise<string | null> {
+  try {
+    const res = await fetch("/api/theme", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ themeId, mode, tokens: resolveSyncTokens() }),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { theme?: { updatedAt?: string } };
+    return data.theme?.updatedAt ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function RemoteThemeController() {
+  useEffect(() => {
+    let cancelled = false;
+
+    async function reconcile() {
+      if (cancelled || document.hidden) return;
+      let snap: { themeId?: string; mode?: string; updatedAt?: string };
+      try {
+        const res = await fetch("/api/theme", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = (await res.json()) as { theme?: typeof snap };
+        snap = data.theme ?? {};
+      } catch {
+        return; // offline / transient — try again next tick
+      }
+      if (cancelled) return;
+      if (!isPreset(snap.themeId)) return; // ignore custom / unknown remote ids
+      const mode = snap.mode === "light" ? "light" : "dark";
+
+      const synced = localStorage.getItem(SYNCED_KEY) ?? "";
+      if (!synced) {
+        // First reconcile on this client: take the desktop's own boot theme as
+        // the baseline rather than adopting from the mirror. This avoids a race
+        // where a stale published entry, read during the brief gap before a
+        // fresh *local* pick finishes publishing, would revert that pick. Live
+        // overrides (desktop already running, baseline set) are unaffected.
+        if (snap.updatedAt) localStorage.setItem(SYNCED_KEY, snap.updatedAt);
+        return;
+      }
+      if (snap.updatedAt && snap.updatedAt <= synced) return; // already handled
+
+      const html = document.documentElement;
+      if (snap.themeId === html.getAttribute("data-theme") && mode === html.getAttribute("data-mode")) {
+        // Already matches (our own publish echoing back) — just record it.
+        if (snap.updatedAt) localStorage.setItem(SYNCED_KEY, snap.updatedAt);
+        return;
+      }
+
+      // A genuine remote override — adopt it, then re-publish resolved tokens so
+      // phone clients get this preset's exact palette.
+      applyRemoteTheme(snap.themeId, mode);
+      if (snap.updatedAt) localStorage.setItem(SYNCED_KEY, snap.updatedAt);
+      window.dispatchEvent(
+        new CustomEvent("cave:theme-changed", { detail: { themeId: snap.themeId, mode } }),
+      );
+      const newUpdatedAt = await republishTokens(snap.themeId, mode);
+      if (!cancelled && newUpdatedAt) localStorage.setItem(SYNCED_KEY, newUpdatedAt);
+    }
+
+    void reconcile();
+    const interval = window.setInterval(() => void reconcile(), POLL_MS);
+    const onVisible = () => {
+      if (!document.hidden) void reconcile();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## What

Two things, per the goal:

1. **A world-class iOS Settings page.** Rebuilt from a flat `Form` into a structured, glanceable surface:
   - A **connection hero card** — themed glyph, desktop host, and a live status pill — replacing the old buried "Address/Status" rows.
   - Clear grouping: **Theme**, **On this phone** (local Light/Dark override), **Chats** (export), **Connection** (status / re-check / change host), **Disconnect**, **About**.

2. **Override the desktop's theme from the phone.** A **Theme picker** — a responsive grid of swatch cards for all 16 desktop presets, each painting the theme's *true* light/dark canvas + accent, with a Light/Dark segmented control that drives both the preview and the pushed mode. VoiceOver-labelled, haptic-confirmed.

## How the override works (the "Both" behaviour)

- Tapping a card `PUT`s `{themeId, mode}` to `/api/theme`. The phone can't resolve the desktop's `oklch` / `color-mix` tokens, so it names the preset and lets the desktop resolve the exact palette.
- New **`RemoteThemeController`** (mounted in the root layout, runs on every surface) polls `/api/theme`, adopts a remote preset that differs from what's applied, and **re-publishes the resolved hex tokens** — which the phone then picks up for full-fidelity chrome on its next poll. So the Mac **and** the phone re-theme together within a couple of seconds.
- The existing local-only Light/Dark override ("On this phone") is kept and unchanged.

### Loop / clobber safety
- An `updatedAt` watermark + a no-op when the publish already matches the DOM → the desktop never ping-pongs with its own writes.
- `custom` / unknown ids are ignored → a stale mirror entry can't clobber a hand-tuned custom theme.
- The first reconcile on a client takes a **baseline** instead of adopting → a stale mirror can't revert a fresh *local* pick during the publish gap.

## Tests / verification
- `ThemeRoster` mirrors `src/lib/theme-palettes.ts` (oklch backgrounds rasterised to hex for SwiftUI).
- New `ios-theme-override` + `remote-theme-controller` source tests pin both sides and assert **roster ⇄ `THEME_IDS` parity**; both wired into `run-tests.mjs`.
- iOS app builds clean (`xcodebuild`, simulator). Full **app** + **mobile** suites green locally. `tsc` + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)