### PR TITLE
feat(chat): drop Code mode from the chat switch on mobile

### DIFF
--- a/src/components/chat-surface-power-mode.test.ts
+++ b/src/components/chat-surface-power-mode.test.ts
@@ -60,8 +60,22 @@ assert.match(
   /<Tabs<ChatMode>\s+variant="segment"/,
   "the mode switch renders as a segmented (lock-in) selector",
 );
-assert.match(surface, /value=\{chatMode\}/, "the switch reflects the active mode");
+assert.match(surface, /value=\{chatModeValue\}/, "the switch reflects the active mode");
 assert.match(surface, /onChange=\{selectChatMode\}/, "the switch drives mode selection");
+
+// ── Code mode is desktop-only (no inline split on a phone) ──────────────────
+assert.match(
+  surface,
+  /const chatModeItems = isMobile \? CHAT_MODE_ITEMS\.filter\(\(m\) => m\.id !== "code"\) : CHAT_MODE_ITEMS/,
+  "the Code segment is dropped from the switch on mobile",
+);
+assert.match(
+  surface,
+  /const chatModeValue: ChatMode = isMobile && chatMode === "code" \? "convo" : chatMode/,
+  "a persisted Code session shows as Convo on mobile (saved preference untouched)",
+);
+assert.match(surface, /items=\{chatModeItems\}/, "the switch renders the mobile-aware item set");
+
 // The legacy binary Power pill is gone — its layout is now one of three locks.
 assert.doesNotMatch(surface, /chat-power-toggle/, "the binary Power toggle is replaced by the mode switch");
 assert.doesNotMatch(css, /\.chat-power-toggle/, "the dead Power-toggle styling is removed");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -372,6 +372,13 @@ export function ChatSurface({
   // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
   // be unreachable. On mobile we render them in a right-edge sheet overlay instead.
   const isMobile = useIsMobile();
+  // Code mode is the inline chat↔code split, which needs desktop width — on a
+  // phone `showPowerPanel` is gated off, so the segment would light up with no
+  // effect. Drop it from the mobile switch and render a persisted "code" session
+  // as Convo there (the saved preference is untouched, so it restores on a wider
+  // screen). The base `chatMode` above stays the source of truth for layout.
+  const chatModeItems = isMobile ? CHAT_MODE_ITEMS.filter((m) => m.id !== "code") : CHAT_MODE_ITEMS;
+  const chatModeValue: ChatMode = isMobile && chatMode === "code" ? "convo" : chatMode;
   const consumedPendingActionNonce = useRef<number | null>(null);
 
   // Right panel — prefer new prop, fall back to legacy bool
@@ -604,9 +611,9 @@ export function ChatSurface({
               size="sm"
               bordered={false}
               ariaLabel="Chat mode"
-              value={chatMode}
+              value={chatModeValue}
               onChange={selectChatMode}
-              items={CHAT_MODE_ITEMS}
+              items={chatModeItems}
             />
           )}
         </div>


### PR DESCRIPTION
## What

Follow-up to #1952/#1961/#1964. Code mode (the inline chat↔code split) is gated `!isMobile` via `showPowerPanel`, so on a phone the **Code** segment lit up but never split. Now that the mode persists (#1964), a phone user who last used Code reopened into that dead state every time.

## How

- On mobile, drop the **Code** segment from the switch (`chatModeItems` → Convo/Projects only).
- Render a persisted `"code"` session as **Convo** on mobile (`chatModeValue`) so the segmented control always has a valid selection — the saved `cave:chat-mode:v1` preference is left untouched, so Code restores on a wider screen.
- Base `chatMode` stays the source of truth for layout; this is purely a presentational guard.

## Verification

- `test:app` (450) ✅ · `test:mobile` (65) ✅ · `tsc --noEmit` clean ✅
- Browser-verified: at 390px the switch shows `[Convo, Projects]`; a persisted `code` shows active **Convo**; desktop with the same storage shows `[Convo, Projects, Code]` active **Code**. `MOBILE FIX: PASS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)