### PR TITLE
[codex] Fix digest carousel on touch devices

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -47,6 +47,11 @@ assert.match(
   /@media \(prefers-reduced-motion: reduce\)[\s\S]*?animation: none/,
   "reduced-motion disables the auto-scroll",
 );
+assert.match(
+  css,
+  /@media[^{]*\((?:hover: none|pointer: coarse)\)[\s\S]*?overflow-x: auto/,
+  "touch/coarse-pointer devices fall back to manual horizontal scroll (no hover to pause)",
+);
 assert.match(css, /mask-image: linear-gradient\(to right/, "soft fade edges on the strip");
 assert.match(css, /home-digest-marquee 100s/, "marquee slowed to 100s for readability");
 assert.match(css, /\.home-digest__track--media[\s\S]*?animation-direction: reverse/, "media row drifts the opposite way, separated from chats");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -877,9 +877,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-@media (prefers-reduced-motion: reduce) {
+/* Touch / coarse-pointer devices have no hover to pause the marquee, so give
+   them a plain manual horizontal scroll instead of an unpausable auto-scroll
+   (mirrors the reduced-motion path). */
+@media (prefers-reduced-motion: reduce), (hover: none), (pointer: coarse) {
   .home-digest {
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
   .home-digest__track {
     animation: none;


### PR DESCRIPTION
## Summary
- disables the auto-scrolling home digest marquee on touch/coarse-pointer devices
- falls back to manual horizontal scrolling with momentum scrolling on iOS
- adds a source assertion covering the touch/coarse-pointer fallback

## Why
Touch devices cannot reliably use hover to pause the marquee, so the digest could become an unpausable moving target. This keeps the desktop marquee behavior while matching the existing reduced-motion fallback on touch.

## Validation
- node --experimental-strip-types src/components/home-digest-carousel.test.ts
- pnpm test:app
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check