### PR TITLE
Release v0.0.122

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.122] - 2026-06-28
+
+Patch release on top of v0.0.121. Headline: chat generation state now survives
+leaving and returning to an in-flight conversation.
+
+### Fixed
+
+- **Chat** - navigating away from a chat while a response is streaming no
+  longer loses the live generation UI. Returning to the session restores the
+  pending assistant turn, active branch, busy state, and cancel controller while
+  continuing to follow stream updates through completion.
+
 ## [0.0.121] - 2026-06-28
 
 Patch release on top of v0.0.120. Headline: flow required-input handling,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.121"
+version = "0.0.122"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.121</string>
+	<string>0.0.122</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.121</string>
+	<string>0.0.122</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.121</string>
+	<string>0.0.122</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.121</string>
+	<string>0.0.122</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.121",
+  "version": "0.0.122",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -20,7 +20,7 @@ assert.match(
 
 assert.match(
   source,
-  /function setAssistantLifecycle\(id: string, lifecycle: ChatTurnLifecycle\)/,
+  /function setAssistantLifecycle\([\s\S]*id: string,[\s\S]*lifecycle: ChatTurnLifecycle,[\s\S]*targetSessionId: string \| null = currentSessionRef\.current/,
   "ChatView should centralize assistant lifecycle updates",
 );
 
@@ -56,7 +56,7 @@ assert.match(
 
 assert.match(
   source,
-  /case "progress":[\s\S]*upsertTurnProgress\(assistantId, ev\)/,
+  /case "progress":[\s\S]*upsertTurnProgress\(assistantId, ev, liveGeneration\.sessionId\)/,
   "Progress events should update the active assistant turn",
 );
 
@@ -92,13 +92,13 @@ assert.match(
 
 assert.match(
   source,
-  /case "assistant_chunk":[\s\S]*setAssistantLifecycle\(assistantId, "streaming"\)/,
+  /case "assistant_chunk":[\s\S]*setAssistantLifecycle\(assistantId, "streaming", liveGeneration\.sessionId\)/,
   "Assistant chunks should move the turn into a streaming lifecycle",
 );
 
 assert.match(
   source,
-  /case "tool_use":[\s\S]*setAssistantLifecycle\(assistantId, "tooling"\)/,
+  /case "tool_use":[\s\S]*setAssistantLifecycle\(assistantId, "tooling", liveGeneration\.sessionId\)/,
   "Tool events should move the turn into a tool-use lifecycle",
 );
 
@@ -136,6 +136,36 @@ assert.match(
   source,
   /const sendRaw = async [\s\S]*?\|\| busy\) return;/,
   "sendRaw should keep its own busy guard as the backstop behind send()'s",
+);
+
+assert.match(
+  source,
+  /const liveChatGenerations = new Map<string, LiveChatGenerationSnapshot>\(\)/,
+  "In-flight chat generations should be persisted outside the ChatView component so navigation away does not lose them",
+);
+
+assert.match(
+  source,
+  /function subscribeLiveChatGeneration\(sessionId: string, listener: LiveChatGenerationListener\)/,
+  "ChatView should subscribe to live generation snapshots when returning to a session",
+);
+
+assert.match(
+  source,
+  /const liveGeneration = \{ sessionId: initialLiveSessionId, controller \}[\s\S]*?recordLiveChatGeneration\(\{\s*sessionId: liveGeneration\.sessionId,[\s\S]*?controller,[\s\S]*?turns: nextTurns/,
+  "sendRaw should persist the active stream snapshot with its abort controller",
+);
+
+assert.match(
+  source,
+  /readLiveChatGeneration\(sessionId\)[\s\S]*?setTurns\(live\.turns\)[\s\S]*?setActiveLeafId\(live\.activeLeafId\)[\s\S]*?abortRef\.current = live\.controller[\s\S]*?setBusy\(true\)/,
+  "History loading should rehydrate a live generation snapshot for the selected session",
+);
+
+assert.match(
+  source,
+  /subscribeLiveChatGeneration\(sessionId, \(live\) => \{[\s\S]*?setTurns\(live\.turns\)[\s\S]*?setBusy\(true\)[\s\S]*?setBusy\(false\)/,
+  "A remounted ChatView should keep following live generation updates and settle when the stream finishes",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -153,6 +153,61 @@ type Turn = {
 // value is a pure function of the turn, so sharing across instances is safe.
 const replyableTurnCache = new WeakMap<Turn, boolean>();
 
+type LiveChatGenerationSnapshot = {
+  sessionId: string;
+  turns: Turn[];
+  activeLeafId: string;
+  controller: AbortController;
+  updatedAt: number;
+};
+type LiveChatGenerationListener = (snapshot: LiveChatGenerationSnapshot | null) => void;
+
+const liveChatGenerations = new Map<string, LiveChatGenerationSnapshot>();
+const liveChatGenerationListeners = new Map<string, Set<LiveChatGenerationListener>>();
+
+function cloneLiveTurn(turn: Turn): Turn {
+  return {
+    ...turn,
+    attachments: turn.attachments ? [...turn.attachments] : undefined,
+    tools: turn.tools ? turn.tools.map((tool) => ({ ...tool })) : undefined,
+    progress: turn.progress ? turn.progress.map((progress) => ({ ...progress })) : undefined,
+  };
+}
+
+function notifyLiveChatGeneration(sessionId: string, snapshot: LiveChatGenerationSnapshot | null) {
+  const listeners = liveChatGenerationListeners.get(sessionId);
+  if (!listeners?.size) return;
+  for (const listener of listeners) listener(snapshot);
+}
+
+function readLiveChatGeneration(sessionId: string): LiveChatGenerationSnapshot | null {
+  return liveChatGenerations.get(sessionId) ?? null;
+}
+
+function recordLiveChatGeneration(snapshot: LiveChatGenerationSnapshot) {
+  const next = {
+    ...snapshot,
+    turns: snapshot.turns.map(cloneLiveTurn),
+  };
+  liveChatGenerations.set(snapshot.sessionId, next);
+  queueMicrotask(() => notifyLiveChatGeneration(snapshot.sessionId, next));
+}
+
+function clearLiveChatGeneration(sessionId: string | null | undefined) {
+  if (!sessionId || !liveChatGenerations.delete(sessionId)) return;
+  queueMicrotask(() => notifyLiveChatGeneration(sessionId, null));
+}
+
+function subscribeLiveChatGeneration(sessionId: string, listener: LiveChatGenerationListener) {
+  const listeners = liveChatGenerationListeners.get(sessionId) ?? new Set<LiveChatGenerationListener>();
+  listeners.add(listener);
+  liveChatGenerationListeners.set(sessionId, listeners);
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) liveChatGenerationListeners.delete(sessionId);
+  };
+}
+
 type Props = {
   familiar: Familiar;
   sessionId: string | null;
@@ -2187,6 +2242,54 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const initialPromptSentRef = useRef(false);
   const keys = useKeySymbols();
 
+  function persistLiveTurns(
+    nextTurns: Turn[],
+    nextActiveLeafId: string,
+    controller: AbortController | null = abortRef.current,
+    targetSessionId: string | null = currentSessionRef.current,
+  ) {
+    const liveSessionId = targetSessionId;
+    if (!liveSessionId || !controller) return;
+    recordLiveChatGeneration({
+      sessionId: liveSessionId,
+      controller,
+      turns: nextTurns,
+      activeLeafId: nextActiveLeafId,
+      updatedAt: Date.now(),
+    });
+  }
+
+  function updateLiveTurns(
+    updater: (prev: Turn[]) => Turn[],
+    nextActiveLeafId: string,
+    controller: AbortController | null = abortRef.current,
+    targetSessionId: string | null = currentSessionRef.current,
+  ) {
+    setTurns((prev) => {
+      const next = updater(prev);
+      turnsRef.current = next;
+      persistLiveTurns(next, nextActiveLeafId, controller, targetSessionId);
+      return next;
+    });
+  }
+
+  useEffect(() => {
+    if (!sessionId) return;
+    return subscribeLiveChatGeneration(sessionId, (live) => {
+      if (live) {
+        setTurns(live.turns);
+        turnsRef.current = live.turns;
+        setActiveLeafId(live.activeLeafId);
+        abortRef.current = live.controller;
+        setHistoryState("loaded");
+        setBusy(true);
+        return;
+      }
+      abortRef.current = null;
+      setBusy(false);
+    });
+  }, [sessionId]);
+
   // ── In-transcript find (CHAT-D9-04) ────────────────────────────────────
   // Turn-level find: case-insensitive substring over each turn's VISIBLE
   // text. `m` counts matching TURNS (honest scope — intra-turn highlighting
@@ -2597,6 +2700,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setHistoryState("idle");
       return;
     }
+    const live = readLiveChatGeneration(sessionId);
+    if (live) {
+      setTurns(live.turns);
+      turnsRef.current = live.turns;
+      setActiveLeafId(live.activeLeafId);
+      abortRef.current = live.controller;
+      setHistoryState("loaded");
+      setBusy(true);
+      return;
+    }
     let cancelled = false;
     void (async () => {
       setHistoryState("loading");
@@ -2993,7 +3106,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     setError(null);
     setDebugError(null);
     setLastFailedSend(null);
-    liveSessionIdRef.current = currentSessionRef.current;
+    const initialLiveSessionId = currentSessionRef.current;
+    liveSessionIdRef.current = initialLiveSessionId;
     setHistoryState("loaded");
 
     // Explicit parentTurnId (including null = root) wins; only fall back to the
@@ -3024,14 +3138,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         { id: "connect", label: "Connecting to chat bridge", status: "running", createdAt: now },
       ],
     };
-    appendTurn([userTurn, assistantTurn]);
-    setTurns((prev) => [...prev, userTurn, assistantTurn]);
-    setActiveLeafId(assistantTurn.id);
-
     const controller = new AbortController();
+    const liveGeneration = { sessionId: initialLiveSessionId, controller };
     abortRef.current = controller;
+    const nextTurns = [...turnsRef.current, userTurn, assistantTurn];
+    appendTurn([userTurn, assistantTurn]);
+    turnsRef.current = nextTurns;
+    setTurns(nextTurns);
+    setActiveLeafId(assistantTurn.id);
+    if (liveGeneration.sessionId) {
+      recordLiveChatGeneration({
+        sessionId: liveGeneration.sessionId,
+        controller,
+        turns: nextTurns,
+        activeLeafId: assistantTurn.id,
+        updatedAt: Date.now(),
+      });
+    }
     try {
-      setAssistantLifecycle(assistantId, "connecting");
+      setAssistantLifecycle(assistantId, "connecting", liveGeneration.sessionId);
       const res = await fetch("/api/chat/send", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -3039,7 +3164,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           familiarId: familiar.id,
           prompt: submitPrompt,
           ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(outgoingAttachments) } : {}),
-          sessionId: currentSessionRef.current,
+          sessionId: liveGeneration.sessionId,
           projectRoot: activeProjectRoot,
           reasoningEffort: thinkingEffort,
           responseSpeed,
@@ -3080,8 +3205,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           id: "connect",
           label: "Chat bridge rejected the request",
           status: "error",
-        });
-        markAssistantError(assistantId);
+        }, liveGeneration.sessionId);
+        markAssistantError(assistantId, liveGeneration.sessionId);
         raiseDebugError({ turnId: assistantId, code: `HTTP ${res.status}` });
         return;
       }
@@ -3090,7 +3215,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         id: "connect",
         label: "Connected to chat bridge",
         status: "done",
-      });
+      }, liveGeneration.sessionId);
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
       let buffer = "";
