### PR TITLE
fix(rail): hide "Create familiar" in right rail when scope is All familiars

### DIFF
--- a/src/components/companion-rail.tsx
+++ b/src/components/companion-rail.tsx
@@ -27,6 +27,10 @@ type Props = {
    * empty state (e.g. the chat surface), set this true so the rail doesn't
    * render a second redundant CTA. */
   suppressEmpty?: boolean;
+  /** True when the familiar scope is "All familiars" (vs. a genuinely empty
+   * selection). In that case the empty state must not pitch "Create familiar"
+   * — the user has explicitly scoped to everything, not asked for a new one. */
+  scopeIsAll?: boolean;
   hideChatTab?: boolean;
   /** Show a needs-attention dot on the Chat tab (e.g. the familiar needs a reply). */
   chatBadge?: boolean;
@@ -68,6 +72,7 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       onCreateFamiliar,
       onTabChange,
       suppressEmpty = false,
+      scopeIsAll = false,
       hideChatTab = false,
       chatBadge = false,
       youtubeActive,
@@ -118,11 +123,15 @@ const CompanionRailInner = forwardRef<ChatRouterHandle, Props>(
       return (
         <aside className="companion-rail companion-rail--empty">
           <div className="companion-rail__empty-body">
-            <p className="companion-rail__empty-title">No familiar yet</p>
-            <p className="companion-rail__empty-sub">
-              Pick a familiar from the sidebar selector, or create one.
+            <p className="companion-rail__empty-title">
+              {scopeIsAll ? "All familiars" : "No familiar yet"}
             </p>
-            {onCreateFamiliar ? (
+            <p className="companion-rail__empty-sub">
+              {scopeIsAll
+                ? "Pick a single familiar from the sidebar selector to see its details here."
+                : "Pick a familiar from the sidebar selector, or create one."}
+            </p>
+            {onCreateFamiliar && !scopeIsAll ? (
               <button
                 type="button"
                 className="companion-rail__empty-cta"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2123,6 +2123,9 @@ export function Workspace() {
               // Chat surface already shows a "Choose a familiar" CTA in the
               // detail panel — suppress the rail's duplicate prompt there.
               suppressEmpty={mode === "chat"}
+              // Empty scope set = "All familiars" is selected (not a missing
+              // pick) — the rail must not pitch "Create familiar" in that case.
+              scopeIsAll={scopeIds.size === 0}
               chatSlot={
                 <FamiliarPanel
                   familiar={active}


### PR DESCRIPTION
## What

When the familiar scope is set to **All familiars** (the default — an empty `scopeIds` set), the right companion rail wrongly showed its *no-familiar* empty state: **"No familiar yet / Create familiar"**. The rail's empty state fires whenever no *single* familiar is active, and "All familiars" / multi-select both leave `activeId === null`.

## Change

- `companion-rail.tsx`: new `scopeIsAll` prop. When true, the empty state reads **"All familiars / Pick a single familiar from the sidebar selector to see its details here."** and the **Create familiar** CTA is omitted.
- `workspace.tsx`: wires `scopeIsAll={scopeIds.size === 0}`.

The genuine no-selection path is unchanged (still offers Create familiar). Source-text test `companion-rail.test.ts` still green (`No familiar yet` copy retained for that case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)