### PR TITLE
feat(group-chat): sequential relay so familiars see each other's replies

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -22,6 +22,10 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
   // Injects the coven roster into each send so a familiar knows who else is present.
   assert.match(view, /renderCovenRoster\(rosterParticipants, r\.familiarId\)/, "injects the per-familiar coven roster");
+  // Full-coven broadcasts relay sequentially so each familiar sees peers' fresh replies.
+  assert.match(view, /const shouldRelay = mentioned\.length === 0 && replies\.length > 1/, "gates relay to full-coven broadcasts");
+  assert.match(view, /for \(const r of replies\)/, "relays sequentially when gated on");
+  assert.match(view, /renderCovenContext\(contextTurns, r\.familiarId/, "injects peers' prior replies as transcript");
   // Strips the piggybacked next-paths block (visible) and surfaces the parsed
   // lines (suggestions) so control markup never leaks and chips can render.
   assert.match(

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -38,6 +38,7 @@ import {
   setGroupParticipants,
   parseMentions,
   renderCovenRoster,
+  renderCovenContext,
   findActiveMention,
   matchMentions,
   applyMention,
@@ -238,7 +239,15 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
 
   // --- broadcast send ------------------------------------------------------
   const streamOne = useCallback(
-    async (group: CovenGroup, reply: GroupReply, prompt: string, signal: AbortSignal) => {
+    async (group: CovenGroup, reply: GroupReply, prompt: string, signal: AbortSignal): Promise<GroupReply> => {
+      // `settled` mirrors the live React state so relay can read the final reply
+      // synchronously (transcriptRef only refreshes on re-render, which doesn't
+      // happen between sequential iterations). Apply every update to both.
+      let settled = reply;
+      const apply = (fn: (r: GroupReply) => GroupReply) => {
+        settled = fn(settled);
+        updateReply(reply.id, fn);
+      };
       try {
         const res = await fetch("/api/chat/send", {
           method: "POST",
@@ -251,10 +260,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
           signal,
         });
         if (!res.ok || !res.body) {
-          updateReply(reply.id, (r) =>
-            applyGroupEvent(r, { kind: "error", message: `request failed (${res.status})` }),
-          );
-          return;
+          apply((r) => applyGroupEvent(r, { kind: "error", message: `request failed (${res.status})` }));
+          return settled;
         }
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
@@ -269,21 +276,22 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             if (ev.kind === "session") recordSession(group.id, reply.familiarId, ev.sessionId);
             if (ev.kind === "done" && ev.sessionId)
               recordSession(group.id, reply.familiarId, ev.sessionId);
-            updateReply(reply.id, (r) => applyGroupEvent(r, ev));
+            apply((r) => applyGroupEvent(r, ev));
           }
         }
         // Stream closed without an explicit `done` — settle anything still live.
-        updateReply(reply.id, (r) =>
+        apply((r) =>
           r.status === "streaming" || r.status === "queued" ? { ...r, status: "done", activity: undefined } : r,
         );
       } catch (err) {
         const aborted = (err as Error)?.name === "AbortError";
-        updateReply(reply.id, (r) =>
+        apply((r) =>
           aborted
             ? { ...r, status: "error", error: "cancelled", activity: undefined }
             : applyGroupEvent(r, { kind: "error", message: (err as Error)?.message ?? "send failed" }),
         );
       }
+      return settled;
     },
     [updateReply, recordSession],
   );
@@ -331,23 +339,51 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         status: "queued",
         createdAt: at,
       }));
+      // Prior rounds (before this turn) — the relay reads peers' replies from
+      // here plus the in-round accumulator. Captured before setTranscript, which
+      // flushes async (transcriptRef only refreshes on re-render).
+      const prior = transcriptRef.current;
       setTranscript((prev) => [...prev, userTurn, ...replies]);
       setDraft("");
       setMention(null);
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
-      await Promise.all(
-        replies.map((r) => {
+      // Full-coven broadcasts relay SEQUENTIALLY so each familiar sees the
+      // others' fresh replies this round; targeted/@mention sends stay parallel
+      // (a lone target has no peers to relay, and parallel keeps latency at 1×).
+      const shouldRelay = mentioned.length === 0 && replies.length > 1;
+      if (shouldRelay) {
+        const relayed: GroupReply[] = [];
+        for (const r of replies) {
+          if (controller.signal.aborted) {
+            updateReply(r.id, (x) => ({ ...x, status: "error", error: "cancelled", activity: undefined }));
+            continue;
+          }
+          // Strip the piggybacked next-paths block from peers' text before
+          // quoting it, so control markup never leaks into the next prompt.
+          const contextTurns = [...prior, userTurn, ...relayed].map((t) =>
+            t.role === "assistant" ? { ...t, text: extractNextPaths(t.text).visible } : t,
+          );
           const roster = renderCovenRoster(rosterParticipants, r.familiarId);
-          const prompt = roster ? `${roster}\n\n${text}` : text;
-          return streamOne(group, r, prompt, controller.signal);
-        }),
-      );
+          const transcript = renderCovenContext(contextTurns, r.familiarId, mentionable);
+          const prompt = [roster, transcript, text].filter(Boolean).join("\n\n");
+          const done = await streamOne(group, r, prompt, controller.signal);
+          if (done.status === "done" && done.text.trim()) relayed.push(done);
+        }
+      } else {
+        await Promise.all(
+          replies.map((r) => {
+            const roster = renderCovenRoster(rosterParticipants, r.familiarId);
+            const prompt = roster ? `${roster}\n\n${text}` : text;
+            return streamOne(group, r, prompt, controller.signal);
+          }),
+        );
+      }
       abortRef.current = null;
       setBusy(false);
     },