@@ -3107,7 +3232,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           if (!payload) continue;
           try {
             const ev = JSON.parse(payload) as StreamEvent;
-            handleEvent(ev, assistantId, request);
+            handleEvent(ev, assistantId, request, liveGeneration);
           } catch {
             /* skip malformed */
           }
@@ -3115,7 +3240,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       }
     } catch (err) {
       if ((err as Error)?.name === "AbortError") {
-        setTurns((prev) =>
+        updateLiveTurns((prev) =>
           prev.map((t) =>
             t.id === assistantId
               ? {
@@ -3134,14 +3259,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 }
               : t,
           ),
+          assistantId,
+          undefined,
+          liveGeneration.sessionId,
         );
       } else {
         setError(err instanceof Error ? err.message : "send failed");
         setLastFailedSend(request);
-        markAssistantError(assistantId);
+        markAssistantError(assistantId, liveGeneration.sessionId);
         raiseDebugError({ turnId: assistantId });
       }
     } finally {
+      clearLiveChatGeneration(liveGeneration.sessionId);
       abortRef.current = null;
       setBusy(false);
     }
@@ -3329,20 +3458,27 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     inputRef.current?.focus();
   };
 
-  const handleEvent = (ev: StreamEvent, assistantId: string, request: FailedSend) => {
+  const handleEvent = (
+    ev: StreamEvent,
+    assistantId: string,
+    request: FailedSend,
+    liveGeneration: { sessionId: string | null; controller: AbortController },
+  ) => {
     switch (ev.kind) {
       case "session": {
+        liveGeneration.sessionId = ev.sessionId;
         if (ev.sessionId !== currentSessionRef.current) {
           liveSessionIdRef.current = ev.sessionId;
           currentSessionRef.current = ev.sessionId;
           setHistoryState("loaded");
           onSessionStarted?.(ev.sessionId);
         }
+        persistLiveTurns(turnsRef.current, assistantId, liveGeneration.controller, liveGeneration.sessionId);
         return;
       }
       case "assistant_chunk": {
-        setAssistantLifecycle(assistantId, "streaming");
-        setTurns((prev) =>
+        setAssistantLifecycle(assistantId, "streaming", liveGeneration.sessionId);
+        updateLiveTurns((prev) =>
           prev.map((t) =>
             t.id === assistantId
               ? {
@@ -3362,15 +3498,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 }
               : t,
           ),
+          assistantId,
+          undefined,
+          liveGeneration.sessionId,
         );
         return;
       }
       case "progress": {
-        upsertTurnProgress(assistantId, ev);
+        upsertTurnProgress(assistantId, ev, liveGeneration.sessionId);
         return;
       }
       case "tool_use": {
-        setAssistantLifecycle(assistantId, "tooling");
+        setAssistantLifecycle(assistantId, "tooling", liveGeneration.sessionId);
         const incoming: ToolEvent = {
           id: ev.id ?? crypto.randomUUID(),
           name: ev.name,
@@ -3379,7 +3518,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           status: ev.status ?? "running",
           durationMs: ev.durationMs,
         };
-        setTurns((prev) =>
+        updateLiveTurns((prev) =>
           prev.map((t) => {
             if (t.id !== assistantId) return t;
             const tools = t.tools ?? [];
@@ -3425,11 +3564,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               }),
             };
           }),
+          assistantId,
+          undefined,
+          liveGeneration.sessionId,
         );
         return;
       }
       case "done": {
-        setTurns((prev) =>
+        updateLiveTurns((prev) =>
           prev.map((t) =>
             t.id === assistantId
               ? {
@@ -3445,6 +3587,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 }
               : t,
           ),
+          assistantId,
+          undefined,
+          liveGeneration.sessionId,
         );
         if (ev.isError) {
           setLastFailedSend(request);
@@ -3456,17 +3601,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         }
         void refreshUsagePlan(ev.responseMetadata?.confirmedModel ?? ev.responseMetadata?.model ?? null);
         if (ev.sessionId && ev.sessionId !== currentSessionRef.current) {
+          liveGeneration.sessionId = ev.sessionId;
           liveSessionIdRef.current = ev.sessionId;
           currentSessionRef.current = ev.sessionId;
           setHistoryState("loaded");
           onSessionStarted?.(ev.sessionId);
         }
+        persistLiveTurns(turnsRef.current, assistantId, liveGeneration.controller, liveGeneration.sessionId);
         return;
       }
       case "error": {
         setError(ev.message);
         setLastFailedSend(request);
-        markAssistantError(assistantId);
+        markAssistantError(assistantId, liveGeneration.sessionId);
         raiseDebugError({ turnId: assistantId, code: ev.code });
         if (ev.code === "ENOENT") onOpenOnboarding?.();
         return;
@@ -3474,19 +3621,29 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   };
 
-  const markAssistantError = (id: string) => {
-    setTurns((prev) =>
+  const markAssistantError = (id: string, targetSessionId: string | null = currentSessionRef.current) => {
+    updateLiveTurns((prev) =>
       prev.map((t) => (
         t.id === id
           ? { ...t, pending: false, error: true, lifecycle: "failed", progress: settleRunningProgress(t.progress, "error") }
           : t
       )),
+      id,
+      undefined,
+      targetSessionId,
     );
   };
 
-  function setAssistantLifecycle(id: string, lifecycle: ChatTurnLifecycle) {
-    setTurns((prev) =>
+  function setAssistantLifecycle(
+    id: string,
+    lifecycle: ChatTurnLifecycle,
+    targetSessionId: string | null = currentSessionRef.current,
+  ) {
+    updateLiveTurns((prev) =>
       prev.map((t) => (t.id === id ? { ...t, lifecycle } : t)),
+      id,
+      undefined,
+      targetSessionId,
     );
   }
 
@@ -3499,9 +3656,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       status?: "running" | "done" | "error";
       durationMs?: number;
     },
+    targetSessionId: string | null = currentSessionRef.current,
   ) {
-    setTurns((prev) =>
+    updateLiveTurns((prev) =>
       prev.map((t) => (t.id === id ? { ...t, progress: upsertProgressEvent(t.progress, event) } : t)),
+      id,
+      undefined,
+      targetSessionId,
     );
   }
 


### PR DESCRIPTION
## Summary
- Preserve live chat generation state when navigating away and returning to an in-flight chat.
- Prepare v0.0.122 release metadata and changelog.

## Verification
- pnpm exec node src/components/chat-view-lifecycle.test.ts && pnpm exec node src/components/chat-view.test.ts && pnpm exec node src/components/chat-switching.test.ts && pnpm exec node src/components/chat-router-switching.test.ts && pnpm exec node src/components/chat-view-render-optimization.test.ts && pnpm typecheck
- pnpm exec node scripts/release-notes.test.mjs
- bash scripts/release-notes.sh v0.0.122 v0.0.121
- pnpm check:tests-wired
- pnpm test:app -> 467 app test files passed
- pnpm test:api -> 95 api test files passed
- pnpm test:mobile -> 65 mobile test files passed
- pnpm build
- cargo check (src-tauri)
- git diff --check HEAD~2..HEAD

Note: local pnpm test:e2e was blocked because an existing Next dev server for this repo was already running (PID 75497); no e2e failures ran.