### PR TITLE
feat(analytics): scannable hero + KPI summary for familiar analytics

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9307,30 +9307,93 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-weight: 700;
   object-fit: cover;
 }
-.fa-score-circle {
+/* Confidence ring — radial progress hero metric. */
+.fa-ring {
+  position: relative;
+  flex: 0 0 auto;
+  width: 104px;
+  height: 104px;
+  --fa-ring-color: var(--accent-presence);
+}
+.fa-ring--low { --fa-ring-color: var(--color-danger); }
+.fa-ring--developing { --fa-ring-color: var(--color-warning); }
+.fa-ring--reliable { --fa-ring-color: var(--accent-presence); }
+.fa-ring--trusted { --fa-ring-color: var(--color-success); }
+.fa-ring svg { width: 100%; height: 100%; display: block; }
+.fa-ring__track {
+  fill: none;
+  stroke: var(--border-hairline);
+  stroke-width: 8;
+}
+.fa-ring__value {
+  fill: none;
+  stroke: var(--fa-ring-color);
+  stroke-width: 8;
+  stroke-linecap: round;
+  transition: stroke-dasharray var(--duration-slow, 260ms) var(--ease-decelerate, ease);
+}
+.fa-ring__label {
+  position: absolute;
+  inset: 0;
   display: grid;
   place-items: center;
-  flex: 0 0 auto;
-  width: 98px;
-  height: 98px;
-  border-radius: 50%;
-  border: 1px solid color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base));
+  align-content: center;
   text-align: center;
 }
-.fa-score-circle strong {
-  display: block;
+.fa-ring__label strong {
   font-size: 30px;
   line-height: 1;
   font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
 }
-.fa-score-circle span {
-  margin-top: 5px;
-  color: var(--text-secondary);
-  font-size: 11px;
-  font-weight: 700;
+.fa-ring__label span {
+  margin-top: 4px;
+  color: var(--fa-ring-color);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+
+/* KPI tiles — scannable summary row. */
+.fa-kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 10px;
+}
+.fa-kpi {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-hairline);
+  border-left: 3px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-surface);
+}
+.fa-kpi--good { border-left-color: var(--color-success); }
+.fa-kpi--warn { border-left-color: var(--color-warning); }
+.fa-kpi--bad { border-left-color: var(--color-danger); }
+.fa-kpi__head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+}
+.fa-kpi__head svg { width: 14px; height: 14px; opacity: 0.85; }
+.fa-kpi__value {
+  font-size: 22px;
+  line-height: 1.1;
+  font-weight: 700;
+  text-transform: capitalize;
+  font-variant-numeric: tabular-nums;
+}
+.fa-kpi--good .fa-kpi__value { color: var(--color-success); }
+.fa-kpi--warn .fa-kpi__value { color: var(--color-warning); }
+.fa-kpi--bad .fa-kpi__value { color: var(--color-danger); }
+.fa-kpi__sub { color: var(--text-muted); font-size: 11px; }
 .fa-section {
   display: flex;
   flex-direction: column;
@@ -9693,9 +9756,9 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
     align-items: flex-start;
     flex-direction: column;
   }
