### PR TITLE
fix: make desktop top bar draggable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3986,6 +3986,14 @@ button:active > .edge-rail-chip {
     /* ~78px clears the three traffic lights + their left inset. */
     padding-left: 78px;
     min-height: 52px;
+  }
+
+  :root[data-tauri-titlebar] :is(
+    .shell-top,
+    .shell-top__bar,
+    .shell-top .menu-bar,
+    .shell-top .top-bar
+  ) {
     -webkit-app-region: drag;
     app-region: drag;
   }

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -107,6 +107,11 @@ assert.match(
 );
 assert.match(
   css,
+  /:root\[data-tauri-titlebar\]\s+:is\(\s*\.shell-top,\s*\.shell-top__bar,\s*\.shell-top \.menu-bar,\s*\.shell-top \.top-bar\s*\)\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
+  "macOS Tauri titlebar mode should make the full rendered top-bar band draggable",
+);
+assert.match(
+  css,
   /\.shell-top-toggle\s*\{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px;[\s\S]*?border:\s*1px solid var\(--border-hairline\);[\s\S]*?background:\s*var\(--bg-base\);/,
   "top-bar toggles match the row's compact bordered icon buttons",
 );


### PR DESCRIPTION
## Summary
- mark the rendered shell top-bar wrappers as macOS Tauri drag regions
- keep the existing no-drag exclusions for buttons, inputs, links, and other controls
- add a shell chrome regression check so the full rendered top-bar band remains draggable

## Verification
- node --experimental-strip-types src/components/shell-edge-rails.test.ts (failed before the CSS patch, then passed)
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check
- pnpm test:app
- pnpm build