### PR TITLE
perf: code-split heavy workspace surfaces + bundle-size analytics

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,13 @@
 import type { NextConfig } from "next";
+import bundleAnalyzer from "@next/bundle-analyzer";
+
+// Opt-in client/server bundle visualizer. `ANALYZE=1 pnpm build` writes
+// interactive treemaps to .next/analyze/ so we can see which chunk a dep lands
+// in (e.g. confirm @xyflow/react / @uiw/react-codemirror left the shared
+// bundle after code-splitting the heavy surfaces). No-op for normal builds.
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === "1" || process.env.ANALYZE === "true",
+});
 
 const nextConfig: NextConfig = {
   // The Next.js dev tools launcher renders in a portal at bottom-left by
@@ -61,4 +70,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "icons:subset": "node scripts/generate-icon-subset.mjs",
     "prebuild": "node scripts/generate-icon-subset.mjs && node scripts/generate-pwa-icons.mjs && node scripts/build-sandbox-runtime.mjs",
     "build": "next build && pnpm build:server",
+    "postbuild": "node scripts/bundle-budget.mjs",
+    "test:bundle": "node scripts/bundle-budget.mjs",
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",
     "test": "node scripts/run-tests.mjs app",
@@ -80,6 +82,7 @@
     "yaml": "2.9.0"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "16.2.6",
     "@playwright/test": "1.60.0",
     "@tailwindcss/postcss": "4.3.0",
     "@tauri-apps/cli": "2.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
         specifier: 2.9.0
         version: 2.9.0
     devDependencies:
+      '@next/bundle-analyzer':
+        specifier: 16.2.6
+        version: 16.2.6
       '@playwright/test':
         specifier: 1.60.0
         version: 1.60.0
@@ -292,6 +295,10 @@ packages:
     peerDependencies:
       '@create-markdown/core': '>=2.0.3'
       react: '>=18.0.0'
+
+  '@discoveryjs/json-ext@0.5.7':
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -729,6 +736,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@next/bundle-analyzer@16.2.6':
+    resolution: {integrity: sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==}
+
   '@next/env@16.2.6':
     resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
@@ -791,6 +801,9 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@replit/codemirror-lang-nix@6.0.1':
     resolution: {integrity: sha512-lvzjoYn9nfJzBD5qdm3Ut6G3+Or2wEacYIDJ49h9+19WSChVnxv4ojf+rNmQ78ncuxIt/bfbMvDLMeMP0xze6g==}
@@ -1371,6 +1384,15 @@ packages:
   '@xyflow/system@0.0.77':
     resolution: {integrity: sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==}
 
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1622,6 +1644,9 @@ packages:
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
+  debounce@1.2.1:
+    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
+
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
@@ -1646,6 +1671,9 @@ packages:
   dompurify@3.4.10:
     resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1663,6 +1691,10 @@ packages:
     resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1701,6 +1733,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gzip-size@6.0.0:
+    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
+    engines: {node: '>=10'}
+
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
 
@@ -1713,6 +1749,9 @@ packages:
   highlight.js@11.11.1:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -1734,6 +1773,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -1865,6 +1908,10 @@ packages:
   micromark-util-types@2.0.2:
     resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -1913,6 +1960,10 @@ packages:
 
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
+    hasBin: true
 
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
@@ -2062,6 +2113,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  sirv@2.0.4:
+    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
+    engines: {node: '>= 10'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2138,6 +2193,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2277,6 +2336,11 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  webpack-bundle-analyzer@4.10.1:
+    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
+    engines: {node: '>= 10.13.0'}
+    hasBin: true
+
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
@@ -2288,6 +2352,18 @@ packages:
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
+
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
@@ -2590,6 +2666,8 @@ snapshots:
     dependencies:
       '@create-markdown/core': 2.0.3
       react: 19.2.4
+
+  '@discoveryjs/json-ext@0.5.7': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -2953,6 +3031,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@next/bundle-analyzer@16.2.6':
+    dependencies:
+      webpack-bundle-analyzer: 4.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@next/env@16.2.6': {}
 
   '@next/swc-darwin-arm64@16.2.6':
@@ -2984,6 +3069,8 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@replit/codemirror-lang-nix@6.0.1(@codemirror/autocomplete@6.20.3)(@codemirror/language@6.12.3)(@codemirror/state@6.6.0)(@codemirror/view@6.43.1)(@lezer/common@1.5.2)(@lezer/highlight@1.2.3)(@lezer/lr@1.4.10)':
     dependencies:
@@ -3558,6 +3645,12 @@ snapshots:
       d3-selection: 3.0.0
       d3-zoom: 3.0.0
 
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
   ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
@@ -3822,6 +3915,8 @@ snapshots:
 
   dayjs@1.11.21: {}
 
+  debounce@1.2.1: {}
+
   decamelize@1.2.0: {}
 
   delaunator@5.1.0:
@@ -3841,6 +3936,8 @@ snapshots:
   dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
+
+  duplexer@0.1.2: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3882,6 +3979,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escape-string-regexp@4.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -3907,6 +4006,10 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gzip-size@6.0.0:
+    dependencies:
+      duplexer: 0.1.2
+
   hachure-fill@0.5.2: {}
 
   hast-util-to-html@9.0.5:
@@ -3929,6 +4032,8 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
+  html-escaper@2.0.2: {}
+
   html-void-elements@3.0.0: {}
 
   iconv-lite@0.6.3:
@@ -3942,6 +4047,8 @@ snapshots:
   internmap@2.0.3: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-plain-object@5.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -4071,6 +4178,8 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
+  mrmime@2.0.1: {}
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -4121,6 +4230,8 @@ snapshots:
       oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  opener@1.5.2: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -4298,6 +4409,12 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  sirv@2.0.4:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   source-map-js@1.2.1: {}
 
   space-separated-tokens@2.0.2: {}
@@ -4362,6 +4479,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  totalist@3.0.1: {}
 
   trim-lines@3.0.1: {}
 
@@ -4457,6 +4576,25 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
+  webpack-bundle-analyzer@4.10.1:
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      acorn: 8.17.0
+      acorn-walk: 8.3.5
+      commander: 7.2.0
+      debounce: 1.2.1
+      escape-string-regexp: 4.0.0
+      gzip-size: 6.0.0
+      html-escaper: 2.0.2
+      is-plain-object: 5.0.0
+      opener: 1.5.2
+      picocolors: 1.1.1
+      sirv: 2.0.4
+      ws: 7.5.11
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   which-module@2.0.1: {}
 
   why-is-node-running@2.3.0:
@@ -4469,6 +4607,8 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  ws@7.5.11: {}
 
   ws@8.21.0: {}
 

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -1,0 +1,108 @@
+// Bundle-size budget gate. Runs automatically after `pnpm build` (as the
+// `postbuild` lifecycle hook), so the existing "Frontend build" CI check fails
+// if client JS regresses past budget — no new required status check needed.
+//
+// What it guards:
+//   1. SHELL — the always-loaded root chunks (build-manifest `rootMainFiles`):
+//      the JS every page load pays for, regardless of surface. This is the
+//      clearest health signal and what code-splitting protects.
+//   2. CATASTROPHIC chunk — a loose ceiling on the single largest chunk, to
+//      catch a heavy dep ballooning one chunk back toward the pre-split ~3 MB.
+//
+// Why not gate per-route "First Load JS": this app builds with Turbopack, which
+// does not emit the App Router client chunk graph (`app-build-manifest.json`),
+// so a precise per-route eager-load number isn't available here. The two
+// signals above are what we can measure robustly.
+//
+// Tune by lowering the budgets as splitting work lands. Override at runtime with
+// BUNDLE_MAX_SHELL_KB / BUNDLE_MAX_CHUNK_KB for experiments.
+//
+// Run: `node scripts/bundle-budget.mjs` (wired as `pnpm test:bundle` + postbuild).
+
+import { readdirSync, statSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const nextDir = path.join(root, ".next");
+const chunksDir = path.join(nextDir, "static", "chunks");
+
+// Budgets, seeded with headroom over the post-split measured values so ordinary
+// feature growth doesn't trip them — only a structural regression does.
+// Measured at introduction: shell ~447 KB, largest chunk ~1713 KB (the lazy
+// code-editor surface: @uiw/react-codemirror + @xterm).
+const MAX_SHELL_BYTES = (Number(process.env.BUNDLE_MAX_SHELL_KB) || 650) * 1024;
+const MAX_CHUNK_BYTES = (Number(process.env.BUNDLE_MAX_CHUNK_KB) || 2400) * 1024;
+
+if (!existsSync(chunksDir)) {
+  console.error(
+    `✗ bundle-budget: ${path.relative(root, chunksDir)} not found — run \`pnpm build\` first.`,
+  );
+  process.exit(1);
+}
+
+const kb = (n) => (n / 1024).toFixed(0).padStart(6) + " KB";
+const sizeOf = (relToNext) => {
+  try {
+    return statSync(path.join(nextDir, relToNext)).size;
+  } catch {
+    return 0;
+  }
+};
+
+// --- All chunks, largest first (for the catastrophic-chunk net + visibility) ---
+function walk(dir, acc) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, acc);
+    else if (entry.name.endsWith(".js"))
+      acc.push({ file: path.relative(chunksDir, full), bytes: statSync(full).size });
+  }
+  return acc;
+}
+const chunks = walk(chunksDir, []).sort((a, b) => b.bytes - a.bytes);
+
+// --- Always-loaded shell (rootMainFiles from the build manifest) ---
+let shellFiles = [];
+try {
+  const manifest = JSON.parse(readFileSync(path.join(nextDir, "build-manifest.json"), "utf8"));
+  shellFiles = (manifest.rootMainFiles || []).filter((f) => f.endsWith(".js"));
+} catch {
+  console.error("✗ bundle-budget: could not read .next/build-manifest.json");
+  process.exit(1);
+}
+const shellBytes = shellFiles.reduce((a, f) => a + sizeOf(f), 0);
+
+console.log(`\nbundle-budget — always-loaded shell (rootMainFiles):`);
+for (const f of shellFiles) console.log(`  ${kb(sizeOf(f))}  ${f.replace("static/chunks/", "")}`);
+console.log(`  ${kb(shellBytes)}  TOTAL shell  (budget: ${kb(MAX_SHELL_BYTES)})`);
+
+console.log(`\nbundle-budget — largest client chunks:`);
+for (const c of chunks.slice(0, 8)) console.log(`  ${kb(c.bytes)}  ${c.file}`);
+const largest = chunks[0];
+console.log(`  largest: ${kb(largest?.bytes ?? 0)}  (budget: ${kb(MAX_CHUNK_BYTES)})`);
+
+let failed = false;
+
+if (shellBytes > MAX_SHELL_BYTES) {
+  failed = true;
+  console.error(
+    `\n✗ bundle-budget: always-loaded shell ${kb(shellBytes).trim()} exceeds budget ` +
+      `${kb(MAX_SHELL_BYTES).trim()}.\n` +
+      `  A dependency likely entered the shared bundle. Check for a new static import\n` +
+      `  of a heavy module reachable from the app shell and route it through\n` +
+      `  src/components/lazy-surfaces.tsx, or raise BUNDLE_MAX_SHELL_KB deliberately.`,
+  );
+}
+
+if (largest && largest.bytes > MAX_CHUNK_BYTES) {
+  failed = true;
+  console.error(
+    `\n✗ bundle-budget: largest chunk ${largest.file} (${kb(largest.bytes).trim()}) exceeds ` +
+      `budget ${kb(MAX_CHUNK_BYTES).trim()}.\n` +
+      `  A heavy dependency ballooned a single chunk. Split it or raise BUNDLE_MAX_CHUNK_KB.`,
+  );
+}
+
+if (failed) process.exit(1);
+console.log(`\n✓ bundle-budget: within budget.\n`);

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+// Code-splitting boundary for heavy, mode-gated workspace surfaces.
+//
+// These surfaces are only ever *rendered* when their nav mode is active, but a
+// static `import` still ships their code (and their heavy transitive deps) in
+// the always-loaded main bundle. Routing them through `next/dynamic` moves each
+// into its own chunk that the browser fetches on first open instead of at app
+// boot. Notably this pulls `@xyflow/react` (FlowView) and
+// `@uiw/react-codemirror` (ComuxView → code-editor) out of the shared bundle.
+//
+// `ssr: false` is safe: the whole app is client-rendered (`workspace.tsx` is a
+// client component) and these surfaces are interactive-only.
+
+import dynamic from "next/dynamic";
+import { SkeletonRows } from "@/components/ui/skeleton";
+
+function SurfaceFallback() {
+  // Fills the surface area while the chunk loads so the layout doesn't jump.
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 p-6" aria-hidden>
+      <SkeletonRows count={6} />
+    </div>
+  );
+}
+
+export const ComuxView = dynamic(
+  () => import("@/components/comux-view").then((m) => m.ComuxView),
+  { ssr: false, loading: SurfaceFallback },
+);
+
+export const GitHubView = dynamic(
+  () => import("@/components/github-view").then((m) => m.GitHubView),
+  { ssr: false, loading: SurfaceFallback },
+);
+
+export const FlowView = dynamic(
+  () => import("@/components/flow/flow-view").then((m) => m.FlowView),
+  { ssr: false, loading: SurfaceFallback },
+);
+
+export const EvalsView = dynamic(
+  () => import("@/components/evals/evals-view").then((m) => m.EvalsView),
+  { ssr: false, loading: SurfaceFallback },
+);
+
+export const CalendarView = dynamic(
+  () => import("@/components/calendar-view").then((m) => m.CalendarView),
+  { ssr: false, loading: SurfaceFallback },
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -9,7 +9,7 @@ import type { WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-m
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
 import { BoardView } from "@/components/board-view";
 import { JournalView } from "@/components/journal/journal-view";
-import { CalendarView, type CalendarDeadline } from "@/components/calendar-view";
+import type { CalendarDeadline } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
 import { InboxEscalationsView } from "@/components/inbox-escalations-view";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
@@ -39,15 +39,21 @@ import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { FamiliarPanel } from "@/components/familiar-panel";
 import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
-import { ComuxView } from "@/components/comux-view";
+// Heavy, mode-gated surfaces are code-split via @/components/lazy-surfaces so
+// their chunks (and deps like @xyflow/react, @uiw/react-codemirror) load on
+// first open instead of shipping in the main bundle. See lazy-surfaces.tsx.
+import {
+  CalendarView,
+  ComuxView,
+  EvalsView,
+  FlowView,
+  GitHubView,
+} from "@/components/lazy-surfaces";
 import { CodeView } from "@/components/code-view";
-import { GitHubView } from "@/components/github-view";
 import { LibraryView } from "@/components/library-view";
 import { CovenPane } from "@/components/docs-pane";
 import { PluginsView } from "@/components/plugins-view";
 import { OpenCovenSubmissionPage } from "@/components/opencoven-submission-page";
-import { FlowView } from "@/components/flow/flow-view";
-import { EvalsView } from "@/components/evals/evals-view";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface, type RightPanelKind } from "@/components/chat-surface";


### PR DESCRIPTION
## Context

First PR of a performance refactor arc (audit/plan: highest-ROI item). The home workspace **statically imported every heavy, mode-gated surface** — `FlowView`, `ComuxView`, `GitHubView`, `EvalsView`, `CalendarView` — so their code and heavy deps shipped in the eagerly-loaded bundle even though each only *renders* when its nav mode is active.

Measured on `origin/main`: a single **3,115 KB** chunk bundled `@xyflow/react` + `@uiw/react-codemirror` + `@xterm` + evals + github **together** (confirmed by grepping the chunk).

## Change

- **`src/components/lazy-surfaces.tsx`** (new) — routes the five heavy surfaces through `next/dynamic` (`ssr: false` + shared skeleton fallback). `workspace.tsx` imports from here instead of statically. Render/mount logic unchanged; only *when the code arrives* changes.
- **`@next/bundle-analyzer`** behind `ANALYZE=1 pnpm build` → interactive treemaps in `.next/analyze/`. No-op for normal builds.
- **`scripts/bundle-budget.mjs`** — gates the always-loaded shell (≤650 KB) and a catastrophic single-chunk ceiling (≤2,400 KB). Wired as **`postbuild`** so the existing **Frontend build** check enforces it (no new required status check), and as **`pnpm test:bundle`** for local runs.

## Measured result (before → after)

| Metric | Before (`origin/main`) | After |
|---|---|---|
| Largest client chunk | **3,115 KB** (xyflow+codemirror+xterm+evals+github combined) | **1,713 KB** (lazy code-editor surface only) |
| Always-loaded shell (`rootMainFiles`) | 447 KB | 447 KB (unchanged) |
| `@xyflow/react` / `@uiw/react-codemirror` | same eager 3 MB chunk | **separate lazy chunks**, fetched on first open |

The 3 MB monster is gone; heavy deps load on demand when their surface opens.

> Note: `message-bubble` already lazy-loads the markdown renderer / shiki / mermaid (`await import`), so no change was needed there. `canvas-artifact-node.tsx` (also imports xyflow) is orphaned dead code — not reachable from the chat surface — so it doesn't affect the bundle.

## Verification

- `pnpm typecheck`, `pnpm check:tests-wired` (625), `pnpm test:app` (468), `pnpm test:api` (95), `pnpm test:mobile` (65) — all green.
- `pnpm build` succeeds; `postbuild` budget gate passes (shell 447/650 KB, largest 1,713/2,400 KB).
- Before/after measured via a clean throwaway build of `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)