### PR TITLE
feat(composer): add project and attachment controls

### DIFF
--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -55,8 +55,20 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label="Add files"/,
-  "Add button should have an explicit accessible label",
+  /const CHAT_ATTACHMENT_ACCEPT = \[[\s\S]*"image\/\*"[\s\S]*"video\/\*"[\s\S]*"application\/pdf"[\s\S]*"\.md"[\s\S]*"\.json"[\s\S]*\]\.join\(","\)/,
+  "Chat attachments should explicitly accept images, videos, documents, and common text/code files",
+);
+
+assert.match(
+  source,
+  /accept=\{CHAT_ATTACHMENT_ACCEPT\}/,
+  "The hidden file input behind the plus button should use the shared attachment accept list",
+);
+
+assert.match(
+  source,
+  /aria-label="Attach images, videos, or files"/,
+  "Add button should have an explicit accessible label for images, videos, and files",
 );
 
 assert.match(
@@ -79,7 +91,13 @@ assert.match(
 
 assert.match(
   source,
-  /className="cave-composer-action-row"[\s\S]*aria-label="Add files"[\s\S]*aria-label="Send message"/,
+  /function attachmentIcon[\s\S]*startsWith\("image\/"\)[\s\S]*"ph:camera"[\s\S]*startsWith\("video\/"\)[\s\S]*"ph:video"[\s\S]*"ph:paperclip"/,
+  "Attachment chips should distinguish images and videos from generic files",
+);
+
+assert.match(
+  source,
+  /className="cave-composer-action-row"[\s\S]*aria-label="Attach images, videos, or files"[\s\S]*aria-label="Send message"/,
   "Composer should keep Add and Send in the primary row above the dropdown divider",
 );
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -206,6 +206,41 @@ const SPEED_OPTIONS: Array<{ value: ComposerResponseSpeed; label: string }> = [
   { value: "balanced", label: "Balanced" },
   { value: "careful", label: "Careful" },
 ];
+const CHAT_ATTACHMENT_ACCEPT = [
+  "image/*",
+  "video/*",
+  "application/pdf",
+  "application/json",
+  "text/*",
+  ".txt",
+  ".md",
+  ".markdown",
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+  ".csv",
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".css",
+  ".scss",
+  ".html",
+  ".xml",
+  ".rs",
+  ".go",
+  ".py",
+  ".rb",
+  ".swift",
+  ".java",
+  ".kt",
+  ".sh",
+  ".zsh",
+  ".fish",
+  ".sql",
+  ".log",
+].join(",");
 
 function readComposerPrefs(): {
   thinkingEffort: ComposerThinkingEffort;
@@ -572,6 +607,16 @@ function isTextLike(file: File): boolean {
   if (file.type.startsWith("text/")) return true;
   if (/\/(json|xml|yaml|toml|javascript|typescript|x-sh|csv)$/i.test(file.type)) return true;
   return /\.(txt|md|markdown|json|yaml|yml|toml|csv|ts|tsx|js|jsx|css|scss|html|xml|rs|go|py|rb|swift|java|kt|sh|zsh|fish|sql|log)$/i.test(file.name);
+}
+
+function attachmentIcon(attachment: Pick<ChatAttachment, "mimeType" | "type">): IconName {
+  const mimeType = attachment.mimeType ?? attachment.type ?? "";
+  if (mimeType.startsWith("image/")) return "ph:camera";
+  if (mimeType.startsWith("video/")) return "ph:video";
+  if (mimeType.startsWith("text/") || /json|xml|yaml|toml|csv|javascript|typescript/.test(mimeType)) {
+    return "ph:file-text";
+  }
+  return "ph:paperclip";
 }
 
 function hasDraggedFiles(types: DataTransfer["types"]): boolean {
@@ -1801,7 +1846,13 @@ function MobileChatActionStrip({
         <Icon name="ph:magnifying-glass" width={13} aria-hidden />
         Summarize
       </button>
-      <button type="button" onClick={onAttach} disabled={!canAttach || busy} className="cave-mobile-action-chip">
+      <button
+        type="button"
+        onClick={onAttach}
+        disabled={!canAttach || busy}
+        className="cave-mobile-action-chip"
+        title="Attach images, videos, or files"
+      >
         <Icon name="ph:paperclip" width={13} aria-hidden />
         Attach
       </button>
@@ -4195,7 +4246,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     key={attachment.id}
                     className="inline-flex max-w-56 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/50 px-2 py-1 text-[11px] text-[var(--text-secondary)]"
                   >
-                    <Icon name="ph:paperclip" width={12} />
+                    <Icon name={attachmentIcon(attachment)} width={12} />
                     <span className="truncate">{attachment.name}</span>
                     <span className="shrink-0 text-[var(--text-muted)]">{fmtBytes(attachment.size)}</span>
                     <button
@@ -4277,6 +4328,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 <input
                   ref={fileInputRef}
                   type="file"
+                  accept={CHAT_ATTACHMENT_ACCEPT}
                   multiple
                   className="hidden"
                   onChange={(e) => {
@@ -4291,8 +4343,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 <button
                   type="button"
                   className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
-                  title="Add files"
-                  aria-label="Add files"
+                  title="Attach images, videos, or files"
+                  aria-label="Attach images, videos, or files"
                   disabled={busy || attachments.length >= 10}
                   onClick={() => fileInputRef.current?.click()}
                 >
@@ -5005,7 +5057,7 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
       >
         {/* Header */}
         <div className="flex items-center gap-2 border-b border-[var(--border-hairline)]/60 px-4 py-2.5">
-          <Icon name="ph:paperclip" width={13} className="shrink-0 text-[var(--text-muted)]" />
+          <Icon name={attachmentIcon(attachment)} width={13} className="shrink-0 text-[var(--text-muted)]" />
           <span className="flex-1 truncate text-[12px] text-[var(--text-secondary)]">{attachment.name}</span>
           <span className="shrink-0 text-[11px] text-[var(--text-muted)]">{fmtBytes(attachment.size)}</span>
           {attachment.truncated ? (
@@ -5152,7 +5204,7 @@ function AttachmentList({ attachments }: { attachments: ChatAttachment[] }) {
             title={`View ${attachment.name}`}
             onClick={() => setSelected(attachment)}
           >
-            <Icon name="ph:paperclip" width={12} className="shrink-0 text-[var(--text-muted)]" />
+            <Icon name={attachmentIcon(attachment)} width={12} className="shrink-0 text-[var(--text-muted)]" />
             <span className="truncate">{attachment.name}</span>
             <span className="shrink-0 text-[var(--text-muted)]">{fmtBytes(attachment.size)}</span>
             {attachment.truncated ? (

--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -46,8 +46,8 @@ assert.match(
 // ───── Phone composer controls are thumb-sized ─────
 assert.match(
   css,
-  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-familiar-select\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "phone composer action bar wraps into thumb-sized familiar/send/destination controls",
+  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-familiar-select\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone composer action bar wraps into thumb-sized familiar/send/two-destination controls",
 );
 
 

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -7,8 +7,13 @@ const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "
 // ───────── Task 1: Destination-aware placeholder + drop subtitle ─────────
 assert.match(
   source,
-  /const PLACEHOLDERS: Record<Destination, string> = \{[\s\S]*?chat:[\s\S]*?board:[\s\S]*?reminder:[\s\S]*?\}/,
-  "PLACEHOLDERS must be a Record<Destination, string> with chat/board/reminder keys",
+  /const PLACEHOLDERS: Record<Destination, string> = \{[\s\S]*?chat:[\s\S]*?board:[\s\S]*?\}/,
+  "PLACEHOLDERS must be a Record<Destination, string> with chat/board keys",
+);
+assert.doesNotMatch(
+  source,
+  /reminder: "Remind me about/,
+  "Reminder should not be a home-composer destination placeholder",
 );
 assert.match(
   source,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -7,20 +7,74 @@ const destinations = source.match(/const DESTINATIONS:[\s\S]*?\n\];/)?.[0] ?? ""
 
 assert.match(
   destinations,
-  /id: "chat"[\s\S]*label: "Familiar"/,
-  "HomeComposer should frame chat launch as a Familiar destination",
+  /id: "chat"[\s\S]*label: "Chat"/,
+  "HomeComposer should frame chat launch as a Chat destination",
 );
 
 assert.match(
   destinations,
-  /id: "board"[\s\S]*label: "Tasks"/,
-  "HomeComposer should keep Tasks as a launch destination",
+  /id: "board"[\s\S]*label: "Task"/,
+  "HomeComposer should keep Task as a launch destination",
 );
 
-assert.match(
+assert.doesNotMatch(
   destinations,
   /id: "reminder"[\s\S]*label: "Reminder"/,
-  "HomeComposer should keep Reminder as a launch destination",
+  "HomeComposer should not offer Reminder as a home launch destination",
+);
+
+assert.match(
+  source,
+  /useProjects\(\{ familiarId: selectedFamiliarId \|\| null \}\)/,
+  "HomeComposer should load a familiar-scoped project list for the project selector",
+);
+
+assert.match(
+  source,
+  /home-composer-headline[\s\S]*?\{`What should we build in \$\{selectedProject\?\.name \?\? "Coven Cave"\}\?`\}/,
+  "HomeComposer headline should reflect the selected project name",
+);
+
+assert.match(
+  source,
+  /aria-label="Choose project"[\s\S]*value=\{selectedProjectId\}/,
+  "HomeComposer should render a project selector",
+);
+
+assert.match(
+  source,
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null\)/,
+  "HomeComposer should hand the selected project root to chat start",
+);
+
+assert.match(
+  source,
+  /body: JSON\.stringify\(\{[\s\S]*?title: prompt,[\s\S]*?familiarId: activeFamiliarId \?\? null,[\s\S]*?cwd: selectedProject\?\.root \?\? null,[\s\S]*?projectId: selectedProject\?\.id \?\? null,[\s\S]*?\}\)/,
+  "HomeComposer should attach the selected project to task creation",
+);
+
+assert.match(
+  source,
+  /aria-label="Choose runtime"[\s\S]*value=\{selectedRuntime\}/,
+  "HomeComposer should expose a runtime selector for the selected familiar",
+);
+
+assert.match(
+  source,
+  /aria-label="Choose model"[\s\S]*value=\{selectedModelId\}/,
+  "HomeComposer should expose a model selector for the selected familiar",
+);
+
+assert.match(
+  source,
+  /const runtimeModelOptions = useMemo\(\(\) => catalogForRuntime\(selectedRuntime\)\?\.models \?\? \[\], \[selectedRuntime\]\)/,
+  "HomeComposer model options should be derived strictly from the selected runtime catalog",
+);
+
+assert.doesNotMatch(
+  source,
+  /<option[^>]*value="openai\/gpt-5\.5"[\s\S]*?<option[^>]*value="anthropic\/claude/,
+  "HomeComposer must not hard-code a mixed-provider model menu",
 );
 
 assert.doesNotMatch(
@@ -43,7 +97,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId\)/,
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null\)/,
   "HomeComposer should hand the selected agent chat prompt to the workspace, which opens a new chat that auto-sends it",
 );
 

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -20,27 +20,27 @@ import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
 import type { ChatModelState } from "@/lib/chat-model-state";
-import { draftReminderFromText } from "@/lib/reminder-draft";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { HomeFeed } from "@/components/home/home-feed";
+import { useProjects } from "@/lib/use-projects";
+import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
+import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type Destination = "chat" | "board" | "reminder";
+export type Destination = "chat" | "board";
 
 const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] = [
-  { id: "chat",     label: "Familiar", icon: "ph:chat-circle-dots" },
-  { id: "board",    label: "Tasks",    icon: "ph:kanban" },
-  { id: "reminder", label: "Reminder", icon: "ph:alarm-fill" },
+  { id: "chat",  label: "Chat", icon: "ph:chat-circle-dots" },
+  { id: "board", label: "Task", icon: "ph:kanban" },
 ];
 
 const PLACEHOLDERS: Record<Destination, string> = {
   chat: "Summon something magical",
   board: "Describe a new task…",
-  reminder: "Remind me about…",
 };
 
 type Props = {
@@ -51,9 +51,8 @@ type Props = {
   /** Open a new chat that sends `prompt` through ChatView's streaming path.
    *  Home never talks to the chat API itself — a fire-and-cancel send here
    *  aborts the request, which kills the harness before the transcript saves. */
-  onStartChat: (prompt: string, familiarId: string) => void;
+  onStartChat: (prompt: string, familiarId: string, projectRoot: string | null) => void;
   onNavigateToBoard: () => void;
-  onNavigateToInbox: () => void;
   onToast: (msg: string) => void;
   /** Submit a slash command. Mirrors the chat composer's escape hatch so
    *  `/inbox`, `/board`, `/remind …` etc. work from the home screen too. */
@@ -98,7 +97,6 @@ export function HomeComposer({
   onSetActiveFamiliar,
   onStartChat,
   onNavigateToBoard,
-  onNavigateToInbox,
   onToast,
   onSlash,
   onOpenSession,
@@ -115,7 +113,28 @@ export function HomeComposer({
   const slashListboxId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const selectedFamiliarId = activeFamiliarId ?? familiars[0]?.id ?? "";
+  const selectedFamiliar = useMemo(
+    () => familiars.find((familiar) => familiar.id === selectedFamiliarId) ?? null,
+    [familiars, selectedFamiliarId],
+  );
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
+  const { projects } = useProjects({ familiarId: selectedFamiliarId || null });
+  const [selectedProjectId, setSelectedProjectId] = useState("");
+  const selectedProject = useMemo(
+    () => projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null,
+    [projects, selectedProjectId],
+  );
+  const selectedRuntime =
+    modelState?.harness ?? selectedFamiliar?.harness ?? selectedFamiliar?.defaultHarness ?? "claude";
+  const runtimeModelOptions = useMemo(() => catalogForRuntime(selectedRuntime)?.models ?? [], [selectedRuntime]);
+  const selectedModelId = runtimeModelOptions.some((model) => model.id === modelState?.effectiveModel)
+    ? modelState!.effectiveModel
+    : runtimeModelOptions[0]?.id ?? "";
+
+  useEffect(() => {
+    if (selectedProjectId && projects.some((project) => project.id === selectedProjectId)) return;
+    setSelectedProjectId(projects[0]?.id ?? "");
+  }, [projects, selectedProjectId]);
 
   // Show the selected familiar's effective model on the home composer. No session
   // exists here, so GET keys on familiarId only. The `cancelled` flag drops any
@@ -170,6 +189,56 @@ export function HomeComposer({
     [selectedFamiliarId],
   );
 
+  const refetchModelState = useCallback(() => {
+    if (!selectedFamiliarId) return;
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/chat/model-state?familiarId=${encodeURIComponent(selectedFamiliarId)}`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as { ok?: boolean; state?: ChatModelState };
+        if (json.ok && json.state) setModelState(json.state);
+      } catch {
+        /* keep the optimistic value */
+      }
+    })();
+  }, [selectedFamiliarId]);
+
+  const handleSelectRuntime = useCallback(
+    (runtime: string) => {
+      if (!selectedFamiliarId) return;
+      const nextModel = defaultModelForRuntime(runtime);
+      setModelState((current) => ({
+        familiarId: selectedFamiliarId,
+        runtime: current?.runtime ?? null,
+        harness: runtime,
+        effectiveModel: nextModel,
+        source: "familiar-default",
+        applicationState: "saved",
+        reason: "Selected from the home composer.",
+      }));
+      void (async () => {
+        try {
+          const res = await fetch("/api/config", {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              familiars: {
+                [selectedFamiliarId]: { harness: runtime, model: nextModel },
+              },
+            }),
+          });
+          const json = (await res.json().catch(() => ({ ok: false }))) as { ok?: boolean };
+          if (json.ok) refetchModelState();
+        } catch {
+          refetchModelState();
+        }
+      })();
+    },
+    [refetchModelState, selectedFamiliarId],
+  );
+
   // Mirror the chat composer's matching rule: surface only while the user is
   // still typing the command token (no whitespace yet).
   const slashSuggestions: SlashCommand[] = useMemo(() => {
@@ -180,7 +249,7 @@ export function HomeComposer({
 
   // Inline model picker: typing "/model <partial>" shows model options.
   const modelHarness =
-    modelState?.harness ?? familiars.find((f) => f.id === selectedFamiliarId)?.harness ?? "claude";
+    modelState?.harness ?? selectedFamiliar?.harness ?? "claude";
   const modelOptions = useMemo(() => modelSlashOptions(text, modelHarness), [text, modelHarness]);
   const modelMenuActive = (modelOptions?.length ?? 0) > 0;
   // Either inline listbox (slash commands or the /model picker) shares the same
@@ -207,22 +276,9 @@ export function HomeComposer({
     setTimeout(() => textareaRef.current?.focus(), 80);
   }, []);
 
-  // Short model label for the toolbar chip (e.g. "openai/gpt-5.5" → "gpt-5.5").
-  const modelLabel = useMemo(() => {
-    const m = modelState?.effectiveModel;
-    if (!m || m === "unknown") return null;
-    return m.includes("/") ? m.slice(m.lastIndexOf("/") + 1) : m;
-  }, [modelState]);
-
-  // The "＋" affordance reveals the slash-command menu (board/remind/model/…),
-  // and the model chip jumps straight to the inline /model picker. Both keep the
-  // home composer's single text entry path — no separate dialogs to wire up.
+  // The "＋" affordance reveals the slash-command menu (board/remind/model/…).
   const openCommands = useCallback(() => {
     setText((t) => (t.trim() ? t : "/"));
-    setTimeout(() => textareaRef.current?.focus(), 0);
-  }, []);
-  const openModelPicker = useCallback(() => {
-    setText("/model ");
     setTimeout(() => textareaRef.current?.focus(), 0);
   }, []);
 
@@ -406,41 +462,23 @@ export function HomeComposer({
           // request server-side — the harness is killed mid-run and the
           // transcript never saves, so the opened chat 404s.
           setText("");
-          onStartChat(prompt, selectedFamiliarId);
+          onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null);
           break;
         }
         case "board": {
           const res = await fetch("/api/board", {
             method: "POST",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify({ title: prompt, familiarId: activeFamiliarId ?? null }),
+            body: JSON.stringify({
+              title: prompt,
+              familiarId: activeFamiliarId ?? null,
+              cwd: selectedProject?.root ?? null,
+              projectId: selectedProject?.id ?? null,
+            }),
           });
           const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
           if (json.ok) { setText(""); onNavigateToBoard(); }
           else onToast("Board card creation failed.");
-          break;
-        }
-        case "reminder": {
-          const reminder = draftReminderFromText(prompt);
-          if (!reminder.ok) {
-            onToast("Add a reminder time with @ 5pm, @ tomorrow 10am, or start with in 30m.");
-            break;
-          }
-          const res = await fetch("/api/inbox", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              kind: "reminder",
-              title: reminder.title,
-              fireAt: reminder.fireAt,
-              recurrence: reminder.recurrence,
-              source: "user",
-              familiarId: activeFamiliarId ?? null,
-            }),
-          });
-          const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
-          if (json.ok) { setText(""); onNavigateToInbox(); }
-          else onToast("Reminder creation failed.");
           break;
         }
       }
@@ -448,14 +486,16 @@ export function HomeComposer({
       setSending(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [text, destination, activeFamiliarId, selectedFamiliarId, sending, onSlash, onStartChat]);
+  }, [text, destination, activeFamiliarId, selectedFamiliarId, selectedProject, sending, onSlash, onStartChat]);
 
   return (
     <div className="home-composer-root">
 
       {/* Headline */}
       <div className="home-composer-hero">
-        <h1 className="home-composer-headline">What should we cast in coven-cave?</h1>
+        <h1 className="home-composer-headline">
+          {`What should we build in ${selectedProject?.name ?? "Coven Cave"}?`}
+        </h1>
       </div>
 
       {/* Composer card — wrapped so the slash menu can render above the
@@ -590,6 +630,28 @@ export function HomeComposer({
             <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
           </label>
 
+          <label className="hc-familiar-selector hc-project-selector">
+            <Icon name="ph:folder" width={13} className="hc-familiar-glyph" aria-hidden />
+            <select
+              aria-label="Choose project"
+              className="hc-familiar-select"
+              value={selectedProjectId}
+              onChange={(e) => setSelectedProjectId(e.currentTarget.value)}
+              disabled={projects.length === 0 || sending}
+            >
+              {projects.length === 0 ? (
+                <option value="">No projects</option>
+              ) : (
+                projects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {project.name}
+                  </option>
+                ))
+              )}
+            </select>
+            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+          </label>
+
           {/* Destination pills */}
           <div
             className="hc-dest-pills"
@@ -615,19 +677,45 @@ export function HomeComposer({
             ))}
           </div>
 
-          {/* Right cluster: model chip + circular send */}
-          {modelLabel ? (
-            <button
-              type="button"
-              className="hc-model-chip"
-              onClick={openModelPicker}
-              title="Change model"
+          <label className="hc-familiar-selector hc-runtime-selector">
+            <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
+            <select
+              aria-label="Choose runtime"
+              className="hc-familiar-select"
+              value={selectedRuntime}
+              onChange={(e) => handleSelectRuntime(e.currentTarget.value)}
+              disabled={!selectedFamiliarId || sending}
             >
-              <Icon name="ph:lightning-fill" width={12} className="hc-model-bolt" aria-hidden />
-              <span className="hc-model-name">{modelLabel}</span>
-              <Icon name="ph:caret-down-bold" width={9} aria-hidden />
-            </button>
-          ) : null}
+              {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
+                <option key={adapter.id} value={adapter.id}>
+                  {adapter.label}
+                </option>
+              ))}
+            </select>
+            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+          </label>
+
+          <label className="hc-familiar-selector hc-model-selector">
+            <Icon name="ph:lightning-fill" width={13} className="hc-familiar-glyph hc-model-bolt" aria-hidden />
+            <select
+              aria-label="Choose model"
+              className="hc-familiar-select"
+              value={selectedModelId}
+              onChange={(e) => handleSelectModel(e.currentTarget.value)}
+              disabled={!selectedFamiliarId || runtimeModelOptions.length === 0 || sending}
+            >
+              {runtimeModelOptions.length === 0 ? (
+                <option value="">Runtime managed</option>
+              ) : (
+                runtimeModelOptions.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.label}
+                  </option>
+                ))
+              )}
+            </select>
+            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+          </label>
 
           <button
             type="button"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1909,9 +1909,8 @@ export function Workspace() {
         activeFamiliarId={activeId}
         sessions={sessions}
         onSetActiveFamiliar={setActiveId}
-        onStartChat={(prompt, fid) => startFamiliarChat(fid, null, prompt)}
+        onStartChat={(prompt, fid, projectRoot) => startFamiliarChat(fid, projectRoot, prompt)}
         onNavigateToBoard={() => setMode("board")}
-        onNavigateToInbox={() => setMode("inbox")}
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}

--- a/src/lib/chat-attachments.test.ts
+++ b/src/lib/chat-attachments.test.ts
@@ -44,6 +44,30 @@ assert.match(prompt, /2\. diagram\.png \(image\/png, 128 B\)\n\(image attachment
 assert.doesNotMatch(prompt, /2\. diagram\.png[^\n]*\n\(content unavailable\)/);
 assert.match(prompt, /3\. secret\.txt \(text\/plain, 12 B\)/);
 
+const mediaPrompt = buildPromptWithAttachments("Summarize these.", normalizeChatAttachments([
+  {
+    name: "demo.mp4",
+    type: "video/mp4",
+    mimeType: "video/mp4",
+    size: 1_048_576,
+  },
+  {
+    name: "bundle.zip",
+    type: "application/zip",
+    mimeType: "application/zip",
+    size: 2048,
+  },
+]));
+assert.match(
+  mediaPrompt,
+  /1\. demo\.mp4 \(video\/mp4, 1\.0 MB\)\n\(video attached as metadata only — frames and audio are not decoded yet\)/,
+);
+assert.match(
+  mediaPrompt,
+  /2\. bundle\.zip \(application\/zip, 2\.0 KB\)\n\(file attached as metadata only — text content was not available\)/,
+);
+assert.doesNotMatch(mediaPrompt, /\(content unavailable\)/);
+
 const attachmentOnly = buildPromptWithAttachments("", [attachments[0]]);
 assert.match(attachmentOnly, /^Review the attached file\./);
 

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -6,6 +6,10 @@ export const IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE =
   "(image attachments are not supported by this harness)";
 const IMAGE_NOT_DELIVERED_NOTE =
   "(image attachment was not delivered — payload missing or over the size limit)";
+const VIDEO_METADATA_ONLY_NOTE =
+  "(video attached as metadata only — frames and audio are not decoded yet)";
+const FILE_METADATA_ONLY_NOTE =
+  "(file attached as metadata only — text content was not available)";
 
 export type ChatAttachment = {
   name: string;
@@ -64,6 +68,10 @@ export function cleanImageDataUrl(
 
 function isImageAttachment(attachment: ChatAttachment): boolean {
   return Boolean((attachment.mimeType ?? attachment.type)?.startsWith("image/"));
+}
+
+function isVideoAttachment(attachment: ChatAttachment): boolean {
+  return Boolean((attachment.mimeType ?? attachment.type)?.startsWith("video/"));
 }
 
 export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
@@ -160,8 +168,10 @@ export function buildPromptWithAttachments(
       } else {
         body = IMAGE_NOT_DELIVERED_NOTE;
       }
+    } else if (isVideoAttachment(attachment)) {
+      body = VIDEO_METADATA_ONLY_NOTE;
     } else {
-      body = "(content unavailable)";
+      body = FILE_METADATA_ONLY_NOTE;
     }
     return `${index + 1}. ${attachment.name} (${metadataFor(attachment)})\n${body}`;
   });

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -141,6 +141,7 @@
 .hc-action-bar {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 10px 14px 14px;
 }
@@ -209,7 +210,8 @@
   border: 1px solid color-mix(in oklch, var(--accent-presence) 25%, transparent);
   border-radius: 8px;
   padding: 3px 7px 3px 6px;
-  flex-shrink: 0;
+  flex: 0 1 auto;
+  min-width: 0;
 }
 
 .hc-familiar-glyph {
@@ -230,7 +232,7 @@
   -webkit-appearance: none;
   cursor: pointer;
   padding-right: 14px;
-  max-width: 100px;
+  max-width: 132px;
 }
 
 .hc-select-caret {
@@ -245,7 +247,7 @@
 .hc-dest-pills {
   display: flex;
   gap: 3px;
-  flex: 1;
+  flex: 1 1 140px;
   flex-wrap: wrap;
 }
 
@@ -320,7 +322,7 @@
     order: 3;
     flex: 1 0 100%;
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 8px;
   }
 
@@ -353,6 +355,7 @@
   background: var(--accent-presence);
   color: #fff;
   cursor: pointer;
+  margin-left: auto;
   flex-shrink: 0;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
 }


### PR DESCRIPTION
## Summary
- add project-aware home composer controls with Chat/Task destinations and runtime-scoped model choices
- pass the selected project into chat/task creation paths
- expand chat composer attachments for images, videos, and files with explicit prompt handling for metadata-only media

## Test Plan
- node --experimental-strip-types src/components/home-composer.test.ts
- node --experimental-strip-types src/components/home-composer-polish.test.ts
- node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts
- node --experimental-strip-types src/lib/chat-attachments.test.ts
- node --experimental-strip-types src/components/chat-view-first-class.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app
- pnpm build