### PR TITLE
feat(evals): EvalGroups management tab (+ groups DELETE route)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -248,6 +248,7 @@ export const SUITES = {
     "src/lib/server/eval-store.test.ts",
     "src/lib/evals/eval-judge.test.ts",
     "src/components/evals/evals-view.test.ts",
+    "src/components/evals/eval-groups-panel.test.ts",
     "src/components/retro-runs-view.test.ts",
     "src/components/debug-pane.test.ts",
     "src/components/library-link-viewer.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -56,7 +56,7 @@ const contracts: RouteContract[] = [
   { route: "/github/assigned", methods: ["GET"], kind: "json" },
   { route: "/github/repos", methods: ["GET"], kind: "json" },
   { route: "/evals/runs", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/evals/groups", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/evals/groups", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/evals/thread-states", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/evals/queue", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/evals/suites", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/evals/groups/route.ts
+++ b/src/app/api/evals/groups/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
-import { listEvalGroups, saveEvalGroup } from "@/lib/server/eval-store";
+import { deleteEvalGroup, listEvalGroups, saveEvalGroup } from "@/lib/server/eval-store";
 import type { EvalGroup } from "@/lib/evals/eval-model";
 
 export const dynamic = "force-dynamic";
@@ -34,4 +34,15 @@ export async function POST(req: Request) {
       { status: 400 },
     );
   }
+}
+
+/** Delete an eval group by `?id=`. */
+export async function DELETE(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const id = new URL(req.url).searchParams.get("id");
+  if (!id) return NextResponse.json({ ok: false, error: "id required" }, { status: 400 });
+  const ok = await deleteEvalGroup(id);
+  return NextResponse.json({ ok });
 }

