### PR TITLE
docs: design specs for Evals analysis-grade + Dashboard world-class

### DIFF
--- a/docs/specs/2026-06-28-dashboard-worldclass-design.md
+++ b/docs/specs/2026-06-28-dashboard-worldclass-design.md
@@ -1,0 +1,73 @@
+# Dashboard — World-Class Upgrade Design
+
+**Date:** 2026-06-28
+**Surface:** `/dashboard` route → `src/components/dashboard/dashboard-cockpit.tsx`
+**Goal:** Make the cockpit a world-class, high-value page — **deepen insights + add interactivity/real-time + a visual pass**, on top of the already-solid cockpit (KPI sparklines, draggable grid, action-inbox, agents/GitHub/reading panels).
+
+## Context
+
+The `/dashboard` cockpit already went past its `2026-06-20-dashboard-refactor-design.md`. It's a standalone Next route (not a workspace mode); the Home composer (`mode: "home"`) is a separate surface and is out of scope. This upgrade is **layered on top** of the existing cockpit, reusing its model, layout persistence (`LAYOUT_KEY`), and `daily-report-ui` / `.dr-*` primitives.
+
+Depends on the shared chart primitives (visx) from the Evals spec's PR 1.
+
+## Data model
+
+**New pure `src/lib/dashboard-analytics.ts`** (kept separate so `dashboard-model.ts` stays thin and its existing tests are untouched):
+
+- `familiarMiniProfiles(sessions, retroRuns, selfReports)` → per-familiar: 7-day session trend, avg confidence, last-active, trend direction. Reuses the existing familiar-analytics/confidence computation rather than reinventing it.
+- `resolutionTrend(inboxHistory)` → inbox pending→done rate over time; `boardThroughput(cards)` → cards moved per day.
+- `signals(model, github, reading, familiars)` → predictive alerts: PR stalled > 7 days, reading queue growing, familiar trending downward.
+
+Prefer reuse of already-fetched `/api/*` data and existing familiar-analytics computation. Flag any genuinely new read endpoint before adding it; aim for none.
+
+## Page structure
+
+The adaptive busy/caught-up layout and draggable grid are **kept**. Changes:
+
+- **Deepen (charts):**
+  - Familiar-load **stacked-area** `TrendChart` (sessions per familiar over 7d).
+  - Confidence **`Heatmap`** (familiars × quality factors).
+  - Board-status **`DonutChart`** (replaces/augments the CSS flexbox bars).
+  - Richer KPI trend tiles (keep sparklines for the smallest).
+- **Familiar mini-profiles:** expand the "Agents" panel — each familiar shows session trend, avg confidence, last update, and a link to its `/dashboard/familiars/[id]/analytics`.
+- **Interactivity:** KPI tiles become **drill-downs** (click → board filtered by that status / the relevant surface); inline quick actions (assign a board card to a familiar; mark a reading item done) on top of the existing action-inbox bulk triage.
+- **Real-time:** convert the request-time cockpit data to a client **polling layer** using the existing `usePausablePoll` pattern (paused when the tab/app is backgrounded, per the established perf convention). SSE is deferred — polling is simpler and matches existing surfaces.
+- **Fix orphans:** wire the dead `/dashboard?view=evals` link (open the Evals surface), and link cockpit sessions → their analytics.
+
+## Data flow
+
+Existing client fetches (`/api/board`, `/api/familiars`, `/api/github/*`, `/api/library/reading`, `/api/inbox`, `/api/sessions/list`) plus the new pure aggregations in `dashboard-analytics.ts`. Polling reuses these endpoints on an interval gated by `usePausablePoll`.
+
+## Error handling
+
+- Each panel degrades independently: a failed fetch shows that panel's skeleton/empty state, never blanks the cockpit (current behavior preserved).
+- Charts show `EmptyState` under sparse data (< 2 points).
+- Optimistic inline actions revert + surface a banner on failure (same pattern as the existing action-inbox).
+
+## Testing
+
+- `src/lib/dashboard-analytics.test.ts` — mini-profile aggregation, resolution/throughput trends, signal thresholds. Pure, no DOM.
+- Chart-primitive source tests (shared with Evals — already covered in PR 1).
+- Extend `src/app/dashboard-page.test.ts`: new panels render, KPI drill-down links present, polling hook wired, `?view=evals` handled.
+- Keep `src/lib/dashboard-model.test.ts` green (model unchanged).
+- Wire new test files into `scripts/run-tests.mjs` (+ `ALIAS_LOADER` if `@/` imports).
+- Typecheck, `check:tests-wired`, app suite before committing.
+
+## Scope guards
+
+- `dashboard-model.ts` and its tests stay intact; new logic lives in `dashboard-analytics.ts`.
+- `daily-report-ui.tsx` / `daily-report.ts` and the shared `.dr-*` global block stay untouched (still shared with `/daily-report`); add only scoped `.dash-*` CSS.
+- visx imported only inside the dashboard lazy chunk.
+- Aim for **no new API routes**; flag and confirm if one proves unavoidable.
+- Lands via a PR on a branch (main is protected; required checks: Frontend build, Rust check, CodeQL, E2E).
+
+## Out of scope
+
+- SSE/websocket push (polling first).
+- Reworking the Home composer surface.
+- Reworking `/daily-report`.
+- Per-familiar theming of the cockpit.
+
+## Sequencing
+
+PR 1 (charts foundation) → PR 3 (this Dashboard upgrade), after the Evals upgrade (PR 2).

