### PR TITLE
feat(group-chat): inject coven roster so familiars know who's present

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -13,13 +13,15 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   // Fan-out: one /api/chat/send per participant carrying the per-familiar id.
   assert.match(view, /fetch\("\/api\/chat\/send"/, "sends through the chat bridge");
   assert.match(view, /familiarId: reply\.familiarId/, "each stream targets one familiar");
-  assert.match(view, /Promise\.all\(replies\.map/, "fans out to every participant in parallel");
+  assert.match(view, /Promise\.all\(\s*replies\.map/, "fans out to every participant in parallel");
   // Reuses the tested pure reducers rather than re-parsing inline.
   assert.match(view, /applyGroupEvent|parseSseBuffer/, "uses the pure stream reducers");
   // Per-familiar session pinning so each thread resumes.
   assert.match(view, /recordSession\(group\.id, reply\.familiarId/, "pins each familiar's session id");
   // A Stop control aborts the in-flight broadcast.
   assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
+  // Injects the coven roster into each send so a familiar knows who else is present.
+  assert.match(view, /renderCovenRoster\(rosterParticipants, r\.familiarId\)/, "injects the per-familiar coven roster");
   // Strips the piggybacked next-paths block (visible) and surfaces the parsed
   // lines (suggestions) so control markup never leaks and chips can render.
   assert.match(

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -37,6 +37,7 @@ import {
   setGroupSession,
   setGroupParticipants,
   parseMentions,
+  renderCovenRoster,
   findActiveMention,
   matchMentions,
   applyMention,
@@ -49,6 +50,7 @@ import {
   type GroupUserTurn,
   type GroupReply,
   type MentionableFamiliar,
+  type RosterParticipant,
 } from "@/lib/group-chat";
 
 type Props = {
@@ -299,6 +301,18 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       }));
       const mentioned = parseMentions(text, mentionable);
       const targetIds = mentioned.length > 0 ? group.familiarIds.filter((id) => mentioned.includes(id)) : group.familiarIds;
+      // Roster reflects the FULL coven (not just @mention targets) — a familiar
+      // should know who else is in the room even when addressed alone. Composed
+      // per-familiar so each sees itself marked "(you)".
+      const rosterParticipants: RosterParticipant[] = [
+        ...group.familiarIds.map((id) => ({
+          id,
+          name: byId.get(id)?.display_name ?? id,
+          role: byId.get(id)?.role ?? "",
+          kind: "familiar" as const,
+        })),
+        { id: "__human__", name: "You", role: "", kind: "human" as const },
+      ];
       const at = nowIso();
       const userTurn: GroupUserTurn = {
         id: newId(),
@@ -323,7 +337,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
-      await Promise.all(replies.map((r) => streamOne(group, r, text, controller.signal)));
+      await Promise.all(
+        replies.map((r) => {
+          const roster = renderCovenRoster(rosterParticipants, r.familiarId);
+          const prompt = roster ? `${roster}\n\n${text}` : text;
+          return streamOne(group, r, prompt, controller.signal);
+        }),
+      );
       abortRef.current = null;
       setBusy(false);
     },

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -10,11 +10,13 @@ import {
   setGroupSession,
   setGroupParticipants,
   parseMentions,
+  renderCovenRoster,
   findActiveMention,
   matchMentions,
   applyMention,
   type GroupReply,
   type MentionableFamiliar,
+  type RosterParticipant,
 } from "./group-chat.ts";
 
 const ROSTER: MentionableFamiliar[] = [
@@ -226,4 +228,42 @@ test("applyMention: replaces the token with '@name ' and moves caret after", () 
   const out = applyMention("hey @Nov rest", 4, "Nov", "Nova");
   assert.equal(out.text, "hey @Nova  rest");
   assert.equal(out.caret, "hey @Nova ".length);
+});
+
+const COVEN: RosterParticipant[] = [
+  { id: "nova", name: "Nova", role: "Lead orchestrator", kind: "familiar" },
+  { id: "charm", name: "Charm", role: "Comms familiar", kind: "familiar" },
+  { id: "__human__", name: "You", role: "", kind: "human" },
+];
+
+test("renderCovenRoster: names every participant with roles", () => {
+  const out = renderCovenRoster(COVEN, "nova");
+  assert.match(out, /- Nova — Lead orchestrator/);
+  assert.match(out, /- Charm — Comms familiar/);
+  assert.match(out, /- You \(human\)/);
+});
+
+test("renderCovenRoster: marks only the receiving familiar (you)", () => {
+  const out = renderCovenRoster(COVEN, "charm");
+  assert.match(out, /- Charm — Comms familiar \(you\)/);
+  assert.doesNotMatch(out, /Nova — Lead orchestrator \(you\)/);
+});
+
+test("renderCovenRoster: instructs the model to count everyone present", () => {
+  const out = renderCovenRoster(COVEN, "nova");
+  assert.match(out, /count everyone/i);
+  assert.match(out, /<coven_roster>[\s\S]*<\/coven_roster>/);
+});
+
+test("renderCovenRoster: human line carries no dangling role separator", () => {
+  const out = renderCovenRoster(COVEN, "nova");
+  assert.doesNotMatch(out, /You — /);
+});
+
+test("renderCovenRoster: returns '' for a degenerate roster (<= 1 participant)", () => {
+  assert.equal(renderCovenRoster([], "nova"), "");
+  assert.equal(
+    renderCovenRoster([{ id: "nova", name: "Nova", role: "Lead", kind: "familiar" }], "nova"),
+    "",
+  );
 });

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -305,6 +305,55 @@ function dedupe(ids: string[]): string[] {
 }
 
 // ---------------------------------------------------------------------------
+// Coven roster (pure) — who is present in the group
+// ---------------------------------------------------------------------------
+
+/** One coven participant for {@link renderCovenRoster}. Framework-free shape so
+ *  the helper stays DOM-/React-free; the view maps its resolved familiars into
+ *  this before calling. */
+export type RosterParticipant = {
+  id: string;
+  name: string;
+  /** Familiar role/lane; ignored for the human. */
+  role: string;
+  kind: "human" | "familiar";
+};
+
+/**
+ * Render the coven roster a familiar needs to know who else is in the room.
+ *
+ * Without this, each familiar resumes a private 1:1 session and cannot see its
+ * co-participants — so it answers "how many are here?" with "two: you and me"
+ * even in a 3-way coven. The block names every participant (with role), marks
+ * the human `(human)` and the receiving familiar `(you)`, and instructs the
+ * model to count everyone present.
+ *
+ * Third-person and framework-free. Composed into the `prompt` (after the
+ * harness-loaded identity, before the user text), so it is task context that
+ * never overrides the familiar's own declared identity. Returns "" for a
+ * degenerate roster (≤1 participant) so 1:1 sends are byte-identical to before.
+ */
+export function renderCovenRoster(
+  participants: RosterParticipant[],
+  receivingFamiliarId: string,
+): string {
+  if (participants.length <= 1) return "";
+  const lines = participants.map((p) => {
+    if (p.kind === "human") return `- ${p.name} (human)`;
+    const role = p.role.trim() ? ` — ${p.role.trim()}` : "";
+    const you = p.id === receivingFamiliarId ? " (you)" : "";
+    return `- ${p.name}${role}${you}`;
+  });
+  return [
+    "<coven_roster>",
+    'You are in a group chat ("coven") with these participants:',
+    ...lines,
+    "When asked who is present or how many are in this chat, count everyone listed above (including yourself and the human).",
+    "</coven_roster>",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
 // Persistence (thin localStorage wrappers — safe to call client-side only)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Fixes **roster blindness**: each coven familiar resumes a private 1:1 session and gets no participant list. In a 3-way coven (Val + Nova + Charm) asked "how many are in this chat?", every familiar answered *"two: you and me"* — it literally cannot see its co-participants.

## Change

- **`renderCovenRoster(participants, receivingFamiliarId)`** — new pure helper in `group-chat.ts`. Builds a `<coven_roster>` block naming every participant + role, marking the human `(human)` and the receiver `(you)`, with a "count everyone present" instruction. Returns `""` for ≤1 participant (1:1 sends byte-identical).
- **`broadcast()`** composes the roster per-familiar into the prompt — **after** the harness-loaded identity (IDENTITY/SOUL + canon), so it's *task* context that never overrides declared identity. Roster reflects the **full coven**, not just `@mention` targets.
- Fan-out stays **parallel** (`Promise.all`). Sequential relay (cross-familiar transcript) is a scoped follow-up PR.

Pure-helper unit tests + source-text pin added.

## Verify
- `pnpm typecheck` — 0 ✓
- `pnpm test:app` — 488 files ✓
- `pnpm test:mobile` — 65 files ✓

Roster blindness is the highest-leverage fix from the Sage research + Cody scoping pass; this is v1 of the coven protocol arc (v1.5 = relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)