### PR TITLE
feat(familiars): scaffold the Familiar Contract on create (identity from birth)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -550,6 +550,7 @@ export const SUITES = {
     "src/lib/session-initiator.test.ts",
     "src/lib/chat-runtime-scope.test.ts",
     "src/lib/chat-history-fallback.test.ts",
+    "src/lib/familiar-identity-scaffold.test.ts",
     "src/lib/session-list-merge.test.ts",
     "src/lib/server/memory-file-sources.test.ts",
     "src/lib/server/familiar-startup-context.test.ts",

--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -76,4 +76,18 @@ assert.match(
   "POST should tolerate a malformed/empty JSON body",
 );
 
+// POST scaffolds the Familiar Contract so a new familiar is compliant from
+// birth. Best-effort: the scaffold call is wrapped so a workspace write failure
+// can't fail creation (the familiar is already registered in toml + config).
+assert.match(
+  source,
+  /scaffoldFamiliarContractFiles\(\{[\s\S]*?id: draft\.id/,
+  "POST should scaffold the familiar's contract files",
+);
+assert.match(
+  source,
+  /try\s*\{\s*contractWrote = await scaffoldFamiliarContractFiles\([\s\S]*?\}\s*catch\s*\{/,
+  "contract scaffolding must be best-effort (never fail creation)",
+);
+
 console.log("familiars route.test.ts: ok");

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -12,6 +12,7 @@ import {
   type OnboardingFamiliarInput,
 } from "@/lib/onboarding-familiars";
 import { adapterManifestScaffoldForHarness } from "@/lib/harness-adapters";
+import { scaffoldFamiliarContractFiles } from "@/lib/server/familiar-contract-files";
 
 export const dynamic = "force-dynamic";
 
@@ -178,5 +179,23 @@ export async function POST(req: Request) {
     },
   });
 
-  return NextResponse.json({ ok: true, id: draft.id });
+  // Scaffold the Familiar Contract (SOUL.md / IDENTITY.md / ward.toml /
+  // MEMORY.md) so the new familiar is contract-compliant from birth instead of
+  // showing up for "rehabilitation" in the Studio Contract tab. Best-effort and
+  // additive: pre-existing files are left untouched, and a write failure must
+  // not fail creation — the familiar is already registered above.
+  let contractWrote: string[] = [];
+  try {
+    contractWrote = await scaffoldFamiliarContractFiles({
+      id: draft.id,
+      displayName: draft.displayName,
+      role: draft.role,
+      description: draft.description,
+      glyph: draft.glyph,
+    });
+  } catch {
+    /* non-fatal — identity files can be authored later via the Contract tab */
+  }
+
+  return NextResponse.json({ ok: true, id: draft.id, contractWrote });
 }

--- a/src/lib/familiar-identity-scaffold.test.ts
+++ b/src/lib/familiar-identity-scaffold.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildFamiliarContractFiles,
+  creatureForGlyph,
+  DEFAULT_PERSON,
+  type IdentityScaffoldInput,
+} from "./familiar-identity-scaffold.ts";
+import { evaluateFamiliarContract, FAMILIAR_PROPERTIES } from "./familiar-contract.ts";
+
+function reportFor(input: IdentityScaffoldInput) {
+  const f = buildFamiliarContractFiles(input);
+  return evaluateFamiliarContract({ soul: f.soul, identity: f.identity, ward: f.ward, memory: f.memory });
+}
+
+test("a full-input scaffold passes the contract with zero violations AND warnings", () => {
+  const report = reportFor({
+    id: "nova",
+    displayName: "Nova",
+    role: "Research familiar",
+    description: "find and summarize papers and keep a living reading list",
+    glyph: "ph:books-fill",
+    person: "Val",
+  });
+  assert.equal(report.violations.length, 0, JSON.stringify(report.violations, null, 2));
+  assert.equal(report.warnings.length, 0, JSON.stringify(report.warnings, null, 2));
+  assert.equal(report.pass, true);
+  // Every one of the five normative properties is green (Persistent Memory too,
+  // because we scaffold MEMORY.md).
+  for (const prop of FAMILIAR_PROPERTIES) {
+    assert.ok(
+      report.properties.find((p) => p.property === prop)?.pass,
+      `${prop} should pass`,
+    );
+  }
+});
+
+test("a minimal scaffold (name only) still passes cleanly", () => {
+  const report = reportFor({ id: "aurora", displayName: "Aurora" });
+  assert.equal(report.violations.length, 0, JSON.stringify(report.violations, null, 2));
+  assert.equal(report.warnings.length, 0);
+  assert.equal(report.pass, true);
+});
+
+test("SOUL name and ward familiar match (cross-file invariant)", () => {
+  // A multi-word display name must stay consistent across SOUL.md and ward.toml.
+  const report = reportFor({ id: "nova-prime", displayName: "Nova Prime" });
+  assert.equal(report.violations.filter((v) => v.file === "cross-file").length, 0);
+  assert.equal(report.pass, true);
+});
+
+test("names with quotes/hashes don't break the ward parser", () => {
+  const report = reportFor({ id: "weird", displayName: 'Od#d "Name"' });
+  assert.equal(report.pass, true, JSON.stringify(report.violations, null, 2));
+});
+
+test("defaults: person falls back to DEFAULT_PERSON and is a protected invariant", () => {
+  const { ward } = buildFamiliarContractFiles({ id: "x", displayName: "X" });
+  assert.match(ward, new RegExp(`person = "${DEFAULT_PERSON}"`));
+  assert.match(ward, new RegExp(`familiar\\.person == '${DEFAULT_PERSON}'`));
+});
+
+test("creatureForGlyph maps known glyphs and falls back to Familiar", () => {
+  assert.equal(creatureForGlyph("ph:cat-fill"), "Cat familiar");
+  assert.equal(creatureForGlyph("ph:does-not-exist"), "Familiar");
+  assert.equal(creatureForGlyph(undefined), "Familiar");
+});

--- a/src/lib/familiar-identity-scaffold.ts
+++ b/src/lib/familiar-identity-scaffold.ts
@@ -1,0 +1,220 @@
+/**
+ * Familiar identity scaffolder.
+ *
+ * Generates the four Familiar Contract files — SOUL.md, IDENTITY.md, ward.toml,
+ * MEMORY.md — for a freshly created familiar, so it is contract-compliant from
+ * birth instead of starting as an "unbound agent" that the Studio Contract tab
+ * flags for rehabilitation.
+ *
+ * The output is designed to PASS `evaluateFamiliarContract` with zero
+ * violations AND zero warnings (all five normative properties green). The
+ * generator is pure (no I/O) so that invariant can be unit-tested by running
+ * the real validator over its output — see familiar-identity-scaffold.test.ts.
+ *
+ * Spec shape mirrors the OpenCoven familiar-contract v0.1.0 minimal example.
+ */
+import { FAMILIAR_CONTRACT_SPEC_VERSION } from "./familiar-contract.ts";
+
+export type IdentityScaffoldInput = {
+  /** Slug id (used for the editable skills path). */
+  id: string;
+  /** Display name — the declared Named Identity. */
+  displayName: string;
+  role?: string;
+  description?: string;
+  /** Phosphor glyph (ph:*) — flavors the IDENTITY "Creature" line. */
+  glyph?: string;
+  /** Human the familiar belongs to (ward [meta].person). */
+  person?: string;
+};
+
+export type ScaffoldedContract = {
+  soul: string;
+  identity: string;
+  ward: string;
+  memory: string;
+};
+
+export const DEFAULT_PERSON = "Keeper";
+
+/** A friendly "creature" for IDENTITY.md, flavored by the chosen glyph. Purely
+ *  cosmetic — the validator only requires a non-empty **Creature:** field. */
+const GLYPH_CREATURE: Record<string, string> = {
+  "ph:cat-fill": "Cat familiar",
+  "ph:ghost-fill": "Spectral familiar",
+  "ph:robot-fill": "Construct familiar",
+  "ph:brain-fill": "Thinking familiar",
+  "ph:flask-fill": "Alchemist familiar",
+  "ph:rocket-fill": "Voyager familiar",
+  "ph:magic-wand-fill": "Conjurer familiar",
+  "ph:butterfly-fill": "Sprite familiar",
+  "ph:planet-fill": "Cosmic familiar",
+  "ph:detective-fill": "Sleuth familiar",
+  "ph:books-fill": "Scholar familiar",
+  "ph:palette-fill": "Artisan familiar",
+  "ph:code-fill": "Builder familiar",
+  "ph:chart-bar-fill": "Analyst familiar",
+  "ph:compass-fill": "Pathfinder familiar",
+};
+
+function clean(value: string | undefined, fallback: string): string {
+  const v = (value ?? "").trim();
+  return v.length > 0 ? v : fallback;
+}
+
+/** TOML/inline-safe: this codebase's hand-rolled ward parser stops a quoted
+ *  value at `"` or `#`, so strip those from interpolated names. */
+function tomlSafe(value: string): string {
+  return value.replace(/["#\n]/g, "").trim();
+}
+
+export function creatureForGlyph(glyph: string | undefined): string {
+  if (glyph && GLYPH_CREATURE[glyph]) return GLYPH_CREATURE[glyph];
+  return "Familiar";
+}
+
+/** The single declared name used across SOUL.md, IDENTITY.md and ward.toml.
+ *  Sanitized so the cross-file name invariant holds even for odd display names
+ *  (the ward parser truncates a quoted value at `"`/`#`). */
+function contractName(input: IdentityScaffoldInput): string {
+  return tomlSafe(clean(input.displayName, input.id)) || input.id;
+}
+
+export function buildSoulMd(input: IdentityScaffoldInput): string {
+  const name = contractName(input);
+  const role = clean(input.role, "Familiar");
+  const purpose = clean(
+    input.description,
+    `support my person with ${role.toLowerCase()} work, within my lane`,
+  );
+  return `# SOUL.md — Who I Am
+
+## I am ${name}
+
+I am ${name}, a familiar in this Coven. My purpose is to ${purpose}.
+
+## Purpose
+
+${purpose.charAt(0).toUpperCase()}${purpose.slice(1)}. I hold one lane and hold it
+well, rather than trying to be everything at once.
+
+## Core Work
+
+- ${role}-focused work within my declared lane.
+- Collaborating with my person and the other familiars of this Coven.
+- Keeping my memory, notes, and contract current and honest.
+
+## What I Am Not
+
+- Not a general-purpose assistant that will attempt anything.
+- Not a replacement for another familiar's lane — I defer work outside mine.
+- Not a system that acts without my person's say on anything irreversible.
+
+## My Boundaries
+
+- I act only within the authority declared in ward.toml.
+- I ask before touching protected files or my own identity.
+- I never invent facts, and I say when I do not know.
+- I never impersonate another familiar or my person.
+`;
+}
+
+export function buildIdentityMd(input: IdentityScaffoldInput): string {
+  const name = contractName(input);
+  const role = clean(input.role, "Familiar");
+  const creature = creatureForGlyph(input.glyph);
+  const purpose = clean(input.description, `help my person with ${role.toLowerCase()} work`);
+  return `# IDENTITY.md - ${name}
+
+- **Name:** ${name}
+- **Creature:** ${creature}
+- **Role:** ${role}
+
+## Purpose
+
+I help my person: ${purpose}. My strength is staying in my lane and being honest
+about what I know, what I don't, and what I'm inferring.
+
+## Person
+
+I belong to my person. My memory, purpose, and work are organized around their
+actual context — not averaged across a user population.
+`;
+}
+
+export function buildWardToml(input: IdentityScaffoldInput): string {
+  const name = contractName(input);
+  const person = tomlSafe(clean(input.person, DEFAULT_PERSON));
+  return `# ${input.id}.ward.toml — ${name}'s Ward
+# Bounded authority for this familiar. Edit deliberately; this file is protected.
+
+[meta]
+version = "${FAMILIAR_CONTRACT_SPEC_VERSION}"
+familiar = "${name}"
+person = "${person}"
+
+[protected]
+# The minimum protected surface — these define who the familiar is and who it
+# belongs to. Do not remove them.
+files = [
+  "SOUL.md",
+  "IDENTITY.md",
+  "MEMORY.md",
+  "ward.toml",
+]
+
+# Semantic invariants: what must remain true no matter what changes.
+invariants = [
+  "familiar.name == '${name}'",
+  "familiar.person == '${person}'",
+]
+
+[editable]
+# What the self-improvement loop may propose changes to.
+paths = [
+  "TOOLS.md",
+  "HEARTBEAT.md",
+  "skills/*/",
+]
+
+[approval_tiers]
+
+[approval_tiers.auto]
+# Tier 0 — low-risk changes that need no human review.
+blocks = ["output_formats", "tool_defaults"]
+gate = "regression_suite"
+
+[approval_tiers.human_review]
+# Tier 2 — anything structural requires my person's approval.
+blocks = ["tool_grants", "system_prompt.execution", "skill_activations"]
+gate = "human_approval"
+`;
+}
+
+export function buildMemoryMd(input: IdentityScaffoldInput): string {
+  const name = contractName(input);
+  return `# MEMORY.md — ${name}
+
+My curated long-term memory: context, decisions, and lessons that persist across
+sessions. This file is on the protected surface; the self-improvement loop cannot
+modify it.
+
+## What goes here
+
+- Important things my person has told me
+- Context about ongoing work
+- Lessons learned from past interactions
+- Things to remember for next time
+`;
+}
+
+/** Build all four contract files for a new familiar. The result passes
+ *  evaluateFamiliarContract with zero violations and zero warnings. */
+export function buildFamiliarContractFiles(input: IdentityScaffoldInput): ScaffoldedContract {
+  return {
+    soul: buildSoulMd(input),
+    identity: buildIdentityMd(input),
+    ward: buildWardToml(input),
+    memory: buildMemoryMd(input),
+  };
+}

--- a/src/lib/server/familiar-contract-files.ts
+++ b/src/lib/server/familiar-contract-files.ts
@@ -1,8 +1,14 @@
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { access } from "node:fs/promises";
 import path from "node:path";
 import { familiarWorkspace } from "@/lib/coven-paths";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import type { ContractFiles } from "@/lib/familiar-contract";
+import {
+  buildFamiliarContractFiles,
+  type IdentityScaffoldInput,
+} from "@/lib/familiar-identity-scaffold";
 
 /**
  * Loader for a familiar's Familiar Contract files, used by
@@ -59,4 +65,49 @@ export async function readFamiliarContractFiles(id: string): Promise<LoadedContr
   ]);
 
   return { workspace, files: { soul, identity, ward, memory } };
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p, fsConstants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Scaffold a new familiar's Familiar Contract files (SOUL.md / IDENTITY.md /
+ * ward.toml / MEMORY.md) into its workspace so it is contract-compliant from
+ * birth. Purely ADDITIVE: a file that already exists is left untouched, so this
+ * can never clobber identity a familiar (or its person) has already authored.
+ *
+ * The `id` is slug-guarded inline before any path is built. Returns the list of
+ * files actually written (empty when they all already existed).
+ */
+export async function scaffoldFamiliarContractFiles(
+  input: IdentityScaffoldInput,
+): Promise<string[]> {
+  if (!isValidFamiliarId(input.id)) {
+    throw new Error("invalid familiar id");
+  }
+  const workspace = await familiarWorkspace(input.id);
+  await mkdir(workspace, { recursive: true });
+
+  const generated = buildFamiliarContractFiles(input);
+  const byFile: Array<[string, string]> = [
+    [CONTRACT_FILE_NAMES.soul, generated.soul],
+    [CONTRACT_FILE_NAMES.identity, generated.identity],
+    [CONTRACT_FILE_NAMES.ward, generated.ward],
+    [CONTRACT_FILE_NAMES.memory, generated.memory],
+  ];
+
+  const wrote: string[] = [];
+  for (const [name, contents] of byFile) {
+    const target = path.join(workspace, path.basename(name));
+    if (await fileExists(target)) continue;
+    await writeFile(target, contents, "utf8");
+    wrote.push(name);
+  }
+  return wrote;
 }

--- a/src/lib/server/familiar-contract-files.ts
+++ b/src/lib/server/familiar-contract-files.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import { access } from "node:fs/promises";
 import path from "node:path";
-import { familiarWorkspace } from "@/lib/coven-paths";
+import { familiarWorkspace, familiarWorkspacesRoot } from "@/lib/coven-paths";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import type { ContractFiles } from "@/lib/familiar-contract";
 import {
@@ -88,15 +88,16 @@ async function fileExists(p: string): Promise<boolean> {
 export async function scaffoldFamiliarContractFiles(
   input: IdentityScaffoldInput,
 ): Promise<string[]> {
-  // Pull the id into a guarded local before it touches the filesystem. The
-  // barrier must gate the SAME value used to build the path — re-reading
-  // `input.id` after the check defeats taint-tracking (CodeQL js/path-injection)
-  // and mirrors the plain-string param the reader above uses.
-  const id = input.id;
-  if (!isValidFamiliarId(id)) {
+  if (!isValidFamiliarId(input.id)) {
     throw new Error("invalid familiar id");
   }
-  const workspace = await familiarWorkspace(id);
+  // Build the workspace path from a FIXED root plus a basename-sanitized id.
+  // `path.basename` is the recognized js/path-injection sanitizer; combined with
+  // the slug guard above it keeps the id from escaping the familiars root. A
+  // brand-new familiar (the only caller — POST 409s on a dup id) has no declared
+  // workspace, so this resolves to the same dir the reader/contract route use.
+  const safeId = path.basename(input.id);
+  const workspace = path.join(familiarWorkspacesRoot(), safeId);
   await mkdir(workspace, { recursive: true });
 
   const generated = buildFamiliarContractFiles(input);

--- a/src/lib/server/familiar-contract-files.ts
+++ b/src/lib/server/familiar-contract-files.ts
@@ -88,10 +88,15 @@ async function fileExists(p: string): Promise<boolean> {
 export async function scaffoldFamiliarContractFiles(
   input: IdentityScaffoldInput,
 ): Promise<string[]> {
-  if (!isValidFamiliarId(input.id)) {
+  // Pull the id into a guarded local before it touches the filesystem. The
+  // barrier must gate the SAME value used to build the path — re-reading
+  // `input.id` after the check defeats taint-tracking (CodeQL js/path-injection)
+  // and mirrors the plain-string param the reader above uses.
+  const id = input.id;
+  if (!isValidFamiliarId(id)) {
     throw new Error("invalid familiar id");
   }
-  const workspace = await familiarWorkspace(input.id);
+  const workspace = await familiarWorkspace(id);
   await mkdir(workspace, { recursive: true });
 
   const generated = buildFamiliarContractFiles(input);


### PR DESCRIPTION
Completes the create-a-familiar arc (after #2059 dialog + #2060 avatar). A UI-created familiar previously started with **no identity files** — so the Familiar Studio "Contract" tab flagged it as non-compliant and offered a rehabilitation flow. Now creating a familiar **scaffolds a complete, compliant Familiar Contract**, so it's identity-bound from the moment it's made.

## Verified end-to-end

Against a throwaway `HOME` (no touching real `~/.coven`), through the real route:
```
POST /api/familiars            → { ok:true, id:"nova", contractWrote:["SOUL.md","IDENTITY.md","ward.toml","MEMORY.md"] }
GET  /api/familiars/nova/contract → pass:true · 5/5 properties green · 0 violations · 0 warnings
```

## What

- **Pure generator** `src/lib/familiar-identity-scaffold.ts` — builds SOUL.md / IDENTITY.md / ward.toml / MEMORY.md from `{id, displayName, role, description, glyph, person}`. Output is engineered to PASS `evaluateFamiliarContract` with **zero violations and zero warnings** (all five normative properties — including Persistent Memory, since MEMORY.md is scaffolded). Description seeds the purpose / core-work; the chosen glyph flavors the IDENTITY "Creature" line; `person` defaults to "Keeper". A single sanitized contract name is reused across all files so the cross-file name invariant holds even for odd display names (the ward parser truncates quoted values at `"`/`#`).
- **Server writer** `scaffoldFamiliarContractFiles` (mirrors the existing reader in `familiar-contract-files.ts`) — slug-guarded, `mkdir` workspace, writes each file **only if absent**: purely additive, never clobbers identity a familiar (or its person) has already authored.
- **Wired into `POST /api/familiars`** after registration, **best-effort** (try/catch) so a workspace write failure can't fail creation — the familiar is already registered in `familiars.toml` + config. Returns `contractWrote`.

Backend-only enrichment — the create dialog already sends role/description/glyph, so there's no UI change.

## Safety

Fully additive (confirmed via research): contract files are read-only elsewhere (the `[id]/contract` route is GET; chat works with or without them). Scaffolding can't break an existing familiar and can't fail creation.

## Tests

- `familiar-identity-scaffold.test.ts` runs the **real validator** over the generator's output: full + minimal input both pass cleanly; cross-file name match; quote/hash-safe names; `person` default + invariant; `glyph→creature` mapping.
- `familiars/route.test.ts` gains scaffold guards (call shape + best-effort wrapper); new lib test wired into `run-tests.mjs`.

`typecheck` ✓, `check:tests-wired` ✓, `test:app` (476) ✓, `test:api` (99) ✓, `test:mobile` (65) ✓, `pnpm build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)