### PR TITLE
fix(flow): apply Tidy / orientation re-layout in place on the canvas

### DIFF
--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -136,11 +136,10 @@ function FlowCanvasInner(props: FlowCanvasProps) {
   // effect can't do this: the fresh canvas mounts with the previous positions
   // and ignores the later controlled update, so a Tidy / orientation switch
   // looked inert (the doc moved but the nodes stayed put).
-  if (syncedViewKey !== viewKey) {
-    setSyncedViewKey(viewKey);
-    nodesRef.current = docNodes;
-    setNodes(docNodes);
-  }
+if (syncedViewKey !== viewKey) {
+  setSyncedViewKey(viewKey);
+  setNodes(docNodes);
+}
 
   // While the view is stable, reconcile structural edits (added/removed nodes)
   // without clobbering the live in-flight positions that keep dragging smooth.

--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -99,7 +99,6 @@ function FlowCanvasInner(props: FlowCanvasProps) {
   // truth for structure, local state only owns in-flight positions.
   const [nodes, setNodes] = useState<Node<FlowNodeData>[]>([]);
   const nodesRef = useRef<Node<FlowNodeData>[]>([]);
-  const mountedKey = useRef<string | null>(null);
 
   const docNodes = useMemo<Node<FlowNodeData>[]>(
     () =>
@@ -126,20 +125,37 @@ function FlowCanvasInner(props: FlowCanvasProps) {
     [doc.nodes, onStickyText, onStickySize, layoutOrientation],
   );
 
+  // Identity for the current canvas "view": changes when the flow is switched
+  // or a relayout/reset bumps viewResetKey (Tidy, orientation flip). ReactFlow
+  // remounts on this same key to re-fit the viewport.
+  const viewKey = `${doc.id}:${viewResetKey}`;
+  const [syncedViewKey, setSyncedViewKey] = useState(viewKey);
+
+  // Adopt the doc's positions *during render* on a view change, so the
+  // remounting ReactFlow paints at the new layout immediately. A post-commit
+  // effect can't do this: the fresh canvas mounts with the previous positions
+  // and ignores the later controlled update, so a Tidy / orientation switch
+  // looked inert (the doc moved but the nodes stayed put).
+  if (syncedViewKey !== viewKey) {
+    setSyncedViewKey(viewKey);
+    nodesRef.current = docNodes;
+    setNodes(docNodes);
+  }
+
+  // While the view is stable, reconcile structural edits (added/removed nodes)
+  // without clobbering the live in-flight positions that keep dragging smooth.
   useEffect(() => {
+    if (syncedViewKey !== viewKey) return;
     setNodes((current) => {
-      const key = `${doc.id}:${viewResetKey}`;
-      const sameDoc = mountedKey.current === key;
-      mountedKey.current = key;
       const live = new Map(current.map((node) => [node.id, node.position]));
       const next = docNodes.map((node) => ({
         ...node,
-        position: (sameDoc ? live.get(node.id) : undefined) ?? node.position,
+        position: live.get(node.id) ?? node.position,
       }));
       nodesRef.current = next;
       return next;
     });
-  }, [docNodes, doc.id, viewResetKey]);
+  }, [docNodes, syncedViewKey, viewKey]);
 
   const renderNodes = useMemo(
     () =>


### PR DESCRIPTION
## Problem

After #1983 added the horizontal⇄vertical layout switch, clicking the orientation toggle (and the pre-existing **Tidy up** button) marked the flow dirty but **did not move the nodes** on the canvas — the switch looked inert.

Root cause: the canvas remounts `<ReactFlow key=…viewResetKey>` to re-fit the viewport on a relayout, but the effect that pushes the new doc positions into the controlled `nodes` state runs *after* commit. So the fresh ReactFlow mounts with the **previous** positions and ignores the later controlled update. The document got the new (tidied / re-oriented) positions, but the rendered nodes stayed put.

## Fix

Adopt the doc's positions **during render** when the canvas view key (`flow id + viewResetKey`) changes — React's "adjust state when a prop changes" pattern — so the remounting canvas paints at the new layout immediately. The post-commit effect now only reconciles *structural* edits (added/removed nodes) while the view is stable, preserving the live in-flight positions that keep dragging smooth.

One file: `src/components/flow/flow-canvas.tsx` (+22/-6).

## Verification

Drove the real app (prod build, Playwright) against a seeded 5-node branching flow:

- **Before:** clicking *Use vertical layout* → `dirty: true` but every node's canvas transform frozen at its old coordinate (2s+). Tidy button equally inert.
- **After:** toggle → nodes re-flow to `tidyFlowLayout`'s vertical column (top→bottom, ports flipped to top/bottom edges); Tidy button repositions too. Transforms match `tidyFlowLayout` output exactly.
- `tsc --noEmit` clean; `pnpm test:app` → 451 test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)