### PR TITLE
fix(retro-runs): unwrap daemon eval-loop envelope

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -84,6 +84,7 @@ export const SUITES = {
     "src/lib/automation-runs.test.ts",
     "src/lib/secret-redaction.test.ts",
     "src/lib/retro-runs.test.ts",
+    "src/lib/eval-loop-daemon.test.ts",
     "src/lib/role-manifest.test.ts",
     "src/lib/chat-cwd-root.test.ts",
     "src/lib/agent-completion-report.test.ts",

--- a/src/app/api/retro-runs/route.ts
+++ b/src/app/api/retro-runs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
 import { bindingFor, loadConfig } from "@/lib/cave-config";
+import { unwrapDaemonEvalState } from "@/lib/eval-loop-daemon";
 import { buildRetroRunsSnapshot, normalizeRetroRunState } from "@/lib/retro-runs";
 import { redactSecretsDeep, redactSecretText } from "@/lib/secret-redaction";
 
@@ -59,7 +60,12 @@ export async function GET(req: Request) {
           },
         });
       }
-      return normalizeRetroRunState({ familiar, state: redactSecretsDeep(stateRes.data) });
+      return normalizeRetroRunState({
+        familiar,
+        // Unwrap the daemon's { ok, state } envelope so normalizeRetroRunState
+        // reads iterations/track_counts off the EvalLoopState, not the wrapper.
+        state: redactSecretsDeep(unwrapDaemonEvalState(stateRes.data)),
+      });
     }),
   );
 

--- a/src/app/api/skills/eval-loop/[familiarId]/route.ts
+++ b/src/app/api/skills/eval-loop/[familiarId]/route.ts
@@ -1,27 +1,9 @@
 import { NextResponse } from "next/server";
 import { callDaemon } from "@/lib/coven-daemon";
+import { unwrapDaemonEvalState } from "@/lib/eval-loop-daemon";
 import { redactSecretsDeep, redactSecretText } from "@/lib/secret-redaction";
 
 export const dynamic = "force-dynamic";
-
-/**
- * The daemon's `/api/v1/skills/eval-loop/:id` already returns an enveloped
- * `{ ok, state: EvalLoopState }`. Hand back just the inner EvalLoopState so the
- * proxy isn't double-wrapped (`{ ok, state: { ok, state } }`) — consumers read
- * `json.state` expecting the state itself, and a double wrap leaves
- * `state.iterations` undefined. Tolerates a daemon that returns the state bare.
- */
-function unwrapDaemonEvalState(data: unknown): unknown {
-  if (
-    data &&
-    typeof data === "object" &&
-    "state" in data &&
-    !("iterations" in data)
-  ) {
-    return (data as { state: unknown }).state;
-  }
-  return data;
-}
 
 /**
  * GET /api/skills/eval-loop/[familiarId]

--- a/src/lib/eval-loop-daemon.test.ts
+++ b/src/lib/eval-loop-daemon.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { unwrapDaemonEvalState } from "./eval-loop-daemon.ts";
+
+describe("unwrapDaemonEvalState", () => {
+  it("returns the inner state from the daemon's { ok, state } envelope", () => {
+    const inner = { iterations: [{ id: "a" }], running: true, total_accepted: 2 };
+    const result = unwrapDaemonEvalState({ ok: true, state: inner });
+    assert.equal(result, inner);
+    assert.equal((result as { iterations: unknown[] }).iterations.length, 1);
+  });
+
+  it("passes through a bare EvalLoopState (daemon that does not envelope)", () => {
+    const bare = { iterations: [], running: false };
+    assert.equal(unwrapDaemonEvalState(bare), bare);
+  });
+
+  it("does not unwrap a state that legitimately carries both keys", () => {
+    // An EvalLoopState with an `iterations` field is the real thing even if some
+    // future field is named `state`; presence of `iterations` wins.
+    const stateLike = { iterations: [{ id: "x" }], state: "running" };
+    assert.equal(unwrapDaemonEvalState(stateLike), stateLike);
+  });
+
+  it("is null/non-object safe", () => {
+    assert.equal(unwrapDaemonEvalState(null), null);
+    assert.equal(unwrapDaemonEvalState(undefined), undefined);
+    assert.equal(unwrapDaemonEvalState("nope"), "nope");
+    assert.deepEqual(unwrapDaemonEvalState({ ok: false }), { ok: false });
+  });
+});

--- a/src/lib/eval-loop-daemon.ts
+++ b/src/lib/eval-loop-daemon.ts
@@ -1,0 +1,22 @@
+/**
+ * The Coven daemon's `/api/v1/skills/eval-loop/:id` returns an enveloped
+ * `{ ok, state: EvalLoopState }`. Several Cave call sites read the EvalLoopState
+ * fields (`iterations`, `running`, `track_counts`, …) directly, so handing them
+ * the envelope leaves every field `undefined` — the "double-wrap" bug.
+ *
+ * `unwrapDaemonEvalState` returns the inner EvalLoopState from that envelope,
+ * while tolerating a daemon that already returns the state bare (detected by the
+ * presence of an `iterations` field). Use it on the raw `callDaemon(...).data`
+ * before reading state fields or re-serializing.
+ */
+export function unwrapDaemonEvalState(data: unknown): unknown {
+  if (
+    data &&
+    typeof data === "object" &&
+    "state" in data &&
+    !("iterations" in data)
+  ) {
+    return (data as { state: unknown }).state;
+  }
+  return data;
+}

