### PR TITLE
fix(analytics): make Contract Compliance grid responsive to panel width

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9778,7 +9778,11 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-contract-grid {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  /* Reflow by the panel's own width, not the viewport — the analytics surface also
+     renders in the narrow inspector sidepanel, where a fixed 5-column grid crushed
+     each cell and broke labels mid-word. auto-fit collapses empty tracks so the
+     items still stretch edge-to-edge on the wide full-page view. */
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 8px;
 }
 .fa-contract-item {
@@ -9794,7 +9798,10 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .fa-contract-item span {
   min-width: 0;
-  overflow-wrap: anywhere;
+  /* Wrap at word boundaries; only break a single over-long word as a last resort
+     (avoids the "Name / d / Identit / y" character shredding in tight columns). */
+  overflow-wrap: break-word;
+  line-height: 1.3;
 }
 .fa-contract-item.is-pass svg { color: var(--color-success); }
 .fa-contract-item.is-fail svg { color: var(--color-danger); }
@@ -9911,7 +9918,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .fa-response-factor-grid,
   .fa-thread-score-grid,
   .fa-thread-grid { grid-template-columns: 1fr; }
-  .fa-contract-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 560px) {
@@ -9942,7 +9948,6 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   }
   .tsc-head { align-items: flex-start; flex-direction: column; }
   .tsc-scores { grid-template-columns: 1fr; }
-  .fa-contract-grid { grid-template-columns: 1fr; }
 }
 
 /* Recommended follow-up: the agent lists next steps best-first, so the top


### PR DESCRIPTION
## Problem

In the **inspector sidepanel** (Analytics tab), the Contract Compliance items were locked to a fixed 5-column grid (`repeat(5, minmax(0, 1fr))`). In the narrow panel each cell collapsed to ~50px and the labels shredded character-by-character — "Name / d / Identit / y". The viewport media queries didn't help because the *panel* is narrow while the *viewport* is wide.

## Fix

- `grid-template-columns: repeat(auto-fit, minmax(120px, 1fr))` — the grid now reflows by its **container's** width: one column in the narrow inspector, stretching back to five edge-to-edge columns on the wide full-page route (`auto-fit` collapses the empty tracks so items fill the row).
- `overflow-wrap: break-word` (was `anywhere`) so labels wrap at word boundaries, never mid-word; plus `line-height: 1.3`.
- Dropped the now-redundant viewport `@media` overrides for `.fa-contract-grid`.

CSS-only; no markup/test changes.

## Verification (built + screenshotted, dev mode)
- **Wide** `/dashboard/familiars/[id]/analytics`: 5 single-line items edge-to-edge (`197px × 5`, empty tracks collapsed).
- **Narrow** inspector Analytics tab: single column, single-line labels, no shredding — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)