### PR TITLE
fix(onboarding): preserve addons, roles, and marketplace when creating a familiar

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -524,6 +524,7 @@ export const SUITES = {
     "src/app/api/library/route-link/route.test.ts",
     "src/app/api/onboarding/status/route.test.ts",
     "src/app/api/onboarding/install/route.test.ts",
+    "src/app/api/onboarding/setup/route.test.ts",
     "src/app/api/onboarding/ssh-check/route.test.ts",
     "src/app/api/skills/local/route.test.ts",
     "src/app/api/capabilities/route.test.ts",

--- a/src/app/api/onboarding/setup/route.test.ts
+++ b/src/app/api/onboarding/setup/route.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+//
+// Guard: creating a familiar through /api/onboarding/setup must NOT wipe
+// the user's existing cave-config.json fields outside of {defaults, familiars}.
+//
+// Before this guard, the setup route reconstructed `nextConfig` with only
+// {version, defaults, familiars} and then wrote it directly via writeFile.
+// That silently nuked addons, roles, and marketplace.installed every time a
+// user added a familiar from the onboarding overlay — a hidden data-loss bug
+// for anyone who'd toggled add-ons on or installed marketplace plugins.
+//
+// We assert against the source string (matches existing route-test pattern;
+// see src/app/api/onboarding/install/route.test.ts and
+// src/app/api/skills/local/route.test.ts) so the guard stays light and doesn't
+// require a Next.js / @-alias test harness. The actual deep-merge semantics
+// are covered by src/lib/cave-config.test.ts.
+//
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+
+// 1. The route must still load the existing config so we can carry over
+//    user-set fields when writing.
+assert.match(
+  source,
+  /const\s+existing\s*=\s*await\s+loadConfig\(\)/,
+  "setup route should call loadConfig() to read the existing cave-config.json before writing",
+);
+
+// 2. The route MUST preserve addons from the existing config.
+assert.match(
+  source,
+  /addons:\s*existing\.addons/,
+  "setup route should preserve existing.addons when writing the next config (otherwise creating a familiar wipes the user's add-on settings)",
+);
+
+// 3. Same for roles.
+assert.match(
+  source,
+  /roles:\s*existing\.roles/,
+  "setup route should preserve existing.roles when writing the next config",
+);
+
+// 4. Same for marketplace.installed.
+assert.match(
+  source,
+  /marketplace:\s*existing\.marketplace/,
+  "setup route should preserve existing.marketplace (installed plugins) when writing the next config",
+);
+
+// 5. Defensive guard: ensure nextConfig is NOT a literal that only enumerates
+//    {version, defaults, familiars} — i.e. block the regression. We assert
+//    the pre-fix shape doesn't appear verbatim.
+assert.doesNotMatch(
+  source,
+  /const\s+nextConfig\s*=\s*\{\s*\n\s*version:\s*existing\.version\s*\|\|\s*1,\s*\n\s*defaults:\s*\{\s*harness,\s*model\s*\},\s*\n\s*familiars:[\s\S]{0,400}?\}\s*\n\s*\};/,
+  "setup route's nextConfig must not be a {version, defaults, familiars}-only literal — that wipes addons/roles/marketplace on every familiar create",
+);
+
+console.log("onboarding-setup-preserve-config.test.ts: ok");

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -107,6 +107,13 @@ export async function POST(req: Request) {
 
   // Always update cave-config.json defaults so the user's chosen adapter
   // binding takes effect even if they re-run setup.
+  //
+  // IMPORTANT: nextConfig must carry over every field from `existing` that we
+  // are not explicitly changing here. Earlier versions of this route emitted a
+  // {version, defaults, familiars}-only literal, which silently wiped the
+  // user's `addons`, `roles`, and `marketplace.installed` settings every time
+  // they added a familiar. Guard against that regression with the source-test
+  // at src/app/api/onboarding/setup/route.test.ts.
   const existing = await loadConfig();
   const nextConfig = {
     version: existing.version || 1,
@@ -124,6 +131,12 @@ export async function POST(req: Request) {
           },
         }
       : (existing.familiars ?? {}),
+    // Carry over user-set fields untouched — these belong to other surfaces
+    // (Settings → Add-ons, Settings → Roles, Marketplace) and creating a
+    // familiar should not touch them.
+    roles: existing.roles,
+    addons: existing.addons,
+    marketplace: existing.marketplace,
   };
   await writeFile(configJson, JSON.stringify(nextConfig, null, 2), "utf8");
   wrote.push("cave-config.json");


### PR DESCRIPTION
Closes the silent data-loss bug Val flagged: **add-ons reset whenever you create a familiar**.

## What

`/api/onboarding/setup` (called from the onboarding overlay when you create a new familiar) built `nextConfig` as a `{version, defaults, familiars}`-only literal and wrote it directly via `writeFile`, **bypassing `saveConfig()`'s deep-merge**.

Every field outside that literal was wiped on the next `loadConfig()` call:

- **`addons`** — your toggles in Settings → Add-ons reverted to all-false
- **`roles`** — Settings → Roles configuration disappeared
- **`marketplace.installed`** — installed marketplace plugins were forgotten

The bug is particularly nasty because users typically toggle add-ons **first** (the toggles live in Settings → Add-ons and the install flow ships them on by default), then add familiars later — which means every onboarding flow that created a familiar reset what they'd just configured.

## How

Carry `existing.roles`, `existing.addons`, and `existing.marketplace` over into `nextConfig`. The route still writes the config directly (rather than going through `saveConfig`) because it has custom semantics around the `familiars[draft.id]` entry that don't fit `saveConfig`'s patch-shape — but it now preserves the fields outside its remit.

```diff
   const nextConfig = {
     version: existing.version || 1,
     defaults: { harness, model },
     familiars: draft
       ? { ...(existing.familiars ?? {}), [draft.id]: { ... } }
       : (existing.familiars ?? {}),
+    // Carry over user-set fields untouched — these belong to other surfaces
+    // (Settings → Add-ons, Settings → Roles, Marketplace) and creating a
+    // familiar should not touch them.
+    roles: existing.roles,
+    addons: existing.addons,
+    marketplace: existing.marketplace,
   };
```

## Tests

New source-string guard at `src/app/api/onboarding/setup/route.test.ts`:

1. Asserts `loadConfig()` is still called before write
2. Asserts `addons: existing.addons` appears in the source
3. Asserts `roles: existing.roles` appears in the source
4. Asserts `marketplace: existing.marketplace` appears in the source
5. **`assert.doesNotMatch`** against the regression literal — explicitly forbids the pre-fix `{version, defaults, familiars}`-only shape so a future edit can't silently reintroduce the bug

Same source-string pattern as the existing `onboarding/install/route.test.ts` and `skills/local/route.test.ts` — keeps the guard light and doesn't require a Next.js / `@/` test harness. Actual deep-merge behavior is already covered by `src/lib/cave-config.test.ts`.

## Verification done locally

- ✅ `pnpm typecheck` clean
- ✅ `pnpm check:tests-wired` — 631 files wired, new test included
- ✅ New test passes (post-fix); test fails (pre-fix) as expected
- ✅ `src/lib/cave-config.test.ts` + `src/lib/cave-config-state-race.test.ts` + `src/lib/onboarding-familiars.test.ts` still pass (regression-clean)
- ✅ Pre-PR collision check — no parallel PRs, no overlapping issues, no sibling worktree on this file

## Risk

Low. Three-line change to one route handler. The fields being preserved are user-owned data that belong to other surfaces — the route had no business touching them in the first place.