### PR TITLE
chore: release CovenCave v0.0.118

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.118] - 2026-06-25
+
+Patch release on top of v0.0.117. Headline: the current production line now
+matches the `main` and `kitty/main-mirror` tree while shipping the latest chat,
+flow, Feed, board-chat, screenshot, and home-composer polish.
+
+### Added
+
+- **Chat** - the Convo / Projects / Code mode switch now persists across reloads
+  and its control is slimmed down to text-only for a quieter production surface
+  (#1961, #1964).
+- **Chat / Mobile** - Code mode is hidden from the compact mobile chat switch
+  while staying available on larger desktop/tablet layouts (#1968).
+- **Flow** - added the latest flow layout-direction controls and iOS Feed wiring
+  from the production main line (#1962).
+- **Docs screenshots** - added familiar Feed tab captures for desktop and iOS
+  so release documentation reflects the shipped interface (#1966).
+
+### Fixed
+
+- **Board chat** - task chats now start in the assigned project context instead
+  of drifting into the wrong workspace.
+- **Home composer** - removed the keyboard-hint UI and CSS from the home
+  composer to keep the mobile production surface tighter.
+
 ## [0.0.117] - 2026-06-25
 
 Patch release on top of v0.0.116. Headline: Cave no longer ships a built-in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.117"
+version = "0.0.118"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.117"
+version = "0.0.118"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.117</string>
+	<string>0.0.118</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.117</string>
+	<string>0.0.118</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.117</string>
+	<string>0.0.118</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.117</string>
+	<string>0.0.118</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary

- Bump CovenCave desktop/Tauri/iOS metadata to v0.0.118.
- Add changelog/release notes for the main + kitty/main-mirror production tree.
- Cut from origin/main after confirming origin/main and origin/kitty/main-mirror have identical trees.

## Verification

- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm check:tests-wired
- node --experimental-strip-types src/lib/app-version.test.ts
- node --experimental-strip-types src/components/chat-surface-power-mode.test.ts
- pnpm test:app
- pnpm test:api
- pnpm build
- git diff --check
- bash scripts/release-notes.sh v0.0.118 v0.0.117

Co-authored-by: Nova <nova@openclaw.local>