### PR TITLE
feat(evals): migrate eval-discuss threads out of the chat list into the Evals page

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -23,6 +23,7 @@ import {
   stripPreviewOnlyAttachmentFields,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
+import type { SessionOrigin } from "@/lib/types";
 import { AssistantFilter } from "@/lib/chat-assistant-filter";
 import {
   flattenToolResultContent,
@@ -123,6 +124,9 @@ type SendBody = {
    *  Explicit null means "branch at the root" (sibling of a root turn) and is
    *  distinct from the field being absent (a normal, non-branch send). */
   parentTurnId?: string | null;
+  /** Provenance for a brand-new conversation (e.g. "eval"). Stamped on the
+   *  conversation file once, when it's first created. */
+  origin?: SessionOrigin;
 };
 
 type ReasoningEffort = "low" | "medium" | "high";
@@ -720,6 +724,7 @@ function openClawChatResponse(args: {
             model: responseMetadata.model,
             runtime: responseMetadata.runtime,
             title: chatTitle,
+            ...(args.body.origin ? { origin: args.body.origin } : {}),
             createdAt: now,
             updatedAt: now,
             turns: [],
@@ -1512,6 +1517,7 @@ export async function POST(req: Request) {
           model: responseMetadata.model,
           runtime: responseMetadata.runtime,
           title: chatTitle,
+          ...(body.origin ? { origin: body.origin } : {}),
           createdAt: now,
           updatedAt: now,
           turns: [],

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -34,7 +34,7 @@ assert.match(
 
 assert.match(
   chatRouter,
-  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null\)/,
+  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null, origin\?: SessionOrigin\)/,
   "Imperative new-chat launches should carry a familiar id with the project root",
 );
 

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -24,11 +24,11 @@ import {
   selectionKey,
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
-import type { Familiar, SessionRow } from "@/lib/types";
+import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 
 type View =
   | { kind: "list" }
-  | { kind: "chat"; sessionId: string | null; projectRoot?: string; initialPrompt?: string; familiarId?: string | null };
+  | { kind: "chat"; sessionId: string | null; projectRoot?: string; initialPrompt?: string; familiarId?: string | null; origin?: SessionOrigin };
 
 type Props = {
   familiar: Familiar | null;
@@ -57,7 +57,7 @@ type Props = {
 
 export type ChatRouterHandle = {
   goToList: () => void;
-  newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null) => void;
+  newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin) => void;
   openSession: (sessionId: string, findQuery?: string) => void;
   currentSessionId: () => string | null;
   clearTranscript: () => void;
@@ -237,6 +237,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
                 projectRoot: prev.projectRoot,
                 initialPrompt: prev.initialPrompt,
                 familiarId: nextFamiliarId,
+                origin: prev.origin,
               }
         : { kind: "list" },
     );
@@ -246,7 +247,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     ref,
     () => ({
       goToList: () => setView({ kind: "list" }),
-      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null) => {
+      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin) => {
         const next = selectFamiliarForChat(familiarId);
         setView({
           kind: "chat",
@@ -254,6 +255,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           projectRoot,
           initialPrompt,
           familiarId: next?.id ?? familiarId ?? null,
+          origin,
         });
       },
       openSession: (sessionId: string, findQuery?: string) => {
@@ -342,6 +344,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             sessionId: null,
             projectRoot: view.kind === "chat" ? view.projectRoot : undefined,
             initialPrompt: view.kind === "chat" ? view.initialPrompt : undefined,
+            origin: view.kind === "chat" ? view.origin : undefined,
             familiarId: next?.id ?? familiarId,
           });
         }}
@@ -399,6 +402,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             session={activeSession}
             projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
             initialPrompt={view.kind === "chat" ? view.initialPrompt : undefined}
+            origin={view.kind === "chat" ? view.origin : undefined}
             openFindQuery={pendingFind?.query}
             openFindNonce={pendingFind?.nonce}
             daemonRunning={daemonRunning}

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -241,7 +241,7 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /newChat\(d\?\.projectRoot \?\? undefined, d\?\.initialPrompt \?\? undefined, d\?\.familiarId\)/,
+  /newChat\(d\?\.projectRoot \?\? undefined, d\?\.initialPrompt \?\? undefined, d\?\.familiarId, d\?\.origin\)/,
   "ChatSurface should forward the seeded initialPrompt into newChat",
 );
 

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -17,7 +17,7 @@ import { Icon } from "@/lib/icon";
 import { CodeInlineToolbar } from "@/components/code-inline-toolbar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
-import type { Familiar, SessionRow } from "@/lib/types";
+import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
 
 // ── Layout persistence ─────────────────────────────────────────────────────────
@@ -413,10 +413,10 @@ export function ChatSurface({
   // Window events
   useEffect(() => {
     const onNewChat = (e: Event) => {
-      const d = (e as CustomEvent<{ familiarId?: string | null; projectRoot?: string | null; initialPrompt?: string | null }>).detail;
+      const d = (e as CustomEvent<{ familiarId?: string | null; projectRoot?: string | null; initialPrompt?: string | null; origin?: SessionOrigin }>).detail;
       if (d?.familiarId) onSetActiveFamiliar(d.familiarId);
       setScope("conversation");
-      window.setTimeout(() => routerRef.current?.newChat(d?.projectRoot ?? undefined, d?.initialPrompt ?? undefined, d?.familiarId), 0);
+      window.setTimeout(() => routerRef.current?.newChat(d?.projectRoot ?? undefined, d?.initialPrompt ?? undefined, d?.familiarId, d?.origin), 0);
     };
     const onOpenSession = (e: Event) => {
       const d = (e as CustomEvent<{ sessionId?: string; familiarId?: string | null }>).detail;

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2,7 +2,7 @@
 
 import { forwardRef, Fragment, memo, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { createPortal } from "react-dom";
-import type { Familiar, SessionRow } from "@/lib/types";
+import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
 import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
 import { ChatArtifactViewer } from "@/components/chat-artifact-viewer";
@@ -216,6 +216,9 @@ type Props = {
   /** Prompt handed off from the home composer. Auto-sent once on mount so the
    *  send runs through this view's streaming path instead of a detached fetch. */
   initialPrompt?: string;
+  /** Provenance for a newly-created conversation (e.g. "eval" for eval-discuss
+   *  threads). Persisted on the conversation so it can be surfaced/hidden by origin. */
+  origin?: SessionOrigin;
   /** When set (with a changing nonce), opens the in-thread find on this query —
    *  used by the ⌘K Conversations result to jump to the matched message. */
   openFindQuery?: string;
@@ -1928,7 +1931,7 @@ function MobileChatActionStrip({
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
+  { familiar, sessionId, session, projectRoot, initialPrompt, origin, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -3164,6 +3167,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           familiarId: familiar.id,
           prompt: submitPrompt,
           ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(outgoingAttachments) } : {}),
+          ...(origin ? { origin } : {}),
           sessionId: liveGeneration.sessionId,
           projectRoot: activeProjectRoot,
           reasoningEffort: thinkingEffort,

--- a/src/components/evals/evals-view.test.ts
+++ b/src/components/evals/evals-view.test.ts
@@ -54,4 +54,10 @@ assert.match(source, /PASS|FAIL/, "shows pass/fail per case");
 // Empty state
 assert.match(source, /EmptyState/, "shows an empty state when there are no suites");
 
+// Migrated eval-discuss threads surfaced here instead of the chat list.
+assert.match(source, /fetch\("\/api\/sessions\/list"\)/, "loads sessions to find eval threads");
+assert.match(source, /s\.origin === "eval"/, "filters to eval-origin threads");
+assert.match(source, /className="evals-thread-row"/, "renders a list of eval discussion threads");
+assert.match(source, /cave:agents-open-session/, "opening a thread reopens it in the chat surface");
+
 console.log("evals-view.test.ts OK");

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type 
 import { Icon } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import type { SessionRow } from "@/lib/types";
 import {
   deriveThreadEvalState,
   rollupEvalGroup,
@@ -65,6 +66,16 @@ function newCase(): EvalCase {
   return { id: freshId("case"), name: "New case", input: "", graders: [{ kind: "contains", value: "" }] };
 }
 
+/** Open a migrated eval-discuss thread back in the chat surface. */
+function openEvalThread(session: SessionRow) {
+  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } }));
+  window.dispatchEvent(
+    new CustomEvent("cave:agents-open-session", {
+      detail: { sessionId: session.id, familiarId: session.familiarId },
+    }),
+  );
+}
+
 export function EvalsView({ familiars, activeFamiliarId }: Props) {
   const [suites, setSuites] = useState<EvalSuite[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -75,6 +86,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
   const [groups, setGroups] = useState<EvalGroup[]>([]);
   const [threadSnapshots, setThreadSnapshots] = useState<ThreadEvalSnapshot[]>([]);
   const [queue, setQueue] = useState<ManualEvalQueueItem[]>([]);
+  const [evalThreads, setEvalThreads] = useState<SessionRow[]>([]);
   const [tab, setTab] = useState<"editor" | "runs">("editor");
   const [saving, setSaving] = useState(false);
   const [running, setRunning] = useState(false);
@@ -100,22 +112,26 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     let alive = true;
     void (async () => {
       try {
-        const [suitesRes, groupsRes, threadStatesRes, queueRes] = await Promise.all([
+        const [suitesRes, groupsRes, threadStatesRes, queueRes, sessionsRes] = await Promise.all([
           fetch("/api/evals/suites"),
           fetch("/api/evals/groups"),
           fetch("/api/evals/thread-states"),
           fetch("/api/evals/queue"),
+          fetch("/api/sessions/list"),
         ]);
         const data = (await suitesRes.json()) as { ok: boolean; suites?: EvalSuite[] };
         const groupsData = (await groupsRes.json()) as { ok: boolean; groups?: EvalGroup[] };
         const threadStatesData = (await threadStatesRes.json()) as { ok: boolean; snapshots?: ThreadEvalSnapshot[] };
         const queueData = (await queueRes.json()) as { ok: boolean; queue?: ManualEvalQueueItem[] };
+        const sessionsData = (await sessionsRes.json()) as { ok: boolean; sessions?: SessionRow[] };
         if (!alive) return;
         const list = data.suites ?? [];
         setSuites(list);
         setGroups(groupsData.groups ?? []);
         setThreadSnapshots(threadStatesData.snapshots ?? []);
         setQueue(queueData.queue ?? []);
+        // Eval-discuss chat threads, migrated out of the chat list into the Evals page.
+        setEvalThreads((sessionsData.sessions ?? []).filter((s) => s.origin === "eval"));
         if (list.length) selectSuite(list[0]);
       } finally {
         if (alive) setLoaded(true);
@@ -261,7 +277,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     if (data.ok && data.queued) setQueue((prev) => [...data.queued!, ...prev]);
   }, [activeGroup, activeGroupStates]);
 
-  if (loaded && suites.length === 0 && !draft) {
+  if (loaded && suites.length === 0 && evalThreads.length === 0 && !draft) {
     return (
       <div className="evals evals-empty">
         <EmptyState
@@ -301,6 +317,29 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
             </li>
           ))}
         </ul>
+        {evalThreads.length > 0 && (
+          <div className="evals-threads">
+            <div className="evals-threads-head">
+              <span>Discussion threads</span>
+              <span className="evals-threads-count">{evalThreads.length}</span>
+            </div>
+            <ul className="evals-thread-list">
+              {evalThreads.map((thread) => (
+                <li key={thread.id}>
+                  <button
+                    type="button"
+                    className="evals-thread-row"
+                    onClick={() => openEvalThread(thread)}
+                    title="Open this eval discussion in chat"
+                  >
+                    <Icon name="ph:chat-circle-dots" width={13} aria-hidden />
+                    <span className="evals-thread-title">{thread.title || "Eval discussion"}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
       </aside>
 
       {draft ? (

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -135,6 +135,7 @@ describe("aggregateThreadSignals", () => {
     assert.match(source, /buildThreadSignalDiscussionPrompt/, "seeds the chat with a topic-specific prompt");
     assert.match(source, /new CustomEvent\("cave:agents-new-chat"/, "opens a new chat with the familiar");
     assert.match(source, /initialPrompt: buildThreadSignalDiscussionPrompt\(item\)/, "primes the chat with the selected item");
+    assert.match(source, /origin: "eval"/, "tags the thread as an eval origin so it migrates to the Evals page");
     assert.match(source, /className="fa-thread-review-item"[\s\S]*onClick=\{\(\) => discussReviewItem\(familiarId, item\)\}/, "each review item is a clickable button");
   });
 });

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -61,7 +61,8 @@ function ListBlock<T>({
 function discussReviewItem(familiarId: string, item: ThreadSignalReviewItem) {
   window.dispatchEvent(
     new CustomEvent("cave:agents-new-chat", {
-      detail: { familiarId, initialPrompt: buildThreadSignalDiscussionPrompt(item) },
+      // origin "eval" routes this thread to the Evals page and hides it from the chat list.
+      detail: { familiarId, initialPrompt: buildThreadSignalDiscussionPrompt(item), origin: "eval" as const },
     }),
   );
 }

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { homedir } from "node:os";
 import type { ChatResponseMetadata } from "./chat-response-metadata.ts";
 import type { ModelApplicationState, ModelScope } from "./chat-model-state.ts";
+import type { SessionOrigin } from "./types.ts";
 import { linearizeLegacy, resolveActivePath } from "./conversation-tree.ts";
 
 const CONV_DIR = path.join(homedir(), ".coven", "cave-conversations");
@@ -71,6 +72,9 @@ export type ConversationFile = {
   modelIntent?: ConversationModelIntent;
   runtime?: string;
   title?: string;
+  /** Provenance — defaults to "chat". "eval" threads are surfaced in the Evals
+   *  page and hidden from the chat list. */
+  origin?: SessionOrigin;
   createdAt: string;
   updatedAt: string;
   turns: ChatTurn[];
@@ -164,6 +168,7 @@ export async function listConversations(): Promise<
     model?: string;
     runtime?: string;
     title?: string;
+    origin?: SessionOrigin;
     status?: string;
     exitCode?: number | null;
     createdAt?: string;
@@ -184,6 +189,7 @@ export async function listConversations(): Promise<
     model?: string;
     runtime?: string;
     title?: string;
+    origin?: SessionOrigin;
     status?: string;
     exitCode?: number | null;
     createdAt?: string;
@@ -203,6 +209,7 @@ export async function listConversations(): Promise<
           model: conv.model,
           runtime: conv.runtime,
           title: conv.title,
+          origin: conv.origin,
           status: terminal.status,
           exitCode: terminal.exitCode,
           createdAt: conv.createdAt,

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -97,4 +97,12 @@ assert.deepEqual(
   "duplicate worktree repo names should include the parent directory so branches are distinguishable",
 );
 
+// Eval-discuss threads are migrated to the Evals page and hidden from the chat list.
+{
+  const evalThread = { ...session("eval-1", "/work/alpha", "2026-06-09T00:00:00.000Z", "cody"), origin: "eval" as const };
+  const visible = filterVisibleChatSessions([...sessions, evalThread], null);
+  assert.ok(!visible.some((s) => s.id === "eval-1"), "eval-origin sessions are excluded from the chat list");
+  assert.ok(visible.some((s) => s.id === "beta"), "ordinary chat sessions still show");
+}
+
 console.log("chat-projects.test.ts: ok");

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -66,6 +66,8 @@ export function filterVisibleChatSessions(
 ): SessionRow[] {
   return sessions
     .filter((session) => !DEAD_CHAT_STATUSES.has(session.status))
+    // Eval-discuss threads live in the Evals page, not the chat list.
+    .filter((session) => session.origin !== "eval")
     .filter((session) => familiarId === null || session.familiarId === familiarId)
     .sort((a, b) => (sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1));
 }

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -229,4 +229,12 @@ assert.equal(
 );
 assert.equal(recoveredStatus[0].exit_code, 0, "newer Cave-local transcript exit code should win");
 
+// An eval-discuss conversation carries its origin through to the session row.
+const evalRows = localConversationSessionRows(
+  [{ ...localConversation, sessionId: "eval-9", origin: "eval" }],
+  { sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {} },
+  false,
+);
+assert.equal(evalRows[0].origin, "eval", "conversation origin 'eval' maps to the session origin");
+
 console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -5,7 +5,7 @@ import {
 } from "./cave-chat-titles.ts";
 import { initiatorFromSessionKey } from "./session-initiator.ts";
 import { inferOrigin } from "./session-origin.ts";
-import type { SessionInitiator, SessionRow } from "./types.ts";
+import type { SessionInitiator, SessionOrigin, SessionRow } from "./types.ts";
 
 export type DaemonSessionRow = Omit<SessionRow, "familiarId" | "origin">;
 
@@ -21,6 +21,7 @@ export type LocalConversationSummary = {
   createdAt?: string;
   updatedAt: string;
   initiator?: SessionInitiator;
+  origin?: SessionOrigin;
 };
 
 type MergeOptions = {
@@ -52,7 +53,7 @@ function localConversationToSession(
     created_at: conv.createdAt ?? conv.updatedAt,
     updated_at: conv.updatedAt,
     familiarId,
-    origin: "chat",
+    origin: conv.origin ?? "chat",
     initiator: conv.initiator ?? { kind: "human", label: "Cave user", channel: "cave" },
   };
 }

--- a/src/lib/session-origin.ts
+++ b/src/lib/session-origin.ts
@@ -8,6 +8,7 @@ export const SESSION_ORIGINS: readonly SessionOrigin[] = [
   "cron",
   "heartbeat",
   "call",
+  "eval",
 ] as const;
 
 export const ORIGIN_LABEL: Record<SessionOrigin, string> = {
@@ -17,6 +18,7 @@ export const ORIGIN_LABEL: Record<SessionOrigin, string> = {
   cron: "cron",
   heartbeat: "heartbeat",
   call: "call",
+  eval: "eval",
 };
 
 export const ORIGIN_ICON: Record<SessionOrigin, IconName> = {
@@ -26,6 +28,7 @@ export const ORIGIN_ICON: Record<SessionOrigin, IconName> = {
   cron: "ph:alarm-fill",
   heartbeat: "ph:heartbeat",
   call: "ph:magic-wand-fill",
+  eval: "ph:flask",
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,7 +89,10 @@ export type SessionOrigin =
   | "board"
   | "cron"
   | "heartbeat"
-  | "call";
+  | "call"
+  // Eval-discuss threads — created from the analytics review queue. Surfaced in
+  // the Evals page, not the chat list.
+  | "eval";
 
 export type SessionInitiator = {
   kind: "human" | "familiar" | "system" | "unknown";

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -44,6 +44,65 @@
   flex-direction: column;
   gap: 2px;
 }
+
+/* Migrated eval-discuss threads — surfaced here instead of the chat list. */
+.evals-threads {
+  margin-top: auto;
+  border-top: 1px solid var(--border-hairline);
+  padding: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-height: 0;
+}
+.evals-threads-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 7px 6px;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.evals-threads-count {
+  padding: 0 6px;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-elevated));
+  color: var(--text-secondary);
+}
+.evals-thread-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.evals-thread-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  text-align: left;
+  padding: 6px 8px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+.evals-thread-row:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, var(--border));
+}
+.evals-thread-row svg { flex: 0 0 auto; color: var(--accent-presence); }
+.evals-thread-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .evals-suite-row {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

Eval-discuss chats — opened from the analytics review queue (#2028) — were piling up in the chat thread list. This gives them a real provenance and **migrates them out of the chat page into the Evals page**, where they belong.

## How (full `eval` origin plumb)

- **New `eval` `SessionOrigin`** (type + label + flask icon).
- **Origin threaded end-to-end:** the `cave:agents-new-chat` event carries `origin` → `ChatSurface.onNewChat` → `ChatRouter.newChat` → `ChatView` → the `/api/chat/send` body, which stamps `conv.origin` on the **new conversation file**. `listConversations` + `localConversationToSession` then carry it onto the `SessionRow`.
- **Tagged at source:** `discussReviewItem` dispatches `origin: "eval"`.
- **Hidden from chat:** `filterVisibleChatSessions` excludes `origin === "eval"`.
- **Surfaced in Evals:** a new **"Discussion threads"** rail section lists eval threads; selecting one reopens it in chat (`cave:navigate-mode` + `cave:agents-open-session`).

## Verification

- `tsc`: 0 errors · `next build`: pass · `check:tests-wired`: clean
- Added tests: `chat-projects` (eval hidden from list), `session-list-merge` (origin maps through), `thread-signals-section` (tags origin), `evals-view` (threads section). Updated two source-text tests that pinned the old `newChat` signature.
- Full suite: **627 test files pass** (app + mobile + api)

Note: eval-*loop* runs are daemon skill-state and don't create chat threads, so this covers the eval-*discuss* threads (the only eval chats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)