### PR TITLE
feat(code): add codex-style code page layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4206,6 +4206,127 @@ button:active > .edge-rail-chip {
   transform: scaleX(-1);
 }
 
+/* Codex-like Code page shell. The underlying chat and comux components keep
+   their behavior; this layer gives the Code surface its own focused IDE chrome. */
+.cave-code-page {
+  --code-page-bg: color-mix(in oklch, var(--bg-base) 86%, black);
+  --code-page-pane: color-mix(in oklch, var(--bg-raised) 78%, black);
+  --code-page-pane-strong: color-mix(in oklch, var(--bg-raised) 88%, black);
+  --code-page-line: color-mix(in oklch, var(--foreground) 10%, transparent);
+  --code-page-accent: color-mix(in oklch, var(--accent-presence) 74%, #7dd3fc);
+  --code-page-warm: color-mix(in oklch, var(--color-warning, #f7c56b) 64%, #f59e0b);
+  height: 100%;
+  padding: 10px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--code-page-pane) 42%, transparent), transparent 26%),
+    var(--code-page-bg);
+}
+
+.cave-code-page__split {
+  overflow: hidden;
+  border: 1px solid var(--code-page-line);
+  border-radius: 8px;
+  background: var(--code-page-bg);
+  box-shadow:
+    inset 0 1px 0 color-mix(in oklch, white 6%, transparent),
+    0 18px 54px color-mix(in oklch, black 28%, transparent);
+}
+
+.cave-code-page__resizable {
+  min-height: 0;
+}
+
+.cave-code-page__pane {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--code-page-pane);
+}
+
+.cave-code-page__pane--chat {
+  border-right: 1px solid color-mix(in oklch, var(--code-page-line) 78%, transparent);
+}
+
+.cave-code-page__pane--workspace {
+  background: color-mix(in oklch, var(--code-page-pane-strong) 92%, var(--code-surface));
+}
+
+.cave-code-page__separator {
+  background: color-mix(in oklch, var(--code-page-line) 72%, transparent);
+}
+
+.cave-code-page .chat-surface,
+.cave-code-page__pane--workspace > div {
+  min-height: 0;
+  background: transparent;
+}
+
+.cave-code-page .chat-scope-tabs {
+  min-height: 36px;
+  border-bottom-color: var(--code-page-line);
+  background:
+    linear-gradient(90deg, color-mix(in oklch, var(--code-page-accent) 7%, transparent), transparent 55%),
+    color-mix(in oklch, var(--code-page-pane) 92%, transparent);
+}
+
+.cave-code-page .code-panel-toggle,
+.cave-code-page :is(.comux-terminal-add-button, .comux-terminal-toolbar-button, .comux-preview-copypath) {
+  border-color: color-mix(in oklch, var(--foreground) 12%, transparent);
+  background: color-mix(in oklch, var(--bg-base) 54%, transparent);
+}
+
+.cave-code-page .comux-project-header {
+  background:
+    linear-gradient(90deg, color-mix(in oklch, var(--code-page-warm) 8%, transparent), transparent 70%),
+    color-mix(in oklch, var(--code-page-pane-strong) 94%, transparent);
+  border-bottom: 1px solid color-mix(in oklch, var(--foreground) 7%, transparent);
+}
+
+.cave-code-page .comux-project-list {
+  background:
+    radial-gradient(90% 70% at 10% 0%, color-mix(in oklch, var(--code-page-accent) 8%, transparent), transparent 72%),
+    color-mix(in oklch, var(--bg-base) 36%, transparent);
+}
+
+.cave-code-page .comux-file-preview {
+  background: color-mix(in oklch, var(--code-surface) 82%, black);
+}
+
+.cave-code-page .comux-terminal-tab-strip,
+.cave-code-page .comux-terminal-pane-bar {
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+  border-color: var(--code-page-line);
+}
+
+.cave-code-page .comux-terminal-pane {
+  border-color: color-mix(in oklch, var(--foreground) 9%, transparent);
+  background: color-mix(in oklch, var(--code-surface) 76%, black);
+}
+
+@media (max-width: 1023px) {
+  .cave-code-page {
+    padding: 0;
+    background: var(--code-page-bg);
+  }
+
+  .cave-code-page--mobile {
+    overflow: hidden;
+  }
+
+  .cave-code-page__mobile-tabs {
+    min-height: 44px;
+    background: color-mix(in oklch, var(--code-page-pane) 94%, transparent);
+    backdrop-filter: blur(14px) saturate(135%);
+    -webkit-backdrop-filter: blur(14px) saturate(135%);
+  }
+
+  .cave-code-page__mobile-pane {
+    min-height: 0;
+    overflow: hidden;
+    background: var(--code-page-pane);
+  }
+}
+
 /* ────────────────────────────────────────────────
    Companion rail — right-side per-familiar pane
    (Phase 2, shell-ia-redesign)

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -11,6 +11,7 @@ const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url)
 const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const preset = await readFile(new URL("../lib/code-layout-preset.ts", import.meta.url), "utf8");
+const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 // The Chat/Split/Review presets + companion-panel toggle now ride on the chat
 // surface's Sessions/Memory tab row, in a self-contained toolbar.
 const toolbar = await readFile(new URL("./code-inline-toolbar.tsx", import.meta.url), "utf8");
@@ -34,6 +35,12 @@ assert.match(
 );
 // Desktop keeps the two-pane resizable split under its own key.
 assert.match(codeView, /panelIds: \["code-chat", "code-comux"\]/, "desktop mounts both panels in the split");
+assert.match(codeView, /data-code-layout="codex"/, "desktop Code mode advertises the Codex-like layout for scoped styling");
+assert.match(codeView, /className="cave-code-page/, "desktop Code mode owns a full-page layout shell");
+assert.match(codeView, /cave-code-page__pane cave-code-page__pane--chat/, "chat pane gets the left conversation-column wrapper");
+assert.match(codeView, /cave-code-page__pane cave-code-page__pane--workspace/, "comux pane gets the main workspace wrapper");
+assert.match(globals, /\.cave-code-page\s*\{[\s\S]*?background:[\s\S]*?\.cave-code-page__pane--workspace/, "Code page shell defines the Codex-like desktop chrome");
+assert.match(globals, /@media \(max-width: 1023px\)[\s\S]*?\.cave-code-page/, "Code page chrome has a mobile/narrow override");
 
 // ── Layout presets (Chat / Split / Review) re-weight the desktop split ───────
 // The preset chips live on the chat surface's tab row (CodeInlineToolbar) and

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -60,8 +60,8 @@ export function CodeView({ chat, comux }: Props) {
   // (hidden, not unmounted) so the terminal/chat keep their state across taps.
   if (isMobile) {
     return (
-      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        <div className="flex shrink-0 items-center justify-center gap-1 border-b border-[var(--border-hairline)] p-1.5">
+      <div className="cave-code-page cave-code-page--mobile flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="cave-code-page__mobile-tabs flex shrink-0 items-center justify-center gap-1 border-b border-[var(--border-hairline)] p-1.5">
           <Tabs
             variant="segment"
             size="sm"
@@ -74,8 +74,8 @@ export function CodeView({ chat, comux }: Props) {
             ]}
           />
         </div>
-        <div className={`min-h-0 flex-1 flex-col ${mobileTab === "chat" ? "flex" : "hidden"}`}>{chat}</div>
-        <div className={`min-h-0 flex-1 flex-col ${mobileTab === "code" ? "flex" : "hidden"}`}>{comux}</div>
+        <div className={`cave-code-page__mobile-pane min-h-0 flex-1 flex-col ${mobileTab === "chat" ? "flex" : "hidden"}`}>{chat}</div>
+        <div className={`cave-code-page__mobile-pane min-h-0 flex-1 flex-col ${mobileTab === "code" ? "flex" : "hidden"}`}>{comux}</div>
       </div>
     );
   }
@@ -116,9 +116,9 @@ function DesktopCodeView({ chat, comux }: Props) {
   }, []);
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+    <div className="cave-code-page flex min-h-0 min-w-0 flex-1 flex-col" data-code-layout="codex">
       <Group
-        className="flex min-h-0 min-w-0 flex-1"
+        className="cave-code-page__split flex min-h-0 min-w-0 flex-1"
         orientation="horizontal"
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
@@ -126,18 +126,18 @@ function DesktopCodeView({ chat, comux }: Props) {
         <Panel
           panelRef={chatPanelRef}
           id="code-chat"
-          className="flex min-h-0 min-w-0"
+          className="cave-code-page__resizable cave-code-page__resizable--chat flex min-h-0 min-w-0"
           defaultSize="38%"
           minSize="28%"
           maxSize="75%"
         >
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{chat}</div>
+          <div className="cave-code-page__pane cave-code-page__pane--chat flex min-h-0 min-w-0 flex-1 flex-col">{chat}</div>
         </Panel>
-        <Separator className="shell-separator hidden lg:flex">
+        <Separator className="cave-code-page__separator shell-separator hidden lg:flex">
           <SeparatorHandle orientation="col" />
         </Separator>
-        <Panel id="code-comux" className="hidden min-h-0 min-w-0 lg:flex" minSize="35%">
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">{comux}</div>
+        <Panel id="code-comux" className="cave-code-page__resizable cave-code-page__resizable--workspace hidden min-h-0 min-w-0 lg:flex" minSize="35%">
+          <div className="cave-code-page__pane cave-code-page__pane--workspace flex min-h-0 min-w-0 flex-1 flex-col">{comux}</div>
         </Panel>
       </Group>
     </div>


### PR DESCRIPTION
## Summary

- scopes a Codex-like layout shell to the existing CovenCave Code workspace surface
- wraps the chat and workspace panes with Code-page-specific class hooks without changing their behavior
- adds desktop chrome for the split Code surface and mobile overrides for the tabbed Code/Chat layout
- extends the CodeView source test so the scoped layout hooks and CSS stay wired

## Verification

- `pnpm exec node src/components/code-view.test.ts`
- `pnpm typecheck`
- `pnpm test:app`
- Browser smoke on local dev server at `/`: clicked the existing Code sidebar item and verified `.cave-code-page` rendered on desktop and mobile
  - desktop screenshot: `/tmp/coven-cave-code-page-desktop.png`
  - mobile screenshot: `/tmp/coven-cave-code-page-mobile.png`

## Notes

This is intentionally scoped to CovenCave's existing Code workspace. No OpenClaw files are touched.