-    [busy, streamOne, byId],
+    [busy, streamOne, byId, updateReply],
   );
 
   // The composer and "click a next-path suggestion to send" chips both go

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -11,9 +11,11 @@ import {
   setGroupParticipants,
   parseMentions,
   renderCovenRoster,
+  renderCovenContext,
   findActiveMention,
   matchMentions,
   applyMention,
+  type GroupTurn,
   type GroupReply,
   type MentionableFamiliar,
   type RosterParticipant,
@@ -266,4 +268,75 @@ test("renderCovenRoster: returns '' for a degenerate roster (<= 1 participant)",
     renderCovenRoster([{ id: "nova", name: "Nova", role: "Lead", kind: "familiar" }], "nova"),
     "",
   );
+});
+
+const NAMES: MentionableFamiliar[] = [
+  { id: "nova", name: "Nova" },
+  { id: "charm", name: "Charm" },
+];
+const user = (id: string, text: string): GroupTurn => ({ id, role: "user", text, createdAt: "t" });
+const reply = (
+  id: string,
+  familiarId: string,
+  replyTo: string,
+  text: string,
+  status: GroupReply["status"] = "done",
+): GroupTurn => ({ id, role: "assistant", familiarId, replyTo, sessionId: null, text, status, createdAt: "t" });
+
+function roundTranscript(): GroupTurn[] {
+  return [
+    user("u1", "how many are here?"),
+    reply("r1", "nova", "u1", "Three: you, me, and Charm."),
+    reply("r2", "charm", "u1", "Agreed — three of us."),
+  ];
+}
+
+test("renderCovenContext: excludes the receiving familiar's own turns", () => {
+  const out = renderCovenContext(roundTranscript(), "nova", NAMES);
+  assert.match(out, /Charm said:/);
+  assert.doesNotMatch(out, /Nova said:/); // nova is the receiver
+  assert.match(out, /Three of us|three of us|Agreed/);
+});
+
+test("renderCovenContext: third-person framing with a stay-yourself guard, never 'you said'", () => {
+  const out = renderCovenContext(roundTranscript(), "nova", NAMES);
+  assert.match(out, /said:/);
+  assert.match(out, /answer as yourself/i);
+  assert.doesNotMatch(out, /you said/i);
+  assert.match(out, /<coven_transcript>[\s\S]*<\/coven_transcript>/);
+});
+
+test("renderCovenContext: windows to the last N rounds, oldest dropped", () => {
+  const turns: GroupTurn[] = [];
+  for (let i = 1; i <= 5; i++) {
+    turns.push(user(`u${i}`, `q${i}`));
+    turns.push(reply(`r${i}`, "charm", `u${i}`, `answer ${i}`));
+  }
+  const out = renderCovenContext(turns, "nova", NAMES, { window: 2 });
+  assert.match(out, /answer 5/);
+  assert.match(out, /answer 4/);
+  assert.doesNotMatch(out, /answer 3/);
+});
+
+test("renderCovenContext: returns '' for empty, only-own, or unsettled transcripts", () => {
+  assert.equal(renderCovenContext([], "nova", NAMES), "");
+  // only the receiver's own turns
+  assert.equal(
+    renderCovenContext([user("u1", "hi"), reply("r1", "nova", "u1", "hello")], "nova", NAMES),
+    "",
+  );
+  // peer reply still streaming / empty → not relayed
+  assert.equal(
+    renderCovenContext(
+      [user("u1", "hi"), reply("r1", "charm", "u1", "partial", "streaming"), reply("r2", "charm", "u1", "  ", "done")],
+      "nova",
+      NAMES,
+    ),
+    "",
+  );
+});
+
+test("renderCovenContext: falls back to the raw id when a name is unknown", () => {
+  const out = renderCovenContext(roundTranscript(), "nova", []);
+  assert.match(out, /charm said:/); // no name map → raw id
 });

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -354,6 +354,80 @@ export function renderCovenRoster(
 }
 
 // ---------------------------------------------------------------------------
