### PR TITLE
chore: release CovenCave v0.0.117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.117] - 2026-06-25
+
+Patch release on top of v0.0.116. Headline: Cave no longer ships a built-in
+familiar roster. Runtime familiar discovery, library routing, workflows, and
+chat/document helpers now resolve familiar identities from user configuration
+instead of hard-coded OpenCoven names (#1957).
+
+### Changed
+
+- **Familiar roster** - removed built-in familiar ids from runtime fallbacks and
+  moved library workspace resolution to `~/.coven/familiars.toml`, preserving
+  per-familiar research roots without assuming any default names (#1957).
+- **Library** - document lookup, document chat, and rename/move paths now choose
+  the configured familiar workspace by request, absolute path, or first
+  configured workspace instead of a static research root (#1957).
+- **Workflows** - bundled workflow templates use role-oriented ids and metadata
+  rather than OpenCoven familiar names (#1957).
+
+### Fixed
+
+- **Regression coverage** - added source guards and API contract coverage so
+  hard-coded runtime familiar rosters do not quietly return (#1957).
+
 ## [0.0.116] - 2026-06-25
 
 Patch release on top of v0.0.115. Headline: flows get a proper production-publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.116",
+  "version": "0.0.117",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.116"
+version = "0.0.117"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.116"
+version = "0.0.117"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.116</string>
+	<string>0.0.117</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.116</string>
+	<string>0.0.117</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.116</string>
+	<string>0.0.117</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.116</string>
+	<string>0.0.117</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.116",
+  "version": "0.0.117",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave app metadata to 0.0.117
- add changelog notes for the dynamic familiar roster fix

## Verification
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm check:tests-wired
- bash scripts/release-notes.sh v0.0.117 v0.0.116
- pnpm build
- git diff --check