--- a/src/lib/retro-runs.test.ts
+++ b/src/lib/retro-runs.test.ts
@@ -4,6 +4,7 @@ import {
   buildRetroRunsSnapshot,
   normalizeRetroRunState,
 } from "./retro-runs.ts";
+import { unwrapDaemonEvalState } from "./eval-loop-daemon.ts";
 
 const daemonState = {
   familiar_id: "nova",
@@ -64,5 +65,24 @@ assert.equal(snapshot.summary.reverted, 1, "summary counts reverts");
 assert.equal(snapshot.summary.runningFamiliars, 1, "summary counts running familiars");
 assert.deepEqual(snapshot.summary.trackCounts, { synthesis: 1, prompt: 1, memory: 0 }, "track counts aggregate");
 assert.equal(snapshot.runs[0].id, "nova:iter-1", "run ids are stable across familiars");
+
+// Regression: the daemon returns an enveloped { ok, state } — the /api/retro-runs
+// route reads it as `unwrapDaemonEvalState(stateRes.data)`. Feeding the envelope
+// straight in under-counts every familiar to zero (the double-wrap bug); the
+// unwrap restores the real runs.
+const daemonEnvelope = { ok: true, state: daemonState };
+
+const fromRawEnvelope = normalizeRetroRunState({
+  familiar: { id: "nova", displayName: "Nova", role: "Guide" },
+  state: daemonEnvelope,
+});
+assert.equal(fromRawEnvelope.runs.length, 0, "the raw envelope mis-parses to zero runs (the bug)");
+
+const fromUnwrapped = normalizeRetroRunState({
+  familiar: { id: "nova", displayName: "Nova", role: "Guide" },
+  state: unwrapDaemonEvalState(daemonEnvelope),
+});
+assert.equal(fromUnwrapped.runs.length, 2, "unwrapping the envelope recovers the real runs");
+assert.equal(fromUnwrapped.running, daemonState.running, "running flag is read off the unwrapped state");
 
 console.log("retro-runs.test.ts: ok");


### PR DESCRIPTION
## What

Second instance of the eval-loop double-wrap, found while auditing the blast radius of #2004.

`/api/retro-runs` calls the daemon's `/api/v1/skills/eval-loop/:id` **directly** (it does not go through the proxy route fixed in #2004), then passes the raw `{ ok, state: EvalLoopState }` envelope into `normalizeRetroRunState`, which reads `iterations` / `track_counts` / `total_accepted` / `running` off the **top level**. On the envelope those are all undefined, so:

- every familiar's retro snapshot came back empty (`totalRuns: 0`, `familiarsWithData: 0`)
- the **Retro Runs dashboard** showed no activity
- the **familiar analytics confidence + growth scores** (which consume `/api/retro-runs` via `familiar-analytics-data.ts`) under-counted eval-loop activity

## Fix

- Extract `unwrapDaemonEvalState` into `src/lib/eval-loop-daemon.ts`, shared by both the proxy route (#2004) and the retro-runs route, so the unwrap logic lives in one place.
- Apply it in `retro-runs/route.ts` before `normalizeRetroRunState`.
- The proxy route now imports the shared helper instead of an inline copy (behaviour identical; `eval-loop-panel.test.ts` still passes).

## Tests
- New `eval-loop-daemon.test.ts`: unit-tests the helper (envelope → inner, bare passthrough, both-keys, null-safety).
- `retro-runs.test.ts`: regression proving the raw envelope mis-parses to **0 runs** while the unwrapped state recovers **2 runs**.
- Wired the new test into the `app` suite; `tsc` clean; `pnpm test:app` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)