### PR TITLE
fix(windows/packaging): keep sharp in the sidecar so raster avatars render (#2010)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,7 +20,10 @@ const nextConfig: NextConfig = {
   // Cave does not use Next's server-side image optimizer in the packaged app;
   // icon generation happens before build via scripts/generate-pwa-icons.mjs.
   images: { unoptimized: true },
-  serverExternalPackages: ["node-pty"],
+  // node-pty: native PTY bridge. sharp: native libvips raster transcoder used
+  // by the familiar avatar route (#2010) — must stay external so Next doesn't
+  // trace/strip its platform-specific `.node` binaries out of the bundle.
+  serverExternalPackages: ["node-pty", "sharp"],
   // Next.js file tracing otherwise sucks the entire src-tauri/target/
   // (multi-GB) into the standalone bundle. Exclude noisy siblings.
   outputFileTracingExcludes: {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-colorful": "5.7.0",
     "react-dom": "19.2.4",
     "react-resizable-panels": "4.11.2",
+    "sharp": "0.34.5",
     "shiki": "4.2.0",
     "sucrase": "3.35.1",
     "ws": "8.21.0",
@@ -87,7 +88,6 @@
     "@types/ws": "8.18.1",
     "esbuild": "0.28.0",
     "highlight.js": "11.11.1",
-    "sharp": "0.34.5",
     "tailwindcss": "4.3.0",
     "typescript": "5.9.3",
     "vitest": "4.1.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-resizable-panels:
         specifier: 4.11.2
         version: 4.11.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      sharp:
+        specifier: 0.34.5
+        version: 0.34.5
       shiki:
         specifier: 4.2.0
         version: 4.2.0
@@ -141,9 +144,6 @@ importers:
       highlight.js:
         specifier: 11.11.1
         version: 11.11.1
-      sharp:
-        specifier: 0.34.5
-        version: 0.34.5
       tailwindcss:
         specifier: 4.3.0
         version: 4.3.0

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -29,6 +29,25 @@ assert.match(src, /prune_sidecar_nonruntime_files\(\)/, "sidecar must prune non-
 assert.match(src, /node_modules\/playwright-core/, "sidecar must remove Playwright test runtime from the packaged app");
 assert.match(src, /node_modules\/@types/, "sidecar must remove TypeScript declaration packages from the packaged app");
 assert.match(src, /-name '\*\.map'/, "sidecar must remove source maps from the packaged app");
-assert.match(src, /node_modules\/sharp/, "sidecar must remove optional Sharp image optimizer from the packaged app");
+
+// Sharp is a RUNTIME dependency: the familiar avatar route transcodes seeded
+// raster avatars with it at request time (#2010). It must survive bundling, so
+// the non-runtime prune must NOT strip node_modules/sharp or node_modules/@img.
+assert.doesNotMatch(
+  src,
+  /"\$dest\/node_modules\/sharp"/,
+  "sidecar must KEEP node_modules/sharp — it powers raster avatar transcoding (#2010)",
+);
+assert.doesNotMatch(
+  src,
+  /"\$dest\/node_modules\/@img"/,
+  "sidecar must KEEP node_modules/@img native binaries that back sharp (#2010)",
+);
+// And the bundle must fail fast if sharp can't actually load from it.
+assert.match(
+  src,
+  /require\('sharp'\)/,
+  "sidecar must verify sharp loads from the bundle before declaring it ready (#2010)",
+);
 
 console.log("sidecar-bundle-deps.test: ok");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -145,13 +145,16 @@ prune_sidecar_nonruntime_files() {
 
   echo "==> pruning sidecar non-runtime files"
 
+  # NOTE: do NOT prune node_modules/sharp or node_modules/@img here — sharp is a
+  # runtime dependency of the familiar avatar route, which transcodes seeded
+  # raster avatars at request time (#2010). prune_foreign_native_packages has
+  # already trimmed @img down to the single build-target sharp + libvips pair,
+  # so keeping them costs little and avatars actually render in the packaged app.
   rm -rf \
     "$dest/node_modules/@playwright" \
     "$dest/node_modules/@types" \
     "$dest/node_modules/playwright" \
-    "$dest/node_modules/playwright-core" \
-    "$dest/node_modules/sharp" \
-    "$dest/node_modules/@img"
+    "$dest/node_modules/playwright-core"
 
   find "$dest" -type f \( \
     -name '*.map' -o \
@@ -296,5 +299,16 @@ for must in node_modules/@next/env node_modules/@swc/helpers/_; do
     exit 1
   fi
 done
+
+# Sharp must actually load from the bundle, or familiar raster avatars 404 in
+# the packaged app (#2010). The prune keeps only the build-host-arch native
+# binary, and release bundles are built on the matching host (same constraint
+# as @next/swc and node-pty), so requiring it here exercises the real load
+# path and fails fast if @img/sharp-<target> or libvips went missing.
+if ! (cd "$DEST" && node -e "require('sharp')") >&2 2>&1; then
+  echo "==> ! sharp failed to load from sidecar bundle — raster avatars will 404 (#2010)" >&2
+  echo "    expected @img/sharp-<build-target> native binary under $DEST/node_modules/@img" >&2
+  exit 1
+fi
 
 echo "==> sidecar bundle ready ($(du -sh "$DEST" | cut -f1))"


### PR DESCRIPTION
Closes #2010.

## Problem

In the packaged desktop app, familiar **raster avatars** (uploaded PNG/JPEG) come back blank, while SVG / initial-letter avatars render fine. `src/app/api/familiars/[id]/avatar/route.ts` imports `sharp` at runtime to downscale + transcode the seeded ~30MB / 4096px workspace avatars, but `sharp` was stripped from the sidecar bundle **twice over**:

1. It was a **devDependency**, so `scripts/sidecar-bundle.sh`'s `pnpm install --prod` skipped it.
2. `prune_sidecar_nonruntime_files()` explicitly `rm -rf`'d both `node_modules/sharp` **and** `node_modules/@img`.

`require('sharp')` then threw inside the packaged Node sidecar → the avatar route 404'd for every raster image. SVG avatars skip the sharp branch, which is why avatars looked only *half* broken.

## Fix

- Move `sharp` from `devDependencies` → `dependencies` (lockfile importer updated to match) so the prod sidecar install includes it.
- Add `sharp` to `serverExternalPackages` in `next.config.ts` (alongside `node-pty`) so Next doesn't trace/strip its native `.node` binaries.
- Stop pruning `node_modules/sharp` and `node_modules/@img` in `prune_sidecar_nonruntime_files()`. `prune_foreign_native_packages()` already trims `@img` down to the single build-target sharp + libvips pair, so the bundle stays small.
- Add a build-time sanity check that `require('sharp')` actually loads from the assembled bundle — fails the release fast if `@img/sharp-<target>` or libvips went missing (release DMGs are built on the matching host arch, same constraint as `@next/swc` / `node-pty`).
- Flip `scripts/sidecar-bundle-deps.test.mjs` from asserting sharp is REMOVED → asserting it is KEPT and that the load sanity check exists (the old test codified the bug).

## Verification

- Simulated the sidecar's `pnpm install --prod --frozen-lockfile --config.node-linker=hoisted` → produces top-level `@img/sharp-darwin-arm64` + `@img/sharp-libvips-darwin-arm64`.
- After pruning to the host target (as the build does), `require('sharp')` loads (vips 8.17.3) — exactly what the new sanity check exercises.
- `pnpm install --frozen-lockfile`, `typecheck`, `check:tests-wired`, `test:app` (466), `test:api` (95), `test:mobile` (65), and the `dependency-policy` + `sidecar-bundle-deps` tests all pass locally.

Original root-cause investigation by @YogiSotho in #2001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)