### PR TITLE
feat(home): daily summary auto-scroll carousel

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -122,6 +122,7 @@ export const SUITES = {
     "src/components/home-chat-handoff.test.ts",
     "src/components/home-composer.test.ts",
     "src/components/home-feed.test.ts",
+    "src/components/home-digest-carousel.test.ts",
     "src/components/home-composer-centering.test.ts",
     "src/components/home-composer-hide-archived.test.ts",
     "src/components/ios-theme-api.test.ts",
@@ -219,6 +220,7 @@ export const SUITES = {
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",
     "src/lib/code-lang.test.ts",
+    "src/lib/home-digest.test.ts",
     "src/lib/project-search.test.ts",
     "src/lib/tool-target-file.test.ts",
     "src/lib/tool-readable.test.ts",
@@ -687,6 +689,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/home-digest.test.ts",
   "src/lib/use-refresh-on-focus.test.ts",
   "src/lib/flow/flow-progress.test.ts",
   "src/lib/familiar-card-data.test.ts",

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -28,6 +28,7 @@ import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
+import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -780,6 +781,14 @@ export function HomeComposer({
           </div>
         </div>
       )}
+
+      {/* Daily summary — an ambient auto-scrolling digest of today's activity
+          and the freshest headlines; pauses on hover so a card can be read. */}
+      <HomeDigestCarousel
+        sessions={sessions}
+        familiarNameById={familiarNameById}
+        onOpenSession={onOpenSession}
+      />
     </div>
   );
 }

