### PR TITLE
fix(familiars): always prefer the avatar image over the icon

### DIFF
--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -12,12 +12,12 @@ assert.match(source, /FamiliarGlyph/, "Must fall back to FamiliarGlyph when no i
 assert.match(source, /<img/, "Must render an <img> for image avatars");
 assert.match(source, /alt=/, "img must have alt text for a11y");
 
-// On a failed image load, fall back to the glyph instead of leaving the
-// browser's broken-image placeholder (the avatar route's 404 contract relies
-// on this). The <img> must carry an onError that flips to the fallback, and
-// the render must be gated on that error state.
-assert.match(source, /onError=\{\(\) => setErrored\(true\)\}/, "img must fall back on load error");
-assert.match(source, /familiar\.avatarImage\)? && !errored/, "render must gate the img on the not-errored state");
-assert.match(source, /useEffect\(\s*\(\) => \{\s*setErrored\(false\);\s*\}, \[familiar\.avatarImage\]\)/, "error state must reset when the avatar src changes");
+// The avatar image is preferred over the glyph, and EVERY image source is tried
+// before the glyph: a failed load advances through the source list (workspace
+// avatar → Cave-local upload) and only renders the glyph once all sources fail.
+assert.match(source, /avatarImageFallback/, "must consume the fallback image source");
+assert.match(source, /onError=\{\(\) => setSrcIdx\(\(i\) => i \+ 1\)\}/, "img must advance to the next source on load error");
+assert.match(source, /const hasImage = Boolean\(currentSrc\)/, "render must gate the img on a resolvable current source");
+assert.match(source, /useEffect\(\s*\(\) => \{\s*setSrcIdx\(0\);\s*\}, \[familiar\.avatarImage, familiar\.avatarImageFallback\]\)/, "source index must reset when either avatar src changes");
 
 console.log("familiar-avatar.test.ts: ok");

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { FamiliarGlyph } from "./familiar-glyph";
 import { Modal } from "./ui/modal";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -20,28 +20,38 @@ type Props = {
 
 export function FamiliarAvatar({ familiar, size = "md", className, title, expandable }: Props) {
   const px = PX[size];
-  // Fall back to the glyph when the avatar image fails to load (e.g. a
-  // transient 404 while the avatar route compiles on a cold start, a timeout,
-  // or a decode failure) instead of leaving the browser's broken-image
-  // placeholder. The avatar route's 404 contract assumes this fallback. Reset
-  // on src change so a new familiar/version re-attempts the image.
-  const [errored, setErrored] = useState(false);
+  // Prefer the avatar image over the glyph, and try EVERY available image source
+  // before ever falling back to the glyph. The glyph is the last resort — it
+  // must only show when no avatar image loads. A failed load (transient 404 on a
+  // cold-start avatar route, a timeout, a decode failure, or a missing format)
+  // advances to the next source (e.g. the workspace avatar → a Cave-local
+  // upload) instead of dropping straight to the icon. Reset on src change so a
+  // new familiar/version re-attempts from the top.
+  const sources = useMemo(
+    () =>
+      [familiar.avatarImage, familiar.avatarImageFallback].filter(
+        (s): s is string => Boolean(s),
+      ),
+    [familiar.avatarImage, familiar.avatarImageFallback],
+  );
+  const [srcIdx, setSrcIdx] = useState(0);
   const [enlarged, setEnlarged] = useState(false);
   useEffect(() => {
-    setErrored(false);
-  }, [familiar.avatarImage]);
+    setSrcIdx(0);
+  }, [familiar.avatarImage, familiar.avatarImageFallback]);
 