+// Coven relay (pure) — what other familiars just said
+// ---------------------------------------------------------------------------
+
+/** Max prior user-rounds of cross-familiar transcript to relay into a prompt.
+ *  Token growth is ~quadratic (coven size × rounds), so window conservatively;
+ *  oldest rounds are dropped first. */
+export const COVEN_RELAY_WINDOW = 3;
+
+/**
+ * Render the recent coven transcript for ONE receiving familiar, so it can see
+ * and build on what the OTHER participants just said (the roster says who is
+ * present; this says what was said). Pairs with {@link renderCovenRoster}.
+ *
+ * Third-person, named, with an explicit stay-yourself guard (Coven canon).
+ * Excludes the receiving familiar's own turns (already in its resumed session),
+ * keeps only settled non-empty replies, and windows to the last N rounds. The
+ * caller passes already-cleaned reply text (next-paths block stripped) so this
+ * stays dependency-free. Returns "" when there is nothing to relay.
+ */
+export function renderCovenContext(
+  transcript: GroupTurn[],
+  receivingFamiliarId: string,
+  participants: MentionableFamiliar[],
+  opts?: { window?: number },
+): string {
+  const window = Math.max(0, opts?.window ?? COVEN_RELAY_WINDOW);
+  if (window === 0) return "";
+  const nameOf = (id: string): string =>
+    participants.find((p) => p.id === id)?.name ?? id;
+
+  type Round = { user: GroupUserTurn; replies: GroupReply[] };
+  const rounds: Round[] = [];
+  const byUserId = new Map<string, Round>();
+  for (const turn of transcript) {
+    if (turn.role === "user") {
+      const round: Round = { user: turn, replies: [] };
+      rounds.push(round);
+      byUserId.set(turn.id, round);
+    } else {
+      byUserId.get(turn.replyTo)?.replies.push(turn);
+    }
+  }
+
+  const kept = rounds
+    .map((r) => ({
+      user: r.user,
+      replies: r.replies.filter(
+        (rep) =>
+          rep.status === "done" &&
+          rep.text.trim() !== "" &&
+          rep.familiarId !== receivingFamiliarId,
+      ),
+    }))
+    .filter((r) => r.replies.length > 0);
+
+  if (kept.length === 0) return "";
+  const windowed = kept.slice(-window);
+
+  const guard =
+    "In this coven, other participants have already responded below. Read what they said, then answer as yourself — in your own identity and lane. You may reference or build on their replies, but do not repeat their words as your own or speak for them.";
+
+  const blocks = windowed.map((r) => {
+    const lines: string[] = [`(human) asked: "${r.user.text.trim()}"`];
+    for (const rep of r.replies) {
+      lines.push(`${nameOf(rep.familiarId)} said:`);
+      lines.push(rep.text.trim());
+    }
+    return lines.join("\n");
+  });
+
+  return `<coven_transcript>\n${guard}\n\n${blocks.join("\n\n")}\n</coven_transcript>`;
+}
+
+// ---------------------------------------------------------------------------
 // Persistence (thin localStorage wrappers — safe to call client-side only)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

v1.5 of the coven protocol arc, on top of the roster (#2106). A **full-coven broadcast now relays sequentially**: each familiar's prompt includes the prior familiars' just-finished replies from the same round — so a coven can *deliberate* (Charm reads Nova's answer and builds on it) instead of producing N blind parallel monologues.

## Change

- **`renderCovenContext()`** — pure helper rendering a `<coven_transcript>` block of other participants' settled replies: third-person, named, stay-yourself guard; excludes the receiver's own turns; windows to the last `COVEN_RELAY_WINDOW` (3) rounds; `""` when nothing to relay.
- **`broadcast()` gated** — full-coven sends (no `@mention`, >1 target) go through an ordered `for…await` with a local accumulator of settled replies. Targeted/`@mention` sends stay **parallel** (`Promise.all`) — a lone target has no peers and parallel keeps latency at 1×. Compose order: **roster → transcript → text**.
- **`streamOne()` returns the settled `GroupReply`** — the React ref is stale between sequential iterations, so relay reads from the return value, not state.
- **Abort/partial-failure:** each iteration checks `signal.aborted` (not-yet-started replies marked cancelled); errored peers are excluded from later context; the loop continues.
- Peers' text is **next-paths-stripped** before quoting so control markup can't leak into the next prompt.

## Tradeoff
Full-coven relay is sequential → ~N× wall-clock (correct round-table behavior). Gated so it only applies when there's actually cross-talk to see.

## Verify
- `pnpm typecheck` — 0 ✓
- `pnpm test:app` — 487 files ✓
- `pnpm test:mobile` — 65 files ✓

Completes the coven protocol arc: **roster** (who's present) + **relay** (what was said) = a coherent, conversational, identity-safe group chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)