### PR TITLE
Fix stale failed status for local Cave chats

### DIFF
--- a/src/lib/cave-conversations.test.ts
+++ b/src/lib/cave-conversations.test.ts
@@ -11,6 +11,7 @@ process.env.HOME = home;
 const {
   deleteConversation,
   isSafeConversationSessionId,
+  listConversations,
   loadConversation,
   saveConversation,
 } = await import("./cave-conversations.ts");
@@ -131,6 +132,66 @@ const noUsageTurn = usageConv?.turns.find((turn) => turn.id === "turn-assistant-
 assert.equal(noUsageTurn?.usage, undefined, "turns without usage stay absent — never fabricated");
 assert.equal(noUsageTurn?.costUsd, undefined, "turns without cost stay absent — never fabricated");
 assert.equal(await deleteConversation("usage-turn"), true);
+
+await saveConversation({
+  sessionId: "summary-ok",
+  familiarId: "charm",
+  harness: "codex",
+  title: "Healthy summary",
+  createdAt: "2026-06-12T00:00:00.000Z",
+  updatedAt: "2026-06-12T00:00:00.000Z",
+  activeLeafId: "summary-ok-assistant",
+  turns: [
+    {
+      id: "summary-ok-user",
+      role: "user",
+      text: "hello",
+      createdAt: "2026-06-12T00:00:00.000Z",
+    },
+    {
+      id: "summary-ok-assistant",
+      role: "assistant",
+      text: "hello",
+      createdAt: "2026-06-12T00:00:01.000Z",
+      parentId: "summary-ok-user",
+      isError: false,
+    },
+  ],
+});
+await saveConversation({
+  sessionId: "summary-failed",
+  familiarId: "charm",
+  harness: "codex",
+  title: "Failed summary",
+  createdAt: "2026-06-12T00:00:00.000Z",
+  updatedAt: "2026-06-12T00:00:00.000Z",
+  activeLeafId: "summary-failed-assistant",
+  turns: [
+    {
+      id: "summary-failed-user",
+      role: "user",
+      text: "fail",
+      createdAt: "2026-06-12T00:00:00.000Z",
+    },
+    {
+      id: "summary-failed-assistant",
+      role: "assistant",
+      text: "failed",
+      createdAt: "2026-06-12T00:00:01.000Z",
+      parentId: "summary-failed-user",
+      isError: true,
+    },
+  ],
+});
+const summaries = await listConversations();
+const okSummary = summaries.find((conv) => conv.sessionId === "summary-ok");
+const failedSummary = summaries.find((conv) => conv.sessionId === "summary-failed");
+assert.equal(okSummary?.status, "completed", "conversation summaries expose successful terminal status");
+assert.equal(okSummary?.exitCode, 0, "successful conversation summaries expose exit code 0");
+assert.equal(failedSummary?.status, "failed", "conversation summaries expose failed terminal status");
+assert.equal(failedSummary?.exitCode, 1, "failed conversation summaries expose exit code 1");
+assert.equal(await deleteConversation("summary-ok"), true);
+assert.equal(await deleteConversation("summary-failed"), true);
 
 // ── CHAT-D9-02: conversation content search ──────────────────────────────────
 // Appended section — searchConversations over fixture transcripts written

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { homedir } from "node:os";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 import type { ModelApplicationState, ModelScope } from "./chat-model-state.ts";
-import { linearizeLegacy } from "./conversation-tree.ts";
+import { linearizeLegacy, resolveActivePath } from "./conversation-tree.ts";
 
 const CONV_DIR = path.join(homedir(), ".coven", "cave-conversations");
 
@@ -82,6 +82,15 @@ export type ConversationFile = {
   branchedFromTurnId?: string;
 };
 
+function conversationTerminalStatus(conv: ConversationFile): { status: string; exitCode: number } {
+  const turns = conv.activeLeafId
+    ? resolveActivePath(conv.turns, conv.activeLeafId)
+    : conv.turns;
+  const latestAssistant = [...turns].reverse().find((turn) => turn.role === "assistant");
+  if (latestAssistant?.isError) return { status: "failed", exitCode: 1 };
+  return { status: "completed", exitCode: 0 };
+}
+
 async function ensureDir() {
   await mkdir(CONV_DIR, { recursive: true });
 }
@@ -155,6 +164,8 @@ export async function listConversations(): Promise<
     model?: string;
     runtime?: string;
     title?: string;
+    status?: string;
+    exitCode?: number | null;
     createdAt?: string;
     updatedAt: string;
   }>
@@ -173,6 +184,8 @@ export async function listConversations(): Promise<
     model?: string;
     runtime?: string;
     title?: string;
+    status?: string;
+    exitCode?: number | null;
     createdAt?: string;
     updatedAt: string;
   }> = [];
