### PR TITLE
Release v0.0.123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.123] - 2026-06-28
+
+Patch release on top of v0.0.122. Headline: desktop updates and the app header
+are easier to use across macOS, Windows, and Linux.
+
+### Fixed
+
+- **Updates** - when the native desktop updater cannot finish installing, the
+  Download action now resolves the direct platform installer through release
+  metadata instead of dropping users on the generic releases page.
+- **Desktop header** - the app header stays contained on one row and keeps
+  controls clickable in macOS titlebar mode while shrinking cleanly on
+  macOS, Windows, and Linux.
+
 ## [0.0.122] - 2026-06-28
 
 Patch release on top of v0.0.121. Headline: chat generation state now survives

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.122"
+version = "0.0.123"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.122"
+version = "0.0.123"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.122</string>
+	<string>0.0.123</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.122</string>
+	<string>0.0.123</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.122</string>
+	<string>0.0.123</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.122</string>
+	<string>0.0.123</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.122",
+  "version": "0.0.123",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4055,20 +4055,26 @@ button:active > .edge-rail-chip {
 .shell-top {
   display: flex;
   align-items: center;
+  flex-wrap: nowrap;
   flex: 0 0 auto;
   min-height: 44px;
   gap: 8px;
   padding-inline: 12px;
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border-hairline);
+  overflow: hidden;
 }
 
 .shell-top__bar {
+  display: flex;
+  align-items: center;
   flex: 1 1 auto;
   min-width: 0;
+  overflow: hidden;
 }
 
 .shell-top .menu-bar {
+  width: 100%;
   min-height: 44px;
   padding-inline: 0;
   border-bottom: 0;
@@ -4103,6 +4109,11 @@ button:active > .edge-rail-chip {
   ) {
     -webkit-app-region: drag;
     app-region: drag;
+  }
+
+  :root[data-tauri-titlebar] .shell-top * {
+    -webkit-app-region: no-drag;
+    app-region: no-drag;
   }
 
   :root[data-tauri-titlebar] .shell-top :is(
@@ -5154,6 +5165,8 @@ button:active > .edge-rail-chip {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  min-width: 0;
+  width: 100%;
   padding: 5px 12px;
   /* min-height (not a fixed height) so the bar grows with scaled-up content
      under screen magnification instead of clipping the search row. */
@@ -5162,6 +5175,7 @@ button:active > .edge-rail-chip {
   border-bottom: 1px solid var(--border-hairline);
   font-size: var(--text-sm);
   user-select: none;
+  overflow: hidden;
 }
 
 @media (min-width: 1024px) {

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -112,6 +112,21 @@ assert.match(
 );
 assert.match(
   css,
+  /:root\[data-tauri-titlebar\]\s+\.shell-top \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?app-region:\s*no-drag;/,
+  "macOS titlebar mode should carve every header descendant out of the drag region so controls stay clickable",
+);
+assert.match(
+  css,
+  /\.shell-top\s*\{[\s\S]*?flex-wrap:\s*nowrap;[\s\S]*?overflow:\s*hidden;/,
+  "the desktop shell header should stay one row and clip/contain crowded content instead of wrapping over controls",
+);
+assert.match(
+  css,
+  /\.menu-bar\s*\{[\s\S]*?min-width:\s*0;[\s\S]*?width:\s*100%;[\s\S]*?overflow:\s*hidden;/,
+  "the rendered desktop menu bar should shrink inside the shell header on macOS/Windows/Linux",
+);
+assert.match(
+  css,
   /\.shell-top-toggle\s*\{[\s\S]*?width:\s*28px;[\s\S]*?height:\s*28px;[\s\S]*?border:\s*1px solid var\(--border-hairline\);[\s\S]*?background:\s*var\(--bg-base\);/,
   "top-bar toggles match the row's compact bordered icon buttons",
 );

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -39,11 +39,16 @@ assert.match(src, /Downloading…/, "shows download progress");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
 
 // A failed native install must not dead-end: it captures the reason and offers
-// a working manual download (the release page) plus a retry, so the update is
-// always reachable even when downloadAndInstall/relaunch throws.
+// a working manual download plus a retry, so the update is always reachable
+// even when downloadAndInstall/relaunch throws. The manual path should resolve
+// the platform installer through the same fallback route instead of hardcoding
+// the releases page.
 assert.match(src, /phase: "failed"/, "tracks a dedicated failed state for a thrown install");
 assert.match(src, /message: err instanceof Error \? err\.message/, "captures the real failure reason instead of swallowing it");
-assert.match(src, /onClick=\{\(\) => void openExternalUrl\(RELEASES_PAGE\)\}/, "failed state offers a manual download to the release page");
+assert.match(src, /async function openManualDownload/, "centralizes manual-download fallback resolution");
+assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "manual download resolves a direct platform installer when release metadata is reachable");
+assert.match(src, /onClick=\{\(\) => void openManualDownload\(\)\}/, "failed state offers the same direct manual download path as fallback updates");
+assert.doesNotMatch(src, /onClick=\{\(\) => void openExternalUrl\(RELEASES_PAGE\)\}/, "failed state must not dead-end on the generic release page when a direct installer can be resolved");
 assert.match(src, />\s*Retry\s*</, "failed state offers a retry");
 
 console.log("update-available.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -106,6 +106,18 @@ async function resolveDownloadUrl(status: UpdateStatus): Promise<string> {
   }
 }
 
+/**
+ * Open the easiest reachable installer for the running desktop platform. This
+ * is used when the native updater cannot finish, so a broken install attempt
+ * still leaves the user one click from the DMG/MSI/AppImage when release
+ * metadata is available.
+ */
+async function openManualDownload(): Promise<void> {
+  const fb = await fetchFallbackStatus();
+  const url = fb ? await resolveDownloadUrl(fb) : RELEASES_PAGE;
+  await openExternalUrl(url);
+}
+
 type Resolved =
   | { kind: "current" }
   | { kind: "native"; version: string; update: TauriUpdate }
@@ -155,7 +167,7 @@ export function UpdateBannerTrigger() {
                   title: reason
                     ? `Update failed (${reason}) — download manually`
                     : "Update failed — download manually",
-                  cta: { label: "Download", onClick: () => void openExternalUrl(RELEASES_PAGE) },
+                  cta: { label: "Download", onClick: () => void openManualDownload() },
                   onDismiss: () => markDismissed(r.version),
                 });
               });
@@ -270,7 +282,7 @@ export function UpdateSettingsRow() {
         >
           Update failed
         </span>
-        <button type="button" onClick={() => void openExternalUrl(RELEASES_PAGE)} className={accentBtn}>
+        <button type="button" onClick={() => void openManualDownload()} className={accentBtn}>
           <Icon name="ph:arrow-square-out" width={12} />
           Download
         </button>


### PR DESCRIPTION
## Summary
- make failed native desktop updates fall back to the direct platform installer when release metadata is available
- keep the desktop header contained on one row and preserve clickable controls in macOS titlebar mode
- bump release metadata/changelog to v0.0.123

## Verification
- pnpm exec node src/components/update-available.test.ts && pnpm exec node src/components/shell-edge-rails.test.ts && pnpm exec node src/components/top-bar.test.ts && pnpm exec node src/components/misc-aria-fixes.test.ts && pnpm exec node src/app/api/app/latest-release/route.test.ts && pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app
- pnpm exec node scripts/release-notes.test.mjs
- bash scripts/release-notes.sh v0.0.123 v0.0.122
- pnpm typecheck
- pnpm test:app
- pnpm build
- cargo check (src-tauri)
- git diff --check