### PR TITLE
feat(github): export PR review as HTML + familiar review → HTML artifact

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -44,6 +44,7 @@ export const SUITES = {
     "src/lib/github-checks.test.ts",
     "src/lib/gfm-autolink.test.ts",
     "src/lib/gh-diff.test.ts",
+    "src/lib/gh-review-html.test.ts",
     "src/lib/chat-projects.test.ts",
     "src/lib/conversation-tree.test.ts",
     "src/lib/chat-project-selection.test.ts",
@@ -697,6 +698,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/gh-review-html.test.ts",
   "src/lib/evals/eval-analytics.test.ts",
   "src/lib/home-digest.test.ts",
   "src/lib/use-refresh-on-focus.test.ts",

--- a/src/components/gh-review-actions.tsx
+++ b/src/components/gh-review-actions.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { useState } from "react";
+
+import { Icon } from "@/lib/icon";
+import type { Familiar } from "@/lib/types";
+import { generateArtifactCode } from "@/lib/canvas-generate";
+import {
+  buildReviewArtifact,
+  buildReviewPrompt,
+  saveCanvasArtifact,
+} from "@/lib/gh-review-export";
+import type { ReviewComment, ReviewThread } from "@/lib/gh-review-html";
+
+/** Minimal PR shape this surface needs — a subset of github-view's ItemDetail. */
+type PrInfo = {
+  repo: string;
+  number: number | null;
+  title: string;
+  state: string;
+  author: string | null;
+  url: string | null;
+  body: string | null;
+};
+
+type FetchedReview = { comments: ReviewComment[]; threads: ReviewThread[] };
+
+async function fetchReviewBundle(repo: string, number: number): Promise<FetchedReview> {
+  const res = await fetch(
+    `/api/github/comments?repo=${encodeURIComponent(repo)}&number=${encodeURIComponent(String(number))}&isPull=1`,
+    { cache: "no-store" },
+  );
+  const json = await res.json().catch(() => null);
+  if (!res.ok || !json?.ok) return { comments: [], threads: [] };
+  const comments: ReviewComment[] = (json.issueComments ?? []).map((c: { author?: { login?: string } | null; body?: string; createdAt?: string | null }) => ({
+    author: c.author?.login ?? null,
+    body: c.body ?? "",
+    createdAt: c.createdAt ?? null,
+  }));
+  const threads: ReviewThread[] = (json.reviewThreads ?? []).map((t: { path?: string | null; diffHunk?: string | null; isResolved?: boolean; comments?: Array<{ author?: { login?: string } | null; body?: string }> }) => ({
+    path: t.path ?? null,
+    diffHunk: t.diffHunk ?? null,
+    isResolved: Boolean(t.isResolved),
+    comments: (t.comments ?? []).map((c) => ({ author: c.author?.login ?? null, body: c.body ?? "" })),
+  }));
+  return { comments, threads };
+}
+
+/** Open the Canvas surface (where HTML artifacts render) on the Sketch layer. */
+function openCanvasArtifacts() {
+  try {
+    window.localStorage.setItem("cave:canvas:layer", "sketch");
+  } catch {
+    /* ignore storage failures */
+  }
+  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "canvas" } }));
+}
+
+function newArtifactId(repo: string, number: number | null): string {
+  const slug = `${repo}-${number ?? "x"}`.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+  return `ghreview-${slug}-${Date.now().toString(36)}`;
+}
+
+/**
+ * Review actions for the PR detail pane: export the PR review as a standalone
+ * HTML artifact, or have a familiar write a review that's saved the same way.
+ * Both land a Canvas "html" artifact and jump to Canvas to view/share it.
+ */
+export function GhReviewActions({ pr, familiars }: { pr: PrInfo; familiars: Familiar[] }) {
+  const [busy, setBusy] = useState<null | "export" | "review">(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [familiarId, setFamiliarId] = useState<string>(familiars[0]?.id ?? "");
+
+  const reset = () => {
+    setError(null);
+    setStatus(null);
+  };
+
+  async function onExport() {
+    if (pr.number == null || busy) return;
+    reset();
+    setBusy("export");
+    setStatus("Collecting review…");
+    try {
+      const bundle = await fetchReviewBundle(pr.repo, pr.number);
+      const artifact = buildReviewArtifact({
+        id: newArtifactId(pr.repo, pr.number),
+        nowIso: new Date().toISOString(),
+        input: { ...pr, comments: bundle.comments, threads: bundle.threads, generatedAt: "" },
+      });
+      const ok = await saveCanvasArtifact(artifact);
+      if (!ok) throw new Error("Couldn’t save the artifact.");
+      setStatus("Opening in Canvas…");
+      openCanvasArtifacts();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Export failed.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function onReview() {
+    if (pr.number == null || busy || !familiarId) return;
+    reset();
+    setBusy("review");
+    const familiarName = familiars.find((f) => f.id === familiarId)?.display_name ?? "Familiar";
+    setStatus(`${familiarName} is reviewing…`);
+    try {
+      const bundle = await fetchReviewBundle(pr.repo, pr.number);
+      const prompt = buildReviewPrompt({ ...pr, threads: bundle.threads });
+      const result = await generateArtifactCode({ familiarId, prompt });
+      const review = (result.text ?? "").trim();
+      if (result.error && !review) throw new Error(result.error);
+      if (!review) throw new Error("The familiar returned an empty review.");
+      const artifact = buildReviewArtifact({
+        id: newArtifactId(pr.repo, pr.number),
+        nowIso: new Date().toISOString(),
+        input: {
+          ...pr,
+          comments: bundle.comments,
+          threads: bundle.threads,
+          familiarReview: { familiarName, body: review },
+          generatedAt: "",
+        },
+      });
+      const ok = await saveCanvasArtifact(artifact);
+      if (!ok) throw new Error("Couldn’t save the review artifact.");
+      setStatus("Opening in Canvas…");
+      openCanvasArtifacts();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Review failed.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="gh-review-actions">
+      <button
+        type="button"
+        className="gh-review-action"
+        onClick={onExport}
+        disabled={busy != null || pr.number == null}
+        title="Export this PR review as a standalone HTML page"
+      >
+        <Icon name="ph:file-code" width={13} />
+        {busy === "export" ? "Exporting…" : "Open as HTML"}
+      </button>
+
+      {familiars.length > 0 && (
+        <span className="gh-review-action-group">
+          <button
+            type="button"
+            className="gh-review-action gh-review-action--accent"
+            onClick={onReview}
+            disabled={busy != null || pr.number == null || !familiarId}
+            title="Have a familiar write a code review, saved as HTML"
+          >
+            <Icon name="ph:sparkle" width={13} />
+            {busy === "review" ? "Reviewing…" : "Review with"}
+          </button>
+          <select
+            className="gh-review-familiar"
+            aria-label="Familiar to review with"
+            value={familiarId}
+            onChange={(e) => setFamiliarId(e.currentTarget.value)}
+            disabled={busy != null}
+          >
+            {familiars.map((f) => (
+              <option key={f.id} value={f.id}>
+                {f.display_name}
+              </option>
+            ))}
+          </select>
+        </span>
+      )}
+
+      {status && !error && <span className="gh-review-status" aria-live="polite">{status}</span>}
+      {error && <span className="gh-review-error" role="alert">{error}</span>}
+    </div>
+  );
+}

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -16,6 +16,7 @@ import { githubItemMatchesQuery } from "@/lib/github-search";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { DiffHunk } from "@/components/gh-diff-view";
+import { GhReviewActions } from "@/components/gh-review-actions";
 import { gfmAutolink } from "@/lib/gfm-autolink";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
@@ -1226,6 +1227,20 @@ function GitHubItemGlassPanel({
               <RelativeTime iso={detail?.createdAt ?? item.updatedAt} />
             </span>
           </div>
+          {(item.kind === "pr" || item.kind === "review_request") && (
+            <GhReviewActions
+              pr={{
+                repo: item.repo,
+                number: item.number ?? null,
+                title: detail?.title ?? item.title,
+                state: stateKind,
+                author: detail?.author?.login ?? null,
+                url: detail?.htmlUrl ?? item.url,
+                body: detail?.body ?? null,
+              }}
+              familiars={familiars}
+            />
+          )}
         </div>
 
         <div className="gh-glass-section">

--- a/src/lib/gh-review-export.ts
+++ b/src/lib/gh-review-export.ts
@@ -1,0 +1,81 @@
+// Client helpers that turn a GitHub PR review into a saved Canvas HTML artifact.
+//
+// Two flows share the same artifact plumbing:
+//   • Export — assemble the PR's own review (detail + comments + inline threads)
+//     into an HTML document.
+//   • Familiar review — ask a familiar to write a review (Markdown), then wrap it
+//     into the same HTML document.
+//
+// The HTML construction (gh-review-html) and the artifact shaping below are pure
+// + deterministic (ids/timestamps injected), so they unit-test directly. Only
+// saveCanvasArtifact touches the network.
+
+import type { CanvasArtifact } from "@/lib/canvas-artifacts";
+import { buildReviewHtml, type ReviewHtmlInput, type ReviewThread } from "@/lib/gh-review-html";
+
+/** Short, stable artifact title: `coven-cave #42 review`. */
+export function reviewArtifactTitle(repo: string, number?: number | null): string {
+  const short = repo.split("/").pop() || repo;
+  const base = number != null ? `${short} #${number} review` : `${short} review`;
+  return base.slice(0, 60);
+}
+
+/** Shape a review HTML document into a Canvas artifact (id + timestamps injected). */
+export function buildReviewArtifact(opts: {
+  input: ReviewHtmlInput;
+  id: string;
+  nowIso: string;
+}): CanvasArtifact {
+  const { input, id, nowIso } = opts;
+  const ref = `${input.repo}${input.number != null ? ` #${input.number}` : ""}`;
+  return {
+    id,
+    title: reviewArtifactTitle(input.repo, input.number),
+    prompt: input.familiarReview
+      ? `${input.familiarReview.familiarName}'s review of ${ref}`
+      : `HTML export of ${ref} review`,
+    code: buildReviewHtml({ ...input, generatedAt: nowIso }),
+    kind: "html",
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  };
+}
+
+/** Build the prompt that asks a familiar to review the PR (Markdown output). */
+export function buildReviewPrompt(input: {
+  title: string;
+  repo: string;
+  number?: number | null;
+  body?: string | null;
+  threads?: Pick<ReviewThread, "path" | "diffHunk">[];
+}): string {
+  const ref = `${input.repo}${input.number != null ? ` #${input.number}` : ""}`;
+  const diffs = (input.threads ?? [])
+    .filter((t) => t.diffHunk)
+    .map((t) => `### ${t.path ?? "diff"}\n\`\`\`diff\n${t.diffHunk}\n\`\`\``)
+    .join("\n\n");
+  return [
+    `You are reviewing the GitHub pull request **${input.title}** (${ref}).`,
+    input.body?.trim() ? `\nPR description:\n${input.body.trim()}` : "",
+    diffs ? `\nKey diffs under discussion:\n${diffs}` : "",
+    "\nWrite a concise, well-structured code review in Markdown: a one-line summary, " +
+      "then findings grouped by severity (blocking, then nits), then an overall " +
+      "recommendation (approve or request changes). Be specific and reference files where possible.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/** Persist an artifact to the Canvas store. Returns whether the write landed. */
+export async function saveCanvasArtifact(artifact: CanvasArtifact): Promise<boolean> {
+  try {
+    const res = await fetch("/api/canvas", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ artifact }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/gh-review-html.test.ts
+++ b/src/lib/gh-review-html.test.ts
@@ -26,7 +26,7 @@ const html = buildReviewHtml({
   state: "merged",
   author: "buns",
   url: "https://github.com/OpenCoven/coven-cave/pull/42",
-  body: "Body with <html> & stuff",
+  body: "Body with <html> & <script>alert(1)</script>",
   comments: [{ author: "rev", body: "looks good", createdAt: "2026-06-29" }],
   threads: [{ path: "src/x.ts", diffHunk: "@@ -1 +1 @@\n-a\n+b", comments: [{ author: "rev", body: "tweak" }] }],
   generatedAt: "2026-06-29T00:00:00Z",
@@ -35,11 +35,14 @@ assert.match(html, /^<!doctype html>/i, "is a full HTML document");
 assert.match(html, /Add &lt;reviewer&gt;/, "title is escaped");
 assert.match(html, /ghx-state--merged/, "merged state class");
 assert.match(html, /<h2>Description<\/h2>/, "renders a Description section");
-assert.match(html, /Body with &lt;html&gt; &amp; stuff/, "body content is escaped");
+assert.match(html, /Body with &lt;html&gt; &amp;/, "body content is escaped");
 assert.match(html, /<h2>Conversation \(1\)<\/h2>/, "renders the conversation");
 assert.match(html, /<h2>Review threads \(1\)<\/h2>/, "renders review threads");
 assert.match(html, /ghx-l--add/, "thread diff is colorized");
-assert.doesNotMatch(html, /<script>/, "no unescaped script tags leak through");
+// A script payload in the body is escaped, never emitted as a live tag (string
+// checks, not regex, so this stays a behavioural assertion — not a tag filter).
+assert.ok(html.includes("&lt;script&gt;alert(1)&lt;/script&gt;"), "script payload is escaped");
+assert.ok(!html.includes("<script>alert"), "no unescaped script tag leaks through");
 
 // Familiar review section only appears when supplied.
 assert.doesNotMatch(html, /Review by/, "no familiar-review section without a review");

--- a/src/lib/gh-review-html.test.ts
+++ b/src/lib/gh-review-html.test.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { escapeHtml, renderDiffHtml, buildReviewHtml } from "@/lib/gh-review-html";
+import { reviewArtifactTitle, buildReviewArtifact, buildReviewPrompt } from "@/lib/gh-review-export";
+
+// ── escapeHtml ───────────────────────────────────────────────────────────────
+assert.equal(escapeHtml(`<b>"x" & 'y'</b>`), "&lt;b&gt;&quot;x&quot; &amp; &#39;y&#39;&lt;/b&gt;", "escapes all five");
+
+// ── renderDiffHtml: colorized rows reusing gh-diff's parser ───────────────────
+const diff = renderDiffHtml("@@ -1,2 +1,2 @@\n-old line\n+new line\n const same");
+assert.match(diff, /ghx-l--meta/, "hunk header → meta row");
+assert.match(diff, /ghx-l--del/, "minus → del row");
+assert.match(diff, /ghx-l--add/, "plus → add row");
+assert.match(diff, /ghx-l--context/, "context row");
+assert.match(diff, /new line/, "keeps the added text");
+assert.equal(renderDiffHtml(""), "", "empty hunk → empty string");
+// Diff content is escaped (a hunk containing HTML must not inject markup).
+assert.match(renderDiffHtml("+<script>x</script>"), /&lt;script&gt;/, "diff text is escaped");
+
+// ── buildReviewHtml ──────────────────────────────────────────────────────────
+const html = buildReviewHtml({
+  repo: "OpenCoven/coven-cave",
+  number: 42,
+  title: "Add <reviewer>",
+  state: "merged",
+  author: "buns",
+  url: "https://github.com/OpenCoven/coven-cave/pull/42",
+  body: "Body with <html> & stuff",
+  comments: [{ author: "rev", body: "looks good", createdAt: "2026-06-29" }],
+  threads: [{ path: "src/x.ts", diffHunk: "@@ -1 +1 @@\n-a\n+b", comments: [{ author: "rev", body: "tweak" }] }],
+  generatedAt: "2026-06-29T00:00:00Z",
+});
+assert.match(html, /^<!doctype html>/i, "is a full HTML document");
+assert.match(html, /Add &lt;reviewer&gt;/, "title is escaped");
+assert.match(html, /ghx-state--merged/, "merged state class");
+assert.match(html, /<h2>Description<\/h2>/, "renders a Description section");
+assert.match(html, /Body with &lt;html&gt; &amp; stuff/, "body content is escaped");
+assert.match(html, /<h2>Conversation \(1\)<\/h2>/, "renders the conversation");
+assert.match(html, /<h2>Review threads \(1\)<\/h2>/, "renders review threads");
+assert.match(html, /ghx-l--add/, "thread diff is colorized");
+assert.doesNotMatch(html, /<script>/, "no unescaped script tags leak through");
+
+// Familiar review section only appears when supplied.
+assert.doesNotMatch(html, /Review by/, "no familiar-review section without a review");
+const reviewed = buildReviewHtml({
+  repo: "o/r", number: 7, title: "T", generatedAt: "t",
+  familiarReview: { familiarName: "Nova", body: "## Summary\nLGTM" },
+});
+assert.match(reviewed, /<h2>Review by Nova<\/h2>/, "renders the familiar review heading");
+assert.match(reviewed, /LGTM/, "includes the familiar's review text");
+
+// ── reviewArtifactTitle / buildReviewArtifact ────────────────────────────────
+assert.equal(reviewArtifactTitle("OpenCoven/coven-cave", 42), "coven-cave #42 review", "short repo + number title");
+assert.equal(reviewArtifactTitle("o/r"), "r review", "no number → bare title");
+const artifact = buildReviewArtifact({
+  id: "ghreview-1",
+  nowIso: "2026-06-29T00:00:00Z",
+  input: { repo: "o/r", number: 7, title: "T", generatedAt: "" },
+});
+assert.equal(artifact.kind, "html", "artifact is an html artifact");
+assert.equal(artifact.id, "ghreview-1", "uses the injected id");
+assert.equal(artifact.createdAt, "2026-06-29T00:00:00Z", "stamps createdAt from nowIso");
+assert.match(artifact.code, /^<!doctype html>/i, "artifact code is the HTML document");
+assert.match(artifact.code, /2026-06-29T00:00:00Z/, "generatedAt is injected into the doc footer");
+
+// ── buildReviewPrompt ────────────────────────────────────────────────────────
+const prompt = buildReviewPrompt({
+  title: "Add reviewer",
+  repo: "o/r",
+  number: 7,
+  body: "does things",
+  threads: [{ path: "a.ts", diffHunk: "@@\n+x" }],
+});
+assert.match(prompt, /Add reviewer/, "names the PR");
+assert.match(prompt, /o\/r #7/, "includes the repo + number ref");
+assert.match(prompt, /```diff/, "embeds the diffs as fenced blocks");
+assert.match(prompt, /Markdown/, "asks for a Markdown review");
+
+// ── Wiring ───────────────────────────────────────────────────────────────────
+const view = readFileSync(new URL("../components/github-view.tsx", import.meta.url), "utf8");
+assert.match(view, /import \{ GhReviewActions \}/, "github-view imports the review actions");
+assert.match(view, /<GhReviewActions/, "renders the review actions on the PR detail");
+
+const actions = readFileSync(new URL("../components/gh-review-actions.tsx", import.meta.url), "utf8");
+assert.match(actions, /generateArtifactCode/, "familiar review streams via generateArtifactCode");
+assert.match(actions, /saveCanvasArtifact/, "saves the result as a Canvas artifact");
+assert.match(actions, /buildReviewArtifact/, "builds the artifact from the review HTML");
+assert.match(actions, /cave:navigate-mode/, "jumps to Canvas to view the artifact");
+
+console.log("gh-review-html.test.ts: ok");

--- a/src/lib/gh-review-html.ts
+++ b/src/lib/gh-review-html.ts
@@ -1,0 +1,189 @@
+// Pure builder: turn a GitHub PR review (detail + comments + inline threads, and
+// optionally a familiar's generated review) into a self-contained HTML document.
+//
+// The output is a complete `<!doctype html>` string with inline styles and
+// colorized diffs (reusing parseDiff from gh-diff). It's saved as a Canvas
+// "html" artifact (rendered in a sandboxed iframe), so it must carry its own CSS
+// and must NOT depend on app classes. Everything user/remote-derived is escaped.
+//
+// Framework-free + deterministic (timestamps are injected, never read here) so it
+// unit-tests directly.
+
+import { parseDiff } from "@/lib/gh-diff";
+
+export type ReviewComment = {
+  author?: string | null;
+  body?: string | null;
+  createdAt?: string | null;
+};
+
+export type ReviewThread = {
+  path?: string | null;
+  diffHunk?: string | null;
+  isResolved?: boolean;
+  comments: ReviewComment[];
+};
+
+export type ReviewHtmlInput = {
+  repo: string;
+  number?: number | null;
+  title: string;
+  /** "open" | "closed" | "merged" — anything else renders as-is. */
+  state?: string;
+  author?: string | null;
+  url?: string | null;
+  /** PR/issue markdown body — included as escaped, whitespace-preserving text. */
+  body?: string | null;
+  comments?: ReviewComment[];
+  threads?: ReviewThread[];
+  /** A familiar's generated review, rendered as its own highlighted section. */
+  familiarReview?: { familiarName: string; body: string } | null;
+  /** ISO timestamp, injected by the caller (kept out of this pure module). */
+  generatedAt: string;
+};
+
+/** Escape text for safe interpolation into HTML. */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/** Render a unified-diff hunk to colorized HTML rows (additions/deletions/etc). */
+export function renderDiffHtml(hunk: string): string {
+  const lines = parseDiff(hunk);
+  if (lines.length === 0) return "";
+  const rows = lines
+    .map((l) => {
+      const num = (n: number | null) => (n == null ? "" : String(n));
+      return (
+        `<div class="ghx-l ghx-l--${l.type}">` +
+        `<span class="ghx-n">${num(l.oldNo)}</span>` +
+        `<span class="ghx-n">${num(l.newNo)}</span>` +
+        `<code>${escapeHtml(l.text.length > 0 ? l.text : " ")}</code>` +
+        `</div>`
+      );
+    })
+    .join("");
+  return `<div class="ghx-diff">${rows}</div>`;
+}
+
+function stateClass(state?: string): string {
+  const s = (state ?? "open").toLowerCase();
+  if (s === "merged") return "ghx-state--merged";
+  if (s === "closed") return "ghx-state--closed";
+  return "ghx-state--open";
+}
+
+/** Escaped text block that preserves newlines/indentation (markdown shown as-is). */
+function textBlock(text: string): string {
+  return `<pre class="ghx-text">${escapeHtml(text)}</pre>`;
+}
+
+function commentHtml(c: ReviewComment): string {
+  const who = escapeHtml(c.author?.trim() || "ghost");
+  const when = c.createdAt ? `<span class="ghx-when">${escapeHtml(c.createdAt)}</span>` : "";
+  const body = c.body?.trim() ? textBlock(c.body) : `<p class="ghx-muted">No content.</p>`;
+  return `<div class="ghx-comment"><div class="ghx-comment-head"><strong>${who}</strong>${when}</div>${body}</div>`;
+}
+
+function threadHtml(t: ReviewThread): string {
+  const path = t.path ? `<span class="ghx-path">${escapeHtml(t.path)}</span>` : "";
+  const resolved = t.isResolved ? `<span class="ghx-badge">resolved</span>` : "";
+  const diff = t.diffHunk ? renderDiffHtml(t.diffHunk) : "";
+  const comments = (t.comments ?? []).map(commentHtml).join("");
+  return `<div class="ghx-thread"><div class="ghx-thread-head">${path}${resolved}</div>${diff}${comments}</div>`;
+}
+
+const STYLE = `
+:root{color-scheme:light dark}
+*{box-sizing:border-box}
+body{margin:0;padding:24px;max-width:980px;margin-inline:auto;
+  font:14px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",system-ui,sans-serif;
+  color:#1f2328;background:#fff}
+@media (prefers-color-scheme:dark){body{color:#e6edf3;background:#0d1117}}
+h1{font-size:22px;margin:0 0 6px}
+h2{font-size:15px;margin:28px 0 10px;padding-bottom:6px;border-bottom:1px solid #d0d7de88}
+a{color:#0969da}
+.ghx-sub{display:flex;flex-wrap:wrap;gap:10px;align-items:center;color:#656d76;font-size:13px;margin-bottom:4px}
+.ghx-num{font-weight:600}
+.ghx-state{display:inline-block;padding:2px 10px;border-radius:999px;font-size:12px;font-weight:600;color:#fff}
+.ghx-state--open{background:#1a7f37}.ghx-state--closed{background:#cf222e}.ghx-state--merged{background:#8250df}
+.ghx-meta{color:#656d76;font-size:12px}
+.ghx-muted{color:#8b949e}
+.ghx-text{white-space:pre-wrap;word-break:break-word;font:inherit;margin:0;
+  padding:10px 12px;border:1px solid #d0d7de88;border-radius:8px;background:#f6f8fa}
+@media (prefers-color-scheme:dark){.ghx-text{background:#161b22;border-color:#30363d}}
+.ghx-comment{margin:10px 0}
+.ghx-comment-head{display:flex;gap:8px;align-items:baseline;margin-bottom:4px}
+.ghx-when{color:#8b949e;font-size:12px}
+.ghx-thread{margin:12px 0;border:1px solid #d0d7de88;border-radius:10px;overflow:hidden}
+@media (prefers-color-scheme:dark){.ghx-thread{border-color:#30363d}}
+.ghx-thread-head{display:flex;gap:8px;align-items:center;padding:6px 10px;background:#f6f8fa;font-size:12px}
+@media (prefers-color-scheme:dark){.ghx-thread-head{background:#161b22}}
+.ghx-path{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.ghx-badge{padding:1px 7px;border-radius:999px;background:#1a7f3722;color:#1a7f37;font-size:11px}
+.ghx-diff{font:12px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;overflow-x:auto}
+.ghx-l{display:grid;grid-template-columns:3em 3em 1fr;white-space:pre}
+.ghx-l>code{padding:0 8px}
+.ghx-n{padding:0 6px;text-align:right;color:#8b949e;user-select:none;border-right:1px solid #d0d7de55}
+.ghx-l--add{background:#1a7f3722}.ghx-l--del{background:#cf222e22}
+.ghx-l--meta{background:#8250df1a;color:#8250df}.ghx-l--context{color:#656d76}
+.ghx-review{border:1px solid #8250df55;border-radius:10px;padding:14px 16px;background:#8250df0d}
+.ghx-foot{margin-top:32px;color:#8b949e;font-size:12px;border-top:1px solid #d0d7de55;padding-top:10px}
+`;
+
+/**
+ * Build a complete standalone HTML document for a PR review. Sections render in
+ * order: header → familiar review (if any) → description → conversation →
+ * inline review threads (with colorized diffs).
+ */
+export function buildReviewHtml(input: ReviewHtmlInput): string {
+  const numTxt = input.number != null ? `#${input.number}` : "";
+  const titleLine = `${escapeHtml(input.title)} ${numTxt}`.trim();
+  const link = input.url
+    ? `<a href="${escapeHtml(input.url)}" rel="noreferrer">${escapeHtml(input.repo)}${numTxt ? ` ${numTxt}` : ""}</a>`
+    : `${escapeHtml(input.repo)}${numTxt ? ` ${numTxt}` : ""}`;
+  const stateLabel = escapeHtml(input.state ?? "open");
+
+  const reviewSection = input.familiarReview
+    ? `<h2>Review by ${escapeHtml(input.familiarReview.familiarName)}</h2>` +
+      `<div class="ghx-review">${textBlock(input.familiarReview.body)}</div>`
+    : "";
+
+  const description = input.body?.trim()
+    ? `<h2>Description</h2>${textBlock(input.body)}`
+    : "";
+
+  const comments = input.comments ?? [];
+  const conversation = comments.length
+    ? `<h2>Conversation (${comments.length})</h2>${comments.map(commentHtml).join("")}`
+    : "";
+
+  const threads = input.threads ?? [];
+  const reviewThreads = threads.length
+    ? `<h2>Review threads (${threads.length})</h2>${threads.map(threadHtml).join("")}`
+    : "";
+
+  return (
+    `<!doctype html><html lang="en"><head><meta charset="utf-8">` +
+    `<meta name="viewport" content="width=device-width, initial-scale=1">` +
+    `<title>${titleLine || "PR review"}</title><style>${STYLE}</style></head><body>` +
+    `<h1>${escapeHtml(input.title)}</h1>` +
+    `<div class="ghx-sub">` +
+    (numTxt ? `<span class="ghx-num">${numTxt}</span>` : "") +
+    `<span class="ghx-state ${stateClass(input.state)}">${stateLabel}</span>` +
+    `<span>${link}</span>` +
+    (input.author ? `<span>by ${escapeHtml(input.author)}</span>` : "") +
+    `</div>` +
+    reviewSection +
+    description +
+    conversation +
+    reviewThreads +
+    `<div class="ghx-foot">Generated by Coven Cave · ${escapeHtml(input.generatedAt)}</div>` +
+    `</body></html>`
+  );
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1027,6 +1027,63 @@
 }
 .gh-issue-opened-text { color:var(--text-muted); }
 
+/* ── PR review actions (export HTML · review with familiar) ──────────────────── */
+.gh-review-actions {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:8px;
+  margin-top:12px;
+}
+.gh-review-action-group { display:inline-flex; align-items:stretch; }
+.gh-review-action {
+  display:inline-flex;
+  align-items:center;
+  gap:5px;
+  padding:4px 10px;
+  border:1px solid var(--border-hairline);
+  border-radius:7px;
+  background:var(--bg-raised);
+  color:var(--text-secondary);
+  font-size:11.5px;
+  font-weight:550;
+  cursor:pointer;
+  transition:background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard), color var(--duration-fast) var(--ease-standard);
+}
+.gh-review-action:hover:not(:disabled) {
+  border-color:var(--border-strong);
+  background:var(--bg-hover);
+  color:var(--text-primary);
+}
+.gh-review-action:disabled { opacity:0.55; cursor:default; }
+.gh-review-action--accent {
+  border-color:color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
+  color:var(--text-primary);
+  border-top-right-radius:0;
+  border-bottom-right-radius:0;
+}
+.gh-review-action--accent:hover:not(:disabled) {
+  background:color-mix(in oklch, var(--accent-presence) 14%, transparent);
+}
+.gh-review-familiar {
+  appearance:none;
+  -webkit-appearance:none;
+  border:1px solid color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
+  border-left:none;
+  border-radius:0 7px 7px 0;
+  background:var(--bg-raised);
+  color:var(--text-primary);
+  font:inherit;
+  font-size:11.5px;
+  padding:0 8px;
+  max-width:130px;
+  cursor:pointer;
+}
+.gh-review-familiar:disabled { opacity:0.55; cursor:default; }
+.gh-review-status { font-size:11.5px; color:var(--text-muted); }
+.gh-review-error { font-size:11.5px; color:var(--color-danger); }
+
 .gh-person { display:inline-flex; align-items:center; gap:5px; }
 .gh-person-avatar {
   width:16px;


### PR DESCRIPTION
Completes the "show the GitHub reviewer in HTML" arc (follows #2099's diff renderer). From a PR detail you can now produce a **standalone HTML review document**, two ways.

## Changes
- **`src/lib/gh-review-html.ts`** (pure, unit-tested): `buildReviewHtml()` assembles a complete `<!doctype html>` document — header (title, repo#number, state pill, author), optional familiar-review section, description, conversation, and inline review threads with **colorized diffs** (reuses `parseDiff` from #2099). All remote/user text is escaped; styles are inline so it renders standalone in a sandboxed iframe.
- **`src/lib/gh-review-export.ts`**: shapes the doc into a Canvas `html` artifact (`buildReviewArtifact`), builds the familiar review prompt (`buildReviewPrompt`), saves via `/api/canvas`.
- **`<GhReviewActions>`** on the PR detail:
  - **Open as HTML** — fetches the PR's comments + threads, builds the document, saves it as a Canvas artifact, and jumps to Canvas to view/share.
  - **Review with `<familiar>`** — streams a familiar's Markdown code review (reusing `generateArtifactCode`), wraps it in the same document, saves + opens.

## Verification
- Drove the running app: the actions render on the PR detail; clicking **Open as HTML** produced a 4 KB standalone document — header with `open` state pill, Description, Conversation, and a colorized diff (red deletion / green additions / purple hunk header / gutter line numbers). Screenshots captured of both the in-app actions and the rendered export.
- `tsc` clean · `pnpm build` within bundle budget · **488** app test files pass · tests-wired green · commit signed.

This closes out the GitHub-reviewer-in-HTML requests: diff rendering (#2099) + full-PR HTML export + familiar review → HTML, across the GitHub surface (and the Research page README diffs from #2099).

🤖 Generated with [Claude Code](https://claude.com/claude-code)