### PR TITLE
feat(chat): two-way Chat/Code toggle, merge projects into Chat

### DIFF
--- a/src/components/chat-surface-power-mode.test.ts
+++ b/src/components/chat-surface-power-mode.test.ts
@@ -1,10 +1,10 @@
 // @ts-nocheck
 // Power mode: the standalone chat transforms its side area into an inline
-// chat↔code split (the comux coding surface beside the conversation), now
-// selected from a three-way segmented mode switch (Convo / Projects / Code)
-// that supersedes the old Sessions/Projects scope tabs + binary Power toggle.
-// Memory is removed from the chat surface entirely — it's not part of a
-// conversation, so it lives in the Familiars surface.
+// chat↔code split (the comux coding surface beside the conversation), selected
+// from a two-way Codex-style segmented toggle (Chat / Code). Projects are
+// merged into Chat (a sub-state, not a peer segment), so the toggle is just the
+// two modes. Memory is removed from the chat surface entirely — it's not part
+// of a conversation, so it lives in the Familiars surface.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -22,21 +22,21 @@ assert.match(
   "entering/leaving code mode persists across reloads",
 );
 
-// ── Three-way mode switch (Convo / Projects / Code) ─────────────────────────
+// ── Two-way Codex toggle (Chat / Code) ──────────────────────────────────────
 assert.match(
   surface,
-  /type ChatMode = "convo" \| "projects" \| "code"/,
-  "the standalone chat has a three-way mode model",
+  /type ChatMode = "chat" \| "code"/,
+  "the standalone chat has a two-way mode model",
 );
 assert.match(
   surface,
-  /const chatMode: ChatMode = scope === "projects" \? "projects" : powerMode \? "code" : "convo"/,
-  "the switch's selection derives from scope + power-mode state",
+  /const chatMode: ChatMode = powerMode \? "code" : "chat"/,
+  "the toggle's selection derives from power-mode state; projects browse stays under Chat",
 );
 assert.match(
   surface,
   /function selectChatMode\(next: ChatMode\)/,
-  "selecting a mode locks the surface into Convo, Projects, or Code",
+  "selecting a mode toggles the surface between Chat and Code",
 );
 // ── The selection is sticky across reloads ──────────────────────────────────
 assert.match(surface, /CHAT_MODE_KEY = "cave:chat-mode:v1"/, "the chosen mode has a stable storage key");
