### PR TITLE
fix(analytics): let the familiar analytics page scroll vertically

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9364,7 +9364,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   flex-direction: column;
   gap: 18px;
-  min-height: 100%;
+  /* Own the vertical scroll: html/body set `overflow: hidden`, so on the
+     full-page analytics route (a flex child of the h-full body) this view must
+     scroll itself or taller content is clipped with no scrollbar. height:100%
+     resolves against the definite-height parent in both the page route and the
+     inspector tab panel. */
+  height: 100%;
+  overflow-y: auto;
   padding: 24px;
   background: var(--bg-base);
   color: var(--text-primary);

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -326,4 +326,12 @@ describe("FamiliarAnalyticsView", () => {
     assert.match(source, /contract\.properties\.filter\(\(p\) => p\.pass\)/, "contract KPI shows the pass rate");
     assert.match(source, /className=\{`fa-kpi\$\{kpi\.tone/, "KPI tiles tint by tone");
   });
+
+  it("makes .fa-page own its vertical scroll (html/body are overflow:hidden)", () => {
+    const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+    const block = globals.match(/\.fa-page\s*\{[^}]*\}/);
+    assert.ok(block, ".fa-page rule should exist");
+    assert.match(block![0], /overflow-y:\s*auto/, ".fa-page must scroll its own content on the full-page route");
+    assert.doesNotMatch(block![0], /min-height:\s*100%/, ".fa-page should fill (height:100%), not just min-height, so overflow can trigger");
+  });
 });


### PR DESCRIPTION
## Bug

The full-page familiar analytics route (`/dashboard/familiars/[id]/analytics`, reached via the "Analytics →" links) was **cut off vertically with no way to scroll**.

`html, body { overflow: hidden }` (intentional — the desktop window never scrolls), so internal containers must own their scroll. `.fa-page` is rendered directly as a flex child of the fixed-height `<body>`, but it had `min-height: 100%` and no overflow, so its content (taller now with the new KPI summary row) overflowed the viewport and was clipped — the lower sections (eval loop, contract) were unreachable. The inspector Analytics tab was unaffected because its panel is already `overflow-y-auto`.

## Fix

`.fa-page` → `height: 100%; overflow-y: auto`, so it scrolls its own content. `height: 100%` resolves against the definite-height parent in **both** contexts (the `h-full` body on the page route, and the `flex-1 min-h-0` panel in the inspector tab).

## Verification

- Reproduced + fixed in a clipped (`overflow:hidden`) viewport: before → content stops mid-page with no scrollbar; after → scrolls to the last section.
- `tsc`: 0 errors · `next build`: pass · analytics test green (6/6, incl. a new guard asserting `.fa-page` keeps `overflow-y: auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)