### PR TITLE
feat(familiars): create a familiar from the UI (New familiar dialog)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -176,6 +176,7 @@ export const SUITES = {
     "src/components/familiar-studio.test.ts",
     "src/components/familiar-studio-look-tab.test.ts",
     "src/components/familiars-view.test.ts",
+    "src/components/create-familiar-dialog.test.ts",
     "src/components/workspace-familiars-landing.test.ts",
     "src/components/board-kanban-keyboard.test.ts",
     "src/components/board-inspector-a11y.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -51,7 +51,7 @@ const contracts: RouteContract[] = [
   { route: "/familiars/[id]/self-reports/[sessionId]", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/self-reports", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/response-confidence", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
-  { route: "/familiars", methods: ["GET"], kind: "json" },
+  { route: "/familiars", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/github/activity", methods: ["GET"], kind: "json" },
   { route: "/github/assigned", methods: ["GET"], kind: "json" },
   { route: "/github/repos", methods: ["GET"], kind: "json" },

--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -25,4 +25,55 @@ assert.match(
   "Familiars API should expose per-familiar auto self-report config with a false default",
 );
 
+// ── POST: in-app "create a familiar" write path ──────────────────────────────
+// Source-text guards (same pattern as src/app/api/onboarding/setup/route.test.ts).
+// Deep-merge semantics are covered by src/lib/cave-config.test.ts; draft
+// normalization by the onboarding-familiars helpers this route reuses.
+
+assert.match(source, /export async function POST\(/, "route should create a familiar via POST");
+
+// Reuses the shared onboarding write primitives so a UI-created familiar is
+// identical to a setup-created one.
+assert.match(
+  source,
+  /normalizeFamiliarDraft\(body\.familiar\)/,
+  "POST should normalize input through the shared onboarding helper",
+);
+assert.match(
+  source,
+  /buildFamiliarsToml\(draft\)/,
+  "POST should build the [[familiar]] block through the shared helper",
+);
+
+// Duplicate protection: never append a second block with the same id.
+assert.match(
+  source,
+  /familiarsTomlContainsId\(existingToml, draft\.id\)/,
+  "POST should detect an existing id before appending",
+);
+assert.match(source, /status:\s*409/, "POST should return 409 on a duplicate id");
+
+// CRITICAL: creating an additional familiar must NOT rewrite the global
+// defaults (that's onboarding's job for the first familiar). The route only
+// upserts this familiar's binding via saveConfig({ familiars }); deep-merge
+// leaves defaults/roles/addons/marketplace untouched.
+assert.match(
+  source,
+  /saveConfig\(\{\s*familiars:/,
+  "POST should upsert the new familiar binding via saveConfig({ familiars })",
+);
+assert.doesNotMatch(
+  source,
+  /defaults:\s*\{/,
+  "POST must NOT write a defaults object — creating a familiar must not change the user's global default harness/model",
+);
+
+// Optional-body (fallback-empty) handling, per the API contract for this route.
+assert.match(source, /let body[\s\S]{0,120}=\s*\{\}/, "POST should initialize an optional request body");
+assert.match(
+  source,
+  /try\s*\{[\s\S]{0,120}req\.json\(\)[\s\S]{0,120}\}\s*catch\s*\{/,
+  "POST should tolerate a malformed/empty JSON body",
+);
+
 console.log("familiars route.test.ts: ok");

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -1,7 +1,17 @@
 import { NextResponse } from "next/server";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
 import { callDaemon } from "@/lib/coven-daemon";
-import { bindingFor, loadConfig } from "@/lib/cave-config";
+import { bindingFor, loadConfig, saveConfig } from "@/lib/cave-config";
 import { resolveFamiliarAvatar } from "@/lib/server/familiar-avatar";
+import {
+  buildFamiliarsToml,
+  familiarsTomlContainsId,
+  normalizeFamiliarDraft,
+  type OnboardingFamiliarInput,
+} from "@/lib/onboarding-familiars";
+import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
 
 export const dynamic = "force-dynamic";
 
@@ -66,4 +76,107 @@ export async function GET() {
     }),
   );
   return NextResponse.json({ ok: true, familiars });
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type CreateBody = { familiar?: OnboardingFamiliarInput };
+
+/**
+ * Create a familiar from the UI ("New familiar" dialog).
+ *
+ * Reuses the same write primitives as onboarding (`normalizeFamiliarDraft`,
+ * `buildFamiliarsToml`, the adapter-manifest scaffold) so a familiar created
+ * here is indistinguishable from one created during first-run setup.
+ *
+ * Difference from `/api/onboarding/setup`: this route NEVER writes
+ * `defaults`. Onboarding sets the global default harness/model from the first
+ * familiar; adding an Nth familiar from the roster must not silently change the
+ * user's default, so we only upsert that one familiar's binding via
+ * `saveConfig({ familiars })`, which deep-merges and leaves everything else
+ * (defaults, roles, add-ons, marketplace) untouched.
+ */
+export async function POST(req: Request) {
+  let body: CreateBody = {};
+  try {
+    body = (await req.json()) as CreateBody;
+  } catch {
+    /* allow empty — handled by the validation below */
+  }
+
+  if (!body.familiar) {
+    return NextResponse.json(
+      { ok: false, error: "Familiar details are required." },
+      { status: 400 },
+    );
+  }
+
+  let draft;
+  try {
+    draft = normalizeFamiliarDraft(body.familiar);
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "Invalid familiar." },
+      { status: 400 },
+    );
+  }
+
+  const covenDir = path.join(homedir(), ".coven");
+  const familiarsToml = path.join(covenDir, "familiars.toml");
+  const adaptersDir = path.join(covenDir, "adapters");
+
+  await mkdir(covenDir, { recursive: true });
+
+  // Reject duplicates rather than appending a second [[familiar]] block with
+  // the same id (the daemon would only ever see the first).
+  const familiarsExists = await pathExists(familiarsToml);
+  if (familiarsExists) {
+    const existingToml = await readFile(familiarsToml, "utf8");
+    if (familiarsTomlContainsId(existingToml, draft.id)) {
+      return NextResponse.json(
+        { ok: false, error: `A familiar with id "${draft.id}" already exists.` },
+        { status: 409 },
+      );
+    }
+    const separator = existingToml.endsWith("\n") ? "\n" : "\n\n";
+    await writeFile(
+      familiarsToml,
+      `${existingToml}${separator}${buildFamiliarsToml(draft).replace(/^# User familiars for this Coven\.\n+/, "")}`,
+      "utf8",
+    );
+  } else {
+    await writeFile(familiarsToml, buildFamiliarsToml(draft), "utf8");
+  }
+
+  // Scaffold the harness adapter manifest if it's missing (parity with
+  // onboarding) so a familiar bound to a not-yet-configured harness still works.
+  const adapterManifest = adapterManifestScaffoldForHarness(draft.harness);
+  if (adapterManifest) {
+    await mkdir(adaptersDir, { recursive: true });
+    const manifestPath = path.join(adaptersDir, adapterManifest.filename);
+    if (!(await pathExists(manifestPath))) {
+      await writeFile(manifestPath, adapterManifest.contents, "utf8");
+    }
+  }
+
+  // Upsert only this familiar's binding. No `defaults` key → global defaults
+  // are preserved (see the doc comment above).
+  await saveConfig({
+    familiars: {
+      [draft.id]: {
+        harness: draft.harness,
+        model: draft.model,
+        ...(draft.runtime ? { runtime: draft.runtime } : {}),
+      },
+    },
+  });
+
+  return NextResponse.json({ ok: true, id: draft.id });
 }

--- a/src/components/create-familiar-dialog.test.ts
+++ b/src/components/create-familiar-dialog.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+//
+// Source-text guards for the "New familiar" dialog. Keeps the contract light
+// (no React render harness) while pinning the behaviours that matter: it posts
+// to the create route, derives a live id, blocks duplicates, and sources its
+// harness list and glyphs from the shared catalogs.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./create-familiar-dialog.tsx", import.meta.url), "utf8");
+
+// Built on the shared Modal primitive (focus trap + escape come for free).
+assert.match(source, /from "@\/components\/ui\/modal"/, "dialog should use the shared Modal");
+assert.match(source, /breadcrumb=\{\["Familiars", "New familiar"\]\}/, "dialog header should read Familiars › New familiar");
+
+// Creates via POST /api/familiars (the new write path), not onboarding/setup.
+assert.match(
+  source,
+  /fetch\("\/api\/familiars",\s*\{[\s\S]*?method:\s*"POST"/,
+  "dialog should POST to /api/familiars",
+);
+assert.doesNotMatch(source, /onboarding\/setup/, "dialog should not call the onboarding setup route");
+
+// Live id preview uses the same slugifier the server applies, so what the user
+// sees matches what gets persisted.
+assert.match(
+  source,
+  /slugifyFamiliarId\(idOverride \?\? name\)/,
+  "dialog should derive the id preview with slugifyFamiliarId",
+);
+
+// Duplicate ids are blocked before submit.
+assert.match(source, /idTaken/, "dialog should compute whether the derived id is taken");
+assert.match(
+  source,
+  /const canCreate =[\s\S]*?!idTaken/,
+  "Create must be disabled when the id is already taken",
+);
+
+// Harness options come from the shared adapter catalog (not a hardcoded list).
+assert.match(
+  source,
+  /COMPATIBILITY_ADAPTERS\.map\(/,
+  "harness dropdown should be built from COMPATIBILITY_ADAPTERS",
+);
+
+// Optional fields are only sent when filled (keeps the payload clean / lets the
+// server apply its defaults).
+assert.match(source, /role\.trim\(\) \?/, "role should be sent only when provided");
+assert.match(source, /model\.trim\(\) \?/, "model should be sent only when provided");
+assert.match(source, /description\.trim\(\) \?/, "description should be sent only when provided");
+
+// Icon picker renders through the free-form glyph renderer (not the strict
+// chrome <Icon>), so any Phosphor glyph displays.
+assert.match(source, /FamiliarGlyph/, "dialog should render glyph swatches with FamiliarGlyph");
+
+console.log("create-familiar-dialog.test.ts: ok");

--- a/src/components/create-familiar-dialog.tsx
+++ b/src/components/create-familiar-dialog.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { Modal } from "@/components/ui/modal";
+import { Button } from "@/components/ui/button";
+import { Icon } from "@/lib/icon";
+import { FamiliarGlyph } from "@/components/familiar-glyph";
+import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
+import { slugifyFamiliarId } from "@/lib/onboarding-familiars";
+
+// Curated starter glyphs — every name is verified present in the trimmed
+// ph-glyph-catalog.json, so none render blank. Users can fine-tune the icon
+// later in Familiar Studio's full picker; this is the quick-create shortlist.
+const STARTER_GLYPHS = [
+  "ph:sparkle-fill",
+  "ph:cat-fill",
+  "ph:robot-fill",
+  "ph:ghost-fill",
+  "ph:brain-fill",
+  "ph:flask-fill",
+  "ph:rocket-fill",
+  "ph:magic-wand-fill",
+  "ph:code-fill",
+  "ph:books-fill",
+  "ph:palette-fill",
+  "ph:chart-bar-fill",
+  "ph:compass-fill",
+  "ph:detective-fill",
+  "ph:planet-fill",
+  "ph:butterfly-fill",
+] as const;
+
+const DEFAULT_GLYPH = "ph:sparkle-fill";
+
+const inputClass =
+  "focus-ring h-9 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2.5 text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:border-[var(--accent-presence)]";
+const labelClass = "mb-1 block text-[11px] font-medium text-[var(--text-secondary)]";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  /** ids already in the roster — used to flag a duplicate before submitting. */
+  existingIds: string[];
+  /** Current global default harness, used to preselect the dropdown. */
+  defaultHarness?: string;
+  /** Called with the new familiar's id after a successful create. */
+  onCreated: (id: string) => void;
+};
+
+export function CreateFamiliarDialog({
+  open,
+  onClose,
+  existingIds,
+  defaultHarness,
+  onCreated,
+}: Props) {
+  const [name, setName] = useState("");
+  const [idOverride, setIdOverride] = useState<string | null>(null);
+  const [glyph, setGlyph] = useState<string>(DEFAULT_GLYPH);
+  const [glyphOpen, setGlyphOpen] = useState(false);
+  const [harness, setHarness] = useState<string>(
+    defaultHarness && COMPATIBILITY_ADAPTERS.some((a) => a.id === defaultHarness)
+      ? defaultHarness
+      : "codex",
+  );
+  const [showMore, setShowMore] = useState(false);
+  const [role, setRole] = useState("");
+  const [model, setModel] = useState("");
+  const [description, setDescription] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const nameRef = useRef<HTMLInputElement | null>(null);
+
+  const derivedId = slugifyFamiliarId(idOverride ?? name);
+  const existing = useMemo(() => new Set(existingIds), [existingIds]);
+  const idTaken = derivedId.length > 0 && existing.has(derivedId);
+  const canCreate = name.trim().length > 0 && derivedId.length > 0 && !idTaken && !submitting;
+
+  function reset() {
+    setName("");
+    setIdOverride(null);
+    setGlyph(DEFAULT_GLYPH);
+    setGlyphOpen(false);
+    setHarness(
+      defaultHarness && COMPATIBILITY_ADAPTERS.some((a) => a.id === defaultHarness)
+        ? defaultHarness
+        : "codex",
+    );
+    setShowMore(false);
+    setRole("");
+    setModel("");
+    setDescription("");
+    setError(null);
+    setSubmitting(false);
+  }
+
+  function handleClose() {
+    if (submitting) return;
+    reset();
+    onClose();
+  }
+
+  async function handleCreate() {
+    if (!canCreate) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/familiars", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          familiar: {
+            id: derivedId,
+            displayName: name.trim(),
+            glyph,
+            harness,
+            ...(role.trim() ? { role: role.trim() } : {}),
+            ...(model.trim() ? { model: model.trim() } : {}),
+            ...(description.trim() ? { description: description.trim() } : {}),
+          },
+        }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; id?: string; error?: string };
+      if (!res.ok || !json.ok) {
+        setError(json.error ?? `Could not create familiar (HTTP ${res.status}).`);
+        setSubmitting(false);
+        return;
+      }
+      const newId = json.id ?? derivedId;
+      reset();
+      onCreated(newId);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Could not create familiar.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      breadcrumb={["Familiars", "New familiar"]}
+      dismissOnBackdrop={!submitting}
+      footerActions={
+        <>
+          <Button variant="ghost" onClick={handleClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            leadingIcon="ph:plus"
+            onClick={() => void handleCreate()}
+            disabled={!canCreate}
+            loading={submitting}
+          >
+            Create familiar
+          </Button>
+        </>
+      }
+    >
+      <form
+        className="flex flex-col gap-3"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleCreate();
+        }}
+      >
+        {/* Name + glyph swatch */}
+        <div>
+          <label className={labelClass} htmlFor="create-familiar-name">
+            Name
+          </label>
+          <div className="flex items-stretch gap-2">
+            <button
+              type="button"
+              onClick={() => setGlyphOpen((v) => !v)}
+              aria-label="Pick an icon"
+              aria-expanded={glyphOpen}
+              title="Pick an icon"
+              className="focus-ring grid h-9 w-9 shrink-0 place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 hover:border-[var(--accent-presence)]"
+            >
+              <FamiliarGlyph glyph={{ kind: "icon", name: glyph }} size="sm" />
+            </button>
+            <input
+              id="create-familiar-name"
+              ref={nameRef}
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Nova"
+              className={inputClass}
+            />
+          </div>
+          <p className="mt-1 text-[11px] text-[var(--text-muted)]">
+            {derivedId ? (
+              idTaken ? (
+                <span className="text-[var(--color-warning)]">
+                  id “{derivedId}” is already taken — pick another name
+                </span>
+              ) : (
+                <>id: {derivedId}</>
+              )
+            ) : (
+              <>A name creates the familiar’s id automatically.</>
+            )}
+          </p>
+        </div>
+
+        {/* Curated glyph grid */}
+        {glyphOpen ? (
+          <div
+            role="listbox"
+            aria-label="Starter icons"
+            className="grid grid-cols-8 gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 p-2"
+          >
+            {STARTER_GLYPHS.map((g) => (
+              <button
+                key={g}
+                type="button"
+                role="option"
+                aria-selected={glyph === g}
+                onClick={() => {
+                  setGlyph(g);
+                  setGlyphOpen(false);
+                }}
+                title={g.replace(/^ph:/, "").replace(/-fill$/, "")}
+                className={`focus-ring grid h-8 w-8 place-items-center rounded-md hover:bg-[var(--bg-raised)] ${
+                  glyph === g
+                    ? "bg-[var(--accent-presence)]/15 ring-1 ring-[var(--accent-presence)]"
+                    : ""
+                }`}
+              >
+                <FamiliarGlyph glyph={{ kind: "icon", name: g }} size="sm" />
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        {/* Harness */}
+        <div>
+          <label className={labelClass} htmlFor="create-familiar-harness">
+            Harness
+          </label>
+          <select
+            id="create-familiar-harness"
+            value={harness}
+            onChange={(e) => setHarness(e.target.value)}
+            className={inputClass}
+          >
+            {COMPATIBILITY_ADAPTERS.map((adapter) => (
+              <option key={adapter.id} value={adapter.id}>
+                {adapter.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* More options */}
+        <button
+          type="button"
+          onClick={() => setShowMore((v) => !v)}
+          aria-expanded={showMore}
+          className="focus-ring inline-flex w-fit items-center gap-1 text-[11px] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name={showMore ? "ph:caret-down" : "ph:caret-right"} width={11} />
+          More options
+        </button>
+
+        {showMore ? (
+          <div className="flex flex-col gap-3 border-l border-[var(--border-hairline)] pl-3">
+            <div>
+              <label className={labelClass} htmlFor="create-familiar-id">
+                id
+              </label>
+              <input
+                id="create-familiar-id"
+                value={idOverride ?? derivedId}
+                onChange={(e) => setIdOverride(e.target.value)}
+                placeholder="auto from name"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass} htmlFor="create-familiar-role">
+                Role
+              </label>
+              <input
+                id="create-familiar-role"
+                value={role}
+                onChange={(e) => setRole(e.target.value)}
+                placeholder="Familiar"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass} htmlFor="create-familiar-model">
+                Model
+              </label>
+              <input
+                id="create-familiar-model"
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                placeholder="Default for this harness"
+                className={inputClass}
+              />
+            </div>
+            <div>
+              <label className={labelClass} htmlFor="create-familiar-description">
+                What it does
+              </label>
+              <textarea
+                id="create-familiar-description"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="A short description of this familiar’s focus."
+                rows={3}
+                className={`${inputClass} h-auto resize-y py-2`}
+              />
+            </div>
+          </div>
+        ) : null}
+
+        {error ? (
+          <p className="flex items-center gap-1.5 rounded-md border border-[var(--color-warning)]/40 bg-[var(--color-warning)]/10 px-2.5 py-1.5 text-[11px] text-[var(--color-warning)]">
+            <Icon name="ph:warning-circle" width={12} />
+            {error}
+          </p>
+        ) : null}
+      </form>
+    </Modal>
+  );
+}

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -19,6 +19,7 @@ import { HomeFeed } from "@/components/home/home-feed";
 import { Modal } from "@/components/ui/modal";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { CreateFamiliarDialog } from "@/components/create-familiar-dialog";
 import {
   buildFamiliarCardStats,
   type FamiliarCardStats,
@@ -49,6 +50,8 @@ type AgentsViewProps = {
   onOpenMemoryFile: (path: string) => void;
   onOpenOnboarding: () => void;
   onOpenUrl: (url: string) => void;
+  /** Refresh the roster after a familiar is created and focus the new one. */
+  onFamiliarCreated?: (id: string) => void;
 };
 
 function familiarMatches(familiar: Familiar, query: string): boolean {
@@ -73,8 +76,10 @@ export function FamiliarsView({
   onOpenMemoryFile,
   onOpenOnboarding,
   onOpenUrl,
+  onFamiliarCreated,
 }: AgentsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  const [createOpen, setCreateOpen] = useState(false);
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [memoryError, setMemoryError] = useState<string | null>(null);
@@ -195,6 +200,15 @@ export function FamiliarsView({
           <div className="flex items-center gap-2">
             <button
               type="button"
+              onClick={() => setCreateOpen(true)}
+              title="Create a new familiar"
+              className="focus-ring inline-flex h-7 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-2.5 text-[11px] font-medium text-[var(--bg-base)] hover:opacity-90"
+            >
+              <Icon name="ph:plus" width={12} />
+              New familiar
+            </button>
+            <button
+              type="button"
               onClick={() => memoryFamiliar && setViewMode("agent-memory")}
               disabled={!memoryFamiliar}
               title={memoryFamiliar ? `Memory for ${memoryFamiliar.display_name}` : "Select a familiar to view memory"}
@@ -263,7 +277,10 @@ export function FamiliarsView({
       <div className="min-h-0 flex-1 overflow-y-auto">
         {familiars.length === 0 ? (
           <div className="p-4">
-            <FamiliarsEmptyState onOpenOnboarding={onOpenOnboarding} />
+            <FamiliarsEmptyState
+              onCreate={() => setCreateOpen(true)}
+              onOpenOnboarding={onOpenOnboarding}
+            />
           </div>
         ) : viewMode === "detail" && selectedFamiliar ? (
           <div className="familiars-view__detail flex h-full min-h-0">
@@ -334,6 +351,13 @@ export function FamiliarsView({
           onClose={() => setPreviewFamiliar(null)}
         />
       ) : null}
+      <CreateFamiliarDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        existingIds={familiars.map((f) => f.id)}
+        defaultHarness={familiars.find((f) => f.defaultHarness)?.defaultHarness}
+        onCreated={(id) => onFamiliarCreated?.(id)}
+      />
     </div>
   );
 }
@@ -348,17 +372,28 @@ function emptyStats(): FamiliarCardStats {
   };
 }
 
-function FamiliarsEmptyState({ onOpenOnboarding }: { onOpenOnboarding: () => void }) {
+function FamiliarsEmptyState({
+  onCreate,
+  onOpenOnboarding,
+}: {
+  onCreate: () => void;
+  onOpenOnboarding: () => void;
+}) {
   return (
     <EmptyState
       className="familiars-view__empty mx-auto my-16 max-w-md"
       icon="ph:sparkle"
       headline="No familiars yet"
-      subtitle="Set up your first familiar to populate the roster."
+      subtitle="Create your first familiar to populate the roster."
       actions={
-        <Button leadingIcon="ph:plus" onClick={onOpenOnboarding}>
-          Set up your first familiar
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="primary" leadingIcon="ph:plus" onClick={onCreate}>
+            Create a familiar
+          </Button>
+          <Button variant="ghost" onClick={onOpenOnboarding}>
+            Run full setup
+          </Button>
+        </div>
       }
     />
   );

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -462,8 +462,9 @@ export function Workspace() {
 
   // Cross-surface "create a familiar" bridge. The dock (and any deep surface
   // that can't reach openOnboarding directly) announces intent and the
-  // Workspace opens onboarding — the app's canonical create-a-familiar flow,
-  // since familiars are daemon-owned and have no cave-side create path.
+  // Workspace opens onboarding — the full first-run flow. The Familiars page
+  // also offers a lighter in-app "New familiar" dialog (POST /api/familiars)
+  // for adding to an existing roster without re-running setup.
   useEffect(() => {
     const openCreate = () => setOnboardingOpen(true);
     window.addEventListener("cave:onboarding-open", openCreate);
@@ -1803,6 +1804,10 @@ export function Workspace() {
         }}
         onOpenOnboarding={openOnboarding}
         onOpenUrl={openUrlExternally}
+        onFamiliarCreated={(id) => {
+          void loadFamiliars();
+          selectFamiliar(id);
+        }}
       />
     ) : mode === "chat" ? (
       <ChatSurface

--- a/src/lib/onboarding-familiars.ts
+++ b/src/lib/onboarding-familiars.ts
@@ -41,7 +41,10 @@ function cleanText(value: string | null | undefined): string {
   return (value ?? "").trim();
 }
 
-function slugify(value: string): string {
+/** Derive a familiar id slug from free text. Exported so the create-familiar
+ *  dialog can show a live `id:` preview that matches what the server will
+ *  persist (the route calls this again via normalizeFamiliarDraft). */
+export function slugifyFamiliarId(value: string): string {
   const slug = value
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -60,10 +63,10 @@ export function normalizeFamiliarDraft(input: OnboardingFamiliarInput): Onboardi
   const displayName = cleanText(input.displayName);
   if (!displayName) throw new Error("Familiar name is required.");
 
-  const id = slugify(cleanText(input.id) || displayName);
+  const id = slugifyFamiliarId(cleanText(input.id) || displayName);
   if (!id) throw new Error("Familiar id is required.");
 
-  const openclawAgentId = slugify(cleanText(input.openclawAgentId));
+  const openclawAgentId = slugifyFamiliarId(cleanText(input.openclawAgentId));
   const harness = cleanText(input.harness) || (openclawAgentId ? "openclaw" : "codex");
   if (!isTrustedOnboardingHarness(harness)) {
     throw new Error(`Unsupported harness: ${harness}.`);


### PR DESCRIPTION
## What

Adds an intuitive, in-app way to **create a familiar** — no more re-running the full onboarding overlay or hand-editing `~/.coven/familiars.toml` just to add one.

## UX (Quick form)

- **"+ New familiar"** button in the Familiars page header; the empty-state CTA now opens the same dialog too (with a secondary "Run full setup" → onboarding).
- **Name** is the only required field — it auto-derives the `id` (live `id: …` preview; duplicates are flagged and block Create).
- Optional **icon picker**: a curated 16-glyph grid (default `ph:sparkle-fill`), rendered through the free-form `FamiliarGlyph` renderer so any Phosphor glyph displays.
- **Harness** dropdown from `COMPATIBILITY_ADAPTERS`, preselected to the workspace default.
- Collapsible **More options**: id override, role, model, description.

Verified in a real browser build:

| Roster + button | Dialog | Glyph grid | More options |
|---|---|---|---|
| header "New familiar" | Quick form | 16 icons | id/role/model/description |

## Write path — `POST /api/familiars` (new handler on the existing route)

- Reuses the onboarding write primitives (`normalizeFamiliarDraft`, `buildFamiliarsToml`, adapter-manifest scaffold) so a UI-created familiar is **identical** to a setup-created one.
- Returns **409** on a duplicate id instead of appending a second `[[familiar]]` block.
- Upserts **only this familiar's binding** via `saveConfig({ familiars })`.
- **Never writes `defaults`.** Onboarding intentionally sets the global default harness/model from the *first* familiar; adding an Nth familiar must not silently change the user's default. (Same spirit as the #2055 config-clobber fix.) `saveConfig` deep-merges, so `roles`/`addons`/`marketplace` stay untouched.

Extracted `slugifyFamiliarId` from `onboarding-familiars` so the dialog's id preview matches exactly what the server persists. `workspace` wires `onFamiliarCreated` → refetch roster + select the new familiar.

## Out of scope (v1)

Avatar upload at creation (use Familiar Studio afterward); SOUL.md/IDENTITY.md scaffolding (daemon-owned; onboarding doesn't do it either — identity is the `description` field); editing existing familiars (already in Familiar Studio).

## Tests

- POST guards appended to `familiars/route.test.ts`: reuses helpers, 409 on dup, **must not write `defaults`**, fallback-empty body.
- New `create-familiar-dialog.test.ts`: Modal usage, POST shape, id preview via `slugifyFamiliarId`, duplicate-block, harness catalog, glyph rendering.
- `api-contracts.test.ts` `/familiars` → `[GET, POST]`; both new tests wired into `run-tests.mjs`.

`typecheck` ✓, `check:tests-wired` ✓, `test:app` (475) ✓, `test:api` (97) ✓, `test:mobile` (65) ✓, `pnpm build` ✓ (bundle within budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)