### PR TITLE
feat(flow): required-input gate (Phase 1)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -60,6 +60,7 @@ export const SUITES = {
     "src/lib/flow/flow-prompt.test.ts",
     "src/lib/flow/flow-catalog.test.ts",
     "src/lib/flow/flow-compile.test.ts",
+    "src/components/flow/flow-node-required-badge.test.ts",
     "src/lib/flow/flow-webhook.test.ts",
     "src/lib/flow/flow-progress.test.ts",
     "src/lib/flow/flow-execution-data.test.ts",

--- a/src/components/flow/flow-node-required-badge.test.ts
+++ b/src/components/flow/flow-node-required-badge.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./flow-node.tsx", import.meta.url), "utf8");
+
+// The node card renders a required badge driven by requiredParams.
+assert.match(src, /requiredParams/);
+assert.match(src, /flow-node-required-badge/);
+assert.match(src, /required/);

--- a/src/components/flow/flow-node.tsx
+++ b/src/components/flow/flow-node.tsx
@@ -91,6 +91,15 @@ export function FlowNodeView({ data, selected }: NodeProps<FlowRFNode>) {
           disabled
         </span>
       )}
+      {node.requiredParams && node.requiredParams.length > 0 && (
+        <span
+          className="flow-node-required-badge"
+          aria-label="Requires input"
+          title="Requires input before running"
+        >
+          *required
+        </span>
+      )}
       {stale && (
         <span className="flow-node-stale-badge" aria-label="Stale data" title="Node data is stale">
           <Icon name="ph:warning" width={13} />

--- a/src/lib/flow/flow-catalog.test.ts
+++ b/src/lib/flow/flow-catalog.test.ts
@@ -88,4 +88,18 @@ const NOW = "2026-01-01T00:00:00.000Z";
   assert.equal(createNode(doc, "does.not.exist", { x: 0, y: 0 }), null);
 }
 
+// input.text exists and createNode seeds requiredParams from requiredByDefault
+{
+  const def = catalogNode("input.text");
+  assert.ok(def, "input.text should be in the catalog");
+  assert.deepEqual(
+    def.params.map((p) => p.key),
+    ["label", "value"],
+  );
+  const doc = emptyFlow("f", "F", "2026-01-01T00:00:00.000Z");
+  const node = createNode(doc, "input.text", { x: 0, y: 0 });
+  assert.ok(node);
+  assert.deepEqual(node.requiredParams, ["value"]);
+}
+
 console.log("flow-catalog.test.ts OK");

--- a/src/lib/flow/flow-catalog.ts
+++ b/src/lib/flow/flow-catalog.ts
@@ -55,6 +55,8 @@ export type FlowNodeType = {
   inputs: FlowPort[];
   outputs: FlowPort[];
   params: FlowParamField[];
+  /** Param keys seeded into a new node's `requiredParams` by createNode. */
+  requiredByDefault?: string[];
   /** Sticky notes are non-executable canvas annotations. */
   sticky?: boolean;
 };
@@ -388,6 +390,22 @@ export const FLOW_CATALOG: FlowNodeType[] = [
 
   // ---- Data --------------------------------------------------------------
   {
+    type: "input.text",
+    label: "Input",
+    category: "data",
+    group: "Data",
+    icon: "ph:file-text",
+    accent: CATEGORY_ACCENT.data,
+    description: "A named input the user must fill in before the flow runs.",
+    inputs: ONE_IN,
+    outputs: MAIN_OUT,
+    params: [
+      { key: "label", label: "Input name", control: "text", placeholder: "Research topic" },
+      { key: "value", label: "Value", control: "textarea", placeholder: "Provided when the flow runs" },
+    ],
+    requiredByDefault: ["value"],
+  },
+  {
     type: "data.set",
     label: "Edit Fields",
     category: "data",
@@ -520,6 +538,9 @@ export function createNode(doc: FlowDoc, type: string, position: FlowPosition): 
     position,
     params: defaultParams(def),
   };
+  if (def.requiredByDefault && def.requiredByDefault.length > 0) {
+    node.requiredParams = [...def.requiredByDefault];
+  }
   if (def.sticky) {
     node.sticky = { text: "I'm a note", color: STICKY_COLORS[0].key, width: 240, height: 160 };
   }

--- a/src/lib/flow/flow-doc.ts
+++ b/src/lib/flow/flow-doc.ts
@@ -70,6 +70,8 @@ export type FlowNode = {
   disabled?: boolean;
   /** Development-only pinned output reused by manual/partial runs. */
   pinnedData?: string;
+  /** Param keys (author-marked) that must be non-empty before the flow runs. */
+  requiredParams?: string[];
   /** Generic n8n-style runtime behavior for this node. Defaults are omitted. */
   settings?: FlowNodeSettings;
   notes?: string;

--- a/src/lib/flow/flow-templates.ts
+++ b/src/lib/flow/flow-templates.ts
@@ -115,13 +115,20 @@ export const FLOW_TEMPLATES: FlowTemplate[] = [
           name: "Start research",
           position: { x: 80, y: 180 },
           params: {},
-          notes: "Set the research topic in the prompt below.",
+        },
+        {
+          id: "topic",
+          type: "input.text",
+          name: "Research topic",
+          position: { x: 320, y: 180 },
+          params: { label: "Research topic", value: "" },
+          requiredParams: ["value"],
         },
         {
           id: "research-plan",
           type: "familiar",
           name: "Research familiar - plan queries",
-          position: { x: 360, y: 180 },
+          position: { x: 600, y: 180 },
           params: {
             familiar: "",
             prompt:
@@ -132,7 +139,7 @@ export const FLOW_TEMPLATES: FlowTemplate[] = [
           id: "research-search",
           type: "familiar",
           name: "Research familiar - search & collect",
-          position: { x: 640, y: 180 },
+          position: { x: 880, y: 180 },
           params: {
             familiar: "",
             prompt:
@@ -143,7 +150,7 @@ export const FLOW_TEMPLATES: FlowTemplate[] = [
           id: "research-synthesize",
           type: "familiar",
           name: "Research familiar - synthesize",
-          position: { x: 920, y: 180 },
+          position: { x: 1160, y: 180 },
           params: {
             familiar: "",
             prompt:
@@ -154,14 +161,14 @@ export const FLOW_TEMPLATES: FlowTemplate[] = [
           id: "approval",
           type: "human.gate",
           name: "Review before sending",
-          position: { x: 1200, y: 180 },
+          position: { x: 1440, y: 180 },
           params: { prompt: "Review the research brief. Approve to send, or reject to discard." },
         },
         {
           id: "delivery",
           type: "familiar",
           name: "Delivery familiar - deliver",
-          position: { x: 1480, y: 120 },
+          position: { x: 1720, y: 120 },
           params: {
             familiar: "",
             prompt: "Send this research brief to Val via Telegram. Use clean formatting suitable for mobile.",
@@ -171,19 +178,20 @@ export const FLOW_TEMPLATES: FlowTemplate[] = [
           id: "out",
           type: "data.output",
           name: "Done",
-          position: { x: 1720, y: 120 },
+          position: { x: 1960, y: 120 },
           params: { label: "brief sent" },
         },
         {
           id: "discarded",
           type: "data.output",
           name: "Discarded",
-          position: { x: 1480, y: 280 },
+          position: { x: 1720, y: 280 },
           params: { label: "discarded" },
         },
       ],
       edges: [
-        { id: "trigger:main->research-plan:in", source: "trigger", sourceHandle: "main", target: "research-plan", targetHandle: "in" },
+        { id: "trigger:main->topic:in", source: "trigger", sourceHandle: "main", target: "topic", targetHandle: "in" },
+        { id: "topic:main->research-plan:in", source: "topic", sourceHandle: "main", target: "research-plan", targetHandle: "in" },
         { id: "research-plan:main->research-search:in", source: "research-plan", sourceHandle: "main", target: "research-search", targetHandle: "in" },
         { id: "research-search:main->research-synthesize:in", source: "research-search", sourceHandle: "main", target: "research-synthesize", targetHandle: "in" },
         { id: "research-synthesize:main->approval:in", source: "research-synthesize", sourceHandle: "main", target: "approval", targetHandle: "in" },

--- a/src/lib/required-inputs.test.ts
+++ b/src/lib/required-inputs.test.ts
@@ -1,53 +1,76 @@
 import assert from "node:assert/strict";
 import { flowMissingRequiredInputs } from "./required-inputs.ts";
-import type { FlowDoc, FlowNode } from "./flow/flow-doc.ts";
+import { addNode, emptyFlow, type FlowDoc, type FlowNode } from "./flow/flow-doc.ts";
 
-function node(id: string, type: string, params: FlowNode["params"]): FlowNode {
-  return { id, type, name: id, position: { x: 0, y: 0 }, params };
-}
+const NOW = "2026-01-01T00:00:00.000Z";
 
-function doc(nodes: FlowNode[]): FlowDoc {
+function inputNode(id: string, value: string, requiredParams: string[] = ["value"]): FlowNode {
   return {
-    id: "flow",
-    name: "Flow",
-    active: false,
-    nodes,
-    edges: [],
-    createdAt: "2026-06-28T00:00:00.000Z",
-    updatedAt: "2026-06-28T00:00:00.000Z",
-    schema: 1,
+    id,
+    type: "input.text",
+    name: id,
+    position: { x: 0, y: 0 },
+    params: { label: "Research topic", value },
+    requiredParams,
   };
 }
 
-assert.deepEqual(
-  flowMissingRequiredInputs(
-    doc([
-      node("manual", "trigger.manual", {}),
-      node("agent", "familiar", { familiar: "", prompt: "  " }),
-      node("http", "http", { method: "GET", url: "https://example.com", headers: "{}", body: "{}" }),
-    ]),
-  ).map((input) => ({
-    key: input.key,
-    nodeId: input.nodeId,
-    paramKey: input.paramKey,
-    label: input.label,
-  })),
-  [
-    { key: "agent.familiar", nodeId: "agent", paramKey: "familiar", label: "agent Familiar" },
-    { key: "agent.prompt", nodeId: "agent", paramKey: "prompt", label: "agent Prompt" },
-  ],
-  "missing required flow params should be returned with stable keys and node labels",
-);
+function node(id: string, type: string, params: FlowNode["params"], requiredParams?: string[]): FlowNode {
+  return { id, type, name: id, position: { x: 0, y: 0 }, params, requiredParams };
+}
+
+function docWith(...nodes: FlowNode[]): FlowDoc {
+  let doc = emptyFlow("f", "F", NOW);
+  for (const item of nodes) doc = addNode(doc, item);
+  return doc;
+}
+
+{
+  const missing = flowMissingRequiredInputs(docWith(inputNode("topic", "")));
+  assert.equal(missing.length, 1);
+  assert.equal(missing[0].key, "topic:value");
+  assert.equal(missing[0].label, "Research topic");
+  assert.equal(missing[0].control, "textarea");
+  assert.equal(missing[0].nodeId, "topic");
+  assert.equal(missing[0].paramKey, "value");
+  assert.equal(missing[0].paramLabel, "Value");
+}
+
+assert.deepEqual(flowMissingRequiredInputs(docWith(inputNode("topic", "LLM agents"))), []);
+assert.equal(flowMissingRequiredInputs(docWith(inputNode("topic", "   "))).length, 1);
+assert.deepEqual(flowMissingRequiredInputs(docWith(inputNode("topic", "", []))), []);
+
+{
+  const item = inputNode("topic", "");
+  item.disabled = true;
+  assert.deepEqual(flowMissingRequiredInputs(docWith(item)), []);
+}
+
+{
+  const missing = flowMissingRequiredInputs(docWith(inputNode("a", ""), inputNode("b", "")));
+  assert.deepEqual(
+    missing.map((item) => item.key).sort(),
+    ["a:value", "b:value"],
+  );
+}
+
+{
+  const missing = flowMissingRequiredInputs(
+    docWith(node("agent", "familiar", { familiar: "", prompt: "  " }, ["familiar", "prompt"])),
+  );
+  assert.deepEqual(
+    missing.map((input) => ({ key: input.key, nodeId: input.nodeId, paramKey: input.paramKey, label: input.label })),
+    [
+      { key: "agent:familiar", nodeId: "agent", paramKey: "familiar", label: "agent Familiar" },
+      { key: "agent:prompt", nodeId: "agent", paramKey: "prompt", label: "agent Prompt" },
+    ],
+  );
+}
 
 assert.deepEqual(
-  flowMissingRequiredInputs(
-    doc([
-      node("schedule", "trigger.schedule", { mode: "interval", everyMinutes: 30 }),
-      node("cron", "trigger.schedule", { mode: "cron", everyMinutes: 30, cron: "" }),
-    ]),
-  ).map((input) => input.key),
-  ["cron.cron"],
-  "cron expression should only be required when the schedule trigger is in cron mode",
+  flowMissingRequiredInputs(docWith(node("agent", "familiar", { familiar: "", prompt: "  " }))),
+  [],
+  "nodes without requiredParams should not be prompted",
 );
 
 console.log("required-inputs.test.ts: ok");

--- a/src/lib/required-inputs.ts
+++ b/src/lib/required-inputs.ts
@@ -1,4 +1,4 @@
-import { catalogNode, type FlowParamControl, type FlowParamField } from "./flow/flow-catalog.ts";
+import { catalogNode, type FlowParamControl } from "./flow/flow-catalog.ts";
 import type { FlowDoc, FlowNode, FlowParamValue } from "./flow/flow-doc.ts";
 
 export type RequiredInput = {
@@ -17,34 +17,36 @@ export function flowMissingRequiredInputs(doc: FlowDoc): RequiredInput[] {
   const missing: RequiredInput[] = [];
   for (const node of doc.nodes) {
     if (node.disabled || node.sticky) continue;
+    const requiredParams = node.requiredParams ?? [];
+    if (requiredParams.length === 0) continue;
     const def = catalogNode(node.type);
-    if (!def) continue;
-    for (const field of def.params) {
-      if (!requiredFieldApplies(node, field)) continue;
-      const value = node.params[field.key];
+    for (const paramKey of requiredParams) {
+      const value = node.params[paramKey];
       if (!isMissingParam(value)) continue;
+      const field = def?.params.find((candidate) => candidate.key === paramKey);
+      const paramLabel = field?.label ?? paramKey;
       missing.push({
-        key: `${node.id}.${field.key}`,
-        label: `${node.name} ${field.label}`,
+        key: `${node.id}:${paramKey}`,
+        label: requiredInputLabel(node, paramKey, paramLabel),
         nodeId: node.id,
         nodeName: node.name,
-        paramKey: field.key,
-        paramLabel: field.label,
-        control: field.control,
-        placeholder: field.placeholder,
-        help: field.help,
+        paramKey,
+        paramLabel,
+        control: field?.control ?? "text",
+        placeholder: field?.placeholder,
+        help: field?.help,
       });
     }
   }
   return missing;
 }
 
-function requiredFieldApplies(node: FlowNode, field: FlowParamField): boolean {
-  if (field.default !== undefined) return false;
-  if (node.type === "trigger.schedule" && field.key === "cron") {
-    return node.params.mode === "cron";
+function requiredInputLabel(node: FlowNode, paramKey: string, paramLabel: string): string {
+  if (node.type === "input.text" && paramKey === "value") {
+    const label = node.params.label;
+    if (typeof label === "string" && label.trim().length > 0) return label.trim();
   }
-  return true;
+  return `${node.name} ${paramLabel}`;
 }
 
 function isMissingParam(value: FlowParamValue | undefined): boolean {

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -12,6 +12,7 @@ import {
   flowRunBlockReason,
   type FlowTriggerInput,
 } from "@/lib/flow/flow-compile";
+import { flowMissingRequiredInputs } from "@/lib/required-inputs";
 import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
 import type { FlowRunRecord } from "@/lib/flows";
 import { recordFlowRun } from "@/lib/server/flow-store";
@@ -47,6 +48,15 @@ export async function startFlowSession(
 ): Promise<StartFlowSessionResult> {
   const blocked = flowRunBlockReason(flow, options.targetNodeId);
   if (!blocked.ok) return { ok: false, error: blocked.reason, status: 400 };
+
+  const missingRequired = flowMissingRequiredInputs(flow);
+  if (missingRequired.length > 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: `Provide required input: ${missingRequired.map((m) => m.label).join(", ")}`,
+    };
+  }
 
   const projectRoot = normalizeProjectRoot(options.projectRoot ?? process.cwd());
   if (!projectRoot) return { ok: false, error: "invalid project root", status: 400 };

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -212,6 +212,7 @@
 .flow-node-note-text { max-width: 150px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-secondary); font-size: var(--text-xs); line-height: 1.25; }
 .flow-node-disabled-badge { position: absolute; top: -8px; left: 10px; padding: 1px 6px; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; border-radius: 999px; background: var(--bg-elevated); color: var(--text-muted); border: 1px solid var(--border); }
 .flow-node-stale-badge { position: absolute; top: -9px; right: 12px; display: grid; place-items: center; width: 20px; height: 20px; border-radius: 6px; background: color-mix(in oklch, var(--color-warning) 22%, var(--bg-elevated)); color: var(--color-warning); border: 1px solid color-mix(in oklch, var(--color-warning) 58%, var(--border)); box-shadow: 0 4px 12px rgb(0 0 0 / 25%); }
+.flow-node-required-badge { position: absolute; bottom: -8px; left: 10px; padding: 1px 6px; font-size: 9px; font-weight: 700; letter-spacing: 0.04em; border-radius: 999px; background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-elevated)); color: var(--accent-presence); border: 1px solid color-mix(in oklch, var(--accent-presence) 50%, var(--border)); }
 
 .flow-node-phase-dot { position: absolute; top: 8px; right: 8px; width: 10px; height: 10px; border-radius: 50%; }
 .flow-node-phase-dot-pending { background: var(--text-muted); }


### PR DESCRIPTION
## What

Adds an explicit **required-input gate** to the Flow editor. An author marks inputs as required (via a new first-class `input.text` node, required by default); when the user runs a flow with any required input empty, a pre-run dialog forces them to fill it before the flow runs — mirroring how Deep Research asks for a topic. Server enforces with HTTP 400.

Implements `docs/superpowers/specs/2026-06-28-flow-required-inputs-design.md` (Flow phase; Workflow is a documented Phase 2 reusing the same dialog).

## Changes (7 commits)

- **Data model:** `FlowNode.requiredParams?: string[]` + new `input.text` catalog node (`requiredByDefault: ["value"]`, seeded by `createNode`).
- **Collector:** `flowMissingRequiredInputs(doc)` in `src/lib/required-inputs.ts` — required-and-empty inputs with unique `nodeId:paramKey` keys.
- **Badge:** `*required` chip on nodes with `requiredParams`.
- **Dialog:** reusable `RequiredInputsDialog` (surface-agnostic, built on `ui/modal`).
- **Gate:** `flow-view.execute` opens the dialog when required inputs are empty; on submit, writes values into node params and proceeds.
- **Server:** `startFlowSession` returns 400 naming missing inputs.
- **Template:** Deep Research Report now uses a required `input.text` "Research topic" node.

## Verification

- `tsc --noEmit` clean; `node scripts/run-tests.mjs app` → 454 pass (incl. new collector + badge tests); `check-tests-wired` green; `pnpm build` passes.
- Final code review: no blocking issues.
- Live dev-mode check: created the Deep Research flow, clicked Execute with the topic empty → the "Required inputs" dialog blocked the run (screenshot verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)