### PR TITLE
fix(links): open feed/chat/board links in the system browser

### DIFF
--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -205,18 +205,23 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const openUrlInCompanionBrowser = useCallback\(\(url: string\) => \{/,
-  "Workspace should provide a dedicated side-panel browser opener for chat links",
+  /const openUrlExternally = useCallback\(\(url: string\) => \{/,
+  "Workspace should provide an external-link opener for chat/feed/board links",
 );
 assert.match(
   workspace,
-  /setRailTab\("browser"\)[\s\S]*requestAnimationFrame\(\(\) => shellRef\.current\?\.openFamiliar\(\)\)[\s\S]*requestAnimationFrame\(\(\) => companionBrowserPaneRef\.current\?\.navigateTo\(url\)\)/,
-  "Chat link opens should select Browser, open the right sidepanel, then navigate the companion browser pane",
+  /window\.open\(url, "_blank", "noopener,noreferrer"\)/,
+  "Link opens should fall back to window.open for the system browser outside Tauri",
 );
 assert.match(
   workspace,
-  /onOpenUrl=\{openUrlInCompanionBrowser\}/,
-  "Workspace should thread the side-panel browser opener into ChatSurface",
+  /invoke\("shell_open", \{ url \}\)/,
+  "Link opens should hand the URL to the system browser via the Tauri shell_open command on desktop",
+);
+assert.match(
+  workspace,
+  /onOpenUrl=\{openUrlExternally\}/,
+  "Workspace should thread the external-link opener into ChatSurface",
 );
 assert.match(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1612,10 +1612,27 @@ export function Workspace() {
     requestAnimationFrame(() => shellRef.current?.openFamiliar());
   }, [familiarPanelOpen, railTab]);
 
-  const openUrlInCompanionBrowser = useCallback((url: string) => {
-    setRailTab("browser");
-    requestAnimationFrame(() => shellRef.current?.openFamiliar());
-    requestAnimationFrame(() => companionBrowserPaneRef.current?.navigateTo(url));
+  // Open a link in the user's real system browser. On desktop (Tauri) we hand
+  // the URL to the `shell_open` Rust command so it lands in Safari/Chrome; in
+  // plain browser dev (and as a fallback if the invoke fails) we fall back to
+  // window.open. This is the path every feed/chat/board "open link" button hits
+  // via onOpenUrl.
+  const openUrlExternally = useCallback((url: string) => {
+    const openExternally = () => window.open(url, "_blank", "noopener,noreferrer");
+    // @ts-expect-error Tauri injects this at runtime
+    const inTauri = typeof window !== "undefined" && !!window.__TAURI_INTERNALS__;
+    if (!inTauri) {
+      openExternally();
+      return;
+    }
+    void (async () => {
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("shell_open", { url });
+      } catch {
+        openExternally();
+      }
+    })();
   }, []);
 
   const openProjectChat = useCallback((projectRoot: string) => {
@@ -1741,13 +1758,13 @@ export function Workspace() {
         onInboxItemChanged={refreshInbox}
         onSessionsChanged={loadSessions}
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-        onOpenUrl={openUrlInCompanionBrowser}
+        onOpenUrl={openUrlExternally}
       />
     ) : mode === "groupchat" ? (
       <GroupChatView
         familiars={resolvedFamiliars}
         onSessionStarted={loadSessions}
-        onOpenUrl={openUrlInCompanionBrowser}
+        onOpenUrl={openUrlExternally}
       />
     ) : mode === "code" ? (
       <CodeView
@@ -1780,7 +1797,7 @@ export function Workspace() {
             onInboxItemChanged={refreshInbox}
             onSessionsChanged={loadSessions}
             onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-            onOpenUrl={openUrlInCompanionBrowser}
+            onOpenUrl={openUrlExternally}
           />
         }
         comux={


### PR DESCRIPTION
## Problem

Buttons routed through `onOpenUrl` — Home feed **Repos**/**Tweets**, chat message links, and board links — appeared to do nothing when clicked. They navigated the in-app companion `BrowserPane`, which only mounts once the browser rail tab is selected. A click from any other tab fired `navigateTo()` against a still-`null` ref, so the navigation was silently dropped.

## Fix

Open links in the user's **system browser** instead:

- **Desktop (Tauri):** invoke the `shell_open` Rust command → Safari/Chrome/etc. via the OS handler (validates http(s); already registered in `src-tauri/src/lib.rs`).
- **Browser dev / on failure:** fall back to `window.open(url, "_blank", "noopener,noreferrer")`.

Renamed the handler `openUrlInCompanionBrowser` → `openUrlExternally` to match. The companion browser rail tab still exists for manual use.

## Test

- Updated the source-text contract in `mobile-shell-smoke.test.ts`.
- Full mobile suite passes (65 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)