### PR TITLE
feat(flow): surface run logs + stall hint so a no-op execution is legible

### DIFF
--- a/src/components/flow/flow-run-steps.tsx
+++ b/src/components/flow/flow-run-steps.tsx
@@ -52,6 +52,12 @@ export function FlowRunSteps({
   onStop,
 }: FlowRunStepsProps) {
   const [collapsed, setCollapsed] = useState(false);
+  const [logsOpen, setLogsOpen] = useState(false);
+
+  const transcript = progress.transcript.trim();
+  // A run that's live but has emitted no `@@step-…` markers is doing nothing
+  // visible — surface that plainly instead of an endless "0/N · pending".
+  const stalled = running && !progress.markersFound;
 
   const nameById = useMemo(
     () => new Map(doc.nodes.map((node) => [node.id, node.name])),
@@ -93,6 +99,17 @@ export function FlowRunSteps({
           </button>
         )}
       </header>
+
+      {!collapsed && stalled && (
+        <p className="flow-run-steps-stall" role="status">
+          <Icon name="ph:warning-circle" width={14} />
+          <span>
+            {transcript
+              ? "Session is running but hasn't reported any step progress yet — check the output below or open the session."
+              : "Waiting for the session to start producing output…"}
+          </span>
+        </p>
+      )}
 
       {!collapsed && (
         <ol className="flow-run-steps-list">
@@ -136,6 +153,31 @@ export function FlowRunSteps({
             );
           })}
         </ol>
+      )}
+
+      {!collapsed && (run.sessionId || transcript) && (
+        <div className="flow-run-logs">
+          <button
+            type="button"
+            className="flow-run-logs-toggle"
+            onClick={() => setLogsOpen((o) => !o)}
+            aria-expanded={logsOpen}
+          >
+            <Icon name={logsOpen ? "ph:caret-down" : "ph:caret-right"} width={12} />
+            Session output
+            {transcript ? <span className="flow-run-logs-size">{transcript.length} chars</span> : null}
+          </button>
+          {logsOpen &&
+            (transcript ? (
+              <pre className="flow-run-logs-body">{transcript.slice(-6000)}</pre>
+            ) : (
+              <p className="flow-run-logs-empty">
+                {running
+                  ? "No output from the session yet."
+                  : "This run produced no session output."}
+              </p>
+            ))}
+        </div>
       )}
 
       {!collapsed && run.sessionId && (

--- a/src/components/flow/use-flow-run.ts
+++ b/src/components/flow/use-flow-run.ts
@@ -12,6 +12,7 @@ const EMPTY: FlowRunProgress = {
   done: false,
   markersFound: false,
   steps: [],
+  transcript: "",
 };
 
 /**

--- a/src/lib/flow/flow-progress.ts
+++ b/src/lib/flow/flow-progress.ts
@@ -27,6 +27,8 @@ export type FlowRunProgress = {
   done: boolean;
   markersFound: boolean;
   steps: WorkflowStepProgress[];
+  /** Raw agent-session output, surfaced as run logs so a stalled run is legible. */
+  transcript: string;
 };
 
 /**
@@ -43,6 +45,7 @@ export function parseFlowRunProgress(transcript: string, orderedNodeIds: string[
     done: result.done,
     markersFound: result.markersFound,
     steps: result.steps,
+    transcript,
   };
 }
 

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -330,6 +330,39 @@
   max-height: 84px; overflow: hidden;
   white-space: pre-wrap; word-break: break-word;
 }
+.flow-run-steps-stall {
+  display: flex; align-items: flex-start; gap: 7px;
+  margin: 0; padding: 8px 10px;
+  font-size: var(--text-2xs); line-height: 1.45; color: var(--text-secondary);
+  background: color-mix(in oklch, var(--color-warning, #d9a441) 12%, transparent);
+  border-top: 1px solid var(--border-hairline);
+  border-bottom: 1px solid var(--border-hairline);
+}
+.flow-run-steps-stall svg { flex-shrink: 0; margin-top: 1px; color: var(--color-warning, #d9a441); }
+
+.flow-run-logs { border-top: 1px solid var(--border-hairline); }
+.flow-run-logs-toggle {
+  width: 100%; display: inline-flex; align-items: center; gap: 6px;
+  padding: 7px 10px; font-size: var(--text-2xs); font-weight: 600; letter-spacing: 0.02em;
+  text-transform: uppercase; color: var(--text-muted);
+  background: transparent; border: 0; cursor: pointer;
+}
+.flow-run-logs-toggle:hover { color: var(--text-secondary); }
+.flow-run-logs-size { margin-left: auto; font-weight: 400; text-transform: none; letter-spacing: 0; color: var(--text-muted); }
+.flow-run-logs-body {
+  margin: 0 8px 8px; padding: 8px 10px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-2xs); line-height: 1.5; color: var(--text-secondary);
+  background: var(--bg-base); border: 1px solid var(--border-hairline); border-radius: var(--radius-sm);
+  max-height: 220px; overflow: auto;
+  white-space: pre-wrap; word-break: break-word;
+}
+.flow-run-logs-empty {
+  margin: 0 8px 8px; padding: 8px 10px;
+  font-size: var(--text-2xs); color: var(--text-muted);
+  background: var(--bg-base); border-radius: var(--radius-sm);
+}
+
 .flow-run-steps-foot { padding: 7px 8px; border-top: 1px solid var(--border-hairline); }
 .flow-run-steps-open {
   width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 6px;


### PR DESCRIPTION
## Problem

Executing a flow whose agent session emits no `@@step-…` progress markers (daemon offline/misbehaving, a non-flow session, or an immediate error) left the run panel stuck at **"Running 0/N · pending"** forever — **no logs, no output, no error, no explanation.** Execution looked like it did literally nothing.

The session transcript *was* already being polled (`useFlowRun`) but only fed to the marker parser and otherwise thrown away — so the agent's real output was never shown anywhere except via "Open session."

## Fix (visibility, additive — 4 files, +79/−0)

- **Expose the raw transcript** on `FlowRunProgress` (`flow-progress.ts`, `use-flow-run.ts`).
- **"Session output" section** in the run panel (`flow-run-steps.tsx`) — a collapsible, monospace, scrollable view of the live transcript with a char count, so the agent's actual output/logs are visible on the page.
- **Stall banner** — when a run is live but has reported no step progress, show a plain hint ("Session is running but hasn't reported any step progress yet — check the output below or open the session") instead of silent pending dots.
- CSS for both (`flow.css`).

This makes a stalled/empty run **legible** — it surfaces *why* nothing is visibly happening. It intentionally does **not** change the executor itself (that's a separate, daemon-dependent fix); if the underlying session genuinely does nothing, you'll now see exactly that.

## Verification

- `tsc --noEmit` clean; `pnpm test:app` → **459 test files pass**.
- Drove the panel with a mocked running run + transcript (no `@@step` markers): the stall banner and the Session output section both render with the live transcript; no page errors. Screenshot below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)