### PR TITLE
feat(analytics): navigation wiring, auto-trigger, blocker escalation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -254,6 +254,7 @@ export const SUITES = {
     "src/lib/familiar-heal-requests.test.ts",
     "src/lib/thread-self-report.test.ts",
     "src/components/familiar-analytics-view.test.ts",
+    "src/components/familiar-analytics-navigation.test.ts",
     "src/lib/server/familiar-self-reports.test.ts",
     "src/components/thread-signal-card.test.ts",
     "src/components/thread-signals-section.test.ts",

--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -19,5 +19,10 @@ assert.match(
   /harnessOverride: configEntry\.harness \?\? null/,
   "Familiars API should expose whether the familiar has an explicit harness override",
 );
+assert.match(
+  source,
+  /autoSelfReport: configEntry\.autoSelfReport \?\? false/,
+  "Familiars API should expose per-familiar auto self-report config with a false default",
+);
 
 console.log("familiars route.test.ts: ok");

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -58,6 +58,7 @@ export async function GET() {
         voiceProvider: binding.voiceProvider,
         voiceModel: binding.voiceModel,
         voiceName: binding.voiceName,
+        autoSelfReport: configEntry.autoSelfReport ?? false,
         avatarUrl: avatar
           ? `/api/familiars/${encodeURIComponent(f.id)}/avatar?v=${Math.round(avatar.mtimeMs)}&format=png`
           : undefined,

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -54,6 +54,18 @@ assert.match(
 
 assert.match(
   source,
+  /familiar\.autoSelfReport[\s\S]*trigger: "auto"/,
+  "Archived chats should only auto-trigger self-report when the familiar config enables autoSelfReport",
+);
+
+assert.match(
+  source,
+  /catch \{[\s\S]*Auto self-report is best-effort and intentionally silent/,
+  "Auto self-report failures should be silent",
+);
+
+assert.match(
+  source,
   /<ThreadSignalCard[\s\S]*report=\{threadSignalReport\}/,
   "Successful reflection should render the ThreadSignalCard in the transcript",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1830,6 +1830,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [reflecting, setReflecting] = useState(false);
   const [reflectError, setReflectError] = useState<string | null>(null);
   const [threadSignalReport, setThreadSignalReport] = useState<ThreadSelfReport | null>(null);
+  const autoSelfReportSessionsRef = useRef<Set<string>>(new Set());
+  const autoSelfReportEligibilityRef = useRef<{ sessionId: string | null; eligible: boolean }>({
+    sessionId: null,
+    eligible: false,
+  });
 
   // Publish live chat state for the session debug pane (right panel / modal).
   // Per-instance token: a second ChatView (right-panel Chat tab) unmounting
@@ -1872,6 +1877,47 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setReflecting(false);
     }
   }, [familiar.display_name, familiar.id, reflecting, session?.title, sessionId]);
+
+  const autoReflectOnThread = useCallback(async (targetSessionId: string) => {
+    if (!familiar.autoSelfReport) return;
+    try {
+      const res = await fetch(`/api/familiars/${encodeURIComponent(familiar.id)}/self-report`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionId: targetSessionId,
+          trigger: "auto",
+          threadTitle: session?.title ?? familiar.display_name,
+        }),
+      });
+      const json = await res.json().catch(() => null) as
+        | { ok: true; report: ThreadSelfReport }
+        | { ok: false; error?: string }
+        | null;
+      if (json?.ok) setThreadSignalReport(json.report);
+    } catch {
+      /* Auto self-report is best-effort and intentionally silent. */
+    }
+  }, [familiar.autoSelfReport, familiar.display_name, familiar.id, session?.title]);
+
+  useEffect(() => {
+    const status = session?.status?.toLowerCase();
+    const eligible = Boolean(
+      session?.archived_at ||
+      status === "closed" ||
+      status === "completed" ||
+      status === "complete" ||
+      status === "done" ||
+      status === "stopped",
+    );
+    const previous = autoSelfReportEligibilityRef.current;
+    const reachedClosedState = previous.sessionId === sessionId && !previous.eligible && eligible;
+    autoSelfReportEligibilityRef.current = { sessionId, eligible };
+    if (!sessionId || !reachedClosedState || !familiar.autoSelfReport) return;
+    if (autoSelfReportSessionsRef.current.has(sessionId)) return;
+    autoSelfReportSessionsRef.current.add(sessionId);
+    void autoReflectOnThread(sessionId);
+  }, [autoReflectOnThread, familiar.autoSelfReport, session?.archived_at, session?.status, sessionId]);
 
   useEffect(() => {
     setThreadSignalReport(null);

--- a/src/components/familiar-analytics-navigation.test.ts
+++ b/src/components/familiar-analytics-navigation.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+describe("Familiar analytics navigation wiring", () => {
+  it("wires the inspector Analytics tab to FamiliarAnalyticsView", () => {
+    const source = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
+
+    assert.match(source, /import \{ FamiliarAnalyticsView \} from "@\/components\/familiar-analytics-view"/);
+    assert.match(source, /type Tab = "memory" \| "familiar" \| "analytics" \| "inbox"/);
+    assert.match(source, /analytics: "Analytics"/);
+    assert.match(source, /tab === "analytics"[\s\S]*<FamiliarAnalyticsView familiarId=\{familiar\.id\} \/>/);
+  });
+
+  it("links growth roster rows to per-familiar analytics", () => {
+    const source = readFileSync(new URL("./familiar-growth-view.tsx", import.meta.url), "utf8");
+
+    assert.match(source, /import Link from "next\/link"/);
+    assert.match(source, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/analytics`\}/);
+    assert.match(source, /Analytics →/);
+  });
+
+  it("links familiar landing cards to per-familiar analytics", () => {
+    const source = readFileSync(new URL("./familiars-view.tsx", import.meta.url), "utf8");
+
+    assert.match(source, /import Link from "next\/link"/);
+    assert.match(source, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/analytics`\}/);
+    assert.match(source, /aria-label=\{`Open analytics for \$\{familiar\.display_name\}`\}/);
+  });
+});

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -286,7 +286,8 @@ describe("FamiliarAnalyticsView", () => {
 
     assert.equal(model.healRequests.length, 1);
     assert.equal(model.threadReports.length, 1);
-    assert.match(source, /model\.healRequests\.length === 1 \? "request" : "requests"/);
+    assert.match(source, /escalateBlockers\(model\.familiarId, threadSignalsAggregate, model\.healRequests\)/);
+    assert.match(source, /healRequests\.length === 1 \? "request" : "requests"/);
     assert.match(source, /<ThreadSignalsSection[\s\S]*reports=\{model\.threadReports\}/);
     assert.match(source, /<EvalLoopPanel[\s\S]*familiarId=\{model\.familiar\.id\}/);
   });

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -11,7 +11,9 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { ThreadSignalsSection } from "@/components/thread-signals-section";
+import { escalateBlockers } from "@/lib/familiar-heal-requests";
 import { Icon } from "@/lib/icon";
+import { aggregateThreadSignals } from "@/lib/thread-self-report";
 
 export function FamiliarAnalyticsView({ familiarId }: { familiarId: string }) {
   const [data, setData] = useState<FamiliarAnalyticsData | null>(null);
@@ -75,6 +77,15 @@ export function FamiliarAnalyticsContent({
 }) {
   const familiarName = model.familiar?.display_name ?? model.familiarId;
   const familiarRole = model.familiar?.role || model.familiar?.harness || "Familiar";
+  const threadSignalsAggregate = useMemo(
+    () => model.threadReports.length > 0 ? aggregateThreadSignals(model.threadReports) : null,
+    [model.threadReports],
+  );
+  const healRequests = useMemo(() => {
+    if (!threadSignalsAggregate) return model.healRequests;
+    const escalated = escalateBlockers(model.familiarId, threadSignalsAggregate, model.healRequests);
+    return [...escalated, ...model.healRequests];
+  }, [model.familiarId, model.healRequests, threadSignalsAggregate]);
 
   return (
     <>
@@ -151,13 +162,13 @@ export function FamiliarAnalyticsContent({
       <section className="fa-section" aria-labelledby="fa-heal-title">
         <div className="fa-section__head">
           <h2 id="fa-heal-title" className="fa-section__title">Self-Heal Requests</h2>
-          <span>{model.healRequests.length} {model.healRequests.length === 1 ? "request" : "requests"}</span>
+          <span>{healRequests.length} {healRequests.length === 1 ? "request" : "requests"}</span>
         </div>
-        {model.healRequests.length === 0 ? (
+        {healRequests.length === 0 ? (
           <EmptyState compact icon="ph:check-circle-bold" headline="No self-heal requests." />
         ) : (
           <div className="fa-heal-list">
-            {model.healRequests.map((request) => (
+            {healRequests.map((request) => (
               <article key={request.id} className={`fa-heal-card fa-heal-card--${request.severity}`}>
                 <div>
                   <span>{request.source}</span>

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -255,6 +256,12 @@ export function FamiliarGrowthView({
                       </span>
                       <i className={`growth-dot growth-dot--${report.healthLabel}`} aria-label={report.healthLabel} />
                     </button>
+                    <Link
+                      href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
+                      className="ml-[54px] mt-1 inline-flex text-[10px] text-[var(--text-muted)] hover:text-[var(--accent-presence)]"
+                    >
+                      Analytics →
+                    </Link>
                   </li>
                 );
               })}

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { Tabs } from "@/components/ui/tabs";
@@ -383,68 +384,77 @@ function FamiliarRosterCard({
   const sessionsLabel =
     stats.sessionsLast7d > 0 ? ` · ${stats.sessionsLast7d} this week` : "";
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className="focus-ring familiars-view__card group flex h-full flex-col items-stretch gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3 text-left transition-colors hover:border-[var(--accent-presence)]/50 hover:bg-[var(--bg-raised)]/60"
-      aria-label={`Open ${familiar.display_name}`}
-    >
-      <div className="flex items-center gap-2">
-        <FamiliarAvatar familiar={familiar} size="sm" />
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-semibold text-[var(--text-primary)]">
-            {familiar.display_name}
-          </span>
-          <span className="block truncate text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
-            {familiar.role || familiar.harness || familiar.id}
-          </span>
-        </span>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
-        <span
-          className={`inline-flex h-1.5 w-1.5 rounded-full ${daemonRunning ? "bg-[var(--accent-presence)]" : "bg-[var(--text-muted)]"}`}
-          aria-hidden="true"
-        />
-        <span>{daemonRunning ? "online" : "offline"}</span>
-        {stats.hasActiveSession ? (
-          <span className="rounded bg-[var(--accent-presence)]/15 px-1.5 py-0.5 text-[9px] text-[var(--accent-presence)]">
-            active session
-          </span>
-        ) : null}
-        {responseNeeded ? (
-          <span className="rounded bg-[var(--color-warning)]/15 px-1.5 py-0.5 text-[9px] text-[var(--color-warning)]">
-            response needed
-          </span>
-        ) : null}
-      </div>
-
-      <p className="text-[11px] text-[var(--text-secondary)]">
-        {lastSessionLabel}{sessionsLabel}
-      </p>
-
-      <div className="mt-auto border-t border-[var(--border-hairline)] pt-2 text-[11px] text-[var(--text-secondary)]">
-        {memoryStatus === "loading" ? (
-          <span className="text-[var(--text-muted)]">Loading memory…</span>
-        ) : memoryStatus === "error" ? (
-          <span className="text-[var(--text-muted)]">Memory unavailable</span>
-        ) : stats.memoryCount === 0 ? (
-          <span className="text-[var(--text-muted)]">No memories yet</span>
-        ) : (
-          <>
-            <span className="block">
-              {stats.memoryCount} memor{stats.memoryCount === 1 ? "y" : "ies"}
-              {stats.latestMemory ? ` · last write ${age(stats.latestMemory.updatedAt)}` : ""}
+    <div className="flex h-full flex-col">
+      <button
+        type="button"
+        onClick={onSelect}
+        className="focus-ring familiars-view__card group flex h-full flex-col items-stretch gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-3 text-left transition-colors hover:border-[var(--accent-presence)]/50 hover:bg-[var(--bg-raised)]/60"
+        aria-label={`Open ${familiar.display_name}`}
+      >
+        <div className="flex items-center gap-2">
+          <FamiliarAvatar familiar={familiar} size="sm" />
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[13px] font-semibold text-[var(--text-primary)]">
+              {familiar.display_name}
             </span>
-            {stats.latestMemory ? (
-              <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">
-                {stats.latestMemory.title}
+            <span className="block truncate text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+              {familiar.role || familiar.harness || familiar.id}
+            </span>
+          </span>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-1.5 text-[10px] uppercase tracking-widest text-[var(--text-muted)]">
+          <span
+            className={`inline-flex h-1.5 w-1.5 rounded-full ${daemonRunning ? "bg-[var(--accent-presence)]" : "bg-[var(--text-muted)]"}`}
+            aria-hidden="true"
+          />
+          <span>{daemonRunning ? "online" : "offline"}</span>
+          {stats.hasActiveSession ? (
+            <span className="rounded bg-[var(--accent-presence)]/15 px-1.5 py-0.5 text-[9px] text-[var(--accent-presence)]">
+              active session
+            </span>
+          ) : null}
+          {responseNeeded ? (
+            <span className="rounded bg-[var(--color-warning)]/15 px-1.5 py-0.5 text-[9px] text-[var(--color-warning)]">
+              response needed
+            </span>
+          ) : null}
+        </div>
+
+        <p className="text-[11px] text-[var(--text-secondary)]">
+          {lastSessionLabel}{sessionsLabel}
+        </p>
+
+        <div className="mt-auto border-t border-[var(--border-hairline)] pt-2 text-[11px] text-[var(--text-secondary)]">
+          {memoryStatus === "loading" ? (
+            <span className="text-[var(--text-muted)]">Loading memory…</span>
+          ) : memoryStatus === "error" ? (
+            <span className="text-[var(--text-muted)]">Memory unavailable</span>
+          ) : stats.memoryCount === 0 ? (
+            <span className="text-[var(--text-muted)]">No memories yet</span>
+          ) : (
+            <>
+              <span className="block">
+                {stats.memoryCount} memor{stats.memoryCount === 1 ? "y" : "ies"}
+                {stats.latestMemory ? ` · last write ${age(stats.latestMemory.updatedAt)}` : ""}
               </span>
-            ) : null}
-          </>
-        )}
-      </div>
-    </button>
+              {stats.latestMemory ? (
+                <span className="mt-0.5 block truncate text-[10px] text-[var(--text-muted)]">
+                  {stats.latestMemory.title}
+                </span>
+              ) : null}
+            </>
+          )}
+        </div>
+      </button>
+      <Link
+        href={`/dashboard/familiars/${encodeURIComponent(familiar.id)}/analytics`}
+        aria-label={`Open analytics for ${familiar.display_name}`}
+        className="mt-1 self-start text-[10px] text-[var(--text-muted)] hover:text-[var(--accent-presence)]"
+      >
+        Analytics →
+      </Link>
+    </div>
   );
 }
 

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
+import { FamiliarAnalyticsView } from "@/components/familiar-analytics-view";
 import { SyntaxBlock, MarkdownBlock } from "@/components/message-bubble";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
 import { SnoozeMenu } from "@/components/snooze-menu";
@@ -17,7 +18,7 @@ import type { AdapterReport } from "@/lib/harness-adapters";
 import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 
-type Tab = "memory" | "familiar" | "inbox";
+type Tab = "memory" | "familiar" | "analytics" | "inbox";
 
 
 
@@ -64,10 +65,11 @@ type Props = {
 const TAB_LABEL: Record<Tab, string> = {
   memory: "Memory",
   familiar: "Familiar",
+  analytics: "Analytics",
   inbox: "Automations",
 };
 
-const INSPECTOR_TABS: Tab[] = ["memory", "familiar", "inbox"];
+const INSPECTOR_TABS: Tab[] = ["memory", "familiar", "analytics", "inbox"];
 
 function InspectorEmpty({
   icon,
@@ -196,6 +198,7 @@ export function InspectorPane({
       >
         {tab === "memory" && !hideMemory ? <MemoryTab familiar={familiar} onOpenFullView={onOpenFullView} /> : null}
         {tab === "familiar" ? <FamiliarCapabilityPanel familiar={familiar} /> : null}
+        {tab === "analytics" && familiar ? <FamiliarAnalyticsView familiarId={familiar.id} /> : null}
         {tab === "inbox" ? (
           <InboxTab
             familiar={familiar}

--- a/src/lib/cave-config.test.ts
+++ b/src/lib/cave-config.test.ts
@@ -69,6 +69,7 @@ try {
         harness: "claude",
         model: "anthropic/claude-sonnet-4-6",
         voiceProvider: "openai",
+        autoSelfReport: true,
       },
     },
   });
@@ -85,6 +86,7 @@ try {
     harness: "claude",
     model: "anthropic/claude-sonnet-4-6",
     voiceProvider: "openai",
+    autoSelfReport: true,
     display_name: "Nova Prime",
     role: "review familiar",
   });
@@ -92,6 +94,8 @@ try {
   const novaBinding = config.bindingFor(cfg, "nova");
   assert.equal(novaBinding.display_name, "Nova Prime");
   assert.equal(novaBinding.role, "review familiar");
+  assert.equal(novaBinding.autoSelfReport, true);
+  assert.equal(config.bindingFor(cfg, "missing").autoSelfReport, false);
 
   await config.saveConfig({
     familiars: {
@@ -104,6 +108,7 @@ try {
   assert.deepEqual(cfg.familiars.nova, {
     harness: "claude",
     model: "anthropic/claude-sonnet-4-6",
+    autoSelfReport: true,
     display_name: "Nova Prime",
     role: "review familiar",
   });

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -71,6 +71,7 @@ export type FamiliarBinding = {
   voiceProvider?: string;
   voiceModel?: string;
   voiceName?: string;
+  autoSelfReport?: boolean;
   runtime?: FamiliarRuntime;
 };
 
@@ -267,6 +268,7 @@ export function bindingFor(config: CaveConfig, familiarId: string): FamiliarBind
     voiceProvider: f.voiceProvider,
     voiceModel: f.voiceModel,
     voiceName: f.voiceName,
+    autoSelfReport: f.autoSelfReport ?? false,
     runtime: normalizeFamiliarRuntime(f.runtime ?? config.defaults.runtime),
   };
 }

--- a/src/lib/familiar-heal-requests.test.ts
+++ b/src/lib/familiar-heal-requests.test.ts
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { FAMILIAR_CONTRACT_SPEC_VERSION, type ContractReport } from "./familiar-contract.ts";
-import { deriveHealRequests } from "./familiar-heal-requests.ts";
+import { deriveHealRequests, escalateBlockers, type SelfHealRequest } from "./familiar-heal-requests.ts";
 import type { FamiliarGrowthReport } from "./familiar-growth-signals.ts";
+import type { ThreadSignalsAggregate } from "./thread-self-report.ts";
 import type { EvalLoopState } from "@/components/eval-loop-panel";
 
 function evalLoopState(): EvalLoopState {
@@ -49,6 +50,42 @@ function evalLoopState(): EvalLoopState {
     total_accepted: 1,
     total_reverted: 2,
     running: false,
+  };
+}
+
+function aggregateWithBlockers(
+  blockers: ThreadSignalsAggregate["persistentBlockers"],
+): ThreadSignalsAggregate {
+  return {
+    averageConfidence: 80,
+    averageToolReliability: 80,
+    averageMemoryRecall: 80,
+    averageFileLocatability: 80,
+    contextCounts: { adequate: 1, tight: 0, excess: 0, critical: 0 },
+    skillsUsedMost: [],
+    skillsNeedingClarity: [],
+    skillsNeedingAccess: [],
+    capabilitiesVital: [],
+    capabilitiesLacking: [],
+    persistentBlockers: blockers,
+  };
+}
+
+function blocker(
+  id: string,
+  category: ThreadSignalsAggregate["persistentBlockers"][number]["category"],
+  crit = true,
+): ThreadSignalsAggregate["persistentBlockers"][number] {
+  return {
+    id,
+    title: `${category} blocker`,
+    category,
+    impact: "blocking",
+    detail: `Persistent ${category} issue.`,
+    suggestedResolution: `Resolve ${category}.`,
+    frequency: 3,
+    rankScore: 12,
+    crit,
   };
 }
 
@@ -178,5 +215,89 @@ describe("deriveHealRequests", () => {
         "1970-01-01T00:00:00.000Z",
       ],
     );
+  });
+});
+
+describe("escalateBlockers", () => {
+  it("turns critical aggregate blockers into critical self-heal requests", () => {
+    const requests = escalateBlockers("cody", aggregateWithBlockers([blocker("auth-oauth", "auth")]), []);
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].id, "auth-oauth");
+    assert.equal(requests[0].familiarId, "cody");
+    assert.equal(requests[0].source, "self-report-aggregate");
+    assert.equal(requests[0].severity, "crit");
+    assert.equal(requests[0].actionKind, "fix-contract");
+  });
+
+  it("skips non-critical blockers", () => {
+    const requests = escalateBlockers("cody", aggregateWithBlockers([blocker("context-noise", "context", false)]), []);
+
+    assert.deepEqual(requests, []);
+  });
+
+  it("does not add duplicates already present by blocker id", () => {
+    const existing: SelfHealRequest[] = [
+      {
+        id: "tooling-missing-cli",
+        familiarId: "cody",
+        source: "growth-signal",
+        severity: "crit",
+        title: "Existing request",
+        detail: "Already tracked.",
+        suggestedAction: "Review it.",
+        actionKind: "manual",
+        createdAt: "2026-06-25T10:00:00.000Z",
+        resolved: false,
+      },
+    ];
+
+    const requests = escalateBlockers(
+      "cody",
+      aggregateWithBlockers([blocker("tooling-missing-cli", "tooling")]),
+      existing,
+    );
+
+    assert.deepEqual(requests, []);
+  });
+
+  it("maps blocker categories to escalation action kinds", () => {
+    const requests = escalateBlockers(
+      "cody",
+      aggregateWithBlockers([
+        blocker("auth", "auth"),
+        blocker("tooling", "tooling"),
+        blocker("permission", "permission"),
+        blocker("infra", "infra"),
+        blocker("context", "context"),
+        blocker("skill", "skill"),
+        blocker("other", "other"),
+      ]),
+      [],
+    );
+
+    assert.deepEqual(
+      requests.map((request) => [request.id, request.actionKind]),
+      [
+        ["auth", "fix-contract"],
+        ["tooling", "manual"],
+        ["permission", "manual"],
+        ["infra", "manual"],
+        ["context", "write-memory"],
+        ["skill", "request-skill"],
+        ["other", "manual"],
+      ],
+    );
+  });
+
+  it("does not mutate aggregate blockers or existing requests", () => {
+    const aggregate = aggregateWithBlockers([blocker("context", "context")]);
+    const existing: SelfHealRequest[] = [];
+    const blockerBefore = { ...aggregate.persistentBlockers[0] };
+
+    escalateBlockers("cody", aggregate, existing);
+
+    assert.deepEqual(aggregate.persistentBlockers[0], blockerBefore);
+    assert.deepEqual(existing, []);
   });
 });

--- a/src/lib/familiar-heal-requests.ts
+++ b/src/lib/familiar-heal-requests.ts
@@ -1,9 +1,10 @@
 import type { EvalLoopState } from "@/components/eval-loop-panel";
 import type { ContractReport, ContractViolation } from "@/lib/familiar-contract";
 import type { FamiliarGrowthReport, GrowthSignal } from "@/lib/familiar-growth-signals";
+import type { BlockerCategory, ThreadSignalsAggregate } from "@/lib/thread-self-report";
 
-export type HealSource = "eval-loop" | "contract" | "growth-signal";
-export type HealActionKind = "run-eval" | "fix-contract" | "write-memory" | "manual";
+export type HealSource = "eval-loop" | "contract" | "growth-signal" | "self-report-aggregate";
+export type HealActionKind = "run-eval" | "fix-contract" | "write-memory" | "request-skill" | "manual";
 
 export type SelfHealRequest = {
   id: string;
@@ -52,6 +53,13 @@ function fromContractViolation(
 function actionKindForGrowthSignal(signal: GrowthSignal): HealActionKind {
   const criticalMemoryKinds = new Set<GrowthSignal["kind"]>(["session-gap", "no-memory", "stale-memory"]);
   if (signal.severity === "crit" && criticalMemoryKinds.has(signal.kind)) return "write-memory";
+  return "manual";
+}
+
+function actionKindForBlockerCategory(category: BlockerCategory): HealActionKind {
+  if (category === "auth") return "fix-contract";
+  if (category === "context") return "write-memory";
+  if (category === "skill") return "request-skill";
   return "manual";
 }
 
@@ -118,4 +126,31 @@ export function deriveHealRequests(args: {
   }
 
   return sortRequests(requests);
+}
+
+export function escalateBlockers(
+  familiarId: string,
+  aggregate: ThreadSignalsAggregate,
+  existingRequests: SelfHealRequest[],
+): SelfHealRequest[] {
+  const existingIds = new Set(existingRequests.map((request) => request.id));
+  return aggregate.persistentBlockers
+    .filter((blocker) => blocker.crit && !existingIds.has(blocker.id))
+    .map((blocker) => {
+      const actionKind = actionKindForBlockerCategory(blocker.category);
+      return {
+        id: blocker.id,
+        familiarId,
+        source: "self-report-aggregate" as const,
+        severity: "crit" as const,
+        title: blocker.title,
+        detail: blocker.detail,
+        suggestedAction:
+          blocker.suggestedResolution ??
+          "Review the recurring blocker and choose the next manual intervention.",
+        actionKind,
+        createdAt: blocker.firstSeenAt ?? STATIC_CREATED_AT,
+        resolved: false,
+      };
+    });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,6 +36,7 @@ export type Familiar = {
   voiceProvider?: string;
   voiceModel?: string;
   voiceName?: string;
+  autoSelfReport?: boolean;
 };
 
 export type DaemonStatus = {


### PR DESCRIPTION
## Summary
- Add Familiar Analytics entry points in the inspector pane, growth roster, and familiars landing cards.
- Add configurable per-familiar auto self-report wiring using cave config `familiars[id].autoSelfReport` (default false) and silent best-effort auto triggers for closed/archived conversations.
- Escalate >50% recurring self-report blockers into critical self-heal requests and merge them into the analytics heal request list.
- Add source-wiring and blocker escalation coverage, and wire the new test into `scripts/run-tests.mjs`.

## Verification
- `npx tsc --noEmit` passed.
- `node scripts/check-tests-wired.mjs` passed.
- `npx vitest run` passed (605 test files).
- `npx next build` passed.

Completes Familiar Analytics Wave 3/3.
