### PR TITLE
perf: skip no-op re-renders from the sessions poll

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 /** Suite name -> ordered list of repo-relative test file paths. */
 export const SUITES = {
   app: [
+    "src/lib/session-list-equal.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -55,7 +55,7 @@ assert.doesNotMatch(
 );
 assert.match(
   workspace,
-  /setSessions\(baseSessions\);[\s\S]{0,220}setSessionsLoaded\(true\);[\s\S]{0,500}githubTasksPromise/,
+  /setSessions\([\s\S]{0,120}baseSessions[\s\S]{0,40}\);[\s\S]{0,260}setSessionsLoaded\(true\);[\s\S]{0,600}githubTasksPromise/,
   "Workspace renders base chat sessions before applying optional GitHub task context",
 );
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { groupInboxFeed } from "@/lib/inbox-feed";
+import { sameSessionList } from "@/lib/session-list-equal";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-mode";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
@@ -605,19 +606,23 @@ export function Workspace() {
         if (!json.ok) return;
 
         const baseSessions = (json.sessions ?? []) as SessionRow[];
-        setSessions(baseSessions);
+        // The 4s poll rebuilds a fresh array each tick; keep the previous
+        // reference when nothing changed so an unchanged list doesn't re-render
+        // every sessions consumer (chat list, rails, badges) for nothing.
+        setSessions((prev) => (sameSessionList(prev, baseSessions) ? prev : baseSessions));
         setSessionsLoaded(true);
         baseSessionsApplied = true;
 
         const githubTasksJson = await githubTasksPromise;
         if (githubTasksJson) {
           setGithubAssignedCount(Array.isArray(githubTasksJson.tasks) ? githubTasksJson.tasks.length : 0);
-          setSessions((currentSessions) =>
-            attachGitHubTaskContext(
+          setSessions((currentSessions) => {
+            const enriched = attachGitHubTaskContext(
               currentSessions.length > 0 ? currentSessions : baseSessions,
               githubTasksJson,
-            ),
-          );
+            );
+            return sameSessionList(currentSessions, enriched) ? currentSessions : enriched;
+          });
         }
       } catch {
         /* transient */

--- a/src/lib/session-list-equal.test.ts
+++ b/src/lib/session-list-equal.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { sameSessionList } from "./session-list-equal.ts";
+
+const row = (over = {}) => ({
+  id: "s1", title: "Chat", status: "completed", origin: "chat",
+  project_root: "/repo", harness: "codex", familiarId: "nova",
+  exit_code: null, archived_at: null, created_at: "t", updated_at: "t",
+  ...over,
+});
+
+test("same reference is equal", () => {
+  const a = [row()];
+  assert.equal(sameSessionList(a, a), true);
+});
+
+test("equal content in new arrays is equal (the poll's no-op case)", () => {
+  assert.equal(sameSessionList([row()], [row()]), true);
+  assert.equal(sameSessionList([], []), true);
+});
+
+test("differing length is not equal", () => {
+  assert.equal(sameSessionList([row()], [row(), row({ id: "s2" })]), false);
+});
+
+test("any changed field is not equal", () => {
+  assert.equal(sameSessionList([row()], [row({ status: "running" })]), false);
+  assert.equal(sameSessionList([row()], [row({ updated_at: "t2" })]), false);
+  assert.equal(sameSessionList([row()], [row({ title: "Renamed" })]), false);
+});
+
+test("order matters", () => {
+  const a = [row({ id: "s1" }), row({ id: "s2" })];
+  const b = [row({ id: "s2" }), row({ id: "s1" })];
+  assert.equal(sameSessionList(a, b), false);
+});
+
+console.log("session-list-equal.test.ts: ok");

--- a/src/lib/session-list-equal.ts
+++ b/src/lib/session-list-equal.ts
@@ -1,0 +1,19 @@
+import type { SessionRow } from "@/lib/types";
+
+// True when two session lists are content-identical (same rows, same order,
+// same field values). The /api/sessions/list poll rebuilds a fresh array every
+// few seconds; feeding an equal-but-new array to setState re-renders the whole
+// sessions tree for nothing. Callers use this to return the previous reference
+// from the state updater so React bails out of the no-op render.
+//
+// Comparison is a per-row JSON.stringify: rows are built by one code path so key
+// order is stable, and the lists are short (a user's session count), so this is
+// cheap to run on every poll.
+export function sameSessionList(a: readonly SessionRow[], b: readonly SessionRow[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Context

`/api/sessions/list` is polled every 4s (visibility-gated since #2037) and `loadSessions` rebuilds a fresh `SessionRow[]` each tick. Handing that *new-but-equal* array to `setSessions` re-rendered **every** sessions consumer — the chat list (and all its rows), thread rails, sidebar badges — for nothing on every steady-state poll.

## Change

Guard both `setSessions` calls in `loadSessions` with a new pure helper `sameSessionList(prev, next)`: when the freshly-fetched (or GitHub-enriched) list is content-identical to the current one, return the **previous reference** so React bails out of the render.

The two-phase "render base sessions first, enrich with GitHub tasks after" flow is preserved (and so is its `surface-loading-states` assertion) — only the no-op renders are removed.

**Steady-state effect:** an unchanged poll triggers no sessions re-render at all when the GitHub addon is off; when it's on, the enrich-phase no-op is skipped. (I considered memoizing the chat-list rows directly, but they're entangled with dnd-kit's sortable render-prop + interleaved section headers — higher risk for narrower gain. Cutting the re-render at the source is simpler and benefits every consumer.)

## Verification

- `pnpm typecheck`, `check:tests-wired` (634), `test:app` (475 — incl. new `session-list-equal.test.ts`), `test:api` (97), `test:mobile` (65), `pnpm build` (+ bundle-budget gate) — all green.
- `surface-loading-states.test.ts` updated: it pinned the literal `setSessions(baseSessions)` call; loosened to the guarded form while keeping the base-before-enrichment intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)