### PR TITLE
Release v0.0.124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.124] - 2026-06-28
+
+Patch release on top of v0.0.123. Headline: flow executions now show real
+startup movement instead of appearing stuck at Start.
+
+### Fixed
+
+- **Flows** - new manual runs now mark local trigger/input steps complete
+  immediately and show the first executable node as running while the daemon
+  session starts producing step markers.
+- **Flows** - live run polling now falls back to the daemon event stream when
+  Cave/OpenClaw transcripts have not been persisted yet, so canvas and sidebar
+  progress can advance during the startup window.
+
+### Changed
+
+- **Polling** - always-on API polls use the visibility gate path from the latest
+  mainline performance work.
+
 ## [0.0.123] - 2026-06-28
 
 Patch release on top of v0.0.122. Headline: desktop updates and the app header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.123"
+version = "0.0.124"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.123"
+version = "0.0.124"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.123</string>
+	<string>0.0.124</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.123</string>
+	<string>0.0.124</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.123</string>
+	<string>0.0.124</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.123</string>
+	<string>0.0.124</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump Coven Cave to v0.0.124 across app, Tauri, Cargo, and iOS version metadata
- add v0.0.124 changelog notes for flow execution startup progress and polling visibility work

## Verification
- node --experimental-strip-types src/lib/app-version.test.ts
- node --experimental-strip-types src/lib/coven-version.test.ts
- node scripts/release-notes.test.mjs
- pnpm exec tsc --noEmit
- cargo check
- pnpm build