### PR TITLE
chore(release): stamp v0.0.116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.116] - 2026-06-25
+
+Patch release on top of v0.0.115. Headline: flows get a proper production-publish
+lane plus n8n-parity polish (per-node settings, duplicate node, display-note
+toggle, tidy layout, expression-vs-fixed param descriptions) (#1947). Familiar
+analytics finished wiring up across the stack (#1944, #1945, #1946).
+
+### Added
+
+- **Flow / Publish** - the flow toolbar now has a Publish action that snapshots
+  the current draft into the production version, so webhook and schedule runs
+  no longer pick up unsaved edits. Republish to roll the production snapshot
+  forward; Unpublish to clear it (#1947).
+- **Flow / Node settings** - n8n-style per-node options: `alwaysOutputData`,
+  `executeOnce`, `retryOnFail` with `maxTries`, and `onError`
+  (`stop` | `continue` | `continueErrorOutput`) (#1947).
+- **Flow / Duplicate node** - one-click duplicate in the node detail view
+  (positions, name, params, settings all cloned) (#1947).
+- **Flow / Display note in flow** - per-node toggle that surfaces the node's
+  notes as a subtitle on the canvas (#1947).
+- **Flow / Tidy layout** - column-based auto-layout helper that respects
+  sticky-note nodes (#1947).
+- **Familiar analytics** - end-to-end wiring for the self-report backend,
+  thread-signal card, chat-reflect trigger, and the analytics surface itself
+  (#1944, #1945, #1946).
+
+### Changed
+
+- **Flow / Compile descriptions** - parameter logs now split expression-bound
+  and fixed values so on-the-fly substitutions are easier to read at a glance
+  (#1947).
+- **Flow store** - `coerceFlowNodes` normalizes legacy node payloads and the
+  new `disabled` / `displayNote` / `settings` / `published` fields on every
+  write, so older flows upgrade cleanly without manual migration (#1947).
+
 ## [0.0.115] - 2026-06-25
 
 Patch release on top of v0.0.114: a harness-identity fix that unblocks native

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.115",
+  "version": "0.0.116",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.115"
+version = "0.0.116"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.115"
+version = "0.0.116"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.115</string>
+	<string>0.0.116</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.115</string>
+	<string>0.0.116</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.115</string>
+	<string>0.0.116</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.115</string>
+	<string>0.0.116</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.115",
+  "version": "0.0.116",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.115. Headline: flows get a proper production-publish
lane and a stack of n8n-parity polish — per-node settings (\`alwaysOutputData\`,
\`executeOnce\`, \`retryOnFail\`/\`maxTries\`, \`onError\`), duplicate node,
display-note toggle, tidy layout, and expression-vs-fixed param logs (#1947).
Familiar analytics also finished wiring up across the stack (#1944, #1945,
#1946).

Bumps:
- \`package.json\`
- \`src-tauri/Cargo.toml\` + \`Cargo.lock\`
- \`src-tauri/tauri.conf.json\`
- \`src-tauri/Info.ios.plist\` + \`gen/apple/app_iOS/Info.plist\`

\`CHANGELOG.md\` updated with a 0.0.116 section.

🐾 Kitty