### PR TITLE
fix(links): open Home feed / Library / Board links in the system browser

### DIFF
--- a/src/components/board-link-browser.test.ts
+++ b/src/components/board-link-browser.test.ts
@@ -8,8 +8,8 @@ const boardInspector = await readFile(new URL("./board-inspector.tsx", import.me
 
 assert.match(
   workspace,
-  /<BoardView[\s\S]*onOpenUrl=\{\(url\) => \{[\s\S]*setMode\("browser"\)[\s\S]*browserPaneRef\.current\?\.navigateTo\(url\)/,
-  "Workspace should route board task links into the embedded BrowserPane",
+  /<BoardView[\s\S]*onOpenUrl=\{openUrlExternally\}/,
+  "Workspace should route board task links to the system browser via openUrlExternally",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1815,11 +1815,7 @@ export function Workspace() {
       />
     ) : mode === "library" ? (
       <LibraryView
-        onOpenUrl={(url) => {
-          setMode("browser");
-          // Give the pane one frame to mount/become active, then navigate
-          requestAnimationFrame(() => browserPaneRef.current?.navigateTo(url));
-        }}
+        onOpenUrl={openUrlExternally}
         sessions={sessions}
         onOpenSession={openFamiliarSession}
         onNewProjectChat={openProjectChat}
@@ -1830,10 +1826,7 @@ export function Workspace() {
         sessions={sessions}
         activeFamiliarId={activeId}
         scopeFamiliarIds={scopeIds}
-        onOpenUrl={(url) => {
-          setMode("browser");
-          requestAnimationFrame(() => browserPaneRef.current?.navigateTo(url));
-        }}
+        onOpenUrl={openUrlExternally}
         onJumpToSession={(sessionId, familiarId) => {
           openFamiliarSession(sessionId, familiarId);
         }}
@@ -1931,10 +1924,7 @@ export function Workspace() {
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
-        onOpenUrl={(url) => {
-          setMode("browser");
-          requestAnimationFrame(() => browserPaneRef.current?.navigateTo(url));
-        }}
+        onOpenUrl={openUrlExternally}
       />
     )}
     </div>


### PR DESCRIPTION
## Follow-up to #1953

While verifying #1953 in the running app, I found it only fixed the **chat / groupchat / code** link consumers. The **Home feed (Repos/Tweets)**, **Library**, and **Board** "open link" handlers still did `setMode("browser")` + `browserPaneRef.navigateTo(url)` — opening the *in-app* full-screen browser pane instead of the user's system browser (and subject to the same async-mount ref-drop the first PR fixed). The Home feed Repos/Tweets buttons are exactly the prominent new links from #1949.

## Fix

Route all three handlers through `openUrlExternally` (added in #1953) so **every** link button opens in Safari/Chrome via the Tauri `shell_open` command on desktop, with a `window.open` fallback in browser dev. `browserPaneRef` is retained for manual Browser mode and the in-app `ref`-link path.

## Verification

- **Empirical (live dev server, merged code):** Playwright clicked a real Home feed Repos row → `window.open` was called with the exact repo URL (the external-open branch). 
- **Desktop branch:** `shell_open` confirmed present in the shipping desktop binary, validates http(s)-only, and is code-identical to the existing "Open in system browser" button in `browser-pane.tsx`.
- Source-text contracts updated (`board-link-browser.test.ts`); full app suite (448 files) + mobile suite (65 files) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)