### PR TITLE
chore: release CovenCave v0.0.119

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.119] - 2026-06-25
+
+Patch release on top of v0.0.118. Headline: the macOS desktop shell's topmost
+bar is draggable again while keeping all toolbar controls clickable.
+
+### Fixed
+
+- **Desktop shell** - macOS Tauri titlebar mode now marks the rendered top-bar
+  wrappers as drag regions, not only the outer shell row, so users can drag the
+  window from the topmost Cave bar while buttons, inputs, links, and other
+  controls remain `no-drag` (#1972).
+
 ## [0.0.118] - 2026-06-25
 
 Patch release on top of v0.0.117. Headline: the current production line now

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.118"
+version = "0.0.119"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.118"
+version = "0.0.119"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.118</string>
+	<string>0.0.119</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.118</string>
+	<string>0.0.119</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.118</string>
+	<string>0.0.119</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.118</string>
+	<string>0.0.119</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump CovenCave desktop/mobile metadata to 0.0.119
- add the v0.0.119 changelog entry for the macOS desktop top-bar drag fix
- prepare the production release that includes #1972

## Verification
- node --experimental-strip-types src/lib/app-version.test.ts
- bash scripts/release-notes.sh v0.0.119 v0.0.118
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check
- pnpm test:app
- node scripts/uninstall-app.test.mjs
- pnpm test:api (rerun alone after an initial parallel-load timeout in uninstall-app.test.mjs)
- pnpm build
- cargo check --locked