### PR TITLE
fix(chat): make thread reflect work (daemon has no chat endpoint)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -85,6 +85,7 @@ export const SUITES = {
     "src/lib/secret-redaction.test.ts",
     "src/lib/retro-runs.test.ts",
     "src/lib/eval-loop-daemon.test.ts",
+    "src/lib/familiar-stream.test.ts",
     "src/lib/role-manifest.test.ts",
     "src/lib/chat-cwd-root.test.ts",
     "src/lib/agent-completion-report.test.ts",
@@ -692,6 +693,7 @@ const ALIAS_LOADER = new Set([
   "src/components/thread-signal-card.test.ts",
   "src/components/thread-signals-section.test.ts",
   "src/components/chat-view.test.ts",
+  "src/lib/familiar-stream.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/app/api/familiars/[id]/self-report/route.ts
+++ b/src/app/api/familiars/[id]/self-report/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server";
-import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
 import { redactSecretsDeep, redactSecretText } from "@/lib/secret-redaction";
 import {
   appendSelfReport,
@@ -23,6 +22,10 @@ type SelfReportBody = {
   sessionId?: unknown;
   trigger?: unknown;
   threadTitle?: unknown;
+  /** Raw JSON text the familiar produced for the reflection (generated client-side
+   *  via the chat bridge; the daemon has no LLM endpoint). The route validates and
+   *  persists it. */
+  payload?: unknown;
 };
 
 const TRIGGERS = new Set(["auto", "manual", "periodic"]);
@@ -31,36 +34,6 @@ const CAPABILITY_STATES = new Set<CapabilityState>(["available", "degraded", "mi
 const BLOCKER_CATEGORIES = new Set<BlockerCategory>(["auth", "tooling", "permission", "infra", "context", "skill", "other"]);
 const BLOCKER_IMPACTS = new Set<BlockerImpact>(["low", "medium", "high", "blocking"]);
 const IMPORTANCE = new Set<CapabilityImportance>(["nice-to-have", "important", "blocking"]);
-
-function promptFor(sessionId: string): string {
-  return `Reflect on the thread just completed (session: ${sessionId}).
-Return ONLY a valid JSON object matching this exact shape - no prose, no markdown fences:
-
-{
-  "overallConfidence": <0-100>,
-  "overallConfidenceReason": "<brief explanation>",
-  "toolReliability": {
-    "score": <0-100>,
-    "failedTools": ["<tool name>", ...],
-    "unreliableTools": ["<tool name>", ...],
-    "notes": "<optional>"
-  },
-  "contextPressure": "<adequate|tight|excess|critical>",
-  "contextNotes": "<optional>",
-  "skillsUsed": ["<skill id>", ...],
-  "skillsNeedingClarity": [{ "skillId": "<id>", "reason": "<why>" }],
-  "skillsNeedingAccess": [{ "skillId": "<id>", "reason": "<why>" }],
-  "capabilitiesLacking": [{ "name": "<name>", "importance": "<nice-to-have|important|blocking>", "detail": "<detail>" }],
-  "capabilitiesVital": [{ "name": "<name>", "currentState": "<available|degraded|missing>", "notes": "<optional>" }],
-  "memoryRecallScore": <0-100>,
-  "memoryRecallNotes": "<optional>",
-  "fileLocatabilityScore": <0-100>,
-  "fileLocatabilityNotes": "<optional>",
-  "persistentBlockers": [{ "id": "<slug>", "title": "<title>", "category": "<auth|tooling|permission|infra|context|skill|other>", "impact": "<low|medium|high|blocking>", "detail": "<detail>", "suggestedResolution": "<optional>" }]
-}
-
-Be honest. Underconfidence is more useful than overconfidence. Only report what you actually experienced.`;
-}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -92,24 +65,6 @@ function enumValue<T extends string>(value: unknown, allowed: Set<T>, field: str
 
 function objectArray(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.filter(isRecord) : [];
-}
-
-function extractDaemonText(data: unknown): string | null {
-  if (typeof data === "string") return data;
-  if (!isRecord(data)) return null;
-  for (const key of ["content", "text", "message", "response", "reply", "output"]) {
-    const value = data[key];
-    if (typeof value === "string") return value;
-  }
-  const messages = data.messages;
-  if (Array.isArray(messages)) {
-    for (const item of [...messages].reverse()) {
-      if (isRecord(item) && typeof item.content === "string") return item.content;
-    }
-  }
-  const turn = data.turn;
-  if (isRecord(turn) && typeof turn.text === "string") return turn.text;
-  return null;
 }
 
 function parseJsonObject(raw: string): Record<string, unknown> {
@@ -197,25 +152,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
     return NextResponse.json({ ok: false, error: "invalid trigger" }, { status: 400 });
   }
 
+  // The familiar's reflection is generated client-side through the chat bridge
+  // (the daemon has no LLM endpoint) and posted here as raw JSON text. This route
+  // validates the shape and persists it.
+  const raw = typeof body.payload === "string" ? body.payload : "";
+  if (!raw.trim()) {
+    return NextResponse.json({ ok: false, error: "missing reflection payload" }, { status: 400 });
+  }
+
   try {
-    const res = await callDaemon<unknown>({
-      method: "POST",
-      path: "/api/v1/chat/send",
-      body: {
-        familiarId: id,
-        sessionId,
-        prompt: promptFor(sessionId),
-      },
-      timeoutMs: 30000,
-    });
-
-    if (!res.ok || !res.data) {
-      return NextResponse.json({ ok: false, error: redactSecretText(extractDaemonError(res) ?? `daemon http ${res.status}`) });
-    }
-
-    const raw = extractDaemonText(res.data);
-    if (!raw) return NextResponse.json({ ok: false, error: "empty daemon response" });
-
     const report = redactSecretsDeep(normalizePayload(parseJsonObject(raw), {
       familiarId: id,
       sessionId,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -80,7 +80,12 @@ import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { resolveActivePath, siblingsOf, childLeaf } from "@/lib/conversation-tree";
-import type { ThreadSelfReport } from "@/lib/thread-self-report";
+import {
+  buildReflectTranscript,
+  buildThreadReflectPrompt,
+  type ThreadSelfReport,
+} from "@/lib/thread-self-report";
+import { streamFamiliarText } from "@/lib/familiar-stream";
 
 type ToolEvent = {
   id: string;
@@ -1911,6 +1916,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setReflecting(true);
     setReflectError(null);
     try {
+      // Generate the reflection client-side via the chat bridge — the daemon has
+      // no LLM endpoint. Run it ephemerally (embed the transcript instead of
+      // resuming the session) so it never appends a turn to the user's thread.
+      const prompt = buildThreadReflectPrompt({ sessionId, transcript: buildReflectTranscript(turns) });
+      const { text, error } = await streamFamiliarText({ familiarId: familiar.id, prompt });
+      if (error) throw new Error(error);
       const res = await fetch(`/api/familiars/${encodeURIComponent(familiar.id)}/self-report`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1918,6 +1929,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           sessionId,
           trigger: "manual",
           threadTitle: session?.title ?? familiar.display_name,
+          payload: text,
         }),
       });
       const json = await res.json() as { ok: true; report: ThreadSelfReport } | { ok: false; error?: string };
@@ -1928,11 +1940,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     } finally {
       setReflecting(false);
     }
-  }, [familiar.display_name, familiar.id, reflecting, session?.title, sessionId]);
+  }, [familiar.display_name, familiar.id, reflecting, session?.title, sessionId, turns]);
 
   const autoReflectOnThread = useCallback(async (targetSessionId: string) => {
     if (!familiar.autoSelfReport) return;
     try {
+      const prompt = buildThreadReflectPrompt({ sessionId: targetSessionId, transcript: buildReflectTranscript(turns) });
+      const { text, error } = await streamFamiliarText({ familiarId: familiar.id, prompt });
+      if (error || !text.trim()) return;
       const res = await fetch(`/api/familiars/${encodeURIComponent(familiar.id)}/self-report`, {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -1940,6 +1955,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           sessionId: targetSessionId,
           trigger: "auto",
           threadTitle: session?.title ?? familiar.display_name,
+          payload: text,
         }),
       });
       const json = await res.json().catch(() => null) as
@@ -1950,7 +1966,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     } catch {
       /* Auto self-report is best-effort and intentionally silent. */
     }
-  }, [familiar.autoSelfReport, familiar.display_name, familiar.id, session?.title]);
+  }, [familiar.autoSelfReport, familiar.display_name, familiar.id, session?.title, turns]);
 
   useEffect(() => {
     const status = session?.status?.toLowerCase();

--- a/src/lib/evals/eval-runner.ts
+++ b/src/lib/evals/eval-runner.ts
@@ -20,7 +20,7 @@ import {
   type GraderResult,
 } from "./eval-model.ts";
 import { buildJudgePrompt, parseJudgeVerdict, judgeRubric } from "./eval-judge.ts";
-import { parseSseFrame } from "../canvas-generate.ts";
+import { streamFamiliarText } from "../familiar-stream.ts";
 
 export type RunProgress = {
   /** Index of the case currently running (0-based). */
@@ -122,46 +122,4 @@ async function gradeCase(
     out.push(applyJudgeVerdict(g, verdict.score, verdict.reason));
   }
   return out;
-}
-
-/** Stream the assistant's full text for `prompt` from `familiarId`. */
-async function streamFamiliarText(opts: {
-  familiarId: string;
-  prompt: string;
-  signal?: AbortSignal;
-}): Promise<{ text: string; error: string | null }> {
-  let res: Response;
-  try {
-    res = await fetch("/api/chat/send", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ familiarId: opts.familiarId, prompt: opts.prompt }),
-      signal: opts.signal,
-    });
-  } catch (err) {
-    return { text: "", error: (err as Error)?.message ?? "request failed" };
-  }
-  if (!res.ok || !res.body) return { text: "", error: `chat bridge ${res.status}` };
-
-  const reader = res.body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-  let text = "";
-  let error: string | null = null;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-    let idx;
-    while ((idx = buffer.indexOf("\n\n")) >= 0) {
-      const frame = buffer.slice(0, idx);
-      buffer = buffer.slice(idx + 2);
-      const ev = parseSseFrame(frame);
-      if (!ev) continue;
-      if (ev.kind === "assistant_chunk") text += ev.text ?? "";
-      else if (ev.kind === "done" && ev.isError) error = error ?? "the familiar reported an error";
-      else if (ev.kind === "error") error = ev.message ?? "generation error";
-    }
-  }
-  return { text, error };
 }

