### PR TITLE
Ship Cave UI and onboarding follow-up fixes

### DIFF
--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -113,6 +113,30 @@ assert.match(
   "npm-missing responses carry a platform-specific Node.js install hint",
 );
 
+assert.match(
+  source,
+  /import \{ covenBin, covenSpawnEnv, refreshCovenSpawnEnv \} from "@\/lib\/coven-bin"/,
+  "install route can refresh Cave's cached PATH before declaring npm missing",
+);
+
+assert.match(
+  source,
+  /commandPath\("npm", \{ refreshOnMiss: true \}\)/,
+  "npm discovery retries with a refreshed PATH so clicking Install again can see newly installed Node.js",
+);
+
+assert.match(
+  source,
+  /code === 1/,
+  "command lookup treats only the normal which/where not-found exit as missing npm",
+);
+
+assert.match(
+  source,
+  /commandLookupFailed/,
+  "transient command lookup failures are reported separately instead of mislabeling them as missing Node.js",
+);
+
 for (const platform of ["darwin", "win32"]) {
   assert.match(
     source,

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -5,7 +5,7 @@ import { constants as fsConstants } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { stripAnsi } from "@/lib/ansi";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenBin, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
 import { callDaemon } from "@/lib/coven-daemon";
 
 export const dynamic = "force-dynamic";
@@ -75,6 +75,7 @@ const INSTALL_TARGETS = {
 } as const;
 
 type InstallTarget = keyof typeof INSTALL_TARGETS;
+type CommandPathResult = { path: string | null; error?: string };
 
 function nodeInstallHint(): string {
   if (process.platform === "darwin") {
@@ -86,17 +87,30 @@ function nodeInstallHint(): string {
   return "Install Node.js LTS from https://nodejs.org or your package manager (e.g. `sudo apt install nodejs npm`), then click Install again.";
 }
 
-async function commandPath(binary: string): Promise<string | null> {
+async function commandPath(
+  binary: string,
+  opts: { refreshOnMiss?: boolean } = {},
+): Promise<CommandPathResult> {
   const finder = process.platform === "win32" ? "where" : "which";
-  try {
-    const { stdout } = await execFileAsync(finder, [binary], {
-      env: covenSpawnEnv(),
-      timeout: 1500,
-    });
-    return stdout.trim().split(/\r?\n/)[0] || null;
-  } catch {
-    return null;
-  }
+  const find = async (env: NodeJS.ProcessEnv) => {
+    try {
+      const { stdout } = await execFileAsync(finder, [binary], {
+        env,
+        timeout: 1500,
+      });
+      return { path: stdout.trim().split(/\r?\n/)[0] || null };
+    } catch (err) {
+      const code = (err as { code?: unknown }).code;
+      if (code === 1) return { path: null };
+      return {
+        path: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  };
+  const found = await find(covenSpawnEnv());
+  if (found.path || found.error || !opts.refreshOnMiss) return found;
+  return find(refreshCovenSpawnEnv());
 }
 
 function isInstallTarget(value: unknown): value is InstallTarget {
@@ -184,11 +198,20 @@ async function spawnPlanFor(
 ): Promise<
   | SpawnPlan
   | { npmMissing: true }
+  | { commandLookupFailed: true; binary: string; error: string }
   | { sudoRequired: true; packageName: string }
   | null
 > {
   if (target.kind === "npm") {
-    const npm = await commandPath("npm");
+    const npmResult = await commandPath("npm", { refreshOnMiss: true });
+    if (npmResult.error) {
+      return {
+        commandLookupFailed: true,
+        binary: "npm",
+        error: npmResult.error,
+      };
+    }
+    const npm = npmResult.path;
     if (!npm) return { npmMissing: true };
 
     // On POSIX a root-owned global prefix (system Node, /usr/local) fails
@@ -480,6 +503,17 @@ export async function POST(req: Request) {
       { status: 422 },
     );
   }
+  if (plan && "commandLookupFailed" in plan) {
+    return NextResponse.json(
+      {
+        ok: false,
+        commandLookupFailed: true,
+        error: `Cave couldn't check ${plan.binary} on PATH`,
+        hint: `Retry in a moment. If it keeps happening, quit stuck terminal/session processes and try again. Details: ${plan.error}`,
+      },
+      { status: 503 },
+    );
+  }
   if (plan && "sudoRequired" in plan) {
     return NextResponse.json(
       {
@@ -547,7 +581,8 @@ export async function POST(req: Request) {
         clearTimeout(timer);
         if (killTimer) clearTimeout(killTimer);
         void (async () => {
-          const installedPath = await commandPath(target.binary);
+          const installed = await commandPath(target.binary);
+          const installedPath = installed.path;
           const ok = code === 0 && !!installedPath && !job.error;
           job.status = "done";
           job.finishedAt = Date.now();
@@ -555,11 +590,12 @@ export async function POST(req: Request) {
           job.code = code;
           job.binaryPath = installedPath;
           if (!ok && !job.error) {
-            job.error =
-              installFailureHint(targetName, job.output) ??
-              (code === 0
-                ? `${target.binary} still is not on PATH after install — open a new terminal or restart Cave, then re-check.`
-                : `installer exited with ${code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`}`);
+            job.error = installed.error
+              ? `Could not verify ${target.binary} on PATH after install: ${installed.error}`
+              : installFailureHint(targetName, job.output) ??
+                (code === 0
+                  ? `${target.binary} still is not on PATH after install — open a new terminal or restart Cave, then re-check.`
+                  : `installer exited with ${code === null ? `signal ${signal ?? "unknown"}` : `code ${code}`}`);
           }
         })();
       });

--- a/src/components/chat-surface-power-mode.test.ts
+++ b/src/components/chat-surface-power-mode.test.ts
@@ -1,10 +1,10 @@
 // @ts-nocheck
 // Power mode: the standalone chat transforms its side area into an inline
-// chat↔code split (the comux coding surface beside the conversation), now
-// selected from a three-way segmented mode switch (Convo / Projects / Code)
-// that supersedes the old Sessions/Projects scope tabs + binary Power toggle.
-// Memory is removed from the chat surface entirely — it's not part of a
-// conversation, so it lives in the Familiars surface.
+// chat↔code split (the comux coding surface beside the conversation), selected
+// from a two-way Codex-style segmented toggle (Chat / Code). Projects are
+// merged into Chat (a sub-state, not a peer segment), so the toggle is just the
+// two modes. Memory is removed from the chat surface entirely — it's not part
+// of a conversation, so it lives in the Familiars surface.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -22,21 +22,21 @@ assert.match(
   "entering/leaving code mode persists across reloads",
 );
 
-// ── Three-way mode switch (Convo / Projects / Code) ─────────────────────────
+// ── Two-way Codex toggle (Chat / Code) ──────────────────────────────────────
 assert.match(
   surface,
-  /type ChatMode = "convo" \| "projects" \| "code"/,
-  "the standalone chat has a three-way mode model",
+  /type ChatMode = "chat" \| "code"/,
+  "the standalone chat has a two-way mode model",
 );
 assert.match(
   surface,
-  /const chatMode: ChatMode = scope === "projects" \? "projects" : powerMode \? "code" : "convo"/,
-  "the switch's selection derives from scope + power-mode state",
+  /const chatMode: ChatMode = powerMode \? "code" : "chat"/,
+  "the toggle's selection derives from power-mode state; projects browse stays under Chat",
 );
 assert.match(
   surface,
   /function selectChatMode\(next: ChatMode\)/,
-  "selecting a mode locks the surface into Convo, Projects, or Code",
+  "selecting a mode toggles the surface between Chat and Code",
 );
 // ── The selection is sticky across reloads ──────────────────────────────────
 assert.match(surface, /CHAT_MODE_KEY = "cave:chat-mode:v1"/, "the chosen mode has a stable storage key");
@@ -71,8 +71,8 @@ assert.match(
 );
 assert.match(
   surface,
-  /const chatModeValue: ChatMode = isMobile && chatMode === "code" \? "convo" : chatMode/,
-  "a persisted Code session shows as Convo on mobile (saved preference untouched)",
+  /const chatModeValue: ChatMode = isMobile && chatMode === "code" \? "chat" : chatMode/,
+  "a persisted Code session shows as Chat on mobile (saved preference untouched)",
 );
 assert.match(surface, /items=\{chatModeItems\}/, "the switch renders the mobile-aware item set");
 

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -10,16 +10,18 @@ assert.match(events, /CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects"/, "ev
 assert.match(surface, /import \{ ProjectsView \} from "@\/components\/projects-view"/, "chat-surface imports ProjectsView");
 assert.match(surface, /CHAT_OPEN_PROJECTS_EVENT/, "chat-surface references the reroute event");
 assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union still includes memory (Code surface) + projects");
-// Standalone chat drives its three layouts from a segmented mode switch:
-// Convo, Projects, then Code — Projects is one of the three locks, not a tab.
-assert.match(
+// The standalone chat's toggle is two-way (Chat / Code). Projects is merged
+// INTO Chat — it is NOT a peer segment, but the full ProjectsView browser still
+// renders as a sub-state of Chat (scope === "projects") reached via ⌘9 / board /
+// the /projects slash, keeping the toggle on "Chat".
+assert.match(surface, /\{\s*id:\s*"chat",\s*label:\s*"Chat"\s*\}/, "Chat is one of the two toggle modes");
+assert.match(surface, /\{\s*id:\s*"code",\s*label:\s*"Code"\s*\}/, "Code is the inline chat↔code split mode");
+assert.doesNotMatch(
   surface,
   /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
-  "Projects is one of the mode-switch options",
+  "Projects is no longer a peer mode-switch segment (merged into Chat)",
 );
-assert.match(surface, /\{\s*id:\s*"convo",\s*label:\s*"Convo"/, "Convo is the conversation-only mode");
-assert.match(surface, /\{\s*id:\s*"code",\s*label:\s*"Code"/, "Code is the inline chat↔code split mode");
-assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects scope renders its own panel (standalone chat only)");
+assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects browse still renders ProjectsView as a sub-state of Chat (standalone chat only)");
 assert.match(surface, /<ProjectsView[\s\S]*?sessions=\{sessions\}/, "projects panel renders ProjectsView with sessions");
 assert.match(surface, /onNewChat=\{startProjectChat\}/, "projects panel wires onNewChat to startProjectChat");
 assert.match(surface, /addEventListener\(CHAT_OPEN_PROJECTS_EVENT/, "listens for the reroute event");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -60,17 +60,18 @@ const chatStorage = {
 
 type FamiliarsScope = "conversation" | "memory" | "projects";
 
-// The standalone chat's mode switch locks the surface into one of three
-// layouts: the conversation alone ("convo"), the Projects browser, or the
-// inline chat↔code split ("code"). It folds the old Sessions/Projects scope
-// tabs and the binary Power toggle into a single segmented selector. Text-only
-// (no icons) so it stays a compact pill — matching the slim GitHub-style filter
-// segments elsewhere rather than reading as a chunky toolbar.
-type ChatMode = "convo" | "projects" | "code";
+// The standalone chat's mode switch is a Codex-style two-way toggle: the
+// conversation ("chat") or the inline chat↔code split ("code"). Projects are
+// *merged into* Chat rather than being a peer tab — the conversation already
+// carries the project sidebar (ChatProjectSidebar groups every project with its
+// sessions), and the full ProjectsView browser opens as a sub-state of Chat
+// (reached via ⌘9 / the board / the /projects slash), never flipping the
+// toggle off "Chat". Text-only (no icons) so it stays a compact pill — matching
+// the slim GitHub-style filter segments elsewhere rather than a chunky toolbar.
+type ChatMode = "chat" | "code";
 
 const CHAT_MODE_ITEMS: { id: ChatMode; label: string }[] = [
-  { id: "convo", label: "Convo" },
-  { id: "projects", label: "Projects" },
+  { id: "chat", label: "Chat" },
   { id: "code", label: "Code" },
 ];
 
@@ -108,9 +109,9 @@ type Props = {
   onOpenUrl?: (url: string) => void;
   /** Which surface embeds this ChatSurface. In "code" mode the chat pane is
    *  transcript-only (the comux pane owns project/file/session navigation), so
-   *  the in-chat project sidebar and the duplicate Projects tab are dropped and
-   *  the transcript gets a readable measure. Defaults to the standalone
-   *  "chat" surface, which keeps the sidebar + all three scope tabs. */
+   *  the in-chat project sidebar is dropped and the transcript gets a readable
+   *  measure. Defaults to the standalone "chat" surface, which keeps the
+   *  sidebar + the two-way Chat/Code toggle. */
   surface?: "chat" | "code";
 };
 
@@ -343,11 +344,11 @@ export function ChatSurface({
       /* ignore */
     }
   }
-  // Current selection for the standalone chat's three-way mode switch, derived
-  // from the existing scope + power-mode state so the rendering below is
-  // unchanged. Projects wins (it owns the whole surface); otherwise power mode
-  // means "code", and a plain conversation means "convo".
-  const chatMode: ChatMode = scope === "projects" ? "projects" : powerMode ? "code" : "convo";
+  // Current selection for the standalone chat's two-way Codex toggle. Power mode
+  // means "code"; everything else — a plain conversation *or* the Projects
+  // browse sub-state — reads as "Chat", so browsing projects never lights the
+  // toggle off "Chat" (projects are merged into the Chat mode, not a peer).
+  const chatMode: ChatMode = powerMode ? "code" : "chat";
   function selectChatMode(next: ChatMode) {
     try {
       window.localStorage.setItem(CHAT_MODE_KEY, next);
@@ -360,13 +361,10 @@ export function ChatSurface({
       persistPowerMode(true);
       return;
     }
+    // Chat: drop the code split and surface the conversation. If we were in the
+    // Projects browse sub-state, selecting Chat returns to the conversation.
     persistPowerMode(false);
-    if (next === "projects") {
-      setScope("projects");
-      return;
-    }
     setScope("conversation");
-    window.setTimeout(() => routerRef.current?.goToList(), 0);
   }
   // Below the desktop shell breakpoint the inline 230px right sidebar is hidden
   // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
@@ -378,7 +376,7 @@ export function ChatSurface({
   // as Convo there (the saved preference is untouched, so it restores on a wider
   // screen). The base `chatMode` above stays the source of truth for layout.
   const chatModeItems = isMobile ? CHAT_MODE_ITEMS.filter((m) => m.id !== "code") : CHAT_MODE_ITEMS;
-  const chatModeValue: ChatMode = isMobile && chatMode === "code" ? "convo" : chatMode;
+  const chatModeValue: ChatMode = isMobile && chatMode === "code" ? "chat" : chatMode;
   const consumedPendingActionNonce = useRef<number | null>(null);
 
   // Right panel — prefer new prop, fall back to legacy bool
@@ -579,8 +577,8 @@ export function ChatSurface({
             {/* The active familiar is selected from the global top menu bar /
                 switcher now. In Code mode the comux pane owns project/file
                 navigation, so that surface keeps a Sessions + Memory underline
-                tab pair flush left. The standalone chat instead drives all three
-                of its modes from the segmented switch on the right. */}
+                tab pair flush left. The standalone chat instead drives its
+                Chat/Code toggle from the segmented switch on the right. */}
             {isCodeSurface ? (
               <Tabs<FamiliarsScope>
                 bordered={false}
@@ -600,9 +598,10 @@ export function ChatSurface({
           </div>
           {/* Code workspace: layout presets + companion-panel toggle ride on
               this row so the Code surface needs no separate toolbar row.
-              Standalone chat gets the mode switch instead — a segmented selector
-              that locks the surface into Convo, Projects, or the inline
-              chat↔code split. */}
+              Standalone chat gets the two-way toggle instead — a segmented
+              Chat/Code selector. Projects browse is merged into Chat (not a
+              peer segment): it opens as a sub-state of Chat via ⌘9 / the board /
+              the /projects slash and keeps the toggle on "Chat". */}
           {isCodeSurface ? (
             <CodeInlineToolbar />
           ) : (

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -255,8 +255,8 @@ assert.match(
 );
 assert.match(
   source,
-  /mermaidPlugin\(\{ theme: "dark", config: \{ securityLevel: "strict" \} \}\)/,
-  "mermaid is initialized with the dark theme and a strict (safe) security level",
+  /mermaidPlugin\(\{[\s\S]{0,180}theme: "dark"[\s\S]{0,180}securityLevel: "strict", suppressErrorRendering: true/,
+  "mermaid is initialized with the dark theme, strict security, and syntax-error SVG rendering disabled",
 );
 assert.match(
   source,

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -493,7 +493,10 @@ async function getMermaidPlugin(): Promise<PreviewPlugin | null> {
         // theme "dark" matches the Cave UI; securityLevel "strict" overrides the
         // plugin's default "loose" so diagrams from untrusted chat content can't
         // smuggle scripts/click handlers (postProcess output bypasses our sanitizer).
-        const plugin = mermaidPlugin({ theme: "dark", config: { securityLevel: "strict" } });
+        const plugin = mermaidPlugin({
+          theme: "dark",
+          config: { securityLevel: "strict", suppressErrorRendering: true },
+        });
         await plugin.init?.();
         return plugin;
       })

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -32,4 +32,10 @@ assert.match(
   "spawn PATH joining uses the platform delimiter instead of hard-coded ':'",
 );
 
+assert.match(
+  source,
+  /export function refreshCovenSpawnEnv\(\)[\s\S]*cachedPath = null[\s\S]*return covenSpawnEnv\(\)/,
+  "desktop install retries can refresh Cave's cached PATH after Node/npm is installed",
+);
+
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -183,3 +183,8 @@ export function covenSpawnEnv(): NodeJS.ProcessEnv {
   }
   return env;
 }
+
+export function refreshCovenSpawnEnv(): NodeJS.ProcessEnv {
+  cachedPath = null;
+  return covenSpawnEnv();
+}

--- a/vault.yaml
+++ b/vault.yaml
@@ -26,6 +26,6 @@ GOOGLE_API_KEY:
   description: "Google AI Studio key, used to mint ephemeral tokens for Gemini Live (v1.1)"
 
 GITHUB_PERSONAL_ACCESS_TOKEN:
-  ref: "op://Developer/GitHub PAT/credential"
+  ref: "op://Development/GitHub PAT/credential"
   description: "GitHub Token"
   required: true


### PR DESCRIPTION
## Summary
- Refresh Cave install PATH discovery after missing npm and report transient command lookup failures separately.
- Collapse standalone chat mode switch to Chat / Code while keeping Projects as a Chat sub-state.
- Disable Mermaid syntax-error SVG rendering and update the GitHub PAT vault reference.

## Test Plan
- node --experimental-strip-types src/app/api/onboarding/install/route.test.ts
- node --experimental-strip-types src/lib/coven-bin.test.ts
- node --experimental-strip-types src/components/chat-surface-power-mode.test.ts
- node --experimental-strip-types src/components/chat-surface-projects-tab.test.ts
- node --experimental-strip-types src/components/message-bubble-markdown.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --cached --check && git diff --check