### PR TITLE
feat(dashboard): predictive signals strip + confidence heatmap

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -33,6 +33,16 @@ assert.match(cockpit, /familiarLoadSeries/, "renders a familiar-load trend panel
 assert.match(cockpit, /usePausablePoll/, "cockpit polls for live updates");
 assert.doesNotMatch(cockpit, /\?view=evals/, "dead ?view=evals link removed");
 
+// Predictive signals strip + confidence heatmap (deferred from #2098).
+assert.match(cockpit, /dashboardSignals/, "cockpit derives predictive signals");
+assert.match(cockpit, /case "signals"/, "a Signals panel is wired into the layout switch");
+assert.match(cockpit, /case "confidence"/, "a Confidence panel is wired into the layout switch");
+assert.match(cockpit, /Heatmap/, "confidence renders the visx heatmap primitive");
+assert.match(cockpit, /deriveConfidenceScore/, "confidence reuses the shared scoring helper");
+assert.match(cockpit, /deriveGrowthReport/, "confidence composes the growth report for scoring");
+assert.match(cockpit, /\/api\/retro-runs/, "confidence pulls the shared retro-runs snapshot");
+assert.match(cockpit, /\/api\/familiars\/\$\{encodeURIComponent\(f\.id\)\}\/contract/, "confidence pulls each familiar's contract");
+
 // Action inbox supports bulk triage: select several items → done/dismiss/snooze together.
 const inboxUrl = new URL("../components/dashboard/action-inbox.tsx", import.meta.url);
 const inbox = readFileSync(inboxUrl, "utf8");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -14,7 +14,13 @@ import { SectionHead, EmptyState, QuickLink } from "@/components/daily-report-ui
 import { Sparkline, type SparkPoint } from "@/components/ui/sparkline";
 import { DonutChart } from "@/components/ui/charts/donut-chart";
 import { TrendChart } from "@/components/ui/charts/trend-chart";
-import { familiarMiniProfiles, familiarLoadSeries } from "@/lib/dashboard-analytics";
+import { familiarMiniProfiles, familiarLoadSeries, dashboardSignals, type DashboardSignal } from "@/lib/dashboard-analytics";
+import { Heatmap } from "@/components/ui/charts/heatmap";
+import { deriveConfidenceScore, type ConfidenceFactor } from "@/lib/familiar-confidence";
+import { deriveGrowthReport } from "@/lib/familiar-growth-signals";
+import { buildFamiliarCardStats, type FamiliarCardStats } from "@/components/familiars-view-stats";
+import type { ContractReport } from "@/lib/familiar-contract";
+import type { RetroRunsSnapshot } from "@/lib/retro-runs";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
 import { TodaySummary } from "@/components/dashboard/today-summary";
@@ -43,10 +49,13 @@ type CockpitData = {
 
 const EMPTY: CockpitData = { cards: [], familiars: [], github: [], reading: [], upcoming: [], sessions: [] };
 
+type ConfidenceRow = { id: string; name: string; score: number; factors: ConfidenceFactor[] };
+const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, lastSessionAt: null, sessionsLast7d: 0, hasActiveSession: false };
+
 // Draggable panel layout — order per column, persisted to localStorage.
 const LAYOUT_KEY = "cave:cockpit:layout";
 type Layout = { main: string[]; rail: string[] };
-const DEFAULT_LAYOUT: Layout = { main: ["needs", "board", "today"], rail: ["agents", "load", "github", "agenda", "reading"] };
+const DEFAULT_LAYOUT: Layout = { main: ["needs", "signals", "board", "today"], rail: ["agents", "confidence", "load", "github", "agenda", "reading"] };
 
 /** Merge a saved order with the defaults: keep known ids in saved order, append
  *  any new defaults, drop anything unknown (survives version changes). */
@@ -177,6 +186,55 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     .sort((a, b) => new Date(a.fireAt!).getTime() - new Date(b.fireAt!).getTime())
     .slice(0, 5);
 
+  // Predictive signals — pure + cheap over already-fetched data.
+  const signals = useMemo(
+    () => dashboardSignals({ github: data.github, reading: data.reading, sessions: data.sessions, familiars: data.familiars, nowMs: now.getTime() }),
+    [data.github, data.reading, data.sessions, data.familiars, now],
+  );
+
+  // ── Confidence heatmap: bounded per-familiar contract fetch (≤6) + one shared
+  //    retro-runs call. Fetch is keyed on the visible familiar set; the heatmap
+  //    rows recompute from live sessions without re-fetching. ──
+  const [confidenceRaw, setConfidenceRaw] = useState<{
+    fams: Familiar[]; contracts: (ContractReport | null)[]; snapshot: RetroRunsSnapshot | null;
+  } | null>(null);
+  const confidenceFams = data.familiars.slice(0, 6);
+  const confidenceKey = confidenceFams.map((f) => f.id).join(",");
+  useEffect(() => {
+    if (!confidenceKey) { setConfidenceRaw(null); return; }
+    let alive = true;
+    const fams = confidenceKey.split(",").map((id) => confidenceFams.find((f) => f.id === id)!).filter(Boolean);
+    void Promise.all([
+      getJson<{ snapshot?: RetroRunsSnapshot }>("/api/retro-runs"),
+      ...fams.map((f) => getJson<{ report?: ContractReport }>(`/api/familiars/${encodeURIComponent(f.id)}/contract`)),
+    ]).then(([retro, ...contracts]) => {
+      if (!alive || !aliveRef.current) return;
+      setConfidenceRaw({
+        fams,
+        contracts: contracts.map((c) => c?.report ?? null),
+        snapshot: retro?.snapshot ?? null,
+      });
+    });
+    return () => { alive = false; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [confidenceKey]);
+
+  const confidence = useMemo<ConfidenceRow[]>(() => {
+    if (!confidenceRaw) return [];
+    const snapshot = confidenceRaw.snapshot;
+    return confidenceRaw.fams.map((f, i) => {
+      const stats = buildFamiliarCardStats({
+        familiars: [f],
+        sessions: data.sessions.filter((s) => s.familiarId === f.id),
+        covenEntries: [],
+      }).get(f.id) ?? EMPTY_STATS;
+      const retroState = snapshot?.familiars.find((r) => r.familiarId === f.id) ?? null;
+      const growthReport = deriveGrowthReport({ familiar: f, stats, retroState });
+      const c = deriveConfidenceScore({ contractReport: confidenceRaw.contracts[i] ?? null, growthReport, familiar: f });
+      return { id: f.id, name: f.display_name, score: c.score, factors: c.factors };
+    });
+  }, [confidenceRaw, data.sessions]);
+
   const kpis: KpiSpec[] = [
     { icon: "ph:warning-circle", value: model.needsAttention.length, label: "Needs you", accent: "rose", metric: "needs" },
     { icon: "ph:kanban-bold", value: open.length, label: "Active tasks", accent: "lavender", src: "cards", metric: "tasks", href: "/#card-" },
@@ -232,9 +290,22 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     }
   };
 
-  const isVisible = (id: string) => id !== "needs" || !model.caughtUp;
+  const isVisible = (id: string) => {
+    if (id === "needs") return !model.caughtUp;
+    if (id === "signals") return signals.length > 0;
+    if (id === "confidence") return confidence.length > 0;
+    return true;
+  };
   const widget = (id: string): ReactNode => {
     switch (id) {
+      case "signals": return signals.length === 0 ? null : (
+        <Panel title="Signals" icon="ph:waveform-bold" count={signals.length}>
+          <SignalsPanel signals={signals} />
+        </Panel>);
+      case "confidence": return confidence.length === 0 ? null : (
+        <Panel title="Confidence" icon="ph:seal-check">
+          <ConfidencePanel rows={confidence} />
+        </Panel>);
       case "needs": return model.caughtUp ? null : (
         <Panel title="Needs attention" icon="ph:warning-circle" count={model.needsAttention.length}>
           <ActionInbox initialItems={model.needsAttention} />
@@ -573,6 +644,59 @@ function ReadingPanel({ items, loaded }: { items: ReadingItem[]; loaded: boolean
 function host(url?: string): string | null {
   if (!url) return null;
   try { return new URL(url).host.replace(/^www\./, ""); } catch { return null; }
+}
+
+// ─── Signals ─────────────────────────────────────────────────────────────────────
+
+const SIGNAL_ICON: Record<DashboardSignal["severity"], IconName> = { warn: "ph:warning", info: "ph:info" };
+function SignalsPanel({ signals }: { signals: DashboardSignal[] }) {
+  return (
+    <ul className="cockpit-signals">
+      {signals.map((s) => (
+        <li key={s.id} className={`cockpit-signal cockpit-signal--${s.severity}`}>
+          <Icon name={SIGNAL_ICON[s.severity]} className="cockpit-signal__icon" aria-hidden />
+          <span className="cockpit-signal__text">{s.text}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ─── Confidence heatmap ──────────────────────────────────────────────────────────
+
+/** Pretty label for a confidence factor key (e.g. "accept_rate" → "Accept"). */
+function prettyFactor(label: string): string {
+  const base = label.replace(/_score$/, "").replace(/_rate$/, "");
+  return base.split("_").map((w) => w.slice(0, 1).toUpperCase() + w.slice(1)).join(" ");
+}
+
+/** 0 → danger, 1 → success, ramped through color-mix in oklch. */
+function confidenceColor(value: number): string {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
+  return `color-mix(in oklch, var(--color-success) ${pct}%, var(--color-danger))`;
+}
+
+function ConfidencePanel({ rows }: { rows: ConfidenceRow[] }) {
+  const cols = rows[0]?.factors.map((f) => prettyFactor(f.label)) ?? [];
+  // Cell value = the factor's normalized 0..1 strength (raw score ÷ 100).
+  const cells = rows.flatMap((r) =>
+    r.factors.map((f) => ({ row: r.name, col: prettyFactor(f.label), value: f.value / 100 })),
+  );
+  return (
+    <div className="cockpit-confidence">
+      <div className="cockpit-confidence__cols" style={{ ["--cols" as string]: cols.length }}>
+        {cols.map((c) => <span key={c}>{c}</span>)}
+      </div>
+      <div className="cockpit-confidence__grid">
+        <div className="cockpit-confidence__rows">
+          {rows.map((r) => (
+            <span key={r.id} title={`${r.name}: confidence ${r.score}`}>{r.name}</span>
+          ))}
+        </div>
+        <Heatmap rows={rows.map((r) => r.name)} cols={cols} cells={cells} colorFor={confidenceColor} height={Math.max(72, rows.length * 26)} />
+      </div>
+    </div>
+  );
 }
 
 // ─── Bits ────────────────────────────────────────────────────────────────────────

--- a/src/lib/dashboard-analytics.test.ts
+++ b/src/lib/dashboard-analytics.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { sessionsPerDay, familiarMiniProfiles, familiarLoadSeries } from "./dashboard-analytics.ts";
+import { sessionsPerDay, familiarMiniProfiles, familiarLoadSeries, dashboardSignals } from "./dashboard-analytics.ts";
 
 const NOW = Date.parse("2026-06-29T12:00:00Z");
 const day = (offset) => new Date(NOW - offset * 86400_000).toISOString();
@@ -45,5 +45,38 @@ assert.equal(series.length, 2, "top 2 familiars by load (f3 has 0, dropped)");
 assert.equal(series[0].id, "f1", "f1 leads (3 sessions)");
 assert.equal(series[0].points.length, 7, "each series has 7 points");
 assert.ok(series[0].points.every((p) => typeof p.x === "number" && typeof p.y === "number"), "points are {x,y}");
+
+// ── dashboardSignals: stalled PR + large reading queue + trending-down familiar ─
+const ghItem = (id, kind, updatedOffset, state, title) => ({
+  id, kind, title, repo: "o/r", url: "#", state, updatedAt: day(updatedOffset),
+});
+const sigGithub = [
+  ghItem("p1", "pr", 9, "open", "Old PR"),          // stalled (>7d)
+  ghItem("p2", "pr", 2, "open", "Fresh PR"),        // not stalled
+  ghItem("p3", "pr", 20, "closed", "Closed PR"),    // closed → ignored
+  ghItem("p4", "issue", 30, "open", "Old issue"),   // not a PR → ignored
+];
+// f1: sessions only in the prior window (offset 5) → trending down.
+// f2: a session today (offset 0) → not trending down.
+const sigSessions = [sess("s1", "f1", 5), sess("s2", "f2", 0)];
+const sigFamiliars = [
+  { id: "f1", display_name: "Sage" },
+  { id: "f2", display_name: "Nova" },
+];
+const sigReading = Array.from({ length: 9 }, (_, i) => ({ status: "want-to-read" }));
+
+const signals = dashboardSignals({
+  github: sigGithub, reading: sigReading, sessions: sigSessions, familiars: sigFamiliars, nowMs: NOW,
+});
+const sigIds = signals.map((s) => s.id);
+assert.ok(sigIds.includes("pr-stalled-p1"), "stalled open PR surfaces a warn signal");
+assert.ok(!sigIds.some((id) => id.startsWith("pr-stalled-p2")), "fresh PR is not flagged");
+assert.ok(!sigIds.some((id) => id.startsWith("pr-stalled-p3")), "closed PR is not flagged");
+assert.ok(!sigIds.some((id) => id.startsWith("pr-stalled-p4")), "issues are not flagged as stalled PRs");
+assert.ok(sigIds.includes("reading-large"), "large reading queue (>8) surfaces an info signal");
+assert.ok(sigIds.includes("familiar-down-f1"), "familiar quiet for 3d after prior activity is flagged");
+assert.ok(!sigIds.includes("familiar-down-f2"), "recently-active familiar is not flagged");
+assert.equal(signals[0].severity, "warn", "warnings sort ahead of info");
+assert.equal(dashboardSignals({ github: [], reading: [], sessions: [], familiars: [], nowMs: NOW }).length, 0, "no signals when nothing is drifting");
 
 console.log("dashboard-analytics.test.ts passed");

--- a/src/lib/dashboard-analytics.ts
+++ b/src/lib/dashboard-analytics.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Familiar, SessionRow } from "@/lib/types";
+import type { GitHubItem } from "@/lib/github-tasks";
 import type { SparkPoint } from "@/components/ui/sparkline";
 import type { TrendSeries } from "@/components/ui/charts/trend-chart";
 
@@ -81,6 +82,86 @@ export function familiarMiniProfiles(
       trend: counts.map((value, i) => ({ label: `${days - 1 - i}d`, value })),
     };
   });
+}
+
+// ─── Predictive signals ──────────────────────────────────────────────────────────
+
+export type DashboardSignal = {
+  id: string;
+  severity: "warn" | "info";
+  text: string;
+};
+
+const STALE_PR_DAYS = 7;
+const READING_QUEUE_LARGE = 8;
+
+/** Cheap, pure, clock-injected "things drifting" detector for the cockpit's
+ *  Signals strip. Reads only what the cockpit already fetches — no extra calls.
+ *
+ *  - PR stalled: an open PR / review request untouched for > 7 days.
+ *  - Reading queue large: the reading list has grown past a comfortable size.
+ *  - Familiar trending down: had sessions in the prior 4-day window (days 3–7
+ *    ago) but none in the last 3 days. */
+export function dashboardSignals(input: {
+  github: GitHubItem[];
+  reading: { status?: string }[];
+  sessions: SessionRow[];
+  familiars: Familiar[];
+  nowMs: number;
+}): DashboardSignal[] {
+  const { github, reading, sessions, familiars, nowMs } = input;
+  const out: DashboardSignal[] = [];
+
+  // PR stalled > 7 days (open PRs / review requests with a stale updatedAt).
+  for (const g of github) {
+    if (g.kind !== "pr" && g.kind !== "review_request") continue;
+    if (g.state === "closed") continue;
+    const t = Date.parse(g.updatedAt);
+    if (!Number.isFinite(t)) continue;
+    const days = Math.floor((nowMs - t) / DAY_MS);
+    if (days > STALE_PR_DAYS) {
+      out.push({
+        id: `pr-stalled-${g.id}`,
+        severity: "warn",
+        text: `PR stalled ${days}d: ${g.title}`,
+      });
+    }
+  }
+
+  // Reading queue grown large.
+  if (reading.length > READING_QUEUE_LARGE) {
+    out.push({
+      id: "reading-large",
+      severity: "info",
+      text: `Reading queue is large (${reading.length} items)`,
+    });
+  }
+
+  // Familiar trending down: active in the prior window, quiet in the last 3 days.
+  const last3Start = startOfDay(nowMs) - 2 * DAY_MS; // today + previous 2 days
+  const priorStart = startOfDay(nowMs) - (STALE_PR_DAYS - 1) * DAY_MS; // 7-day window start
+  for (const f of familiars) {
+    let recent = 0;
+    let prior = 0;
+    for (const s of sessions) {
+      if (s.archived_at || s.familiarId !== f.id) continue;
+      const t = sessionDayMs(s);
+      if (t === null) continue;
+      const dayStart = startOfDay(t);
+      if (dayStart >= last3Start) recent += 1;
+      else if (dayStart >= priorStart) prior += 1;
+    }
+    if (recent === 0 && prior > 0) {
+      out.push({
+        id: `familiar-down-${f.id}`,
+        severity: "warn",
+        text: `${f.display_name} is trending down — no sessions in 3 days`,
+      });
+    }
+  }
+
+  // Surface warnings ahead of info.
+  return out.sort((a, b) => (a.severity === b.severity ? 0 : a.severity === "warn" ? -1 : 1));
 }
 
 /** Multi-series session-load over time for the top-N busiest familiars (by

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -311,6 +311,23 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-readrow__title { flex: 1; min-width: 0; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cockpit-readrow__host { font-size: 10.5px; color: var(--text-muted); flex: 0 0 auto; }
 
+/* Signals */
+.cockpit-signals { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.cockpit-signal { display: flex; align-items: flex-start; gap: 8px; padding: 6px 8px; border-radius: 8px; font-size: 12px; color: var(--text-primary); }
+.cockpit-signal__icon { flex: 0 0 auto; margin-top: 1px; }
+.cockpit-signal--warn .cockpit-signal__icon { color: var(--color-warning); }
+.cockpit-signal--info .cockpit-signal__icon { color: var(--color-info); }
+.cockpit-signal__text { min-width: 0; }
+
+/* Confidence heatmap */
+.cockpit-confidence { display: flex; flex-direction: column; gap: 6px; }
+.cockpit-confidence__cols { display: grid; grid-template-columns: repeat(var(--cols, 4), 1fr); gap: 6px; margin-left: 84px;
+  font-size: 9.5px; color: var(--text-muted); text-align: center; }
+.cockpit-confidence__grid { display: flex; align-items: stretch; gap: 6px; }
+.cockpit-confidence__rows { display: flex; flex-direction: column; justify-content: space-around; width: 78px; flex: 0 0 auto; }
+.cockpit-confidence__rows span { font-size: 11px; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cockpit-confidence .cave-chart--heatmap { flex: 1; min-width: 0; }
+
 /* Quick launch + skeleton */
 .cockpit-launch { display: flex; flex-direction: column; gap: 10px; }
 .cockpit-quicklinks { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; }


### PR DESCRIPTION
Follow-up (2 of 3 deferred items from the dashboard/evals arc) — the two pieces deferred from PR #2098 because they need per-familiar data.

## What's added (additive)
- **Predictive signals strip** — new pure `dashboardSignals({github, reading, sessions, familiars, nowMs})` flags: open PRs/review-requests stalled > 7 days, a large reading queue, and familiars trending down (active in the prior window, silent the last 3 days). Compact panel, hidden when there are no signals.
- **Confidence heatmap** — familiars × confidence factors, colored on a danger→success ramp. Reuses the existing scoring (`deriveConfidenceScore` + `deriveGrowthReport` + `buildFamiliarCardStats`) — no reimplementation.

## Design / safety
- New logic is pure + tested in `dashboard-analytics.ts`. Confidence fetches are **bounded**: a dedicated effect keyed on the first-6 familiar ids fires one `/api/retro-runs` + ≤6 `/api/familiars/{id}/contract` in parallel, **does not refetch on the 30s poll** (keyed on the joined-id string value), has an abort guard, and degrades to null on failure. **No new API routes.**
- `dashboard-model.ts` untouched; existing panels intact.

## Verification
- `tsc` clean; `dashboard-analytics.test.ts` + `dashboard-page.test.ts` green (existing pinned assertions intact); app suite 486; `pnpm build` + bundle-budget ✓ (no new dependency — visx + `Heatmap` already in the dashboard chunk).
- Built TDD via subagent; **adversarial review APPROVED** — verified the fetch-effect has no refetch-loop and the `factor.value/100` scaling is correct (factor values are clamped 0..100).

## Note
Heatmap labels are rendered around the visx SVG (band-scale alignment is approximate, not pixel-locked) — fine for the ≤6-row grid; worth a visual pass if exact alignment matters later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)