### PR TITLE
fix(windows): launch coven via node, not the .cmd shim, so /api/harnesses stops 500ing

### DIFF
--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/cave-board-types";
 import { normalizeTaskGitHubLinks } from "@/lib/task-github";
 import { bindingFor, loadConfig } from "@/lib/cave-config";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenInvocation, covenSpawnEnv } from "@/lib/coven-bin";
 import { familiarWorkspace } from "@/lib/coven-paths";
 import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import { spawn } from "node:child_process";
@@ -221,7 +221,8 @@ function runCoven(
     try {
       let out = "";
       let settled = false;
-      const child = spawn(covenBin(), args, {
+      const { command, prefixArgs } = covenInvocation();
+      const child = spawn(command, [...prefixArgs, ...args], {
         cwd: familiarWorkspacePath ?? process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],
         env: covenSpawnEnv(),

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -31,7 +31,7 @@ import {
   toPersistedTools,
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenInvocation, covenSpawnEnv } from "@/lib/coven-bin";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import {
   buildPromptWithKnowledgeVault,
@@ -393,7 +393,8 @@ function covenRunSupportsModel(): Promise<boolean> {
         resolve(value);
       };
       try {
-        const child = spawn(covenBin(), ["run", "--help"], {
+        const { command, prefixArgs } = covenInvocation();
+        const child = spawn(command, [...prefixArgs, "run", "--help"], {
           env: covenSpawnEnv(),
           stdio: ["ignore", "pipe", "pipe"],
         });
@@ -1300,16 +1301,22 @@ export async function POST(req: Request) {
                   env: covenSpawnEnv(),
                 });
               })()
-            : spawn(covenBin(), spawnArgs, {
-                // Spawn IN the familiar's workspace when no project root was
-                // supplied, so coven's project-root resolver picks that dir as
-                // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
-                // from the familiar's home. When a project root IS supplied,
-                // honor that instead.
-                cwd: familiarCwd ?? cwd,
-                stdio: ["ignore", "pipe", "pipe"],
-                env: covenSpawnEnv(),
-              });
+            : (() => {
+                // covenInvocation() resolves the Windows `.cmd` shim to
+                // `node coven.js` so the prompt-bearing argv never goes through
+                // a shell (no quoting/injection hazard); identity elsewhere.
+                const { command, prefixArgs } = covenInvocation();
+                return spawn(command, [...prefixArgs, ...spawnArgs], {
+                  // Spawn IN the familiar's workspace when no project root was
+                  // supplied, so coven's project-root resolver picks that dir as
+                  // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
+                  // from the familiar's home. When a project root IS supplied,
+                  // honor that instead.
+                  cwd: familiarCwd ?? cwd,
+                  stdio: ["ignore", "pipe", "pipe"],
+                  env: covenSpawnEnv(),
+                });
+              })();
 
           const onAbort = () => {
             try {

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import { stripAnsi } from "@/lib/ansi";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenInvocation, covenSpawnEnv } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 
 export const dynamic = "force-dynamic";
@@ -31,7 +31,8 @@ export async function POST(req: Request) {
   const args = [body.command, ...(SUBCOMMAND_ARGS[body.command] ?? [])];
 
   return new Promise<Response>((resolve) => {
-    const child = spawn(covenBin(), args, {
+    const { command, prefixArgs } = covenInvocation();
+    const child = spawn(command, [...prefixArgs, ...args], {
       stdio: ["ignore", "pipe", "pipe"],
       env: covenSpawnEnv(),
     });

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -11,7 +11,7 @@ import {
   type AdapterReport,
   type CovenAdapterSummary,
 } from "@/lib/harness-adapters";
-import { covenBin, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
+import { covenInvocation, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
 
 export const dynamic = "force-dynamic";
 
@@ -57,7 +57,16 @@ async function which(binary: string): Promise<string | null> {
 
 function probeVersion(binary: string, args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn(binary, args, { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    let child;
+    try {
+      // spawn() throws synchronously (EINVAL) for a `.cmd`/`.bat` binary on
+      // modern Node — a version probe is best-effort, so degrade to null
+      // instead of letting it reject and 500 the whole route.
+      child = spawn(binary, args, { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      resolve(null);
+      return;
+    }
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -78,7 +87,8 @@ function probeVersion(binary: string, args: string[]): Promise<string | null> {
 
 function covenSupportsAdapterList(): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn(covenBin(), ["--help"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    const { command, prefixArgs } = covenInvocation();
+    const child = spawn(command, [...prefixArgs, "--help"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -99,7 +109,8 @@ function covenSupportsAdapterList(): Promise<boolean> {
 
 function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
   return new Promise((resolve) => {
-    const child = spawn(covenBin(), ["adapter", "list", "--json"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
+    const { command, prefixArgs } = covenInvocation();
+    const child = spawn(command, [...prefixArgs, "adapter", "list", "--json"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     const t = setTimeout(() => {
       child.kill("SIGTERM");

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenInvocation, covenSpawnEnv } from "@/lib/coven-bin";
 import {
   openCovenToolStatuses,
   type OpenCovenToolStatus,
@@ -121,14 +121,15 @@ async function checkHarnessAdapters(
 
 async function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
   try {
-    const { stdout: helpText } = await execFileAsync(covenBin(), ["--help"], {
+    const { command, prefixArgs } = covenInvocation();
+    const { stdout: helpText } = await execFileAsync(command, [...prefixArgs, "--help"], {
       env: covenSpawnEnv(),
       timeout: 1500,
     });
     if (!covenHelpSupportsAdapterList(helpText)) return [];
     const { stdout } = await execFileAsync(
-      covenBin(),
-      ["adapter", "list", "--json"],
+      command,
+      [...prefixArgs, "adapter", "list", "--json"],
       {
         env: covenSpawnEnv(),
         timeout: 3000,

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -38,4 +38,28 @@ assert.match(
   "desktop install retries can refresh Cave's cached PATH after Node/npm is installed",
 );
 
+// Modern Node throws EINVAL when spawning a `.cmd`/`.bat` without shell:true
+// (CVE-2024-27980). covenInvocation() sidesteps that on Windows by running the
+// shim's underlying Node script via `node <script>`, which is also safe for the
+// prompt-bearing chat argv (no shell quoting/injection). The two regressions
+// this guards against: a 500 on /api/harnesses (blank onboarding "Option A")
+// and broken chat spawns on Windows.
+assert.match(
+  source,
+  /export function covenInvocation\(\):/,
+  "covenInvocation() is exported for spawn sites to resolve the launch command",
+);
+
+assert.match(
+  source,
+  /process\.platform === "win32"[\s\S]*\\\.\(cmd\|bat\)[\s\S]*process\.execPath/,
+  "covenInvocation routes a Windows .cmd/.bat shim through `node` (process.execPath)",
+);
+
+assert.match(
+  source,
+  /resolveWindowsShimTarget[\s\S]*%dp0%[\s\S]*\.\[cm\]\?js/,
+  "the shim resolver parses the npm/pnpm .cmd for its node script (.js/.cjs/.mjs) target",
+);
+
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -23,12 +23,13 @@
 // `covenSpawnEnv()` for the env option.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 let cachedBin: string | null = null;
 let cachedPath: string | null = null;
+let cachedInvocation: { command: string; prefixArgs: string[] } | null = null;
 
 const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT"] as const;
 
@@ -151,6 +152,63 @@ export function covenBin(): string {
 
   cachedBin = "coven";
   return cachedBin;
+}
+
+// Parse an npm/pnpm `.cmd` shim for the Node script it execs, e.g. the line
+//   "%_prog%" "%dp0%\node_modules\@opencoven\cli\bin\coven.js" %*
+// Falls back to the conventional npm-global layout when the shim format is
+// unrecognized. Returns an absolute path to the `.js` entry, or null.
+function resolveWindowsShimTarget(cmdPath: string): string | null {
+  const binDir = path.dirname(cmdPath);
+  try {
+    const text = readFileSync(cmdPath, "utf-8");
+    const match = text.match(/%dp0%[\\/]+(\S+?\.[cm]?js)"/i);
+    if (match) {
+      const resolved = path.join(binDir, match[1].replace(/[\\/]+/g, path.sep));
+      if (existsSync(resolved)) return resolved;
+    }
+  } catch {
+    /* unreadable shim — fall through to the conventional layout */
+  }
+  const fallback = path.join(
+    binDir,
+    "node_modules",
+    "@opencoven",
+    "cli",
+    "bin",
+    "coven.js",
+  );
+  return existsSync(fallback) ? fallback : null;
+}
+
+/**
+ * Resolve how to launch `coven` as a child process: the command plus a fixed
+ * argv prefix that callers prepend to their own args.
+ *
+ * Why this exists: on Windows, npm/pnpm install `coven` as a `.cmd` (batch)
+ * shim. Since the CVE-2024-27980 hardening (Node >=18.20 / 20.12 / 21.7),
+ * `child_process.spawn()`/`execFile()` THROW `EINVAL` when handed a `.cmd` or
+ * `.bat` unless `shell: true` is set — and shell mode is unsafe for argv that
+ * carries user text (chat prompt content). So resolve the shim to the Node
+ * script it wraps and run `node <script>` directly, which safely accepts
+ * arbitrary args. On macOS/Linux `coven` is a real executable, so this is the
+ * identity ({ command: covenBin(), prefixArgs: [] }).
+ *
+ * Usage: const { command, prefixArgs } = covenInvocation();
+ *        spawn(command, [...prefixArgs, ...yourArgs], opts);
+ */
+export function covenInvocation(): { command: string; prefixArgs: string[] } {
+  if (cachedInvocation) return cachedInvocation;
+  const bin = covenBin();
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(bin)) {
+    const script = resolveWindowsShimTarget(bin);
+    if (script) {
+      cachedInvocation = { command: process.execPath, prefixArgs: [script] };
+      return cachedInvocation;
+    }
+  }
+  cachedInvocation = { command: bin, prefixArgs: [] };
+  return cachedInvocation;
 }
 
 /**

--- a/src/lib/coven-version.ts
+++ b/src/lib/coven-version.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { covenBin, covenSpawnEnv } from "./coven-bin.ts";
+import { covenInvocation, covenSpawnEnv } from "./coven-bin.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -26,7 +26,8 @@ export function displayCovenVersion({
 
 export async function installedCovenVersion(): Promise<string | null> {
   try {
-    const { stdout, stderr } = await execFileAsync(covenBin(), ["--version"], {
+    const { command, prefixArgs } = covenInvocation();
+    const { stdout, stderr } = await execFileAsync(command, [...prefixArgs, "--version"], {
       env: covenSpawnEnv(),
       timeout: 2500,
     });


### PR DESCRIPTION
## Problem

On Windows, `/api/harnesses` returns **HTTP 500 (`spawn EINVAL`)**, so the onboarding *"Create your familiar"* step renders a **blank Option A / empty runtime list** even when runtimes (Claude Code, Hermes) are installed. The user gets stuck at onboarding with nothing selectable.

### Root cause

npm installs `coven` as a `.cmd` shim on Windows. Since the CVE-2024-27980 hardening (Node ≥18.20 / 20.12 / 21.7), `child_process.spawn()` / `execFile()` throw `EINVAL` when handed a `.cmd`/`.bat` unless `shell: true`. Several routes spawn `covenBin()` (which resolves to `coven.cmd`) directly:

```
⨯ Error: spawn EINVAL
    at covenSupportsAdapterList (src/app/api/harnesses/route.ts)
    at GET
  errno: -4071, code: 'EINVAL', syscall: 'spawn'
```

`covenSupportsAdapterList()` rejects → `GET` 500s → the client's `loadHarnesses` swallows the error → `harnesses` stays `[]` → blank grid.

The recent empty-state + PATH re-probe work (#1985 / #1988) improves the *message* but not the outcome on Windows: PATH was never the problem — the `.cmd` spawn is.

## Fix

Add `covenInvocation()` to `coven-bin.ts`: on a Windows `.cmd`/`.bat` shim it resolves the underlying Node script and returns `{ command: <node>, prefixArgs: [script] }`; it's the identity on macOS/Linux. Unlike `shell: true`, running `node <script>` directly stays **safe for the prompt-bearing `chat/send` argv** (no shell quoting/injection).

Routed the broken spawn/exec sites through it — `harnesses`, `onboarding/status`, `chat/send`, `coven-version`, `board/enrich-steps`, `coven/exec` — and made the harness version probe `EINVAL`-safe. `daemon/start` and `onboarding/install` already used `shell: process.platform === "win32"` for their fixed argv and are left unchanged.

## Verification

- Repro on Windows 11 / Node 24.12: `/api/harnesses` flipped **500 → 200**, now returns Claude Code + Hermes as `installed: true`; Option A renders them selectable.
- `coven-bin.test.ts` extended with assertions for the new path (kept alongside the `refreshCovenSpawnEnv` assertion from #1985); passes.
- Type-strip syntax check passes on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
