### PR TITLE
feat(code): replace primary sidebar in code mode

### DIFF
--- a/src/components/code-sidebar.tsx
+++ b/src/components/code-sidebar.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { deriveComuxProjects, type ComuxProject } from "@/lib/comux-projects";
+import { sessionRailTitle } from "@/lib/session-rail-title";
+import { relativeTime } from "@/lib/relative-time";
+import type { SessionRow } from "@/lib/types";
+
+type Props = {
+  sessions: SessionRow[];
+  activeSessionId?: string | null;
+  onBack: () => void;
+  onOpenSession: (session: SessionRow) => void;
+  onNewChat: (projectRoot: string | null) => void;
+};
+
+function compactTime(iso: string): string {
+  return relativeTime(iso, Date.now(), "compact");
+}
+
+function statusClass(status: string): string {
+  if (status === "running") return "bg-[var(--color-success)]";
+  if (status === "failed") return "bg-[var(--color-danger)]";
+  if (status === "queued") return "bg-[var(--color-warning)]";
+  return "bg-[var(--text-muted)]";
+}
+
+function sessionsForProject(sessions: SessionRow[], project: ComuxProject): SessionRow[] {
+  return sessions
+    .filter((session) => session.project_root?.replace(/\\/g, "/").replace(/\/+$/, "") === project.root)
+    .sort((a, b) => (b.updated_at || b.created_at).localeCompare(a.updated_at || a.created_at));
+}
+
+export function CodeSidebar({
+  sessions,
+  activeSessionId,
+  onBack,
+  onOpenSession,
+  onNewChat,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [expandedRoots, setExpandedRoots] = useState<Set<string>>(() => new Set());
+
+  const projects = useMemo(() => deriveComuxProjects(sessions), [sessions]);
+  const visibleProjects = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return projects;
+    return projects.filter((project) => {
+      if (project.name.toLowerCase().includes(q) || project.root.toLowerCase().includes(q)) return true;
+      return sessionsForProject(sessions, project).some((session) =>
+        sessionRailTitle(session).toLowerCase().includes(q),
+      );
+    });
+  }, [projects, query, sessions]);
+
+  const toggleProject = (root: string) => {
+    setExpandedRoots((current) => {
+      const next = new Set(current);
+      if (next.has(root)) next.delete(root);
+      else next.add(root);
+      return next;
+    });
+  };
+
+  const selectProject = (project: ComuxProject) => {
+    window.dispatchEvent(new CustomEvent("cave:code-select-project", { detail: { root: project.root } }));
+  };
+
+  return (
+    <div className="code-sidebar flex h-full min-h-0 flex-col bg-[color-mix(in_oklch,var(--bg-raised)_88%,transparent)]">
+      <header className="code-sidebar__header flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-2 py-2">
+        <button
+          type="button"
+          aria-label="Back to previous surface"
+          title="Back to previous surface"
+          onClick={onBack}
+          className="focus-ring grid h-7 w-7 shrink-0 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name="ph:arrow-left-bold" width={13} aria-hidden />
+        </button>
+        <div className="min-w-0">
+          <div className="truncate text-[12px] font-semibold text-[var(--text-primary)]">Code</div>
+          <div className="truncate text-[10px] uppercase tracking-[0.12em] text-[var(--text-muted)]">Projects</div>
+        </div>
+      </header>
+
+      <div className="shrink-0 border-b border-[var(--border-hairline)] px-2 py-2">
+        <label className="flex h-7 items-center gap-1.5 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)]/55 px-2 focus-within:border-[var(--border-strong)]">
+          <Icon name="ph:magnifying-glass" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search projects or threads..."
+            aria-label="Search Code projects and threads"
+            className="min-w-0 flex-1 bg-transparent text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+          />
+          {query ? (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => setQuery("")}
+              className="text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            >
+              <Icon name="ph:x-bold" width={10} aria-hidden />
+            </button>
+          ) : null}
+        </label>
+      </div>
+
+      <nav aria-label="Code projects and threads" className="min-h-0 flex-1 overflow-y-auto pb-2">
+        {visibleProjects.length === 0 ? (
+          <p className="px-3 py-4 text-center text-[11px] text-[var(--text-muted)]">
+            No code projects yet.
+          </p>
+        ) : (
+          <ul>
+            {visibleProjects.map((project) => {
+              const projectSessions = sessionsForProject(sessions, project);
+              const expanded = expandedRoots.has(project.root) || query.trim().length > 0;
+              return (
+                <li key={project.root}>
+                  <div className="group relative flex items-center border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)]">
+                    <button
+                      type="button"
+                      aria-expanded={expanded}
+                      aria-label={`${expanded ? "Collapse" : "Expand"} ${project.name} threads`}
+                      onClick={() => {
+                        selectProject(project);
+                        toggleProject(project.root);
+                      }}
+                      className="focus-ring flex min-h-[38px] min-w-0 flex-1 items-center gap-1.5 rounded py-2 pl-2 pr-8 text-left text-[12px] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                    >
+                      <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                      <Icon name={expanded ? "ph:folder-open" : "ph:folder"} width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                      <span className="min-w-0 flex-1 truncate font-semibold text-[var(--text-primary)]" title={project.root}>
+                        {project.name}
+                      </span>
+                      <span className="shrink-0 font-mono text-[11px] text-[var(--text-muted)]">{projectSessions.length}</span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        selectProject(project);
+                        onNewChat(project.root);
+                      }}
+                      title={`New code chat in ${project.name}`}
+                      aria-label={`New code chat in ${project.name}`}
+                      className="touch-always-visible focus-ring absolute right-1 grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
+                    >
+                      <Icon name="ph:plus" width={11} aria-hidden />
+                    </button>
+                  </div>
+                  {expanded ? (
+                    projectSessions.length === 0 ? (
+                      <p className="py-1 pl-8 pr-3 text-[11px] text-[var(--text-muted)]">No threads yet.</p>
+                    ) : (
+                      <ul>
+                        {projectSessions.map((session) => {
+                          const title = sessionRailTitle(session);
+                          const active = activeSessionId === session.id;
+                          return (
+                            <li key={session.id}>
+                              <button
+                                type="button"
+                                aria-current={active ? "page" : undefined}
+                                onClick={() => {
+                                  selectProject(project);
+                                  onOpenSession(session);
+                                }}
+                                className={[
+                                  "flex min-h-[34px] w-full items-center gap-1.5 py-2 pl-4 pr-2 text-left text-[12px] transition-colors",
+                                  active
+                                    ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+                                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
+                                ].join(" ")}
+                              >
+                                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusClass(session.status)}`} aria-hidden />
+                                <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
+                                <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">
+                                  {compactTime(session.updated_at || session.created_at)}
+                                </span>
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -8,6 +8,7 @@ import { readFile } from "node:fs/promises";
 const codeView = await readFile(new URL("./code-view.tsx", import.meta.url), "utf8");
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const codeSidebar = await readFile(new URL("./code-sidebar.tsx", import.meta.url), "utf8");
 const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const preset = await readFile(new URL("../lib/code-layout-preset.ts", import.meta.url), "utf8");
@@ -58,13 +59,59 @@ assert.match(chatSurface, /isCodeSurface \? \([\s\S]*?<CodeInlineToolbar \/>/, "
 assert.match(toolbar, /code-panel-toggle/, "the toolbar includes the companion-panel toggle");
 assert.match(toolbar, /cave:toggle-right-panel/, "the panel toggle asks the shell to toggle the companion panel");
 
-// ── The projects list is merged into the file-explorer column (in comux) ──────
-// It's a collapsible "Projects" section above the file tree, sharing one column
-// with it (no separate 200px column / rail). The Code toolbar no longer carries
-// the toggle; it drives the section's collapse via projectListCollapsed.
+// ── Code mode owns project/thread nav in the primary sidebar ─────────────────
+// The app shell swaps the far-left application menu for CodeSidebar when
+// mode === "code"; comux keeps file/search/diff concerns and hides its internal
+// project/session navigator in that mode.
+assert.match(workspace, /import \{ CodeSidebar \}/, "Workspace imports the CodeSidebar");
+assert.match(
+  workspace,
+  /const codeSidebar = \([\s\S]*?<CodeSidebar[\s\S]*?onBack=\{exitCodeMode\}/,
+  "Workspace builds a CodeSidebar with a back action",
+);
+assert.match(
+  workspace,
+  /nav=\{mode === "code" \? codeSidebar : sidebar\}/,
+  "Code mode replaces the primary nav slot instead of supplementing it",
+);
+assert.match(
+  workspace,
+  /const \[lastNonCodeMode, setLastNonCodeMode\] = useState<WorkspaceMode>\("home"\)/,
+  "Workspace tracks the previous non-Code surface for Back",
+);
+assert.match(
+  workspace,
+  /const exitCodeMode = useCallback\(\(\) => \{[\s\S]*?setMode\(lastNonCodeMode === "code" \? "home" : lastNonCodeMode\)/,
+  "Back exits Code to the previous non-Code surface with Home fallback",
+);
+assert.match(
+  codeSidebar,
+  /export function CodeSidebar/,
+  "CodeSidebar is a dedicated component",
+);
+assert.match(codeSidebar, /aria-label="Back to previous surface"/, "CodeSidebar exposes the Back control");
+assert.match(codeSidebar, /aria-label="Code projects and threads"/, "CodeSidebar names its project/thread navigator");
+assert.match(codeSidebar, /cave:code-select-project/, "CodeSidebar announces project selection to the Code surface");
+assert.match(codeSidebar, /onOpenSession\(session\)/, "CodeSidebar opens thread rows through the workspace/session bridge");
+assert.match(
+  workspace,
+  /<ComuxView[\s\S]*?view="projects"[\s\S]*?hideProjectNavigator/,
+  "Code-mode ComuxView hides duplicate project/thread navigation",
+);
+assert.match(comux, /hideProjectNavigator\?: boolean/, "ComuxView accepts hideProjectNavigator");
+assert.match(comux, /if \(hideProjectNavigator\) return;/, "Comux project-list shortcuts are disabled when hidden");
+assert.match(comux, /cave:code-select-project/, "Comux listens for CodeSidebar project selection");
+assert.match(
+  comux,
+  /\{!hideProjectNavigator && \([\s\S]*?Projects — merged into this column/,
+  "Comux wraps the project switcher in the hideProjectNavigator guard",
+);
+assert.match(
+  comux,
+  /\{!hideProjectNavigator && \([\s\S]*?Recent sessions/,
+  "Comux wraps duplicate recent sessions in the hideProjectNavigator guard",
+);
 assert.doesNotMatch(codeView, /toggleProjects|aria-label=\{?"?(Hide|Show) projects/i, "the collapse toggle is not in the Code toolbar anymore");
-assert.match(comux, /onClick=\{\(\) => setProjectListVisible\(projectListCollapsed\)\}/, "the merged Projects section header toggles its own collapse");
-assert.match(comux, /comux-project-row/, "the projects list renders project rows in the explorer column");
 // Right-click a project row → a context menu with cwd-scoped actions. The row
 // is an extracted SortableProjectRow; the wiring lives in the onRowContextMenu
 // callback passed to it.

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -116,6 +116,10 @@ type Props = {
    *  review (right). Omitted elsewhere (e.g. the Library projects browser), where
    *  comux stays two-column (tree | preview/changes). */
   centerSlot?: ReactNode;
+  /** Code mode moves project/thread navigation into the primary shell sidebar.
+   *  When this is true, keep this column focused on the selected project's
+   *  details, search, files, terminals, preview, and diff state. */
+  hideProjectNavigator?: boolean;
 };
 
 type ProjectFilePreview =
@@ -403,7 +407,7 @@ function SortableProjectRow({
   );
 }
 
-export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange, centerSlot }: Props) {
+export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange, centerSlot, hideProjectNavigator = false }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const layoutKey = STORAGE_LAYOUT + storageNamespace;
   const sessionsKey = STORAGE_SESSIONS + storageNamespace;
@@ -591,6 +595,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // GitHub-style "/" focuses the project filter while the Code surface is shown,
   // unless the user is already typing or holding a modifier.
   useEffect(() => {
+    if (hideProjectNavigator) return;
     if (!active) return;
     function onKey(e: KeyboardEvent) {
       if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
@@ -603,7 +608,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [active]);
+  }, [active, hideProjectNavigator]);
 
   // Keep the selected project on screen — when the list is long, or after a
   // filter changes which rows are rendered. block:"nearest" is a no-op if it's
@@ -1031,6 +1036,18 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       window.removeEventListener("cave:open-file-diff", onOpenDiff as EventListener);
     };
   }, [active, openFilePreview, selectedRoot, projects, selectedProjectRoot]);
+
+  useEffect(() => {
+    if (view !== "projects" || !active) return;
+    const onSelectProject = (event: Event) => {
+      const root = (event as CustomEvent<{ root?: string }>).detail?.root;
+      if (!root) return;
+      setSelectedProjectRoot(root);
+      setProjectDetailCollapsed(false);
+    };
+    window.addEventListener("cave:code-select-project", onSelectProject as EventListener);
+    return () => window.removeEventListener("cave:code-select-project", onSelectProject as EventListener);
+  }, [active, view]);
 
   // Code workspace toolbar wiring (projects view only): the Projects toggle
   // shows/hides this column, and a layout preset additionally switches the
@@ -1726,6 +1743,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         scrolling up bleed into the gap above it. Top breathing
                         room lives inside the header instead (its own padding). */}
                     <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+                    {!hideProjectNavigator && (
+                      <>
                     {/* Projects — merged into this column above the file tree so
                         the project switcher and the file browser share one
                         explorer. Collapsible; the Code toolbar's Projects toggle
@@ -1886,6 +1905,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         </>
                       )}
                     </ContextMenu>
+                      </>
+                    )}
                     {/* Project-wide code search (CODE-SEARCH-01) */}
                     <div className="mb-3">
                       <div className="relative">
@@ -2005,6 +2026,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       )}
                     </div>
 
+                    {!hideProjectNavigator && (
+                      <>
                     {/* Recent sessions — collapsible */}
                     <div className="mb-2">
                       <button
@@ -2056,6 +2079,8 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         )
                       )}
                     </div>
+                      </>
+                    )}
 
                     {/* Files — native tree */}
                     <div>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -52,6 +52,7 @@ import {
   FlowView,
   GitHubView,
 } from "@/components/lazy-surfaces";
+import { CodeSidebar } from "@/components/code-sidebar";
 import { CodeView } from "@/components/code-view";
 import { LibraryView } from "@/components/library-view";
 import { PluginsView } from "@/components/plugins-view";
@@ -200,6 +201,7 @@ export function Workspace() {
   const [topSearchQuery, setTopSearchQuery] = useState("");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
   const [mode, setMode] = useState<WorkspaceMode>("home");
+  const [lastNonCodeMode, setLastNonCodeMode] = useState<WorkspaceMode>("home");
   // Whether the first daemon status poll has resolved. Until it has, the daemon
   // state is *unknown* (not "offline"), so the offline banner must stay hidden.
   const [daemonStatusResolved, setDaemonStatusResolved] = useState(false);
@@ -288,6 +290,15 @@ export function Workspace() {
   modeRef.current = mode;
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
+
+  useEffect(() => {
+    if (mode !== "code") setLastNonCodeMode(mode);
+  }, [mode]);
+
+  const exitCodeMode = useCallback(() => {
+    setMode(lastNonCodeMode === "code" ? "home" : lastNonCodeMode);
+    shellRef.current?.dismissNavMobile();
+  }, [lastNonCodeMode]);
 
   const setMobileModeEnabled = useCallback((enabled: boolean) => {
     writeMobileModeEnabled(enabled);
@@ -1717,6 +1728,17 @@ export function Workspace() {
     startFamiliarChat(activeId, projectRoot);
   }, [activeId, startFamiliarChat]);
 
+  const openCodeProjectChat = useCallback((projectRoot: string | null) => {
+    setPendingProjectChatRoot(projectRoot ?? null);
+    setPendingChatAction({
+      kind: "new",
+      familiarId: activeId,
+      projectRoot,
+      nonce: Date.now(),
+    });
+    setMode("code");
+  }, [activeId]);
+
   const sidebar = (
     <SidebarMinimal
       mode={mode}
@@ -1763,6 +1785,26 @@ export function Workspace() {
       boardOpenCount={boardTaskCount}
       scheduleNeedsCount={scheduleNeedsCount}
       githubAssignedCount={githubAssignedCount}
+    />
+  );
+
+  const codeSidebar = (
+    <CodeSidebar
+      sessions={sessions}
+      activeSessionId={routerRef.current?.currentSessionId() ?? null}
+      onBack={exitCodeMode}
+      onOpenSession={(session) => {
+        if (session.familiarId) setActiveId(session.familiarId);
+        setPendingChatAction({
+          kind: "open",
+          sessionId: session.id,
+          familiarId: session.familiarId,
+          nonce: Date.now(),
+        });
+        setMode("code");
+        shellRef.current?.dismissNavMobile();
+      }}
+      onNewChat={openCodeProjectChat}
     />
   );
 
@@ -1888,11 +1930,12 @@ export function Workspace() {
             view="projects"
             active={mode === "code"}
             storageNamespace=":code"
+            hideProjectNavigator
             sessions={sessions}
             onOpenSession={(sessionId, familiarId) => {
               openFamiliarSession(sessionId, familiarId);
             }}
-            onNewChat={openProjectChat}
+            onNewChat={openCodeProjectChat}
           />
         }
       />
@@ -2102,7 +2145,7 @@ export function Workspace() {
           />
           </>
         )}
-        nav={sidebar}
+        nav={mode === "code" ? codeSidebar : sidebar}
         list={list}
         detail={detail}
         agent={


### PR DESCRIPTION
## Summary
- Replace the normal far-left app sidebar with a dedicated Code sidebar while `mode === "code"`.
- Add a Code sidebar with Back navigation, project search, expandable project folders, related thread rows, and per-project new-chat actions.
- Hide the duplicate inner Comux project/thread navigator in Code mode so only one far-left sidebar is visible.

## Behavior
- Back returns to the previous non-Code surface, with Home as fallback.
- Code mode keeps the existing center conversation and right Environment rail for files/changes.

## Validation
- `node --experimental-strip-types src/components/code-view.test.ts`
- `node --experimental-strip-types src/components/comux-view-terminal.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app` (483 app test files)
- `git diff --check`