### PR TITLE
feat(home): slower digest carousel + separate media row with image headlines

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -23,6 +23,16 @@ assert.match(view, /tabIndex={tabIndex}/, "duplicated cards are removed from the
 // ── Empty/loading: nothing renders until ready, and nothing when no cards ──────
 assert.match(view, /if \(!ready \|\| cards\.length === 0\) return null/, "hidden until there's something to show");
 
+// ── Two rows: media (headlines) is split out onto its own track, away from chats
+assert.match(view, /home-digest__track--media/, "media headlines render on their own separate track");
+assert.match(view, /c\.kind === "summary" \|\| c\.kind === "session"/, "chats row = summary + session cards");
+assert.match(view, /c\.kind === "rss"/, "media row = the rss headline cards");
+
+// ── Media cards support an image thumbnail (with icon fallback on error) ───────
+assert.match(view, /home-digest__thumb/, "media card renders an image thumbnail when available");
+assert.match(view, /card\.image/, "media thumbnail is sourced from the card's image field");
+assert.match(view, /onError=\{\(\) => setImgError\(true\)\}/, "thumbnail falls back to the icon on load error");
+
 // ── CSS: the marquee, the subtle hover pause, and reduced-motion fallback ──────
 assert.match(css, /@keyframes home-digest-marquee/, "defines the marquee animation");
 assert.match(css, /translateX\(-50%\)/, "loops at -50% to pair with the duplicated row");
@@ -38,6 +48,9 @@ assert.match(
   "reduced-motion disables the auto-scroll",
 );
 assert.match(css, /mask-image: linear-gradient\(to right/, "soft fade edges on the strip");
+assert.match(css, /home-digest-marquee 100s/, "marquee slowed to 100s for readability");
+assert.match(css, /\.home-digest__track--media[\s\S]*?animation-direction: reverse/, "media row drifts the opposite way, separated from chats");
+assert.match(css, /\.home-digest__thumb[\s\S]*?object-fit: cover/, "media thumbnail is a cover-fit image");
 
 // ── Wired into the home composer below "Jump back in" ─────────────────────────
 assert.match(composer, /import \{ HomeDigestCarousel \}/, "home composer imports the carousel");

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -3,12 +3,13 @@
 /**
  * HomeDigestCarousel — the home surface's "Daily summary" strip.
  *
- * A continuous, subtle horizontal marquee of today's activity (a summary card +
- * session cards) followed by the freshest merged RSS headlines. The marquee
- * auto-scrolls and pauses on hover/focus so a card can be read or clicked; it
- * falls back to a manual horizontal scroll under `prefers-reduced-motion`
- * (handled in CSS). Data is assembled client-side from the existing /api/inbox
- * and /api/rss endpoints — no new server route.
+ * Two stacked, subtle horizontal marquees: a CHATS row (today's summary +
+ * session cards) and, separated out beneath it, a MEDIA row of the freshest
+ * merged RSS headlines with image thumbnails. Both auto-scroll slowly and pause
+ * on hover/focus so a card can be read or clicked; they fall back to manual
+ * horizontal scroll under `prefers-reduced-motion` (handled in CSS). Data is
+ * assembled client-side from the existing /api/inbox and /api/rss endpoints —
+ * no new server route.
  */
 
 import { useEffect, useMemo, useState } from "react";
@@ -17,7 +18,7 @@ import type { SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { FeedItem } from "@/lib/rss";
 import { openExternalUrl } from "@/lib/open-external";
-import { buildDigestCards, type DigestCard } from "@/lib/home-digest";
+import { buildDigestCards, type DigestCard, type DigestRssCard } from "@/lib/home-digest";
 
 type Props = {
   sessions: SessionRow[];
@@ -60,14 +61,25 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
 
   if (!ready || cards.length === 0) return null;
 
+  // Keep chats (summary + sessions) and media (headlines) on separate rows so
+  // the media drifts alone, away from the chats.
+  const chatCards = cards.filter((c) => c.kind === "summary" || c.kind === "session");
+  const mediaCards = cards.filter((c): c is DigestRssCard => c.kind === "rss");
+
   return (
     <section className="home-digest" aria-label="Daily summary">
-      {/* The track holds two identical rows so the marquee loops seamlessly at
-          -50%. The second row is a presentational duplicate, hidden from a11y. */}
-      <div className="home-digest__track">
-        <DigestRow cards={cards} onOpenSession={onOpenSession} />
-        <DigestRow cards={cards} onOpenSession={onOpenSession} duplicate />
-      </div>
+      {chatCards.length > 0 ? (
+        <div className="home-digest__track" aria-label="Today's chats">
+          <DigestRow cards={chatCards} onOpenSession={onOpenSession} />
+          <DigestRow cards={chatCards} onOpenSession={onOpenSession} duplicate />
+        </div>
+      ) : null}
+      {mediaCards.length > 0 ? (
+        <div className="home-digest__track home-digest__track--media" aria-label="Media headlines">
+          <DigestRow cards={mediaCards} onOpenSession={onOpenSession} />
+          <DigestRow cards={mediaCards} onOpenSession={onOpenSession} duplicate />
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -139,15 +151,35 @@ function DigestCardView({
     );
   }
 
+  return <MediaCardView card={card} focusable={focusable} />;
+}
+
+/**
+ * Media (headline) card — leads with the article's image thumbnail when the feed
+ * supplied one, falling back to the newspaper icon (also on image load error).
+ */
+function MediaCardView({ card, focusable }: { card: DigestRssCard; focusable: boolean }) {
+  const [imgError, setImgError] = useState(false);
+  const showImg = Boolean(card.image) && !imgError;
   return (
     <button
       type="button"
-      className="home-digest__card home-digest__card--rss"
-      tabIndex={tabIndex}
+      className="home-digest__card home-digest__card--rss home-digest__card--media"
+      tabIndex={focusable ? undefined : -1}
       onClick={() => void openExternalUrl(card.url)}
       title={card.title}
     >
-      <Icon name="ph:newspaper" width={13} className="home-digest__icon" aria-hidden />
+      {showImg ? (
+        <img
+          src={card.image}
+          alt=""
+          aria-hidden
+          className="home-digest__thumb"
+          onError={() => setImgError(true)}
+        />
+      ) : (
+        <Icon name="ph:newspaper" width={13} className="home-digest__icon" aria-hidden />
+      )}
       <span className="home-digest__body">
         <span className="home-digest__title">{card.title}</span>
         <span className="home-digest__meta">

--- a/src/lib/home-digest.test.ts
+++ b/src/lib/home-digest.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { buildDigestCards } from "./home-digest.ts";
+import { buildDigestCards, firstImageUrl } from "./home-digest.ts";
 
 // Midday UTC so the small ±hour offsets below stay on the same calendar day in
 // CI's timezone (and most others), keeping the "today" filter deterministic.
@@ -20,7 +20,7 @@ const items = [
 ];
 
 const rssItems = [
-  { id: "r1", title: "Headline one", link: "https://example.com/a", isoDate: hoursAgo(1), source: "Example" },
+  { id: "r1", title: "Headline one", link: "https://example.com/a", isoDate: hoursAgo(1), source: "Example", descriptionHtml: '<p>x</p><img src="https://img.example.com/a.jpg" alt="">' },
   { id: "r2", title: "No link skipped", link: "", isoDate: hoursAgo(1), source: "Example" },
   { id: "r3", title: "Headline two", link: "https://news.test/b", isoDate: hoursAgo(2), source: "News" },
 ];
@@ -58,6 +58,22 @@ const rssCards = cards.filter((c) => c.kind === "rss");
 assert.equal(rssCards.length, 2, "the linkless rss item is dropped");
 assert.equal(rssCards[0].url, "https://example.com/a");
 assert.equal(rssCards[0].host, "example.com", "host is derived from the link");
+
+// ── Media thumbnails: image pulled from the item body when present ─────────────
+assert.equal(
+  rssCards[0].image,
+  "https://img.example.com/a.jpg",
+  "rss card carries the first http(s) image from descriptionHtml",
+);
+assert.equal(rssCards[1].image, undefined, "rss card with no body image has no thumbnail");
+
+// firstImageUrl: only absolute http(s) images; skips data/relative/none.
+assert.equal(firstImageUrl('<img src="https://x/a.png">'), "https://x/a.png");
+assert.equal(firstImageUrl("<img src='http://x/b.gif' />"), "http://x/b.gif");
+assert.equal(firstImageUrl('<img src="//x/c.jpg">'), undefined, "protocol-relative skipped");
+assert.equal(firstImageUrl('<img src="data:image/png;base64,AAA">'), undefined, "data URI skipped");
+assert.equal(firstImageUrl("<p>no image here</p>"), undefined);
+assert.equal(firstImageUrl(undefined), undefined);
 
 // ── maxRss cap is honored ─────────────────────────────────────────────────────
 const capped = buildDigestCards({ items, sessions, rssItems, nowMs: NOW, maxRss: 1 });

--- a/src/lib/home-digest.ts
+++ b/src/lib/home-digest.ts
@@ -45,6 +45,8 @@ export type DigestRssCard = {
   url: string;
   /** Compact relative age, e.g. "2h". */
   age: string;
+  /** First http(s) image pulled from the item body — the media row's thumbnail. */
+  image?: string;
 };
 
 export type DigestCard = DigestSummaryCard | DigestSessionCard | DigestRssCard;
@@ -74,6 +76,17 @@ function sameLocalDay(iso: string | null | undefined, now: Date): boolean {
 
 function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
   return `${count} ${count === 1 ? singular : pluralForm}`;
+}
+
+/**
+ * Pull the first http(s) image out of a feed item's body HTML for the media-row
+ * thumbnail. Returns undefined for protocol-relative/inline/data URIs or no img,
+ * so the card cleanly falls back to its icon. Pure — unit-tested.
+ */
+export function firstImageUrl(html: string | undefined): string | undefined {
+  if (!html) return undefined;
+  const src = html.match(/<img[^>]+\bsrc=["']([^"']+)["']/i)?.[1];
+  return src && /^https?:\/\//i.test(src) ? src : undefined;
 }
 
 function dayLabel(now: Date): string {
@@ -149,6 +162,7 @@ export function buildDigestCards(input: BuildDigestInput): DigestCard[] {
       host: hostFromUrl(r.link),
       url: r.link,
       age: relativeAge(r.isoDate, nowMs),
+      image: firstImageUrl(r.descriptionHtml),
     });
   }
 

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -781,8 +781,15 @@
 .home-digest__track {
   display: flex;
   width: max-content;
-  animation: home-digest-marquee 64s linear infinite;
+  /* Slower drift (was 64s) so cards are comfortably readable as they pass. */
+  animation: home-digest-marquee 100s linear infinite;
   will-change: transform;
+}
+/* The media headlines drift on their own row beneath the chats, in the opposite
+   direction, so the two streams read as clearly separate. */
+.home-digest__track--media {
+  margin-top: 10px;
+  animation-direction: reverse;
 }
 .home-digest:hover .home-digest__track,
 .home-digest:focus-within .home-digest__track {
@@ -837,6 +844,17 @@
 .home-digest__icon {
   color: var(--accent-presence);
   flex-shrink: 0;
+}
+/* Media-row thumbnail: the article image leads the card; the newspaper icon is
+   the fallback when the feed had no usable image (or it fails to load). */
+.home-digest__thumb {
+  width: 38px;
+  height: 38px;
+  margin: -3px 0;
+  border-radius: 9px;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg-base);
 }
 .home-digest__body {
   display: flex;


### PR DESCRIPTION
## What

The Home **"Daily summary"** carousel mixed chat cards (summary + sessions) and news headlines in one fast 64s strip. Now:

- **Slower** — drifts at **100s/loop** (was 64s) so cards are comfortably readable.
- **Media separated out, alone** — headlines ride their **own track beneath the chats**, drifting in the **opposite direction** so the two streams read as distinct (chats up top, media below).
- **Image support** — media cards lead with the **article's image thumbnail** (extracted from the feed item body), falling back to the newspaper icon when there's no usable image or it fails to load.

## How

`buildDigestCards` still returns the same flat, ordered list (summary → sessions → rss) — its ordering test is untouched. The carousel splits that list into a chats row (`summary`+`session`) and a media row (`rss`). New pure `firstImageUrl(html)` pulls the first `http(s)` `<img>` from `descriptionHtml`; `DigestRssCard` gains an `image?` field.

## Verification (live dev server)

- Two `.home-digest__track`s (media row present, `animation-direction: reverse`), `animationDuration: 100s`.
- Media cards render real article thumbnails (e.g. The Verge) with newspaper-icon fallback (BBC, Hacker News).
- Unit tests for `firstImageUrl` + the rss image field; carousel source-text test updated; `pnpm typecheck` clean; tests-wired OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)