### PR TITLE
feat: unify eval analysis surfaces

### DIFF
--- a/docs/specs/2026-06-28-unified-evals-analysis-design.md
+++ b/docs/specs/2026-06-28-unified-evals-analysis-design.md
@@ -1,0 +1,61 @@
+# Unified Evals Analysis Design
+
+## Goal
+
+Merge the split `Eval Loops` and `Evals` workspaces into one analysis-first Evals control room. The unified surface should help a maintainer answer:
+
+- Are suite-based evals passing or drifting?
+- Are familiar eval-loop iterations being accepted or reverted?
+- Are loop locks/runs healthy or stale?
+- Which thread eval snapshots are stale, blocked, queued, or never run?
+
+## Surface Model
+
+The `evals` workspace mode becomes the canonical UI. `/evals` and `/eval-loops` both route there. The old `retro` mode remains as a compatibility alias only, so deep links do not break, but it is no longer a separate sidebar/settings surface.
+
+The sidebar exposes one `Evals` item with the flask icon. The title remains `Evals`, and the page itself explains the merged scope through operational data rather than marketing copy.
+
+## Page Structure
+
+`EvalsView` owns the unified surface:
+
+- Analysis header: total suites, total suite runs, latest suite pass rate, eval-loop accept/revert counts, running familiars, stale grouped thread count, and queued manual eval count.
+- Overview tab: compact analysis cards, coverage notes, and the recent eval-loop run list.
+- Suites tab: the existing suite editor and run controls.
+- Runs tab: the existing per-suite run history and result detail.
+- Loops tab: embedded `EvalLoopPanel` for the selected familiar plus sanitized loop history/export controls.
+- Thread freshness tab: grouped eval snapshot details and the manual stale-eval queue action.
+
+The existing grouped eval panel and suite runner stay intact, but the group panel moves out of the editor-only flow so it reads as operational state.
+
+## Data Flow
+
+The unified view loads the existing endpoints:
+
+- `/api/evals/suites`
+- `/api/evals/runs`
+- `/api/evals/groups`
+- `/api/evals/thread-states`
+- `/api/evals/queue`
+- `/api/retro-runs`
+- `/api/skills/eval-loop/:familiarId`
+
+No new persistence layer is required. Analysis rollups are derived client-side from existing DTOs and sanitized API responses.
+
+## Compatibility
+
+- Keep `/dashboard/retro` and `/retro` as redirects to the unified Evals route.
+- Keep `/eval-loops` slash command support, but make it open `evals`.
+- Keep `retro` mode accepted internally as an alias to render `EvalsView`, so saved state or stale links do not blank the workspace.
+
+## Testing
+
+Use focused source tests first because these surfaces already pin wiring through source assertions. Add coverage that:
+
+- sidebar/settings no longer expose a separate `retro` add-on surface
+- `/evals` and `/eval-loops` open `evals`
+- the unified Evals view fetches retro-loop snapshot data
+- the unified Evals view renders analysis, suite, run, loop, and thread freshness sections
+- the embedded loop controls remain available through `EvalLoopPanel`
+
+Then run focused component/source tests, typecheck, wired-test check, whitespace check, and the app test suite before committing.

--- a/docs/specs/2026-06-28-unified-evals-analysis-plan.md
+++ b/docs/specs/2026-06-28-unified-evals-analysis-plan.md
@@ -1,0 +1,64 @@
+# Unified Evals Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Merge the split Eval Loops and Evals workspaces into one richer Evals analysis/control room.
+
+**Architecture:** Keep existing backend endpoints and persistence. Refactor `EvalsView` to derive richer rollups from existing eval-suite, eval-run, grouped-thread, queue, and retro-loop data. Treat `retro` as a compatibility alias in workspace routing while removing it from the visible nav/add-on surface.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, source-text tests, Node test runner, PNPM.
+
+---
+
+### Task 1: Red Tests
+
+**Files:**
+- Modify: `src/components/evals/evals-view.test.ts`
+- Modify: `src/components/retro-runs-view.test.ts`
+
+- [ ] Add assertions that `EvalsView` fetches `/api/retro-runs`, imports/renders `EvalLoopPanel`, has analysis tabs, and renders eval-loop and thread freshness analysis copy.
+- [ ] Add assertions that workspace slash commands route `/evals` and `/eval-loops` to `evals`, the sidebar has no visible `retro` row, and settings no longer expose a `retro` add-on.
+- [ ] Run `node --experimental-strip-types --test src/components/evals/evals-view.test.ts src/components/retro-runs-view.test.ts` and confirm the new assertions fail before production edits.
+
+### Task 2: Unified Evals View
+
+**Files:**
+- Modify: `src/components/evals/evals-view.tsx`
+- Modify: `src/styles/evals.css`
+
+- [ ] Load `/api/retro-runs` alongside existing eval data.
+- [ ] Add analysis helpers for suite pass rate, total runs, eval-loop accept/revert counts, running familiar count, stale thread count, and queued eval count.
+- [ ] Add top analysis cards and tabs: `Overview`, `Suites`, `Runs`, `Loops`, `Thread freshness`.
+- [ ] Move the grouped eval panel into the thread freshness tab and preserve `Run stale evals`.
+- [ ] Embed `EvalLoopPanel` in the loop tab for the selected familiar.
+- [ ] Add sanitized loop snapshot export and compact recent loop history in overview/loop areas.
+- [ ] Run the focused Evals source test and fix failures.
+
+### Task 3: Route And Nav Consolidation
+
+**Files:**
+- Modify: `src/components/workspace.tsx`
+- Modify: `src/components/sidebar-minimal.tsx`
+- Modify: `src/components/command-palette.tsx`
+- Modify: `src/components/settings-shell.tsx`
+- Modify: `src/lib/slash-commands.ts`
+- Modify: `src/app/dashboard/retro/page.tsx`
+- Modify: `src/app/retro/page.tsx`
+
+- [ ] Route `/evals` and `/eval-loops` slash commands to `evals`.
+- [ ] Render `EvalsView` for both `mode === "evals"` and legacy `mode === "retro"`.
+- [ ] Remove visible `retro` sidebar/settings/add-on gating while keeping the mode type for compatibility.
+- [ ] Redirect `/dashboard/retro` and `/retro` to the unified Evals route.
+- [ ] Run the focused retro/nav source test and fix failures.
+
+### Task 4: Verification And Merge
+
+**Files:**
+- All touched files
+
+- [ ] Run focused tests for evals, retro/nav, eval loop panel, and affected surface loading/error states.
+- [ ] Run `pnpm typecheck`.
+- [ ] Run `pnpm check:tests-wired`.
+- [ ] Run `git diff --check`.
+- [ ] Run `pnpm test:app`.
+- [ ] Commit with hooks enabled, push `feat/unified-eval-analysis`, open PR, review comments/CI, merge to `main`, delete feature branch/worktree, release Coven claim.

