### PR TITLE
docs: update CovenCave v0.0.118 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ flow, Feed, board-chat, screenshot, and home-composer polish.
 
 ### Fixed
 
+- **Tauri permissions** - allowed loopback browser event listeners in the
+  desktop permission set so the native shell can receive local browser events.
 - **Board chat** - task chats now start in the assigned project context instead
   of drifting into the wrong workspace.
 - **Home composer** - removed the keyboard-hint UI and CSS from the home


### PR DESCRIPTION
## Summary

- Add the loopback browser event-listener permission fix to the v0.0.118 changelog before tagging the release.

## Verification

- bash scripts/release-notes.sh v0.0.118 v0.0.117
- node src-tauri/permissions/desktop-permissions.test.mjs
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm check:tests-wired
- pnpm build
- git diff --check

Co-authored-by: Nova <nova@openclaw.local>