### PR TITLE
fix(sidecar): keep sharp + @img in the packaged bundle

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,7 @@ const nextConfig: NextConfig = {
   // Cave does not use Next's server-side image optimizer in the packaged app;
   // icon generation happens before build via scripts/generate-pwa-icons.mjs.
   images: { unoptimized: true },
-  serverExternalPackages: ["node-pty"],
+  serverExternalPackages: ["node-pty", "sharp"],
   // Next.js file tracing otherwise sucks the entire src-tauri/target/
   // (multi-GB) into the standalone bundle. Exclude noisy siblings.
   outputFileTracingExcludes: {

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -29,6 +29,22 @@ assert.match(src, /prune_sidecar_nonruntime_files\(\)/, "sidecar must prune non-
 assert.match(src, /node_modules\/playwright-core/, "sidecar must remove Playwright test runtime from the packaged app");
 assert.match(src, /node_modules\/@types/, "sidecar must remove TypeScript declaration packages from the packaged app");
 assert.match(src, /-name '\*\.map'/, "sidecar must remove source maps from the packaged app");
-assert.match(src, /node_modules\/sharp/, "sidecar must remove optional Sharp image optimizer from the packaged app");
+
+// The familiar-avatar route loads `sharp` at runtime to downscale uploaded
+// raster avatars (src/app/api/familiars/[id]/avatar/route.ts). Earlier builds
+// pruned node_modules/sharp + node_modules/@img out of the sidecar, which made
+// every raster avatar 404 in the packaged app while SVG avatars kept working
+// (issue #2010). Lock both packages in so the runtime require() can resolve
+// them; the per-target prune already trims @img/sharp-* to one platform.
+assert.doesNotMatch(
+  src,
+  /"\$dest\/node_modules\/sharp"/,
+  "sidecar must KEEP node_modules/sharp — runtime avatar downscaling needs it (#2010)",
+);
+assert.doesNotMatch(
+  src,
+  /"\$dest\/node_modules\/@img"/,
+  "sidecar must KEEP node_modules/@img — sharp loads native libvips from here at runtime (#2010)",
+);
 
 console.log("sidecar-bundle-deps.test: ok");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -149,9 +149,13 @@ prune_sidecar_nonruntime_files() {
     "$dest/node_modules/@playwright" \
     "$dest/node_modules/@types" \
     "$dest/node_modules/playwright" \
-    "$dest/node_modules/playwright-core" \
-    "$dest/node_modules/sharp" \
-    "$dest/node_modules/@img"
+    "$dest/node_modules/playwright-core"
+  # NOTE: Do NOT remove node_modules/sharp or node_modules/@img here. The
+  # familiar-avatar route (src/app/api/familiars/[id]/avatar/route.ts) loads
+  # `sharp` at runtime to downscale uploaded raster avatars; without it,
+  # raster avatars 404 in the packaged app while SVG avatars keep working.
+  # The per-target prune_foreign_native_packages() pass above already trims
+  # @img/sharp-* down to just the build target, so the bundle stays small.
 
   find "$dest" -type f \( \
     -name '*.map' -o \


### PR DESCRIPTION
Closes #2010.

## Problem

Familiar raster avatars (uploaded PNG/JPEG) 404 in the packaged desktop app while SVG/initial-letter avatars render fine. In dev (`localhost:3000`) everything works.

## Root cause

`src/app/api/familiars/[id]/avatar/route.ts` imports `sharp` at runtime to downscale uploaded raster avatars (the seeded ones under `~/.coven/workspaces/familiars/<id>/avatars/` can be ~30MB / 4096px). But the sidecar bundle pipeline removed `sharp` in two places that backstopped each other:

1. `prune_sidecar_nonruntime_files()` in `scripts/sidecar-bundle.sh` did `rm -rf \$dest/node_modules/sharp \$dest/node_modules/@img`.
2. `scripts/sidecar-bundle-deps.test.mjs` asserted the removal was correct — so any attempt to restore sharp would have been blocked by CI.

`require('sharp')` then threw inside the packaged Node sidecar → the avatar route 404'd for every raster image. SVG avatars skip the sharp branch, so they kept working, which is why it looked like avatars were only *half* broken.

## Fix

Three small changes:

| File | Change |
|---|---|
| `scripts/sidecar-bundle.sh` | Drop the `sharp` and `@img` lines from `prune_sidecar_nonruntime_files()`. The per-target `prune_foreign_native_packages()` already trims `@img/sharp-*` to just the build target, so the bundle stays small. |
| `scripts/sidecar-bundle-deps.test.mjs` | Flip the assertion: sharp + @img must be **KEPT** (with the issue number in the failure message so this can't silently regress). |
| `next.config.ts` | Add `"sharp"` to `serverExternalPackages` so the Next tracer treats it like `node-pty` and doesn't try to bundle its native `.node` into the route closure. |

`sharp` is already in `dependencies` (0.34.5), so the production install step already pulls it in — this PR is purely about not deleting it afterward.

## Verification

- `node scripts/sidecar-bundle-deps.test.mjs` → ok
- `bash -n scripts/sidecar-bundle.sh` → ok
- `pnpm tsc --noEmit -p tsconfig.json` → clean
- `node scripts/check-tests-wired.mjs` → ✓ all 622 test files wired

## Build host note

Same caveat as before — the macOS DMG must be built on macOS so the per-target prune keys off the build host arch (`@img/sharp-darwin-arm64` or `-x64`). This PR doesn't change that constraint.

## Credit

Root-cause writeup by @YogiSotho in the closed #2001 / #2010 — implementation landed via the internal contribution path per the [external PR freeze policy](https://github.com/OpenCoven/coven-cave/blob/main/CONTRIBUTING.md).