### PR TITLE
Remove home composer shortcut hint

### DIFF
--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -51,13 +51,8 @@ assert.match(
 );
 
 
-// ───── Keyboard hint hides on touch ─────
-// Touch devices have no physical keyboard — hide the desktop-only legend.
-assert.match(
-  css,
-  /@media \(pointer: coarse\)\s*\{[\s\S]*?\.hc-keyboard-hint\s*\{[\s\S]*?display:\s*none;/,
-  "@media (pointer: coarse) hides .hc-keyboard-hint",
-);
+// The keyboard shortcut legend was removed from the home composer entirely.
+assert.doesNotMatch(css, /\.hc-keyboard-hint\b/, ".hc-keyboard-hint CSS stays removed");
 
 // ───── Data-panel outer wrapper hide on mobile ─────
 // react-resizable-panels wraps each <Panel> in `<div data-panel id="..">`

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -32,11 +32,11 @@ assert.doesNotMatch(
 );
 
 // ───────── Task 2: Keyboard hint strip ─────────
-assert.match(source, /<div className="hc-keyboard-hint">/, "hc-keyboard-hint div in JSX");
-assert.match(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ commands/, "Hint copy: send/newline/history/commands");
+assert.doesNotMatch(source, /hc-keyboard-hint/, "home composer should not render the keyboard hint strip");
+assert.doesNotMatch(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ commands/, "old shortcut hint copy is removed");
 
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
-assert.match(css, /\.hc-keyboard-hint\s*\{[\s\S]*?color:\s*var\(--text-muted\)/, ".hc-keyboard-hint CSS with --text-muted");
+assert.doesNotMatch(css, /\.hc-keyboard-hint\b/, "unused .hc-keyboard-hint CSS is removed");
 
 // ───────── Task 3: Circular icon-only Send button ─────────
 // The Codex-style composer uses a round arrow button. The visible "Send" text

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -730,10 +730,6 @@ export function HomeComposer({
         </div>
       </div>
 
-      <div className="hc-keyboard-hint">
-        ⏎ send · ⇧⏎ newline · ↑↓ history · / commands
-      </div>
-
       {/* Jump back in — resume a recent chat. The composer above starts new
           intent; this is the "continue where you left off" path. */}
       {onOpenSession && recentSessions.length > 0 && (

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -683,21 +683,6 @@
   color: var(--text-muted);
 }
 
-.hc-keyboard-hint {
-  margin-top: 12px;
-  text-align: center;
-  font-size: 10px;
-  color: var(--text-muted);
-}
-
-/* Touch devices have no physical keyboard — hide the desktop-only shortcut
- * legend so phones don't waste vertical space on irrelevant guidance. */
-@media (pointer: coarse) {
-  .hc-keyboard-hint {
-    display: none;
-  }
-}
-
 /* "Jump back in" — recent chats strip, secondary to the composer hero. */
 .home-recent {
   display: flex;


### PR DESCRIPTION
## Summary
- Remove the home composer keyboard shortcut hint line from the homepage.
- Drop the unused `.hc-keyboard-hint` CSS and update source tests to keep it removed.

## Test Plan
- [x] `node --experimental-strip-types src/components/home-composer-polish.test.ts`
- [x] `node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts`
- [x] `node --experimental-strip-types src/components/home-composer.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] `pnpm test:app`
- [x] `git diff --check`