### PR TITLE
perf: visibility-gate always-on API polls via usePausablePoll

### DIFF
--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
@@ -209,9 +210,9 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
 
   useEffect(() => {
     void load();
-    const t = setInterval(load, 30_000);
-    return () => clearInterval(t);
   }, [load]);
+  // Pauses in a hidden tab; refreshes on return.
+  usePausablePoll(() => void load(), 30_000);
 
   useEffect(() => {
     if (activeFamiliar?.id) setFamiliarFilter(activeFamiliar.id);

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -50,8 +50,8 @@ assert.match(
 
 assert.match(
   source,
-  /setInterval\(loadMemory, 30_000\)/,
-  "Memory data refreshes on 30s interval",
+  /usePausablePoll\(\(\) => void loadMemory\(\), 30_000\)/,
+  "Memory data refreshes on a 30s pausable poll (pauses in a hidden tab)",
 );
 
 assert.match(

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { Tabs } from "@/components/ui/tabs";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
@@ -136,9 +137,9 @@ export function FamiliarsView({
 
   useEffect(() => {
     void loadMemory();
-    const t = setInterval(loadMemory, 30_000);
-    return () => clearInterval(t);
   }, [loadMemory]);
+  // Pauses in a hidden tab; refreshes on return.
+  usePausablePoll(() => void loadMemory(), 30_000);
 
   const stats = useMemo(
     () => buildFamiliarCardStats({ familiars, sessions, covenEntries }),

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -52,7 +52,7 @@ assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscal
 assert.match(settings, /MobileModeToggle/, "Settings should render a mobile mode toggle component");
 assert.match(settings, /mobileModeEnabled/, "Settings should receive the live mobile mode enabled state");
 assert.match(settings, /onMobileModeChange/, "Settings should expose a toggle callback for mobile mode");
-assert.match(settings, /setInterval\(\(\) => void reconcileMobileMode\(true\), 60_000\)/, "Settings should keep reconciling mobile mode while enabled");
+assert.match(settings, /usePausablePoll\(\(\) => void reconcileMobileMode\(true\), 60_000, \{\s*enabled: mobileModeEnabled,?\s*\}\)/, "Settings should keep reconciling mobile mode while enabled (pausable poll, paused in a hidden tab)");
 assert.match(settings, /Mobile mode/, "Settings should label the one-click native iOS route switch");
 assert.match(settings, /Default on/, "Settings should communicate that mobile mode is on by default");
 assert.doesNotMatch(settings, /CopyValue value="pnpm mobile:tailscale:app"/, "Settings should not require copying a terminal command for normal mobile mode");

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { relativeTime } from "@/lib/relative-time";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { modelIcon } from "@/lib/model-label";
@@ -67,27 +68,22 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
     });
   };
 
-  useEffect(() => {
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const res = await fetch("/api/sessions/list", { cache: "no-store" });
-        const json = await res.json();
-        if (cancelled) return;
-        const rows: SessionRow[] = Array.isArray(json?.sessions) ? json.sessions : [];
-        setSessions(rows.filter((s) => !s.archived_at).slice(0, MAX_ROWS));
-        setLoaded(true);
-      } catch {
-        if (!cancelled) setLoaded(true);
-      }
-    };
-    void load();
-    const t = setInterval(load, POLL_MS);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sessions/list", { cache: "no-store" });
+      const json = await res.json();
+      const rows: SessionRow[] = Array.isArray(json?.sessions) ? json.sessions : [];
+      setSessions(rows.filter((s) => !s.archived_at).slice(0, MAX_ROWS));
+      setLoaded(true);
+    } catch {
+      setLoaded(true);
+    }
   }, []);
+  useEffect(() => {
+    void load();
+  }, [load]);
+  // Pauses in a hidden tab; refreshes on return.
+  usePausablePoll(() => void load(), POLL_MS);
 
   const rows = useMemo(() => sessions, [sessions]);
 

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { Icon } from "@/lib/icon";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { SettingsGroup, settingsGroupId } from "@/components/ui/settings-group";
 import { SettingControlRow, Segmented } from "@/components/ui/settings-controls";
 import { SearchInput } from "@/components/ui/search-input";
@@ -1597,10 +1598,11 @@ function MobileModeToggle() {
 
   useEffect(() => {
     void reconcileMobileMode(mobileModeEnabled);
-    if (!mobileModeEnabled) return;
-    const timer = window.setInterval(() => void reconcileMobileMode(true), 60_000);
-    return () => window.clearInterval(timer);
   }, [mobileModeEnabled, reconcileMobileMode]);
+  // Recurring reconcile only while mobile mode is on; pauses in a hidden tab.
+  usePausablePoll(() => void reconcileMobileMode(true), 60_000, {
+    enabled: mobileModeEnabled,
+  });
 
   return (
     <SettingsRow

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/familiar-memory";
 import { recordFamiliarUsed } from "@/lib/familiar-quick-switch";
 import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
 import { FamiliarPanel } from "@/components/familiar-panel";
 import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
@@ -323,21 +324,13 @@ export function Workspace() {
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    const run = async () => {
-      if (cancelled) return;
-      await reconcileMobileMode(mobileModeEnabled);
-    };
-    void run();
-    if (!mobileModeEnabled) return () => {
-      cancelled = true;
-    };
-    const timer = window.setInterval(() => void run(), 60_000);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
+    void reconcileMobileMode(mobileModeEnabled);
   }, [mobileModeEnabled, reconcileMobileMode]);
+  // Recurring reconcile only while mobile mode is on; usePausablePoll pauses it
+  // in a hidden tab and refreshes on return.
+  usePausablePoll(() => void reconcileMobileMode(mobileModeEnabled), 60_000, {
+    enabled: mobileModeEnabled,
+  });
 
   const refreshDaemonStatus = useCallback(async (opts?: { trusted?: boolean }) => {
     let running = false;
@@ -523,11 +516,11 @@ export function Workspace() {
   }, []);
 
   // Daemon status poll (previously lived on DaemonBar before chrome consolidation)
+  // — pauses while the tab is hidden and refreshes on return (usePausablePoll).
   useEffect(() => {
     void refreshDaemonStatus();
-    const t = setInterval(() => { void refreshDaemonStatus(); }, 5000);
-    return () => { clearInterval(t); };
   }, [refreshDaemonStatus]);
+  usePausablePoll(() => void refreshDaemonStatus(), 5000);
 
   // Push / dismiss the daemon-offline banner into the shared shell channel so
   // it appears at the top of every surface, not just Chat.
@@ -641,9 +634,8 @@ export function Workspace() {
   useEffect(() => {
     loadFamiliars();
     loadSessions();
-    const t = setInterval(loadSessions, 4000);
-    return () => clearInterval(t);
   }, [loadFamiliars, loadSessions]);
+  usePausablePoll(() => void loadSessions(), 4000);
 
   const refreshPrefs = useCallback(async () => {
     try {
@@ -926,39 +918,33 @@ export function Workspace() {
 
   // Poll Inbox for unresolved-escalations count — drives the
   // sidebar/daemon-bar Inbox badge. Cheap GET every 30s; the route
-  // already de-dupes via reconcileEscalations().
-  useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      try {
-        const res = await fetch("/api/escalations", { cache: "no-store" });
-        const json = await res.json();
-        if (cancelled) return;
-        if (json.ok && Array.isArray(json.items)) {
-          const now = Date.now();
-          const unresolved = (json.items as Array<{
-            state: string;
-            snoozeUntil?: string;
-          }>).filter((it) => {
-            if (it.state === "resolved" || it.state === "dismissed") return false;
-            if (it.state === "snoozed" && it.snoozeUntil) {
-              return new Date(it.snoozeUntil).getTime() <= now;
-            }
-            return true;
-          }).length;
-          setEscalationsUnresolved(unresolved);
-        }
-      } catch {
-        /* keep last value on transient failure */
+  // already de-dupes via reconcileEscalations(). Pauses in a hidden tab.
+  const refreshEscalations = useCallback(async () => {
+    try {
+      const res = await fetch("/api/escalations", { cache: "no-store" });
+      const json = await res.json();
+      if (json.ok && Array.isArray(json.items)) {
+        const now = Date.now();
+        const unresolved = (json.items as Array<{
+          state: string;
+          snoozeUntil?: string;
+        }>).filter((it) => {
+          if (it.state === "resolved" || it.state === "dismissed") return false;
+          if (it.state === "snoozed" && it.snoozeUntil) {
+            return new Date(it.snoozeUntil).getTime() <= now;
+          }
+          return true;
+        }).length;
+        setEscalationsUnresolved(unresolved);
       }
-    };
-    void tick();
-    const t = setInterval(tick, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
+    } catch {
+      /* keep last value on transient failure */
+    }
   }, []);
+  useEffect(() => {
+    void refreshEscalations();
+  }, [refreshEscalations]);
+  usePausablePoll(() => void refreshEscalations(), 30_000);
 
   const refreshOpenTaskCards = useCallback(async () => {
     try {
@@ -997,20 +983,12 @@ export function Workspace() {
   }, []);
 
   // Poll the board for the count of open task cards (anything not yet "done")
-  // — drives the desktop menu bar's Tasks badge. Cheap GET every 60s.
+  // — drives the desktop menu bar's Tasks badge. Cheap GET every 60s; pauses
+  // in a hidden tab.
   useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      if (cancelled) return;
-      await refreshOpenTaskCards();
-    };
-    void tick();
-    const t = setInterval(tick, 60_000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
+    void refreshOpenTaskCards();
   }, [refreshOpenTaskCards]);
+  usePausablePoll(() => void refreshOpenTaskCards(), 60_000);
 
   const handleEnrichTasks = useCallback(async () => {
     if (!activeId || enrichingTasks) return;


### PR DESCRIPTION
## Context

Workstream C of the performance arc (follow-up to #2036). The audit found ~24 client `setInterval` poll sites but only **1** used the existing visibility-aware helper `src/lib/use-pausable-poll.ts` — so most polls keep hitting the network on a raw timer **even in a backgrounded tab**. The biggest offenders are the always-on workspace root polls (daemon every 5s, sessions every 4s).

## Change

Route nine ungated API polls through `usePausablePoll` (pauses the interval while `document.hidden`, refreshes immediately on regaining focus — browser + Tauri):

| File | Endpoint(s) | Interval |
|---|---|---|
| `workspace.tsx` | `/api/daemon/status` | 5s |
| `workspace.tsx` | `/api/sessions/list` | 4s |
| `workspace.tsx` | `/api/escalations` | 30s |
| `workspace.tsx` | `/api/board` | 60s |
| `workspace.tsx` | mobile-handoff reconcile | 60s (enabled-gated) |
| `recent-activity-rollup.tsx` | `/api/sessions/list` | POLL_MS |
| `familiars-view.tsx` | `/api/coven-memory` + `/api/memory` | 30s |
| `familiars-memory-view.tsx` | `/api/coven-memory` + `/api/memory` | 30s |
| `settings-shell.tsx` | mobile-handoff reconcile | 60s (enabled-gated) |

Net **−22 lines** (the helper replaces the hand-rolled `setInterval` + cleanup boilerplate).

### Deliberately left alone
- **Already-gated** polls: `automations-view`, `remote-theme-controller`, `session-changes-panel`, `debug-pane`, `browser-pane`.
- **Pure internal timers** (no network): chat elapsed, calendar/voice-call clocks, `thinking-indicator`, flow duration.
- The audit's *"delete the redundant `/api/inbox` poll"* was **incorrect** — `automations-view` fetches its own inbox and already pauses while hidden. Verified against the code; left untouched.

## Verification

- `pnpm typecheck`, `check:tests-wired` (625), `test:app` (468), `test:api` (95), `test:mobile` (65), `pnpm build` (+ inherited bundle-budget gate) — all green.
- Updated the two source-text tests that pinned the old `setInterval` (`familiars-view.test.ts`, `mobile-handoff.test.ts`) to assert the `usePausablePoll` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)