--- a/src/lib/familiar-stream.test.ts
+++ b/src/lib/familiar-stream.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { streamFamiliarText } from "./familiar-stream.ts";
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+/** Build a Response-like object whose body streams the given SSE frame strings. */
+function sseResponse(frames: string[], init: { ok?: boolean } = {}) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const f of frames) controller.enqueue(encoder.encode(f));
+      controller.close();
+    },
+  });
+  return { ok: init.ok ?? true, body } as unknown as Response;
+}
+
+function frame(obj: unknown): string {
+  return `data: ${JSON.stringify(obj)}\n\n`;
+}
+
+describe("streamFamiliarText", () => {
+  it("concatenates assistant_chunk text across frames", async () => {
+    globalThis.fetch = (async () => sseResponse([
+      frame({ kind: "assistant_chunk", text: "Hel" }),
+      frame({ kind: "assistant_chunk", text: "lo " }),
+      frame({ kind: "assistant_chunk", text: "world" }),
+      frame({ kind: "done" }),
+    ])) as typeof fetch;
+
+    const { text, error } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
+    assert.equal(text, "Hello world");
+    assert.equal(error, null);
+  });
+
+  it("includes sessionId in the request body only when provided", async () => {
+    const bodies: string[] = [];
+    globalThis.fetch = (async (_url: unknown, init: { body?: string }) => {
+      bodies.push(init.body ?? "");
+      return sseResponse([frame({ kind: "done" })]);
+    }) as typeof fetch;
+
+    await streamFamiliarText({ familiarId: "nova", prompt: "p" });
+    await streamFamiliarText({ familiarId: "nova", prompt: "p", sessionId: "sess-9" });
+
+    assert.equal(JSON.parse(bodies[0]).sessionId, undefined, "ephemeral run omits sessionId");
+    assert.equal(JSON.parse(bodies[1]).sessionId, "sess-9", "resume run includes sessionId");
+  });
+
+  it("surfaces an error frame", async () => {
+    globalThis.fetch = (async () => sseResponse([
+      frame({ kind: "assistant_chunk", text: "partial" }),
+      frame({ kind: "error", message: "boom" }),
+    ])) as typeof fetch;
+
+    const { text, error } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
+    assert.equal(text, "partial");
+    assert.equal(error, "boom");
+  });
+
+  it("reports a non-ok HTTP status as an error", async () => {
+    globalThis.fetch = (async () => ({ ok: false, status: 502, body: null }) as unknown as Response) as typeof fetch;
+    const { error } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
+    assert.match(error ?? "", /chat bridge 502/);
+  });
+});

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -1,0 +1,57 @@
+// Client helper: stream a one-shot prompt to a familiar through the chat bridge
+// (`/api/chat/send`, SSE) and return the concatenated assistant text. This is the
+// sanctioned client-side LLM path — the same bridge evals, workflow-generate, and
+// canvas-generate use. There is no server-side LLM route (the daemon exposes only
+// sessions + events), so anything that needs a familiar to "think" runs here.
+//
+// Pass `sessionId` to resume an existing thread's context (the harness continues
+// that conversation). Omit it for a fresh, ephemeral run that never touches the
+// user's saved conversations — useful for meta tasks like thread reflection.
+
+import { parseSseFrame } from "@/lib/canvas-generate";
+
+export async function streamFamiliarText(opts: {
+  familiarId: string;
+  prompt: string;
+  sessionId?: string;
+  signal?: AbortSignal;
+}): Promise<{ text: string; error: string | null }> {
+  let res: Response;
+  try {
+    res = await fetch("/api/chat/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        familiarId: opts.familiarId,
+        prompt: opts.prompt,
+        ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
+      }),
+      signal: opts.signal,
+    });
+  } catch (err) {
+    return { text: "", error: (err as Error)?.message ?? "request failed" };
+  }
+  if (!res.ok || !res.body) return { text: "", error: `chat bridge ${res.status}` };
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+  let error: string | null = null;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx;
+    while ((idx = buffer.indexOf("\n\n")) >= 0) {
+      const frame = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      const ev = parseSseFrame(frame);
+      if (!ev) continue;
+      if (ev.kind === "assistant_chunk") text += ev.text ?? "";
+      else if (ev.kind === "done" && ev.isError) error = error ?? "the familiar reported an error";
+      else if (ev.kind === "error") error = ev.message ?? "generation error";
+    }
+  }
+  return { text, error };
+}

