### PR TITLE
feat(familiars): move the content feed into a per-familiar Feed tab

### DIFF
--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -14,6 +14,7 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
 import type { FileMemoryEntry } from "@/components/familiars-memory-view";
 import { FamiliarDailyNotes } from "@/components/familiar-daily-notes";
+import { HomeFeed } from "@/components/home/home-feed";
 import { Modal } from "@/components/ui/modal";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
@@ -46,6 +47,7 @@ type AgentsViewProps = {
   onOpenSession: (sessionId: string, familiarId?: string | null) => void;
   onOpenMemoryFile: (path: string) => void;
   onOpenOnboarding: () => void;
+  onOpenUrl: (url: string) => void;
 };
 
 function familiarMatches(familiar: Familiar, query: string): boolean {
@@ -69,6 +71,7 @@ export function FamiliarsView({
   onOpenSession,
   onOpenMemoryFile,
   onOpenOnboarding,
+  onOpenUrl,
 }: AgentsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
@@ -282,6 +285,7 @@ export function FamiliarsView({
               onStartChat={() => onStartChat(selectedFamiliar.id)}
               onOpenSession={(sid) => onOpenSession(sid, selectedFamiliar.id)}
               onOpenMemoryFile={onOpenMemoryFile}
+              onOpenUrl={onOpenUrl}
             />
           </div>
         ) : visibleFamiliars.length === 0 ? (
@@ -572,13 +576,14 @@ function FamiliarDetailRail({ familiars, selectedId, onSelect, onPreview, onBack
 // FamiliarDetailPanel — right-side panel with Memory / Files / Sessions tabs
 // ────────────────────────────────────────────────────────────────────────────
 
-type DetailTab = "memory" | "daily-notes" | "files" | "sessions";
+type DetailTab = "memory" | "daily-notes" | "files" | "sessions" | "feed";
 
 const DETAIL_TABS: { id: DetailTab; label: string }[] = [
   { id: "memory", label: "Memory" },
   { id: "daily-notes", label: "Daily Notes" },
   { id: "files", label: "Files" },
   { id: "sessions", label: "Sessions" },
+  { id: "feed", label: "Feed" },
 ];
 
 type AgentDetailPanelProps = {
@@ -593,6 +598,7 @@ type AgentDetailPanelProps = {
   onStartChat: () => void;
   onOpenSession: (sessionId: string) => void;
   onOpenMemoryFile: (path: string) => void;
+  onOpenUrl: (url: string) => void;
 };
 
 function FamiliarDetailPanel({
@@ -607,6 +613,7 @@ function FamiliarDetailPanel({
   onStartChat,
   onOpenSession,
   onOpenMemoryFile,
+  onOpenUrl,
 }: AgentDetailPanelProps) {
   const [tab, setTab] = useState<DetailTab>("memory");
   const familiarSessions = useMemo(
@@ -713,6 +720,10 @@ function FamiliarDetailPanel({
             <p className="mt-2 text-[10px] text-[var(--text-muted)]">
               Only files traced to {familiar.display_name} are shown here.
             </p>
+          </div>
+        ) : tab === "feed" ? (
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
+            <HomeFeed onOpenUrl={onOpenUrl} />
           </div>
         ) : (
           <div className="h-full overflow-y-auto p-4">

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -24,7 +24,6 @@ import { readComposerHistory, writeComposerHistory } from "@/lib/composer-histor
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
-import { HomeFeed } from "@/components/home/home-feed";
 import { useProjects } from "@/lib/use-projects";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
@@ -59,8 +58,6 @@ type Props = {
   onSlash?: (command: string, args: string) => void;
   /** Resume a recent chat from the "Jump back in" strip. */
   onOpenSession?: (sessionId: string, familiarId: string | null) => void;
-  /** Open an RSS article in Cave's in-app browser. */
-  onOpenUrl?: (url: string) => void;
 };
 
 // Persist the in-progress prompt so a page reload doesn't eat what you were
@@ -100,7 +97,6 @@ export function HomeComposer({
   onToast,
   onSlash,
   onOpenSession,
-  onOpenUrl,
 }: Props) {
   const [text, setText] = useState(() => readHomeDraft());
   const [destination, setDestination] = useState<Destination>("chat");
@@ -768,14 +764,6 @@ export function HomeComposer({
           </div>
         </div>
       )}
-
-      {/* Content feed — YouTube videos, curated X posts, and GitHub repos. */}
-      <HomeFeed
-        onOpenUrl={(url) => {
-          if (onOpenUrl) onOpenUrl(url);
-          else window.open(url, "_blank", "noopener,noreferrer");
-        }}
-      />
     </div>
   );
 }

--- a/src/components/home-feed.test.ts
+++ b/src/components/home-feed.test.ts
@@ -4,10 +4,14 @@ import { readFileSync } from "node:fs";
 
 const feed = readFileSync(new URL("./home/home-feed.tsx", import.meta.url), "utf8");
 const composer = readFileSync(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const familiarsView = readFileSync(new URL("./familiars-view.tsx", import.meta.url), "utf8");
 
-// Home renders the content feed, not the old RSS/world-news widget.
-assert.match(composer, /import \{ HomeFeed \} from "@\/components\/home\/home-feed"/, "home-composer imports HomeFeed");
-assert.match(composer, /<HomeFeed/, "home-composer renders HomeFeed");
+// The content feed now lives as a per-familiar "Feed" tab in the Familiars
+// detail panel, not on the Home composer.
+assert.match(familiarsView, /import \{ HomeFeed \} from "@\/components\/home\/home-feed"/, "familiars-view imports HomeFeed");
+assert.match(familiarsView, /<HomeFeed onOpenUrl=\{onOpenUrl\}/, "familiars-view renders HomeFeed in the Feed tab");
+assert.match(familiarsView, /\{ id: "feed", label: "Feed" \}/, "detail panel exposes a Feed tab");
+assert.doesNotMatch(composer, /<HomeFeed/, "the content feed no longer renders on the Home composer");
 assert.doesNotMatch(composer, /HomeRssWidget|rss-widget/, "the old RSS widget is gone from home");
 
 // Two tabs: Tweets · Repos. The YouTube/Videos tab was removed.

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1729,6 +1729,7 @@ export function Workspace() {
           window.location.hash = `memory:${encodeURIComponent(path)}`;
         }}
         onOpenOnboarding={openOnboarding}
+        onOpenUrl={openUrlExternally}
       />
     ) : mode === "chat" ? (
       <ChatSurface
@@ -1924,7 +1925,6 @@ export function Workspace() {
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
-        onOpenUrl={openUrlExternally}
       />
     )}
     </div>


### PR DESCRIPTION
## What

Moves the **Tweets / Repos content feed** off the Home composer and into the **Familiars** detail panel as a new **Feed** tab (next to Memory · Daily Notes · Files · Sessions).

## Changes

- **familiars-view**: add the `"feed"` `DetailTab` + render `<HomeFeed>` in it, threading `onOpenUrl` through `FamiliarsView` → `FamiliarDetailPanel`.
- **workspace**: wire `FamiliarsView onOpenUrl={openUrlExternally}` so feed links open in the **system browser** (consistent with the rest of the app); remove the now-unused `onOpenUrl` pass-through to `HomeComposer`.
- **home-composer**: remove the `HomeFeed` render, import, and `onOpenUrl` prop.

The feed's `home-feed__*` styles are global (`home-composer.css` is `@import`ed by `globals.css`), so the tab renders styled without moving any CSS.

## Verification

Empirically against the live dev server:
- Feed removed from Home (`.home-feed` count = 0). 
- **Feed** tab present in each familiar's detail panel; switching to it shows Tweets/Repos.
- Clicking a Repos row opens the URL in the system browser (`window.open` fallback / `shell_open` on desktop).

Source-text contracts updated (`home-feed.test.ts`); full app suite (448) + mobile (65) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)