### PR TITLE
chore: allow WebSearch/WebFetch for flow runs (checked-in .claude/settings.json)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "WebSearch",
+      "WebFetch"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,9 @@ ehthumbs.db
 .zed/
 
 # Agent / tool scratch state (local automation, not for sharing)
-.claude/
+.claude/*
+# …except the shared, version-controlled Claude Code project settings.
+!.claude/settings.json
 .cursor/
 .aider*
 .comux*


### PR DESCRIPTION
## Why

Flow runs spawn a daemon harness session (`flow-executor.ts` → `POST /api/v1/sessions`) **with no permission directive**. The **codex** harness is already non-interactive on configured machines (`approval_policy="never"`, `sandbox_mode="danger-full-access"`), but the **claude** harness inherits interactive prompting — so a flow's research node hits a *"Do you want to proceed?"* gate for `WebSearch` with no human to answer, and the run **hangs forever**. Dozens of these wedged runs piled up over a single overnight window (each at 0% CPU, 7–12h old) before being reaped.

Daemon-spawned claude sessions read the project's `.claude/settings.json`, so a checked-in allowlist makes flow runs auto-approve the read-only web tools **on any machine/clone** — not just wherever a personal `settings.local.json` happens to exist.

## Changes

- **`.gitignore`** — narrow `.claude/` → `.claude/*` and re-include `!.claude/settings.json`. This is the standard Claude Code split: `settings.json` is the shared/version-controlled project config; `settings.local.json` stays personal and ignored (verified: it does **not** get staged).
- **`.claude/settings.json`** — `permissions.allow: ["WebSearch", "WebFetch"]`. Both are read-only and low-risk to blanket-allow for a research-oriented app.

## Scope / non-goals

- The **Human-Approval** flow node still pauses by design — that's an intentional review gate, not affected here.
- A flow's **delivery** node (e.g. "send via Telegram") may use its own tool; if that ever stalls, it needs its own allow entry. The observed blocker (`WebSearch`) is what this fixes.
- Build/test/CI behavior is unaffected — `.claude/settings.json` only governs Claude Code sessions.

## Verification

Launched a claude session through the **same daemon path flow runs use** (`POST /api/v1/sessions`, `harness=claude`, cwd=repo) asking it to web-search. With the allowlist in place it ran `WebSearch` with **no permission prompt** (`⏵⏵ auto mode on`) and completed with a real result. The identical path previously hung indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)