### PR TITLE
refactor(analytics): harden + decompose familiar analytics view

### DIFF
--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -89,21 +89,42 @@ function emptyStats(): FamiliarCardStats {
   };
 }
 
-async function getJson<T>(url: string): Promise<T> {
-  const res = await fetch(url, { cache: "no-store" });
-  return (await res.json()) as T;
-}
+type ApiEnvelope = { ok: boolean; error?: string };
 
-async function getOptionalJson<T>(url: string, fallback: T): Promise<T> {
+/**
+ * Fetch a single analytics endpoint without ever rejecting. A non-2xx response
+ * or a network/parse error degrades to `fallback` (which carries `ok: false`)
+ * so one failing endpoint surfaces in the `errors` banner instead of blanking
+ * the whole view.
+ */
+async function fetchResource<T extends ApiEnvelope>(url: string, fallback: T): Promise<T> {
   try {
-    return await getJson<T>(url);
-  } catch {
-    return fallback;
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) {
+      return { ...fallback, error: `HTTP ${res.status}` } as T;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    return { ...fallback, error: err instanceof Error ? err.message : "request failed" } as T;
   }
 }
 
 function retroStateFor(snapshot: RetroRunsSnapshot, familiarId: string): RetroFamiliarState | null {
   return snapshot.familiars.find((state) => state.familiarId === familiarId) ?? null;
+}
+
+/**
+ * The daemon proxy can hand back either an EvalLoopState directly or a wrapped
+ * `{ state: EvalLoopState }` envelope (the live daemon double-wraps). Normalize
+ * to the inner state so downstream `iterations`/`track_counts` reads are safe.
+ */
+function normalizeEvalLoopState(raw: EvalLoopState | null | undefined): EvalLoopState | null {
+  if (!raw || typeof raw !== "object") return null;
+  const candidate = raw as EvalLoopState & { state?: EvalLoopState | null };
+  if (!Array.isArray(candidate.iterations) && candidate.state && typeof candidate.state === "object") {
+    return candidate.state;
+  }
+  return candidate;
 }
 
 function responseError(response: { ok: boolean; error?: string }, fallback: string): string | null {
@@ -121,13 +142,13 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     retroJson,
     selfReportsJson,
   ] = await Promise.all([
-    getJson<FamiliarsResponse>("/api/familiars"),
-    getJson<ContractResponse>(`/api/familiars/${encodedId}/contract`),
-    getJson<EvalLoopResponse>(`/api/skills/eval-loop/${encodedId}`),
-    getJson<SessionsResponse>("/api/sessions/list"),
-    getJson<CovenMemoryResponse>("/api/coven-memory"),
-    getJson<RetroApiResponse>("/api/retro-runs"),
-    getOptionalJson<SelfReportsResponse>(`/api/familiars/${encodedId}/self-reports?limit=30`, { ok: true, reports: [], total: 0 }),
+    fetchResource<FamiliarsResponse>("/api/familiars", { ok: false, familiars: [] }),
+    fetchResource<ContractResponse>(`/api/familiars/${encodedId}/contract`, { ok: false }),
+    fetchResource<EvalLoopResponse>(`/api/skills/eval-loop/${encodedId}`, { ok: false, state: null }),
+    fetchResource<SessionsResponse>("/api/sessions/list", { ok: false, sessions: [] }),
+    fetchResource<CovenMemoryResponse>("/api/coven-memory", { ok: false, entries: [] }),
+    fetchResource<RetroApiResponse>("/api/retro-runs", { ok: false }),
+    fetchResource<SelfReportsResponse>(`/api/familiars/${encodedId}/self-reports?limit=30`, { ok: false, reports: [], total: 0 }),
   ]);
 
   const errors = [
@@ -143,7 +164,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     familiarId,
     familiars: familiarsJson.familiars ?? [],
     contractReport: contractJson.report ?? null,
-    evalLoopState: evalLoopJson.state ?? null,
+    evalLoopState: normalizeEvalLoopState(evalLoopJson.state),
     sessions: sessionsJson.sessions ?? [],
     covenEntries: memoryJson.entries ?? [],
     retroSnapshot: retroJson.snapshot ?? EMPTY_SNAPSHOT,
@@ -154,15 +175,19 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
 
 export function buildFamiliarAnalyticsModel(data: FamiliarAnalyticsData): FamiliarAnalyticsModel {
   const familiar = data.familiars.find((item) => item.id === data.familiarId) ?? null;
-  const statsByFamiliar = buildFamiliarCardStats({
-    familiars: data.familiars,
-    sessions: data.sessions,
-    covenEntries: data.covenEntries,
-  });
+  // Scope the stats computation to the single familiar this view renders rather
+  // than bucketing every familiar's sessions/memory just to read one entry.
+  const stats = familiar
+    ? buildFamiliarCardStats({
+        familiars: [familiar],
+        sessions: data.sessions.filter((session) => session.familiarId === familiar.id),
+        covenEntries: data.covenEntries.filter((entry) => entry.familiar_id === familiar.id),
+      }).get(familiar.id) ?? emptyStats()
+    : emptyStats();
   const growthReport = familiar
     ? deriveGrowthReport({
         familiar,
-        stats: statsByFamiliar.get(familiar.id) ?? emptyStats(),
+        stats,
         retroState: retroStateFor(data.retroSnapshot, familiar.id),
       })
     : null;

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -257,6 +257,8 @@ function mockFetchFor(score: "low" | "trusted") {
   ]);
 
   globalThis.fetch = (async (url: RequestInfo | URL) => ({
+    ok: true,
+    status: 200,
     json: async () => responses.get(String(url)),
   })) as typeof fetch;
 }
@@ -277,6 +279,25 @@ describe("FamiliarAnalyticsView", () => {
     const model = buildFamiliarAnalyticsModel(data);
 
     assert.equal(model.confidence.label, "Trusted");
+  });
+
+  it("degrades gracefully when an endpoint fails instead of blanking the view", async () => {
+    mockFetchFor("trusted");
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: RequestInfo | URL) => {
+      if (String(url) === "/api/familiars/cody/contract") {
+        return { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+      }
+      return realFetch(url);
+    }) as typeof fetch;
+
+    const data = await loadFamiliarAnalyticsData("cody");
+    const model = buildFamiliarAnalyticsModel(data);
+
+    // The whole load still resolves; the failure is surfaced, not thrown.
+    assert.ok(model.errors.some((message) => message.includes("HTTP 500")));
+    assert.equal(model.familiar?.id, "cody");
+    assert.equal(model.contractReport, null);
   });
 
   it("renders the heal request count and keeps EvalLoopPanel present", async () => {

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   buildFamiliarAnalyticsModel,
   loadFamiliarAnalyticsData,
@@ -11,7 +11,9 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { ThreadSignalsSection } from "@/components/thread-signals-section";
-import { escalateBlockers } from "@/lib/familiar-heal-requests";
+import { escalateBlockers, type SelfHealRequest } from "@/lib/familiar-heal-requests";
+import type { ConfidenceScore } from "@/lib/familiar-confidence";
+import type { ContractReport } from "@/lib/familiar-contract";
 import { Icon } from "@/lib/icon";
 import { aggregateThreadSignals } from "@/lib/thread-self-report";
 
@@ -65,6 +67,89 @@ export function FamiliarAnalyticsView({ familiarId }: { familiarId: string }) {
     </main>
   );
 }
+
+/** Section shell — shared head (title + count) wrapper used by every panel. */
+function FaSection({
+  id,
+  title,
+  count,
+  children,
+}: {
+  id: string;
+  title: string;
+  count: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="fa-section" aria-labelledby={`${id}-title`}>
+      <div className="fa-section__head">
+        <h2 id={`${id}-title`} className="fa-section__title">{title}</h2>
+        <span>{count}</span>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+const ConfidenceBreakdown = memo(function ConfidenceBreakdown({ confidence }: { confidence: ConfidenceScore }) {
+  return (
+    <FaSection id="fa-confidence" title="Confidence Breakdown" count={`${confidence.factors.length} factors`}>
+      <div className="fa-factor-list">
+        {confidence.factors.map((factor) => (
+          <div key={factor.label} className="fa-factor">
+            <div className="fa-factor__meta">
+              <b>{factor.label.replaceAll("_", " ")}</b>
+              <span>{Math.round(factor.value)} × {factor.weight.toFixed(2)}</span>
+            </div>
+            <div className="fa-factor-bar" aria-label={`${factor.label} contributes ${factor.contribution.toFixed(1)}`}>
+              <span className="fa-factor-segment" style={{ width: `${Math.max(0, Math.min(100, factor.value))}%` }} />
+            </div>
+            <small>{factor.contribution.toFixed(1)} points</small>
+          </div>
+        ))}
+      </div>
+    </FaSection>
+  );
+});
+
+const SelfHealList = memo(function SelfHealList({ requests }: { requests: SelfHealRequest[] }) {
+  if (requests.length === 0) {
+    return <EmptyState compact icon="ph:check-circle-bold" headline="No self-heal requests." />;
+  }
+  return (
+    <div className="fa-heal-list">
+      {requests.map((request) => (
+        <article key={request.id} className={`fa-heal-card fa-heal-card--${request.severity}`}>
+          <div>
+            <span>{request.source}</span>
+            <h3>{request.title}</h3>
+            <p>{request.detail}</p>
+          </div>
+          <b>{request.actionKind}</b>
+        </article>
+      ))}
+    </div>
+  );
+});
+
+const ContractCompliance = memo(function ContractCompliance({ report }: { report: ContractReport | null }) {
+  return (
+    <FaSection id="fa-contract" title="Contract Compliance" count={report?.pass ? "passing" : "needs review"}>
+      {report ? (
+        <div className="fa-contract-grid">
+          {report.properties.map((property) => (
+            <div key={property.property} className={`fa-contract-item${property.pass ? " is-pass" : " is-fail"}`}>
+              <Icon name={property.pass ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
+              <span>{property.property}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyState compact icon="ph:file-text" headline="No contract report available." />
+      )}
+    </FaSection>
+  );
+});
 
 export function FamiliarAnalyticsContent({
   model,
@@ -138,88 +223,33 @@ export function FamiliarAnalyticsContent({
         </div>
       </header>
 
-      <section className="fa-section" aria-labelledby="fa-confidence-title">
-        <div className="fa-section__head">
-          <h2 id="fa-confidence-title" className="fa-section__title">Confidence Breakdown</h2>
-          <span>{model.confidence.factors.length} factors</span>
-        </div>
-        <div className="fa-factor-list">
-          {model.confidence.factors.map((factor) => (
-            <div key={factor.label} className="fa-factor">
-              <div className="fa-factor__meta">
-                <b>{factor.label.replaceAll("_", " ")}</b>
-                <span>{Math.round(factor.value)} × {factor.weight.toFixed(2)}</span>
-              </div>
-              <div className="fa-factor-bar" aria-label={`${factor.label} contributes ${factor.contribution.toFixed(1)}`}>
-                <span className="fa-factor-segment" style={{ width: `${Math.max(0, Math.min(100, factor.value))}%` }} />
-              </div>
-              <small>{factor.contribution.toFixed(1)} points</small>
-            </div>
-          ))}
-        </div>
-      </section>
+      <ConfidenceBreakdown confidence={model.confidence} />
 
-      <section className="fa-section" aria-labelledby="fa-heal-title">
-        <div className="fa-section__head">
-          <h2 id="fa-heal-title" className="fa-section__title">Self-Heal Requests</h2>
-          <span>{healRequests.length} {healRequests.length === 1 ? "request" : "requests"}</span>
-        </div>
-        {healRequests.length === 0 ? (
-          <EmptyState compact icon="ph:check-circle-bold" headline="No self-heal requests." />
-        ) : (
-          <div className="fa-heal-list">
-            {healRequests.map((request) => (
-              <article key={request.id} className={`fa-heal-card fa-heal-card--${request.severity}`}>
-                <div>
-                  <span>{request.source}</span>
-                  <h3>{request.title}</h3>
-                  <p>{request.detail}</p>
-                </div>
-                <b>{request.actionKind}</b>
-              </article>
-            ))}
-          </div>
-        )}
-      </section>
+      <FaSection
+        id="fa-heal"
+        title="Self-Heal Requests"
+        count={`${healRequests.length} ${healRequests.length === 1 ? "request" : "requests"}`}
+      >
+        <SelfHealList requests={healRequests} />
+      </FaSection>
 
-      <section className="fa-section" aria-labelledby="fa-thread-signals-title">
-        <div className="fa-section__head">
-          <h2 id="fa-thread-signals-title" className="fa-section__title">Thread Signals</h2>
-          <span>{model.threadReports.length} {model.threadReports.length === 1 ? "report" : "reports"}</span>
-        </div>
+      <FaSection
+        id="fa-thread-signals"
+        title="Thread Signals"
+        count={`${model.threadReports.length} ${model.threadReports.length === 1 ? "report" : "reports"}`}
+      >
         <ThreadSignalsSection familiarId={model.familiarId} reports={model.threadReports} />
-      </section>
+      </FaSection>
 
-      <section className="fa-section" aria-labelledby="fa-eval-title">
-        <div className="fa-section__head">
-          <h2 id="fa-eval-title" className="fa-section__title">Eval Loop</h2>
-          <span>{model.evalLoopState?.iterations.length ?? 0} iterations</span>
-        </div>
+      <FaSection id="fa-eval" title="Eval Loop" count={`${model.evalLoopState?.iterations?.length ?? 0} iterations`}>
         {model.familiar ? (
           <EvalLoopPanel familiarId={model.familiar.id} familiarName={familiarName} />
         ) : (
           <EmptyState compact icon="ph:arrows-clockwise-bold" headline="Eval loop unavailable." />
         )}
-      </section>
+      </FaSection>
 
-      <section className="fa-section" aria-labelledby="fa-contract-title">
-        <div className="fa-section__head">
-          <h2 id="fa-contract-title" className="fa-section__title">Contract Compliance</h2>
-          <span>{model.contractReport?.pass ? "passing" : "needs review"}</span>
-        </div>
-        {model.contractReport ? (
-          <div className="fa-contract-grid">
-            {model.contractReport.properties.map((property) => (
-              <div key={property.property} className={`fa-contract-item${property.pass ? " is-pass" : " is-fail"}`}>
-                <Icon name={property.pass ? "ph:check-circle-bold" : "ph:warning-circle"} aria-hidden />
-                <span>{property.property}</span>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <EmptyState compact icon="ph:file-text" headline="No contract report available." />
-        )}
-      </section>
+      <ContractCompliance report={model.contractReport} />
     </>
   );
 }


### PR DESCRIPTION
## What

Refactor and optimize the per-familiar analytics view (`/dashboard/familiars/[id]/analytics`).

### Refactor
- Decompose the monolithic `FamiliarAnalyticsContent` into a reusable `FaSection` head wrapper plus `memo`-wrapped `ConfidenceBreakdown` / `SelfHealList` / `ContractCompliance` sub-components. DOM output and CSS classes are unchanged — no visual regression.

### Optimize / harden
- **Resilient loading**: replaced `getJson`/`getOptionalJson` with a single `fetchResource` helper that checks `res.ok` and never rejects. Before, one failing endpoint rejected `Promise.all` and blanked the entire view; now each failure degrades into the existing `errors` banner while the rest renders.
- **Scoped stats**: `buildFamiliarAnalyticsModel` no longer buckets every familiar's sessions/memory to read one entry — it filters to the target familiar first.

### Bug fix
- `/api/skills/eval-loop/[id]` double-wraps its payload (`{ok,state:{ok,state:{...}}}`) when the daemon is online, leaving `evalLoopState.iterations` undefined and crashing the whole page on `?.iterations.length`. Added `normalizeEvalLoopState()` to unwrap, plus a defensive optional chain. (Pre-existing on `main`; route/`EvalLoopPanel` left untouched as the daemon contract is owned by a separate eval-loop branch.)

## Verification
- `tsc --noEmit` clean; `pnpm test:app` green (incl. a new test locking in graceful degradation).
- Rendered live in a browser against a real familiar — all five sections render, no console errors; the Eval Loop panel (previously a crash) now displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)