### PR TITLE
fix(eval-loop): unwrap daemon envelope in proxy route

### DIFF
--- a/src/app/api/skills/eval-loop/[familiarId]/route.ts
+++ b/src/app/api/skills/eval-loop/[familiarId]/route.ts
@@ -5,6 +5,25 @@ import { redactSecretsDeep, redactSecretText } from "@/lib/secret-redaction";
 export const dynamic = "force-dynamic";
 
 /**
+ * The daemon's `/api/v1/skills/eval-loop/:id` already returns an enveloped
+ * `{ ok, state: EvalLoopState }`. Hand back just the inner EvalLoopState so the
+ * proxy isn't double-wrapped (`{ ok, state: { ok, state } }`) — consumers read
+ * `json.state` expecting the state itself, and a double wrap leaves
+ * `state.iterations` undefined. Tolerates a daemon that returns the state bare.
+ */
+function unwrapDaemonEvalState(data: unknown): unknown {
+  if (
+    data &&
+    typeof data === "object" &&
+    "state" in data &&
+    !("iterations" in data)
+  ) {
+    return (data as { state: unknown }).state;
+  }
+  return data;
+}
+
+/**
  * GET /api/skills/eval-loop/[familiarId]
  *
  * Proxies the daemon's eval-loop state for a given familiar.
@@ -32,5 +51,5 @@ export async function GET(
     );
   }
 
-  return NextResponse.json({ ok: true, state: redactSecretsDeep(res.data) });
+  return NextResponse.json({ ok: true, state: redactSecretsDeep(unwrapDaemonEvalState(res.data)) });
 }

--- a/src/components/eval-loop-panel.test.ts
+++ b/src/components/eval-loop-panel.test.ts
@@ -63,6 +63,12 @@ assert.doesNotMatch(
 );
 
 assert.match(
+  evalLoopRoute,
+  /state: redactSecretsDeep\(unwrapDaemonEvalState\(res\.data\)\)/,
+  "successful eval-loop reads should unwrap the daemon envelope so consumers get the EvalLoopState directly (not a double-wrapped { ok, state })",
+);
+
+assert.match(
   skillsRoute,
   /NextResponse\.json\([\s\S]*?ok: false,[\s\S]*?skills: \[\]/,
   "offline skills reads should return a quiet ok:false payload",


### PR DESCRIPTION
## What

Root-cause fix for the eval-loop double-wrap surfaced while refactoring the familiar analytics view (#2003).

`GET /api/skills/eval-loop/[familiarId]` proxies the daemon, whose `/api/v1/skills/eval-loop/:id` **already** returns `{ ok, state: EvalLoopState }`. The route wrapped `res.data` again, producing a double-wrapped `{ ok, state: { ok, state } }`. Consumers read `json.state` expecting the `EvalLoopState` itself, so the double wrap left `state.iterations` undefined:

- `EvalLoopPanel` cast `json.state as EvalLoopState` → showed no iterations even when present.
- The familiar analytics view crashed the whole page on `?.iterations.length` when the daemon was online.

## Fix

Unwrap the daemon envelope at the route (tolerating a daemon that returns the state bare), so `json.state` is the `EvalLoopState` directly. The offline `{ ok: false, state: null }` branch is unchanged.

This makes `normalizeEvalLoopState()` in the analytics data layer (added in #2003) a defensive no-op rather than load-bearing.

## Verification
- `tsc --noEmit` clean; `pnpm test:app` green, including a new `eval-loop-panel.test.ts` assertion that the success branch unwraps via `unwrapDaemonEvalState(res.data)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)