--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -1,0 +1,46 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const view = await readFile(new URL("./home/home-digest-carousel.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
+const composer = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+
+// ── Data sources: assembled client-side from existing endpoints (no new route)
+assert.match(view, /\/api\/inbox/, "pulls today's activity from /api/inbox");
+assert.match(view, /\/api\/rss/, "pulls headlines from /api/rss");
+assert.match(view, /buildDigestCards/, "delegates ordering to the pure builder");
+
+// ── Click behavior: rss opens externally, sessions resume in-app ──────────────
+assert.match(view, /openExternalUrl\(card\.url\)/, "rss cards open the link externally");
+assert.match(view, /onOpenSession\?\.\(card\.sessionId/, "session cards resume the chat");
+
+// ── Seamless marquee: a duplicated, a11y-hidden second row ─────────────────────
+assert.match(view, /duplicate/, "renders a duplicate row so the loop is seamless");
+assert.match(view, /aria-hidden=\{duplicate/, "the duplicate row is hidden from assistive tech");
+assert.match(view, /tabIndex={tabIndex}/, "duplicated cards are removed from the tab order");
+
+// ── Empty/loading: nothing renders until ready, and nothing when no cards ──────
+assert.match(view, /if \(!ready \|\| cards\.length === 0\) return null/, "hidden until there's something to show");
+
+// ── CSS: the marquee, the subtle hover pause, and reduced-motion fallback ──────
+assert.match(css, /@keyframes home-digest-marquee/, "defines the marquee animation");
+assert.match(css, /translateX\(-50%\)/, "loops at -50% to pair with the duplicated row");
+assert.match(
+  css,
+  /\.home-digest:hover \.home-digest__track[\s\S]*?animation-play-state: paused/,
+  "auto-scroll pauses on hover",
+);
+assert.match(css, /focus-within \.home-digest__track/, "also pauses when a card is focused");
+assert.match(
+  css,
+  /@media \(prefers-reduced-motion: reduce\)[\s\S]*?animation: none/,
+  "reduced-motion disables the auto-scroll",
+);
+assert.match(css, /mask-image: linear-gradient\(to right/, "soft fade edges on the strip");
+
+// ── Wired into the home composer below "Jump back in" ─────────────────────────
+assert.match(composer, /import \{ HomeDigestCarousel \}/, "home composer imports the carousel");
+assert.match(composer, /<HomeDigestCarousel/, "home composer renders the carousel");
+
+console.log("home-digest-carousel.test.ts passed");

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * HomeDigestCarousel — the home surface's "Daily summary" strip.
+ *
+ * A continuous, subtle horizontal marquee of today's activity (a summary card +
+ * session cards) followed by the freshest merged RSS headlines. The marquee
+ * auto-scrolls and pauses on hover/focus so a card can be read or clicked; it
+ * falls back to a manual horizontal scroll under `prefers-reduced-motion`
+ * (handled in CSS). Data is assembled client-side from the existing /api/inbox
+ * and /api/rss endpoints — no new server route.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import type { SessionRow } from "@/lib/types";
+import type { InboxItem } from "@/lib/cave-inbox";
+import type { FeedItem } from "@/lib/rss";
+import { openExternalUrl } from "@/lib/open-external";
+import { buildDigestCards, type DigestCard } from "@/lib/home-digest";
+
+type Props = {
+  sessions: SessionRow[];
+  familiarNameById: Map<string, string>;
+  onOpenSession?: (sessionId: string, familiarId: string | null) => void;
+};
+
+export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }: Props) {
+  const [items, setItems] = useState<InboxItem[]>([]);
+  const [rss, setRss] = useState<FeedItem[]>([]);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      const [inboxRes, rssRes] = await Promise.allSettled([
+        fetch("/api/inbox", { cache: "no-store" }).then((r) => r.json()),
+        fetch("/api/rss", { cache: "no-store" }).then((r) => r.json()),
+      ]);
+      if (!alive) return;
+      if (inboxRes.status === "fulfilled" && Array.isArray(inboxRes.value?.items)) {
+        setItems(inboxRes.value.items as InboxItem[]);
+      }
+      if (rssRes.status === "fulfilled" && Array.isArray(rssRes.value?.items)) {
+        setRss(rssRes.value.items as FeedItem[]);
+      }
+      setNowMs(Date.now());
+      setReady(true);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const cards = useMemo(
+    () => buildDigestCards({ items, sessions, rssItems: rss, familiarNameById, nowMs }),
+    [items, sessions, rss, familiarNameById, nowMs],
+  );
+
+  if (!ready || cards.length === 0) return null;
+
+  return (
+    <section className="home-digest" aria-label="Daily summary">
+      {/* The track holds two identical rows so the marquee loops seamlessly at
+          -50%. The second row is a presentational duplicate, hidden from a11y. */}
+      <div className="home-digest__track">
+        <DigestRow cards={cards} onOpenSession={onOpenSession} />
+        <DigestRow cards={cards} onOpenSession={onOpenSession} duplicate />
+      </div>
+    </section>
+  );
+}
+
+function DigestRow({
+  cards,
+  onOpenSession,
+  duplicate,
+}: {
+  cards: DigestCard[];
+  onOpenSession?: (sessionId: string, familiarId: string | null) => void;
+  duplicate?: boolean;
+}) {
+  return (
+    <ul
+      className="home-digest__row"
+      role={duplicate ? "presentation" : "list"}
+      aria-hidden={duplicate || undefined}
+    >
+      {cards.map((card) => (
+        <li key={(duplicate ? "dup:" : "") + card.id} className="home-digest__cell">
+          <DigestCardView card={card} onOpenSession={onOpenSession} focusable={!duplicate} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DigestCardView({
+  card,
+  onOpenSession,
+  focusable,
+}: {
+  card: DigestCard;
+  onOpenSession?: (sessionId: string, familiarId: string | null) => void;
+  focusable: boolean;
+}) {
+  const tabIndex = focusable ? undefined : -1;
+
+  if (card.kind === "summary") {
+    return (
+      <div className="home-digest__card home-digest__card--summary">
+        <Icon name="ph:sparkle" width={14} className="home-digest__icon" aria-hidden />
+        <span className="home-digest__body">
+          <span className="home-digest__title">
+            {card.title} · {card.dayLabel}
+          </span>
+          <span className="home-digest__meta">{card.lines.join(" · ")}</span>
+        </span>
+      </div>
+    );
+  }
+
+  if (card.kind === "session") {
+    return (
+      <button
+        type="button"
+        className="home-digest__card home-digest__card--session"
+        tabIndex={tabIndex}
+        onClick={() => onOpenSession?.(card.sessionId, card.familiarId)}
+        title={`Resume “${card.title}”`}
+      >
+        <Icon name="ph:chat-circle-dots" width={13} className="home-digest__icon" aria-hidden />
+        <span className="home-digest__body">
+          <span className="home-digest__title">{card.title}</span>
+          {card.subtitle ? <span className="home-digest__meta">{card.subtitle}</span> : null}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className="home-digest__card home-digest__card--rss"
+      tabIndex={tabIndex}
+      onClick={() => void openExternalUrl(card.url)}
+      title={card.title}
+    >
+      <Icon name="ph:newspaper" width={13} className="home-digest__icon" aria-hidden />
+      <span className="home-digest__body">
+        <span className="home-digest__title">{card.title}</span>
+        <span className="home-digest__meta">
+          {[card.source || card.host, card.age].filter(Boolean).join(" · ")}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/src/lib/home-digest.test.ts
+++ b/src/lib/home-digest.test.ts
@@ -1,0 +1,79 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { buildDigestCards } from "./home-digest.ts";
+
+// Midday UTC so the small ±hour offsets below stay on the same calendar day in
+// CI's timezone (and most others), keeping the "today" filter deterministic.
+const NOW = Date.parse("2026-06-28T12:00:00Z");
+const hoursAgo = (h) => new Date(NOW - h * 3600_000).toISOString();
+
+const sessions = [
+  { id: "s1", title: "Fix the carousel", updated_at: hoursAgo(2), created_at: hoursAgo(3), familiarId: "f1", diff: { additions: 12, deletions: 4 } },
+  { id: "s2", title: "Older work", updated_at: hoursAgo(40), created_at: hoursAgo(41), familiarId: null }, // yesterday
+  { id: "s3", title: "Archived today", updated_at: hoursAgo(1), created_at: hoursAgo(1), archived_at: hoursAgo(1) },
+];
+
+const items = [
+  { id: "i1", kind: "reminder", status: "fired", firedAt: hoursAgo(1), updatedAt: hoursAgo(1) },
+  { id: "i2", kind: "response-needed", status: "pending", updatedAt: hoursAgo(2) },
+  { id: "i3", kind: "reminder", status: "fired", firedAt: hoursAgo(50), updatedAt: hoursAgo(50) }, // yesterday, ignored
+];
+
+const rssItems = [
+  { id: "r1", title: "Headline one", link: "https://example.com/a", isoDate: hoursAgo(1), source: "Example" },
+  { id: "r2", title: "No link skipped", link: "", isoDate: hoursAgo(1), source: "Example" },
+  { id: "r3", title: "Headline two", link: "https://news.test/b", isoDate: hoursAgo(2), source: "News" },
+];
+
+const familiarNameById = new Map([["f1", "Sage"]]);
+
+const cards = buildDigestCards({ items, sessions, rssItems, familiarNameById, nowMs: NOW });
+
+// ── Ordering: summary first, then sessions, then rss ──────────────────────────
+assert.equal(cards[0].kind, "summary", "summary card leads the carousel");
+const kinds = cards.map((c) => c.kind);
+assert.ok(
+  kinds.indexOf("session") < kinds.indexOf("rss"),
+  "session cards come before rss cards",
+);
+
+// ── Summary card content reflects today's counts ──────────────────────────────
+const summary = cards[0];
+assert.equal(summary.title, "Daily summary");
+assert.ok(summary.dayLabel.length > 0, "summary has a day label");
+assert.ok(summary.lines.includes("1 session"), "one non-archived session today");
+assert.ok(summary.lines.includes("1 reminder"), "one reminder fired today");
+assert.ok(summary.lines.includes("1 waiting"), "one response waiting today");
+
+// ── Session cards: today only, archived + yesterday excluded ──────────────────
+const sessionCards = cards.filter((c) => c.kind === "session");
+assert.equal(sessionCards.length, 1, "only today's non-archived session");
+assert.equal(sessionCards[0].sessionId, "s1");
+assert.equal(sessionCards[0].familiarId, "f1");
+assert.ok(sessionCards[0].subtitle.includes("Sage"), "subtitle resolves the familiar name");
+assert.ok(sessionCards[0].subtitle.includes("+12 -4"), "subtitle includes the diff");
+
+// ── RSS cards: linkless items dropped, newest-first preserved ──────────────────
+const rssCards = cards.filter((c) => c.kind === "rss");
+assert.equal(rssCards.length, 2, "the linkless rss item is dropped");
+assert.equal(rssCards[0].url, "https://example.com/a");
+assert.equal(rssCards[0].host, "example.com", "host is derived from the link");
+
+// ── maxRss cap is honored ─────────────────────────────────────────────────────
+const capped = buildDigestCards({ items, sessions, rssItems, nowMs: NOW, maxRss: 1 });
+assert.equal(capped.filter((c) => c.kind === "rss").length, 1, "maxRss caps rss cards");
+
+// ── Empty when there's nothing today and no headlines ─────────────────────────
+const empty = buildDigestCards({
+  items: [],
+  sessions: [{ id: "old", title: "x", updated_at: hoursAgo(80), created_at: hoursAgo(80) }],
+  rssItems: [],
+  nowMs: NOW,
+});
+assert.deepEqual(empty, [], "no activity and no rss → no cards (strip stays hidden)");
+
+// ── RSS-only still renders (no summary, no sessions) ──────────────────────────
+const rssOnly = buildDigestCards({ items: [], sessions: [], rssItems, nowMs: NOW });
+assert.equal(rssOnly[0].kind, "rss", "rss-only digest has no leading summary card");
+
+console.log("home-digest.test.ts passed");

--- a/src/lib/home-digest.ts
+++ b/src/lib/home-digest.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure builder for the home-page "Daily summary" carousel.
+ *
+ * Combines three signals into one ordered card list:
+ *   1. a single summary card — today's at-a-glance counts (sessions, reminders,
+ *      responses waiting, familiar updates), mirroring the daily-summary digest;
+ *   2. session cards — the chats touched today, newest first (click to resume);
+ *   3. RSS cards — the freshest merged headlines (click opens externally).
+ *
+ * Everything here is pure and clock-injected (`nowMs`) so it unit-tests without
+ * a network, DOM, or wall clock (see home-digest.test.ts).
+ */
+
+import type { InboxItem } from "@/lib/cave-inbox";
+import type { SessionRow } from "@/lib/types";
+import { hostFromUrl, relativeAge, type FeedItem } from "@/lib/rss";
+
+export type DigestSummaryCard = {
+  kind: "summary";
+  id: string;
+  /** Always "Daily summary". */
+  title: string;
+  /** Short month/day label, e.g. "Jun 28". */
+  dayLabel: string;
+  /** Pre-formatted count chips, e.g. ["3 sessions", "1 reminder"]. */
+  lines: string[];
+};
+
+export type DigestSessionCard = {
+  kind: "session";
+  id: string;
+  sessionId: string;
+  familiarId: string | null;
+  title: string;
+  /** "familiar · 3h · +12 -4" (only the present parts). */
+  subtitle: string;
+};
+
+export type DigestRssCard = {
+  kind: "rss";
+  id: string;
+  title: string;
+  source: string;
+  host: string | null;
+  url: string;
+  /** Compact relative age, e.g. "2h". */
+  age: string;
+};
+
+export type DigestCard = DigestSummaryCard | DigestSessionCard | DigestRssCard;
+
+export type BuildDigestInput = {
+  items: InboxItem[];
+  sessions: SessionRow[];
+  rssItems: FeedItem[];
+  /** Maps a familiar id to its display name (for session subtitles). */
+  familiarNameById?: Map<string, string>;
+  nowMs: number;
+  /** Max session cards (default 6) and RSS cards (default 14). */
+  maxSessions?: number;
+  maxRss?: number;
+};
+
+function sameLocalDay(iso: string | null | undefined, now: Date): boolean {
+  if (!iso) return false;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return false;
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  );
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralForm}`;
+}
+
+function dayLabel(now: Date): string {
+  return now.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+/** Build the ordered carousel cards. Returns [] when there's nothing to show
+ *  (no activity today and no headlines), so the home strip stays hidden. */
+export function buildDigestCards(input: BuildDigestInput): DigestCard[] {
+  const { items, sessions, rssItems, familiarNameById, nowMs } = input;
+  const maxSessions = input.maxSessions ?? 6;
+  const maxRss = input.maxRss ?? 14;
+  const now = new Date(nowMs);
+
+  const todaySessions = sessions
+    .filter((s) => !s.archived_at && sameLocalDay(s.updated_at ?? s.created_at, now))
+    .sort((a, b) =>
+      (b.updated_at ?? b.created_at ?? "").localeCompare(a.updated_at ?? a.created_at ?? ""),
+    );
+
+  const remindersFired = items.filter(
+    (i) => i.kind === "reminder" && i.status === "fired" && sameLocalDay(i.firedAt ?? i.updatedAt, now),
+  ).length;
+  const responsesWaiting = items.filter(
+    (i) =>
+      i.kind === "response-needed" &&
+      (i.status === "pending" || i.status === "fired") &&
+      sameLocalDay(i.updatedAt, now),
+  ).length;
+  const familiarUpdates = items.filter(
+    (i) => i.kind === "agent" && i.status === "fired" && sameLocalDay(i.firedAt ?? i.updatedAt, now),
+  ).length;
+
+  const cards: DigestCard[] = [];
+
+  const summaryLines: string[] = [];
+  if (todaySessions.length) summaryLines.push(plural(todaySessions.length, "session"));
+  if (remindersFired) summaryLines.push(plural(remindersFired, "reminder"));
+  if (responsesWaiting) summaryLines.push(`${responsesWaiting} waiting`);
+  if (familiarUpdates) summaryLines.push(plural(familiarUpdates, "familiar update"));
+
+  if (summaryLines.length) {
+    cards.push({
+      kind: "summary",
+      id: "summary",
+      title: "Daily summary",
+      dayLabel: dayLabel(now),
+      lines: summaryLines,
+    });
+  }
+
+  for (const s of todaySessions.slice(0, maxSessions)) {
+    const fam = s.familiarId ? familiarNameById?.get(s.familiarId) ?? null : null;
+    const age = relativeAge(s.updated_at ?? s.created_at ?? null, nowMs);
+    const diff = s.diff ? `+${s.diff.additions} -${s.diff.deletions}` : "";
+    const subtitle = [fam, age, diff].filter(Boolean).join(" · ");
+    cards.push({
+      kind: "session",
+      id: `session:${s.id}`,
+      sessionId: s.id,
+      familiarId: s.familiarId ?? null,
+      title: s.title?.trim() || "Untitled session",
+      subtitle,
+    });
+  }
+
+  for (const r of rssItems.filter((it) => it.link).slice(0, maxRss)) {
+    cards.push({
+      kind: "rss",
+      id: `rss:${r.id}`,
+      title: r.title,
+      source: r.source,
+      host: hostFromUrl(r.link),
+      url: r.link,
+      age: relativeAge(r.isoDate, nowMs),
+    });
+  }
+
+  return cards;
+}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -754,3 +754,109 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+/* ── Daily summary — an ambient, auto-scrolling digest of today's activity +
+   freshest headlines. A continuous marquee that pauses on hover/focus so a
+   card can be read or clicked, with soft fade edges. Under reduced-motion it
+   degrades to a plain manual horizontal scroll (the duplicate row is hidden). */
+.home-digest {
+  width: 100%;
+  max-width: min(1200px, 100%);
+  margin-inline: auto;
+  margin-top: 18px;
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 7%, #000 93%, transparent);
+  mask-image: linear-gradient(to right, transparent, #000 7%, #000 93%, transparent);
+}
+.home-digest__track {
+  display: flex;
+  width: max-content;
+  animation: home-digest-marquee 64s linear infinite;
+  will-change: transform;
+}
+.home-digest:hover .home-digest__track,
+.home-digest:focus-within .home-digest__track {
+  animation-play-state: paused;
+}
+@keyframes home-digest-marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+.home-digest__row {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  margin: 0;
+  padding: 0 5px;
+  list-style: none;
+}
+.home-digest__cell {
+  display: flex;
+}
+.home-digest__card {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  width: 248px;
+  padding: 9px 13px;
+  border-radius: 13px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  text-align: left;
+  cursor: pointer;
+  opacity: 0.82;
+  transition: border-color 0.14s, background 0.14s, transform 0.14s, opacity 0.14s;
+}
+.home-digest__card:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  transform: translateY(-2px);
+  opacity: 1;
+}
+.home-digest__card:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: 1px;
+  opacity: 1;
+}
+.home-digest__card--summary {
+  cursor: default;
+  opacity: 1;
+  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 35%, var(--border-hairline));
+}
+.home-digest__icon {
+  color: var(--accent-presence);
+  flex-shrink: 0;
+}
+.home-digest__body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 1px;
+}
+.home-digest__title {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.home-digest__meta {
+  font-size: 10.5px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+@media (prefers-reduced-motion: reduce) {
+  .home-digest {
+    overflow-x: auto;
+  }
+  .home-digest__track {
+    animation: none;
+  }
+  .home-digest__row[aria-hidden="true"] {
+    display: none;
+  }
+}


### PR DESCRIPTION
Adds an ambient **"Daily summary"** strip to the home page (below "Jump back in"): a continuous horizontal **auto-scroll carousel** that **pauses subtly on hover/focus** so a card can be read or clicked.

## What it shows
One combined, ordered strip:
1. **Summary card** — today's at-a-glance counts (sessions touched, reminders fired, responses waiting, familiar updates).
2. **Session cards** — the chats updated today, newest first → click to resume in-app.
3. **RSS headline cards** — the freshest merged feed items (HN, The Verge, Ars, Hugging Face, GitHub Blog, BBC World…) → click opens externally.

## Behavior
- Continuous CSS marquee; **pauses on hover and on focus-within**.
- Seamless loop via a duplicated, `aria-hidden` second row (its cards are removed from the tab order).
- Soft fade edges (mask gradient).
- **`prefers-reduced-motion`** → auto-scroll disabled, becomes a plain manual horizontal scroll.
- Hidden entirely when there's nothing to show (no activity today and no headlines).

## Design notes
- **No new API route.** Data is assembled client-side from the existing `/api/inbox` + `/api/rss`, plus the `sessions` the home composer already has.
- Ordering/formatting lives in a pure, clock-injected `buildDigestCards()` (`src/lib/home-digest.ts`) — fully unit-tested without a network or DOM.
- RSS links use the existing `openExternalUrl`; session cards reuse `onOpenSession`.

## Tests
- `home-digest.test.ts` — ordering (summary → session → rss), today-only filtering (archived/yesterday excluded), linkless-item drop, `maxRss` cap, empty + rss-only cases.
- `home-digest-carousel.test.ts` — source-text wiring + CSS behavior (marquee keyframe, hover/focus pause, reduced-motion fallback, duplicated a11y-hidden row, composer wiring).
- Both wired into `run-tests.mjs`; `tsc --noEmit` clean.

## Not done here
No live screenshot pass (the auto-scroll/hover behavior isn't meaningfully captured in a static image; CI's Frontend build + E2E exercise the home surface). Happy to do a visual pass on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)