### PR TITLE
feat(settings): per-section overview header (icon + highlights)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -350,6 +350,7 @@ export const SUITES = {
     "src/components/salem/salem.test.ts",
     "src/components/settings-shell-polish.test.ts",
     "src/components/settings-section-tabs.test.ts",
+    "src/components/settings-overview.test.ts",
     "src/components/theme-script.test.ts",
     "src/components/ui/error-state.test.ts",
     "src/components/ui/live-region.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -424,6 +424,69 @@ select {
   .settings-group--found > div:last-child { transition: none; }
 }
 
+/* Per-section overview header (SettingsOverview): accent mark + kicker + title +
+   description, with a short "what's in here" highlight strip. */
+.settings-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.settings-overview__heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+.settings-overview__mark {
+  display: grid;
+  place-items: center;
+  height: 2.25rem;
+  width: 2.25rem;
+  flex-shrink: 0;
+  border-radius: 0.625rem;
+}
+.settings-overview__kicker {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.settings-overview__title {
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--text-primary);
+}
+.settings-overview__description {
+  margin-top: 0.125rem;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.settings-overview__strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.settings-overview__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-raised) 50%, transparent);
+  padding: 0.125rem 0.5rem;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.settings-overview__chip-dot {
+  flex-shrink: 0;
+  color: var(--accent-presence);
+  opacity: 0.7;
+}
+
 /* Skip-to-content link: off-screen until it receives keyboard focus, then it
    slides into the top-left so the first Tab on any surface reaches it. */
 .skip-link {

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+import {
+  SECTIONS,
+  SECTION_HIGHLIGHTS,
+  getSectionMeta,
+  settingsSectionLabel,
+} from "./settings-sections.ts";
+
+// ── settings-sections catalog (pure) ─────────────────────────────────────────
+
+test("every section has full overview metadata + a highlight strip", () => {
+  const ids = ["general", "daemon", "familiars", "addons", "mobile", "appearance", "about"];
+  assert.deepEqual(SECTIONS.map((s) => s.id), ids, "the section set matches the shell nav");
+  for (const s of SECTIONS) {
+    assert.ok(s.label && s.icon.startsWith("ph:") && s.description.length > 0, `${s.id} has label/icon/description`);
+    assert.match(s.accent, /^#[0-9a-f]{6}$/i, `${s.id} has a hex accent`);
+    assert.ok(Array.isArray(SECTION_HIGHLIGHTS[s.id]) && SECTION_HIGHLIGHTS[s.id].length > 0, `${s.id} has highlights`);
+  }
+});
+
+test("getSectionMeta / settingsSectionLabel resolve, with a safe fallback", () => {
+  assert.equal(getSectionMeta("appearance").label, "Appearance");
+  assert.equal(settingsSectionLabel("mobile"), "Phone");
+  // Unknown id falls back to the first section rather than throwing.
+  assert.equal(getSectionMeta("nope").id, "general");
+});
+
+// ── SettingsOverview header (source-text) ────────────────────────────────────
+
+const overview = readFileSync(new URL("./settings-overview.tsx", import.meta.url), "utf8");
+
+test("the overview header renders mark, kicker, title, description, and the strip", () => {
+  assert.match(overview, /getSectionMeta\(section\)/, "pulls section metadata");
+  assert.match(overview, /settings-overview__mark[\s\S]*backgroundColor[\s\S]*meta\.accent/, "accent-tinted mark");
+  assert.match(overview, /settings-overview__kicker[\s\S]*meta\.label/, "kicker names the section");
+  assert.match(overview, /settings-overview__title">\{meta\.label\}/, "title is the section label");
+  assert.match(overview, /settings-overview__description">\{meta\.description\}/, "one-line description");
+  assert.match(overview, /SECTION_HIGHLIGHTS\[section\]\.map/, "renders the highlight strip");
+});
+
+// ── shell wiring (source-text) ───────────────────────────────────────────────
+
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+
+test("the shell sources sections from settings-sections and renders the overview", () => {
+  assert.match(shell, /import \{ SettingsOverview \} from "\.\/settings-overview"/);
+  assert.match(shell, /import \{ SECTIONS, settingsSectionLabel, type Section \} from "\.\/settings-sections"/);
+  // SettingsPage swaps the plain <h1> for the overview when a section is given.
+  assert.match(shell, /section \? \(\s*<SettingsOverview section=\{section\} \/>/);
+  // The search index stays in the shell (next to its search box).
+  assert.match(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/);
+  // Each SettingsPage-based section opts into its overview header.
+  for (const id of ["general", "daemon", "addons", "mobile", "appearance", "about"]) {
+    assert.match(shell, new RegExp(`section="${id}"`), `${id} page passes its section`);
+  }
+});
+
+console.log("settings-overview.test.ts: ok");

--- a/src/components/settings-overview.tsx
+++ b/src/components/settings-overview.tsx
@@ -1,0 +1,46 @@
+import { Icon } from "@/lib/icon";
+import {
+  SECTION_HIGHLIGHTS,
+  getSectionMeta,
+  type Section,
+} from "@/components/settings-sections";
+
+/**
+ * Rich per-section header for a settings page: an accent-marked icon, a
+ * "Settings / <Section>" breadcrumb kicker, the section title + one-line
+ * description, and a short "what's in here" highlight strip. Replaces the plain
+ * <h1>/description block so each settings section opens with a clearer sense of
+ * place.
+ */
+export function SettingsOverview({ section }: { section: Section }) {
+  const meta = getSectionMeta(section);
+  return (
+    <header className="settings-overview" aria-label={`${meta.label} settings`}>
+      <div className="settings-overview__heading">
+        <span
+          className="settings-overview__mark"
+          style={{
+            backgroundColor: `color-mix(in oklch, ${meta.accent} 18%, transparent)`,
+            color: meta.accent,
+          }}
+          aria-hidden="true"
+        >
+          <Icon name={meta.icon as Parameters<typeof Icon>[0]["name"]} width={18} />
+        </span>
+        <div className="min-w-0">
+          <p className="settings-overview__kicker">Settings · {meta.label}</p>
+          <h1 className="settings-overview__title">{meta.label}</h1>
+          <p className="settings-overview__description">{meta.description}</p>
+        </div>
+      </div>
+      <ul className="settings-overview__strip" aria-label="In this section">
+        {SECTION_HIGHLIGHTS[section].map((label) => (
+          <li key={label} className="settings-overview__chip">
+            <Icon name="ph:check-circle" width={12} className="settings-overview__chip-dot" />
+            <span>{label}</span>
+          </li>
+        ))}
+      </ul>
+    </header>
+  );
+}

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -1,0 +1,54 @@
+// Settings section catalog — the navigable sections plus the metadata the
+// per-section overview header renders (accent, one-line description, and a short
+// "what's in here" highlight strip). Kept in its own module so the shell nav and
+// the SettingsOverview header share one source of truth.
+//
+// NOTE: the search index (SETTINGS_INDEX) intentionally stays in settings-shell
+// next to the search box it drives.
+
+export type Section =
+  | "general"
+  | "daemon"
+  | "familiars"
+  | "addons"
+  | "mobile"
+  | "appearance"
+  | "about";
+
+export type SectionMeta = {
+  id: Section;
+  label: string;
+  icon: string;
+  /** One-line summary shown under the section title in the overview header. */
+  description: string;
+  /** Accent colour for the section mark (kept subtle; section identity cue). */
+  accent: string;
+};
+
+export const SECTIONS: SectionMeta[] = [
+  { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9a8ecd" },
+  { id: "daemon", label: "Daemon", icon: "ph:terminal-window", description: "Local runtime status and process controls.", accent: "#69d6a6" },
+  { id: "familiars", label: "Familiars", icon: "ph:users-three", description: "Roster, identity, permissions, and pin order.", accent: "#d8a9ff" },
+  { id: "addons", label: "Add-ons", icon: "ph:puzzle-piece", description: "Optional integrations and sidebar surfaces.", accent: "#7bb7ff" },
+  { id: "mobile", label: "Phone", icon: "ph:device-mobile", description: "Native iOS handoff over your Tailscale network.", accent: "#73d9d0" },
+  { id: "appearance", label: "Appearance", icon: "ph:paint-brush", description: "Theme, typography, and reading controls.", accent: "#ff9fb5" },
+  { id: "about", label: "About", icon: "ph:info", description: "Version, updates, and project links.", accent: "#b8d8ff" },
+];
+
+export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
+  general: ["Workspace path", "Launch behavior", "Default start view"],
+  daemon: ["Runtime health", "Restart action", "Socket & version"],
+  familiars: ["Roster & identity", "Per-familiar permissions", "Pinned strip order"],
+  addons: ["Sidebar surfaces", "Integrations", "Hidden when disabled"],
+  mobile: ["Mobile mode", "Tailscale handoff", "Native iOS guide"],
+  appearance: ["Theme & colors", "Typography", "Reading comfort"],
+  about: ["App version", "Tool updates", "Project links"],
+};
+
+export function getSectionMeta(section: Section): SectionMeta {
+  return SECTIONS.find((s) => s.id === section) ?? SECTIONS[0];
+}
+
+export function settingsSectionLabel(section: Section): string {
+  return getSectionMeta(section).label;
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -27,6 +27,8 @@ import { rgbaBytesToHex } from "@/lib/theme-token-hex";
 import { FontSettings } from "./settings-fonts";
 import { SettingsTabbed } from "./settings-section-tabs";
 import type { TabItem } from "@/components/ui/tabs";
+import { SettingsOverview } from "./settings-overview";
+import { SECTIONS, settingsSectionLabel, type Section } from "./settings-sections";
 import {
   CORNER_RADIUS_OPTIONS,
   CORNER_RADIUS_LABELS,
@@ -70,17 +72,9 @@ function writeMobileModeEnabled(enabled: boolean) {
   window.localStorage.setItem(MOBILE_MODE_STORAGE_KEY, enabled ? "true" : "false");
 }
 
-type Section = "general" | "daemon" | "familiars" | "addons" | "mobile" | "appearance" | "about";
-
-const SECTIONS: { id: Section; label: string; icon: string }[] = [
-  { id: "general",    label: "General",    icon: "ph:sliders-horizontal" },
-  { id: "daemon",     label: "Daemon",     icon: "ph:terminal-window" },
-  { id: "familiars",  label: "Familiars",  icon: "ph:users-three" },
-  { id: "addons",     label: "Add-ons",    icon: "ph:puzzle-piece" },
-  { id: "mobile",     label: "Phone",      icon: "ph:device-mobile" },
-  { id: "appearance", label: "Appearance", icon: "ph:paint-brush" },
-  { id: "about",      label: "About",      icon: "ph:info" },
-];
+// `Section` + the navigable `SECTIONS` (with overview metadata) live in
+// ./settings-sections so the nav and the SettingsOverview header share one
+// source of truth. The search index below stays here, next to its search box.
 
 // ─── Search index ───────────────────────────────────────────────────────────
 // One entry per searchable settings group. `group` matches the SettingsGroup
@@ -332,7 +326,7 @@ export function SettingsShell() {
 
 function GeneralSection() {
   return (
-    <SettingsPage title="General" description="App-wide preferences.">
+    <SettingsPage section="general" title="General" description="App-wide preferences.">
       <SettingsGroup label="Workspace">
         <SettingsRow label="Workspace path" description="Where Coven stores familiar workspaces.">
           <WorkspacePathField />
@@ -421,7 +415,7 @@ function DaemonSection() {
   };
 
   return (
-    <SettingsPage title="Daemon" description="The coven daemon manages familiar sessions and the workspace.">
+    <SettingsPage section="daemon" title="Daemon" description="The coven daemon manages familiar sessions and the workspace.">
       <SettingsGroup label="Status">
         <div className="flex flex-wrap items-center gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-3">
           <span className={`h-2.5 w-2.5 shrink-0 rounded-full ${
@@ -675,7 +669,7 @@ function AddonsSection({ scrollTarget }: { scrollTarget?: string | null }) {
   );
 
   return (
-    <SettingsPage title="Add-ons" description="Optional surfaces and integrations. Anything disabled here is hidden from the sidebar — turn on what you need.">
+    <SettingsPage section="addons" title="Add-ons" description="Optional surfaces and integrations. Anything disabled here is hidden from the sidebar — turn on what you need.">
       {toggleError && (
         <p role="alert" className="mb-2 px-1 text-[12px] text-[var(--color-danger)]">{toggleError}</p>
       )}
@@ -1349,7 +1343,7 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
   };
 
   return (
-    <SettingsPage title="Appearance" description="Colors and visual style.">
+    <SettingsPage section="appearance" title="Appearance" description="Colors and visual style.">
       <SettingsTabbed
         ariaLabel="Appearance settings"
         tabs={APPEARANCE_TABS}
@@ -1690,6 +1684,7 @@ function MobileModeToggle() {
 function MobileSection() {
   return (
     <SettingsPage
+      section="mobile"
       title="Connect on your phone"
       description="Run the native Coven Cave app on your iPhone or iPad and reach this desktop over your Tailscale network — no token, no password."
     >
@@ -1747,7 +1742,7 @@ function AboutSection() {
   }, []);
 
   return (
-    <SettingsPage title="About" description="Version and build information.">
+    <SettingsPage section="about" title="About" description="Version and build information.">
       <SettingsGroup label="CovenCave">
         <SettingsKV label="App version" value={APP_VERSION} />
         <UpdateSettingsRow />
@@ -1786,13 +1781,17 @@ function AboutSection() {
 
 // ─── Primitives ───────────────────────────────────────────────────────────────
 
-function SettingsPage({ title, description, children }: { title: string; description?: string; children: React.ReactNode }) {
+function SettingsPage({ title, description, section, children }: { title: string; description?: string; section?: Section; children: React.ReactNode }) {
   return (
     <div className="max-w-none space-y-6">
-      <div>
-        <h1 className="text-[18px] font-semibold text-[var(--text-primary)]">{title}</h1>
-        {description && <p className="mt-1 text-[12px] text-[var(--text-muted)]">{description}</p>}
-      </div>
+      {section ? (
+        <SettingsOverview section={section} />
+      ) : (
+        <div>
+          <h1 className="text-[18px] font-semibold text-[var(--text-primary)]">{title}</h1>
+          {description && <p className="mt-1 text-[12px] text-[var(--text-muted)]">{description}</p>}
+        </div>
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
Each Settings section now opens with a richer header instead of a plain title — an accent-marked section icon, a **"Settings · <Section>"** kicker, the title + one-line description, and a short **"what's in here"** highlight strip. Gives each page a clearer sense of place.

Verified in a browser (Appearance = pink theme accent + Theme & colors / Typography / Reading comfort chips; Daemon = green accent + Runtime health / Restart action / Socket & version).

## What
- **`settings-sections.ts`** (new): the navigable `SECTIONS` (now carrying a per-section `description` + `accent`), `SECTION_HIGHLIGHTS`, and `getSectionMeta` / `settingsSectionLabel` — shared by the shell nav and the overview header so there's one source of truth. The search index stays in `settings-shell` next to its search box, so `settings-search`'s guard is untouched.
- **`settings-overview.tsx`** (new): the header component. Styles in `globals.css` (`.settings-overview*`).
- **`settings-shell.tsx`**: imports `Section`/`SECTIONS` from the new module (drops the local copies); `SettingsPage` renders `<SettingsOverview>` when given a `section`; the 6 `SettingsPage`-based sections opt in (Familiars keeps its own studio-panel header).

Clean from-scratch implementation off current `main` — the section set already matches (the `permissions` section was folded into Familiars by #2080).

## Tests
- `settings-overview.test.ts`: section-catalog completeness (every section has label/icon/accent/description + highlights), `getSectionMeta` fallback, and overview/shell source-text wiring. Wired into `run-tests.mjs`.
- Existing `settings-search` / `settings-shell-polish` stay green (`SETTINGS_INDEX` + `sectionLabel` kept in the shell; `max-w-none` wrapper + `SECTIONS` usage preserved).

`typecheck` ✓, `check:tests-wired` ✓, `test:app` (481) ✓, `test:api` (101) ✓, `test:mobile` (65) ✓, `pnpm build` ✓.

> Note: a concurrent session has an unmerged variant of this idea in the shared checkout; this PR is an independent, clean implementation off `main` (per your request to recreate rather than salvage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)