--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  buildReflectTranscript,
+  buildThreadReflectPrompt,
   contextPressureLabel,
   deriveThreadScore,
   type ThreadSelfReport,
@@ -75,5 +77,47 @@ describe("thread self-report helpers", () => {
 
     assert.equal(report.id, "report-1");
     assert.equal(report.persistentBlockers[0].impact, "medium");
+  });
+});
+
+describe("buildReflectTranscript", () => {
+  it("formats user/assistant turns and drops system/empty ones", () => {
+    const out = buildReflectTranscript([
+      { role: "system", text: "boot" },
+      { role: "user", text: "  hi there  " },
+      { role: "assistant", text: "hello" },
+      { role: "assistant", text: "   " },
+    ]);
+    assert.equal(out, "user: hi there\nassistant: hello");
+  });
+
+  it("keeps only the most recent turns and truncates long ones", () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({ role: "user" as const, text: `m${i}` }));
+    const out = buildReflectTranscript(many);
+    assert.equal(out.split("\n").length, 24, "caps at the most recent 24 turns");
+    assert.ok(out.includes("m39") && !out.includes("m0\n") && !out.startsWith("user: m0"));
+
+    const long = buildReflectTranscript([{ role: "assistant", text: "x".repeat(2000) }]);
+    assert.ok(long.length < 700 && long.endsWith("…"), "long turns are clipped with an ellipsis");
+  });
+});
+
+describe("buildThreadReflectPrompt", () => {
+  it("embeds the transcript and the exact JSON shape the route validates", () => {
+    const prompt = buildThreadReflectPrompt({
+      sessionId: "sess-1",
+      transcript: "user: do the thing\nassistant: done",
+    });
+    assert.ok(prompt.includes("session: sess-1"));
+    assert.ok(prompt.includes("user: do the thing"));
+    for (const key of ["overallConfidence", "toolReliability", "contextPressure", "persistentBlockers"]) {
+      assert.ok(prompt.includes(`"${key}"`), `prompt declares ${key}`);
+    }
+    assert.ok(/Return ONLY a valid JSON object/.test(prompt));
+  });
+
+  it("falls back to a context-free instruction when no transcript is given", () => {
+    const prompt = buildThreadReflectPrompt({ sessionId: "sess-2" });
+    assert.ok(prompt.includes("Reflect on the thread just completed (session: sess-2)"));
   });
 });

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -4,6 +4,67 @@ export type BlockerCategory = "auth" | "tooling" | "permission" | "infra" | "con
 export type BlockerImpact = "low" | "medium" | "high" | "blocking";
 export type CapabilityImportance = "nice-to-have" | "important" | "blocking";
 
