### PR TITLE
feat(chat): readable tool fields, togglable thinking, expandable tables

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -221,6 +221,7 @@ export const SUITES = {
     "src/lib/code-lang.test.ts",
     "src/lib/project-search.test.ts",
     "src/lib/tool-target-file.test.ts",
+    "src/lib/tool-readable.test.ts",
     "src/lib/tool-visual.test.ts",
     "src/lib/terminal-layout.test.ts",
     "src/lib/terminal-nav.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10231,3 +10231,51 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   color: color-mix(in oklch, var(--text-muted) 55%, transparent);
   flex-shrink: 0;
 }
+
+/* ── Reusable confirm button: green fill-up on success ─────────────────────────
+   Layer over any button (`className="<base classes> cave-fill-btn"`) and drive
+   it with `data-state="idle|copied|failed"` (or "success"/"error"). On success a
+   green wash sweeps left→right under the label as a tactile confirmation; on
+   failure it washes red. Composes with the existing utility/`cave-btn` classes —
+   the pattern lives here so every copy/confirm action can adopt it consistently.
+   The fill sits on a -1 z-index pseudo so the label/icon stay readable. */
+.cave-fill-btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  transition:
+    color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+.cave-fill-btn::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  transform: scaleX(0);
+  transform-origin: left center;
+  background: var(--color-success);
+  transition: transform 0.5s var(--ease-standard);
+}
+.cave-fill-btn[data-state="copied"]::before,
+.cave-fill-btn[data-state="success"]::before {
+  transform: scaleX(1);
+}
+.cave-fill-btn[data-state="copied"],
+.cave-fill-btn[data-state="success"] {
+  color: #fff;
+  border-color: color-mix(in oklch, var(--color-success) 75%, transparent);
+}
+.cave-fill-btn[data-state="failed"]::before,
+.cave-fill-btn[data-state="error"]::before {
+  background: var(--color-danger);
+  transform: scaleX(1);
+}
+.cave-fill-btn[data-state="failed"],
+.cave-fill-btn[data-state="error"] {
+  color: #fff;
+  border-color: color-mix(in oklch, var(--color-danger) 75%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-fill-btn::before { transition: none; }
+}

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { toolArgSummary } from "../lib/tool-arg-summary.ts";
+import { toolArgDetail, toolArgSummary } from "../lib/tool-arg-summary.ts";
 import { toolInputAsDiff } from "../lib/tool-input-diff.ts";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
@@ -185,6 +185,13 @@ assert.ok(oversize.length <= 48, "summary is capped at 48 chars");
 assert.ok(oversize.endsWith("…"), "oversize summary ends with an ellipsis");
 assert.ok(!oversize.includes("\n"), "summary is never multi-line");
 
+const longSearchQuery = "multi-agent LLM workflow architectures orchestrator worker patterns 2025";
+assert.equal(
+  toolArgDetail("Web Search", JSON.stringify({ query: longSearchQuery })),
+  longSearchQuery,
+  "detail keeps the full web-search query for readable live activity context",
+);
+
 // Absent input yields an empty string.
 assert.equal(toolArgSummary("Read", undefined), "", "absent input gives empty summary");
 assert.equal(toolArgSummary("Read", "   "), "", "whitespace-only input gives empty summary");
@@ -207,6 +214,22 @@ assert.match(
   source,
   /detail: argSummary \? `\$\{incoming\.name\}\(\$\{argSummary\}\)` : incoming\.name/,
   "Tool progress detail carries Name(arg) instead of the bare tool name",
+);
+
+assert.match(
+  source,
+  /const runningToolDetail = live && runningTool \? toolArgDetail\(runningTool\.name, runningTool\.input\) : ""/,
+  "RunActivityStrip computes a full running-tool detail, separate from the capped summary",
+);
+assert.match(
+  source,
+  /cave-run-activity-context[\s\S]*?\{runningTool\.name\}\([\s\S]*?\{runningToolDetail\}[\s\S]*?\)/,
+  "RunActivityStrip renders full running-tool context where it can wrap instead of truncating",
+);
+assert.match(
+  styles,
+  /\.cave-run-activity-context[\s\S]*?white-space:\s*pre-wrap[\s\S]*?overflow-wrap:\s*anywhere/,
+  "RunActivityStrip context wraps long search/tool input instead of clipping it",
 );
 
 // ── Edit/Write tool inputs render as structured diffs (CHAT-D8-02) ──────────
@@ -290,11 +313,12 @@ const bigLines = bigDiff.split("\n");
 assert.ok(bigLines.length <= 401, "diff output is capped near 400 lines");
 assert.match(bigLines[bigLines.length - 1], /more lines truncated/, "capped diff ends with a truncation marker");
 
-// ToolBlock routes the Input section through toolInputAsDiff with diff chrome.
+// ToolBlock routes the Input section through toolInputAsDiff with diff chrome,
+// otherwise through ToolInputView (readable fields + raw-JSON toggle).
 assert.match(
   source,
-  /function ToolBlock[\s\S]*?const inputDiff = toolInputAsDiff\(tool\.name, tool\.input\)[\s\S]*?\{inputDiff \? <SyntaxBlock text=\{inputDiff\} lang="diff" \/> : <SyntaxBlock text=\{tool\.input\} \/>\}/,
-  "ToolBlock Input renders the structured diff when available, raw payload otherwise",
+  /function ToolBlock[\s\S]*?const inputDiff = toolInputAsDiff\(tool\.name, tool\.input\)[\s\S]*?inputDiff \? \([\s\S]*?<SyntaxBlock text=\{inputDiff\} lang="diff" \/>[\s\S]*?<ToolInputView input=\{tool\.input\} \/>/,
+  "ToolBlock Input renders the structured diff when available, readable fields otherwise",
 );
 
 // ── Diff gutter excludes file headers; @@ rows are muted meta (CHAT-D8-03) ──

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -67,6 +67,19 @@ assert.match(
   "ReasoningBlock should render thinking in a collapsed disclosure with formatted text",
 );
 
+// Thinking is togglable: the global Show-thinking preference opens every
+// reasoning block at once via a controlled `open` (default-collapsed in markup).
+assert.match(
+  source,
+  /function ReasoningBlock[\s\S]*const \[showThinking\] = useShowThinking\(\)[\s\S]*open=\{showThinking \|\| undefined\}/,
+  "ReasoningBlock open state is driven by the global Show-thinking preference",
+);
+assert.match(
+  source,
+  /function HeaderThinkingToggle[\s\S]*useShowThinking\(\)[\s\S]*aria-pressed=\{showThinking\}/,
+  "A header toggle flips the global Show-thinking preference",
+);
+
 assert.match(
   source,
   /function ToolGroup[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*Tool activity[\s\S]*tools\.map[\s\S]*<ToolBlock/,
@@ -75,8 +88,21 @@ assert.match(
 
 assert.match(
   source,
-  /function ToolBlock[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*<summary[\s\S]*tool\.name[\s\S]*<SyntaxBlock text=\{tool\.input\}[\s\S]*<SyntaxBlock text=\{tool\.output\}/,
-  "ToolBlock should keep individual tool payloads collapsed and format input/output with SyntaxBlock",
+  /function ToolBlock[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*<summary[\s\S]*tool\.name[\s\S]*<ToolInputView input=\{tool\.input\}[\s\S]*<SyntaxBlock text=\{prettyToolOutput\(tool\.output\)\}/,
+  "ToolBlock keeps payloads collapsed, renders readable input fields, and pretty-prints output",
+);
+
+// JSON tool input is converted to a human-readable labelled field list, with
+// the raw JSON available behind a toggle.
+assert.match(
+  source,
+  /function ToolInputView[\s\S]*toolReadableFields\(input\)[\s\S]*showRaw \? <SyntaxBlock text=\{input\}/,
+  "ToolInputView renders readable fields by default and raw JSON on toggle",
+);
+assert.match(
+  source,
+  /function ToolFieldList[\s\S]*field\.label[\s\S]*field\.value/,
+  "ToolFieldList renders each readable field's humanised label and value",
 );
 
 // Tool rows are color-coded by category for quick visual inspection.
@@ -87,14 +113,23 @@ assert.match(
   "ToolBlock should color-code by tool category (data-tool-category + per-category icon)",
 );
 
+// Tool-use disclosures must never default open (the transcript stays clean).
+// ReasoningBlock is the one exception — its `open` is a controlled binding to
+// the global Show-thinking preference (asserted above), not a hardcoded default.
 assert.doesNotMatch(
   [
-    source.match(/function ReasoningBlock[\s\S]*?function ProgressGroup/)?.[0] ?? "",
     source.match(/function ToolGroup[\s\S]*?function ToolBlock/)?.[0] ?? "",
-    source.match(/function ToolBlock[\s\S]*?function ThinkingIndicator/)?.[0] ?? "",
+    source.match(/function ToolBlock[\s\S]*?function ToolInputView/)?.[0] ?? "",
   ].join("\n"),
   /<details[^>]*\sopen(?:=|\s|>)/,
-  "Thinking and tool-use disclosures must not default open",
+  "Tool-use disclosures must not default open",
+);
+// A hardcoded `open` (open with no binding) on the reasoning block would defeat
+// the toggle — only the controlled `open={showThinking || undefined}` is allowed.
+assert.doesNotMatch(
+  source.match(/function ReasoningBlock[\s\S]*?function ProgressGroup/)?.[0] ?? "",
+  /<details[^>]*\sopen(?:\s|>)/,
+  "ReasoningBlock must not hardcode the disclosure open",
 );
 
 // --- Tool activity renders in a designated section on settled turns ---

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -75,8 +75,10 @@ import {
 } from "@/lib/chat-projects";
 import type { CaveProject } from "@/lib/cave-projects";
 import { useProjects } from "@/lib/use-projects";
-import { toolArgSummary } from "@/lib/tool-arg-summary";
+import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolVisual } from "@/lib/tool-visual";
+import { toolReadableFields, prettyToolOutput, type ReadableField } from "@/lib/tool-readable";
+import { useShowThinking } from "@/lib/reasoning-visibility";
 import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
@@ -1017,6 +1019,24 @@ function SessionOverflowMenu({
         </PopoverBody>
       </Popover>
     </>
+  );
+}
+
+/** Header toggle for the global "Show thinking" preference — flips every
+ *  reasoning disclosure in the transcript open/closed at once. */
+function HeaderThinkingToggle() {
+  const [showThinking, setShowThinking] = useShowThinking();
+  return (
+    <button
+      type="button"
+      className={`focus-ring cave-chat-icon-button${showThinking ? " cave-chat-icon-button--active" : ""}`}
+      aria-label={showThinking ? "Hide thinking" : "Show thinking"}
+      aria-pressed={showThinking}
+      title={showThinking ? "Hide reasoning blocks" : "Show reasoning blocks"}
+      onClick={() => setShowThinking(!showThinking)}
+    >
+      <Icon name={showThinking ? "ph:brain-bold" : "ph:brain"} width={15} aria-hidden />
+    </button>
   );
 }
 
@@ -4167,6 +4187,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onPrev={findPrev}
               />
             ) : null}
+            {turns.length > 0 ? <HeaderThinkingToggle /> : null}
             {sessionId && (
               <HeaderDebugButton onOpenDebug={openDebug} />
             )}
@@ -5148,15 +5169,31 @@ function TurnRowImpl({
 }
 
 function ReasoningBlock({ reasoning }: { reasoning: string }) {
+  // The global "Show thinking" toggle (header) opens every reasoning block at
+  // once; an individual block can still be collapsed/expanded locally. The
+  // disclosure stays default-collapsed in markup — `open` is driven by the
+  // shared preference so toggling it re-opens blocks that were never touched.
+  const [showThinking] = useShowThinking();
+  const wordCount = useMemo(
+    () => reasoning.split(/\s+/).filter(Boolean).length,
+    [reasoning],
+  );
   return (
-    <details className="cave-reasoning-block mt-3" data-default-collapsed="true">
+    <details
+      className="cave-reasoning-block mt-3"
+      data-default-collapsed="true"
+      open={showThinking || undefined}
+    >
       <summary className="cave-tool-summary">
         <span className="inline-flex items-center gap-1.5">
           <Icon name="ph:brain" width={12} aria-hidden />
           Thinking
         </span>
+        <span className="ml-auto font-mono text-[10px] normal-case tracking-normal text-[var(--text-muted)]">
+          {wordCount} {wordCount === 1 ? "word" : "words"}
+        </span>
       </summary>
-      <div className="mt-2 border-t border-[var(--border-hairline)]/70 pt-2 text-[12px] leading-5 text-[var(--text-secondary)]">
+      <div className="cave-reasoning-body mt-2 border-t border-[var(--border-hairline)]/70 pt-2 text-[12px] leading-5 text-[var(--text-secondary)]">
         <RichText text={reasoning} />
       </div>
     </details>
@@ -5339,18 +5376,72 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
         <DurationText durationMs={tool.durationMs} />
       </summary>
       {tool.input ? (
-        <div className="mt-2">
-          <div className="mb-1 text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Input</div>
-          {inputDiff ? <SyntaxBlock text={inputDiff} lang="diff" /> : <SyntaxBlock text={tool.input} />}
+        <div className="cave-tool-io mt-2">
+          <div className="cave-tool-io-label">Input</div>
+          {inputDiff ? (
+            <SyntaxBlock text={inputDiff} lang="diff" />
+          ) : (
+            <ToolInputView input={tool.input} />
+          )}
         </div>
       ) : null}
       {tool.output ? (
-        <div className="mt-2">
-          <div className="mb-1 text-[10px] uppercase tracking-[0.08em] text-[var(--text-muted)]">Output</div>
-          <SyntaxBlock text={tool.output} />
+        <div className="cave-tool-io mt-2">
+          <div className="cave-tool-io-label">Output</div>
+          <SyntaxBlock text={prettyToolOutput(tool.output)} />
         </div>
       ) : null}
     </details>
+  );
+}
+
+/**
+ * Readable tool input: a labelled field list (`File: …`, `Find: …`) derived
+ * from the JSON payload, with the raw JSON one toggle away for auditing. Falls
+ * back to the raw SyntaxBlock when the payload is not a JSON object (bare
+ * command lines, arrays, truncated blobs).
+ */
+function ToolInputView({ input }: { input: string }) {
+  const fields = useMemo(() => toolReadableFields(input), [input]);
+  const [showRaw, setShowRaw] = useState(false);
+  if (!fields) return <SyntaxBlock text={input} />;
+  return (
+    <div className="cave-tool-input">
+      {showRaw ? <SyntaxBlock text={input} /> : <ToolFieldList fields={fields} />}
+      <button
+        type="button"
+        className="cave-tool-raw-toggle focus-ring"
+        aria-pressed={showRaw}
+        onClick={() => setShowRaw((v) => !v)}
+      >
+        <Icon name={showRaw ? "ph:list-bullets" : "ph:code"} width={11} aria-hidden />
+        {showRaw ? "Readable" : "Raw JSON"}
+      </button>
+    </div>
+  );
+}
+
+function ToolFieldList({ fields }: { fields: ReadableField[] }) {
+  return (
+    <dl className="cave-tool-fields">
+      {fields.map((field) => (
+        <div
+          key={field.key}
+          className="cave-tool-field"
+          data-kind={field.kind}
+          data-multiline={field.multiline ? "true" : undefined}
+        >
+          <dt className="cave-tool-field-label">{field.label}</dt>
+          <dd className="cave-tool-field-value">
+            {field.multiline ? (
+              <SyntaxBlock text={field.value} lang={field.kind === "json" ? "json" : undefined} />
+            ) : (
+              <span className="cave-tool-field-inline">{field.value}</span>
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 
@@ -5484,6 +5575,7 @@ function RunActivityStrip({
   if (tools.length === 0 && progress.length === 0) return null;
 
   const runningTool = [...tools].reverse().find((t) => t.status === "running");
+  const runningToolDetail = live && runningTool ? toolArgDetail(runningTool.name, runningTool.input) : "";
   const step = currentProgress(progress);
   const running =
     tools.filter((t) => t.status === "running").length +
@@ -5544,6 +5636,10 @@ function RunActivityStrip({
         <div className="mt-1.5">
           {progress.length ? <ProgressGroup progress={progress} pending={live} /> : null}
           {tools.length ? <ToolGroup tools={tools} /> : null}
+        </div>
+      ) : live && runningTool && runningToolDetail ? (
+        <div className="cave-run-activity-context" title={`${runningTool.name}(${runningToolDetail})`}>
+          <span className="cave-run-activity-context__tool">{runningTool.name}</span>({runningToolDetail})
         </div>
       ) : null}
     </div>

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -729,6 +729,92 @@ function wireFilePathLinks(container: HTMLElement) {
   }
 }
 
+// Wide markdown tables are cramped in the narrow chat column. Each rendered
+// table (mdToHtml wraps every one in `.cave-table-scroll`) gets an "Expand"
+// affordance that opens it full-size in a dismissable lightbox so it can be
+// read comfortably. Wired imperatively because the markdown HTML is injected
+// via dangerouslySetInnerHTML; idempotent per table via the `_caveTableWired`
+// flag, like the copy/link wiring above.
+function wireExpandableTables(container: HTMLElement) {
+  for (const scroll of Array.from(container.querySelectorAll<HTMLElement>(".cave-table-scroll"))) {
+    const flagged = scroll as HTMLElement & { _caveTableWired?: boolean };
+    if (flagged._caveTableWired) continue;
+    if (!scroll.querySelector("table")) continue;
+    // Flag BEFORE moving the node so the wrapper insertion's own mutation
+    // observer pass skips it instead of double-wrapping.
+    flagged._caveTableWired = true;
+
+    const wrap = document.createElement("div");
+    wrap.className = "cave-table-block";
+    scroll.parentNode?.insertBefore(wrap, scroll);
+    wrap.appendChild(scroll);
+
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "cave-table-expand-btn";
+    btn.title = "Expand table";
+    btn.setAttribute("aria-label", "Expand table");
+    btn.innerHTML = '<span class="cave-table-expand-glyph" aria-hidden="true">⤢</span> Expand';
+    btn.addEventListener("click", () => openTableLightbox(scroll));
+    wrap.appendChild(btn);
+  }
+}
+
+function openTableLightbox(scroll: HTMLElement) {
+  const table = scroll.querySelector("table");
+  if (!table) return;
+
+  const overlay = document.createElement("div");
+  overlay.className = "cave-table-lightbox";
+  overlay.setAttribute("role", "dialog");
+  overlay.setAttribute("aria-modal", "true");
+  overlay.setAttribute("aria-label", "Expanded table");
+
+  const panel = document.createElement("div");
+  panel.className = "cave-table-lightbox__panel";
+
+  const bar = document.createElement("div");
+  bar.className = "cave-table-lightbox__bar";
+  const title = document.createElement("span");
+  title.className = "cave-table-lightbox__title";
+  title.textContent = "Table";
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "cave-table-lightbox__close focus-ring";
+  close.textContent = "Close";
+  bar.append(title, close);
+
+  // cave-md scopes the table styling; the clone is detached from its turn so
+  // it carries no live listeners — purely a readable, scrollable copy.
+  const body = document.createElement("div");
+  body.className = "cave-table-lightbox__body cave-md";
+  body.appendChild(table.cloneNode(true));
+
+  panel.append(bar, body);
+  overlay.appendChild(panel);
+  document.body.appendChild(overlay);
+
+  const prevOverflow = document.body.style.overflow;
+  document.body.style.overflow = "hidden";
+  const dismiss = () => {
+    document.body.style.overflow = prevOverflow;
+    document.removeEventListener("keydown", onKey);
+    overlay.remove();
+  };
+  const onKey = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      dismiss();
+    }
+  };
+  overlay.addEventListener("click", (event) => {
+    if (event.target === overlay) dismiss();
+  });
+  close.addEventListener("click", dismiss);
+  document.addEventListener("keydown", onKey);
+  close.focus();
+}
+
 /**
  * Shared post-render hook: wires `.cave-copy-btn` clicks inside the container
  * whenever the injected HTML changes. Every component that injects
@@ -748,6 +834,7 @@ function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => vo
       wireCopyButtons(el);
       wireMarkdownLinks(el, onOpenUrl);
       wireMermaidDiagrams(el);
+      wireExpandableTables(el);
       if (linkifyPaths) wireFilePathLinks(el);
     };
     wireAll();

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -276,13 +276,14 @@ export function OpenCovenToolsUpdate() {
       window.setTimeout(() => setDiagnosticsStatus("idle"), 1800);
     } catch {
       setDiagnosticsStatus("failed");
+      window.setTimeout(() => setDiagnosticsStatus("idle"), 1800);
     }
   };
 
   const accentBtn =
     "focus-ring inline-flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50";
   const ghostBtn =
-    "focus-ring rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
+    "focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
   const footerStatusText =
     diagnosticsStatus === "copied"
       ? "Diagnostics copied"
@@ -351,8 +352,29 @@ export function OpenCovenToolsUpdate() {
           {footerStatusText}
         </span>
         <div className="flex shrink-0 flex-wrap items-center gap-2">
-          <button type="button" onClick={() => void copyDiagnostics()} className={ghostBtn}>
-            Copy diagnostics
+          <button
+            type="button"
+            onClick={() => void copyDiagnostics()}
+            className={`${ghostBtn} cave-fill-btn`}
+            data-state={diagnosticsStatus}
+            aria-live="polite"
+          >
+            <Icon
+              name={
+                diagnosticsStatus === "copied"
+                  ? "ph:check-bold"
+                  : diagnosticsStatus === "failed"
+                    ? "ph:warning"
+                    : "ph:copy"
+              }
+              width={12}
+              aria-hidden
+            />
+            {diagnosticsStatus === "copied"
+              ? "Copied"
+              : diagnosticsStatus === "failed"
+                ? "Copy failed"
+                : "Copy diagnostics"}
           </button>
           <button type="button" onClick={() => void load()} className={ghostBtn} disabled={checking}>
             Check tools

--- a/src/lib/reasoning-visibility.ts
+++ b/src/lib/reasoning-visibility.ts
@@ -1,0 +1,61 @@
+// Global "show thinking" preference for the chat transcript.
+//
+// Reasoning (`<thinking>`/`<reasoning>`) blocks default to collapsed so the
+// transcript reads as clean prose. A single global toggle lets the user expand
+// every reasoning block at once — the preference is persisted in localStorage
+// and broadcast via a custom event so the toggle control and all on-screen
+// ReasoningBlocks (which live deep inside memoised turn rows) stay in sync
+// without threading state through every parent.
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "cave:chat:show-thinking";
+const EVENT = "cave:show-thinking-change";
+
+export function readShowThinking(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function writeShowThinking(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    /* private mode / quota — fall back to in-memory broadcast only */
+  }
+  window.dispatchEvent(new CustomEvent<boolean>(EVENT, { detail: value }));
+}
+
+/**
+ * Subscribe to the global show-thinking preference. Returns the current value
+ * and a setter that persists + broadcasts the change to every subscriber.
+ */
+export function useShowThinking(): [boolean, (value: boolean) => void] {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    setShow(readShowThinking());
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<boolean>).detail;
+      setShow(typeof detail === "boolean" ? detail : readShowThinking());
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) setShow(readShowThinking());
+    };
+    window.addEventListener(EVENT, onChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(EVENT, onChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  return [show, writeShowThinking];
+}

--- a/src/lib/tool-arg-summary.ts
+++ b/src/lib/tool-arg-summary.ts
@@ -61,6 +61,21 @@ function summarizeRecord(name: string, record: Record<string, unknown>): string 
   return ellipsize(JSON.stringify(record));
 }
 
+function fullRecordDetail(name: string, record: Record<string, unknown>): string {
+  const keys: readonly string[] = COMMAND_FIRST_TOOLS.test(name)
+    ? ["command", ...PREFERRED_KEYS.filter((k) => k !== "command")]
+    : PREFERRED_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value.replace(/\s+/g, " ").trim();
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+  }
+  for (const value of Object.values(record)) {
+    if (typeof value === "string" && value.trim()) return value.replace(/\s+/g, " ").trim();
+  }
+  return JSON.stringify(record);
+}
+
 /**
  * Derive a one-line argument summary from a tool's input payload.
  * Always single-line, at most ~48 chars, empty string when input is absent.
@@ -92,4 +107,24 @@ export function toolArgSummary(name: string, input?: string | null): string {
 
   // Plain string payload (e.g. a Bash command line) — use it directly.
   return ellipsize(raw);
+}
+
+/**
+ * Derive the full readable argument detail for live activity surfaces.
+ * Unlike toolArgSummary(), this does not cap length; callers should wrap or
+ * scroll it in the UI.
+ */
+export function toolArgDetail(name: string, input?: string | null): string {
+  const raw = (input ?? "").trim();
+  if (!raw) return "";
+
+  const parsed = tryParseJson(raw);
+  if (parsed !== undefined && parsed !== null) {
+    if (typeof parsed === "string") return parsed.replace(/\s+/g, " ").trim();
+    if (Array.isArray(parsed)) return parsed.map((v) => String(v)).join(" ").replace(/\s+/g, " ").trim();
+    if (typeof parsed === "object") return fullRecordDetail(name, parsed as Record<string, unknown>);
+    return String(parsed);
+  }
+
+  return raw.replace(/\s+/g, " ").trim();
 }

--- a/src/lib/tool-readable.test.ts
+++ b/src/lib/tool-readable.test.ts
@@ -1,0 +1,103 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+const { humaniseKey, toolReadableFields, prettyToolOutput } = await import("./tool-readable.ts");
+
+// ── humaniseKey: snake/kebab/camel → Title case with acronym fixups ──────────
+{
+  assert.equal(humaniseKey("file_path"), "File path");
+  assert.equal(humaniseKey("newString"), "New string");
+  assert.equal(humaniseKey("output-mode"), "Output mode");
+  assert.equal(humaniseKey("url"), "URL");
+  assert.equal(humaniseKey("api_url"), "API URL");
+  assert.equal(humaniseKey("notebook_id"), "Notebook ID");
+  assert.equal(humaniseKey(""), "");
+}
+
+// ── toolReadableFields: JSON object → ordered, labelled fields ───────────────
+{
+  const fields = toolReadableFields(
+    JSON.stringify({ limit: 100, file_path: "/repo/src/a.ts" }),
+  );
+  assert.ok(fields, "parses a JSON object payload");
+  // file_path sorts before limit (KEY_ORDER), regardless of payload order.
+  assert.equal(fields[0].key, "file_path");
+  assert.equal(fields[0].label, "File");
+  assert.equal(fields[0].kind, "path");
+  assert.equal(fields[0].value, "/repo/src/a.ts");
+  assert.equal(fields[1].key, "limit");
+  assert.equal(fields[1].label, "Limit");
+  assert.equal(fields[1].kind, "number");
+  assert.equal(fields[1].value, "100");
+  assert.equal(fields[1].multiline, false);
+}
+
+// Edit-style payload: old/new render as code, multiline.
+{
+  const fields = toolReadableFields(
+    JSON.stringify({ file_path: "/x.ts", old_string: "const a = 1", new_string: "const a = 2" }),
+  );
+  const find = fields.find((f) => f.key === "old_string");
+  assert.equal(find.label, "Find");
+  assert.equal(find.kind, "code");
+  assert.equal(find.multiline, true);
+  const repl = fields.find((f) => f.key === "new_string");
+  assert.equal(repl.label, "Replace with");
+}
+
+// command → command kind; url → url kind.
+{
+  const cmd = toolReadableFields(JSON.stringify({ command: "ls -la" }));
+  assert.equal(cmd[0].kind, "command");
+  const web = toolReadableFields(JSON.stringify({ url: "https://example.com/x" }));
+  assert.equal(web[0].kind, "url");
+  assert.equal(web[0].label, "URL");
+}
+
+// Long strings and newlines flip multiline; short strings stay inline.
+{
+  const fields = toolReadableFields(
+    JSON.stringify({ query: "short", description: "x".repeat(80) }),
+  );
+  assert.equal(fields.find((f) => f.key === "query").multiline, false);
+  assert.equal(fields.find((f) => f.key === "description").multiline, true);
+}
+
+// Nested objects/arrays serialise as pretty JSON, kind "json".
+{
+  const fields = toolReadableFields(JSON.stringify({ todos: [{ id: 1, text: "a" }] }));
+  assert.equal(fields[0].kind, "json");
+  assert.equal(fields[0].multiline, true);
+  assert.match(fields[0].value, /"text": "a"/);
+}
+
+// Empty / null / whitespace values are dropped; all-empty → null.
+{
+  assert.equal(toolReadableFields(JSON.stringify({ a: "", b: null, c: undefined })), null);
+  const fields = toolReadableFields(JSON.stringify({ a: "", keep: "yes" }));
+  assert.equal(fields.length, 1);
+  assert.equal(fields[0].key, "keep");
+}
+
+// Non-object payloads (bare string, array, non-JSON, empty) → null.
+{
+  assert.equal(toolReadableFields(JSON.stringify("just a string")), null);
+  assert.equal(toolReadableFields(JSON.stringify([1, 2, 3])), null);
+  assert.equal(toolReadableFields("ls -la"), null);
+  assert.equal(toolReadableFields(""), null);
+  assert.equal(toolReadableFields(null), null);
+}
+
+// ── prettyToolOutput: pretty-print JSON output, pass through the rest ────────
+{
+  assert.equal(prettyToolOutput('{"a":1,"b":2}'), '{\n  "a": 1,\n  "b": 2\n}');
+  assert.equal(prettyToolOutput('[1,2]'), "[\n  1,\n  2\n]");
+  // Non-JSON text passes through verbatim.
+  assert.equal(prettyToolOutput("plain log line"), "plain log line");
+  // Malformed JSON-ish text is left alone.
+  assert.equal(prettyToolOutput("{not json"), "{not json");
+  assert.equal(prettyToolOutput(""), "");
+  assert.equal(prettyToolOutput(null), "");
+}
+
+console.log("tool-readable.test.ts passed");

--- a/src/lib/tool-readable.ts
+++ b/src/lib/tool-readable.ts
@@ -1,0 +1,214 @@
+// Human-readable rendering of tool-call inputs and outputs.
+//
+// Tool inputs arrive as JSON strings (see src/app/api/chat/send/route.ts and
+// chat-tool-events.ts). Rendering that raw JSON blob in the transcript buries
+// the actual intent of the call behind braces and quotes. This module turns a
+// tool's input payload into a labelled list of fields — `File: src/foo.ts`,
+// `Find: …`, `Limit: 100` — with humanised labels and a per-field kind hint the
+// UI uses to choose inline vs. block rendering. The raw JSON stays one toggle
+// away for auditing; this is the default, readable view.
+//
+// Pure and unit-tested. The React layer (ToolBlock in chat-view) consumes the
+// structured output; the colours/spacing live in cave-chat.css.
+
+/** Coarse render hint for a single field value. */
+export type ReadableFieldKind =
+  | "path"
+  | "command"
+  | "code"
+  | "url"
+  | "number"
+  | "boolean"
+  | "text"
+  | "json";
+
+export type ReadableField = {
+  /** Original JSON key. */
+  key: string;
+  /** Humanised label, e.g. `file_path` → "File". */
+  label: string;
+  /** String representation of the value. */
+  value: string;
+  kind: ReadableFieldKind;
+  /** True when the value wants a wrapped block rather than an inline span
+   *  (long strings, code, multi-line content, nested JSON). */
+  multiline: boolean;
+};
+
+// Render the most identifying keys first; everything else follows in payload
+// order. Mirrors PREFERRED_KEYS in tool-arg-summary.ts but tuned for the full
+// field list rather than a one-line summary.
+const KEY_ORDER = [
+  "file_path",
+  "path",
+  "notebook_path",
+  "command",
+  "pattern",
+  "url",
+  "query",
+  "prompt",
+  "description",
+  "skill",
+  "old_string",
+  "new_string",
+  "content",
+  "new_source",
+  "limit",
+  "offset",
+] as const;
+
+// Nicer labels than a raw humanisation would produce. Keys not listed here fall
+// back to humaniseKey().
+const LABEL_OVERRIDES: Record<string, string> = {
+  file_path: "File",
+  path: "Path",
+  notebook_path: "Notebook",
+  command: "Command",
+  pattern: "Pattern",
+  url: "URL",
+  query: "Query",
+  prompt: "Prompt",
+  description: "Description",
+  skill: "Skill",
+  old_string: "Find",
+  new_string: "Replace with",
+  new_str: "Replace with",
+  old_str: "Find",
+  content: "Content",
+  new_source: "Content",
+  limit: "Limit",
+  offset: "Offset",
+  todos: "To-dos",
+  subagent_type: "Agent",
+  glob: "Glob",
+  output_mode: "Output mode",
+};
+
+// Acronyms that should stay upper-cased after humanisation.
+const ACRONYMS = new Set(["url", "uri", "id", "api", "ip", "sql", "json", "html", "css", "ui", "ux"]);
+
+/** snake_case / kebab-case / camelCase → "Title case" with acronym fixups. */
+export function humaniseKey(key: string): string {
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2") // camelCase boundary
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+  if (words.length === 0) return key;
+  return words
+    .map((word, i) => {
+      if (ACRONYMS.has(word)) return word.toUpperCase();
+      if (i === 0) return word.charAt(0).toUpperCase() + word.slice(1);
+      return word;
+    })
+    .join(" ");
+}
+
+function labelFor(key: string): string {
+  return LABEL_OVERRIDES[key] ?? humaniseKey(key);
+}
+
+const URL_RE = /^(https?:\/\/|www\.)/i;
+const CODE_KEYS = new Set(["old_string", "new_string", "old_str", "new_str", "content", "new_source"]);
+const PATH_KEYS = new Set(["file_path", "path", "notebook_path", "cwd", "directory"]);
+
+function kindFor(key: string, value: unknown): ReadableFieldKind {
+  if (typeof value === "number") return "number";
+  if (typeof value === "boolean") return "boolean";
+  if (value !== null && typeof value === "object") return "json";
+  const str = typeof value === "string" ? value : String(value ?? "");
+  if (CODE_KEYS.has(key)) return "code";
+  if (key === "command") return "command";
+  if (PATH_KEYS.has(key)) return "path";
+  if (URL_RE.test(str.trim())) return "url";
+  return "text";
+}
+
+/** A value wants a wrapped block when it is code, nested JSON, has newlines, or
+ *  is simply too long to sit inline next to its label. */
+function isMultiline(kind: ReadableFieldKind, value: string): boolean {
+  if (kind === "code" || kind === "json") return true;
+  if (value.includes("\n")) return true;
+  return value.length > 56;
+}
+
+function stringifyValue(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function tryParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Turn a tool input payload into an ordered list of labelled fields.
+ *
+ * Returns null when the input is absent, not JSON, or not a JSON object (bare
+ * strings/arrays have no key/value structure to label) — callers fall back to
+ * their raw rendering.
+ */
+export function toolReadableFields(input?: string | null): ReadableField[] | null {
+  const raw = (input ?? "").trim();
+  if (!raw) return null;
+  const parsed = tryParseJson(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+
+  const record = parsed as Record<string, unknown>;
+  const entries = Object.entries(record).filter(
+    ([, v]) => v !== undefined && v !== null && !(typeof v === "string" && v.trim() === ""),
+  );
+  if (entries.length === 0) return null;
+
+  const orderIndex = (key: string): number => {
+    const i = (KEY_ORDER as readonly string[]).indexOf(key);
+    return i === -1 ? KEY_ORDER.length : i;
+  };
+  entries.sort(([a], [b]) => orderIndex(a) - orderIndex(b));
+
+  return entries.map(([key, value]) => {
+    const kind = kindFor(key, value);
+    const str = stringifyValue(value);
+    return {
+      key,
+      label: labelFor(key),
+      value: str,
+      kind,
+      multiline: isMultiline(kind, str),
+    };
+  });
+}
+
+/**
+ * Pretty-print a tool output payload. JSON outputs get 2-space indentation so
+ * the structure is legible; everything else (logs, plain text, diffs) passes
+ * through untouched.
+ */
+export function prettyToolOutput(output?: string | null): string {
+  const raw = output ?? "";
+  const trimmed = raw.trim();
+  if (!trimmed) return raw;
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    const parsed = tryParseJson(trimmed);
+    if (parsed !== undefined) {
+      try {
+        return JSON.stringify(parsed, null, 2);
+      } catch {
+        return raw;
+      }
+    }
+  }
+  return raw;
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -224,6 +224,134 @@
   border-radius: 2px;
 }
 
+/* Expandable tables: each rendered table is wrapped in .cave-table-block with a
+   hover-revealed Expand chip that opens it full-size in a lightbox. */
+.cave-md .cave-table-block {
+  position: relative;
+  margin: 8px 0 16px;
+}
+.cave-md .cave-table-block > .cave-table-scroll {
+  margin: 0;
+}
+
+.cave-table-expand-btn {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-elevated) 88%, transparent);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+.cave-table-block:hover .cave-table-expand-btn,
+.cave-table-block:focus-within .cave-table-expand-btn,
+.cave-table-expand-btn:focus-visible {
+  opacity: 1;
+}
+.cave-table-expand-btn:hover {
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, transparent);
+}
+.cave-table-expand-glyph {
+  font-size: 12px;
+  line-height: 1;
+}
+/* Touch devices have no hover — keep the affordance visible. */
+@media (hover: none) {
+  .cave-table-expand-btn { opacity: 0.85; }
+}
+
+.cave-table-lightbox {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12px, 4vw, 48px);
+  background: color-mix(in oklch, var(--bg-base) 72%, transparent);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  animation: cave-table-lightbox-in var(--duration-fast) var(--ease-standard);
+}
+@keyframes cave-table-lightbox-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.cave-table-lightbox__panel {
+  display: flex;
+  flex-direction: column;
+  max-width: min(96vw, 1280px);
+  max-height: 90vh;
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  background: var(--bg-raised);
+  box-shadow: 0 24px 70px color-mix(in oklch, black 45%, transparent);
+  overflow: hidden;
+}
+.cave-table-lightbox__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-elevated) 60%, transparent);
+}
+.cave-table-lightbox__title {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.cave-table-lightbox__close {
+  padding: 3px 12px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+.cave-table-lightbox__close:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--bg-hover) 70%, transparent);
+}
+.cave-table-lightbox__body {
+  min-height: 0;
+  overflow: auto;
+  padding: 14px 16px;
+}
+.cave-table-lightbox__body table {
+  font-size: 13px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-table-lightbox { animation: none; }
+}
+
 /* Mermaid diagrams (```mermaid fences). The plugin's postProcess swaps the
    placeholder <pre class="cm-mermaid"> for <div class="cm-mermaid-diagram"><svg>.
    The diagram's own colors come from the mermaid "dark" theme; we only style the
@@ -1513,6 +1641,27 @@ details[open] > .cave-tool-summary::before {
   transform: rotate(90deg);
 }
 
+.cave-run-activity-context {
+  max-height: min(28vh, 180px);
+  overflow: auto;
+  margin: 7px 0 2px 21px;
+  border: 1px solid color-mix(in oklch, var(--foreground) 7%, transparent);
+  border-radius: 7px;
+  background: color-mix(in oklch, var(--bg-elevated) 72%, transparent);
+  padding: 7px 8px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  scrollbar-width: thin;
+}
+
+.cave-run-activity-context__tool {
+  color: var(--text-muted);
+}
+
 .cave-tool-count {
   border: 1px solid var(--border-hairline);
   border-radius: 5px;
@@ -1606,6 +1755,119 @@ details[open] > .cave-tool-summary::before {
    :not() leaves the "Show more" toggle able to lift the clamp. */
 .cave-tool-block .cave-code-wrap:not(.cave-code-wrap--expanded) {
   max-height: min(48vh, 360px);
+}
+
+/* ── Readable tool I/O ─────────────────────────────────────────────────────
+   Tool input renders as a labelled field list (File / Find / Limit …) instead
+   of a raw JSON blob; the raw payload stays one toggle away. */
+.cave-tool-io {
+  min-width: 0;
+}
+
+.cave-tool-io-label {
+  margin-bottom: 5px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.cave-tool-input {
+  min-width: 0;
+}
+
+.cave-tool-fields {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  min-width: 0;
+}
+
+/* Inline field: label gutter + value on one row. Multiline fields stack the
+   value beneath the label so code/JSON gets full width. */
+.cave-tool-field {
+  display: grid;
+  grid-template-columns: minmax(56px, 132px) minmax(0, 1fr);
+  align-items: baseline;
+  gap: 4px 10px;
+  min-width: 0;
+}
+
+.cave-tool-field[data-multiline="true"] {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 4px;
+}
+
+.cave-tool-field-label {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.cave-tool-field-value {
+  margin: 0;
+  min-width: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.cave-tool-field-inline {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+/* Path / command / url inline values pick up a subtle accent so the eye lands
+   on the operative argument. */
+.cave-tool-field[data-kind="path"] .cave-tool-field-inline,
+.cave-tool-field[data-kind="url"] .cave-tool-field-inline {
+  color: color-mix(in oklch, var(--accent-presence) 70%, var(--text-primary));
+}
+
+.cave-tool-field[data-kind="command"] .cave-tool-field-inline {
+  color: var(--text-primary);
+}
+
+.cave-tool-raw-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 7px;
+  padding: 2px 7px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--bg-elevated) 60%, transparent);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.cave-tool-raw-toggle:hover {
+  border-color: color-mix(in oklch, var(--border-strong) 70%, transparent);
+  color: var(--text-secondary);
+}
+
+.cave-tool-raw-toggle[aria-pressed="true"] {
+  color: var(--text-secondary);
+}
+
+/* Reasoning body gets a touch more breathing room when expanded by the global
+   Show-thinking toggle. */
+.cave-reasoning-body {
+  max-height: min(60vh, 520px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .cave-composer-dock {
@@ -1989,6 +2251,18 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-icon-button:disabled {
   opacity: 0.45;
+}
+
+.cave-chat-icon-button--active {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  color: var(--accent-presence);
+}
+
+.cave-chat-icon-button--active:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  color: var(--accent-presence);
 }
 
 .cave-chat-back-button {


### PR DESCRIPTION
Rescues finished-but-uncommitted chat tool-usage UI/UX work that had been left in the shared main checkout (session deliberately avoided `git add -A` because the working tree held other sessions' WIP). Lifted into an isolated worktree off `origin/main` with explicit pathspecs only — no YouTube-viewer or board-enrich-steps changes were swept in.

## What's in this PR
- **`tool-readable.ts`** (`toolReadableFields` / `prettyToolOutput`) → `ToolInputView` renders human-readable tool fields with a **Raw JSON** toggle.
- **`reasoning-visibility.ts`** (`useShowThinking`, localStorage + cross-component event) + **HeaderThinkingToggle**; `ReasoningBlock` opens per the toggle.
- **`message-bubble`** `wireExpandableTables` → markdown tables get an **Expand** chip + lightbox.
- Reusable **`.cave-fill-btn`** (`data-state` green/red fill sweep) adopted by **Copy diagnostics**.

## Verification
- `tsc --noEmit` clean
- `tool-readable`, `chat-view-polish`, `chat-header-row` suites pass (the latter covers `tool-arg-summary`)
- `check:tests-wired` green (`tool-readable.test.ts` wired into the app suite)

## Notes
- `globals.css` was split by hand: only the `.cave-fill-btn` EOF block is included; the unrelated `.youtube-viewer__*` hunks (a different session's WIP) were left behind.
- `scripts/run-tests.mjs`: merged the one-line test wiring onto the current upstream version rather than clobbering it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)