### PR TITLE
fix(chat): portal lightbox & expand overlays to document.body

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { forwardRef, Fragment, memo, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { createPortal } from "react-dom";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
@@ -5040,7 +5041,12 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
   // focus to the attachment-chip trigger on close. Always active: this
   // component only mounts while the lightbox is open.
   useFocusTrap(true, dialogRef, { onEscape: onClose });
-  return (
+  // Portal to <body> so the overlay escapes the chat transcript's containing
+  // blocks (`.cave-mode-fade` sets `transform`; `.cave-linear-turn` sets
+  // `content-visibility: auto`) — both trap `position: fixed`, which would
+  // otherwise clamp this lightbox to the message's turn box instead of the
+  // full viewport. See ui/modal.tsx for the same pattern.
+  return createPortal(
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
@@ -5093,7 +5099,8 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
           </div>
         )}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -23,6 +23,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import { parse } from "@create-markdown/core";
 import type { Block } from "@create-markdown/core";
 import type { PreviewPlugin } from "@create-markdown/preview";
@@ -1177,7 +1178,14 @@ function MarkdownExpandModal({
     copyTimer.current = setTimeout(() => setCopied(false), 2000);
   }, [text]);
 
-  return (
+  // Portal to <body>: the chat transcript lives under `.cave-mode-fade` (which
+  // sets `transform`) and `.cave-linear-turn` (`content-visibility: auto`), and
+  // both establish a containing block for `position: fixed`. Rendered inline the
+  // overlay is clamped to the message's turn box instead of the viewport, so the
+  // "Expand" reading view never actually goes full-screen (it sits in a small
+  // box with a huge empty area beside/below it). Portaling escapes those
+  // ancestors so `inset-0` resolves to the real viewport. See ui/modal.tsx.
+  return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 backdrop-blur-sm"
       onClick={onClose}
@@ -1218,6 +1226,7 @@ function MarkdownExpandModal({
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## What

`AttachmentLightbox` and `MarkdownExpandModal` render `position: fixed` overlays, but the chat transcript lives under `.cave-mode-fade` (`transform`) and `.cave-linear-turn` (`content-visibility: auto`) — both establish a containing block for `fixed` descendants. Rendered inline, the overlays were clamped to the message's turn box instead of the viewport, so the attachment lightbox and the **Expand** reading view never actually went full-screen (they sat in a small box with empty space around them).

This portals both overlays to `document.body` via `createPortal`, so `inset-0` resolves to the real viewport — matching the existing pattern in `ui/modal.tsx`.

## Notes

Recovered from an uncommitted WIP left in a now-merged worktree (`fix/run-activity-fill`); re-based cleanly onto current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)