### PR TITLE
feat(analytics): select a thread-signal review item to discuss it

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9739,19 +9739,47 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   list-style: none;
 }
 .fa-thread-review-list li {
+  min-width: 0;
+}
+/* Each review item is a button — selecting it opens a discussion on the topic. */
+.fa-thread-review-item {
   display: flex;
   align-items: flex-start;
   gap: 8px;
+  width: 100%;
   min-width: 0;
+  text-align: left;
   padding: 9px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
   color: var(--text-secondary);
+  font: inherit;
   font-size: 12px;
   line-height: 1.4;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
 }
-.fa-thread-review-list li.is-critical {
+.fa-thread-review-item:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  background: var(--bg-hover);
+}
+.fa-thread-review-item:focus-visible {
+  outline: 2px solid var(--accent-presence);
+  outline-offset: 1px;
+}
+.fa-thread-review-discuss {
+  margin-left: auto;
+  align-self: center;
+  color: var(--accent-presence) !important;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.fa-thread-review-item:hover .fa-thread-review-discuss,
+.fa-thread-review-item:focus-visible .fa-thread-review-discuss {
+  opacity: 1;
+}
+.fa-thread-review-list li.is-critical .fa-thread-review-item {
   border-color: color-mix(in oklch, var(--color-danger) 45%, var(--border-hairline));
 }
 .fa-thread-review-list li.is-critical svg {

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -130,4 +130,11 @@ describe("aggregateThreadSignals", () => {
     assert.match(source, /fa-thread-review-list/, "component renders the review queue as a scan-first list");
     assert.match(source, /Latest report/, "component shows recency for the summary");
   });
+
+  it("lets you select a review item to unlock a discussion on the topic", () => {
+    assert.match(source, /buildThreadSignalDiscussionPrompt/, "seeds the chat with a topic-specific prompt");
+    assert.match(source, /new CustomEvent\("cave:agents-new-chat"/, "opens a new chat with the familiar");
+    assert.match(source, /initialPrompt: buildThreadSignalDiscussionPrompt\(item\)/, "primes the chat with the selected item");
+    assert.match(source, /className="fa-thread-review-item"[\s\S]*onClick=\{\(\) => discussReviewItem\(familiarId, item\)\}/, "each review item is a clickable button");
+  });
 });

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -5,8 +5,10 @@ import { Icon } from "@/lib/icon";
 import {
   aggregateThreadSignals,
   buildThreadSignalReviewQueue,
+  buildThreadSignalDiscussionPrompt,
   THREAD_SIGNALS_EMPTY_STATE,
   type ThreadSignalsAggregate,
+  type ThreadSignalReviewItem,
   type ThreadSelfReport,
 } from "@/lib/thread-self-report";
 
@@ -55,6 +57,15 @@ function ListBlock<T>({
   );
 }
 
+/** Open a new chat with this familiar, primed to discuss the selected topic. */
+function discussReviewItem(familiarId: string, item: ThreadSignalReviewItem) {
+  window.dispatchEvent(
+    new CustomEvent("cave:agents-new-chat", {
+      detail: { familiarId, initialPrompt: buildThreadSignalDiscussionPrompt(item) },
+    }),
+  );
+}
+
 export function ThreadSignalsSection({ familiarId, reports }: { familiarId: string; reports: ThreadSelfReport[] }) {
   if (reports.length === 0) {
     return (
@@ -84,11 +95,20 @@ export function ThreadSignalsSection({ familiarId, reports }: { familiarId: stri
           <ul className="fa-thread-review-list">
             {reviewQueue.map((item, index) => (
               <li key={`${item.kind}-${item.title}-${index}`} className={`is-${item.severity}`}>
-                <Icon name={item.severity === "critical" ? "ph:warning-circle" : "ph:info"} aria-hidden />
-                <span>
-                  <b>{item.title}</b>
-                  {item.detail}
-                </span>
+                <button
+                  type="button"
+                  className="fa-thread-review-item"
+                  onClick={() => discussReviewItem(familiarId, item)}
+                  title={`Discuss "${item.title}" with this familiar`}
+                  aria-label={`Discuss ${item.title}`}
+                >
+                  <Icon name={item.severity === "critical" ? "ph:warning-circle" : "ph:info"} aria-hidden />
+                  <span>
+                    <b>{item.title}</b>
+                    {item.detail}
+                  </span>
+                  <Icon name="ph:chat-circle-dots" className="fa-thread-review-discuss" aria-hidden />
+                </button>
               </li>
             ))}
           </ul>

--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -4,6 +4,7 @@ import {
   aggregateResponseConfidenceEvents,
   buildReflectTranscript,
   buildThreadReflectPrompt,
+  buildThreadSignalDiscussionPrompt,
   contextPressureLabel,
   deriveThreadScore,
   normalizeResponseConfidenceEvent,
@@ -202,5 +203,23 @@ describe("buildThreadReflectPrompt", () => {
   it("falls back to a context-free instruction when no transcript is given", () => {
     const prompt = buildThreadReflectPrompt({ sessionId: "sess-2" });
     assert.ok(prompt.includes("Reflect on the thread just completed (session: sess-2)"));
+  });
+
+  it("builds a focused discussion prompt for a selected review item", () => {
+    const prompt = buildThreadSignalDiscussionPrompt({
+      kind: "skill-access",
+      severity: "critical",
+      title: "github",
+      detail: "needs push access to land PRs",
+    });
+    assert.ok(prompt.includes("skill access gap"), "names the item kind in plain language");
+    assert.ok(prompt.includes("**github**"), "highlights the topic title");
+    assert.ok(prompt.includes("needs push access to land PRs"), "carries the detail");
+    assert.ok(/root cause/i.test(prompt), "asks for a root cause + concrete fix");
+    // every review kind maps to a label (no "undefined" leaking into the prompt)
+    for (const kind of ["blocker", "skill-clarity", "capability", "context-pressure", "low-score"] as const) {
+      const p = buildThreadSignalDiscussionPrompt({ kind, severity: "info", title: "t", detail: "d" });
+      assert.doesNotMatch(p, /undefined/, `${kind} resolves to a label`);
+    }
   });
 });

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -228,6 +228,31 @@ export type ThreadSignalReviewItem = {
   detail: string;
 };
 
+const REVIEW_KIND_LABEL: Record<ThreadSignalReviewItem["kind"], string> = {
+  blocker: "persistent blocker",
+  "skill-access": "skill access gap",
+  "skill-clarity": "skill clarity gap",
+  capability: "capability gap",
+  "context-pressure": "context pressure issue",
+  "low-score": "low signal score",
+};
+
+/**
+ * Seed prompt for a focused discussion about one review-queue item. Selecting an
+ * item in the Thread Signals review queue opens a new chat with the familiar
+ * primed with this, so the topic is "unlocked" into a working conversation.
+ */
+export function buildThreadSignalDiscussionPrompt(item: ThreadSignalReviewItem): string {
+  return [
+    `Let's work through a ${REVIEW_KIND_LABEL[item.kind]} from your thread self-reports:`,
+    "",
+    `**${item.title}**`,
+    item.detail,
+    "",
+    "What's the root cause, and what concrete change — prompt, memory, skill, or access — would resolve it? Walk me through it.",
+  ].join("\n");
+}
+
 export const THREAD_SIGNALS_EMPTY_STATE = "No thread reports yet. Use 'Reflect on this thread' to generate the first one.";
 
 const IMPORTANCE_WEIGHT: Record<CapabilityImportance, number> = { "nice-to-have": 1, important: 2, blocking: 3 };


### PR DESCRIPTION
## What

In the **Thread Signals** section, the **review queue** listed urgent items (persistent blockers, skill/access gaps, context pressure, low scores) as static text. Now **selecting a review item unlocks a discussion on that topic** — clicking one opens a new chat with the familiar, primed with a topic-specific prompt.

- New pure, unit-tested `buildThreadSignalDiscussionPrompt(item)` seeds the chat with the item's kind, title, and detail — asking the familiar for a root cause and a concrete fix (prompt / memory / skill / access).
- Each review-queue item is now a button that dispatches the existing `cave:agents-new-chat` event with `{ familiarId, initialPrompt }` (the same path `familiar-studio` uses for its rehabilitation brief). A chat "discuss" affordance reveals on hover/focus; severity colors and the scan-first layout are preserved.

## Verification

- `tsc`: 0 errors · `next build`: pass
- `buildThreadSignalDiscussionPrompt` unit-tested (kind labels, title/detail, root-cause ask); component test pins the select-to-discuss wiring; `check:tests-wired` clean
- Full suite: **532 test files pass** (app + mobile)
- Rendered & reviewed (interactive review-queue cards + hover discuss icon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)