### PR TITLE
fix(flow): align onboarding prompt actions with the textarea

### DIFF
--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -135,10 +135,11 @@
 .flow-toolbar-stop-spinner { width: 11px; height: 11px; border-radius: 50%; border: 2px solid color-mix(in oklch, var(--color-danger) 35%, transparent); border-top-color: var(--color-danger); animation: flow-spin 0.7s linear infinite; }
 
 .flow-notice { padding: 7px var(--space-3); font-size: var(--text-sm); color: var(--text-primary); background: color-mix(in oklch, var(--accent-presence) 16%, var(--bg-raised)); border-bottom: 1px solid var(--border-hairline); }
-.flow-onboarding-actions { display: flex; align-items: stretch; gap: var(--space-2); width: min(520px, 100%); }
-.flow-onboarding-prompt { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: var(--space-2); flex: 1; }
+.flow-onboarding-actions { display: flex; align-items: center; gap: var(--space-2); width: min(520px, 100%); }
+.flow-onboarding-prompt { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: var(--space-2); flex: 1; }
 .flow-onboarding-prompt textarea { min-height: 68px; }
-.flow-onboarding-actions .flow-toolbar-save { display: inline-flex; align-items: center; gap: 5px; justify-content: center; align-self: end; min-height: 33px; }
+.flow-onboarding-actions .flow-toolbar-save,
+.flow-onboarding-prompt .flow-toolbar-execute { display: inline-flex; align-items: center; gap: 5px; justify-content: center; align-self: center; min-height: 34px; }
 
 /* ---- Editor (canvas + NDV) --------------------------------------------- */
 .flow-editor { position: relative; flex: 1; min-height: 0; display: flex; }


### PR DESCRIPTION
## What

In the **Build a flow** empty-state, the **Create** and **Blank** buttons were `align-items: end` / `align-self: end`, bottom-hugging the 68px-tall describe-a-flow textarea. That left them floating at the bottom-right with a lopsided empty gap above (see the reported screenshot). The Create button also had no `min-height` while Blank set `33px`, so the two buttons weren't even the same height.

## Fix

- Center both buttons against the textarea (`align-items: center` on the actions row and the prompt grid; `align-self: center` on the buttons).
- Give both buttons a shared `min-height: 34px` so they're identical and their labels align.

Pure CSS, `src/styles/flow.css` only — no markup or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)