+/** One settled turn of a thread, condensed for the reflection prompt. */
+export type ReflectTranscriptTurn = { role: "user" | "assistant" | "system"; text: string };
+
+const REFLECT_MAX_TURNS = 24;
+const REFLECT_MAX_CHARS_PER_TURN = 600;
+
+/** Render a compact, size-bounded transcript for embedding in the reflect prompt. */
+export function buildReflectTranscript(turns: readonly ReflectTranscriptTurn[]): string {
+  const lines = turns
+    .filter((t) => (t.role === "user" || t.role === "assistant") && t.text.trim())
+    .slice(-REFLECT_MAX_TURNS)
+    .map((t) => {
+      const body = t.text.trim().replace(/\s+/g, " ");
+      const clipped = body.length > REFLECT_MAX_CHARS_PER_TURN
+        ? `${body.slice(0, REFLECT_MAX_CHARS_PER_TURN)}…`
+        : body;
+      return `${t.role}: ${clipped}`;
+    });
+  return lines.join("\n");
+}
+
+/**
+ * Build the thread self-report ("reflect") prompt. Generation runs client-side
+ * through the chat bridge (there is no server LLM route), so the prompt — and the
+ * exact JSON shape the route validates — lives here, shared by the caller and the
+ * persistence route. `transcript` (from {@link buildReflectTranscript}) grounds an
+ * ephemeral run that does not resume/pollute the original thread.
+ */
+export function buildThreadReflectPrompt(opts: { sessionId: string; transcript?: string }): string {
+  const context = opts.transcript?.trim()
+    ? `Here is the thread you just completed (session: ${opts.sessionId}), oldest to newest:\n\n${opts.transcript}\n\n`
+    : `Reflect on the thread just completed (session: ${opts.sessionId}).\n\n`;
+  return `${context}Reflect honestly on how that thread went for you as the familiar.
+Return ONLY a valid JSON object matching this exact shape - no prose, no markdown fences:
+
+{
+  "overallConfidence": <0-100>,
+  "overallConfidenceReason": "<brief explanation>",
+  "toolReliability": {
+    "score": <0-100>,
+    "failedTools": ["<tool name>", ...],
+    "unreliableTools": ["<tool name>", ...],
+    "notes": "<optional>"
+  },
+  "contextPressure": "<adequate|tight|excess|critical>",
+  "contextNotes": "<optional>",
+  "skillsUsed": ["<skill id>", ...],
+  "skillsNeedingClarity": [{ "skillId": "<id>", "reason": "<why>" }],
+  "skillsNeedingAccess": [{ "skillId": "<id>", "reason": "<why>" }],
+  "capabilitiesLacking": [{ "name": "<name>", "importance": "<nice-to-have|important|blocking>", "detail": "<detail>" }],
+  "capabilitiesVital": [{ "name": "<name>", "currentState": "<available|degraded|missing>", "notes": "<optional>" }],
+  "memoryRecallScore": <0-100>,
+  "memoryRecallNotes": "<optional>",
+  "fileLocatabilityScore": <0-100>,
+  "fileLocatabilityNotes": "<optional>",
+  "persistentBlockers": [{ "id": "<slug>", "title": "<title>", "category": "<auth|tooling|permission|infra|context|skill|other>", "impact": "<low|medium|high|blocking>", "detail": "<detail>", "suggestedResolution": "<optional>" }]
+}
+
+Be honest. Underconfidence is more useful than overconfidence. Only report what you actually experienced.`;
+}
+
 export type ThreadSelfReport = {
   id: string;
   familiarId: string;


### PR DESCRIPTION
## Problem

The **"Reflect on this thread"** button (chat header, brain icon) always failed with **"Route not found."**

Root cause: `POST /api/familiars/[id]/self-report` proxied the daemon at `/api/v1/chat/send`, but that daemon route **doesn't exist** — the daemon only exposes `sessions` + `events` (confirmed live: `{"error":{"code":"not_found","message":"Route not found."}}`, HTTP 404). `extractDaemonError` surfaced that string to the button. This endpoint was the *only* `callDaemon('/api/v1/chat/send')` site in the repo; everything else (main chat, evals, canvas, workflow-generate) runs the LLM **client-side** via `/api/chat/send`.

## Fix

Align reflect with the sanctioned client-side pattern:
- Generate the reflection in the browser through the `/api/chat/send` bridge. The run is **ephemeral** (no `sessionId`) with the thread **transcript embedded** in the prompt — same shape as `canvas-generate`/evals — so it never appends a turn to the user's conversation.
- The familiar's raw JSON is POSTed to the route, which now **validates the shape and persists it** (no daemon call). Guards (path/json/session/trigger) unchanged; a new `payload` is required.
- Extracted the shared client streamer into `src/lib/familiar-stream.ts` (reused by evals; adds optional `sessionId` to resume context).
- Moved the reflect prompt + transcript builders into `thread-self-report.ts` so the caller and the validating route share one definition.

## Tests
- New `familiar-stream.test.ts` — SSE assembly, `sessionId` wiring, error/HTTP paths.
- `thread-self-report.test.ts` — `buildThreadReflectPrompt` (embeds transcript + exact JSON shape) and `buildReflectTranscript` (filter/cap/truncate).
- `tsc` clean; `test:app` + `test:mobile` green. `chat-view.test.ts` still passes (the self-report POST keeps `sessionId` + `trigger`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)