### PR TITLE
test(ci): cross-environment conformance suite + 3-OS matrix (#1990, Slice A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,31 @@ jobs:
       # and runs the three viewport projects. CI=true makes the config use
       # workers:2 + retries:1; per-test timeout is 60s for dev-server compile.
       - run: pnpm exec playwright test
+
+  # Cross-environment conformance (#1990). The SAME conformance suite runs on
+  # all three target OSes, so "it works here" is verified per-platform — not
+  # just on the neutral Linux baseline above. Anchored on the platform-divergent
+  # logic that has bitten the packaged app (coven .cmd spawn #2011, sidecar
+  # native prune #2010). fail-fast:false so one OS failing still reports the
+  # others. Neutral defaults + per-OS deltas: docs/cross-environment.md.
+  conformance:
+    name: Cross-environment (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - run: pnpm install --frozen-lockfile
+
+      # Same assertions on every OS; per-OS branches run for real on their host
+      # and are explicit skips elsewhere (see the suite). No silent no-ops.
+      - run: pnpm test:conformance

--- a/docs/cross-environment.md
+++ b/docs/cross-environment.md
@@ -1,0 +1,89 @@
+# Cross-environment behavior
+
+Coven Cave ships across **Linux, macOS, and Windows** (dev server, the Tauri
+desktop app, and the bundled Node sidecar). This doc is the source of truth for
+the **neutral defaults** every platform starts from and the **per-OS deltas**
+that diverge. It pairs with the conformance suite that enforces them.
+
+## How it's verified
+
+- **Neutral baseline** — the `Frontend build` job (`ubuntu-latest`) runs the
+  platform-agnostic checks every PR must pass: typecheck, `check:tests-wired`,
+  `test:app` / `test:api` / `test:mobile`, and `pnpm build`. No OS-specific
+  behavior lives here.
+- **Cross-OS matrix** — the `Cross-environment (<os>)` job runs
+  `pnpm test:conformance` on `ubuntu-latest`, `windows-latest`, and
+  `macos-latest` from one matrix spec, so the *same* definition of "works" is
+  executed on every target. `fail-fast: false`, so one OS failing still reports
+  the others.
+- **The conformance suite** — [`scripts/cross-environment.test.ts`](../scripts/cross-environment.test.ts).
+  Identical assertions on every OS; branches that can only run on one platform
+  run there for real and are **explicit, reasoned skips** elsewhere (printed as
+  `↷ skipped: <reason>`), never silent no-ops. Run it locally with
+  `pnpm test:conformance`.
+
+What is **not** yet covered (tracked as Slice B in #1990, surfaced as explicit
+skips): booting the packaged OS-specific sidecar and transcoding a raster
+avatar end-to-end, and mDNS / Tailscale host discovery. Both need per-OS build
+hosts / network stacks rather than a pure unit matrix.
+
+## Neutral defaults
+
+| Concern | Default | Override |
+| --- | --- | --- |
+| Dev server port | `3000` | `PORT` env ([`server.ts`](../server.ts)) |
+| E2E (Playwright) port | `3100` (fixed, avoids colliding with `pnpm dev`) | `PORT` env ([`playwright.config.ts`](../playwright.config.ts)) |
+| Config / state home | `~/.coven/` | `COVEN_HOME` env ([`src/lib/coven-paths.ts`](../src/lib/coven-paths.ts)) |
+| Familiar workspaces | `~/.coven/workspaces/familiars/<id>/` | via `COVEN_HOME` |
+| `coven` CLI binary | discovered on PATH / well-known install dirs | `COVEN_BIN` env ([`src/lib/coven-bin.ts`](../src/lib/coven-bin.ts)) |
+| CI Node.js | `22` | — |
+
+## Per-OS deltas
+
+### Filesystem & paths
+
+| | Linux | macOS | Windows |
+| --- | --- | --- | --- |
+| Path separator (`path.sep`) | `/` | `/` | `\` |
+| PATH delimiter (`path.delimiter`) | `:` | `:` | `;` |
+| Line ending (`os.EOL`) | `\n` | `\n` | `\r\n` |
+
+PATH parsing/joining must use `path.delimiter`, never a hard-coded `:` — a
+Windows PATH split on `:` collapses `C:\...` entries into garbage. Enforced in
+[`src/lib/coven-bin.ts`](../src/lib/coven-bin.ts) and asserted by the suite.
+
+### Spawning the `coven` CLI
+
+npm installs `coven` as a **`.cmd` shim** on Windows. Since the CVE-2024-27980
+hardening (Node ≥ 18.20 / 20.12 / 21.7), `child_process.spawn()` throws
+`EINVAL` when handed a `.cmd`/`.bat` unless `shell: true`. Cave therefore
+resolves the underlying npm script and launches **`node <script>`** instead
+(`covenLaunchCommandForBinary` → `{ command: node, fixedArgs: [script] }`) — not
+`shell: true`, so the prompt-bearing `chat/send` argv stays safe from shell
+quoting/injection. On macOS/Linux this is identity (launch the binary directly).
+Root cause: #2011.
+
+### Sidecar native packages
+
+The packaged Node sidecar keeps exactly **one** platform's native binaries and
+prunes the rest. The `(platform, arch, libc) → package` mapping is owned by
+[`scripts/sidecar-target.mjs`](../scripts/sidecar-target.mjs) — the single
+source of truth shared by `scripts/sidecar-bundle.sh` (via
+`eval "$(node scripts/sidecar-target.mjs --sh …)"`) and the conformance suite.
+
+| Target | `@next/swc` | `sharp` (`@img`) | libvips |
+| --- | --- | --- | --- |
+| `darwin-<arch>` | `@next/swc-darwin-<arch>` | `@img/sharp-darwin-<arch>` | `@img/sharp-libvips-darwin-<arch>` |
+| `linux-<arch>` (glibc) | `@next/swc-linux-<arch>-gnu` | `@img/sharp-linux-<arch>` | `@img/sharp-libvips-linux-<arch>` |
+| `linux-<arch>` (musl) | `@next/swc-linux-<arch>-musl` | `@img/sharp-linuxmusl-<arch>` | `@img/sharp-libvips-linuxmusl-<arch>` |
+| `win32-<arch>` | `@next/swc-win32-<arch>-msvc` | `@img/sharp-win32-<arch>` | *(bundled inside sharp)* |
+
+Notes:
+- `sharp` must remain a **runtime** dependency (not dev) so the production
+  sidecar install includes it — the familiar avatar route transcodes raster
+  avatars at request time. Root cause: #2010.
+- `fsevents` is kept only on darwin.
+- The release DMG/installer must be built **on the matching host arch** — the
+  prune keys off the build host, same as `@next/swc` and `node-pty`. Mobile
+  Tauri targets (iOS/Android) skip the sidecar entirely and point at the user's
+  remote Tailscale daemon (see [`mobile-tailscale.md`](./mobile-tailscale.md)).

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:api": "node scripts/run-tests.mjs api",
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "test:mobile": "node scripts/run-tests.mjs mobile",
+    "test:conformance": "node scripts/run-tests.mjs conformance",
     "e2e:install": "playwright install chromium webkit",
     "test:e2e:mobile": "pnpm e2e:install && playwright test --project=pixel-5 --project=iphone-13",
     "test:e2e": "pnpm e2e:install && playwright test",

--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -1,0 +1,184 @@
+// @ts-nocheck
+// Cross-environment conformance suite (#1990).
+//
+// One definition of "works" that runs IDENTICALLY on ubuntu-latest /
+// windows-latest / macos-latest via the `Cross-environment` CI matrix
+// (.github/workflows/ci.yml). The same assertions execute on every OS; where a
+// branch can only be exercised on one platform, it runs there for real and is
+// an EXPLICIT, reasoned skip elsewhere (printed below) — never a silent no-op.
+//
+// Covers the platform-divergent logic that has actually bitten the packaged
+// app:
+//   - coven shim launch resolution  (the #2011 spawn-EINVAL class)
+//   - sidecar native target mapping (the #2010 sharp-prune class)
+//   - path / line-ending / env semantics
+//
+// Neutral defaults and per-OS deltas are documented in docs/cross-environment.md.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { resolveSidecarTarget } from "./sidecar-target.mjs";
+import { covenLaunchCommandForBinary } from "../src/lib/coven-bin.ts";
+
+const skips: string[] = [];
+function skip(reason: string): void {
+  skips.push(reason);
+  console.log(`  ↷ skipped: ${reason}`);
+}
+
+// ---------------------------------------------------------------------------
+// Contract A — sidecar native target resolution (pure; identical on every OS).
+// Mirrors scripts/sidecar-bundle.sh's prune, which now consumes this same
+// module, so these assertions pin the release prune on all three runners.
+// ---------------------------------------------------------------------------
+{
+  assert.deepEqual(resolveSidecarTarget({ platform: "darwin", arch: "arm64" }), {
+    supported: true,
+    platform: "darwin",
+    arch: "arm64",
+    libc: "",
+    target: "darwin-arm64",
+    nextPkg: "@next/swc-darwin-arm64",
+    sharpPkg: "@img/sharp-darwin-arm64",
+    sharpVipsPkg: "@img/sharp-libvips-darwin-arm64",
+    nodePtyPrebuild: "darwin-arm64",
+    keepFsevents: true,
+  });
+
+  assert.equal(resolveSidecarTarget({ platform: "darwin", arch: "x64" }).sharpPkg, "@img/sharp-darwin-x64");
+
+  // linux glibc vs musl diverge in BOTH the sharp and @next/swc package names.
+  const gnu = resolveSidecarTarget({ platform: "linux", arch: "x64", libc: "gnu" });
+  assert.equal(gnu.nextPkg, "@next/swc-linux-x64-gnu");
+  assert.equal(gnu.sharpPkg, "@img/sharp-linux-x64");
+  assert.equal(gnu.sharpVipsPkg, "@img/sharp-libvips-linux-x64");
+  assert.equal(gnu.keepFsevents, false);
+
+  const musl = resolveSidecarTarget({ platform: "linux", arch: "arm64", libc: "musl" });
+  assert.equal(musl.nextPkg, "@next/swc-linux-arm64-musl");
+  assert.equal(musl.sharpPkg, "@img/sharp-linuxmusl-arm64");
+  assert.equal(musl.sharpVipsPkg, "@img/sharp-libvips-linuxmusl-arm64");
+
+  // win32: @next/swc carries the -msvc suffix and sharp bundles libvips inside
+  // the platform package (no separate @img/sharp-libvips-win32-*).
+  const win = resolveSidecarTarget({ platform: "win32", arch: "x64" });
+  assert.equal(win.nextPkg, "@next/swc-win32-x64-msvc");
+  assert.equal(win.sharpPkg, "@img/sharp-win32-x64");
+  assert.equal(win.sharpVipsPkg, "");
+
+  // Unsupported platforms must report `supported: false` so the prune bails
+  // (and leaves native packages intact) rather than guessing a target.
+  assert.equal(resolveSidecarTarget({ platform: "sunos", arch: "x64" }).supported, false);
+}
+
+// Host-reality: on the three matrix OSes, the *running* host must resolve to a
+// supported target — this is the assertion that genuinely differs per runner.
+{
+  const host = resolveSidecarTarget({
+    platform: process.platform,
+    arch: process.arch,
+    libc: process.platform === "linux" ? "gnu" : "",
+  });
+  if (["darwin", "linux", "win32"].includes(process.platform)) {
+    assert.equal(host.supported, true, `host ${process.platform}/${process.arch} must resolve to a sidecar target`);
+    assert.ok(host.sharpPkg?.startsWith("@img/sharp-"), "host sharp package is an @img native binary");
+  } else {
+    skip(`sidecar host-target assertion: unsupported CI platform ${process.platform} (matrix covers darwin/linux/win32)`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contract B — coven launch command resolution (the #2011 .cmd-spawn class).
+// The forced-platform table runs identically on every OS; the host branch
+// exercises the REAL process.platform path on each runner.
+// ---------------------------------------------------------------------------
+{
+  // Forced POSIX: launch the resolved binary directly.
+  assert.deepEqual(
+    covenLaunchCommandForBinary("/usr/local/bin/coven", "darwin"),
+    { command: "/usr/local/bin/coven", fixedArgs: [] },
+    "posix launches the coven binary directly",
+  );
+  assert.deepEqual(
+    covenLaunchCommandForBinary("/usr/bin/coven", "linux"),
+    { command: "/usr/bin/coven", fixedArgs: [] },
+    "linux launches the coven binary directly",
+  );
+
+  // Forced win32 with a realistic npm .cmd shim → node + the resolved script.
+  // This runs on every OS (the platform is forced), proving the shim-parse path
+  // is not Windows-host-dependent.
+  const shimDir = mkdtempSync(path.join(os.tmpdir(), "coven-conf-shim-"));
+  const shimScript = path.join(shimDir, "node_modules", "@opencoven", "cli", "bin", "coven.js");
+  mkdirSync(path.dirname(shimScript), { recursive: true });
+  writeFileSync(shimScript, "console.log('coven');\n");
+  const shim = path.join(shimDir, "coven.cmd");
+  writeFileSync(
+    shim,
+    [
+      "@ECHO off",
+      "SETLOCAL",
+      "CALL :find_dp0",
+      'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\cli\\bin\\coven.js" %*',
+      "",
+    ].join("\r\n"),
+  );
+  assert.deepEqual(
+    covenLaunchCommandForBinary(shim, "win32"),
+    { command: process.execPath, fixedArgs: [shimScript] },
+    "win32 .cmd shims launch through node + the resolved script (never spawned directly — CVE-2024-27980 EINVAL)",
+  );
+
+  // Host branch — the genuinely per-OS assertion.
+  if (process.platform === "win32") {
+    // On a real Windows runner, a .cmd path must resolve to node + script using
+    // the host's actual filesystem + path semantics.
+    const real = covenLaunchCommandForBinary(shim);
+    assert.equal(real.command, process.execPath, "Windows host resolves .cmd shim to node");
+    assert.deepEqual(real.fixedArgs, [shimScript], "Windows host resolves the shim's target script");
+  } else {
+    // On macOS / Linux the resolved binary is launched directly, identity.
+    assert.deepEqual(
+      covenLaunchCommandForBinary("/usr/local/bin/coven"),
+      { command: "/usr/local/bin/coven", fixedArgs: [] },
+      "posix host launches the coven binary directly",
+    );
+    skip("coven .cmd-shim host resolution: requires a Windows host (matrix runs it on windows-latest)");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Contract C — path / line-ending semantics that diverge per OS, asserted for
+// real against the running platform.
+// ---------------------------------------------------------------------------
+{
+  if (process.platform === "win32") {
+    assert.equal(path.sep, "\\", "win32 path separator is backslash");
+    assert.equal(path.delimiter, ";", "win32 PATH delimiter is semicolon");
+    assert.equal(os.EOL, "\r\n", "win32 line ending is CRLF");
+  } else {
+    assert.equal(path.sep, "/", "posix path separator is slash");
+    assert.equal(path.delimiter, ":", "posix PATH delimiter is colon");
+    assert.equal(os.EOL, "\n", "posix line ending is LF");
+  }
+
+  // PATH splitting must use the platform delimiter (not a hard-coded ":"), or
+  // Windows PATH entries collapse into one bogus path — the bug coven-bin.ts
+  // guards against. Verify the contract end-to-end with a constructed PATH.
+  const entries = ["a", "b", "c"];
+  const joined = entries.join(path.delimiter);
+  assert.deepEqual(joined.split(path.delimiter), entries, "PATH round-trips through the platform delimiter");
+}
+
+// ---------------------------------------------------------------------------
+// Contract D — explicit, reasoned gaps (Slice B). These are deliberately NOT
+// asserted here; they are surfaced as skips so the report shows the gap rather
+// than a falsely-green check (#1990 acceptance criterion 5).
+// ---------------------------------------------------------------------------
+skip("packaged-sidecar boot + raster-avatar transcode: requires building the OS-specific sidecar bundle (Slice B)");
+skip("mDNS / Tailscale host discovery: requires the platform's networking stack (Slice B)");
+
+console.log(`cross-environment.test.ts: ok on ${process.platform}/${process.arch} (${skips.length} explicit skip(s))`);

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -15,6 +15,10 @@ const sidecarScript = readFileSync(
   fileURLToPath(new URL("./sidecar-bundle.sh", import.meta.url)),
   "utf8",
 );
+const sidecarTargetModule = readFileSync(
+  fileURLToPath(new URL("./sidecar-target.mjs", import.meta.url)),
+  "utf8",
+);
 
 test("macOS release signing includes node-pty spawn-helper Mach-O files", () => {
   assert.match(
@@ -85,8 +89,14 @@ test("sidecar bundle prunes foreign native packages before release bundling", ()
   assert.match(sidecarScript, /prune_foreign_native_packages\(\)/);
   assert.match(sidecarScript, /process\.platform/);
   assert.match(sidecarScript, /process\.arch/);
-  assert.match(sidecarScript, /@next\/swc-\$target-\$libc/);
-  assert.match(sidecarScript, /@img\/sharp-libvips-\$target/);
+  // The per-target native package names now live in the shared, importable
+  // single source of truth (scripts/sidecar-target.mjs), consumed by the prune
+  // via `eval "$(node … --sh …)"` and asserted per-OS by the cross-environment
+  // conformance suite (#1990). Verify the prune wires up the module and that
+  // the module still derives the @next/swc-<libc> + @img/sharp-libvips targets.
+  assert.match(sidecarScript, /sidecar-target\.mjs.*--sh/);
+  assert.match(sidecarTargetModule, /@next\/swc-linux-\$\{arch\}-\$\{libc\}/);
+  assert.match(sidecarTargetModule, /@img\/sharp-libvips-darwin-\$\{arch\}/);
   assert.match(sidecarScript, /node-pty\/prebuilds/);
   assert.match(sidecarScript, /rm -rf "\$base\/fsevents"/);
   assert(

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -653,6 +653,13 @@ export const SUITES = {
     "src/components/library-mobile-command-center.test.ts",
     "src/components/chat-artifact-viewer.test.ts",
   ],
+  // Cross-environment conformance (#1990). Runs on the ubuntu/windows/macos CI
+  // matrix via `pnpm test:conformance` — the SAME assertions on every OS. Kept
+  // out of the app/api/mobile suites (the neutral Linux baseline) on purpose;
+  // the matrix is where per-OS behavior is verified.
+  conformance: [
+    "scripts/cross-environment.test.ts",
+  ],
 };
 
 // `.mjs` tests that still need the TS type-stripper (most `.mjs` tests do not).

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -50,4 +50,20 @@ assert.match(
   "sidecar must verify sharp loads from the bundle before declaring it ready (#2010)",
 );
 
+// The native target mapping (@img/sharp-<target>, @next/swc-<target>, …) is now
+// owned by scripts/sidecar-target.mjs and shared with the cross-environment
+// conformance suite (#1990). The prune must consume that single source of truth
+// rather than re-deriving the package names in a duplicated bash `case`, so the
+// two can never drift.
+assert.match(
+  src,
+  /sidecar-target\.mjs.*--sh/,
+  "sidecar prune must resolve native targets from scripts/sidecar-target.mjs (single source of truth, #1990)",
+);
+assert.doesNotMatch(
+  src,
+  /sharp_pkg="@img\/sharp-/,
+  "sidecar must NOT hard-code @img/sharp package names — they come from sidecar-target.mjs (#1990)",
+);
+
 console.log("sidecar-bundle-deps.test: ok");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -53,7 +53,7 @@ prune_foreign_native_packages() {
     return 0
   fi
 
-  local platform arch libc target next_pkg sharp_pkg sharp_vips_pkg node_pty_prebuild
+  local platform arch libc target next_pkg sharp_pkg sharp_vips_pkg node_pty_prebuild SIDECAR_SUPPORTED
   platform="$(node -p "process.platform")"
   arch="$(node -p "process.arch")"
   libc=""
@@ -61,37 +61,15 @@ prune_foreign_native_packages() {
     libc="$(node -p "process.report?.getReport?.().header?.glibcVersionRuntime ? 'gnu' : 'musl'")"
   fi
 
-  case "$platform" in
-    darwin)
-      target="darwin-$arch"
-      next_pkg="@next/swc-$target"
-      sharp_pkg="@img/sharp-$target"
-      sharp_vips_pkg="@img/sharp-libvips-$target"
-      node_pty_prebuild="$target"
-      ;;
-    linux)
-      target="linux-$arch"
-      next_pkg="@next/swc-$target-$libc"
-      sharp_pkg="@img/sharp-$target"
-      sharp_vips_pkg="@img/sharp-libvips-$target"
-      if [ "$libc" = "musl" ]; then
-        sharp_pkg="@img/sharp-linuxmusl-$arch"
-        sharp_vips_pkg="@img/sharp-libvips-linuxmusl-$arch"
-      fi
-      node_pty_prebuild="$target"
-      ;;
-    win32)
-      target="win32-$arch"
-      next_pkg="@next/swc-$target-msvc"
-      sharp_pkg="@img/sharp-$target"
-      sharp_vips_pkg=""
-      node_pty_prebuild="$target"
-      ;;
-    *)
-      echo "==> sidecar native prune: unsupported platform $platform/$arch; leaving native packages intact"
-      return 0
-      ;;
-  esac
+  # Single source of truth for the native target mapping, shared with the
+  # cross-environment conformance suite (scripts/sidecar-target.mjs). Keeps the
+  # release prune from ever drifting from what the tests assert per-OS.
+  SIDECAR_SUPPORTED=0
+  eval "$(node "$ROOT/scripts/sidecar-target.mjs" --sh "$platform" "$arch" "$libc")"
+  if [ "$SIDECAR_SUPPORTED" != "1" ]; then
+    echo "==> sidecar native prune: unsupported platform $platform/$arch; leaving native packages intact"
+    return 0
+  fi
 
   echo "==> pruning sidecar native packages for $platform/$arch${libc:+/$libc}"
 

--- a/scripts/sidecar-target.mjs
+++ b/scripts/sidecar-target.mjs
@@ -1,0 +1,135 @@
+// Single source of truth for the per-(platform, arch, libc) native package
+// targets the sidecar bundle KEEPS and the foreign-arch prune DROPS.
+//
+// Why this is a standalone pure module: the same `platform/arch/libc →
+// @img/sharp-<target> + @next/swc-<target> + node-pty prebuild` mapping is
+// needed in two places that can't share bash:
+//
+//   1. scripts/sidecar-bundle.sh — `prune_foreign_native_packages()` consumes
+//      this via `eval "$(node scripts/sidecar-target.mjs --sh <p> <a> <libc>)"`
+//      so the release prune never drifts from the test's idea of "the target".
+//   2. The cross-environment conformance suite (#1990) — imports
+//      `resolveSidecarTarget()` and asserts it per-OS, so a Windows / macOS /
+//      Linux runner verifies the real mapping rather than a simulated one.
+//
+// Keep this in lockstep with the values prune_foreign_native_packages relied on
+// before the extraction:
+//   darwin:  next @next/swc-darwin-<arch>          sharp @img/sharp-darwin-<arch>      + libvips, keep fsevents
+//   linux:   next @next/swc-linux-<arch>-<libc>    sharp @img/sharp-(linux|linuxmusl)-<arch> + libvips
+//   win32:   next @next/swc-win32-<arch>-msvc      sharp @img/sharp-win32-<arch>       (libvips bundled inside sharp)
+
+/**
+ * @param {{ platform: string, arch: string, libc?: string }} host
+ *   `libc` is only meaningful on linux and must be "gnu" or "musl" (the same
+ *   token @next/swc uses); it is ignored on darwin / win32.
+ * @returns {{
+ *   supported: boolean,
+ *   platform: string,
+ *   arch: string,
+ *   libc: string,
+ *   target?: string,
+ *   nextPkg?: string,
+ *   sharpPkg?: string,
+ *   sharpVipsPkg?: string,
+ *   nodePtyPrebuild?: string,
+ *   keepFsevents?: boolean,
+ * }}
+ */
+export function resolveSidecarTarget({ platform, arch, libc = "" }) {
+  switch (platform) {
+    case "darwin":
+      return {
+        supported: true,
+        platform,
+        arch,
+        libc: "",
+        target: `darwin-${arch}`,
+        nextPkg: `@next/swc-darwin-${arch}`,
+        sharpPkg: `@img/sharp-darwin-${arch}`,
+        sharpVipsPkg: `@img/sharp-libvips-darwin-${arch}`,
+        nodePtyPrebuild: `darwin-${arch}`,
+        keepFsevents: true,
+      };
+    case "linux": {
+      const isMusl = libc === "musl";
+      return {
+        supported: true,
+        platform,
+        arch,
+        libc,
+        target: `linux-${arch}`,
+        nextPkg: `@next/swc-linux-${arch}-${libc}`,
+        sharpPkg: isMusl ? `@img/sharp-linuxmusl-${arch}` : `@img/sharp-linux-${arch}`,
+        sharpVipsPkg: isMusl
+          ? `@img/sharp-libvips-linuxmusl-${arch}`
+          : `@img/sharp-libvips-linux-${arch}`,
+        nodePtyPrebuild: `linux-${arch}`,
+        keepFsevents: false,
+      };
+    }
+    case "win32":
+      return {
+        supported: true,
+        platform,
+        arch,
+        libc: "",
+        target: `win32-${arch}`,
+        nextPkg: `@next/swc-win32-${arch}-msvc`,
+        sharpPkg: `@img/sharp-win32-${arch}`,
+        // sharp ships libvips compiled into the win32 package, so there is no
+        // separate @img/sharp-libvips-win32-* to keep.
+        sharpVipsPkg: "",
+        nodePtyPrebuild: `win32-${arch}`,
+        keepFsevents: false,
+      };
+    default:
+      return { supported: false, platform, arch, libc };
+  }
+}
+
+// Emit single-quoted shell assignments so scripts/sidecar-bundle.sh can
+// `eval "$(node scripts/sidecar-target.mjs --sh <platform> <arch> <libc>)"`.
+// All values are fixed package-name literals (no user input), and single
+// quotes keep the `@`, `/`, `-` characters inert.
+function toShell(t) {
+  if (!t.supported) {
+    return "SIDECAR_SUPPORTED=0\n";
+  }
+  const lines = [
+    "SIDECAR_SUPPORTED=1",
+    `target='${t.target}'`,
+    `next_pkg='${t.nextPkg}'`,
+    `sharp_pkg='${t.sharpPkg}'`,
+    `sharp_vips_pkg='${t.sharpVipsPkg}'`,
+    `node_pty_prebuild='${t.nodePtyPrebuild}'`,
+  ];
+  return lines.join("\n") + "\n";
+}
+
+// CLI: `node scripts/sidecar-target.mjs --sh <platform> <arch> [libc]`
+//      `node scripts/sidecar-target.mjs --json <platform> <arch> [libc]`
+// Defaults to the running host when platform/arch are omitted.
+function main(argv) {
+  let format = "--json";
+  const rest = [];
+  for (const a of argv) {
+    if (a === "--sh" || a === "--json") format = a;
+    else rest.push(a);
+  }
+  const platform = rest[0] || process.platform;
+  const arch = rest[1] || process.arch;
+  let libc = rest[2] || "";
+  if (platform === "linux" && !libc) {
+    // Match the bash probe: glibc runtime present → gnu, else musl.
+    const report = process.report?.getReport?.();
+    libc = report?.header?.glibcVersionRuntime ? "gnu" : "musl";
+  }
+  const resolved = resolveSidecarTarget({ platform, arch, libc });
+  if (format === "--sh") process.stdout.write(toShell(resolved));
+  else process.stdout.write(JSON.stringify(resolved, null, 2) + "\n");
+}
+
+import { fileURLToPath } from "node:url";
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main(process.argv.slice(2));
+}


### PR DESCRIPTION
Implements **Slice A** of #1990 (per the scoping comment there): a shared conformance suite run identically on Linux / macOS / Windows via a CI matrix, anchored on the platform-divergent logic that actually broke the packaged app (#2011 spawn-EINVAL, #2010 sharp-prune). Slice B (boot the OS-specific packaged sidecar + transcode a raster avatar e2e; mDNS/Tailscale discovery) is intentionally deferred and tracked in #1990.

## What's here

- **Conformance suite** — [`scripts/cross-environment.test.ts`](../blob/feat/cross-env-conformance/scripts/cross-environment.test.ts). Same assertions on every OS:
  - **coven `.cmd` launch** (`covenLaunchCommandForBinary`): POSIX identity vs Windows `.cmd` → `node <script>`. The forced-platform table runs on every OS; the **host branch exercises the real `process.platform` path** on each runner.
  - **sidecar native target mapping** (`@img/sharp-<target>`, `@next/swc-<target>`, node-pty prebuild) for darwin/linux-gnu/linux-musl/win32 + a host-reality check.
  - **path / line-ending / env semantics** (`path.sep`, `path.delimiter`, `os.EOL`) asserted for real against the running platform.
- **3-OS matrix** — new `Cross-environment (<os>)` job in `.github/workflows/ci.yml` over `ubuntu-latest` / `windows-latest` / `macos-latest` (`fail-fast: false`), running `pnpm test:conformance`. The existing `Frontend build` job stays the neutral Linux baseline.
- **Single source of truth** — extracted the native target mapping out of `scripts/sidecar-bundle.sh` into pure [`scripts/sidecar-target.mjs`](../blob/feat/cross-env-conformance/scripts/sidecar-target.mjs). The bash prune now consumes it via `eval "$(node scripts/sidecar-target.mjs --sh …)"`, so the release prune and the test can't drift. `sidecar-bundle-deps.test.mjs` guards this.
- **Docs** — [`docs/cross-environment.md`](../blob/feat/cross-env-conformance/docs/cross-environment.md): neutral defaults (ports/paths/config) + per-OS deltas.

## Quality bar (the #1990 hard requirement)

No test passes via a silent platform short-circuit. Branches that can only run on one OS run there **for real** and are **explicit, reasoned skips** elsewhere, printed as `↷ skipped: <reason>`. Slice B gaps are surfaced as explicit skips too, so the report shows the gap instead of a falsely-green check. Example (macOS run):

```
↷ skipped: coven .cmd-shim host resolution: requires a Windows host (matrix runs it on windows-latest)
↷ skipped: packaged-sidecar boot + raster-avatar transcode: requires building the OS-specific sidecar bundle (Slice B)
↷ skipped: mDNS / Tailscale host discovery: requires the platform's networking stack (Slice B)
cross-environment.test.ts: ok on darwin/arm64 (3 explicit skip(s))
```

## Verification

- Verified the bash prune keeps **identical** packages before/after the `sidecar-target.mjs` extraction (fixture `node_modules` → darwin-arm64 host keeps `sharp-darwin-arm64` + libvips + `swc-darwin-arm64` + fsevents + darwin-arm64 prebuild).
- `typecheck`, `check:tests-wired` (624 wired), `test:conformance`, `sidecar-bundle-deps` all pass locally on darwin/arm64.

## Note on required checks

The 3 matrix jobs are **not** added to branch-protection required checks (that's a settings change I left to you, and matrix job names need an aggregate to avoid the CodeQL-style ambiguity). They run and report on every PR as-is.

Addresses #1990 (Slice A). Leaving the issue open for Slice B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)