### PR TITLE
chore(browser): drop the Frymatic Arcade default pinned tab

### DIFF
--- a/src/components/browser-pane-default-tabs.test.ts
+++ b/src/components/browser-pane-default-tabs.test.ts
@@ -16,3 +16,9 @@ assert.doesNotMatch(
   /vercel\.com\/dashboard|title: "Vercel"|id: "vercel"/,
   "Browser defaults should not include Vercel",
 );
+
+assert.doesNotMatch(
+  defaults,
+  /frymatic\.us|FTSArcade|id: "arcade"/,
+  "Browser defaults should not include the Frymatic arcade tab",
+);

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -177,7 +177,6 @@ function defaultPinnedTabs(): BrowserTab[] {
     { id: "home", url: HOME_URL, title: "OpenCoven", pinned: true, kind: "pinned" },
     { id: "opencvn-x", url: "https://x.com/OpenCvn", title: "OpenCvn", pinned: true, kind: "pinned" },
     { id: "github", url: "https://github.com/OpenCoven", title: "GitHub", pinned: true, kind: "pinned" },
-    { id: "arcade", url: "https://frymatic.us/FTSArcade", title: "Arcade", pinned: true, kind: "pinned" },
   ];
 }
 


### PR DESCRIPTION
Rescues a small orphaned change that was sitting uncommitted in the shared main checkout (no owning session, on no branch).

## Change
- Remove the `frymatic.us/FTSArcade` **"Arcade"** entry from `defaultPinnedTabs()` in `browser-pane.tsx`.
- Add a `doesNotMatch` regression assertion in `browser-pane-default-tabs.test.ts` (mirrors the existing Vercel-tab guard).

## Verification
- `browser-pane-default-tabs` test passes.

## Context
The larger YouTube-viewer rewrite that was in the same working tree turned out to have **already landed** on `main` (commit `4d3ffe80`, "Replace YouTube iframe with native frame shell"), so only this Arcade-tab removal remained genuinely uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)