### PR TITLE
perf: runtime Web Vitals instrumentation + dev perf overlay

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 /** Suite name -> ordered list of repo-relative test file paths. */
 export const SUITES = {
   app: [
+    "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",
     "src/lib/endpoint-validators.test.ts",
     "src/lib/familiar-avatar-src.test.ts",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,8 @@ import { LiveRegionProvider } from "@/components/ui/live-region";
 import { ConfirmProvider } from "@/components/ui/confirm-dialog";
 import { PwaRegister } from "@/components/pwa-register";
 import { DevCacheResetScript } from "@/components/dev-cache-reset-script";
+import { WebVitalsReporter } from "@/components/perf/web-vitals-reporter";
+import { PerfOverlay } from "@/components/perf/perf-overlay";
 
 export const metadata: Metadata = {
   title: "CovenCave",
@@ -86,6 +88,8 @@ export default function RootLayout({
             <CornerRadiusController />
             <RemoteThemeController />
             <PwaRegister />
+            <WebVitalsReporter />
+            <PerfOverlay />
             {children}
             </ConfirmProvider>
           </LiveRegionProvider>

--- a/src/components/perf/perf-overlay.tsx
+++ b/src/components/perf/perf-overlay.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+// Display-only perf HUD. Hidden by default; enable with `?perf=1` in the URL or
+// `localStorage.setItem("cave:perf-overlay", "1")`. Shows live Web Vitals
+// (colored by rating) and the most recent custom perf measures (markStart/
+// markEnd). pointer-events-none so it never steals clicks from the app.
+
+import { useEffect, useState } from "react";
+import { formatWebVital, type WebVitalRating } from "@/lib/perf/web-vitals-format";
+import { getPerfMeasures, type PerfMeasure } from "@/lib/perf/marks";
+import type { CaveVital } from "@/components/perf/web-vitals-reporter";
+
+const RATING_COLOR: Record<WebVitalRating, string> = {
+  good: "#34d399",
+  "needs-improvement": "#fbbf24",
+  poor: "#f87171",
+  unknown: "#9ca3af",
+};
+
+function enabledFromEnv(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const q = new URLSearchParams(window.location.search);
+    if (q.get("perf") === "1") return true;
+    return window.localStorage.getItem("cave:perf-overlay") === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function PerfOverlay() {
+  const [enabled, setEnabled] = useState(false);
+  const [vitals, setVitals] = useState<Record<string, CaveVital>>({});
+  const [measures, setMeasures] = useState<readonly PerfMeasure[]>([]);
+
+  // Gate read happens post-mount so SSR markup stays empty (no hydration drift).
+  useEffect(() => {
+    setEnabled(enabledFromEnv());
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    setVitals(window.__caveVitals ?? {});
+    setMeasures([...getPerfMeasures()]);
+    const onVital = () => setVitals({ ...(window.__caveVitals ?? {}) });
+    const onMeasure = () => setMeasures([...getPerfMeasures()]);
+    window.addEventListener("cave:web-vital", onVital as EventListener);
+    window.addEventListener("cave:perf-measure", onMeasure as EventListener);
+    return () => {
+      window.removeEventListener("cave:web-vital", onVital as EventListener);
+      window.removeEventListener("cave:perf-measure", onMeasure as EventListener);
+    };
+  }, [enabled]);
+
+  if (!enabled) return null;
+
+  const vitalRows = Object.values(vitals).sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "fixed",
+        right: 8,
+        bottom: 8,
+        zIndex: 2147483647,
+        pointerEvents: "none",
+        font: "11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace",
+        color: "#e5e7eb",
+        background: "rgba(17,17,19,0.82)",
+        border: "1px solid rgba(255,255,255,0.12)",
+        borderRadius: 8,
+        padding: "8px 10px",
+        maxWidth: 240,
+        backdropFilter: "blur(6px)",
+      }}
+    >
+      <div style={{ opacity: 0.6, marginBottom: 4, letterSpacing: 0.4 }}>PERF</div>
+      {vitalRows.length === 0 ? (
+        <div style={{ opacity: 0.5 }}>waiting for vitals…</div>
+      ) : (
+        vitalRows.map((v) => (
+          <div key={v.name} style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+            <span style={{ color: RATING_COLOR[v.rating] }}>{v.name}</span>
+            <span>{formatWebVital(v.name, v.value)}</span>
+          </div>
+        ))
+      )}
+      {measures.length > 0 && (
+        <div style={{ marginTop: 6, borderTop: "1px solid rgba(255,255,255,0.12)", paddingTop: 4 }}>
+          {measures.slice(-4).map((m, i) => (
+            <div key={`${m.name}-${i}`} style={{ display: "flex", justifyContent: "space-between", gap: 12, opacity: 0.85 }}>
+              <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{m.name}</span>
+              <span>{Math.round(m.duration)} ms</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/perf/web-vitals-reporter.tsx
+++ b/src/components/perf/web-vitals-reporter.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+// Captures Core Web Vitals (LCP, INP, CLS, FCP, TTFB) via Next's built-in
+// reporter — no extra dependency, no network. Each metric is:
+//   • stashed on window.__caveVitals (inspect from the console any time),
+//   • logged via console.debug in development,
+//   • re-broadcast as a `cave:web-vital` CustomEvent the PerfOverlay listens for.
+//
+// Renders nothing. Mounted once in the root layout. This is the runtime half of
+// the perf analytics: before/after numbers for the bundle-split / polling work
+// and anything that follows.
+
+import { useReportWebVitals } from "next/web-vitals";
+import { rateWebVital, type WebVitalRating } from "@/lib/perf/web-vitals-format";
+
+export type CaveVital = {
+  name: string;
+  value: number;
+  rating: WebVitalRating;
+  at: number;
+};
+
+declare global {
+  interface Window {
+    __caveVitals?: Record<string, CaveVital>;
+  }
+}
+
+export function WebVitalsReporter() {
+  useReportWebVitals((metric) => {
+    const entry: CaveVital = {
+      name: metric.name,
+      value: metric.value,
+      rating: rateWebVital(metric.name, metric.value),
+      at: Date.now(),
+    };
+    if (typeof window !== "undefined") {
+      window.__caveVitals = { ...window.__caveVitals, [metric.name]: entry };
+      window.dispatchEvent(new CustomEvent("cave:web-vital", { detail: entry }));
+    }
+    if (process.env.NODE_ENV === "development") {
+      // eslint-disable-next-line no-console
+      console.debug(`[web-vital] ${entry.name} ${entry.value.toFixed(1)} (${entry.rating})`);
+    }
+  });
+  return null;
+}

--- a/src/lib/perf/marks.ts
+++ b/src/lib/perf/marks.ts
@@ -1,0 +1,54 @@
+// Lightweight custom-span instrumentation on top of the User Timing API.
+//
+// `markStart("chat:first-token")` … `markEnd("chat:first-token")` records a
+// `performance.measure`, keeps the last N durations in an in-memory ring (read
+// via getPerfMeasures()), and dispatches a `cave:perf-measure` CustomEvent the
+// dev overlay listens for. All calls are no-ops when the User Timing API is
+// absent (SSR, old runtimes), so callers don't need to guard.
+
+export type PerfMeasure = { name: string; duration: number; at: number };
+
+const RING_MAX = 50;
+const ring: PerfMeasure[] = [];
+
+const hasPerf = () =>
+  typeof performance !== "undefined" && typeof performance.mark === "function";
+
+const startMark = (name: string) => `cave:${name}:start`;
+
+export function markStart(name: string): void {
+  if (!hasPerf()) return;
+  try {
+    performance.mark(startMark(name));
+  } catch {
+    /* mark name clash or quota — non-fatal */
+  }
+}
+
+/** Close the span opened by markStart(name); returns the duration in ms, or null. */
+export function markEnd(name: string): number | null {
+  if (!hasPerf()) return null;
+  try {
+    const measure = performance.measure(`cave:${name}`, startMark(name));
+    // performance.measure returns the entry in modern browsers; fall back to
+    // reading it back by name if not.
+    const duration =
+      measure?.duration ??
+      performance.getEntriesByName(`cave:${name}`).at(-1)?.duration ??
+      0;
+    const entry: PerfMeasure = { name, duration, at: Date.now() };
+    ring.push(entry);
+    if (ring.length > RING_MAX) ring.shift();
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new CustomEvent("cave:perf-measure", { detail: entry }));
+    }
+    return duration;
+  } catch {
+    // markEnd without a matching markStart, etc. — non-fatal.
+    return null;
+  }
+}
+
+export function getPerfMeasures(): readonly PerfMeasure[] {
+  return ring;
+}

--- a/src/lib/perf/web-vitals-format.test.ts
+++ b/src/lib/perf/web-vitals-format.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  WEB_VITAL_THRESHOLDS,
+  rateWebVital,
+  formatWebVital,
+} from "./web-vitals-format.ts";
+
+test("rateWebVital classifies against the good/poor thresholds", () => {
+  // LCP: good ≤2500, poor >4000
+  assert.equal(rateWebVital("LCP", 1200), "good");
+  assert.equal(rateWebVital("LCP", 2500), "good"); // boundary is inclusive-good
+  assert.equal(rateWebVital("LCP", 3200), "needs-improvement");
+  assert.equal(rateWebVital("LCP", 4001), "poor");
+  // CLS is unitless
+  assert.equal(rateWebVital("CLS", 0.05), "good");
+  assert.equal(rateWebVital("CLS", 0.2), "needs-improvement");
+  assert.equal(rateWebVital("CLS", 0.3), "poor");
+});
+
+test("rateWebVital returns unknown for unrecognized metrics or bad values", () => {
+  assert.equal(rateWebVital("FID", 10), "unknown");
+  assert.equal(rateWebVital("LCP", Number.NaN), "unknown");
+});
+
+test("every threshold metric has a sane [goodMax, poorMin] pair", () => {
+  for (const [name, [goodMax, poorMin]] of Object.entries(WEB_VITAL_THRESHOLDS)) {
+    assert.ok(goodMax < poorMin, `${name}: goodMax must be below poorMin`);
+  }
+});
+
+test("formatWebVital renders ms for timings and 3-decimals for CLS", () => {
+  assert.equal(formatWebVital("LCP", 2499.6), "2500 ms");
+  assert.equal(formatWebVital("CLS", 0.1234), "0.123");
+  assert.equal(formatWebVital("LCP", Number.NaN), "—");
+});
+
+console.log("web-vitals-format.test.ts: ok");

--- a/src/lib/perf/web-vitals-format.ts
+++ b/src/lib/perf/web-vitals-format.ts
@@ -1,0 +1,34 @@
+// Pure helpers for rating + formatting Web Vitals, shared by the reporter and
+// the dev overlay. Kept free of browser/React imports so it's unit-testable.
+//
+// Thresholds follow Google's Core Web Vitals guidance (good / needs-improvement
+// / poor). Values are in milliseconds except CLS, which is unitless.
+
+export type WebVitalName = "LCP" | "INP" | "CLS" | "FCP" | "TTFB";
+export type WebVitalRating = "good" | "needs-improvement" | "poor" | "unknown";
+
+// [goodMax, poorMin]: value <= goodMax → good; value > poorMin → poor;
+// in between → needs-improvement.
+export const WEB_VITAL_THRESHOLDS: Record<WebVitalName, [number, number]> = {
+  LCP: [2500, 4000],
+  INP: [200, 500],
+  CLS: [0.1, 0.25],
+  FCP: [1800, 3000],
+  TTFB: [800, 1800],
+};
+
+export function rateWebVital(name: string, value: number): WebVitalRating {
+  const t = WEB_VITAL_THRESHOLDS[name as WebVitalName];
+  if (!t || !Number.isFinite(value)) return "unknown";
+  const [goodMax, poorMin] = t;
+  if (value <= goodMax) return "good";
+  if (value > poorMin) return "poor";
+  return "needs-improvement";
+}
+
+/** Human-readable value: CLS is unitless to 3 decimals; everything else is ms. */
+export function formatWebVital(name: string, value: number): string {
+  if (!Number.isFinite(value)) return "—";
+  if (name === "CLS") return value.toFixed(3);
+  return `${Math.round(value)} ms`;
+}


### PR DESCRIPTION
## Context

Workstream A of the performance arc — the *runtime* half of the analytics the audit called for (the build-time half, `bundle-budget`, shipped in #2036). This gives live before/after numbers for the bundle-split (#2036), polling (#2037), and any future perf work.

## Change (all additive)

- **`WebVitalsReporter`** (mounted in root layout) — captures LCP / INP / CLS / FCP / TTFB via Next's built-in `useReportWebVitals` (**no new dependency, no network**). Each metric is stashed on `window.__caveVitals`, `console.debug`'d in dev, and re-broadcast as a `cave:web-vital` event.
- **`src/lib/perf/marks.ts`** — `markStart`/`markEnd` custom-span helper over the User Timing API (SSR-safe no-ops when absent) for instrumenting spans like chat first-token; keeps a ring of recent measures and emits `cave:perf-measure`.
- **`PerfOverlay`** — display-only HUD, **hidden by default**, enabled with `?perf=1` or `localStorage.setItem("cave:perf-overlay","1")`. `pointer-events-none` so it never steals clicks. Shows live vitals colored by Google's good / needs-improvement / poor rating, plus recent custom measures.
- **`src/lib/perf/web-vitals-format.ts`** — pure rating/format helpers (Core Web Vitals thresholds), unit-tested.

No behavior change for users who don't opt into the overlay.

## Verification

- `pnpm typecheck`, `check:tests-wired` (626), `test:app` (469 — includes the new `web-vitals-format.test.ts`, wired into the app suite), `test:api` (95), `test:mobile` (65), `pnpm build` (+ bundle-budget gate) — all green.

### Usage
Open the app with `?perf=1` (or set the localStorage flag) to see the HUD; inspect `window.__caveVitals` from the console anytime. Instrument a span with:
```ts
import { markStart, markEnd } from "@/lib/perf/marks";
markStart("chat:first-token"); /* … */ markEnd("chat:first-token");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)