### PR TITLE
Fix tokenless sidecar auth monitor warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,6 +53,8 @@ export const viewport: Viewport = {
   ],
 };
 
+export const dynamic = "force-dynamic";
+
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/src/components/security/sidecar-auth-bridge.tsx
+++ b/src/components/security/sidecar-auth-bridge.tsx
@@ -69,6 +69,22 @@ export const SIDECAR_AUTH_BRIDGE = `
 })();
 `;
 
+function sidecarAuthRequired(): boolean {
+  return (
+    Boolean(process.env.COVEN_CAVE_AUTH_TOKEN) ||
+    process.env.COVEN_CAVE_BUNDLE === "1"
+  );
+}
+
 export function SidecarAuthBridge() {
-  return <script dangerouslySetInnerHTML={{ __html: SIDECAR_AUTH_BRIDGE }} />;
+  const authRequirementScript = `window.__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__ = ${JSON.stringify(
+    sidecarAuthRequired(),
+  )};`;
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `${authRequirementScript}\n${SIDECAR_AUTH_BRIDGE}`,
+      }}
+    />
+  );
 }

--- a/src/components/security/sidecar-auth-monitor.tsx
+++ b/src/components/security/sidecar-auth-monitor.tsx
@@ -7,6 +7,11 @@ import { useIsTauriDesktop } from "@/lib/tauri-platform";
 const TOKEN_PARAM = "covenCaveToken";
 const STORAGE_KEY = "coven-cave:sidecar-auth-token";
 const BANNER_ID = "sidecar-auth-failed";
+const AUTH_REQUIRED_KEY = "__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__";
+
+type SidecarAuthWindow = Window & {
+  __COVEN_CAVE_SIDECAR_AUTH_REQUIRED__?: boolean;
+};
 
 // Client companion for SidecarAuthBridge. The inline script runs before React
 // hydrates; this surfaces missing-token failures in the shell after mount.
@@ -15,9 +20,12 @@ export function SidecarAuthMonitor() {
   const isTauriDesktop = useIsTauriDesktop();
 
   useEffect(() => {
+    const sidecarAuthRequired = Boolean((window as SidecarAuthWindow)[AUTH_REQUIRED_KEY]);
+
     // Only desktop Tauri has a local sidecar. Browser dev and mobile Tauri use
-    // remote/webview paths, so a missing sidecar token is expected there.
-    if (!isTauriDesktop) {
+    // remote/webview paths, so a missing sidecar token is expected there. Tauri
+    // desktop dev can also point at a tokenless live dev server.
+    if (!isTauriDesktop || !sidecarAuthRequired) {
       dismissBanner(BANNER_ID);
       return;
     }

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -6,6 +6,7 @@ const source = await readFile(new URL("./proxy.ts", import.meta.url), "utf8");
 const tauriSource = await readFile(new URL("../src-tauri/src/lib.rs", import.meta.url), "utf8");
 const sidecarBridgeSource = await readFile(new URL("./components/security/sidecar-auth-bridge.tsx", import.meta.url), "utf8");
 const sidecarMonitorSource = await readFile(new URL("./components/security/sidecar-auth-monitor.tsx", import.meta.url), "utf8");
+const layoutSource = await readFile(new URL("./app/layout.tsx", import.meta.url), "utf8");
 const mobileScriptSource = await readFile(new URL("../scripts/mobile-tailscale.sh", import.meta.url), "utf8");
 const mobileDocsSource = await readFile(new URL("../docs/mobile-tailscale.md", import.meta.url), "utf8");
 const nextConfigSource = await readFile(new URL("../next.config.ts", import.meta.url), "utf8");
@@ -77,8 +78,23 @@ assert.match(
 assert.match(source, /if \(queryVerification\.ok\)/, "invalid query tokens should not overwrite the access cookie");
 assert.match(source, /maxAge/, "signed mobile cookie lifetime should track token expiry");
 assert.match(source, /req\.method === "GET" \|\| req\.method === "HEAD"/, "mobile token bootstrap should avoid redirects for mutating requests");
+assert.match(
+  sidecarBridgeSource,
+  /__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__/,
+  "sidecar bootstrap should expose whether this server requires a sidecar token",
+);
+assert.match(
+  layoutSource,
+  /export const dynamic = "force-dynamic"/,
+  "root layout must render sidecar auth requirement from runtime env, not build-time env",
+);
 assert.match(sidecarBridgeSource, /window\.history\.replaceState/, "sidecar token bootstrap should remove the token from the visible URL");
 assert.match(sidecarMonitorSource, /useIsTauriDesktop/, "sidecar auth warning should only run for desktop Tauri");
+assert.match(
+  sidecarMonitorSource,
+  /__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__[\s\S]*dismissBanner\(BANNER_ID\)/,
+  "sidecar auth warning should stay quiet when the current server does not require a token",
+);
 assert.doesNotMatch(sidecarMonitorSource, /Boolean\(window\.__TAURI_INTERNALS__\)/, "mobile Tauri should not be treated as a sidecar host");
 assert.match(mobileScriptSource, /tailscale_cmd serve --bg "\$TAILSCALE_BACKEND"/, "mobile script should publish the exact loopback backend it started");
 assert.match(mobileScriptSource, /"authorization": `Bearer \$\{createMobileAccessToken\(accessToken\)\}`/, "mobile script should authenticate its local invite API request with a derived token");


### PR DESCRIPTION
## Summary
- expose whether the current server requires sidecar auth from the server-rendered bridge
- keep the desktop monitor quiet for tokenless dev servers while preserving bundled-sidecar failure reporting
- force the root layout dynamic so the auth-required flag reflects runtime env

## Test Plan
- [x] node --experimental-strip-types src/middleware.test.ts
- [x] node --experimental-strip-types src/components/security/sidecar-auth-bridge.test.ts
- [x] pnpm typecheck
- [x] pnpm check:tests-wired
- [x] pnpm test:app
