### PR TITLE
feat(chat): replace Power toggle with Convo/Projects/Code mode switch

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7559,57 +7559,6 @@ a.mobile-handoff__link:hover {
   padding-block: 8px;
 }
 
-/* Power-mode toggle — sits at the right edge of the standalone chat's scope-tab
-   row. Off = quiet ghost button; on = lit accent pill, signalling the inline
-   chat↔code split is active. */
-.chat-power-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-  height: 26px;
-  padding-inline: 10px;
-  border-radius: 999px;
-  border: 1px solid var(--border-hairline);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1;
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-}
-
-.chat-power-toggle:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-
-.chat-power-toggle:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--ring-focus);
-}
-
-.chat-power-toggle--on {
-  /* Alias the theme accent once so the lit state reads in a single place. */
-  --power-accent: var(--accent);
-  border-color: color-mix(in oklch, var(--power-accent) 55%, transparent);
-  background: color-mix(in oklch, var(--power-accent) 18%, transparent);
-  color: var(--power-accent);
-}
-
-.chat-power-toggle--on:hover {
-  background: color-mix(in oklch, var(--power-accent) 26%, transparent);
-  color: var(--power-accent);
-}
-
-/* Collapse the label to an icon-only chip on narrow screens. */
-@media (max-width: 640px) {
-  .chat-power-toggle__label {
-    display: none;
-  }
-}
-
 /* Dynamic viewport units for layout shell + modals — `100vh` on iOS
    includes the address bar height, so a `100vh` element would push
    content under the chrome. `100dvh` tracks the visible area, including

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -850,7 +850,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 disabled={bulkBusy || cardSelect.selectedCount === 0}
                 value=""
                 onChange={(e) => { if (e.target.value) void bulkMove(e.target.value as CardStatus); }}
-                className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
+                className="focus-ring h-6 box-border rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
               >
                 <option value="">Move to…</option>
                 {STATUSES.map((s) => <option key={s} value={s}>{STATUS_LABELS[s]}</option>)}
@@ -861,7 +861,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 disabled={bulkBusy || cardSelect.selectedCount === 0}
                 value=""
                 onChange={(e) => { if (e.target.value) void bulkAssign(e.target.value); }}
-                className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
+                className="focus-ring h-6 box-border rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
               >
                 <option value="">Assign to…</option>
                 {familiars.map((f) => <option key={f.id} value={f.id}>{f.display_name}</option>)}
@@ -872,7 +872,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 disabled={bulkBusy || cardSelect.selectedCount === 0}
                 value=""
                 onChange={(e) => { if (e.target.value) void bulkSetPriority(e.target.value as CardPriority); }}
-                className="focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
+                className="focus-ring h-6 box-border rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-secondary)] disabled:opacity-50"
               >
                 <option value="">Priority…</option>
                 {PRIORITIES.map((p) => <option key={p} value={p}>{PRIORITY_LABELS[p]}</option>)}
@@ -888,7 +888,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                   placeholder="Add label…"
                   aria-label="Add a label to selected tasks"
                   disabled={bulkBusy || cardSelect.selectedCount === 0}
-                  className="focus-ring w-24 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] disabled:opacity-50"
+                  className="focus-ring h-6 box-border w-24 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] disabled:opacity-50"
                 />
                 <datalist id="board-bulk-label-options">
                   {bulkLabelOptions.map((l) => <option key={l} value={l} />)}
@@ -897,7 +897,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                   type="submit"
                   disabled={bulkBusy || cardSelect.selectedCount === 0 || !labelDraft.trim()}
                   title="Add this label to the selected tasks"
-                  className="focus-ring inline-flex items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 py-0.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
+                  className="focus-ring h-6 box-border inline-flex items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-1.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] disabled:opacity-50"
                 >
                   <Icon name="ph:tag-bold" width={11} aria-hidden />
                   Label
@@ -907,7 +907,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 type="button"
                 disabled={bulkBusy || cardSelect.selectedCount === 0}
                 onClick={() => void bulkDelete()}
-                className="focus-ring inline-flex items-center gap-1 rounded border border-[var(--color-danger)]/50 bg-[var(--color-danger)]/10 px-1.5 py-0.5 text-[11px] text-[var(--color-danger)] hover:bg-[var(--color-danger)]/15 disabled:opacity-50"
+                className="focus-ring h-6 box-border inline-flex items-center gap-1 rounded border border-[var(--color-danger)]/50 bg-[var(--color-danger)]/10 px-1.5 text-[11px] text-[var(--color-danger)] hover:bg-[var(--color-danger)]/15 disabled:opacity-50"
               >
                 <Icon name="ph:trash-bold" width={11} aria-hidden />
                 {bulkBusy ? "Working…" : `Delete${cardSelect.selectedCount ? ` ${cardSelect.selectedCount}` : ""}`}

--- a/src/components/chat-surface-power-mode.test.ts
+++ b/src/components/chat-surface-power-mode.test.ts
@@ -1,8 +1,10 @@
 // @ts-nocheck
 // Power mode: the standalone chat transforms its side area into an inline
-// chat↔code split (the comux coding surface beside the conversation), toggled
-// from the scope-tab row. Memory is removed from the chat surface entirely —
-// it's not part of a conversation, so it lives in the Familiars surface.
+// chat↔code split (the comux coding surface beside the conversation), now
+// selected from a three-way segmented mode switch (Convo / Projects / Code)
+// that supersedes the old Sessions/Projects scope tabs + binary Power toggle.
+// Memory is removed from the chat surface entirely — it's not part of a
+// conversation, so it lives in the Familiars surface.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -10,21 +12,42 @@ const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "ut
 const inspector = readFileSync(new URL("./inspector-pane.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
-// ── Power-mode toggle + state ───────────────────────────────────────────────
+// ── Power-mode state ────────────────────────────────────────────────────────
 assert.match(surface, /import \{ ComuxView \} from "@\/components\/comux-view"/, "chat-surface embeds the comux coding surface");
 assert.match(surface, /POWER_MODE_KEY = "cave:chat-power-mode:v1"/, "power-mode preference has a stable storage key");
 assert.match(surface, /const \[powerMode, setPowerMode\] = useState\(false\)/, "power mode is off by default");
 assert.match(
   surface,
   /window\.localStorage\.setItem\(POWER_MODE_KEY, next \? "1" : "0"\)/,
-  "toggling power mode persists across reloads",
+  "entering/leaving code mode persists across reloads",
+);
+
+// ── Three-way mode switch (Convo / Projects / Code) ─────────────────────────
+assert.match(
+  surface,
+  /type ChatMode = "convo" \| "projects" \| "code"/,
+  "the standalone chat has a three-way mode model",
 );
 assert.match(
   surface,
-  /className=\{`chat-power-toggle\$\{powerMode \? " chat-power-toggle--on" : ""\}`\}/,
-  "the toggle reflects its on/off state via a modifier class",
+  /const chatMode: ChatMode = scope === "projects" \? "projects" : powerMode \? "code" : "convo"/,
+  "the switch's selection derives from scope + power-mode state",
 );
-assert.match(surface, /aria-pressed=\{powerMode\}/, "the toggle exposes pressed state to assistive tech");
+assert.match(
+  surface,
+  /function selectChatMode\(next: ChatMode\)/,
+  "selecting a mode locks the surface into Convo, Projects, or Code",
+);
+assert.match(
+  surface,
+  /<Tabs<ChatMode>\s+variant="segment"/,
+  "the mode switch renders as a segmented (lock-in) selector",
+);
+assert.match(surface, /value=\{chatMode\}/, "the switch reflects the active mode");
+assert.match(surface, /onChange=\{selectChatMode\}/, "the switch drives mode selection");
+// The legacy binary Power pill is gone — its layout is now one of three locks.
+assert.doesNotMatch(surface, /chat-power-toggle/, "the binary Power toggle is replaced by the mode switch");
+assert.doesNotMatch(css, /\.chat-power-toggle/, "the dead Power-toggle styling is removed");
 
 // Power mode is standalone-chat only — the Code workspace already is a split.
 assert.match(
@@ -61,9 +84,5 @@ assert.match(
 );
 // chat-surface passes hideMemory to every inspector it mounts.
 assert.match(surface, /onInboxItemChanged=\{onInboxItemChanged\}\s*\n\s*hideMemory/, "chat-surface hides memory in its inspector");
-
-// ── Toggle styling matches the bar ──────────────────────────────────────────
-assert.match(css, /\.chat-power-toggle \{[\s\S]*?border-radius: 999px;/, "the power toggle is a pill chip");
-assert.match(css, /\.chat-power-toggle--on \{[\s\S]*?--power-accent: var\(--accent\);/, "the active toggle lights up in the theme accent");
 
 console.log("chat-surface-power-mode.test.ts: ok");

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -10,31 +10,27 @@ assert.match(events, /CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects"/, "ev
 assert.match(surface, /import \{ ProjectsView \} from "@\/components\/projects-view"/, "chat-surface imports ProjectsView");
 assert.match(surface, /CHAT_OPEN_PROJECTS_EVENT/, "chat-surface references the reroute event");
 assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union still includes memory (Code surface) + projects");
-// Standalone chat is intentionally minimal: Sessions then Projects, no Memory —
-// memory is not part of a conversation (it lives in the Familiars surface). The
-// standalone branch is the ` : [ … ]` arm after the isCodeSurface ternary.
+// Standalone chat drives its three layouts from a segmented mode switch:
+// Convo, Projects, then Code — Projects is one of the three locks, not a tab.
 assert.match(
   surface,
-  /:\s*\[\s*\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\},?\s*\]/,
-  "standalone chat tab list is Sessions then Projects (Memory dropped)",
+  /\{\s*id:\s*"projects",\s*label:\s*"Projects",\s*icon:\s*"ph:folder"\s*\}/,
+  "Projects is one of the mode-switch options",
 );
-assert.doesNotMatch(
-  surface,
-  /:\s*\[\s*\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"memory"/,
-  "standalone chat tab list must not include a Memory tab",
-);
-assert.match(surface, /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/, "projects tab is labeled");
+assert.match(surface, /\{\s*id:\s*"convo",\s*label:\s*"Convo"/, "Convo is the conversation-only mode");
+assert.match(surface, /\{\s*id:\s*"code",\s*label:\s*"Code"/, "Code is the inline chat↔code split mode");
 assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects scope renders its own panel (standalone chat only)");
 assert.match(surface, /<ProjectsView[\s\S]*?sessions=\{sessions\}/, "projects panel renders ProjectsView with sessions");
 assert.match(surface, /onNewChat=\{startProjectChat\}/, "projects panel wires onNewChat to startProjectChat");
 assert.match(surface, /addEventListener\(CHAT_OPEN_PROJECTS_EVENT/, "listens for the reroute event");
 
-// Code surface drops the duplicate Projects tab (the comux pane owns project /
-// file navigation there) — the tab list is Sessions + Memory only when isCodeSurface.
+// Code surface keeps its own Sessions + Memory underline tab pair (the comux
+// pane owns project/file navigation there, so it has no Projects tab) and is
+// gated behind isCodeSurface — the standalone chat shows the mode switch instead.
 assert.match(
   surface,
-  /isCodeSurface\s*\?\s*\[\s*\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\},?\s*\]\s*:\s*\[/,
-  "Code surface tab list omits the Projects tab",
+  /isCodeSurface\s*\?\s*\(\s*<Tabs<FamiliarsScope>[\s\S]*?\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\},?\s*\][\s\S]*?\)\s*:\s*null/,
+  "Code surface tab list is Sessions + Memory only, gated on isCodeSurface",
 );
 
 console.log("chat-surface-projects-tab.test.ts: ok");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -54,6 +54,18 @@ const chatStorage = {
 
 type FamiliarsScope = "conversation" | "memory" | "projects";
 
+// The standalone chat's mode switch locks the surface into one of three
+// layouts: the conversation alone ("convo"), the Projects browser, or the
+// inline chat↔code split ("code"). It folds the old Sessions/Projects scope
+// tabs and the binary Power toggle into a single segmented selector.
+type ChatMode = "convo" | "projects" | "code";
+
+const CHAT_MODE_ITEMS: { id: ChatMode; label: string; icon: "ph:chat-circle-dots" | "ph:folder" | "ph:code-bold" }[] = [
+  { id: "convo", label: "Convo", icon: "ph:chat-circle-dots" },
+  { id: "projects", label: "Projects", icon: "ph:folder" },
+  { id: "code", label: "Code", icon: "ph:code-bold" },
+];
+
 export type RightPanelKind = "inspector" | "changes" | "debug";
 
 type Props = {
@@ -308,16 +320,33 @@ export function ChatSurface({
       /* ignore — strict privacy mode */
     }
   }, [isCodeSurface]);
