### PR TITLE
feat(code): collapse the Code surface into Chat·Files·Changes tabs

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -17,46 +17,50 @@ const globals = await readFile(new URL("../app/globals.css", import.meta.url), "
 const toolbar = await readFile(new URL("./code-inline-toolbar.tsx", import.meta.url), "utf8");
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 
-// ── CodeView is a two-pane resizable shell, chat | comux ─────────────────────
-assert.match(codeView, /orientation="horizontal"/, "CodeView lays the panes out horizontally");
-assert.match(codeView, /id="code-chat"[\s\S]*?\{chat\}/, "the left pane renders the chat slot");
-assert.match(codeView, /id="code-comux"[\s\S]*?\{comux\}/, "the right pane renders the comux slot");
-// Its own persisted layout key, independent of chat/shell.
-assert.match(codeView, /CODE_GROUP_ID = "cave\.code\.widths\.v1"/, "CodeView persists under its own storage key");
-// Mobile: a Chat / Code segmented switcher swaps which pane is full-screen
-// (a horizontal split is unusable on a phone); both panes stay mounted so
-// their state survives tab taps.
-assert.match(codeView, /if \(isMobile\) \{/, "mobile gets a dedicated layout branch");
-assert.match(codeView, /onChange=\{setMobileTab\}/, "mobile has a Chat/Code tab switcher via shared Tabs");
+// ── CodeView is a single tabbed surface — Chat · Files · Changes ─────────────
+// One tab fills the surface at a time (Codex-style, no side-by-side split). All
+// three panes stay mounted (hidden, not unmounted) so chat/terminals/preview/
+// diff keep their state across tab taps.
+assert.match(codeView, /type CodeTab = "chat" \| "files" \| "changes"/, "CodeView models the three tabs");
+assert.match(codeView, /<Tabs[\s\S]*?ariaLabel="Code view"[\s\S]*?value=\{tab\}/, "a shared Tabs control switches Chat/Files/Changes");
+assert.match(codeView, /id: "chat"[\s\S]*?id: "files"[\s\S]*?id: "changes"/, "the tab bar lists chat, files and changes");
+assert.match(codeView, /cave-code-page__pane--chat[\s\S]*?tab === "chat" \? "flex" : "hidden"/, "the chat pane shows only on the Chat tab (hidden, not unmounted)");
+assert.match(codeView, /cave-code-page__pane--workspace[\s\S]*?tab !== "chat" \? "flex" : "hidden"/, "the comux pane backs both the Files and Changes tabs");
+assert.match(codeView, /\{chat\}/, "the chat pane renders the chat slot");
+// Files and Changes are two faces of ONE comux instance: it's cloned with a
+// controlled rightView tied to the active tab, so toggling Files↔Changes never
+// remounts the terminals or preview. comux routes its own diff-first / file-open
+// switches back through onRightViewChange to select the matching tab.
 assert.match(
   codeView,
-  /mobileTab === "chat" \? "flex" : "hidden"[\s\S]*?mobileTab === "code" \? "flex" : "hidden"/,
-  "the inactive mobile pane is hidden (not unmounted) so state persists",
+  /cloneElement\([\s\S]*?rightView: tab === "changes" \? "changes" : "files",[\s\S]*?onRightViewChange,/,
+  "comux is cloned with a controlled rightView bound to the active tab",
 );
-// Desktop keeps the two-pane resizable split under its own key.
-assert.match(codeView, /panelIds: \["code-chat", "code-comux"\]/, "desktop mounts both panels in the split");
-assert.match(codeView, /data-code-layout="codex"/, "desktop Code mode advertises the Codex-like layout for scoped styling");
-assert.match(codeView, /className="cave-code-page/, "desktop Code mode owns a full-page layout shell");
-assert.match(codeView, /cave-code-page__pane cave-code-page__pane--chat/, "chat pane gets the left conversation-column wrapper");
-assert.match(codeView, /cave-code-page__pane cave-code-page__pane--workspace/, "comux pane gets the main workspace wrapper");
-assert.match(globals, /\.cave-code-page\s*\{[\s\S]*?background:[\s\S]*?\.cave-code-page__pane--workspace/, "Code page shell defines the Codex-like desktop chrome");
+assert.match(
+  codeView,
+  /const onRightViewChange = useCallback\(\(next: "files" \| "changes"\) => setTab\(next\)/,
+  "comux's own view switches (file-open, diff-first) select the matching tab",
+);
+assert.match(codeView, /data-code-layout="codex"/, "Code mode advertises the Codex-like layout for scoped styling");
+assert.match(codeView, /className="cave-code-page/, "Code mode owns a full-page layout shell");
+assert.match(codeView, /cave-code-page__pane cave-code-page__pane--chat/, "chat pane keeps the conversation-column wrapper");
+assert.match(codeView, /cave-code-page__pane cave-code-page__pane--workspace/, "comux pane keeps the main workspace wrapper");
+assert.match(globals, /\.cave-code-page\s*\{[\s\S]*?background:[\s\S]*?\.cave-code-page__pane--workspace/, "Code page shell defines the Codex-like chrome");
 assert.match(globals, /@media \(max-width: 1023px\)[\s\S]*?\.cave-code-page/, "Code page chrome has a mobile/narrow override");
+// The side-by-side split is gone: no resizable Group/Panel, no panel-resize presets.
+assert.doesNotMatch(codeView, /orientation="horizontal"/, "the resizable split is replaced by tabs");
+assert.doesNotMatch(codeView, /usePanelRef|panelRef=\{chatPanelRef\}|CODE_PRESET_CHAT_SIZE/, "no chat-panel resize logic remains");
 
-// ── Layout presets (Chat / Split / Review) re-weight the desktop split ───────
+// ── Layout presets (Chat / Split / Review) map onto the tabs ─────────────────
 // The preset chips live on the chat surface's tab row (CodeInlineToolbar) and
-// broadcast CODE_PRESET_EVENT; code-view owns the chat-panel resize via a
-// listener — no remount, so the comux terminals/preview keep their state. The
-// chip selection persists under its own key; pane sizes persist under CODE_GROUP_ID.
-assert.match(codeView, /usePanelRef/, "desktop uses a panel ref to drive presets");
-assert.match(codeView, /panelRef=\{chatPanelRef\}/, "the chat panel takes the preset handle via panelRef");
-assert.match(codeView, /addEventListener\(CODE_PRESET_EVENT/, "code-view listens for the preset broadcast");
-assert.match(codeView, /chatPanelRef\.current\?\.resize\(CODE_PRESET_CHAT_SIZE\[/, "presets resize the chat panel (comux fills the rest)");
-assert.match(toolbar, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
+// broadcast CODE_PRESET_EVENT; CodeView maps Chat→Chat, Split→Files, Review→Changes.
+assert.match(codeView, /addEventListener\(CODE_PRESET_EVENT/, "CodeView listens for the preset broadcast");
 assert.match(
   codeView,
-  /codeStorage\.getItem\(CODE_GROUP_ID\) == null/,
-  "the stored preset is applied only when no dragged layout exists (no clobbering manual drags)",
+  /preset === "chat" \? "chat" : preset === "review" \? "changes" : "files"/,
+  "each preset selects its matching tab",
 );
+assert.match(toolbar, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
 assert.match(toolbar, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
 // The toolbar is mounted on the Code surface's tab row + carries the panel toggle.
 // (Standalone chat shows the Power-mode toggle on that row instead of null.)

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -1,145 +1,84 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
-import { Group, Panel, Separator, useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { cloneElement, isValidElement, useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
 import { Tabs } from "@/components/ui/tabs";
-import { Icon } from "@/lib/icon";
-import { useIsMobile } from "@/lib/use-viewport";
 import {
-  CODE_PRESET_CHAT_SIZE,
   CODE_PRESET_EVENT,
-  readCodePreset,
   type CodePreset,
 } from "@/lib/code-layout-preset";
 
-const CODE_GROUP_ID = "cave.code.widths.v1";
-
-const codeStorage = {
-  getItem(key: string): string | null {
-    if (typeof window === "undefined") return null;
-    try {
-      return window.localStorage.getItem(key);
-    } catch {
-      return null;
-    }
-  },
-  setItem(key: string, value: string): void {
-    if (typeof window === "undefined") return;
-    try {
-      window.localStorage.setItem(key, value);
-    } catch {
-      /* ignore — strict privacy mode or storage quota */
-    }
-  },
-};
-
 type Props = {
-  /** Familiar conversation pane (left). */
+  /** Familiar conversation pane. */
   chat: ReactNode;
-  /** Code pane (right): the comux surface — file tree + editable preview +
-   *  terminal + project search. */
+  /** Code pane: the comux surface — file tree + editable preview + terminal +
+   *  project search + the working-tree changes review. */
   comux: ReactNode;
 };
 
 /**
- * Unified Code workspace (mode "code"): a familiar chat on the left beside the
- * full comux coding surface on the right, in one resizable two-pane split. A
- * thin layout shell — both panes are existing components (ChatSurface,
- * ComuxView) composed here, not rewritten. The split width persists under its
- * own storage key, independent of the chat surface's and shell's layouts.
+ * Unified Code workspace (mode "code"): a single tabbed surface with three
+ * tabs — Chat · Files · Changes. Instead of a side-by-side split, one tab fills
+ * the surface at a time (Codex-style). All three panes stay mounted (hidden, not
+ * unmounted) so the conversation, terminals, file preview, and diff review keep
+ * their state across tab switches.
+ *
+ * The Files and Changes tabs are two faces of the same ComuxView instance: it is
+ * rendered once and told which sub-view to show via the controlled `rightView`
+ * prop, so switching Files↔Changes never remounts the terminals or preview.
  */
-type MobileTab = "chat" | "code";
+type CodeTab = "chat" | "files" | "changes";
 
 export function CodeView({ chat, comux }: Props) {
-  const isMobile = useIsMobile();
-  const [mobileTab, setMobileTab] = useState<MobileTab>("chat");
+  // Default to Files: choosing "Code" over "Chat" is a request to see code, and
+  // the conversation is one tab away. Edits auto-surface the Changes tab.
+  const [tab, setTab] = useState<CodeTab>("files");
 
-  // Mobile: a side-by-side split is unusable on a phone, so show one pane
-  // full-screen with a Chat / Code segmented switcher. Both panes stay mounted
-  // (hidden, not unmounted) so the terminal/chat keep their state across taps.
-  if (isMobile) {
-    return (
-      <div className="cave-code-page cave-code-page--mobile flex min-h-0 min-w-0 flex-1 flex-col">
-        <div className="cave-code-page__mobile-tabs flex shrink-0 items-center justify-center gap-1 border-b border-[var(--border-hairline)] p-1.5">
-          <Tabs
-            variant="segment"
-            size="sm"
-            ariaLabel="Code view"
-            value={mobileTab}
-            onChange={setMobileTab}
-            items={[
-              { id: "chat", label: "Chat", icon: "ph:chats" },
-              { id: "code", label: "Code", icon: "ph:code" },
-            ]}
-          />
-        </div>
-        <div className={`cave-code-page__mobile-pane min-h-0 flex-1 flex-col ${mobileTab === "chat" ? "flex" : "hidden"}`}>{chat}</div>
-        <div className={`cave-code-page__mobile-pane min-h-0 flex-1 flex-col ${mobileTab === "code" ? "flex" : "hidden"}`}>{comux}</div>
-      </div>
-    );
-  }
+  // Files and Changes are the same comux surface in two states. Render it once
+  // and drive its right pane from the active tab; comux routes its own
+  // diff-first auto-switch / file-open events back through onRightViewChange so
+  // an agent edit (or a file click in chat) lands us on the right tab.
+  const onRightViewChange = useCallback((next: "files" | "changes") => setTab(next), []);
+  const comuxNode = isValidElement(comux)
+    ? cloneElement(comux as ReactElement<Record<string, unknown>>, {
+        rightView: tab === "changes" ? "changes" : "files",
+        onRightViewChange,
+      })
+    : comux;
 
-  return (
-    <DesktopCodeView chat={chat} comux={comux} />
-  );
-}
-
-function DesktopCodeView({ chat, comux }: Props) {
-  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
-    id: CODE_GROUP_ID,
-    panelIds: ["code-chat", "code-comux"],
-    storage: codeStorage,
-  });
-  const chatPanelRef = usePanelRef();
-
+  // The Chat/Split/Review preset chips (CodeInlineToolbar, on the chat tab row)
+  // map onto the tabs: Chat → Chat, Split → Files, Review → Changes. comux also
+  // nudges Files/Changes via onRightViewChange, so this only has to own the Chat
+  // case — but mapping all three keeps the behaviour explicit and self-contained.
   useEffect(() => {
-    // Apply the stored preset's width ONLY on a first-ever load (no dragged
-    // layout persisted yet), so we never clobber a manual drag on reload — the
-    // "default only when unstored" idiom. After this, useDefaultLayout restores
-    // the persisted sizes.
-    if (codeStorage.getItem(CODE_GROUP_ID) == null) {
-      chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[readCodePreset()]);
-    }
-    // The preset chips now live on the chat surface's tab row (CodeInlineToolbar)
-    // and broadcast CODE_PRESET_EVENT; here we own the chat-pane resize. Going
-    // through onLayoutChanged persists the size, and there's no remount so the
-    // comux terminals/file preview keep their state.
     const onPreset = (e: Event) => {
       const preset = (e as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
-      if (preset) chatPanelRef.current?.resize(CODE_PRESET_CHAT_SIZE[preset]);
+      if (!preset) return;
+      setTab(preset === "chat" ? "chat" : preset === "review" ? "changes" : "files");
     };
     window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
     return () => window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
-    // run once on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
-    <div className="cave-code-page flex min-h-0 min-w-0 flex-1 flex-col" data-code-layout="codex">
-      <Group
-        className="cave-code-page__split flex min-h-0 min-w-0 flex-1"
-        orientation="horizontal"
-        defaultLayout={defaultLayout}
-        onLayoutChanged={onLayoutChanged}
-      >
-        <Panel
-          panelRef={chatPanelRef}
-          id="code-chat"
-          className="cave-code-page__resizable cave-code-page__resizable--chat flex min-h-0 min-w-0"
-          defaultSize="38%"
-          minSize="28%"
-          maxSize="75%"
-        >
-          <div className="cave-code-page__pane cave-code-page__pane--chat flex min-h-0 min-w-0 flex-1 flex-col">{chat}</div>
-        </Panel>
-        <Separator className="cave-code-page__separator shell-separator hidden lg:flex">
-          <SeparatorHandle orientation="col" />
-        </Separator>
-        <Panel id="code-comux" className="cave-code-page__resizable cave-code-page__resizable--workspace hidden min-h-0 min-w-0 lg:flex" minSize="35%">
-          <div className="cave-code-page__pane cave-code-page__pane--workspace flex min-h-0 min-w-0 flex-1 flex-col">{comux}</div>
-        </Panel>
-      </Group>
+    <div className="cave-code-page cave-code-page--tabbed flex min-h-0 min-w-0 flex-1 flex-col" data-code-layout="codex">
+      <div className="cave-code-page__tabs flex shrink-0 items-center justify-center gap-1 border-b border-[var(--border-hairline)] p-1.5">
+        <Tabs
+          variant="segment"
+          size="sm"
+          ariaLabel="Code view"
+          value={tab}
+          onChange={(id) => setTab(id as CodeTab)}
+          items={[
+            { id: "chat", label: "Chat", icon: "ph:chats" },
+            { id: "files", label: "Files", icon: "ph:file-code" },
+            { id: "changes", label: "Changes", icon: "ph:git-diff" },
+          ]}
+        />
+      </div>
+      {/* Inactive panes are hidden (not unmounted) so terminals/chat/preview keep
+          their state across tab taps. */}
+      <div className={`cave-code-page__pane cave-code-page__pane--chat min-h-0 flex-1 flex-col ${tab === "chat" ? "flex" : "hidden"}`}>{chat}</div>
+      <div className={`cave-code-page__pane cave-code-page__pane--workspace min-h-0 flex-1 flex-col ${tab !== "chat" ? "flex" : "hidden"}`}>{comuxNode}</div>
     </div>
   );
 }

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -241,7 +241,10 @@ assert.match(
 );
 assert.match(
   source,
-  /ProjectTree[\s\S]*?<\/div>\s*<\/div>\s*<\/div>\s*\)\}\s*\{filePreviewCollapsed \? \([\s\S]*?<div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">[\s\S]*?previewPath/,
+  // The file-tree column is wrapped in a `{!(isControlledRightView && rightView === "changes") && (…)}`
+  // guard (so Changes is a full-width tab when the Code workspace controls the
+  // view), hence the doubled `))}` closing the tree-column ternary.
+  /ProjectTree[\s\S]*?<\/div>\s*<\/div>\s*<\/div>\s*\)\)\}\s*\{filePreviewCollapsed \? \([\s\S]*?<div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">[\s\S]*?previewPath/,
   "Projects preview pane should be the right full-height half of the split",
 );
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -103,6 +103,13 @@ type Props = {
    *  from other ComuxView instances (e.g. the Code workspace keeps its own
    *  terminals separate from the standalone Terminal surface). */
   storageNamespace?: string;
+  /** Controlled right-pane view. When provided (with onRightViewChange), the
+   *  parent owns the Files↔Changes selection — the Code workspace drives it from
+   *  its top-level tabs — and comux hides its own inline Files/Changes toggle and
+   *  collapses the file-tree column while Changes is shown (so Changes is a
+   *  full-width tab). Omit both for the standalone, self-toggling behaviour. */
+  rightView?: "files" | "changes";
+  onRightViewChange?: (view: "files" | "changes") => void;
 };
 
 type ProjectFilePreview =
@@ -390,7 +397,7 @@ function SortableProjectRow({
   );
 }
 
-export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "" }: Props) {
+export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const layoutKey = STORAGE_LAYOUT + storageNamespace;
   const sessionsKey = STORAGE_SESSIONS + storageNamespace;
@@ -434,7 +441,20 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [projectDetailCollapsed, setProjectDetailCollapsed] = useState(false);
   const [filePreviewCollapsed, setFilePreviewCollapsed] = useState(false);
   // Right pane view: the file preview, or the project's git changes/diff review.
-  const [rightView, setRightView] = useState<"files" | "changes">("files");
+  // Controllable: when the parent passes onRightViewChange (the Code workspace's
+  // top-level Files/Changes tabs), the prop wins and every setRightView call is
+  // forwarded up; otherwise this is local, self-toggling state. The setter name
+  // stays `setRightView` so the diff-first/auto-switch logic below is unchanged.
+  const [rightViewState, setRightViewState] = useState<"files" | "changes">("files");
+  const isControlledRightView = onRightViewChange != null;
+  const rightView = isControlledRightView ? (rightViewProp ?? "files") : rightViewState;
+  const setRightView = useCallback(
+    (next: "files" | "changes") => {
+      if (onRightViewChange) onRightViewChange(next);
+      else setRightViewState(next);
+    },
+    [onRightViewChange],
+  );
   // Diff-first review: auto-switch to Changes the first time an agent run
   // produces edits — but never fight an explicit user choice. pinnedRightView
   // flips once the user clicks a toggle or opens a file; prevChangeCount tracks
@@ -1628,7 +1648,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
           <div className="flex min-w-0 min-h-0 flex-1 flex-col">
             {selectedProject ? (
               <div className="flex min-h-0 flex-1 flex-col xl:flex-row">
-                {projectDetailCollapsed ? (
+                {/* File-tree column (projects · search · sessions · tree) — the
+                    Files tab. Hidden in controlled Changes mode so the diff
+                    review fills the surface as its own tab. */}
+                {!(isControlledRightView && rightView === "changes") && (projectDetailCollapsed ? (
                   <button
                     type="button"
                     aria-label="Show project details"
@@ -2053,7 +2076,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                     </div>
                     </div>
                   </div>
-                )}
+                ))}
 
                 {filePreviewCollapsed ? (
                   <button
@@ -2073,7 +2096,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 ) : (
                   <div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">
                   {/* Files / Changes toggle — review the familiar's working-tree
-                      diffs (revert + checkpoints) without leaving the surface. */}
+                      diffs (revert + checkpoints) without leaving the surface.
+                      Hidden when a parent owns the selection (Code workspace's
+                      top-level tabs); shown for the standalone surface. */}
+                  {!isControlledRightView && (
                   <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-2 py-1.5">
                     <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
                       <button
@@ -2103,6 +2129,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       <Icon name="ph:sidebar-simple-fill" width={14} />
                     </button>
                   </div>
+                  )}
                   {rightView === "changes" ? (
                     <div className="min-h-0 flex-1 overflow-hidden">
                       <SessionChangesInner


### PR DESCRIPTION
## What

Replaces the Code surface's side-by-side **chat | comux** split with a single tabbed pane — **Chat · Files · Changes** — so one surface fills the view at a time (Codex-style). The file tree folds into the **Files** tab, and the working-tree diff review becomes its own full-width **Changes** tab.

This is the "3 tabbed interface: chat, files, changes" requested.

## How

- **`code-view.tsx`** — a shared `Tabs` (segment) bar drives three panes. All three stay **mounted** (hidden, not unmounted) so chat / terminals / file preview / diff keep their state across tab taps. Files and Changes are two faces of **one** `ComuxView` instance: it's cloned with a controlled `rightView` bound to the active tab, so toggling Files↔Changes never remounts the terminals or preview. The Chat/Split/Review preset chips map onto the tabs (Chat→Chat, Split→Files, Review→Changes). The old resizable `Group`/`Panel` split + chat-panel resize presets are gone.
- **`comux-view.tsx`** — `ComuxView` gains optional controlled `rightView` + `onRightViewChange`. When controlled (the Code workspace), it hides its inline Files/Changes toggle and collapses the file-tree column while Changes is shown (so Changes is a clean full-width tab). Its diff-first auto-switch / `cave:open-project-file` / `cave:open-file-diff` events route up through `onRightViewChange` to select the matching tab. The standalone **Terminal** surface (uncontrolled) is unchanged.

## Verification

- `pnpm typecheck` — clean
- `pnpm test:app` — full suite green (643 wired); updated the source-text guards in `code-view.test.ts` (now pins the tabbed shell) and one boundary regex in `comux-view-terminal.test.ts` (`comux-view-changes.test.ts` passes unchanged)
- `pnpm build` — compiles; bundle within budget
- Drove the prod build with Playwright: the centered **Chat · Files · Changes** tab bar renders and each tab swaps the pane content (chat ↔ comux files ↔ comux changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)