### PR TITLE
feat(chat): color-code tool-use rows by category

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -212,6 +212,7 @@ export const SUITES = {
     "src/lib/code-lang.test.ts",
     "src/lib/project-search.test.ts",
     "src/lib/tool-target-file.test.ts",
+    "src/lib/tool-visual.test.ts",
     "src/lib/terminal-layout.test.ts",
     "src/lib/terminal-nav.test.ts",
     "src/lib/tree-keynav.test.ts",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -79,6 +79,14 @@ assert.match(
   "ToolBlock should keep individual tool payloads collapsed and format input/output with SyntaxBlock",
 );
 
+// Tool rows are color-coded by category for quick visual inspection.
+assert.match(source, /import \{ toolVisual \} from "@\/lib\/tool-visual"/, "chat view imports the tool visual map");
+assert.match(
+  source,
+  /function ToolBlock[\s\S]*const visual = toolVisual\(tool\.name\)[\s\S]*data-tool-category=\{visual\.category\}[\s\S]*<Icon name=\{visual\.icon\}/,
+  "ToolBlock should color-code by tool category (data-tool-category + per-category icon)",
+);
+
 assert.doesNotMatch(
   [
     source.match(/function ReasoningBlock[\s\S]*?function ProgressGroup/)?.[0] ?? "",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -75,6 +75,7 @@ import {
 import type { CaveProject } from "@/lib/cave-projects";
 import { useProjects } from "@/lib/use-projects";
 import { toolArgSummary } from "@/lib/tool-arg-summary";
+import { toolVisual } from "@/lib/tool-visual";
 import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
@@ -4970,11 +4971,12 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
       }),
     );
   };
