### PR TITLE
fix(sidecar): ship sharp so familiar avatars render in the packaged app

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,12 @@ const nextConfig: NextConfig = {
   // Cave does not use Next's server-side image optimizer in the packaged app;
   // icon generation happens before build via scripts/generate-pwa-icons.mjs.
   images: { unoptimized: true },
-  serverExternalPackages: ["node-pty"],
+  // node-pty and sharp are native addons. Keep them external so Next doesn't try
+  // to trace/bundle their platform binaries into .next/ (which strips the .node
+  // files). sharp powers the familiar avatar route's downscale/transcode — see
+  // src/app/api/familiars/[id]/avatar/route.ts. It must resolve from node_modules
+  // at runtime, so it has to be a production dependency that the sidecar ships.
+  serverExternalPackages: ["node-pty", "sharp"],
   // Next.js file tracing otherwise sucks the entire src-tauri/target/
   // (multi-GB) into the standalone bundle. Exclude noisy siblings.
   outputFileTracingExcludes: {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-colorful": "5.7.0",
     "react-dom": "19.2.4",
     "react-resizable-panels": "4.11.2",
+    "sharp": "0.34.5",
     "shiki": "4.2.0",
     "sucrase": "3.35.1",
     "ws": "8.21.0",
@@ -87,7 +88,6 @@
     "@types/ws": "8.18.1",
     "esbuild": "0.28.0",
     "highlight.js": "11.11.1",
-    "sharp": "0.34.5",
     "tailwindcss": "4.3.0",
     "typescript": "5.9.3",
     "vitest": "4.1.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-resizable-panels:
         specifier: 4.11.2
         version: 4.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sharp:
+        specifier: 0.34.5
+        version: 0.34.5
       shiki:
         specifier: 4.2.0
         version: 4.2.0
@@ -141,9 +144,6 @@ importers:
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
-      sharp:
-        specifier: 0.34.5
-        version: 0.34.5
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -29,6 +29,25 @@ assert.match(src, /prune_sidecar_nonruntime_files\(\)/, "sidecar must prune non-
 assert.match(src, /node_modules\/playwright-core/, "sidecar must remove Playwright test runtime from the packaged app");
 assert.match(src, /node_modules\/@types/, "sidecar must remove TypeScript declaration packages from the packaged app");
 assert.match(src, /-name '\*\.map'/, "sidecar must remove source maps from the packaged app");
-assert.match(src, /node_modules\/sharp/, "sidecar must remove optional Sharp image optimizer from the packaged app");
+
+// Sharp is a RUNTIME dependency: src/app/api/familiars/[id]/avatar/route.ts
+// imports it to downscale + transcode the (~30MB/4096px) workspace avatars.
+// Sharp and its @img native binaries MUST ship in the packaged app — regression
+// guard for the macOS DMG bug where avatars 404'd after the bundle stripped sharp.
+assert.doesNotMatch(
+  src,
+  /"\$dest\/node_modules\/sharp"/,
+  "sidecar must NOT prune sharp — the avatar route needs it at runtime",
+);
+assert.doesNotMatch(
+  src,
+  /"\$dest\/node_modules\/@img"/,
+  "sidecar must NOT prune @img — sharp's native binaries are required at runtime",
+);
+assert.match(
+  src,
+  /node_modules\/@img\/sharp-\*/,
+  "sidecar must verify the platform sharp binary is present before shipping",
+);
 
 console.log("sidecar-bundle-deps.test: ok");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -145,13 +145,18 @@ prune_sidecar_nonruntime_files() {
 
   echo "==> pruning sidecar non-runtime files"
 
+  # Do NOT prune sharp / @img here. They look optional (images.unoptimized is
+  # true, so Next's own optimizer never loads sharp) but the familiar avatar
+  # route (src/app/api/familiars/[id]/avatar/route.ts) imports sharp at runtime
+  # to downscale + transcode workspace avatars. Stripping them made that route
+  # 404 on every platform — most visibly the macOS DMG, where no global sharp
+  # was reachable as a fallback. prune_foreign_native_packages already trims
+  # @img down to just the build target, so the bundle stays small.
   rm -rf \
     "$dest/node_modules/@playwright" \
     "$dest/node_modules/@types" \
     "$dest/node_modules/playwright" \
-    "$dest/node_modules/playwright-core" \
-    "$dest/node_modules/sharp" \
-    "$dest/node_modules/@img"
+    "$dest/node_modules/playwright-core"
 
   find "$dest" -type f \( \
     -name '*.map' -o \
@@ -290,11 +295,18 @@ fi
 prune_sidecar_nonruntime_files "$DEST"
 
 # Sanity check
-for must in node_modules/@next/env node_modules/@swc/helpers/_; do
+for must in node_modules/@next/env node_modules/@swc/helpers/_ node_modules/sharp; do
   if [ ! -e "$DEST/$must" ]; then
     echo "==> ! bundle still missing $must — sidecar will not boot" >&2
     exit 1
   fi
 done
+
+# sharp needs its platform-native binary (@img/sharp-<target>); without it the
+# familiar avatar route throws at runtime and every avatar 404s.
+if ! ls "$DEST"/node_modules/@img/sharp-* >/dev/null 2>&1; then
+  echo "==> ! bundle missing @img/sharp-* native binary — avatars will 404" >&2
+  exit 1
+fi
 
 echo "==> sidecar bundle ready ($(du -sh "$DEST" | cut -f1))"


### PR DESCRIPTION
## Problem

Familiar (agent) avatars don't render in the packaged desktop app — most visibly the macOS DMG — even though they render fine in dev (`localhost:3000`). SVG / initial avatars show; uploaded raster avatars come back blank.

## Root cause

`src/app/api/familiars/[id]/avatar/route.ts` imports `sharp` at runtime to downscale + transcode workspace avatars (the seeded ones are ~30MB / 4096px PNGs under `~/.coven/workspaces/familiars/<id>/avatars/`). But `sharp` was dropped from the sidecar bundle **twice over**:

1. It was a **devDependency**, so the sidecar's `pnpm install --prod` (`scripts/sidecar-bundle.sh`) skipped it.
2. `prune_sidecar_nonruntime_files` explicitly `rm -rf`'d `node_modules/sharp` **and** `node_modules/@img`.

So `require('sharp')` threw in the packaged Node server and the route 404'd for every raster image. SVG avatars skip the sharp branch, so they kept working — which is why it looked like avatars were only *half* broken. `images.unoptimized` disables Next's own image optimizer but not this direct `sharp` use in the route.

## Fix

- Move `sharp` → `dependencies` so the production sidecar install includes it.
- Add `sharp` to `serverExternalPackages` so Next doesn't trace/strip its native `.node` binaries.
- Stop pruning `sharp` / `@img` in `sidecar-bundle.sh`; add a guard that fails the build if the `@img/sharp-<target>` native binary is missing.
- Flip `sidecar-bundle-deps.test.mjs` to assert `sharp` is **kept** (it was asserting removal — codifying the bug).

`prune_foreign_native_packages` still trims `@img` down to just the build target, so the bundle stays small, and `pnpm.supportedArchitectures` already fetches the per-OS binaries.

## Verification

- `dependency-policy`, `sidecar-bundle`, and `sidecar-bundle-deps` tests pass.
- Replicated the bundler's `pnpm install --prod --frozen-lockfile` staging step: `node_modules/sharp` is now present, and `@img/sharp-darwin-arm64` / `-x64` + libvips are fetched — the binaries the macOS DMG needs.

## Build note

The release DMG must be built on macOS — the prune keys off the build host's arch, same as `@next/swc` and `node-pty` already do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
