### PR TITLE
test(chat): battle-test resume-replay + live-snapshot fixes (#2039 follow-up)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -143,6 +143,7 @@ export const SUITES = {
     "src/components/chat-view-polish.test.ts",
     "src/components/run-activity-strip.test.ts",
     "src/components/chat-view-lifecycle.test.ts",
+    "src/lib/live-chat-snapshot.test.ts",
     "src/components/chat-view-render-optimization.test.ts",
     "src/components/chat-view-canvas-artifact.test.ts",
     "src/components/csv-import-modal.test.ts",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -353,13 +353,13 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*await runAttempt\([\s\S]*?buildArgs\(null, prependPriorConversation\(harnessPrompt, priorBlock\)\)[\s\S]*?\)[\s\S]*pushProgress\("resume-retry", "Fresh chat started", "done"/,
+  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*await runAttempt\(buildArgs\(null, retry\.prompt\)\)[\s\S]*pushProgress\("resume-retry", "Fresh chat started", "done"/,
   "Transparent resume fallback should be visible in the progress timeline",
 );
 
 assert.match(
   chatRoute,
-  /const priorBlock = buildPriorConversationBlock\(existingConversation\)[\s\S]*?await runAttempt\([\s\S]*?prependPriorConversation\(harnessPrompt, priorBlock\)/,
+  /const retry = buildResumeRetryPrompt\(harnessPrompt, existingConversation\)[\s\S]*?retry\.replayedHistory[\s\S]*?await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
   "Fresh-session retry should replay recent conversation history so the familiar keeps context",
 );
 
@@ -377,7 +377,7 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\([\s\S]*?buildArgs\(null, prependPriorConversation\(harnessPrompt, priorBlock\)\)/,
+  /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
   "Fresh-chat retry should clear stale diagnostic tails before the retry attempt",
 );
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -62,10 +62,7 @@ import {
   loadConversation,
   saveConversation,
 } from "@/lib/cave-conversations";
-import {
-  buildPriorConversationBlock,
-  prependPriorConversation,
-} from "@/lib/chat-history-fallback";
+import { buildResumeRetryPrompt } from "@/lib/chat-history-fallback";
 import {
   cleanModelId,
   modelApplicationForHarness,
@@ -1415,10 +1412,10 @@ export async function POST(req: Request) {
       // otherwise the familiar answers as if the thread just started and the
       // user has to remind it of everything said so far.
       if (resumeFailed && body.sessionId) {
-        const priorBlock = buildPriorConversationBlock(existingConversation);
+        const retry = buildResumeRetryPrompt(harnessPrompt, existingConversation);
         pushProgress(
           "resume-retry",
-          priorBlock
+          retry.replayedHistory
             ? "Resume failed; replaying recent context into a fresh chat"
             : "Resume failed; starting a fresh chat",
           "running",
@@ -1432,9 +1429,7 @@ export async function POST(req: Request) {
         stderrTail.length = 0;
         stdoutErrTail.length = 0;
         resumeFailed = false;
-        await runAttempt(
-          buildArgs(null, prependPriorConversation(harnessPrompt, priorBlock)),
-        );
+        await runAttempt(buildArgs(null, retry.prompt));
         pushProgress("resume-retry", "Fresh chat started", "done");
       }
 

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -171,11 +171,13 @@ assert.match(
 // A live snapshot whose writing component unmounted (or whose stream died
 // without running cleanup) is never cleared from the registry; without a
 // staleness guard, every later mount on that session inherits a zombie
-// `busy = true` and shows "Streaming…" forever with nothing streaming.
+// `busy = true` and shows "Streaming…" forever with nothing streaming. The
+// liveness rule itself lives in @/lib/live-chat-snapshot (unit-tested there);
+// ChatView imports and applies it at both adoption sites.
 assert.match(
   source,
-  /function isLiveSnapshotActive\(snapshot: LiveChatGenerationSnapshot, now: number\): boolean \{[\s\S]*?signal\.aborted[\s\S]*?updatedAt < LIVE_SNAPSHOT_TTL_MS/,
-  "A live snapshot should only count as streaming while unaborted and recently updated",
+  /import \{ isLiveSnapshotActive \} from "@\/lib\/live-chat-snapshot"/,
+  "ChatView should consume the extracted, unit-tested liveness rule",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -8,6 +8,7 @@ import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/compone
 import { ChatArtifactViewer } from "@/components/chat-artifact-viewer";
 import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib/canvas-artifacts";
 import { segmentTurn } from "@/lib/turn-segments";
+import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { slashSaveParse } from "@/lib/slash-save-parser";
@@ -208,22 +209,10 @@ function subscribeLiveChatGeneration(sessionId: string, listener: LiveChatGenera
   };
 }
 
-/** A live snapshot is treated as still streaming only while its controller is
- *  unaborted AND it has emitted an update recently. The writing component's
- *  `finally` clears the registry when a stream ends normally — but if that
- *  component unmounted mid-stream, or the stream died without running cleanup,
- *  the entry is never cleared. Without this guard any view that later mounts on
- *  the same session adopts a zombie `busy = true` from `readLiveChatGeneration`
- *  and shows "Streaming…" forever with nothing actually streaming. An
- *  actually-live stream refreshes `updatedAt` on every chunk (persistLiveTurns),
- *  so the 90s TTL is generous enough to span long tool/think gaps without
- *  tripping on a healthy generation. */
-const LIVE_SNAPSHOT_TTL_MS = 90_000;
-
-function isLiveSnapshotActive(snapshot: LiveChatGenerationSnapshot, now: number): boolean {
-  if (snapshot.controller.signal.aborted) return false;
-  return now - snapshot.updatedAt < LIVE_SNAPSHOT_TTL_MS;
-}
+// `isLiveSnapshotActive` lives in @/lib/live-chat-snapshot so the staleness rule
+// (the guard that stops a remounted view from inheriting a zombie "Streaming…"
+// state) can be unit-tested without React. The full LiveChatGenerationSnapshot
+// is structurally assignable to the helper's minimal SnapshotLiveness shape.
 
 type Props = {
   familiar: Familiar;

--- a/src/lib/chat-history-fallback.test.ts
+++ b/src/lib/chat-history-fallback.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   MAX_FALLBACK_HISTORY_TURNS,
+  MAX_FALLBACK_CHARS_PER_TURN,
   buildPriorConversationBlock,
+  buildResumeRetryPrompt,
   prependPriorConversation,
 } from "./chat-history-fallback.ts";
 import type { ChatTurn, ConversationFile } from "./cave-conversations.ts";
@@ -89,4 +91,139 @@ test("prependPriorConversation is a no-op for an empty block", () => {
 test("prependPriorConversation joins block, rule, and prompt", () => {
   const out = prependPriorConversation("PROMPT", "## Prior conversation\n\n**User:** hi");
   assert.equal(out, "## Prior conversation\n\n**User:** hi\n\n---\n\nPROMPT");
+});
+
+// ── adversarial / robustness edge cases ──────────────────────────────────────
+
+test("missing activeLeafId falls back to chronological order", () => {
+  // Out-of-order array, no activeLeafId: resolveActivePath linearizes by createdAt.
+  const turns = [
+    turn({ id: "b", role: "assistant", text: "second", createdAt: "2026-06-28T00:00:02.000Z" }),
+    turn({ id: "a", role: "user", text: "first", createdAt: "2026-06-28T00:00:01.000Z" }),
+  ];
+  const block = buildPriorConversationBlock(conv(turns));
+  assert.ok(
+    block.indexOf("first") < block.indexOf("second"),
+    "turns should be replayed oldest-first regardless of array order",
+  );
+});
+
+test("a dangling activeLeafId (no such turn) falls back instead of throwing", () => {
+  const turns = [
+    turn({ id: "a", role: "user", text: "hello", createdAt: "2026-06-28T00:00:01.000Z" }),
+    turn({ id: "b", parentId: "a", role: "assistant", text: "hi there", createdAt: "2026-06-28T00:00:02.000Z" }),
+  ];
+  const block = buildPriorConversationBlock(conv(turns, "does-not-exist"));
+  assert.match(block, /hello/);
+  assert.match(block, /hi there/);
+});
+
+test("a parentId cycle does not hang and still yields a bounded block", () => {
+  // Corrupt ring: a -> b -> a. resolveActivePath guards against revisiting.
+  const a = turn({ id: "a", parentId: "b", role: "user", text: "ring one" });
+  const b = turn({ id: "b", parentId: "a", role: "assistant", text: "ring two" });
+  const block = buildPriorConversationBlock(conv([a, b], "a"));
+  // Whatever the traversal yields, it must terminate and stay a valid block.
+  assert.match(block, /^## Prior conversation/);
+  const lines = block.split("\n").filter((l) => l.startsWith("**"));
+  assert.ok(lines.length >= 1 && lines.length <= 2);
+});
+
+test("oversized turn text is clamped with a truncation marker", () => {
+  const huge = "x".repeat(MAX_FALLBACK_CHARS_PER_TURN + 5000);
+  const block = buildPriorConversationBlock(
+    conv([turn({ id: "a", role: "user", text: huge })], "a"),
+  );
+  assert.match(block, /… \(truncated\)/);
+  // The single line must be bounded near the cap, not the full 9000 chars.
+  const line = block.split("\n").find((l) => l.startsWith("**User:**"))!;
+  assert.ok(line.length < MAX_FALLBACK_CHARS_PER_TURN + 100);
+});
+
+test("maxCharsPerTurn override clamps shorter and is honoured", () => {
+  const block = buildPriorConversationBlock(
+    conv([turn({ id: "a", role: "user", text: "abcdefghij" })], "a"),
+    { maxCharsPerTurn: 4 },
+  );
+  assert.match(block, /\*\*User:\*\* abcd… \(truncated\)/);
+});
+
+test("maxTurns override narrows the window", () => {
+  const turns: ChatTurn[] = [];
+  let parent: string | null = null;
+  for (let i = 0; i < 6; i++) {
+    const id = `t${i}`;
+    turns.push(
+      turn({
+        id,
+        parentId: parent,
+        role: i % 2 === 0 ? "user" : "assistant",
+        text: `msg ${i}`,
+        createdAt: `2026-06-28T00:00:0${i}.000Z`,
+      }),
+    );
+    parent = id;
+  }
+  const block = buildPriorConversationBlock(conv(turns, "t5"), { maxTurns: 2 });
+  const lines = block.split("\n").filter((l) => l.startsWith("**"));
+  assert.equal(lines.length, 2);
+  assert.match(block, /msg 5/);
+  assert.match(block, /msg 4/);
+  assert.doesNotMatch(block, /msg 3/);
+});
+
+test("MAX_FALLBACK_CHARS_PER_TURN keeps a full window bounded", () => {
+  // Worst case: a full window of maxed-out turns stays within a predictable cap.
+  const cap = MAX_FALLBACK_HISTORY_TURNS * (MAX_FALLBACK_CHARS_PER_TURN + 64);
+  const turns: ChatTurn[] = [];
+  let parent: string | null = null;
+  for (let i = 0; i < MAX_FALLBACK_HISTORY_TURNS + 4; i++) {
+    const id = `t${i}`;
+    turns.push(
+      turn({
+        id,
+        parentId: parent,
+        role: i % 2 === 0 ? "user" : "assistant",
+        text: "y".repeat(MAX_FALLBACK_CHARS_PER_TURN * 3),
+        createdAt: `2026-06-28T00:${String(i).padStart(2, "0")}:00.000Z`,
+      }),
+    );
+    parent = id;
+  }
+  const block = buildPriorConversationBlock(conv(turns, `t${MAX_FALLBACK_HISTORY_TURNS + 3}`));
+  assert.ok(block.length < cap, `block (${block.length}) should stay under ${cap}`);
+});
+
+// ── buildResumeRetryPrompt: the exact transformation the route applies ────────
+
+test("buildResumeRetryPrompt replays history ahead of the live prompt", () => {
+  const turns = [
+    turn({ id: "a", role: "user", text: "the deploy token is ABC", createdAt: "2026-06-28T00:00:01.000Z" }),
+    turn({ id: "b", parentId: "a", role: "assistant", text: "noted", createdAt: "2026-06-28T00:00:02.000Z" }),
+  ];
+  const { prompt, replayedHistory } = buildResumeRetryPrompt("LIVE INSTRUCTION", conv(turns, "b"));
+  assert.equal(replayedHistory, true);
+  assert.match(prompt, /## Prior conversation/);
+  assert.match(prompt, /the deploy token is ABC/);
+  assert.ok(
+    prompt.indexOf("the deploy token is ABC") < prompt.indexOf("LIVE INSTRUCTION"),
+    "replayed history must precede the live instruction",
+  );
+  assert.ok(prompt.endsWith("LIVE INSTRUCTION"));
+});
+
+test("buildResumeRetryPrompt is a transparent passthrough when there is no history", () => {
+  const { prompt, replayedHistory } = buildResumeRetryPrompt("LIVE INSTRUCTION", null);
+  assert.equal(replayedHistory, false);
+  assert.equal(prompt, "LIVE INSTRUCTION");
+});
+
+test("buildResumeRetryPrompt reports no replay when only unusable turns exist", () => {
+  const turns = [
+    turn({ id: "s", role: "system", text: "preamble" }),
+    turn({ id: "e", parentId: "s", role: "assistant", text: "boom", isError: true }),
+  ];
+  const { prompt, replayedHistory } = buildResumeRetryPrompt("LIVE", conv(turns, "e"));
+  assert.equal(replayedHistory, false);
+  assert.equal(prompt, "LIVE");
 });

--- a/src/lib/chat-history-fallback.ts
+++ b/src/lib/chat-history-fallback.ts
@@ -22,7 +22,21 @@ import { resolveActivePath } from "./conversation-tree.ts";
  *  continuity. */
 export const MAX_FALLBACK_HISTORY_TURNS = 12;
 
+/** Per-turn character cap. A single pasted wall of text (a stack trace, a whole
+ *  file) replayed verbatim could dominate or blow the prompt budget; clamp each
+ *  replayed turn so the block stays bounded (~12 turns × this) regardless of how
+ *  large any one historical message was. Generous enough to preserve the gist. */
+export const MAX_FALLBACK_CHARS_PER_TURN = 4000;
+
+const TRUNCATION_MARKER = "… (truncated)";
+
 type ConversationHistorySource = Pick<ConversationFile, "turns" | "activeLeafId">;
+
+function clampTurnText(text: string, maxChars: number): string {
+  const trimmed = text.trim();
+  if (maxChars <= 0 || trimmed.length <= maxChars) return trimmed;
+  return `${trimmed.slice(0, maxChars).trimEnd()}${TRUNCATION_MARKER}`;
+}
 
 /**
  * Render a "Prior conversation" markdown block from the most recent user and
@@ -33,10 +47,11 @@ type ConversationHistorySource = Pick<ConversationFile, "turns" | "activeLeafId"
  */
 export function buildPriorConversationBlock(
   conversation: ConversationHistorySource | null | undefined,
-  opts: { maxTurns?: number } = {},
+  opts: { maxTurns?: number; maxCharsPerTurn?: number } = {},
 ): string {
   if (!conversation?.turns?.length) return "";
   const maxTurns = opts.maxTurns ?? MAX_FALLBACK_HISTORY_TURNS;
+  const maxCharsPerTurn = opts.maxCharsPerTurn ?? MAX_FALLBACK_CHARS_PER_TURN;
   const path = resolveActivePath(conversation.turns, conversation.activeLeafId ?? "");
   const usable = path.filter(
     (t: ChatTurn) =>
@@ -48,7 +63,7 @@ export function buildPriorConversationBlock(
   if (windowed.length === 0) return "";
   const lines = windowed.map((t) => {
     const label = t.role === "user" ? "User" : "Assistant";
-    return `**${label}:** ${t.text.trim()}`;
+    return `**${label}:** ${clampTurnText(t.text, maxCharsPerTurn)}`;
   });
   return ["## Prior conversation", "", ...lines].join("\n");
 }
@@ -61,4 +76,24 @@ export function buildPriorConversationBlock(
 export function prependPriorConversation(prompt: string, block: string): string {
   if (!block) return prompt;
   return `${block}\n\n---\n\n${prompt}`;
+}
+
+/**
+ * The exact prompt transformation the chat/send route applies when a harness
+ * resume fails and it has to fork a fresh session: replay recent history (if
+ * any) into the prompt so the new session keeps context. Returns the prompt to
+ * spawn with plus whether history was actually replayed (so the caller can
+ * reflect it in the progress timeline). Keeping this as one pure function lets
+ * the route's fallback behaviour be unit-tested without spawning a harness.
+ */
+export function buildResumeRetryPrompt(
+  harnessPrompt: string,
+  conversation: ConversationHistorySource | null | undefined,
+  opts: { maxTurns?: number; maxCharsPerTurn?: number } = {},
+): { prompt: string; replayedHistory: boolean } {
+  const block = buildPriorConversationBlock(conversation, opts);
+  return {
+    prompt: prependPriorConversation(harnessPrompt, block),
+    replayedHistory: block.length > 0,
+  };
 }

--- a/src/lib/live-chat-snapshot.test.ts
+++ b/src/lib/live-chat-snapshot.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  LIVE_SNAPSHOT_TTL_MS,
+  isLiveSnapshotActive,
+  type SnapshotLiveness,
+} from "./live-chat-snapshot.ts";
+
+function snap(updatedAt: number, aborted = false): SnapshotLiveness {
+  return { controller: { signal: { aborted } }, updatedAt };
+}
+
+test("a fresh, unaborted snapshot is active", () => {
+  const now = 1_000_000;
+  assert.equal(isLiveSnapshotActive(snap(now), now), true);
+});
+
+test("an aborted snapshot is never active, even when fresh", () => {
+  const now = 1_000_000;
+  assert.equal(isLiveSnapshotActive(snap(now, true), now), false);
+});
+
+test("a snapshot just under the TTL is still active", () => {
+  const now = 5_000_000;
+  const updatedAt = now - (LIVE_SNAPSHOT_TTL_MS - 1);
+  assert.equal(isLiveSnapshotActive(snap(updatedAt), now), true);
+});
+
+test("a snapshot exactly at the TTL boundary is stale (strict <)", () => {
+  const now = 5_000_000;
+  const updatedAt = now - LIVE_SNAPSHOT_TTL_MS;
+  assert.equal(isLiveSnapshotActive(snap(updatedAt), now), false);
+});
+
+test("a long-idle snapshot is stale — the zombie-busy case", () => {
+  const now = 5_000_000;
+  const updatedAt = now - LIVE_SNAPSHOT_TTL_MS * 10;
+  assert.equal(isLiveSnapshotActive(snap(updatedAt), now), false);
+});
+
+test("an aborted snapshot past the TTL is also stale (both conditions fail)", () => {
+  const now = 5_000_000;
+  assert.equal(isLiveSnapshotActive(snap(now - LIVE_SNAPSHOT_TTL_MS * 2, true), now), false);
+});
+
+test("clock skew (updatedAt slightly in the future) is treated as active", () => {
+  // A negative elapsed time is < TTL, so a snapshot stamped a moment ahead of
+  // this view's clock still counts as live rather than being wrongly evicted.
+  const now = 5_000_000;
+  assert.equal(isLiveSnapshotActive(snap(now + 500), now), true);
+});
+
+test("TTL is generous enough to span a multi-second tool/think gap", () => {
+  const now = 5_000_000;
+  // 60s of silence (a long tool call) must not be mistaken for a dead stream.
+  assert.equal(isLiveSnapshotActive(snap(now - 60_000), now), true);
+});

--- a/src/lib/live-chat-snapshot.ts
+++ b/src/lib/live-chat-snapshot.ts
@@ -1,0 +1,36 @@
+/**
+ * Liveness rule for an in-flight chat-generation snapshot.
+ *
+ * ChatView tracks active generations in a module-level registry so a stream
+ * survives navigating between threads. The component that started the stream
+ * clears its registry entry in a `finally` when the stream ends normally — but
+ * if that component unmounts mid-stream, or the stream dies without running
+ * cleanup, the entry is never cleared. Without a liveness check, any view that
+ * later mounts on the same session adopts a zombie `busy = true` and shows
+ * "Streaming…" forever with nothing actually streaming.
+ *
+ * A snapshot counts as still streaming only while its controller is unaborted
+ * AND it emitted an update recently. A healthy stream refreshes `updatedAt` on
+ * every chunk (see persistLiveTurns in chat-view), so the TTL is generous
+ * enough to span long tool/think gaps without tripping on a live generation.
+ *
+ * Pure + dependency-light (it only needs the controller's aborted flag and the
+ * timestamp) so the liveness decision can be unit-tested without React.
+ */
+
+/** Max idle time before a registry snapshot is presumed dead. Generous on
+ *  purpose: a live stream pings `updatedAt` every chunk, so only a genuinely
+ *  stalled/orphaned generation goes quiet this long. */
+export const LIVE_SNAPSHOT_TTL_MS = 90_000;
+
+/** Minimal shape the liveness check needs. The real LiveChatGenerationSnapshot
+ *  (with a full AbortController and Turn[]) is structurally assignable. */
+export type SnapshotLiveness = {
+  controller: { signal: { aborted: boolean } };
+  updatedAt: number;
+};
+
+export function isLiveSnapshotActive(snapshot: SnapshotLiveness, now: number): boolean {
+  if (snapshot.controller.signal.aborted) return false;
+  return now - snapshot.updatedAt < LIVE_SNAPSHOT_TTL_MS;
+}


### PR DESCRIPTION
Follow-up to #2039. Those fixes were guarded mostly by **source-text regex assertions** — they prove the code *reads* right but never *execute* it. This PR converts the core decision logic into pure, behaviorally-tested helpers and shrinks the untested surface to trivial wiring.

## Why not a full-route behavioral test?

The send route spawns the harness via raw `node:child_process.spawn` (wrapped by `covenLaunchCommand`/`covenSpawnEnv`) with **no mock seam**, and there's no precedent in the codebase for mocking `child_process`. Executing `POST` end-to-end would require mocking config, `coven-bin`, the filesystem conversation store, and the knowledge vault, plus orchestrating two timed spawns over an SSE stream — far more fragile than the bug it would catch. Instead I **extracted the route's actual decision logic into pure functions** and test those directly; the route is now thin wiring over tested units.

## Changes

### Live-snapshot staleness (Issue 1) — now behaviorally tested
- Extracted `isLiveSnapshotActive` + `LIVE_SNAPSHOT_TTL_MS` into `src/lib/live-chat-snapshot.ts`; `ChatView` imports it. The full `LiveChatGenerationSnapshot` is structurally assignable to the helper's minimal shape.
- `live-chat-snapshot.test.ts` exercises the real decision: aborted controller (never live), fresh, **exactly at the TTL boundary** (stale, strict `<`), long-idle zombie, clock skew (future `updatedAt` → still live), and a 60s tool/think gap (still live).

### Resume-failure transform (Issue 2) — now behaviorally tested
- Extracted the route's exact retry transformation into `buildResumeRetryPrompt(harnessPrompt, conversation) → { prompt, replayedHistory }`. The route's retry path calls it instead of inlining `buildPriorConversationBlock`/`prependPriorConversation`.
- Tests assert the replayed history **precedes** the live instruction, transparent passthrough with no history, and "no replay" when only system/empty/errored turns exist.

### Robustness hardening
- Added a per-turn char cap (`MAX_FALLBACK_CHARS_PER_TURN = 4000`) so a single pasted wall of text (stack trace, whole file) can't dominate or blow the prompt budget. A full 12-turn window now stays provably bounded.
- Adversarial history-builder tests: missing/dangling `activeLeafId` fallback, **`parentId` cycle** (terminates, bounded output), oversized-turn clamping, `maxTurns`/`maxCharsPerTurn` overrides, worst-case full-window size bound.

### Test bookkeeping
- Updated source-text assertions (`harness-routing`, `chat-view-lifecycle`) for the extracted helpers; wired `live-chat-snapshot.test.ts` into the app suite.

## Verification
`typecheck` ✓, `check:tests-wired` ✓, `test:app` (470) ✓, `test:api` (96) ✓, `test:mobile` (65) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)