### PR TITLE
fix(openclaw): use current session id flag

### DIFF
--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -136,7 +136,7 @@ function openClawCapabilityManifest(scannedAt: string): HarnessCapabilityManifes
         enabled: true,
         transport: "local-cli",
         command: "openclaw",
-        args: ["agent", "--json", "--session-key"],
+        args: ["agent", "--json", "--session-id"],
       },
     ],
     warnings: [

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -136,13 +136,13 @@ assert.match(
 
 // Session persistence contract (regression: chats forked into new sessions
 // every time OpenClaw rotated its internal session id):
-// 1. every turn pins the conversation to a cave-owned session KEY — keys are
-//    OpenClaw's durable identity; session ids rotate on reset/compaction;
+// 1. every turn pins the conversation to a cave-owned explicit session id/key — values are
+//    OpenClaw's durable identity; internally generated session ids rotate on reset/compaction;
 // 2. the gateway's session id is never adopted as the conversation key.
 assert.match(
   openclawBridge,
-  /"--session-key",\s*\n?\s*openClawSessionKey\(conversationId\)/,
-  "OpenClaw native chat must pin a per-conversation session key",
+  /"--session-id",\s*\n?\s*openClawSessionKey\(conversationId\)/,
+  "OpenClaw native chat must pin a per-conversation explicit session id/key",
 );
 assert.match(
   chatRoute,
@@ -176,8 +176,8 @@ assert.match(
 );
 assert.doesNotMatch(
   chatRoute,
-  /"--session-id"/,
-  "OpenClaw bridge no longer passes raw session ids — keys are the resume contract",
+  /"--session-key"/,
+  "OpenClaw chat route must not emit the removed --session-key flag",
 );
 // Model parity superseded the old "never emit --model" guard: --model is now
 // forwarded, but ONLY behind the coven run capability probe (see the gated

--- a/src/app/api/library/chat/route.ts
+++ b/src/app/api/library/chat/route.ts
@@ -306,7 +306,7 @@ export async function POST(req: Request): Promise<Response> {
         fullPrompt,
         "--json",
         "--no-persist",
-        "--session-key",
+        "--session-id",
         openClawSessionKey(sessionId),
       ]);
 

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -152,13 +152,13 @@ assert.deepEqual(openClawAgentArgs("hi", "nova", "ABC_123"), [
   "--message",
   "hi",
   "--json",
-  "--session-key",
+  "--session-id",
   "cave-abc-123",
 ]);
 assert.equal(
   openClawAgentArgs("hi", "nova", "ABC_123").includes("--session-id"),
-  false,
-  "OpenClaw bridge must never use raw session ids for resume",
+  true,
+  "OpenClaw bridge must pass the stable Cave-owned id through --session-id",
 );
 
 assert.equal(

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -250,10 +250,10 @@ export function extractOpenClawSessionId(
 
 /**
  * Conversation identity for the OpenClaw bridge is CAVE-owned. OpenClaw
- * sessions are persisted per session *key* (`agent:<id>:<key>`); the
+ * sessions are persisted per explicit session id/key (`agent:<id>:explicit:<value>`); the
  * `sessionId` inside an entry rotates on daily resets, `/new`, and
- * compaction. Pinning each Cave chat to its own `--session-key` keeps one
- * durable gateway session per conversation. Without a key, every turn lands
+ * compaction. Pinning each Cave chat to its own explicit `--session-id` value keeps one
+ * durable gateway session per conversation. Without an explicit id/key, every turn lands
  * in the shared `agent:<id>:main` session — id rotation then forked each
  * Cave chat into a brand-new conversation, and concurrent chats with the
  * same familiar interleaved context.
@@ -274,7 +274,7 @@ export function openClawAgentArgs(
     "--message",
     harnessPrompt,
     "--json",
-    "--session-key",
+    "--session-id",
     openClawSessionKey(conversationId),
   ];
 }


### PR DESCRIPTION
## Summary
- Replace removed OpenClaw `--session-key` usage with current `--session-id` flag
- Keep Cave-owned stable `cave-*` conversation identity for OpenClaw resume behavior
- Update OpenClaw bridge/capability/library route tests and guards to prevent regressions

## Why
OpenClaw 2026.5.x rejects `--session-key` with:

```text
error: unknown option '--session-key'
(Did you mean --session-id?)
```

This caused CovenCave OpenClaw chats to fail after updating. Passing the same stable Cave-owned value through `--session-id` preserves the existing per-conversation resume contract while matching the current CLI.

## Validation
- `node --experimental-strip-types src/lib/openclaw-bridge.test.ts`
- `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm test:app` — 450 test files passed
