### PR TITLE
chore: release v0.0.125

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.124"
+version = "0.0.125"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.124"
+version = "0.0.125"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.124</string>
+	<string>0.0.125</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.124</string>
+	<string>0.0.125</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.124</string>
+	<string>0.0.125</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.124</string>
+	<string>0.0.125</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.124",
+  "version": "0.0.125",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Release v0.0.125

Bumps the app version across **every sync'd surface** so `app-version.test` and the Rust check stay green:

- `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (the `app` crate — or the Rust check fails)
- `src-tauri/Info.ios.plist` + `src-tauri/gen/apple/app_iOS/Info.plist` (both short + build version)

Once merged, pushing tag **`v0.0.125`** triggers `release.yml`, which builds + signs all platforms and publishes the artifacts **and `latest.json`** that the in-app updater consumes — so the **Settings ▸ About ▸ Updates** button (and the launch banner) will offer "Install & restart" to v0.0.125.

### Ships everything merged since v0.0.124
- Avatar image preferred over the icon/glyph (#2076)
- Codex-style composer: compact height (#2066) + single control row (#2070)
- Command-palette dismiss-on-press + click-through (#2061)
- Rail: hide "Create familiar" in *All familiars* scope (#2058)

🤖 Generated with [Claude Code](https://claude.com/claude-code)