### PR TITLE
Remove workflows from Automations; add flow layout & iOS feed

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -527,6 +527,66 @@ struct CaveClient {
         try await inboxAction(id, "snooze", body: try JSONEncoder().encode(["minutes": minutes]))
     }
 
+    // MARK: - Content feed (Tweets · Repos)
+
+    /// One OpenCoven repo from the curated star list. Mirrors the web
+    /// `RepoItem` (src/lib/home-feed.ts).
+    struct RepoFeedItem: Decodable, Identifiable {
+        let id: String
+        let fullName: String
+        let description: String?
+        let stars: Int
+        let language: String?
+        let url: String
+        let pushedAt: String?
+    }
+
+    /// One post from the OpenCoven timeline (RSS-backed). Mirrors the web
+    /// `TweetItem` (src/lib/home-feed.ts).
+    struct TweetFeedItem: Decodable, Identifiable {
+        let id: String
+        let url: String
+        let title: String
+        let handle: String?
+        let isoDate: String?
+    }
+
+    private struct ReposResponse: Decodable {
+        let ok: Bool?
+        let items: [RepoFeedItem]?
+        let configured: Bool?
+    }
+    private struct TweetsResponse: Decodable {
+        let ok: Bool?
+        let items: [TweetFeedItem]?
+    }
+
+    /// Repos from the OpenCoven star list. `configured == false` means the
+    /// desktop has no GitHub token yet (the list query needs one).
+    func repos() async throws -> (items: [RepoFeedItem], configured: Bool) {
+        let req = try request("api/github/repos")
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            let decoded = try JSONDecoder().decode(ReposResponse.self, from: data)
+            return (decoded.items ?? [], decoded.configured ?? true)
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// Latest OpenCoven posts. `refresh` bypasses the desktop's short cache.
+    func homeTweets(refresh: Bool = false) async throws -> [TweetFeedItem] {
+        let req = try request("api/home-tweets" + (refresh ? "?refresh=1" : ""))
+        let (data, resp) = try await session.data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(TweetsResponse.self, from: data).items ?? []
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
     // MARK: - Helpers
 
     private static func check(_ resp: URLResponse) throws {

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarFeedView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarFeedView.swift
@@ -1,0 +1,188 @@
+import SwiftUI
+
+/// The OpenCoven content feed — latest posts (Tweets) and curated repos —
+/// surfaced inside a familiar's view as the "Feed" segment, mirroring the
+/// desktop's per-familiar Feed tab. The content itself is global (it comes from
+/// the desktop's `/api/home-tweets` and `/api/github/repos`); the familiar is
+/// just the place you reach it from.
+struct FamiliarFeedView: View {
+    @Environment(AppModel.self) private var app
+
+    private enum Segment: String, CaseIterable, Identifiable {
+        case tweets = "Tweets"
+        case repos = "Repos"
+        var id: String { rawValue }
+    }
+
+    @State private var segment: Segment = .tweets
+    @State private var tweets: [CaveClient.TweetFeedItem] = []
+    @State private var repos: [CaveClient.RepoFeedItem] = []
+    @State private var reposConfigured = true
+    @State private var tweetsLoaded = false
+    @State private var reposLoaded = false
+    @State private var loading = false
+    @State private var error: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Feed", selection: $segment) {
+                ForEach(Segment.allCases) { Text($0.rawValue).tag($0) }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            content
+        }
+        .task(id: segment) { await loadActive() }
+        .refreshable { await loadActive(force: true) }
+    }
+
+    @ViewBuilder private var content: some View {
+        if loading && currentIsEmpty {
+            ProgressView().controlSize(.large)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error, currentIsEmpty {
+            ContentUnavailableView {
+                Label("Couldn’t load feed", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(error)
+            } actions: {
+                Button("Retry") { Task { await loadActive(force: true) } }
+                    .buttonStyle(.borderedProminent)
+            }
+        } else {
+            switch segment {
+            case .tweets: tweetList
+            case .repos: repoList
+            }
+        }
+    }
+
+    // MARK: - Tweets
+
+    @ViewBuilder private var tweetList: some View {
+        if tweets.isEmpty {
+            ContentUnavailableView("No posts yet", systemImage: "bird")
+        } else {
+            List(tweets) { tweet in
+                if let url = URL(string: tweet.url) {
+                    Link(destination: url) { TweetRow(item: tweet) }
+                } else {
+                    TweetRow(item: tweet)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .themedListBackground()
+        }
+    }
+
+    // MARK: - Repos
+
+    @ViewBuilder private var repoList: some View {
+        if !reposConfigured {
+            ContentUnavailableView {
+                Label("GitHub not configured", systemImage: "key.slash")
+            } description: {
+                Text("Add a GitHub token on the desktop to load the OpenCoven repo list.")
+            }
+        } else if repos.isEmpty {
+            ContentUnavailableView("No repositories yet", systemImage: "shippingbox")
+        } else {
+            List(repos) { repo in
+                if let url = URL(string: repo.url) {
+                    Link(destination: url) { RepoRow(item: repo) }
+                } else {
+                    RepoRow(item: repo)
+                }
+            }
+            .listStyle(.insetGrouped)
+            .themedListBackground()
+        }
+    }
+
+    // MARK: - Loading
+
+    private var currentIsEmpty: Bool {
+        segment == .tweets ? tweets.isEmpty : repos.isEmpty
+    }
+
+    private func loadActive(force: Bool = false) async {
+        guard let client = app.client else { return }
+        switch segment {
+        case .tweets:
+            if tweetsLoaded && !force { return }
+            loading = true
+            defer { loading = false }
+            do {
+                tweets = try await client.homeTweets(refresh: force)
+                tweetsLoaded = true
+                error = nil
+            } catch { self.error = error.localizedDescription }
+        case .repos:
+            if reposLoaded && !force { return }
+            loading = true
+            defer { loading = false }
+            do {
+                let result = try await client.repos()
+                repos = result.items
+                reposConfigured = result.configured
+                reposLoaded = true
+                error = nil
+            } catch { self.error = error.localizedDescription }
+        }
+    }
+}
+
+private struct TweetRow: View {
+    let item: CaveClient.TweetFeedItem
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "bubble.left").font(.caption).foregroundStyle(.secondary)
+                Text(item.title).font(.subheadline).lineLimit(3)
+            }
+            HStack(spacing: 6) {
+                if let handle = item.handle, !handle.isEmpty {
+                    Text(handle).font(.caption2).foregroundStyle(.secondary)
+                }
+                if let when = relativeFeedDate(item.isoDate) {
+                    Text("· \(when)").font(.caption2).foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+private struct RepoRow: View {
+    let item: CaveClient.RepoFeedItem
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.caption).foregroundStyle(.secondary)
+                Text(item.fullName).font(.subheadline).fontWeight(.medium).lineLimit(1)
+            }
+            if let desc = item.description, !desc.isEmpty {
+                Text(desc).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+            }
+            HStack(spacing: 8) {
+                if let lang = item.language, !lang.isEmpty {
+                    Text(lang).font(.caption2).foregroundStyle(.secondary)
+                }
+                Label("\(item.stars)", systemImage: "star").font(.caption2).foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// Compact "2h" / "Jun 12" relative date for an ISO-8601 string. Returns nil
+/// when the string is missing or unparseable.
+private func relativeFeedDate(_ iso: String?) -> String? {
+    guard let iso, let date = caveParseISO(iso) else { return nil }
+    let fmt = RelativeDateTimeFormatter()
+    fmt.unitsStyle = .abbreviated
+    return fmt.localizedString(for: date, relativeTo: Date())
+}

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -19,6 +19,9 @@ struct FamiliarThreadsView: View {
     @State private var selectedIds: Set<String> = []
     @State private var confirmingBulkDelete = false
     @State private var exportArchive: ExportArchive?
+    /// Threads vs the OpenCoven content feed (mirrors the desktop Feed tab).
+    @State private var section: ThreadSection = .threads
+    private enum ThreadSection { case threads, feed }
 
     /// One row in the list: an on-device thread or a server-only session.
     private enum Entry: Identifiable {
@@ -55,11 +58,24 @@ struct FamiliarThreadsView: View {
     }
 
     var body: some View {
-        Group {
-            if entries.isEmpty && archivedLocalCount == 0 {
-                emptyState
-            } else {
-                threadList
+        VStack(spacing: 0) {
+            Picker("Section", selection: $section) {
+                Text("Threads").tag(ThreadSection.threads)
+                Text("Feed").tag(ThreadSection.feed)
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+
+            switch section {
+            case .threads:
+                if entries.isEmpty && archivedLocalCount == 0 {
+                    emptyState
+                } else {
+                    threadList
+                }
+            case .feed:
+                FamiliarFeedView()
             }
         }
         .navigationTitle(familiar.displayName)
@@ -84,7 +100,7 @@ struct FamiliarThreadsView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                if !selectMode && hasLocalThreads {
+                if !selectMode && hasLocalThreads && section == .threads {
                     Button("Select") { withAnimation { selectMode = true } }
                 }
             }
@@ -93,7 +109,7 @@ struct FamiliarThreadsView: View {
         .task { await app.loadSessions() }
         .onAppear { app.markFamiliarViewed([familiar.id]) }
         .safeAreaInset(edge: .bottom) {
-            if selectMode {
+            if selectMode && section == .threads {
                 HStack {
                     Button(allLocalSelected ? "Deselect All" : "Select All") { toggleSelectAll() }
                     Spacer()

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -33,7 +33,6 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { automationMatchesFilter } from "@/lib/familiar-multiselect";
 import { AutomationCreateDialog, type AutomationCreateInput } from "@/components/automation-create-dialog";
-import { listWorkflows, runWorkflow, type WorkflowSummary } from "@/lib/workflows";
 import { listFlows, runFlow, type FlowDoc } from "@/lib/flows";
 import {
   buildAutomationEntries,
@@ -67,12 +66,12 @@ function linkLabel(link: LinkRef): string {
   return "Memory";
 }
 
-// The Automations surface unifies four primitives under one typed model:
-// reminders, crons (Codex automations), workflows, and flows — plus an Activity
+// The Automations surface unifies three primitives under one typed model:
+// reminders, crons (Codex automations), and flows — plus an Activity
 // feed (the full inbox). "all" shows every automation in one list.
-type AutomationTab = "all" | "reminders" | "crons" | "workflows" | "flows" | "activity";
+type AutomationTab = "all" | "reminders" | "crons" | "flows" | "activity";
 
-// Fire a cross-surface navigation so "Open" on a workflow/flow jumps to its
+// Fire a cross-surface navigation so "Open" on a flow jumps to its
 // dedicated editor surface (the Workspace owns setMode; see cave:navigate-mode).
 function navigateToMode(mode: string) {
   if (typeof window === "undefined") return;
@@ -1532,7 +1531,7 @@ function AutomationAllList({
   );
 }
 
-// Shared row shell for the workflow + flow tabs: name, meta, Run + Open actions.
+// Shared row shell for managed automation tabs: name, meta, Run + Open actions.
 function ManagedAutomationRow({
   type,
   name,
@@ -1577,45 +1576,6 @@ function ManagedAutomationRow({
         <Icon name="ph:arrow-square-out" width={11} aria-hidden />
         Open
       </button>
-    </div>
-  );
-}
-
-function WorkflowList({
-  workflows,
-  query,
-  busyId,
-  familiarLabel,
-  onRun,
-  onOpen,
-}: {
-  workflows: WorkflowSummary[];
-  query: string;
-  busyId: string | null;
-  familiarLabel: (id?: string | null) => string | null;
-  onRun: (wf: WorkflowSummary) => void;
-  onOpen: (wf: WorkflowSummary) => void;
-}) {
-  const visible = workflows.filter(
-    (w) => !query || (w.name ?? w.id).toLowerCase().includes(query) || (w.summary ?? "").toLowerCase().includes(query),
-  );
-  return (
-    <div className="space-y-1.5 pt-1">
-      {visible.map((wf) => {
-        const fam = familiarLabel(wf.familiar);
-        const steps = wf.steps?.length ? `${wf.steps.length} steps` : "Workflow";
-        return (
-          <ManagedAutomationRow
-            key={wf.id}
-            type="workflow"
-            name={wf.name ?? wf.id}
-            meta={[wf.summary || steps, fam].filter(Boolean).join(" · ")}
-            busy={busyId === `workflow:${wf.id}`}
-            onRun={() => onRun(wf)}
-            onOpen={() => onOpen(wf)}
-          />
-        );
-      })}
     </div>
   );
 }
@@ -1665,7 +1625,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const [query, setQuery] = useState("");
   const [items, setItems] = useState<InboxItem[]>([]);
   const [codexAutos, setCodexAutos] = useState<CodexAutomation[]>([]);
-  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
   const [flows, setFlows] = useState<FlowDoc[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [initialLoadDone, setInitialLoadDone] = useState(false);
@@ -1689,10 +1648,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
   const load = useCallback(async () => {
     try {
-      const [inboxRes, codexRes, wfRes, flowRes] = await Promise.all([
+      const [inboxRes, codexRes, flowRes] = await Promise.all([
         fetch("/api/inbox", { cache: "no-store" }),
         fetch("/api/codex-automations", { cache: "no-store" }),
-        listWorkflows().catch(() => ({ ok: false, workflows: [] })),
         listFlows().catch(() => ({ ok: false, flows: [] })),
       ]);
       const inboxJson = await inboxRes.json();
@@ -1702,9 +1660,8 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
       const codexJson = await codexRes.json();
       if (!mountedRef.current) return;
       if (codexJson.ok) setCodexAutos(codexJson.automations ?? []);
-      // Workflows + flows are best-effort: a missing daemon/store shouldn't
-      // blank the whole surface, just drop those two types from the list.
-      if (wfRes.ok) setWorkflows(wfRes.workflows ?? []);
+      // Flows are best-effort: a missing daemon/store shouldn't blank the whole
+      // surface, just drop Flow rows from the list.
       if (flowRes.ok) setFlows(flowRes.flows ?? []);
       setError(null);
     } catch (err) {
@@ -1948,24 +1905,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   }, [load]);
 
-  // ── Workflows + flows ───────────────────────────────────────────────────
+  // ── Flows ───────────────────────────────────────────────────────────────
   // Cave has no native execution engine, so "run" is daemon-first and returns
   // { unavailable: true } when the daemon is offline rather than faking a run.
-  const runWorkflowNow = useCallback(async (wf: WorkflowSummary) => {
-    if (!(await confirm({ title: `Run “${wf.name ?? wf.id}”?`, body: "This spawns an agent session to execute the workflow.", confirmLabel: "Run" }))) return;
-    setBusyId(`workflow:${wf.id}`);
-    try {
-      const res = await runWorkflow({ id: wf.id });
-      if (res.unavailable) { setError("Workflows run through the Coven daemon — it isn't reachable right now."); return; }
-      if (!res.ok) throw new Error(res.error ?? "run failed");
-      if (res.sessionId) onOpenSession?.(res.sessionId, wf.familiar ?? null);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "workflow run failed");
-    } finally {
-      setBusyId(null);
-    }
-  }, [confirm, onOpenSession]);
-
   const runFlowNow = useCallback(async (flow: FlowDoc) => {
     if (!(await confirm({ title: `Run “${flow.name}”?`, body: "This spawns an agent session to execute the flow graph.", confirmLabel: "Run" }))) return;
     setBusyId(`flow:${flow.id}`);
@@ -1983,7 +1925,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
   // "Open" routes to each type's dedicated editor surface.
   const openEntry = useCallback((entry: AutomationEntry) => {
-    if (entry.type === "workflow") { navigateToMode("roles"); return; }
     if (entry.type === "flow") { navigateToMode("flow"); return; }
     // reminders + crons are edited inline here — select their detail panel.
     if (entry.type === "reminder") {
@@ -2138,12 +2079,11 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
         buildAutomationEntries({
           reminders: items.filter((it) => isScheduleInboxItem(it) && !hiddenIds.has(it.id)),
           crons: codexAutos.filter((a) => !hiddenIds.has(a.id)),
-          workflows,
           flows,
         }),
         q,
       ),
-    [items, codexAutos, workflows, flows, hiddenIds, q],
+    [items, codexAutos, flows, hiddenIds, q],
   );
   const typeCounts = useMemo(
     () =>
@@ -2151,11 +2091,10 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
         buildAutomationEntries({
           reminders: items.filter(isScheduleInboxItem),
           crons: codexAutos,
-          workflows,
           flows,
         }),
       ),
-    [items, codexAutos, workflows, flows],
+    [items, codexAutos, flows],
   );
 
   const selectTab = (tab: AutomationTab) => {
@@ -2185,7 +2124,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               Automations
             </h1>
             <p className="mt-0.5 text-[12px]" style={{ color: "var(--text-muted)" }}>
-              Reminders, crons, workflows, and flows — everything that runs for you, in one place.
+              Reminders, crons, and flows — everything that runs for you, in one place.
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -2200,7 +2139,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                 Select
               </button>
             )}
-            {/* Typed "New" menu — one entry point for all four automation types. */}
+            {/* Typed "New" menu — one entry point for the automation types. */}
             <div className="relative">
               <Button className="automation-create-chat-btn" leadingIcon="ph:plus" onClick={() => setNewMenuOpen((v) => !v)} aria-haspopup="menu" aria-expanded={newMenuOpen}>
                 New
@@ -2230,13 +2169,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                       onClick={() => { setNewMenuOpen(false); setCreateOpen(true); }}
                     />
                     <NewMenuItem
-                      icon={AUTOMATION_TYPE_META.workflow.icon}
-                      accent={AUTOMATION_TYPE_META.workflow.accent}
-                      label="Workflow"
-                      blurb={AUTOMATION_TYPE_META.workflow.blurb}
-                      onClick={() => { setNewMenuOpen(false); navigateToMode("roles"); }}
-                    />
-                    <NewMenuItem
                       icon={AUTOMATION_TYPE_META.flow.icon}
                       accent={AUTOMATION_TYPE_META.flow.accent}
                       label="Flow"
@@ -2260,7 +2192,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               { id: "all", label: "All", count: allEntries.length },
               { id: "reminders", label: "Reminders", count: typeCounts.reminder },
               { id: "crons", label: "Crons", count: typeCounts.cron },
-              { id: "workflows", label: "Workflows", count: typeCounts.workflow },
               { id: "flows", label: "Flows", count: typeCounts.flow },
               { id: "activity", label: "Activity", count: items.length },
             ] satisfies TabItem<AutomationTab>[]}
@@ -2270,10 +2201,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
         {/* Text filter for the active tab. Gated on the UNfiltered presence of
             rows so filtering to zero never hides the box (you can still clear). */}
         {initialLoadDone && !reminderSelect.selectMode && (
-          activeTab === "all" ? typeCounts.reminder + typeCounts.cron + typeCounts.workflow + typeCounts.flow > 0
+          activeTab === "all" ? typeCounts.reminder + typeCounts.cron + typeCounts.flow > 0
           : activeTab === "activity" ? items.length > 0
           : activeTab === "crons" ? codexAutos.length > 0
-          : activeTab === "workflows" ? workflows.length > 0
           : activeTab === "flows" ? flows.length > 0
           : items.some(isScheduleInboxItem)
         ) ? (
@@ -2285,7 +2215,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               placeholder={
                 activeTab === "all" ? "Filter automations…"
                 : activeTab === "crons" ? "Filter crons…"
-                : activeTab === "workflows" ? "Filter workflows…"
                 : activeTab === "flows" ? "Filter flows…"
                 : activeTab === "activity" ? "Filter activity…"
                 : "Filter reminders…"
@@ -2327,7 +2256,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             (activeTab === "all" && allEntries.length === 0) ||
             (activeTab === "reminders" && remindersEmpty) ||
             (activeTab === "crons" && codexActive.length + codexPaused.length === 0) ||
-            (activeTab === "workflows" && workflows.filter((w) => (w.name ?? w.id).toLowerCase().includes(q) || (w.summary ?? "").toLowerCase().includes(q)).length === 0) ||
             (activeTab === "flows" && flows.filter((f) => (f.name || "").toLowerCase().includes(q)).length === 0) ||
             (activeTab === "activity" && inboxFeed.needsYou.length + inboxFeed.active.length + inboxFeed.resolved.length === 0)
           ) ? (
@@ -2342,7 +2270,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               className="mt-12"
               icon="ph:lightning-bold"
               headline="No automations yet"
-              subtitle="Reminders, crons, workflows, and flows all live here. Use “New” to create one."
+              subtitle="Reminders, crons, and flows all live here. Use “New” to create one."
             />
           ) : activeTab === "reminders" && remindersEmpty ? (
             <EmptyState
@@ -2365,14 +2293,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               headline="No crons configured"
               subtitle="A cron runs a familiar on a recurring schedule — set one up to get started."
               actions={<Button leadingIcon="ph:plus" onClick={() => setCreateOpen(true)}>New cron</Button>}
-            />
-          ) : activeTab === "workflows" && workflows.length === 0 ? (
-            <EmptyState
-              className="mt-12"
-              icon="ph:graph"
-              headline="No workflows yet"
-              subtitle="Workflows are multi-step agent pipelines. Build one in Roles → Workflows."
-              actions={<Button leadingIcon="ph:arrow-square-out" onClick={() => navigateToMode("roles")}>Open Roles</Button>}
             />
           ) : activeTab === "flows" && flows.length === 0 ? (
             <EmptyState
@@ -2455,15 +2375,6 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   selectedId={selectedReminderId}
                   familiarLabel={familiarLabel}
                   onSelect={(item) => { setSelectedItem(item); setSelectedCodex(null); }}
-                />
-              ) : activeTab === "workflows" ? (
-                <WorkflowList
-                  workflows={workflows}
-                  query={q}
-                  busyId={busyId}
-                  familiarLabel={familiarLabel}
-                  onRun={runWorkflowNow}
-                  onOpen={() => navigateToMode("roles")}
                 />
               ) : activeTab === "flows" ? (
                 <FlowList

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -335,7 +335,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                         {manifest.skills.length > 3 ? ` +${manifest.skills.length - 3} more` : ""}</>
                     )}
                   </p>
-                  {/* Skills are building blocks of Workflows — see the Workflows tab in Capabilities */}
+                  {/* Skills are building blocks for Flow nodes and capability assignments. */}
                   {manifest.warnings.length > 0 && (
                     <p className="familiar-studio-brain__capabilities-line familiar-studio-brain__capabilities-line--warn">
                       {manifest.warnings.length} parse warning

--- a/src/components/flow/flow-canvas.test.ts
+++ b/src/components/flow/flow-canvas.test.ts
@@ -10,10 +10,18 @@ const styles = readFileSync(new URL("../../styles/flow.css", import.meta.url), "
 assert.match(canvas, /onTidy: \(\) => void/, "FlowCanvas should accept a tidy-workflow action");
 assert.match(canvas, /title="Tidy up workflow"/, "Canvas toolbar should expose n8n-style tidy action");
 assert.match(canvas, /props\.onTidy/, "Canvas tidy button should call the provided action");
+assert.match(canvas, /layoutOrientation: FlowLayoutOrientation/, "FlowCanvas should receive the active layout orientation");
+assert.match(canvas, /onLayoutOrientation: \(orientation: FlowLayoutOrientation\) => void/, "FlowCanvas should expose an orientation switch action");
+assert.match(canvas, /aria-label="Use horizontal layout"/, "Canvas toolbar should expose a horizontal layout switch");
+assert.match(canvas, /aria-label="Use vertical layout"/, "Canvas toolbar should expose a vertical layout switch");
 assert.match(view, /tidyFlowLayout/, "FlowView should import the pure tidy layout mutation");
+assert.match(view, /useState<FlowLayoutOrientation>\("horizontal"\)/, "FlowView should default Flow layout to horizontal");
+assert.match(view, /tidyFlowLayout\(d, layoutOrientation\)/, "Tidy should use the active Flow layout orientation");
+assert.match(view, /tidyFlowLayout\(d, orientation\)/, "Switching orientation should retidy the canvas immediately");
 assert.match(view, /setViewResetKey/, "FlowView should be able to force React Flow to consume tidied positions");
 assert.match(view, /setViewResetKey\(\(key\) => key \+ 1\)/, "Tidy should reset the canvas local position cache");
 assert.match(view, /onTidy=\{tidy\}/, "FlowView should wire tidy into the canvas toolbar");
+assert.match(view, /onLayoutOrientation=\{setAndApplyLayoutOrientation\}/, "FlowView should wire orientation switching into the canvas toolbar");
 assert.match(canvas, /staleNodeIds\?: Record<string, boolean>/, "FlowCanvas should accept stale-node markers");
 assert.match(view, /staleNodeIds/, "FlowView should compute canvas stale-node markers from the active run snapshot");
 assert.match(node, /node\.displayNote/, "Flow nodes should honor the display-note flag");

--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -22,7 +22,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { catalogNode } from "@/lib/flow/flow-catalog";
-import type { FlowDoc, FlowPosition } from "@/lib/flow/flow-doc";
+import type { FlowDoc, FlowLayoutOrientation, FlowPosition } from "@/lib/flow/flow-doc";
 import {
   FlowNodeView,
   FlowStickyView,
@@ -48,6 +48,7 @@ export type FlowCanvasProps = {
   staleNodeIds?: Record<string, boolean>;
   activeNodeId?: string | null;
   viewResetKey: number;
+  layoutOrientation: FlowLayoutOrientation;
   onSelectNode: (id: string | null) => void;
   onOpenNode: (id: string) => void;
   onConnect: (source: string, sourceHandle: string, target: string, targetHandle: string) => void;
@@ -64,6 +65,7 @@ export type FlowCanvasProps = {
   onStickyText: (id: string, text: string) => void;
   onStickySize: (id: string, width: number, height: number) => void;
   onTidy: () => void;
+  onLayoutOrientation: (orientation: FlowLayoutOrientation) => void;
 };
 
 function FlowCanvasInner(props: FlowCanvasProps) {
@@ -74,6 +76,7 @@ function FlowCanvasInner(props: FlowCanvasProps) {
     staleNodeIds,
     activeNodeId,
     viewResetKey,
+    layoutOrientation,
     onSelectNode,
     onOpenNode,
     onConnect,
@@ -288,6 +291,28 @@ function FlowCanvasInner(props: FlowCanvasProps) {
         >
           <Icon name="ph:graph" width={14} />
         </button>
+        <div className="flow-canvas-layout-toggle" role="group" aria-label="Flow layout orientation">
+          <button
+            type="button"
+            className={`flow-canvas-tool flow-canvas-layout-tool${layoutOrientation === "horizontal" ? " is-active" : ""}`}
+            aria-pressed={layoutOrientation === "horizontal"}
+            aria-label="Use horizontal layout"
+            title="Use horizontal layout"
+            onClick={() => props.onLayoutOrientation("horizontal")}
+          >
+            <Icon name="ph:columns" width={14} />
+          </button>
+          <button
+            type="button"
+            className={`flow-canvas-tool flow-canvas-layout-tool${layoutOrientation === "vertical" ? " is-active" : ""}`}
+            aria-pressed={layoutOrientation === "vertical"}
+            aria-label="Use vertical layout"
+            title="Use vertical layout"
+            onClick={() => props.onLayoutOrientation("vertical")}
+          >
+            <Icon name="ph:rows" width={14} />
+          </button>
+        </div>
         <button
           type="button"
           className="flow-canvas-tool"

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -40,6 +40,7 @@ import {
   type FlowDoc,
   type FlowDraftAction,
   type FlowDraftState,
+  type FlowLayoutOrientation,
   type FlowNodeSettings,
   type FlowParamValue,
   type FlowPosition,
@@ -106,6 +107,7 @@ export function FlowView() {
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
   const [templateGalleryOpen, setTemplateGalleryOpen] = useState(false);
+  const [layoutOrientation, setLayoutOrientation] = useState<FlowLayoutOrientation>("horizontal");
   // The run currently overlaid on the canvas (live session, or a finished run
   // whose final state we keep painted until the user switches flows).
   const [activeRun, setActiveRun] = useState<FlowRunRecord | null>(null);
@@ -689,7 +691,12 @@ export function FlowView() {
   );
   const onMoveNodes = useCallback((positions: Record<string, FlowPosition>) => mutate((d) => moveNodes(d, positions)), [mutate]);
   const tidy = useCallback(() => {
-    mutate((d) => tidyFlowLayout(d));
+    mutate((d) => tidyFlowLayout(d, layoutOrientation));
+    setViewResetKey((key) => key + 1);
+  }, [layoutOrientation, mutate]);
+  const setAndApplyLayoutOrientation = useCallback((orientation: FlowLayoutOrientation) => {
+    setLayoutOrientation(orientation);
+    mutate((d) => tidyFlowLayout(d, orientation));
     setViewResetKey((key) => key + 1);
   }, [mutate]);
   const onRenameNode = useCallback((id: string, name: string) => mutate((d) => renameNode(d, id, name)), [mutate]);
@@ -851,6 +858,7 @@ export function FlowView() {
                   staleNodeIds={staleNodeIds}
                   activeNodeId={running ? progress.activeNodeId : null}
                   viewResetKey={viewResetKey}
+                  layoutOrientation={layoutOrientation}
                   onSelectNode={setSelectedNodeId}
                   onOpenNode={setSelectedNodeId}
                   onConnect={onConnect}
@@ -861,6 +869,7 @@ export function FlowView() {
                   onConnectToNew={requestConnectToNew}
                   onInsertEdge={requestInsertEdge}
                   onTidy={tidy}
+                  onLayoutOrientation={setAndApplyLayoutOrientation}
                   onStickyText={(id, text) => onChangeSticky(id, { text })}
                   onStickySize={(id, width, height) => onChangeSticky(id, { width, height })}
                 />

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-// The Automations surface (nav id `inbox`) unifies the four "runs for you"
-// primitives — reminders, crons, workflows, flows — plus an Activity feed, all
+// The Automations surface (nav id `inbox`) unifies the three "runs for you"
+// primitives — reminders, crons, flows — plus an Activity feed, all
 // under one typed model. This pins the renamed surface + its tab structure.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
@@ -47,8 +47,8 @@ assert.match(
 // ── Unified typed tab model ─────────────────────────────────────────────────
 assert.match(
   automations,
-  /type AutomationTab = "all" \| "reminders" \| "crons" \| "workflows" \| "flows" \| "activity"/,
-  "Surface exposes the six-way unified tab union",
+  /type AutomationTab = "all" \| "reminders" \| "crons" \| "flows" \| "activity"/,
+  "Surface exposes the five-way unified tab union",
 );
 assert.match(
   automations,
@@ -62,13 +62,13 @@ assert.match(automations, /<Tabs[\s\S]{0,200}variant="segment"/, "Tabs use the s
 assert.match(automations, /\{ id: "all", label: "All", count: allEntries\.length \}/, "All tab over the unified entry list");
 assert.match(automations, /\{ id: "reminders", label: "Reminders", count: typeCounts\.reminder \}/, "Reminders tab");
 assert.match(automations, /\{ id: "crons", label: "Crons", count: typeCounts\.cron \}/, "Crons tab (renamed from Automations)");
-assert.match(automations, /\{ id: "workflows", label: "Workflows", count: typeCounts\.workflow \}/, "Workflows tab");
+assert.doesNotMatch(automations, /\{ id: "workflows", label: "Workflows"/, "Workflows tab should be removed now that Flow owns this surface");
 assert.match(automations, /\{ id: "flows", label: "Flows", count: typeCounts\.flow \}/, "Flows tab");
 assert.match(automations, /\{ id: "activity", label: "Activity", count: items\.length \}/, "Activity tab over the full inbox feed");
 assert.match(
   automations,
-  /id: "all"[\s\S]*id: "reminders"[\s\S]*id: "crons"[\s\S]*id: "workflows"[\s\S]*id: "flows"[\s\S]*id: "activity"/,
-  "tabs ordered All, Reminders, Crons, Workflows, Flows, Activity",
+  /id: "all"[\s\S]*id: "reminders"[\s\S]*id: "crons"[\s\S]*id: "flows"[\s\S]*id: "activity"/,
+  "tabs ordered All, Reminders, Crons, Flows, Activity",
 );
 
 // ── The four primitives are merged through one pure model ────────────────────
@@ -81,21 +81,21 @@ assert.match(automations, /buildAutomationEntries\(\{/, "All entries come from b
 assert.match(automations, /countByType\(/, "Tab counts come from countByType");
 assert.match(automations, /function AutomationAllList/, "All tab renders through a unified list component");
 assert.match(automations, /function AutomationTypeChip/, "Each entry carries a type chip");
-assert.match(automations, /function WorkflowList/, "Workflows tab renders workflows");
+assert.doesNotMatch(automations, /function WorkflowList/, "Legacy Workflows list component should be removed from Automations");
 assert.match(automations, /function FlowList/, "Flows tab renders flows");
 assert.match(automations, /function InboxFeedList/, "Activity tab renders through the inbox feed-list component");
 
-// Workflows + flows are loaded alongside reminders + crons.
-assert.match(automations, /listWorkflows\(\)/, "Surface loads workflow manifests");
+// Flows are loaded alongside reminders + crons. Legacy workflow manifests are no longer shown here.
+assert.doesNotMatch(automations, /listWorkflows\(\)/, "Surface should not load legacy workflow manifests");
 assert.match(automations, /listFlows\(\)/, "Surface loads flow docs");
 // Run is daemon-first and honest when offline.
-assert.match(automations, /runWorkflow\(\{ id: wf\.id \}\)/, "Workflows run via the workflow run client");
+assert.doesNotMatch(automations, /runWorkflow\(/, "Surface should not expose legacy workflow runs");
 assert.match(automations, /runFlow\(flow\.id\)/, "Flows run via the flow run client");
 assert.match(automations, /isn't reachable right now/, "Run surfaces an honest message when the daemon is offline");
 
-// "Open" on a workflow/flow jumps to its dedicated editor surface.
+// "Open" on a flow jumps to its dedicated editor surface.
 assert.match(automations, /cave:navigate-mode/, "Open routes to a dedicated editor surface via the navigation bridge");
-assert.match(automations, /navigateToMode\("roles"\)/, "Workflows open in the Roles surface");
+assert.doesNotMatch(automations, /navigateToMode\("roles"\)/, "Legacy workflow opens should not route users to Roles");
 assert.match(automations, /navigateToMode\("flow"\)/, "Flows open in the Flow editor surface");
 
 // Reminders are still the schedule-shaped inbox subset.

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -545,7 +545,7 @@ const ADDON_ROWS: Array<{
     label: "Roles",
     icon: "ph:mask-happy",
     group: "surfaces",
-    description: "Agent personas, workflows, skills, and capabilities.",
+    description: "Agent personas, skills, and capabilities.",
   },
   {
     key: "groupchat",

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -103,14 +103,14 @@ const FOLDER_MODES: Array<{
   { id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
   { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
-  { id: "inbox", label: "Automations", iconName: "ph:lightning-bold", group: "work", kbd: "⌘5", description: "Reminders, crons, workflows, and flows in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
+  { id: "inbox", label: "Automations", iconName: "ph:lightning-bold", group: "work", kbd: "⌘5", description: "Reminders, crons, and flows in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
   // Tools
   { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘6", description: "Built-in web browser" },
   { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘7", description: "Shell session in your project" },
   { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘8", description: "Chat with a familiar beside your files and terminal" },
   { id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘0", description: "Saved docs, links, and reading" },
   { id: "docs", label: "Coven", iconName: "ph:book-bookmark", group: "tools", description: "OpenCoven docs, feedback, and social tabs" },
-  { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, workflows, skills, and the capabilities your familiars can use" },
+  { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, skills, and the capabilities your familiars can use" },
   { id: "flow", label: "Flow", iconName: "ph:flow-arrow", group: "tools", description: "Freeform n8n-style automation editor — wire nodes on a canvas" },
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.

--- a/src/lib/flow/flow-doc.test.ts
+++ b/src/lib/flow/flow-doc.test.ts
@@ -167,6 +167,14 @@ function base(): FlowDoc {
   assert.equal(tidied.nodes.find((n) => n.id === "b")?.position.x, 380, "parallel downstream nodes share a column");
   assert.notEqual(tidied.nodes.find((n) => n.id === "a")?.position.y, tidied.nodes.find((n) => n.id === "b")?.position.y, "parallel nodes are vertically staggered");
   assert.equal(tidyFlowLayout(tidied), tidied, "already tidy layouts are a no-op");
+
+  const vertical = tidyFlowLayout(doc, "vertical");
+  assert.deepEqual(vertical.edges, doc.edges, "vertical tidy does not rewrite graph connections");
+  assert.deepEqual(vertical.nodes.find((n) => n.id === "note")?.position, { x: 333, y: 444 }, "vertical tidy preserves sticky notes");
+  assert.deepEqual(vertical.nodes.find((n) => n.id === "trigger")?.position, { x: 120, y: 120 }, "vertical tidy keeps the root at the tidy origin");
+  assert.equal(vertical.nodes.find((n) => n.id === "a")?.position.y, 252, "vertical tidy moves downstream nodes into the next row");
+  assert.equal(vertical.nodes.find((n) => n.id === "b")?.position.y, 252, "parallel downstream nodes share a row in vertical layout");
+  assert.notEqual(vertical.nodes.find((n) => n.id === "a")?.position.x, vertical.nodes.find((n) => n.id === "b")?.position.x, "parallel vertical nodes are horizontally staggered");
 }
 
 // renameNode keeps names unique

--- a/src/lib/flow/flow-doc.ts
+++ b/src/lib/flow/flow-doc.ts
@@ -12,6 +12,7 @@
 // catalog (see flow-catalog.ts).
 
 export type FlowPosition = { x: number; y: number };
+export type FlowLayoutOrientation = "horizontal" | "vertical";
 
 export type FlowParamValue = string | number | boolean;
 
@@ -198,7 +199,7 @@ const TIDY_ORIGIN: FlowPosition = { x: 120, y: 120 };
 const TIDY_COLUMN_GAP = 260;
 const TIDY_ROW_GAP = 132;
 
-export function tidyFlowLayout(doc: FlowDoc): FlowDoc {
+export function tidyFlowLayout(doc: FlowDoc, orientation: FlowLayoutOrientation = "horizontal"): FlowDoc {
   const layoutNodes = doc.nodes.filter((node) => !node.sticky);
   if (layoutNodes.length === 0) return doc;
   const layoutIds = new Set(layoutNodes.map((node) => node.id));
@@ -256,10 +257,13 @@ export function tidyFlowLayout(doc: FlowDoc): FlowDoc {
   for (const [layer, nodes] of [...layers.entries()].sort(([a], [b]) => a - b)) {
     nodes.sort(compareNodesForTidy);
     nodes.forEach((node, row) => {
-      positions.set(node.id, {
-        x: TIDY_ORIGIN.x + layer * TIDY_COLUMN_GAP,
-        y: TIDY_ORIGIN.y + row * TIDY_ROW_GAP,
-      });
+      const x = orientation === "vertical"
+        ? TIDY_ORIGIN.x + row * TIDY_COLUMN_GAP
+        : TIDY_ORIGIN.x + layer * TIDY_COLUMN_GAP;
+      const y = orientation === "vertical"
+        ? TIDY_ORIGIN.y + layer * TIDY_ROW_GAP
+        : TIDY_ORIGIN.y + row * TIDY_ROW_GAP;
+      positions.set(node.id, { x, y });
     });
   }
 

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -150,6 +150,9 @@
 .flow-canvas-tool { display: inline-flex; align-items: center; gap: 5px; height: 30px; padding: 0 9px; border: 1px solid var(--border); border-radius: var(--radius-control); background: color-mix(in oklch, var(--card) 90%, transparent); color: var(--text-primary); font-size: var(--text-sm); font-weight: 500; box-shadow: 0 6px 20px rgb(0 0 0 / 22%); cursor: pointer; }
 .flow-canvas-tool:hover, .flow-canvas-tool.is-active { border-color: color-mix(in oklch, var(--accent-presence) 54%, var(--border)); background: color-mix(in oklch, var(--card) 80%, var(--accent-presence) 20%); }
 .flow-canvas-add { font-weight: 600; }
+.flow-canvas-layout-toggle { display: inline-flex; overflow: hidden; border-radius: var(--radius-control); box-shadow: 0 6px 20px rgb(0 0 0 / 22%); }
+.flow-canvas-layout-tool { width: 31px; justify-content: center; padding: 0; border-radius: 0; box-shadow: none; }
+.flow-canvas-layout-tool + .flow-canvas-layout-tool { margin-left: -1px; }
 
 /* React Flow theming */
 .flow-canvas .react-flow__background { background: var(--bg-base); }


### PR DESCRIPTION
## What

Lands the commit that was blocked from a direct push to `main` (branch protection — all changes go through a PR).

- **Automations**: drop the Workflows surface from the Automations view (`automations-view.tsx`, `schedules-tabs.test.ts`).
- **Flow**: layout tweaks to the flow canvas/view + doc model (`flow/flow-canvas.tsx`, `flow/flow-view.tsx`, `lib/flow/flow-doc.ts`, `flow.css`) with test updates.
- **iOS**: new `FamiliarFeedView`, `CaveClient` feed networking, and `FamiliarThreadsView` wiring.
- Minor: `familiar-studio-brain-tab`, `settings-shell`, `sidebar-minimal`.

14 files, +367 / −135.

## Notes

- Single signed commit (`af927c7d`), cut from `kitty/main-mirror`, 0 behind `origin/main`.
- iOS Swift isn't built by CI — the 4 required checks (Frontend build, Rust check, CodeQL, E2E) cover the web/Rust side; Swift changes ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)