### PR TITLE
feat: merge Calendar into the Automations surface (one schedule page)

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -57,6 +57,12 @@ type Props = {
   onNewReminder?: () => void;
   onEdit?: (item: InboxItem) => void;
   onOpenLink?: (link: LinkRef) => void;
+  /** When provided, adds a "Calendar" tab that renders this node full-height.
+   *  Lets the Calendar surface live inside Automations as one schedule page
+   *  without coupling this view to CalendarView's prop shape. */
+  calendarSlot?: ReactNode;
+  /** Tab to open on mount (deep-link target — e.g. the Calendar nav button). */
+  initialTab?: AutomationTab;
 };
 
 function linkLabel(link: LinkRef): string {
@@ -68,8 +74,10 @@ function linkLabel(link: LinkRef): string {
 
 // The Automations surface unifies three primitives under one typed model:
 // reminders, crons (Codex automations), and flows — plus an Activity
-// feed (the full inbox). "all" shows every automation in one list.
-type AutomationTab = "all" | "reminders" | "crons" | "flows" | "activity";
+// feed (the full inbox). "all" shows every automation in one list. "calendar"
+// (only present when a calendarSlot is supplied) hosts the Calendar surface so
+// the two former top-level pages share one schedule view.
+type AutomationTab = "all" | "reminders" | "crons" | "flows" | "activity" | "calendar";
 
 // Fire a cross-surface navigation so "Open" on a flow jumps to its
 // dedicated editor surface (the Workspace owns setMode; see cave:navigate-mode).
@@ -1616,7 +1624,7 @@ function FlowList({
 }
 
 // ── Root ──────────────────────────────────────────────────────────────────────
-export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink }: Props) {
+export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdit, onOpenLink, calendarSlot, initialTab }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const confirm = useConfirm(); // still used by "Run now" (a non-delete action)
   // Deferred + undoable deletes (reminders, automations, bulk): rows hide at
@@ -1629,7 +1637,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const [error, setError] = useState<string | null>(null);
   const [initialLoadDone, setInitialLoadDone] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<AutomationTab>("all");
+  const [activeTab, setActiveTab] = useState<AutomationTab>(
+    initialTab && (initialTab !== "calendar" || calendarSlot) ? initialTab : "all",
+  );
   const [newMenuOpen, setNewMenuOpen] = useState(false);
   // Selected item is either an InboxItem or a CodexAutomation — track by kind
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
@@ -2124,7 +2134,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               Automations
             </h1>
             <p className="mt-0.5 text-[12px]" style={{ color: "var(--text-muted)" }}>
-              Reminders, crons, and flows — everything that runs for you, in one place.
+              {activeTab === "calendar"
+                ? "Your reminders, crons, and deadlines on a calendar."
+                : "Reminders, crons, and flows — everything that runs for you, in one place."}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -2189,6 +2201,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             value={activeTab}
             onChange={selectTab}
             items={[
+              ...(calendarSlot ? [{ id: "calendar" as const, label: "Calendar" }] : []),
               { id: "all", label: "All", count: allEntries.length },
               { id: "reminders", label: "Reminders", count: typeCounts.reminder },
               { id: "crons", label: "Crons", count: typeCounts.cron },
@@ -2200,7 +2213,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
         {/* Text filter for the active tab. Gated on the UNfiltered presence of
             rows so filtering to zero never hides the box (you can still clear). */}
-        {initialLoadDone && !reminderSelect.selectMode && (
+        {activeTab !== "calendar" && initialLoadDone && !reminderSelect.selectMode && (
           activeTab === "all" ? typeCounts.reminder + typeCounts.cron + typeCounts.flow > 0
           : activeTab === "activity" ? items.length > 0
           : activeTab === "crons" ? codexAutos.length > 0
@@ -2241,9 +2254,11 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
           </div>
         )}
 
-        {/* List */}
-        <div className="flex-1 overflow-y-auto px-8 pb-8">
-          {!initialLoadDone ? (
+        {/* List (or the Calendar surface when that tab is active) */}
+        <div className={activeTab === "calendar" ? "flex-1 min-h-0 overflow-hidden" : "flex-1 overflow-y-auto px-8 pb-8"}>
+          {activeTab === "calendar" ? (
+            calendarSlot
+          ) : !initialLoadDone ? (
             <div className="space-y-2 pt-2">
               {Array.from({ length: 5 }).map((_, index) => (
                 <div

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { AutomationsView } from "@/components/automations-view";
 import type { Escalation } from "@/lib/escalations-types";
 import type { Familiar } from "@/lib/types";
@@ -14,6 +15,10 @@ type Props = {
   onEditReminder?: (item: InboxItem) => void;
   onOpenLink?: (link: LinkRef) => void;
   defaultTab?: "escalations" | "schedules";
+  /** Calendar surface rendered as the leading tab (merged schedule page). */
+  calendarSlot?: ReactNode;
+  /** Tab to open on mount — "calendar" deep-links the Calendar nav button. */
+  initialTab?: "all" | "reminders" | "crons" | "flows" | "activity" | "calendar";
 };
 
 export function InboxEscalationsView({
@@ -22,6 +27,8 @@ export function InboxEscalationsView({
   onOpenSession,
   onEditReminder,
   onOpenLink,
+  calendarSlot,
+  initialTab,
 }: Props) {
   return (
     <section className="h-full bg-background text-foreground">
@@ -31,6 +38,8 @@ export function InboxEscalationsView({
         onOpenSession={onOpenSession}
         onEdit={onEditReminder}
         onOpenLink={onOpenLink}
+        calendarSlot={calendarSlot}
+        initialTab={initialTab}
       />
     </section>
   );

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -52,7 +52,9 @@ assert.match(
 );
 assert.match(
   automations,
-  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\("all"\)/,
+  // Defaults to "all"; an optional initialTab (e.g. the Calendar deep-link)
+  // may override on mount.
+  /const \[activeTab, setActiveTab\] = useState<AutomationTab>\([\s\S]*?: "all",?\s*\)/,
   "Surface defaults to the unified All tab",
 );
 assert.match(automations, /<h1[\s\S]*?>\s*Automations\s*<\/h1>/, "Surface header reads Automations");

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -14,7 +14,9 @@ assert.match(
 );
 assert.match(
   inbox,
-  /\{!initialLoadDone \? \([\s\S]*?animate-pulse[\s\S]*?\) : activeTab === "reminders" && remindersEmpty \? \(/,
+  // The Calendar tab branch may precede this (calendarSlot is rendered first),
+  // so the skeleton ternary need not be the very first child of the list box.
+  /!initialLoadDone \? \([\s\S]*?animate-pulse[\s\S]*?\) : activeTab === "reminders" && remindersEmpty \? \(/,
   "Schedules shows a skeleton before first load, ahead of the Reminders empty state",
 );
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1923,8 +1923,14 @@ export function Workspace() {
       />
     ) : mode === "journal" ? (
       <JournalView familiars={familiars} activeFamiliarId={activeId} scopeFamiliarIds={scopeIds} />
-    ) : mode === "inbox" ? (
+    ) : mode === "inbox" || mode === "calendar" ? (
+      // Calendar and Automations are one "Schedule" surface: Calendar is the
+      // leading tab of the Automations view. The "calendar" mode still resolves
+      // here (nav button / deep links) but opens that tab; keying on the mode
+      // remounts so the deep link lands on it.
       <InboxEscalationsView
+        key={mode}
+        initialTab={mode === "calendar" ? "calendar" : "all"}
         onOpenSource={(item) => {
           if (item.sourceSessionKey) {
             openFamiliarSession(item.sourceSessionKey);
@@ -1943,6 +1949,36 @@ export function Workspace() {
           setReminderModalOpen(true);
         }}
         onOpenLink={openReminderLink}
+        calendarSlot={
+          <CalendarView
+            items={inboxItems}
+            familiars={familiars}
+            activeFamiliarId={calendarFamiliarId}
+            scopeFamiliarIds={scopeIds}
+            deadlines={boardDeadlines}
+            onOpenDeadline={(id) => {
+              setMode("board");
+              window.dispatchEvent(new Event("cave:board:reload"));
+              window.location.hash = `card-${id}`;
+            }}
+            onAddEntry={(defaults) => {
+              openReminderModal(
+                defaults?.title ?? "",
+                defaults?.whenText ?? "",
+                defaults?.fireAt ?? "",
+              );
+            }}
+            onOpenItem={(item) => {
+              if (item.sessionId) {
+                openFamiliarSession(item.sessionId, item.familiarId);
+              }
+            }}
+            onComplete={completeInboxItem}
+            onDismiss={dismissInboxItem}
+            onSnooze={snoozeInboxItem}
+            onReschedule={rescheduleInboxItem}
+          />
+        }
       />
     ) : mode === "browser" ? (
       <BrowserPane ref={browserPaneRef} label="main" activeFamiliarId={active?.id ?? null} />
@@ -1972,37 +2008,6 @@ export function Workspace() {
       <FlowView />
     ) : mode === "evals" || mode === "retro" ? (
       <EvalsView familiars={resolvedFamiliars} activeFamiliarId={mode === "retro" ? retroFamiliarId : activeId} />
-    ) : mode === "calendar" ? (
-      <CalendarView
-        items={inboxItems}
-        familiars={familiars}
-        activeFamiliarId={calendarFamiliarId}
-        scopeFamiliarIds={scopeIds}
-        deadlines={boardDeadlines}
-        onOpenDeadline={(id) => {
-          setMode("board");
-          window.dispatchEvent(new Event("cave:board:reload"));
-          window.location.hash = `card-${id}`;
-        }}
-        onAddEntry={(defaults) => {
-          openReminderModal(
-            defaults?.title ?? "",
-            defaults?.whenText ?? "",
-            defaults?.fireAt ?? "",
-          );
-        }}
-        onOpenItem={(item) => {
-          if (item.sessionId) {
-            openFamiliarSession(item.sessionId, item.familiarId);
-          } else {
-            setMode("inbox");
-          }
-        }}
-        onComplete={completeInboxItem}
-        onDismiss={dismissInboxItem}
-        onSnooze={snoozeInboxItem}
-        onReschedule={rescheduleInboxItem}
-      />
     ) : (
       <HomeComposer
         familiars={familiars}


### PR DESCRIPTION
## What & why

**Calendar** and **Automations** were two separate full-page surfaces in the *Work* nav group that both surfaced the same scheduled work — reminders, crons, and deadlines — just in different layouts (a month/timeline grid vs. tabbed lists). That's a duplicative page. This PR merges them into a **single schedule surface**: the Calendar is now the leading tab of the Automations view.

This follows the codebase's established `capabilities → roles` pattern: two nav entries, one page component, with the secondary mode deep-linking to a specific tab.

## Changes

- **`automations-view.tsx`** — new optional `calendarSlot` + `initialTab` props. When a slot is supplied, a leading **"Calendar"** tab renders it full-height (search filter + list skipped for that tab). The slot keeps `AutomationsView` decoupled from `CalendarView`'s prop shape. Subtitle adapts per tab.
- **`inbox-escalations-view.tsx`** — forwards the two new props.
- **`workspace.tsx`** — `inbox` and `calendar` modes now resolve to the *same* `InboxEscalationsView`; `calendar` opens the Calendar tab (`key={mode}` remount for the deep link). The standalone `CalendarView` mode branch is removed.
- **Tests** — updated the two source-text assertions (`surface-loading-states`, `schedules-tabs`) that pinned the exact markup I touched.

Both nav buttons still work: **Calendar (⌘4)** deep-links to the Calendar tab; **Automations (⌘5)** opens the All tab — two shortcuts into one merged surface.

## Verification

- `pnpm typecheck` ✅
- `node scripts/run-tests.mjs app` → **468 files pass** ✅
- `node scripts/run-tests.mjs mobile` → **65 files pass** ✅
- `pnpm check:tests-wired` ✅
- The e2e `foundations` spec drives `calendar` mode for no-overflow; `CalendarView`'s `h-full` root sits inside a bounded `flex-1 min-h-0 overflow-hidden` container, so it fits and scrolls internally (validated by CI E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)