-  const hasImage = Boolean(familiar.avatarImage) && !errored;
+  const currentSrc = sources[srcIdx];
+  const hasImage = Boolean(currentSrc);
 
   const imgEl = hasImage ? (
     <img
-      src={familiar.avatarImage}
+      src={currentSrc}
       alt={familiar.display_name}
       width={px}
       height={px}
       className={className ?? "inline-block rounded-sm object-cover"}
       title={title}
-      onError={() => setErrored(true)}
+      onError={() => setSrcIdx((i) => i + 1)}
     />
   ) : (
     <FamiliarGlyph
@@ -73,7 +83,7 @@ export function FamiliarAvatar({ familiar, size = "md", className, title, expand
           >
             <div className="grid aspect-square w-full max-w-[320px] place-items-center overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)]">
               <img
-                src={familiar.avatarImage}
+                src={currentSrc}
                 alt={`${familiar.display_name} avatar`}
                 className="h-full w-full object-cover"
               />

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -25,6 +25,8 @@ import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
@@ -132,6 +134,13 @@ export function HomeComposer({
   const selectedFamiliar = useMemo(
     () => familiars.find((familiar) => familiar.id === selectedFamiliarId) ?? null,
     [familiars, selectedFamiliarId],
+  );
+  // Resolve avatars so the selector chip shows the selected familiar's actual
+  // avatar image (falling back to its glyph) instead of a static sparkle icon.
+  const resolvedFamiliars = useResolvedFamiliars(familiars);
+  const selectedResolved = useMemo(
+    () => resolvedFamiliars.find((familiar) => familiar.id === selectedFamiliarId) ?? null,
+    [resolvedFamiliars, selectedFamiliarId],
   );
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
   const { projects } = useProjects({ familiarId: selectedFamiliarId || null });
@@ -623,7 +632,11 @@ export function HomeComposer({
           </button>
 
           <label className="hc-familiar-selector">
-            <Icon name="ph:sparkle" width={13} className="hc-familiar-glyph" aria-hidden />
+            {selectedResolved ? (
+              <FamiliarAvatar familiar={selectedResolved} size="sm" className="hc-familiar-glyph hc-familiar-avatar" />
+            ) : (
+              <Icon name="ph:sparkle" width={13} className="hc-familiar-glyph" aria-hidden />
+            )}
             <select
               aria-label="Choose chat agent"
               className="hc-familiar-select"

--- a/src/lib/familiar-resolve.test.ts
+++ b/src/lib/familiar-resolve.test.ts
@@ -51,6 +51,33 @@ const base = {
   assert.equal(r.avatarImage, "data:image/png;base64,AAA");
   // Glyph still resolved for fallback
   assert.equal(r.glyph.name, "ph:wand-fill");
+  // Upload-only: no second source to fall back through.
+  assert.equal(r.avatarImageFallback, undefined);
+}
+
+// Workspace avatar present: it's the primary image source.
+{
+  const r = resolveFamiliar(
+    { ...base, avatarUrl: "/api/familiars/x/avatar?v=1" },
+    { archived: false },
+  );
+  assert.equal(r.avatarImage, "/api/familiars/x/avatar?v=1");
+  assert.equal(r.avatarImageFallback, undefined, "no upload → no fallback source");
+}
+
+// BOTH a workspace avatar AND a Cave-local upload: the workspace avatar is the
+// primary and the upload is kept as the fallback so a failed workspace image
+// degrades to the upload (never straight to the glyph).
+{
+  const r = resolveFamiliar(
+    { ...base, avatarUrl: "/api/familiars/x/avatar?v=1" },
+    {
+      image: { dataUrl: "data:image/png;base64,AAA", mime: "image/png", updatedAt: "2026-06-08T00:00:00Z" },
+      archived: false,
+    },
+  );
+  assert.equal(r.avatarImage, "/api/familiars/x/avatar?v=1");
+  assert.equal(r.avatarImageFallback, "data:image/png;base64,AAA");
 }
 
 // Glyph override wins

--- a/src/lib/familiar-resolve.ts
+++ b/src/lib/familiar-resolve.ts
@@ -21,6 +21,13 @@ export type ResolvedFamiliar = Omit<Familiar, "display_name" | "role"> & {
    * exists — the glyph renders instead.
    */
   avatarImage?: string;
+  /**
+   * The *other* avatar image source, if both exist — lets `FamiliarAvatar`
+   * degrade a failed primary image to the alternate image (workspace avatar ↔
+   * Cave-local upload) before ever falling back to the glyph. Undefined when
+   * only one source exists.
+   */
+  avatarImageFallback?: string;
   /** Absolute `~/.coven` workspace avatar path (loads only via Tauri's asset
    *  protocol, resolved client-side post-mount). Consumed by familiar-avatar-src. */
   avatarPath?: string;
@@ -49,9 +56,13 @@ export function resolveFamiliar(base: Familiar, ctx: ResolveContext): ResolvedFa
     description: ov.description ?? base.description,
     color: ov.color ?? base.color ?? "var(--accent-presence)",
     // The familiar's workspace avatar (.../familiars/<id>/avatars/<img>) is the
-    // source of truth and always wins; a Cave-local upload is only the fallback
-    // when the familiar has no workspace avatar on disk.
+    // source of truth and wins as the primary; a Cave-local upload is the
+    // fallback. Crucially, when BOTH exist the upload is kept as
+    // `avatarImageFallback` so a failed workspace image degrades to the upload
+    // (not straight to the glyph) — the avatar image is always preferred over
+    // the icon when any source can load.
     avatarImage: base.avatarUrl ?? ctx.image?.dataUrl,
+    avatarImageFallback: base.avatarUrl ? ctx.image?.dataUrl : undefined,
     glyph: resolveFamiliarGlyph(
       { id: base.id, icon: base.icon, emoji: base.emoji, role: ov.role ?? base.role },
       glyphOverrides,

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -221,6 +221,16 @@
   flex-shrink: 0;
 }
 
+/* Avatar image variant of the selector glyph: passing a className to
+   FamiliarAvatar overrides its default img styling, so restore the rounded,
+   cover-fit avatar look at the selector's icon size. */
+.hc-familiar-avatar {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  object-fit: cover;
+}
+
 .hc-familiar-select {
   font-size: 12px;
   font-weight: 500;


### PR DESCRIPTION
## Problem

Familiars kept showing their **icon/glyph** even though they have avatar images. Two distinct causes:

1. **`FamiliarAvatar` gave up too early.** On *any* image load failure (a cold-start 404 while the `sharp`-backed avatar route compiles, a timeout, a decode/format hiccup) it fell **straight to the glyph**, ignoring any other available image source.
2. **The Home composer never showed an avatar at all.** Its familiar selector rendered a hardcoded `ph:sparkle` icon next to the `<select>` — so the prominent home-screen chip was always an icon (`✦ Nova`), never the familiar's portrait.

## Fix

- **`familiar-avatar.tsx`** — render through an ordered list of image sources (workspace avatar → Cave-local upload) and only fall back to the glyph once **every** source fails. `resolveFamiliar` exposes the alternate source as `avatarImageFallback`.
- **`home-composer.tsx`** — the selector chip now renders the selected familiar's `FamiliarAvatar` (image, with glyph fallback) instead of the static sparkle. `+` small CSS for the 16px rounded chip avatar.

The glyph is now strictly the **last resort** — the image always wins when any source can load.

## Verification (live dev server)

- Avatar route returns `200 image/png`; the Home chip renders Nova's portrait (`naturalWidth 256`) in place of the sparkle.
- Updated unit test (`familiar-resolve`: both-sources → `avatarImageFallback` set) + source-text test (`familiar-avatar`: source-chain) + all home-composer tests green; `pnpm typecheck` clean.

### Before → After (Home composer chip)
`✦ Nova`  →  `🖼 Nova` (actual avatar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)