### PR TITLE
fix(onboarding): empty-state for the runtime install list

### DIFF
--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1900,7 +1900,22 @@ function StepRuntimes({
         </button>
       </div>
       <div className="grid gap-2 sm:grid-cols-2">
-        {chatHarnesses.map((adapter) => {
+        {chatHarnesses.length === 0 ? (
+          <div className="rounded-md border border-dashed border-[var(--border-hairline)] bg-[var(--bg-base)]/35 px-3 py-4 text-[11px] leading-5 text-[var(--text-secondary)] sm:col-span-2">
+            <p className="font-medium text-[var(--text-primary)]">
+              Couldn&rsquo;t load the runtime list.
+            </p>
+            <p className="mt-1">
+              Cave couldn&rsquo;t reach the runtime probe. Click{" "}
+              <span className="font-medium text-[var(--text-primary)]">
+                Refresh
+              </span>{" "}
+              above, or restart Cave so its PATH applies — installed runtimes
+              show up here once detected.
+            </p>
+          </div>
+        ) : (
+          chatHarnesses.map((adapter) => {
           const oneClick = HARNESS_ONE_CLICK[adapter.id];
           const result = oneClick ? installResults[oneClick.target] : undefined;
           const job = oneClick ? installJobs[oneClick.target] : undefined;
@@ -2027,7 +2042,8 @@ function StepRuntimes({
               ) : null}
             </div>
           );
-        })}
+          })
+        )}
       </div>
       {nodeHint ? (
         <p className="text-[11px] leading-4 text-[var(--color-warning)]">


### PR DESCRIPTION
## Problem

Follow-up to #1985. The **"Install a runtime"** step (`StepRuntimes`) maps `chatHarnesses` into a `grid` with no empty-state. When `/api/harnesses` returns `[]` — the degraded minimal-PATH case (cave launched from Finder/Spotlight) where the probe can't even reach the runtime catalog — the grid renders **blank**, the same visual bug #1985 fixed for Option A on step 5.

## Change

Wrap the map in a `chatHarnesses.length === 0` empty-state: a full-width (`sm:col-span-2`) dashed-border message:

> **Couldn't load the runtime list.** Cave couldn't reach the runtime probe. Click **Refresh** above, or restart Cave so its PATH applies — installed runtimes show up here once detected.

The copy intentionally differs from Option A's "install one in step 3" — an empty runtime *catalog* (vs. an empty *installed* list) means the probe/route failed, so this points at Refresh/restart rather than installing.

## Verification

Drove the real onboarding component to step 3 with `/api/harnesses` mocked to `[]` (dev server, live source) and screenshotted — the empty-state renders full-width where the grid was previously blank. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)