### PR TITLE
fix(palette): dismiss command palette on press so it stops eating the first click

### DIFF
--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -795,14 +795,21 @@ export function CommandPalette({
 
   return (
     <div
-      onClick={onClose}
+      // Dismiss on press (pointerdown), not click, so a single press anywhere
+      // outside the dialog closes the palette immediately instead of leaving a
+      // full-viewport backdrop "armed" to swallow the next click on whatever the
+      // user actually meant to hit (e.g. a top-bar familiar avatar). Closing on
+      // click made that first click a dead no-op — it only dismissed the overlay.
+      onPointerDown={onClose}
       role="presentation"
       className="fixed inset-0 z-50 flex items-start justify-center bg-[var(--backdrop-scrim)] backdrop-blur-sm"
       style={{ animation: "ui-modal-fade-in var(--duration-fast) var(--ease-decelerate)" }}
     >
       <div
         ref={dialogRef}
-        onClick={(e) => e.stopPropagation()}
+        // Keep presses inside the dialog from bubbling to the backdrop's
+        // pointerdown dismissal (matches the dismissal event above).
+        onPointerDown={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-label="Command palette"

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -791,16 +791,50 @@ export function CommandPalette({
     }
   };
 
+  // Click-through dismissal. Pressing the scrim closes the palette AND forwards
+  // that same press to whatever interactive control sits underneath, so a user
+  // reaching past the open palette for (say) a top-bar familiar avatar gets the
+  // selection in one gesture. Without this the full-viewport backdrop swallowed
+  // the first click as a throwaway dismiss, and the real target only registered
+  // on a second click ("doesn't grab unless I unfocus first").
+  const onScrimPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    const { clientX, clientY, button } = e;
+    const scrim = e.currentTarget;
+    let target: HTMLElement | null = null;
+    // Only a primary (left) press forwards through; secondary/middle just close.
+    // Presses inside the dialog never reach here (it stops propagation), so the
+    // hit point is always over the backdrop itself.
+    if (button === 0) {
+      // Make the scrim transparent to hit-testing so elementFromPoint reports
+      // the app control beneath it, then restore it before unmounting.
+      const prev = scrim.style.pointerEvents;
+      scrim.style.pointerEvents = "none";
+      const under = document.elementFromPoint(clientX, clientY);
+      scrim.style.pointerEvents = prev;
+      target =
+        under?.closest<HTMLElement>(
+          'a[href], button:not([disabled]), input, textarea, select, [role="button"], [role="option"], [role="menuitem"], [role="tab"], [role="link"], [role="checkbox"], [role="switch"]',
+        ) ?? null;
+    }
+    onClose();
+    if (!target) return;
+    // Defer activation until the overlay has unmounted so the forwarded click
+    // lands with the palette already gone (and any close side-effects settled).
+    requestAnimationFrame(() => {
+      const tag = target!.tagName.toLowerCase();
+      if (tag === "input" || tag === "textarea" || tag === "select") target!.focus();
+      else target!.click();
+    });
+  };
+
   if (!open) return null;
 
   return (
     <div
-      // Dismiss on press (pointerdown), not click, so a single press anywhere
-      // outside the dialog closes the palette immediately instead of leaving a
-      // full-viewport backdrop "armed" to swallow the next click on whatever the
-      // user actually meant to hit (e.g. a top-bar familiar avatar). Closing on
-      // click made that first click a dead no-op — it only dismissed the overlay.
-      onPointerDown={onClose}
+      // Dismiss on press (pointerdown), not click, so the backdrop never lingers
+      // "armed" to swallow the next click. onScrimPointerDown also forwards the
+      // press to the control underneath (click-through) — see its definition.
+      onPointerDown={onScrimPointerDown}
       role="presentation"
       className="fixed inset-0 z-50 flex items-start justify-center bg-[var(--backdrop-scrim)] backdrop-blur-sm"
       style={{ animation: "ui-modal-fade-in var(--duration-fast) var(--ease-decelerate)" }}


### PR DESCRIPTION
## The bug

Reported as: *"when I unfocus then select it works, but if I select anywhere in the app it does not grab."*

While the command palette is open it renders a full-viewport backdrop (`fixed inset-0 z-50`) that dismissed on **`click`**. That left the overlay *armed*: the first click anywhere in the app hit the backdrop and only closed the palette — the control the user actually aimed at (e.g. a top-bar **familiar avatar**, the rail's Create button) never received that click. So a selection "didn't grab" until a second click.

It's easy to leave the palette engaged without noticing: the top-bar search opens it (`familiar-menu-bar.tsx` → `onClick={onOpenSearch}`, and typing sets `paletteOpen(true)`) and it traps/restores focus to the search input.

## The fix — two layers (`command-palette.tsx`)

1. **Dismiss on press.** The backdrop now closes on `pointerdown` instead of `click`, so it never lingers "armed" between a press and its release. Presses inside the dialog stop propagation so they don't close it.
2. **Click-through.** The dismissing press is *forwarded* to the interactive control beneath it: on scrim `pointerdown` we momentarily set the scrim's `pointer-events: none` so `elementFromPoint` resolves the app control at the press point, close the palette, then on the next frame focus (inputs) or click (everything else) that control. So reaching past the open palette for a familiar avatar selects it in **one gesture**.

Only a primary (left) press forwards through; secondary/middle just dismiss. No change to keyboard (Escape) or in-dialog interaction.

Verified: `pnpm typecheck` clean (0 errors); source-text tests `command-palette*.test.ts` + `modal-trap-adoption.test.ts` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)