### PR TITLE
feat(code): open Code on Chat; Files leftmost tab

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -23,7 +23,8 @@ const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url
 // diff keep their state across tab taps.
 assert.match(codeView, /type CodeTab = "chat" \| "files" \| "changes"/, "CodeView models the three tabs");
 assert.match(codeView, /<Tabs[\s\S]*?ariaLabel="Code view"[\s\S]*?value=\{tab\}/, "a shared Tabs control switches Chat/Files/Changes");
-assert.match(codeView, /id: "chat"[\s\S]*?id: "files"[\s\S]*?id: "changes"/, "the tab bar lists chat, files and changes");
+assert.match(codeView, /id: "files"[\s\S]*?id: "chat"[\s\S]*?id: "changes"/, "the tab bar lists files (leftmost), then chat and changes");
+assert.match(codeView, /useState<CodeTab>\("chat"\)/, "the Code surface opens on the Chat tab by default");
 assert.match(codeView, /cave-code-page__pane--chat[\s\S]*?tab === "chat" \? "flex" : "hidden"/, "the chat pane shows only on the Chat tab (hidden, not unmounted)");
 assert.match(codeView, /cave-code-page__pane--workspace[\s\S]*?tab !== "chat" \? "flex" : "hidden"/, "the comux pane backs both the Files and Changes tabs");
 assert.match(codeView, /\{chat\}/, "the chat pane renders the chat slot");

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -29,9 +29,9 @@ type Props = {
 type CodeTab = "chat" | "files" | "changes";
 
 export function CodeView({ chat, comux }: Props) {
-  // Default to Files: choosing "Code" over "Chat" is a request to see code, and
-  // the conversation is one tab away. Edits auto-surface the Changes tab.
-  const [tab, setTab] = useState<CodeTab>("files");
+  // Default to Chat: entering Code lands on the conversation; Files (leftmost
+  // tab) and Changes are a click away, and edits auto-surface the Changes tab.
+  const [tab, setTab] = useState<CodeTab>("chat");
 
   // Files and Changes are the same comux surface in two states. Render it once
   // and drive its right pane from the active tab; comux routes its own
@@ -69,8 +69,8 @@ export function CodeView({ chat, comux }: Props) {
           value={tab}
           onChange={(id) => setTab(id as CodeTab)}
           items={[
-            { id: "chat", label: "Chat", icon: "ph:chats" },
             { id: "files", label: "Files", icon: "ph:file-code" },
+            { id: "chat", label: "Chat", icon: "ph:chats" },
             { id: "changes", label: "Changes", icon: "ph:git-diff" },
           ]}
         />


### PR DESCRIPTION
Follow-up to #2077. Two small Code-surface tweaks:

- **Tab order → Files · Chat · Changes** (Files is now the leftmost tab).
- **Default tab → Chat** — entering Code lands on the conversation; Files and Changes are a click away.

Verified: `code-view.test.ts` updated (pins the new order + default) and passing; `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)