### PR TITLE
fix(group-chat): strip next-paths block from coven replies

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -20,6 +20,8 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   assert.match(view, /recordSession\(group\.id, reply\.familiarId/, "pins each familiar's session id");
   // A Stop control aborts the in-flight broadcast.
   assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
+  // Strips the piggybacked next-paths block so control markup never leaks into a bubble.
+  assert.match(view, /extractNextPaths\(r\.text\)\.visible/, "strips the next-paths block from coven replies");
 });
 
 test("@mentions target a subset of the coven", () => {

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -19,6 +19,7 @@ import {
   useState,
 } from "react";
 import { Icon } from "@/lib/icon";
+import { extractNextPaths } from "@/lib/next-paths";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Popover } from "@/components/ui/popover";
@@ -596,6 +597,11 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                       <div className="flex flex-col gap-3 pl-1">
                         {replies.map((r) => {
                           const f = byId.get(r.familiarId);
+                          // Strip the piggybacked `<coven:next-paths>` suggestions
+                          // block (and its streaming partial) from the visible
+                          // reply, mirroring the single-chat surface — otherwise
+                          // the raw control markup leaks into the coven bubble.
+                          const visibleText = extractNextPaths(r.text).visible;
                           return (
                             <div key={r.id} className="flex gap-2">
                               {f && (
@@ -608,7 +614,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                   role="assistant"
                                   label={f?.display_name ?? r.familiarId}
                                   content={
-                                    r.text ||
+                                    visibleText ||
                                     (r.status === "error"
                                       ? `⚠️ ${r.error ?? "failed"}`
                                       : r.activity


### PR DESCRIPTION
## What

The Group Chat ("coven") surface rendered raw assistant reply text, so the piggybacked `<coven:next-paths>` suggestions block (and its streaming partial) leaked into the bubble as **literal control markup** — visible in a Nova+Kitty broadcast.

The single-chat surface already strips this via `extractNextPaths`; the coven fan-out never did.

## Change

- `group-chat-view.tsx`: render `extractNextPaths(r.text).visible` instead of raw `r.text`, mirroring `chat-view`. Streaming-safe (hides the block while it streams).
- `group-chat-view.test.ts`: source-text assertion pinning the strip so it can't regress.

**Strip-only:** no chips surfaced yet, no fan-out/relay change. (`group-chat.ts` untouched.)

## Verify

- `pnpm test:app` — 418 files ✓
- `pnpm test:mobile` — 65 files ✓
- `pnpm typecheck` — exit 0 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)