### PR TITLE
feat: response confidence events for thread reflect

### DIFF
--- a/docs/specs/2026-06-28-response-confidence-events-design.md
+++ b/docs/specs/2026-06-28-response-confidence-events-design.md
@@ -1,0 +1,65 @@
+# Response Confidence Events Design
+
+## Goal
+
+Add per-response familiar confidence diagnostics so Cave can track self-reported 1-100 confidence over time, correlate low confidence with factors like tool use, context, skills, permissions, memory, and evidence, and feed those rollups into Familiar Analytics and Eval Loops.
+
+## Architecture
+
+Response confidence is a sibling layer under the existing familiar self-report system. Thread self-reports remain the manual/end-of-thread summary. Response confidence events are append-only JSONL diagnostics stored per familiar and loaded into Familiar Analytics as a separate series.
+
+The first implementation ships the data model, storage, listing API, analytics rollup, UI section, and eval-loop diagnostic summary. It does not yet make the chat runtime call the daemon after every assistant response; that collection hook should be added behind the existing auto-self-report setting once the storage and analytics surfaces are stable.
+
+## Data Model
+
+`ResponseConfidenceEvent` contains:
+
+- identity fields: `id`, `familiarId`, `sessionId`, `responseId`, optional `turnId`, optional `threadTitle`
+- timing fields: `responseAt`, `reportedAt`
+- score fields: `overallConfidence` clamped to 1-100
+- weighted factor map: `toolUse`, `context`, `skills`, `permissions`, `memory`, `instructionFit`, `evidence`
+- each factor has `score`, `weight`, `reason`, and `signals`
+- diagnostics: `diagnosticTags`, optional `calibrationNotes`, and `rubricVersion`
+
+## Rollups
+
+Analytics computes a `ResponseConfidenceRollup` from recent events:
+
+- event count
+- average confidence
+- low-confidence count for scores below 60
+- average weighted factor scores
+- top diagnostic tags
+- newest event
+
+These rollups are diagnostic signals only. They do not replace tests, eval-loop outcomes, tool evidence, or human feedback.
+
+## Storage And API
+
+Storage stays append-only and redacted before write:
+
+- thread reports: `<familiar workspace>/self-reports/YYYY-MM-DD.jsonl`
+- response confidence events: `<familiar workspace>/self-reports/response-confidence/YYYY-MM-DD.jsonl`
+
+New list route:
+
+- `GET /api/familiars/:id/response-confidence?limit=100&before=<iso>`
+
+The route validates familiar ids, supports pagination by `reportedAt`, and returns newest-first redacted events.
+
+## UI
+
+Familiar Analytics gets a "Response Confidence" section above Thread Signals. It shows average confidence, low-confidence turns, newest confidence, factor breakdowns, and repeated diagnostic tags.
+
+Eval Loop gets a compact diagnostic strip when analytics data is available, so eval review can see whether recent response confidence is trending low without treating self-confidence as the source of truth.
+
+## Testing
+
+Tests cover:
+
+- clamped factor and overall score normalization
+- weighted rollup calculations and tag ranking
+- append/list storage redaction and newest-first pagination
+- analytics data fetch/model propagation
+- source-level UI wiring for the new section and eval-loop confidence prop
+- API contract registration for the new route

