### PR TITLE
feat(analytics): synthesize a plain-language insight banner

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -265,6 +265,7 @@ export const SUITES = {
     "src/lib/familiar-growth-signals.test.ts",
     "src/lib/familiar-growth-route-wiring.test.ts",
     "src/lib/familiar-confidence.test.ts",
+    "src/lib/familiar-analytics-insight.test.ts",
     "src/lib/familiar-heal-requests.test.ts",
     "src/lib/thread-self-report.test.ts",
     "src/components/familiar-analytics-view.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9483,6 +9483,26 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 
 /* KPI tiles — scannable summary row. */
+/* Insight banner — one-line synthesized read of the familiar's state. */
+.fa-insight {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  padding: 10px 14px;
+  border: 1px solid var(--border-hairline);
+  border-left: 3px solid var(--fa-insight-accent, var(--text-muted));
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--fa-insight-accent, var(--text-muted)) 8%, var(--bg-surface));
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+.fa-insight svg { flex: 0 0 auto; width: 16px; height: 16px; color: var(--fa-insight-accent, var(--text-muted)); }
+.fa-insight--good { --fa-insight-accent: var(--color-success); }
+.fa-insight--warn { --fa-insight-accent: var(--color-warning); }
+.fa-insight--bad { --fa-insight-accent: var(--color-danger); }
+
 .fa-kpis {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -381,6 +381,15 @@ describe("FamiliarAnalyticsView", () => {
     assert.match(source, /className=\{`fa-kpi\$\{kpi\.tone/, "KPI tiles tint by tone");
   });
 
+  it("synthesizes a plain-language insight banner above the KPIs", () => {
+    assert.match(source, /import \{ deriveAnalyticsInsight \} from "@\/lib\/familiar-analytics-insight"/, "view uses the insight helper");
+    assert.match(source, /<AnalyticsInsightBanner model=\{model\} healRequestCount=\{healRequests\.length\}/, "banner is rendered with the model");
+    assert.match(source, /deriveAnalyticsInsight\(model, healRequestCount\)/, "banner derives the insight from the model");
+    assert.match(source, /fa-insight--\$\{insight\.tone\}/, "banner is tinted by tone");
+    // Idle eval loop reads as "Not run", not a bare dash.
+    assert.match(source, /evals === 0 \? "Not run"/, "empty eval tile is meaningful");
+  });
+
   it("makes .fa-page own its vertical scroll (html/body are overflow:hidden)", () => {
     const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
     const block = globals.match(/\.fa-page\s*\{[^}]*\}/);

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -15,6 +15,7 @@ import { escalateBlockers, type SelfHealRequest } from "@/lib/familiar-heal-requ
 import type { ConfidenceScore } from "@/lib/familiar-confidence";
 import type { ContractReport } from "@/lib/familiar-contract";
 import { Icon } from "@/lib/icon";
+import { deriveAnalyticsInsight } from "@/lib/familiar-analytics-insight";
 import {
   RESPONSE_CONFIDENCE_EMPTY_STATE,
   RESPONSE_CONFIDENCE_FACTOR_KEYS,
@@ -283,8 +284,8 @@ function deriveKpis(model: FamiliarAnalyticsModel, healRequestCount: number): Kp
       key: "evals",
       icon: "ph:arrows-clockwise-bold",
       label: "Eval acceptance",
-      value: acceptRate == null ? "—" : `${Math.round(acceptRate * 100)}%`,
-      sub: `${evals} iteration${evals === 1 ? "" : "s"}`,
+      value: acceptRate != null ? `${Math.round(acceptRate * 100)}%` : evals === 0 ? "Not run" : "—",
+      sub: evals === 0 && acceptRate == null ? "loop idle" : `${evals} iteration${evals === 1 ? "" : "s"}`,
       tone: acceptRate == null ? undefined : acceptRate >= 0.6 ? "good" : acceptRate >= 0.3 ? "warn" : "bad",
     },
     {
@@ -312,6 +313,29 @@ function deriveKpis(model: FamiliarAnalyticsModel, healRequestCount: number): Kp
     },
   ];
 }
+
+const INSIGHT_ICON: Record<"good" | "warn" | "bad", Parameters<typeof Icon>[0]["name"]> = {
+  good: "ph:check-circle-bold",
+  warn: "ph:warning-circle",
+  bad: "ph:warning-circle",
+};
+
+/** One-line plain-language read of the familiar's state — turns numbers into meaning. */
+const AnalyticsInsightBanner = memo(function AnalyticsInsightBanner({
+  model,
+  healRequestCount,
+}: {
+  model: FamiliarAnalyticsModel;
+  healRequestCount: number;
+}) {
+  const insight = deriveAnalyticsInsight(model, healRequestCount);
+  return (
+    <p className={`fa-insight fa-insight--${insight.tone}`} role="note">
+      <Icon name={INSIGHT_ICON[insight.tone]} aria-hidden />
+      <span>{insight.text}</span>
+    </p>
+  );
+});
 
 /** Scannable KPI row — surfaces growth, eval, contract, and heal signals up top. */
 const FamiliarKpis = memo(function FamiliarKpis({
@@ -406,6 +430,8 @@ export function FamiliarAnalyticsContent({
         </div>
         <ConfidenceRing confidence={model.confidence} />
       </header>
+
+      <AnalyticsInsightBanner model={model} healRequestCount={healRequests.length} />
 
       <FamiliarKpis model={model} healRequestCount={healRequests.length} />
 

--- a/src/lib/familiar-analytics-insight.test.ts
+++ b/src/lib/familiar-analytics-insight.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { deriveAnalyticsInsight } from "./familiar-analytics-insight.ts";
+import type { FamiliarAnalyticsModel } from "@/components/familiar-analytics-data.ts";
+
+// Build a model with only the fields the insight reads; cast the rest.
+function model(over: Partial<FamiliarAnalyticsModel> = {}): FamiliarAnalyticsModel {
+  return {
+    familiarId: "f",
+    familiar: null,
+    contractReport: null,
+    evalLoopState: null,
+    growthReport: null,
+    confidence: { score: 50, label: "Developing", factors: [] },
+    healRequests: [],
+    threadReports: [],
+    errors: [],
+    ...over,
+  } as FamiliarAnalyticsModel;
+}
+
+function contract(pass: boolean, total: number, passing: number) {
+  return {
+    pass,
+    properties: Array.from({ length: total }, (_, i) => ({ property: `p${i}`, pass: i < passing })),
+  } as unknown as FamiliarAnalyticsModel["contractReport"];
+}
+function growth(healthLabel: string, retroAcceptRate: number | null = null) {
+  return { healthLabel, sessionsLast7d: 3, retroAcceptRate, lastActiveAt: null, signals: [], recentRuns: [], trackStats: {} } as unknown as FamiliarAnalyticsModel["growthReport"];
+}
+
+// ---- leads with confidence + activity ----
+{
+  const i = deriveAnalyticsInsight(model({ confidence: { score: 80, label: "Trusted", factors: [] }, growthReport: growth("active") }), 0);
+  assert.match(i.text, /^Trusted, actively used/, "leads with label + activity phrase");
+}
+
+// ---- concerns: contract failing dominates tone ----
+{
+  const i = deriveAnalyticsInsight(model({ contractReport: contract(false, 5, 3), growthReport: growth("active") }), 0);
+  assert.equal(i.tone, "bad", "failing contract → bad tone");
+  assert.match(i.text, /contract needs review \(3\/5\)/, "names the failing contract");
+}
+
+// ---- stalled activity → bad ----
+{
+  const i = deriveAnalyticsInsight(model({ growthReport: growth("stalled") }), 0);
+  assert.equal(i.tone, "bad", "stalled → bad");
+  assert.match(i.text, /stalled/);
+}
+
+// ---- self-heal + no eval run → warn ----
+{
+  const i = deriveAnalyticsInsight(model({ contractReport: contract(true, 5, 5), growthReport: growth("active") }), 1);
+  assert.equal(i.tone, "warn", "open heal request → warn");
+  assert.match(i.text, /1 self-heal request open/, "singular request");
+  assert.match(i.text, /eval loop hasn't run/, "flags an idle eval loop");
+}
+
+// ---- all clear → good, lists positives ----
+{
+  const i = deriveAnalyticsInsight(model({ confidence: { score: 90, label: "Trusted", factors: [] }, contractReport: contract(true, 5, 5), growthReport: growth("active", 0.8) }), 0);
+  assert.equal(i.tone, "good", "clean state → good");
+  assert.match(i.text, /contract clean \(5\/5\)/);
+  assert.match(i.text, /eval acceptance 80%/);
+}
+
+// ---- joins two clauses with "and" ----
+{
+  const i = deriveAnalyticsInsight(model({ contractReport: contract(false, 4, 2), growthReport: growth("quiet") }), 2);
+  assert.match(i.text, / and /, "two concerns joined with 'and'");
+  assert.match(i.text, /2 self-heal requests open/, "plural requests");
+}
+
+console.log("familiar-analytics-insight.test.ts OK");

--- a/src/lib/familiar-analytics-insight.ts
+++ b/src/lib/familiar-analytics-insight.ts
@@ -1,0 +1,71 @@
+// Synthesizes the scattered familiar-analytics signals (confidence, activity,
+// contract, eval loop, self-heal) into a single plain-language "so what" line,
+// so the KPI numbers carry meaning at a glance. Pure + unit-tested; the view
+// renders the result as a tinted insight banner above the KPI row.
+
+import type { FamiliarAnalyticsModel } from "@/components/familiar-analytics-data";
+
+export type InsightTone = "good" | "warn" | "bad";
+export type AnalyticsInsight = { text: string; tone: InsightTone };
+
+const HEALTH_PHRASE: Record<string, string> = {
+  active: "actively used",
+  steady: "steady",
+  quiet: "quiet lately",
+  stalled: "stalled",
+};
+
+/** Join clauses naturally: ["a"] → "a"; ["a","b"] → "a and b". */
+function joinClauses(parts: string[]): string {
+  if (parts.length <= 1) return parts[0] ?? "";
+  return `${parts.slice(0, -1).join(", ")} and ${parts[parts.length - 1]}`;
+}
+
+/**
+ * Build a one-line interpretation of a familiar's current analytics state.
+ * Leads with confidence + activity, then names up to two concerns (or, if all
+ * clear, up to two positives). Tone reflects the most pressing signal.
+ */
+export function deriveAnalyticsInsight(
+  model: FamiliarAnalyticsModel,
+  healRequestCount: number,
+): AnalyticsInsight {
+  const c = model.confidence;
+  const g = model.growthReport;
+  const contract = model.contractReport;
+  const contractTotal = contract?.properties.length ?? 0;
+  const contractPass = contract ? contract.properties.filter((p) => p.pass).length : 0;
+  const evals = model.evalLoopState?.iterations?.length ?? 0;
+  const acceptRate = g?.retroAcceptRate ?? null;
+
+  const healthPhrase = g ? HEALTH_PHRASE[g.healthLabel] ?? null : null;
+  const lead = healthPhrase ? `${c.label}, ${healthPhrase}` : c.label;
+
+  const concerns: string[] = [];
+  const positives: string[] = [];
+
+  if (contractTotal > 0) {
+    if (contract!.pass) positives.push(`contract clean (${contractPass}/${contractTotal})`);
+    else concerns.push(`contract needs review (${contractPass}/${contractTotal})`);
+  }
+  if (healRequestCount > 0) {
+    concerns.push(`${healRequestCount} self-heal request${healRequestCount === 1 ? "" : "s"} open`);
+  }
+  if (evals === 0 && acceptRate == null) {
+    concerns.push("the eval loop hasn't run");
+  } else if (acceptRate != null) {
+    positives.push(`eval acceptance ${Math.round(acceptRate * 100)}%`);
+  }
+
+  const contractFailing = contractTotal > 0 && !contract!.pass;
+  const tone: InsightTone =
+    contractFailing || g?.healthLabel === "stalled"
+      ? "bad"
+      : healRequestCount > 0 || (evals === 0 && acceptRate == null)
+        ? "warn"
+        : "good";
+
+  const tail = concerns.length ? concerns.slice(0, 2) : positives.slice(0, 2);
+  const text = tail.length ? `${lead} — ${joinClauses(tail)}.` : `${lead}.`;
+  return { text, tone };
+}


### PR DESCRIPTION
## What

The familiar-analytics KPI row showed isolated facts ("—", "1", "4 reports") without conveying what they *mean*. This makes the page meaningful at a glance:

- **Insight banner** — a new pure, unit-tested `deriveAnalyticsInsight(model, healCount)` synthesizes the signals into one plain-language line: leads with confidence + activity, then names up to two concerns (or, if all clear, positives), with a tone (good/warn/bad) reflecting the most pressing signal. Rendered as a tinted banner between the hero and the KPI row.
  - e.g. *"Developing, actively used — the eval loop hasn't run and 1 self-heal request open."*
- **Meaningful eval tile** — reads **"Not run / loop idle"** instead of a dead "— / 0 iterations" when the eval loop has never run.

## Verification

- `tsc`: 0 errors · `next build`: pass
- New `familiar-analytics-insight.test.ts` (lead/concerns/positives/tone/joining) green; view test pins the banner + eval-tile wiring; `check:tests-wired` clean
- Full suite: **532 test files pass** (app + mobile)
- Rendered & reviewed (banner + updated KPI row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)