### PR TITLE
feat(chat): slim the Convo/Projects/Code mode switch to text-only

### DIFF
--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -14,7 +14,7 @@ assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "proj
 // Convo, Projects, then Code — Projects is one of the three locks, not a tab.
 assert.match(
   surface,
-  /\{\s*id:\s*"projects",\s*label:\s*"Projects",\s*icon:\s*"ph:folder"\s*\}/,
+  /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
   "Projects is one of the mode-switch options",
 );
 assert.match(surface, /\{\s*id:\s*"convo",\s*label:\s*"Convo"/, "Convo is the conversation-only mode");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -57,13 +57,15 @@ type FamiliarsScope = "conversation" | "memory" | "projects";
 // The standalone chat's mode switch locks the surface into one of three
 // layouts: the conversation alone ("convo"), the Projects browser, or the
 // inline chat↔code split ("code"). It folds the old Sessions/Projects scope
-// tabs and the binary Power toggle into a single segmented selector.
+// tabs and the binary Power toggle into a single segmented selector. Text-only
+// (no icons) so it stays a compact pill — matching the slim GitHub-style filter
+// segments elsewhere rather than reading as a chunky toolbar.
 type ChatMode = "convo" | "projects" | "code";
 
-const CHAT_MODE_ITEMS: { id: ChatMode; label: string; icon: "ph:chat-circle-dots" | "ph:folder" | "ph:code-bold" }[] = [
-  { id: "convo", label: "Convo", icon: "ph:chat-circle-dots" },
-  { id: "projects", label: "Projects", icon: "ph:folder" },
-  { id: "code", label: "Code", icon: "ph:code-bold" },
+const CHAT_MODE_ITEMS: { id: ChatMode; label: string }[] = [
+  { id: "convo", label: "Convo" },
+  { id: "projects", label: "Projects" },
+  { id: "code", label: "Code" },
 ];
 
 export type RightPanelKind = "inspector" | "changes" | "debug";


### PR DESCRIPTION
## What

Follow-up to #1952. The `Convo / Projects / Code` mode switch carried per-segment icons that made each pill read as a chunky toolbar. This drops the icons so the switch is a slim, compact text-only pill — matching the GitHub-style filter segments (`None / Org / Repo`).

## How

- Removed the `icon` field from `CHAT_MODE_ITEMS` in `chat-surface.tsx` (the `Tabs` segment density stays at `sm`).
- Updated the one source-text test that pinned `icon: "ph:folder"` on the Projects item.

## Verification

- `chat-surface-power-mode.test.ts` ✅ · `chat-surface-projects-tab.test.ts` ✅ · `tsc --noEmit` clean ✅
- Built + screenshotted the real app: the switch renders as a slim ~180px text-only pill (active segment raised), matching the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)