### PR TITLE
feat(flow): style the Required inputs dialog and clarify each field

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1049,6 +1049,100 @@ tr[role="checkbox"]:focus-visible {
   flex-shrink: 0;
 }
 
+/* ---- Flow "Required inputs" dialog -------------------------- */
+.required-inputs-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.required-inputs-copy {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.required-inputs-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.required-inputs-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.required-inputs-field-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.required-inputs-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.required-inputs-node {
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 55%;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.required-inputs-control {
+  width: 100%;
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 13px;
+  color: var(--foreground);
+  background: var(--bg-base);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  transition: border-color var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+.required-inputs-control::placeholder {
+  color: var(--text-muted);
+}
+
+.required-inputs-control:hover {
+  border-color: color-mix(in oklch, var(--border) 60%, var(--text-muted));
+}
+
+.required-inputs-control:focus,
+.required-inputs-control:focus-visible {
+  outline: none;
+  border-color: var(--accent-presence);
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-presence) 28%, transparent);
+}
+
+textarea.required-inputs-control {
+  resize: vertical;
+  min-height: 64px;
+  line-height: 1.5;
+}
+
+.required-inputs-help {
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
 /* ---- Property pill ----------------------------------------- */
 .ui-pill {
   display: inline-flex;

--- a/src/components/required-inputs-dialog.tsx
+++ b/src/components/required-inputs-dialog.tsx
@@ -49,34 +49,46 @@ export function RequiredInputsDialog({ inputs, onSubmit, onCancel }: RequiredInp
       >
         <div className="required-inputs-dialog">
           <p className="required-inputs-copy">
-            Add the missing values before running this flow.
+            {inputs.length === 1
+              ? "One value is required before this flow can run."
+              : `${inputs.length} values are required before this flow can run.`}
           </p>
-          {inputs.map((input) => (
-            <label key={input.key} className="required-inputs-field">
-              <span className="required-inputs-label">{input.label}</span>
-              {input.control === "textarea" || input.control === "code" || input.control === "json" ? (
-                <textarea
-                  required
-                  value={values[input.key] ?? ""}
-                  placeholder={input.placeholder}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, [input.key]: event.target.value }))
-                  }
-                />
-              ) : (
-                <input
-                  required
-                  type={input.control === "number" ? "number" : "text"}
-                  value={values[input.key] ?? ""}
-                  placeholder={input.placeholder}
-                  onChange={(event) =>
-                    setValues((current) => ({ ...current, [input.key]: event.target.value }))
-                  }
-                />
-              )}
-              {input.help ? <span className="required-inputs-help">{input.help}</span> : null}
-            </label>
-          ))}
+          <div className="required-inputs-list">
+            {inputs.map((input) => (
+              <label key={input.key} className="required-inputs-field">
+                <span className="required-inputs-field-head">
+                  <span className="required-inputs-label">{input.paramLabel}</span>
+                  <span className="required-inputs-node" title={`Step: ${input.nodeName}`}>
+                    {input.nodeName}
+                  </span>
+                </span>
+                {input.control === "textarea" || input.control === "code" || input.control === "json" ? (
+                  <textarea
+                    required
+                    className="required-inputs-control"
+                    rows={3}
+                    value={values[input.key] ?? ""}
+                    placeholder={input.placeholder}
+                    onChange={(event) =>
+                      setValues((current) => ({ ...current, [input.key]: event.target.value }))
+                    }
+                  />
+                ) : (
+                  <input
+                    required
+                    className="required-inputs-control"
+                    type={input.control === "number" ? "number" : "text"}
+                    value={values[input.key] ?? ""}
+                    placeholder={input.placeholder}
+                    onChange={(event) =>
+                      setValues((current) => ({ ...current, [input.key]: event.target.value }))
+                    }
+                  />
+                )}
+                {input.help ? <span className="required-inputs-help">{input.help}</span> : null}
+              </label>
+            ))}
+          </div>
         </div>
       </form>
     </Modal>


### PR DESCRIPTION
## What

The required-input preflight dialog (shipped in #1996) had **no CSS** for its `.required-inputs-*` classes, so the fields rendered as unstyled inline elements that collided into an unreadable wall of text — and each field label mashed the node name and param label into one run-on string. This styles it and clarifies each field.

## Changes

- **Add the missing style block** (`globals.css`, by the modal styles): stacked fields, real bordered/focusable input controls, proper spacing, and a scrollable list — using the modal's design tokens (`--space-*`, `--bg-base`, `--border`, `--radius-control`, `--accent-presence`, `--text-muted`).
- **Clarify each field** (`required-inputs-dialog.tsx`): render the param label (e.g. **"Familiar"**) as the field label, with the owning **step name** as a truncating context chip on the right — instead of the run-together `${nodeName} ${paramLabel}` string.
- **Lead with a count**: *"N values are required before this flow can run."*

Kept the test-pinned classes (`required-inputs-form`, `required-inputs-field`, `required-inputs-dialog`). +133/−27 across 2 files.

## Before → After

| Before | After |
|---|---|
| Labels + values collided into one text block; no visible input fields | Each field: bold param label + node-context chip + a real input box, evenly spaced |

## Verification

- Drove the dialog in a built app (clicked **Execute** on a flow with empty required params): 4 fields, labels `Familiar`, node chips `Research familiar - plan queries` … `Delivery familiar - deliver`, 4 input controls, copy "4 values are required before this flow can run." — no page errors. Screenshot confirms clean layout.
- `tsc --noEmit` clean; `pnpm test:app` → **454 test files pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)