-  function togglePowerMode() {
-    setPowerMode((prev) => {
-      const next = !prev;
-      try {
-        window.localStorage.setItem(POWER_MODE_KEY, next ? "1" : "0");
-      } catch {
-        /* ignore */
-      }
-      return next;
-    });
+  function persistPowerMode(next: boolean) {
+    setPowerMode(next);
+    try {
+      window.localStorage.setItem(POWER_MODE_KEY, next ? "1" : "0");
+    } catch {
+      /* ignore */
+    }
+  }
+  // Current selection for the standalone chat's three-way mode switch, derived
+  // from the existing scope + power-mode state so the rendering below is
+  // unchanged. Projects wins (it owns the whole surface); otherwise power mode
+  // means "code", and a plain conversation means "convo".
+  const chatMode: ChatMode = scope === "projects" ? "projects" : powerMode ? "code" : "convo";
+  function selectChatMode(next: ChatMode) {
+    if (next === "code") {
+      // Keep whatever thread is open; just bring the code split up beside it.
+      setScope("conversation");
+      persistPowerMode(true);
+      return;
+    }
+    persistPowerMode(false);
+    if (next === "projects") {
+      setScope("projects");
+      return;
+    }
+    setScope("conversation");
+    window.setTimeout(() => routerRef.current?.goToList(), 0);
   }
   // Below the desktop shell breakpoint the inline 230px right sidebar is hidden
   // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
@@ -521,51 +550,44 @@ export function ChatSurface({
         <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4">
           <div className="flex min-w-0 items-center gap-3">
             {/* The active familiar is selected from the global top menu bar /
-                switcher now, so the chat header carries only its scope tabs.
-                Vercel-style borderless underline tabs, flush left. */}
-            <Tabs<FamiliarsScope>
-              bordered={false}
-              value={scope}
-              onChange={(s) => {
-                setScope(s);
-                if (s === "conversation") {
-                  window.setTimeout(() => routerRef.current?.goToList(), 0);
-                }
-              }}
-              // Standalone chat is intentionally minimal: just Sessions + Projects.
-              // Memory is not part of a conversation, so it lives in the Familiars
-              // surface, not the chat header. In Code mode the comux pane owns
-              // project/file navigation, so that surface keeps Sessions + Memory.
-              items={
-                isCodeSurface
-                  ? [
-                      { id: "conversation", label: "Sessions" },
-                      { id: "memory", label: "Memory" },
-                    ]
-                  : [
-                      { id: "conversation", label: "Sessions" },
-                      { id: "projects", label: "Projects" },
-                    ]
-              }
-            />
+                switcher now. In Code mode the comux pane owns project/file
+                navigation, so that surface keeps a Sessions + Memory underline
+                tab pair flush left. The standalone chat instead drives all three
+                of its modes from the segmented switch on the right. */}
+            {isCodeSurface ? (
+              <Tabs<FamiliarsScope>
+                bordered={false}
+                value={scope}
+                onChange={(s) => {
+                  setScope(s);
+                  if (s === "conversation") {
+                    window.setTimeout(() => routerRef.current?.goToList(), 0);
+                  }
+                }}
+                items={[
+                  { id: "conversation", label: "Sessions" },
+                  { id: "memory", label: "Memory" },
+                ]}
+              />
+            ) : null}
           </div>
           {/* Code workspace: layout presets + companion-panel toggle ride on
               this row so the Code surface needs no separate toolbar row.
-              Standalone chat gets the Power-mode toggle instead — it transforms
-              the side area into an inline chat↔code split. */}
+              Standalone chat gets the mode switch instead — a segmented selector
+              that locks the surface into Convo, Projects, or the inline
+              chat↔code split. */}
           {isCodeSurface ? (
             <CodeInlineToolbar />
           ) : (
-            <button
-              type="button"
-              className={`chat-power-toggle${powerMode ? " chat-power-toggle--on" : ""}`}
-              aria-pressed={powerMode}
-              onClick={togglePowerMode}
-              title={powerMode ? "Exit power mode" : "Power mode — split chat with code & terminal"}
-            >
-              <Icon name="ph:lightning-fill" width={13} />
-              <span className="chat-power-toggle__label">Power</span>
-            </button>
+            <Tabs<ChatMode>
+              variant="segment"
+              size="sm"
+              bordered={false}
+              ariaLabel="Chat mode"
+              value={chatMode}
+              onChange={selectChatMode}
+              items={CHAT_MODE_ITEMS}
+            />
           )}
         </div>
 


### PR DESCRIPTION
## What

The standalone chat header used a binary **Power** toggle (on = inline chat↔code split) sitting beside separate Sessions/Projects scope tabs. This folds both into a single **three-way segmented switch** that locks the surface into one of: **Convo · Projects · Code**.

## How

- Added a `ChatMode = "convo" | "projects" | "code"` model **derived** from the existing `scope` + `powerMode` state, so all downstream rendering is unchanged. `selectChatMode()` performs the lock-in and preserves the `cave:chat-power-mode:v1` persistence.
- Rendered via the shared `Tabs` `variant="segment"` (rounded pill, raised active segment) at the right edge where Power sat. **Convo** = conversation only, **Projects** = ProjectsView, **Code** = comux split (keeps the open thread).
- The **Code** workspace surface (`isCodeSurface`) is untouched — it keeps its Sessions/Memory underline tabs + `CodeInlineToolbar`.
- Removed the now-dead `.chat-power-toggle*` CSS; updated the two source-text tests that pinned the old toggle markup and scope-tab arrays.

## Verification

- `test:app` (448 files) ✅ · `test:mobile` (65 files) ✅ · `tsc --noEmit` clean ✅
- Built + drove the real app: Convo → conversation; Code → comux split mounts (`#code-power`); Projects → ProjectsView. Switch locks to each mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)