### PR TITLE
fix(flow): harden the step-marker protocol so runs report progress

### DIFF
--- a/src/lib/flow/flow-compile.test.ts
+++ b/src/lib/flow/flow-compile.test.ts
@@ -274,6 +274,12 @@ function build(nodes: Array<[string, string]>, edges: Array<[string, string]>): 
   assert.match(prompt, /\[t\]/);
   assert.match(prompt, /\[writer\]/);
   assert.ok(prompt.indexOf("[t]") < prompt.indexOf("[writer]"), "nodes listed in execution order");
+  // Hardened marker protocol: prominent, with a concrete first-node example,
+  // and an explicit "no backticks" rule (a backticked marker fails the parser).
+  assert.match(prompt, /PROGRESS PROTOCOL/);
+  assert.match(prompt, /@@step-start t\b/, "shows a concrete example using the first node id");
+  assert.match(prompt, /own line/, "tells the agent to print each marker on its own line");
+  assert.doesNotMatch(prompt, /`@@step-(start|done|fail)/, "never wraps a marker in backticks");
 }
 
 console.log("flow-compile.test.ts OK");

--- a/src/lib/flow/flow-compile.ts
+++ b/src/lib/flow/flow-compile.ts
@@ -265,10 +265,19 @@ export function compileFlowPrompt(
     lines.push("");
   }
   lines.push(
-    "Carry out each node below in order, passing the result of one node as the input to the nodes it connects to. " +
-      "Before you start a node print a line `@@step-start <id>`; when it succeeds print `@@step-done <id>`; if it " +
-      "fails print `@@step-fail <id>`. Use the exact node id shown in brackets.",
+    "Carry out each node below in order, passing the result of one node as the input to the nodes it connects to.",
   );
+  lines.push("");
+  lines.push("PROGRESS PROTOCOL — REQUIRED. The UI tracks this run only from these markers, so you MUST emit them:");
+  lines.push("- Print each marker as plain text on its own line, with nothing else on that line.");
+  lines.push("- Do NOT wrap a marker in backticks or a code block, and do NOT put it inside a sentence — a marker that isn't a bare line is ignored and the run will look stuck.");
+  lines.push("- Immediately before working a node, print:  @@step-start <id>");
+  lines.push("- When that node has succeeded, print:        @@step-done <id>");
+  lines.push("- If that node fails, print:                  @@step-fail <id>  (then stop unless the node says to continue).");
+  lines.push("- Use the exact id shown in [brackets] below — not the node's name.");
+  if (order.length > 0) {
+    lines.push(`For example, the very first line of your reply should be:  @@step-start ${order[0]}`);
+  }
   lines.push("");
   lines.push("Nodes:");
   for (const id of order) {


### PR DESCRIPTION
## Root cause (the "execution does nothing" dig)

A flow executes as **one agent session**: the graph is compiled into a prompt (`compileFlowPrompt`), a session is spawned, and the agent is expected to print `@@step-start/done/fail <id>` markers as it works. The Executions parser turns those into per-node progress. **No parseable markers → "Running 0/N · pending" forever**, which is exactly the silent no-op you saw.

The marker parser is strict: `MARKER_RE = /^[ \t]*@@step-(start|done|fail)[ \t]+(\S+)[ \t]*$/gim` — a marker must be **alone on its own line**. The old prompt actively worked against that:
- the instruction was **buried mid-paragraph**;
- it displayed the markers **wrapped in `backticks`**, so a model copying the format echoes `` `@@step-start …` `` — and a leading backtick fails the line anchor, so the parser **drops it**;
- **no concrete example**, and it never said "plain text, on its own line."

Net: even a cooperative model could emit markers the parser silently discarded.

## Fix

Rewrite the protocol as a prominent **"PROGRESS PROTOCOL — REQUIRED"** block:
- each marker on its own **bare line**, explicitly **no backticks / code blocks / inline prose**;
- exact `[bracket]` ids (not node names);
- a concrete example using the **real first node id** (e.g. `@@step-start trigger`).

`flow-compile.ts` (+15/−3) and its test. This is a prompt-reliability fix — it does **not** change the daemon/harness. It pairs with #2007 (just merged), which now shows the raw session output, so any *remaining* non-compliance is visible rather than silent.

## Verification

- `tsc --noEmit` clean; `pnpm test:app` → **459 test files pass**.
- New test asserts the prominent protocol, the concrete first-node example, the "own line" rule, and that **no marker is wrapped in backticks** (`assert.doesNotMatch(prompt, /\`@@step-/)`).
- Printed the compiled prompt for a sample flow to confirm it reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)