### PR TITLE
fix(flow): spawn flow runs as a plain harness session (drop native familiarId)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -63,6 +63,7 @@ export const SUITES = {
     "src/components/flow/flow-node-required-badge.test.ts",
     "src/lib/flow/flow-webhook.test.ts",
     "src/lib/flow/flow-progress.test.ts",
+    "src/lib/server/flow-executor.test.ts",
     "src/lib/flow/flow-execution-data.test.ts",
     "src/lib/flow/flow-execution-duration.test.ts",
     "src/lib/flow/flow-execution-filters.test.ts",

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./flow-executor.ts", import.meta.url), "utf8");
+
+// A flow runs as a plain harness session. Passing `familiarId` natively to the
+// daemon makes some setups try to run the session *as* that familiar and reject
+// it with "no familiar configured for this harness". The familiar is carried in
+// the compiled prompt and mirrored into cave-state via recordSessionFamiliar, so
+// the daemon body must NOT include familiarId.
+assert.match(
+  source,
+  /body: \{ projectRoot, harness: binding\.harness, prompt \},/,
+  "flow session spawn must not pass familiarId natively to the daemon",
+);
+assert.match(source, /recordSessionFamiliar\(sessionId, familiarId\)/, "familiar is still mirrored into cave-state");
+
+console.log("flow-executor.test.ts: ok");

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -80,7 +80,14 @@ export async function startFlowSession(
   const res = await callDaemon<{ id: string; status: string }>({
     method: "POST",
     path: "/api/v1/sessions",
-    body: { projectRoot, harness: binding.harness, prompt, ...(familiarId ? { familiarId } : {}) },
+    // Spawn a plain harness session (no native `familiarId`), the same way task
+    // chat does. Passing `familiarId` makes some daemon setups try to run the
+    // session *as* that familiar and reject it with "no familiar configured for
+    // this harness" when the familiar isn't registered for that harness on the
+    // daemon. The familiar is already described in the compiled prompt and is
+    // mirrored into cave-state below via recordSessionFamiliar, so attribution
+    // and the run→familiar link survive.
+    body: { projectRoot, harness: binding.harness, prompt },
     timeoutMs: 8000,
   });
 


### PR DESCRIPTION
## Root cause — "no familiar configured for this harness"

Executing a flow failed with the daemon error **"no familiar configured for this harness"**. That string is **daemon-side** (not in this repo), so it's a daemon-spawn problem, not a Cave-logic one.

The difference that causes it:

| Path | daemon `/api/v1/sessions` body | works? |
|---|---|---|
| **Task / board chat** (familiars) | `{ projectRoot, harness, prompt }` — **no** familiarId | ✅ |
| **Flow executor** | `{ projectRoot, harness, prompt, familiarId }` | ❌ → the error |

Passing `familiarId` makes some daemon setups try to run the session **as** that familiar and reject it when the familiar isn't registered for that harness on the daemon. The familiar-picker fix (#2012) ensured a *valid* familiar, but the error persisted because it's about native session attribution, not the value.

## Fix

Match the working chat path: drop `familiarId` from the flow daemon body — spawn a plain harness session. `recordSessionFamiliar` still links the session→familiar for Cave's UI, and the familiar is already described in the compiled prompt, so attribution and the run link survive. (`familiarId` was already optional here — familiar-less flows always spawned this way.)

`flow-executor.ts` (+ comment), new `flow-executor.test.ts` pinning the body shape, wired into `run-tests.mjs`. +27/−1.

## Verification

- Reproduced against the **live daemon**: with the fix, a flow run spawns a session with **no "no familiar configured" error** (polled the session for ~48s, error absent).
- `tsc` clean; `pnpm test:app` → **460 test files pass**; `check:tests-wired` ✓.

**Honest scope:** this eliminates the reported error path. In my local env the session transcript comes back empty regardless (a separate output-visibility factor in my setup, not this error), so end-to-end "nodes light up" should be confirmed on your machine. Completes the executor arc: #2007 (logs/stall) · #2009 (markers) · #2012 (familiar picker) · this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)