### PR TITLE
Fix titlebar dragging and flow session fallback

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4053,6 +4053,7 @@ button:active > .edge-rail-chip {
    `.menu-bar` breakpoint; below that the mobile `.top-bar` carries its own.
    ──────────────────────────────────────────────── */
 .shell-top {
+  position: relative;
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
@@ -4063,6 +4064,10 @@ button:active > .edge-rail-chip {
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border-hairline);
   overflow: hidden;
+}
+
+.shell-titlebar-drag-lane {
+  display: none;
 }
 
 .shell-top__bar {
@@ -4101,25 +4106,45 @@ button:active > .edge-rail-chip {
     min-height: 52px;
   }
 
+  :root[data-tauri-titlebar] .shell-titlebar-drag-lane {
+    position: absolute;
+    inset: 0 0 auto 0;
+    z-index: 2;
+    display: block;
+    height: 10px;
+    -webkit-app-region: drag;
+    app-region: drag;
+  }
+
   :root[data-tauri-titlebar] :is(
     .shell-top,
     .shell-top__bar,
     .shell-top .menu-bar,
-    .shell-top .top-bar
+    .shell-top .top-bar,
+    .shell-top .menu-bar__group,
+    .shell-top .top-bar__lead,
+    .shell-top .top-bar__actions
   ) {
     -webkit-app-region: drag;
     app-region: drag;
   }
 
-  :root[data-tauri-titlebar] .shell-top * {
-    -webkit-app-region: no-drag;
-    app-region: no-drag;
-  }
-
   :root[data-tauri-titlebar] .shell-top :is(
     button, a, input, select, textarea, kbd, label,
     [role="button"], [role="textbox"], [contenteditable], .menu-bar__search
-  ) {
+  ),
+  :root[data-tauri-titlebar] .shell-top :is(
+    button, a, input, select, textarea, kbd, label,
+    [role="button"], [role="textbox"], [contenteditable], .menu-bar__search
+  ) *,
+  :root[data-tauri-titlebar] .shell-top :is(
+    .top-bar__search,
+    .top-bar__account
+  ),
+  :root[data-tauri-titlebar] .shell-top :is(
+    .top-bar__search,
+    .top-bar__account
+  ) * {
     -webkit-app-region: no-drag;
     app-region: no-drag;
   }

--- a/src/components/chat-linked-context.test.ts
+++ b/src/components/chat-linked-context.test.ts
@@ -116,3 +116,27 @@ assert.match(
   /historyState === "missing"[\s\S]*Chat history unavailable/,
   "ChatView should make missing history visible instead of silently opening a blank chat",
 );
+
+assert.match(
+  chatView,
+  /function isFlowBackedSession\(session: SessionRow \| null \| undefined\)/,
+  "ChatView should explicitly detect sessions created by flow execution",
+);
+
+assert.match(
+  chatView,
+  /fetch\(`\/api\/flows\/session-transcript\?\$\{params\.toString\(\)\}`/,
+  "ChatView should query the flow transcript endpoint when a flow session has no saved chat conversation",
+);
+
+assert.match(
+  chatView,
+  /const cleanedTranscript = transcript \? stripStepMarkers\(transcript\) : ""[\s\S]*setFlowTranscriptFallback\(cleanedTranscript\)/,
+  "ChatView should render scrubbed flow output instead of the generic missing-history card",
+);
+
+assert.match(
+  chatView,
+  /title=\{flowBackedSession \? "Flow output unavailable" : "Chat history unavailable"\}/,
+  "Flow-backed sessions with no transcript should show a flow-specific fallback message",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -82,6 +82,7 @@ import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { resolveActivePath, siblingsOf, childLeaf } from "@/lib/conversation-tree";
+import { stripStepMarkers } from "@/lib/workflow-step-progress";
 import {
   buildReflectTranscript,
   buildThreadReflectPrompt,
@@ -250,6 +251,26 @@ export type ChatViewHandle = {
 
 type ComposerAttachment = ChatAttachment & { id: string };
 type ChatHistoryState = "idle" | "loading" | "loaded" | "missing" | "error";
+
+function isFlowBackedSession(session: SessionRow | null | undefined): boolean {
+  const origin = session?.origin as string | undefined;
+  const title = session?.title?.trim() ?? "";
+  return origin === "flow" || title.startsWith("Flow: ") || title.startsWith("Flow step: ");
+}
+
+async function loadFlowSessionTranscript(sessionId: string): Promise<string | null> {
+  const params = new URLSearchParams({ sessionId });
+  try {
+    const res = await fetch(`/api/flows/session-transcript?${params.toString()}`, { cache: "no-store" });
+    if (!res.ok) return null;
+    const json = await res.json() as { ok?: boolean; transcript?: string };
+    const transcript = typeof json.transcript === "string" ? json.transcript.trim() : "";
+    if (!json.ok || !transcript) return null;
+    return transcript;
+  } catch {
+    return null;
+  }
+}
 type FailedSend = {
   text: string;
   attachments: ChatAttachment[];
@@ -1160,6 +1181,53 @@ function ChatHistoryNotice({
   );
 }
 
+function FlowSessionTranscriptFallback({
+  transcript,
+  onRetry,
+  onBack,
+}: {
+  transcript: string;
+  onRetry?: (() => void) | null;
+  onBack?: (() => void) | null;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-4 text-left">
+      <div className="flex items-start gap-3">
+        <Icon name="ph:flow-arrow" width={20} className="mt-0.5 shrink-0 text-[var(--text-muted)]" />
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-semibold text-[var(--text-primary)]">Flow session output</p>
+          <p className="mt-1 max-w-[68ch] text-[12px] leading-[1.5] text-[var(--text-muted)]">
+            This flow session has no saved chat transcript yet, so CovenCave is showing the flow output instead.
+          </p>
+        </div>
+        {(onRetry || onBack) && (
+          <div className="flex shrink-0 gap-2">
+            {onBack && (
+              <button
+                type="button"
+                className="cave-btn cave-btn--ghost cave-btn--sm"
+                onClick={onBack}
+              >
+                Back
+              </button>
+            )}
+            {onRetry && (
+              <button
+                type="button"
+                className="cave-btn cave-btn--primary cave-btn--sm"
+                onClick={onRetry}
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      <pre className="mt-4 max-h-[min(58vh,640px)] overflow-auto whitespace-pre-wrap rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 p-4 font-mono text-[12px] leading-relaxed text-[var(--text-primary)]">{transcript}</pre>
+    </div>
+  );
+}
+
 function ChatTitleEditable({
   session,
   displayTitleOverride,
@@ -1956,10 +2024,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // is what lets the first exchange branch instead of silently appending.
   const [pendingBranchParent, setPendingBranchParent] = useState<string | null | undefined>(undefined);
   const [historyState, setHistoryState] = useState<ChatHistoryState>("idle");
+  const [flowTranscriptFallback, setFlowTranscriptFallback] = useState<string | null>(null);
   const [debugModalOpen, setDebugModalOpen] = useState(false);
   const [reflecting, setReflecting] = useState(false);
   const [reflectError, setReflectError] = useState<string | null>(null);
   const [threadSignalReport, setThreadSignalReport] = useState<ThreadSelfReport | null>(null);
+  const flowBackedSession = useMemo(() => isFlowBackedSession(session ?? null), [session]);
   const autoSelfReportSessionsRef = useRef<Set<string>>(new Set());
   const autoSelfReportEligibilityRef = useRef<{ sessionId: string | null; eligible: boolean }>({
     sessionId: null,
@@ -2745,6 +2815,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     currentSessionRef.current = sessionId;
     liveSessionIdRef.current = null;
     setLinkedContext(null);
+    setFlowTranscriptFallback(null);
     if (!sessionId) {
       setTurns([]);
       setActiveLeafId("");
@@ -2756,6 +2827,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setTurns(live.turns);
       turnsRef.current = live.turns;
       setActiveLeafId(live.activeLeafId);
+      setFlowTranscriptFallback(null);
       abortRef.current = live.controller;
       setHistoryState("loaded");
       setBusy(true);
@@ -2773,13 +2845,31 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       try {
         const res = await fetch(`/api/chat/conversation/${sessionId}`, { cache: "no-store" });
         if (!res.ok) {
-          if (!cancelled) {
+          if (cancelled) return;
+          if (keepLiveSession()) {
+            setHistoryState("loaded");
+            return;
+          }
+          if (res.status === 404 && flowBackedSession) {
+            const transcript = await loadFlowSessionTranscript(sessionId);
+            if (cancelled) return;
             if (keepLiveSession()) {
               setHistoryState("loaded");
               return;
             }
+            const cleanedTranscript = transcript ? stripStepMarkers(transcript) : "";
+            if (cleanedTranscript) {
+              setTurns([]);
+              setActiveLeafId("");
+              setFlowTranscriptFallback(cleanedTranscript);
+              setHistoryState("loaded");
+              return;
+            }
+          }
+          if (!cancelled) {
             setTurns([]);
             setActiveLeafId("");
+            setFlowTranscriptFallback(null);
             setHistoryState(res.status === 404 ? "missing" : "error");
           }
           return;
@@ -2811,6 +2901,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         if (cancelled) return;
         setLinkedContext(json.context ?? null);
         if (json.ok && json.conversation) {
+          setFlowTranscriptFallback(null);
           setTurns(
             (json.conversation.turns ?? [])
               .filter(
@@ -2862,6 +2953,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             setHistoryState("loaded");
             return;
           }
+          setFlowTranscriptFallback(null);
           setTurns([]);
           setActiveLeafId("");
           setHistoryState("loaded");
@@ -2870,6 +2962,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             setHistoryState("loaded");
             return;
           }
+          setFlowTranscriptFallback(null);
           setTurns([]);
           setActiveLeafId("");
           setHistoryState("missing");
@@ -2880,6 +2973,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             setHistoryState("loaded");
             return;
           }
+          setFlowTranscriptFallback(null);
           setTurns([]);
           setActiveLeafId("");
           setHistoryState("error");
@@ -2889,7 +2983,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return () => {
       cancelled = true;
     };
-  }, [sessionId, historyRetryKey]);
+  }, [sessionId, historyRetryKey, flowBackedSession]);
 
   // Pin: while following, every turns mutation snaps the scroller to the
   // bottom INSTANTLY (scrollTop assignment inside a rAF, coalescing multiple
@@ -4112,10 +4206,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           {turns.length === 0 ? (
             historyState === "loading" ? (
               <ChatHistorySkeleton />
+            ) : flowTranscriptFallback ? (
+              <FlowSessionTranscriptFallback
+                transcript={flowTranscriptFallback}
+                onRetry={retryHistory}
+                onBack={onBack}
+              />
             ) : historyState === "missing" ? (
               <ChatHistoryNotice
-                title="Chat history unavailable"
-                body="This session exists, but CovenCave could not find a saved transcript for it yet."
+                title={flowBackedSession ? "Flow output unavailable" : "Chat history unavailable"}
+                body={flowBackedSession
+                  ? "This flow session exists, but CovenCave could not find saved chat history or flow output for it yet."
+                  : "This session exists, but CovenCave could not find a saved transcript for it yet."}
                 onRetry={retryHistory}
                 onBack={onBack}
               />

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -43,6 +43,11 @@ assert.match(
 );
 assert.match(
   shell,
+  /<div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" \/>\s*\{navToggle\}/,
+  "the desktop top bar should expose a dedicated non-interactive drag lane before its controls",
+);
+assert.match(
+  shell,
   /shell-top-toggle shell-top-toggle--nav/,
   "shell renders a top-bar nav toggle for the sidebar",
 );
@@ -107,13 +112,28 @@ assert.match(
 );
 assert.match(
   css,
-  /:root\[data-tauri-titlebar\]\s+:is\(\s*\.shell-top,\s*\.shell-top__bar,\s*\.shell-top \.menu-bar,\s*\.shell-top \.top-bar\s*\)\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
-  "macOS Tauri titlebar mode should make the full rendered top-bar band draggable",
+  /\.shell-titlebar-drag-lane\s*\{[\s\S]*?display:\s*none;/,
+  "the drag lane should be hidden outside the macOS Tauri titlebar mode",
 );
 assert.match(
   css,
-  /:root\[data-tauri-titlebar\]\s+\.shell-top \*\s*\{[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?app-region:\s*no-drag;/,
-  "macOS titlebar mode should carve every header descendant out of the drag region so controls stay clickable",
+  /:root\[data-tauri-titlebar\]\s+\.shell-titlebar-drag-lane\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?height:\s*10px;[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
+  "macOS Tauri titlebar mode should expose a fixed-height draggable lane above the controls",
+);
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\]\s+:is\(\s*\.shell-top,\s*\.shell-top__bar,\s*\.shell-top \.menu-bar,\s*\.shell-top \.top-bar,\s*\.shell-top \.menu-bar__group,\s*\.shell-top \.top-bar__lead,\s*\.shell-top \.top-bar__actions\s*\)\s*\{[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
+  "macOS Tauri titlebar mode should keep the full rendered top-bar band draggable, including inert layout wrappers",
+);
+assert.doesNotMatch(
+  css,
+  /:root\[data-tauri-titlebar\]\s+\.shell-top \*\s*\{[\s\S]*?app-region:\s*no-drag;/,
+  "macOS titlebar mode must not carve every header descendant out of the drag region",
+);
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\]\s+\.shell-top :is\(\s*button,\s*a,\s*input,\s*select,\s*textarea,\s*kbd,\s*label,[\s\S]*?\[role="button"\],[\s\S]*?\[role="textbox"\],[\s\S]*?\[contenteditable\],[\s\S]*?\.menu-bar__search\s*\),[\s\S]*?-webkit-app-region:\s*no-drag;[\s\S]*?app-region:\s*no-drag;/,
+  "macOS titlebar mode should carve only interactive header controls out of the drag region so controls stay clickable",
 );
 assert.match(
   css,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -432,6 +432,7 @@ function ShellInner({
     return (
       <div className="shell-frame flex h-full w-full flex-col">
         <div className="shell-top">
+          <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
           <div className="shell-top__bar">{renderedTopBar}</div>
         </div>
         <div className="shell-body flex flex-1 min-h-0">
@@ -621,6 +622,7 @@ function ShellInner({
           surface. Visually hidden until focused (see .skip-link in globals). */}
       <a className="skip-link" href="#shell-main-content">Skip to main content</a>
       <div className="shell-top">
+        <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
         {navToggle}
         <div className="shell-top__bar">{renderedTopBar}</div>
         {rightToggles}


### PR DESCRIPTION
## Summary
- Add a dedicated macOS/Tauri titlebar drag lane so the top edge remains draggable after interacting with the app.
- Preserve clickable header controls by limiting no-drag regions to interactive elements instead of every header descendant.
- Render flow session output from `/api/flows/session-transcript` when a flow-backed session has no saved chat transcript.

## Test Plan
- `node --experimental-strip-types src/components/shell-edge-rails.test.ts`
- `node --experimental-strip-types src/components/chat-linked-context.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `git diff --check HEAD`
- `pnpm build`