### PR TITLE
Replace YouTube iframe with native frame shell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4645,7 +4645,8 @@ button:active > .edge-rail-chip {
   background: #000;
 }
 
-.youtube-viewer__frame iframe {
+.youtube-viewer__native-frame,
+.youtube-viewer__dev-frame {
   position: absolute;
   inset: 0;
   width: 100%;
@@ -4653,11 +4654,107 @@ button:active > .edge-rail-chip {
   border: 0;
 }
 
+.youtube-viewer__native-frame {
+  overflow: hidden;
+  background: #000;
+}
+
+.youtube-viewer__dev-frame {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  background-color: #050505;
+  background-position: center;
+  background-size: cover;
+}
+
+.youtube-viewer__dev-frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(to bottom, rgb(0 0 0 / 0.44), transparent 34%, rgb(0 0 0 / 0.66)),
+    radial-gradient(circle at center, rgb(255 255 255 / 0.08), transparent 34%);
+}
+
+.youtube-viewer__dev-frame-top,
+.youtube-viewer__dev-frame-bottom {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 12px;
+}
+
+.youtube-viewer__dev-frame-top span {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: rgb(255 255 255 / 0.72);
+}
+
+.youtube-viewer__dev-frame-top span:nth-child(1) {
+  width: 42%;
+}
+
+.youtube-viewer__dev-frame-top span:nth-child(2) {
+  width: 18px;
+  margin-left: auto;
+}
+
+.youtube-viewer__dev-frame-top span:nth-child(3) {
+  width: 18px;
+}
+
+.youtube-viewer__dev-frame-play {
+  position: absolute;
+  z-index: 1;
+  left: 50%;
+  top: 50%;
+  display: flex;
+  width: 64px;
+  height: 44px;
+  transform: translate(-50%, -50%);
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: rgb(0 0 0 / 0.72);
+  color: #fff;
+  box-shadow: 0 10px 28px rgb(0 0 0 / 0.36);
+}
+
+.youtube-viewer__dev-frame-bottom {
+  gap: 9px;
+}
+
+.youtube-viewer__dev-frame-progress {
+  display: block;
+  height: 4px;
+  flex: 1;
+  border-radius: 999px;
+  background:
+    linear-gradient(to right, #ff0033 0 38%, rgb(255 255 255 / 0.35) 38% 100%);
+}
+
+.youtube-viewer__dev-frame-chip {
+  display: block;
+  width: 18px;
+  height: 8px;
+  border-radius: 2px;
+  border: 1px solid rgb(255 255 255 / 0.6);
+}
+
+.youtube-viewer__dev-frame-chip--short {
+  width: 13px;
+}
+
 /* ── Collapsed video strip ──────────────────────────────────────────────
    When the companion rail is collapsed to its peek width while the Video
    pane is on, it becomes a thin sliver showing only the video, rotated 90°
-   so it runs top→bottom. The YouTube iframe stays mounted across the
-   collapse (CSS-only restyle, no remount) so playback continues. */
+   so it runs top→bottom. The native frame is hidden in the collapsed strip
+   and the visible area becomes the now-playing indicator. */
 
 /* Re-expand affordance — hidden until the rail is a strip, where it becomes a
    full-area transparent overlay so tapping anywhere on the video expands the
@@ -4724,9 +4821,8 @@ button:active > .edge-rail-chip {
 }
 
 /* In the narrow peek strip we DON'T show the video sideways (a 16:9 frame
-   rotated into a ~55px column is a head-tilt sliver). Keep the iframe mounted
-   as an invisible sliver so audio never stops, and hand the strip to a calm,
-   upright "now playing" indicator instead. */
+   rotated into a ~55px column is a head-tilt sliver). Keep the frame as an
+   invisible sliver and hand the strip to a calm, upright indicator instead. */
 .companion-rail--video-strip .youtube-viewer__frame {
   flex: 0 0 1px;
   min-height: 0;
@@ -4778,7 +4874,7 @@ button:active > .edge-rail-chip {
    In the open (full-width) rail, the Video pane can collapse straight down to
    a single full-width row — transport + title + volume — so a playlist keeps
    playing in the background while the rest of the rail reclaims the height.
-   The iframe stays mounted (slivered, not unmounted) so audio never stops. */
+   The frame parks as a sliver while the visible area becomes a status row. */
 
 /* Caret toggle, shared by the URL bar (collapse) and the mini bar (expand). */
 .youtube-viewer__chevron {
@@ -4810,8 +4906,8 @@ button:active > .edge-rail-chip {
   display: none;
 }
 
-/* Keep the iframe rendered (a 1px, transparent sliver) so playback continues,
-   but hand the visible row to the mini bar. */
+/* Keep the frame parked as a 1px transparent sliver, but hand the visible row
+   to the mini bar. */
 .youtube-viewer[data-collapsed="true"] .youtube-viewer__frame {
   flex: 0 0 1px;
   min-height: 0;
@@ -4849,21 +4945,6 @@ button:active > .edge-rail-chip {
 
 .youtube-viewer__mini-btn:active {
   transform: scale(0.92);
-}
-
-/* The play/pause control reads as primary: a filled accent disc. */
-.youtube-viewer__mini-btn--primary {
-  width: 26px;
-  height: 26px;
-  border-radius: 999px;
-  background: var(--accent);
-  color: var(--accent-contrast, #fff);
-}
-
-.youtube-viewer__mini-btn--primary:hover {
-  background: var(--accent);
-  color: var(--accent-contrast, #fff);
-  filter: brightness(1.08);
 }
 
 /* Equalizer + title share the flexible middle so the title truncates, not the
@@ -4928,44 +5009,6 @@ button:active > .edge-rail-chip {
 
 @media (prefers-reduced-motion: reduce) {
   .youtube-viewer__eq[data-playing="true"] i { animation: none; transform: scaleY(0.7); }
-}
-
-/* Slim accent volume slider — the filled portion follows --vol (set inline). */
-.youtube-viewer__volume {
-  flex-shrink: 0;
-  width: 72px;
-  height: 4px;
-  margin: 0 2px;
-  border-radius: 999px;
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: pointer;
-  background: linear-gradient(
-    to right,
-    var(--accent) 0,
-    var(--accent) var(--vol, 100%),
-    var(--border-strong) var(--vol, 100%),
-    var(--border-strong) 100%
-  );
-}
-
-.youtube-viewer__volume::-webkit-slider-thumb {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 11px;
-  height: 11px;
-  border-radius: 999px;
-  background: var(--text-primary);
-  border: 0;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 0.35);
-}
-
-.youtube-viewer__volume::-moz-range-thumb {
-  width: 11px;
-  height: 11px;
-  border-radius: 999px;
-  background: var(--text-primary);
-  border: 0;
 }
 
 /* Pull the bottom pane down to just the mini bar and let the top pane take the

--- a/src/components/youtube-collapse.test.ts
+++ b/src/components/youtube-collapse.test.ts
@@ -5,32 +5,28 @@ import { readFile } from "node:fs/promises";
 const view = await readFile(new URL("./youtube-viewer.tsx", import.meta.url), "utf8");
 const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
-// The JS-API params are added only on the live iframe (withJsApi), never baked
-// into the logical src returned by parseYoutubeEmbed.
-assert.match(view, /function withJsApi\(/, "JS-API params live in a separate wrapper");
-assert.match(view, /src=\{withJsApi\(src\)\}/, "the iframe src is wrapped, the logical src stays clean");
-
-// ── Player API wiring (needed for title + volume in the mini bar) ────────────
-assert.match(view, /enablejsapi/, "iframe opts into the YouTube IFrame API");
-assert.match(view, /new YT\.Player\(/, "a YT.Player attaches to the live iframe");
-assert.match(view, /getVideoData\(\)/, "reads the real video title for the mini bar");
-assert.match(view, /\.setVolume\(/, "drives volume through the player");
-assert.match(view, /\.nextVideo\(\)/, "mini bar can skip to the next track");
+// The embedded YouTube surface must not use a DOM iframe or the YouTube IFrame
+// Player API. In desktop Tauri it requests a native child webview; in plain dev
+// browser mode it renders a non-interactive frame that keeps the same footprint.
+assert.doesNotMatch(view, /<iframe\b/, "YouTube viewer should not render a DOM iframe");
+assert.doesNotMatch(view, /youtube\.com\/iframe_api|YT\.Player|enablejsapi/, "YouTube iframe API should not be loaded");
+assert.match(view, /browser_navigate/, "YouTube viewer should request a native child webview when available");
+assert.match(view, /youtube-viewer__native-frame/, "renders a native-frame placeholder for webview bounds");
+assert.match(view, /youtube-viewer__dev-frame/, "renders the dev-only non-interactive frame fallback");
 
 // ── Collapse state ───────────────────────────────────────────────────────────
 assert.match(view, /data-collapsed=\{collapsed \? "true" : undefined\}/, "root exposes the collapsed state to CSS");
 assert.match(view, /cave:youtube:collapsed/, "collapse choice persists across reloads");
 assert.match(view, /youtube-viewer__mini/, "renders the mini now-playing bar");
 
-// The iframe must NOT remount on collapse (audio would stop) — collapse is a
-// pure state flip, and the iframe key tracks only the source.
-assert.match(view, /key=\{src\}/, "iframe is keyed on src only (collapse never remounts it)");
+// No playback controls: this is an embedded web frame, not a custom player.
+assert.doesNotMatch(view, /playVideo|pauseVideo|nextVideo|setVolume|type="range"/, "no custom player controls");
 
-// ── CSS: collapsed pane shrinks to the mini bar; iframe stays a live sliver ──
+// ── CSS: collapsed pane shrinks to the mini bar; native frame is hidden ──────
 assert.match(
   css,
   /\.youtube-viewer\[data-collapsed="true"\] \.youtube-viewer__frame \{[\s\S]*?flex: 0 0 1px[\s\S]*?opacity: 0/,
-  "collapsed: the iframe is slivered (kept playing), not unmounted",
+  "collapsed: the frame is parked as a hidden sliver",
 );
 assert.match(
   css,
@@ -43,12 +39,8 @@ assert.match(
   "collapsed: the bottom pane parks at the mini-bar height so the top pane reclaims the space",
 );
 
-// ── Now-playing polish: primary play disc + an animated equalizer ────────────
-assert.match(
-  view,
-  /youtube-viewer__mini-btn--primary/,
-  "the mini bar's play/pause reads as the primary control",
-);
+// ── Now-playing polish: static indicator + an animated-ready equalizer ───────
+assert.doesNotMatch(view, /youtube-viewer__mini-btn--primary/, "mini bar has no primary playback control");
 assert.match(view, /<Equalizer playing=\{playing\}/, "the mini bar shows a now-playing equalizer");
 assert.match(
   css,

--- a/src/components/youtube-viewer.tsx
+++ b/src/components/youtube-viewer.tsx
@@ -2,6 +2,7 @@
 
 import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useTauriPlatform } from "@/lib/tauri-platform";
 
 // The playlist the panel opens on by default.
 const DEFAULT_PLAYLIST_ID = "PLp61JrZcGK7-uuXOWzezyZkz61RQb0XOG";
@@ -11,6 +12,7 @@ const ID_RE = /^[a-zA-Z0-9_-]{11}$/;
 const PLAYLIST_RE = /^[a-zA-Z0-9_-]{12,}$/;
 
 const COLLAPSED_KEY = "cave:youtube:collapsed";
+const NATIVE_FRAME_LABEL = "cave-youtube-native-frame";
 
 // Shared params: `list=...` exposes YouTube's in-player playlist list/menu so you
 // can browse and jump between entries without leaving the panel.
@@ -59,73 +61,37 @@ export function parseYoutubeEmbed(raw: string): string | null {
   return null;
 }
 
-// ── YouTube IFrame Player API ────────────────────────────────────────────────
-// The collapsed "now playing" bar needs the real video title and live volume,
-// which a bare <iframe> can't provide. Adding `enablejsapi=1` and attaching a
-// YT.Player lets us read getVideoData()/getVolume() and drive
-// play/pause/next/volume from native controls.
-
-type YTPlayer = {
-  getVolume: () => number;
-  setVolume: (v: number) => void;
-  isMuted: () => boolean;
-  mute: () => void;
-  unMute: () => void;
-  playVideo: () => void;
-  pauseVideo: () => void;
-  nextVideo: () => void;
-  previousVideo: () => void;
-  getVideoData: () => { title?: string } | undefined;
-  destroy?: () => void;
+type TauriBridge = {
+  invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
 };
 
-type YTNamespace = {
-  Player: new (
-    el: Element,
-    opts: { events?: Record<string, (e: { target: YTPlayer; data?: number }) => void> },
-  ) => YTPlayer;
-  PlayerState: { PLAYING: number };
-};
-
-type YTWindow = Window & {
-  YT?: YTNamespace;
-  onYouTubeIframeAPIReady?: () => void;
-};
-
-let ytApiPromise: Promise<YTNamespace> | null = null;
-
-function loadYouTubeApi(): Promise<YTNamespace> {
-  if (typeof window === "undefined") return Promise.reject(new Error("no window"));
-  const w = window as YTWindow;
-  if (w.YT?.Player) return Promise.resolve(w.YT);
-  if (ytApiPromise) return ytApiPromise;
-  ytApiPromise = new Promise<YTNamespace>((resolve) => {
-    const prev = w.onYouTubeIframeAPIReady;
-    w.onYouTubeIframeAPIReady = () => {
-      prev?.();
-      if (w.YT) resolve(w.YT);
-    };
-    if (!document.querySelector("script[data-youtube-iframe-api]")) {
-      const s = document.createElement("script");
-      s.src = "https://www.youtube.com/iframe_api";
-      s.async = true;
-      s.dataset.youtubeIframeApi = "";
-      document.head.appendChild(s);
-    }
-  });
-  return ytApiPromise;
+async function loadTauriBridge(): Promise<TauriBridge | null> {
+  if (typeof window === "undefined") return null;
+  if ((window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ === undefined) return null;
+  const { invoke } = await import("@tauri-apps/api/core");
+  return { invoke };
 }
 
-/** Append the params the Player API needs without mutating the logical src. */
-function withJsApi(src: string): string {
+function frameTitle(src: string): string {
   try {
     const url = new URL(src);
-    url.searchParams.set("enablejsapi", "1");
-    url.searchParams.set("playsinline", "1");
-    if (typeof window !== "undefined") url.searchParams.set("origin", window.location.origin);
-    return url.toString();
+    const list = url.searchParams.get("list");
+    const videoId = url.pathname.split("/").filter(Boolean).at(-1);
+    if (videoId && ID_RE.test(videoId)) return `YouTube ${videoId}`;
+    if (list) return "YouTube playlist";
   } catch {
-    return src;
+    // fall through
+  }
+  return "YouTube";
+}
+
+function youtubeThumbnailFromEmbed(src: string): string | null {
+  try {
+    const url = new URL(src);
+    const videoId = url.pathname.split("/").filter(Boolean).at(-1);
+    return videoId && ID_RE.test(videoId) ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg` : null;
+  } catch {
+    return null;
   }
 }
 
@@ -134,24 +100,20 @@ function withJsApi(src: string): string {
  * rail's resizable bottom pane (the "Video" toggle). Paste any YouTube link,
  * video id, or playlist; the embed reloads when you hit Load / Enter.
  *
- * Collapses to a full-width, minimal-height "now playing" bar (transport +
- * title + volume) so it keeps playing in the background while the rest of the
- * rail reclaims the height. The iframe stays mounted across the collapse so
- * audio never stops.
+ * Desktop Tauri uses a native child webview aligned to the frame placeholder.
+ * Plain browser dev gets a non-interactive visual frame with the same footprint.
  */
 export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: string }) {
   const [src, setSrc] = useState(defaultSrc);
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
-
   const [collapsed, setCollapsed] = useState(false);
-  const [playing, setPlaying] = useState(false);
-  const [muted, setMuted] = useState(false);
-  const [volume, setVolume] = useState(100);
-  const [title, setTitle] = useState("");
-
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const playerRef = useRef<YTPlayer | null>(null);
+  const [bridge, setBridge] = useState<TauriBridge | null>(null);
+  const platform = useTauriPlatform();
+  const nativeBrowserAvailable = platform === "desktop";
+  const nativeFrameRef = useRef<HTMLDivElement>(null);
+  const title = frameTitle(src);
+  const playing = false;
 
   // Restore the last collapse choice so the player reopens the way it was left.
   useEffect(() => {
@@ -171,49 +133,85 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
     }
   }, []);
 
-  const syncTitle = useCallback(() => {
-    try {
-      const data = playerRef.current?.getVideoData?.();
-      if (data?.title) setTitle(data.title);
-    } catch {
-      // getVideoData can throw before the player is ready
-    }
-  }, []);
-
-  // Attach a YT.Player to the live iframe so the controls work. Recreated when
-  // the source changes (the iframe remounts via its `key`).
   useEffect(() => {
+    if (platform === "unknown") return;
+    if (!nativeBrowserAvailable) {
+      setBridge(null);
+      return;
+    }
     let cancelled = false;
-    void loadYouTubeApi().then((YT) => {
-      if (cancelled || !iframeRef.current) return;
-      playerRef.current = new YT.Player(iframeRef.current, {
-        events: {
-          onReady: (e) => {
-            try {
-              setVolume(Math.round(e.target.getVolume()));
-              setMuted(e.target.isMuted());
-            } catch {
-              // defaults stand in until the next state change
-            }
-            syncTitle();
-          },
-          onStateChange: (e) => {
-            setPlaying(e.data === YT.PlayerState.PLAYING);
-            syncTitle();
-          },
-        },
-      });
+    void loadTauriBridge().then((next) => {
+      if (!cancelled) setBridge(next);
     });
     return () => {
       cancelled = true;
-      try {
-        playerRef.current?.destroy?.();
-      } catch {
-        // the keyed iframe may already be gone — destroy is best-effort
-      }
-      playerRef.current = null;
     };
-  }, [src, syncTitle]);
+  }, [nativeBrowserAvailable, platform]);
+
+  useEffect(() => {
+    if (!bridge || !nativeBrowserAvailable) return;
+    const surface = nativeFrameRef.current;
+    if (!surface) return;
+
+    let raf = 0;
+    let hidden = false;
+    let last = { x: 0, y: 0, w: 0, h: 0 };
+
+    const hide = () => {
+      if (!hidden) {
+        hidden = true;
+        void bridge.invoke("browser_hide", { label: NATIVE_FRAME_LABEL });
+      }
+    };
+
+    const tick = () => {
+      const rect = surface.getBoundingClientRect();
+      if (collapsed || rect.width <= 1 || rect.height <= 1) {
+        hide();
+      } else {
+        const next = {
+          x: Math.round(rect.left),
+          y: Math.round(rect.top),
+          w: Math.round(rect.width),
+          h: Math.round(rect.height),
+        };
+        if (hidden || next.x !== last.x || next.y !== last.y || next.w !== last.w || next.h !== last.h) {
+          last = next;
+          hidden = false;
+          void bridge.invoke("browser_set_bounds", { label: NATIVE_FRAME_LABEL, ...next });
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+
+    const timer = window.setTimeout(() => {
+      const rect = surface.getBoundingClientRect();
+      if (collapsed || rect.width <= 1 || rect.height <= 1) {
+        hide();
+        return;
+      }
+      hidden = false;
+      last = {
+        x: Math.round(rect.left),
+        y: Math.round(rect.top),
+        w: Math.round(rect.width),
+        h: Math.round(rect.height),
+      };
+      void bridge.invoke("browser_navigate", {
+        label: NATIVE_FRAME_LABEL,
+        url: src,
+        ...last,
+        readOnlyUrl: src,
+      });
+      raf = requestAnimationFrame(tick);
+    }, 80);
+
+    return () => {
+      window.clearTimeout(timer);
+      cancelAnimationFrame(raf);
+      void bridge.invoke("browser_close", { label: NATIVE_FRAME_LABEL });
+    };
+  }, [bridge, collapsed, nativeBrowserAvailable, src]);
 
   const load = () => {
     const next = parseYoutubeEmbed(input);
@@ -225,54 +223,6 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
     setSrc(next);
     setInput("");
   };
-
-  const togglePlay = useCallback(() => {
-    const p = playerRef.current;
-    if (!p) return;
-    if (playing) p.pauseVideo();
-    else p.playVideo();
-  }, [playing]);
-
-  const toggleMute = useCallback(() => {
-    const p = playerRef.current;
-    if (!p) return;
-    if (muted) {
-      p.unMute();
-      setMuted(false);
-      if (volume === 0) {
-        p.setVolume(50);
-        setVolume(50);
-      }
-    } else {
-      p.mute();
-      setMuted(true);
-    }
-  }, [muted, volume]);
-
-  const changeVolume = useCallback(
-    (next: number) => {
-      const p = playerRef.current;
-      setVolume(next);
-      if (!p) return;
-      p.setVolume(next);
-      if (next === 0) {
-        p.mute();
-        setMuted(true);
-      } else if (muted) {
-        p.unMute();
-        setMuted(false);
-      }
-    },
-    [muted],
-  );
-
-  const effectiveVolume = muted ? 0 : volume;
-  const volumeIcon =
-    effectiveVolume === 0
-      ? "ph:speaker-slash-fill"
-      : effectiveVolume < 50
-        ? "ph:speaker-low-fill"
-        : "ph:speaker-high-fill";
 
   return (
     <div className="youtube-viewer" data-collapsed={collapsed ? "true" : undefined}>
@@ -315,63 +265,23 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
         </p>
       ) : null}
       <div className="youtube-viewer__frame">
-        <iframe
-          key={src}
-          ref={iframeRef}
-          src={withJsApi(src)}
-          title="YouTube video player"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-          referrerPolicy="strict-origin-when-cross-origin"
-          allowFullScreen
-        />
+        <div
+          ref={nativeFrameRef}
+          className="youtube-viewer__native-frame"
+          aria-label="Embedded YouTube native web frame"
+        >
+          {!bridge || !nativeBrowserAvailable ? <YoutubeDevFrame src={src} /> : null}
+        </div>
       </div>
-      {/* Mini player — shown only when collapsed (CSS). Full width, one row:
-          a primary play button, next, a now-playing equalizer + title, volume,
-          and an expand caret. */}
+      {/* Mini player — shown only when collapsed (CSS). It is a status row, not
+          a custom playback controller. */}
       <div className="youtube-viewer__mini">
-        <button
-          type="button"
-          className="youtube-viewer__mini-btn youtube-viewer__mini-btn--primary focus-ring"
-          onClick={togglePlay}
-          aria-label={playing ? "Pause" : "Play"}
-          title={playing ? "Pause" : "Play"}
-        >
-          <Icon name={playing ? "ph:pause-fill" : "ph:play-fill"} width={13} />
-        </button>
-        <button
-          type="button"
-          className="youtube-viewer__mini-btn focus-ring"
-          onClick={() => playerRef.current?.nextVideo()}
-          aria-label="Next"
-          title="Next"
-        >
-          <Icon name="ph:skip-forward-fill" width={13} />
-        </button>
         <span className="youtube-viewer__nowplaying">
           <Equalizer playing={playing} />
           <span className="youtube-viewer__mini-title" title={title || "YouTube"}>
             {title || "YouTube"}
           </span>
         </span>
-        <button
-          type="button"
-          className="youtube-viewer__mini-btn focus-ring"
-          onClick={toggleMute}
-          aria-label={effectiveVolume === 0 ? "Unmute" : "Mute"}
-          title={effectiveVolume === 0 ? "Unmute" : "Mute"}
-        >
-          <Icon name={volumeIcon} width={14} />
-        </button>
-        <input
-          type="range"
-          min={0}
-          max={100}
-          value={effectiveVolume}
-          onChange={(e) => changeVolume(Number(e.target.value))}
-          className="youtube-viewer__volume"
-          aria-label="Volume"
-          style={{ "--vol": `${effectiveVolume}%` } as CSSProperties}
-        />
         <button
           type="button"
           className="youtube-viewer__chevron focus-ring"
@@ -384,12 +294,36 @@ export function YoutubeViewer({ defaultSrc = DEFAULT_SRC }: { defaultSrc?: strin
       </div>
       {/* Vertical "now playing" strip — shown only when the whole rail is
           collapsed to its peek width (CSS, under .companion-rail--video-strip).
-          The iframe keeps playing audio (hidden); this is a calm, upright
-          now-playing indicator instead of a sideways-rotated video. The rail's
-          transparent overlay handles tap-to-expand. */}
+          This is a calm, upright now-playing indicator instead of a sideways
+          video frame. The rail's transparent overlay handles tap-to-expand. */}
       <div className="youtube-viewer__strip" aria-hidden="true">
         <Equalizer playing={playing} className="youtube-viewer__eq--lg" />
         <span className="youtube-viewer__strip-title">{title || "YouTube"}</span>
+      </div>
+    </div>
+  );
+}
+
+function YoutubeDevFrame({ src }: { src: string }) {
+  const thumbnail = youtubeThumbnailFromEmbed(src);
+  return (
+    <div
+      className="youtube-viewer__dev-frame"
+      aria-hidden="true"
+      style={thumbnail ? ({ backgroundImage: `linear-gradient(rgb(0 0 0 / 0.22), rgb(0 0 0 / 0.4)), url(${thumbnail})` } as CSSProperties) : undefined}
+    >
+      <div className="youtube-viewer__dev-frame-top">
+        <span />
+        <span />
+        <span />
+      </div>
+      <div className="youtube-viewer__dev-frame-play">
+        <Icon name="ph:play-fill" width={26} />
+      </div>
+      <div className="youtube-viewer__dev-frame-bottom">
+        <span className="youtube-viewer__dev-frame-progress" />
+        <span className="youtube-viewer__dev-frame-chip" />
+        <span className="youtube-viewer__dev-frame-chip youtube-viewer__dev-frame-chip--short" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replaces the YouTube DOM iframe/player API path with a native Tauri webview bridge
- adds a non-interactive browser/dev frame fallback that preserves the player footprint
- updates the regression contract to forbid iframe/API playback controls

## Test Plan
- node src/components/youtube-collapse.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:app
- pnpm build
- Playwright render check: Chat -> Video, iframeCount=0, frame/native/dev rects all 343.6x302.8, no Next error overlay