### PR TITLE
fix(chat): suppress mermaid syntax error rendering

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -255,8 +255,8 @@ assert.match(
 );
 assert.match(
   source,
-  /mermaidPlugin\(\{ theme: "dark", config: \{ securityLevel: "strict" \} \}\)/,
-  "mermaid is initialized with the dark theme and a strict (safe) security level",
+  /mermaidPlugin\(\{[\s\S]{0,180}theme: "dark"[\s\S]{0,180}securityLevel: "strict", suppressErrorRendering: true/,
+  "mermaid is initialized with the dark theme, strict security, and syntax-error SVG rendering disabled",
 );
 assert.match(
   source,

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -493,7 +493,10 @@ async function getMermaidPlugin(): Promise<PreviewPlugin | null> {
         // theme "dark" matches the Cave UI; securityLevel "strict" overrides the
         // plugin's default "loose" so diagrams from untrusted chat content can't
         // smuggle scripts/click handlers (postProcess output bypasses our sanitizer).
-        const plugin = mermaidPlugin({ theme: "dark", config: { securityLevel: "strict" } });
+        const plugin = mermaidPlugin({
+          theme: "dark",
+          config: { securityLevel: "strict", suppressErrorRendering: true },
+        });
         await plugin.init?.();
         return plugin;
       })


### PR DESCRIPTION
## Summary
- Disable Mermaid's built-in syntax-error SVG rendering for chat markdown diagrams.
- Keep invalid Mermaid blocks as sanitized source fallback instead of showing/carrying over the large error SVG.
- Pin the Mermaid plugin config in the message-bubble source assertion.

## Test Plan
- `node --experimental-strip-types src/components/message-bubble-markdown.test.ts`
- `node --experimental-strip-types src/components/mermaid-viewer.test.ts`
- `git diff --check`
- `pnpm typecheck`
- `pnpm test:app`