--- a/src/components/evals/eval-groups-panel.test.ts
+++ b/src/components/evals/eval-groups-panel.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+// Source-text test for the EvalGroups management panel: pins the CRUD wiring
+// (create/save via POST, delete via DELETE), the rollup summary, and the
+// scope/tracks/member controls that make the tab functional.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./eval-groups-panel.tsx", import.meta.url), "utf8");
+
+// Client component receiving groups, derived states, familiars, and a refetch hook.
+assert.match(source, /"use client"/, "is a client component");
+assert.match(source, /export function EvalGroupsPanel/, "exports the panel");
+assert.match(source, /groups: EvalGroup\[\]/, "receives the groups list");
+assert.match(source, /states: (readonly )?ThreadEvalState\[\]/, "receives derived thread eval states");
+assert.match(source, /familiars: ResolvedFamiliar\[\]/, "receives the familiars prop for member selection");
+assert.match(source, /onChanged/, "calls back to refetch groups after a mutation");
+
+// Rollup summary per group.
+assert.match(source, /rollupEvalGroup\(/, "rolls each group's state into status counts");
+assert.match(source, /freshThreads/, "shows fresh thread count");
+assert.match(source, /staleThreads/, "shows stale thread count");
+assert.match(source, /neverRunThreads/, "shows never-run thread count");
+
+// CRUD wiring against the API.
+assert.match(source, /fetch\("\/api\/evals\/groups"/, "saves a group via POST /api/evals/groups");
+assert.match(source, /method: "POST"/, "creates/edits via POST");
+assert.match(source, /JSON\.stringify\(\{ group/, "POST body wraps the group");
+assert.match(source, /\/api\/evals\/groups\?id=/, "deletes via DELETE /api/evals/groups?id=");
+assert.match(source, /method: "DELETE"/, "supports group deletion");
+assert.match(source, /crypto\.randomUUID\(\)/, "new groups get a generated id");
+
+// Form controls: scope select, tracks multi-toggle, stale TTL (hours), familiar members.
+assert.match(source, /EvalGroupScope|SCOPE_OPTIONS/, "scope is constrained to EvalGroupScope");
+assert.match(source, /EvalTrack|TRACK_OPTIONS/, "tracks are constrained to EvalTrack");
+assert.match(source, /ttl|ttlMs/i, "stale policy TTL is editable");
+assert.match(source, /kind: "familiar"/, "familiar members are stored as familiar-kind members");
+assert.match(source, /schedulePolicy/, "sets a schedule policy on new groups");
+
+console.log("eval-groups-panel.test.ts OK");

--- a/src/components/evals/eval-groups-panel.test.ts
+++ b/src/components/evals/eval-groups-panel.test.ts
@@ -11,7 +11,7 @@ const source = readFileSync(new URL("./eval-groups-panel.tsx", import.meta.url),
 assert.match(source, /"use client"/, "is a client component");
 assert.match(source, /export function EvalGroupsPanel/, "exports the panel");
 assert.match(source, /groups: EvalGroup\[\]/, "receives the groups list");
-assert.match(source, /states: (readonly )?ThreadEvalState\[\]/, "receives derived thread eval states");
+assert.match(source, /statesById: Map<string, ThreadEvalState\[\]>/, "receives derived thread eval states scoped per group id");
 assert.match(source, /familiars: ResolvedFamiliar\[\]/, "receives the familiars prop for member selection");
 assert.match(source, /onChanged/, "calls back to refetch groups after a mutation");
 

--- a/src/components/evals/eval-groups-panel.tsx
+++ b/src/components/evals/eval-groups-panel.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { EmptyState } from "@/components/ui/empty-state";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import {
+  rollupEvalGroup,
+  type EvalGroup,
+  type EvalGroupScope,
+  type EvalTrack,
+  type ThreadEvalState,
+} from "@/lib/evals/eval-model";
+
+type Props = {
+  groups: EvalGroup[];
+  states: ThreadEvalState[];
+  familiars: ResolvedFamiliar[];
+  onChanged: () => void;
+};
+
+const SCOPE_OPTIONS: Array<{ value: EvalGroupScope; label: string }> = [
+  { value: "thread", label: "Thread" },
+  { value: "familiar", label: "Familiar" },
+  { value: "project", label: "Project" },
+  { value: "release", label: "Release" },
+  { value: "custom", label: "Custom" },
+];
+
+const TRACK_OPTIONS: Array<{ value: EvalTrack; label: string }> = [
+  { value: "synthesis", label: "Synthesis" },
+  { value: "prompt", label: "Prompt" },
+  { value: "memory", label: "Memory" },
+  { value: "confidence", label: "Confidence" },
+  { value: "regression", label: "Regression" },
+];
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function newGroup(rubricVersion: string): EvalGroup {
+  const now = new Date().toISOString();
+  let id: string;
+  try {
+    id = crypto.randomUUID();
+  } catch {
+    id = `group-${Date.now().toString(36)}`;
+  }
+  return {
+    id,
+    name: "Untitled group",
+    description: "",
+    scope: "custom",
+    members: [],
+    tracks: ["synthesis"],
+    rubricVersion: rubricVersion || "v1",
+    stalePolicy: {},
+    schedulePolicy: { mode: "manual" },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function EvalGroupsPanel({ groups, states, familiars, onChanged }: Props) {
+  const [draft, setDraft] = useState<EvalGroup | null>(null);
+  const [isNew, setIsNew] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const familiarName = useCallback(
+    (id: string) => familiars.find((f) => f.id === id)?.display_name ?? id,
+    [familiars],
+  );
+
+  const rollups = useMemo(
+    () => new Map(groups.map((group) => [group.id, rollupEvalGroup(group, states)])),
+    [groups, states],
+  );
+
+  const existingRubric = groups[0]?.rubricVersion ?? "v1";
+
+  const startCreate = useCallback(() => {
+    setDraft(newGroup(existingRubric));
+    setIsNew(true);
+    setError(null);
+  }, [existingRubric]);
+
+  const startEdit = useCallback((group: EvalGroup) => {
+    setDraft(structuredClone(group));
+    setIsNew(false);
+    setError(null);
+  }, []);
+
+  const cancel = useCallback(() => {
+    setDraft(null);
+    setError(null);
+  }, []);
+
+  const patch = useCallback((p: Partial<EvalGroup>) => {
+    setDraft((d) => (d ? { ...d, ...p } : d));
+  }, []);
+
+  const toggleTrack = useCallback((track: EvalTrack) => {
+    setDraft((d) => {
+      if (!d) return d;
+      const has = d.tracks.includes(track);
+      return { ...d, tracks: has ? d.tracks.filter((t) => t !== track) : [...d.tracks, track] };
+    });
+  }, []);
+
+  const toggleFamiliar = useCallback((familiarId: string) => {
+    setDraft((d) => {
+      if (!d) return d;
+      const has = d.members.some((m) => m.kind === "familiar" && m.id === familiarId);
+      const members = has
+        ? d.members.filter((m) => !(m.kind === "familiar" && m.id === familiarId))
+        : [...d.members, { kind: "familiar" as const, id: familiarId, familiarId }];
+      return { ...d, members };
+    });
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!draft) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const group: EvalGroup = { ...draft, updatedAt: new Date().toISOString() };
+      const res = await fetch("/api/evals/groups", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ group }),
+      });
+      const data = (await res.json()) as { ok: boolean; error?: string };
+      if (!res.ok || !data.ok) {
+        setError(data.error || "Save failed");
+        return;
+      }
+      setDraft(null);
+      onChanged();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, onChanged]);
+
+  const remove = useCallback(
+    async (id: string) => {
+      try {
+        await fetch(`/api/evals/groups?id=${encodeURIComponent(id)}`, { method: "DELETE" });
+        if (draft?.id === id) setDraft(null);
+        onChanged();
+      } catch {
+        // best-effort; the list refetch will reflect reality
+      }
+    },
+    [draft, onChanged],
+  );
+
+  return (
+    <div className="evals-groups">
+      <div className="evals-section-head">
+        <span className="evals-group-kicker">Eval groups</span>
+        <button type="button" className="evals-btn" onClick={startCreate}>
+          <Icon name="ph:plus" width={13} /> New group
+        </button>
+      </div>
+
+      {groups.length === 0 && !draft ? (
+        <EmptyState
+          icon="ph:squares-four"
+          headline="No eval groups yet"
+          subtitle="Group threads and familiars into a tracked eval set, choose which tracks to run, and watch freshness roll up across the group."
+          actions={
+            <button type="button" className="evals-btn evals-btn-primary" onClick={startCreate}>
+              <Icon name="ph:plus" width={14} /> New group
+            </button>
+          }
+        />
+      ) : null}
+
+      {draft ? (
+        <article className="evals-group-editor" aria-label="Edit eval group">
+          <label className="evals-field">
+            <span>Name</span>
+            <input
+              className="evals-group-name-input"
+              value={draft.name}
+              onChange={(e) => patch({ name: e.target.value })}
+              aria-label="Group name"
+            />
+          </label>
+          <label className="evals-field">
+            <span>Description</span>
+            <textarea
+              className="evals-desc"
+              value={draft.description ?? ""}
+              placeholder="What does this group track? (optional)"
+              onChange={(e) => patch({ description: e.target.value })}
+              rows={2}
+              aria-label="Group description"
+            />
+          </label>
+          <label className="evals-field">
+            <span>Scope</span>
+            <select
+              className="evals-grader-kind"
+              value={draft.scope}
+              onChange={(e) => patch({ scope: e.target.value as EvalGroupScope })}
+              aria-label="Group scope"
+            >
+              {SCOPE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="evals-field">
+            <span>Tracks</span>
+            <div className="evals-track-toggles" role="group" aria-label="Eval tracks">
+              {TRACK_OPTIONS.map((o) => {
+                const on = draft.tracks.includes(o.value);
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    className={`evals-toggle-chip${on ? " is-on" : ""}`}
+                    aria-pressed={on}
+                    onClick={() => toggleTrack(o.value)}
+                  >
+                    {o.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <label className="evals-field">
+            <span>Stale after (hours)</span>
+            <input
+              type="number"
+              min={0}
+              value={draft.stalePolicy.ttlMs != null ? Math.round(draft.stalePolicy.ttlMs / HOUR_MS) : ""}
+              placeholder="never"
+              onChange={(e) => {
+                const hours = e.target.value === "" ? undefined : Number(e.target.value);
+                patch({
+                  stalePolicy: {
+                    ttlMs: hours == null || Number.isNaN(hours) || hours <= 0 ? undefined : Math.round(hours * HOUR_MS),
+                  },
+                });
+              }}
+              aria-label="Stale policy TTL in hours"
+            />
+          </label>
+
+          <div className="evals-field">
+            <span>Familiar members</span>
+            {familiars.length === 0 ? (
+              <small className="evals-group-muted">No familiars available</small>
+            ) : (
+              <div className="evals-member-toggles" role="group" aria-label="Familiar members">
+                {familiars.map((f) => {
+                  const on = draft.members.some((m) => m.kind === "familiar" && m.id === f.id);
+                  return (
+                    <button
+                      key={f.id}
+                      type="button"
+                      className={`evals-toggle-chip${on ? " is-on" : ""}`}
+                      aria-pressed={on}
+                      onClick={() => toggleFamiliar(f.id)}
+                    >
+                      {f.display_name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {error ? <p className="evals-group-error">{error}</p> : null}
+
+          <div className="evals-toolbar-actions">
+            <button type="button" className="evals-btn evals-btn-primary" onClick={save} disabled={saving || !draft.name.trim()}>
+              <Icon name="ph:check" width={13} /> {isNew ? "Create group" : "Save group"}
+            </button>
+            <button type="button" className="evals-btn" onClick={cancel} disabled={saving}>
+              Cancel
+            </button>
+          </div>
+        </article>
+      ) : null}
+
+      <ul className="evals-group-list">
+        {groups.map((group) => {
+          const rollup = rollups.get(group.id);
+          const memberFamiliars = group.members.filter((m) => m.kind === "familiar");
+          return (
+            <li key={group.id} className="evals-group-card">
+              <div className="evals-group-card-head">
+                <div className="evals-group-summary">
+                  <b>{group.name}</b>
+                  <span className="evals-group-muted">
+                    {group.scope} · {group.tracks.length ? group.tracks.join(", ") : "no tracks"}
+                  </span>
+                </div>
+                <div className="evals-group-card-actions">
+                  <button type="button" className="evals-icon-btn" onClick={() => startEdit(group)} title="Edit group" aria-label="Edit group">
+                    <Icon name="ph:pencil-simple" width={13} />
+                  </button>
+                  <button type="button" className="evals-icon-btn" onClick={() => void remove(group.id)} title="Delete group" aria-label="Delete group">
+                    <Icon name="ph:trash" width={13} />
+                  </button>
+                </div>
+              </div>
+              {group.description ? <p className="evals-group-desc">{group.description}</p> : null}
+              {rollup ? (
+                <div className="evals-group-rollup" aria-label="Group freshness rollup">
+                  <span className="evals-chip">{rollup.totalThreads} threads</span>
+                  <span className="evals-chip is-pass">{rollup.freshThreads} fresh</span>
+                  <span className="evals-chip is-fail">{rollup.staleThreads} stale</span>
+                  <span className="evals-chip">{rollup.neverRunThreads} never run</span>
+                </div>
+              ) : null}
+              {memberFamiliars.length ? (
+                <div className="evals-group-members">
+                  {memberFamiliars.map((m) => (
+                    <span key={m.id} className="evals-toggle-chip is-on">
+                      {familiarName(m.familiarId ?? m.id)}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/evals/eval-groups-panel.tsx
+++ b/src/components/evals/eval-groups-panel.tsx
@@ -14,7 +14,7 @@ import {
 
 type Props = {
   groups: EvalGroup[];
-  states: ThreadEvalState[];
+  statesById: Map<string, ThreadEvalState[]>;
   familiars: ResolvedFamiliar[];
   onChanged: () => void;
 };
@@ -60,7 +60,7 @@ function newGroup(rubricVersion: string): EvalGroup {
   };
 }
 
-export function EvalGroupsPanel({ groups, states, familiars, onChanged }: Props) {
+export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Props) {
   const [draft, setDraft] = useState<EvalGroup | null>(null);
   const [isNew, setIsNew] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -72,8 +72,8 @@ export function EvalGroupsPanel({ groups, states, familiars, onChanged }: Props)
   );
 
   const rollups = useMemo(
-    () => new Map(groups.map((group) => [group.id, rollupEvalGroup(group, states)])),
-    [groups, states],
+    () => new Map(groups.map((group) => [group.id, rollupEvalGroup(group, statesById.get(group.id) ?? [])])),
+    [groups, statesById],
   );
 
   const existingRubric = groups[0]?.rubricVersion ?? "v1";
@@ -144,10 +144,11 @@ export function EvalGroupsPanel({ groups, states, familiars, onChanged }: Props)
   }, [draft, onChanged]);
 
   const remove = useCallback(
-    async (id: string) => {
+    async (group: EvalGroup) => {
+      if (typeof window !== "undefined" && !window.confirm(`Delete eval group "${group.name}"?`)) return;
       try {
-        await fetch(`/api/evals/groups?id=${encodeURIComponent(id)}`, { method: "DELETE" });
-        if (draft?.id === id) setDraft(null);
+        await fetch(`/api/evals/groups?id=${encodeURIComponent(group.id)}`, { method: "DELETE" });
+        if (draft?.id === group.id) setDraft(null);
         onChanged();
       } catch {
         // best-effort; the list refetch will reflect reality
@@ -309,7 +310,7 @@ export function EvalGroupsPanel({ groups, states, familiars, onChanged }: Props)
                   <button type="button" className="evals-icon-btn" onClick={() => startEdit(group)} title="Edit group" aria-label="Edit group">
                     <Icon name="ph:pencil-simple" width={13} />
                   </button>
-                  <button type="button" className="evals-icon-btn" onClick={() => void remove(group.id)} title="Delete group" aria-label="Delete group">
+                  <button type="button" className="evals-icon-btn" onClick={() => void remove(group)} title="Delete group" aria-label="Delete group">
                     <Icon name="ph:trash" width={13} />
                   </button>
                 </div>

--- a/src/components/evals/evals-view.test.ts
+++ b/src/components/evals/evals-view.test.ts
@@ -32,8 +32,10 @@ assert.match(source, /EvalLoopPanel/, "embeds eval-loop controls in the unified 
 assert.match(source, /EvalsAnalysisSummary/, "renders a rich analysis summary");
 assert.match(source, /LoopAnalysisPanel/, "renders eval-loop analysis inside Evals");
 assert.match(source, /ThreadFreshnessPanel/, "renders grouped thread freshness analysis inside Evals");
+assert.match(source, /EvalGroupsPanel/, "renders the eval groups management panel inside Evals");
+assert.match(source, /\["groups", "Groups"\]/, "includes a Groups tab in the nav");
 assert.match(source, /downloadRetroSnapshot/, "keeps sanitized eval-loop export available inside Evals");
-assert.match(source, /"overview" \| "insights" \| "suites" \| "runs" \| "compare" \| "loops" \| "threads"/, "unified surface has analysis-first tabs");
+assert.match(source, /"overview" \| "insights" \| "suites" \| "runs" \| "compare" \| "loops" \| "threads" \| "groups"/, "unified surface has analysis-first tabs");
 assert.match(source, /Overview/, "includes an Overview tab");
 assert.match(source, /Suites/, "includes a Suites tab");
 assert.match(source, /Loops/, "includes a Loops tab");

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/evals/eval-templates";
 import { Modal } from "@/components/ui/modal";
 import { EvalsInsightsPanel } from "@/components/evals/evals-insights-panel";
+import { EvalGroupsPanel } from "@/components/evals/eval-groups-panel";
 import { RunCompare } from "@/components/evals/run-compare";
 import "@/styles/evals.css";
 
@@ -40,7 +41,7 @@ type Props = {
 };
 
 type GraderKindOption = { kind: GraderKind; label: string; hint: string; valueless?: boolean };
-type EvalsTab = "overview" | "insights" | "suites" | "runs" | "compare" | "loops" | "threads";
+type EvalsTab = "overview" | "insights" | "suites" | "runs" | "compare" | "loops" | "threads" | "groups";
 type RetroApiResponse =
   | { ok: true; snapshot: RetroRunsSnapshot }
   | { ok: false; snapshot?: RetroRunsSnapshot; error?: string };
@@ -140,6 +141,18 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     () => activeGroup ? rollupEvalGroup(activeGroup, activeGroupStates) : null,
     [activeGroup, activeGroupStates],
   );
+  // Union of every group's derived thread states (deduped by thread) so the
+  // Groups panel can roll each group up against a single states array; the
+  // rollup scopes itself to the group's own thread members.
+  const allGroupStates = useMemo(() => {
+    const byThread = new Map<string, ThreadEvalState>();
+    for (const group of groups) {
+      for (const state of deriveEvalGroupStates(group, threadSnapshots)) {
+        byThread.set(state.threadId, state);
+      }
+    }
+    return [...byThread.values()];
+  }, [groups, threadSnapshots]);
   const familiarName = (familiars.find((f) => f.id === familiarId)?.display_name ?? familiarId) || "Familiar";
   const activeLoopState = retroSnapshot.familiars.find((familiar) => familiar.familiarId === familiarId) ?? null;
   const analysis = useMemo(
@@ -194,6 +207,18 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
       alive = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const reloadGroups = useCallback(() => {
+    void (async () => {
+      try {
+        const res = await fetch("/api/evals/groups");
+        const data = (await res.json()) as { ok: boolean; groups?: EvalGroup[] };
+        setGroups(data.groups ?? []);
+      } catch {
+        // leave the current list in place on a transient failure
+      }
+    })();
   }, []);
 
   const selectSuite = useCallback((suite: EvalSuite) => {
@@ -470,6 +495,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
             ["compare", "Compare"],
             ["loops", "Loops"],
             ["threads", "Thread freshness"],
+            ["groups", "Groups"],
           ] as Array<[EvalsTab, string]>).map(([id, label]) => (
             <button key={id} type="button" role="tab" aria-selected={tab === id} className={`evals-tab${tab === id ? " is-active" : ""}`} onClick={() => setTab(id)}>
               {label}
@@ -523,13 +549,20 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
             snapshot={retroSnapshot}
             activeLoopState={activeLoopState}
           />
-        ) : (
+        ) : tab === "threads" ? (
           <ThreadFreshnessPanel
             group={activeGroup}
             states={activeGroupStates}
             rollup={activeGroupRollup}
             queuedCount={queue.length}
             onQueue={queueStaleGroup}
+          />
+        ) : (
+          <EvalGroupsPanel
+            groups={groups}
+            states={allGroupStates}
+            familiars={familiars}
+            onChanged={reloadGroups}
           />
         )}
       </section>

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -141,18 +141,13 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     () => activeGroup ? rollupEvalGroup(activeGroup, activeGroupStates) : null,
     [activeGroup, activeGroupStates],
   );
-  // Union of every group's derived thread states (deduped by thread) so the
-  // Groups panel can roll each group up against a single states array; the
-  // rollup scopes itself to the group's own thread members.
-  const allGroupStates = useMemo(() => {
-    const byThread = new Map<string, ThreadEvalState>();
-    for (const group of groups) {
-      for (const state of deriveEvalGroupStates(group, threadSnapshots)) {
-        byThread.set(state.threadId, state);
-      }
-    }
-    return [...byThread.values()];
-  }, [groups, threadSnapshots]);
+  // Each group rolls up against its OWN derived thread states. A shared union
+  // would make every group that has no thread members (rollupEvalGroup's
+  // size===0 fallthrough) count every other group's threads.
+  const groupStatesById = useMemo(
+    () => new Map(groups.map((g) => [g.id, deriveEvalGroupStates(g, threadSnapshots)])),
+    [groups, threadSnapshots],
+  );
   const familiarName = (familiars.find((f) => f.id === familiarId)?.display_name ?? familiarId) || "Familiar";
   const activeLoopState = retroSnapshot.familiars.find((familiar) => familiar.familiarId === familiarId) ?? null;
   const analysis = useMemo(
@@ -560,7 +555,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
         ) : (
           <EvalGroupsPanel
             groups={groups}
-            states={allGroupStates}
+            statesById={groupStatesById}
             familiars={familiars}
             onChanged={reloadGroups}
           />

--- a/src/lib/server/eval-store.ts
+++ b/src/lib/server/eval-store.ts
@@ -253,6 +253,15 @@ export async function saveEvalGroup(input: unknown): Promise<EvalGroup> {
   return group;
 }
 
+export async function deleteEvalGroup(id: string): Promise<boolean> {
+  try {
+    await rm(path.join(groupsDir(), fileName(id, "group")), { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function listThreadEvalSnapshots(): Promise<ThreadEvalSnapshot[]> {
   const snapshots = await listJsonDir(threadStatesDir(), coerceThreadEvalSnapshot);
   snapshots.sort((a, b) => (b.evaluatedAt > a.evaluatedAt ? 1 : b.evaluatedAt < a.evaluatedAt ? -1 : 0));

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -555,6 +555,93 @@
   font-style: normal;
 }
 
+/* ---- Groups management -------------------------------------------------- */
+.evals-groups {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+.evals-group-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+}
+.evals-group-name-input {
+  width: 100%;
+}
+.evals-track-toggles,
+.evals-member-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.evals-toggle-chip {
+  padding: 3px 9px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill, 999px);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+.evals-toggle-chip.is-on {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border));
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  color: var(--text-primary);
+}
+.evals-group-error {
+  margin: 0;
+  color: var(--color-danger);
+  font-size: var(--text-xs);
+}
+.evals-group-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.evals-group-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+}
+.evals-group-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+.evals-group-card-actions {
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.evals-group-desc {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+.evals-group-rollup,
+.evals-group-members {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
 /* ---- Editor ------------------------------------------------------------- */
 .evals-editor {
   flex: 1;


### PR DESCRIPTION
Follow-up (3 of 3 deferred items from the dashboard/evals arc) — the EvalGroups management UI deferred from PR #2094. EvalGroups existed in the model + a GET/POST API but had no UI and no delete.

## What's added
- **Groups tab** in the Evals surface: lists groups, each with a `rollupEvalGroup` health summary (fresh/stale/never-run); create/edit form (name, description, scope, tracks, stale-TTL in hours, familiar members); delete.
- **`deleteEvalGroup(id)`** in the eval store (mirrors `deleteSuite`, same traversal-safe filename helper) + a **DELETE** handler on `/api/evals/groups` (`?id=`, local-origin guarded) + `api-contracts` updated to `["GET","POST","DELETE"]`.

## Design / correctness
- Save via `POST {group}`, delete via `DELETE ?id=`; new groups get a uuid, `schedulePolicy{mode:"manual"}`, timestamps.
- **Rollup is scoped per-group** — each group rolls up against its *own* derived thread states (`statesById.get(group.id)`), not a shared union. (An adversarial review caught an earlier version that rolled every group against the union of all groups' states — fixed.)
- Delete is **confirmed** (`window.confirm`) so an accidental click can't silently destroy a group.
- Additive — existing tabs/panels/routes untouched; the Threads tab is intact.

## Verification
- `tsc` clean; `api-contracts` (151 contracts), `evals-view.test.ts`, new `eval-groups-panel.test.ts` green; app suite 487; `pnpm build` + bundle-budget ✓. Signed commits.
- Built TDD via subagent; adversarial spec+quality review (path-injection safety on the DELETE confirmed; rollup-scoping Blocker found and fixed; re-verified).

## Scope note
The member picker edits **familiar** membership (thread members still roll up correctly if present). A richer thread/project member picker is a future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)