### PR TITLE
feat(chat): Codex-style composer — one line, grow to 13, scroll at 14

### DIFF
--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -13,8 +13,8 @@ assert.match(
 
 assert.match(
   source,
-  /const COMPOSER_MAX_HEIGHT = 220;/,
-  "Chat composer should keep its scroll threshold aligned with the 6-8 row desktop height",
+  /const COMPOSER_MAX_HEIGHT = 332;/,
+  "Chat composer should keep its scroll threshold aligned with the 13-row desktop height",
 );
 
 assert.match(
@@ -131,8 +131,8 @@ assert.match(
 
 assert.match(
   styles,
-  /\.cave-composer-input\s*\{[\s\S]*min-height:\s*96px[\s\S]*max-height:\s*220px[\s\S]*overflow-x:\s*hidden[\s\S]*overflow-y:\s*hidden/,
-  "Composer textarea should start taller without showing scroll overflow",
+  /\.cave-composer-input\s*\{[\s\S]*min-height:\s*44px[\s\S]*max-height:\s*332px[\s\S]*overflow-x:\s*hidden[\s\S]*overflow-y:\s*hidden/,
+  "Composer textarea should start compact (single line) and grow to a 13-line cap without showing scroll overflow",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -259,7 +259,9 @@ type FailedSend = {
 type ComposerThinkingEffort = "low" | "medium" | "high";
 type ComposerResponseSpeed = "fast" | "balanced" | "careful";
 
-const COMPOSER_MAX_HEIGHT = 220;
+// Fallback cap when the computed CSS max-height can't be read; kept in sync with
+// the .cave-composer-input rule (13 lines: 13*24 + 20px padding).
+const COMPOSER_MAX_HEIGHT = 332;
 const COMPOSER_PREFS_KEY = "cave:chat-composer-controls:v1";
 // Persist the in-progress composer text so a page reload doesn't eat a
 // half-written message. The composer is a single shared input (it isn't

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1641,8 +1641,11 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-composer-input {
-  min-height: 96px;
-  max-height: 220px;
+  /* Codex-style: start at a single line (line-height 24px + 12/8 padding = 44px)
+     and grow with content. The cap shows 13 lines (13*24 + 20 = 332px); the
+     14th line tips it into the scroll the JS resizer turns on. */
+  min-height: 44px;
+  max-height: 332px;
   overflow-x: hidden;
   overflow-y: hidden;
   scrollbar-width: thin;


### PR DESCRIPTION
## What

The desktop chat composer started at **96px** (~4 empty lines) and capped at **220px** (~9 lines). This makes it emulate Codex: **start at a single line**, grow with content up to a **13-line cap**, then **scroll at 14**.

## Change (`src/styles/cave-chat.css` · `.cave-composer-input`)

| | before | after |
|---|---|---|
| `min-height` | 96px | **44px** (1 line: 24px line-height + 12/8 padding) |
| `max-height` | 220px | **332px** (13 lines: 13×24 + 20 padding) |

The 14th line tips `scrollHeight` (356px) past the cap, so the existing JS resizer (`resizeComposer`) flips `overflow-y` to `auto`. `COMPOSER_MAX_HEIGHT` fallback bumped 220 → 332 to stay in sync. **Mobile rule unchanged.**

## Verification (Playwright against the live dev server, real composer)

| State | clientHeight | scrollHeight | overflow-y |
|---|---|---|---|
| empty | 44px | 44 | hidden |
| 13 lines | 332px | 332 | hidden (no scrollbar) |
| 14 lines | 332px (capped) | 356 | **auto** (scrolls) |

Source-text tests updated (`chat-view-first-class.test.ts`) + `chat-view-mobile-command-center` / `chat-view-polish` still green; `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)