### PR TITLE
feat(workflow): mirror @@step-note per-step summaries into workflow run prompt

### DIFF
--- a/src/lib/workflow-run-prompt.test.ts
+++ b/src/lib/workflow-run-prompt.test.ts
@@ -80,6 +80,10 @@ const dependent: WorkflowSummary = {
   assert.match(prompt, /@@step-start <id>/, "prompt documents the start marker");
   assert.match(prompt, /@@step-done <id>/, "prompt documents the done marker");
   assert.match(prompt, /@@step-fail <id>/, "prompt documents the fail marker");
+  // Per-step clarity (mirrors the flow PROGRESS PROTOCOL): a one-line summary
+  // note + explicit narration ask so the run's transcript reads clearly.
+  assert.match(prompt, /@@step-note <id>/, "prompt documents the per-step summary note");
+  assert.match(prompt, /narrate/i, "prompt asks the agent to narrate each step");
 }
 
 console.log("workflow-run-prompt.test.ts ✓");

--- a/src/lib/workflow-run-prompt.ts
+++ b/src/lib/workflow-run-prompt.ts
@@ -106,11 +106,11 @@ export function buildWorkflowRunPrompt(workflow: WorkflowSummary, inputs?: Recor
       "",
       "Progress markers — print these on their own line so progress can be tracked:",
       "- Before starting a step, print:  @@step-start <id>",
-      "- After a step succeeds, print:    @@step-done <id>",
-      "- If a step fails, print:          @@step-fail <id>",
-      "Use the exact id shown in parentheses for each step above. Between a step's",
-      "start and done markers, narrate what you're doing and show the step's output —",
-      "that narration is surfaced as the step's debugging detail.",
+      "- While working a step, narrate what you're doing in plain language and show the step's output — that narration is surfaced as the step's log, so be clear and specific.",
+      "- When a step succeeds, FIRST print a one-line summary of what it produced:  @@step-note <id> <summary>",
+      "- Then print:                     @@step-done <id>",
+      "- If a step fails, print a @@step-note <id> <why it failed> then:  @@step-fail <id>",
+      "Use the exact id shown in parentheses for each step above. Keep each marker on its own line and never wrap one in backticks.",
     );
   }
 


### PR DESCRIPTION
## Why

Follow-up to #2048 (flow per-step logs). A workflow run is spawned as an agent **session viewed in chat** (the standalone Workflows page was folded into Automations, so workflows have no dedicated step panel like flows do). Mirroring the flow PROGRESS PROTOCOL into `buildWorkflowRunPrompt` makes that run **transcript read clearly per step**.

## Change

- `workflow-run-prompt.ts` — the agent now narrates each step in plain language and prints a one-line **`@@step-note <id> <summary>`** headline before `@@step-done` (and a `@@step-note` reason before `@@step-fail`). Existing start/done/fail markers unchanged.

The shared parser (`workflow-step-progress.ts`, from #2048) already understands `@@step-note`, so if a workflow step panel is ever (re)added it surfaces the headline for free — no further wiring needed.

## Scope note

Prompt-only by design. Workflows currently surface in chat, not a step panel, so the win is transcript readability; building a step UI would be orphaned work on a de-emphasized surface.

## Verification

- `pnpm typecheck` ✅ · `node scripts/run-tests.mjs app` → **472 files** ✅
- Test asserts the new `@@step-note <id>` + narration instructions; existing start/done/fail assertions preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)