### PR TITLE
fix(windows): launch coven npm shim through node

### DIFF
--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/cave-board-types";
 import { normalizeTaskGitHubLinks } from "@/lib/task-github";
 import { bindingFor, loadConfig } from "@/lib/cave-config";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
 import { familiarWorkspace } from "@/lib/coven-paths";
 import { isTrustedChatHarness } from "@/lib/harness-adapters";
 import { spawn } from "node:child_process";
@@ -221,7 +221,8 @@ function runCoven(
     try {
       let out = "";
       let settled = false;
-      const child = spawn(covenBin(), args, {
+      const { command, fixedArgs } = covenLaunchCommand();
+      const child = spawn(command, [...fixedArgs, ...args], {
         cwd: familiarWorkspacePath ?? process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],
         env: covenSpawnEnv(),

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -31,7 +31,7 @@ import {
   toPersistedTools,
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import {
   buildPromptWithKnowledgeVault,
@@ -393,7 +393,8 @@ function covenRunSupportsModel(): Promise<boolean> {
         resolve(value);
       };
       try {
-        const child = spawn(covenBin(), ["run", "--help"], {
+        const { command, fixedArgs } = covenLaunchCommand();
+        const child = spawn(command, [...fixedArgs, "run", "--help"], {
           env: covenSpawnEnv(),
           stdio: ["ignore", "pipe", "pipe"],
         });
@@ -1300,16 +1301,19 @@ export async function POST(req: Request) {
                   env: covenSpawnEnv(),
                 });
               })()
-            : spawn(covenBin(), spawnArgs, {
-                // Spawn IN the familiar's workspace when no project root was
-                // supplied, so coven's project-root resolver picks that dir as
-                // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
-                // from the familiar's home. When a project root IS supplied,
-                // honor that instead.
-                cwd: familiarCwd ?? cwd,
-                stdio: ["ignore", "pipe", "pipe"],
-                env: covenSpawnEnv(),
-              });
+            : (() => {
+                const { command, fixedArgs } = covenLaunchCommand();
+                return spawn(command, [...fixedArgs, ...spawnArgs], {
+                  // Spawn IN the familiar's workspace when no project root was
+                  // supplied, so coven's project-root resolver picks that dir as
+                  // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
+                  // from the familiar's home. When a project root IS supplied,
+                  // honor that instead.
+                  cwd: familiarCwd ?? cwd,
+                  stdio: ["ignore", "pipe", "pipe"],
+                  env: covenSpawnEnv(),
+                });
+              })();
 
           const onAbort = () => {
             try {

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import { stripAnsi } from "@/lib/ansi";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 
 export const dynamic = "force-dynamic";
@@ -31,7 +31,8 @@ export async function POST(req: Request) {
   const args = [body.command, ...(SUBCOMMAND_ARGS[body.command] ?? [])];
 
   return new Promise<Response>((resolve) => {
-    const child = spawn(covenBin(), args, {
+    const { command, fixedArgs } = covenLaunchCommand();
+    const child = spawn(command, [...fixedArgs, ...args], {
       stdio: ["ignore", "pipe", "pipe"],
       env: covenSpawnEnv(),
     });

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -11,7 +11,7 @@ import {
   type AdapterReport,
   type CovenAdapterSummary,
 } from "@/lib/harness-adapters";
-import { covenBin, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
 
 export const dynamic = "force-dynamic";
 
@@ -57,7 +57,13 @@ async function which(binary: string): Promise<string | null> {
 
 function probeVersion(binary: string, args: string[]): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = spawn(binary, args, { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    let child;
+    try {
+      child = spawn(binary, args, { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    } catch {
+      resolve(null);
+      return;
+    }
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -78,7 +84,8 @@ function probeVersion(binary: string, args: string[]): Promise<string | null> {
 
 function covenSupportsAdapterList(): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn(covenBin(), ["--help"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    const { command, fixedArgs } = covenLaunchCommand();
+    const child = spawn(command, [...fixedArgs, "--help"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -99,7 +106,8 @@ function covenSupportsAdapterList(): Promise<boolean> {
 
 function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
   return new Promise((resolve) => {
-    const child = spawn(covenBin(), ["adapter", "list", "--json"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
+    const { command, fixedArgs } = covenLaunchCommand();
+    const child = spawn(command, [...fixedArgs, "adapter", "list", "--json"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     const t = setTimeout(() => {
       child.kill("SIGTERM");

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
 import {
   openCovenToolStatuses,
   type OpenCovenToolStatus,
@@ -121,14 +121,15 @@ async function checkHarnessAdapters(
 
 async function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
   try {
-    const { stdout: helpText } = await execFileAsync(covenBin(), ["--help"], {
+    const { command, fixedArgs } = covenLaunchCommand();
+    const { stdout: helpText } = await execFileAsync(command, [...fixedArgs, "--help"], {
       env: covenSpawnEnv(),
       timeout: 1500,
     });
     if (!covenHelpSupportsAdapterList(helpText)) return [];
     const { stdout } = await execFileAsync(
-      covenBin(),
-      ["adapter", "list", "--json"],
+      command,
+      [...fixedArgs, "adapter", "list", "--json"],
       {
         env: covenSpawnEnv(),
         timeout: 3000,

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -4,7 +4,10 @@
 // that shape when launched as a desktop app, otherwise /api/onboarding/status
 // can find `coven` while later spawns still fail with ENOENT.
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { covenLaunchCommandForBinary } from "./coven-bin.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 
@@ -36,6 +39,47 @@ assert.match(
   source,
   /export function refreshCovenSpawnEnv\(\)[\s\S]*cachedPath = null[\s\S]*return covenSpawnEnv\(\)/,
   "desktop install retries can refresh Cave's cached PATH after Node/npm is installed",
+);
+
+assert.deepEqual(
+  covenLaunchCommandForBinary("/usr/local/bin/coven", "darwin"),
+  { command: "/usr/local/bin/coven", fixedArgs: [] },
+  "non-Windows platforms launch the resolved coven binary directly",
+);
+
+const npmShimDir = await mkdtemp(path.join(os.tmpdir(), "coven-npm-shim-"));
+const npmShimScript = path.join(npmShimDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
+await mkdir(path.dirname(npmShimScript), { recursive: true });
+await writeFile(npmShimScript, "console.log('coven');\n");
+const npmShim = path.join(npmShimDir, "coven.cmd");
+await writeFile(
+  npmShim,
+  [
+    "@ECHO off",
+    "SETLOCAL",
+    "CALL :find_dp0",
+    'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\cli\\bin\\coven.js" %*',
+    "",
+  ].join("\r\n"),
+);
+
+assert.deepEqual(
+  covenLaunchCommandForBinary(npmShim, "win32"),
+  { command: process.execPath, fixedArgs: [npmShimScript] },
+  "Windows npm .cmd shims launch through node plus the shim target script",
+);
+
+const fallbackShimDir = await mkdtemp(path.join(os.tmpdir(), "coven-fallback-shim-"));
+const fallbackScript = path.join(fallbackShimDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
+await mkdir(path.dirname(fallbackScript), { recursive: true });
+await writeFile(fallbackScript, "console.log('fallback coven');\n");
+const fallbackShim = path.join(fallbackShimDir, "coven.cmd");
+await writeFile(fallbackShim, "@ECHO off\r\nREM unknown shim shape\r\n");
+
+assert.deepEqual(
+  covenLaunchCommandForBinary(fallbackShim, "win32"),
+  { command: process.execPath, fixedArgs: [fallbackScript] },
+  "Windows .cmd shims fall back to the standard npm global coven.js location",
 );
 
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -19,16 +19,22 @@
 //      profile (custom rc edits, asdf, mise, etc.) still works.
 //   3. Cache the result for the lifetime of the server process.
 //
-// All cave spawn sites of `coven` should use `covenBin()` for argv[0] and
-// `covenSpawnEnv()` for the env option.
+// Cave call sites that execute `coven` with dynamic argv should use
+// `covenLaunchCommand()` for argv[0] plus fixed args, and `covenSpawnEnv()`
+// for the env option.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 let cachedBin: string | null = null;
 let cachedPath: string | null = null;
+
+export type CovenLaunchCommand = {
+  command: string;
+  fixedArgs: string[];
+};
 
 const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT"] as const;
 
@@ -151,6 +157,49 @@ export function covenBin(): string {
 
   cachedBin = "coven";
   return cachedBin;
+}
+
+function windowsShimTargetFromFile(shimPath: string): string | null {
+  const binDir = path.dirname(shimPath);
+  try {
+    const shim = readFileSync(shimPath, "utf-8");
+    const quotedTargets = shim.matchAll(/"(%(?:~?dp0)%?)[\\/]*([^"]+\.[cm]?js)"/gi);
+    for (const match of quotedTargets) {
+      const relativeTarget = match[2]?.replace(/[\\/]+/g, path.sep);
+      if (!relativeTarget) continue;
+      const candidate = path.resolve(binDir, relativeTarget);
+      if (existsSync(candidate)) return candidate;
+    }
+  } catch {
+    /* fall through to the conventional npm global layout */
+  }
+
+  const conventionalTarget = path.join(
+    binDir,
+    "node_modules",
+    "@opencoven",
+    "cli",
+    "bin",
+    "coven.js",
+  );
+  return existsSync(conventionalTarget) ? conventionalTarget : null;
+}
+
+export function covenLaunchCommandForBinary(
+  binary: string,
+  platform: NodeJS.Platform = process.platform,
+): CovenLaunchCommand {
+  if (platform !== "win32" || !/\.(cmd|bat)$/i.test(binary)) {
+    return { command: binary, fixedArgs: [] };
+  }
+
+  const script = windowsShimTargetFromFile(binary);
+  if (!script) return { command: binary, fixedArgs: [] };
+  return { command: process.execPath, fixedArgs: [script] };
+}
+
+export function covenLaunchCommand(): CovenLaunchCommand {
+  return covenLaunchCommandForBinary(covenBin());
 }
 
 /**

--- a/src/lib/coven-version.ts
+++ b/src/lib/coven-version.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { covenBin, covenSpawnEnv } from "./coven-bin.ts";
+import { covenLaunchCommand, covenSpawnEnv } from "./coven-bin.ts";
 
 const execFileAsync = promisify(execFile);
 
@@ -26,7 +26,8 @@ export function displayCovenVersion({
 
 export async function installedCovenVersion(): Promise<string | null> {
   try {
-    const { stdout, stderr } = await execFileAsync(covenBin(), ["--version"], {
+    const { command, fixedArgs } = covenLaunchCommand();
+    const { stdout, stderr } = await execFileAsync(command, [...fixedArgs, "--version"], {
       env: covenSpawnEnv(),
       timeout: 2500,
     });


### PR DESCRIPTION
## Summary
- close #1993 by routing Windows npm `.cmd` shims through `node <coven.js>` before appending dynamic args
- update Cave coven spawn/exec call sites used by harness discovery, onboarding status, chat send, coven exec/version, and board step enrichment
- add behavior coverage for direct POSIX launch, npm shim parsing, and fallback npm-global layout

## Problem Coverage
- `/api/harnesses`: avoids direct `spawn(coven.cmd, ...)` for adapter list probes and degrades version-probe spawn errors to a missing version instead of a route-level 500
- onboarding Option A/runtime list: `onboarding/status` uses the same safe launch path for adapter summaries, so installed runtimes are not hidden by Windows shim `EINVAL`

## Verification
- `node src/lib/coven-bin.test.ts`
- `pnpm check:tests-wired`
- `npx tsc --noEmit`
- `git diff --check`
- `node scripts/run-tests.mjs app`
- `CIRCLE_NODE_TOTAL=1 npx next build`

Closes #1993