### PR TITLE
feat(flow): add layout direction switch

### DIFF
--- a/src/components/flow/flow-canvas.test.ts
+++ b/src/components/flow/flow-canvas.test.ts
@@ -10,10 +10,18 @@ const styles = readFileSync(new URL("../../styles/flow.css", import.meta.url), "
 assert.match(canvas, /onTidy: \(\) => void/, "FlowCanvas should accept a tidy-workflow action");
 assert.match(canvas, /title="Tidy up workflow"/, "Canvas toolbar should expose n8n-style tidy action");
 assert.match(canvas, /props\.onTidy/, "Canvas tidy button should call the provided action");
+assert.match(canvas, /layoutOrientation: FlowLayoutOrientation/, "FlowCanvas should receive the active layout orientation");
+assert.match(canvas, /onLayoutOrientation: \(orientation: FlowLayoutOrientation\) => void/, "FlowCanvas should expose an orientation switch action");
+assert.match(canvas, /aria-label="Use horizontal layout"/, "Canvas toolbar should expose a horizontal layout switch");
+assert.match(canvas, /aria-label="Use vertical layout"/, "Canvas toolbar should expose a vertical layout switch");
 assert.match(view, /tidyFlowLayout/, "FlowView should import the pure tidy layout mutation");
+assert.match(view, /useState<FlowLayoutOrientation>\("horizontal"\)/, "FlowView should default Flow layout to horizontal");
+assert.match(view, /tidyFlowLayout\(d, layoutOrientation\)/, "Tidy should use the active Flow layout orientation");
+assert.match(view, /tidyFlowLayout\(d, orientation\)/, "Switching orientation should retidy the canvas immediately");
 assert.match(view, /setViewResetKey/, "FlowView should be able to force React Flow to consume tidied positions");
 assert.match(view, /setViewResetKey\(\(key\) => key \+ 1\)/, "Tidy should reset the canvas local position cache");
 assert.match(view, /onTidy=\{tidy\}/, "FlowView should wire tidy into the canvas toolbar");
+assert.match(view, /onLayoutOrientation=\{setAndApplyLayoutOrientation\}/, "FlowView should wire orientation switching into the canvas toolbar");
 assert.match(canvas, /staleNodeIds\?: Record<string, boolean>/, "FlowCanvas should accept stale-node markers");
 assert.match(view, /staleNodeIds/, "FlowView should compute canvas stale-node markers from the active run snapshot");
 assert.match(node, /node\.displayNote/, "Flow nodes should honor the display-note flag");

--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -22,7 +22,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { catalogNode } from "@/lib/flow/flow-catalog";
-import type { FlowDoc, FlowPosition } from "@/lib/flow/flow-doc";
+import type { FlowDoc, FlowLayoutOrientation, FlowPosition } from "@/lib/flow/flow-doc";
 import {
   FlowNodeView,
   FlowStickyView,
@@ -48,6 +48,7 @@ export type FlowCanvasProps = {
   staleNodeIds?: Record<string, boolean>;
   activeNodeId?: string | null;
   viewResetKey: number;
+  layoutOrientation: FlowLayoutOrientation;
   onSelectNode: (id: string | null) => void;
   onOpenNode: (id: string) => void;
   onConnect: (source: string, sourceHandle: string, target: string, targetHandle: string) => void;
@@ -64,6 +65,7 @@ export type FlowCanvasProps = {
   onStickyText: (id: string, text: string) => void;
   onStickySize: (id: string, width: number, height: number) => void;
   onTidy: () => void;
+  onLayoutOrientation: (orientation: FlowLayoutOrientation) => void;
 };
 
 function FlowCanvasInner(props: FlowCanvasProps) {
@@ -74,6 +76,7 @@ function FlowCanvasInner(props: FlowCanvasProps) {
     staleNodeIds,
     activeNodeId,
     viewResetKey,
+    layoutOrientation,
     onSelectNode,
     onOpenNode,
     onConnect,
@@ -288,6 +291,28 @@ function FlowCanvasInner(props: FlowCanvasProps) {
         >
           <Icon name="ph:graph" width={14} />
         </button>
+        <div className="flow-canvas-layout-toggle" role="group" aria-label="Flow layout orientation">
+          <button
+            type="button"
+            className={`flow-canvas-tool flow-canvas-layout-tool${layoutOrientation === "horizontal" ? " is-active" : ""}`}
+            aria-pressed={layoutOrientation === "horizontal"}
+            aria-label="Use horizontal layout"
+            title="Use horizontal layout"
+            onClick={() => props.onLayoutOrientation("horizontal")}
+          >
+            <Icon name="ph:columns" width={14} />
+          </button>
+          <button
+            type="button"
+            className={`flow-canvas-tool flow-canvas-layout-tool${layoutOrientation === "vertical" ? " is-active" : ""}`}
+            aria-pressed={layoutOrientation === "vertical"}
+            aria-label="Use vertical layout"
+            title="Use vertical layout"
+            onClick={() => props.onLayoutOrientation("vertical")}
+          >
+            <Icon name="ph:rows" width={14} />
+          </button>
+        </div>
         <button
           type="button"
           className="flow-canvas-tool"

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -40,6 +40,7 @@ import {
   type FlowDoc,
   type FlowDraftAction,
   type FlowDraftState,
+  type FlowLayoutOrientation,
   type FlowNodeSettings,
   type FlowParamValue,
   type FlowPosition,
@@ -106,6 +107,7 @@ export function FlowView() {
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
   const [templateGalleryOpen, setTemplateGalleryOpen] = useState(false);
+  const [layoutOrientation, setLayoutOrientation] = useState<FlowLayoutOrientation>("horizontal");
   // The run currently overlaid on the canvas (live session, or a finished run
   // whose final state we keep painted until the user switches flows).
   const [activeRun, setActiveRun] = useState<FlowRunRecord | null>(null);
@@ -689,7 +691,12 @@ export function FlowView() {
   );
   const onMoveNodes = useCallback((positions: Record<string, FlowPosition>) => mutate((d) => moveNodes(d, positions)), [mutate]);
   const tidy = useCallback(() => {
-    mutate((d) => tidyFlowLayout(d));
+    mutate((d) => tidyFlowLayout(d, layoutOrientation));
+    setViewResetKey((key) => key + 1);
+  }, [layoutOrientation, mutate]);
+  const setAndApplyLayoutOrientation = useCallback((orientation: FlowLayoutOrientation) => {
+    setLayoutOrientation(orientation);
+    mutate((d) => tidyFlowLayout(d, orientation));
     setViewResetKey((key) => key + 1);
   }, [mutate]);
   const onRenameNode = useCallback((id: string, name: string) => mutate((d) => renameNode(d, id, name)), [mutate]);
@@ -851,6 +858,7 @@ export function FlowView() {
                   staleNodeIds={staleNodeIds}
                   activeNodeId={running ? progress.activeNodeId : null}
                   viewResetKey={viewResetKey}
+                  layoutOrientation={layoutOrientation}
                   onSelectNode={setSelectedNodeId}
                   onOpenNode={setSelectedNodeId}
                   onConnect={onConnect}
@@ -861,6 +869,7 @@ export function FlowView() {
                   onConnectToNew={requestConnectToNew}
                   onInsertEdge={requestInsertEdge}
                   onTidy={tidy}
+                  onLayoutOrientation={setAndApplyLayoutOrientation}
                   onStickyText={(id, text) => onChangeSticky(id, { text })}
                   onStickySize={(id, width, height) => onChangeSticky(id, { width, height })}
                 />

--- a/src/lib/flow/flow-doc.test.ts
+++ b/src/lib/flow/flow-doc.test.ts
@@ -167,6 +167,14 @@ function base(): FlowDoc {
   assert.equal(tidied.nodes.find((n) => n.id === "b")?.position.x, 380, "parallel downstream nodes share a column");
   assert.notEqual(tidied.nodes.find((n) => n.id === "a")?.position.y, tidied.nodes.find((n) => n.id === "b")?.position.y, "parallel nodes are vertically staggered");
   assert.equal(tidyFlowLayout(tidied), tidied, "already tidy layouts are a no-op");
+
+  const vertical = tidyFlowLayout(doc, "vertical");
+  assert.deepEqual(vertical.edges, doc.edges, "vertical tidy does not rewrite graph connections");
+  assert.deepEqual(vertical.nodes.find((n) => n.id === "note")?.position, { x: 333, y: 444 }, "vertical tidy preserves sticky notes");
+  assert.deepEqual(vertical.nodes.find((n) => n.id === "trigger")?.position, { x: 120, y: 120 }, "vertical tidy keeps the root at the tidy origin");
+  assert.equal(vertical.nodes.find((n) => n.id === "a")?.position.y, 252, "vertical tidy moves downstream nodes into the next row");
+  assert.equal(vertical.nodes.find((n) => n.id === "b")?.position.y, 252, "parallel downstream nodes share a row in vertical layout");
+  assert.notEqual(vertical.nodes.find((n) => n.id === "a")?.position.x, vertical.nodes.find((n) => n.id === "b")?.position.x, "parallel vertical nodes are horizontally staggered");
 }
 
 // renameNode keeps names unique

--- a/src/lib/flow/flow-doc.ts
+++ b/src/lib/flow/flow-doc.ts
@@ -12,6 +12,7 @@
 // catalog (see flow-catalog.ts).
 
 export type FlowPosition = { x: number; y: number };
+export type FlowLayoutOrientation = "horizontal" | "vertical";
 
 export type FlowParamValue = string | number | boolean;
 
@@ -198,7 +199,7 @@ const TIDY_ORIGIN: FlowPosition = { x: 120, y: 120 };
 const TIDY_COLUMN_GAP = 260;
 const TIDY_ROW_GAP = 132;
 
-export function tidyFlowLayout(doc: FlowDoc): FlowDoc {
+export function tidyFlowLayout(doc: FlowDoc, orientation: FlowLayoutOrientation = "horizontal"): FlowDoc {
   const layoutNodes = doc.nodes.filter((node) => !node.sticky);
   if (layoutNodes.length === 0) return doc;
   const layoutIds = new Set(layoutNodes.map((node) => node.id));
@@ -256,10 +257,13 @@ export function tidyFlowLayout(doc: FlowDoc): FlowDoc {
   for (const [layer, nodes] of [...layers.entries()].sort(([a], [b]) => a - b)) {
     nodes.sort(compareNodesForTidy);
     nodes.forEach((node, row) => {
-      positions.set(node.id, {
-        x: TIDY_ORIGIN.x + layer * TIDY_COLUMN_GAP,
-        y: TIDY_ORIGIN.y + row * TIDY_ROW_GAP,
-      });
+      const x = orientation === "vertical"
+        ? TIDY_ORIGIN.x + row * TIDY_COLUMN_GAP
+        : TIDY_ORIGIN.x + layer * TIDY_COLUMN_GAP;
+      const y = orientation === "vertical"
+        ? TIDY_ORIGIN.y + layer * TIDY_ROW_GAP
+        : TIDY_ORIGIN.y + row * TIDY_ROW_GAP;
+      positions.set(node.id, { x, y });
     });
   }
 

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -150,6 +150,9 @@
 .flow-canvas-tool { display: inline-flex; align-items: center; gap: 5px; height: 30px; padding: 0 9px; border: 1px solid var(--border); border-radius: var(--radius-control); background: color-mix(in oklch, var(--card) 90%, transparent); color: var(--text-primary); font-size: var(--text-sm); font-weight: 500; box-shadow: 0 6px 20px rgb(0 0 0 / 22%); cursor: pointer; }
 .flow-canvas-tool:hover, .flow-canvas-tool.is-active { border-color: color-mix(in oklch, var(--accent-presence) 54%, var(--border)); background: color-mix(in oklch, var(--card) 80%, var(--accent-presence) 20%); }
 .flow-canvas-add { font-weight: 600; }
+.flow-canvas-layout-toggle { display: inline-flex; overflow: hidden; border-radius: var(--radius-control); box-shadow: 0 6px 20px rgb(0 0 0 / 22%); }
+.flow-canvas-layout-tool { width: 31px; justify-content: center; padding: 0; border-radius: 0; box-shadow: none; }
+.flow-canvas-layout-tool + .flow-canvas-layout-tool { margin-left: -1px; }
 
 /* React Flow theming */
 .flow-canvas .react-flow__background { background: var(--bg-base); }


### PR DESCRIPTION
## Summary
- add horizontal/vertical layout orientation controls to the Flow canvas toolbar
- retidy Flow node positions immediately when switching orientation
- extend Flow layout tests for vertical positioning and toolbar wiring

## Test Plan
- `node --experimental-strip-types src/lib/flow/flow-doc.test.ts`
- `node --experimental-strip-types src/components/flow/flow-canvas.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`