@@ -71,8 +71,8 @@ assert.match(
 );
 assert.match(
   surface,
-  /const chatModeValue: ChatMode = isMobile && chatMode === "code" \? "convo" : chatMode/,
-  "a persisted Code session shows as Convo on mobile (saved preference untouched)",
+  /const chatModeValue: ChatMode = isMobile && chatMode === "code" \? "chat" : chatMode/,
+  "a persisted Code session shows as Chat on mobile (saved preference untouched)",
 );
 assert.match(surface, /items=\{chatModeItems\}/, "the switch renders the mobile-aware item set");
 

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -10,16 +10,18 @@ assert.match(events, /CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects"/, "ev
 assert.match(surface, /import \{ ProjectsView \} from "@\/components\/projects-view"/, "chat-surface imports ProjectsView");
 assert.match(surface, /CHAT_OPEN_PROJECTS_EVENT/, "chat-surface references the reroute event");
 assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union still includes memory (Code surface) + projects");
-// Standalone chat drives its three layouts from a segmented mode switch:
-// Convo, Projects, then Code — Projects is one of the three locks, not a tab.
-assert.match(
+// The standalone chat's toggle is two-way (Chat / Code). Projects is merged
+// INTO Chat — it is NOT a peer segment, but the full ProjectsView browser still
+// renders as a sub-state of Chat (scope === "projects") reached via ⌘9 / board /
+// the /projects slash, keeping the toggle on "Chat".
+assert.match(surface, /\{\s*id:\s*"chat",\s*label:\s*"Chat"\s*\}/, "Chat is one of the two toggle modes");
+assert.match(surface, /\{\s*id:\s*"code",\s*label:\s*"Code"\s*\}/, "Code is the inline chat↔code split mode");
+assert.doesNotMatch(
   surface,
   /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
-  "Projects is one of the mode-switch options",
+  "Projects is no longer a peer mode-switch segment (merged into Chat)",
 );
-assert.match(surface, /\{\s*id:\s*"convo",\s*label:\s*"Convo"/, "Convo is the conversation-only mode");
-assert.match(surface, /\{\s*id:\s*"code",\s*label:\s*"Code"/, "Code is the inline chat↔code split mode");
-assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects scope renders its own panel (standalone chat only)");
+assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects browse still renders ProjectsView as a sub-state of Chat (standalone chat only)");
 assert.match(surface, /<ProjectsView[\s\S]*?sessions=\{sessions\}/, "projects panel renders ProjectsView with sessions");
 assert.match(surface, /onNewChat=\{startProjectChat\}/, "projects panel wires onNewChat to startProjectChat");
 assert.match(surface, /addEventListener\(CHAT_OPEN_PROJECTS_EVENT/, "listens for the reroute event");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -60,17 +60,18 @@ const chatStorage = {
 
 type FamiliarsScope = "conversation" | "memory" | "projects";
 
-// The standalone chat's mode switch locks the surface into one of three
-// layouts: the conversation alone ("convo"), the Projects browser, or the
-// inline chat↔code split ("code"). It folds the old Sessions/Projects scope
-// tabs and the binary Power toggle into a single segmented selector. Text-only
-// (no icons) so it stays a compact pill — matching the slim GitHub-style filter
-// segments elsewhere rather than reading as a chunky toolbar.
-type ChatMode = "convo" | "projects" | "code";
+// The standalone chat's mode switch is a Codex-style two-way toggle: the
+// conversation ("chat") or the inline chat↔code split ("code"). Projects are
+// *merged into* Chat rather than being a peer tab — the conversation already
+// carries the project sidebar (ChatProjectSidebar groups every project with its
+// sessions), and the full ProjectsView browser opens as a sub-state of Chat
+// (reached via ⌘9 / the board / the /projects slash), never flipping the
+// toggle off "Chat". Text-only (no icons) so it stays a compact pill — matching
+// the slim GitHub-style filter segments elsewhere rather than a chunky toolbar.
+type ChatMode = "chat" | "code";
 
 const CHAT_MODE_ITEMS: { id: ChatMode; label: string }[] = [
-  { id: "convo", label: "Convo" },
-  { id: "projects", label: "Projects" },
+  { id: "chat", label: "Chat" },
   { id: "code", label: "Code" },
 ];
 
@@ -108,9 +109,9 @@ type Props = {
   onOpenUrl?: (url: string) => void;
   /** Which surface embeds this ChatSurface. In "code" mode the chat pane is
    *  transcript-only (the comux pane owns project/file/session navigation), so
-   *  the in-chat project sidebar and the duplicate Projects tab are dropped and
-   *  the transcript gets a readable measure. Defaults to the standalone
-   *  "chat" surface, which keeps the sidebar + all three scope tabs. */
+   *  the in-chat project sidebar is dropped and the transcript gets a readable
+   *  measure. Defaults to the standalone "chat" surface, which keeps the
+   *  sidebar + the two-way Chat/Code toggle. */
   surface?: "chat" | "code";
 };
 
@@ -343,11 +344,11 @@ export function ChatSurface({
       /* ignore */
     }
   }
-  // Current selection for the standalone chat's three-way mode switch, derived
-  // from the existing scope + power-mode state so the rendering below is
-  // unchanged. Projects wins (it owns the whole surface); otherwise power mode
-  // means "code", and a plain conversation means "convo".
-  const chatMode: ChatMode = scope === "projects" ? "projects" : powerMode ? "code" : "convo";
+  // Current selection for the standalone chat's two-way Codex toggle. Power mode
+  // means "code"; everything else — a plain conversation *or* the Projects
+  // browse sub-state — reads as "Chat", so browsing projects never lights the
+  // toggle off "Chat" (projects are merged into the Chat mode, not a peer).
+  const chatMode: ChatMode = powerMode ? "code" : "chat";
   function selectChatMode(next: ChatMode) {
     try {
       window.localStorage.setItem(CHAT_MODE_KEY, next);
@@ -360,13 +361,10 @@ export function ChatSurface({
       persistPowerMode(true);
       return;
     }
+    // Chat: drop the code split and surface the conversation. If we were in the
+    // Projects browse sub-state, selecting Chat returns to the conversation.
     persistPowerMode(false);
-    if (next === "projects") {
-      setScope("projects");
-      return;
-    }
     setScope("conversation");
-    window.setTimeout(() => routerRef.current?.goToList(), 0);
   }
   // Below the desktop shell breakpoint the inline 230px right sidebar is hidden
   // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
@@ -378,7 +376,7 @@ export function ChatSurface({
   // as Convo there (the saved preference is untouched, so it restores on a wider
   // screen). The base `chatMode` above stays the source of truth for layout.
   const chatModeItems = isMobile ? CHAT_MODE_ITEMS.filter((m) => m.id !== "code") : CHAT_MODE_ITEMS;
-  const chatModeValue: ChatMode = isMobile && chatMode === "code" ? "convo" : chatMode;
+  const chatModeValue: ChatMode = isMobile && chatMode === "code" ? "chat" : chatMode;
   const consumedPendingActionNonce = useRef<number | null>(null);
 
   // Right panel — prefer new prop, fall back to legacy bool
@@ -579,8 +577,8 @@ export function ChatSurface({
             {/* The active familiar is selected from the global top menu bar /
                 switcher now. In Code mode the comux pane owns project/file
                 navigation, so that surface keeps a Sessions + Memory underline
-                tab pair flush left. The standalone chat instead drives all three
-                of its modes from the segmented switch on the right. */}
+                tab pair flush left. The standalone chat instead drives its
+                Chat/Code toggle from the segmented switch on the right. */}
             {isCodeSurface ? (
               <Tabs<FamiliarsScope>
                 bordered={false}
@@ -600,9 +598,10 @@ export function ChatSurface({
           </div>
           {/* Code workspace: layout presets + companion-panel toggle ride on
               this row so the Code surface needs no separate toolbar row.
-              Standalone chat gets the mode switch instead — a segmented selector
-              that locks the surface into Convo, Projects, or the inline
-              chat↔code split. */}
+              Standalone chat gets the two-way toggle instead — a segmented
+              Chat/Code selector. Projects browse is merged into Chat (not a
+              peer segment): it opens as a sub-state of Chat via ⌘9 / the board /
+              the /projects slash and keeps the toggle on "Chat". */}
           {isCodeSurface ? (
             <CodeInlineToolbar />
           ) : (


### PR DESCRIPTION
## What

Reworks the standalone chat surface's mode switch from the three-way **Convo / Projects / Code** segment into a Codex-style **two-way `Chat | Code` toggle**, and **merges Projects into Chat**.

- `ChatMode` is now `"chat" | "code"`; the toggle derives from `powerMode`.
- **Projects merged into Chat** — no longer a peer segment. The full `ProjectsView` browser opens as a *sub-state* of Chat (reached via ⌘9 / board "open in projects" / the `/projects` slash / `CHAT_OPEN_PROJECTS_EVENT`), and the toggle stays lit on **Chat** while browsing. The in-conversation `ChatProjectSidebar` already groups every project with its sessions — that's the visible merge.
- **Code** = the existing inline chat↔code split (ComuxView file-tree + preview + terminal beside the conversation), unchanged.
- Back-compat hydration still honors persisted `"projects"` / `"code"` preferences from `CHAT_MODE_KEY` / `POWER_MODE_KEY`.

## Why

Goal: toggle between chat and code modes and merge projects + conversation into a single Codex-like experience.

## Tests

Updated the two source-text tests (`chat-surface-power-mode.test.ts`, `chat-surface-projects-tab.test.ts`) to the new two-way model.

Local verification: `typecheck` clean · `test:app` (450 files) · `test:mobile` (65 files) · `check:tests-wired` all green. Built + ran the app and confirmed visually: the `Chat | Code` toggle renders, Chat shows projects merged in, and **Code** brings up the inline chat↔code split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)