### PR TITLE
perf: cap initial transcript render for long chats

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 /** Suite name -> ordered list of repo-relative test file paths. */
 export const SUITES = {
   app: [
+    "src/components/chat-view-render-cap.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",
     "src/lib/endpoint-validators.test.ts",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -460,7 +460,7 @@ assert.match(
 );
 assert.match(
   source,
-  /useEffect\(\(\) => \{\s*updateFollowing\(true\);\s*\}, \[sessionId, updateFollowing\]\)/,
+  /useEffect\(\(\) => \{\s*updateFollowing\(true\);[\s\S]*?\}, \[sessionId, updateFollowing\]\)/,
   "A freshly opened chat / session switch must re-engage following by default",
 );
 

--- a/src/components/chat-view-render-cap.test.ts
+++ b/src/components/chat-view-render-cap.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+// Transcript render cap (perf): while the reader is pinned to the newest
+// content, only the last TRANSCRIPT_RENDER_CAP grouped turns mount, so opening a
+// long transcript doesn't build hundreds of DOM nodes up front. The cap must
+// dissolve the instant the reader leaves the bottom or opens find, so seeking
+// and find are never limited by it. These source-text assertions guard that
+// wiring (the behavior is exercised live; this catches accidental removal).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+assert.match(src, /const TRANSCRIPT_RENDER_CAP = \d+;/, "a numeric render cap constant exists");
+
+assert.match(
+  src,
+  /historyExpanded \|\| groupedTurns\.length <= TRANSCRIPT_RENDER_CAP\s*\?\s*groupedTurns\s*:\s*groupedTurns\.slice\(-TRANSCRIPT_RENDER_CAP\)/,
+  "the transcript renders the capped tail unless expanded or already short",
+);
+
+assert.match(
+  src,
+  /return renderGroups\.map\(\(g\) =>/,
+  "the render loop maps the capped renderGroups (not the full groupedTurns)",
+);
+
+// Leaving the bottom (updateFollowing(false)) must mount the full transcript so
+// scroll-up / find-jump never land on an unmounted row.
+assert.match(
+  src,
+  /else if \(!historyExpandedRef\.current\)\s*\{[\s\S]*?setHistoryExpanded\(true\)/,
+  "updateFollowing(false) expands the transcript (covers wheel/touch/keys/find-jump)",
+);
+
+assert.match(
+  src,
+  /if \(findOpen\) setHistoryExpanded\(true\)/,
+  "opening find mounts the whole transcript so jumps resolve via data-turn-id",
+);
+
+// Switching sessions resets the cap so a long previous transcript is released.
+assert.match(
+  src,
+  /updateFollowing\(true\);\s*setHistoryExpanded\(false\);/,
+  "a session switch resets the render cap",
+);
+
+// The reveal must not jolt the viewport: distance-from-bottom is restored.
+assert.match(
+  src,
+  /useLayoutEffect\(\(\) => \{[\s\S]*?el\.scrollTop = Math\.max\(0, el\.scrollHeight - anchor\)/,
+  "expanding restores the pre-expansion scroll anchor in a layout effect",
+);
+
+console.log("chat-view-render-cap.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, Fragment, memo, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { forwardRef, Fragment, memo, useCallback, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { createPortal } from "react-dom";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
@@ -278,6 +278,14 @@ const COMPOSER_PREFS_KEY = "cave:chat-composer-controls:v1";
 const COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1";
 // Persisted ↑/↓ prompt-history recall stack for the chat composer.
 const COMPOSER_HISTORY_KEY = "cave:chat-composer-history:v1";
+// Initial render cap: while the reader is pinned to the newest content, only the
+// last N grouped turns are mounted, so opening a long transcript doesn't build
+// hundreds of DOM nodes up front (off-screen rows already get
+// content-visibility:auto, but the nodes still cost mount + memory). The moment
+// the reader scrolls up or opens find — both routed through updateFollowing /
+// the find effect — the full transcript renders, so seeking, find, and deep
+// scroll are never limited by the cap.
+const TRANSCRIPT_RENDER_CAP = 60;
 const THINKING_OPTIONS: Array<{ value: ComposerThinkingEffort; label: string }> = [
   { value: "low", label: "Low" },
   { value: "medium", label: "Medium" },
@@ -2151,14 +2159,41 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [following, setFollowing] = useState(true);
   const followingRef = useRef(true);
   const [newTurnsCount, setNewTurnsCount] = useState(0);
+  // Transcript render cap (see TRANSCRIPT_RENDER_CAP). Sticky for the session:
+  // once the reader leaves the bottom we mount the whole transcript and keep it
+  // mounted, so re-pinning doesn't churn rows in/out.
+  const [historyExpanded, setHistoryExpanded] = useState(false);
+  const historyExpandedRef = useRef(false);
+  historyExpandedRef.current = historyExpanded;
+  // Distance-from-bottom captured at the instant of expansion so the prepended
+  // older rows don't visually shove the viewport (restored in a layout effect).
+  const expandAnchorRef = useRef<number | null>(null);
   const updateFollowing = useCallback((next: boolean) => {
     followingRef.current = next;
     setFollowing(next);
     if (next) {
       // Reset count when returning to the bottom
       setNewTurnsCount(0);
+    } else if (!historyExpandedRef.current) {
+      // Leaving the bottom (wheel/touch/keys/find-jump all funnel here) — mount
+      // the full transcript and anchor the scroll so older rows slide in above
+      // the current view instead of jumping it.
+      const el = scrollRef.current;
+      expandAnchorRef.current = el ? el.scrollHeight - el.scrollTop : null;
+      setHistoryExpanded(true);
     }
   }, []);
+
+  // Restore the pre-expansion distance-from-bottom once the full transcript has
+  // mounted, so revealing the older rows doesn't jump the reader's viewport.
+  useLayoutEffect(() => {
+    if (!historyExpanded) return;
+    const anchor = expandAnchorRef.current;
+    expandAnchorRef.current = null;
+    if (anchor == null) return;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = Math.max(0, el.scrollHeight - anchor);
+  }, [historyExpanded]);
 
   const refreshModelState = useCallback(async (): Promise<ChatModelState | null> => {
     const params = new URLSearchParams({ familiarId: familiar.id });
@@ -2357,6 +2392,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       findDebouncedQuery,
     );
   }, [findOpen, findDebouncedQuery, turns]);
+
+  // Find searches the whole transcript, so opening it mounts every turn — a
+  // jump (jumpToFindMatch) resolves its target via querySelector and must find
+  // the row in the DOM regardless of the render cap.
+  useEffect(() => {
+    if (findOpen) setHistoryExpanded(true);
+  }, [findOpen]);
 
   // Keep the active pointer in bounds when the match set shrinks.
   useEffect(() => {
@@ -2882,8 +2924,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   // A freshly opened chat (or session switch) follows by default; the pin
   // effect above then handles the initial scroll-to-bottom once history lands.
+  // Reset the render cap too so a long previous transcript doesn't keep the
+  // whole DOM mounted for the next session.
   useEffect(() => {
     updateFollowing(true);
+    setHistoryExpanded(false);
+    expandAnchorRef.current = null;
   }, [sessionId, updateFollowing]);
 
   // Release on intent: only USER input events detach following. Programmatic
@@ -4111,7 +4157,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             // feeds the per-row prev-turn timestamp-gap lookup and must match
             // the same sequence used for grouping.
             const allTurns = activePath;
-            return groupedTurns.map((g) => {
+            // Render cap (TRANSCRIPT_RENDER_CAP): while pinned to the bottom, only
+            // mount the newest groups. The per-row prev-turn lookup still reads
+            // the full `allTurns`/`turnIndexMap`, so the first visible row's
+            // timestamp gap stays correct. Expands to the whole transcript the
+            // moment the reader scrolls up or opens find (see historyExpanded).
+            const renderGroups =
+              historyExpanded || groupedTurns.length <= TRANSCRIPT_RENDER_CAP
+                ? groupedTurns
+                : groupedTurns.slice(-TRANSCRIPT_RENDER_CAP);
+            return renderGroups.map((g) => {
               if (g.kind === "single") {
                 const t = g.turn;
                 const i = turnIndexMap.get(t.id) ?? -1;


### PR DESCRIPTION
## Context

Final item of the performance arc. Opening a long conversation mounted **every** turn up front. Off-screen rows already get `content-visibility:auto` (skipping paint/layout), but the DOM nodes still cost creation + memory, so a several-hundred-turn chat paid a large mount on open.

## Change

Cap the rendered tail to the newest `TRANSCRIPT_RENDER_CAP` (60) grouped turns **while the reader is pinned to the bottom**. The cap dissolves to the full transcript the instant the reader leaves the bottom or opens find — so seeking, find, branch nav, and deep scroll are never limited by it:

- `updateFollowing(false)` (wheel / touch / keys / find-jump all funnel through this single choke point) sets `historyExpanded` and captures distance-from-bottom; a `useLayoutEffect` restores it after the older rows mount, so revealing them never jolts the viewport.
- `findOpen` forces full render so `jumpToFindMatch` resolves its target via `data-turn-id` regardless of the cap.
- Session switch resets the cap so a long previous transcript is released.
- The per-row prev-turn lookup still reads the full `activePath`/`turnIndexMap`, so the first visible row's timestamp gap stays correct.

The pin-to-bottom logic, scroll machinery, and `TurnRow` markup are **untouched** (so the `cave-chat-transcript` / `cave-chat-thread`→`role=log` / `data-turn-id` source-text tests all stay green).

## Verification (real app, 80-turn mock)

| Check | Result |
|---|---|
| Rows mounted on open | **60** (capped); newest turn present |
| Scroll up | expands to **80**, viewport anchored (distance-from-bottom preserved) |
| Find an early (capped-out) turn | find expands all → target mounts → scrolls into view ✓ |
| Pin regression? | none — baseline (no cap) opens at the same scroll position |

- `pnpm typecheck`, `check:tests-wired` (629), `test:app` (471), `test:api` (96), `test:mobile` (65), `pnpm build` (+ bundle-budget gate) — all green.
- Added `chat-view-render-cap.test.ts`; updated `chat-view-polish.test.ts` (the session-reset effect body grew).

🤖 Generated with [Claude Code](https://claude.com/claude-code)