--- a/docs/specs/2026-06-28-evals-analysis-grade-design.md
+++ b/docs/specs/2026-06-28-evals-analysis-grade-design.md
@@ -1,0 +1,85 @@
+# Evals — Analysis-Grade Upgrade Design
+
+**Date:** 2026-06-28
+**Surface:** `evals` workspace mode (`src/components/evals/evals-view.tsx`)
+**Goal:** Take the already-unified Evals control room to *full coverage* — surface the eval data that exists in the model/API but isn't shown today, and make it a world-class analysis surface. Additive, not a rewrite.
+
+## Context
+
+The current 5-tab Evals view (Overview / Suites / Runs / Loops / Threads) is the implemented output of `2026-06-28-unified-evals-analysis-design.md`. Eval work is **concurrently in flight** (open PR #2049 eval templates; today's `eval-loop-control-plane` and `grouped-eval-stale-state` specs). Therefore this upgrade is deliberately **additive** — new panels + a pure analytics lib — and leaves existing tab internals alone to avoid collisions.
+
+Coverage gaps this design closes (all four chosen):
+1. **Trends over time** — pass-rate / accept-revert history, not just the latest run.
+2. **Run-vs-run comparison** — case-level diffs and regressions.
+3. **Failure clustering & filtering** — which cases/graders fail most; filter to failures.
+4. **EvalGroups UI + SLA** — `EvalGroup` exists in the model + `/api/evals/groups`, but has no UI; add management + pass-rate thresholds with breach alerts.
+
+## Prerequisite: shared chart primitives (lands first, PR 1)
+
+World-class viz needs more than the single `Sparkline`. We add **visx** (modular, tree-shakeable) — chosen over Recharts so each surface's lazy chunk ships only the chart code it uses (the build is gated by `bundle-budget.mjs`).
+
+- New `src/components/ui/charts/`: `TrendChart` (multi-series line/area + threshold marker), `BarChart`, `Heatmap`, `DonutChart`. Thin wrappers themed to our CSS tokens; each independently testable.
+- **Imported only inside lazy chunks** (Evals + Dashboard are already route/lazy-split) so the main bundle stays lean. Bump the relevant per-chunk budget in `bundle-budget.mjs` if the gate trips, and `log` the change.
+- `Sparkline` stays for tiny inline tiles.
+
+## Data model
+
+**New pure `src/lib/evals/eval-analytics.ts`** — derives everything from existing DTOs; **no new persistence**:
+
+- `suiteTrend(runs: EvalRun[])` → time series of pass rate per suite, with a per-grader-kind breakdown.
+- `loopTrend(loopRuns)` → accept/revert counts over time, per track.
+- `diffRuns(a: EvalRun, b: EvalRun)` → per-case status matrix: `pass→pass`, `pass→fail` (regression), `fail→pass` (fix), `fail→fail`, plus added/removed cases.
+- `failureClusters(runs: EvalRun[])` → per-case and per-grader failure frequency + flakiness (alternating pass/fail across runs).
+- `groupHealth(groups, runs, threadStates)` → per-group rollups + **SLA breach** (latest pass rate below the group's threshold).
+
+The only schema change: add an optional `slaPolicy?: { minPassRate: number }` to `EvalGroup` (`eval-model.ts`) and persist it through the existing `/api/evals/groups` POST. No new route.
+
+## Page structure (additive)
+
+`EvalsView` gains two tabs and one enhancement; existing tabs untouched:
+
+- **New "Insights" tab** — the analytical home:
+  - Suite pass-rate `TrendChart` (per suite; threshold marker when an SLA is set).
+  - Loop accept/revert `TrendChart` per track.
+  - Failure-frequency `BarChart` + flaky-case list (from `failureClusters`).
+  - A coverage badge: suites/threads covered, SLA status roll-up.
+- **Runs tab → "Compare" mode** — pick run A and run B → `diffRuns` matrix with **regressions highlighted**; plus results filtering (failures-only / by grader kind / text search). The existing run history/detail stays.
+- **New "Groups" tab** — EvalGroups CRUD (create/edit/delete, member selection), per-group health (`groupHealth`) with a `Heatmap` or status list, and **SLA threshold config with breach badges**.
+
+## Data flow
+
+All from existing endpoints, loaded as today: `/api/evals/{suites,runs,groups,thread-states,queue}`, `/api/retro-runs`, `/api/skills/eval-loop/:familiarId`. Analytics rollups are derived client-side (pure lib). Group SLA writes go through the existing groups POST.
+
+Remember the daemon envelope gotcha: run eval-loop daemon responses through `unwrapDaemonEvalState` (`src/lib/eval-loop-daemon.ts`) before reading iteration/state fields.
+
+## Error handling
+
+- Charts render an empty/`EmptyState` when a series has < 2 points (no misleading single-point lines).
+- `diffRuns` handles non-overlapping case sets (added/removed) without throwing.
+- SLA breach is informational (a badge), never blocks running an eval.
+
+## Testing
+
+- `src/lib/evals/eval-analytics.test.ts` — `diffRuns` (regression/fix/added/removed), `suiteTrend`/`loopTrend` shapes, `failureClusters` (frequency + flakiness), `groupHealth` SLA breach thresholds. Pure, no DOM.
+- Chart-primitive source tests (axis/series/threshold props wired; themed classes present).
+- Additive assertions in `src/components/evals/evals-view.test.ts`: Insights tab renders the trend/bar charts; Runs Compare mode + filters present; Groups tab CRUD + SLA wired.
+- Wire all new test files into `scripts/run-tests.mjs` (and `ALIAS_LOADER` if they import via `@/`).
+- Run typecheck, `check:tests-wired`, and the app suite before committing.
+
+## Scope guards / collision management
+
+- **Additive only.** Do not rewrite the existing tab internals — coordinate with the live eval PRs (#2049 templates is a creation flow; this is analysis — non-overlapping).
+- One small additive field on `EvalGroup` + the groups POST; no new persistence layer, no new routes.
+- visx imported only inside the Evals lazy chunk; main bundle unaffected.
+- Lands via a PR on a branch (main is protected; required checks: Frontend build, Rust check, CodeQL, E2E).
+
+## Out of scope
+
+- CI/CD auto-running evals on `git push` / PR.
+- LLM-judge calibration tooling.
+- Audit trail of suite edits.
+- Cross-run statistical significance testing.
+
+## Sequencing
+
+PR 1 (charts foundation, shared with Dashboard) → PR 2 (this Evals upgrade).


### PR DESCRIPTION
Two **design specs** from a brainstorming pass on making the Evals and Dashboard surfaces world-class / full-coverage. **Specs only — no code changes.**

- `docs/specs/2026-06-28-evals-analysis-grade-design.md` — additive **Insights** tab (pass-rate/accept-revert trends), **run-vs-run comparison** + regressions, **failure clustering & filtering**, and an **EvalGroups + SLA** tab (model/API exist, no UI today). Includes the shared **visx chart-primitives** prerequisite.
- `docs/specs/2026-06-28-dashboard-worldclass-design.md` — **deepen insights** (charts, familiar mini-profiles), **interactivity/drill-down + polling real-time**, and a **visual pass**. New `dashboard-analytics.ts`; `dashboard-model.ts` kept intact.

Both are deliberately **additive** to avoid colliding with the in-flight eval work (#2049, etc.). Sequenced as 3 PRs: charts foundation → Evals → Dashboard.

Landing these as a docs PR so they're tracked and reviewable. Implementation plans (writing-plans) follow once reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)