### PR TITLE
fix(chat): keep context on resume-failure retry + stop zombie "Streaming…" state

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -539,6 +539,7 @@ export const SUITES = {
     "src/lib/openclaw-conversation.test.ts",
     "src/lib/session-initiator.test.ts",
     "src/lib/chat-runtime-scope.test.ts",
+    "src/lib/chat-history-fallback.test.ts",
     "src/lib/session-list-merge.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -353,8 +353,14 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /pushProgress\("resume-retry", "Resume failed; starting a fresh chat", "running"[\s\S]*await runAttempt\(buildArgs\(null\)\)[\s\S]*pushProgress\("resume-retry", "Fresh chat started", "done"/,
+  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*await runAttempt\([\s\S]*?buildArgs\(null, prependPriorConversation\(harnessPrompt, priorBlock\)\)[\s\S]*?\)[\s\S]*pushProgress\("resume-retry", "Fresh chat started", "done"/,
   "Transparent resume fallback should be visible in the progress timeline",
+);
+
+assert.match(
+  chatRoute,
+  /const priorBlock = buildPriorConversationBlock\(existingConversation\)[\s\S]*?await runAttempt\([\s\S]*?prependPriorConversation\(harnessPrompt, priorBlock\)/,
+  "Fresh-session retry should replay recent conversation history so the familiar keeps context",
 );
 
 assert.match(
@@ -371,7 +377,7 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\(buildArgs\(null\)\)/,
+  /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\([\s\S]*?buildArgs\(null, prependPriorConversation\(harnessPrompt, priorBlock\)\)/,
   "Fresh-chat retry should clear stale diagnostic tails before the retry attempt",
 );
 
@@ -1010,10 +1016,10 @@ assert.match(
 
 // --model is emitted before the `--` separator, never after (the prompt is a
 // variadic positional that would otherwise swallow it).
-const localArgvBlock = chatRoute.match(/const a = \["run", binding\.harness, "--stream-json"\];[\s\S]*?a\.push\("--", harnessPrompt\);/);
+const localArgvBlock = chatRoute.match(/const a = \["run", binding\.harness, "--stream-json"\];[\s\S]*?a\.push\("--", prompt\);/);
 assert.ok(localArgvBlock, "local argv builder block should be present");
 assert.ok(
-  localArgvBlock[0].indexOf('a.push("--model"') < localArgvBlock[0].indexOf('a.push("--", harnessPrompt)'),
+  localArgvBlock[0].indexOf('a.push("--model"') < localArgvBlock[0].indexOf('a.push("--", prompt)'),
   "--model must be pushed before the -- prompt separator",
 );
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -63,6 +63,10 @@ import {
   saveConversation,
 } from "@/lib/cave-conversations";
 import {
+  buildPriorConversationBlock,
+  prependPriorConversation,
+} from "@/lib/chat-history-fallback";
+import {
   cleanModelId,
   modelApplicationForHarness,
   resolveChatModelState,
@@ -1038,13 +1042,20 @@ export async function POST(req: Request) {
   // Emitted BEFORE the `--` separator for the same reason every other flag is.
   const forwardModel =
     modelForwardingEnabled && cleanModelId(desiredModel) ? desiredModel : null;
-  const buildArgs = (resumeSessionId: string | null): string[] => {
+  // `promptOverride` lets the transparent resume-retry (below) prime a fresh
+  // harness session with replayed conversation history — without it the retry
+  // forks a context-free session and the familiar loses the thread.
+  const buildArgs = (
+    resumeSessionId: string | null,
+    promptOverride?: string,
+  ): string[] => {
+    const prompt = promptOverride ?? harnessPrompt;
     if (sshRuntime) {
       return buildSshSpawnArgs({
         runtime: sshRuntime,
         harness: binding.harness,
         familiarId: body.familiarId,
-        prompt: harnessPrompt,
+        prompt,
         sessionId: resumeSessionId,
         model: forwardModel,
       });
@@ -1058,7 +1069,7 @@ export async function POST(req: Request) {
     if (/^[a-z0-9_-]+$/i.test(body.familiarId)) {
       a.push("--familiar", body.familiarId);
     }
-    a.push("--", harnessPrompt);
+    a.push("--", prompt);
     return a;
   };
   // Resume the harness's latest session id, not the stable conversation id —
@@ -1399,9 +1410,19 @@ export async function POST(req: Request) {
 
       // Transparent retry: if codex reported its rollout-resume failed and
       // we had been resuming, start a fresh thread (no --continue) so the
-      // user's prompt still gets answered.
+      // user's prompt still gets answered. A fresh harness session has no
+      // history of its own, so replay the recent conversation into the prompt —
+      // otherwise the familiar answers as if the thread just started and the
+      // user has to remind it of everything said so far.
       if (resumeFailed && body.sessionId) {
-        pushProgress("resume-retry", "Resume failed; starting a fresh chat", "running");
+        const priorBlock = buildPriorConversationBlock(existingConversation);
+        pushProgress(
+          "resume-retry",
+          priorBlock
+            ? "Resume failed; replaying recent context into a fresh chat"
+            : "Resume failed; starting a fresh chat",
+          "running",
+        );
         sessionId = null;
         assistantFilter = new AssistantFilter();
         assistantText = "";
@@ -1411,7 +1432,9 @@ export async function POST(req: Request) {
         stderrTail.length = 0;
         stdoutErrTail.length = 0;
         resumeFailed = false;
-        await runAttempt(buildArgs(null));
+        await runAttempt(
+          buildArgs(null, prependPriorConversation(harnessPrompt, priorBlock)),
+        );
         pushProgress("resume-retry", "Fresh chat started", "done");
       }
 

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -168,6 +168,28 @@ assert.match(
   "A remounted ChatView should keep following live generation updates and settle when the stream finishes",
 );
 
+// A live snapshot whose writing component unmounted (or whose stream died
+// without running cleanup) is never cleared from the registry; without a
+// staleness guard, every later mount on that session inherits a zombie
+// `busy = true` and shows "Streaming…" forever with nothing streaming.
+assert.match(
+  source,
+  /function isLiveSnapshotActive\(snapshot: LiveChatGenerationSnapshot, now: number\): boolean \{[\s\S]*?signal\.aborted[\s\S]*?updatedAt < LIVE_SNAPSHOT_TTL_MS/,
+  "A live snapshot should only count as streaming while unaborted and recently updated",
+);
+
+assert.match(
+  source,
+  /readLiveChatGeneration\(sessionId\)[\s\S]*?isLiveSnapshotActive\(live, Date\.now\(\)\)[\s\S]*?setBusy\(true\)[\s\S]*?clearLiveChatGeneration\(sessionId\)/,
+  "Mount-time adoption should ignore and evict a stale live snapshot instead of pinning busy",
+);
+
+assert.match(
+  source,
+  /subscribeLiveChatGeneration\(sessionId, \(live\) => \{\s*if \(live && isLiveSnapshotActive\(live, Date\.now\(\)\)\)/,
+  "The live-generation subscription should gate busy on snapshot liveness",
+);
+
 assert.match(
   styles,
   /\.cave-chat-meta-line\s*\{[\s\S]*min-height:/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -208,6 +208,23 @@ function subscribeLiveChatGeneration(sessionId: string, listener: LiveChatGenera
   };
 }
 
+/** A live snapshot is treated as still streaming only while its controller is
+ *  unaborted AND it has emitted an update recently. The writing component's
+ *  `finally` clears the registry when a stream ends normally — but if that
+ *  component unmounted mid-stream, or the stream died without running cleanup,
+ *  the entry is never cleared. Without this guard any view that later mounts on
+ *  the same session adopts a zombie `busy = true` from `readLiveChatGeneration`
+ *  and shows "Streaming…" forever with nothing actually streaming. An
+ *  actually-live stream refreshes `updatedAt` on every chunk (persistLiveTurns),
+ *  so the 90s TTL is generous enough to span long tool/think gaps without
+ *  tripping on a healthy generation. */
+const LIVE_SNAPSHOT_TTL_MS = 90_000;
+
+function isLiveSnapshotActive(snapshot: LiveChatGenerationSnapshot, now: number): boolean {
+  if (snapshot.controller.signal.aborted) return false;
+  return now - snapshot.updatedAt < LIVE_SNAPSHOT_TTL_MS;
+}
+
 type Props = {
   familiar: Familiar;
   sessionId: string | null;
@@ -2279,7 +2296,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   useEffect(() => {
     if (!sessionId) return;
     return subscribeLiveChatGeneration(sessionId, (live) => {
-      if (live) {
+      if (live && isLiveSnapshotActive(live, Date.now())) {
         setTurns(live.turns);
         turnsRef.current = live.turns;
         setActiveLeafId(live.activeLeafId);
@@ -2704,7 +2721,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       return;
     }
     const live = readLiveChatGeneration(sessionId);
-    if (live) {
+    if (live && isLiveSnapshotActive(live, Date.now())) {
       setTurns(live.turns);
       turnsRef.current = live.turns;
       setActiveLeafId(live.activeLeafId);
@@ -2712,6 +2729,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setHistoryState("loaded");
       setBusy(true);
       return;
+    }
+    if (live) {
+      // Stale/aborted snapshot whose cleanup never ran — evict it so neither
+      // this view nor the subscription re-adopts a dead "Streaming…" state,
+      // then fall through to loading the conversation from disk.
+      clearLiveChatGeneration(sessionId);
     }
     let cancelled = false;
     void (async () => {

--- a/src/lib/chat-history-fallback.test.ts
+++ b/src/lib/chat-history-fallback.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  MAX_FALLBACK_HISTORY_TURNS,
+  buildPriorConversationBlock,
+  prependPriorConversation,
+} from "./chat-history-fallback.ts";
+import type { ChatTurn, ConversationFile } from "./cave-conversations.ts";
+
+function turn(partial: Partial<ChatTurn> & Pick<ChatTurn, "id" | "role" | "text">): ChatTurn {
+  return {
+    parentId: null,
+    createdAt: "2026-06-28T00:00:00.000Z",
+    ...partial,
+  };
+}
+
+function conv(turns: ChatTurn[], activeLeafId?: string): Pick<ConversationFile, "turns" | "activeLeafId"> {
+  return { turns, activeLeafId };
+}
+
+test("empty / null conversations yield no block", () => {
+  assert.equal(buildPriorConversationBlock(null), "");
+  assert.equal(buildPriorConversationBlock(undefined), "");
+  assert.equal(buildPriorConversationBlock(conv([])), "");
+});
+
+test("renders a labelled transcript along the active path", () => {
+  const a = turn({ id: "a", role: "user", text: "remember the api key is XYZ", createdAt: "2026-06-28T00:00:00.000Z" });
+  const b = turn({ id: "b", parentId: "a", role: "assistant", text: "Got it, noted.", createdAt: "2026-06-28T00:00:01.000Z" });
+  const block = buildPriorConversationBlock(conv([a, b], "b"));
+  assert.match(block, /^## Prior conversation/);
+  assert.match(block, /\*\*User:\*\* remember the api key is XYZ/);
+  assert.match(block, /\*\*Assistant:\*\* Got it, noted\./);
+});
+
+test("drops system, empty, and errored turns", () => {
+  const turns = [
+    turn({ id: "s", role: "system", text: "system preamble" }),
+    turn({ id: "u", parentId: "s", role: "user", text: "hello" }),
+    turn({ id: "blank", parentId: "u", role: "assistant", text: "   " }),
+    turn({ id: "err", parentId: "blank", role: "assistant", text: "boom", isError: true }),
+    turn({ id: "ok", parentId: "err", role: "assistant", text: "real answer" }),
+  ];
+  const block = buildPriorConversationBlock(conv(turns, "ok"));
+  assert.doesNotMatch(block, /system preamble/);
+  assert.doesNotMatch(block, /boom/);
+  assert.match(block, /\*\*User:\*\* hello/);
+  assert.match(block, /\*\*Assistant:\*\* real answer/);
+});
+
+test("windows to the most recent N turns", () => {
+  const turns: ChatTurn[] = [];
+  let parent: string | null = null;
+  for (let i = 0; i < 40; i++) {
+    const id = `t${i}`;
+    turns.push(
+      turn({
+        id,
+        parentId: parent,
+        role: i % 2 === 0 ? "user" : "assistant",
+        text: `msg ${i}`,
+        createdAt: `2026-06-28T00:00:${String(i).padStart(2, "0")}.000Z`,
+      }),
+    );
+    parent = id;
+  }
+  const block = buildPriorConversationBlock(conv(turns, "t39"));
+  const lines = block.split("\n").filter((l) => l.startsWith("**"));
+  assert.equal(lines.length, MAX_FALLBACK_HISTORY_TURNS);
+  // Keeps the tail, not the head.
+  assert.match(block, /msg 39/);
+  assert.doesNotMatch(block, /msg 0\b/);
+});
+
+test("follows the selected branch, not abandoned siblings", () => {
+  const root = turn({ id: "root", role: "user", text: "start", createdAt: "2026-06-28T00:00:00.000Z" });
+  const branchA = turn({ id: "a", parentId: "root", role: "assistant", text: "answer A", createdAt: "2026-06-28T00:00:01.000Z" });
+  const branchB = turn({ id: "b", parentId: "root", role: "assistant", text: "answer B", createdAt: "2026-06-28T00:00:02.000Z" });
+  const block = buildPriorConversationBlock(conv([root, branchA, branchB], "a"));
+  assert.match(block, /answer A/);
+  assert.doesNotMatch(block, /answer B/);
+});
+
+test("prependPriorConversation is a no-op for an empty block", () => {
+  assert.equal(prependPriorConversation("PROMPT", ""), "PROMPT");
+});
+
+test("prependPriorConversation joins block, rule, and prompt", () => {
+  const out = prependPriorConversation("PROMPT", "## Prior conversation\n\n**User:** hi");
+  assert.equal(out, "## Prior conversation\n\n**User:** hi\n\n---\n\nPROMPT");
+});

--- a/src/lib/chat-history-fallback.ts
+++ b/src/lib/chat-history-fallback.ts
@@ -1,0 +1,64 @@
+/**
+ * Fallback conversation context for the chat/send route.
+ *
+ * The normal path keeps the model's memory by passing `--continue
+ * <harnessSessionId>` so the harness reconstructs history from its own rollout
+ * store — the prompt itself carries only the new message. That breaks when the
+ * harness reports its resume failed (rollout DB rotated/cleared, session locked
+ * by another process, or "not found in local store"): the route then transparently
+ * retries WITHOUT `--continue`, which starts a brand-new harness session with
+ * ZERO history. The familiar loses the thread mid-conversation and the user has
+ * to remind it of what was already said.
+ *
+ * This module rebuilds a compact transcript of the active conversation path so
+ * the fresh-session retry can be primed with recent context instead of starting
+ * blank. It is pure (no I/O) so it can be unit-tested in isolation.
+ */
+import type { ChatTurn, ConversationFile } from "./cave-conversations.ts";
+import { resolveActivePath } from "./conversation-tree.ts";
+
+/** Last N user/assistant turns to replay (~6 exchanges). Bounded so a long
+ *  thread doesn't blow the prompt budget — the active tail is what matters for
+ *  continuity. */
+export const MAX_FALLBACK_HISTORY_TURNS = 12;
+
+type ConversationHistorySource = Pick<ConversationFile, "turns" | "activeLeafId">;
+
+/**
+ * Render a "Prior conversation" markdown block from the most recent user and
+ * assistant turns along the active path. Returns "" when there is nothing
+ * usable to replay (no turns, only system/empty/errored turns). The caller is
+ * expected to load the conversation BEFORE appending the current turn, so the
+ * returned block never includes the message being sent.
+ */
+export function buildPriorConversationBlock(
+  conversation: ConversationHistorySource | null | undefined,
+  opts: { maxTurns?: number } = {},
+): string {
+  if (!conversation?.turns?.length) return "";
+  const maxTurns = opts.maxTurns ?? MAX_FALLBACK_HISTORY_TURNS;
+  const path = resolveActivePath(conversation.turns, conversation.activeLeafId ?? "");
+  const usable = path.filter(
+    (t: ChatTurn) =>
+      (t.role === "user" || t.role === "assistant") &&
+      !t.isError &&
+      t.text.trim().length > 0,
+  );
+  const windowed = usable.slice(-maxTurns);
+  if (windowed.length === 0) return "";
+  const lines = windowed.map((t) => {
+    const label = t.role === "user" ? "User" : "Assistant";
+    return `**${label}:** ${t.text.trim()}`;
+  });
+  return ["## Prior conversation", "", ...lines].join("\n");
+}
+
+/**
+ * Prepend a prior-conversation block to a harness prompt, separated by a rule so
+ * the model can tell the replayed history from the live instruction. A no-op
+ * when the block is empty.
+ */
+export function prependPriorConversation(prompt: string, block: string): string {
+  if (!block) return prompt;
+  return `${block}\n\n---\n\n${prompt}`;
+}


### PR DESCRIPTION
## Symptoms

Two reported chat bugs, both traced to the streaming/session lifecycle:

1. **The familiar loses conversation context mid-thread** — the user has to remind it of things said earlier in the same chat.
2. **The composer shows "Streaming… (esc to cancel)" but no live tokens render** — sometimes permanently, with no in-flight bubble at all.

## Root causes

### 1. Context loss — `/api/chat/send` never sends history; the resume-failure fallback forks an empty session

The send route builds `harnessPrompt` from **only the current message** (`route.ts` ~`994‑1018`). Conversation history is delegated entirely to the harness via `--continue <harnessSessionId>` (`1053`). When the harness reports its resume failed — `RESUME_ERR_RE`: rollout DB rotated/cleared, "Session ID … is already in use", "No conversation found", "not found in local store" (`1081‑1082`) — the route transparently retries **without `--continue`** (`~1403`), starting a brand-new harness session with **zero history**. The familiar answers as if the thread just started.

The library chat route already does this correctly (windowed transcript in the prompt); the familiar chat had no such fallback.

**Fix:** new pure lib `src/lib/chat-history-fallback.ts` rebuilds a windowed transcript of the **active conversation path** (`resolveActivePath`, last 12 turns, system/empty/errored turns dropped). On the resume-failure retry, that block is prepended to the prompt so the fresh session keeps context. `buildArgs` gains an optional `promptOverride`. The progress chip reflects whether context was replayed.

### 2. Stuck "Streaming…" — a zombie live-generation snapshot pins `busy = true`

In-flight generations are tracked in a module-level registry (`liveChatGenerations`) so they survive navigating between threads. The writing component's `finally` clears the entry on a normal end — but if that component **unmounts mid-stream**, or the stream **dies without running cleanup**, the entry is never cleared. Any view that later mounts on the same session then adopts a zombie `busy = true` via `readLiveChatGeneration` (and the subscription) and shows "Streaming…" forever with nothing streaming.

**Fix:** gate both adoption sites (mount + subscription) on a new `isLiveSnapshotActive(snapshot, now)` — the snapshot only counts as streaming while its controller is **unaborted** AND it was **updated within a 90s TTL**. Stale entries are evicted on mount so neither path re-adopts a dead state. A healthy stream refreshes `updatedAt` on every chunk (`persistLiveTurns`), so long tool/think gaps don't trip it; the guard only affects views *adopting* a registry snapshot, never the live writing instance.

> Note: a genuinely hung daemon stream (server never sends `done`) is a separate server-side concern — this PR fixes the client zombie-inheritance path that makes the indicator stick across remounts/navigation.

## Tests

- `src/lib/chat-history-fallback.test.ts` — windowing, active-branch following, filtering of system/empty/errored turns, prepend joining. Wired into the `api` suite.
- `chat-view-lifecycle.test.ts` — source-text assertions for the liveness guard at both adoption sites.
- `harness-routing.test.ts` — updated for the `promptOverride` `buildArgs` and the history-replay retry.

Local: `typecheck` ✓, `check:tests-wired` ✓, `test:app` (468) ✓, `test:api` (96) ✓, `test:mobile` (65) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)