### PR TITLE
chore: release v0.0.121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.121] - 2026-06-28
+
+Patch release on top of v0.0.120. Headline: flow required-input handling,
+familiar eval loops, Windows runtime discovery, chat, onboarding, and
+group-chat follow-ups on the mobile-mode release line.
+
+### Added
+
+- **Flow** - added explicit required flow inputs, a reusable required-input
+  dialog, server-side required-input rejection, required badges, Deep Research
+  topic prompting, vertical layout / port-flip controls, and a labelled
+  Active/Inactive toolbar toggle (#1983, #1994, #1997, #1998).
+- **Familiar evals** - added eval-loop control-plane wiring plus a dedicated
+  eval surface for running and reviewing familiar evals (#1999, #2000).
+- **Vault** - added encrypted local secrets support for Cave-managed secret
+  storage (#1987).
+- **Chat / Code** - added the two-way Chat / Code toggle and merged projects
+  into the Chat surface (#1980).
+- **Group chat** - added next-path suggestion chips for click-to-send follow-up
+  prompts (#1979).
+
+### Fixed
+
+- **Windows runtime discovery** - Windows now launches `coven.cmd` npm shims
+  through Node for prompt-bearing spawn paths, fixing `spawn EINVAL` failures in
+  `/api/harnesses` and onboarding runtime discovery (#1992, closes #1993).
+- **Flow** - missing required inputs now prompt from the run path, onboarding
+  prompt actions align with the textarea, and Tidy / orientation re-layout
+  applies in place on the canvas (#1986, #1995, #1996).
+- **Onboarding** - Option A and runtime install lists now show honest empty
+  states and re-probe PATH when adapter discovery misses locally installed
+  runtimes (#1985, #1988).
+- **Chat** - newer local session status wins over stale status, mermaid syntax
+  errors no longer render as hard failures, and lightbox / expand overlays mount
+  through `document.body` (#1978, #1981, #1984).
+- **Group chat** - next-paths metadata is stripped from Coven replies before
+  display (#1976).
+- **OpenClaw integration** - launch paths now use the current session id flag
+  when forwarding into OpenClaw (#1989).
+
+### Changed
+
+- **Cave follow-ups** - bundled small follow-up fixes on the v0.0.120 line so
+  the release matches the current mainline UI and flow behavior (#1982).
+
 ## [0.0.120] - 2026-06-27
 
 Patch release on top of v0.0.119. Headline: native mobile mode can keep the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.120"
+version = "0.0.121"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.120"
+version = "0.0.121"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.120</string>
+	<string>0.0.121</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.120</string>
+	<string>0.0.121</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.120</string>
+	<string>0.0.121</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.120</string>
+	<string>0.0.121</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Stamp Coven Cave v0.0.121 across package, Tauri, Cargo, and iOS version surfaces.
- Add the v0.0.121 changelog entry covering flow required inputs, familiar evals, Windows runtime discovery, vault, chat/onboarding, and group-chat follow-ups.

## Verification
- `node --experimental-strip-types src/lib/app-version.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm test:app`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `CIRCLE_NODE_TOTAL=1 npx next build`
