### PR TITLE
feat(permissions): a console for the full project-permissions protocol

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -35,6 +35,7 @@ export const SUITES = {
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/cave-projects.test.ts",
     "src/lib/project-permissions.test.ts",
+    "src/lib/permissions-console.test.ts",
     "src/lib/project-status.test.ts",
     "src/lib/github-checks.test.ts",
     "src/lib/gfm-autolink.test.ts",

--- a/src/app/api/project-grants/route.ts
+++ b/src/app/api/project-grants/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import {
   grantProjectToFamiliar,
   listProjectGrants,
+  listRecentPermissionAudit,
   loadHumanPermissionConfig,
   revokeProjectFromFamiliar,
 } from "@/lib/project-permissions";
@@ -41,13 +42,15 @@ function grantInput(payload: Record<string, unknown>) {
 }
 
 export async function GET() {
-  const [grants, config] = await Promise.all([
+  const [grants, config, audit] = await Promise.all([
     listProjectGrants(),
     loadHumanPermissionConfig(),
+    listRecentPermissionAudit(),
   ]);
   // `supremeFamiliarId` has access to every project regardless of grants — the
-  // Permissions UI marks it as all-access and locks its toggles on.
-  return NextResponse.json({ ok: true, grants, supremeFamiliarId: config.supremeFamiliarId });
+  // Permissions UI marks it as all-access and locks its toggles on. `audit` is a
+  // bounded recent window of access decisions for the console's audit log.
+  return NextResponse.json({ ok: true, grants, supremeFamiliarId: config.supremeFamiliarId, audit });
 }
 
 export async function POST(req: Request) {

--- a/src/components/settings-permissions.test.ts
+++ b/src/components/settings-permissions.test.ts
@@ -39,11 +39,28 @@ assert.match(perms, /role="switch"/, "each project row is a switch");
 assert.match(perms, /fam\.id === supremeFamiliarId/, "marks the supreme (all-access) familiar");
 assert.match(perms, /has access to every project/i, "explains the all-access familiar");
 
+// ── Console exposes the whole protocol: Access / Requests / Audit tabs ───────
+assert.match(perms, /id: "access"/, "has an Access (grant matrix) tab");
+assert.match(perms, /id: "requests"/, "has a Requests (grant-proposal inbox) tab");
+assert.match(perms, /id: "audit"/, "has an Audit (access-decision log) tab");
+
+// Requests tab: the human resolves a grant proposal by id (PATCH), sending only
+// the decision — never a relayed approval.
+assert.match(perms, /fetch\("\/api\/grant-proposals"/, "loads the grant-proposal inbox");
+assert.match(perms, /\/api\/grant-proposals\/\$\{id\}/, "resolves a proposal by id");
+assert.match(perms, /method: "PATCH"/, "proposal decisions are a PATCH");
+assert.match(perms, /JSON\.stringify\(\{ decision \}\)/, "sends only the accept/reject decision");
+
+// Audit tab: renders the access-decision log from the grants GET `audit` window.
+assert.match(perms, /filterAudit/, "renders the access audit log");
+
 // ── API exposes the supreme familiar so the UI can lock it on ────────────────
 assert.match(
   route,
   /supremeFamiliarId: config\.supremeFamiliarId/,
   "the grants GET returns the supreme familiar id",
 );
+// …and a bounded recent audit window for the console's Audit tab.
+assert.match(route, /listRecentPermissionAudit/, "the grants GET returns a recent audit window");
 
 console.log("settings-permissions.test.ts: ok");

--- a/src/components/settings-permissions.tsx
+++ b/src/components/settings-permissions.tsx
@@ -1,50 +1,134 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 
-import { Icon } from "@/lib/icon";
+import { Icon, type IconName } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { SearchInput } from "@/components/ui/search-input";
+import { Segmented } from "@/components/ui/settings-controls";
 import { SettingsGroup } from "@/components/ui/settings-group";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
+import {
+  accessSummary,
+  auditDecisionMeta,
+  auditReasonLabel,
+  familiarLabel,
+  filterAccess,
+  filterAudit,
+  grantKey,
+  grantSourceMeta,
+  nameResolver,
+  pendingProposalCount,
+  proposalStatusMeta,
+  splitProposals,
+  surfaceLabel,
+  type AuditFilter,
+  type ConsoleAuditEntry,
+  type ConsoleFamiliar,
+  type ConsoleGrant,
+  type ConsoleProject,
+  type ConsoleProposal,
+  type PermissionTab,
+  type Tone,
+} from "@/lib/permissions-console";
 
-type Familiar = { id: string; displayName?: string; name?: string };
-type Project = { id: string; name: string; root: string; color?: string };
-type Grant = { familiarId: string; projectId: string };
+type Familiar = ConsoleFamiliar;
+type Project = ConsoleProject;
 
-const grantKey = (familiarId: string, projectId: string) => `${familiarId}::${projectId}`;
+const toneVar: Record<Tone, string> = {
+  positive: "var(--accent-presence)",
+  negative: "var(--color-danger)",
+  pending: "var(--accent-presence)",
+  neutral: "var(--text-muted)",
+};
+
+/** A small status chip: tinted icon + label, used for decisions and statuses. */
+function StatusChip({ tone, icon, label }: { tone: Tone; icon: IconName; label: string }) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium"
+      style={{ color: toneVar[tone], background: "color-mix(in oklab, currentColor 12%, transparent)" }}
+    >
+      <Icon name={icon} width={13} height={13} className="shrink-0" />
+      {label}
+    </span>
+  );
+}
+
+/** Tinted icon (Phosphor icons inherit `currentColor`), coloured by a tone var. */
+function ToneIcon({ tone, icon, size = 15 }: { tone: Tone; icon: IconName; size?: number }) {
+  return (
+    <span className="inline-flex shrink-0" style={{ color: toneVar[tone] }}>
+      <Icon name={icon} width={size} height={size} />
+    </span>
+  );
+}
+
+/** Neutral metadata chip (surface name, reason, …). */
+function MetaChip({ children, title }: { children: ReactNode; title?: string }) {
+  return (
+    <span
+      title={title}
+      className="inline-flex items-center rounded-md border border-[var(--border-hairline)] px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-[var(--text-muted)]"
+    >
+      {children}
+    </span>
+  );
+}
 
 /**
- * Settings → Permissions. Per familiar, shows every project and a toggle for
- * whether that familiar can see/use it. Toggling drives the human-confirmed
- * `/api/project-grants` grant (POST) / revoke (DELETE). The supreme familiar has
- * access to every project; its toggles are locked on.
+ * Settings → Permissions — the console for the project-permissions protocol.
+ *
+ * Three tabs surface the whole protocol:
+ *  • Access   — the grant matrix. Per familiar, a toggle per project drives the
+ *               human-confirmed `/api/project-grants` grant (POST) / revoke
+ *               (DELETE). The supreme familiar has access to every project and
+ *               its toggles are locked on.
+ *  • Requests — the grant-proposal inbox. Supreme drafts proposals; the human
+ *               accepts/rejects each via PATCH `/api/grant-proposals/[id]`.
+ *  • Audit    — the access-decision log (allow/deny, surface, reason).
  */
 export function PermissionsSection() {
+  const [tab, setTab] = useState<PermissionTab>("access");
+
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
   const [granted, setGranted] = useState<Set<string>>(new Set());
+  const [grantMeta, setGrantMeta] = useState<Map<string, ConsoleGrant>>(new Map());
   const [supremeFamiliarId, setSupremeFamiliarId] = useState<string | null>(null);
+  const [proposals, setProposals] = useState<ConsoleProposal[]>([]);
+  const [audit, setAudit] = useState<ConsoleAuditEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Keys mid-flight, so a row can't be double-toggled while its request runs.
   const [pending, setPending] = useState<Set<string>>(new Set());
+  const [resolving, setResolving] = useState<Set<string>>(new Set());
+
+  const [accessQuery, setAccessQuery] = useState("");
+  const [auditQuery, setAuditQuery] = useState("");
+  const [auditFilter, setAuditFilter] = useState<AuditFilter>("all");
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
-      const [famRes, projRes, grantRes] = await Promise.all([
+      const [famRes, projRes, grantRes, proposalRes] = await Promise.all([
         fetch("/api/familiars", { cache: "no-store" }).then((r) => r.json()),
         fetch("/api/projects", { cache: "no-store" }).then((r) => r.json()),
         fetch("/api/project-grants", { cache: "no-store" }).then((r) => r.json()),
+        fetch("/api/grant-proposals", { cache: "no-store" }).then((r) => r.json()),
       ]);
       setFamiliars(Array.isArray(famRes?.familiars) ? famRes.familiars : []);
       setProjects(Array.isArray(projRes?.projects) ? projRes.projects : []);
-      setGranted(
-        new Set(
-          (Array.isArray(grantRes?.grants) ? (grantRes.grants as Grant[]) : []).map((g) =>
-            grantKey(g.familiarId, g.projectId),
-          ),
-        ),
+      const grants = Array.isArray(grantRes?.grants) ? (grantRes.grants as ConsoleGrant[]) : [];
+      setGranted(new Set(grants.map((g) => grantKey(g.familiarId, g.projectId))));
+      setGrantMeta(new Map(grants.map((g) => [grantKey(g.familiarId, g.projectId), g])));
+      setSupremeFamiliarId(
+        typeof grantRes?.supremeFamiliarId === "string" ? grantRes.supremeFamiliarId : null,
       );
-      setSupremeFamiliarId(typeof grantRes?.supremeFamiliarId === "string" ? grantRes.supremeFamiliarId : null);
+      setAudit(Array.isArray(grantRes?.audit) ? (grantRes.audit as ConsoleAuditEntry[]) : []);
+      setProposals(Array.isArray(proposalRes?.proposals) ? proposalRes.proposals : []);
       setError(null);
     } catch {
       setError("Couldn’t load permissions. Is the desktop reachable?");
@@ -96,11 +180,46 @@ export function PermissionsSection() {
     [],
   );
 
-  const familiarName = (f: Familiar) => f.displayName?.trim() || f.name?.trim() || f.id;
-  const sortedFamiliars = useMemo(
-    () => [...familiars].sort((a, b) => familiarName(a).localeCompare(familiarName(b))),
-    [familiars],
+  const resolveProposal = useCallback(
+    async (id: string, decision: "accepted" | "rejected") => {
+      setResolving((s) => new Set(s).add(id));
+      try {
+        const res = await fetch(`/api/grant-proposals/${id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ decision }),
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        setError(null);
+        // Reload so the new grant, updated proposal status, and audit entry all
+        // reflect immediately.
+        await load();
+      } catch {
+        setError("Couldn’t record that decision.");
+      } finally {
+        setResolving((s) => {
+          const copy = new Set(s);
+          copy.delete(id);
+          return copy;
+        });
+      }
+    },
+    [load],
   );
+
+  const familiarName = useMemo(() => nameResolver(familiars, familiarLabel), [familiars]);
+  const projectName = useMemo(() => nameResolver(projects, (p) => p.name), [projects]);
+  const summary = useMemo(
+    () => accessSummary(familiars, projects, granted, supremeFamiliarId),
+    [familiars, projects, granted, supremeFamiliarId],
+  );
+  const pendingCount = useMemo(() => pendingProposalCount(proposals), [proposals]);
+
+  const tabs: TabItem<PermissionTab>[] = [
+    { id: "access", label: "Access", icon: "ph:users-three" },
+    { id: "requests", label: "Requests", icon: "ph:tray", count: pendingCount || undefined },
+    { id: "audit", label: "Audit", icon: "ph:clock-counter-clockwise" },
+  ];
 
   if (loading) {
     return (
@@ -113,12 +232,8 @@ export function PermissionsSection() {
   }
 
   return (
-    <div className="space-y-5">
-      <p className="px-1 text-[12px] text-[var(--text-muted)]">
-        Choose which projects each familiar can see and work in. A familiar only has visibility into
-        the projects granted here (chats, sessions, file access, and the project picker all respect
-        it). Changes apply immediately.
-      </p>
+    <div className="space-y-4">
+      <Tabs items={tabs} value={tab} onChange={setTab} variant="segment" ariaLabel="Permissions" />
 
       {error && (
         <p role="alert" className="px-1 text-[12px] text-[var(--color-danger)]">
@@ -126,33 +241,136 @@ export function PermissionsSection() {
         </p>
       )}
 
-      {sortedFamiliars.length === 0 ? (
-        <SettingsGroup label="Familiars">
-          <p className="px-4 py-3 text-[13px] text-[var(--text-muted)]">No familiars yet.</p>
-        </SettingsGroup>
+      {tab === "access" && (
+        <AccessTab
+          familiars={familiars}
+          projects={projects}
+          granted={granted}
+          grantMeta={grantMeta}
+          supremeFamiliarId={supremeFamiliarId}
+          pending={pending}
+          query={accessQuery}
+          onQuery={setAccessQuery}
+          summary={summary}
+          onToggle={toggle}
+        />
+      )}
+
+      {tab === "requests" && (
+        <RequestsTab
+          proposals={proposals}
+          familiarName={familiarName}
+          projectName={projectName}
+          resolving={resolving}
+          onResolve={resolveProposal}
+        />
+      )}
+
+      {tab === "audit" && (
+        <AuditTab
+          audit={audit}
+          familiarName={familiarName}
+          projectName={projectName}
+          query={auditQuery}
+          onQuery={setAuditQuery}
+          filter={auditFilter}
+          onFilter={setAuditFilter}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Access tab ───────────────────────────────────────────────────────────────
+
+function AccessTab({
+  familiars,
+  projects,
+  granted,
+  grantMeta,
+  supremeFamiliarId,
+  pending,
+  query,
+  onQuery,
+  summary,
+  onToggle,
+}: {
+  familiars: Familiar[];
+  projects: Project[];
+  granted: Set<string>;
+  grantMeta: Map<string, ConsoleGrant>;
+  supremeFamiliarId: string | null;
+  pending: Set<string>;
+  query: string;
+  onQuery: (next: string) => void;
+  summary: { familiars: number; projects: number; grants: number };
+  onToggle: (familiarId: string, projectId: string, next: boolean) => void;
+}) {
+  const rows = useMemo(
+    () => filterAccess(familiars, projects, supremeFamiliarId, query),
+    [familiars, projects, supremeFamiliarId, query],
+  );
+
+  if (familiars.length === 0) {
+    return (
+      <EmptyState
+        icon="ph:users-three"
+        headline="No familiars yet"
+        subtitle="Create a familiar, then grant it access to the projects it should see."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="px-1 text-[12px] text-[var(--text-muted)]">
+        Choose which projects each familiar can see and work in. A familiar only has visibility into
+        the projects granted here — chats, sessions, file access, and the project picker all respect
+        it. Changes apply immediately.
+      </p>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 px-1">
+        <SearchInput
+          value={query}
+          onValueChange={onQuery}
+          onClear={() => onQuery("")}
+          placeholder="Filter familiars or projects…"
+          containerClassName="min-w-[220px] flex-1"
+        />
+        <span className="text-[11px] text-[var(--text-muted)]">
+          {summary.familiars} familiars · {summary.projects} projects ·{" "}
+          <span className="text-[var(--text-secondary)]">{summary.grants}</span> grants
+        </span>
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyState icon="ph:magnifying-glass" headline="No matches" subtitle={`Nothing matches “${query}”.`} compact />
       ) : (
-        sortedFamiliars.map((fam) => {
+        rows.map(({ familiar: fam, projects: rowProjects }) => {
           const isSupreme = supremeFamiliarId != null && fam.id === supremeFamiliarId;
           return (
             <SettingsGroup
               key={fam.id}
-              label={familiarName(fam)}
-              description={isSupreme ? "Access to all projects" : undefined}
+              label={familiarLabel(fam)}
+              description={isSupreme ? "Supreme · all-access" : undefined}
             >
               {isSupreme ? (
                 <p className="flex items-center gap-2 px-4 py-3 text-[12px] text-[var(--text-muted)]">
-                  <Icon name="ph:seal-check" width={15} className="shrink-0 text-[var(--accent-presence)]" />
-                  This familiar has access to every project.
+                  <ToneIcon tone="positive" icon="ph:seal-check" size={15} />
+                  This familiar has access to every project — its grants are managed by the protocol,
+                  not toggled here.
                 </p>
-              ) : projects.length === 0 ? (
+              ) : rowProjects.length === 0 ? (
                 <p className="px-4 py-3 text-[13px] text-[var(--text-muted)]">
                   No projects yet — add one in the Code workspace.
                 </p>
               ) : (
-                projects.map((project) => {
+                rowProjects.map((project) => {
                   const key = grantKey(fam.id, project.id);
                   const on = granted.has(key);
                   const busy = pending.has(key);
+                  const meta = grantMeta.get(key);
+                  const source = on && meta ? grantSourceMeta(meta.source) : null;
                   return (
                     <div key={project.id} className="flex items-center justify-between gap-4 px-4 py-3">
                       <div className="flex min-w-0 items-center gap-3">
@@ -162,9 +380,25 @@ export function PermissionsSection() {
                           style={{ background: project.color || "var(--text-muted)" }}
                         />
                         <div className="min-w-0">
-                          <p className="truncate text-[13px] text-[var(--text-primary)]">{project.name}</p>
+                          <p className="flex items-center gap-2 truncate text-[13px] text-[var(--text-primary)]">
+                            {project.name}
+                            {source && (
+                              <span
+                                title={source.title}
+                                className="rounded-full bg-[var(--bg-hover)] px-1.5 py-px text-[10px] font-medium text-[var(--text-muted)]"
+                              >
+                                {source.label}
+                              </span>
+                            )}
+                          </p>
                           <p className="truncate text-[11px] text-[var(--text-muted)]" title={project.root}>
                             {project.root}
+                            {on && meta?.grantedAt && (
+                              <>
+                                {" · "}
+                                <RelativeTime iso={meta.grantedAt} className="text-[var(--text-muted)]" />
+                              </>
+                            )}
                           </p>
                         </div>
                       </div>
@@ -172,9 +406,9 @@ export function PermissionsSection() {
                         type="button"
                         role="switch"
                         aria-checked={on}
-                        aria-label={`${on ? "Revoke" : "Grant"} ${project.name} for ${familiarName(fam)}`}
+                        aria-label={`${on ? "Revoke" : "Grant"} ${project.name} for ${familiarLabel(fam)}`}
                         disabled={busy}
-                        onClick={() => void toggle(fam.id, project.id, !on)}
+                        onClick={() => onToggle(fam.id, project.id, !on)}
                         className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
                           on ? "bg-[var(--accent-presence)]" : "bg-[var(--bg-elevated)]"
                         } ${busy ? "opacity-60" : ""}`}
@@ -192,6 +426,196 @@ export function PermissionsSection() {
             </SettingsGroup>
           );
         })
+      )}
+    </div>
+  );
+}
+
+// ── Requests tab (grant-proposal inbox) ──────────────────────────────────────
+
+function RequestsTab({
+  proposals,
+  familiarName,
+  projectName,
+  resolving,
+  onResolve,
+}: {
+  proposals: ConsoleProposal[];
+  familiarName: (id: string) => string;
+  projectName: (id: string) => string;
+  resolving: Set<string>;
+  onResolve: (id: string, decision: "accepted" | "rejected") => void;
+}) {
+  const { pending, resolved } = useMemo(() => splitProposals(proposals), [proposals]);
+
+  if (proposals.length === 0) {
+    return (
+      <EmptyState
+        icon="ph:tray"
+        headline="No access requests"
+        subtitle="When the Supreme familiar proposes granting a project to another familiar, it lands here for you to accept or reject. Only you can decide."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="px-1 text-[12px] text-[var(--text-muted)]">
+        The Supreme familiar can propose granting a project to another familiar. Each proposal waits
+        here for your decision — grants are never relayed through a familiar.
+      </p>
+
+      {pending.length > 0 && (
+        <SettingsGroup label={`Awaiting you (${pending.length})`}>
+          {pending.map((p) => {
+            const busy = resolving.has(p.id);
+            return (
+              <div key={p.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0">
+                  <p className="text-[13px] text-[var(--text-primary)]">
+                    Grant <span className="font-medium">{projectName(p.projectId)}</span> to{" "}
+                    <span className="font-medium">{familiarName(p.targetFamiliarId)}</span>
+                  </p>
+                  <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                    proposed by {familiarName(p.proposedBy)} · <RelativeTime iso={p.createdAt} />
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button
+                    variant="ghost"
+                    onClick={() => onResolve(p.id, "rejected")}
+                    disabled={busy}
+                    aria-label={`Reject granting ${projectName(p.projectId)} to ${familiarName(p.targetFamiliarId)}`}
+                  >
+                    Reject
+                  </Button>
+                  <Button
+                    variant="primary"
+                    onClick={() => onResolve(p.id, "accepted")}
+                    disabled={busy}
+                    aria-label={`Accept granting ${projectName(p.projectId)} to ${familiarName(p.targetFamiliarId)}`}
+                  >
+                    Accept
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </SettingsGroup>
+      )}
+
+      {resolved.length > 0 && (
+        <SettingsGroup label="History">
+          {resolved.map((p) => {
+            const meta = proposalStatusMeta(p.status);
+            return (
+              <div key={p.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
+                <div className="min-w-0">
+                  <p className="truncate text-[13px] text-[var(--text-secondary)]">
+                    Grant {projectName(p.projectId)} to {familiarName(p.targetFamiliarId)}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-[var(--text-muted)]">
+                    <RelativeTime iso={p.createdAt} />
+                  </p>
+                </div>
+                <StatusChip tone={meta.tone} icon={meta.icon} label={meta.label} />
+              </div>
+            );
+          })}
+        </SettingsGroup>
+      )}
+    </div>
+  );
+}
+
+// ── Audit tab (access-decision log) ──────────────────────────────────────────
+
+const AUDIT_FILTERS: AuditFilter[] = ["all", "allow", "deny"];
+
+function AuditTab({
+  audit,
+  familiarName,
+  projectName,
+  query,
+  onQuery,
+  filter,
+  onFilter,
+}: {
+  audit: ConsoleAuditEntry[];
+  familiarName: (id: string) => string;
+  projectName: (id: string) => string;
+  query: string;
+  onQuery: (next: string) => void;
+  filter: AuditFilter;
+  onFilter: (next: AuditFilter) => void;
+}) {
+  const entries = useMemo(
+    () => filterAudit(audit, { decision: filter, query, familiarName, projectName }),
+    [audit, filter, query, familiarName, projectName],
+  );
+
+  if (audit.length === 0) {
+    return (
+      <EmptyState
+        icon="ph:clock-counter-clockwise"
+        headline="No access decisions yet"
+        subtitle="Every time a familiar reaches a project surface, the allow/deny decision is logged here with its reason."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="px-1 text-[12px] text-[var(--text-muted)]">
+        Every access decision the protocol makes — which familiar reached which project surface, and
+        whether it was allowed or denied. Showing the most recent {audit.length}.
+      </p>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 px-1">
+        <SearchInput
+          value={query}
+          onValueChange={onQuery}
+          onClear={() => onQuery("")}
+          placeholder="Filter by familiar, project, or surface…"
+          containerClassName="min-w-[220px] flex-1"
+        />
+        <Segmented
+          options={AUDIT_FILTERS}
+          value={filter}
+          onChange={onFilter}
+          getLabel={(o) => (o === "all" ? "All" : o === "allow" ? "Allowed" : "Denied")}
+          ariaLabel="Filter audit decisions"
+        />
+      </div>
+
+      {entries.length === 0 ? (
+        <EmptyState icon="ph:magnifying-glass" headline="No matching decisions" compact />
+      ) : (
+        <SettingsGroup label={`${entries.length} decision${entries.length === 1 ? "" : "s"}`}>
+          {entries.map((e) => {
+            const meta = auditDecisionMeta(e.decision);
+            return (
+              <div key={e.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5">
+                <div className="flex min-w-0 items-center gap-3">
+                  <ToneIcon tone={meta.tone} icon={meta.icon} size={15} />
+                  <div className="min-w-0">
+                    <p className="truncate text-[12px] text-[var(--text-primary)]">
+                      <span className="font-medium">{familiarName(e.familiarId)}</span>
+                      <span className="text-[var(--text-muted)]"> · {projectName(e.projectId)}</span>
+                    </p>
+                    <p className="mt-0.5 flex items-center gap-1.5 text-[11px] text-[var(--text-muted)]">
+                      {meta.label} · {auditReasonLabel(e.reason)}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <MetaChip title="Permission surface">{surfaceLabel(e.surface)}</MetaChip>
+                  <RelativeTime iso={e.at} className="text-[11px] text-[var(--text-muted)]" />
+                </div>
+              </div>
+            );
+          })}
+        </SettingsGroup>
       )}
     </div>
   );

--- a/src/lib/permissions-console.test.ts
+++ b/src/lib/permissions-console.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+
+import {
+  accessSummary,
+  auditDecisionMeta,
+  auditReasonLabel,
+  familiarLabel,
+  filterAccess,
+  filterAudit,
+  grantKey,
+  grantSourceMeta,
+  matchesQuery,
+  nameResolver,
+  pendingProposalCount,
+  proposalStatusMeta,
+  sortFamiliars,
+  splitProposals,
+  surfaceLabel,
+  type ConsoleAuditEntry,
+  type ConsoleFamiliar,
+  type ConsoleProject,
+  type ConsoleProposal,
+} from "./permissions-console.ts";
+
+const SUPREME = "supreme";
+const familiars: ConsoleFamiliar[] = [
+  { id: SUPREME, displayName: "Supreme" },
+  { id: "zelda", displayName: "Zelda" },
+  { id: "atlas", name: "Atlas" },
+];
+const projects: ConsoleProject[] = [
+  { id: "p-web", name: "Web App", root: "/code/web" },
+  { id: "p-api", name: "API Service", root: "/code/api" },
+];
+
+// familiarLabel + grantKey
+assert.equal(familiarLabel({ id: "x", displayName: " Neo " }), "Neo");
+assert.equal(familiarLabel({ id: "x", name: "Trin" }), "Trin");
+assert.equal(familiarLabel({ id: "fallback-id" }), "fallback-id");
+assert.equal(grantKey("a", "b"), "a::b");
+
+// matchesQuery
+assert.equal(matchesQuery("Web App", ""), true, "empty query matches all");
+assert.equal(matchesQuery("Web App", "web"), true);
+assert.equal(matchesQuery("Web App", "API"), false);
+
+// sortFamiliars — supreme pinned first, rest alphabetical
+assert.deepEqual(
+  sortFamiliars(familiars, SUPREME).map((f) => f.id),
+  [SUPREME, "atlas", "zelda"],
+  "supreme first, then alpha by label",
+);
+assert.deepEqual(
+  sortFamiliars(familiars, null).map((f) => f.id),
+  ["atlas", SUPREME, "zelda"],
+  "with no supreme it is pure alpha (Atlas, Supreme, Zelda)",
+);
+
+// filterAccess
+const allRows = filterAccess(familiars, projects, SUPREME, "");
+assert.equal(allRows.length, 3, "empty query shows every familiar");
+assert.equal(allRows[0].familiar.id, SUPREME);
+assert.equal(allRows[0].projects.length, 2, "empty query shows all projects per familiar");
+
+const byProject = filterAccess(familiars, projects, SUPREME, "api service");
+assert.ok(
+  byProject.every((r) => r.projects.length === 1 && r.projects[0].id === "p-api"),
+  "a project-name query narrows each row to the matching project",
+);
+
+const byFamiliar = filterAccess(familiars, projects, SUPREME, "zelda");
+assert.equal(byFamiliar.length, 1, "a familiar-name query keeps only that familiar");
+assert.equal(byFamiliar[0].familiar.id, "zelda");
+assert.equal(byFamiliar[0].projects.length, 2, "matched familiar shows all its projects");
+
+// accessSummary — grants exclude the supreme familiar
+const granted = new Set([grantKey("zelda", "p-web"), grantKey("atlas", "p-api"), grantKey(SUPREME, "p-web")]);
+assert.deepEqual(accessSummary(familiars, projects, granted, SUPREME), {
+  familiars: 3,
+  projects: 2,
+  grants: 2,
+});
+
+// proposals
+const proposals: ConsoleProposal[] = [
+  { id: "1", proposedBy: SUPREME, targetFamiliarId: "zelda", projectId: "p-web", status: "pending", createdAt: "2026-01-02T00:00:00Z" },
+  { id: "2", proposedBy: SUPREME, targetFamiliarId: "atlas", projectId: "p-api", status: "accepted", createdAt: "2026-01-01T00:00:00Z" },
+  { id: "3", proposedBy: SUPREME, targetFamiliarId: "atlas", projectId: "p-web", status: "pending", createdAt: "2026-01-01T00:00:00Z" },
+];
+const split = splitProposals(proposals);
+assert.deepEqual(split.pending.map((p) => p.id), ["3", "1"], "pending is oldest-first (FIFO queue)");
+assert.deepEqual(split.resolved.map((p) => p.id), ["2"], "resolved excludes pending");
+assert.equal(pendingProposalCount(proposals), 2);
+assert.equal(proposalStatusMeta("pending").tone, "pending");
+assert.equal(proposalStatusMeta("accepted").tone, "positive");
+assert.equal(proposalStatusMeta("rejected").tone, "negative");
+
+// audit
+const audit: ConsoleAuditEntry[] = [
+  { id: "a1", at: "2026-01-01T00:00:00Z", familiarId: "zelda", projectId: "p-web", surface: "file-read", decision: "allow", reason: "grant" },
+  { id: "a2", at: "2026-01-03T00:00:00Z", familiarId: "atlas", projectId: "p-api", surface: "shell", decision: "deny", reason: "missing-grant" },
+  { id: "a3", at: "2026-01-02T00:00:00Z", familiarId: SUPREME, projectId: "p-web", surface: "chat", decision: "allow", reason: "supreme" },
+];
+const familiarName = nameResolver(familiars, familiarLabel);
+const projectName = nameResolver(projects, (p) => p.name);
+const newestFirst = filterAudit(audit, { decision: "all", query: "", familiarName, projectName });
+assert.deepEqual(newestFirst.map((e) => e.id), ["a2", "a3", "a1"], "audit is newest-first");
+const denies = filterAudit(audit, { decision: "deny", query: "", familiarName, projectName });
+assert.deepEqual(denies.map((e) => e.id), ["a2"], "decision filter narrows to denies");
+const byQuery = filterAudit(audit, { decision: "all", query: "API Service", familiarName, projectName });
+assert.deepEqual(byQuery.map((e) => e.id), ["a2"], "query matches the resolved project name");
+const bySurface = filterAudit(audit, { decision: "all", query: "shell", familiarName, projectName });
+assert.deepEqual(bySurface.map((e) => e.id), ["a2"], "query matches the surface label");
+
+// labels / meta
+assert.equal(surfaceLabel("file-write"), "File write");
+assert.equal(surfaceLabel("project-api"), "Project API");
+assert.equal(auditDecisionMeta("allow").tone, "positive");
+assert.equal(auditDecisionMeta("deny").tone, "negative");
+assert.equal(auditReasonLabel("missing-grant"), "no grant");
+assert.equal(auditReasonLabel("supreme"), "all-access familiar");
+assert.equal(grantSourceMeta("bootstrap").label, "Auto");
+assert.equal(grantSourceMeta("human").label, "You");
+assert.equal(nameResolver(familiars, familiarLabel)("ghost"), "ghost", "resolver falls back to the id");
+
+console.log("permissions-console.test.ts: ok");

--- a/src/lib/permissions-console.ts
+++ b/src/lib/permissions-console.ts
@@ -1,0 +1,265 @@
+// Pure logic for the Permissions console (Settings → Permissions).
+//
+// The console surfaces the full project-permissions protocol — the grant matrix
+// (which familiars can see which projects), the human-in-the-loop grant-proposal
+// inbox (Supreme proposes → human accepts/rejects), and the access audit log
+// (every allow/deny decision, with its surface + reason). This module holds the
+// framework-free shaping/sorting/filtering so it can be unit-tested directly;
+// the React surface (settings-permissions.tsx) stays a thin rendering layer.
+
+import type { IconName } from "@/lib/icon";
+
+export type ConsoleFamiliar = { id: string; displayName?: string; name?: string };
+export type ConsoleProject = { id: string; name: string; root: string; color?: string };
+
+export type GrantSource = "bootstrap" | "human";
+export type ConsoleGrant = {
+  familiarId: string;
+  projectId: string;
+  source?: GrantSource;
+  grantedAt?: string;
+};
+
+export type ProposalStatus = "pending" | "accepted" | "rejected";
+export type ConsoleProposal = {
+  id: string;
+  proposedBy: string;
+  targetFamiliarId: string;
+  projectId: string;
+  status: ProposalStatus;
+  createdAt: string;
+};
+
+export type AuditDecision = "allow" | "deny";
+export type AuditReason = "grant" | "supreme" | "missing-grant";
+export type PermissionSurface =
+  | "chat"
+  | "session-launch"
+  | "shell"
+  | "file-browse"
+  | "file-read"
+  | "file-write"
+  | "project-api"
+  | "mobile"
+  | "project-picker";
+export type ConsoleAuditEntry = {
+  id: string;
+  at: string;
+  familiarId: string;
+  projectId: string;
+  surface: PermissionSurface;
+  decision: AuditDecision;
+  reason: AuditReason;
+};
+
+export type PermissionTab = "access" | "requests" | "audit";
+export type AuditFilter = "all" | AuditDecision;
+
+/** Stable key for a (familiar, project) grant pair. */
+export const grantKey = (familiarId: string, projectId: string): string =>
+  `${familiarId}::${projectId}`;
+
+/** Display name for a familiar, falling back through displayName → name → id. */
+export function familiarLabel(f: ConsoleFamiliar): string {
+  return f.displayName?.trim() || f.name?.trim() || f.id;
+}
+
+/** Case-insensitive substring match; empty query matches everything. */
+export function matchesQuery(haystack: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return haystack.toLowerCase().includes(q);
+}
+
+/**
+ * Sort familiars for the access matrix: the Supreme familiar is pinned first
+ * (it is the all-access root of the protocol), then the rest alphabetically by
+ * label so the list is scannable and stable.
+ */
+export function sortFamiliars(
+  familiars: ConsoleFamiliar[],
+  supremeFamiliarId: string | null,
+): ConsoleFamiliar[] {
+  return [...familiars].sort((a, b) => {
+    const aSupreme = supremeFamiliarId != null && a.id === supremeFamiliarId;
+    const bSupreme = supremeFamiliarId != null && b.id === supremeFamiliarId;
+    if (aSupreme !== bSupreme) return aSupreme ? -1 : 1;
+    return familiarLabel(a).localeCompare(familiarLabel(b));
+  });
+}
+
+export type AccessRow = { familiar: ConsoleFamiliar; projects: ConsoleProject[] };
+
+/**
+ * Build the access matrix rows for a search query. A familiar appears when its
+ * own label matches (then all projects show) or when at least one of its
+ * projects matches (then only the matching projects show). With an empty query
+ * every familiar + project is shown.
+ */
+export function filterAccess(
+  familiars: ConsoleFamiliar[],
+  projects: ConsoleProject[],
+  supremeFamiliarId: string | null,
+  query: string,
+): AccessRow[] {
+  const sorted = sortFamiliars(familiars, supremeFamiliarId);
+  const q = query.trim();
+  return sorted
+    .map((familiar) => {
+      const familiarMatches = matchesQuery(familiarLabel(familiar), q);
+      const visibleProjects = familiarMatches
+        ? projects
+        : projects.filter(
+            (p) => matchesQuery(p.name, q) || matchesQuery(p.root, q),
+          );
+      return { familiar, projects: visibleProjects, familiarMatches };
+    })
+    .filter((row) => !q || row.familiarMatches || row.projects.length > 0)
+    .map(({ familiar, projects: rowProjects }) => ({ familiar, projects: rowProjects }));
+}
+
+/** Headline counts for the access tab. `grants` counts non-Supreme grant links. */
+export function accessSummary(
+  familiars: ConsoleFamiliar[],
+  projects: ConsoleProject[],
+  granted: ReadonlySet<string>,
+  supremeFamiliarId: string | null,
+): { familiars: number; projects: number; grants: number } {
+  let grants = 0;
+  for (const familiar of familiars) {
+    if (supremeFamiliarId != null && familiar.id === supremeFamiliarId) continue;
+    for (const project of projects) {
+      if (granted.has(grantKey(familiar.id, project.id))) grants += 1;
+    }
+  }
+  return { familiars: familiars.length, projects: projects.length, grants };
+}
+
+export function isSupreme(
+  familiarId: string,
+  supremeFamiliarId: string | null,
+): boolean {
+  return supremeFamiliarId != null && familiarId === supremeFamiliarId;
+}
+
+/**
+ * Split proposals into the actionable inbox (pending, oldest first so the human
+ * works the queue FIFO) and the resolved history (newest first).
+ */
+export function splitProposals(proposals: ConsoleProposal[]): {
+  pending: ConsoleProposal[];
+  resolved: ConsoleProposal[];
+} {
+  const pending = proposals
+    .filter((p) => p.status === "pending")
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const resolved = proposals
+    .filter((p) => p.status !== "pending")
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return { pending, resolved };
+}
+
+export function pendingProposalCount(proposals: ConsoleProposal[]): number {
+  return proposals.reduce((n, p) => (p.status === "pending" ? n + 1 : n), 0);
+}
+
+export type Tone = "pending" | "positive" | "negative" | "neutral";
+
+export function proposalStatusMeta(status: ProposalStatus): {
+  label: string;
+  icon: IconName;
+  tone: Tone;
+} {
+  switch (status) {
+    case "accepted":
+      return { label: "Accepted", icon: "ph:check-circle-fill", tone: "positive" };
+    case "rejected":
+      return { label: "Rejected", icon: "ph:x-circle-fill", tone: "negative" };
+    default:
+      return { label: "Awaiting you", icon: "ph:hourglass", tone: "pending" };
+  }
+}
+
+/** Human-readable labels for the eight protocol surfaces. */
+export const SURFACE_LABEL: Record<PermissionSurface, string> = {
+  chat: "Chat",
+  "session-launch": "Session launch",
+  shell: "Shell",
+  "file-browse": "File browse",
+  "file-read": "File read",
+  "file-write": "File write",
+  "project-api": "Project API",
+  mobile: "Mobile",
+  "project-picker": "Project picker",
+};
+
+export function surfaceLabel(surface: PermissionSurface): string {
+  return SURFACE_LABEL[surface] ?? surface;
+}
+
+export function auditDecisionMeta(decision: AuditDecision): {
+  label: string;
+  icon: IconName;
+  tone: Tone;
+} {
+  return decision === "allow"
+    ? { label: "Allowed", icon: "ph:check-circle-fill", tone: "positive" }
+    : { label: "Denied", icon: "ph:x-circle-fill", tone: "negative" };
+}
+
+export function auditReasonLabel(reason: AuditReason): string {
+  switch (reason) {
+    case "supreme":
+      return "all-access familiar";
+    case "grant":
+      return "explicit grant";
+    case "missing-grant":
+      return "no grant";
+    default:
+      return reason;
+  }
+}
+
+export function grantSourceMeta(source: GrantSource | undefined): {
+  label: string;
+  title: string;
+} {
+  return source === "bootstrap"
+    ? { label: "Auto", title: "Granted automatically when the project was registered" }
+    : { label: "You", title: "Granted by you" };
+}
+
+/**
+ * Filter + order the audit log: newest first, narrowed by decision and a free
+ * text query that matches the resolved familiar/project label or the surface.
+ */
+export function filterAudit(
+  entries: ConsoleAuditEntry[],
+  opts: {
+    decision: AuditFilter;
+    query: string;
+    familiarName: (id: string) => string;
+    projectName: (id: string) => string;
+  },
+): ConsoleAuditEntry[] {
+  const q = opts.query.trim();
+  return [...entries]
+    .filter((e) => opts.decision === "all" || e.decision === opts.decision)
+    .filter((e) => {
+      if (!q) return true;
+      const hay = `${opts.familiarName(e.familiarId)} ${opts.projectName(e.projectId)} ${surfaceLabel(
+        e.surface,
+      )} ${auditReasonLabel(e.reason)}`;
+      return matchesQuery(hay, q);
+    })
+    .sort((a, b) => b.at.localeCompare(a.at));
+}
+
+/** Index a list by id into a lookup that falls back to the id when absent. */
+export function nameResolver<T extends { id: string }>(
+  items: T[],
+  label: (item: T) => string,
+): (id: string) => string {
+  const map = new Map(items.map((item) => [item.id, label(item)]));
+  return (id: string) => map.get(id) ?? id;
+}

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -157,6 +157,19 @@ export async function listGrantProposals(): Promise<GrantProposal[]> {
   return (await loadProjectPermissions()).grantProposals;
 }
 
+/**
+ * Most-recent access-decision audit entries, newest first, capped to `limit`.
+ * Powers the Permissions console's audit log; the audit array is append-only and
+ * can grow without bound, so callers always read a bounded recent window.
+ */
+export async function listRecentPermissionAudit(limit = 200): Promise<PermissionAuditEntry[]> {
+  const audit = (await loadProjectPermissions()).permissionAudit;
+  return audit
+    .slice()
+    .sort((a, b) => b.at.localeCompare(a.at))
+    .slice(0, Math.max(0, limit));
+}
+
 export function canAccessProject(
   file: Pick<ProjectPermissionsFile, "projectGrants">,
   ctx: ProjectAccessContext,


### PR DESCRIPTION
## Why

Settings → Permissions only ever exposed the **grant matrix**. The rest of the project-permissions protocol had **no UI at all**:

- The **grant-proposal lifecycle** (Supreme drafts a proposal → the human accepts/rejects) existed in the API and data model but a human had no way to act on a pending proposal.
- The **access-decision audit log** (every allow/deny, with its surface + reason) was recorded but never surfaced.

This turns the flat section into a **three-tab console** that makes the whole protocol legible and operable.

## What

**Access** — the grant matrix, elevated: search/filter across familiars + projects, a live summary (`N familiars · N projects · N grants`), grant provenance (You/Auto badge + granted-time), and the Supreme familiar pinned as all-access. The human-confirmed grant toggle (POST/DELETE `/api/project-grants`, `role="switch"`) is unchanged.

**Requests** — the grant-proposal inbox (previously UI-less). Pending proposals show Accept/Reject and resolve via PATCH `/api/grant-proposals/[id]` sending **only the decision** (the route still rejects relayed approvals). The pending count badges the tab; resolved history is kept with status chips.

**Audit** — the access-decision log: who reached which surface, allow/deny, and why, with an All/Allowed/Denied filter and free-text search.

## How

- All framework-free shaping/sorting/filtering lives in a pure, unit-tested module `src/lib/permissions-console.ts` — the React surface stays thin.
- Backend: a **bounded recent audit window** is added to the `GET /api/project-grants` response (new `listRecentPermissionAudit()` — the audit array is append-only, so reads are capped). **No new routes, no contract change** — route methods are unchanged (`api-contracts.test` still passes, 149 contracts).
- Every behavior the existing `settings-permissions.test` pinned is preserved; the test is extended to pin the new tabs + proposal resolution.

## Verification

Ran the built app in a real browser and screenshotted all three tabs (richly mocked data) — Access, Requests (pending badge + Accept/Reject + history), and Audit (color-coded allow/deny, surface chips, reasons) all render correctly.

Local green: `typecheck`, `check:tests-wired` (625), `test:app` (468), `test:api` (95), `api-contracts` (149 contracts), and the new `permissions-console` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)