### PR TITLE
feat(evals): analysis-grade — Insights tab + run-vs-run Compare

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -241,6 +241,7 @@ export const SUITES = {
     "src/components/library-file-actions.test.ts",
     "src/components/eval-loop-panel.test.ts",
     "src/lib/evals/eval-model.test.ts",
+    "src/lib/evals/eval-analytics.test.ts",
     "src/lib/evals/eval-templates.test.ts",
     "src/lib/server/eval-store.test.ts",
     "src/lib/evals/eval-judge.test.ts",
@@ -691,6 +692,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/evals/eval-analytics.test.ts",
   "src/lib/home-digest.test.ts",
   "src/lib/use-refresh-on-focus.test.ts",
   "src/lib/flow/flow-progress.test.ts",

--- a/src/components/evals/evals-insights-panel.tsx
+++ b/src/components/evals/evals-insights-panel.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useMemo } from "react";
+import { TrendChart } from "@/components/ui/charts/trend-chart";
+import { BarChart } from "@/components/ui/charts/bar-chart";
+import { suitePassRateTrend, failureClusters } from "@/lib/evals/eval-analytics";
+import type { EvalRun, EvalSuite } from "@/lib/evals/eval-model";
+
+/**
+ * Insights tab body. Shows, for the selected suite's run history: a pass-rate
+ * trend (with the SLA floor as a threshold line + a breach/ok badge) and a
+ * failure-frequency bar with a flaky-case list. Empty until the suite has runs.
+ */
+export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; runs: EvalRun[] }) {
+  const suiteRuns = useMemo(
+    () => (suite ? runs.filter((r) => r.suiteId === suite.id) : runs),
+    [suite, runs],
+  );
+  const trend = useMemo(() => suitePassRateTrend(suiteRuns), [suiteRuns]);
+  const clusters = useMemo(() => failureClusters(suiteRuns), [suiteRuns]);
+
+  if (suiteRuns.length === 0) {
+    return <div className="evals-empty">No runs yet — run a suite to see trends and failure analysis.</div>;
+  }
+
+  const sla = suite?.slaMinPassRate;
+  const latest = trend.length ? trend[trend.length - 1].y : null;
+  const breached = sla != null && latest != null && latest < sla;
+  const pct = (n: number) => `${Math.round(n * 100)}%`;
+
+  const failBars = clusters.byCase
+    .filter((c) => c.failures > 0)
+    .slice(0, 8)
+    .map((c) => ({ label: c.name, value: c.failures, color: "var(--color-danger)" }));
+
+  return (
+    <div className="evals-insights">
+      <section className="evals-insights__card">
+        <div className="evals-insights__head">
+          <span className="evals-insights__title">Pass rate over time</span>
+          {sla != null ? (
+            breached ? (
+              <span className="evals-insights__breach">SLA breach · {pct(latest!)} &lt; {pct(sla)}</span>
+            ) : (
+              <span className="evals-insights__ok">Meets SLA · {pct(sla)}</span>
+            )
+          ) : null}
+        </div>
+        <TrendChart
+          series={[{ id: suite?.id ?? "all", label: "Pass rate", color: "var(--accent-presence)", points: trend }]}
+          threshold={sla}
+          height={160}
+        />
+      </section>
+
+      {failBars.length > 0 ? (
+        <section className="evals-insights__card">
+          <div className="evals-insights__head">
+            <span className="evals-insights__title">Failures by case</span>
+          </div>
+          <BarChart data={failBars} height={150} />
+        </section>
+      ) : null}
+
+      {clusters.byCase.some((c) => c.flaky) ? (
+        <section className="evals-insights__card">
+          <div className="evals-insights__head">
+            <span className="evals-insights__title">Flaky cases</span>
+          </div>
+          <ul className="evals-insights__flaky">
+            {clusters.byCase
+              .filter((c) => c.flaky)
+              .map((c) => (
+                <li key={c.caseId}>
+                  <b>{c.name}</b>
+                  <span>
+                    {c.failures}/{c.runs} failed
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/evals/evals-view.test.ts
+++ b/src/components/evals/evals-view.test.ts
@@ -33,7 +33,7 @@ assert.match(source, /EvalsAnalysisSummary/, "renders a rich analysis summary");
 assert.match(source, /LoopAnalysisPanel/, "renders eval-loop analysis inside Evals");
 assert.match(source, /ThreadFreshnessPanel/, "renders grouped thread freshness analysis inside Evals");
 assert.match(source, /downloadRetroSnapshot/, "keeps sanitized eval-loop export available inside Evals");
-assert.match(source, /"overview" \| "suites" \| "runs" \| "loops" \| "threads"/, "unified surface has analysis-first tabs");
+assert.match(source, /"overview" \| "insights" \| "suites" \| "runs" \| "compare" \| "loops" \| "threads"/, "unified surface has analysis-first tabs");
 assert.match(source, /Overview/, "includes an Overview tab");
 assert.match(source, /Suites/, "includes a Suites tab");
 assert.match(source, /Loops/, "includes a Loops tab");
@@ -78,5 +78,12 @@ assert.match(source, /fetch\("\/api\/sessions\/list"\)/, "loads sessions to find
 assert.match(source, /s\.origin === "eval"/, "filters to eval-origin threads");
 assert.match(source, /className="evals-thread-row"/, "renders a list of eval discussion threads");
 assert.match(source, /cave:agents-open-session/, "opening a thread reopens it in the chat surface");
+
+// Insights + Compare additions
+assert.match(source, /EvalsInsightsPanel/, "renders the Insights panel");
+assert.match(source, /RunCompare/, "renders the run Compare view");
+assert.match(source, /"insights"/, "has an insights tab");
+assert.match(source, /"compare"/, "has a compare tab");
+assert.match(source, /slaMinPassRate/, "suite editor wires the SLA field");
 
 console.log("evals-view.test.ts OK");

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -30,6 +30,8 @@ import {
   type EvalTemplate,
 } from "@/lib/evals/eval-templates";
 import { Modal } from "@/components/ui/modal";
+import { EvalsInsightsPanel } from "@/components/evals/evals-insights-panel";
+import { RunCompare } from "@/components/evals/run-compare";
 import "@/styles/evals.css";
 
 type Props = {
@@ -38,7 +40,7 @@ type Props = {
 };
 
 type GraderKindOption = { kind: GraderKind; label: string; hint: string; valueless?: boolean };
-type EvalsTab = "overview" | "suites" | "runs" | "loops" | "threads";
+type EvalsTab = "overview" | "insights" | "suites" | "runs" | "compare" | "loops" | "threads";
 type RetroApiResponse =
   | { ok: true; snapshot: RetroRunsSnapshot }
   | { ok: false; snapshot?: RetroRunsSnapshot; error?: string };
@@ -462,8 +464,10 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
         <div className="evals-toolbar-tabs evals-section-tabs" role="tablist" aria-label="Evals sections">
           {([
             ["overview", "Overview"],
+            ["insights", "Insights"],
             ["suites", "Suites"],
             ["runs", `Runs${runs.length ? ` (${runs.length})` : ""}`],
+            ["compare", "Compare"],
             ["loops", "Loops"],
             ["threads", "Thread freshness"],
           ] as Array<[EvalsTab, string]>).map(([id, label]) => (
@@ -480,6 +484,8 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
             activeLoopState={activeLoopState}
             activeGroupRollup={activeGroupRollup}
           />
+        ) : tab === "insights" ? (
+          <EvalsInsightsPanel suite={draft} runs={allRuns} />
         ) : tab === "suites" ? (
           draft ? (
             <SuiteEditor draft={draft} patchDraft={patchDraft} patchCase={patchCase} patchGrader={patchGrader} setDraft={setDraft} />
@@ -508,6 +514,8 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
             expandedRunId={expandedRunId}
             onToggle={(id) => setExpandedRunId((cur) => (cur === id ? null : id))}
           />
+        ) : tab === "compare" ? (
+          <RunCompare runs={draft ? allRuns.filter((r) => r.suiteId === draft.id) : allRuns} />
         ) : tab === "loops" ? (
           <LoopAnalysisPanel
             familiarId={familiarId}
@@ -965,6 +973,22 @@ function SuiteEditor({
         rows={2}
         aria-label="Suite description"
       />
+      <label className="evals-field">
+        <span>Pass-rate SLA (%)</span>
+        <input
+          type="number"
+          min={0}
+          max={100}
+          value={draft.slaMinPassRate != null ? Math.round(draft.slaMinPassRate * 100) : ""}
+          onChange={(e) => {
+            const pct = e.target.value === "" ? undefined : Number(e.target.value);
+            patchDraft({
+              slaMinPassRate: pct == null || Number.isNaN(pct) ? undefined : Math.min(1, Math.max(0, pct / 100)),
+            });
+          }}
+          aria-label="Pass-rate SLA percent"
+        />
+      </label>
       <div className="evals-cases">
         {draft.cases.map((c, ci) => (
           <article className="evals-case" key={c.id}>

--- a/src/components/evals/run-compare.tsx
+++ b/src/components/evals/run-compare.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { diffRuns, type RunDiffStatus } from "@/lib/evals/eval-analytics";
+import type { EvalRun } from "@/lib/evals/eval-model";
+
+const STATUS_LABEL: Record<RunDiffStatus, string> = {
+  regressed: "Regressed",
+  fixed: "Fixed",
+  fail: "Fail",
+  added: "Added",
+  removed: "Removed",
+  pass: "Pass",
+};
+
+/**
+ * Pick two runs (defaults: previous vs latest) and show a case-by-case diff,
+ * regressions first. Optionally filter to only changed/failing rows.
+ */
+export function RunCompare({ runs }: { runs: EvalRun[] }) {
+  const ordered = useMemo(
+    () => [...runs].sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt)),
+    [runs],
+  );
+  const [afterId, setAfterId] = useState(() => ordered[0]?.id ?? "");
+  const [beforeId, setBeforeId] = useState(() => ordered[1]?.id ?? ordered[0]?.id ?? "");
+  const [onlyChanged, setOnlyChanged] = useState(true);
+
+  if (ordered.length < 2) {
+    return <div className="evals-empty">Need at least two runs to compare.</div>;
+  }
+
+  const before = ordered.find((r) => r.id === beforeId) ?? ordered[1];
+  const after = ordered.find((r) => r.id === afterId) ?? ordered[0];
+  const rows = diffRuns(before, after);
+  const shown = onlyChanged
+    ? rows.filter((r) => r.status !== "pass")
+    : rows;
+
+  const label = (r: EvalRun) =>
+    `${new Date(r.startedAt).toLocaleString()} · ${Math.round(r.summary.passRate * 100)}%`;
+
+  return (
+    <div className="evals-compare">
+      <div className="evals-compare__pickers">
+        <label>
+          Before{" "}
+          <select value={beforeId} onChange={(e) => setBeforeId(e.target.value)} aria-label="Baseline run">
+            {ordered.map((r) => (
+              <option key={r.id} value={r.id}>{label(r)}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          After{" "}
+          <select value={afterId} onChange={(e) => setAfterId(e.target.value)} aria-label="Comparison run">
+            {ordered.map((r) => (
+              <option key={r.id} value={r.id}>{label(r)}</option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <input type="checkbox" checked={onlyChanged} onChange={(e) => setOnlyChanged(e.target.checked)} /> Only changes
+        </label>
+      </div>
+      <table className="evals-diff">
+        <thead>
+          <tr>
+            <th>Case</th>
+            <th>Before</th>
+            <th>After</th>
+            <th>Change</th>
+          </tr>
+        </thead>
+        <tbody>
+          {shown.map((r) => (
+            <tr key={r.caseId} className={`evals-diff__row--${r.status}`}>
+              <td>{r.name}</td>
+              <td>{r.before == null ? "—" : r.before ? "Pass" : "Fail"}</td>
+              <td>{r.after == null ? "—" : r.after ? "Pass" : "Fail"}</td>
+              <td className="evals-diff__status">{STATUS_LABEL[r.status]}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/evals/eval-analytics.test.ts
+++ b/src/lib/evals/eval-analytics.test.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { suitePassRateTrend, diffRuns, failureClusters } from "./eval-analytics.ts";
+
+const caseRes = (caseId, name, pass, graders = []) => ({
+  caseId, name, input: "", output: "", latencyMs: 1, graders, pass, score: pass ? 1 : 0,
+});
+const run = (id, startedAt, results) => ({
+  id, suiteId: "s1", suiteName: "S", familiarId: "f", startedAt, results,
+  summary: {
+    total: results.length,
+    passed: results.filter((r) => r.pass).length,
+    failed: results.filter((r) => !r.pass).length,
+    passRate: results.length ? results.filter((r) => r.pass).length / results.length : 0,
+    avgScore: 0, avgLatencyMs: 1,
+  },
+});
+
+// ── suitePassRateTrend: chronological (x asc), y = passRate, empties dropped ───
+const trend = suitePassRateTrend([
+  run("r2", "2026-06-02T00:00:00Z", [caseRes("c1", "C1", true), caseRes("c2", "C2", false)]),
+  run("r1", "2026-06-01T00:00:00Z", [caseRes("c1", "C1", true), caseRes("c2", "C2", true)]),
+  run("r0", "2026-06-03T00:00:00Z", []), // empty run dropped
+]);
+assert.equal(trend.length, 2, "empty run dropped");
+assert.ok(trend[0].x < trend[1].x, "sorted oldest-first");
+assert.equal(trend[0].y, 1, "first run 2/2 passed");
+assert.equal(trend[1].y, 0.5, "second run 1/2 passed");
+
+// ── diffRuns: regression / fix / added / removed / pass / fail ─────────────────
+const before = run("a", "2026-06-01T00:00:00Z", [
+  caseRes("keep-pass", "Keep pass", true),
+  caseRes("regress", "Regress", true),
+  caseRes("fix", "Fix", false),
+  caseRes("gone", "Gone", true),
+]);
+const after = run("b", "2026-06-02T00:00:00Z", [
+  caseRes("keep-pass", "Keep pass", true),
+  caseRes("regress", "Regress", false),
+  caseRes("fix", "Fix", true),
+  caseRes("new", "New", false),
+]);
+const diff = diffRuns(before, after);
+const byId = Object.fromEntries(diff.map((d) => [d.caseId, d.status]));
+assert.equal(byId["regress"], "regressed");
+assert.equal(byId["fix"], "fixed");
+assert.equal(byId["gone"], "removed");
+assert.equal(byId["new"], "added");
+assert.equal(byId["keep-pass"], "pass");
+assert.equal(diff[0].status, "regressed", "regressions sort first");
+
+// ── failureClusters: per-case failures + flakiness + per-grader fails ─────────
+const g = (kind, pass) => ({ kind, label: kind, pass, score: pass ? 1 : 0, detail: "" });
+const clusters = failureClusters([
+  run("r1", "2026-06-01T00:00:00Z", [caseRes("flaky", "Flaky", true, [g("contains", true)]), caseRes("bad", "Bad", false, [g("regex", false)])]),
+  run("r2", "2026-06-02T00:00:00Z", [caseRes("flaky", "Flaky", false, [g("contains", false)]), caseRes("bad", "Bad", false, [g("regex", false)])]),
+  run("r3", "2026-06-03T00:00:00Z", [caseRes("flaky", "Flaky", true, [g("contains", true)]), caseRes("bad", "Bad", false, [g("regex", false)])]),
+]);
+const bad = clusters.byCase.find((c) => c.caseId === "bad");
+const flaky = clusters.byCase.find((c) => c.caseId === "flaky");
+assert.equal(bad.failures, 3, "bad failed all 3 runs");
+assert.equal(flaky.flaky, true, "flaky alternated pass/fail (>=2 transitions)");
+assert.equal(bad.flaky, false, "consistently failing is not flaky");
+assert.equal(clusters.byCase[0].caseId, "bad", "most failures first");
+assert.equal(clusters.byGrader[0].kind, "regex", "regex grader failed most");
+
+console.log("eval-analytics.test.ts passed");

--- a/src/lib/evals/eval-analytics.ts
+++ b/src/lib/evals/eval-analytics.ts
@@ -1,0 +1,119 @@
+/**
+ * Pure analysis derivations over eval runs. Everything here takes plain DTOs
+ * (EvalRun/EvalCaseResult from eval-model) and returns display-ready data, so it
+ * unit-tests without a network, DOM, or clock (see eval-analytics.test.ts).
+ */
+
+import type { EvalRun, GraderKind } from "@/lib/evals/eval-model";
+
+/** A point for the trend chart: x = run start (ms epoch), y = pass rate 0..1. */
+export type TrendPoint = { x: number; y: number };
+
+/** Pass-rate over time for a set of runs (one suite's history), oldest-first.
+ *  Runs with no cases are dropped (no meaningful rate). */
+export function suitePassRateTrend(runs: EvalRun[]): TrendPoint[] {
+  return runs
+    .filter((r) => r.summary.total > 0)
+    .map((r) => ({ x: Date.parse(r.startedAt), y: r.summary.passRate }))
+    .filter((p) => Number.isFinite(p.x))
+    .sort((a, b) => a.x - b.x);
+}
+
+export type RunDiffStatus = "regressed" | "fixed" | "fail" | "added" | "removed" | "pass";
+
+export type RunDiffRow = {
+  caseId: string;
+  name: string;
+  status: RunDiffStatus;
+  before: boolean | null;
+  after: boolean | null;
+};
+
+const DIFF_ORDER: Record<RunDiffStatus, number> = {
+  regressed: 0,
+  fixed: 1,
+  fail: 2,
+  added: 3,
+  removed: 4,
+  pass: 5,
+};
+
+/** Case-by-case diff between two runs, matched on caseId. Regressions
+ *  (was passing, now failing) sort first; unchanged passes sink to the bottom. */
+export function diffRuns(before: EvalRun, after: EvalRun): RunDiffRow[] {
+  const beforeById = new Map(before.results.map((r) => [r.caseId, r]));
+  const afterById = new Map(after.results.map((r) => [r.caseId, r]));
+  const ids = [...new Set([...beforeById.keys(), ...afterById.keys()])];
+
+  const rows: RunDiffRow[] = ids.map((id) => {
+    const b = beforeById.get(id);
+    const a = afterById.get(id);
+    const name = a?.name ?? b?.name ?? id;
+    if (b && !a) return { caseId: id, name, status: "removed", before: b.pass, after: null };
+    if (!b && a) return { caseId: id, name, status: "added", before: null, after: a.pass };
+    // both present
+    const bp = b!.pass;
+    const ap = a!.pass;
+    let status: RunDiffStatus;
+    if (bp && !ap) status = "regressed";
+    else if (!bp && ap) status = "fixed";
+    else status = ap ? "pass" : "fail";
+    return { caseId: id, name, status, before: bp, after: ap };
+  });
+
+  return rows.sort((x, y) => DIFF_ORDER[x.status] - DIFF_ORDER[y.status] || x.name.localeCompare(y.name));
+}
+
+export type CaseFailureStat = {
+  caseId: string;
+  name: string;
+  failures: number;
+  runs: number;
+  /** Alternated pass/fail >= 2 times across the run history. */
+  flaky: boolean;
+};
+
+export type GraderFailureStat = { kind: GraderKind; failures: number };
+
+/** Failure analysis across a run history: per-case failure counts + flakiness,
+ *  and per-grader-kind failure counts. Runs are read oldest-first so flakiness
+ *  (pass/fail transitions) is meaningful. Only cases that failed at least once
+ *  or are flaky are returned, most-failures first. */
+export function failureClusters(runs: EvalRun[]): {
+  byCase: CaseFailureStat[];
+  byGrader: GraderFailureStat[];
+} {
+  const sorted = [...runs].sort((a, b) => Date.parse(a.startedAt) - Date.parse(b.startedAt));
+  const caseMap = new Map<string, { name: string; results: boolean[] }>();
+  const graderFails = new Map<GraderKind, number>();
+
+  for (const run of sorted) {
+    for (const res of run.results) {
+      const entry = caseMap.get(res.caseId) ?? { name: res.name, results: [] };
+      entry.name = res.name;
+      entry.results.push(res.pass);
+      caseMap.set(res.caseId, entry);
+      for (const grader of res.graders) {
+        if (!grader.pass) graderFails.set(grader.kind, (graderFails.get(grader.kind) ?? 0) + 1);
+      }
+    }
+  }
+
+  const byCase: CaseFailureStat[] = [...caseMap.entries()]
+    .map(([caseId, e]) => {
+      const failures = e.results.filter((p) => !p).length;
+      let transitions = 0;
+      for (let i = 1; i < e.results.length; i++) {
+        if (e.results[i] !== e.results[i - 1]) transitions++;
+      }
+      return { caseId, name: e.name, failures, runs: e.results.length, flaky: transitions >= 2 };
+    })
+    .filter((c) => c.failures > 0 || c.flaky)
+    .sort((a, b) => b.failures - a.failures || a.name.localeCompare(b.name));
+
+  const byGrader: GraderFailureStat[] = [...graderFails.entries()]
+    .map(([kind, failures]) => ({ kind, failures }))
+    .sort((a, b) => b.failures - a.failures);
+
+  return { byCase, byGrader };
+}

--- a/src/lib/evals/eval-model.ts
+++ b/src/lib/evals/eval-model.ts
@@ -43,6 +43,9 @@ export type EvalSuite = {
   id: string;
   name: string;
   description?: string;
+  /** Optional pass-rate SLA floor (0..1). The Insights trend draws it as a
+   *  threshold line and flags a breach when the latest run dips below it. */
+  slaMinPassRate?: number;
   /** Default familiar to run against; the run UI may override. */
   familiarId?: string;
   cases: EvalCase[];

--- a/src/lib/server/eval-store.ts
+++ b/src/lib/server/eval-store.ts
@@ -99,6 +99,10 @@ function coerceSuite(value: unknown): EvalSuite | null {
     id: s.id,
     name: typeof s.name === "string" && s.name.trim() ? s.name : s.id,
     description: typeof s.description === "string" ? s.description : undefined,
+    slaMinPassRate:
+      typeof s.slaMinPassRate === "number" && Number.isFinite(s.slaMinPassRate)
+        ? Math.min(1, Math.max(0, s.slaMinPassRate))
+        : undefined,
     familiarId: typeof s.familiarId === "string" ? s.familiarId : undefined,
     cases: Array.isArray(s.cases)
       ? s.cases.map(coerceCase).filter((c): c is EvalCase => c !== null)

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -843,3 +843,18 @@
 .evals-insights__flaky { list-style: none; margin: 8px 0 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
 .evals-insights__flaky li { display: flex; justify-content: space-between; font-size: 12px; color: var(--text-secondary); }
 .evals-insights__flaky b { color: var(--text-primary); font-weight: 500; }
+
+/* Run comparison. */
+.evals-compare { display: flex; flex-direction: column; gap: 12px; }
+.evals-compare__pickers { display: flex; gap: 10px; flex-wrap: wrap; }
+.evals-compare__pickers select {
+  background: var(--bg-base); color: var(--text-primary);
+  border: 1px solid var(--border-hairline); border-radius: 8px; padding: 6px 8px; font-size: 12px;
+}
+.evals-diff { width: 100%; border-collapse: collapse; font-size: 12px; }
+.evals-diff th, .evals-diff td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border-hairline); }
+.evals-diff th { color: var(--text-muted); font-weight: 600; }
+.evals-diff__status { font-weight: 600; }
+.evals-diff__row--regressed { background: color-mix(in oklch, var(--color-danger) 10%, transparent); }
+.evals-diff__row--regressed .evals-diff__status { color: var(--color-danger); }
+.evals-diff__row--fixed .evals-diff__status { color: var(--color-success); }

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -819,3 +819,27 @@
   font-weight: 600;
   color: var(--accent-presence);
 }
+
+/* Insights tab — trend + failure analysis. */
+.evals-insights { display: flex; flex-direction: column; gap: 18px; }
+.evals-insights__card {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control, 10px);
+  background: var(--bg-raised);
+  padding: 14px 16px;
+}
+.evals-insights__head {
+  display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px;
+}
+.evals-insights__title { font-size: 12.5px; font-weight: 600; color: var(--text-primary); }
+.evals-insights__breach {
+  font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px;
+  background: color-mix(in oklch, var(--color-danger) 18%, transparent); color: var(--color-danger);
+}
+.evals-insights__ok {
+  font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px;
+  background: color-mix(in oklch, var(--color-success) 16%, transparent); color: var(--color-success);
+}
+.evals-insights__flaky { list-style: none; margin: 8px 0 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
+.evals-insights__flaky li { display: flex; justify-content: space-between; font-size: 12px; color: var(--text-secondary); }
+.evals-insights__flaky b { color: var(--text-primary); font-weight: 500; }


### PR DESCRIPTION
**PR 2 of 3** from the Evals/Dashboard specs. Adds an analysis layer to the Evals surface, built on the visx chart primitives from #2093. **Additive** — existing tabs/panels/routes untouched (one optional suite field only); coordinated to avoid colliding with the in-flight eval work.

## What's added
- **Insights tab** — for the selected suite's run history:
  - pass-rate **TrendChart** with the suite's **SLA floor** drawn as a threshold line + a **breach/ok badge** (latest run vs SLA),
  - **failures-by-case BarChart**, and a **flaky-case list** (cases that alternate pass/fail).
- **Compare tab** — pick two runs (defaults: previous vs latest) → case-by-case **diff table** with **regressions first**, plus an "Only changes" filter.
- **Suite SLA field** — optional `slaMinPassRate` (0..1) on `EvalSuite`, edited as a 0–100% input in the suite editor; flows through `coerceSuite` → existing save POST (no new persistence).

## Design
- All derivations live in a new **pure, fully-tested** `src/lib/evals/eval-analytics.ts` (`suitePassRateTrend`, `diffRuns`, `failureClusters`). UI is two small self-contained components, so `evals-view.tsx` only gains tab entries + render branches + the SLA field.
- **No new API routes.** SLA lives on the **suite** (data-model-correct: suites carry `passRate`; groups model thread-freshness).

## Deferred (flagged)
The **EvalGroups management UI (CRUD)** — the groups route has no DELETE and groups are thread-freshness scoped — is a PR2-follow-up, not in this PR.

## Verification
- `tsc` clean; new `eval-analytics.test.ts` (trend/diff/clusters) green and wired (app suite + ALIAS_LOADER); existing `evals-view.test.ts` still passes (only the tab-union string synced); `check:tests-wired` ✓; `pnpm build` + bundle-budget ✓ (Evals lazy chunk 1714/2400 KB, shell unchanged 447/650 KB).
- Built TDD via subagent; adversarial spec+quality review APPROVED (analytics logic, SLA round-trip, null-suite safety, undefined-threshold all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)