### PR TITLE
feat(chat): single-row Codex-style composer controls

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4702,6 +4702,28 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 >
                   <Icon name="ph:plus-bold" width={14} />
                 </button>
+                {/* Vertical separator between the attach control and the
+                    inline response selectors (was a horizontal rule when the
+                    controls stacked into two rows). */}
+                <div className="cave-composer-divider" aria-hidden />
+                <div className="cave-composer-settings-row" aria-label="Chat response controls">
+                  <ComposerControlSelect
+                    label="Thinking"
+                    icon="ph:sparkle-bold"
+                    value={thinkingEffort}
+                    options={THINKING_OPTIONS}
+                    disabled={busy}
+                    onChange={setThinkingEffort}
+                  />
+                  <ComposerControlSelect
+                    label="Speed"
+                    icon="ph:lightning-bold"
+                    value={responseSpeed}
+                    options={SPEED_OPTIONS}
+                    disabled={busy}
+                    onChange={setResponseSpeed}
+                  />
+                </div>
                 {busy ? (
                   <button
                     type="button"
@@ -4724,25 +4746,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     <Icon name="ph:arrow-up-bold" width={13} aria-hidden />
                   </button>
                 )}
-              </div>
-              <div className="cave-composer-divider" aria-hidden />
-              <div className="cave-composer-settings-row" aria-label="Chat response controls">
-                <ComposerControlSelect
-                  label="Thinking"
-                  icon="ph:sparkle-bold"
-                  value={thinkingEffort}
-                  options={THINKING_OPTIONS}
-                  disabled={busy}
-                  onChange={setThinkingEffort}
-                />
-                <ComposerControlSelect
-                  label="Speed"
-                  icon="ph:lightning-bold"
-                  value={responseSpeed}
-                  options={SPEED_OPTIONS}
-                  disabled={busy}
-                  onChange={setResponseSpeed}
-                />
               </div>
             </div>
           </div>

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1664,7 +1664,10 @@ details[open] > .cave-tool-summary::before {
   display: flex;
   min-height: 34px;
   align-items: center;
-  justify-content: space-between;
+  /* Codex-style single control row: attach · selectors (grows) · send.
+     The settings row's flex-grow pushes the send button to the far edge. */
+  justify-content: flex-start;
+  gap: 8px;
   color: var(--text-muted);
 }
 
@@ -1675,21 +1678,23 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-composer-divider {
-  height: 1px;
-  margin: 7px 0 8px;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    color-mix(in oklch, var(--foreground) 12%, transparent) 12%,
-    color-mix(in oklch, var(--foreground) 12%, transparent) 88%,
-    transparent
-  );
+  /* Vertical hairline separating the attach control from the inline selectors
+     (was a full-width horizontal rule between the old stacked rows). */
+  width: 1px;
+  height: 18px;
+  flex: 0 0 auto;
+  align-self: center;
+  margin: 0 2px;
+  background: color-mix(in oklch, var(--foreground) 12%, transparent);
 }
 
 .cave-composer-settings-row {
   display: flex;
   min-width: 0;
-  width: 100%;
+  /* Grow to fill the middle of the single control row so the send button is
+     pushed to the trailing edge (was width:100% when this sat on its own row). */
+  flex: 1 1 auto;
+  width: auto;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
@@ -3252,6 +3257,16 @@ details[open] > .cave-tool-summary::before {
 
   .cave-composer-action-row {
     min-height: 48px;
+    /* Phones don't have room for attach · selectors · send on one line, so
+       let the row wrap: attach + send sit on top (spread to the edges) and
+       the selectors drop to their own full-width line below. */
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  /* The desktop vertical hairline has no place in the wrapped phone layout. */
+  .cave-composer-divider {
+    display: none;
   }
 
   .cave-composer-settings-row {
@@ -3259,6 +3274,10 @@ details[open] > .cave-tool-summary::before {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 6px;
     overflow: visible;
+    /* Force the selectors onto their own row beneath attach/send. */
+    order: 3;
+    flex-basis: 100%;
+    width: 100%;
   }
 
   .cave-composer-settings-row .cave-chat-model-control,


### PR DESCRIPTION
## What

The chat composer stacked **two** control rows below the input — an action row (attach + send) over a separate settings row (Thinking / Speed), joined by a horizontal divider. Codex puts it all on **one** line. This folds them together:

`＋  │  ✦ Thinking High   ⚡ Speed Fast  ···········  ↑`

attach · vertical hairline · the inline selectors (flex-grow) · send pushed to the trailing edge.

## How

The DOM keeps **every existing class** (`cave-composer-action-row`, `cave-composer-divider`, `cave-composer-settings-row`) so the pinned source-text tests still hold — the divider just becomes a *vertical* hairline and the settings row now sits inside the action row between attach and send. CSS: `action-row` is `justify-content: flex-start; gap`, `settings-row` is `flex: 1 1 auto` (pushes send right).

**Mobile (<768px) preserved:** the action row wraps — attach/send stay on the top row (spread to the edges) and the selectors drop to their own full-width line below; the vertical divider is hidden.

## Verification (Playwright, live dev server)

- **Desktop**: action-row is a single **34px** row; all controls share one baseline (`childTops` all ≈ same y).
- **Mobile (390px)**: attach + send on row 1, selectors wrapped to row 2.

Tests green: `chat-view-first-class`, `chat-view-mobile-command-center`, `composer-density`, `chat-view-polish`; `pnpm typecheck` clean.

Pairs with #2066 (compact composer height) — together: compact start **and** one control row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)