### PR TITLE
feat(code): remove the left file-tree explorer panel from the Code surface

### DIFF
--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -111,6 +111,19 @@ assert.match(
   /\{!hideProjectNavigator && \([\s\S]*?Recent sessions/,
   "Comux wraps duplicate recent sessions in the hideProjectNavigator guard",
 );
+// Code surface drops the whole left file-tree explorer column (#removed): the
+// surface is chat + preview/Changes only. The Library projects browser keeps it.
+assert.match(
+  workspace,
+  /<ComuxView[\s\S]*?view="projects"[\s\S]*?hideFileTree/,
+  "Code-mode ComuxView removes the left file-tree explorer column",
+);
+assert.match(comux, /hideFileTree\?: boolean/, "ComuxView accepts hideFileTree");
+assert.match(
+  comux,
+  /\{!hideFileTree && !\(isControlledRightView && rightView === "changes"\) && \(projectDetailCollapsed \? \(/,
+  "Comux gates the entire file-tree column behind hideFileTree",
+);
 assert.doesNotMatch(codeView, /toggleProjects|aria-label=\{?"?(Hide|Show) projects/i, "the collapse toggle is not in the Code toolbar anymore");
 // Right-click a project row → a context menu with cwd-scoped actions. The row
 // is an extracted SortableProjectRow; the wiring lives in the onRowContextMenu

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -120,6 +120,11 @@ type Props = {
    *  When this is true, keep this column focused on the selected project's
    *  details, search, files, terminals, preview, and diff state. */
   hideProjectNavigator?: boolean;
+  /** Remove the left file-tree explorer column entirely (project header,
+   *  Terminal/New chat, in-project search, sessions, and the FILES tree), so the
+   *  surface is just the conversation + preview/Changes. The Code surface sets
+   *  this; the Library projects browser keeps its tree. */
+  hideFileTree?: boolean;
 };
 
 type ProjectFilePreview =
@@ -407,7 +412,7 @@ function SortableProjectRow({
   );
 }
 
-export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange, centerSlot, hideProjectNavigator = false }: Props) {
+export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNewChat, active = true, storageNamespace = "", rightView: rightViewProp, onRightViewChange, centerSlot, hideProjectNavigator = false, hideFileTree = false }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const layoutKey = STORAGE_LAYOUT + storageNamespace;
   const sessionsKey = STORAGE_SESSIONS + storageNamespace;
@@ -1674,7 +1679,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 {/* File-tree column (projects · search · sessions · tree) — the
                     Files tab. Hidden in controlled Changes mode so the diff
                     review fills the surface as its own tab. */}
-                {!(isControlledRightView && rightView === "changes") && (projectDetailCollapsed ? (
+                {!hideFileTree && !(isControlledRightView && rightView === "changes") && (projectDetailCollapsed ? (
                   <button
                     type="button"
                     aria-label="Show project details"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1931,6 +1931,7 @@ export function Workspace() {
             active={mode === "code"}
             storageNamespace=":code"
             hideProjectNavigator
+            hideFileTree
             sessions={sessions}
             onOpenSession={(sessionId, familiarId) => {
               openFamiliarSession(sessionId, familiarId);


### PR DESCRIPTION
## What
Removes the Code surface's **left file-tree explorer column** (the panel in the screenshot: project header `familiars/nova`, Terminal/New chat, in-project Search, recent sessions, and the FILES tree). The Code surface is now **chat (center) + file preview/Changes (right)**.

## How
`comux-view.tsx` is a **shared** component (Code surface *and* the Library projects browser). Rather than delete the markup — which would break the Library browser and a stack of source-text tests — I added a **`hideFileTree`** prop that gates the whole file-tree column, and set it **only at the Code-surface call site** (`workspace.tsx`, alongside the existing `hideProjectNavigator`).

- Library projects browser: **unchanged** (keeps its tree as primary navigation).
- Files referenced in chat still open in the preview (`cave:open-project-file`).
- Gating keeps the shared component + its source-text tests intact.

## Verification
- Live dev (`mode: code`): no `comux-project-header`, no in-project Search, no project-tree in the DOM.
- `pnpm typecheck` clean; `code-view`, `comux-view-search-options`, `comux-view-terminal`, `comux-view-changes/edit`, `comux-chrome/pane-nav/preview-crumbs` tests all green; added `code-view.test` coverage for the new prop + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)