### PR TITLE
feat(home): image-forward media row in the digest carousel

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -56,6 +56,8 @@ assert.match(css, /mask-image: linear-gradient\(to right/, "soft fade edges on t
 assert.match(css, /home-digest-marquee 100s/, "marquee slowed to 100s for readability");
 assert.match(css, /\.home-digest__track--media[\s\S]*?animation-direction: reverse/, "media row drifts the opposite way, separated from chats");
 assert.match(css, /\.home-digest__thumb[\s\S]*?object-fit: cover/, "media thumbnail is a cover-fit image");
+assert.match(css, /\.home-digest__thumb[\s\S]*?width: 46px/, "media thumbnail is enlarged for the image-forward row");
+assert.match(css, /\.home-digest__card--media[\s\S]*?padding-left/, "media cards are image-forward (thumbnail hugs the leading edge)");
 
 // ── Wired into the home composer below "Jump back in" ─────────────────────────
 assert.match(composer, /import \{ HomeDigestCarousel \}/, "home composer imports the carousel");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -847,14 +847,31 @@
 }
 /* Media-row thumbnail: the article image leads the card; the newspaper icon is
    the fallback when the feed had no usable image (or it fails to load). */
+/* Media cards are image-forward: a larger thumbnail hugs the card's left edge so
+   the row reads as a media strip rather than another lane of chat chips. */
+.home-digest__card--media {
+  gap: 11px;
+  padding-left: 7px;
+}
 .home-digest__thumb {
-  width: 38px;
-  height: 38px;
-  margin: -3px 0;
-  border-radius: 9px;
+  width: 46px;
+  height: 46px;
+  margin: -4px 0;
+  border-radius: 10px;
   object-fit: cover;
   flex-shrink: 0;
   background: var(--bg-base);
+}
+/* Keep the fallback newspaper icon visually centered in the same footprint the
+   thumbnail would occupy, so imaged and icon-only media cards align. */
+.home-digest__card--media .home-digest__icon {
+  width: 46px;
+  height: 46px;
+  margin: -4px 0;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
 }
 .home-digest__body {
   display: flex;


### PR DESCRIPTION
## What

Follow-up polish to the split digest carousel (#2083) — "make both rows look great."

Ran dev on Home and the media row's tiny 38px thumbnails barely read as images and looked nearly identical to the chats row. Now the media row is genuinely **image-forward**:

- **Larger 46px thumbnail** that hugs the card's left edge → the row reads as a media strip, not another lane of chat chips.
- **Image-less headlines** get a matching rounded, accent-tinted **icon box** in the same 46px footprint, so imaged and icon-only media cards stay aligned.

The chats row (summary + sessions) is unchanged and sits above it.

## Verification (live dev on Home)

Both rows render and read as distinct: chats on top with small chat icons; image-forward media beneath with real article thumbnails (The Verge/Nest, etc.) and consistent icon fallback (BBC, Hacker News). `pnpm typecheck` clean; carousel source-text test updated + green.

CSS-only change (+ test). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)