@@ -182,6 +195,7 @@ export async function listConversations(): Promise<
       const sessionId = name.replace(/\.json$/, "");
       const conv = await loadConversation(sessionId);
       if (conv) {
+        const terminal = conversationTerminalStatus(conv);
         results.push({
           sessionId: conv.sessionId,
           familiarId: conv.familiarId,
@@ -189,6 +203,8 @@ export async function listConversations(): Promise<
           model: conv.model,
           runtime: conv.runtime,
           title: conv.title,
+          status: terminal.status,
+          exitCode: terminal.exitCode,
           createdAt: conv.createdAt,
           updatedAt: conv.updatedAt,
         });

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -191,4 +191,42 @@ assert.deepEqual(
   "the genuinely-recent chat outranks the just-reopened older chat",
 );
 
+// A stale daemon row can outlive a Cave-local chat transcript for the same id.
+// When the local transcript has newer message activity, it should own the row's
+// terminal status so a successful chat is not stuck with an old failed badge.
+const staleFailedDaemon = {
+  id: "chat-stale-failed",
+  project_root: "/repo",
+  harness: "codex",
+  title: "Runtime filesystem boundary:",
+  status: "failed",
+  exit_code: 1,
+  archived_at: null,
+  created_at: "2026-06-25T04:23:34.393Z",
+  updated_at: "2026-06-25T04:26:13.470Z",
+};
+const newerCompletedLocal = {
+  sessionId: "chat-stale-failed",
+  familiarId: "charm",
+  harness: "codex",
+  title: "Howdy",
+  updatedAt: "2026-06-25T04:27:31.202Z",
+  status: "completed",
+  exitCode: 0,
+};
+
+const recoveredStatus = mergeSessionRows({
+  daemonSessions: [staleFailedDaemon],
+  localConversations: [newerCompletedLocal],
+  state: { sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {} },
+  includeArchived: false,
+});
+
+assert.equal(
+  recoveredStatus[0].status,
+  "completed",
+  "newer Cave-local transcript status should override stale daemon failure",
+);
+assert.equal(recoveredStatus[0].exit_code, 0, "newer Cave-local transcript exit code should win");
+
 console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -16,6 +16,8 @@ export type LocalConversationSummary = {
   model?: string;
   runtime?: string;
   title?: string;
+  status?: string;
+  exitCode?: number | null;
   createdAt?: string;
   updatedAt: string;
   initiator?: SessionInitiator;
@@ -36,6 +38,7 @@ function localConversationToSession(
   const title =
     state.sessionTitles[conv.sessionId] ?? sanitizeSessionTitle(conv.title) ?? "Chat";
   const familiarId = state.sessionFamiliar[conv.sessionId] ?? conv.familiarId ?? null;
+  const status = conv.status ?? "completed";
   return {
     id: conv.sessionId,
     project_root: "",
@@ -43,8 +46,8 @@ function localConversationToSession(
     ...(conv.model ? { model: conv.model } : {}),
     ...(conv.runtime ? { runtime: conv.runtime } : {}),
     title,
-    status: "completed",
-    exit_code: 0,
+    status,
+    exit_code: conv.exitCode ?? (status === "failed" || status === "error" ? 1 : 0),
     archived_at: state.sessionArchived[conv.sessionId] ?? null,
     created_at: conv.createdAt ?? conv.updatedAt,
     updated_at: conv.updatedAt,
@@ -87,8 +90,12 @@ export function mergeSessionRows({
   // message sent or received. Prefer that message-authoritative timestamp so
   // the list orders by real activity, not by what you last looked at.
   const localUpdatedById = new Map<string, string>();
+  const localById = new Map<string, LocalConversationSummary>();
   for (const conv of localConversations) {
-    if (conv.updatedAt) localUpdatedById.set(conv.sessionId, conv.updatedAt);
+    if (conv.updatedAt) {
+      localUpdatedById.set(conv.sessionId, conv.updatedAt);
+      localById.set(conv.sessionId, conv);
+    }
   }
 
   for (const session of daemonSessions) {
@@ -100,9 +107,17 @@ export function mergeSessionRows({
     const archivedLocal = state.sessionArchived[session.id] ?? null;
     const archived_at = archivedLocal ?? session.archived_at;
     const localUpdatedAt = localUpdatedById.get(session.id);
+    const local = localById.get(session.id);
+    const localIsNewer =
+      localUpdatedAt != null &&
+      Number.isFinite(Date.parse(localUpdatedAt)) &&
+      Number.isFinite(Date.parse(session.updated_at)) &&
+      Date.parse(localUpdatedAt) > Date.parse(session.updated_at);
     const row: SessionRow = {
       ...session,
       ...(localUpdatedAt ? { updated_at: localUpdatedAt } : {}),
+      ...(localIsNewer && local?.status ? { status: local.status } : {}),
+      ...(localIsNewer && local ? { exit_code: local.exitCode ?? 0 } : {}),
       // Daemon titles derive from the harness prompt, which the chat route
       // prefixes with the identity canon — sanitize so the preamble never
       // surfaces as a session title.


### PR DESCRIPTION
## Summary
- Derive terminal status/exit code from Cave-local conversation transcripts.
- Let newer local transcript status override stale daemon terminal rows during session-list merge.
- Add regression coverage for successful local chats stuck behind stale failed daemon rows.

## Test Plan
- node --experimental-strip-types src/lib/cave-conversations.test.ts
- node --experimental-strip-types src/lib/session-list-merge.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check
- Live merge proof for session 0344b869-8203-4ac3-a8e8-3a7c0fc6d73d returns completed / exit_code 0