### PR TITLE
perf: measure lazy-surface chunk load time

### DIFF
--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -14,6 +14,7 @@
 
 import dynamic from "next/dynamic";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { markStart, markEnd } from "@/lib/perf/marks";
 
 function SurfaceFallback() {
   // Fills the surface area while the chunk loads so the layout doesn't jump.
@@ -24,27 +25,41 @@ function SurfaceFallback() {
   );
 }
 
+// Wrap a lazy loader so the chunk's fetch+parse time is recorded as a
+// `surface-load:<name>` perf measure (visible in the ?perf=1 overlay). This is
+// the runtime cost of code-splitting these surfaces — worth watching so a
+// lazy chunk doesn't grow into a noticeable open-delay.
+function timed<C>(name: string, loader: () => Promise<C>): () => Promise<C> {
+  return () => {
+    markStart(`surface-load:${name}`);
+    return loader().then((component) => {
+      markEnd(`surface-load:${name}`);
+      return component;
+    });
+  };
+}
+
 export const ComuxView = dynamic(
-  () => import("@/components/comux-view").then((m) => m.ComuxView),
+  timed("comux", () => import("@/components/comux-view").then((m) => m.ComuxView)),
   { ssr: false, loading: SurfaceFallback },
 );
 
 export const GitHubView = dynamic(
-  () => import("@/components/github-view").then((m) => m.GitHubView),
+  timed("github", () => import("@/components/github-view").then((m) => m.GitHubView)),
   { ssr: false, loading: SurfaceFallback },
 );
 
 export const FlowView = dynamic(
-  () => import("@/components/flow/flow-view").then((m) => m.FlowView),
+  timed("flow", () => import("@/components/flow/flow-view").then((m) => m.FlowView)),
   { ssr: false, loading: SurfaceFallback },
 );
 
 export const EvalsView = dynamic(
-  () => import("@/components/evals/evals-view").then((m) => m.EvalsView),
+  timed("evals", () => import("@/components/evals/evals-view").then((m) => m.EvalsView)),
   { ssr: false, loading: SurfaceFallback },
 );
 
 export const CalendarView = dynamic(
-  () => import("@/components/calendar-view").then((m) => m.CalendarView),
+  timed("calendar", () => import("@/components/calendar-view").then((m) => m.CalendarView)),
   { ssr: false, loading: SurfaceFallback },
 );


### PR DESCRIPTION
## Context

Follow-up to #2036 (surface code-splitting) and #2042 (perf-marks helper). Code-splitting trades a smaller initial bundle for a fetch+parse delay the first time each heavy surface (Flow/Code/GitHub/Evals/Calendar) is opened. This makes that trade-off **measurable**.

## Change

Wrap each `next/dynamic` loader in `lazy-surfaces.tsx` with a small `timed()` helper that brackets the import in `markStart`/`markEnd` (`@/lib/perf/marks`). The chunk's load time is recorded as a `surface-load:<name>` measure — visible in the `?perf=1` overlay and on `window.__cavePerf`.

Pure instrumentation: no change to what loads or when. So a lazy chunk growing into a noticeable open-delay surfaces instead of going unnoticed.

## Verification

- `pnpm typecheck`, `pnpm test:app` (469), `pnpm build` (+ bundle-budget gate, largest chunk unchanged at 1,713 KB) — all green. Marks helper was already verified live in #2042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)