### PR TITLE
feat(code): Codex 3-column layout — files left, chat center, Changes right

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -17,61 +17,38 @@ const globals = await readFile(new URL("../app/globals.css", import.meta.url), "
 const toolbar = await readFile(new URL("./code-inline-toolbar.tsx", import.meta.url), "utf8");
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 
-// ── CodeView is the Codex split — conversation + Environment rail ────────────
-// The familiar conversation owns the center column; a right-hand Environment rail
-// hosts the working tree (Changes — the git diff — and Files — tree + preview +
-// terminal). Both columns stay mounted side by side so chat/terminals/preview/diff
-// keep their state; the rail collapses to a thin strip to give the chat full width.
-assert.match(codeView, /type EnvView = "changes" \| "files"/, "CodeView models the rail's two views");
-assert.match(codeView, /const \[envOpen, setEnvOpen\] = useState\(true\)/, "the Environment rail starts open");
-assert.match(codeView, /const \[envView, setEnvView\] = useState<EnvView>\("changes"\)/, "the rail opens on Changes by default");
-assert.match(codeView, /cave-code-page__conversation[\s\S]*?\{chat\}/, "the center column renders the chat slot");
-assert.match(codeView, /aria-label="Environment"/, "the right rail is the labelled Environment panel");
-assert.match(codeView, /cave-code-page__env-title">Environment</, "the rail header is titled Environment");
-// The Changes/Files segment drives ONE comux instance (cloned with a controlled
-// rightView), so toggling Changes↔Files never remounts the terminals or preview.
-assert.match(codeView, /cave-code-page__env-tab[\s\S]*?v === "changes" \? "ph:git-diff" : "ph:file-code"[\s\S]*?v === "changes" \? "Changes" : "Files"/, "the rail header lists the Changes and Files views");
-assert.match(codeView, /onClick=\{\(\) => setEnvView\(v\)\}/, "the rail segment switches the comux view");
+// ── CodeView is the Codex 3-column shell — Files · Chat · Changes ────────────
+// Three columns side by side: the file-tree explorer (left), the familiar
+// conversation (center), and the working tree (right — file preview + a Files/
+// Changes toggle to the git diff). ComuxView owns the three-column layout so the
+// tree and the diff sit on opposite sides of the chat from ONE comux instance (no
+// duplicated state); CodeView feeds the conversation in as comux's centerSlot.
+// Every pane stays mounted so chat/terminals/preview/diff keep their state.
 assert.match(
   codeView,
-  /cloneElement\([\s\S]*?rightView: envView,[\s\S]*?onRightViewChange,/,
-  "comux is cloned with a controlled rightView bound to the active rail view",
+  /cloneElement\([\s\S]*?\{ centerSlot: chat \}/,
+  "CodeView injects the conversation as comux's centerSlot (comux owns the columns)",
 );
-assert.match(
-  codeView,
-  /const onRightViewChange = useCallback\(\(next: EnvView\) => \{[\s\S]*?setEnvView\(next\);[\s\S]*?setEnvOpen\(true\)/,
-  "comux's own view switches (file-open, diff-first) open the rail on the matching view",
-);
-// The rail can be collapsed (its own control, or the Chat preset) and reopened
-// from a thin rail button — both faces of the same envOpen state.
-assert.match(codeView, /aria-label="Hide Environment"[\s\S]*?onClick=\{\(\) => setEnvOpen\(false\)\}/, "the rail header collapses the Environment");
-assert.match(codeView, /cave-code-page__env-rail[\s\S]*?aria-label="Show Environment"[\s\S]*?onClick=\{\(\) => setEnvOpen\(true\)\}/, "a thin rail reopens a collapsed Environment");
-assert.match(codeView, /data-env-open=\{envOpen \? "1" : "0"\}/, "the shell advertises the rail's open state");
 assert.match(codeView, /data-code-layout="codex"/, "Code mode advertises the Codex-like layout for scoped styling");
 assert.match(codeView, /className="cave-code-page cave-code-page--codex/, "Code mode owns a full-page Codex layout shell");
-assert.match(codeView, /cave-code-page__conversation flex/, "the conversation keeps the center-column wrapper");
-assert.match(codeView, /cave-code-page__env flex/, "the Environment keeps the rail wrapper");
 assert.match(globals, /\.cave-code-page\s*\{[\s\S]*?background:[\s\S]*?\.cave-code-page__env/, "Code page shell defines the Codex-like chrome");
 assert.match(globals, /@media \(max-width: 1023px\)[\s\S]*?\.cave-code-page/, "Code page chrome has a mobile/narrow override");
-// No resizable split: the columns are a plain flex layout, the rail a fixed width.
-assert.doesNotMatch(codeView, /orientation="horizontal"/, "no resizable Group drives the split");
+// No resizable split, no tabbed pane: a plain side-by-side column layout.
+assert.doesNotMatch(codeView, /orientation="horizontal"/, "no resizable Group drives the layout");
 assert.doesNotMatch(codeView, /usePanelRef|panelRef=\{chatPanelRef\}|CODE_PRESET_CHAT_SIZE/, "no chat-panel resize logic remains");
 
-// ── Layout presets (Chat / Split / Review) map onto the Codex split ──────────
-// The preset chips live on the chat surface's tab row (CodeInlineToolbar) and
-// broadcast CODE_PRESET_EVENT; CodeView maps Chat→collapse the rail, Split→Files,
-// Review→Changes.
-assert.match(codeView, /addEventListener\(CODE_PRESET_EVENT/, "CodeView listens for the preset broadcast");
+// ── comux lays out the three columns: tree · chat (centerSlot) · preview/Changes ─
+assert.match(comux, /centerSlot\?: ReactNode/, "ComuxView accepts a centerSlot (the conversation)");
 assert.match(
-  codeView,
-  /if \(preset === "chat"\) \{\s*setEnvOpen\(false\);/,
-  "the Chat preset collapses the Environment rail",
+  comux,
+  /\{centerSlot \? \([\s\S]*?comux-center-column[\s\S]*?\{centerSlot\}/,
+  "the conversation renders as the center column between the tree and the preview/Changes column",
 );
-assert.match(
-  codeView,
-  /setEnvView\(preset === "review" \? "changes" : "files"\)/,
-  "Review opens the diff, Split opens the files",
-);
+
+// ── Layout presets (Chat / Split / Review) drive comux's right column ────────
+// The preset chips live on the chat surface's header row (CodeInlineToolbar) and
+// broadcast CODE_PRESET_EVENT; comux switches its preview/Changes column to match
+// (Split → Files, Review → Changes).
 assert.match(toolbar, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
 assert.match(toolbar, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
 // The toolbar is mounted on the Code surface's header row + carries the panel

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -1,133 +1,36 @@
 "use client";
 
-import { cloneElement, isValidElement, useCallback, useEffect, useState, type ReactElement, type ReactNode } from "react";
-import { Icon } from "@/lib/icon";
-import {
-  CODE_PRESET_EVENT,
-  type CodePreset,
-} from "@/lib/code-layout-preset";
+import { cloneElement, isValidElement, type ReactElement, type ReactNode } from "react";
 
 type Props = {
-  /** Familiar conversation pane. Holds the center column. */
+  /** Familiar conversation pane — the center column of the Codex layout. */
   chat: ReactNode;
-  /** Code pane: the comux surface — file tree + editable preview + terminal +
-   *  project search + the working-tree changes review. Lives in the Environment rail. */
+  /** Code pane: the comux surface. In the Code workspace it owns the whole
+   *  three-column layout (file tree · conversation · preview/Changes); the chat
+   *  is injected as comux's centerSlot. */
   comux: ReactNode;
 };
 
 /**
- * Unified Code workspace (mode "code"), styled after the OpenAI Codex layout: the
- * familiar conversation owns the center column, and a right-hand **Environment**
- * rail hosts the working tree — Changes (the git diff) and Files (tree + editable
- * preview + terminal). Both columns stay mounted side by side so the conversation,
- * terminals, preview, and diff review keep their state; the rail can be collapsed
- * to give the conversation the full width.
+ * Unified Code workspace (mode "code"), styled after the OpenAI Codex layout —
+ * three columns side by side: the file-tree explorer (left), the familiar
+ * conversation (center), and the working tree (right: the file preview with a
+ * Files/Changes toggle to the git diff review).
  *
- * Files and Changes are two faces of the same ComuxView instance: it is rendered
- * once inside the rail and told which sub-view to show via the controlled
- * `rightView` prop, so toggling Files↔Changes (or an agent edit auto-surfacing the
- * diff) never remounts the terminals or preview.
+ * ComuxView owns the three-column layout so the tree and the diff can sit on
+ * opposite sides of the conversation from a SINGLE comux instance (no duplicated
+ * selection/preview/terminal state); CodeView just feeds the conversation in as
+ * comux's `centerSlot`. Every pane stays mounted so chat, terminals, preview, and
+ * diff keep their state.
  */
-type EnvView = "changes" | "files";
-
 export function CodeView({ chat, comux }: Props) {
-  // The Environment rail starts open on Changes: opening the Code surface is a
-  // request to watch what the familiar is doing to the working tree. Collapse it
-  // (via the rail's own control, or the Chat preset) to focus the conversation.
-  const [envOpen, setEnvOpen] = useState(true);
-  const [envView, setEnvView] = useState<EnvView>("changes");
-
-  // The rail body is one comux surface in two states. Render it once and drive its
-  // right pane from the active segment; comux routes its own diff-first auto-switch
-  // / file-open events back through onRightViewChange so an agent edit (or a file
-  // click in chat) opens the rail on the right view.
-  const onRightViewChange = useCallback((next: EnvView) => {
-    setEnvView(next);
-    setEnvOpen(true);
-  }, []);
   const comuxNode = isValidElement(comux)
-    ? cloneElement(comux as ReactElement<Record<string, unknown>>, {
-        rightView: envView,
-        onRightViewChange,
-      })
+    ? cloneElement(comux as ReactElement<Record<string, unknown>>, { centerSlot: chat })
     : comux;
 
-  // The Chat/Split/Review preset chips (CodeInlineToolbar, on the chat tab row)
-  // map onto the Codex split: Chat collapses the rail (conversation only), Split
-  // opens it on Files, Review opens it on Changes. comux also nudges Files/Changes
-  // via onRightViewChange, so this owns the open/collapse intent.
-  useEffect(() => {
-    const onPreset = (e: Event) => {
-      const preset = (e as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
-      if (!preset) return;
-      if (preset === "chat") {
-        setEnvOpen(false);
-        return;
-      }
-      setEnvOpen(true);
-      setEnvView(preset === "review" ? "changes" : "files");
-    };
-    window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
-    return () => window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
-  }, []);
-
   return (
-    <div
-      className="cave-code-page cave-code-page--codex flex min-h-0 min-w-0 flex-1"
-      data-code-layout="codex"
-      data-env-open={envOpen ? "1" : "0"}
-    >
-      {/* Center column — the familiar conversation. */}
-      <main className="cave-code-page__conversation flex min-h-0 min-w-0 flex-1 flex-col">{chat}</main>
-
-      {/* Right Environment rail — the working tree (Changes / Files). Stays mounted
-          even while collapsed so terminals/preview/diff keep their state; a thin
-          rail button reopens it. */}
-      {envOpen ? (
-        <aside className="cave-code-page__env flex min-h-0 shrink-0 flex-col" aria-label="Environment">
-          <header className="cave-code-page__env-head flex shrink-0 items-center gap-2">
-            <Icon name="ph:cube" width={15} />
-            <span className="cave-code-page__env-title">Environment</span>
-            <div className="cave-code-page__env-seg ml-auto flex items-center" role="tablist" aria-label="Environment view">
-              {(["changes", "files"] as EnvView[]).map((v) => (
-                <button
-                  key={v}
-                  type="button"
-                  role="tab"
-                  aria-selected={envView === v}
-                  className="cave-code-page__env-tab"
-                  data-active={envView === v ? "1" : "0"}
-                  onClick={() => setEnvView(v)}
-                >
-                  <Icon name={v === "changes" ? "ph:git-diff" : "ph:file-code"} width={13} />
-                  <span>{v === "changes" ? "Changes" : "Files"}</span>
-                </button>
-              ))}
-            </div>
-            <button
-              type="button"
-              className="cave-code-page__env-collapse focus-ring"
-              aria-label="Hide Environment"
-              title="Hide Environment"
-              onClick={() => setEnvOpen(false)}
-            >
-              <Icon name="ph:sidebar-simple-fill" width={14} />
-            </button>
-          </header>
-          <div className="cave-code-page__env-body flex min-h-0 flex-1 flex-col">{comuxNode}</div>
-        </aside>
-      ) : (
-        <button
-          type="button"
-          className="cave-code-page__env-rail focus-ring"
-          aria-label="Show Environment"
-          title="Show Environment"
-          onClick={() => setEnvOpen(true)}
-        >
-          <Icon name="ph:cube" width={16} />
-          <span className="cave-code-page__env-rail-label">Environment</span>
-        </button>
-      )}
+    <div className="cave-code-page cave-code-page--codex flex min-h-0 min-w-0 flex-1 flex-col" data-code-layout="codex">
+      {comuxNode}
     </div>
   );
 }

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -242,10 +242,11 @@ assert.match(
 assert.match(
   source,
   // The file-tree column is wrapped in a `{!(isControlledRightView && rightView === "changes") && (…)}`
-  // guard (so Changes is a full-width tab when the Code workspace controls the
-  // view), hence the doubled `))}` closing the tree-column ternary.
-  /ProjectTree[\s\S]*?<\/div>\s*<\/div>\s*<\/div>\s*\)\)\}\s*\{filePreviewCollapsed \? \([\s\S]*?<div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">[\s\S]*?previewPath/,
-  "Projects preview pane should be the right full-height half of the split",
+  // guard, hence the doubled `))}` closing the tree-column ternary; the optional
+  // centerSlot (the Code workspace's conversation column) then sits between the
+  // tree and the preview/Changes column, before `{filePreviewCollapsed`.
+  /ProjectTree[\s\S]*?<\/div>\s*<\/div>\s*<\/div>\s*\)\)\}[\s\S]*?\{filePreviewCollapsed \? \([\s\S]*?<div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">[\s\S]*?previewPath/,
+  "Projects preview pane should be the right full-height half of the layout",
 );
 assert.match(
   source,

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -110,6 +110,12 @@ type Props = {
    *  full-width tab). Omit both for the standalone, self-toggling behaviour. */
   rightView?: "files" | "changes";
   onRightViewChange?: (view: "files" | "changes") => void;
+  /** Center column slot — the familiar conversation. When provided (the Code
+   *  workspace), the projects view lays out three columns in the Codex position:
+   *  the file-tree explorer (left), this chat (center), and the preview / Changes
+   *  review (right). Omitted elsewhere (e.g. the Library projects browser), where
+   *  comux stays two-column (tree | preview/changes). */
+  centerSlot?: ReactNode;
 };
 
 type ProjectFilePreview =
@@ -397,7 +403,7 @@ function SortableProjectRow({
   );
 }
 
-export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange }: Props) {
+export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange, centerSlot }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const layoutKey = STORAGE_LAYOUT + storageNamespace;
   const sessionsKey = STORAGE_SESSIONS + storageNamespace;
@@ -2077,6 +2083,16 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                     </div>
                   </div>
                 ))}
+
+                {/* Center column — the familiar conversation (Codex position:
+                    file tree on the left, chat in the middle, preview/Changes on
+                    the right). Only the Code workspace passes a centerSlot; the
+                    Library projects browser stays two-column. */}
+                {centerSlot ? (
+                  <div className="comux-center-column flex min-w-0 min-h-0 flex-[2.4] flex-col overflow-hidden border-b border-[var(--border-hairline)] xl:border-b-0 xl:border-r">
+                    {centerSlot}
+                  </div>
+                ) : null}
 
                 {filePreviewCollapsed ? (
                   <button


### PR DESCRIPTION
Moves the **file tree to the far-left column**, emulating the OpenAI Codex app position (`docs/familiar-chatout-codex/codex-reference.jpg`): a persistent explorer/nav rail on the left, the conversation in the center, and the working tree (file preview + Changes diff) on the right.

Supersedes the previous chat-center + right "Environment" rail (#2084) per the user's request to put Files on the left.

## How

- **`comux-view.tsx`** — `ComuxView` gains an optional `centerSlot` (the conversation). In the Code workspace it renders **three columns from a single instance** — file-tree explorer (left) · `centerSlot`/chat (center) · preview-or-Changes (right) — so the tree and the diff sit on opposite sides of the chat without duplicating selection / preview / terminal state. The `Files/Changes` toggle stays in the right column. The Library projects browser passes no `centerSlot` and stays two-column.
- **`code-view.tsx`** — now a thin shell that clones comux with `centerSlot={chat}` (replaces the env-rail split).

## Verification

- `pnpm typecheck` clean · `pnpm test:app` green (480 files) · `pnpm build` within bundle budget
- Updated source-text guards: `code-view.test.ts` (3-column shell + `centerSlot`), one boundary regex in `comux-view-terminal.test.ts`; `comux-view-changes.test.ts` passes unchanged
- Drove the prod build with Playwright (mocked project data) — confirmed three columns render: **Files explorer (left) · Chat (center) · preview/Changes with the Files/Changes toggle (right)**

> Note: this surface is being actively reshaped across sessions (#2077 → #2081 → #2084 → this). Built on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)