### PR TITLE
fix(onboarding): empty-state for Option A + re-probe PATH on miss

### DIFF
--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -11,7 +11,7 @@ import {
   type AdapterReport,
   type CovenAdapterSummary,
 } from "@/lib/harness-adapters";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenBin, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
 
 export const dynamic = "force-dynamic";
 
@@ -34,15 +34,25 @@ type HarnessReport = HarnessSpec & {
   version: string | null;
 };
 
-function which(binary: string): Promise<string | null> {
+function whichWith(binary: string, env: NodeJS.ProcessEnv): Promise<string | null> {
   return new Promise((resolve) => {
     const command = process.platform === "win32" ? "where" : "which";
-    const child = spawn(command, [binary], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
+    const child = spawn(command, [binary], { env, stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.on("close", (code) => resolve(code === 0 ? out.trim() || null : null));
     child.on("error", () => resolve(null));
   });
+}
+
+// covenSpawnEnv() caches PATH for the server's lifetime. A cave launched from
+// Finder/Spotlight starts with a minimal PATH (no nvm/fnm), so installed
+// runtimes go undetected and Option A renders empty. Re-probe once with a
+// freshly rebuilt PATH on a miss before reporting the runtime as absent.
+async function which(binary: string): Promise<string | null> {
+  const found = await whichWith(binary, covenSpawnEnv());
+  if (found) return found;
+  return whichWith(binary, refreshCovenSpawnEnv());
 }
 
 function probeVersion(binary: string, args: string[]): Promise<string | null> {

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -2153,42 +2153,64 @@ function StepFamiliar(props: {
             this machine.
           </p>
           <div className="mt-2 grid gap-2">
-            {chatHarnesses.map((adapter) => {
-              const active = selectedHarnessId === adapter.id;
-              return (
-                <button
-                  key={adapter.id}
-                  onClick={() => props.onSelectHarness(adapter)}
-                  disabled={!adapter.installed}
-                  className={`focus-ring rounded-lg border p-2.5 text-left ${
-                    active
-                      ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] text-[var(--text-primary)]"
-                      : adapter.installed
-                        ? "border-[var(--border-hairline)] bg-[var(--bg-base)]/45 text-[var(--text-secondary)] hover:border-[var(--border-strong)]"
-                        : "border-[var(--border-hairline)] bg-[var(--bg-base)]/35 text-[var(--text-muted)] opacity-70"
-                  }`}
-                  title={
-                    adapter.installed
-                      ? undefined
-                      : `Not installed yet — see step 3. ${adapter.installHint}`
-                  }
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="truncate text-[12px] font-medium">
-                      {adapter.label}
-                    </span>
-                    {active ? (
-                      <Icon
-                        name="ph:check-bold"
-                        className="text-[var(--accent-presence)]"
-                      />
-                    ) : !adapter.installed ? (
-                      <span className="text-[10px]">not installed</span>
-                    ) : null}
-                  </div>
-                </button>
-              );
-            })}
+            {chatHarnesses.length === 0 ? (
+              <div className="rounded-md border border-dashed border-[var(--border-hairline)] bg-[var(--bg-base)]/35 px-3 py-4 text-[11px] leading-5 text-[var(--text-secondary)]">
+                <p className="font-medium text-[var(--text-primary)]">
+                  No runtimes detected on this machine yet.
+                </p>
+                <p className="mt-1">
+                  Install one in{" "}
+                  <span className="font-medium text-[var(--text-primary)]">
+                    step 3
+                  </span>{" "}
+                  (Codex, Claude Code, …) — this list refreshes automatically. If
+                  you just installed a runtime, restart Cave so its PATH applies.
+                </p>
+                <p className="mt-1">
+                  <span className="font-medium text-[var(--text-primary)]">
+                    Option B
+                  </span>{" "}
+                  remains available to connect an existing OpenClaw agent.
+                </p>
+              </div>
+            ) : (
+              chatHarnesses.map((adapter) => {
+                const active = selectedHarnessId === adapter.id;
+                return (
+                  <button
+                    key={adapter.id}
+                    onClick={() => props.onSelectHarness(adapter)}
+                    disabled={!adapter.installed}
+                    className={`focus-ring rounded-lg border p-2.5 text-left ${
+                      active
+                        ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] text-[var(--text-primary)]"
+                        : adapter.installed
+                          ? "border-[var(--border-hairline)] bg-[var(--bg-base)]/45 text-[var(--text-secondary)] hover:border-[var(--border-strong)]"
+                          : "border-[var(--border-hairline)] bg-[var(--bg-base)]/35 text-[var(--text-muted)] opacity-70"
+                    }`}
+                    title={
+                      adapter.installed
+                        ? undefined
+                        : `Not installed yet — see step 3. ${adapter.installHint}`
+                    }
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate text-[12px] font-medium">
+                        {adapter.label}
+                      </span>
+                      {active ? (
+                        <Icon
+                          name="ph:check-bold"
+                          className="text-[var(--accent-presence)]"
+                        />
+                      ) : !adapter.installed ? (
+                        <span className="text-[10px]">not installed</span>
+                      ) : null}
+                    </div>
+                  </button>
+                );
+              })
+            )}
           </div>
         </div>
 

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { compareSemver } from "@/lib/app-update";
-import { covenSpawnEnv } from "@/lib/coven-bin";
+import { covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
 
 const execFileAsync = promisify(execFile);
 
@@ -45,15 +45,24 @@ export type OpenCovenToolStatus = {
 
 async function commandPath(binary: string): Promise<string | null> {
   const finder = process.platform === "win32" ? "where" : "which";
-  try {
-    const { stdout } = await execFileAsync(finder, [binary], {
-      env: covenSpawnEnv(),
-      timeout: 1500,
-    });
-    return stdout.trim().split(/\r?\n/)[0] || null;
-  } catch {
-    return null;
-  }
+  const find = async (env: NodeJS.ProcessEnv): Promise<string | null> => {
+    try {
+      const { stdout } = await execFileAsync(finder, [binary], {
+        env,
+        timeout: 1500,
+      });
+      return stdout.trim().split(/\r?\n/)[0] || null;
+    } catch {
+      return null;
+    }
+  };
+  // covenSpawnEnv() caches PATH for the server's lifetime. A cave launched from
+  // Finder/Spotlight starts with a minimal PATH (no nvm/fnm), so a tool the
+  // user actually has goes undetected and shows as "Not installed". Re-probe
+  // once with a freshly rebuilt PATH before concluding the binary is missing.
+  const found = await find(covenSpawnEnv());
+  if (found) return found;
+  return find(refreshCovenSpawnEnv());
 }
 
 function firstSemver(text: string): string | null {


### PR DESCRIPTION
## Problem

Two onboarding surfaces fail silently when the cave is launched from Finder/Spotlight, where macOS hands the process a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and interactive shell setup (nvm/fnm) never runs — the exact scenario `coven-bin.ts` exists to work around.

| Symptom | Route | Cause |
|---|---|---|
| **Step 5 "Create your familiar" → Option A renders blank** | `/api/harnesses` | `chatHarnesses.map()` had no empty-state, so a heading + description floated over an empty gap when no runtimes were detected. |
| **"Installed, version unknown" / runtimes undetected** | `/api/opencoven-tools/status`, `/api/harnesses` | `covenSpawnEnv()` caches PATH for the server's lifetime; a stale minimal PATH made installed binaries invisible. These two probe sites never re-probed (the install route already did). |

## Changes

1. **Option A empty-state** (`onboarding-overlay.tsx`) — when `chatHarnesses` is empty, render a dashed-border message mirroring Option B's pattern: points to step 3, notes the list auto-refreshes, and that a restart re-applies PATH. The "installed: false" rows still render as disabled "not installed" entries as before.

2. **`refreshOnMiss` wired into the two remaining probe sites** — `opencoven-tools-status.commandPath()` and `harnesses/route.which()` now re-probe with a freshly rebuilt PATH (`refreshCovenSpawnEnv()`) on a miss before reporting the binary absent, matching the retry pattern already used by `onboarding/install/route.ts`.

Net effect: the degraded environment now **recovers gracefully** (re-probe) and **fails legibly** (empty-state) instead of looking broken.

## Verification

- `tsc --noEmit` → clean
- `opencoven-tools/status` route test → passes
- No test pins the Option A markup (grepped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)