### PR TITLE
Fix flow execution startup progress

### DIFF
--- a/src/app/api/flows/session-transcript/route.test.ts
+++ b/src/app/api/flows/session-transcript/route.test.ts
@@ -21,6 +21,9 @@ assert.match(
   /loadConversationFromJsonl\(sessionId, familiarId\)[\s\S]*assistantTranscript\(jsonlConversation\)[\s\S]*found: true/,
   "route should fall back to OpenClaw JSONL transcripts",
 );
+assert.match(route, /callDaemon<\{ events: CovenEvent\[\] \}>/, "route should read daemon events for live flow sessions");
+assert.match(route, /eventOutputTranscript/, "route should convert daemon output events into a pollable transcript");
+assert.match(route, /stripAnsi/, "daemon PTY output should be ANSI-stripped before progress parsing");
 assert.match(
   route,
   /NextResponse\.json\(\{ ok: true, transcript: "", found: false \}\)/,

--- a/src/app/api/flows/session-transcript/route.ts
+++ b/src/app/api/flows/session-transcript/route.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from "next/server";
 import { isSafeConversationSessionId, loadConversation } from "../../../../lib/cave-conversations.ts";
 import { loadState } from "../../../../lib/cave-config.ts";
+import { callDaemon } from "../../../../lib/coven-daemon.ts";
 import { loadConversationFromJsonl } from "../../../../lib/openclaw-conversation.ts";
+import { stripAnsi } from "../../../../lib/ansi.ts";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+type CovenEvent = {
+  kind: string;
+  payload_json: string;
+};
 
 function assistantTranscript(conversation: { turns?: Array<{ role?: string; text?: string }> } | null): string {
   return (conversation?.turns ?? [])
@@ -13,9 +20,33 @@ function assistantTranscript(conversation: { turns?: Array<{ role?: string; text
     .join("\n");
 }
 
+function eventOutputTranscript(events: CovenEvent[]): string {
+  const parts: string[] = [];
+  for (const event of events) {
+    if (event.kind !== "output") continue;
+    try {
+      const payload = JSON.parse(event.payload_json) as { data?: unknown };
+      if (typeof payload.data === "string") parts.push(stripAnsi(payload.data));
+    } catch {
+      // Ignore malformed daemon payloads; the next poll can still catch up.
+    }
+  }
+  return parts.join("");
+}
+
+async function daemonEventTranscript(sessionId: string): Promise<string> {
+  const res = await callDaemon<{ events: CovenEvent[] }>({
+    path: `/api/v1/events?sessionId=${encodeURIComponent(sessionId)}&afterSeq=0&limit=500`,
+    timeoutMs: 4000,
+  });
+  if (!res.ok || !res.data?.events) return "";
+  return eventOutputTranscript(res.data.events);
+}
+
 /**
  * Flow execution polling endpoint. A live flow run can have a daemon session id
- * before Cave has a persisted conversation or OpenClaw JSONL transcript for it.
+ * before Cave has a persisted conversation or OpenClaw JSONL transcript for it,
+ * so the final fallback reads the daemon's PTY event stream directly.
  * Return an empty 200 in that normal gap so browser polling does not emit 404
  * resource errors while the session is still coming up.
  */
@@ -26,16 +57,29 @@ export async function GET(req: Request) {
   }
 
   const conversation = await loadConversation(sessionId);
-  if (conversation) {
-    return NextResponse.json({ ok: true, transcript: assistantTranscript(conversation), found: true });
+  const conversationTranscript = assistantTranscript(conversation);
+  if (conversationTranscript.trim()) {
+    return NextResponse.json({ ok: true, transcript: conversationTranscript, found: true });
   }
 
   const state = await loadState();
   const familiarId = state.sessionFamiliar[sessionId];
   if (familiarId) {
     const jsonlConversation = await loadConversationFromJsonl(sessionId, familiarId);
-    if (jsonlConversation) {
-      return NextResponse.json({ ok: true, transcript: assistantTranscript(jsonlConversation), found: true });
+    const jsonlTranscript = assistantTranscript(jsonlConversation);
+    if (jsonlTranscript.trim()) {
+      return NextResponse.json({ ok: true, transcript: jsonlTranscript, found: true });
+    }
+  }
+
+  const owned =
+    Boolean(state.sessionOwned?.[sessionId]) ||
+    Boolean(state.sessionFamiliar?.[sessionId]) ||
+    Boolean(state.sessionTitles?.[sessionId]);
+  if (owned) {
+    const eventTranscript = await daemonEventTranscript(sessionId);
+    if (eventTranscript.trim()) {
+      return NextResponse.json({ ok: true, transcript: eventTranscript, found: true });
     }
   }
 

--- a/src/components/flow/flow-executions.test.ts
+++ b/src/components/flow/flow-executions.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const executions = readFileSync(new URL("./flow-executions.tsx", import.meta.url), "utf8");
 const view = readFileSync(new URL("./flow-view.tsx", import.meta.url), "utf8");
+const runSteps = readFileSync(new URL("./flow-run-steps.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../../styles/flow.css", import.meta.url), "utf8");
 
 assert.match(executions, /onInspectRun: \(run: FlowRunRecord\) => void/, "Executions list should expose an inspect callback");
@@ -50,8 +51,10 @@ assert.match(styles, /\.flow-exec-custom-input/, "Custom execution data filters 
 assert.match(styles, /\.flow-exec-filter\.is-active/, "Active execution filter should be styled");
 assert.match(styles, /\.flow-exec-mode-production/, "Production execution mode badge should be styled");
 assert.match(styles, /\.flow-exec-custom-data/, "Custom execution data chips should be styled");
-assert.match(view, /phasesFromRunSteps/, "Flow view should paint stored run step statuses when transcript markers are unavailable");
+assert.match(view, /activeRun \? progress\.phases : null/, "Flow view should paint seeded progress before transcript markers arrive");
 assert.match(view, /progress\.markersFound \? progress\.steps : activeRun\.steps/, "Flow view should inspect persisted node data when transcript markers are unavailable");
+assert.match(runSteps, /progress\.phases\[id\] \?\? persisted/, "Run steps should use seeded progress before transcript markers arrive");
+assert.match(runSteps, /!progress\.markersFound && !moving/, "Run steps should not show a stall warning once seeded progress is visible");
 assert.match(view, /inspectRun/, "Flow view should have a named inspected-run handler");
 assert.match(view, /retryRun/, "Flow view should have a named retry-run handler");
 assert.match(view, /mode: "current" \| "original"/, "Flow view retry handler should model n8n retry modes");

--- a/src/components/flow/flow-run-steps.tsx
+++ b/src/components/flow/flow-run-steps.tsx
@@ -55,10 +55,6 @@ export function FlowRunSteps({
   const [logsOpen, setLogsOpen] = useState(false);
 
   const transcript = progress.transcript.trim();
-  // A run that's live but has emitted no `@@step-…` markers is doing nothing
-  // visible — surface that plainly instead of an endless "0/N · pending".
-  const stalled = running && !progress.markersFound;
-
   const nameById = useMemo(
     () => new Map(doc.nodes.map((node) => [node.id, node.name])),
     [doc.nodes],
@@ -68,12 +64,14 @@ export function FlowRunSteps({
     [progress.steps],
   );
 
-  // Prefer the live-parsed phase; fall back to the run's persisted step status
-  // (e.g. a finished run reopened, or before any markers land).
+  // Prefer parsed/seeded progress; fall back to the stored run state for older
+  // historical records that predate live progress snapshots.
   const phaseFor = (id: string, persisted: FlowRunStepRecordStatus): FlowNodePhase =>
-    (progress.markersFound ? progress.phases[id] : undefined) ?? persisted;
+    progress.phases[id] ?? persisted;
 
   const doneCount = run.steps.filter((step) => phaseFor(step.id, step.status) === "succeeded").length;
+  const moving = run.steps.some((step) => phaseFor(step.id, step.status) !== "pending");
+  const waitingForOutput = running && !progress.markersFound && !moving;
 
   return (
     <aside className={`flow-run-steps${collapsed ? " is-collapsed" : ""}`} aria-label="Flow run steps">
@@ -100,7 +98,7 @@ export function FlowRunSteps({
         )}
       </header>
 
-      {!collapsed && stalled && (
+      {!collapsed && waitingForOutput && (
         <p className="flow-run-steps-stall" role="status">
           <Icon name="ph:warning-circle" width={14} />
           <span>

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -49,7 +49,7 @@ import { buildPromptFlow, flowNameFromPrompt } from "@/lib/flow/flow-prompt";
 import { flowPublishBlockReason, flowRunBlockReason } from "@/lib/flow/flow-compile";
 import { flowMissingRequiredInputs, type RequiredInput } from "@/lib/required-inputs";
 import { RequiredInputsDialog } from "@/components/required-inputs-dialog";
-import { finalizeFlowSteps, phasesFromRunSteps, selectNodeRunData } from "@/lib/flow/flow-progress";
+import { finalizeFlowSteps, selectNodeRunData } from "@/lib/flow/flow-progress";
 import {
   clearFlowRuns,
   deleteFlow,
@@ -122,8 +122,8 @@ export function FlowView() {
   const progress = useFlowRun(activeRun);
   const running = activeRun?.status === "running" && !progress.done;
   const displayedPhases = useMemo(
-    () => activeRun ? (progress.markersFound ? progress.phases : phasesFromRunSteps(activeRun.steps)) : null,
-    [activeRun, progress.markersFound, progress.phases],
+    () => activeRun ? progress.phases : null,
+    [activeRun, progress.phases],
   );
 
   // What picking a catalog node should do: drop it free, wire it to a dragged

--- a/src/components/flow/use-flow-run.ts
+++ b/src/components/flow/use-flow-run.ts
@@ -59,5 +59,5 @@ export function useFlowRun(run: FlowRunRecord | null): FlowRunProgress {
   }, [sessionId, live]);
 
   if (!run) return EMPTY;
-  return parseFlowRunProgress(transcript, run.steps.map((step) => step.id));
+  return parseFlowRunProgress(transcript, run.steps);
 }

--- a/src/lib/flow/flow-progress.test.ts
+++ b/src/lib/flow/flow-progress.test.ts
@@ -55,6 +55,41 @@ const ORDER = ["t", "a", "b"];
   assert.deepEqual(Object.values(p.phases), ["pending", "pending", "pending"]);
 }
 
+// no markers yet → seeded run-step statuses still make startup movement visible
+{
+  const p = parseFlowRunProgress("session booting, no markers yet", [
+    { id: "t", type: "trigger.manual", status: "succeeded" },
+    { id: "a", type: "familiar", status: "running" },
+    { id: "b", type: "data.output", status: "pending" },
+  ]);
+  assert.equal(p.markersFound, false);
+  assert.deepEqual(p.phases, { t: "succeeded", a: "running", b: "pending" });
+  assert.equal(p.activeNodeId, "a");
+}
+
+// old running records written before startup seeding still move past local nodes
+{
+  const p = parseFlowRunProgress("session booting, no markers yet", [
+    { id: "t", type: "trigger.manual", status: "pending" },
+    { id: "topic", type: "input.text", status: "pending" },
+    { id: "a", type: "familiar", status: "pending" },
+  ]);
+  assert.deepEqual(p.phases, { t: "succeeded", topic: "succeeded", a: "running" });
+  assert.equal(p.activeNodeId, "a");
+}
+
+// once real markers arrive, terminal seeded nodes stay complete but live markers win
+{
+  const p = parseFlowRunProgress("@@step-start a\nagent is working", [
+    { id: "t", type: "trigger.manual", status: "succeeded" },
+    { id: "a", type: "familiar", status: "running" },
+    { id: "b", type: "data.output", status: "pending" },
+  ]);
+  assert.equal(p.markersFound, true);
+  assert.deepEqual(p.phases, { t: "succeeded", a: "running", b: "pending" });
+  assert.equal(p.activeNodeId, "a");
+}
+
 // finalizeFlowSteps: preserves type, maps statuses, overall verdict
 {
   const runSteps: FlowRunStepRecord[] = [

--- a/src/lib/flow/flow-progress.ts
+++ b/src/lib/flow/flow-progress.ts
@@ -33,18 +33,58 @@ export type FlowRunProgress = {
 
 /**
  * Parse the transcript into per-node phases for the canvas overlay.
- * `orderedNodeIds` is the run's step ids in execution order.
+ * `ordered` is the run's steps (preferred) or ids in execution order. Passing
+ * steps preserves seeded local progress before transcript markers arrive.
  */
-export function parseFlowRunProgress(transcript: string, orderedNodeIds: string[]): FlowRunProgress {
+export function parseFlowRunProgress(
+  transcript: string,
+  ordered: string[] | Array<Pick<FlowRunStepRecord, "id" | "status" | "type">>,
+): FlowRunProgress {
+  const orderedNodeIds = ordered.map((step) => typeof step === "string" ? step : step.id);
+  const seedById = new Map<string, FlowRunStepStatus>();
+  let seenActiveAgentStep = false;
+  for (const step of ordered) {
+    if (typeof step === "string") continue;
+    let status = step.status;
+    if (status === "pending") {
+      if (step.type.startsWith("trigger.") || step.type.startsWith("input.")) {
+        status = "succeeded";
+      } else if (!seenActiveAgentStep) {
+        status = "running";
+      }
+    }
+    if (status === "running") seenActiveAgentStep = true;
+    seedById.set(step.id, status);
+  }
   const result = parseWorkflowStepProgress(transcript, orderedNodeIds);
   const phases: Record<string, FlowNodePhase> = {};
-  for (const step of result.steps) phases[step.id] = flowPhase(step.status);
+  let activeNodeId = result.activeStepId;
+  const steps = result.steps.map((step) => {
+    const seeded = seedById.get(step.id);
+    let status = step.status;
+    if (!result.markersFound && seeded) {
+      status = seeded === "running" ? "active" : seeded === "skipped" ? "succeeded" : seeded;
+    }
+    const phase = flowPhase(status);
+    if (result.markersFound && phase === "pending" && (seeded === "succeeded" || seeded === "skipped")) {
+      phases[step.id] = seeded;
+    } else {
+      phases[step.id] = phase;
+    }
+    return { ...step, status };
+  });
+  if (!result.markersFound) {
+    activeNodeId = orderedNodeIds.find((id) => seedById.get(id) === "running") ?? null;
+  }
+  const done =
+    orderedNodeIds.length > 0 &&
+    orderedNodeIds.every((id) => phases[id] === "succeeded" || phases[id] === "failed" || phases[id] === "skipped");
   return {
     phases,
-    activeNodeId: result.activeStepId,
-    done: result.done,
+    activeNodeId,
+    done,
     markersFound: result.markersFound,
-    steps: result.steps,
+    steps,
     transcript,
   };
 }

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -14,5 +14,25 @@ assert.match(
   "flow session spawn must not pass familiarId natively to the daemon",
 );
 assert.match(source, /recordSessionFamiliar\(sessionId, familiarId\)/, "familiar is still mirrored into cave-state");
+assert.match(
+  source,
+  /function initialFlowRunStepStatus/,
+  "flow runs should seed local trigger/input step status immediately",
+);
+assert.match(
+  source,
+  /def\?\.isTrigger[\s\S]*"succeeded"/,
+  "trigger nodes should start as succeeded so runs visibly move past Start",
+);
+assert.match(
+  source,
+  /node\?\.type\.startsWith\("input\."\)[\s\S]*"succeeded"/,
+  "input nodes should start as succeeded because required inputs were already collected",
+);
+assert.match(
+  source,
+  /seenActiveAgentStep[\s\S]*"running"/,
+  "first non-local executable node should start as running until live markers arrive",
+);
 
 console.log("flow-executor.test.ts: ok");

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -1,5 +1,6 @@
 import { bindingFor, loadConfig, recordSessionFamiliar, setSessionTitle } from "@/lib/cave-config";
 import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
+import { catalogNode } from "@/lib/flow/flow-catalog";
 import {
   flowRunRedactsData,
   type FlowDoc,
@@ -14,7 +15,7 @@ import {
 } from "@/lib/flow/flow-compile";
 import { flowMissingRequiredInputs } from "@/lib/required-inputs";
 import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
-import type { FlowRunRecord } from "@/lib/flows";
+import type { FlowRunRecord, FlowRunStepStatus } from "@/lib/flows";
 import { recordFlowRun } from "@/lib/server/flow-store";
 import { isAllowedHarness, normalizeProjectRoot } from "@/lib/server/session-security";
 
@@ -35,6 +36,22 @@ function flowFamiliar(flow: FlowDoc): string | null {
     if (typeof familiar === "string" && familiar.trim()) return familiar.trim();
   }
   return null;
+}
+
+function initialFlowRunStepStatus(
+  flow: FlowDoc,
+  stepId: string,
+  seenActiveAgentStep: { value: boolean },
+): FlowRunStepStatus {
+  const node = flow.nodes.find((item) => item.id === stepId);
+  const def = node ? catalogNode(node.type) : undefined;
+  if (def?.isTrigger) return "succeeded";
+  if (node?.type.startsWith("input.")) return "succeeded";
+  if (!seenActiveAgentStep.value) {
+    seenActiveAgentStep.value = true;
+    return "running";
+  }
+  return "pending";
 }
 
 export async function startFlowSession(
@@ -115,6 +132,7 @@ export async function startFlowSession(
   const byId = new Map(flow.nodes.map((node) => [node.id, node]));
   const customData = extractFlowCustomData(flow);
   const redacted = flowRunRedactsData(flow, options.mode ?? "manual");
+  const seenActiveAgentStep = { value: false };
   const run = await recordFlowRun({
     flowId: flow.id,
     flowName: flow.name,
@@ -126,7 +144,7 @@ export async function startFlowSession(
     steps: order.map((stepId) => ({
       id: stepId,
       type: byId.get(stepId)?.type ?? "unknown",
-      status: "pending" as const,
+      status: initialFlowRunStepStatus(flow, stepId, seenActiveAgentStep),
     })),
     summary: `agent session ${sessionId.slice(0, 8)}`,
     source: "cave",


### PR DESCRIPTION
## Summary
- seed flow run progress so trigger/input nodes complete immediately and the first executable node shows running instead of leaving the flow stuck at Start
- poll live daemon output as a transcript fallback when Cave/OpenClaw persisted transcripts have not landed yet
- wire seeded progress into the canvas and run sidebar before step markers arrive

## Verification
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/flow/flow-progress.test.ts
- node --experimental-strip-types src/lib/server/flow-executor.test.ts
- node --experimental-strip-types src/app/api/flows/session-transcript/route.test.ts
- node --experimental-strip-types src/components/flow/flow-executions.test.ts
- pnpm exec tsc --noEmit
- pnpm test:app
- pnpm build
- cargo check