### PR TITLE
chore: freeze external PRs through July 1st, 2026

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Heads up before you fill this out:
+
+  Coven Cave is NOT accepting external pull requests through July 1st, 2026.
+
+  PRs opened from outside the OpenCoven organization will be closed without
+  review during the freeze. The intent will be captured as an issue so the
+  work isn't lost. See CONTRIBUTING.md for the full policy.
+
+  If you are an OpenCoven maintainer, please replace this template with the
+  PR description below.
+-->
+
+## Summary
+
+<!-- What does this change do, in one or two sentences? -->
+
+## Why
+
+<!-- Why is this change needed? Link the issue, plan, or release notes if any. -->
+
+## Changes
+
+<!-- Bullet list of the meaningful changes in this PR. -->
+
+-
+
+## Verification
+
+<!--
+What did you run locally to convince yourself this works?
+Tests, builds, manual repro steps, screenshots, anything that matters.
+-->
+
+## Risk + rollout notes
+
+<!--
+Anything reviewers should look at carefully?
+Anything that needs a release-note line, migration, or follow-up issue?
+-->

--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -1,0 +1,54 @@
+name: Close external PRs
+
+# Coven Cave is not accepting external pull requests through July 1st, 2026.
+# This workflow auto-closes any PR whose author isn't on the allow-list and
+# posts a friendly comment pointing them at CONTRIBUTING.md and the issue
+# tracker. See CONTRIBUTING.md for the full policy.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close:
+    name: Close non-allowlisted PR
+    runs-on: ubuntu-latest
+    # The maintainer allow-list. Add usernames here to grant PR access.
+    # Bots required for the repo to function (dependabot, codeql, etc.) can
+    # be allow-listed individually as needed.
+    if: >-
+      github.actor != 'BunsDev' &&
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'github-actions[bot]'
+    steps:
+      - name: Comment + close
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          body=$(cat <<EOF
+          Thank you for the contribution, @${PR_AUTHOR}.
+
+          Coven Cave is **not accepting external pull requests through July 1st, 2026**.
+          See [CONTRIBUTING.md](https://github.com/${REPO}/blob/main/CONTRIBUTING.md)
+          for the full policy.
+
+          Closing this PR per the freeze. Please **open a GitHub issue** describing
+          the change instead — the technical context here will not be lost, and a
+          maintainer may pick the work up in-house or revisit it after July 1st.
+
+          For security issues, please follow [SECURITY.md](https://github.com/${REPO}/blob/main/SECURITY.md)
+          instead of opening a public issue.
+          EOF
+          )
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body"
+          gh pr close "$PR_NUMBER" --repo "$REPO"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Coven Cave
+
+Thank you for your interest in Coven Cave.
+
+## Pull request freeze (through July 1st, 2026)
+
+**We are not accepting external pull requests at this time.**
+
+This freeze runs through **July 1st, 2026**, while we work through internal
+architecture and release-stability work. Any PRs opened from outside the
+OpenCoven organization will be closed without review. The intent and any
+attached technical context will be filed as an issue so the work isn't lost,
+and an OpenCoven maintainer may re-implement the change in-house when the
+freeze lifts (or sooner, at maintainer discretion).
+
+This is not a comment on the quality of contributions — we appreciate the
+care that goes into PRs against this repo. It is purely a coordination
+choice while internal work consolidates.
+
+## What is in scope right now
+
+Until the freeze lifts, the most helpful things outside contributors can do:
+
+- **Open a clear bug report or feature request** as a GitHub Issue. Include
+  reproduction steps, environment, and the smallest possible example.
+- **Discuss design tradeoffs** in issue comments before implementation.
+- **Report security issues privately** through the policy in
+  [SECURITY.md](./SECURITY.md). Do not open public PRs or public issues for
+  security reports.
+
+## After the freeze lifts
+
+When external PRs reopen, this file will be updated with the full contribution
+flow: branch hygiene, test requirements, sign-off, and review expectations.
+For the in-house workflow that is in effect today, see
+[AGENTS.md](./AGENTS.md).
+
+## Questions
+
+If something is unclear or you think your change should be considered as an
+exception, please file an issue rather than opening a PR. The maintainer
+will respond there.


### PR DESCRIPTION
## Summary

Freezes external pull requests on coven-cave through **July 1st, 2026**, with three layered pieces.

## Why

We need internal architecture and release work to consolidate without external PR triage in the loop. The freeze is documented, surfaced at PR-open time, and enforced by an Actions workflow so the policy is uniform regardless of which surface a contributor uses.

## Changes

- **`CONTRIBUTING.md`** — documents the freeze, the exception path (file an issue), and points security reports at `SECURITY.md`.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — comment block at the top of every new PR composer warning external contributors about the freeze before they write the body.
- **`.github/workflows/close-external-prs.yml`** — `pull_request_target` workflow that auto-comments + closes any PR whose author isn't allow-listed. Allow-list inline in the workflow: `BunsDev`, `dependabot[bot]`, `github-actions[bot]`. Scopes `pull-requests: write` + `issues: write` (narrow).

## Verification

- All three files are new, no deletions, no edits to existing files.
- Workflow uses `pull_request_target` (correct event for cross-fork access to `GITHUB_TOKEN`).
- Permissions block scopes the workflow tightly.
- Author allow-list lives inline for fast edit / opt-in.

## Risk + rollout notes

- The workflow will fire on the **next** PR opened against this repo after merge — it does not back-close existing open PRs (#1991, #2001, etc.). Those need manual handling per your protocol decision.
- After July 1st, edit the workflow's allow-list (or delete the workflow + update CONTRIBUTING.md) to reopen contributions.
- Repo-level "disable forks" is a separate UI/settings change and not part of this PR; that's the recommended belt-and-braces follow-up.