### PR TITLE
Fix task chats to start in assigned project

### DIFF
--- a/src/app/api/board/[id]/chat/route.ts
+++ b/src/app/api/board/[id]/chat/route.ts
@@ -59,8 +59,9 @@ export async function POST(
     });
   }
 
-  // card.cwd wins; body.projectRoot covers "card had no CWD, user supplied one" flow.
-  const projectRoot = normalizeProjectRoot(card.cwd ?? body.projectRoot ?? process.cwd());
+  // The UI sends the root for card.projectId when present; prefer that explicit
+  // project scope over any older cwd persisted on the card.
+  const projectRoot = normalizeProjectRoot(body.projectRoot ?? card.cwd ?? process.cwd());
   if (!projectRoot) {
     return NextResponse.json({ ok: false, error: "invalid project root" }, { status: 400 });
   }
@@ -150,10 +151,11 @@ export async function POST(
     familiarId,
     // When we isolated into a worktree, pin the card's CWD to it so reopening
     // the chat lands back in the same worktree. Otherwise keep the prior
-    // behavior of recording a start-time CWD only when the card had none.
+    // behavior of recording the explicit project root when the caller supplied
+    // one.
     ...(worktree
       ? { cwd: sessionRoot }
-      : (!card.cwd && body.projectRoot ? { cwd: body.projectRoot } : {})),
+      : (body.projectRoot ? { cwd: projectRoot } : {})),
   });
   if (!updated) {
     return NextResponse.json({ ok: false, error: "card disappeared" }, { status: 404 });

--- a/src/components/board-chat-link.test.ts
+++ b/src/components/board-chat-link.test.ts
@@ -23,6 +23,11 @@ assert.match(
   "Task chat action should navigate to the linked session",
 );
 assert.match(
+  boardView,
+  /const project = card\?\.projectId \? chatProjectById\(card\.projectId, projects\) : null;[\s\S]{0,140}await startTaskChat\(id, project\.root\)/,
+  "Task chats for project-assigned cards should start in the assigned project root",
+);
+assert.match(
   boardInspector,
   /Start chat|Open chat/,
   "Board inspector should show a visible chat button for every task",
@@ -41,6 +46,11 @@ assert.match(
   route,
   /buildInitialTaskChatPrompt\(card\)/,
   "Board chat endpoint should seed new sessions with task context",
+);
+assert.match(
+  route,
+  /normalizeProjectRoot\(body\.projectRoot \?\? card\.cwd \?\? process\.cwd\(\)\)/,
+  "Board chat endpoint should prefer the explicitly assigned project root over stale card cwd",
 );
 assert.match(
   route,

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -554,12 +554,12 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
 
   const onOpenTaskChat = async (id: string) => {
     const card = cards.find((candidate) => candidate.id === id);
+    const project = card?.projectId ? chatProjectById(card.projectId, projects) : null;
+    if (project) {
+      await startTaskChat(id, project.root);
+      return;
+    }
     if (card && !card.sessionId && !card.cwd) {
-      const project = card.projectId ? chatProjectById(card.projectId, projects) : null;
-      if (project) {
-        await startTaskChat(id, project.root);
-        return;
-      }
       setChatLinkError("Choose a project for this task before starting chat, or open Projects to create one.");
       return;
     }

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // Chats pick a persisted project, and that project owns the runtime root.
-// Task chats still honor the task's stored cwd for existing board cards.
+// Task chats honor the task's assigned project before any older stored cwd.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -70,22 +70,22 @@ assert.doesNotMatch(
   "ChatView should not expose user-facing ROOT/CWD inputs for normal chats",
 );
 
-// ── Task chat: card CWD wins; project selection when absent ─────────────────
+// ── Task chat: assigned project wins; card CWD is the fallback ───────────────
 
 assert.match(
   taskChatRoute,
-  /card\.cwd \?\? body\.projectRoot \?\? process\.cwd\(\)/,
-  "Task chat sessions start in the card's CWD when it has one",
+  /body\.projectRoot \?\? card\.cwd \?\? process\.cwd\(\)/,
+  "Task chat sessions start in the assigned project root when one is supplied",
 );
 assert.match(
   taskChatRoute,
-  /!card\.cwd && body\.projectRoot \? \{ cwd: body\.projectRoot \}/,
-  "A start-time CWD is persisted onto the card",
+  /body\.projectRoot \? \{ cwd: projectRoot \}/,
+  "The assigned project root is persisted onto the card for subsequent task-chat starts",
 );
 assert.match(
   boardView,
-  /const project = card\.projectId \? chatProjectById\(card\.projectId, projects\) : null;[\s\S]{0,180}await startTaskChat\(id, project\.root\);/,
-  "Starting a task chat for a card with only a projectId should use the project's root without a follow-up dialog",
+  /const project = card\?\.projectId \? chatProjectById\(card\.projectId, projects\) : null;[\s\S]{0,180}await startTaskChat\(id, project\.root\);/,
+  "Starting a task chat for a card with projectId should use the project's root without a follow-up dialog",
 );
 assert.match(
   boardInspector,


### PR DESCRIPTION
## Summary
- Start task-linked chats from the task assigned project root when `projectId` is set.
- Prefer explicit project roots over stale stored `cwd` in the board chat endpoint.
- Update task-chat source contracts for assigned-project precedence.

## Test Plan
- `node --experimental-strip-types src/components/board-chat-link.test.ts`
- `node --experimental-strip-types src/components/task-chat-cwd.test.ts`
- `node --experimental-strip-types src/components/board-project-picker.test.ts`
- `node --experimental-strip-types src/lib/chat-projects.test.ts`
- `node --experimental-strip-types src/lib/task-chat-context.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app`
- `git diff --check`