### PR TITLE
feat(flow): readable session output + per-step logs for flow runs

### DIFF
--- a/src/components/flow/flow-run-steps.tsx
+++ b/src/components/flow/flow-run-steps.tsx
@@ -6,6 +6,7 @@ import { catalogNode } from "@/lib/flow/flow-catalog";
 import type { FlowDoc } from "@/lib/flow/flow-doc";
 import type { FlowNodePhase, FlowRunProgress } from "@/lib/flow/flow-progress";
 import type { FlowRunRecord } from "@/lib/flows";
+import { stripStepMarkers } from "@/lib/workflow-step-progress";
 
 const STATUS_LABEL: Record<FlowRunRecord["status"], string> = {
   preview: "Preview",
@@ -36,10 +37,12 @@ export type FlowRunStepsProps = {
 
 /**
  * Live step list docked beside the canvas. Walks the run's steps in execution
- * order, painting each with its live phase parsed from the agent transcript and
- * surfacing the active step's narration — so the run is legible on the page, not
- * only as coloured dots scattered across the graph. Click a step to focus its
- * node.
+ * order, painting each with its live phase parsed from the agent transcript.
+ * Each step headlines its `@@step-note` summary and expands to reveal its own
+ * cleaned log (the active step auto-opens) — so the run is legible per step, not
+ * only as coloured dots scattered across the graph. Click a step's row to focus
+ * its node; click the chevron to open its log. The "Session output" pane shows
+ * the full transcript with bookkeeping markers scrubbed out.
  */
 export function FlowRunSteps({
   doc,
@@ -53,14 +56,29 @@ export function FlowRunSteps({
 }: FlowRunStepsProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
+  // Steps the user has manually expanded to read the full per-step log.
+  const [expandedSteps, setExpandedSteps] = useState<Set<string>>(() => new Set());
+  const toggleStep = (id: string) =>
+    setExpandedSteps((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
 
-  const transcript = progress.transcript.trim();
+  // Marker lines (`@@step-…`) are bookkeeping, not output — scrub them so the
+  // session log reads as prose. Show the most recent window.
+  const transcript = useMemo(() => stripStepMarkers(progress.transcript), [progress.transcript]);
   const nameById = useMemo(
     () => new Map(doc.nodes.map((node) => [node.id, node.name])),
     [doc.nodes],
   );
   const detailById = useMemo(
     () => new Map(progress.steps.map((step) => [step.id, step.detail])),
+    [progress.steps],
+  );
+  const noteById = useMemo(
+    () => new Map(progress.steps.map((step) => [step.id, step.note ?? ""])),
     [progress.steps],
   );
 
@@ -116,36 +134,56 @@ export function FlowRunSteps({
             const def = catalogNode(step.type);
             const name = nameById.get(step.id) ?? def?.label ?? step.type;
             const detail = detailById.get(step.id) ?? "";
+            const note = noteById.get(step.id) ?? "";
             const isActive = phase === "running";
             const isSelected = step.id === selectedNodeId;
+            // The active step auto-opens so live narration is visible; otherwise
+            // the row's log stays collapsed until the user expands it.
+            const isExpanded = expandedSteps.has(step.id) || (isActive && detail !== "");
+            const canExpand = detail !== "";
             return (
               <li
                 key={step.id}
                 className={`flow-run-step flow-run-step-${phase}${isSelected ? " is-selected" : ""}`}
               >
-                <button
-                  type="button"
-                  className="flow-run-step-row"
-                  onClick={() => onSelectNode(step.id)}
-                  title={`Focus ${name}`}
-                >
-                  <span className={`flow-run-step-icon flow-run-step-icon-${phase}`} aria-hidden>
-                    <Icon
-                      name={PHASE_ICON[phase]}
-                      width={15}
-                      className={isActive ? "flow-run-step-spin" : undefined}
-                    />
-                  </span>
-                  <span className="flow-run-step-body">
-                    <span className="flow-run-step-name">{name}</span>
-                    <span className="flow-run-step-type">{def?.label ?? step.type}</span>
-                  </span>
-                  <span className="flow-run-step-phase" aria-label={phase}>
-                    {phase}
-                  </span>
-                </button>
-                {isActive && detail && (
-                  <p className="flow-run-step-detail">{detail.slice(0, 280)}</p>
+                <div className="flow-run-step-row">
+                  <button
+                    type="button"
+                    className="flow-run-step-main"
+                    onClick={() => onSelectNode(step.id)}
+                    title={`Focus ${name}`}
+                  >
+                    <span className={`flow-run-step-icon flow-run-step-icon-${phase}`} aria-hidden>
+                      <Icon
+                        name={PHASE_ICON[phase]}
+                        width={15}
+                        className={isActive ? "flow-run-step-spin" : undefined}
+                      />
+                    </span>
+                    <span className="flow-run-step-body">
+                      <span className="flow-run-step-name">{name}</span>
+                      {/* A `@@step-note` summary headlines what the step produced;
+                          fall back to the node type when there's no note yet. */}
+                      <span className="flow-run-step-type">{note || def?.label || step.type}</span>
+                    </span>
+                    <span className="flow-run-step-phase" aria-label={phase}>
+                      {phase}
+                    </span>
+                  </button>
+                  {canExpand && (
+                    <button
+                      type="button"
+                      className="flow-run-step-expand"
+                      onClick={() => toggleStep(step.id)}
+                      aria-expanded={isExpanded}
+                      title={isExpanded ? "Hide step log" : "Show step log"}
+                    >
+                      <Icon name={isExpanded ? "ph:caret-down" : "ph:caret-right"} width={12} />
+                    </button>
+                  )}
+                </div>
+                {isExpanded && detail && (
+                  <pre className="flow-run-step-detail">{detail}</pre>
                 )}
               </li>
             );

--- a/src/lib/flow/flow-compile.test.ts
+++ b/src/lib/flow/flow-compile.test.ts
@@ -280,6 +280,10 @@ function build(nodes: Array<[string, string]>, edges: Array<[string, string]>): 
   assert.match(prompt, /@@step-start t\b/, "shows a concrete example using the first node id");
   assert.match(prompt, /own line/, "tells the agent to print each marker on its own line");
   assert.doesNotMatch(prompt, /`@@step-(start|done|fail)/, "never wraps a marker in backticks");
+  // Per-step logging: asks for a one-line @@step-note summary and plain-language
+  // narration so each step's log/headline is clear.
+  assert.match(prompt, /@@step-note <id>/, "asks for a one-line per-step summary note");
+  assert.match(prompt, /narrate/i, "asks the agent to narrate each step's work");
 }
 
 console.log("flow-compile.test.ts OK");

--- a/src/lib/flow/flow-compile.ts
+++ b/src/lib/flow/flow-compile.ts
@@ -272,8 +272,11 @@ export function compileFlowPrompt(
   lines.push("- Print each marker as plain text on its own line, with nothing else on that line.");
   lines.push("- Do NOT wrap a marker in backticks or a code block, and do NOT put it inside a sentence — a marker that isn't a bare line is ignored and the run will look stuck.");
   lines.push("- Immediately before working a node, print:  @@step-start <id>");
-  lines.push("- When that node has succeeded, print:        @@step-done <id>");
-  lines.push("- If that node fails, print:                  @@step-fail <id>  (then stop unless the node says to continue).");
+  lines.push("- While working a node, narrate what you are doing in plain language — these lines become that step's expandable log, so be clear and specific (inputs used, actions taken, what you found).");
+  lines.push("- When a node succeeds, FIRST print a one-line summary of what it produced:  @@step-note <id> <summary>");
+  lines.push("  (e.g. `@@step-note research-search Collected 6 sources on EU/US AI-safety policy`). This becomes the step's headline — keep it to one line, no backticks.");
+  lines.push("- Then print:                                 @@step-done <id>");
+  lines.push("- If that node fails, print a `@@step-note <id> <why it failed>` then:  @@step-fail <id>  (then stop unless the node says to continue).");
   lines.push("- Use the exact id shown in [brackets] below — not the node's name.");
   if (order.length > 0) {
     lines.push(`For example, the very first line of your reply should be:  @@step-start ${order[0]}`);

--- a/src/lib/workflow-step-progress.test.ts
+++ b/src/lib/workflow-step-progress.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { parseWorkflowStepProgress } from "./workflow-step-progress.ts";
+import { parseWorkflowStepProgress, stripStepMarkers } from "./workflow-step-progress.ts";
 
 const ORDER = ["gather", "draft", "review", "publish"];
 
@@ -77,6 +77,48 @@ const ORDER = ["gather", "draft", "review", "publish"];
 {
   const r = parseWorkflowStepProgress("we will @@step-start gather when ready", ORDER);
   assert.equal(r.markersFound, false, "inline mention is not a marker");
+}
+
+// 8. @@step-note becomes the step's one-line headline; marker lines (start/done/
+//    note) are scrubbed out of the captured detail body.
+{
+  const t = [
+    "@@step-start gather",
+    "searching the web for sources…",
+    "@@step-note gather Collected 6 sources on AI-safety policy",
+    "@@step-done gather",
+    "@@step-start draft",
+    "writing now",
+  ].join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.equal(r.steps[0].note, "Collected 6 sources on AI-safety policy", "note becomes the headline");
+  assert.match(r.steps[0].detail, /searching the web for sources/, "detail keeps the narration");
+  assert.doesNotMatch(r.steps[0].detail, /@@step-/, "detail has no leftover marker lines");
+  assert.equal(r.steps[1].note, undefined, "a step with no note reports undefined");
+}
+
+// 9. Last note for a step wins; notes naming unknown ids are ignored.
+{
+  const t = [
+    "@@step-start gather",
+    "@@step-note gather first guess",
+    "@@step-note gather final summary",
+    "@@step-note bogus should be dropped",
+    "@@step-done gather",
+  ].join("\n");
+  const r = parseWorkflowStepProgress(t, ORDER);
+  assert.equal(r.steps[0].note, "final summary", "the latest note wins");
+  assert.equal(r.steps.find((s) => s.id === "bogus"), undefined, "unknown-id note never creates a step");
+}
+
+// 10. stripStepMarkers scrubs every marker line and collapses the gaps.
+{
+  const out = stripStepMarkers(
+    ["@@step-start gather", "real output line", "@@step-note gather summary", "@@step-done gather", "more output"].join("\n"),
+  );
+  assert.doesNotMatch(out, /@@step-/, "no markers survive");
+  assert.match(out, /real output line/);
+  assert.match(out, /more output/);
 }
 
 console.log("workflow-step-progress.test.ts: ok");

--- a/src/lib/workflow-step-progress.ts
+++ b/src/lib/workflow-step-progress.ts
@@ -10,11 +10,13 @@
  *
  *   @@step-start <id>
  *   …the agent's work / reasoning / output for that step…
+ *   @@step-note <id> <one-line summary of what the step produced>   (optional)
  *   @@step-done <id>      (or @@step-fail <id>)
  *
  * This pure parser maps that transcript back onto the manifest's ordered steps,
  * capturing the text between a step's start marker and the next marker as that
- * step's debug detail. It's deliberately tolerant: a step that started and was
+ * step's debug detail (with marker lines scrubbed out), plus the optional
+ * one-line `@@step-note` as a clean per-step headline. It's deliberately tolerant: a step that started and was
  * superseded by a later start is treated as implicitly succeeded, and a run
  * whose agent emitted no markers at all reports `markersFound: false` so the UI
  * can fall back to showing the raw transcript.
@@ -25,8 +27,14 @@ export type WorkflowStepProgressStatus = "pending" | "active" | "succeeded" | "f
 export type WorkflowStepProgress = {
   id: string;
   status: WorkflowStepProgressStatus;
-  /** Agent narration captured while this step was active — the debug detail. */
+  /** Agent narration captured while this step was active — the debug detail.
+   *  Step-marker lines (including `@@step-note`) are stripped so it reads as
+   *  clean prose. */
   detail: string;
+  /** One-line summary the agent emitted via `@@step-note <id> <text>` — a clean
+   *  headline for the step, distinct from the fuller `detail` body. Last note
+   *  for a step wins; undefined when the agent emitted none. */
+  note?: string;
 };
 
 export type WorkflowStepProgressResult = {
@@ -42,9 +50,17 @@ export type WorkflowStepProgressResult = {
 type Marker = { kind: "start" | "done" | "fail"; id: string; at: number; end: number };
 
 const MARKER_RE = /^[ \t]*@@step-(start|done|fail)[ \t]+(\S+)[ \t]*$/gim;
+// A per-step summary line: `@@step-note <id> <free text>`. Kept separate from
+// MARKER_RE so the trailing free text doesn't break the strict start/done/fail
+// shape, and so notes never act as step boundaries.
+const NOTE_RE = /^[ \t]*@@step-note[ \t]+(\S+)[ \t]+(.+?)[ \t]*$/gim;
+// Any step-marker line (start/done/fail/note) — used to scrub markers out of the
+// human-facing detail/transcript text.
+const ANY_MARKER_LINE_RE = /^[ \t]*@@step-(?:start|done|fail|note)\b.*$/gim;
 const MAX_DETAIL = 4000;
+const MAX_NOTE = 240;
 
-/** Extract every step marker in source order. */
+/** Extract every start/done/fail marker in source order. */
 function findMarkers(transcript: string): Marker[] {
   const markers: Marker[] = [];
   MARKER_RE.lastIndex = 0;
@@ -55,8 +71,32 @@ function findMarkers(transcript: string): Marker[] {
   return markers;
 }
 
+/** Extract every `@@step-note` as {id, text} in source order. */
+function findNotes(transcript: string): Array<{ id: string; text: string }> {
+  const notes: Array<{ id: string; text: string }> = [];
+  NOTE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = NOTE_RE.exec(transcript)) !== null) {
+    notes.push({ id: m[1], text: m[2].trim() });
+  }
+  return notes;
+}
+
+/**
+ * Remove every step-marker line from agent text so the human-facing log/output
+ * reads as clean prose. Collapses the blank lines a stripped marker leaves
+ * behind. Exported so the run UI's "Session output" pane and per-step detail
+ * share one scrubbing rule.
+ */
+export function stripStepMarkers(text: string): string {
+  return (text ?? "")
+    .replace(ANY_MARKER_LINE_RE, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function clip(text: string): string {
-  const trimmed = text.trim();
+  const trimmed = stripStepMarkers(text);
   return trimmed.length > MAX_DETAIL ? `${trimmed.slice(0, MAX_DETAIL)}\n…` : trimmed;
 }
 
@@ -109,7 +149,8 @@ export function parseWorkflowStepProgress(
     }
   }
 
-  // Capture each start's detail = text up to the next marker of any step.
+  // Capture each start's detail = text up to the next marker of any step, with
+  // step-marker lines scrubbed out (clip() strips them) so the body is prose.
   for (let i = 0; i < real.length; i++) {
     const mk = real[i];
     if (mk.kind !== "start") continue;
@@ -118,10 +159,19 @@ export function parseWorkflowStepProgress(
     if (slice) detail.set(mk.id, slice);
   }
 
+  // Per-step one-line summaries (last note for a step wins). Only honour notes
+  // that name a real step, mirroring the marker-id guard above.
+  const note = new Map<string, string>();
+  for (const n of findNotes(transcript ?? "")) {
+    if (!known.has(n.id) || !n.text) continue;
+    note.set(n.id, n.text.length > MAX_NOTE ? `${n.text.slice(0, MAX_NOTE)}…` : n.text);
+  }
+
   const steps: WorkflowStepProgress[] = orderedStepIds.map((id) => ({
     id,
     status: status.get(id) ?? "pending",
     detail: detail.get(id) ?? "",
+    ...(note.has(id) ? { note: note.get(id) } : {}),
   }));
 
   const done = steps.length > 0 && steps.every((s) => s.status === "succeeded" || s.status === "failed");

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -298,12 +298,19 @@
 }
 .flow-run-step { border-radius: var(--radius-control); }
 .flow-run-step.is-selected { background: color-mix(in oklch, var(--accent-presence) 16%, transparent); }
-.flow-run-step-row {
-  width: 100%; display: flex; align-items: center; gap: 9px;
+.flow-run-step-row { width: 100%; display: flex; align-items: stretch; }
+.flow-run-step-main {
+  flex: 1; min-width: 0; display: flex; align-items: center; gap: 9px;
   padding: 7px 8px; border: 0; border-radius: var(--radius-control);
   background: transparent; text-align: left; cursor: pointer;
 }
-.flow-run-step-row:hover { background: var(--bg-hover); }
+.flow-run-step-main:hover { background: var(--bg-hover); }
+.flow-run-step-expand {
+  flex: none; display: grid; place-items: center; width: 26px;
+  border: 0; border-radius: var(--radius-control);
+  background: transparent; color: var(--text-muted); cursor: pointer;
+}
+.flow-run-step-expand:hover { background: var(--bg-hover); color: var(--text-secondary); }
 .flow-run-step-icon { flex: none; display: grid; place-items: center; width: 17px; height: 17px; }
 .flow-run-step-icon-pending { color: var(--text-muted); }
 .flow-run-step-icon-running { color: var(--color-warning); }
@@ -316,7 +323,11 @@
   font-size: var(--text-sm); font-weight: 600; color: var(--text-primary);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.flow-run-step-type { font-size: var(--text-2xs); color: var(--text-muted); }
+.flow-run-step-type {
+  font-size: var(--text-2xs); color: var(--text-muted);
+  display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+  overflow: hidden; word-break: break-word;
+}
 .flow-run-step-phase {
   flex: none; font-size: var(--text-2xs); text-transform: uppercase;
   letter-spacing: 0.04em; color: var(--text-muted);
@@ -325,9 +336,10 @@
 .flow-run-step-failed .flow-run-step-phase { color: var(--color-danger); }
 .flow-run-step-detail {
   margin: 0 8px 7px 34px; padding: 6px 8px;
+  font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--text-2xs); line-height: 1.45; color: var(--text-secondary);
   background: var(--bg-base); border-radius: var(--radius-sm);
-  max-height: 84px; overflow: hidden;
+  max-height: 200px; overflow: auto;
   white-space: pre-wrap; word-break: break-word;
 }
 .flow-run-steps-stall {


### PR DESCRIPTION
## Why

Flow runs execute as a single agent session that prints `@@step-start/done/fail` markers. The parser already captured the prose between markers, but the run view under-surfaced it: only the **active** step showed a 280-char peek, and the **Session output** pane was a raw transcript dump with `@@step-*` markers interleaved. It was hard to see what each step actually did.

This makes the per-step detail clear at every step, and the session output readable.

## Changes

- **`flow-compile.ts`** — the PROGRESS PROTOCOL now asks the agent to (a) **narrate each node** in plain language (that text becomes the step's expandable log) and (b) print a one-line **`@@step-note <id> <summary>`** before `@@step-done`, used as the step's headline.
- **`workflow-step-progress.ts`** — parse the optional `@@step-note` into a per-step **`note`** (last note wins, real-id-guarded); scrub all `@@step-*` lines out of the captured `detail`; export **`stripStepMarkers`** so the UI shares one rule. Fully backward compatible — runs without notes are unchanged. (`flow-progress.ts` spreads the step through, so `note` flows to the UI for free.)
- **`flow-run-steps.tsx`** — every step row now **headlines its note** and **expands to show its own cleaned log** (the active step auto-opens) via a chevron, instead of only the active step's truncated peek. "Session output" renders the transcript with markers scrubbed.
- **`flow.css`** — split the row into a focus button + an expand toggle; the per-step log is scrollable.

## Scope

Flows only, per request. Workflows share `workflow-step-progress.ts`, so they inherit `note` parsing + marker-scrubbing for free, but their prompt (`workflow-run-prompt.ts`) is untouched — an easy follow-up if wanted.

## Verification

- `pnpm typecheck` ✅ · `node scripts/run-tests.mjs app` → **471 files** ✅ · `mobile` → **65 files** ✅ · `check:tests-wired` ✅
- New tests cover `@@step-note` parsing (headline, last-wins, unknown-id guard), marker stripping, `stripStepMarkers`, and the new prompt instructions.
- Existing source-text guards preserved (the backtick-marker rule only forbids `start|done|fail`, not the new `note` example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)