### PR TITLE
feat(analytics): familiar analytics foundation — confidence score, heal requests, thread report types

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -248,6 +248,10 @@ export const SUITES = {
     "src/components/familiar-roster-card.test.ts",
     "src/lib/familiar-growth-signals.test.ts",
     "src/lib/familiar-growth-route-wiring.test.ts",
+    "src/lib/familiar-confidence.test.ts",
+    "src/lib/familiar-heal-requests.test.ts",
+    "src/lib/thread-self-report.test.ts",
+    "src/components/familiar-analytics-view.test.ts",
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",
     "src/components/automations-view.test.ts",
@@ -663,6 +667,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/theme-token-hex.test.ts",
   "src/lib/familiar-growth-signals.test.ts",
   "src/lib/familiar-growth-route-wiring.test.ts",
+  "src/components/familiar-analytics-view.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -5,7 +5,7 @@ import { resolveFamiliarAvatar } from "@/lib/server/familiar-avatar";
 
 export const dynamic = "force-dynamic";
 
-type DaemonFamiliar = {
+export type DaemonFamiliar = {
   id: string;
   display_name: string;
   role: string;

--- a/src/app/dashboard/familiars/[id]/analytics/page.tsx
+++ b/src/app/dashboard/familiars/[id]/analytics/page.tsx
@@ -1,0 +1,8 @@
+import { FamiliarAnalyticsView } from "@/components/familiar-analytics-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function FamiliarAnalyticsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <FamiliarAnalyticsView familiarId={id} />;
+}

--- a/src/app/familiars/[id]/analytics/page.tsx
+++ b/src/app/familiars/[id]/analytics/page.tsx
@@ -1,0 +1,8 @@
+import { FamiliarAnalyticsView } from "@/components/familiar-analytics-view";
+
+export const dynamic = "force-dynamic";
+
+export default async function FamiliarAnalyticsPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  return <FamiliarAnalyticsView familiarId={id} />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9167,6 +9167,223 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .growth-signal--info svg { color: var(--color-info); }
 .growth-signal--warn svg { color: var(--color-warning); }
 .growth-signal--crit svg { color: var(--color-danger); }
+
+/* ── Familiar Analytics ──────────────────────────────────────────────────── */
+.fa-page {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-height: 100%;
+  padding: 24px;
+  background: var(--bg-base);
+  color: var(--text-primary);
+}
+.fa-topbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.fa-topbar a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+.fa-topbar a:hover { color: var(--text-primary); }
+.fa-topbar b {
+  color: var(--text-primary);
+  font-weight: 620;
+}
+.fa-topbar .retro-icon-btn { margin-left: auto; }
+.fa-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 18px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-surface);
+}
+.fa-header__identity {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+.fa-header h1 {
+  margin: 4px 0 3px;
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+.fa-header p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.fa-avatar {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--accent-presence) 16%, var(--bg-raised));
+  color: var(--text-primary);
+  font-size: 22px;
+  font-weight: 700;
+  object-fit: cover;
+}
+.fa-score-circle {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 98px;
+  height: 98px;
+  border-radius: 50%;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base));
+  text-align: center;
+}
+.fa-score-circle strong {
+  display: block;
+  font-size: 30px;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.fa-score-circle span {
+  margin-top: 5px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.fa-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-surface);
+}
+.fa-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.fa-section__head > span {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.fa-section__title {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0;
+}
+.fa-factor-list,
+.fa-heal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.fa-factor {
+  display: grid;
+  grid-template-columns: minmax(150px, 0.9fr) minmax(160px, 1.6fr) 72px;
+  align-items: center;
+  gap: 12px;
+}
+.fa-factor__meta b {
+  display: block;
+  font-size: 13px;
+  text-transform: capitalize;
+}
+.fa-factor__meta span,
+.fa-factor small {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+.fa-factor-bar {
+  position: relative;
+  overflow: hidden;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--bg-raised);
+}
+.fa-factor-segment {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent-presence), var(--color-success));
+}
+.fa-heal-card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border-hairline);
+  border-left-width: 3px;
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+}
+.fa-heal-card--crit { border-left-color: var(--color-danger); }
+.fa-heal-card--warn { border-left-color: var(--color-warning); }
+.fa-heal-card--info { border-left-color: var(--color-info); }
+.fa-heal-card span {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.fa-heal-card h3 {
+  margin: 3px 0;
+  font-size: 13px;
+}
+.fa-heal-card p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.fa-heal-card > b {
+  flex: 0 0 auto;
+  padding: 3px 6px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.fa-contract-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 8px;
+}
+.fa-contract-item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.fa-contract-item span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.fa-contract-item.is-pass svg { color: var(--color-success); }
+.fa-contract-item.is-fail svg { color: var(--color-danger); }
+
 @media (max-width: 560px) {
   .dr-metric__value { font-size: 32px; }
   .dr-row__open span { display: none; }
@@ -9182,6 +9399,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .growth-sidebar { position: static; }
   .growth-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .growth-signals { grid-template-columns: 1fr; }
+  .fa-contract-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 560px) {
@@ -9196,6 +9414,21 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .growth-summary,
   .growth-track-grid { grid-template-columns: 1fr; }
   .growth-section__head { align-items: flex-start; flex-direction: column; }
+  .fa-page { padding: 16px; }
+  .fa-header,
+  .fa-section__head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .fa-score-circle {
+    width: 82px;
+    height: 82px;
+  }
+  .fa-factor {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+  .fa-contract-grid { grid-template-columns: 1fr; }
 }
 
 /* Recommended follow-up: the agent lists next steps best-first, so the top

--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -22,9 +22,9 @@ import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/date
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
-type Track = "synthesis" | "prompt" | "memory";
+export type Track = "synthesis" | "prompt" | "memory";
 
-type LoopIteration = {
+export type LoopIteration = {
   id: string;
   timestamp: string;
   track: Track;
@@ -37,7 +37,7 @@ type LoopIteration = {
   notes?: string;
 };
 
-type EvalLoopState = {
+export type EvalLoopState = {
   familiar_id: string;
   last_run: string | null;
   iterations: LoopIteration[];

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -1,0 +1,173 @@
+import type { EvalLoopState } from "@/components/eval-loop-panel";
+import {
+  buildFamiliarCardStats,
+  type CovenMemoryEntry,
+  type FamiliarCardStats,
+} from "@/components/familiars-view-stats";
+import { deriveConfidenceScore, type ConfidenceScore } from "@/lib/familiar-confidence";
+import type { ContractReport } from "@/lib/familiar-contract";
+import { deriveGrowthReport, type FamiliarGrowthReport } from "@/lib/familiar-growth-signals";
+import { deriveHealRequests, type SelfHealRequest } from "@/lib/familiar-heal-requests";
+import type { RetroFamiliarState, RetroRunsSnapshot } from "@/lib/retro-runs";
+import type { Familiar, SessionRow } from "@/lib/types";
+
+type FamiliarsResponse =
+  | { ok: true; familiars: Familiar[] }
+  | { ok: false; familiars?: Familiar[]; error?: string };
+
+type ContractResponse =
+  | { ok: true; report: ContractReport }
+  | { ok: false; report?: ContractReport; error?: string };
+
+type EvalLoopResponse =
+  | { ok: true; state: EvalLoopState | null }
+  | { ok: false; state?: EvalLoopState | null; error?: string };
+
+type SessionsResponse =
+  | { ok: true; sessions: SessionRow[] }
+  | { ok: false; sessions?: SessionRow[]; error?: string };
+
+type CovenMemoryResponse =
+  | { ok: true; entries: CovenMemoryEntry[] }
+  | { ok: false; entries?: CovenMemoryEntry[]; error?: string };
+
+type RetroApiResponse =
+  | { ok: true; snapshot: RetroRunsSnapshot }
+  | { ok: false; snapshot?: RetroRunsSnapshot; error?: string };
+
+export type FamiliarAnalyticsData = {
+  familiarId: string;
+  familiars: Familiar[];
+  contractReport: ContractReport | null;
+  evalLoopState: EvalLoopState | null;
+  sessions: SessionRow[];
+  covenEntries: CovenMemoryEntry[];
+  retroSnapshot: RetroRunsSnapshot;
+  errors: string[];
+};
+
+export type FamiliarAnalyticsModel = {
+  familiarId: string;
+  familiar: Familiar | null;
+  contractReport: ContractReport | null;
+  evalLoopState: EvalLoopState | null;
+  growthReport: FamiliarGrowthReport | null;
+  confidence: ConfidenceScore;
+  healRequests: SelfHealRequest[];
+  errors: string[];
+};
+
+const EMPTY_SNAPSHOT: RetroRunsSnapshot = {
+  generatedAt: new Date(0).toISOString(),
+  summary: {
+    totalRuns: 0,
+    accepted: 0,
+    reverted: 0,
+    runningFamiliars: 0,
+    familiarsWithData: 0,
+    trackCounts: { synthesis: 0, prompt: 0, memory: 0 },
+    lastRun: null,
+  },
+  familiars: [],
+  runs: [],
+};
+
+function emptyStats(): FamiliarCardStats {
+  return {
+    memoryCount: 0,
+    latestMemory: null,
+    lastSessionAt: null,
+    sessionsLast7d: 0,
+    hasActiveSession: false,
+  };
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { cache: "no-store" });
+  return (await res.json()) as T;
+}
+
+function retroStateFor(snapshot: RetroRunsSnapshot, familiarId: string): RetroFamiliarState | null {
+  return snapshot.familiars.find((state) => state.familiarId === familiarId) ?? null;
+}
+
+function responseError(response: { ok: boolean; error?: string }, fallback: string): string | null {
+  return response.ok ? null : response.error ?? fallback;
+}
+
+export async function loadFamiliarAnalyticsData(familiarId: string): Promise<FamiliarAnalyticsData> {
+  const encodedId = encodeURIComponent(familiarId);
+  const [
+    familiarsJson,
+    contractJson,
+    evalLoopJson,
+    sessionsJson,
+    memoryJson,
+    retroJson,
+  ] = await Promise.all([
+    getJson<FamiliarsResponse>("/api/familiars"),
+    getJson<ContractResponse>(`/api/familiars/${encodedId}/contract`),
+    getJson<EvalLoopResponse>(`/api/skills/eval-loop/${encodedId}`),
+    getJson<SessionsResponse>("/api/sessions/list"),
+    getJson<CovenMemoryResponse>("/api/coven-memory"),
+    getJson<RetroApiResponse>("/api/retro-runs"),
+  ]);
+
+  const errors = [
+    responseError(familiarsJson, "familiars unavailable"),
+    responseError(contractJson, "contract unavailable"),
+    responseError(evalLoopJson, "eval-loop unavailable"),
+    responseError(sessionsJson, "sessions unavailable"),
+    responseError(memoryJson, "memory unavailable"),
+    responseError(retroJson, "retro runs unavailable"),
+  ].filter((error): error is string => Boolean(error));
+
+  return {
+    familiarId,
+    familiars: familiarsJson.familiars ?? [],
+    contractReport: contractJson.report ?? null,
+    evalLoopState: evalLoopJson.state ?? null,
+    sessions: sessionsJson.sessions ?? [],
+    covenEntries: memoryJson.entries ?? [],
+    retroSnapshot: retroJson.snapshot ?? EMPTY_SNAPSHOT,
+    errors,
+  };
+}
+
+export function buildFamiliarAnalyticsModel(data: FamiliarAnalyticsData): FamiliarAnalyticsModel {
+  const familiar = data.familiars.find((item) => item.id === data.familiarId) ?? null;
+  const statsByFamiliar = buildFamiliarCardStats({
+    familiars: data.familiars,
+    sessions: data.sessions,
+    covenEntries: data.covenEntries,
+  });
+  const growthReport = familiar
+    ? deriveGrowthReport({
+        familiar,
+        stats: statsByFamiliar.get(familiar.id) ?? emptyStats(),
+        retroState: retroStateFor(data.retroSnapshot, familiar.id),
+      })
+    : null;
+  const confidence = deriveConfidenceScore({
+    contractReport: data.contractReport,
+    growthReport,
+    familiar,
+  });
+  const healRequests = deriveHealRequests({
+    familiarId: data.familiarId,
+    evalLoopState: data.evalLoopState,
+    contractReport: data.contractReport,
+    growthReport,
+  });
+
+  return {
+    familiarId: data.familiarId,
+    familiar,
+    contractReport: data.contractReport,
+    evalLoopState: data.evalLoopState,
+    growthReport,
+    confidence,
+    healRequests,
+    errors: data.errors,
+  };
+}

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { afterEach, describe, it } from "node:test";
+import {
+  buildFamiliarAnalyticsModel,
+  loadFamiliarAnalyticsData,
+} from "./familiar-analytics-data.ts";
+
+const source = readFileSync(new URL("./familiar-analytics-view.tsx", import.meta.url), "utf8");
+
+const highEvalState = {
+  familiar_id: "cody",
+  last_run: "2026-06-25T12:00:00.000Z",
+  iterations: [
+    {
+      id: "revert-1",
+      timestamp: "2026-06-25T12:00:00.000Z",
+      track: "prompt",
+      iteration: 1,
+      change_summary: "Prompt change reverted",
+      metric_before: 0.7,
+      metric_after: 0.5,
+      delta: -0.2,
+      outcome: "REVERT",
+    },
+  ],
+  track_counts: { synthesis: 0, prompt: 1, memory: 0 },
+  total_accepted: 0,
+  total_reverted: 1,
+  running: false,
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchFor(score: "low" | "trusted") {
+  const familiar =
+    score === "trusted"
+      ? { id: "cody", display_name: "Cody", role: "agent", memory_freshness: "fresh", avatarUrl: "/avatar.png" }
+      : { id: "cody", display_name: "Cody", role: "agent", memory_freshness: null };
+  const contract =
+    score === "trusted"
+      ? {
+          specVersion: "0.1.0",
+          pass: true,
+          properties: [
+            { property: "Named Identity", pass: true },
+            { property: "Defined Purpose", pass: true },
+            { property: "Bounded Authority", pass: true },
+            { property: "Persistent Memory", pass: true },
+            { property: "Human Belonging", pass: true },
+          ],
+          violations: [],
+          warnings: [],
+        }
+      : {
+          specVersion: "0.1.0",
+          pass: false,
+          properties: [
+            { property: "Named Identity", pass: false },
+            { property: "Defined Purpose", pass: false },
+            { property: "Bounded Authority", pass: false },
+            { property: "Persistent Memory", pass: false },
+            { property: "Human Belonging", pass: false },
+          ],
+          violations: [],
+          warnings: [],
+        };
+
+  const responses = new Map<string, unknown>([
+    ["/api/familiars", { ok: true, familiars: [familiar] }],
+    ["/api/familiars/cody/contract", { ok: true, report: contract }],
+    ["/api/skills/eval-loop/cody", { ok: true, state: score === "trusted" ? highEvalState : null }],
+    [
+      "/api/sessions/list",
+      {
+        ok: true,
+        sessions: score === "trusted"
+          ? Array.from({ length: 10 }, (_, index) => ({
+              id: `session-${index}`,
+              project_root: "/tmp/cave",
+              harness: "codex",
+              title: "Session",
+              status: "complete",
+              exit_code: 0,
+              archived_at: null,
+              created_at: "2026-06-25T12:00:00.000Z",
+              updated_at: "2026-06-25T12:00:00.000Z",
+              familiarId: "cody",
+            }))
+          : [],
+      },
+    ],
+    [
+      "/api/coven-memory",
+      {
+        ok: true,
+        entries: score === "trusted"
+          ? [
+              {
+                id: "memory-1",
+                familiar_id: "cody",
+                title: "Recent memory",
+                path: "memory.md",
+                updated_at: "2026-06-25T12:00:00.000Z",
+              },
+            ]
+          : [],
+      },
+    ],
+    [
+      "/api/retro-runs",
+      {
+        ok: true,
+        snapshot: {
+          generatedAt: "2026-06-25T12:00:00.000Z",
+          summary: {
+            totalRuns: score === "trusted" ? 5 : 0,
+            accepted: score === "trusted" ? 5 : 0,
+            reverted: 0,
+            runningFamiliars: 0,
+            familiarsWithData: score === "trusted" ? 1 : 0,
+            trackCounts: { synthesis: score === "trusted" ? 5 : 0, prompt: 0, memory: 0 },
+            lastRun: null,
+          },
+          familiars:
+            score === "trusted"
+              ? [
+                  {
+                    familiarId: "cody",
+                    familiarName: "Cody",
+                    familiarRole: "agent",
+                    lastRun: "2026-06-25T12:00:00.000Z",
+                    running: false,
+                    trackCounts: { synthesis: 5, prompt: 0, memory: 0 },
+                    totalAccepted: 5,
+                    totalReverted: 0,
+                    runs: [
+                      {
+                        id: "run-1",
+                        familiarId: "cody",
+                        familiarName: "Cody",
+                        familiarRole: "agent",
+                        iterationId: "iter-1",
+                        iteration: 1,
+                        timestamp: "2026-06-25T12:00:00.000Z",
+                        track: "synthesis",
+                        outcome: "ACCEPT",
+                        changeSummary: "Accepted",
+                        metricBefore: 0,
+                        metricAfter: 1,
+                        delta: 1,
+                        raw: {},
+                      },
+                      {
+                        id: "run-2",
+                        familiarId: "cody",
+                        familiarName: "Cody",
+                        familiarRole: "agent",
+                        iterationId: "iter-2",
+                        iteration: 2,
+                        timestamp: "2026-06-24T12:00:00.000Z",
+                        track: "synthesis",
+                        outcome: "ACCEPT",
+                        changeSummary: "Accepted",
+                        metricBefore: 0,
+                        metricAfter: 1,
+                        delta: 1,
+                        raw: {},
+                      },
+                      {
+                        id: "run-3",
+                        familiarId: "cody",
+                        familiarName: "Cody",
+                        familiarRole: "agent",
+                        iterationId: "iter-3",
+                        iteration: 3,
+                        timestamp: "2026-06-23T12:00:00.000Z",
+                        track: "synthesis",
+                        outcome: "ACCEPT",
+                        changeSummary: "Accepted",
+                        metricBefore: 0,
+                        metricAfter: 1,
+                        delta: 1,
+                        raw: {},
+                      },
+                      {
+                        id: "run-4",
+                        familiarId: "cody",
+                        familiarName: "Cody",
+                        familiarRole: "agent",
+                        iterationId: "iter-4",
+                        iteration: 4,
+                        timestamp: "2026-06-22T12:00:00.000Z",
+                        track: "synthesis",
+                        outcome: "ACCEPT",
+                        changeSummary: "Accepted",
+                        metricBefore: 0,
+                        metricAfter: 1,
+                        delta: 1,
+                        raw: {},
+                      },
+                      {
+                        id: "run-5",
+                        familiarId: "cody",
+                        familiarName: "Cody",
+                        familiarRole: "agent",
+                        iterationId: "iter-5",
+                        iteration: 5,
+                        timestamp: "2026-06-21T12:00:00.000Z",
+                        track: "synthesis",
+                        outcome: "ACCEPT",
+                        changeSummary: "Accepted",
+                        metricBefore: 0,
+                        metricAfter: 1,
+                        delta: 1,
+                        raw: {},
+                      },
+                    ],
+                    raw: {},
+                  },
+                ]
+              : [],
+          runs: [],
+        },
+      },
+    ],
+  ]);
+
+  globalThis.fetch = (async (url: RequestInfo | URL) => ({
+    json: async () => responses.get(String(url)),
+  })) as typeof fetch;
+}
+
+describe("FamiliarAnalyticsView", () => {
+  it("builds a renderable model with mocked fetch responses and shows the Low label", async () => {
+    mockFetchFor("low");
+    const data = await loadFamiliarAnalyticsData("cody");
+    const model = buildFamiliarAnalyticsModel(data);
+
+    assert.equal(model.confidence.label, "Low");
+    assert.match(source, /export function FamiliarAnalyticsContent/);
+  });
+
+  it("shows the Trusted label for high-data mocks", async () => {
+    mockFetchFor("trusted");
+    const data = await loadFamiliarAnalyticsData("cody");
+    const model = buildFamiliarAnalyticsModel(data);
+
+    assert.equal(model.confidence.label, "Trusted");
+  });
+
+  it("renders the heal request count and keeps EvalLoopPanel present", async () => {
+    mockFetchFor("trusted");
+    const data = await loadFamiliarAnalyticsData("cody");
+    const model = buildFamiliarAnalyticsModel(data);
+
+    assert.equal(model.healRequests.length, 1);
+    assert.match(source, /model\.healRequests\.length === 1 \? "request" : "requests"/);
+    assert.match(source, /<EvalLoopPanel[\s\S]*familiarId=\{model\.familiar\.id\}/);
+  });
+});

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  buildFamiliarAnalyticsModel,
+  loadFamiliarAnalyticsData,
+  type FamiliarAnalyticsData,
+  type FamiliarAnalyticsModel,
+} from "@/components/familiar-analytics-data";
+import { EmptyState } from "@/components/ui/empty-state";
+import { EvalLoopPanel } from "@/components/eval-loop-panel";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Icon } from "@/lib/icon";
+
+export function FamiliarAnalyticsView({ familiarId }: { familiarId: string }) {
+  const [data, setData] = useState<FamiliarAnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async ({ quiet = false } = {}) => {
+    if (quiet) setRefreshing(true);
+    else setLoading(true);
+    setError(null);
+    try {
+      setData(await loadFamiliarAnalyticsData(familiarId));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "analytics data unavailable");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [familiarId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const model = useMemo(() => data ? buildFamiliarAnalyticsModel(data) : null, [data]);
+
+  if (loading && !model) {
+    return (
+      <main className="fa-page" aria-busy="true">
+        <div className="fa-section">
+          <SkeletonRows count={8} />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="fa-page" aria-busy={refreshing}>
+      {error ? (
+        <div className="retro-callout" role="alert">
+          <Icon name="ph:warning-circle" aria-hidden />
+          <span>{error}</span>
+        </div>
+      ) : null}
+      {model ? <FamiliarAnalyticsContent model={model} onRefresh={() => void load({ quiet: true })} refreshing={refreshing} /> : (
+        <EmptyState compact icon="ph:users-three-bold" headline="No familiar analytics available." />
+      )}
+    </main>
+  );
+}
+
+export function FamiliarAnalyticsContent({
+  model,
+  onRefresh,
+  refreshing = false,
+}: {
+  model: FamiliarAnalyticsModel;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+}) {
+  const familiarName = model.familiar?.display_name ?? model.familiarId;
+  const familiarRole = model.familiar?.role || model.familiar?.harness || "Familiar";
+
+  return (
+    <>
+      <nav className="fa-topbar" aria-label="Breadcrumb">
+        <a href="/dashboard">Dashboard</a>
+        <span>/</span>
+        <a href="/dashboard/familiars/growth">Familiars</a>
+        <span>/</span>
+        <b>Analytics</b>
+        {onRefresh ? (
+          <button
+            type="button"
+            className="retro-icon-btn"
+            aria-label="Refresh familiar analytics"
+            title="Refresh familiar analytics"
+            disabled={refreshing}
+            onClick={onRefresh}
+          >
+            <Icon name="ph:arrows-clockwise-bold" aria-hidden />
+          </button>
+        ) : null}
+      </nav>
+
+      {model.errors.length > 0 ? (
+        <div className="retro-callout" role="alert">
+          <Icon name="ph:warning-circle" aria-hidden />
+          <span>{model.errors.join(" · ")}</span>
+        </div>
+      ) : null}
+
+      <header className="fa-header">
+        <div className="fa-header__identity">
+          {model.familiar?.avatarUrl ? (
+            <img className="fa-avatar" src={model.familiar.avatarUrl} alt={familiarName} />
+          ) : (
+            <span className="fa-avatar" aria-hidden>{familiarName.slice(0, 1).toUpperCase()}</span>
+          )}
+          <div>
+            <p className="retro-eyebrow">
+              <Icon name="ph:chart-bar-bold" aria-hidden />
+              Familiar Analytics
+            </p>
+            <h1>{familiarName}</h1>
+            <p>{familiarRole}</p>
+          </div>
+        </div>
+        <div className="fa-score-circle" aria-label={`Confidence score ${model.confidence.score}, ${model.confidence.label}`}>
+          <strong>{model.confidence.score}</strong>
+          <span>{model.confidence.label}</span>
+        </div>
+      </header>
+
+      <section className="fa-section" aria-labelledby="fa-confidence-title">
+        <div className="fa-section__head">
+          <h2 id="fa-confidence-title" className="fa-section__title">Confidence Breakdown</h2>
+          <span>{model.confidence.factors.length} factors</span>
+        </div>
+        <div className="fa-factor-list">
+          {model.confidence.factors.map((factor) => (
+            <div key={factor.label} className="fa-factor">
+              <div className="fa-factor__meta">
+                <b>{factor.label.replaceAll("_", " ")}</b>
+                <span>{Math.round(factor.value)} × {factor.weight.toFixed(2)}</span>
+              </div>
+              <div className="fa-factor-bar" aria-label={`${factor.label} contributes ${factor.contribution.toFixed(1)}`}>
+                <span className="fa-factor-segment" style={{ width: `${Math.max(0, Math.min(100, factor.value))}%` }} />
+              </div>
+              <small>{factor.contribution.toFixed(1)} points</small>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="fa-section" aria-labelledby="fa-heal-title">
+        <div className="fa-section__head">
+          <h2 id="fa-heal-title" className="fa-section__title">Self-Heal Requests</h2>
+          <span>{model.healRequests.length} {model.healRequests.length === 1 ? "request" : "requests"}</span>
+        </div>
+        {model.healRequests.length === 0 ? (
+          <EmptyState compact icon="ph:check-circle-bold" headline="No self-heal requests." />
+        ) : (
+          <div className="fa-heal-list">
+            {model.healRequests.map((request) => (
+              <article key={request.id} className={`fa-heal-card fa-heal-card--${request.severity}`}>
+                <div>
+                  <span>{request.source}</span>
+                  <h3>{request.title}</h3>
+                  <p>{request.detail}</p>
+                </div>
+                <b>{request.actionKind}</b>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="fa-section" aria-labelledby="fa-eval-title">
+        <div className="fa-section__head">
+          <h2 id="fa-eval-title" className="fa-section__title">Eval Loop</h2>
+          <span>{model.evalLoopState?.iterations.length ?? 0} iterations</span>
+        </div>
+        {model.familiar ? (
+          <EvalLoopPanel familiarId={model.familiar.id} familiarName={familiarName} />
+        ) : (
+          <EmptyState compact icon="ph:arrows-clockwise-bold" headline="Eval loop unavailable." />
+        )}
+      </section>
+
+      <section className="fa-section" aria-labelledby="fa-contract-title">
+        <div className="fa-section__head">
+          <h2 id="fa-contract-title" className="fa-section__title">Contract Compliance</h2>
+          <span>{model.contractReport?.pass ? "passing" : "needs review"}</span>
+        </div>
+        {model.contractReport ? (
+          <div className="fa-contract-grid">
+            {model.contractReport.properties.map((property) => (
+              <div key={property.property} className={`fa-contract-item${property.pass ? " is-pass" : " is-fail"}`}>
+                <Icon name={property.pass ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
+                <span>{property.property}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState compact icon="ph:file-text" headline="No contract report available." />
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/lib/familiar-confidence.test.ts
+++ b/src/lib/familiar-confidence.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { FAMILIAR_CONTRACT_SPEC_VERSION, type ContractReport } from "./familiar-contract.ts";
+import { deriveConfidenceScore } from "./familiar-confidence.ts";
+import type { FamiliarGrowthReport } from "./familiar-growth-signals.ts";
+
+function contractReport(passing: number): ContractReport {
+  const properties = [
+    "Named Identity",
+    "Defined Purpose",
+    "Bounded Authority",
+    "Persistent Memory",
+    "Human Belonging",
+  ] as const;
+
+  return {
+    specVersion: FAMILIAR_CONTRACT_SPEC_VERSION,
+    pass: passing === properties.length,
+    properties: properties.map((property, index) => ({ property, pass: index < passing })),
+    violations: [],
+    warnings: [],
+  };
+}
+
+function growthReport(args: {
+  runs: number;
+  accepted: number;
+  sessionsLast7d?: number;
+}): FamiliarGrowthReport {
+  const runs = Array.from({ length: args.runs }, (_, index) => ({
+    id: `run-${index}`,
+    familiarId: "cody",
+    familiarName: "Cody",
+    familiarRole: "agent",
+    iterationId: `iter-${index}`,
+    iteration: index + 1,
+    timestamp: `2026-06-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+    track: "synthesis" as const,
+    outcome: index < args.accepted ? ("ACCEPT" as const) : ("REVERT" as const),
+    changeSummary: "Iteration",
+    metricBefore: 0,
+    metricAfter: 1,
+    delta: 1,
+    raw: {},
+  }));
+
+  return {
+    familiarId: "cody",
+    healthLabel: "active",
+    sessionsLast7d: args.sessionsLast7d ?? 0,
+    retroAcceptRate: args.runs === 0 ? null : args.accepted / args.runs,
+    lastActiveAt: null,
+    signals: [],
+    recentRuns: runs,
+    trackStats: {
+      synthesis: { total: args.runs, accepted: args.accepted },
+      prompt: { total: 0, accepted: 0 },
+      memory: { total: 0, accepted: 0 },
+    },
+  };
+}
+
+describe("deriveConfidenceScore", () => {
+  it("assigns all four label thresholds", () => {
+    assert.equal(
+      deriveConfidenceScore({
+        contractReport: contractReport(0),
+        growthReport: growthReport({ runs: 0, accepted: 0 }),
+        familiar: { memory_freshness: null },
+      }).label,
+      "Low",
+    );
+
+    assert.equal(
+      deriveConfidenceScore({
+        contractReport: contractReport(5),
+        growthReport: growthReport({ runs: 0, accepted: 0 }),
+        familiar: { memory_freshness: "aging" },
+      }).label,
+      "Developing",
+    );
+
+    assert.equal(
+      deriveConfidenceScore({
+        contractReport: contractReport(5),
+        growthReport: growthReport({ runs: 4, accepted: 3 }),
+        familiar: { memory_freshness: "aging" },
+      }).label,
+      "Reliable",
+    );
+
+    assert.equal(
+      deriveConfidenceScore({
+        contractReport: contractReport(5),
+        growthReport: growthReport({ runs: 5, accepted: 5, sessionsLast7d: 10 }),
+        familiar: { memory_freshness: "fresh" },
+      }).label,
+      "Trusted",
+    );
+  });
+
+  it("guards accept rate at zero until at least three retro runs exist", () => {
+    const score = deriveConfidenceScore({
+      contractReport: contractReport(0),
+      growthReport: growthReport({ runs: 2, accepted: 2 }),
+      familiar: { memory_freshness: null },
+    });
+
+    assert.equal(score.factors.find((factor) => factor.label === "accept_rate")?.value, 0);
+  });
+
+  it("maps each freshness state to its weighted factor value", () => {
+    const cases = [
+      ["fresh", 100],
+      ["aging", 60],
+      ["stale", 20],
+      [null, 0],
+      [undefined, 0],
+    ] as const;
+
+    for (const [memory_freshness, expected] of cases) {
+      const score = deriveConfidenceScore({
+        contractReport: contractReport(0),
+        growthReport: growthReport({ runs: 0, accepted: 0 }),
+        familiar: { memory_freshness },
+      });
+
+      assert.equal(score.factors.find((factor) => factor.label === "freshness_score")?.value, expected);
+    }
+  });
+
+  it("caps activity contribution at ten sessions", () => {
+    const score = deriveConfidenceScore({
+      contractReport: contractReport(0),
+      growthReport: growthReport({ runs: 0, accepted: 0, sessionsLast7d: 18 }),
+      familiar: { memory_freshness: null },
+    });
+
+    assert.equal(score.factors.find((factor) => factor.label === "activity_score")?.value, 100);
+    assert.equal(score.factors.find((factor) => factor.label === "activity_score")?.contribution, 10);
+  });
+
+  it("keeps factor contributions aligned with the rounded score", () => {
+    const score = deriveConfidenceScore({
+      contractReport: contractReport(3),
+      growthReport: growthReport({ runs: 4, accepted: 2, sessionsLast7d: 4 }),
+      familiar: { memory_freshness: "aging" },
+    });
+    const contributionSum = score.factors.reduce((sum, factor) => sum + factor.contribution, 0);
+
+    assert.equal(score.score, Math.round(contributionSum));
+  });
+
+  it("returns the zero edge case", () => {
+    assert.deepEqual(
+      deriveConfidenceScore({
+        contractReport: contractReport(0),
+        growthReport: growthReport({ runs: 0, accepted: 0 }),
+        familiar: { memory_freshness: null },
+      }),
+      {
+        score: 0,
+        label: "Low",
+        factors: [
+          { label: "contract_score", value: 0, weight: 0.3, contribution: 0 },
+          { label: "accept_rate", value: 0, weight: 0.4, contribution: 0 },
+          { label: "freshness_score", value: 0, weight: 0.2, contribution: 0 },
+          { label: "activity_score", value: 0, weight: 0.1, contribution: 0 },
+        ],
+      },
+    );
+  });
+
+  it("returns the max edge case", () => {
+    const score = deriveConfidenceScore({
+      contractReport: contractReport(5),
+      growthReport: growthReport({ runs: 5, accepted: 5, sessionsLast7d: 10 }),
+      familiar: { memory_freshness: "fresh" },
+    });
+
+    assert.equal(score.score, 100);
+    assert.equal(score.label, "Trusted");
+  });
+});

--- a/src/lib/familiar-confidence.ts
+++ b/src/lib/familiar-confidence.ts
@@ -1,0 +1,87 @@
+import type { DaemonFamiliar } from "@/app/api/familiars/route";
+import type { ContractReport } from "@/lib/familiar-contract";
+import type { FamiliarGrowthReport } from "@/lib/familiar-growth-signals";
+
+export type ConfidenceFactor = {
+  label: string;
+  value: number;
+  weight: number;
+  contribution: number;
+};
+
+export type ConfidenceScore = {
+  score: number;
+  label: "Low" | "Developing" | "Reliable" | "Trusted";
+  factors: ConfidenceFactor[];
+};
+
+const CONTRACT_WEIGHT = 0.3;
+const ACCEPT_RATE_WEIGHT = 0.4;
+const FRESHNESS_WEIGHT = 0.2;
+const ACTIVITY_WEIGHT = 0.1;
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
+function labelForScore(score: number): ConfidenceScore["label"] {
+  if (score >= 80) return "Trusted";
+  if (score >= 60) return "Reliable";
+  if (score >= 40) return "Developing";
+  return "Low";
+}
+
+function totalRetroRuns(report: FamiliarGrowthReport | null): number {
+  if (!report) return 0;
+  return Object.values(report.trackStats).reduce((sum, stat) => sum + stat.total, 0);
+}
+
+function freshnessValue(memoryFreshness: string | null | undefined): number {
+  if (memoryFreshness === "fresh") return 100;
+  if (memoryFreshness === "aging") return 60;
+  if (memoryFreshness === "stale") return 20;
+  return 0;
+}
+
+function factor(label: string, value: number, weight: number): ConfidenceFactor {
+  const safeValue = clampPercent(value);
+  return {
+    label,
+    value: safeValue,
+    weight,
+    contribution: safeValue * weight,
+  };
+}
+
+export function deriveConfidenceScore(args: {
+  contractReport: ContractReport | null;
+  growthReport: FamiliarGrowthReport | null;
+  familiar: Pick<DaemonFamiliar, "memory_freshness"> | { memory_freshness?: string | null } | null;
+}): ConfidenceScore {
+  const propertyCount = args.contractReport?.properties.length ?? 0;
+  const passingProperties = args.contractReport?.properties.filter((property) => property.pass).length ?? 0;
+  const contractScore = propertyCount > 0 ? (passingProperties / propertyCount) * 100 : 0;
+
+  const retroRuns = totalRetroRuns(args.growthReport);
+  const acceptRate = retroRuns >= 3 && args.growthReport?.retroAcceptRate != null
+    ? args.growthReport.retroAcceptRate * 100
+    : 0;
+
+  const freshnessScore = freshnessValue(args.familiar?.memory_freshness);
+  const activityScore = Math.min(Math.max(args.growthReport?.sessionsLast7d ?? 0, 0), 10) * 10;
+
+  const factors = [
+    factor("contract_score", contractScore, CONTRACT_WEIGHT),
+    factor("accept_rate", acceptRate, ACCEPT_RATE_WEIGHT),
+    factor("freshness_score", freshnessScore, FRESHNESS_WEIGHT),
+    factor("activity_score", activityScore, ACTIVITY_WEIGHT),
+  ];
+  const score = Math.round(factors.reduce((sum, item) => sum + item.contribution, 0));
+
+  return {
+    score,
+    label: labelForScore(score),
+    factors,
+  };
+}

--- a/src/lib/familiar-heal-requests.test.ts
+++ b/src/lib/familiar-heal-requests.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { FAMILIAR_CONTRACT_SPEC_VERSION, type ContractReport } from "./familiar-contract.ts";
+import { deriveHealRequests } from "./familiar-heal-requests.ts";
+import type { FamiliarGrowthReport } from "./familiar-growth-signals.ts";
+import type { EvalLoopState } from "@/components/eval-loop-panel";
+
+function evalLoopState(): EvalLoopState {
+  return {
+    familiar_id: "cody",
+    last_run: "2026-06-25T10:00:00.000Z",
+    iterations: [
+      {
+        id: "accepted",
+        timestamp: "2026-06-25T09:00:00.000Z",
+        track: "prompt",
+        iteration: 1,
+        change_summary: "Accepted prompt change",
+        metric_before: 0.4,
+        metric_after: 0.7,
+        delta: 0.3,
+        outcome: "ACCEPT",
+      },
+      {
+        id: "reverted-a",
+        timestamp: "2026-06-25T10:00:00.000Z",
+        track: "memory",
+        iteration: 2,
+        change_summary: "Memory change reverted",
+        metric_before: 0.7,
+        metric_after: 0.5,
+        delta: -0.2,
+        outcome: "REVERT",
+        notes: "needs review",
+      },
+      {
+        id: "reverted-b",
+        timestamp: "2026-06-25T11:00:00.000Z",
+        track: "synthesis",
+        iteration: 3,
+        change_summary: "Synthesis change reverted",
+        metric_before: 0.7,
+        metric_after: 0.6,
+        delta: -0.1,
+      outcome: "REVERT",
+      },
+    ],
+    track_counts: { synthesis: 1, prompt: 1, memory: 1 },
+    total_accepted: 1,
+    total_reverted: 2,
+    running: false,
+  };
+}
+
+function contractReport(): ContractReport {
+  return {
+    specVersion: FAMILIAR_CONTRACT_SPEC_VERSION,
+    pass: false,
+    properties: [
+      { property: "Named Identity", pass: false },
+      { property: "Defined Purpose", pass: true },
+      { property: "Bounded Authority", pass: true },
+      { property: "Persistent Memory", pass: true },
+      { property: "Human Belonging", pass: true },
+    ],
+    violations: [
+      { file: "SOUL.md", field: "name", message: "Missing name." },
+      { file: "MEMORY.md", field: "file", message: "Missing memory." },
+    ],
+    warnings: [],
+  };
+}
+
+function growthReport(): FamiliarGrowthReport {
+  return {
+    familiarId: "cody",
+    healthLabel: "stalled",
+    sessionsLast7d: 0,
+    retroAcceptRate: null,
+    lastActiveAt: null,
+    recentRuns: [],
+    trackStats: {
+      synthesis: { total: 0, accepted: 0 },
+      prompt: { total: 0, accepted: 0 },
+      memory: { total: 0, accepted: 0 },
+    },
+    signals: [
+      {
+        kind: "session-gap",
+        label: "Session gap is critical",
+        detail: "No sessions.",
+        severity: "crit",
+      },
+      {
+        kind: "low-accept-rate",
+        label: "Prompt track is reverting often",
+        detail: "Too many reverts.",
+        severity: "warn",
+      },
+    ],
+  };
+}
+
+describe("deriveHealRequests", () => {
+  it("turns eval-loop reverts into warning run-eval requests", () => {
+    const requests = deriveHealRequests({
+      familiarId: "cody",
+      evalLoopState: evalLoopState(),
+      contractReport: null,
+      growthReport: null,
+    });
+
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].source, "eval-loop");
+    assert.equal(requests[0].severity, "warn");
+    assert.equal(requests[0].actionKind, "run-eval");
+    assert.equal(requests[0].createdAt, "2026-06-25T11:00:00.000Z");
+  });
+
+  it("turns contract violations into critical fix-contract requests", () => {
+    const requests = deriveHealRequests({
+      familiarId: "cody",
+      evalLoopState: null,
+      contractReport: contractReport(),
+      growthReport: null,
+    });
+
+    assert.equal(requests.length, 2);
+    assert.ok(requests.every((request) => request.source === "contract"));
+    assert.ok(requests.every((request) => request.severity === "crit"));
+    assert.ok(requests.every((request) => request.actionKind === "fix-contract"));
+  });
+
+  it("maps growth critical memory/session signals to write-memory and warnings to manual", () => {
+    const requests = deriveHealRequests({
+      familiarId: "cody",
+      evalLoopState: null,
+      contractReport: null,
+      growthReport: growthReport(),
+    });
+
+    assert.equal(requests[0].source, "growth-signal");
+    assert.equal(requests[0].severity, "crit");
+    assert.equal(requests[0].actionKind, "write-memory");
+    assert.equal(requests[1].severity, "warn");
+    assert.equal(requests[1].actionKind, "manual");
+  });
+
+  it("returns an empty list for empty inputs", () => {
+    assert.deepEqual(
+      deriveHealRequests({
+        familiarId: "cody",
+        evalLoopState: null,
+        contractReport: null,
+        growthReport: null,
+      }),
+      [],
+    );
+  });
+
+  it("sorts critical requests first, then warnings, newest first within severity", () => {
+    const requests = deriveHealRequests({
+      familiarId: "cody",
+      evalLoopState: evalLoopState(),
+      contractReport: contractReport(),
+      growthReport: growthReport(),
+    });
+
+    assert.deepEqual(
+      requests.map((request) => request.severity),
+      ["crit", "crit", "crit", "warn", "warn", "warn"],
+    );
+    assert.deepEqual(
+      requests.filter((request) => request.severity === "warn").map((request) => request.createdAt),
+      [
+        "2026-06-25T11:00:00.000Z",
+        "2026-06-25T10:00:00.000Z",
+        "1970-01-01T00:00:00.000Z",
+      ],
+    );
+  });
+});

--- a/src/lib/familiar-heal-requests.ts
+++ b/src/lib/familiar-heal-requests.ts
@@ -1,0 +1,121 @@
+import type { EvalLoopState } from "@/components/eval-loop-panel";
+import type { ContractReport, ContractViolation } from "@/lib/familiar-contract";
+import type { FamiliarGrowthReport, GrowthSignal } from "@/lib/familiar-growth-signals";
+
+export type HealSource = "eval-loop" | "contract" | "growth-signal";
+export type HealActionKind = "run-eval" | "fix-contract" | "write-memory" | "manual";
+
+export type SelfHealRequest = {
+  id: string;
+  familiarId: string;
+  source: HealSource;
+  severity: "info" | "warn" | "crit";
+  title: string;
+  detail: string;
+  suggestedAction: string;
+  actionKind: HealActionKind;
+  createdAt: string;
+  resolved: boolean;
+};
+
+const STATIC_CREATED_AT = "1970-01-01T00:00:00.000Z";
+
+const SEVERITY_RANK: Record<SelfHealRequest["severity"], number> = {
+  crit: 0,
+  warn: 1,
+  info: 2,
+};
+
+function titleCase(value: string): string {
+  return value.slice(0, 1).toUpperCase() + value.slice(1);
+}
+
+function fromContractViolation(
+  familiarId: string,
+  violation: ContractViolation,
+  index: number,
+): SelfHealRequest {
+  return {
+    id: `${familiarId}:contract:${index}:${violation.file}:${violation.field}`,
+    familiarId,
+    source: "contract",
+    severity: "crit",
+    title: `${violation.file} contract violation`,
+    detail: violation.message,
+    suggestedAction: `Fix ${violation.field} in ${violation.file}.`,
+    actionKind: "fix-contract",
+    createdAt: STATIC_CREATED_AT,
+    resolved: false,
+  };
+}
+
+function actionKindForGrowthSignal(signal: GrowthSignal): HealActionKind {
+  const criticalMemoryKinds = new Set<GrowthSignal["kind"]>(["session-gap", "no-memory", "stale-memory"]);
+  if (signal.severity === "crit" && criticalMemoryKinds.has(signal.kind)) return "write-memory";
+  return "manual";
+}
+
+function fromGrowthSignal(familiarId: string, signal: GrowthSignal, index: number): SelfHealRequest | null {
+  if (signal.severity !== "crit" && signal.severity !== "warn") return null;
+  const actionKind = actionKindForGrowthSignal(signal);
+  return {
+    id: `${familiarId}:growth-signal:${signal.kind}:${signal.track ?? "all"}:${index}`,
+    familiarId,
+    source: "growth-signal",
+    severity: signal.severity,
+    title: signal.label,
+    detail: signal.detail,
+    suggestedAction: actionKind === "write-memory"
+      ? "Write or refresh memory for this familiar."
+      : "Review the growth signal and choose the next manual intervention.",
+    actionKind,
+    createdAt: STATIC_CREATED_AT,
+    resolved: false,
+  };
+}
+
+function sortRequests(requests: SelfHealRequest[]): SelfHealRequest[] {
+  return [...requests].sort((a, b) => {
+    const severityDelta = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+    if (severityDelta !== 0) return severityDelta;
+    return Date.parse(b.createdAt) - Date.parse(a.createdAt);
+  });
+}
+
+export function deriveHealRequests(args: {
+  familiarId: string;
+  evalLoopState: EvalLoopState | null;
+  contractReport: ContractReport | null;
+  growthReport: FamiliarGrowthReport | null;
+}): SelfHealRequest[] {
+  const requests: SelfHealRequest[] = [];
+
+  for (const iteration of args.evalLoopState?.iterations ?? []) {
+    if (iteration.outcome !== "REVERT") continue;
+    requests.push({
+      id: `${args.familiarId}:eval-loop:${iteration.id}`,
+      familiarId: args.familiarId,
+      source: "eval-loop",
+      severity: "warn",
+      title: `${titleCase(iteration.track)} eval reverted`,
+      detail: iteration.notes
+        ? `${iteration.change_summary} ${iteration.notes}`
+        : iteration.change_summary,
+      suggestedAction: `Run a follow-up ${iteration.track} eval iteration.`,
+      actionKind: "run-eval",
+      createdAt: iteration.timestamp || STATIC_CREATED_AT,
+      resolved: false,
+    });
+  }
+
+  for (const [index, violation] of (args.contractReport?.violations ?? []).entries()) {
+    requests.push(fromContractViolation(args.familiarId, violation, index));
+  }
+
+  for (const [index, signal] of (args.growthReport?.signals ?? []).entries()) {
+    const request = fromGrowthSignal(args.familiarId, signal, index);
+    if (request) requests.push(request);
+  }
+
+  return sortRequests(requests);
+}

--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  contextPressureLabel,
+  deriveThreadScore,
+  type ThreadSelfReport,
+} from "./thread-self-report.ts";
+
+function fullReport(): ThreadSelfReport {
+  return {
+    id: "report-1",
+    familiarId: "cody",
+    sessionId: "session-1",
+    threadTitle: "Analytics foundation",
+    reportedAt: "2026-06-25T12:00:00.000Z",
+    overallConfidence: 80,
+    overallConfidenceReason: "Most signals were healthy.",
+    toolReliability: {
+      score: 60,
+      failedTools: ["build"],
+      unreliableTools: ["search"],
+      notes: "One transient failure.",
+    },
+    contextPressure: "tight",
+    contextNotes: "Enough room, but close.",
+    skillsUsed: ["test-driven-development"],
+    skillsNeedingClarity: [{ skillId: "verification-before-completion", reason: "Scope of CI checks." }],
+    skillsNeedingAccess: [{ skillId: "github", reason: "Needs PR merge access." }],
+    capabilitiesLacking: [
+      {
+        name: "Self-report API",
+        importance: "blocking",
+        detail: "Thread signals cannot persist yet.",
+      },
+    ],
+    capabilitiesVital: [
+      {
+        name: "GitHub CLI",
+        currentState: "available",
+        notes: "Authenticated.",
+      },
+    ],
+    memoryRecallScore: 50,
+    memoryRecallNotes: "Memory was available.",
+    fileLocatabilityScore: 90,
+    fileLocatabilityNotes: "Files were easy to find.",
+    persistentBlockers: [
+      {
+        id: "blocker-1",
+        title: "Missing daemon",
+        category: "infra",
+        firstSeenAt: "2026-06-24T12:00:00.000Z",
+        impact: "medium",
+        detail: "Daemon unavailable in local tests.",
+        suggestedResolution: "Mock route responses.",
+      },
+    ],
+  };
+}
+
+describe("thread self-report helpers", () => {
+  it("derives the weighted composite thread score", () => {
+    assert.equal(deriveThreadScore(fullReport()), 71);
+  });
+
+  it("maps every context pressure to a display label and severity", () => {
+    assert.deepEqual(contextPressureLabel("adequate"), { label: "Adequate", severity: "ok" });
+    assert.deepEqual(contextPressureLabel("tight"), { label: "Tight", severity: "warn" });
+    assert.deepEqual(contextPressureLabel("excess"), { label: "Excess", severity: "warn" });
+    assert.deepEqual(contextPressureLabel("critical"), { label: "Critical", severity: "crit" });
+  });
+
+  it("constructs a complete ThreadSelfReport shape", () => {
+    const report = fullReport();
+
+    assert.equal(report.id, "report-1");
+    assert.equal(report.persistentBlockers[0].impact, "medium");
+  });
+});

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -1,0 +1,72 @@
+export type ContextPressure = "adequate" | "tight" | "excess" | "critical";
+export type CapabilityState = "available" | "degraded" | "missing";
+export type BlockerCategory = "auth" | "tooling" | "permission" | "infra" | "context" | "skill" | "other";
+export type BlockerImpact = "low" | "medium" | "high" | "blocking";
+export type CapabilityImportance = "nice-to-have" | "important" | "blocking";
+
+export type ThreadSelfReport = {
+  id: string;
+  familiarId: string;
+  sessionId: string;
+  threadTitle?: string;
+  reportedAt: string;
+
+  overallConfidence: number;
+  overallConfidenceReason?: string;
+
+  toolReliability: {
+    score: number;
+    failedTools: string[];
+    unreliableTools: string[];
+    notes?: string;
+  };
+
+  contextPressure: ContextPressure;
+  contextNotes?: string;
+
+  skillsUsed: string[];
+  skillsNeedingClarity: { skillId: string; reason: string }[];
+  skillsNeedingAccess: { skillId: string; reason: string }[];
+
+  capabilitiesLacking: {
+    name: string;
+    importance: CapabilityImportance;
+    detail: string;
+  }[];
+  capabilitiesVital: {
+    name: string;
+    currentState: CapabilityState;
+    notes?: string;
+  }[];
+
+  memoryRecallScore: number;
+  memoryRecallNotes?: string;
+  fileLocatabilityScore: number;
+  fileLocatabilityNotes?: string;
+
+  persistentBlockers: {
+    id: string;
+    title: string;
+    category: BlockerCategory;
+    firstSeenAt?: string;
+    impact: BlockerImpact;
+    detail: string;
+    suggestedResolution?: string;
+  }[];
+};
+
+export function deriveThreadScore(report: ThreadSelfReport): number {
+  return Math.round(
+    report.overallConfidence * 0.35 +
+    report.toolReliability.score * 0.25 +
+    report.memoryRecallScore * 0.2 +
+    report.fileLocatabilityScore * 0.2,
+  );
+}
+
+export function contextPressureLabel(pressure: ContextPressure): { label: string; severity: "ok" | "warn" | "crit" } {
+  if (pressure === "critical") return { label: "Critical", severity: "crit" };
+  if (pressure === "tight") return { label: "Tight", severity: "warn" };
+  if (pressure === "excess") return { label: "Excess", severity: "warn" };
+  return { label: "Adequate", severity: "ok" };
+}


### PR DESCRIPTION
## Deliverables

1. Added `src/lib/familiar-confidence.ts` with pure weighted confidence scoring.
2. Added `src/lib/familiar-confidence.test.ts` with threshold, freshness, activity cap, contribution, zero, and max coverage.
3. Added `src/lib/familiar-heal-requests.ts` with pure self-heal request derivation from eval-loop, contract, and growth reports.
4. Added `src/lib/familiar-heal-requests.test.ts` covering reverts, contract violations, growth mappings, empty inputs, and sort order.
5. Added `src/lib/thread-self-report.ts` with Wave 1 thread report types plus score and context pressure helpers.
6. Added `src/lib/thread-self-report.test.ts` covering weighted scoring, all pressure labels, and full report shape construction.
7. Added analytics route placeholders for `/dashboard/familiars/[id]/analytics` and `/familiars/[id]/analytics`.
8. Added `src/components/familiar-analytics-view.tsx` skeleton plus a data/model helper for familiar/contract/eval/growth loading, confidence breakdown, self-heal requests, EvalLoopPanel reuse, and contract compliance.
9. Added `src/components/familiar-analytics-view.test.ts` with mocked fetch model coverage for Low/Trusted states, heal request count, and EvalLoopPanel presence.
10. Added analytics CSS classes to `src/app/globals.css`.

## Deferred

- Wave 2: self-report backend/API and Thread Signals section.
- Wave 3: inspector pane, chat surface, and navigation wiring.

## Verification

- `npx tsc --noEmit` passed.
- `npx vitest run` passed: 599 test files; the Wave 1 node:test files add 18 cases.
- `npx next build` passed.
- `pnpm check:tests-wired` passed.
- `pnpm test:app` passed: 439 app test files.
- GitHub CI passed: Frontend build, Rust check, E2E (Playwright), CodeQL.

Note: `next build` still reports the existing Turbopack NFT trace warning from `next.config.ts` via `src/app/api/onboarding/install/route.ts`; build exits 0.