### PR TITLE
feat(daemon): add restart control

### DIFF
--- a/src/app/api/daemon/start/route.test.ts
+++ b/src/app/api/daemon/start/route.test.ts
@@ -16,4 +16,22 @@ assert.match(
   "daemon start runs Windows npm .cmd shims through shell mode",
 );
 
+assert.match(
+  source,
+  /export async function POST\(request: Request\)/,
+  "daemon start route should inspect the request body",
+);
+
+assert.match(
+  source,
+  /const restart = body\?\.restart === true/,
+  "daemon start route should accept an explicit restart option",
+);
+
+assert.match(
+  source,
+  /if \(!restart\) \{[\s\S]*callDaemon\(\{ path: "\/api\/v1\/health", timeoutMs: 1500 \}\)[\s\S]*alreadyRunning: true[\s\S]*\}/,
+  "plain start should stay idempotent while restart bypasses the healthy-daemon guard",
+);
+
 console.log("daemon start route.test.ts: ok");

--- a/src/app/api/daemon/start/route.ts
+++ b/src/app/api/daemon/start/route.ts
@@ -6,15 +6,20 @@ import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spaw
 
 export const dynamic = "force-dynamic";
 
-export async function POST() {
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as { restart?: boolean } | null;
+  const restart = body?.restart === true;
+
   // Idempotent start: if a daemon is already serving, don't spawn `coven daemon
   // start`. That subcommand *restarts* the daemon, which fights a supervisor
   // (e.g. a launchd KeepAlive agent) for the socket — the supervisor relaunches
   // its copy while the restart spawns another, churning the socket. A healthy
   // daemon means "start" has nothing to do, so report it as already running.
-  const health = await callDaemon({ path: "/api/v1/health", timeoutMs: 1500 });
-  if (health.ok) {
-    return NextResponse.json({ ok: true, alreadyRunning: true });
+  if (!restart) {
+    const health = await callDaemon({ path: "/api/v1/health", timeoutMs: 1500 });
+    if (health.ok) {
+      return NextResponse.json({ ok: true, alreadyRunning: true });
+    }
   }
 
   return new Promise<Response>((resolve) => {
@@ -58,7 +63,7 @@ export async function POST() {
     child.on("close", (code) => {
       clearTimeout(timer);
       resolve(
-        NextResponse.json({ ok: code === 0, exitCode: code, stdout, stderr }),
+        NextResponse.json({ ok: code === 0, exitCode: code, restart, stdout, stderr }),
       );
     });
   });

--- a/src/components/daemon-start-button.test.ts
+++ b/src/components/daemon-start-button.test.ts
@@ -7,8 +7,15 @@ const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "u
 
 assert.match(settings, /fetch\("\/api\/daemon\/start", \{ method: "POST" \}\)/);
 assert.match(settings, /Start daemon/);
+assert.match(settings, /Restart daemon/);
 assert.match(settings, /rocket-launch-bold/);
 assert.match(settings, /!loading && !status\?\.running/);
+assert.match(settings, /status\?\.running && \(/);
+assert.match(
+  settings,
+  /fetch\("\/api\/daemon\/start", \{[\s\S]*method: "POST"[\s\S]*JSON\.stringify\(\{ restart: true \}\)/,
+  "daemon settings should post an explicit restart request when restarting",
+);
 
 assert.match(
   workspace,

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -358,6 +358,7 @@ function DaemonSection() {
   const [status, setStatus] = useState<DaemonStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [starting, setStarting] = useState(false);
+  const [restarting, setRestarting] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
 
   const refresh = () => {
@@ -384,6 +385,27 @@ function DaemonSection() {
       setStartError(err instanceof Error ? err.message : "daemon did not start");
     } finally {
       setStarting(false);
+    }
+  };
+
+  const restartDaemon = async () => {
+    setRestarting(true);
+    setStartError(null);
+    try {
+      const res = await fetch("/api/daemon/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ restart: true }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json?.ok === false) {
+        throw new Error(json?.error || json?.stderr || "daemon did not restart");
+      }
+      refresh();
+    } catch (err) {
+      setStartError(err instanceof Error ? err.message : "daemon did not restart");
+    } finally {
+      setRestarting(false);
     }
   };
 
@@ -416,10 +438,22 @@ function DaemonSection() {
               {starting ? "Starting..." : "Start daemon"}
             </button>
           )}
+          {status?.running && (
+            <button
+              type="button"
+              onClick={restartDaemon}
+              disabled={restarting}
+              className="focus-ring inline-flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] font-medium text-[var(--accent-presence-foreground)] hover:opacity-90 disabled:opacity-60"
+              title="coven daemon start"
+            >
+              <Icon name="ph:arrow-clockwise" width={12} />
+              {restarting ? "Restarting..." : "Restart daemon"}
+            </button>
+          )}
           <button
             type="button"
             onClick={refresh}
-            className={`focus-ring ${status?.running ? "ml-auto" : ""} flex items-center gap-1 rounded px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]`}
+            className="focus-ring flex items-center gap-1 rounded px-2 py-1 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:arrow-clockwise" width={11} />
             Refresh


### PR DESCRIPTION
## Summary
- adds an explicit restart mode to `/api/daemon/start` while keeping plain start idempotent
- adds a Settings → Daemon `Restart daemon` control when the daemon is running
- extends daemon start/source assertion coverage

## Test Plan
- `node --experimental-strip-types src/app/api/daemon/start/route.test.ts`
- `node --experimental-strip-types src/components/daemon-start-button.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`