+  const visual = toolVisual(tool.name);
   return (
-    <details className="cave-tool-block" data-default-collapsed="true">
+    <details className="cave-tool-block" data-default-collapsed="true" data-tool-category={visual.category}>
       <summary className="flex min-w-0 cursor-pointer select-none flex-wrap items-center gap-2 text-[11px]">
-        <Icon name="ph:terminal-window" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-        <span className="min-w-0 truncate font-mono text-[var(--text-secondary)]">{tool.name}</span>
+        <Icon name={visual.icon} width={12} className="cave-tool-icon shrink-0" aria-hidden />
+        <span className="cave-tool-name min-w-0 truncate font-mono">{tool.name}</span>
         {argSummary ? (
           targetFile ? (
             <button

--- a/src/lib/tool-visual.test.ts
+++ b/src/lib/tool-visual.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { toolCategory, toolVisual } from "./tool-visual.ts";
+
+// ---- categories ----
+{
+  assert.equal(toolCategory("Bash"), "shell", "Bash → shell");
+  assert.equal(toolCategory("Read"), "read", "Read → read");
+  assert.equal(toolCategory("Glob"), "search", "Glob → search");
+  assert.equal(toolCategory("Grep"), "search", "Grep → search");
+  assert.equal(toolCategory("ToolSearch"), "search", "ToolSearch → search");
+  assert.equal(toolCategory("Edit"), "edit", "Edit → edit");
+  assert.equal(toolCategory("Write"), "edit", "Write → edit");
+  assert.equal(toolCategory("MultiEdit"), "edit", "MultiEdit → edit");
+  assert.equal(toolCategory("NotebookEdit"), "edit", "NotebookEdit → edit");
+  assert.equal(toolCategory("Agent"), "agent", "Agent → agent");
+  assert.equal(toolCategory("Task"), "agent", "bare Task → agent (subagent dispatch)");
+  assert.equal(toolCategory("Workflow"), "agent", "Workflow → agent");
+  assert.equal(toolCategory("WebFetch"), "web", "WebFetch → web");
+  assert.equal(toolCategory("WebSearch"), "web", "WebSearch → web (not search)");
+  assert.equal(toolCategory("TodoWrite"), "task", "TodoWrite → task management (todo wins over edit)");
+  assert.equal(toolCategory("TaskCreate"), "task", "TaskCreate → task management");
+  assert.equal(toolCategory("TaskList"), "task", "TaskList → task management");
+  assert.equal(toolCategory("CronCreate"), "task", "CronCreate → task management");
+  assert.equal(toolCategory("mcp__huggingface__paper_search"), "mcp", "mcp__ tools → mcp");
+  assert.equal(toolCategory("SomethingUnknown"), "other", "unknown → other");
+  assert.equal(toolCategory(""), "other", "empty → other");
+}
+
+// ---- icons + stability ----
+{
+  assert.equal(toolVisual("Bash").icon, "ph:terminal-window");
+  assert.equal(toolVisual("Read").icon, "ph:file-text");
+  assert.equal(toolVisual("Agent").icon, "ph:robot");
+  // every category resolves to a non-empty ph: icon
+  for (const name of ["Bash", "Read", "Grep", "Edit", "Agent", "WebFetch", "TaskCreate", "mcp__x__y", "Weird"]) {
+    const v = toolVisual(name);
+    assert.match(v.icon, /^ph:/, `${name} resolves to a ph icon`);
+    assert.ok(v.category, `${name} resolves to a category`);
+  }
+  // case-insensitive + stable
+  assert.equal(toolCategory("bash"), toolCategory("BASH"), "classification is case-insensitive");
+}
+
+console.log("tool-visual.test.ts OK");

--- a/src/lib/tool-visual.ts
+++ b/src/lib/tool-visual.ts
@@ -1,0 +1,57 @@
+// Maps a tool name to a stable visual identity (category + icon) so tool-use
+// rows in the chat can be color-coded for quick visual inspection. Pure and
+// unit-tested; the colors themselves live in cave-chat.css keyed by the
+// `data-tool-category` attribute this drives.
+
+import type { IconName } from "@/lib/icon";
+
+export type ToolCategory =
+  | "shell"
+  | "read"
+  | "search"
+  | "edit"
+  | "agent"
+  | "web"
+  | "task"
+  | "mcp"
+  | "other";
+
+export type ToolVisual = { category: ToolCategory; icon: IconName };
+
+const ICON_BY_CATEGORY: Record<ToolCategory, IconName> = {
+  shell: "ph:terminal-window",
+  read: "ph:file-text",
+  search: "ph:magnifying-glass",
+  edit: "ph:pencil-simple",
+  agent: "ph:robot",
+  web: "ph:globe",
+  task: "ph:kanban",
+  mcp: "ph:plug",
+  other: "ph:wrench",
+};
+
+/** Classify a tool by name into a coarse, color-coded category. */
+export function toolCategory(name: string): ToolCategory {
+  const n = (name || "").trim().toLowerCase();
+  if (!n) return "other";
+
+  // MCP tools are namespaced `mcp__server__tool` — group them together.
+  if (n.startsWith("mcp__") || n.startsWith("mcp_")) return "mcp";
+
+  // Order matters: more specific buckets win before the broad ones.
+  if (/(todo|task(create|update|list|get|output|stop)|cron|schedule|reminder)/.test(n)) return "task";
+  if (/(edit|write|str_replace|notebook|apply.?patch|create.?file)/.test(n)) return "edit";
+  if (/(bash|shell|terminal|exec|command|run.?command)/.test(n)) return "shell";
+  if (/(web|fetch|http|url|browse|crawl|google)/.test(n)) return "web";
+  if (/(grep|glob|search|ripgrep|find|locate|toolsearch)/.test(n)) return "search";
+  if (/(^|_)(read|view|cat|open|ls|list.?dir|file.?read)/.test(n)) return "read";
+  if (/(agent|task|dispatch|subagent|spawn|fork|workflow)/.test(n)) return "agent";
+
+  return "other";
+}
+
+/** Full visual identity (category + icon) for a tool name. */
+export function toolVisual(name: string): ToolVisual {
+  const category = toolCategory(name);
+  return { category, icon: ICON_BY_CATEGORY[category] };
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1581,7 +1581,23 @@ details[open] > .cave-tool-summary::before {
   border-radius: 7px;
   background: color-mix(in oklch, var(--bg-base) 58%, transparent);
   padding: 9px;
+  /* Color-coded by tool category (data-tool-category) for quick visual
+     inspection — each category drives --tool-accent below. */
+  --tool-accent: var(--text-muted);
+  border-left: 2px solid color-mix(in oklch, var(--tool-accent) 70%, transparent);
 }
+.cave-tool-icon { color: var(--tool-accent); }
+.cave-tool-name { color: color-mix(in oklch, var(--tool-accent) 80%, var(--text-secondary)); }
+
+.cave-tool-block[data-tool-category="shell"]  { --tool-accent: oklch(0.80 0.15 150); } /* green */
+.cave-tool-block[data-tool-category="read"]   { --tool-accent: oklch(0.74 0.13 235); } /* blue */
+.cave-tool-block[data-tool-category="search"] { --tool-accent: oklch(0.74 0.16 295); } /* violet */
+.cave-tool-block[data-tool-category="edit"]   { --tool-accent: oklch(0.82 0.14 75); }  /* amber */
+.cave-tool-block[data-tool-category="agent"]  { --tool-accent: oklch(0.74 0.18 350); } /* magenta */
+.cave-tool-block[data-tool-category="web"]    { --tool-accent: oklch(0.78 0.12 200); } /* teal */
+.cave-tool-block[data-tool-category="task"]   { --tool-accent: oklch(0.80 0.13 95); }  /* lime */
+.cave-tool-block[data-tool-category="mcp"]    { --tool-accent: oklch(0.72 0.14 270); } /* indigo */
+.cave-tool-block[data-tool-category="other"]  { --tool-accent: var(--text-muted); }
 
 /* CHAT-D4-07: expanded tool I/O is secondary context — clamp it tighter than
    prose code blocks (which cap at min(60vh, 520px), CHAT-D7-03). 360px sits


### PR DESCRIPTION
## What

Tool-use rows in the chat all rendered with the same terminal icon and muted name, so a long run of tool calls was hard to scan. This **color-codes each row by tool category** for quick visual inspection.

- New pure, unit-tested `toolVisual(name)` (`src/lib/tool-visual.ts`) classifies a tool into a category and picks a per-category icon.
- `ToolBlock` sets `data-tool-category` + the category icon; `cave-chat.css` drives a distinct `--tool-accent` per category applied to the **icon**, the **tool name**, and a **left-border stripe**.

| Category | Tools | Color |
|---|---|---|
| shell | Bash | green |
| read | Read | blue |
| search | Grep, Glob, ToolSearch | violet |
| edit | Edit, Write, MultiEdit, NotebookEdit | amber |
| agent | Agent, Task, Workflow | magenta |
| web | WebFetch, WebSearch | teal |
| task | TaskCreate, TodoWrite, Cron… | lime |
| mcp | `mcp__*` | indigo |
| other | fallback | muted |

## Verification

- `tsc`: 0 errors · `next build`: pass
- New `tool-visual.test.ts` (classification + icons) green; polish test updated to pin the wiring; `check:tests-wired` clean
- Full suite: **527 test files pass** (app + mobile)
- Color-coding rendered & reviewed across all categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)