### PR TITLE
fix(home): touch/coarse-pointer manual scroll for the digest carousel

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -47,6 +47,11 @@ assert.match(
   /@media \(prefers-reduced-motion: reduce\)[\s\S]*?animation: none/,
   "reduced-motion disables the auto-scroll",
 );
+assert.match(
+  css,
+  /@media[^{]*\((?:hover: none|pointer: coarse)\)[\s\S]*?overflow-x: auto/,
+  "touch/coarse-pointer devices fall back to manual horizontal scroll (no hover to pause)",
+);
 assert.match(css, /mask-image: linear-gradient\(to right/, "soft fade edges on the strip");
 assert.match(css, /home-digest-marquee 100s/, "marquee slowed to 100s for readability");
 assert.match(css, /\.home-digest__track--media[\s\S]*?animation-direction: reverse/, "media row drifts the opposite way, separated from chats");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -877,9 +877,13 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-@media (prefers-reduced-motion: reduce) {
+/* Touch / coarse-pointer devices have no hover to pause the marquee, so give
+   them a plain manual horizontal scroll instead of an unpausable auto-scroll
+   (mirrors the reduced-motion path). */
+@media (prefers-reduced-motion: reduce), (hover: none), (pointer: coarse) {
   .home-digest {
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
   }
   .home-digest__track {
     animation: none;


### PR DESCRIPTION
Follow-up to the daily-summary carousel (#2074, #2083). On touch / coarse-pointer devices the marquee had no usable interaction model.

## Problem
The carousel only fell back to manual horizontal scroll under `prefers-reduced-motion`. On a phone:
- there's no hover to pause the auto-scroll, and
- `overflow: hidden` blocked hand-scrolling,

so it drifted unpausably and couldn't be read or browsed. (There was even a never-implemented "(pointer: coarse) gate" note left in the CSS.)

## Fix
Widen the manual-scroll fallback to also trigger on `(hover: none), (pointer: coarse)` — mirroring the existing reduced-motion path: `overflow-x: auto` + `-webkit-overflow-scrolling: touch`, animation off, duplicate (a11y) row hidden. Desktop/hover behavior is unchanged.

Adds a source-text assertion for the coarse-pointer fallback.

## Verification
- `tsc --noEmit` clean; `home-digest-carousel` test passes.
- 2 files, +10/-1; built on latest origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)