### PR TITLE
fix(evals): make /?mode=evals deep-link actually open the Evals surface

### DIFF
--- a/src/app/dashboard/retro/page.tsx
+++ b/src/app/dashboard/retro/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function RetroDashboardRedirectPage() {
-  redirect("/dashboard?view=evals");
+  redirect("/?mode=evals");
 }

--- a/src/app/retro/page.tsx
+++ b/src/app/retro/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function RetroRedirectPage() {
-  redirect("/dashboard?view=evals");
+  redirect("/?mode=evals");
 }

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -322,7 +322,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
           <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
           <QuickLink href="/dashboard/familiars/growth" icon="ph:chart-bar-bold" label="Growth" sub="Familiar performance" />
-          <QuickLink href="/" icon="ph:flask" label="Evals" sub="Suites, loops, freshness" />
+          <QuickLink href="/?mode=evals" icon="ph:flask" label="Evals" sub="Suites, loops, freshness" />
           <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
           <QuickLink href="/" icon="ph:books-bold" label="Library" sub="Saved knowledge" />
           <QuickLink href="/settings" icon="ph:gear-six" label="Settings" sub="Preferences" />

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -205,7 +205,7 @@ export function FamiliarGrowthView({
           >
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
           </button>
-          <a className="retro-btn" href="/dashboard?view=evals">
+          <a className="retro-btn" href="/?mode=evals">
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
             Evals
           </a>

--- a/src/components/retro-runs-view.test.ts
+++ b/src/components/retro-runs-view.test.ts
@@ -17,8 +17,10 @@ const retroRedirectPage = readFileSync(new URL("../app/retro/page.tsx", import.m
 const retroPageUrl = new URL("../app/dashboard/retro/page.tsx", import.meta.url);
 
 assert.equal(existsSync(retroPageUrl), true, "legacy /dashboard/retro page still exists as a redirect");
-assert.match(dashboardRetroPage, /redirect\("\/dashboard\?view=evals"\)/, "legacy /dashboard/retro redirects to unified Evals");
-assert.match(retroRedirectPage, /redirect\("\/dashboard\?view=evals"\)/, "legacy /retro redirects to unified Evals");
+assert.match(dashboardRetroPage, /redirect\("\/\?mode=evals"\)/, "legacy /dashboard/retro redirects to the Evals deep link");
+assert.match(retroRedirectPage, /redirect\("\/\?mode=evals"\)/, "legacy /retro redirects to the Evals deep link");
+assert.match(workspace, /readModeParam\(\)/, "workspace reads the ?mode= deep-link param on mount");
+assert.match(workspace, /clearModeParam\(\)/, "workspace strips the ?mode= param after navigating");
 assert.match(
   component,
   /familiarId \? `\/api\/retro-runs\?familiarId=\$\{encodeURIComponent\(familiarId\)\}` : "\/api\/retro-runs"/,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -129,6 +129,35 @@ function clearChatHash() {
   window.history.replaceState(null, "", window.location.pathname + window.location.search);
 }
 
+// Mode deep links (e.g. `/?mode=evals`): the Evals surface (and the other
+// workspace modes) live inside this SPA shell and aren't URL-addressable on
+// their own. A `?mode=<WorkspaceMode>` query param lets external links
+// (redirects from /retro, dashboard buttons) land directly on a surface.
+// Only modes the shell can actually render are honoured — validated against
+// WORKSPACE_MODE_TITLES, which is keyed by every WorkspaceMode — so unknown
+// values are ignored silently.
+function readModeParam(): WorkspaceMode | null {
+  if (typeof window === "undefined") return null;
+  const raw = new URLSearchParams(window.location.search).get("mode");
+  if (raw && Object.prototype.hasOwnProperty.call(WORKSPACE_MODE_TITLES, raw)) {
+    return raw as WorkspaceMode;
+  }
+  return null;
+}
+
+function clearModeParam() {
+  if (typeof window === "undefined") return;
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has("mode")) return;
+  params.delete("mode");
+  const query = params.toString();
+  window.history.replaceState(
+    null,
+    "",
+    window.location.pathname + (query ? `?${query}` : "") + window.location.hash,
+  );
+}
+
 function readMobileModeEnabled() {
   if (typeof window === "undefined") return true;
   return window.localStorage.getItem(MOBILE_MODE_STORAGE_KEY) !== "false";
@@ -491,6 +520,18 @@ export function Workspace() {
     };
     window.addEventListener("cave:navigate-mode", onNavigate as EventListener);
     return () => window.removeEventListener("cave:navigate-mode", onNavigate as EventListener);
+  }, []);
+
+  // `?mode=<WorkspaceMode>` deep link: external links (e.g. /retro redirects,
+  // dashboard buttons) can land directly on a surface. Runs once on mount,
+  // mirrors the hash deep-link idiom — switch then strip the param so reloads
+  // and back/forward stay clean.
+  useEffect(() => {
+    const target = readModeParam();
+    if (!target) return;
+    setMode(target);
+    clearModeParam();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Click-to-open a file from chat: the comux pane (Code/Terminal) handles


### PR DESCRIPTION
Follow-up (1 of 3 deferred items from the dashboard/evals arc). The `?view=evals` deep link was a **no-op app-wide** — `app/dashboard/page.tsx` ignores searchParams and there is no URL-addressable evals route (the surface only opens via an in-SPA `cave:navigate-mode` event).

## Fix
- **Real URL→mode routing:** `workspace.tsx` now reads `?mode=<WorkspaceMode>` once on mount, validates it against the existing exhaustive `WORKSPACE_MODE_TITLES` record (unknown values ignored), `setMode`s it, and strips just that param (preserving other query params + the hash). SSR-safe; mirrors the existing hash deep-link idiom.
- **Retargeted all four dead links** from `/dashboard?view=evals` → `/?mode=evals`: `app/dashboard/retro` + `app/retro` redirects, the `familiar-growth-view` button, and the dashboard cockpit Evals tile.
- Updated `retro-runs-view.test.ts` (which pinned the old target) + added assertions that the workspace wires `readModeParam`/`clearModeParam`.

Generalizes: any surface is now deep-linkable via `/?mode=<mode>`.

## Verification
- `tsc` clean; `check:tests-wired` (650); `retro-runs-view.test.ts` ok; app suite (486) green; `pnpm build` + bundle-budget ok. Signed commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)