### PR TITLE
fix(flow): pick required familiars from a list instead of typing free-hand

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1138,6 +1138,18 @@ textarea.required-inputs-control {
   line-height: 1.5;
 }
 
+.required-inputs-select {
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 30px;
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position: calc(100% - 16px) center, calc(100% - 11px) center;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+}
+
 .required-inputs-help {
   font-size: 11px;
   line-height: 1.4;

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -847,6 +847,7 @@ export function FlowView() {
       {requiredInputsPrompt && (
         <RequiredInputsDialog
           inputs={requiredInputsPrompt.inputs}
+          familiarOptions={familiarOptions}
           onSubmit={submitRequiredInputs}
           onCancel={() => setRequiredInputsPrompt(null)}
         />

--- a/src/components/required-inputs-dialog.test.ts
+++ b/src/components/required-inputs-dialog.test.ts
@@ -9,5 +9,10 @@ assert.match(source, /onSubmit: \(values: Record<string, string>\) => void/, "di
 assert.match(source, /required-inputs-form/, "dialog should render a stable form class");
 assert.match(source, /required-inputs-field/, "dialog should render labelled fields");
 assert.match(source, /required-inputs-dialog/, "dialog should expose stable body class");
+// Familiar params must be picked from the valid familiar list, not typed free-hand
+// (an unknown/empty familiar makes the daemon reject the run).
+assert.match(source, /familiarOptions/, "dialog should accept the valid familiar list");
+assert.match(source, /input\.control === "familiar"/, "familiar params should render a picker, not a text field");
+assert.match(source, /<select/, "familiar control should render a select of familiars");
 
 console.log("required-inputs-dialog.test.ts: ok");

--- a/src/components/required-inputs-dialog.tsx
+++ b/src/components/required-inputs-dialog.tsx
@@ -5,13 +5,19 @@ import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import type { RequiredInput } from "@/lib/required-inputs";
 
+export type RequiredInputOption = { value: string; label: string };
+
 type RequiredInputsDialogProps = {
   inputs: RequiredInput[];
+  /** Valid familiars for `control:"familiar"` params — rendered as a picker so a
+   * step can't be handed an unknown/empty familiar (the daemon then rejects the
+   * run with "no familiar configured for this harness"). */
+  familiarOptions?: RequiredInputOption[];
   onSubmit: (values: Record<string, string>) => void;
   onCancel: () => void;
 };
 
-export function RequiredInputsDialog({ inputs, onSubmit, onCancel }: RequiredInputsDialogProps) {
+export function RequiredInputsDialog({ inputs, familiarOptions = [], onSubmit, onCancel }: RequiredInputsDialogProps) {
   const initialValues = useMemo(
     () => Object.fromEntries(inputs.map((input) => [input.key, ""])),
     [inputs],
@@ -62,7 +68,25 @@ export function RequiredInputsDialog({ inputs, onSubmit, onCancel }: RequiredInp
                     {input.nodeName}
                   </span>
                 </span>
-                {input.control === "textarea" || input.control === "code" || input.control === "json" ? (
+                {input.control === "familiar" ? (
+                  <select
+                    required
+                    className="required-inputs-control required-inputs-select"
+                    value={values[input.key] ?? ""}
+                    onChange={(event) =>
+                      setValues((current) => ({ ...current, [input.key]: event.target.value }))
+                    }
+                  >
+                    <option value="" disabled>
+                      {familiarOptions.length ? "Choose a familiar…" : "No familiars available"}
+                    </option>
+                    {familiarOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                ) : input.control === "textarea" || input.control === "code" || input.control === "json" ? (
                   <textarea
                     required
                     className="required-inputs-control"


### PR DESCRIPTION
## Problem (the "no familiar configured for this harness" dig)

A flow runs as one daemon session bound to a familiar (`flowExecutor` → first node `familiar` param → `harness` + `familiarId`). The required-inputs dialog asked for the **Familiar** value as a **plain text input**, so a run could be handed a value that isn't a real familiar id (a display name, a description) — or effectively empty. The session then spawns with no valid familiar and the **daemon** rejects it with **"no familiar configured for this harness"**, which surfaces as the silent/erroring run you saw. (That string isn't in this repo — it's daemon-side, confirming the familiar binding is what's wrong.)

## Fix

Render `control:"familiar"` required inputs as a **`<select>` of valid familiars** instead of a text field — the same list the flow node inspector already uses (`/api/familiars` → `familiarOptions`, threaded through from `FlowView`). A step can now only be bound to a real familiar (`nova`, `sage`, …), so the daemon never gets an unknown/empty one. Non-familiar inputs are unchanged.

`required-inputs-dialog.tsx` (+select branch & prop), `flow-view.tsx` (pass `familiarOptions`), `globals.css` (select styling), test. +44/−2.

## Verification

- `tsc --noEmit` clean; `pnpm test:app` → **459 test files pass**; new assertions pin the familiar picker (`familiarOptions`, `control === "familiar"`, `<select>`).
- Drove the built app: a flow with required `familiar` params now shows two **"Choose a familiar…"** dropdowns populated with `Nova (nova)`, `Sage (sage)`, `Kitty (kitty)`, etc. — screenshot below. No page errors.

Pairs with #2007 (run logs/stall) and #2009 (marker protocol) from this run on the flow executor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)