### PR TITLE
chore: release v0.0.126

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.126] - 2026-06-28
+
+Patch release on top of v0.0.125. Headline: Cave now ships inline
+agent-produced chat attachments, Cave-native eval templates, the latest Code
+surface rebuild, and settings/home polish from the release-ready main line.
+
+### Added
+
+- **Chat attachments** - familiar replies can now surface files they produced as
+  inline assistant-turn attachments, with allowlist-guarded file reads,
+  sanitized names, bounded previews, live streaming, and reload persistence
+  (#2035).
+- **Evals** - added Cave-native starter eval templates for review risks, tool
+  reliability, project context, merge readiness, permission blockers, memory
+  hygiene, thread freshness, response confidence, eval-loop recovery, fast
+  status updates, and familiar voice (#2049).
+- **Code surface** - rebuilt the Code workspace around a Codex-style
+  conversation and environment split, following the tab/order cleanup that
+  landed on the same release line (#2077, #2081, #2084).
+- **Settings** - section pages now include a compact overview header with icons
+  and highlights so long settings areas are easier to scan (#2088).
+- **Design specs** - added analysis-grade Evals and world-class Dashboard design
+  specs for the next polish pass (#2087).
+
+### Fixed
+
+- **Home digest** - touch and coarse-pointer devices now use manual momentum
+  scrolling instead of an unpausable auto-marquee (#2086).
+
 ## [0.0.124] - 2026-06-28
 
 Patch release on top of v0.0.123. Headline: flow executions now show real

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.125"
+version = "0.0.126"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.125"
+version = "0.0.126"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.125</string>
+	<string>0.0.126</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.125</string>
+	<string>0.0.126</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.125</string>
+	<string>0.0.126</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.125</string>
+	<string>0.0.126</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Bump Cave app/package/Tauri/Cargo/iOS metadata to `0.0.126`
- Add the `0.0.126` changelog entry for the latest release-ready main line
- Prepare the tag-driven desktop release for v0.0.126

## Verification
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `node --import "./scripts/test-alias-register.mjs" --experimental-strip-types src/lib/app-version.test.ts`
- `node scripts/ios-app-store-assets.test.mjs`
- `node scripts/release-macos-signing.test.mjs`
- `npx --yes tsx --test scripts/release-notes.test.mjs`
- `bash scripts/release-notes.sh v0.0.126 v0.0.125 >/tmp/coven-cave-v0.0.126-notes.md`
- `git diff --check`
- `pnpm build`