-  .fa-score-circle {
-    width: 82px;
-    height: 82px;
+  .fa-ring {
+    width: 86px;
+    height: 86px;
   }
   .fa-factor {
     grid-template-columns: 1fr;

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -312,4 +312,18 @@ describe("FamiliarAnalyticsView", () => {
     assert.match(source, /<ThreadSignalsSection[\s\S]*reports=\{model\.threadReports\}/);
     assert.match(source, /<EvalLoopPanel[\s\S]*familiarId=\{model\.familiar\.id\}/);
   });
+
+  it("renders a confidence ring and a scannable KPI summary row", () => {
+    // Hero confidence ring (radial progress) replaces the flat score box.
+    assert.match(source, /<ConfidenceRing confidence=\{model\.confidence\}/, "header uses the confidence ring");
+    assert.match(source, /className="fa-ring__value"/, "ring draws a progress arc");
+    assert.match(source, /strokeDasharray/, "ring arc length tracks the score");
+
+    // KPI row surfaces growth / eval / contract / heal signals up top.
+    assert.match(source, /<FamiliarKpis model=\{model\} healRequestCount=\{healRequests\.length\}/, "KPI row is wired to the model");
+    assert.match(source, /function deriveKpis/, "KPIs are derived from the model");
+    assert.match(source, /model\.growthReport/, "KPIs read the (previously unsurfaced) growth report");
+    assert.match(source, /contract\.properties\.filter\(\(p\) => p\.pass\)/, "contract KPI shows the pass rate");
+    assert.match(source, /className=\{`fa-kpi\$\{kpi\.tone/, "KPI tiles tint by tone");
+  });
 });

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -151,6 +151,127 @@ const ContractCompliance = memo(function ContractCompliance({ report }: { report
   );
 });
 
+/** Map a confidence label to a tier class so the ring + KPIs read at a glance. */
+function confidenceTier(label: ConfidenceScore["label"]): "low" | "developing" | "reliable" | "trusted" {
+  switch (label) {
+    case "Trusted": return "trusted";
+    case "Reliable": return "reliable";
+    case "Developing": return "developing";
+    default: return "low";
+  }
+}
+
+/** Radial progress ring for the confidence score — a glanceable hero metric. */
+const ConfidenceRing = memo(function ConfidenceRing({ confidence }: { confidence: ConfidenceScore }) {
+  const score = Math.max(0, Math.min(100, confidence.score));
+  const r = 42;
+  const circ = 2 * Math.PI * r;
+  const dash = (score / 100) * circ;
+  const tier = confidenceTier(confidence.label);
+  return (
+    <div
+      className={`fa-ring fa-ring--${tier}`}
+      role="img"
+      aria-label={`Confidence score ${confidence.score} of 100, ${confidence.label}`}
+    >
+      <svg viewBox="0 0 100 100" aria-hidden>
+        <circle className="fa-ring__track" cx="50" cy="50" r={r} />
+        <circle
+          className="fa-ring__value"
+          cx="50"
+          cy="50"
+          r={r}
+          strokeDasharray={`${dash} ${circ}`}
+          transform="rotate(-90 50 50)"
+        />
+      </svg>
+      <div className="fa-ring__label">
+        <strong>{confidence.score}</strong>
+        <span>{confidence.label}</span>
+      </div>
+    </div>
+  );
+});
+
+type Kpi = { key: string; icon: Parameters<typeof Icon>[0]["name"]; label: string; value: string; sub: string; tone?: "good" | "warn" | "bad" };
+
+/** Derive the at-a-glance KPI tiles from the model's (otherwise buried) signals. */
+function deriveKpis(model: FamiliarAnalyticsModel, healRequestCount: number): Kpi[] {
+  const growth = model.growthReport;
+  const contract = model.contractReport;
+  const contractPass = contract ? contract.properties.filter((p) => p.pass).length : 0;
+  const contractTotal = contract ? contract.properties.length : 0;
+  const acceptRate = growth?.retroAcceptRate ?? null;
+  const evals = model.evalLoopState?.iterations?.length ?? 0;
+
+  return [
+    {
+      key: "activity",
+      icon: "ph:lightning-bold",
+      label: "Activity",
+      value: growth ? growth.healthLabel : "—",
+      sub: growth ? `${growth.sessionsLast7d} session${growth.sessionsLast7d === 1 ? "" : "s"} · 7d` : "no data",
+      tone: growth?.healthLabel === "stalled" ? "bad" : growth?.healthLabel === "quiet" ? "warn" : "good",
+    },
+    {
+      key: "evals",
+      icon: "ph:arrows-clockwise-bold",
+      label: "Eval acceptance",
+      value: acceptRate == null ? "—" : `${Math.round(acceptRate * 100)}%`,
+      sub: `${evals} iteration${evals === 1 ? "" : "s"}`,
+      tone: acceptRate == null ? undefined : acceptRate >= 0.6 ? "good" : acceptRate >= 0.3 ? "warn" : "bad",
+    },
+    {
+      key: "contract",
+      icon: "ph:check-circle-bold",
+      label: "Contract",
+      value: contractTotal ? `${contractPass}/${contractTotal}` : "—",
+      sub: contract ? (contract.pass ? "passing" : "needs review") : "no report",
+      tone: !contractTotal ? undefined : contract?.pass ? "good" : "warn",
+    },
+    {
+      key: "heal",
+      icon: "ph:wrench-bold",
+      label: "Self-heal",
+      value: String(healRequestCount),
+      sub: healRequestCount === 0 ? "all clear" : healRequestCount === 1 ? "open request" : "open requests",
+      tone: healRequestCount === 0 ? "good" : "warn",
+    },
+    {
+      key: "signals",
+      icon: "ph:waveform-bold",
+      label: "Thread signals",
+      value: String(model.threadReports.length),
+      sub: model.threadReports.length === 1 ? "report" : "reports",
+    },
+  ];
+}
+
+/** Scannable KPI row — surfaces growth, eval, contract, and heal signals up top. */
+const FamiliarKpis = memo(function FamiliarKpis({
+  model,
+  healRequestCount,
+}: {
+  model: FamiliarAnalyticsModel;
+  healRequestCount: number;
+}) {
+  const kpis = deriveKpis(model, healRequestCount);
+  return (
+    <div className="fa-kpis" role="list" aria-label="Key metrics">
+      {kpis.map((kpi) => (
+        <div key={kpi.key} className={`fa-kpi${kpi.tone ? ` fa-kpi--${kpi.tone}` : ""}`} role="listitem">
+          <div className="fa-kpi__head">
+            <Icon name={kpi.icon} aria-hidden />
+            <span className="fa-kpi__label">{kpi.label}</span>
+          </div>
+          <strong className="fa-kpi__value">{kpi.value}</strong>
+          <span className="fa-kpi__sub">{kpi.sub}</span>
+        </div>
+      ))}
+    </div>
+  );
+});
+
 export function FamiliarAnalyticsContent({
   model,
   onRefresh,
@@ -217,11 +338,10 @@ export function FamiliarAnalyticsContent({
             <p>{familiarRole}</p>
           </div>
         </div>
-        <div className="fa-score-circle" aria-label={`Confidence score ${model.confidence.score}, ${model.confidence.label}`}>
-          <strong>{model.confidence.score}</strong>
-          <span>{model.confidence.label}</span>
-        </div>
+        <ConfidenceRing confidence={model.confidence} />
       </header>
+
+      <FamiliarKpis model={model} healRequestCount={healRequests.length} />
 
       <ConfidenceBreakdown confidence={model.confidence} />
 


### PR DESCRIPTION
## What

The per-familiar analytics view (inspector → Analytics tab) was a flat stack of detail sections, with only a plain confidence *number* up top — and several already-computed signals (growth report, session activity, eval acceptance, contract pass-rate) were never surfaced at all. This leads with a **glanceable summary**:

- **Confidence ring** — a tier-colored radial progress hero (Low → red, Developing → amber, Reliable → lavender, Trusted → green) replaces the flat score box.
- **KPI row** — five toned tiles surfacing previously-buried signals: **Activity** (health + sessions/7d), **Eval acceptance** %, **Contract** pass-rate, open **Self-heal** requests, **Thread-signal** count. All derived from the existing model — no new fetches.

The detail sections (confidence breakdown, self-heal, thread signals, eval loop, contract) are unchanged below. Pure presentation.

## Verification

- `tsc --noEmit`: 0 errors · `next build`: pass
- `familiar-analytics-view.test.ts` updated + green (new assertions pin the ring + KPI wiring); `check:tests-wired` clean
- Full suite: **524 test files pass** (app + mobile)
- Visual design rendered & reviewed (hero ring + KPI tiles + detail sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)