### PR TITLE
feat(vault): add encrypted local secrets

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -370,6 +370,7 @@ export const SUITES = {
     "src/lib/use-undo-delete-keyboard.test.ts",
     "src/lib/use-roving-tabindex.test.ts",
     "src/lib/vault.test.ts",
+    "src/lib/local-encrypted-vault.test.ts",
     "src/app/globals-background.test.ts",
     "src/components/board-chat-link.test.ts",
     "src/components/chat-list-panel.test.ts",

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -86,6 +86,21 @@ test("packaged sidecar bootstraps mobile handoff tokens", async () => {
   );
 });
 
+test("Windows packaged sidecar starts without a console window", async () => {
+  const launcher = await readFile(new URL("./src/lib.rs", import.meta.url), "utf8");
+
+  assert.match(
+    launcher,
+    /std::os::windows::process::CommandExt/,
+    "Windows launcher must import CommandExt so sidecar spawn flags are available",
+  );
+  assert.match(
+    launcher,
+    /cmd\.creation_flags\(0x08000000\)/,
+    "Windows launcher must use CREATE_NO_WINDOW for the Node sidecar process",
+  );
+});
+
 test("macOS release signing includes nested executables like bundled Node", async () => {
   const releaseScript = await readFile(
     new URL("../scripts/release.sh", import.meta.url),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,11 @@
 // Tauri tray/menu/webview-builder APIs that aren't available on iOS or
 // Android. Mobile binaries are thin shells: webview only, no sidecar.
 #[cfg(desktop)]
+use rand::{rngs::OsRng, RngCore};
+#[cfg(desktop)]
 use std::net::TcpListener;
+#[cfg(all(desktop, target_os = "windows"))]
+use std::os::windows::process::CommandExt;
 #[cfg(desktop)]
 use std::path::{Path, PathBuf};
 #[cfg(desktop)]
@@ -14,8 +18,6 @@ use std::sync::Mutex;
 use std::thread;
 #[cfg(desktop)]
 use std::time::{Duration, Instant};
-#[cfg(desktop)]
-use rand::{rngs::OsRng, RngCore};
 #[cfg(desktop)]
 use tauri::{
     image::Image,
@@ -1028,6 +1030,11 @@ pub fn run() {
                 cmd.stderr(Stdio::from(err));
             } else {
                 cmd.stderr(Stdio::null());
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
             }
 
             let child = match cmd.spawn() {

--- a/src/app/api/github/pat/route.ts
+++ b/src/app/api/github/pat/route.ts
@@ -5,18 +5,18 @@
  *         NEVER returns the PAT value itself.
  *
  * POST — body: { pat: string }
- *         Validates the PAT against GitHub, then writes it to .env.local
- *         under GITHUB_PAT. The PAT is only ever stored on this local
- *         machine in .env.local (gitignored). It is never logged, never
- *         returned to the client, never sent anywhere except api.github.com.
+ *         Validates the PAT against GitHub, then stores it in the local
+ *         encrypted Cave vault. It is never logged, never returned to the
+ *         client, never sent anywhere except api.github.com.
  *
- * DELETE — removes GITHUB_PAT from .env.local
+ * DELETE — removes GITHUB_PAT from .env.local and the local encrypted vault.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { dirname } from "path";
-import { resolveSecret } from "@/lib/vault";
+import { deleteLocalEncryptedSecret, hasLocalEncryptedSecret, setLocalEncryptedSecret } from "@/lib/local-encrypted-vault";
+import { loadVaultMap, resolveSecret, saveVaultMap } from "@/lib/vault";
 import { envLocalPath, upsertEnvContent } from "@/lib/env-file";
 
 export const dynamic = "force-dynamic";
@@ -35,13 +35,6 @@ function applyEnvUpdates(updates: Record<string, string | null>): void {
   mkdirSync(dirname(envPath), { recursive: true });
   const existing = existsSync(envPath) ? readFileSync(envPath, "utf8") : "";
   writeFileSync(envPath, upsertEnvContent(existing, updates), "utf8");
-}
-
-/** True when .env.local already declares <key> (constant keys only). */
-function envFileHasKey(key: string): boolean {
-  const envPath = envLocalPath();
-  if (!existsSync(envPath)) return false;
-  return new RegExp(`^\\s*${key}\\s*=`, "m").test(readFileSync(envPath, "utf8"));
 }
 
 async function validatePat(pat: string): Promise<{ valid: boolean; login: string | null }> {
@@ -64,13 +57,19 @@ async function validatePat(pat: string): Promise<{ valid: boolean; login: string
 
 // GET — just reports presence, never exposes the value
 export async function GET() {
-  // Resolve from vault first (1Password), then fall back to .env.local
+  // Resolve from env, encrypted local vault, 1Password, or legacy .env.local.
   const patFromVault = resolveSecret("GITHUB_PAT");
   const loginFromVault = resolveSecret("GITHUB_USERNAME");
 
   const hasPat = !!(patFromVault ?? process.env.GITHUB_PAT?.trim());
   const login  = loginFromVault ?? process.env.GITHUB_USERNAME?.trim() ?? null;
-  const source: "vault" | "env" | "none" = patFromVault ? "vault" : hasPat ? "env" : "none";
+  const source: "encrypted" | "vault" | "env" | "none" = hasLocalEncryptedSecret(PAT_KEY)
+    ? "encrypted"
+    : patFromVault
+      ? "vault"
+      : hasPat
+        ? "env"
+        : "none";
 
   return NextResponse.json({ hasPat, login, source });
 }
@@ -97,13 +96,19 @@ export async function POST(req: NextRequest) {
     login = result.login ?? login;
   }
 
-  // Write to .env.local — never log the PAT value. Skip persisting the PAT as
-  // plaintext when it already matches the resolved secret (e.g. it comes from
-  // the 1Password vault), so we don't leave a dead shadow copy on disk.
-  const resolvedPat = resolveSecret(PAT_KEY);
-  const patIsVaultBacked = !!pat && pat === resolvedPat && !envFileHasKey(PAT_KEY);
   const updates: Record<string, string | null> = {};
-  if (pat && !patIsVaultBacked) updates[PAT_KEY] = pat;
+
+  if (pat) {
+    setLocalEncryptedSecret(PAT_KEY, pat);
+    const map = loadVaultMap(true);
+    map[PAT_KEY] = {
+      storage: "encrypted",
+      description: "GitHub Personal Access Token",
+      required: false,
+    };
+    saveVaultMap(map);
+    updates[PAT_KEY] = null;
+  }
   if (login) updates[LOGIN_KEY] = login;
   if (Object.keys(updates).length) applyEnvUpdates(updates);
 
@@ -111,12 +116,18 @@ export async function POST(req: NextRequest) {
   if (pat) process.env[PAT_KEY] = pat;
   if (login) process.env[LOGIN_KEY] = login;
 
-  return NextResponse.json({ ok: true, login, patStoredIn: patIsVaultBacked ? "vault" : pat ? "env" : undefined });
+  return NextResponse.json({ ok: true, login, patStoredIn: pat ? "encrypted" : undefined });
 }
 
 // DELETE — remove PAT
 export async function DELETE() {
   applyEnvUpdates({ [PAT_KEY]: null });
+  deleteLocalEncryptedSecret(PAT_KEY);
+  const map = loadVaultMap(true);
+  if (map[PAT_KEY]?.storage === "encrypted") {
+    delete map[PAT_KEY];
+    saveVaultMap(map);
+  }
   delete process.env[PAT_KEY];
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/marketplace/config/route.ts
+++ b/src/app/api/marketplace/config/route.ts
@@ -5,8 +5,8 @@
  * POST { id, key, value } -> save a NON-sensitive plain config value to .env.local
  * DELETE { id, key }      -> clear a NON-sensitive plain config value
  *
- * Sensitive fields are NOT handled here — they go through /api/vault as op://
- * refs. The env key written is always taken from the trusted plugin manifest
+ * Sensitive fields are NOT handled here — they go through /api/vault as local
+ * encrypted secrets or op:// refs. The env key written is always taken from the trusted plugin manifest
  * (allowlist-selected via the user's `key`), never built from request strings.
  */
 
@@ -40,7 +40,7 @@ export async function GET(req: Request) {
     const inEnv = readEnvLocalValue(f.env) !== undefined || !!process.env[f.env]?.trim();
     const vaultEntry = vault.find((v) => v.key === f.env) ?? null;
     const satisfied = inEnv || canResolve(f.env);
-    const source = inEnv ? "env" : satisfied ? "vault" : "none";
+    const source = inEnv ? "env" : vaultEntry?.status === "encrypted" ? "encrypted" : satisfied ? "vault" : "none";
     return {
       key: f.key,
       env: f.env,

--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -4,12 +4,18 @@
  * GET    — returns vault mappings + resolution status for each entry.
  *          Never returns secret values.
  *
- * POST   — adds or updates a mapping: { key, ref, description?, required? }
+ * POST   — adds or updates a mapping:
+ *          { key, ref, description?, required? } for 1Password refs, or
+ *          { key, storage: "encrypted", value, description?, required? } for local encrypted secrets.
  *
  * DELETE — removes a mapping: { key }
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import {
+  deleteLocalEncryptedSecret,
+  setLocalEncryptedSecret,
+} from "@/lib/local-encrypted-vault";
 import {
   getVaultStatuses,
   loadVaultMap,
@@ -35,27 +41,52 @@ export async function GET() {
 // ── POST — add / update a mapping ─────────────────────────────────────────────
 
 export async function POST(req: NextRequest) {
-  let body: { key?: string; ref?: string; description?: string; required?: boolean } = {};
+  let body: {
+    key?: string;
+    ref?: string;
+    storage?: string;
+    value?: string;
+    description?: string;
+    required?: boolean;
+  } = {};
   try { body = await req.json(); } catch { /**/ }
 
   const key = typeof body.key === "string" ? body.key.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_") : "";
   const ref = typeof body.ref === "string" ? body.ref.trim() : "";
+  const storage = body.storage === "encrypted" || typeof body.value === "string" ? "encrypted" : "1password";
 
   if (!key) return NextResponse.json({ ok: false, error: "key is required" }, { status: 400 });
 
-  const refError = validateOpRef(ref);
-  if (refError) return NextResponse.json({ ok: false, error: refError }, { status: 400 });
-
   const map = loadVaultMap(true);
-  const entry: VaultEntry = {
-    ref,
+
+  const baseEntry = {
     description: typeof body.description === "string" ? body.description.trim() : undefined,
     required: body.required ?? false,
   };
+
+  let entry: VaultEntry;
+  if (storage === "encrypted") {
+    const value = typeof body.value === "string" ? body.value : "";
+    if (!value) return NextResponse.json({ ok: false, error: "value is required" }, { status: 400 });
+    setLocalEncryptedSecret(key, value);
+    entry = { ...baseEntry, storage: "encrypted" };
+  } else {
+    const refError = validateOpRef(ref);
+    if (refError) return NextResponse.json({ ok: false, error: refError }, { status: 400 });
+    deleteLocalEncryptedSecret(key);
+    entry = { ...baseEntry, ref };
+  }
+
   map[key] = entry;
   saveVaultMap(map);
 
-  return NextResponse.json({ ok: true, key, ref });
+  if (storage === "encrypted" && typeof body.value === "string") {
+    process.env[key] = body.value;
+  } else {
+    delete process.env[key];
+  }
+
+  return NextResponse.json({ ok: true, key, ref: entry.ref ?? null, storage: entry.storage ?? "1password" });
 }
 
 // ── DELETE — remove a mapping ─────────────────────────────────────────────────
@@ -72,6 +103,7 @@ export async function DELETE(req: NextRequest) {
 
   delete map[key];
   saveVaultMap(map);
+  deleteLocalEncryptedSecret(key);
 
   // Clear from process.env too so it picks up fresh next resolve
   delete process.env[key];

--- a/src/components/board-inspector-a11y.test.ts
+++ b/src/components/board-inspector-a11y.test.ts
@@ -40,4 +40,8 @@ assert.match(src, /transition: reducedMotion \? "none" : "width 0\.2s/, "the pro
 assert.match(src, /transition: reducedMotion \? "none" : "background 0\.15s"/, "the step checkbox drops its transition under reduced motion");
 assert.match(src, /@media \(prefers-reduced-motion: reduce\) \{ \.step-actions \{ transition: none; \} \}/, "the step-actions hover reveal honors reduced motion");
 
+assert.match(src, /import \{ openExternalUrl \} from "@\/lib\/open-external"/, "inline PAT setup imports the system-browser opener");
+assert.match(src, /onClick=\{\(\) => void openExternalUrl\(GITHUB_PAT_URL\)\}/, "inline PAT setup opens GitHub token creation outside the local app");
+assert.doesNotMatch(src, /href="https:\/\/github\.com\/settings\/tokens\/new/, "inline PAT setup no longer uses a plain localhost-bound anchor");
+
 console.log("board-inspector-a11y.test.ts: ok");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -25,8 +25,10 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
+import { openExternalUrl } from "@/lib/open-external";
 
 const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+const GITHUB_PAT_URL = "https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local";
 
 type LifecycleMove = { to: CardLifecycle; label: string; retry?: boolean };
 const NEXT_MOVES: Record<CardLifecycle, LifecycleMove[]> = {
@@ -133,11 +135,10 @@ function InlinePATSetup({ onSaved }: { onSaved: () => void }) {
       </div>
       {error && <p style={{ fontSize: 10, color: "var(--color-danger)", margin: 0 }}>{error}</p>}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 2 }}>
-        <a href="https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local"
-          target="_blank" rel="noreferrer"
-          style={{ fontSize: 10, color: "var(--accent-presence)", textDecoration: "none" }}>
+        <button type="button" onClick={() => void openExternalUrl(GITHUB_PAT_URL)}
+          style={{ background: "transparent", border: 0, padding: 0, fontSize: 10, color: "var(--accent-presence)", textDecoration: "none", cursor: "pointer" }}>
           Generate PAT →
-        </a>
+        </button>
         <button type="button" disabled={(!pat.trim() && !usernameInput.trim()) || saving} onClick={() => void save()}
           style={{ background: "var(--accent-presence)", color: "var(--text-primary)", border: "none", borderRadius: 6,
             padding: "4px 12px", fontSize: 11, fontWeight: 500, cursor: "pointer", opacity: saving ? 0.6 : 1 }}>

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -341,4 +341,20 @@ assert.match(source, /aria-label="Search GitHub items by title, repo, or number"
 assert.match(source, /No items match/, "a no-match query gets its own empty state");
 assert.match(boardCss, /\.gh-search \{/, "the search box is styled to match the toolbar controls");
 
+assert.match(
+  source,
+  /import \{ openExternalUrl \} from "@\/lib\/open-external"/,
+  "PAT setup imports the system-browser opener",
+);
+assert.match(
+  source,
+  /onClick=\{\(\) => void openExternalUrl\(GITHUB_PAT_URL\)\}/,
+  "PAT setup opens token creation on github.com outside the local app surface",
+);
+assert.doesNotMatch(
+  source,
+  /href="https:\/\/github\.com\/settings\/tokens\/new/,
+  "PAT setup no longer relies on a plain anchor that can stay inside localhost",
+);
+
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -22,6 +22,7 @@ import {
   type PopoverMode,
 } from "@/components/github-action-popover";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
+import { openExternalUrl } from "@/lib/open-external";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -41,6 +42,8 @@ type SortKey = "kind" | "repo" | "title" | "tasks" | "updatedAt";
 type SortDir = "asc" | "desc";
 
 type GroupBy = "none" | "org" | "repo";
+
+const GITHUB_PAT_URL = "https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local";
 
 /** `item.repo` is "owner/name" — the organization is the slash prefix. */
 function orgOf(repo: string): string {
@@ -286,14 +289,13 @@ function PatSetupModal({
           )}
 
           <div className="flex items-center justify-between mt-4">
-            <a
-              href="https://github.com/settings/tokens/new?scopes=read:user,repo,notifications&description=Cave+local"
-              target="_blank"
-              rel="noreferrer"
-              className="text-[11px] text-[var(--accent-presence)] hover:underline"
+            <button
+              type="button"
+              onClick={() => void openExternalUrl(GITHUB_PAT_URL)}
+              className="border-0 bg-transparent p-0 text-[11px] text-[var(--accent-presence)] hover:underline"
             >
               Generate a PAT on GitHub →
-            </a>
+            </button>
             <button
               type="submit"
               disabled={(!pat.trim() && !usernameInput.trim()) || saving}

--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -13,7 +13,7 @@ type FieldStatus = {
   sensitive: boolean;
   validatable: boolean;
   satisfied: boolean;
-  source: "env" | "vault" | "none";
+  source: "env" | "vault" | "encrypted" | "none";
   ref: string | null;
 };
 
@@ -85,18 +85,17 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
   const save = useCallback(async (field: FieldStatus) => {
     const draft = (drafts[field.key] ?? "").trim();
     if (!draft) return;
-    if (field.sensitive && !draft.startsWith("op://")) {
-      setError(`${field.title}: enter a 1Password reference (op://Vault/Item/field)`);
-      return;
-    }
     setBusyKey(field.key);
     setError(null);
     try {
+      const sensitiveBody = draft.startsWith("op://")
+        ? { key: field.env, ref: draft, required: true, description: field.title }
+        : { key: field.env, storage: "encrypted", value: draft, required: true, description: field.title };
       const res = field.sensitive
         ? await fetch("/api/vault", {
             method: "POST",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify({ key: field.env, ref: draft, required: true, description: field.title }),
+            body: JSON.stringify(sensitiveBody),
           })
         : await fetch("/api/marketplace/config", {
             method: "POST",
@@ -126,8 +125,8 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
     >
       <div className="flex flex-col gap-4">
         <p className="text-[12px] text-[var(--text-muted)]">
-          {displayName} needs the following before its tools can run. Secrets are stored as 1Password
-          references — Cave never keeps the raw value.
+          {displayName} needs the following before its tools can run. Secrets are saved in the
+          encrypted local vault or stored as 1Password references.
         </p>
         {error ? (
           <p className="rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
@@ -143,7 +142,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
                 <span className="text-[13px] font-medium text-[var(--text-primary)]">{f.title}</span>
                 <span className={`inline-flex items-center gap-1 text-[11px] ${f.satisfied ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
                   <Icon name={f.satisfied ? "ph:check-circle" : "ph:warning"} width={12} aria-hidden />
-                  {f.satisfied ? `Set${f.source === "vault" ? " · 1Password" : ""}` : "Not set"}
+                  {f.satisfied ? `Set${f.source === "encrypted" ? " · encrypted" : f.source === "vault" ? " · 1Password" : ""}` : "Not set"}
                 </span>
               </div>
               {f.description ? <p className="text-[11px] text-[var(--text-muted)]">{f.description}</p> : null}
@@ -152,7 +151,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
                   type="text"
                   value={drafts[f.key] ?? ""}
                   onChange={(e) => setDrafts((d) => ({ ...d, [f.key]: e.target.value }))}
-                  placeholder={f.sensitive ? "op://Vault/Item/field" : "Enter a value (e.g. a directory path)"}
+                  placeholder={f.sensitive ? "Paste a secret or op://Vault/Item/field" : "Enter a value (e.g. a directory path)"}
                   aria-label={`${f.title} value`}
                   className="min-w-0 flex-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 text-[12px] text-[var(--text-primary)] outline-none focus:border-[var(--border-strong)]"
                   style={{ height: 32 }}
@@ -184,7 +183,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
               ) : null}
               {f.sensitive ? (
                 <p className="text-[10px] text-[var(--text-muted)]">
-                  Requires the 1Password CLI (op). Manage refs in Settings → Vault.
+                  Raw values are saved encrypted on this machine. op:// refs still use 1Password.
                 </p>
               ) : null}
             </div>

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -18,6 +18,10 @@ assert.match(src, /tool\.outdated \? `\$\{tool\.current\} -> \$\{tool\.latest\}`
 assert.doesNotMatch(src, /tool\.latest\s*\?\s*` -> \$\{tool\.latest\}`/, "version line must not advertise latest when npm latest is older than installed");
 assert.doesNotMatch(src, /tool\.installed \? "Up to date" : "Not found"/, "installed-but-version-unknown tools must not fall through to Up to date");
 assert.match(src, /coven-code/, "coven-code is included in the client install target type");
+assert.match(src, /function buildDiagnosticsText/, "tool diagnostics text is centralized");
+assert.match(src, /navigator\.clipboard\.writeText/, "component can copy tool diagnostics for debugging");
+assert.match(src, /Copy diagnostics/, "About tools exposes a copy diagnostics action");
+assert.match(src, /sidecarTokenPresent/, "diagnostics include whether the sidecar auth bridge captured a token");
 assert.match(src, /Check tools/, "component offers a manual re-check");
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");
 assert.match(settings, /<SettingsGroup label="OpenCoven tools">[\s\S]*<OpenCovenToolsUpdate \/>/, "About settings renders the OpenCoven tools group");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -31,6 +31,8 @@ type InstallResult = {
   detail: string;
 };
 
+const SIDECAR_TOKEN_STORAGE_KEY = "coven-cave:sidecar-auth-token";
+
 function formatElapsed(ms: number): string {
   const seconds = Math.max(0, Math.floor(ms / 1000));
   const minutes = Math.floor(seconds / 60);
@@ -54,10 +56,53 @@ function toolStatusText(tool: ToolStatus): string {
   return "Up to date";
 }
 
+function buildDiagnosticsText({
+  tools,
+  checking,
+  error,
+  installJobs,
+  installResults,
+  href,
+  userAgent,
+  sidecarTokenPresent,
+  tauriInternalsPresent,
+}: {
+  tools: ToolStatus[];
+  checking: boolean;
+  error: string | null;
+  installJobs: Partial<Record<InstallTarget, InstallJobView>>;
+  installResults: Partial<Record<InstallTarget, InstallResult>>;
+  href: string;
+  userAgent: string;
+  sidecarTokenPresent: boolean;
+  tauriInternalsPresent: boolean;
+}): string {
+  return JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      surface: "Settings/About/OpenCoven tools",
+      location: href,
+      userAgent,
+      sidecarTokenPresent,
+      tauriInternalsPresent,
+      checking,
+      error,
+      tools,
+      installJobs,
+      installResults,
+    },
+    null,
+    2,
+  );
+}
+
 export function OpenCovenToolsUpdate() {
   const [tools, setTools] = useState<ToolStatus[]>([]);
   const [checking, setChecking] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [diagnosticsStatus, setDiagnosticsStatus] = useState<
+    "idle" | "copied" | "failed"
+  >("idle");
   const [installJobs, setInstallJobs] = useState<
     Partial<Record<InstallTarget, InstallJobView>>
   >({});
@@ -211,10 +256,43 @@ export function OpenCovenToolsUpdate() {
     }
   };
 
+  const copyDiagnostics = async () => {
+    try {
+      const text = buildDiagnosticsText({
+        tools,
+        checking,
+        error,
+        installJobs,
+        installResults,
+        href: window.location.href,
+        userAgent: navigator.userAgent,
+        sidecarTokenPresent: Boolean(
+          window.sessionStorage.getItem(SIDECAR_TOKEN_STORAGE_KEY),
+        ),
+        tauriInternalsPresent: "__TAURI_INTERNALS__" in window,
+      });
+      await navigator.clipboard.writeText(text);
+      setDiagnosticsStatus("copied");
+      window.setTimeout(() => setDiagnosticsStatus("idle"), 1800);
+    } catch {
+      setDiagnosticsStatus("failed");
+    }
+  };
+
   const accentBtn =
     "focus-ring inline-flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50";
   const ghostBtn =
     "focus-ring rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
+  const footerStatusText =
+    diagnosticsStatus === "copied"
+      ? "Diagnostics copied"
+      : diagnosticsStatus === "failed"
+        ? "Diagnostics copy failed"
+        : error
+          ? `Check failed: ${error}`
+          : checking
+            ? "Checking tools..."
+            : "Version source: npm latest";
 
   return (
     <>
@@ -268,13 +346,18 @@ export function OpenCovenToolsUpdate() {
           </div>
         );
       })}
-      <div className="flex items-center justify-between gap-4 px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
         <span className="text-[12px] text-[var(--text-secondary)]">
-          {error ? `Check failed: ${error}` : checking ? "Checking tools..." : "Version source: npm latest"}
+          {footerStatusText}
         </span>
-        <button type="button" onClick={() => void load()} className={ghostBtn} disabled={checking}>
-          Check tools
-        </button>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          <button type="button" onClick={() => void copyDiagnostics()} className={ghostBtn}>
+            Copy diagnostics
+          </button>
+          <button type="button" onClick={() => void load()} className={ghostBtn} disabled={checking}>
+            Check tools
+          </button>
+        </div>
       </div>
     </>
   );

--- a/src/components/vault-automations-filter.test.ts
+++ b/src/components/vault-automations-filter.test.ts
@@ -8,8 +8,8 @@ const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8"
 const vault = read("./vault-panel.tsx");
 assert.match(vault, /import \{ SearchInput \} from "@\/components\/ui\/search-input"/, "vault imports SearchInput");
 assert.match(vault, /<SearchInput[\s\S]*?placeholder="Filter secrets…"/, "vault renders a secrets filter");
-// Filter composes with the undo-pending hide and matches key / ref / description.
-assert.match(vault, /\[m\.key, m\.ref \?\? "", m\.description \?\? ""\]\.join\(" "\)\.toLowerCase\(\)\.includes\(q\)/, "vault filters by key/ref/description");
+// Filter composes with the undo-pending hide and matches key / ref / storage / description.
+assert.match(vault, /\[m\.key, m\.ref \?\? "", m\.storage \?\? "", m\.description \?\? ""\]\.join\(" "\)\.toLowerCase\(\)\.includes\(q\)/, "vault filters by key/ref/storage/description");
 assert.match(vault, /No secrets match/, "vault shows a no-matches message");
 
 const auto = read("./automations-view.tsx");

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -12,11 +12,12 @@ import { useUndoDelete } from "@/lib/use-undo-delete";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type VaultStatus = "resolved" | "env-only" | "unresolved" | "error" | "no-ref";
+type VaultStatus = "resolved" | "encrypted" | "env-only" | "unresolved" | "error" | "no-ref";
 
 type Mapping = {
   key: string;
   ref: string | null;
+  storage: "1password" | "encrypted" | null;
   description: string | null;
   required: boolean;
   status: VaultStatus;
@@ -28,6 +29,7 @@ type Mapping = {
 
 const STATUS_META: Record<VaultStatus, { label: string; color: string; icon: string }> = {
   resolved:   { label: "1Password",   color: "var(--color-success)", icon: "ph:vault" },
+  encrypted:  { label: "encrypted",   color: "var(--accent-presence)", icon: "ph:lock-key" },
   "env-only": { label: "env only",    color: "oklch(0.75 0.15 80)", icon: "ph:file-text" },
   unresolved: { label: "unresolved",  color: "var(--color-danger)", icon: "ph:warning" },
   error:      { label: "error",       color: "var(--color-danger)", icon: "ph:x-circle" },
@@ -61,6 +63,10 @@ function AddMappingForm({
 }) {
   const [key, setKey]         = useState(initial?.key ?? "");
   const [ref, setRef]         = useState(initial?.ref ?? "op://");
+  const [storage, setStorage] = useState<"1password" | "encrypted">(
+    initial?.storage === "encrypted" || initial?.status === "encrypted" ? "encrypted" : "1password",
+  );
+  const [secret, setSecret]   = useState("");
   const [desc, setDesc]       = useState(initial?.description ?? "");
   const [required, setReq]    = useState(initial?.required ?? false);
   const [busy, setBusy]       = useState(false);
@@ -73,7 +79,9 @@ function AddMappingForm({
       const res = await fetch("/api/vault", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ key, ref, description: desc || undefined, required }),
+        body: JSON.stringify(storage === "encrypted"
+          ? { key, storage: "encrypted", value: secret, description: desc || undefined, required }
+          : { key, ref, description: desc || undefined, required }),
       });
       const j = await res.json() as { ok: boolean; error?: string };
       if (!j.ok) throw new Error(j.error ?? "Failed to save");
@@ -99,7 +107,40 @@ function AddMappingForm({
             disabled={!!initial}
           />
         </label>
-        <label className="vault-add-label" style={{ flex: 2 }}>
+        <div className="vault-add-label" style={{ flex: 2 }}>
+          Storage
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              className={`vault-btn${storage === "encrypted" ? " vault-btn--primary" : ""}`}
+              onClick={() => setStorage("encrypted")}
+            >
+              Local encrypted
+            </button>
+            <button
+              type="button"
+              className={`vault-btn${storage === "1password" ? " vault-btn--primary" : ""}`}
+              onClick={() => setStorage("1password")}
+            >
+              1Password
+            </button>
+          </div>
+        </div>
+      </div>
+      {storage === "encrypted" ? (
+        <label className="vault-add-label">
+          Secret value
+          <input
+            className="vault-add-input"
+            type="password"
+            value={secret}
+            onChange={(e) => setSecret(e.target.value)}
+            placeholder={initial ? "Enter a new value" : "Paste secret value"}
+            required
+          />
+        </label>
+      ) : (
+        <label className="vault-add-label">
           1Password reference
           <input
             className="vault-add-input vault-ref-input"
@@ -109,7 +150,7 @@ function AddMappingForm({
             required
           />
         </label>
-      </div>
+      )}
       <label className="vault-add-label">
         Description (optional)
         <input
@@ -204,7 +245,7 @@ export function VaultPanel() {
     const q = query.trim().toLowerCase();
     if (!q) return afterPending;
     return afterPending.filter((m) =>
-      [m.key, m.ref ?? "", m.description ?? ""].join(" ").toLowerCase().includes(q));
+      [m.key, m.ref ?? "", m.storage ?? "", m.description ?? ""].join(" ").toLowerCase().includes(q));
   }, [mappings, deletePending, query]);
 
   return (
@@ -215,7 +256,7 @@ export function VaultPanel() {
           <Icon name="ph:vault" width={14} />
           Secret Vault
         </div>
-        <span className="vault-header-sub">env vars → 1Password references</span>
+        <span className="vault-header-sub">env vars → encrypted local secrets or 1Password references</span>
         <button
           type="button"
           className="vault-btn vault-btn--primary"
@@ -266,7 +307,7 @@ export function VaultPanel() {
           compact
           icon="ph:vault"
           headline="No mappings yet"
-          subtitle="Add one to pull secrets from 1Password automatically."
+          subtitle="Add one to store a local encrypted secret or pull from 1Password."
           actions={
             <Button
               size="xs"
@@ -303,6 +344,9 @@ export function VaultPanel() {
               </div>
               {m.ref && (
                 <div className="vault-row-ref">{m.ref}</div>
+              )}
+              {m.storage === "encrypted" && !m.ref && (
+                <div className="vault-row-ref">Local encrypted secret</div>
               )}
               {m.description && (
                 <div className="vault-row-desc">{m.description}</div>
@@ -348,8 +392,8 @@ export function VaultPanel() {
 
       {/* Footer note */}
       <div className="vault-footer-note">
-        Secrets are never stored on disk — resolved live via <code>op read</code> and
-        cached in process memory. Requires 1Password desktop app + CLI authed.
+        Local secrets are encrypted on disk with a machine-local Cave key. 1Password
+        entries are resolved live via <code>op read</code> and cached in process memory.
       </div>
 
       {deletePending ? (

--- a/src/lib/local-encrypted-vault.test.ts
+++ b/src/lib/local-encrypted-vault.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const home = await mkdtemp(path.join(tmpdir(), "cave-local-vault-"));
+process.env.COVEN_HOME = home;
+delete process.env.GITHUB_PAT;
+
+const {
+  deleteLocalEncryptedSecret,
+  getLocalEncryptedSecret,
+  hasLocalEncryptedSecret,
+  setLocalEncryptedSecret,
+} = await import("./local-encrypted-vault.ts");
+
+await setLocalEncryptedSecret("GITHUB_PAT", "ghp_super_secret_token");
+
+assert.equal(
+  await getLocalEncryptedSecret("GITHUB_PAT"),
+  "ghp_super_secret_token",
+  "encrypted local vault returns the original secret",
+);
+assert.equal(await hasLocalEncryptedSecret("GITHUB_PAT"), true, "encrypted local vault reports stored keys");
+
+const encryptedFile = path.join(home, "cave", "local-vault.enc.json");
+const rawFile = await readFile(encryptedFile, "utf8");
+assert.doesNotMatch(rawFile, /ghp_super_secret_token/, "ciphertext file never stores the plaintext secret");
+assert.match(rawFile, /"alg":\s*"aes-256-gcm"/, "ciphertext records the encryption algorithm");
+
+await deleteLocalEncryptedSecret("GITHUB_PAT");
+assert.equal(await getLocalEncryptedSecret("GITHUB_PAT"), null, "delete removes the encrypted secret");
+assert.equal(await hasLocalEncryptedSecret("GITHUB_PAT"), false, "delete clears stored status");
+
+await rm(home, { recursive: true, force: true });
+
+console.log("local-encrypted-vault.test.ts: ok");

--- a/src/lib/local-encrypted-vault.ts
+++ b/src/lib/local-encrypted-vault.ts
@@ -1,0 +1,132 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { covenHome } from "./coven-paths.ts";
+
+type EncryptedSecret = {
+  v: 1;
+  alg: "aes-256-gcm";
+  iv: string;
+  tag: string;
+  ciphertext: string;
+  updatedAt: string;
+};
+
+type LocalVaultStore = {
+  version: 1;
+  secrets: Record<string, EncryptedSecret>;
+};
+
+function normalizeSecretKey(key: string): string {
+  return key.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+}
+
+function localVaultDir(): string {
+  return join(covenHome(), "cave");
+}
+
+function localVaultKeyPath(): string {
+  return process.env.COVEN_CAVE_LOCAL_VAULT_KEY_FILE?.trim() || join(localVaultDir(), "local-vault.key");
+}
+
+function localVaultPath(): string {
+  return process.env.COVEN_CAVE_LOCAL_VAULT_FILE?.trim() || join(localVaultDir(), "local-vault.enc.json");
+}
+
+function writePrivateText(file: string, value: string): void {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, value, { encoding: "utf8", mode: 0o600 });
+  try { chmodSync(file, 0o600); } catch { /* Windows ignores POSIX modes. */ }
+}
+
+function readOrCreateKey(): Buffer {
+  const file = localVaultKeyPath();
+  if (existsSync(file)) {
+    const raw = readFileSync(file, "utf8").trim();
+    const key = Buffer.from(raw, "base64");
+    if (key.length === 32) return key;
+    throw new Error("local encrypted vault key is invalid");
+  }
+
+  const key = randomBytes(32);
+  writePrivateText(file, `${key.toString("base64")}\n`);
+  return key;
+}
+
+function readStore(): LocalVaultStore {
+  const file = localVaultPath();
+  if (!existsSync(file)) return { version: 1, secrets: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8")) as Partial<LocalVaultStore>;
+    if (parsed.version !== 1 || !parsed.secrets || typeof parsed.secrets !== "object") {
+      return { version: 1, secrets: {} };
+    }
+    return { version: 1, secrets: parsed.secrets };
+  } catch {
+    return { version: 1, secrets: {} };
+  }
+}
+
+function writeStore(store: LocalVaultStore): void {
+  const file = localVaultPath();
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(store, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+  try { chmodSync(tmp, 0o600); } catch { /* Windows ignores POSIX modes. */ }
+  renameSync(tmp, file);
+}
+
+export function setLocalEncryptedSecret(key: string, value: string): void {
+  const normalized = normalizeSecretKey(key);
+  if (!normalized) throw new Error("key is required");
+  if (!value) throw new Error("secret value is required");
+
+  const vaultKey = readOrCreateKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", vaultKey, iv);
+  cipher.setAAD(Buffer.from(normalized, "utf8"));
+  const ciphertext = Buffer.concat([cipher.update(value, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const store = readStore();
+  store.secrets[normalized] = {
+    v: 1,
+    alg: "aes-256-gcm",
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+    ciphertext: ciphertext.toString("base64"),
+    updatedAt: new Date().toISOString(),
+  };
+  writeStore(store);
+}
+
+export function getLocalEncryptedSecret(key: string): string | null {
+  const normalized = normalizeSecretKey(key);
+  if (!normalized) return null;
+  const entry = readStore().secrets[normalized];
+  if (!entry) return null;
+
+  const vaultKey = readOrCreateKey();
+  const decipher = createDecipheriv("aes-256-gcm", vaultKey, Buffer.from(entry.iv, "base64"));
+  decipher.setAAD(Buffer.from(normalized, "utf8"));
+  decipher.setAuthTag(Buffer.from(entry.tag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(entry.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return plaintext.toString("utf8");
+}
+
+export function hasLocalEncryptedSecret(key: string): boolean {
+  const normalized = normalizeSecretKey(key);
+  return !!normalized && !!readStore().secrets[normalized];
+}
+
+export function deleteLocalEncryptedSecret(key: string): void {
+  const normalized = normalizeSecretKey(key);
+  if (!normalized) return;
+  const store = readStore();
+  if (!store.secrets[normalized]) return;
+  delete store.secrets[normalized];
+  writeStore(store);
+}

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { validateOpRef } from "./vault.ts";
 
 assert.equal(validateOpRef("op://Personal/GitHub/token"), null);
@@ -9,3 +10,23 @@ assert.equal(validateOpRef({ ref: "op://Personal/GitHub/token" }), "ref must be 
 assert.equal(validateOpRef("https://example.test"), "ref must start with op://");
 assert.equal(validateOpRef("op://Personal/GitHub"), "ref must include vault, item, and field segments");
 assert.equal(validateOpRef("op://Personal/GitHub/token;rm -rf"), "ref contains invalid characters");
+
+const vaultSource = readFileSync(new URL("./vault.ts", import.meta.url), "utf8");
+const routeSource = readFileSync(new URL("../app/api/vault/route.ts", import.meta.url), "utf8");
+const githubPatRouteSource = readFileSync(new URL("../app/api/github/pat/route.ts", import.meta.url), "utf8");
+const panelSource = readFileSync(new URL("../components/vault-panel.tsx", import.meta.url), "utf8");
+const marketplaceConfigureSource = readFileSync(new URL("../components/marketplace/marketplace-configure.tsx", import.meta.url), "utf8");
+
+assert.match(vaultSource, /getLocalEncryptedSecret/, "vault resolver can load locally encrypted secrets");
+assert.match(vaultSource, /"encrypted"/, "vault statuses include encrypted local storage");
+assert.match(routeSource, /setLocalEncryptedSecret/, "/api/vault can save encrypted local secrets");
+assert.match(routeSource, /deleteLocalEncryptedSecret/, "/api/vault deletes encrypted local secrets");
+assert.doesNotMatch(routeSource, /applyEnvUpdates/, "/api/vault must not persist encrypted secrets to .env.local");
+assert.match(githubPatRouteSource, /setLocalEncryptedSecret\(PAT_KEY, pat\)/, "GitHub PAT setup stores tokens in the encrypted local vault");
+assert.doesNotMatch(githubPatRouteSource, /updates\[PAT_KEY\] = pat/, "GitHub PAT setup does not write tokens to .env.local");
+assert.match(panelSource, /Local encrypted/, "Vault panel exposes local encrypted storage as a first-class option");
+assert.match(panelSource, /type="password"/, "Vault panel uses a password input for raw local secrets");
+assert.match(marketplaceConfigureSource, /storage: "encrypted", value: draft/, "Marketplace sensitive config can save raw values through the encrypted vault");
+assert.doesNotMatch(marketplaceConfigureSource, /enter a 1Password reference/, "Marketplace sensitive config no longer requires 1Password");
+
+console.log("vault.test.ts: ok");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,12 +1,14 @@
 /**
- * Cave Vault — resolves env vars from 1Password secret references
+ * Cave Vault — resolves env vars from encrypted local secrets or 1Password references
  *
- * vault.yaml maps ENV_VAR_NAME → { ref: "op://Vault/Item/field", ... }
+ * vault.yaml maps ENV_VAR_NAME → { storage: "encrypted" } or { ref: "op://Vault/Item/field", ... }
  *
  * Resolution priority:
  *   1. Already in process.env (e.g. set by .env.local or OS env) → use as-is
- *   2. vault.yaml has a ref for this key → resolve via `op read`
- *   3. undefined
+ *   2. Writable .env.local legacy fallback → use as-is
+ *   3. Local encrypted vault → decrypt into process memory
+ *   4. vault.yaml has a ref for this key → resolve via `op read`
+ *   5. undefined
  *
  * Resolved values are cached in process.env for the lifetime of the process
  * so subsequent calls are instant. The raw secret value is NEVER written to
@@ -19,22 +21,25 @@ import { dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { covenHome } from "./coven-paths.ts";
 import { readEnvLocalValue } from "./env-file.ts";
+import { getLocalEncryptedSecret, hasLocalEncryptedSecret } from "./local-encrypted-vault.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export type VaultEntry = {
-  ref: string;
+  ref?: string;
+  storage?: "1password" | "encrypted";
   description?: string;
   required?: boolean;
 };
 
 export type VaultMap = Record<string, VaultEntry>;
 
-export type VaultStatus = "resolved" | "env-only" | "unresolved" | "error" | "no-ref";
+export type VaultStatus = "resolved" | "encrypted" | "env-only" | "unresolved" | "error" | "no-ref";
 
 export type VaultMappingStatus = {
   key: string;
   ref: string | null;
+  storage: "1password" | "encrypted" | null;
   description: string | null;
   required: boolean;
   status: VaultStatus;
@@ -118,21 +123,27 @@ export function loadVaultMap(force = false): VaultMap {
 export function saveVaultMap(map: VaultMap): void {
   // Serialise back to YAML manually (keeps comments stripped but structure clean)
   const lines = [
-    "# Cave Vault — env var → 1Password secret reference map",
+    "# Cave Vault — env var → encrypted local secret or 1Password reference map",
     "#",
     "# Format:",
     '#   ENV_VAR_NAME:',
+    '#     storage: "encrypted"',
+    "#   ANOTHER_ENV_VAR:",
     '#     ref: "op://VaultName/ItemTitle/field"',
     '#     description: "human-readable note"',
     "#     required: false",
     "#",
-    "# Secrets are NEVER stored here — only the op:// reference.",
+    "# Secrets are NEVER stored here — only storage metadata or an op:// reference.",
     "# Safe to commit; contains no credentials.",
     "",
   ];
   for (const [key, entry] of Object.entries(map)) {
     lines.push(`${key}:`);
-    lines.push(`  ref: "${entry.ref}"`);
+    if (entry.storage === "encrypted") {
+      lines.push('  storage: "encrypted"');
+    } else if (entry.ref) {
+      lines.push(`  ref: "${entry.ref}"`);
+    }
     if (entry.description) lines.push(`  description: "${entry.description.replace(/"/g, "'")}"`);
     if (entry.required) lines.push(`  required: true`);
     lines.push("");
@@ -182,7 +193,7 @@ function opRead(ref: string): string | null {
 
 /**
  * Resolve an env var by key.
- * Checks process.env first, then vault.yaml → `op read`.
+ * Checks process.env first, then local encrypted vault, then vault.yaml → `op read`.
  * Caches in process.env on success.
  * Never logs or persists the value to disk.
  */
@@ -200,9 +211,18 @@ export function resolveSecret(key: string): string | undefined {
     return fromFile;
   }
 
-  // Try vault
   const map = loadVaultMap();
   const entry = map[key];
+
+  const localEncrypted = entry?.storage === "encrypted" || hasLocalEncryptedSecret(key)
+    ? getLocalEncryptedSecret(key)
+    : null;
+  if (localEncrypted?.trim()) {
+    process.env[key] = localEncrypted.trim();
+    return localEncrypted.trim();
+  }
+
+  // Try 1Password vault reference
   if (!entry?.ref) return undefined;
 
   const value = opRead(entry.ref);
@@ -225,9 +245,48 @@ export function getVaultStatuses(): VaultMappingStatus[] {
   return Object.entries(map).map(([key, entry]) => {
     const inEnv = !!(process.env[key]?.trim());
 
+    if (entry.storage === "encrypted" || hasLocalEncryptedSecret(key)) {
+      try {
+        const value = getLocalEncryptedSecret(key);
+        if (value) {
+          process.env[key] = value;
+          return {
+            key, ref: entry.ref ?? null, description: entry.description ?? null,
+            storage: "encrypted",
+            required: entry.required ?? false,
+            status: "encrypted" as VaultStatus, hasValue: true,
+          };
+        }
+        if (inEnv) {
+          return {
+            key, ref: entry.ref ?? null, description: entry.description ?? null,
+            storage: "encrypted",
+            required: entry.required ?? false,
+            status: "env-only" as VaultStatus, hasValue: true,
+          };
+        }
+        return {
+          key, ref: entry.ref ?? null, description: entry.description ?? null,
+          storage: "encrypted",
+          required: entry.required ?? false,
+          status: "unresolved" as VaultStatus, hasValue: false,
+          error: "encrypted local secret is missing",
+        };
+      } catch (e) {
+        return {
+          key, ref: entry.ref ?? null, description: entry.description ?? null,
+          storage: "encrypted",
+          required: entry.required ?? false,
+          status: "error" as VaultStatus, hasValue: false,
+          error: e instanceof Error ? e.message : "unknown error",
+        };
+      }
+    }
+
     if (inEnv) {
       return {
-        key, ref: entry.ref, description: entry.description ?? null,
+        key, ref: entry.ref ?? null, description: entry.description ?? null,
+        storage: entry.storage ?? (entry.ref ? "1password" : null),
         required: entry.required ?? false,
         status: "env-only" as VaultStatus, hasValue: true,
       };
@@ -236,6 +295,7 @@ export function getVaultStatuses(): VaultMappingStatus[] {
     if (!entry.ref) {
       return {
         key, ref: null, description: entry.description ?? null,
+        storage: entry.storage ?? null,
         required: entry.required ?? false,
         status: "no-ref" as VaultStatus, hasValue: false,
       };
@@ -247,12 +307,14 @@ export function getVaultStatuses(): VaultMappingStatus[] {
         process.env[key] = value; // cache
         return {
           key, ref: entry.ref, description: entry.description ?? null,
+          storage: "1password",
           required: entry.required ?? false,
           status: "resolved" as VaultStatus, hasValue: true,
         };
       }
       return {
         key, ref: entry.ref, description: entry.description ?? null,
+        storage: "1password",
         required: entry.required ?? false,
         status: "unresolved" as VaultStatus, hasValue: false,
         error: "op read returned empty — check ref or 1Password auth",
@@ -260,6 +322,7 @@ export function getVaultStatuses(): VaultMappingStatus[] {
     } catch (e) {
       return {
         key, ref: entry.ref, description: entry.description ?? null,
+        storage: "1password",
         required: entry.required ?? false,
         status: "error" as VaultStatus, hasValue: false,
         error: e instanceof Error ? e.message : "unknown error",


### PR DESCRIPTION
## Summary
- add a local AES-256-GCM encrypted vault backend for env secrets when users opt out of 1Password
- route GitHub PAT saves into the encrypted vault and remove plaintext PAT shadow writes to .env.local
- open GitHub PAT creation through the external browser helper instead of localhost-hosted app navigation
- add About/OpenCoven tools diagnostics copying and suppress Windows sidecar console windows

## Verification
- pnpm test:app
- node --experimental-strip-types src/lib/local-encrypted-vault.test.ts
- node --experimental-strip-types src/lib/vault.test.ts
- node --experimental-strip-types src/components/github-view-polish.test.ts
- node --experimental-strip-types src/components/board-inspector-a11y.test.ts
- node --experimental-strip-types src/components/open-coven-tools-update.test.ts
- node src-tauri/release-runtime.test.mjs
- pnpm exec tsc --noEmit
- pnpm check:tests-wired
- cargo check --manifest-path src-tauri/Cargo.toml
- git diff --check