### PR TITLE
feat(github): render PR review diffs as HTML (colored, line-numbered, expandable)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -43,6 +43,7 @@ export const SUITES = {
     "src/lib/project-status.test.ts",
     "src/lib/github-checks.test.ts",
     "src/lib/gfm-autolink.test.ts",
+    "src/lib/gh-diff.test.ts",
     "src/lib/chat-projects.test.ts",
     "src/lib/conversation-tree.test.ts",
     "src/lib/chat-project-selection.test.ts",

--- a/src/components/gh-diff-view.tsx
+++ b/src/components/gh-diff-view.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { parseDiff, diffStats, diffLineClass } from "@/lib/gh-diff";
+
+/**
+ * Render a GitHub unified-diff hunk as a colorized, line-numbered diff table.
+ *
+ * Replaces the old raw `<pre>` (which only showed the last few lines as flat
+ * text). Additions are green, deletions red, hunk headers tinted; old/new line
+ * numbers sit in gutter columns. Long hunks collapse to the trailing
+ * `previewLines` (the context nearest a review comment) with an expand toggle.
+ */
+export function DiffHunk({
+  hunk,
+  previewLines = 6,
+  className,
+}: {
+  hunk: string;
+  previewLines?: number;
+  className?: string;
+}) {
+  const lines = useMemo(() => parseDiff(hunk), [hunk]);
+  const stats = useMemo(() => diffStats(lines), [lines]);
+  const [expanded, setExpanded] = useState(false);
+
+  if (lines.length === 0) return null;
+
+  const collapsible = lines.length > previewLines;
+  const shown = expanded || !collapsible ? lines : lines.slice(-previewLines);
+  const hidden = lines.length - shown.length;
+
+  return (
+    <div className={`gh-diff gh-diff--hunk ${className ?? ""}`}>
+      <div className="gh-diff__bar">
+        <span
+          className="gh-diff__stat"
+          aria-label={`${stats.additions} additions, ${stats.deletions} deletions`}
+        >
+          <span className="gh-diff__stat-add">+{stats.additions}</span>
+          <span className="gh-diff__stat-del">−{stats.deletions}</span>
+        </span>
+        {collapsible && (
+          <button
+            type="button"
+            className="gh-diff__expand"
+            onClick={() => setExpanded((v) => !v)}
+            aria-expanded={expanded}
+          >
+            {expanded ? "Collapse" : `Show ${hidden} more line${hidden === 1 ? "" : "s"}`}
+          </button>
+        )}
+      </div>
+      <div className="gh-diff__body" role="table" aria-label="Diff">
+        {shown.map((line, i) => (
+          <div key={i} className={diffLineClass(line.type)} role="row">
+            <span className="gh-diff__no gh-diff__no--old" aria-hidden>
+              {line.oldNo ?? ""}
+            </span>
+            <span className="gh-diff__no gh-diff__no--new" aria-hidden>
+              {line.newNo ?? ""}
+            </span>
+            <code className="gh-diff__code">{line.text.length > 0 ? line.text : "​"}</code>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -15,6 +15,7 @@ import type { GitHubItem } from "@/lib/github-tasks";
 import { githubItemMatchesQuery } from "@/lib/github-search";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { MarkdownBlock } from "@/components/message-bubble";
+import { DiffHunk } from "@/components/gh-diff-view";
 import { gfmAutolink } from "@/lib/gfm-autolink";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
@@ -1027,9 +1028,7 @@ function GitHubComments({
                     )}
                   </div>
                   {thread.diffHunk && (
-                    <pre className="gh-thread-diff">
-                      {thread.diffHunk.split("\n").slice(-4).join("\n")}
-                    </pre>
+                    <DiffHunk hunk={thread.diffHunk} previewLines={4} className="gh-thread-diff" />
                   )}
                   {thread.comments.map((c) => (
                     <div key={c.id} className="gh-comment gh-comment--inline">

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -8,6 +8,7 @@ import { Skeleton, SkeletonGroup } from "@/components/ui/skeleton";
 import { copyText } from "@/lib/clipboard";
 import { useCopy } from "@/lib/use-copy";
 import { sanitizeHtml } from "@/lib/html-sanitize";
+import { wireDiffBlocks } from "@/lib/gh-diff";
 import { parseLeadingMetadata, type MetaEntry } from "@/lib/library-metadata";
 import { isSafeGitHubUrl, isSafeHttpUrl, isSafeVscodeFileUrl } from "@/lib/url-safety";
 import { useTauriPlatform } from "@/lib/tauri-platform";
@@ -433,6 +434,18 @@ function RenderedMarkdown({ text, containerRef }: RenderedMarkdownProps) {
     })();
     return () => { cancelled = true; };
   }, [text]);
+
+  // Colorize any ```diff fenced blocks (e.g. a README's changelog) into a real
+  // diff once the markdown lands. Idempotent + observed so a late syntax
+  // highlighter pass is caught too.
+  useEffect(() => {
+    const el = ref.current;
+    if (!html || !el) return;
+    wireDiffBlocks(el);
+    const observer = new MutationObserver(() => wireDiffBlocks(el));
+    observer.observe(el, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, [html, ref]);
 
   if (loading) return (
     <div className="library-md-skeleton">

--- a/src/lib/gh-diff.test.ts
+++ b/src/lib/gh-diff.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { classifyDiffLine, parseDiff, diffStats, diffLineClass } from "./gh-diff.ts";
+
+// ── classifyDiffLine ─────────────────────────────────────────────────────────
+assert.equal(classifyDiffLine("+added"), "add", "plus → add");
+assert.equal(classifyDiffLine("-removed"), "del", "minus → del");
+assert.equal(classifyDiffLine(" context"), "context", "space → context");
+assert.equal(classifyDiffLine("plain"), "context", "no marker → context");
+assert.equal(classifyDiffLine("@@ -1,3 +1,4 @@ fn()"), "meta", "hunk header → meta");
+assert.equal(classifyDiffLine("diff --git a/x b/x"), "meta", "diff --git → meta");
+assert.equal(classifyDiffLine("--- a/x"), "meta", "--- file header → meta (not a deletion)");
+assert.equal(classifyDiffLine("+++ b/x"), "meta", "+++ file header → meta (not an addition)");
+
+// ── parseDiff: line numbers track across the @@ header ────────────────────────
+const patch = [
+  "@@ -10,3 +10,4 @@ function foo() {",
+  " const a = 1;",
+  "-const b = 2;",
+  "+const b = 3;",
+  "+const c = 4;",
+  " return a;",
+].join("\n");
+const lines = parseDiff(patch);
+assert.equal(lines.length, 6, "parses every line including the header");
+assert.equal(lines[0].type, "meta", "first row is the hunk header");
+assert.deepEqual([lines[0].oldNo, lines[0].newNo], [null, null], "header has no line numbers");
+// context line starts both counters at 10
+assert.deepEqual([lines[1].type, lines[1].oldNo, lines[1].newNo], ["context", 10, 10], "context numbered on both sides");
+// deletion advances old only
+assert.deepEqual([lines[2].type, lines[2].oldNo, lines[2].newNo], ["del", 11, null], "deletion numbered on the old side only");
+// additions advance new only
+assert.deepEqual([lines[3].type, lines[3].oldNo, lines[3].newNo], ["add", null, 11], "first addition numbered on the new side only");
+assert.deepEqual([lines[4].type, lines[4].oldNo, lines[4].newNo], ["add", null, 12], "second addition increments the new side");
+// trailing context continues from where add/del left the counters
+assert.deepEqual([lines[5].oldNo, lines[5].newNo], [12, 13], "trailing context resumes both counters");
+
+// ── diffStats ────────────────────────────────────────────────────────────────
+assert.deepEqual(diffStats(lines), { additions: 2, deletions: 1 }, "counts adds and dels, ignores context/meta");
+assert.deepEqual(diffStats(parseDiff("")), { additions: 0, deletions: 0 }, "empty patch → zero stats");
+assert.equal(parseDiff("").length, 0, "empty patch → no rows");
+
+// ── diffLineClass ────────────────────────────────────────────────────────────
+assert.match(diffLineClass("add"), /gh-diff__line--add/, "add class");
+assert.match(diffLineClass("del"), /gh-diff__line--del/, "del class");
+assert.match(diffLineClass("meta"), /gh-diff__line--meta/, "meta class");
+assert.match(diffLineClass("context"), /gh-diff__line--ctx/, "context class");
+
+// ── Wiring: the renderer is used where GitHub review content lands ────────────
+const ghView = readFileSync(new URL("../components/github-view.tsx", import.meta.url), "utf8");
+assert.match(ghView, /import \{ DiffHunk \} from "@\/components\/gh-diff-view"/, "github-view imports DiffHunk");
+assert.match(ghView, /<DiffHunk hunk=\{thread\.diffHunk\}/, "review threads render the diff via DiffHunk, not a raw <pre>");
+assert.doesNotMatch(ghView, /thread\.diffHunk\.split\("\\n"\)\.slice\(-4\)/, "the old raw last-4-lines <pre> is gone");
+
+const diffView = readFileSync(new URL("../components/gh-diff-view.tsx", import.meta.url), "utf8");
+assert.match(diffView, /export function DiffHunk/, "exports DiffHunk");
+assert.match(diffView, /parseDiff/, "DiffHunk parses the hunk");
+
+// The research/library GitHub README uses the plain markdown renderer (which
+// emits `<code class="language-diff">`), so wireDiffBlocks colorizes ```diff
+// there. (The chat/PR-body MarkdownBlock pipeline already colorizes diff fences
+// via its Shiki renderer's cave-diff-* classes, so it needs no extra wiring.)
+const lib = readFileSync(new URL("../components/library-doc-preview.tsx", import.meta.url), "utf8");
+assert.match(lib, /import \{ wireDiffBlocks \} from "@\/lib\/gh-diff"/, "research/library markdown imports wireDiffBlocks");
+assert.match(lib, /wireDiffBlocks\(el\)/, "research GitHub README colorizes ```diff blocks");
+
+console.log("gh-diff.test.ts: ok");

--- a/src/lib/gh-diff.ts
+++ b/src/lib/gh-diff.ts
@@ -1,0 +1,122 @@
+// Pure logic for rendering GitHub unified-diff hunks as structured HTML.
+//
+// GitHub review threads (and `\`\`\`diff` code fences in PR bodies, comments, and
+// READMEs) carry raw unified-diff text. This module turns that text into
+// classified, line-numbered rows so the React surface (gh-diff-view.tsx) and the
+// markdown post-processor (wireDiffBlocks) can render a real reviewer-style diff
+// — green additions, red deletions, hunk headers — instead of a flat `<pre>`.
+//
+// Framework-free so it can be unit-tested directly; the DOM helper at the bottom
+// is the only browser-touching part and is guarded to be idempotent.
+
+export type DiffLineType = "add" | "del" | "context" | "meta";
+
+export type DiffLine = {
+  type: DiffLineType;
+  /** The raw line, including its leading +/-/space marker. */
+  text: string;
+  /** 1-based line number in the old file, or null for additions/headers. */
+  oldNo: number | null;
+  /** 1-based line number in the new file, or null for deletions/headers. */
+  newNo: number | null;
+};
+
+const META_PREFIX =
+  /^(@@|diff |index |--- |\+\+\+ |new file|deleted file|rename |similarity |old mode|new mode|Binary files)/;
+
+/** Classify a single unified-diff line by its leading marker. */
+export function classifyDiffLine(line: string): DiffLineType {
+  if (META_PREFIX.test(line)) return "meta";
+  if (line.startsWith("+")) return "add";
+  if (line.startsWith("-")) return "del";
+  return "context";
+}
+
+/**
+ * Parse a unified-diff hunk (or multi-hunk patch) into classified rows with
+ * old/new line numbers tracked across `@@ -a,b +c,d @@` headers. Trailing
+ * newlines are trimmed so the row count matches the visible lines.
+ */
+export function parseDiff(patch: string): DiffLine[] {
+  const out: DiffLine[] = [];
+  if (!patch) return out;
+  let oldNo = 0;
+  let newNo = 0;
+  for (const text of patch.replace(/\n+$/, "").split("\n")) {
+    const type = classifyDiffLine(text);
+    if (type === "meta") {
+      const m = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(text);
+      if (m) {
+        oldNo = Number.parseInt(m[1], 10);
+        newNo = Number.parseInt(m[2], 10);
+      }
+      out.push({ type, text, oldNo: null, newNo: null });
+      continue;
+    }
+    if (type === "add") {
+      out.push({ type, text, oldNo: null, newNo: newNo++ });
+    } else if (type === "del") {
+      out.push({ type, text, oldNo: oldNo++, newNo: null });
+    } else {
+      out.push({ type, text, oldNo: oldNo++, newNo: newNo++ });
+    }
+  }
+  return out;
+}
+
+/** Count added/removed lines in a parsed diff (for the `+a −b` summary chip). */
+export function diffStats(lines: DiffLine[]): { additions: number; deletions: number } {
+  let additions = 0;
+  let deletions = 0;
+  for (const l of lines) {
+    if (l.type === "add") additions += 1;
+    else if (l.type === "del") deletions += 1;
+  }
+  return { additions, deletions };
+}
+
+const DIFF_LINE_CLASS: Record<DiffLineType, string> = {
+  add: "gh-diff__line gh-diff__line--add",
+  del: "gh-diff__line gh-diff__line--del",
+  context: "gh-diff__line gh-diff__line--ctx",
+  meta: "gh-diff__line gh-diff__line--meta",
+};
+
+/** CSS class for a diff row of the given type. */
+export function diffLineClass(type: DiffLineType): string {
+  return DIFF_LINE_CLASS[type];
+}
+
+/**
+ * Post-process rendered markdown: turn every `\`\`\`diff` fenced block
+ * (`<code class="language-diff">`) into a colorized, line-classified diff. Each
+ * line becomes a `<span class="gh-diff__line gh-diff__line--*">`, and the parent
+ * `<pre>` gains the `gh-diff` class so the same stylesheet drives both surfaces.
+ *
+ * Idempotent: a processed block is tagged `data-gh-diff-wired` and skipped on
+ * re-runs, so it composes with the markdown MutationObserver without looping.
+ */
+export function wireDiffBlocks(container: HTMLElement): void {
+  if (typeof document === "undefined") return;
+  const blocks = container.querySelectorAll<HTMLElement>('code[class*="language-diff"]');
+  blocks.forEach((code) => {
+    if (code.dataset.ghDiffWired === "1") return;
+    code.dataset.ghDiffWired = "1";
+    const lines = parseDiff(code.textContent ?? "");
+    if (lines.length === 0) return;
+    const frag = document.createDocumentFragment();
+    for (const line of lines) {
+      const span = document.createElement("span");
+      span.className = diffLineClass(line.type);
+      // Keep blank lines visible (zero-width space) so the row keeps its height.
+      span.textContent = line.text.length > 0 ? line.text : "​";
+      frag.appendChild(span);
+    }
+    code.replaceChildren(frag);
+    const pre = code.closest("pre");
+    if (pre) {
+      pre.classList.add("gh-diff", "gh-diff--md");
+      pre.dataset.ghDiff = "1";
+    }
+  });
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1200,16 +1200,64 @@
   border-color:var(--accent-presence);
   color:var(--text-primary);
 }
-.gh-thread-diff {
+/* ── GitHub diff renderer (review threads + ```diff fences) ──────────────────
+   Shared by <DiffHunk> (gh-diff-view.tsx) and wireDiffBlocks (markdown post-
+   processing). Reviewer-style: green additions, red deletions, tinted hunk
+   headers, gutter line numbers. */
+.gh-diff {
   margin:0 0 6px;
-  padding:6px 8px;
-  border-radius:7px;
+  border:1px solid var(--border-hairline);
+  border-radius:8px;
   background:var(--bg-raised);
-  color:var(--text-muted);
-  font-size:10.5px;
+  overflow:hidden;
   font-family:var(--font-mono, ui-monospace, monospace);
+  font-size:11px;
+  line-height:1.55;
+}
+.gh-diff--hunk.gh-thread-diff { margin:0 0 6px; }
+.gh-diff__bar {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  padding:3px 8px;
+  border-bottom:1px solid var(--border-hairline);
+  background:color-mix(in oklch, var(--bg-elevated) 60%, transparent);
+}
+.gh-diff__stat { display:inline-flex; gap:6px; font-size:10.5px; font-weight:600; }
+.gh-diff__stat-add { color:var(--color-success, #3fb950); }
+.gh-diff__stat-del { color:var(--color-danger, #f85149); }
+.gh-diff__expand {
+  border:none; background:transparent; cursor:pointer; padding:1px 4px;
+  font:inherit; font-size:10.5px; color:var(--text-muted); border-radius:5px;
+}
+.gh-diff__expand:hover { color:var(--text-primary); background:var(--bg-hover); }
+.gh-diff__body { overflow-x:auto; }
+.gh-diff__line {
+  display:grid;
+  grid-template-columns:var(--gh-diff-gutter, 2.6em) var(--gh-diff-gutter, 2.6em) 1fr;
   white-space:pre;
-  overflow-x:auto;
+}
+.gh-diff__no {
+  padding:0 6px; text-align:right; user-select:none;
+  color:var(--text-faint, var(--text-muted)); opacity:0.7; font-size:10px;
+  border-right:1px solid color-mix(in oklch, var(--border-hairline) 60%, transparent);
+}
+/* Color set on the line so it inherits to the component's <code> child AND
+   applies to the markdown path where text sits directly in the line span. */
+.gh-diff__code { padding:0 8px; color:inherit; background:none; }
+.gh-diff__line--ctx { color:var(--text-muted); }
+.gh-diff__line--add { background:color-mix(in oklch, var(--color-success, #3fb950) 14%, transparent); color:var(--text-primary); }
+.gh-diff__line--del { background:color-mix(in oklch, var(--color-danger, #f85149) 14%, transparent); color:var(--text-primary); }
+.gh-diff__line--meta { background:color-mix(in oklch, var(--accent-presence) 10%, transparent); color:var(--accent-presence); }
+
+/* ```diff fenced blocks rewritten by wireDiffBlocks: the <pre>/<code> keep their
+   markdown styling reset, lines become block spans with the same coloring. */
+pre.gh-diff--md { padding:0; }
+pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
+.gh-diff--md .gh-diff__line {
+  grid-template-columns:1fr;
+  padding:0 10px;
 }
 
 /* ── Composer (reply + familiar tagging) ─────────────────────────────────── */


### PR DESCRIPTION
## What

The GitHub reviewer rendered inline PR review-thread diffs as **flat monospace text** — just the last 4 lines in a bare `<pre>`. This renders them as a real reviewer-style HTML diff, and extends the same treatment to the Research/Library GitHub viewer.

## Changes
- **`src/lib/gh-diff.ts`** (pure, unit-tested): `parseDiff()` classifies each line (`add`/`del`/`context`/`meta`) and tracks old/new line numbers across `@@` hunk headers; `diffStats()` + `diffLineClass()` helpers; `wireDiffBlocks()` colorizes ` ```diff ` fenced blocks in rendered markdown.
- **`<DiffHunk>`** (`gh-diff-view.tsx`): green additions, red deletions, tinted hunk headers, gutter line numbers, a `+a −b` stats chip, and a "show N more lines" expander for long hunks. Wired into the **PR review threads** in `github-view.tsx`.
- **Research/Library GitHub README** (`library-doc-preview.tsx`): runs `wireDiffBlocks`, so ` ```diff ` blocks in a README render colorized — the plain markdown renderer it uses doesn't otherwise style diffs.

## Notes
- The chat/PR-body `MarkdownBlock` pipeline **already** colorizes diff fences via its Shiki renderer (`cave-diff-*` classes), so it needs no extra wiring — I removed a redundant no-op call after discovering this.

## Verification
- Drove the running app with a mocked PR review thread: the diff renders colored with the `+3 −2` stats chip, gutter line numbers, and the "show 4 more lines" expander (screenshot confirmed).
- `tsc` clean · `pnpm build` within bundle budget · **486** app test files pass · tests-wired green · commit signed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)