--- a/docs/specs/2026-06-28-response-confidence-events-plan.md
+++ b/docs/specs/2026-06-28-response-confidence-events-plan.md
@@ -1,0 +1,77 @@
+# Response Confidence Events Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add append-only per-response familiar confidence diagnostics and surface their rollups in Familiar Analytics and Eval Loops.
+
+**Architecture:** Reuse the existing familiar self-report domain. Add response-level event types and rollups in `thread-self-report.ts`, append/list storage in `familiar-self-reports.ts`, a guarded listing API route, analytics data/model fields, and compact UI panels.
+
+**Tech Stack:** Next.js App Router, TypeScript, node:test, JSONL filesystem storage, existing Cave CSS tokens.
+
+---
+
+### Task 1: Model And Rollups
+
+**Files:**
+- Modify: `src/lib/thread-self-report.ts`
+- Modify: `src/lib/thread-self-report.test.ts`
+
+- [ ] Write failing tests for `normalizeResponseConfidenceEvent` clamping 1-100 scores and for `aggregateResponseConfidenceEvents` computing average confidence, low-confidence count, factor averages, tags, and newest event.
+- [ ] Run `node --experimental-strip-types --test src/lib/thread-self-report.test.ts` and confirm the new tests fail because the helpers do not exist.
+- [ ] Add `ResponseConfidenceFactorKey`, `ResponseConfidenceFactor`, `ResponseConfidenceEvent`, `ResponseConfidenceRollup`, `normalizeResponseConfidenceEvent`, and `aggregateResponseConfidenceEvents`.
+- [ ] Re-run the focused test and confirm it passes.
+
+### Task 2: Storage
+
+**Files:**
+- Modify: `src/lib/server/familiar-self-reports.ts`
+- Modify: `src/lib/server/familiar-self-reports.test.ts`
+
+- [ ] Write failing tests for `appendResponseConfidenceEvent` and `listResponseConfidenceEvents`, including secret redaction, newest-first order, limit, `before`, missing directory, and familiar path guard behavior.
+- [ ] Run `node --experimental-strip-types --test src/lib/server/familiar-self-reports.test.ts` and confirm failure on missing exports.
+- [ ] Add response-confidence JSONL read/list/append helpers under `self-reports/response-confidence`.
+- [ ] Re-run the focused storage test and confirm it passes.
+
+### Task 3: API
+
+**Files:**
+- Create: `src/app/api/familiars/[id]/response-confidence/route.ts`
+- Modify: `src/app/api/api-contracts.test.ts`
+
+- [ ] Add the API contract row for `/familiars/[id]/response-confidence`.
+- [ ] Run `node --experimental-strip-types --test src/app/api/api-contracts.test.ts` and confirm the route is missing.
+- [ ] Implement a guarded GET route that reads `limit` and `before`, calls `listResponseConfidenceEvents`, and returns `{ ok, events, total }`.
+- [ ] Re-run the API contract test and confirm it passes.
+
+### Task 4: Analytics Data And UI
+
+**Files:**
+- Modify: `src/components/familiar-analytics-data.ts`
+- Modify: `src/components/familiar-analytics-view.tsx`
+- Modify: `src/components/familiar-analytics-view.test.ts`
+- Modify: `src/components/eval-loop-panel.tsx`
+- Modify: `src/app/globals.css`
+
+- [ ] Add failing analytics tests that mock `/api/familiars/cody/response-confidence?limit=100`, assert model response confidence rollup values, and assert source wiring for a `ResponseConfidenceSection` plus `EvalLoopPanel` prop.
+- [ ] Run `node --experimental-strip-types --test src/components/familiar-analytics-view.test.ts` and confirm failure on missing fields/source wiring.
+- [ ] Fetch response confidence events in analytics data, include them in the model, and compute the rollup with `aggregateResponseConfidenceEvents`.
+- [ ] Add `ResponseConfidenceSection` and pass the rollup into `EvalLoopPanel`.
+- [ ] Add compact CSS for factor/tag display using existing `fa-*` patterns.
+- [ ] Re-run the focused analytics test and confirm it passes.
+
+### Task 5: Verification
+
+**Files:**
+- All touched files.
+
+- [ ] Run focused tests:
+  - `node --experimental-strip-types --test src/lib/thread-self-report.test.ts`
+  - `node --experimental-strip-types --test src/lib/server/familiar-self-reports.test.ts`
+  - `node --experimental-strip-types --test src/app/api/api-contracts.test.ts`
+  - `node --experimental-strip-types --test src/components/familiar-analytics-view.test.ts`
+- [ ] Run project gates:
+  - `pnpm typecheck`
+  - `pnpm check:tests-wired`
+  - targeted `pnpm test:app` if time permits, otherwise at minimum the focused tests above.
+- [ ] Run `git diff --check`.
+- [ ] Report local branch status and ask before commit/push/PR.

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -50,6 +50,7 @@ const contracts: RouteContract[] = [
   { route: "/familiars/[id]/self-report", methods: ["POST", "GET"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/familiars/[id]/self-reports/[sessionId]", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/self-reports", methods: ["GET"], kind: "json", pathGuard: true },
+  { route: "/familiars/[id]/response-confidence", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/familiars", methods: ["GET"], kind: "json" },
   { route: "/github/activity", methods: ["GET"], kind: "json" },
   { route: "/github/assigned", methods: ["GET"], kind: "json" },

--- a/src/app/api/familiars/[id]/response-confidence/route.ts
+++ b/src/app/api/familiars/[id]/response-confidence/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { redactSecretsDeep } from "@/lib/secret-redaction";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import {
+  appendResponseConfidenceEvent,
+  listResponseConfidenceEvents,
+} from "@/lib/server/familiar-self-reports";
+import {
+  RESPONSE_CONFIDENCE_FACTOR_KEYS,
+  normalizeResponseConfidenceEvent,
+  type ResponseConfidenceEvent,
+  type ResponseConfidenceFactorKey,
+} from "@/lib/thread-self-report";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function text(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function score(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) throw new Error(`${field} must be numeric`);
+  return value;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function normalizeFactors(value: unknown): ResponseConfidenceEvent["factors"] {
+  if (!isRecord(value)) throw new Error("factors invalid");
+  const factors = {} as ResponseConfidenceEvent["factors"];
+  for (const key of RESPONSE_CONFIDENCE_FACTOR_KEYS) {
+    const raw = value[key];
+    if (!isRecord(raw)) throw new Error(`factors.${key} invalid`);
+    factors[key as ResponseConfidenceFactorKey] = {
+      score: score(raw.score, `factors.${key}.score`),
+      weight: typeof raw.weight === "number" && Number.isFinite(raw.weight) ? raw.weight : 1,
+      reason: text(raw.reason),
+      signals: stringArray(raw.signals),
+    };
+  }
+  return factors;
+}
+
+function normalizeBody(payload: unknown, familiarId: string): ResponseConfidenceEvent {
+  if (!isRecord(payload)) throw new Error("event invalid");
+  const sessionId = text(payload.sessionId);
+  const responseId = text(payload.responseId);
+  const responseAt = text(payload.responseAt);
+  const reportedAt = text(payload.reportedAt, new Date().toISOString());
+  if (!sessionId) throw new Error("sessionId required");
+  if (!responseId) throw new Error("responseId required");
+  if (!responseAt) throw new Error("responseAt required");
+
+  return normalizeResponseConfidenceEvent({
+    id: text(payload.id, crypto.randomUUID()),
+    familiarId,
+    sessionId,
+    responseId,
+    turnId: optionalText(payload.turnId),
+    threadTitle: optionalText(payload.threadTitle),
+    responseAt,
+    reportedAt,
+    overallConfidence: score(payload.overallConfidence, "overallConfidence"),
+    factors: normalizeFactors(payload.factors),
+    diagnosticTags: stringArray(payload.diagnosticTags),
+    calibrationNotes: optionalText(payload.calibrationNotes),
+    rubricVersion: text(payload.rubricVersion, "2026-06-28.v1"),
+  });
+}
+
+export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  if (!isValidFamiliarId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const limitRaw = url.searchParams.get("limit");
+  const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+  const before = url.searchParams.get("before") ?? undefined;
+  const result = await listResponseConfidenceEvents(id, { limit, before });
+  return NextResponse.json({ ok: true, events: redactSecretsDeep(result.events), total: result.total });
+}
+
+export async function POST(req: Request, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  if (!isValidFamiliarId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json" }, { status: 400 });
+  }
+
+  try {
+    const event = redactSecretsDeep(normalizeBody(body, id));
+    await appendResponseConfidenceEvent(id, event);
+    return NextResponse.json({ ok: true, event });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "response confidence invalid" },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9620,6 +9620,54 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex-direction: column;
   gap: 12px;
 }
+.fa-response-confidence {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.fa-response-factor-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+.fa-response-factor {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+}
+.fa-response-factor span {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.25;
+}
+.fa-response-factor b {
+  display: block;
+  margin: 5px 0 7px;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
+.fa-response-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.fa-response-tags > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+.fa-response-tags b {
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+}
 .fa-thread-empty { min-width: 0; }
 .fa-thread-score-grid {
   display: grid;
@@ -9854,6 +9902,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .growth-sidebar { position: static; }
   .growth-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .growth-signals { grid-template-columns: 1fr; }
+  .fa-response-factor-grid,
   .fa-thread-score-grid,
   .fa-thread-grid { grid-template-columns: 1fr; }
   .fa-contract-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }

--- a/src/components/eval-loop-panel.tsx
+++ b/src/components/eval-loop-panel.tsx
@@ -19,6 +19,7 @@ import type { IconName } from "@/lib/icon";
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
 import { relativeTime as age } from "@/lib/relative-time";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
+import type { ResponseConfidenceRollup } from "@/lib/thread-self-report";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -72,6 +73,7 @@ export type EvalLoopState = {
 type Props = {
   familiarId: string;
   familiarName: string;
+  responseConfidenceRollup?: ResponseConfidenceRollup;
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -136,7 +138,7 @@ const TRACK_LABEL: Record<Track, string> = {
 
 // ── Component ────────────────────────────────────────────────────────────────
 
-export function EvalLoopPanel({ familiarId, familiarName }: Props) {
+export function EvalLoopPanel({ familiarId, familiarName, responseConfidenceRollup }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [state, setState] = useState<EvalLoopState | null>(null);
   const [loading, setLoading] = useState(true);
@@ -291,6 +293,20 @@ export function EvalLoopPanel({ familiarId, familiarName }: Props) {
               <Stat label="Accepted" value={totalAccepted(state)} accent="text-[var(--color-success)]" />
               <Stat label="Reverted" value={totalReverted(state)} accent="text-[var(--color-danger)]" />
               <Stat label="Total" value={totalAccepted(state) + totalReverted(state)} />
+            </div>
+          ) : null}
+
+          {responseConfidenceRollup && responseConfidenceRollup.eventCount > 0 ? (
+            <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 py-2">
+              <div className="flex items-center justify-between gap-3">
+                <span className="text-[10px] uppercase tracking-widest text-[var(--text-secondary)]">
+                  response confidence
+                </span>
+                <b className="font-mono text-[var(--text-primary)]">{responseConfidenceRollup.averageConfidence}</b>
+              </div>
+              <p className="mt-1 text-[10px] text-[var(--text-muted)]">
+                {responseConfidenceRollup.lowConfidenceCount} low-confidence turns from {responseConfidenceRollup.eventCount} events
+              </p>
             </div>
           ) : null}
 

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -9,7 +9,12 @@ import type { ContractReport } from "@/lib/familiar-contract";
 import { deriveGrowthReport, type FamiliarGrowthReport } from "@/lib/familiar-growth-signals";
 import { deriveHealRequests, type SelfHealRequest } from "@/lib/familiar-heal-requests";
 import type { RetroFamiliarState, RetroRunsSnapshot } from "@/lib/retro-runs";
-import type { ThreadSelfReport } from "@/lib/thread-self-report";
+import {
+  aggregateResponseConfidenceEvents,
+  type ResponseConfidenceEvent,
+  type ResponseConfidenceRollup,
+  type ThreadSelfReport,
+} from "@/lib/thread-self-report";
 import type { Familiar, SessionRow } from "@/lib/types";
 
 type FamiliarsResponse =
@@ -40,6 +45,10 @@ type SelfReportsResponse =
   | { ok: true; reports: ThreadSelfReport[]; total: number }
   | { ok: false; reports?: ThreadSelfReport[]; total?: number; error?: string };
 
+type ResponseConfidenceResponse =
+  | { ok: true; events: ResponseConfidenceEvent[]; total: number }
+  | { ok: false; events?: ResponseConfidenceEvent[]; total?: number; error?: string };
+
 export type FamiliarAnalyticsData = {
   familiarId: string;
   familiars: Familiar[];
@@ -49,6 +58,7 @@ export type FamiliarAnalyticsData = {
   covenEntries: CovenMemoryEntry[];
   retroSnapshot: RetroRunsSnapshot;
   threadReports: ThreadSelfReport[];
+  responseConfidenceEvents: ResponseConfidenceEvent[];
   errors: string[];
 };
 
@@ -61,6 +71,8 @@ export type FamiliarAnalyticsModel = {
   confidence: ConfidenceScore;
   healRequests: SelfHealRequest[];
   threadReports: ThreadSelfReport[];
+  responseConfidenceEvents: ResponseConfidenceEvent[];
+  responseConfidenceRollup: ResponseConfidenceRollup;
   errors: string[];
 };
 
@@ -141,6 +153,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     memoryJson,
     retroJson,
     selfReportsJson,
+    responseConfidenceJson,
   ] = await Promise.all([
     fetchResource<FamiliarsResponse>("/api/familiars", { ok: false, familiars: [] }),
     fetchResource<ContractResponse>(`/api/familiars/${encodedId}/contract`, { ok: false }),
@@ -149,6 +162,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     fetchResource<CovenMemoryResponse>("/api/coven-memory", { ok: false, entries: [] }),
     fetchResource<RetroApiResponse>("/api/retro-runs", { ok: false }),
     fetchResource<SelfReportsResponse>(`/api/familiars/${encodedId}/self-reports?limit=30`, { ok: false, reports: [], total: 0 }),
+    fetchResource<ResponseConfidenceResponse>(`/api/familiars/${encodedId}/response-confidence?limit=100`, { ok: false, events: [], total: 0 }),
   ]);
 
   const errors = [
@@ -158,6 +172,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     responseError(sessionsJson, "sessions unavailable"),
     responseError(memoryJson, "memory unavailable"),
     responseError(retroJson, "retro runs unavailable"),
+    responseError(responseConfidenceJson, "response confidence unavailable"),
   ].filter((error): error is string => Boolean(error));
 
   return {
@@ -169,6 +184,7 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     covenEntries: memoryJson.entries ?? [],
     retroSnapshot: retroJson.snapshot ?? EMPTY_SNAPSHOT,
     threadReports: selfReportsJson.ok ? selfReportsJson.reports : [],
+    responseConfidenceEvents: responseConfidenceJson.ok ? responseConfidenceJson.events : [],
     errors,
   };
 }
@@ -212,6 +228,8 @@ export function buildFamiliarAnalyticsModel(data: FamiliarAnalyticsData): Famili
     confidence,
     healRequests,
     threadReports: data.threadReports,
+    responseConfidenceEvents: data.responseConfidenceEvents,
+    responseConfidenceRollup: aggregateResponseConfidenceEvents(data.responseConfidenceEvents),
     errors: data.errors,
   };
 }

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -254,6 +254,55 @@ function mockFetchFor(score: "low" | "trusted") {
         ],
       },
     ],
+    [
+      "/api/familiars/cody/response-confidence?limit=100",
+      {
+        ok: true,
+        total: 2,
+        events: [
+          {
+            id: "confidence-2",
+            familiarId: "cody",
+            sessionId: "session-2",
+            responseId: "response-2",
+            responseAt: "2026-06-25T12:04:00.000Z",
+            reportedAt: "2026-06-25T12:04:02.000Z",
+            overallConfidence: 90,
+            factors: {
+              toolUse: { score: 100, weight: 1, reason: "Tools clean.", signals: [] },
+              context: { score: 80, weight: 1, reason: "Context enough.", signals: [] },
+              skills: { score: 75, weight: 1, reason: "Skill used.", signals: [] },
+              permissions: { score: 100, weight: 1, reason: "No block.", signals: [] },
+              memory: { score: 60, weight: 1, reason: "Memory partial.", signals: [] },
+              instructionFit: { score: 85, weight: 1, reason: "On task.", signals: [] },
+              evidence: { score: 80, weight: 1, reason: "Tests present.", signals: [] },
+            },
+            diagnosticTags: ["needs-source"],
+            rubricVersion: "2026-06-28.v1",
+          },
+          {
+            id: "confidence-1",
+            familiarId: "cody",
+            sessionId: "session-1",
+            responseId: "response-1",
+            responseAt: "2026-06-25T12:00:00.000Z",
+            reportedAt: "2026-06-25T12:00:02.000Z",
+            overallConfidence: 50,
+            factors: {
+              toolUse: { score: 20, weight: 2, reason: "Tool failed.", signals: ["tool-failed"] },
+              context: { score: 40, weight: 1, reason: "Context tight.", signals: ["context-tight"] },
+              skills: { score: 70, weight: 1, reason: "Skill ok.", signals: [] },
+              permissions: { score: 80, weight: 1, reason: "No block.", signals: [] },
+              memory: { score: 60, weight: 1, reason: "Memory partial.", signals: [] },
+              instructionFit: { score: 90, weight: 1, reason: "Fit.", signals: [] },
+              evidence: { score: 30, weight: 1, reason: "Thin evidence.", signals: ["needs-source"] },
+            },
+            diagnosticTags: ["tool-failed", "needs-source"],
+            rubricVersion: "2026-06-28.v1",
+          },
+        ],
+      },
+    ],
   ]);
 
   globalThis.fetch = (async (url: RequestInfo | URL) => ({
@@ -270,6 +319,9 @@ describe("FamiliarAnalyticsView", () => {
     const model = buildFamiliarAnalyticsModel(data);
 
     assert.equal(model.confidence.label, "Low");
+    assert.equal(model.responseConfidenceRollup.eventCount, 2);
+    assert.equal(model.responseConfidenceRollup.averageConfidence, 70);
+    assert.equal(model.responseConfidenceRollup.lowConfidenceCount, 1);
     assert.match(source, /export function FamiliarAnalyticsContent/);
   });
 
@@ -309,6 +361,8 @@ describe("FamiliarAnalyticsView", () => {
     assert.equal(model.threadReports.length, 1);
     assert.match(source, /escalateBlockers\(model\.familiarId, threadSignalsAggregate, model\.healRequests\)/);
     assert.match(source, /healRequests\.length === 1 \? "request" : "requests"/);
+    assert.match(source, /ResponseConfidenceSection/);
+    assert.match(source, /responseConfidenceRollup=\{model\.responseConfidenceRollup\}/);
     assert.match(source, /<ThreadSignalsSection[\s\S]*reports=\{model\.threadReports\}/);
     assert.match(source, /<EvalLoopPanel[\s\S]*familiarId=\{model\.familiar\.id\}/);
   });

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -15,7 +15,13 @@ import { escalateBlockers, type SelfHealRequest } from "@/lib/familiar-heal-requ
 import type { ConfidenceScore } from "@/lib/familiar-confidence";
 import type { ContractReport } from "@/lib/familiar-contract";
 import { Icon } from "@/lib/icon";
-import { aggregateThreadSignals } from "@/lib/thread-self-report";
+import {
+  RESPONSE_CONFIDENCE_EMPTY_STATE,
+  RESPONSE_CONFIDENCE_FACTOR_KEYS,
+  aggregateThreadSignals,
+  type ResponseConfidenceFactorKey,
+  type ResponseConfidenceRollup,
+} from "@/lib/thread-self-report";
 
 export function FamiliarAnalyticsView({ familiarId }: { familiarId: string }) {
   const [data, setData] = useState<FamiliarAnalyticsData | null>(null);
@@ -111,6 +117,66 @@ const ConfidenceBreakdown = memo(function ConfidenceBreakdown({ confidence }: { 
     </FaSection>
   );
 });
+
+const RESPONSE_CONFIDENCE_LABELS: Record<ResponseConfidenceFactorKey, string> = {
+  toolUse: "Tool use",
+  context: "Context",
+  skills: "Skills",
+  permissions: "Permissions",
+  memory: "Memory",
+  instructionFit: "Instruction fit",
+  evidence: "Evidence",
+};
+
+const ResponseConfidenceSection = memo(function ResponseConfidenceSection({
+  rollup,
+}: {
+  rollup: ResponseConfidenceRollup;
+}) {
+  if (rollup.eventCount === 0) {
+    return <EmptyState compact icon="ph:chart-bar-bold" headline={RESPONSE_CONFIDENCE_EMPTY_STATE} />;
+  }
+
+  return (
+    <div className="fa-response-confidence">
+      <div className="fa-thread-score-grid">
+        <ScoreTile label="Avg confidence" value={rollup.averageConfidence} />
+        <ScoreTile label="Low confidence" value={rollup.lowConfidenceCount} />
+        <ScoreTile label="Events" value={rollup.eventCount} />
+        <ScoreTile label="Newest" value={rollup.newestEvent?.overallConfidence ?? 0} />
+      </div>
+      <div className="fa-response-factor-grid" aria-label="Response confidence factor averages">
+        {RESPONSE_CONFIDENCE_FACTOR_KEYS.map((key) => (
+          <div key={key} className="fa-response-factor">
+            <span>{RESPONSE_CONFIDENCE_LABELS[key]}</span>
+            <b>{rollup.factorAverages[key]}</b>
+            <div className="fa-factor-bar" aria-label={`${RESPONSE_CONFIDENCE_LABELS[key]} ${rollup.factorAverages[key]}`}>
+              <span className="fa-factor-segment" style={{ width: `${Math.max(0, Math.min(100, rollup.factorAverages[key]))}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="fa-response-tags" aria-label="Top response confidence diagnostic tags">
+        {rollup.topDiagnosticTags.length === 0 ? <span>No diagnostic tags yet.</span> : rollup.topDiagnosticTags.map((item) => (
+          <span key={item.tag}>
+            {item.tag} <b>{item.count}</b>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+function ScoreTile({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="fa-thread-score">
+      <div>
+        <span>{label}</span>
+        <b>{value}</b>
+      </div>
+    </div>
+  );
+}
 
 const SelfHealList = memo(function SelfHealList({ requests }: { requests: SelfHealRequest[] }) {
   if (requests.length === 0) {
@@ -346,6 +412,14 @@ export function FamiliarAnalyticsContent({
       <ConfidenceBreakdown confidence={model.confidence} />
 
       <FaSection
+        id="fa-response-confidence"
+        title="Response Confidence"
+        count={`${model.responseConfidenceRollup.eventCount} ${model.responseConfidenceRollup.eventCount === 1 ? "event" : "events"}`}
+      >
+        <ResponseConfidenceSection rollup={model.responseConfidenceRollup} />
+      </FaSection>
+
+      <FaSection
         id="fa-heal"
         title="Self-Heal Requests"
         count={`${healRequests.length} ${healRequests.length === 1 ? "request" : "requests"}`}
@@ -363,7 +437,11 @@ export function FamiliarAnalyticsContent({
 
       <FaSection id="fa-eval" title="Eval Loop" count={`${model.evalLoopState?.iterations?.length ?? 0} iterations`}>
         {model.familiar ? (
-          <EvalLoopPanel familiarId={model.familiar.id} familiarName={familiarName} />
+          <EvalLoopPanel
+            familiarId={model.familiar.id}
+            familiarName={familiarName}
+            responseConfidenceRollup={model.responseConfidenceRollup}
+          />
         ) : (
           <EmptyState compact icon="ph:arrows-clockwise-bold" headline="Eval loop unavailable." />
         )}

--- a/src/lib/server/familiar-self-reports.test.ts
+++ b/src/lib/server/familiar-self-reports.test.ts
@@ -4,10 +4,12 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, it } from "node:test";
-import type { ThreadSelfReport } from "@/lib/thread-self-report";
+import type { ResponseConfidenceEvent, ThreadSelfReport } from "@/lib/thread-self-report";
 import {
+  appendResponseConfidenceEvent,
   appendSelfReport,
   findSelfReport,
+  listResponseConfidenceEvents,
   listSelfReports,
 } from "./familiar-self-reports.ts";
 
@@ -51,6 +53,32 @@ function report(overrides: Partial<ThreadSelfReport> = {}): ThreadSelfReport {
     fileLocatabilityScore: overrides.fileLocatabilityScore ?? 65,
     fileLocatabilityNotes: overrides.fileLocatabilityNotes,
     persistentBlockers: overrides.persistentBlockers ?? [],
+  };
+}
+
+function responseEvent(overrides: Partial<ResponseConfidenceEvent> = {}): ResponseConfidenceEvent {
+  return {
+    id: overrides.id ?? randomUUID(),
+    familiarId: overrides.familiarId ?? "cody",
+    sessionId: overrides.sessionId ?? "session-a",
+    responseId: overrides.responseId ?? "response-a",
+    turnId: overrides.turnId,
+    threadTitle: overrides.threadTitle,
+    responseAt: overrides.responseAt ?? "2026-06-25T12:00:00.000Z",
+    reportedAt: overrides.reportedAt ?? "2026-06-25T12:00:01.000Z",
+    overallConfidence: overrides.overallConfidence ?? 80,
+    factors: overrides.factors ?? {
+      toolUse: { score: 90, weight: 1, reason: "Tools worked.", signals: [] },
+      context: { score: 80, weight: 1, reason: "Context enough.", signals: [] },
+      skills: { score: 75, weight: 1, reason: "Skill used.", signals: [] },
+      permissions: { score: 100, weight: 1, reason: "No block.", signals: [] },
+      memory: { score: 60, weight: 1, reason: "Memory partial.", signals: [] },
+      instructionFit: { score: 85, weight: 1, reason: "On task.", signals: [] },
+      evidence: { score: 70, weight: 1, reason: "Evidence present.", signals: [] },
+    },
+    diagnosticTags: overrides.diagnosticTags ?? [],
+    calibrationNotes: overrides.calibrationNotes,
+    rubricVersion: overrides.rubricVersion ?? "2026-06-28.v1",
   };
 }
 
@@ -102,5 +130,56 @@ describe("familiar self-report storage", () => {
 
   it("listSelfReports returns an empty result for a missing directory", async () => {
     assert.deepEqual(await listSelfReports("cody", {}), { reports: [], total: 0 });
+  });
+
+  it("appendResponseConfidenceEvent creates dated JSONL files and appends redacted events", async () => {
+    await appendResponseConfidenceEvent("cody", responseEvent({
+      id: "event-1",
+      responseId: "response-1",
+      reportedAt: "2026-06-25T10:00:00.000Z",
+    }));
+    await appendResponseConfidenceEvent("cody", responseEvent({
+      id: "event-2",
+      responseId: "response-2",
+      reportedAt: "2026-06-25T11:00:00.000Z",
+      calibrationNotes: "token=sk-proj-abcdefghijklmnopqrstuvwxyz",
+    }));
+
+    const listed = await listResponseConfidenceEvents("cody", {});
+
+    assert.equal(listed.total, 2);
+    assert.deepEqual(listed.events.map((item) => item.id), ["event-2", "event-1"]);
+    assert.equal(listed.events[0].calibrationNotes, "token=[redacted]");
+  });
+
+  it("listResponseConfidenceEvents returns newest-first events with limit and before cursor", async () => {
+    await appendResponseConfidenceEvent("cody", responseEvent({
+      id: "old",
+      responseId: "response-old",
+      reportedAt: "2026-06-23T10:00:00.000Z",
+    }));
+    await appendResponseConfidenceEvent("cody", responseEvent({
+      id: "new",
+      responseId: "response-new",
+      reportedAt: "2026-06-25T10:00:00.000Z",
+    }));
+    await appendResponseConfidenceEvent("cody", responseEvent({
+      id: "mid",
+      responseId: "response-mid",
+      reportedAt: "2026-06-24T10:00:00.000Z",
+    }));
+
+    const limited = await listResponseConfidenceEvents("cody", { limit: 2 });
+    const before = await listResponseConfidenceEvents("cody", { before: "2026-06-25T00:00:00.000Z" });
+    const fallbackLimit = await listResponseConfidenceEvents("cody", { limit: Number.NaN });
+
+    assert.equal(limited.total, 3);
+    assert.deepEqual(limited.events.map((item) => item.id), ["new", "mid"]);
+    assert.deepEqual(before.events.map((item) => item.id), ["mid", "old"]);
+    assert.deepEqual(fallbackLimit.events.map((item) => item.id), ["new", "mid", "old"]);
+  });
+
+  it("listResponseConfidenceEvents returns an empty result for a missing directory", async () => {
+    assert.deepEqual(await listResponseConfidenceEvents("cody", {}), { events: [], total: 0 });
   });
 });

--- a/src/lib/server/familiar-self-reports.ts
+++ b/src/lib/server/familiar-self-reports.ts
@@ -2,7 +2,11 @@ import { readdir, readFile, appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { familiarWorkspace } from "@/lib/coven-paths";
 import { redactSecretsDeep } from "@/lib/secret-redaction";
-import type { ThreadSelfReport } from "@/lib/thread-self-report";
+import {
+  normalizeResponseConfidenceEvent,
+  type ResponseConfidenceEvent,
+  type ThreadSelfReport,
+} from "@/lib/thread-self-report";
 import { isValidFamiliarId } from "./familiar-id";
 
 export const SELF_REPORT_SESSION_ID_RE = /^[a-z0-9_-]+$/i;
@@ -16,13 +20,31 @@ function reportDate(report: ThreadSelfReport): string {
   return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : new Date().toISOString().slice(0, 10);
 }
 
+function eventDate(event: ResponseConfidenceEvent): string {
+  const date = event.reportedAt.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : new Date().toISOString().slice(0, 10);
+}
+
 async function reportsDir(familiarId: string): Promise<string> {
   assertFamiliarId(familiarId);
   return path.join(await familiarWorkspace(familiarId), "self-reports");
 }
 
+async function responseConfidenceDir(familiarId: string): Promise<string> {
+  return path.join(await reportsDir(familiarId), "response-confidence");
+}
+
 function sortNewestFirst(a: ThreadSelfReport, b: ThreadSelfReport): number {
   return new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime();
+}
+
+function sortEventsNewestFirst(a: ResponseConfidenceEvent, b: ResponseConfidenceEvent): number {
+  return new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime();
+}
+
+function normalizeListLimit(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(500, Math.floor(value)));
 }
 
 async function readAllReports(familiarId: string): Promise<ThreadSelfReport[]> {
@@ -57,11 +79,53 @@ async function readAllReports(familiarId: string): Promise<ThreadSelfReport[]> {
   return reports.sort(sortNewestFirst);
 }
 
+async function readAllResponseConfidenceEvents(familiarId: string): Promise<ResponseConfidenceEvent[]> {
+  const dir = await responseConfidenceDir(familiarId);
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const events: ResponseConfidenceEvent[] = [];
+  for (const file of files.filter((name) => name.endsWith(".jsonl")).sort()) {
+    const fullPath = path.join(dir, file);
+    let raw = "";
+    try {
+      raw = await readFile(fullPath, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        events.push(normalizeResponseConfidenceEvent(redactSecretsDeep(JSON.parse(trimmed) as ResponseConfidenceEvent)));
+      } catch {
+        /* Ignore malformed historical lines; append-only storage should keep listing usable. */
+      }
+    }
+  }
+  return events.sort(sortEventsNewestFirst);
+}
+
 export async function appendSelfReport(familiarId: string, report: ThreadSelfReport): Promise<void> {
   const dir = await reportsDir(familiarId);
   await mkdir(dir, { recursive: true });
   const redacted = redactSecretsDeep(report);
   await appendFile(path.join(dir, `${reportDate(redacted)}.jsonl`), `${JSON.stringify(redacted)}\n`, "utf8");
+}
+
+export async function appendResponseConfidenceEvent(
+  familiarId: string,
+  event: ResponseConfidenceEvent,
+): Promise<void> {
+  const dir = await responseConfidenceDir(familiarId);
+  await mkdir(dir, { recursive: true });
+  const redacted = normalizeResponseConfidenceEvent(redactSecretsDeep(event));
+  await appendFile(path.join(dir, `${eventDate(redacted)}.jsonl`), `${JSON.stringify(redacted)}\n`, "utf8");
 }
 
 export async function listSelfReports(
@@ -75,6 +139,19 @@ export async function listSelfReports(
     : reports;
   const limit = Math.max(0, Math.min(100, Math.floor(opts.limit ?? 20)));
   return { reports: filtered.slice(0, limit), total: filtered.length };
+}
+
+export async function listResponseConfidenceEvents(
+  familiarId: string,
+  opts: { limit?: number; before?: string },
+): Promise<{ events: ResponseConfidenceEvent[]; total: number }> {
+  const events = await readAllResponseConfidenceEvents(familiarId);
+  const beforeMs = opts.before ? new Date(opts.before).getTime() : null;
+  const filtered = Number.isFinite(beforeMs)
+    ? events.filter((event) => new Date(event.reportedAt).getTime() < (beforeMs as number))
+    : events;
+  const limit = normalizeListLimit(opts.limit, 100);
+  return { events: filtered.slice(0, limit), total: filtered.length };
 }
 
 export async function findSelfReport(familiarId: string, sessionId: string): Promise<ThreadSelfReport | null> {

--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  aggregateResponseConfidenceEvents,
   buildReflectTranscript,
   buildThreadReflectPrompt,
   contextPressureLabel,
   deriveThreadScore,
+  normalizeResponseConfidenceEvent,
+  type ResponseConfidenceEvent,
   type ThreadSelfReport,
 } from "./thread-self-report.ts";
 
@@ -77,6 +80,86 @@ describe("thread self-report helpers", () => {
 
     assert.equal(report.id, "report-1");
     assert.equal(report.persistentBlockers[0].impact, "medium");
+  });
+
+  it("normalizes response confidence events by clamping scores and preserving diagnostics", () => {
+    const event = normalizeResponseConfidenceEvent({
+      id: "event-1",
+      familiarId: "cody",
+      sessionId: "session-1",
+      responseId: "response-1",
+      responseAt: "2026-06-28T06:00:00.000Z",
+      reportedAt: "2026-06-28T06:00:03.000Z",
+      overallConfidence: 123,
+      factors: {
+        toolUse: { score: 0, weight: 1.5, reason: "Tool failed.", signals: ["tool-failed"] },
+        context: { score: -8, weight: 1, reason: "Context was missing.", signals: ["context-missing"] },
+        skills: { score: 88, weight: 0.8, reason: "Correct skill used.", signals: ["skill-used"] },
+        permissions: { score: 65, weight: 0.7, reason: "No permission block.", signals: [] },
+        memory: { score: 74, weight: 0.9, reason: "Memory was partial.", signals: ["memory-partial"] },
+        instructionFit: { score: 91, weight: 1.2, reason: "Matched the ask.", signals: ["on-task"] },
+        evidence: { score: 101, weight: 1.1, reason: "Tests cited.", signals: ["tests-run"] },
+      },
+      diagnosticTags: ["tool-failed", "context-missing", "tool-failed"],
+      calibrationNotes: "Low confidence was warranted.",
+      rubricVersion: "2026-06-28.v1",
+    });
+
+    assert.equal(event.overallConfidence, 100);
+    assert.equal(event.factors.toolUse.score, 1);
+    assert.equal(event.factors.context.score, 1);
+    assert.equal(event.factors.evidence.score, 100);
+    assert.deepEqual(event.diagnosticTags, ["tool-failed", "context-missing"]);
+    assert.equal(event.calibrationNotes, "Low confidence was warranted.");
+  });
+
+  it("aggregates response confidence events into weighted factor trends", () => {
+    const base: ResponseConfidenceEvent = normalizeResponseConfidenceEvent({
+      id: "event-1",
+      familiarId: "cody",
+      sessionId: "session-1",
+      responseId: "response-1",
+      responseAt: "2026-06-28T06:00:00.000Z",
+      reportedAt: "2026-06-28T06:00:05.000Z",
+      overallConfidence: 50,
+      factors: {
+        toolUse: { score: 20, weight: 2, reason: "Tool failed.", signals: ["tool-failed"] },
+        context: { score: 40, weight: 1, reason: "Context tight.", signals: ["context-tight"] },
+        skills: { score: 70, weight: 1, reason: "Skill ok.", signals: [] },
+        permissions: { score: 80, weight: 1, reason: "No block.", signals: [] },
+        memory: { score: 60, weight: 1, reason: "Partial.", signals: [] },
+        instructionFit: { score: 90, weight: 1, reason: "Fit.", signals: [] },
+        evidence: { score: 30, weight: 1, reason: "Thin evidence.", signals: ["needs-source"] },
+      },
+      diagnosticTags: ["tool-failed", "needs-source"],
+      rubricVersion: "2026-06-28.v1",
+    });
+    const newer: ResponseConfidenceEvent = normalizeResponseConfidenceEvent({
+      ...base,
+      id: "event-2",
+      responseId: "response-2",
+      reportedAt: "2026-06-28T07:00:05.000Z",
+      overallConfidence: 90,
+      factors: {
+        ...base.factors,
+        toolUse: { score: 100, weight: 1, reason: "Tool clean.", signals: [] },
+        evidence: { score: 80, weight: 1, reason: "Evidence present.", signals: [] },
+      },
+      diagnosticTags: ["needs-source", "context-tight"],
+    });
+
+    const rollup = aggregateResponseConfidenceEvents([base, newer]);
+
+    assert.equal(rollup.eventCount, 2);
+    assert.equal(rollup.averageConfidence, 70);
+    assert.equal(rollup.lowConfidenceCount, 1);
+    assert.equal(rollup.newestEvent?.id, "event-2");
+    assert.equal(rollup.factorAverages.toolUse, 47);
+    assert.equal(rollup.factorAverages.evidence, 55);
+    assert.deepEqual(rollup.topDiagnosticTags.slice(0, 2), [
+      { tag: "needs-source", count: 2 },
+      { tag: "context-tight", count: 1 },
+    ]);
   });
 });
 

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -3,6 +3,61 @@ export type CapabilityState = "available" | "degraded" | "missing";
 export type BlockerCategory = "auth" | "tooling" | "permission" | "infra" | "context" | "skill" | "other";
 export type BlockerImpact = "low" | "medium" | "high" | "blocking";
 export type CapabilityImportance = "nice-to-have" | "important" | "blocking";
+export type ResponseConfidenceFactorKey =
+  | "toolUse"
+  | "context"
+  | "skills"
+  | "permissions"
+  | "memory"
+  | "instructionFit"
+  | "evidence";
+
+export type ResponseConfidenceFactor = {
+  score: number;
+  weight: number;
+  reason: string;
+  signals: string[];
+};
+
+export type ResponseConfidenceEvent = {
+  id: string;
+  familiarId: string;
+  sessionId: string;
+  responseId: string;
+  turnId?: string;
+  threadTitle?: string;
+  responseAt: string;
+  reportedAt: string;
+  overallConfidence: number;
+  factors: Record<ResponseConfidenceFactorKey, ResponseConfidenceFactor>;
+  diagnosticTags: string[];
+  calibrationNotes?: string;
+  rubricVersion: string;
+};
+
+export type ResponseConfidenceRollup = {
+  eventCount: number;
+  averageConfidence: number;
+  lowConfidenceCount: number;
+  factorAverages: Record<ResponseConfidenceFactorKey, number>;
+  topDiagnosticTags: { tag: string; count: number }[];
+  newestEvent: ResponseConfidenceEvent | null;
+};
+
+export const RESPONSE_CONFIDENCE_FACTOR_KEYS: ResponseConfidenceFactorKey[] = [
+  "toolUse",
+  "context",
+  "skills",
+  "permissions",
+  "memory",
+  "instructionFit",
+  "evidence",
+];
+
+export const RESPONSE_CONFIDENCE_EMPTY_STATE =
+  "No response confidence events yet. Enable response self-reporting to build confidence trends.";
+
+const DEFAULT_RESPONSE_CONFIDENCE_RUBRIC = "2026-06-28.v1";
 
 /** One settled turn of a thread, condensed for the reflection prompt. */
 export type ReflectTranscriptTurn = { role: "user" | "assistant" | "system"; text: string };
@@ -177,6 +232,69 @@ function libAvg(values: number[]): number {
 }
 function libIncrement(map: Map<string, number>, key: string) {
   map.set(key, (map.get(key) ?? 0) + 1);
+}
+
+function clampConfidence(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(1, Math.min(100, Math.round(value)));
+}
+
+function dedupeStrings(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}
+
+export function normalizeResponseConfidenceEvent(event: ResponseConfidenceEvent): ResponseConfidenceEvent {
+  const factors = {} as Record<ResponseConfidenceFactorKey, ResponseConfidenceFactor>;
+  for (const key of RESPONSE_CONFIDENCE_FACTOR_KEYS) {
+    const factor = event.factors[key];
+    factors[key] = {
+      score: clampConfidence(factor.score),
+      weight: Math.max(0, Number.isFinite(factor.weight) ? factor.weight : 0),
+      reason: factor.reason,
+      signals: dedupeStrings(factor.signals),
+    };
+  }
+  return {
+    ...event,
+    overallConfidence: clampConfidence(event.overallConfidence),
+    factors,
+    diagnosticTags: dedupeStrings(event.diagnosticTags),
+    rubricVersion: event.rubricVersion || DEFAULT_RESPONSE_CONFIDENCE_RUBRIC,
+  };
+}
+
+export function aggregateResponseConfidenceEvents(events: ResponseConfidenceEvent[]): ResponseConfidenceRollup {
+  const normalized = events.map(normalizeResponseConfidenceEvent);
+  const sorted = [...normalized].sort((a, b) => new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime());
+  const factorAverages = {} as Record<ResponseConfidenceFactorKey, number>;
+  const tagCounts = new Map<string, number>();
+
+  for (const key of RESPONSE_CONFIDENCE_FACTOR_KEYS) {
+    let weightedScore = 0;
+    let totalWeight = 0;
+    for (const event of normalized) {
+      const factor = event.factors[key];
+      weightedScore += factor.score * factor.weight;
+      totalWeight += factor.weight;
+    }
+    factorAverages[key] = totalWeight > 0 ? Math.round(weightedScore / totalWeight) : 0;
+  }
+
+  for (const event of normalized) {
+    for (const tag of event.diagnosticTags) libIncrement(tagCounts, tag);
+  }
+
+  return {
+    eventCount: normalized.length,
+    averageConfidence: libAvg(normalized.map((event) => event.overallConfidence)),
+    lowConfidenceCount: normalized.filter((event) => event.overallConfidence < 60).length,
+    factorAverages,
+    topDiagnosticTags: [...tagCounts.entries()]
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .slice(0, 8)
+      .map(([tag, count]) => ({ tag, count })),
+    newestEvent: sorted[0] ?? null,
+  };
 }
 
 export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSignalsAggregate {


### PR DESCRIPTION
## Summary

Adds append-only per-response confidence diagnostics for familiars so Cave can track self-reported 1-100 confidence over time and correlate low scores with factors like tool use, context, skills, permissions, memory, instruction fit, and evidence.

## Changes

- Added `ResponseConfidenceEvent` types, normalization, and rollups beside the existing thread self-report model.
- Added redacted append/list storage under `self-reports/response-confidence/`.
- Added guarded `GET`/`POST /api/familiars/:id/response-confidence` route.
- Surfaced response-confidence rollups in Familiar Analytics and added a compact Eval Loop diagnostic strip.
- Added design and implementation plan docs for the feature.

## Validation

- `node --experimental-strip-types --test src/lib/thread-self-report.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/server/familiar-self-reports.test.ts`
- `node --experimental-strip-types --test src/app/api/api-contracts.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/components/familiar-analytics-view.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired` - all 614 test files wired
- `git diff --check`
- `pnpm test:app` - 458 test files passed

Co-authored with Nova.