### PR TITLE
perf: skip no-op re-renders from the board poll

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 /** Suite name -> ordered list of repo-relative test file paths. */
 export const SUITES = {
   app: [
+    "src/lib/array-content-equal.test.ts",
     "src/lib/session-list-equal.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { groupInboxFeed } from "@/lib/inbox-feed";
 import { sameSessionList } from "@/lib/session-list-equal";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-mode";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
@@ -964,24 +965,25 @@ export function Workspace() {
           familiarId?: string | null;
           endDate?: string | null;
         }>;
-        setOpenTaskCards(
-          cards
-            .filter((c) => c.status !== "done")
-            .map((c) => ({ familiarId: c.familiarId ?? null })),
-        );
+        // The 60s board poll rebuilds these arrays each tick; keep the previous
+        // reference when the content is unchanged so an idle board doesn't
+        // re-render the Tasks badge / calendar deadline markers for nothing.
+        const nextOpenCards = cards
+          .filter((c) => c.status !== "done")
+          .map((c) => ({ familiarId: c.familiarId ?? null }));
+        setOpenTaskCards((prev) => (arrayContentEqual(prev, nextOpenCards) ? prev : nextOpenCards));
         // Open cards with a due date become read-only calendar deadline markers
         // (a shipped/"done" task is no longer an upcoming deadline).
-        setBoardDeadlines(
-          cards
-            .filter((c) => c.id && c.endDate && c.status !== "done")
-            .map((c) => ({
-              id: c.id as string,
-              title: c.title?.trim() || "Untitled task",
-              date: c.endDate as string,
-              familiarId: c.familiarId ?? null,
-              status: c.status,
-            })),
-        );
+        const nextDeadlines = cards
+          .filter((c) => c.id && c.endDate && c.status !== "done")
+          .map((c) => ({
+            id: c.id as string,
+            title: c.title?.trim() || "Untitled task",
+            date: c.endDate as string,
+            familiarId: c.familiarId ?? null,
+            status: c.status,
+          }));
+        setBoardDeadlines((prev) => (arrayContentEqual(prev, nextDeadlines) ? prev : nextDeadlines));
       }
     } catch {
       /* keep last value on transient failure */

--- a/src/lib/array-content-equal.test.ts
+++ b/src/lib/array-content-equal.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { arrayContentEqual } from "./array-content-equal.ts";
+
+test("same reference is equal", () => {
+  const a = [{ id: "1" }];
+  assert.equal(arrayContentEqual(a, a), true);
+});
+
+test("equal content in fresh arrays is equal (the poll no-op case)", () => {
+  assert.equal(arrayContentEqual([{ familiarId: "n" }], [{ familiarId: "n" }]), true);
+  assert.equal(arrayContentEqual([], []), true);
+  assert.equal(
+    arrayContentEqual(
+      [{ id: "c1", title: "T", date: "d", familiarId: null, status: "open" }],
+      [{ id: "c1", title: "T", date: "d", familiarId: null, status: "open" }],
+    ),
+    true,
+  );
+});
+
+test("different length is not equal", () => {
+  assert.equal(arrayContentEqual([{ id: "1" }], [{ id: "1" }, { id: "2" }]), false);
+});
+
+test("any changed field is not equal", () => {
+  assert.equal(arrayContentEqual([{ familiarId: "a" }], [{ familiarId: "b" }]), false);
+  assert.equal(arrayContentEqual([{ id: "c1", status: "open" }], [{ id: "c1", status: "done" }]), false);
+});
+
+test("order matters", () => {
+  assert.equal(arrayContentEqual([{ id: "1" }, { id: "2" }], [{ id: "2" }, { id: "1" }]), false);
+});
+
+console.log("array-content-equal.test.ts: ok");

--- a/src/lib/array-content-equal.ts
+++ b/src/lib/array-content-equal.ts
@@ -1,0 +1,16 @@
+// True when two arrays are content-identical (same length, same order, same
+// per-element value by structural JSON compare). Polls that rebuild a fresh
+// array each tick (e.g. /api/board → openTaskCards / boardDeadlines) use this to
+// return the previous reference from a state updater, so an unchanged result
+// doesn't re-render every consumer for nothing.
+//
+// Intended for small, JSON-serializable arrays (badge/deadline lists). Elements
+// are built by one code path so key order is stable.
+export function arrayContentEqual<T>(a: readonly T[], b: readonly T[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (JSON.stringify(a[i]) !== JSON.stringify(b[i])) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Context

Final cleanup of the polling-re-render theme (after #2057 did the same for sessions). `refreshOpenTaskCards` — the 60s `/api/board` poll — rebuilds `openTaskCards` and `boardDeadlines` via `.filter().map()` every tick, so an idle board still re-rendered the Tasks badge and the calendar's deadline markers for nothing on every poll.

## Change

Guard both `setState` calls with a new generic `arrayContentEqual(prev, next)` helper: when the freshly-derived array is content-identical to the current one, return the **previous reference** so React bails out of the render. Adds `array-content-equal.ts` + unit test.

## Verification

- `pnpm typecheck`, `check:tests-wired` (637), `test:app` (477 — incl. new `array-content-equal.test.ts`), `test:api` (98), `test:mobile` (65), `pnpm build` (+ bundle-budget gate) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)