### PR TITLE
feat: surface familiar eval loops

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -146,6 +146,9 @@ enum SlashCatalog {
                      description: "Toggle the Familiar Chat side panel on desktop.",
                      section: .view, availability: .desktopOnly,
                      action: .desktopOnly("Familiar side panel")),
+        SlashCommand(name: "/evals", aliases: ["/eval-loops"], hint: "Eval Loops",
+                     description: "Familiar eval loops live on the desktop.",
+                     section: .view, availability: .desktopOnly, action: .desktopOnly("Eval Loops")),
 
         // MARK: Launch
         SlashCommand(name: "/run", hint: "run task",

--- a/docs/specs/2026-06-28-eval-loop-control-plane-design.md
+++ b/docs/specs/2026-06-28-eval-loop-control-plane-design.md
@@ -1,0 +1,66 @@
+# Eval Loop Control Plane Design
+
+## Goal
+
+Let familiars run and recover their own eval-loop iterations from a sanctioned control plane, either from Cave's dedicated UI or through daemon APIs, without requiring a human or agent to delete files inside a familiar workspace by hand.
+
+## Current State
+
+- Coven daemon already exposes eval-loop state and run enqueue endpoints.
+- Eval-loop enqueue writes `eval-loop/run.json` and `eval-loop/run.lock` in the familiar workspace.
+- A stale `run.lock` blocks new runs with `409 run_in_progress`.
+- Cave already proxies state and run requests, has an `EvalLoopPanel`, and has a hidden `Retro Runs` workspace mode.
+- Cave should not directly delete arbitrary files inside familiar workspaces.
+
+## Architecture
+
+The Coven daemon remains the only layer allowed to inspect or clear eval-loop lock files. Cave calls daemon-owned endpoints and renders the result in a dedicated workspace surface.
+
+Daemon additions:
+
+- Add `EvalLoopLockDto` to the eval-loop state, including `locked`, `run_id`, `run_json_exists`, `lock_updated_at`, and `stale`.
+- Add `clear_eval_loop_lock(coven_home, familiar_id, force)` that removes only the resolved familiar's `eval-loop/run.lock`.
+- Add `DELETE /api/v1/skills/eval-loop/:familiarId/run-lock` with JSON body `{ "force": true }`.
+- Reject clearing a non-stale lock unless `force` is true.
+
+Cave additions:
+
+- Add a Next API route `DELETE /api/skills/eval-loop/:familiarId/run-lock` that proxies to the daemon and redacts errors.
+- Promote the hidden Retro Runs mode into an optional sidebar surface named `Eval Loops`.
+- Rename the surface title from `Retro Runs` to `Eval Loops`, keeping the existing retro history list as the lower-level data model.
+- Add per-familiar controls to run synthesis, prompt, or memory iterations and to clear a blocked/stale lock.
+
+## UI Shape
+
+The dedicated Cave surface should be an operational dashboard, not a marketing page:
+
+- Header: "Eval Loops", refresh, export.
+- Metrics: total runs, accepted, reverted, running/blocked familiars.
+- Familiar panel: one row per familiar with active/running/blocked state.
+- Detail panel: existing `EvalLoopPanel` for the selected familiar, including run buttons.
+- Recovery affordance: if state reports a lock, show the run id, age, whether `run.json` exists, and a "Clear lock" button. The button calls the Cave proxy route and refreshes state.
+
+## Safety
+
+- Cave never constructs workspace filesystem paths for lock removal.
+- Daemon resolves the familiar workspace from `familiars.toml` or the standard fallback.
+- Daemon removes only `eval-loop/run.lock`, never `run.json` or result history.
+- Non-stale locks require `force: true`; the UI labels that as an override.
+- All daemon data returned to Cave stays redacted at the Next route boundary.
+
+## Verification
+
+Daemon:
+
+- Unit test lock metadata in state.
+- Unit test stale and non-stale lock clearing.
+- API routing test for `DELETE /skills/eval-loop/:id/run-lock`.
+- `cargo test -p coven-cli eval_loop`.
+
+Cave:
+
+- Route contract test for the new DELETE proxy.
+- Component/source tests that the sidebar can expose Eval Loops and the surface renders `EvalLoopPanel`.
+- Focused component tests for blocked lock affordance.
+- `pnpm test:app -- eval-loop retro-runs` or the closest supported targeted runner.
+

--- a/docs/specs/2026-06-28-eval-loop-control-plane-plan.md
+++ b/docs/specs/2026-06-28-eval-loop-control-plane-plan.md
@@ -1,0 +1,93 @@
+# Eval Loop Control Plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a daemon-owned eval-loop lock recovery API and a dedicated Cave Eval Loops surface that can run and unblock familiar eval loops safely.
+
+**Architecture:** Coven owns eval-loop filesystem state and exposes lock metadata plus a constrained clear-lock endpoint. Cave proxies that endpoint and promotes the existing hidden Retro Runs mode into an operational Eval Loops space with run and recovery controls.
+
+**Tech Stack:** Rust daemon/API in `OpenCoven/coven`, Next.js/React/Tauri Cave UI in `OpenCoven/coven-cave`, filesystem-backed eval-loop state, existing source-level tests.
+
+---
+
+### Task 1: Daemon Lock Metadata
+
+**Files:**
+- Modify: `OpenCoven/coven/crates/coven-cli/src/eval_loop.rs`
+
+- [ ] Add failing tests for lock metadata:
+  - `get_eval_loop_state_reports_lock_metadata`
+  - `get_eval_loop_state_marks_old_lock_stale`
+- [ ] Run `cargo test -p coven-cli get_eval_loop_state_reports_lock_metadata get_eval_loop_state_marks_old_lock_stale` and confirm both fail because the DTO has no lock metadata.
+- [ ] Add `EvalLoopLockDto` and include `lock: EvalLoopLockDto` on `EvalLoopStateDto`.
+- [ ] Implement metadata from `eval-loop/run.lock` and `eval-loop/run.json`.
+- [ ] Mark locks stale when modified more than one hour ago.
+- [ ] Re-run the focused tests and confirm they pass.
+
+### Task 2: Daemon Clear-Lock API
+
+**Files:**
+- Modify: `OpenCoven/coven/crates/coven-cli/src/eval_loop.rs`
+- Modify: `OpenCoven/coven/crates/coven-cli/src/api.rs`
+
+- [ ] Add failing eval-loop tests:
+  - `clear_eval_loop_lock_removes_stale_lock`
+  - `clear_eval_loop_lock_requires_force_for_fresh_lock`
+  - `clear_eval_loop_lock_returns_false_when_missing`
+- [ ] Run the focused tests and confirm they fail because `clear_eval_loop_lock` does not exist.
+- [ ] Implement `clear_eval_loop_lock(coven_home, familiar_id, force)`.
+- [ ] Add API route `DELETE /skills/eval-loop/:familiarId/run-lock`.
+- [ ] Add API route tests for success and fresh-lock conflict.
+- [ ] Run `cargo test -p coven-cli eval_loop` and relevant API tests.
+
+### Task 3: Cave Proxy Route
+
+**Files:**
+- Create: `OpenCoven/coven-cave/src/app/api/skills/eval-loop/[familiarId]/run-lock/route.ts`
+- Modify: `OpenCoven/coven-cave/src/app/api/api-contracts.test.ts`
+- Modify: `OpenCoven/coven-cave/src/components/eval-loop-panel.test.ts`
+
+- [ ] Add failing API contract assertion for `DELETE /skills/eval-loop/[familiarId]/run-lock`.
+- [ ] Add failing source assertion that the proxy calls `/api/v1/skills/eval-loop/${familiarId}/run-lock`.
+- [ ] Implement the DELETE proxy route with `{ force?: boolean }` body parsing and redacted errors.
+- [ ] Run the focused tests and confirm they pass.
+
+### Task 4: EvalLoopPanel Recovery Controls
+
+**Files:**
+- Modify: `OpenCoven/coven-cave/src/components/eval-loop-panel.tsx`
+- Modify: `OpenCoven/coven-cave/src/components/eval-loop-panel.test.ts`
+
+- [ ] Add failing source/component assertions for lock status and a keyboard-accessible "Clear eval-loop lock" button.
+- [ ] Extend `EvalLoopState` with optional `lock` metadata.
+- [ ] Add clear-lock handler that calls the new Cave route, clears errors on success, and refreshes state.
+- [ ] Show locked/stale/run-json metadata when present.
+- [ ] Run focused tests.
+
+### Task 5: Dedicated Cave Surface
+
+**Files:**
+- Modify: `OpenCoven/coven-cave/src/components/retro-runs-view.tsx`
+- Modify: `OpenCoven/coven-cave/src/components/retro-runs-view.test.ts`
+- Modify: `OpenCoven/coven-cave/src/components/sidebar-minimal.tsx`
+- Modify: `OpenCoven/coven-cave/src/components/settings-shell.tsx`
+- Modify: `OpenCoven/coven-cave/src/lib/slash-commands.ts`
+- Modify: `OpenCoven/coven-cave/src/components/workspace.tsx`
+
+- [ ] Add failing tests that the surface is named `Eval Loops`, is exposed as an optional sidebar add-on, and slash command `/evals` opens it.
+- [ ] Rename visible surface copy from Retro Runs to Eval Loops while keeping internal `retro` mode if that minimizes churn.
+- [ ] Add `retro`/`evals` to add-on settings and sidebar gating.
+- [ ] Update workspace title to `Eval Loops`.
+- [ ] Run focused tests.
+
+### Task 6: Verification And PR Readiness
+
+**Files:**
+- Both repos.
+
+- [ ] Run Coven focused tests: `cargo test -p coven-cli eval_loop`.
+- [ ] Run Cave focused tests for eval loop and retro surface.
+- [ ] Run formatting/type checks that match touched areas.
+- [ ] Review diffs for no unrelated primary-checkout changes.
+- [ ] Ask Val before pushing or opening PRs.
+

--- a/scripts/ios-slash-commands.test.mjs
+++ b/scripts/ios-slash-commands.test.mjs
@@ -83,7 +83,7 @@ assert.match(
   "switchModel should PATCH the chosen model through setChatModel",
 );
 
-for (const command of ["/journal", "/automations", "/remind", "/attach", "/tui", "/toggle-agent"]) {
+for (const command of ["/journal", "/automations", "/remind", "/attach", "/tui", "/toggle-agent", "/evals"]) {
   const escaped = command.replace("/", "\\/");
   assert.match(
     iosSlash,

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -141,6 +141,7 @@ const contracts: RouteContract[] = [
   { route: "/skills/file", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/skills/eval-loop/[familiarId]", methods: ["GET"], kind: "json" },
   { route: "/skills/eval-loop/[familiarId]/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/skills/eval-loop/[familiarId]/run-lock", methods: ["DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/skills/local", methods: ["GET"], kind: "json" },
   { route: "/skills", methods: ["GET"], kind: "json" },
   { route: "/theme", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/skills/eval-loop/[familiarId]/run-lock/route.ts
+++ b/src/app/api/skills/eval-loop/[familiarId]/run-lock/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
+import { redactSecretText } from "@/lib/secret-redaction";
+
+export const dynamic = "force-dynamic";
+
+type Body = { force?: boolean };
+
+/**
+ * DELETE /api/skills/eval-loop/[familiarId]/run-lock
+ *
+ * Proxies daemon-owned eval-loop lock recovery. Cave never deletes files in a
+ * familiar workspace directly; the daemon resolves and clears its own lock.
+ */
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ familiarId: string }> },
+) {
+  const { familiarId } = await params;
+
+  let body: Body = {};
+  try {
+    body = (await req.json()) as Body;
+  } catch {
+    // body optional
+  }
+
+  const res = await callDaemon<unknown>({
+    path: `/api/v1/skills/eval-loop/${familiarId}/run-lock`,
+    method: "DELETE",
+    body: { force: body.force === true },
+  });
+
+  if (!res.ok) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: redactSecretText(extractDaemonError(res) ?? `daemon http ${res.status}`),
+      },
+    );
+  }
+
+  return NextResponse.json({ ok: true, ...((res.data as object) ?? {}) });
+}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -573,6 +573,7 @@ export function CommandPalette({
           if (fm.id === "groupchat") return addons?.groupchat === true;
           if (fm.id === "journal") return addons?.journal === true;
           if (fm.id === "docs") return addons?.docs === true;
+          if (fm.id === "retro") return addons?.retro === true;
           return true;
         })
           // Fuzzy on the short label/id; substring-only on the long description

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -295,7 +295,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
           <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
           <QuickLink href="/dashboard/familiars/growth" icon="ph:chart-bar-bold" label="Growth" sub="Familiar performance" />
-          <QuickLink href="/dashboard/retro" icon="ph:arrows-clockwise-bold" label="Retro Runs" sub="Eval iterations" />
+          <QuickLink href="/dashboard/retro" icon="ph:arrows-clockwise-bold" label="Eval Loops" sub="Eval iterations" />
           <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
           <QuickLink href="/" icon="ph:books-bold" label="Library" sub="Saved knowledge" />
           <QuickLink href="/settings" icon="ph:gear-six" label="Settings" sub="Preferences" />

--- a/src/components/eval-loop-panel.test.ts
+++ b/src/components/eval-loop-panel.test.ts
@@ -6,6 +6,7 @@ const source = readFileSync(new URL("./eval-loop-panel.tsx", import.meta.url), "
 const skillsRoute = readFileSync(new URL("../app/api/skills/route.ts", import.meta.url), "utf8");
 const evalLoopRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/route.ts", import.meta.url), "utf8");
 const evalLoopRunRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/run/route.ts", import.meta.url), "utf8");
+const evalLoopRunLockRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/run-lock/route.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -29,6 +30,24 @@ assert.match(
   source,
   /if \(json\.ok\) \{[\s\S]{0,120}setState\(json\.state as EvalLoopState\);[\s\S]{0,80}setError\(null\);/,
   "successful refreshes should clear the inactive/error state",
+);
+
+assert.match(
+  source,
+  /type EvalLoopLockState = \{[\s\S]*?locked: boolean;[\s\S]*?runId\?: string \| null;[\s\S]*?stale: boolean;/,
+  "EvalLoopPanel should model daemon lock metadata",
+);
+
+assert.match(
+  source,
+  /aria-label=\{`Clear eval-loop lock for \$\{familiarName\}`\}/,
+  "locked eval-loop state should render a keyboard-accessible clear-lock button",
+);
+
+assert.match(
+  source,
+  /fetch\("\/api\/skills\/eval-loop\/" \+ familiarId \+ "\/run-lock"/,
+  "clear-lock handler should call the Cave run-lock proxy",
 );
 
 assert.match(
@@ -65,6 +84,18 @@ assert.doesNotMatch(
   evalLoopRunRoute,
   /\{\s*status:\s*503\s*\}/,
   "failed optional eval-loop runs should not create browser-console 503 noise",
+);
+
+assert.match(
+  evalLoopRunLockRoute,
+  /path: `\/api\/v1\/skills\/eval-loop\/\$\{familiarId\}\/run-lock`/,
+  "run-lock proxy should call the daemon-owned lock recovery endpoint",
+);
+
+assert.match(
+  evalLoopRunLockRoute,
+  /let body:[\s\S]{0,160}=\s*\{\}/,
+  "run-lock proxy should tolerate empty or malformed JSON bodies",
 );
 
 console.log("eval-loop-panel.test.ts: ok");

--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -29,22 +29,44 @@ export type LoopIteration = {
   timestamp: string;
   track: Track;
   iteration: number;
-  change_summary: string;
-  metric_before: number;
-  metric_after: number;
+  change_summary?: string;
+  changeSummary?: string;
+  metric_before?: number;
+  metricBefore?: number;
+  metric_after?: number;
+  metricAfter?: number;
   delta: number;
   outcome: "ACCEPT" | "REVERT";
   notes?: string;
 };
 
+export type EvalLoopLockState = {
+  locked: boolean;
+  runId?: string | null;
+  run_id?: string | null;
+  runJsonExists?: boolean;
+  run_json_exists?: boolean;
+  requestedAt?: string | null;
+  requested_at?: string | null;
+  lockUpdatedAt?: string | null;
+  lock_updated_at?: string | null;
+  stale: boolean;
+};
+
 export type EvalLoopState = {
-  familiar_id: string;
-  last_run: string | null;
+  familiar_id?: string;
+  familiarId?: string;
+  last_run?: string | null;
+  lastRun?: string | null;
   iterations: LoopIteration[];
-  track_counts: Record<Track, number>;
-  total_accepted: number;
-  total_reverted: number;
+  track_counts?: Record<Track, number>;
+  trackCounts?: Record<Track, number>;
+  total_accepted?: number;
+  totalAccepted?: number;
+  total_reverted?: number;
+  totalReverted?: number;
   running: boolean;
+  lock?: EvalLoopLockState;
 };
 
 type Props = {
@@ -58,6 +80,46 @@ function deltaColor(delta: number): string {
   if (delta > 0) return "text-[var(--color-success)]";
   if (delta < 0) return "text-[var(--color-danger)]";
   return "text-[var(--text-muted)]";
+}
+
+function lastRun(state: EvalLoopState | null): string | null {
+  return state?.last_run ?? state?.lastRun ?? null;
+}
+
+function totalAccepted(state: EvalLoopState): number {
+  return state.total_accepted ?? state.totalAccepted ?? 0;
+}
+
+function totalReverted(state: EvalLoopState): number {
+  return state.total_reverted ?? state.totalReverted ?? 0;
+}
+
+function iterationSummary(iteration: LoopIteration): string {
+  return iteration.change_summary ?? iteration.changeSummary ?? "Iteration recorded";
+}
+
+function metricBefore(iteration: LoopIteration): number {
+  return iteration.metric_before ?? iteration.metricBefore ?? 0;
+}
+
+function metricAfter(iteration: LoopIteration): number {
+  return iteration.metric_after ?? iteration.metricAfter ?? 0;
+}
+
+function lockRunId(lock: EvalLoopLockState): string | null {
+  return lock.runId ?? lock.run_id ?? null;
+}
+
+function lockRequestedAt(lock: EvalLoopLockState): string | null {
+  return lock.requestedAt ?? lock.requested_at ?? null;
+}
+
+function lockUpdatedAt(lock: EvalLoopLockState): string | null {
+  return lock.lockUpdatedAt ?? lock.lock_updated_at ?? null;
+}
+
+function lockHasRunJson(lock: EvalLoopLockState): boolean {
+  return lock.runJsonExists ?? lock.run_json_exists ?? false;
 }
 
 const TRACK_ICON: Record<Track, IconName> = {
@@ -80,6 +142,7 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [triggering, setTriggering] = useState(false);
+  const [clearingLock, setClearingLock] = useState(false);
   const [activeTrack, setActiveTrack] = useState<Track | "all">("all");
 
   useEffect(() => {
@@ -150,9 +213,33 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
     }
   }
 
+  async function clearRunLock(force = false) {
+    setClearingLock(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/skills/eval-loop/" + familiarId + "/run-lock", {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ force }),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json?.ok) {
+        setError(json?.error ?? "failed to clear eval-loop lock");
+        return;
+      }
+      await refreshState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to clear eval-loop lock");
+    } finally {
+      setClearingLock(false);
+    }
+  }
+
   const visibleIterations = state?.iterations
     ?.filter((i) => activeTrack === "all" || i.track === activeTrack)
     .slice(0, 20) ?? [];
+  const currentLastRun = lastRun(state);
+  const currentLock = state?.lock?.locked ? state.lock : null;
 
   return (
     <div className="flex flex-col gap-4 p-3 text-xs">
@@ -169,9 +256,9 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
             </span>
           ) : null}
         </div>
-        {state?.last_run ? (
+        {currentLastRun ? (
           <span className="text-[10px] text-[var(--text-muted)]">
-            last run {age(state.last_run)}
+            last run {age(currentLastRun)}
           </span>
         ) : null}
       </div>
@@ -201,9 +288,38 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
         <>
           {state ? (
             <div className="grid grid-cols-3 gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2">
-              <Stat label="Accepted" value={state.total_accepted} accent="text-[var(--color-success)]" />
-              <Stat label="Reverted" value={state.total_reverted} accent="text-[var(--color-danger)]" />
-              <Stat label="Total" value={state.total_accepted + state.total_reverted} />
+              <Stat label="Accepted" value={totalAccepted(state)} accent="text-[var(--color-success)]" />
+              <Stat label="Reverted" value={totalReverted(state)} accent="text-[var(--color-danger)]" />
+              <Stat label="Total" value={totalAccepted(state) + totalReverted(state)} />
+            </div>
+          ) : null}
+
+          {currentLock ? (
+            <div className="rounded-md border border-[color-mix(in_oklch,var(--color-warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_8%,transparent)] px-3 py-2">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-[10px] uppercase tracking-widest text-[var(--color-warning)]">
+                    Run lock {currentLock.stale ? "stale" : "active"}
+                  </p>
+                  <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-secondary)]">
+                    {lockRunId(currentLock) ?? "unknown run"}
+                  </p>
+                  <p className="mt-1 text-[10px] text-[var(--text-muted)]">
+                    {lockHasRunJson(currentLock) ? "run.json present" : "run.json missing"}
+                    {lockRequestedAt(currentLock) ? ` · requested ${age(lockRequestedAt(currentLock)!)}` : ""}
+                    {lockUpdatedAt(currentLock) ? ` · lock ${age(lockUpdatedAt(currentLock)!)}` : ""}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  disabled={clearingLock}
+                  onClick={() => void clearRunLock(!currentLock.stale)}
+                  aria-label={`Clear eval-loop lock for ${familiarName}`}
+                  className="shrink-0 rounded border border-[var(--border-strong)] px-2 py-1 text-[10px] uppercase tracking-widest text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {clearingLock ? "clearing" : "clear lock"}
+                </button>
+              </div>
             </div>
           ) : null}
 
@@ -242,8 +358,8 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
                         className="mt-px shrink-0 text-[var(--text-muted)]"
                         width="0.7rem"
                       />
-                      <span className="truncate text-[var(--text-primary)]" title={it.change_summary}>
-                        {it.change_summary}
+                      <span className="truncate text-[var(--text-primary)]" title={iterationSummary(it)}>
+                        {iterationSummary(it)}
                       </span>
                     </div>
                     <span
@@ -262,7 +378,7 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
                       {it.delta > 0 ? "+" : ""}{it.delta.toFixed(1)}
                     </span>
                     <span className="text-[var(--text-muted)]">
-                      {it.metric_before.toFixed(1)} → {it.metric_after.toFixed(1)}
+                      {metricBefore(it).toFixed(1)} → {metricAfter(it).toFixed(1)}
                     </span>
                     <span className="ml-auto text-[var(--text-muted)]" title={formatTimestamp(it.timestamp, readDateTimePrefs())}>
                       {age(it.timestamp)}

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -207,7 +207,7 @@ export function FamiliarGrowthView({
           </button>
           <a className="retro-btn" href="/dashboard/retro">
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
-            Retro Runs
+            Eval Loops
           </a>
         </div>
       </header>

--- a/src/components/retro-runs-view.test.ts
+++ b/src/components/retro-runs-view.test.ts
@@ -6,6 +6,8 @@ const component = readFileSync(new URL("./retro-runs-view.tsx", import.meta.url)
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
+const settings = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const slash = readFileSync(new URL("../lib/slash-commands.ts", import.meta.url), "utf8");
 const apiRoute = readFileSync(new URL("../app/api/retro-runs/route.ts", import.meta.url), "utf8");
 const evalLoopRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/route.ts", import.meta.url), "utf8");
 const retroPageUrl = new URL("../app/dashboard/retro/page.tsx", import.meta.url);
@@ -20,18 +22,22 @@ assert.match(component, /fetch\(apiPath/, "RetroRunsView loads retro runs throug
 assert.match(component, /downloadRetroSnapshot/, "RetroRunsView offers a sanitized export");
 assert.match(component, /JSON\.stringify\(snapshot/, "exports the API snapshot rather than raw daemon payloads");
 assert.match(component, /<Tabs[\s\S]{0,160}variant="segment"/, "track filters use the shared segment Tabs");
-assert.match(component, /ariaLabel="Retro track filter"/, "track filter tablist is labelled");
-assert.match(component, /aria-label="Refresh retro runs"/, "refresh is an icon button with an accessible name");
+assert.match(component, /ariaLabel="Eval loop track filter"/, "track filter tablist is labelled for Eval Loops");
+assert.match(component, /aria-label="Refresh eval loops"/, "refresh is an icon button with an accessible name");
 assert.match(apiRoute, /redactSecretsDeep/, "aggregate retro API redacts daemon data at the route boundary");
 assert.match(evalLoopRoute, /redactSecretsDeep/, "per-familiar eval-loop proxy redacts daemon data too");
-assert.match(workspace, /retro: "Retro Runs"/, "workspace has a Retro Runs mode title");
+assert.match(workspace, /retro: "Eval Loops"/, "workspace has an Eval Loops mode title");
 assert.match(
   workspace,
   /const retroFamiliarId = activeId \?\? familiars\[0\]\?\.id \?\? null/,
   "workspace Retro mode should collapse All familiars to one familiar instead of aggregating every familiar",
 );
 assert.match(workspace, /<RetroRunsView familiarId=\{retroFamiliarId\}/, "workspace renders Retro Runs scoped to one familiar");
-assert.doesNotMatch(sidebar, /id: "retro"/, "desktop sidebar should not expose a Retro tab");
+assert.match(sidebar, /\{ id: "retro", label: "Eval Loops"/, "desktop sidebar should expose Eval Loops as an optional surface");
+assert.match(sidebar, /if \(fm\.id === "retro"\) return addons\?\.retro === true;/, "Eval Loops sidebar row should be add-on gated");
+assert.match(settings, /\|\s*"retro"/, "Settings add-on keys should include retro");
+assert.match(settings, /key: "retro"[\s\S]{0,120}label: "Eval Loops"/, "Settings should expose the Eval Loops add-on");
+assert.match(slash, /name: "\/evals"[\s\S]{0,120}Eval Loops/, "slash command catalog should include /evals for Eval Loops");
 assert.doesNotMatch(mobileTabs, /id: "retro"/, "mobile bottom tabs should not expose a Retro tab");
 
 console.log("retro-runs-view.test.ts: ok");

--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -59,7 +59,7 @@ function downloadRetroSnapshot(snapshot: RetroRunsSnapshot) {
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
-  anchor.download = `coven-retro-runs-${new Date().toISOString().slice(0, 10)}.json`;
+  anchor.download = `coven-eval-loops-${new Date().toISOString().slice(0, 10)}.json`;
   anchor.click();
   URL.revokeObjectURL(url);
 }
@@ -169,24 +169,24 @@ export function RetroRunsView({
   const shellClass = `retro-surface${standalone ? " retro-surface--standalone" : ""}`;
 
   return (
-    <section className={shellClass} aria-label="Retro Runs">
+    <section className={shellClass} aria-label="Eval Loops">
       <header className="retro-hero">
         <div className="retro-hero__copy">
           <p className="retro-eyebrow">
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
-            Retro Runs
+            Eval Loops
           </p>
-          <h2>Eval-loop retros, scrubbed clean.</h2>
+          <h2>Familiar eval loops, scrubbed clean.</h2>
           <p>
-            Inspect synthesis, prompt, and memory iterations across familiars with secrets redacted before they reach the surface.
+            Inspect and operate synthesis, prompt, and memory iterations across familiars with secrets redacted before they reach the surface.
           </p>
         </div>
         <div className="retro-hero__actions">
           <button
             type="button"
             className="retro-icon-btn"
-            aria-label="Refresh retro runs"
-            title="Refresh retro runs"
+            aria-label="Refresh eval loops"
+            title="Refresh eval loops"
             onClick={() => void load({ quiet: true })}
             disabled={refreshing}
           >
@@ -241,7 +241,7 @@ export function RetroRunsView({
         <Tabs
           variant="segment"
           size="sm"
-          ariaLabel="Retro track filter"
+          ariaLabel="Eval loop track filter"
           value={track}
           onChange={setTrack}
           items={TRACKS}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -499,6 +499,7 @@ type AddonKey =
   | "roles"
   | "groupchat"
   | "journal"
+  | "retro"
   | "docs";
 
 const ADDON_ROWS: Array<{
@@ -572,6 +573,13 @@ const ADDON_ROWS: Array<{
     icon: "ph:book-open",
     group: "surfaces",
     description: "Your daily journal and generated sketches.",
+  },
+  {
+    key: "retro",
+    label: "Eval Loops",
+    icon: "ph:arrows-clockwise-bold",
+    group: "surfaces",
+    description: "Run, inspect, and recover familiar eval loops.",
   },
   {
     key: "docs",

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -38,6 +38,7 @@ export type FolderMode =
   | "library"
   | "capabilities"
   | "journal"
+  | "retro"
   | "docs";
 
 export type AddonsConfig = {
@@ -51,6 +52,7 @@ export type AddonsConfig = {
   groupchat?: boolean;
   journal?: boolean;
   docs?: boolean;
+  retro?: boolean;
 };
 
 export type SidebarMinimalProps = {
@@ -110,6 +112,7 @@ const FOLDER_MODES: Array<{
   { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘8", description: "Chat with a familiar beside your files and terminal" },
   { id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘0", description: "Saved docs, links, and reading" },
   { id: "docs", label: "Coven", iconName: "ph:book-bookmark", group: "tools", description: "OpenCoven docs, feedback, and social tabs" },
+  { id: "retro", label: "Eval Loops", iconName: "ph:arrows-clockwise-bold", group: "tools", description: "Run and inspect familiar eval loops" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, skills, and the capabilities your familiars can use" },
   { id: "flow", label: "Flow", iconName: "ph:flow-arrow", group: "tools", description: "Freeform n8n-style automation editor — wire nodes on a canvas" },
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
@@ -257,6 +260,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     if (fm.id === "groupchat") return addons?.groupchat === true;
     if (fm.id === "journal") return addons?.journal === true;
     if (fm.id === "docs") return addons?.docs === true;
+    if (fm.id === "retro") return addons?.retro === true;
     return true;
   });
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -91,7 +91,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   roles: "Roles",
   flow: "Flow",
   submissions: "Submissions",
-  retro: "Retro Runs",
+  retro: "Eval Loops",
   capabilities: "Capabilities",
   journal: "Journal",
   docs: "Coven",
@@ -252,7 +252,19 @@ export function Workspace() {
   const [mobileModeEnabled, setMobileModeEnabledState] = useState(readMobileModeEnabled);
   const [mobileModeHost, setMobileModeHost] = useState<string | null>(null);
   const [mobileModeError, setMobileModeError] = useState<string | null>(null);
-  const [addons, setAddons] = useState<{ github?: boolean; library?: boolean }>({});
+  const [addons, setAddons] = useState<{
+    github?: boolean;
+    library?: boolean;
+    code?: boolean;
+    terminal?: boolean;
+    browser?: boolean;
+    flow?: boolean;
+    roles?: boolean;
+    groupchat?: boolean;
+    journal?: boolean;
+    docs?: boolean;
+    retro?: boolean;
+  }>({});
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
   // Deep-link target captured at mount, held until the async sessions fetch
@@ -497,7 +509,7 @@ export function Workspace() {
   useEffect(() => {
     fetch("/api/config", { cache: "no-store" })
       .then((r) => r.json())
-      .then((j: { ok?: boolean; config?: { addons?: { github?: boolean; library?: boolean } } }) => {
+      .then((j: { ok?: boolean; config?: { addons?: typeof addons } }) => {
         if (j.ok && j.config?.addons) setAddons(j.config.addons);
       })
       .catch(() => {/* keep defaults */});
@@ -1459,6 +1471,10 @@ export function Workspace() {
       case "/automations":
       case "/inbox":
         setMode("inbox");
+        return true;
+      case "/evals":
+      case "/eval-loops":
+        setMode("retro");
         return true;
       case "/remind": {
         const trimmedArgs = args.trim();

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -113,6 +113,7 @@ export type CaveConfig = {
     groupchat?: boolean;
     journal?: boolean;
     docs?: boolean;
+    retro?: boolean;
   };
   marketplace: {
     installed: Record<string, MarketplaceInstallEntry>;
@@ -152,6 +153,7 @@ export async function loadConfig(): Promise<CaveConfig> {
         groupchat: parsed.addons?.groupchat ?? false,
         journal: parsed.addons?.journal ?? false,
         docs: parsed.addons?.docs ?? false,
+        retro: parsed.addons?.retro ?? false,
       },
       marketplace: {
         installed: parsed.marketplace?.installed ?? {},

--- a/src/lib/familiar-heal-requests.ts
+++ b/src/lib/familiar-heal-requests.ts
@@ -90,6 +90,13 @@ function sortRequests(requests: SelfHealRequest[]): SelfHealRequest[] {
   });
 }
 
+function iterationChangeSummary(iteration: {
+  change_summary?: string;
+  changeSummary?: string;
+}): string {
+  return iteration.change_summary ?? iteration.changeSummary ?? "Iteration recorded";
+}
+
 export function deriveHealRequests(args: {
   familiarId: string;
   evalLoopState: EvalLoopState | null;
@@ -100,15 +107,14 @@ export function deriveHealRequests(args: {
 
   for (const iteration of args.evalLoopState?.iterations ?? []) {
     if (iteration.outcome !== "REVERT") continue;
+    const changeSummary = iterationChangeSummary(iteration);
     requests.push({
       id: `${args.familiarId}:eval-loop:${iteration.id}`,
       familiarId: args.familiarId,
       source: "eval-loop",
       severity: "warn",
       title: `${titleCase(iteration.track)} eval reverted`,
-      detail: iteration.notes
-        ? `${iteration.change_summary} ${iteration.notes}`
-        : iteration.change_summary,
+      detail: iteration.notes ? `${changeSummary} ${iteration.notes}` : changeSummary,
       suggestedAction: `Run a follow-up ${iteration.track} eval iteration.`,
       actionKind: "run-eval",
       createdAt: iteration.timestamp || STATIC_CREATED_AT,

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -43,6 +43,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/board", hint: "Tasks", description: "Open the Tasks kanban and table view.", section: "view" },
   { name: "/chats", hint: "Chats", description: "Switch back to the Chats view.", section: "view" },
   { name: "/automations", hint: "Automations", description: "Open Automations.", section: "view" },
+  { name: "/evals", aliases: ["/eval-loops"], hint: "Eval Loops", description: "Open Eval Loops.", section: "view" },
   { name: "/remind", hint: "new reminder", description: "Create a reminder. Try “/remind in 30m check the build”.", argPlaceholder: "when + text", section: "view" },
 
   { name: "/terminal", aliases: ["/comux"], hint: "Terminal", description: "Open the integrated terminal view.", section: "view" },


### PR DESCRIPTION
## Summary
- Exposes Eval Loops as a dedicated Cave workspace surface instead of hidden Retro Runs.
- Adds a Cave proxy route for daemon-owned lock recovery at `/api/skills/eval-loop/:familiarId/run-lock`.
- Adds lock status, stale/fresh clear affordance, slash commands, add-on/nav wiring, and implementation docs.

## Why
Familiars need a sanctioned way to run and recover eval loops through Cave without asking the UI or agent to directly mutate familiar workspace files.

## Companion PR
Requires daemon endpoint from OpenCoven/coven#263.

## Verification
- `pnpm typecheck`
- `pnpm check:tests-wired` → all 610 test files wired into CI
- `pnpm test:app` → 454 test files passed
- `git diff --check`
