### PR TITLE
fix(settings): resize typography pair selector

### DIFF
--- a/src/components/settings-fonts.test.ts
+++ b/src/components/settings-fonts.test.ts
@@ -16,6 +16,11 @@ assert.match(src, /fontStack\(/, "preview rendered with fontStack");
 assert.match(src, /DEFAULT_FONT_PAIR_ID/, "reset targets the default pair");
 assert.match(src, /Reset/, "exposes a reset control");
 assert.match(src, /Typography pair/, "renders a single pair selector");
+assert.match(
+  src,
+  /id="typography-pair"[\s\S]*?style=\{\{ width: "min\(100%, 300px\)", maxWidth: "100%" \}\}/,
+  "typography pair selector uses a responsive width that fits curated pair labels",
+);
 assert.match(src, /Interface/, "keeps the interface preview");
 assert.match(src, /Code &amp; terminal/, "keeps the code and terminal preview");
 

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -315,7 +315,7 @@ export function FontSettings() {
           <select
             id="typography-pair"
             className="gh-select"
-            style={{ maxWidth: "260px" }}
+            style={{ width: "min(100%, 300px)", maxWidth: "100%" }}
             value={pairId}
             onChange={(e) => selectPair(e.target.value)}
             aria-label="Typography pair"


### PR DESCRIPTION
## Summary
- makes the Typography pair selector use a responsive 300px target width instead of the old fixed 260px cap
- keeps `max-width: 100%` so the control stays inside narrow settings rows
- adds source coverage to prevent regressing the selector width

## Test Plan
- node --experimental-strip-types src/components/settings-fonts.test.ts
- node --experimental-strip-types src/lib/font-settings.test.ts
- pnpm typecheck
- git diff --check
- pnpm check:tests-wired
- pnpm test:app
- pnpm build
- Playwright rendered check at http://127.0.0.1:3017/settings, desktop and mobile selector metrics/screenshots

## Notes
- Browser plugin path failed before page interaction with `sandboxCwd must be an absolute file URI`, so rendered validation used repo Playwright.
