### PR TITLE
feat(settings): tab long sections to cut scrolling (Appearance, Add-ons)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -348,6 +348,7 @@ export const SUITES = {
     "src/components/right-sidebar-fit.test.ts",
     "src/components/salem/salem.test.ts",
     "src/components/settings-shell-polish.test.ts",
+    "src/components/settings-section-tabs.test.ts",
     "src/components/theme-script.test.ts",
     "src/components/ui/error-state.test.ts",
     "src/components/ui/live-region.test.ts",

--- a/src/components/settings-section-tabs.test.ts
+++ b/src/components/settings-section-tabs.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import { tabForScrollTarget } from "../lib/settings-section-tab-map.ts";
+
+// Identity idOf so the test is independent of the real settingsGroupId slugger.
+const idOf = (label) => label;
+
+const GROUPS = {
+  theme: ["Mode", "Theme", "Import from tweakcn"],
+  colors: ["Theme tokens"],
+  text: ["Reading text"],
+  interface: ["Familiar switcher", "Corners"],
+};
+
+test("returns null when there is no scroll target", () => {
+  assert.equal(tabForScrollTarget(GROUPS, null, idOf), null);
+  assert.equal(tabForScrollTarget(GROUPS, undefined, idOf), null);
+});
+
+test("maps a group to the tab that owns it", () => {
+  assert.equal(tabForScrollTarget(GROUPS, "Mode", idOf), "theme");
+  assert.equal(tabForScrollTarget(GROUPS, "Import from tweakcn", idOf), "theme");
+  assert.equal(tabForScrollTarget(GROUPS, "Theme tokens", idOf), "colors");
+  assert.equal(tabForScrollTarget(GROUPS, "Reading text", idOf), "text");
+  assert.equal(tabForScrollTarget(GROUPS, "Corners", idOf), "interface");
+});
+
+test("returns null for an unknown group", () => {
+  assert.equal(tabForScrollTarget(GROUPS, "Nonexistent", idOf), null);
+});
+
+test("uses idOf to compare (so it works on derived DOM ids, not raw labels)", () => {
+  const slug = (label) => `settings-group-${label.toLowerCase().replace(/\s+/g, "-")}`;
+  assert.equal(tabForScrollTarget(GROUPS, "settings-group-corners", slug), "interface");
+  assert.equal(tabForScrollTarget(GROUPS, "Corners", slug), null); // raw label no longer matches
+});
+
+// Source guard: the long sections route through the shared tabbed wrapper so the
+// "minimize scrolling" behaviour can't silently regress to a flat scroll. Every
+// gated group label must also appear in its tab map (search/deep-link relies on
+// the labels matching the SettingsGroup labels).
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+
+test("Appearance and Add-ons render through SettingsTabbed", () => {
+  assert.match(shell, /import \{ SettingsTabbed \} from "\.\/settings-section-tabs"/);
+  assert.match(shell, /tabs=\{APPEARANCE_TABS\}/, "Appearance uses the appearance tab set");
+  assert.match(shell, /tabs=\{ADDONS_TABS\}/, "Add-ons uses the add-ons tab set");
+});
+
+test("every tab-map group label still has a matching SettingsGroup in the shell", () => {
+  const labels = [
+    "Mode", "Theme", "Theme tokens", "Import from tweakcn",
+    "Familiar switcher", "Corners", "Sidebar surfaces", "Integrations",
+  ];
+  for (const label of labels) {
+    assert.match(shell, new RegExp(`<SettingsGroup label="${label}"`), `${label} group still rendered`);
+  }
+});
+
+console.log("settings-section-tabs.test.ts: ok");

--- a/src/components/settings-section-tabs.tsx
+++ b/src/components/settings-section-tabs.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
+import { settingsGroupId } from "@/components/ui/settings-group";
+import { tabForScrollTarget } from "@/lib/settings-section-tab-map";
+
+/**
+ * Tabbed grouping for a long settings section.
+ *
+ * Some sections (Appearance, Add-ons) stack many SettingsGroups into one long
+ * scroll. This splits them into a few tabs so the common controls are reachable
+ * without scrolling, while keeping every group in the source (just gated by the
+ * active tab) so the section's search/deep-link behaviour and source-text guards
+ * still hold.
+ *
+ * Search integration: when the shell's `scrollTarget` (a settingsGroupId) points
+ * at a group that lives on an inactive tab, we switch to that tab first so the
+ * shell's scroll-into-view lands on a mounted element instead of a no-op.
+ */
+
+type Props<T extends string> = {
+  ariaLabel: string;
+  tabs: ReadonlyArray<TabItem<T>>;
+  /** group labels (matching their SettingsGroup label) owned by each tab. */
+  groupsByTab: Record<T, readonly string[]>;
+  /** The shell's active search/deep-link scroll target, if any. */
+  scrollTarget?: string | null;
+  /** Render the panel for the active tab. */
+  children: (tab: T) => ReactNode;
+};
+
+export function SettingsTabbed<T extends string>({
+  ariaLabel,
+  tabs,
+  groupsByTab,
+  scrollTarget,
+  children,
+}: Props<T>) {
+  const [tab, setTab] = useState<T>(tabs[0].id);
+  // Track whether the user has manually picked a tab, so a stale scrollTarget
+  // doesn't yank them away — only an *active* search target switches tabs.
+  const lastTarget = useRef<string | null>(null);
+
+  useEffect(() => {
+    const current = scrollTarget ?? null;
+    if (current === lastTarget.current) return;
+    lastTarget.current = current;
+    const target = tabForScrollTarget(groupsByTab, current, settingsGroupId);
+    if (target) setTab(target);
+  }, [scrollTarget, groupsByTab]);
+
+  return (
+    <>
+      <div className="mb-4">
+        <Tabs
+          items={tabs}
+          value={tab}
+          onChange={setTab}
+          ariaLabel={ariaLabel}
+          variant="segment"
+          size="sm"
+        />
+      </div>
+      {children(tab)}
+    </>
+  );
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -26,6 +26,8 @@ import { useIsMobile } from "@/lib/use-viewport";
 import { ThemeColorEditor } from "@/components/theme-color-editor";
 import { rgbaBytesToHex } from "@/lib/theme-token-hex";
 import { FontSettings } from "./settings-fonts";
+import { SettingsTabbed } from "./settings-section-tabs";
+import type { TabItem } from "@/components/ui/tabs";
 import {
   CORNER_RADIUS_OPTIONS,
   CORNER_RADIUS_LABELS,
@@ -316,9 +318,9 @@ export function SettingsShell() {
           {section === "daemon"   && <DaemonSection />}
           {section === "familiars" && <FamiliarsSection />}
           {section === "permissions" && <PermissionsSection />}
-          {section === "addons"   && <AddonsSection />}
+          {section === "addons"   && <AddonsSection scrollTarget={scrollTarget} />}
           {section === "mobile"   && <MobileSection />}
-          {section === "appearance" && <AppearanceSection />}
+          {section === "appearance" && <AppearanceSection scrollTarget={scrollTarget} />}
           {section === "about"    && <AboutSection />}
         </main>
       </div>
@@ -587,7 +589,17 @@ const DEFAULT_ADDONS = Object.fromEntries(
   ADDON_ROWS.map((r) => [r.key, false]),
 ) as Record<AddonKey, boolean>;
 
-function AddonsSection() {
+type AddonsTab = "surfaces" | "integrations";
+const ADDONS_TABS: ReadonlyArray<TabItem<AddonsTab>> = [
+  { id: "surfaces", label: "Surfaces" },
+  { id: "integrations", label: "Integrations" },
+];
+const ADDONS_TAB_GROUPS: Record<AddonsTab, readonly string[]> = {
+  surfaces: ["Sidebar surfaces"],
+  integrations: ["Integrations"],
+};
+
+function AddonsSection({ scrollTarget }: { scrollTarget?: string | null }) {
   const [addons, setAddons] = useState<Record<AddonKey, boolean>>(DEFAULT_ADDONS);
   const [loading, setLoading] = useState(true);
   const [toggleError, setToggleError] = useState<string | null>(null);
@@ -679,12 +691,27 @@ function AddonsSection() {
       {toggleError && (
         <p role="alert" className="mb-2 px-1 text-[12px] text-[var(--color-danger)]">{toggleError}</p>
       )}
+      <SettingsTabbed
+        ariaLabel="Add-on settings"
+        tabs={ADDONS_TABS}
+        groupsByTab={ADDONS_TAB_GROUPS}
+        scrollTarget={scrollTarget}
+      >
+        {(tab) => (
+          <>
+      {tab === "surfaces" && (
       <SettingsGroup label="Sidebar surfaces">
         {loading ? skeleton(4) : ADDON_ROWS.filter((r) => r.group === "surfaces").map(renderRow)}
       </SettingsGroup>
+      )}
+      {tab === "integrations" && (
       <SettingsGroup label="Integrations">
         {loading ? skeleton(2) : ADDON_ROWS.filter((r) => r.group === "integrations").map(renderRow)}
       </SettingsGroup>
+      )}
+          </>
+        )}
+      </SettingsTabbed>
     </SettingsPage>
   );
 }
@@ -1142,7 +1169,25 @@ function ThemeTokenOverrides({
 
 // ─── Section: Appearance ───────────────────────────────────────────────────────────────────────
 
-function AppearanceSection() {
+// Appearance stacks 7 groups — tab them so the common controls don't require a
+// long scroll. Labels in APPEARANCE_TAB_GROUPS must match each SettingsGroup
+// label so search/deep-link can switch to the right tab. Module-level (stable
+// ref) so the tab effect doesn't re-run every render.
+type AppearanceTab = "theme" | "colors" | "text" | "interface";
+const APPEARANCE_TABS: ReadonlyArray<TabItem<AppearanceTab>> = [
+  { id: "theme", label: "Theme" },
+  { id: "colors", label: "Colors" },
+  { id: "text", label: "Text" },
+  { id: "interface", label: "Interface" },
+];
+const APPEARANCE_TAB_GROUPS: Record<AppearanceTab, readonly string[]> = {
+  theme: ["Mode", "Theme", "Import from tweakcn"],
+  colors: ["Theme tokens"],
+  text: ["Reading text"],
+  interface: ["Familiar switcher", "Corners"],
+};
+
+function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
   const [activeTheme, setActiveTheme] = useState<ActiveTheme>("coven");
   const [mode, setMode] = useState<ModePref>("dark");
   const [customData, setCustomData] = useState<CustomThemeData | null>(null);
@@ -1317,14 +1362,25 @@ function AppearanceSection() {
 
   return (
     <SettingsPage title="Appearance" description="Colors and visual style.">
+      <SettingsTabbed
+        ariaLabel="Appearance settings"
+        tabs={APPEARANCE_TABS}
+        groupsByTab={APPEARANCE_TAB_GROUPS}
+        scrollTarget={scrollTarget}
+      >
+        {(tab) => (
+          <>
       {/* ── Mode toggle ── */}
+      {tab === "theme" && (
       <SettingsGroup label="Mode">
         <div className="px-4 py-3">
           <ModeToggle value={mode} onChange={handleSetMode} />
         </div>
       </SettingsGroup>
+      )}
 
       {/* ── Preset themes ── */}
+      {tab === "theme" && (
       <SettingsGroup label="Theme">
         {/* Custom theme chip */}
         {activeTheme === "custom" && customData && (
@@ -1396,8 +1452,10 @@ function AppearanceSection() {
           </div>
         )}
       </SettingsGroup>
+      )}
 
       {/* ── Per-token overrides + manual resync ── */}
+      {tab === "colors" && (
       <SettingsGroup label="Theme tokens">
         <ThemeTokenOverrides
           mode={resolveMode(mode)}
@@ -1423,8 +1481,10 @@ function AppearanceSection() {
           </span>
         </div>
       </SettingsGroup>
+      )}
 
       {/* ── tweakcn import ── */}
+      {tab === "theme" && (
       <SettingsGroup label="Import from tweakcn">
         <div className="flex flex-col gap-2 px-4 py-3">
           <p className="text-[12px] text-[var(--text-muted)]">
@@ -1483,11 +1543,13 @@ function AppearanceSection() {
           )}
         </div>
       </SettingsGroup>
+      )}
 
-      <FontSettings />
+      {tab === "text" && <FontSettings />}
 
       {/* ── Familiar switcher ── choose the top-bar familiar control: a row of
           quick-switch avatars, or just the switcher dropdown. */}
+      {tab === "interface" && (
       <SettingsGroup label="Familiar switcher">
         <SettingControlRow
           label="Top-bar style"
@@ -1534,9 +1596,11 @@ function AppearanceSection() {
           </>
         ) : null}
       </SettingsGroup>
+      )}
 
       {/* ── Corner radius ── a minor shape tweak (drives the shared --radius
           tokens), kept last so the primary color/theme and text controls lead. */}
+      {tab === "interface" && (
       <SettingsGroup label="Corners">
         <SettingControlRow
           label="Corner radius"
@@ -1551,6 +1615,10 @@ function AppearanceSection() {
           />
         </SettingControlRow>
       </SettingsGroup>
+      )}
+          </>
+        )}
+      </SettingsTabbed>
     </SettingsPage>
   );
 }

--- a/src/lib/settings-section-tab-map.ts
+++ b/src/lib/settings-section-tab-map.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure mapping from a settings scroll-target (a settingsGroupId) to the tab that
+ * owns it, so a tabbed settings section can switch tabs when search/deep-link
+ * points at a group on an inactive tab. React-free so it can be unit-tested
+ * without the settings-group / tabs component modules.
+ */
+export function tabForScrollTarget<T extends string>(
+  groupsByTab: Record<T, readonly string[]>,
+  scrollTarget: string | null | undefined,
+  idOf: (label: string) => string,
+): T | null {
+  if (!scrollTarget) return null;
+  for (const tab of Object.keys(groupsByTab) as T[]) {
+    if (groupsByTab[tab].some((label) => idOf(label) === scrollTarget)) return tab;
+  }
+  return null;
+}


### PR DESCRIPTION
Settings → **Appearance** stacked 7 groups (Mode, Theme, Theme tokens, tweakcn import, Reading text, Familiar switcher, Corners) into one long scroll. This splits it into tabs so the common controls are reachable without scrolling, and applies the same pattern to **Add-ons**.

## What you get

- **Appearance** → tabs: **Theme** (Mode + presets + tweakcn import) · **Colors** (theme tokens) · **Text** (reading/fonts) · **Interface** (familiar switcher + corners).
- **Add-ons** → tabs: **Surfaces** · **Integrations**.

Verified all tabs render in a real browser build.

## How

- New reusable **`SettingsTabbed`** wrapper on the shared `Tabs` component (segment variant). Groups stay in the source — just gated by the active tab — so each section's source-text guards and the settings **search index** keep working unchanged.
- **Search / deep-link preserved**: the shell's `scrollTarget` (a `settingsGroupId`) is passed into the section; when it points at a group on an inactive tab, `SettingsTabbed` switches to that tab first so scroll-into-view lands on a mounted element instead of a no-op. The mapping is a pure, React-free helper (`settings-section-tab-map.ts`) so it's unit-tested in isolation.
- Nothing removed — every group, toggle, and control is unchanged.

## Tests

- `settings-section-tabs.test.ts`: `tabForScrollTarget` mapping (incl. the `idOf` indirection so it works on derived DOM ids) + source guards that both sections route through `SettingsTabbed` and every tab-map label still renders its `SettingsGroup`. Wired into `run-tests.mjs`.
- Existing `settings-search` / `settings-shell-polish` / `settings-permissions` tests still pass (`SETTINGS_INDEX` untouched, all group JSX retained).

`typecheck` ✓, `check:tests-wired` ✓, `test:app` (480) ✓, `test:api` (100) ✓, `test:mobile` (65) ✓, `pnpm build` ✓.

> ⚠️ Heads-up: a concurrent session is refactoring the Settings **shell** (extracting `SETTINGS_INDEX` into `settings-sections.ts` + a `SettingsOverview` picker). This PR only edits the `AppearanceSection`/`AddonsSection` bodies, so overlap is small, but whichever lands second on `settings-shell.tsx` will need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)