--- a/src/app/dashboard/retro/page.tsx
+++ b/src/app/dashboard/retro/page.tsx
@@ -1,26 +1,5 @@
-import { CopyLinkButton } from "@/components/copy-link-button";
-import { RetroRunsView } from "@/components/retro-runs-view";
-import { Icon } from "@/lib/icon";
+import { redirect } from "next/navigation";
 
-export const dynamic = "force-dynamic";
-
-export default function RetroDashboardPage() {
-  return (
-    <main className="dr-page">
-      <div className="dr-topbar">
-        <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-          <a className="dr-back" href="/dashboard">
-            <Icon name="ph:arrow-left" aria-hidden />
-            Dashboard
-          </a>
-          <span className="dr-crumb-sep" aria-hidden>/</span>
-          <span className="dr-crumb-current">Retro Runs</span>
-        </nav>
-        <div className="dr-topbar__actions">
-          <CopyLinkButton />
-        </div>
-      </div>
-      <RetroRunsView standalone />
-    </main>
-  );
+export default function RetroDashboardRedirectPage() {
+  redirect("/dashboard?view=evals");
 }

--- a/src/app/retro/page.tsx
+++ b/src/app/retro/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function RetroRedirectPage() {
-  redirect("/dashboard/retro");
+  redirect("/dashboard?view=evals");
 }

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -573,7 +573,6 @@ export function CommandPalette({
           if (fm.id === "groupchat") return addons?.groupchat === true;
           if (fm.id === "journal") return addons?.journal === true;
           if (fm.id === "docs") return addons?.docs === true;
-          if (fm.id === "retro") return addons?.retro === true;
           return true;
         })
           // Fuzzy on the short label/id; substring-only on the long description

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -295,7 +295,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
           <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
           <QuickLink href="/dashboard/familiars/growth" icon="ph:chart-bar-bold" label="Growth" sub="Familiar performance" />
-          <QuickLink href="/dashboard/retro" icon="ph:arrows-clockwise-bold" label="Eval Loops" sub="Eval iterations" />
+          <QuickLink href="/dashboard?view=evals" icon="ph:flask" label="Evals" sub="Suites, loops, freshness" />
           <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
           <QuickLink href="/" icon="ph:books-bold" label="Library" sub="Saved knowledge" />
           <QuickLink href="/settings" icon="ph:gear-six" label="Settings" sub="Preferences" />

--- a/src/components/evals/evals-view.test.ts
+++ b/src/components/evals/evals-view.test.ts
@@ -18,15 +18,26 @@ assert.match(source, /\/api\/evals\/runs/, "lists and persists runs via the API"
 assert.match(source, /\/api\/evals\/groups/, "loads eval groups from the API");
 assert.match(source, /\/api\/evals\/thread-states/, "loads thread eval state snapshots from the API");
 assert.match(source, /\/api\/evals\/queue/, "queues manual grouped eval runs via the API");
+assert.match(source, /\/api\/retro-runs/, "loads eval-loop snapshot data into the unified Evals surface");
 assert.match(source, /method: "DELETE"/, "supports suite deletion");
 
 // Run engine + readiness gate
 assert.match(source, /runSuite\(/, "runs the suite through the client engine");
 assert.match(source, /suiteRunBlockReason/, "gates Run on suite readiness");
-assert.match(source, /disabled=\{Boolean\(blockReason\)\}/, "Run is disabled when blocked");
+assert.match(source, /disabled=\{!draft \|\| Boolean\(blockReason\)\}/, "Run is disabled when blocked or no suite is selected");
 assert.match(source, /AbortController/, "a run can be stopped");
 assert.match(source, /deriveThreadEvalState/, "derives thread eval freshness");
 assert.match(source, /rollupEvalGroup/, "rolls grouped eval state into status counts");
+assert.match(source, /EvalLoopPanel/, "embeds eval-loop controls in the unified Evals surface");
+assert.match(source, /EvalsAnalysisSummary/, "renders a rich analysis summary");
+assert.match(source, /LoopAnalysisPanel/, "renders eval-loop analysis inside Evals");
+assert.match(source, /ThreadFreshnessPanel/, "renders grouped thread freshness analysis inside Evals");
+assert.match(source, /downloadRetroSnapshot/, "keeps sanitized eval-loop export available inside Evals");
+assert.match(source, /"overview" \| "suites" \| "runs" \| "loops" \| "threads"/, "unified surface has analysis-first tabs");
+assert.match(source, /Overview/, "includes an Overview tab");
+assert.match(source, /Suites/, "includes a Suites tab");
+assert.match(source, /Loops/, "includes a Loops tab");
+assert.match(source, /Thread freshness/, "includes a Thread freshness tab");
 assert.match(source, /Run stale evals/, "exposes a manual queue action for stale group evals");
 assert.match(source, /evals-group-panel/, "renders grouped eval state");
 assert.match(source, /evals-stale-reason/, "renders stale reasons");
@@ -46,7 +57,7 @@ assert.match(source, /GRADER_OPTIONS/, "exposes the grader kinds");
 assert.match(source, /llm_judge/, "supports the LLM-judge grader");
 
 // Tabs + results
-assert.match(source, /tab === "editor"/, "has an editor tab");
+assert.match(source, /tab === "suites"/, "has a suites tab");
 assert.match(source, /tab === "runs"/, "has a runs tab");
 assert.match(source, /evals-result/, "renders per-case results");
 assert.match(source, /PASS|FAIL/, "shows pass/fail per case");

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -2,8 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { Icon } from "@/lib/icon";
+import type { IconName } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
+import { EvalLoopPanel } from "@/components/eval-loop-panel";
+import { RetroRunsView } from "@/components/retro-runs-view";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import type { RetroRun, RetroRunsSnapshot } from "@/lib/retro-runs";
 import {
   deriveThreadEvalState,
   rollupEvalGroup,
@@ -27,6 +31,25 @@ type Props = {
 };
 
 type GraderKindOption = { kind: GraderKind; label: string; hint: string; valueless?: boolean };
+type EvalsTab = "overview" | "suites" | "runs" | "loops" | "threads";
+type RetroApiResponse =
+  | { ok: true; snapshot: RetroRunsSnapshot }
+  | { ok: false; snapshot?: RetroRunsSnapshot; error?: string };
+
+const EMPTY_RETRO_SNAPSHOT: RetroRunsSnapshot = {
+  generatedAt: new Date(0).toISOString(),
+  summary: {
+    totalRuns: 0,
+    accepted: 0,
+    reverted: 0,
+    runningFamiliars: 0,
+    familiarsWithData: 0,
+    trackCounts: { synthesis: 0, prompt: 0, memory: 0 },
+    lastRun: null,
+  },
+  familiars: [],
+  runs: [],
+};
 
 const GRADER_OPTIONS: GraderKindOption[] = [
   { kind: "contains", label: "Contains", hint: "substring the answer must include" },
@@ -72,10 +95,12 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
   const [draft, setDraft] = useState<EvalSuite | null>(null);
   const [savedJson, setSavedJson] = useState<string>("");
   const [runs, setRuns] = useState<EvalRun[]>([]);
+  const [allRuns, setAllRuns] = useState<EvalRun[]>([]);
   const [groups, setGroups] = useState<EvalGroup[]>([]);
   const [threadSnapshots, setThreadSnapshots] = useState<ThreadEvalSnapshot[]>([]);
   const [queue, setQueue] = useState<ManualEvalQueueItem[]>([]);
-  const [tab, setTab] = useState<"editor" | "runs">("editor");
+  const [retroSnapshot, setRetroSnapshot] = useState<RetroRunsSnapshot>(EMPTY_RETRO_SNAPSHOT);
+  const [tab, setTab] = useState<EvalsTab>("overview");
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
   const [progress, setProgress] = useState<RunProgress | null>(null);
@@ -94,28 +119,47 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     () => activeGroup ? rollupEvalGroup(activeGroup, activeGroupStates) : null,
     [activeGroup, activeGroupStates],
   );
+  const familiarName = (familiars.find((f) => f.id === familiarId)?.display_name ?? familiarId) || "Familiar";
+  const activeLoopState = retroSnapshot.familiars.find((familiar) => familiar.familiarId === familiarId) ?? null;
+  const analysis = useMemo(
+    () => deriveEvalsAnalysis({
+      suites,
+      allRuns,
+      selectedRuns: runs,
+      retroSnapshot,
+      activeGroupRollup,
+      queueCount: queue.length,
+    }),
+    [activeGroupRollup, allRuns, queue.length, retroSnapshot, runs, suites],
+  );
 
   // Load suites and grouped eval metadata once.
   useEffect(() => {
     let alive = true;
     void (async () => {
       try {
-        const [suitesRes, groupsRes, threadStatesRes, queueRes] = await Promise.all([
+        const [suitesRes, allRunsRes, groupsRes, threadStatesRes, queueRes, retroRes] = await Promise.all([
           fetch("/api/evals/suites"),
+          fetch("/api/evals/runs"),
           fetch("/api/evals/groups"),
           fetch("/api/evals/thread-states"),
           fetch("/api/evals/queue"),
+          fetch("/api/retro-runs"),
         ]);
         const data = (await suitesRes.json()) as { ok: boolean; suites?: EvalSuite[] };
+        const allRunsData = (await allRunsRes.json()) as { ok: boolean; runs?: EvalRun[] };
         const groupsData = (await groupsRes.json()) as { ok: boolean; groups?: EvalGroup[] };
         const threadStatesData = (await threadStatesRes.json()) as { ok: boolean; snapshots?: ThreadEvalSnapshot[] };
         const queueData = (await queueRes.json()) as { ok: boolean; queue?: ManualEvalQueueItem[] };
+        const retroData = (await retroRes.json()) as RetroApiResponse;
         if (!alive) return;
         const list = data.suites ?? [];
         setSuites(list);
+        setAllRuns(allRunsData.runs ?? []);
         setGroups(groupsData.groups ?? []);
         setThreadSnapshots(threadStatesData.snapshots ?? []);
         setQueue(queueData.queue ?? []);
+        setRetroSnapshot(retroData.snapshot ?? EMPTY_RETRO_SNAPSHOT);
         if (list.length) selectSuite(list[0]);
       } finally {
         if (alive) setLoaded(true);
@@ -132,7 +176,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     setDraft(structuredClone(suite));
     setSavedJson(JSON.stringify(suite));
     setExpandedRunId(null);
-    setTab("editor");
+    setTab("suites");
     void (async () => {
       try {
         const res = await fetch(`/api/evals/runs?suiteId=${encodeURIComponent(suite.id)}`);
@@ -151,7 +195,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     setDraft(suite);
     setSavedJson(""); // unsaved
     setRuns([]);
-    setTab("editor");
+    setTab("suites");
   }, []);
 
   const patchDraft = useCallback((patch: Partial<EvalSuite>) => {
@@ -232,6 +276,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
         onProgress: setProgress,
       });
       setRuns((prev) => [result, ...prev]);
+      setAllRuns((prev) => [result, ...prev.filter((run) => run.id !== result.id)]);
       setExpandedRunId(result.id);
       // Persist (best-effort; desktop-only route).
       void fetch("/api/evals/runs", {
@@ -261,25 +306,8 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     if (data.ok && data.queued) setQueue((prev) => [...data.queued!, ...prev]);
   }, [activeGroup, activeGroupStates]);
 
-  if (loaded && suites.length === 0 && !draft) {
-    return (
-      <div className="evals evals-empty">
-        <EmptyState
-          icon="ph:flask"
-          headline="Run evals on your familiars"
-          subtitle="Build a suite of test cases, grade each answer with deterministic checks or an LLM judge, and track pass rates over time."
-          actions={
-            <button type="button" className="evals-btn evals-btn-primary" onClick={createSuite}>
-              <Icon name="ph:plus" width={14} /> New eval suite
-            </button>
-          }
-        />
-      </div>
-    );
-  }
-
   return (
-    <div className="evals">
+    <div className="evals evals-unified">
       <aside className="evals-rail">
         <div className="evals-rail-head">
           <span className="evals-rail-title">Evals</span>
@@ -303,81 +331,122 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
         </ul>
       </aside>
 
-      {draft ? (
-        <section className="evals-main">
-          <header className="evals-toolbar">
-            <input
-              className="evals-name-input"
-              value={draft.name}
-              onChange={(e) => patchDraft({ name: e.target.value })}
-              aria-label="Suite name"
-            />
-            <label className="evals-familiar-pick">
-              <span className="evals-familiar-label">Familiar</span>
-              <select
-                value={familiarId}
-                onChange={(e) => patchDraft({ familiarId: e.target.value })}
-                aria-label="Familiar to evaluate"
+      <section className="evals-main">
+        <header className="evals-toolbar evals-unified-toolbar">
+          <div className="evals-title-block">
+            <span className="evals-group-kicker">Unified Evals</span>
+            {draft ? (
+              <input
+                className="evals-name-input"
+                value={draft.name}
+                onChange={(e) => patchDraft({ name: e.target.value })}
+                aria-label="Suite name"
+              />
+            ) : (
+              <h2>Evals</h2>
+            )}
+          </div>
+          <label className="evals-familiar-pick">
+            <span className="evals-familiar-label">Familiar</span>
+            <select
+              value={familiarId}
+              onChange={(e) => patchDraft({ familiarId: e.target.value })}
+              aria-label="Familiar to evaluate"
+              disabled={!draft}
+            >
+              {familiars.length === 0 && <option value="">No familiars</option>}
+              {familiars.map((f) => (
+                <option key={f.id} value={f.id}>
+                  {f.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <div className="evals-toolbar-actions">
+            <button type="button" className="evals-btn" onClick={save} disabled={!draft || saving || !dirty}>
+              {saving ? "Saving…" : dirty ? "Save" : "Saved"}
+            </button>
+            {running ? (
+              <button type="button" className="evals-btn evals-btn-stop" onClick={stop}>
+                <span className="evals-spinner" aria-hidden /> Stop
+              </button>
+            ) : (
+              <button
+                type="button"
+                className="evals-btn evals-btn-primary"
+                onClick={run}
+                disabled={!draft || Boolean(blockReason)}
+                title={blockReason ?? "Run this suite against the familiar"}
               >
-                {familiars.length === 0 && <option value="">No familiars</option>}
-                {familiars.map((f) => (
-                  <option key={f.id} value={f.id}>
-                    {f.display_name}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <div className="evals-toolbar-tabs" role="tablist" aria-label="Suite view">
-              <button type="button" role="tab" aria-selected={tab === "editor"} className={`evals-tab${tab === "editor" ? " is-active" : ""}`} onClick={() => setTab("editor")}>
-                Editor
+                <Icon name="ph:play" width={13} /> Run
               </button>
-              <button type="button" role="tab" aria-selected={tab === "runs"} className={`evals-tab${tab === "runs" ? " is-active" : ""}`} onClick={() => setTab("runs")}>
-                Runs{runs.length ? ` (${runs.length})` : ""}
-              </button>
-            </div>
-            <div className="evals-toolbar-actions">
-              <button type="button" className="evals-btn" onClick={save} disabled={saving || !dirty}>
-                {saving ? "Saving…" : dirty ? "Save" : "Saved"}
-              </button>
-              {running ? (
-                <button type="button" className="evals-btn evals-btn-stop" onClick={stop}>
-                  <span className="evals-spinner" aria-hidden /> Stop
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="evals-btn evals-btn-primary"
-                  onClick={run}
-                  disabled={Boolean(blockReason)}
-                  title={blockReason ?? "Run this suite against the familiar"}
-                >
-                  <Icon name="ph:play" width={13} /> Run
-                </button>
-              )}
-            </div>
-          </header>
+            )}
+          </div>
+        </header>
 
-          <EvalGroupPanel
+        <EvalsAnalysisSummary analysis={analysis} />
+
+        <div className="evals-toolbar-tabs evals-section-tabs" role="tablist" aria-label="Evals sections">
+          {([
+            ["overview", "Overview"],
+            ["suites", "Suites"],
+            ["runs", `Runs${runs.length ? ` (${runs.length})` : ""}`],
+            ["loops", "Loops"],
+            ["threads", "Thread freshness"],
+          ] as Array<[EvalsTab, string]>).map(([id, label]) => (
+            <button key={id} type="button" role="tab" aria-selected={tab === id} className={`evals-tab${tab === id ? " is-active" : ""}`} onClick={() => setTab(id)}>
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {tab === "overview" ? (
+          <EvalsOverview
+            analysis={analysis}
+            recentLoopRuns={retroSnapshot.runs.slice(0, 5)}
+            activeLoopState={activeLoopState}
+            activeGroupRollup={activeGroupRollup}
+          />
+        ) : tab === "suites" ? (
+          draft ? (
+            <SuiteEditor draft={draft} patchDraft={patchDraft} patchCase={patchCase} patchGrader={patchGrader} setDraft={setDraft} />
+          ) : (
+            <EmptyState
+              icon="ph:flask"
+              headline="Run evals on your familiars"
+              subtitle="Build a suite of test cases, grade each answer with deterministic checks or an LLM judge, and track pass rates over time."
+              actions={
+                <button type="button" className="evals-btn evals-btn-primary" onClick={createSuite}>
+                  <Icon name="ph:plus" width={14} /> New eval suite
+                </button>
+              }
+            />
+          )
+        ) : tab === "runs" ? (
+          <RunsPanel
+            runs={runs}
+            progress={progress}
+            running={running}
+            expandedRunId={expandedRunId}
+            onToggle={(id) => setExpandedRunId((cur) => (cur === id ? null : id))}
+          />
+        ) : tab === "loops" ? (
+          <LoopAnalysisPanel
+            familiarId={familiarId}
+            familiarName={familiarName}
+            snapshot={retroSnapshot}
+            activeLoopState={activeLoopState}
+          />
+        ) : (
+          <ThreadFreshnessPanel
             group={activeGroup}
             states={activeGroupStates}
             rollup={activeGroupRollup}
             queuedCount={queue.length}
             onQueue={queueStaleGroup}
           />
-
-          {tab === "editor" ? (
-            <SuiteEditor draft={draft} patchDraft={patchDraft} patchCase={patchCase} patchGrader={patchGrader} setDraft={setDraft} />
-          ) : (
-            <RunsPanel
-              runs={runs}
-              progress={progress}
-              running={running}
-              expandedRunId={expandedRunId}
-              onToggle={(id) => setExpandedRunId((cur) => (cur === id ? null : id))}
-            />
-          )}
-        </section>
-      ) : null}
+        )}
+      </section>
     </div>
   );
 }
@@ -401,6 +470,234 @@ function deriveEvalGroupStates(group: EvalGroup, snapshots: ThreadEvalSnapshot[]
         groupUpdatedAt: group.updatedAt,
       });
     });
+}
+
+type EvalGroupRollup = ReturnType<typeof rollupEvalGroup>;
+
+type EvalsAnalysis = {
+  suiteCount: number;
+  totalSuiteRuns: number;
+  selectedSuiteRuns: number;
+  latestPassRate: number | null;
+  passTrend: number | null;
+  loopRuns: number;
+  loopAccepted: number;
+  loopReverted: number;
+  runningFamiliars: number;
+  staleThreads: number;
+  blockedThreads: number;
+  queuedCount: number;
+};
+
+function deriveEvalsAnalysis({
+  suites,
+  allRuns,
+  selectedRuns,
+  retroSnapshot,
+  activeGroupRollup,
+  queueCount,
+}: {
+  suites: EvalSuite[];
+  allRuns: EvalRun[];
+  selectedRuns: EvalRun[];
+  retroSnapshot: RetroRunsSnapshot;
+  activeGroupRollup: EvalGroupRollup | null;
+  queueCount: number;
+}): EvalsAnalysis {
+  const sortedSelectedRuns = [...selectedRuns].sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+  const latestPassRate = sortedSelectedRuns[0]?.summary.passRate ?? null;
+  const previousPassRate = sortedSelectedRuns[1]?.summary.passRate ?? null;
+  return {
+    suiteCount: suites.length,
+    totalSuiteRuns: allRuns.length,
+    selectedSuiteRuns: selectedRuns.length,
+    latestPassRate,
+    passTrend: latestPassRate != null && previousPassRate != null ? latestPassRate - previousPassRate : null,
+    loopRuns: retroSnapshot.summary.totalRuns,
+    loopAccepted: retroSnapshot.summary.accepted,
+    loopReverted: retroSnapshot.summary.reverted,
+    runningFamiliars: retroSnapshot.summary.runningFamiliars,
+    staleThreads: (activeGroupRollup?.staleThreads ?? 0) + (activeGroupRollup?.neverRunThreads ?? 0),
+    blockedThreads: activeGroupRollup?.blockedThreads ?? 0,
+    queuedCount: queueCount,
+  };
+}
+
+function passRateLabel(value: number | null): string {
+  return value == null ? "No runs" : pct(value);
+}
+
+function trendLabel(value: number | null): string {
+  if (value == null) return "No trend";
+  if (Math.abs(value) < 0.005) return "flat";
+  return `${value > 0 ? "+" : ""}${Math.round(value * 100)} pts`;
+}
+
+function downloadRetroSnapshot(snapshot: RetroRunsSnapshot) {
+  const payload = JSON.stringify(snapshot, null, 2);
+  const blob = new Blob([payload], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = `coven-evals-loop-snapshot-${new Date().toISOString().slice(0, 10)}.json`;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function EvalsAnalysisSummary({ analysis }: { analysis: EvalsAnalysis }) {
+  return (
+    <section className="evals-analysis-summary" aria-label="Evals analysis summary">
+      <AnalysisCard icon="ph:flask" label="Suites" value={String(analysis.suiteCount)} detail={`${analysis.totalSuiteRuns} recorded runs`} />
+      <AnalysisCard icon="ph:chart-bar-bold" label="Latest suite pass" value={passRateLabel(analysis.latestPassRate)} detail={trendLabel(analysis.passTrend)} />
+      <AnalysisCard icon="ph:arrows-clockwise-bold" label="Loop accept/revert" value={`${analysis.loopAccepted}/${analysis.loopReverted}`} detail={`${analysis.loopRuns} loop runs`} />
+      <AnalysisCard icon="ph:clock-countdown" label="Thread freshness" value={`${analysis.staleThreads} stale`} detail={`${analysis.blockedThreads} blocked · ${analysis.queuedCount} queued`} />
+      <AnalysisCard icon="ph:heartbeat" label="Running loops" value={String(analysis.runningFamiliars)} detail="familiar eval loops" />
+    </section>
+  );
+}
+
+function AnalysisCard({ icon, label, value, detail }: { icon: IconName; label: string; value: string; detail: string }) {
+  return (
+    <article className="evals-analysis-card">
+      <Icon name={icon} width={16} aria-hidden />
+      <span>{label}</span>
+      <b>{value}</b>
+      <small>{detail}</small>
+    </article>
+  );
+}
+
+function EvalsOverview({
+  analysis,
+  recentLoopRuns,
+  activeLoopState,
+  activeGroupRollup,
+}: {
+  analysis: EvalsAnalysis;
+  recentLoopRuns: RetroRun[];
+  activeLoopState: RetroRunsSnapshot["familiars"][number] | null;
+  activeGroupRollup: EvalGroupRollup | null;
+}) {
+  return (
+    <div className="evals-overview">
+      <section className="evals-analysis-panel">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Analysis</span>
+          <b>What needs attention</b>
+        </div>
+        <ul className="evals-insight-list">
+          <li>{analysis.latestPassRate == null ? "No suite runs yet." : `Latest selected-suite pass rate is ${passRateLabel(analysis.latestPassRate)}.`}</li>
+          <li>{analysis.passTrend == null ? "Run the suite twice to establish trend." : `Pass-rate trend is ${trendLabel(analysis.passTrend)}.`}</li>
+          <li>{analysis.staleThreads > 0 ? `${analysis.staleThreads} thread eval snapshots need review.` : "Grouped thread eval snapshots are fresh where configured."}</li>
+          <li>{activeLoopState?.running ? `${activeLoopState.familiarName} has an eval loop running.` : "No selected familiar eval loop is currently running."}</li>
+        </ul>
+      </section>
+      <section className="evals-analysis-panel">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Recent eval-loop runs</span>
+          <b>{recentLoopRuns.length ? `${recentLoopRuns.length} newest` : "No loop runs"}</b>
+        </div>
+        <LoopRunList runs={recentLoopRuns} />
+      </section>
+      <section className="evals-analysis-panel">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Group health</span>
+          <b>{activeGroupRollup ? `${activeGroupRollup.totalThreads} threads` : "No group"}</b>
+        </div>
+        <p className="evals-analysis-copy">
+          {activeGroupRollup
+            ? `${activeGroupRollup.freshThreads} fresh, ${activeGroupRollup.staleThreads} stale, ${activeGroupRollup.neverRunThreads} never run, ${activeGroupRollup.blockedThreads} blocked.`
+            : "Create an eval group to connect thread freshness, stale reasons, and manual queueing."}
+        </p>
+      </section>
+    </div>
+  );
+}
+
+function LoopAnalysisPanel({
+  familiarId,
+  familiarName,
+  snapshot,
+  activeLoopState,
+}: {
+  familiarId: string;
+  familiarName: string;
+  snapshot: RetroRunsSnapshot;
+  activeLoopState: RetroRunsSnapshot["familiars"][number] | null;
+}) {
+  return (
+    <div className="evals-loop-analysis">
+      <section className="evals-analysis-panel">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Loop analysis</span>
+          <b>{activeLoopState?.familiarName ?? familiarName}</b>
+          <button type="button" className="evals-btn" onClick={() => downloadRetroSnapshot(snapshot)} disabled={snapshot.runs.length === 0}>
+            <Icon name="ph:floppy-disk-bold" width={13} /> Export loop snapshot
+          </button>
+        </div>
+        <div className="evals-loop-metrics">
+          <ThreadEvalDetail label="Accepted" value={String(activeLoopState?.totalAccepted ?? 0)} />
+          <ThreadEvalDetail label="Reverted" value={String(activeLoopState?.totalReverted ?? 0)} />
+          <ThreadEvalDetail label="Runs" value={String(activeLoopState?.runs.length ?? 0)} />
+          <ThreadEvalDetail label="Status" value={activeLoopState?.running ? "running" : "idle"} />
+        </div>
+        <LoopRunList runs={(activeLoopState?.runs ?? []).slice(0, 8)} />
+      </section>
+      {familiarId ? (
+        <section className="evals-analysis-panel evals-loop-control">
+          <EvalLoopPanel familiarId={familiarId} familiarName={familiarName} />
+        </section>
+      ) : (
+        <EmptyState compact icon="ph:user" headline="Select a familiar to run eval loops." />
+      )}
+      {familiarId ? <RetroRunsView familiarId={familiarId} /> : null}
+    </div>
+  );
+}
+
+function ThreadFreshnessPanel({
+  group,
+  states,
+  rollup,
+  queuedCount,
+  onQueue,
+}: {
+  group: EvalGroup | null;
+  states: ThreadEvalState[];
+  rollup: EvalGroupRollup | null;
+  queuedCount: number;
+  onQueue: () => void;
+}) {
+  return (
+    <div className="evals-thread-freshness">
+      <section className="evals-analysis-panel">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Thread freshness</span>
+          <b>{rollup ? `${rollup.runnableThreadIds.length} runnable stale evals` : "No group configured"}</b>
+        </div>
+        <p className="evals-analysis-copy">
+          Thread freshness compares evaluated-through turn, latest turn, rubric versions, confidence events, skills, permissions, and group policy.
+        </p>
+      </section>
+      <EvalGroupPanel group={group} states={states} rollup={rollup} queuedCount={queuedCount} onQueue={onQueue} />
+    </div>
+  );
+}
+
+function LoopRunList({ runs }: { runs: RetroRun[] }) {
+  if (runs.length === 0) return <p className="evals-runs-empty">No eval-loop runs recorded yet.</p>;
+  return (
+    <ul className="evals-loop-run-list">
+      {runs.map((run) => (
+        <li key={run.id} className="evals-loop-run">
+          <span className={`evals-chip${run.outcome === "ACCEPT" ? " is-pass" : " is-fail"}`}>{run.outcome === "ACCEPT" ? "ACCEPT" : "REVERT"}</span>
+          <b>{run.familiarName}</b>
+          <span>{run.track} · iteration {run.iteration}</span>
+          <small>{run.changeSummary}</small>
+        </li>
+      ))}
+    </ul>
+  );
 }
 
 function EvalGroupPanel({

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -205,9 +205,9 @@ export function FamiliarGrowthView({
           >
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
           </button>
-          <a className="retro-btn" href="/dashboard/retro">
+          <a className="retro-btn" href="/dashboard?view=evals">
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
-            Eval Loops
+            Evals
           </a>
         </div>
       </header>

--- a/src/components/retro-runs-view.test.ts
+++ b/src/components/retro-runs-view.test.ts
@@ -3,16 +3,22 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 
 const component = readFileSync(new URL("./retro-runs-view.tsx", import.meta.url), "utf8");
+const evals = readFileSync(new URL("./evals/evals-view.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
 const settings = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 const slash = readFileSync(new URL("../lib/slash-commands.ts", import.meta.url), "utf8");
+const commandPalette = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
 const apiRoute = readFileSync(new URL("../app/api/retro-runs/route.ts", import.meta.url), "utf8");
 const evalLoopRoute = readFileSync(new URL("../app/api/skills/eval-loop/[familiarId]/route.ts", import.meta.url), "utf8");
+const dashboardRetroPage = readFileSync(new URL("../app/dashboard/retro/page.tsx", import.meta.url), "utf8");
+const retroRedirectPage = readFileSync(new URL("../app/retro/page.tsx", import.meta.url), "utf8");
 const retroPageUrl = new URL("../app/dashboard/retro/page.tsx", import.meta.url);
 
-assert.equal(existsSync(retroPageUrl), true, "dedicated /dashboard/retro page exists");
+assert.equal(existsSync(retroPageUrl), true, "legacy /dashboard/retro page still exists as a redirect");
+assert.match(dashboardRetroPage, /redirect\("\/dashboard\?view=evals"\)/, "legacy /dashboard/retro redirects to unified Evals");
+assert.match(retroRedirectPage, /redirect\("\/dashboard\?view=evals"\)/, "legacy /retro redirects to unified Evals");
 assert.match(
   component,
   /familiarId \? `\/api\/retro-runs\?familiarId=\$\{encodeURIComponent\(familiarId\)\}` : "\/api\/retro-runs"/,
@@ -26,18 +32,22 @@ assert.match(component, /ariaLabel="Eval loop track filter"/, "track filter tabl
 assert.match(component, /aria-label="Refresh eval loops"/, "refresh is an icon button with an accessible name");
 assert.match(apiRoute, /redactSecretsDeep/, "aggregate retro API redacts daemon data at the route boundary");
 assert.match(evalLoopRoute, /redactSecretsDeep/, "per-familiar eval-loop proxy redacts daemon data too");
-assert.match(workspace, /retro: "Eval Loops"/, "workspace has an Eval Loops mode title");
+assert.match(evals, /RetroRunsView/, "unified Evals embeds the sanitized eval-loop run list");
+assert.match(evals, /EvalLoopPanel/, "unified Evals embeds eval-loop run and recovery controls");
+assert.match(workspace, /retro: "Evals"/, "legacy retro mode is titled as Evals");
 assert.match(
   workspace,
   /const retroFamiliarId = activeId \?\? familiars\[0\]\?\.id \?\? null/,
-  "workspace Retro mode should collapse All familiars to one familiar instead of aggregating every familiar",
+  "workspace keeps a familiar fallback for legacy retro mode",
 );
-assert.match(workspace, /<RetroRunsView familiarId=\{retroFamiliarId\}/, "workspace renders Retro Runs scoped to one familiar");
-assert.match(sidebar, /\{ id: "retro", label: "Eval Loops"/, "desktop sidebar should expose Eval Loops as an optional surface");
-assert.match(sidebar, /if \(fm\.id === "retro"\) return addons\?\.retro === true;/, "Eval Loops sidebar row should be add-on gated");
-assert.match(settings, /\|\s*"retro"/, "Settings add-on keys should include retro");
-assert.match(settings, /key: "retro"[\s\S]{0,120}label: "Eval Loops"/, "Settings should expose the Eval Loops add-on");
-assert.match(slash, /name: "\/evals"[\s\S]{0,120}Eval Loops/, "slash command catalog should include /evals for Eval Loops");
+assert.match(workspace, /mode === "evals" \|\| mode === "retro"/, "workspace renders unified Evals for canonical and legacy modes");
+assert.doesNotMatch(sidebar, /\{ id: "retro", label: "Eval Loops"/, "desktop sidebar should not expose a duplicate Eval Loops surface");
+assert.doesNotMatch(sidebar, /if \(fm\.id === "retro"\) return addons\?\.retro === true;/, "sidebar should not gate a removed retro add-on");
+assert.doesNotMatch(commandPalette, /if \(fm\.id === "retro"\) return addons\?\.retro === true;/, "command palette should not expose a duplicate retro add-on");
+assert.doesNotMatch(settings, /\|\s*"retro"/, "Settings add-on keys should not include retro");
+assert.doesNotMatch(settings, /key: "retro"[\s\S]{0,120}label: "Eval Loops"/, "Settings should not expose a duplicate Eval Loops add-on");
+assert.match(slash, /name: "\/evals"[\s\S]{0,120}Open Evals/, "slash command catalog should open unified Evals");
+assert.match(slash, /aliases: \["\/eval-loops"\]/, "slash command keeps /eval-loops as a compatibility alias");
 assert.doesNotMatch(mobileTabs, /id: "retro"/, "mobile bottom tabs should not expose a Retro tab");
 
 console.log("retro-runs-view.test.ts: ok");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -499,7 +499,6 @@ type AddonKey =
   | "roles"
   | "groupchat"
   | "journal"
-  | "retro"
   | "docs";
 
 const ADDON_ROWS: Array<{
@@ -573,13 +572,6 @@ const ADDON_ROWS: Array<{
     icon: "ph:book-open",
     group: "surfaces",
     description: "Your daily journal and generated sketches.",
-  },
-  {
-    key: "retro",
-    label: "Eval Loops",
-    icon: "ph:arrows-clockwise-bold",
-    group: "surfaces",
-    description: "Run, inspect, and recover familiar eval loops.",
   },
   {
     key: "docs",

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -53,7 +53,6 @@ export type AddonsConfig = {
   groupchat?: boolean;
   journal?: boolean;
   docs?: boolean;
-  retro?: boolean;
 };
 
 export type SidebarMinimalProps = {
@@ -113,7 +112,6 @@ const FOLDER_MODES: Array<{
   { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘8", description: "Chat with a familiar beside your files and terminal" },
   { id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘0", description: "Saved docs, links, and reading" },
   { id: "docs", label: "Coven", iconName: "ph:book-bookmark", group: "tools", description: "OpenCoven docs, feedback, and social tabs" },
-  { id: "retro", label: "Eval Loops", iconName: "ph:arrows-clockwise-bold", group: "tools", description: "Run and inspect familiar eval loops" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, skills, and the capabilities your familiars can use" },
   { id: "flow", label: "Flow", iconName: "ph:flow-arrow", group: "tools", description: "Freeform n8n-style automation editor — wire nodes on a canvas" },
   { id: "evals", label: "Evals", iconName: "ph:flask", group: "tools", description: "Run test-case eval suites against a familiar and track pass rates" },
@@ -262,7 +260,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     if (fm.id === "groupchat") return addons?.groupchat === true;
     if (fm.id === "journal") return addons?.journal === true;
     if (fm.id === "docs") return addons?.docs === true;
-    if (fm.id === "retro") return addons?.retro === true;
     return true;
   });
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -48,7 +48,6 @@ import { PluginsView } from "@/components/plugins-view";
 import { OpenCovenSubmissionPage } from "@/components/opencoven-submission-page";
 import { FlowView } from "@/components/flow/flow-view";
 import { EvalsView } from "@/components/evals/evals-view";
-import { RetroRunsView } from "@/components/retro-runs-view";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface, type RightPanelKind } from "@/components/chat-surface";
@@ -93,7 +92,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   flow: "Flow",
   evals: "Evals",
   submissions: "Submissions",
-  retro: "Eval Loops",
+  retro: "Evals",
   capabilities: "Capabilities",
   journal: "Journal",
   docs: "Coven",
@@ -1476,7 +1475,7 @@ export function Workspace() {
         return true;
       case "/evals":
       case "/eval-loops":
-        setMode("retro");
+        setMode("evals");
         return true;
       case "/remind": {
         const trimmedArgs = args.trim();
@@ -1971,10 +1970,8 @@ export function Workspace() {
       <OpenCovenSubmissionPage />
     ) : mode === "flow" ? (
       <FlowView />
-    ) : mode === "evals" ? (
-      <EvalsView familiars={resolvedFamiliars} activeFamiliarId={activeId} />
-    ) : mode === "retro" ? (
-      <RetroRunsView familiarId={retroFamiliarId} />
+    ) : mode === "evals" || mode === "retro" ? (
+      <EvalsView familiars={resolvedFamiliars} activeFamiliarId={mode === "retro" ? retroFamiliarId : activeId} />
     ) : mode === "calendar" ? (
       <CalendarView
         items={inboxItems}

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -43,7 +43,7 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/board", hint: "Tasks", description: "Open the Tasks kanban and table view.", section: "view" },
   { name: "/chats", hint: "Chats", description: "Switch back to the Chats view.", section: "view" },
   { name: "/automations", hint: "Automations", description: "Open Automations.", section: "view" },
-  { name: "/evals", aliases: ["/eval-loops"], hint: "Eval Loops", description: "Open Eval Loops.", section: "view" },
+  { name: "/evals", aliases: ["/eval-loops"], hint: "Open Evals", description: "Open Evals.", section: "view" },
   { name: "/remind", hint: "new reminder", description: "Create a reminder. Try “/remind in 30m check the build”.", argPlaceholder: "when + text", section: "view" },
 
   { name: "/terminal", aliases: ["/comux"], hint: "Terminal", description: "Open the integrated terminal view.", section: "view" },

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -84,6 +84,7 @@
   flex-direction: column;
   min-height: 0;
   min-width: 0;
+  overflow: hidden;
 }
 .evals-toolbar {
   display: flex;
@@ -91,6 +92,22 @@
   gap: var(--space-2);
   padding: var(--space-2) var(--space-3);
   border-bottom: 1px solid var(--border-hairline);
+}
+.evals-unified-toolbar {
+  align-items: stretch;
+}
+.evals-title-block {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+}
+.evals-title-block h2 {
+  margin: 0;
+  font-size: var(--text-md);
+  line-height: 1.2;
 }
 .evals-name-input {
   flex: 0 1 auto;
@@ -144,6 +161,15 @@
 .evals-tab:hover { color: var(--text-primary); }
 .evals-tab.is-active { background: var(--bg-elevated); color: var(--text-primary); }
 .evals-toolbar-actions { display: inline-flex; align-items: center; gap: 6px; }
+.evals-section-tabs {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+  border-radius: 0;
+  background: var(--bg-panel);
+  overflow-x: auto;
+}
 
 .evals-btn {
   display: inline-flex;
@@ -190,6 +216,165 @@
   animation: evals-spin 0.7s linear infinite;
 }
 @keyframes evals-spin { to { transform: rotate(360deg); } }
+
+/* ---- Unified analysis --------------------------------------------------- */
+.evals-analysis-summary {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(120px, 1fr));
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+}
+.evals-analysis-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 2px 8px;
+  min-width: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+}
+.evals-analysis-card svg {
+  grid-row: span 3;
+  color: var(--accent-presence);
+}
+.evals-analysis-card span,
+.evals-analysis-card small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.evals-analysis-card span {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.evals-analysis-card b {
+  font-size: var(--text-lg);
+  line-height: 1.15;
+}
+.evals-analysis-card small {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+.evals-overview,
+.evals-loop-analysis,
+.evals-thread-freshness {
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-3);
+}
+.evals-overview {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+}
+.evals-loop-analysis {
+  display: grid;
+  grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+  gap: var(--space-3);
+}
+.evals-loop-analysis > .retro-surface {
+  grid-column: 1 / -1;
+  min-height: 420px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+}
+.evals-thread-freshness {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.evals-analysis-panel {
+  min-width: 0;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-raised);
+}
+.evals-section-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+}
+.evals-section-head b {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.evals-section-head .evals-btn {
+  margin-left: auto;
+}
+.evals-insight-list,
+.evals-loop-run-list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-3);
+}
+.evals-insight-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+.evals-insight-list li {
+  padding-left: var(--space-2);
+  border-left: 2px solid color-mix(in oklch, var(--accent-presence) 45%, var(--border));
+}
+.evals-analysis-copy {
+  margin: 0;
+  padding: var(--space-3);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+.evals-loop-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+}
+.evals-loop-run-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.evals-loop-run {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 2px 8px;
+  align-items: center;
+  padding: var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-panel);
+}
+.evals-loop-run b,
+.evals-loop-run span,
+.evals-loop-run small {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.evals-loop-run small {
+  grid-column: 2 / -1;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+.evals-loop-control {
+  overflow: hidden;
+}
 
 /* ---- Eval groups -------------------------------------------------------- */
 .evals-group-panel {
@@ -474,7 +659,38 @@
 .evals-grader-result-label { font-weight: 600; color: var(--text-primary); }
 .evals-grader-result-detail { color: var(--text-muted); }
 
+@media (max-width: 1120px) {
+  .evals-analysis-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .evals-overview,
+  .evals-loop-analysis {
+    grid-template-columns: 1fr;
+  }
+  .evals-loop-analysis > .retro-surface {
+    grid-column: auto;
+  }
+}
+
 @media (max-width: 720px) {
   .evals { grid-template-columns: 1fr; }
   .evals-rail { display: none; }
+  .evals-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .evals-analysis-summary,
+  .evals-overview,
+  .evals-loop-analysis {
+    grid-template-columns: 1fr;
+  }
+  .evals-loop-analysis > .retro-surface {
+    grid-column: auto;
+  }
+  .evals-loop-run {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+  .evals-loop-run > span:not(.evals-chip) {
+    grid-column: 2;
+  }
 }


### PR DESCRIPTION
## Summary
- Merge the separate Evals and Eval Loops surfaces into one analysis-first Evals workspace.
- Add overview metrics for suite runs, pass-rate trend, loop accept/revert counts, running loop state, stale grouped threads, and queued evals.
- Keep legacy retro routes and /eval-loops compatibility as redirects/aliases while removing the duplicate sidebar/settings surface.

## Verification
- node --experimental-strip-types --test src/components/evals/evals-view.test.ts src/components/retro-runs-view.test.ts src/components/eval-loop-panel.test.ts src/components/surface-error-states.test.ts src/components/surface-loading-states.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check
- pnpm test:app