### PR TITLE
Allow loopback terminal event listeners

### DIFF
--- a/src-tauri/capabilities/loopback-browser.json
+++ b/src-tauri/capabilities/loopback-browser.json
@@ -13,6 +13,8 @@
     ]
   },
   "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
     "allow-pty-start",
     "allow-pty-write",
     "allow-pty-resize",

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -129,6 +129,12 @@ test("packaged sidecar loopback origins can use browser commands and main-webvie
     capabilityAllowsOrigin(loopbackBrowserCapability, "http://[::1]:64203/"),
     "packaged random IPv6 loopback sidecar port should be allowed restricted browser IPC",
   );
+  for (const permission of ["core:event:allow-listen", "core:event:allow-unlisten"]) {
+    assert.ok(
+      loopbackBrowserCapability.permissions.includes(permission),
+      `loopback terminal/browser pages must be allowed to use Tauri event ${permission}`,
+    );
+  }
   for (const permission of [
     "allow-pty-start",
     "allow-pty-write",


### PR DESCRIPTION
## Summary
- Grant loopback sidecar pages the Tauri core event listen/unlisten permissions needed by terminal/browser surfaces.
- Add a desktop permission guard so `plugin:event|listen` ACL regressions stay caught.

## Test Plan
- [x] `node src-tauri/permissions/desktop-permissions.test.mjs`
- [x] `node --experimental-strip-types src/components/bottom-terminal-ws-bridge.test.ts`
- [x] `node --experimental-strip-types src/components/comux-view-terminal.test.ts`
- [x] `node --experimental-strip-types src/server-pty-ws.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] `git diff --check`