### PR TITLE
perf(ios): pause the theme poll while the app is backgrounded

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -33,6 +33,7 @@ struct RootView: View {
 /// initial selection, so the app reliably reopens on the last-used tab.
 struct MainTabView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.scenePhase) private var scenePhase
 
     /// Tab order, used to map ⌘1–5 to the right tab.
     private let tabOrder: [AppTab] = [.chats, .tasks, .calendar, .dev, .settings]
@@ -71,8 +72,12 @@ struct MainTabView: View {
         }
         // Keep the app chrome in step with desktop theme changes: re-fetch while
         // connected. `loadTheme` is best-effort and only assigns on change, so an
-        // unchanged theme is a cheap no-op.
-        .task {
+        // unchanged theme is a cheap no-op. Keyed on scenePhase so the 20s poll
+        // only runs while the app is active — backgrounding cancels the task
+        // (no needless network while the user isn't looking), and returning to
+        // the foreground restarts it with an immediate refresh.
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
             while !Task.isCancelled {
                 if app.connectionState == .connected { await app.loadTheme() }
                 try? await Task.sleep(for: .seconds(20))

--- a/src/components/ios-theme-api.test.ts
+++ b/src/components/ios-theme-api.test.ts
@@ -32,5 +32,9 @@ assert.match(root, /@Environment\(\\\.chrome\) private var chrome/, "RootView re
 assert.match(root, /\.background\(chrome\.bgBase\.ignoresSafeArea\(\)\)[\s\S]*\.foregroundStyle\(chrome\.textPrimary\)/, "RootView applies desktop background and foreground");
 assert.match(root, /\.glassBars\(\)/, "RootView applies the frosted, theme-tinted tab + navigation bar chrome");
 assert.match(root, /while !Task\.isCancelled[\s\S]*await app\.loadTheme\(\)[\s\S]*Task\.sleep\(for:\s*\.seconds\(20\)\)/, "MainTabView polls the desktop theme while connected");
+// The poll is scenePhase-gated: keyed on scenePhase and guarded so it only runs
+// while the app is active (backgrounding cancels it, foregrounding restarts it).
+assert.match(root, /@Environment\(\\\.scenePhase\) private var scenePhase/, "MainTabView observes scenePhase");
+assert.match(root, /\.task\(id: scenePhase\) \{\s*guard scenePhase == \.active else \{ return \}/, "the theme poll only runs while the scene is active");
 
 console.log("ios-theme-api.test.ts: ok");


### PR DESCRIPTION
## Context

Extends the visibility-gating work (#2037, web) to the iOS app. `MainTabView` polls `/api/theme` every 20s in a `.task` loop, but the loop ran across scene phases — firing during inactive/background states (app switcher, notifications, on the way to suspension) when nobody's looking.

## Change

Key the poll task on `scenePhase` and guard it to `.active`:

```swift
.task(id: scenePhase) {
    guard scenePhase == .active else { return }
    while !Task.isCancelled {
        if app.connectionState == .connected { await app.loadTheme() }
        try? await Task.sleep(for: .seconds(20))
    }
}
```

Backgrounding cancels the task (no network while the user isn't looking); foregrounding restarts it with an immediate refresh, so the chrome is current the moment you return. The poll body is unchanged.

This is the last polling site that wasn't visibility-gated, now consistent across web + iOS.

## Verification

- **iOS compiles:** `xcodegen generate` + `xcodebuild -project CovenCave.xcodeproj -scheme CovenCave -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**. (apps/ios is not built by the required CI checks, so this was verified locally.)
- `pnpm test:mobile` (65) + `test:app` (476) green — `ios-theme-api.test.ts` reads `RootView.swift`; updated it to assert the scenePhase gating.

> Note on scope: I evaluated the other remaining items and found them poor bets — chat-list row memoization is defeated by dnd-kit's `useSortable` returning unstable `listeners` (no payoff), and `<ChatComposer>` extraction is a large refactor with reduced value now the transcript is capped (#2050). This iOS gate was the remaining correct, low-risk win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)