### PR TITLE
Route links through browser and add thread close

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -29,6 +29,7 @@ export const SUITES = {
     "src/lib/endpoint-validators.test.ts",
     "src/lib/familiar-avatar-src.test.ts",
     "src/lib/app-update.test.ts",
+    "src/lib/open-external.test.ts",
     "src/lib/coven-version.test.ts",
     "src/components/update-available.test.ts",
     "src/components/open-coven-tools-update.test.ts",

--- a/src/components/board-link-browser.test.ts
+++ b/src/components/board-link-browser.test.ts
@@ -8,8 +8,8 @@ const boardInspector = await readFile(new URL("./board-inspector.tsx", import.me
 
 assert.match(
   workspace,
-  /<BoardView[\s\S]*onOpenUrl=\{openUrlExternally\}/,
-  "Workspace should route board task links to the system browser via openUrlExternally",
+  /<BoardView[\s\S]*onOpenUrl=\{openUrlInAppBrowser\}/,
+  "Workspace should route board task links to the in-app browser",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -32,6 +32,7 @@ import {
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import type { Card } from "@/lib/cave-board-types";
 import { TaskLinkPicker } from "@/components/task-link-picker";
+import { openExternalUrl } from "@/lib/open-external";
 import {
   extractAgentAttachmentMarkers,
   MAX_ATTACHMENT_IMAGE_BYTES,
@@ -1851,10 +1852,12 @@ function LinkedContextRow({
         <a
           key={item.id}
           href={item.url}
-          target="_blank"
-          rel="noreferrer"
           title={`Open on GitHub: ${item.title}`}
           className="cave-chat-linked-chip cave-chat-linked-chip--github inline-flex min-w-0 max-w-[18rem] items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 px-2 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text-primary)]"
+          onClick={(event) => {
+            event.preventDefault();
+            openExternalUrl(item.url);
+          }}
         >
           <Icon name={githubIcon(item.kind)} width={12} className="shrink-0 text-[var(--text-muted)]" />
           <span className="shrink-0">{githubLabel(item.kind)}</span>
@@ -1965,9 +1968,11 @@ function MobileChatContextMenu({
               <a
                 key={item.id}
                 href={item.url}
-                target="_blank"
-                rel="noreferrer"
                 className="cave-mobile-context-link"
+                onClick={(event) => {
+                  event.preventDefault();
+                  openExternalUrl(item.url);
+                }}
               >
                 <Icon name={githubIcon(item.kind)} width={13} aria-hidden />
                 <span className="min-w-0 flex-1 truncate">{githubLabel(item.kind)} · {item.repo}{item.number ? ` #${item.number}` : ""}</span>

--- a/src/components/code-sidebar.tsx
+++ b/src/components/code-sidebar.tsx
@@ -13,6 +13,7 @@ type Props = {
   onBack: () => void;
   onOpenSession: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
+  onDeleteSession: (session: SessionRow) => Promise<void>;
 };
 
 function compactTime(iso: string): string {
@@ -38,9 +39,12 @@ export function CodeSidebar({
   onBack,
   onOpenSession,
   onNewChat,
+  onDeleteSession,
 }: Props) {
   const [query, setQuery] = useState("");
   const [expandedRoots, setExpandedRoots] = useState<Set<string>>(() => new Set());
+  const [confirmingSessionId, setConfirmingSessionId] = useState<string | null>(null);
+  const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null);
 
   const projects = useMemo(() => deriveComuxProjects(sessions), [sessions]);
   const visibleProjects = useMemo(() => {
@@ -160,28 +164,73 @@ export function CodeSidebar({
                         {projectSessions.map((session) => {
                           const title = sessionRailTitle(session);
                           const active = activeSessionId === session.id;
+                          const confirming = confirmingSessionId === session.id;
+                          const deleting = deletingSessionId === session.id;
                           return (
                             <li key={session.id}>
-                              <button
-                                type="button"
-                                aria-current={active ? "page" : undefined}
-                                onClick={() => {
-                                  selectProject(project);
-                                  onOpenSession(session);
-                                }}
+                              <div
                                 className={[
-                                  "flex min-h-[34px] w-full items-center gap-1.5 py-2 pl-4 pr-2 text-left text-[12px] transition-colors",
+                                  "group/code-thread flex min-h-[34px] w-full items-center gap-1.5 transition-colors",
                                   active
                                     ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
                                     : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]/50 hover:text-[var(--text-primary)]",
                                 ].join(" ")}
                               >
-                                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusClass(session.status)}`} aria-hidden />
-                                <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
-                                <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">
-                                  {compactTime(session.updated_at || session.created_at)}
-                                </span>
-                              </button>
+                                <button
+                                  type="button"
+                                  aria-current={active ? "page" : undefined}
+                                  onClick={() => {
+                                    selectProject(project);
+                                    onOpenSession(session);
+                                  }}
+                                  className="focus-ring flex min-h-[34px] min-w-0 flex-1 items-center gap-1.5 rounded py-2 pl-4 pr-1 text-left text-[12px]"
+                                >
+                                  <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusClass(session.status)}`} aria-hidden />
+                                  <span className="min-w-0 flex-1 truncate" title={title}>{title}</span>
+                                  {confirming ? null : (
+                                    <span className="shrink-0 font-mono text-[10px] text-[var(--text-muted)]">
+                                      {compactTime(session.updated_at || session.created_at)}
+                                    </span>
+                                  )}
+                                </button>
+                                {confirming ? (
+                                  <span className="flex shrink-0 items-center gap-1 pr-1">
+                                    <button
+                                      type="button"
+                                      onClick={() => setConfirmingSessionId(null)}
+                                      className="focus-ring rounded px-1.5 py-0.5 text-[10px] text-[var(--text-muted)] hover:bg-[var(--bg-hover)]"
+                                    >
+                                      Cancel
+                                    </button>
+                                    <button
+                                      type="button"
+                                      disabled={deleting}
+                                      onClick={async () => {
+                                        setDeletingSessionId(session.id);
+                                        try {
+                                          await onDeleteSession(session);
+                                          setConfirmingSessionId(null);
+                                        } finally {
+                                          setDeletingSessionId(null);
+                                        }
+                                      }}
+                                      className="focus-ring rounded border border-[var(--color-danger)]/50 bg-[var(--color-danger)]/10 px-1.5 py-0.5 text-[10px] text-[var(--color-danger)] hover:bg-[var(--color-danger)]/15 disabled:opacity-50"
+                                    >
+                                      {deleting ? "Deleting..." : "Delete"}
+                                    </button>
+                                  </span>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    title="Delete thread"
+                                    aria-label={`Delete thread ${title}`}
+                                    onClick={() => setConfirmingSessionId(session.id)}
+                                    className="touch-always-visible focus-ring mr-1 grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-55 transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover/code-thread:opacity-100"
+                                  >
+                                    <Icon name="ph:x-bold" width={10} aria-hidden />
+                                  </button>
+                                )}
+                              </div>
                             </li>
                           );
                         })}

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -13,8 +13,8 @@ const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const preset = await readFile(new URL("../lib/code-layout-preset.ts", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
-// The Chat/Split/Review presets + companion-panel toggle now ride on the chat
-// surface's Sessions/Memory tab row, in a self-contained toolbar.
+// The Code/Changes segmented toggle now rides on the chat surface's
+// Sessions/Memory tab row, in a self-contained toolbar.
 const toolbar = await readFile(new URL("./code-inline-toolbar.tsx", import.meta.url), "utf8");
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 
@@ -46,18 +46,16 @@ assert.match(
   "the conversation renders as the center column between the tree and the preview/Changes column",
 );
 
-// ── Layout presets (Chat / Split / Review) drive comux's right column ────────
-// The preset chips live on the chat surface's header row (CodeInlineToolbar) and
-// broadcast CODE_PRESET_EVENT; comux switches its preview/Changes column to match
-// (Split → Files, Review → Changes).
+// ── Code / Changes segmented toggle drives comux's right column ──────────────
+// The two toggle buttons live on the chat surface's header row
+// (CodeInlineToolbar) and broadcast CODE_PRESET_EVENT; comux switches its
+// preview/Changes column and column weighting to match.
 assert.match(toolbar, /writeCodePreset\(next\)/, "selecting a preset persists the chip");
 assert.match(toolbar, /CODE_PRESETS\.map\(/, "the toolbar renders a chip per preset");
 // The toolbar is mounted on the Code surface's header row + carries the panel
-// toggle. The standalone chat has no header row at all now (the Chat/Code toggle
-// was removed), so the whole header is gated behind `isCodeSurface`.
+// toggle. The standalone chat has no header row at all now (the old Chat/Code
+// toggle was removed), so the whole header is gated behind `isCodeSurface`.
 assert.match(chatSurface, /isCodeSurface \? \([\s\S]*?<CodeInlineToolbar \/>/, "the Code header row hosts the inline toolbar");
-assert.match(toolbar, /code-panel-toggle/, "the toolbar includes the companion-panel toggle");
-assert.match(toolbar, /cave:toggle-right-panel/, "the panel toggle asks the shell to toggle the companion panel");
 
 // ── Code mode owns project/thread nav in the primary sidebar ─────────────────
 // The app shell swaps the far-left application menu for CodeSidebar when
@@ -94,9 +92,29 @@ assert.match(codeSidebar, /aria-label="Code projects and threads"/, "CodeSidebar
 assert.match(codeSidebar, /cave:code-select-project/, "CodeSidebar announces project selection to the Code surface");
 assert.match(codeSidebar, /onOpenSession\(session\)/, "CodeSidebar opens thread rows through the workspace/session bridge");
 assert.match(
+  codeSidebar,
+  /aria-label=\{`Delete thread \$\{title\}`\}[\s\S]{0,520}?<Icon name="ph:x-bold"/,
+  "CodeSidebar exposes an inline close-button delete affordance on thread rows",
+);
+assert.match(
+  workspace,
+  /onDeleteSession=\{async \(session\) => \{[\s\S]*?fetch\(`\/api\/chat\/conversation\/\$\{encodeURIComponent\(session\.id\)\}`,[\s\S]*?method: "DELETE"[\s\S]*?loadSessions\(\)/,
+  "Workspace wires CodeSidebar thread delete through the authoritative conversation DELETE route and refreshes sessions",
+);
+assert.match(
   workspace,
   /<ComuxView[\s\S]*?view="projects"[\s\S]*?hideProjectNavigator/,
   "Code-mode ComuxView hides duplicate project/thread navigation",
+);
+assert.match(
+  workspace,
+  /const \[codeRightView, setCodeRightView\] = useState<"files" \| "changes">\("files"\)/,
+  "Workspace owns the Code surface's right-pane selection",
+);
+assert.match(
+  workspace,
+  /<ComuxView[\s\S]*?view="projects"[\s\S]*?rightView=\{codeRightView\}[\s\S]*?onRightViewChange=\{setCodeRightView\}/,
+  "Code-mode ComuxView is controlled so its duplicate Files/Changes toggle stays hidden",
 );
 assert.match(comux, /hideProjectNavigator\?: boolean/, "ComuxView accepts hideProjectNavigator");
 assert.match(comux, /if \(hideProjectNavigator\) return;/, "Comux project-list shortcuts are disabled when hidden");
@@ -153,37 +171,21 @@ assert.doesNotMatch(
   "the code/comux Panel is never collapsed — only the projects list is",
 );
 
-// Presets are task setups, not just widths: each broadcasts a context preset
-// and shows/hides the projects list (Chat focuses the conversation).
+// Presets are task setups, not just labels: each broadcasts a context preset
+// and Comux applies the matching right pane.
 assert.match(
   toolbar,
   /new CustomEvent\(CODE_PRESET_EVENT, \{ detail: \{ preset: next \} \}\)/,
   "selecting a preset broadcasts the context preset",
 );
-assert.match(
-  toolbar,
-  /new CustomEvent\(CODE_PROJECT_LIST_EVENT, \{ detail: \{ collapsed \} \}\)/,
-  "a preset shows/hides the projects list over CODE_PROJECT_LIST_EVENT",
-);
-assert.match(
-  toolbar,
-  /CODE_PRESET_HIDES_PROJECT_LIST\[next\]/,
-  "the preset's list visibility comes from its definition",
-);
 
-// ── comux reacts: hides the projects list + switches the right pane per preset ─
-assert.match(comux, /addEventListener\(CODE_PROJECT_LIST_EVENT/, "comux listens for the projects-list toggle");
+// ── comux reacts: switches the right pane per preset ─────────────────────────
 assert.match(comux, /addEventListener\(CODE_PRESET_EVENT/, "comux listens for the layout preset");
 assert.match(
   comux,
   /CODE_PRESET_RIGHT_VIEW\[preset\][\s\S]*?setRightView\(nextRight\)/,
-  "a preset switches comux's right pane (Review → Changes, Split → Files)",
+  "a preset switches comux's right pane (Code → Files, Changes → Changes)",
 );
-
-// The Review preset must target the git diff, and Split the files view —
-// otherwise the chips are just width tweaks.
-assert.match(preset, /review: "changes"/, "Review opens the git changes/diff");
-assert.match(preset, /split: "files"/, "Split shows the file tree & preview");
 
 // ── ComuxView accepts a storage namespace so Code-mode terminals are isolated ─
 assert.match(comux, /storageNamespace\?: string/, "ComuxView accepts a storageNamespace prop");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -33,6 +33,7 @@ import {
   SortableContext, useSortable, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { openExternalUrl } from "@/lib/open-external";
 
 // ─── Data shapes (client-fetched) ──────────────────────────────────────────────
 
@@ -570,7 +571,14 @@ function GithubPanel({ items, loaded }: { items: GitHubItem[]; loaded: boolean }
     <ul className="cockpit-gh">
       {items.slice(0, 6).map((g) => (
         <li key={g.id}>
-          <a className="cockpit-ghrow" href={g.url} target="_blank" rel="noreferrer">
+          <a
+            className="cockpit-ghrow"
+            href={g.url}
+            onClick={(event) => {
+              event.preventDefault();
+              openExternalUrl(g.url);
+            }}
+          >
             <Icon name={GH_ICON[g.kind]} className="cockpit-ghrow__icon" aria-hidden />
             <span className="cockpit-ghrow__title" title={g.title}>{g.title}</span>
             <span className="cockpit-ghrow__meta">

--- a/src/components/familiar-studio-contract-tab.tsx
+++ b/src/components/familiar-studio-contract-tab.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/lib/icon";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { ContractReport, ContractFile } from "@/lib/familiar-contract";
 import { buildRehabilitationBrief } from "@/lib/familiar-rehabilitation";
+import { openExternalUrl } from "@/lib/open-external";
 
 type Props = { familiar: ResolvedFamiliar };
 
@@ -63,9 +64,11 @@ export function FamiliarStudioContractTab({ familiar }: Props) {
           Tests this familiar against the{" "}
           <a
             href="https://github.com/OpenCoven/familiar-contract"
-            target="_blank"
-            rel="noreferrer"
             className="familiar-studio-contract__link"
+            onClick={(event) => {
+              event.preventDefault();
+              openExternalUrl("https://github.com/OpenCoven/familiar-contract");
+            }}
           >
             Familiar Contract
           </a>{" "}

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -255,14 +255,14 @@ assert.match(
 );
 
 // Rows are keyboard-navigable: ↑/↓ + Home/End rove a tab stop tied to the
-// selected row, selection follows focus, and Enter opens the item on GitHub.
+// selected row, selection follows focus, and Enter opens the item in Cave's Browser.
 assert.match(source, /case "ArrowDown": e\.preventDefault\(\); focusRow/, "ArrowDown roves to the next row");
 assert.match(source, /case "ArrowUp": e\.preventDefault\(\); focusRow/, "ArrowUp roves to the previous row");
 assert.match(source, /data-gh-row="true"[\s\S]{0,160}?data-item-id=\{item\.id\}/, "item rows carry the roving + id hooks");
 assert.match(source, /tabIndex=\{selectedItem\?\.id === item\.id \? 0 : -1\}/, "the selected row is the roving tab stop");
 assert.match(source, /role="grid" aria-label="GitHub activity/, "the table is a labelled grid");
 assert.match(source, /setSelectedItemId\(row\.dataset\.itemId\)/, "selection follows keyboard focus");
-assert.match(source, /window\.open\(url, "_blank", "noopener,noreferrer"\)/, "Enter opens the focused row on GitHub");
+assert.match(source, /openExternalUrl\(url\)/, "Enter opens the focused row through the in-app Browser handoff");
 assert.match(source, /\}, \[sorted\.length\]\);/, "row-nav listeners rebind when the table mounts after the async fetch");
 
 // Polling pauses while the tab is hidden (saves the visible rate limit) and

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -794,12 +794,14 @@ function CommentHeader({ comment }: { comment: GhComment }) {
       {comment.url && (
         <a
           href={comment.url}
-          target="_blank"
-          rel="noreferrer"
           className="gh-comment-link"
           title="Open this comment on GitHub"
           aria-label="Open this comment on GitHub"
-          onClick={(e) => e.stopPropagation()}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            if (comment.url) openExternalUrl(comment.url);
+          }}
         >
           <Icon name="ph:arrow-square-out" width={11} />
         </a>
@@ -1314,9 +1316,11 @@ function GitHubItemGlassPanel({
           />
           <a
             href={item.url}
-            target="_blank"
-            rel="noreferrer"
             className="gh-action-btn"
+            onClick={(e) => {
+              e.preventDefault();
+              openExternalUrl(item.url);
+            }}
           >
             <Icon name="ph:arrow-square-out" width={12} />
             <span className="gh-action-btn-label">GitHub</span>
@@ -1619,7 +1623,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
         case "End": e.preventDefault(); focusRow(list.length - 1); break;
         case "Enter": {
           const url = cur?.dataset.url;
-          if (url) { e.preventDefault(); window.open(url, "_blank", "noopener,noreferrer"); }
+          if (url) { e.preventDefault(); openExternalUrl(url); }
           break;
         }
       }
@@ -1939,10 +1943,12 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                       <td>
                         <a
                           href={item.url}
-                          target="_blank"
-                          rel="noreferrer"
                           className="gh-title"
-                          onClick={(e) => e.stopPropagation()}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            openExternalUrl(item.url);
+                          }}
                           title={item.title}
                         >
                           {item.title}
@@ -2031,12 +2037,14 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                           />
                           <a
                             href={item.url}
-                            target="_blank"
-                            rel="noreferrer"
                             title="Open on GitHub"
                             aria-label="Open on GitHub"
                             className="gh-action-btn gh-action-btn--icon"
-                            onClick={(e) => e.stopPropagation()}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              openExternalUrl(item.url);
+                            }}
                           >
                             <Icon name="ph:arrow-square-out" width={11} />
                           </a>

--- a/src/components/library-bookmarks-list.tsx
+++ b/src/components/library-bookmarks-list.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { RelativeTime } from "@/components/ui/relative-time";
 import type { LibraryBookmark } from "@/lib/library-types";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
+import { openExternalUrl } from "@/lib/open-external";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -527,10 +528,12 @@ export function LibraryBookmarksList({ selectedId, onSelect, onDelete, onAddToBo
                           <ItemFavicon url={item.url} title={item.title} />
                           <a
                             href={item.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
                             className="library-bookmark-link"
-                            onClick={(e) => e.stopPropagation()}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              openExternalUrl(item.url);
+                            }}
                           >
                             {item.title}
                           </a>

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -27,6 +27,7 @@ import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { LibraryChatPanel } from "@/components/library-chat-panel";
 import { formatCount, type GitHubRepoMeta } from "@/lib/github-repo";
 import type { ExtractedArticle } from "@/lib/article-extract";
+import { openExternalUrl } from "@/lib/open-external";
 
 // ── Discriminated union ──────────────────────────────────────────
 export type SelectedItem =
@@ -88,6 +89,10 @@ function canOpenUrl(url: string, kind: UrlOpenKind): boolean {
 
 async function openUrl(url: string, kind: UrlOpenKind = "web") {
   if (!canOpenUrl(url, kind)) return;
+  if (kind !== "vscode-file") {
+    openExternalUrl(url);
+    return;
+  }
   // Use Tauri shell_open when running as desktop app
   if (typeof window !== "undefined" && "__TAURI_INTERNALS__" in window) {
     try {
@@ -372,9 +377,11 @@ function LibraryLinkViewer({
               </p>
               <a
                 href={url}
-                target="_blank"
-                rel="noreferrer"
                 className="library-link-viewer-fallback__url"
+                onClick={(e) => {
+                  e.preventDefault();
+                  openExternalUrl(url);
+                }}
               >
                 {url}
               </a>
@@ -790,7 +797,14 @@ function ReadingDetail({ item }: { item: LibraryReadingItem }) {
             )}
             {item.url && (
               <FieldRow label="Source">
-                <a className="library-preview-link library-reading-detail__url" href={item.url} target="_blank" rel="noreferrer">
+                <a
+                  className="library-preview-link library-reading-detail__url"
+                  href={item.url}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    openExternalUrl(item.url!);
+                  }}
+                >
                   {item.url}
                 </a>
               </FieldRow>

--- a/src/components/library-github-list.tsx
+++ b/src/components/library-github-list.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/task-github";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
+import { openExternalUrl } from "@/lib/open-external";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -246,7 +247,14 @@ function AttachTaskModal({
           <form className="gh-modal-body" onSubmit={handleSubmit}>
             {/* Source item */}
             <div className="gh-modal-source">
-              <a href={item.url} target="_blank" rel="noopener noreferrer" className="gh-modal-source-link">
+              <a
+                href={item.url}
+                className="gh-modal-source-link"
+                onClick={(event) => {
+                  event.preventDefault();
+                  openExternalUrl(item.url);
+                }}
+              >
                 {item.title}
               </a>
               <span className="gh-modal-source-meta">{item.repo}{item.number ? ` #${item.number}` : ""}</span>
@@ -463,7 +471,14 @@ function HandoffModal({
           <form className="gh-modal-body" onSubmit={handleLaunch}>
             {/* Source item */}
             <div className="gh-modal-source">
-              <a href={item.url} target="_blank" rel="noopener noreferrer" className="gh-modal-source-link">
+              <a
+                href={item.url}
+                className="gh-modal-source-link"
+                onClick={(event) => {
+                  event.preventDefault();
+                  openExternalUrl(item.url);
+                }}
+              >
                 {item.title}
               </a>
               <span className="gh-modal-source-meta">{item.repo}{item.number ? ` #${item.number}` : ""} · {item.kind}</span>
@@ -878,10 +893,12 @@ export function LibraryGitHubList({ selectedId, onSelect, onDelete, onOpenSessio
                               <span className="board-table-title gh-title-text">{item.title}</span>
                               <a
                                 href={item.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
                                 className="gh-open-link"
-                                onClick={(event) => event.stopPropagation()}
+                                onClick={(event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  openExternalUrl(item.url);
+                                }}
                                 aria-label={`Open ${item.title} on GitHub`}
                               >
                                 <Icon name="ph:arrow-square-out" width={12} />

--- a/src/components/library-link-viewer.test.ts
+++ b/src/components/library-link-viewer.test.ts
@@ -50,12 +50,18 @@ assert.match(
 
 // The link viewer redesign (#797a1507) replaced the sandboxed browser-fallback
 // iframe with a native read-only webview surface plus, where that is unavailable,
-// a non-embedding fallback card that links out externally. The native path stays
-// read-only (asserted above + in browser.rs); the web fallback embeds nothing.
+// a non-embedding fallback card. External inspection still routes through Cave's
+// shared in-app Browser handoff instead of a new system tab.
 assert.match(
   preview,
-  /library-link-viewer-fallback__card[\s\S]{0,500}href=\{url\}[\s\S]{0,160}rel="noreferrer"/,
-  "When the native webview is unavailable, the link viewer falls back to a safe external link (no embedded iframe)",
+  /library-link-viewer-fallback__card[\s\S]{0,500}href=\{url\}[\s\S]{0,220}openExternalUrl\(url\)/,
+  "When the native webview is unavailable, the link viewer falls back to a safe in-app Browser handoff (no embedded iframe)",
+);
+
+assert.doesNotMatch(
+  preview,
+  /library-link-viewer-fallback__card[\s\S]{0,500}target="_blank"/,
+  "Library link viewer fallback must not bypass Cave with a new external tab",
 );
 
 assert.doesNotMatch(
@@ -74,8 +80,8 @@ assert.match(
 // link), not the embedded viewer; bookmarks and GitHub items keep <LibraryLinkViewer>.
 assert.match(
   preview,
-  /function ReadingDetail[\s\S]*library-reading-detail__url" href=\{item\.url\}/,
-  "Reading items render a structured detail view exposing the source URL as a link",
+  /function ReadingDetail[\s\S]*library-reading-detail__url[\s\S]{0,120}href=\{item\.url\}[\s\S]{0,220}openExternalUrl\(item\.url!\)/,
+  "Reading items render a structured detail view exposing the source URL through the in-app Browser handoff",
 );
 
 assert.match(

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { pluginBadgeState, type MarketplacePlugin } from "@/lib/marketplace-catalog";
+import { openExternalUrl } from "@/lib/open-external";
 
 const TRUST_LABEL: Record<string, string> = {
   "official-remote": "Official remote",
@@ -143,8 +144,30 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
         {plugin.homepage || plugin.repository ? (
           <Section title="Links">
             <div className="flex flex-col gap-1 text-[12px]">
-              {plugin.homepage ? <a className="text-[var(--text-primary)] underline" href={plugin.homepage} target="_blank" rel="noreferrer">Homepage</a> : null}
-              {plugin.repository ? <a className="text-[var(--text-primary)] underline" href={plugin.repository} target="_blank" rel="noreferrer">Repository</a> : null}
+              {plugin.homepage ? (
+                <a
+                  className="text-[var(--text-primary)] underline"
+                  href={plugin.homepage}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    openExternalUrl(plugin.homepage || "");
+                  }}
+                >
+                  Homepage
+                </a>
+              ) : null}
+              {plugin.repository ? (
+                <a
+                  className="text-[var(--text-primary)] underline"
+                  href={plugin.repository}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    openExternalUrl(plugin.repository || "");
+                  }}
+                >
+                  Repository
+                </a>
+              ) : null}
             </div>
           </Section>
         ) : null}

--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 import { copyText } from "@/lib/clipboard";
+import { openExternalUrl } from "@/lib/open-external";
 
 type HandoffReady = {
   ok: true;
@@ -217,8 +218,10 @@ export function MobileHandoffModal({
                 <a
                   className="mobile-handoff__url mobile-handoff__link"
                   href={handoff.inviteUrl || handoff.url}
-                  target="_blank"
-                  rel="noreferrer"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    openExternalUrl(handoff.inviteUrl || handoff.url || "");
+                  }}
                 >
                   {handoff.inviteUrl || handoff.url}
                 </a>

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -205,23 +205,23 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const openUrlExternally = useCallback\(\(url: string\) => \{/,
-  "Workspace should provide an external-link opener for chat/feed/board links",
+  /const openUrlInAppBrowser = useCallback\(\(url: string\) => \{/,
+  "Workspace should provide an in-app browser opener for chat/feed/board links",
 );
 assert.match(
   workspace,
-  /window\.open\(url, "_blank", "noopener,noreferrer"\)/,
-  "Link opens should fall back to window.open for the system browser outside Tauri",
+  /browserPaneRef\.current\?\.navigateTo\(url\)/,
+  "Link opens should navigate the embedded Browser pane",
 );
 assert.match(
   workspace,
-  /invoke\("shell_open", \{ url \}\)/,
-  "Link opens should hand the URL to the system browser via the Tauri shell_open command on desktop",
+  /setMode\("browser"\)/,
+  "Link opens should switch the main detail surface to Browser mode",
 );
 assert.match(
   workspace,
-  /onOpenUrl=\{openUrlExternally\}/,
-  "Workspace should thread the external-link opener into ChatSurface",
+  /onOpenUrl=\{openUrlInAppBrowser\}/,
+  "Workspace should thread the in-app browser opener into ChatSurface",
 );
 assert.match(
   workspace,

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -15,6 +15,7 @@ import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { SalemPathfinderEntry } from "@/components/salem/salem-pathfinder-entry";
 import type { SalemPathfinderRequest } from "@/lib/salem/pathfinder-types";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
+import { openExternalUrl } from "@/lib/open-external";
 
 // Guided onboarding: one numbered path from "nothing installed" to "chatting
 // with a familiar". Every step carries its own instructions, a one-click
@@ -2550,9 +2551,11 @@ function StepFamiliar(props: {
                   Must start with <code className="font-mono">ph:</code> — see{" "}
                   <a
                     href="https://phosphoricons.com"
-                    target="_blank"
-                    rel="noreferrer"
                     className="underline"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      openExternalUrl("https://phosphoricons.com");
+                    }}
                   >
                     phosphoricons.com
                   </a>

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -23,6 +23,11 @@ assert.match(src, /navigator\.clipboard\.writeText/, "component can copy tool di
 assert.match(src, /Copy diagnostics/, "About tools exposes a copy diagnostics action");
 assert.match(src, /sidecarTokenPresent/, "diagnostics include whether the sidecar auth bridge captured a token");
 assert.match(src, /Check tools/, "component offers a manual re-check");
+assert.match(
+  src,
+  /const ghostBtn =[\s\S]*settings-touch-action/,
+  "About tools footer buttons should use the shared Settings action touch target",
+);
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");
 assert.match(settings, /<SettingsGroup label="OpenCoven tools">[\s\S]*<OpenCovenToolsUpdate \/>/, "About settings renders the OpenCoven tools group");
 assert.match(runner, /src\/components\/open-coven-tools-update\.test\.ts/, "OpenCoven tools update test is wired into the test:app suite (scripts/run-tests.mjs)");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -281,9 +281,9 @@ export function OpenCovenToolsUpdate() {
   };
 
   const accentBtn =
-    "focus-ring inline-flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50";
+    "settings-touch-action focus-ring gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 text-[11px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50";
   const ghostBtn =
-    "focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
+    "settings-touch-action focus-ring gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
   const footerStatusText =
     diagnosticsStatus === "copied"
       ? "Diagnostics copied"

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -367,6 +367,11 @@ assert.match(projectsView, /Delete project…/, "project menu offers delete (rou
 assert.match(projectsView, /setExpanded\(true\); setConfirmDelete\(true\)/, "menu delete expands the card and shows the two-step confirm");
 assert.match(projectsView, /Actions for \$\{title\}/, "each session row has a context menu");
 assert.match(projectsView, /Delete chat…/, "session menu offers delete (routes through the inline confirm)");
+assert.match(
+  projectsView,
+  /aria-label=\{`Delete thread \$\{title\}`\}[\s\S]{0,520}?<Icon name="ph:x-bold"/,
+  "each thread row exposes a close-button delete affordance inline",
+);
 // The header actions stay visible while a delete confirm is pending, so a
 // menu-triggered delete's Cancel/Delete buttons aren't hidden behind hover.
 assert.match(projectsView, /confirmDelete\s*\?\s*"opacity-100"/, "the action cluster stays visible while confirming a delete");

--- a/src/components/projects/session-row.tsx
+++ b/src/components/projects/session-row.tsx
@@ -187,11 +187,11 @@ export function ProjectChatRow({
               e.stopPropagation();
               setConfirmDelete(true);
             }}
-            title="Delete chat"
-            aria-label={`Delete ${title}`}
-            className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover/pc:opacity-100 [@media(pointer:coarse)]:opacity-100"
+            title="Delete thread"
+            aria-label={`Delete thread ${title}`}
+            className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-55 transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--color-danger)] focus-visible:opacity-100 group-hover/pc:opacity-100 [@media(pointer:coarse)]:opacity-100"
           >
-            <Icon name="ph:trash-bold" width={11} aria-hidden />
+            <Icon name="ph:x-bold" width={10} aria-hidden />
           </button>
         )}
       </div>

--- a/src/components/salem/salem-pathfinder-card.tsx
+++ b/src/components/salem/salem-pathfinder-card.tsx
@@ -6,6 +6,7 @@ import { copyText } from "@/lib/clipboard";
 import type { IconName } from "@/lib/icon";
 import { sanitizeCard } from "@/lib/salem/pathfinder-card";
 import type { SalemPathfinderAction, SalemPathfinderCard } from "@/lib/salem/pathfinder-types";
+import { openExternalUrl } from "@/lib/open-external";
 
 // Renders a deterministic Salem pathfinder card in Cave's operational UI
 // language: a compact card with a why-line, a numbered checklist (copyable
@@ -107,7 +108,7 @@ export function SalemPathfinderCard({ card, density = "full", onRoute, onRunDoct
         if (a.target) void copyText(a.target);
         return;
       case "external-link":
-        if (a.target) window.open(a.target, "_blank", "noopener,noreferrer");
+        if (a.target) openExternalUrl(a.target);
         return;
       case "cave-route":
         if (!a.target) return;
@@ -198,10 +199,10 @@ export function SalemPathfinderCard({ card, density = "full", onRoute, onRunDoct
       {!slim && safe.links.length > 0 ? (
         <div className="salem-pf__links">
           {safe.links.map((l, i) => (
-            <a key={i} className="salem-pf__link" href={l.url} target="_blank" rel="noopener noreferrer">
+            <button key={i} type="button" className="salem-pf__link" onClick={() => openExternalUrl(l.url)}>
               <Icon name="ph:arrow-square-out" width={11} aria-hidden />
               <span>{l.label}</span>
-            </a>
+            </button>
           ))}
         </div>
       ) : null}

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -47,11 +47,14 @@ const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "ut
 
 test("the shell sources sections from settings-sections and renders the overview", () => {
   assert.match(shell, /import \{ SettingsOverview \} from "\.\/settings-overview"/);
-  assert.match(shell, /import \{ SECTIONS, settingsSectionLabel, type Section \} from "\.\/settings-sections"/);
+  assert.match(shell, /SETTINGS_INDEX/);
+  assert.match(shell, /SECTIONS/);
+  assert.match(shell, /settingsSectionLabel/);
+  assert.match(shell, /type Section/);
   // SettingsPage swaps the plain <h1> for the overview when a section is given.
   assert.match(shell, /section \? \(\s*<SettingsOverview section=\{section\} \/>/);
-  // The search index stays in the shell (next to its search box).
-  assert.match(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/);
+  // The shared search index is sourced from settings-sections.
+  assert.doesNotMatch(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/);
   // Each SettingsPage-based section opts into its overview header.
   for (const id of ["general", "daemon", "addons", "mobile", "appearance", "about"]) {
     assert.match(shell, new RegExp(`section="${id}"`), `${id} page passes its section`);

--- a/src/components/settings-overview.tsx
+++ b/src/components/settings-overview.tsx
@@ -16,7 +16,7 @@ export function SettingsOverview({ section }: { section: Section }) {
   const meta = getSectionMeta(section);
   return (
     <header className="settings-overview" aria-label={`${meta.label} settings`}>
-      <div className="settings-overview__heading">
+      <div className="settings-overview__title-row">
         <span
           className="settings-overview__mark"
           style={{
@@ -33,10 +33,10 @@ export function SettingsOverview({ section }: { section: Section }) {
           <p className="settings-overview__description">{meta.description}</p>
         </div>
       </div>
-      <ul className="settings-overview__strip" aria-label="In this section">
+      <ul className="settings-overview-strip" aria-label="In this section">
         {SECTION_HIGHLIGHTS[section].map((label) => (
-          <li key={label} className="settings-overview__chip">
-            <Icon name="ph:check-circle" width={12} className="settings-overview__chip-dot" />
+          <li key={label} className="settings-overview-strip__item">
+            <Icon name="ph:check-circle" width={12} className="settings-overview-strip__icon" />
             <span>{label}</span>
           </li>
         ))}

--- a/src/components/settings-search.test.ts
+++ b/src/components/settings-search.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const sections = readFileSync(new URL("./settings-sections.ts", import.meta.url), "utf8");
 const group = readFileSync(new URL("./ui/settings-group.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
@@ -12,10 +13,14 @@ assert.match(group, /id=\{settingsGroupId\(label\)\} data-settings-group/, "Sett
 
 // The shell builds a search index and a SearchInput over it.
 assert.match(shell, /import \{ SearchInput \}/, "settings-shell imports SearchInput");
-assert.match(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/, "settings-shell defines a search index");
+assert.match(sections, /export const SETTINGS_INDEX: SettingsIndexEntry\[\]/, "settings-sections defines a search index");
+assert.match(shell, /SETTINGS_INDEX/, "settings-shell consumes the search index");
 assert.match(shell, /placeholder="Search settings…"/, "settings-shell renders the search box");
+assert.doesNotMatch(shell, /role="listbox"/, "settings search results should not pretend command buttons are a listbox");
+assert.match(shell, /role="list" aria-label="Settings search results"/, "settings search results render as a labelled list");
+assert.match(shell, /role="listitem"/, "each settings search result is wrapped as a list item");
 // Results filter the index by section label + group + keywords.
-assert.match(shell, /\$\{sectionLabel\(e\.section\)\} \$\{e\.group \?\? ""\} \$\{e\.keywords\}/, "search matches section/group/keywords");
+assert.match(shell, /\$\{settingsSectionLabel\(e\.section\)\} \$\{e\.group \?\? ""\} \$\{e\.keywords\}/, "search matches section/group/keywords");
 // Picking a result opens the section and scrolls/highlights the group.
 assert.match(shell, /function goToSetting\(entry: SettingsIndexEntry\)/, "search results route through goToSetting");
 assert.match(shell, /settingsGroupId\(entry\.group\)/, "goToSetting resolves the group scroll target");

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -3,9 +3,6 @@
 // "what's in here" highlight strip). Kept in its own module so the shell nav and
 // the SettingsOverview header share one source of truth.
 //
-// NOTE: the search index (SETTINGS_INDEX) intentionally stays in settings-shell
-// next to the search box it drives.
-
 export type Section =
   | "general"
   | "daemon"
@@ -15,15 +12,9 @@ export type Section =
   | "appearance"
   | "about";
 
-export type SectionMeta = {
-  id: Section;
-  label: string;
-  icon: string;
-  /** One-line summary shown under the section title in the overview header. */
-  description: string;
-  /** Accent colour for the section mark (kept subtle; section identity cue). */
-  accent: string;
-};
+export type SectionMeta = { id: Section; label: string; icon: string; description: string; accent: string };
+
+export type SettingsIndexEntry = { section: Section; group?: string; keywords: string };
 
 export const SECTIONS: SectionMeta[] = [
   { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9a8ecd" },
@@ -44,6 +35,28 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
   appearance: ["Theme & colors", "Typography", "Reading comfort"],
   about: ["App version", "Tool updates", "Project links"],
 };
+
+export const SETTINGS_INDEX: SettingsIndexEntry[] = [
+  { section: "general", group: "Workspace", keywords: "workspace directory root folder project path" },
+  { section: "general", group: "Startup", keywords: "startup launch autostart open boot" },
+  { section: "daemon", group: "Status", keywords: "daemon status running start stop restart" },
+  { section: "daemon", group: "Info", keywords: "daemon info version socket pid api" },
+  { section: "familiars", keywords: "familiars agents personas avatar name look permissions projects access grants allow deny tool policy guard security audit requests vault memory" },
+  { section: "addons", group: "Integrations", keywords: "add-ons addons integrations plugins github youtube sidebar surfaces code terminal browser flow roles journal coven group chat library" },
+  { section: "mobile", group: "Steps", keywords: "phone mobile connect qr pair tailscale" },
+  { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
+  { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },
+  { section: "appearance", group: "Mode", keywords: "mode dark light system appearance scheme" },
+  { section: "appearance", group: "Theme", keywords: "theme color palette swatch preset" },
+  { section: "appearance", group: "Theme tokens", keywords: "theme tokens colors hex custom background accent border" },
+  { section: "appearance", group: "Import from tweakcn", keywords: "import tweakcn css variables theme" },
+  { section: "appearance", group: "Familiar switcher", keywords: "familiar switcher style strip scope" },
+  { section: "appearance", group: "Corners", keywords: "corners radius rounded sharp square" },
+  { section: "appearance", group: "Reading text", keywords: "font typeface family size reading text density relative time chat library" },
+  { section: "about", group: "CovenCave", keywords: "about version covencave build" },
+  { section: "about", group: "OpenCoven tools", keywords: "tools update cli opencoven" },
+  { section: "about", group: "Links", keywords: "links docs help github support" },
+];
 
 export function getSectionMeta(section: Section): SectionMeta {
   return SECTIONS.find((s) => s.id === section) ?? SECTIONS[0];

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -1,15 +1,21 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const source = readFileSync(
   new URL("./settings-shell.tsx", import.meta.url),
   "utf8",
 );
+const sectionsUrl = new URL("./settings-sections.ts", import.meta.url);
+const overviewUrl = new URL("./settings-overview.tsx", import.meta.url);
+const sections = existsSync(sectionsUrl) ? readFileSync(sectionsUrl, "utf8") : "";
+const overview = existsSync(overviewUrl) ? readFileSync(overviewUrl, "utf8") : "";
 const globals = readFileSync(
   new URL("../app/globals.css", import.meta.url),
   "utf8",
 );
+const dashboardCssUrl = new URL("../styles/dashboard.css", import.meta.url);
+const dashboardCss = existsSync(dashboardCssUrl) ? readFileSync(dashboardCssUrl, "utf8") : "";
 
 assert.match(
   source,
@@ -28,12 +34,27 @@ assert.match(
   /useEffect\(\(\) => \{[\s\S]*window\.location\.hash\.replace\("#", ""\) as Section[\s\S]*setSection\(hash\)[\s\S]*setPickerView\(false\)/,
   "SettingsShell should apply hash deep-links after hydration",
 );
+assert.match(
+  source,
+  /window\.addEventListener\("hashchange", applyHashSection\)/,
+  "SettingsShell should respond when the hash changes after the settings page has mounted",
+);
+assert.match(
+  source,
+  /window\.removeEventListener\("hashchange", applyHashSection\)/,
+  "SettingsShell should clean up the hashchange listener",
+);
 
 // Keyboard hint footer at the bottom of the shell.
 assert.match(
   source,
   /Esc back · ↑↓ navigate sections/,
   "renders the keyboard hint footer below the content area",
+);
+assert.match(
+  source,
+  /isMobile \? \(pickerView \? "Tap a section to open" : "Back returns to Settings"\) : "Esc back · ↑↓ navigate sections"/,
+  "footer hint should match desktop keyboard navigation and mobile tap/back navigation",
 );
 
 assert.match(
@@ -70,6 +91,11 @@ assert.match(
   /SECTIONS\.findIndex\(\(s\) => s\.id === section\)/,
   "section index is looked up from SECTIONS",
 );
+assert.match(
+  source,
+  /openSection\(SECTIONS\[next\]\.id\)/,
+  "arrow-key section navigation should reuse openSection so the URL hash stays in sync",
+);
 
 // Keydown handler skips inputs/textareas/selects/contentEditable.
 assert.match(
@@ -102,6 +128,56 @@ assert.match(
   /setToggleError\("Couldn't save that change/,
   "a failed add-on toggle surfaces an inline error",
 );
+assert.match(
+  source,
+  /aria-label=\{`\$\{row\.label\} add-on`\}/,
+  "each add-on switch should expose the add-on name to assistive tech",
+);
+assert.match(
+  source,
+  /className="settings-addon-switch/,
+  "add-on switches should use the dedicated touch-target class",
+);
+assert.match(
+  source,
+  /className="settings-addon-switch__track"/,
+  "add-on switches should keep a compact visual track inside the larger hit target",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-addon-switch\s*\{[\s\S]*?min-width:\s*var\(--touch-target\)[\s\S]*?min-height:\s*var\(--touch-target\)/,
+  "add-on switch hit targets should meet the shared touch target without enlarging the track",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-addon-switch__track\s*\{[\s\S]*?width:\s*36px[\s\S]*?height:\s*20px/,
+  "add-on switch visual track should remain compact inside the touch target",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-touch-action\s*\{[\s\S]*?min-height:\s*var\(--touch-target\)/,
+  "Settings text actions should share the native touch-target floor",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-mobile-switch\s*\{[\s\S]*?min-width:\s*64px[\s\S]*?min-height:\s*var\(--touch-target\)/,
+  "Mobile mode switch should meet the native touch-target floor",
+);
+assert.match(
+  source,
+  /className=\{`settings-mobile-switch/,
+  "Mobile mode switch should use the dedicated touch-target switch class",
+);
+assert.match(
+  source,
+  /className="settings-touch-action[\s\S]*Setup guide/,
+  "Mobile setup guide link should use the shared Settings action touch target",
+);
+assert.match(
+  source,
+  /className="settings-touch-action[\s\S]*\{l\.label\}/,
+  "About external links should use the shared Settings action touch target",
+);
 // Settings section nav exposes the active section to assistive tech.
 assert.match(
   source,
@@ -115,6 +191,126 @@ assert.match(
   "the custom-theme reset button names the theme it resets",
 );
 
-assert.match(source, /<div className="max-w-none space-y-6">/, "settings pages fill the full pane width (no narrow max-w-2xl column on desktop)");
+assert.match(source, /className="max-w-none space-y-6"/, "settings pages fill the full pane width (no narrow max-w-2xl column on desktop)");
+
+assert.match(
+  source,
+  /<section className="max-w-none space-y-6" aria-labelledby=\{pageTitleId\}>/,
+  "SettingsPage should expose an accessible section label without adding a second visible page heading",
+);
+
+assert.match(
+  source,
+  /<h2 id=\{pageTitleId\} className="sr-only">\{title\}<\/h2>/,
+  "SettingsPage should keep the section title available to assistive tech",
+);
+
+assert.doesNotMatch(
+  source,
+  /<h1 className="text-\[18px\] font-semibold text-\[var\(--text-primary\)\]">\{title\}<\/h1>/,
+  "SettingsPage should not visibly repeat the overview title",
+);
+
+assert.match(
+  globals,
+  /@import "\.\.\/styles\/dashboard\.css";/,
+  "globals.css should import the operational surface stylesheet that owns Settings shell styles",
+);
+
+assert.match(
+  dashboardCss,
+  /\.settings-shell\s*\{[\s\S]*?background:/,
+  "Settings shell styles should live in an imported tracked stylesheet so the dev CSS bundle includes them reliably",
+);
+
+assert.match(
+  dashboardCss,
+  /\.settings-overview-strip\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/,
+  "Settings overview strip grid should live in the imported Settings stylesheet owner",
+);
+
+assert.match(
+  sections,
+  /type SectionMeta = \{ id: Section; label: string; icon: string; description: string; accent: string \}/,
+  "Settings sections should carry descriptions and accent metadata for a richer desktop-native nav",
+);
+
+assert.match(
+  sections,
+  /export const SECTION_HIGHLIGHTS: Record<Section, string\[\]>/,
+  "Settings should define section-specific summary points for the overview strip",
+);
+
+assert.match(
+  source,
+  /import \{ SettingsOverview \} from "\.\/settings-overview"/,
+  "SettingsShell should import the overview component from a focused module",
+);
+
+assert.match(
+  source,
+  /import \{[\s\S]*SECTIONS[\s\S]*SETTINGS_INDEX[\s\S]*settingsSectionLabel[\s\S]*type Section[\s\S]*\} from "\.\/settings-sections"/,
+  "SettingsShell should import section metadata/search ownership from a focused module",
+);
+
+assert.match(
+  source,
+  /<SettingsOverview section=\{section\} \/>/,
+  "Settings content should render a section overview before the detailed controls",
+);
+
+assert.match(
+  overview,
+  /export function SettingsOverview\(\{ section \}: \{ section: Section \}\)/,
+  "SettingsOverview should live outside the shell component",
+);
+
+assert.match(
+  source,
+  /className="settings-shell/,
+  "SettingsShell should use a dedicated shell class instead of only utility classes",
+);
+
+assert.match(
+  source,
+  /className="settings-shell__sidebar/,
+  "SettingsShell should expose a dedicated desktop sidebar class",
+);
+
+assert.match(
+  source,
+  /className="settings-nav__description/,
+  "Settings nav items should show concise descriptions, not only labels",
+);
+
+assert.match(
+  source,
+  /CovenCave control room/,
+  "Settings header should identify the desktop control-room context",
+);
+
+assert.match(
+  source,
+  /Tauri desktop/,
+  "Settings header should explicitly frame the native Tauri app surface",
+);
+
+assert.match(
+  dashboardCss,
+  /\.settings-shell__sidebar[\s\S]*width:\s*248px/,
+  "Settings sidebar should have a stable desktop width",
+);
+
+assert.match(
+  dashboardCss,
+  /\.settings-overview-strip[\s\S]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/,
+  "Settings overview should use a stable three-column summary strip on desktop",
+);
+
+assert.match(
+  dashboardCss,
+  /@media \(max-width: 767px\) \{[\s\S]*\.settings-overview-strip[\s\S]*grid-template-columns:\s*1fr/,
+  "Settings overview should collapse to one column on mobile",
+);
 
 console.log("settings-shell-polish.test.ts OK");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -28,7 +28,13 @@ import { FontSettings } from "./settings-fonts";
 import { SettingsTabbed } from "./settings-section-tabs";
 import type { TabItem } from "@/components/ui/tabs";
 import { SettingsOverview } from "./settings-overview";
-import { SECTIONS, settingsSectionLabel, type Section } from "./settings-sections";
+import {
+  SECTIONS,
+  SETTINGS_INDEX,
+  settingsSectionLabel,
+  type Section,
+  type SettingsIndexEntry,
+} from "./settings-sections";
 import {
   CORNER_RADIUS_OPTIONS,
   CORNER_RADIUS_LABELS,
@@ -49,6 +55,7 @@ import {
   useFamiliarStripScope,
 } from "@/lib/familiar-strip-scope";
 import { readableTextColor } from "@/lib/readable-text-color";
+import { openExternalUrl } from "@/lib/open-external";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -72,38 +79,6 @@ function writeMobileModeEnabled(enabled: boolean) {
   window.localStorage.setItem(MOBILE_MODE_STORAGE_KEY, enabled ? "true" : "false");
 }
 
-// `Section` + the navigable `SECTIONS` (with overview metadata) live in
-// ./settings-sections so the nav and the SettingsOverview header share one
-// source of truth. The search index below stays here, next to its search box.
-
-// ─── Search index ───────────────────────────────────────────────────────────
-// One entry per searchable settings group. `group` matches the SettingsGroup
-// label (so settingsGroupId() resolves the scroll target); omit it for sections
-// without boxed groups (open the section, no in-page scroll). `keywords` carry
-// the synonyms a user is likely to type.
-type SettingsIndexEntry = { section: Section; group?: string; keywords: string };
-const SETTINGS_INDEX: SettingsIndexEntry[] = [
-  { section: "general", group: "Workspace", keywords: "workspace directory root folder project path" },
-  { section: "general", group: "Startup", keywords: "startup launch autostart open boot" },
-  { section: "daemon", group: "Status", keywords: "daemon status running start stop restart" },
-  { section: "daemon", group: "Info", keywords: "daemon info version socket pid api" },
-  { section: "familiars", keywords: "familiars agents personas avatar name look permissions projects access grants allow deny tool policy guard security audit requests vault memory" },
-  { section: "addons", group: "Integrations", keywords: "add-ons addons integrations plugins github youtube sidebar surfaces code terminal browser flow roles journal coven group chat library" },
-  { section: "mobile", group: "Steps", keywords: "phone mobile connect qr pair tailscale" },
-  { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
-  { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },
-  { section: "appearance", group: "Mode", keywords: "mode dark light system appearance scheme" },
-  { section: "appearance", group: "Theme", keywords: "theme color palette swatch preset" },
-  { section: "appearance", group: "Theme tokens", keywords: "theme tokens colors hex custom background accent border" },
-  { section: "appearance", group: "Import from tweakcn", keywords: "import tweakcn css variables theme" },
-  { section: "appearance", group: "Familiar switcher", keywords: "familiar switcher style strip scope" },
-  { section: "appearance", group: "Corners", keywords: "corners radius rounded sharp square" },
-  { section: "appearance", group: "Reading text", keywords: "font typeface family size reading text density relative time chat library" },
-  { section: "about", group: "CovenCave", keywords: "about version covencave build" },
-  { section: "about", group: "OpenCoven tools", keywords: "tools update cli opencoven" },
-  { section: "about", group: "Links", keywords: "links docs help github support" },
-];
-
 // ─── Shell ────────────────────────────────────────────────────────────────────
 
 export function SettingsShell() {
@@ -122,12 +97,11 @@ export function SettingsShell() {
   // ── Search across settings ────────────────────────────────────────────────
   const [query, setQuery] = useState("");
   const [scrollTarget, setScrollTarget] = useState<string | null>(null);
-  const sectionLabel = (s: Section) => SECTIONS.find((x) => x.id === s)?.label ?? s;
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
     return SETTINGS_INDEX.filter((e) =>
-      `${sectionLabel(e.section)} ${e.group ?? ""} ${e.keywords}`.toLowerCase().includes(q));
+      `${settingsSectionLabel(e.section)} ${e.group ?? ""} ${e.keywords}`.toLowerCase().includes(q));
   }, [query]);
 
   function goToSetting(entry: SettingsIndexEntry) {
@@ -169,13 +143,18 @@ export function SettingsShell() {
   // Support hash-based deep-linking, e.g. /settings#familiars. Read it after
   // hydration so SSR and the first client render both start on General.
   useEffect(() => {
-    const hash = window.location.hash.replace("#", "") as Section;
-    if (SECTIONS.some((s) => s.id === hash)) {
-      setSection(hash);
-      setPickerView(false);
-      return;
-    }
-    setPickerView(true);
+    const applyHashSection = () => {
+      const hash = window.location.hash.replace("#", "") as Section;
+      if (SECTIONS.some((s) => s.id === hash)) {
+        setSection(hash);
+        setPickerView(false);
+        return;
+      }
+      setPickerView(true);
+    };
+    applyHashSection();
+    window.addEventListener("hashchange", applyHashSection);
+    return () => window.removeEventListener("hashchange", applyHashSection);
   }, []);
 
   useEffect(() => {
@@ -194,7 +173,7 @@ export function SettingsShell() {
         const idx = SECTIONS.findIndex((s) => s.id === section);
         const delta = e.key === "ArrowDown" ? 1 : -1;
         const next = (idx + delta + SECTIONS.length) % SECTIONS.length;
-        setSection(SECTIONS[next].id);
+        openSection(SECTIONS[next].id);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -203,12 +182,12 @@ export function SettingsShell() {
 
   return (
     <FamiliarStudioProvider>
-    <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-[var(--bg-base)] text-[var(--text-primary)]">
+    <div className="settings-shell flex h-[100dvh] w-full flex-col overflow-hidden bg-[var(--bg-base)] text-[var(--text-primary)]">
       {/* Header. On mobile the back button has two roles: from a section
           page it drops back to the picker; from the picker it pops the
           route. Desktop always pops the route. */}
       <header
-        className="flex shrink-0 items-center gap-3 border-b border-[var(--border-hairline)] px-4 py-2.5"
+        className="settings-shell__header flex shrink-0 items-center gap-3 border-b border-[var(--border-hairline)] px-4 py-2.5"
         style={{ paddingTop: "calc(0.625rem + var(--sai-top))" }}
       >
         <button
@@ -222,9 +201,12 @@ export function SettingsShell() {
           <Icon name="ph:arrow-left" width={13} />
           {isMobile && !pickerView ? "Settings" : "Back"}
         </button>
-        <span className="text-[13px] font-semibold text-[var(--text-primary)]">
-          {isMobile && !pickerView ? (activeSection?.label ?? "Settings") : "Settings"}
-        </span>
+        <div className="min-w-0">
+          <span className="block text-[13px] font-semibold text-[var(--text-primary)]">
+            {isMobile && !pickerView ? (activeSection?.label ?? "CovenCave control room") : "CovenCave control room"}
+          </span>
+          <span className="settings-shell__native-badge">Tauri desktop</span>
+        </div>
       </header>
 
       <div className="flex min-h-0 flex-1 flex-col md:flex-row">
@@ -233,9 +215,9 @@ export function SettingsShell() {
             view (iOS-Settings drill-down). Once a section is picked the
             picker hides and the content fills the screen. */}
         <nav
-          className={`shrink-0 py-3 md:w-[200px] md:border-r md:border-[var(--border-hairline)] ${
-            showPicker ? "flex-1 w-full" : isMobile ? "hidden" : "w-[200px]"
-          }`}
+          hidden={isMobile && !showPicker}
+          className="settings-shell__sidebar shrink-0 py-3 md:w-[200px] md:border-r md:border-[var(--border-hairline)]"
+          style={showPicker ? { flex: "1 1 auto", width: "100%" } : undefined}
         >
           <p className="mb-1 px-4 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
             Settings
@@ -250,19 +232,20 @@ export function SettingsShell() {
             />
           </div>
           {query.trim() ? (
-            <div className={`space-y-px ${showPicker ? "px-3" : "px-2"}`} role="listbox" aria-label="Settings search results">
+            <div className={`space-y-px ${showPicker ? "px-3" : "px-2"}`} role="list" aria-label="Settings search results">
               {results.length === 0 ? (
                 <p className="px-2.5 py-2 text-[11px] text-[var(--text-muted)]">No settings match “{query.trim()}”.</p>
               ) : results.map((e) => (
-                <button
-                  key={`${e.section}:${e.group ?? ""}`}
-                  type="button"
-                  onClick={() => goToSetting(e)}
-                  className="focus-ring flex w-full flex-col items-start rounded-[5px] px-2.5 py-[5px] text-left text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
-                >
-                  <span className="text-[12px] font-medium">{e.group ?? sectionLabel(e.section)}</span>
-                  <span className="text-[10px] text-[var(--text-muted)]">{sectionLabel(e.section)}</span>
-                </button>
+                <div key={`${e.section}:${e.group ?? ""}`} role="listitem">
+                  <button
+                    type="button"
+                    onClick={() => goToSetting(e)}
+                    className="focus-ring flex w-full flex-col items-start rounded-[5px] px-2.5 py-[5px] text-left text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+                  >
+                    <span className="text-[12px] font-medium">{e.group ?? settingsSectionLabel(e.section)}</span>
+                    <span className="text-[10px] text-[var(--text-muted)]">{settingsSectionLabel(e.section)}</span>
+                  </button>
+                </div>
               ))}
             </div>
           ) : (
@@ -273,7 +256,7 @@ export function SettingsShell() {
                 type="button"
                 onClick={() => openSection(s.id)}
                 aria-current={section === s.id && !showPicker ? "page" : undefined}
-                className={`focus-ring flex w-full items-center rounded-[5px] px-2.5 text-left transition-colors ${
+                className={`settings-nav__item focus-ring flex w-full items-center rounded-[5px] px-2.5 text-left transition-colors ${
                   showPicker
                     ? "min-h-[var(--touch-target)] gap-3 py-3 text-[14px]"
                     : "gap-2 py-[6px] text-[12px]"
@@ -288,7 +271,10 @@ export function SettingsShell() {
                   width={showPicker ? 18 : 13}
                   className={section === s.id && !showPicker ? "text-[var(--accent-presence-foreground)] opacity-70" : "text-[var(--text-muted)]"}
                 />
-                <span className="flex-1">{s.label}</span>
+                <span className="flex flex-1 flex-col">
+                  <span>{s.label}</span>
+                  <span className="settings-nav__description">{s.description}</span>
+                </span>
                 {showPicker ? (
                   <Icon name="ph:caret-right" width={14} className="text-[var(--text-muted)]" />
                 ) : null}
@@ -300,9 +286,8 @@ export function SettingsShell() {
 
         {/* Content */}
         <main
-          className={`min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8 ${
-            showPicker ? "hidden md:block" : ""
-          }`}
+          hidden={showPicker}
+          className="settings-shell__content min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8"
           style={{ paddingBottom: "calc(1.5rem + var(--sai-bottom))" }}
         >
           {section === "general" && <GeneralSection />}
@@ -315,7 +300,7 @@ export function SettingsShell() {
         </main>
       </div>
       <footer className="shrink-0 border-t border-[var(--border-hairline)] px-4 py-1.5 text-center text-[10px] text-[var(--text-muted)]">
-        Esc back · ↑↓ navigate sections
+        {isMobile ? (pickerView ? "Tap a section to open" : "Back returns to Settings") : "Esc back · ↑↓ navigate sections"}
       </footer>
     </div>
     </FamiliarStudioProvider>
@@ -641,18 +626,16 @@ function AddonsSection({ scrollTarget }: { scrollTarget?: string | null }) {
         type="button"
         role="switch"
         aria-checked={addons[row.key]}
+        aria-label={`${row.label} add-on`}
         onClick={() => void toggle(row.key)}
-        className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
-          addons[row.key]
-            ? "bg-[var(--accent-presence)]"
-            : "bg-[var(--bg-elevated)]"
-        }`}
+        className="settings-addon-switch focus-ring relative inline-flex shrink-0 cursor-pointer items-center justify-center"
       >
         <span
-          className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-150 ${
-            addons[row.key] ? "translate-x-4" : "translate-x-0.5"
-          } mt-0.5`}
-        />
+          className="settings-addon-switch__track"
+          aria-hidden="true"
+        >
+          <span className="settings-addon-switch__thumb" />
+        </span>
       </button>
     </div>
   );
@@ -1666,7 +1649,7 @@ function MobileModeToggle() {
           aria-checked={mobileModeEnabled}
           onClick={() => void onMobileModeChange(!mobileModeEnabled)}
           disabled={busy}
-          className={`rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+          className={`settings-mobile-switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
             mobileModeEnabled
               ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-contrast)]"
               : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
@@ -1715,15 +1698,14 @@ function MobileSection() {
       <SettingsGroup label="Get the app">
         <SettingsRow label="Build it with Xcode" description="apps/ios/CovenCave — open in Xcode and run on your device, or install the TestFlight build." />
         <div className="flex flex-wrap gap-2 px-4 py-3">
-          <a
-            href="https://github.com/OpenCoven/coven-cave/blob/main/docs/ios-native-rebuild.md"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+          <button
+            type="button"
+            onClick={() => openExternalUrl("https://github.com/OpenCoven/coven-cave/blob/main/docs/ios-native-rebuild.md")}
+            className="settings-touch-action gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:file-text" width={12} />
             Setup guide
-          </a>
+          </button>
         </div>
       </SettingsGroup>
     </SettingsPage>
@@ -1762,16 +1744,15 @@ function AboutSection() {
             { label: "Grimoire", href: "https://mind.opencoven.ai",               icon: "ph:book-open" as const },
             { label: "Podcast",  href: "https://pod.opencoven.ai",                icon: "ph:waveform-bold" as const },
           ].map((l) => (
-            <a
+            <button
               key={l.href}
-              href={l.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              type="button"
+              onClick={() => openExternalUrl(l.href)}
+              className="settings-touch-action gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
             >
               <Icon name={l.icon} width={12} />
               {l.label}
-            </a>
+            </button>
           ))}
         </div>
       </SettingsGroup>
@@ -1782,18 +1763,20 @@ function AboutSection() {
 // ─── Primitives ───────────────────────────────────────────────────────────────
 
 function SettingsPage({ title, description, section, children }: { title: string; description?: string; section?: Section; children: React.ReactNode }) {
+  const pageTitleId = section ? `settings-${section}-title` : "settings-page-title";
   return (
-    <div className="max-w-none space-y-6">
+    <section className="max-w-none space-y-6" aria-labelledby={pageTitleId}>
+      <h2 id={pageTitleId} className="sr-only">{title}</h2>
       {section ? (
         <SettingsOverview section={section} />
       ) : (
         <div>
-          <h1 className="text-[18px] font-semibold text-[var(--text-primary)]">{title}</h1>
+          <p className="text-[18px] font-semibold text-[var(--text-primary)]">{title}</p>
           {description && <p className="mt-1 text-[12px] text-[var(--text-muted)]">{description}</p>}
         </div>
       )}
       {children}
-    </div>
+    </section>
   );
 }
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -78,6 +78,10 @@ import { useShellBanners } from "@/lib/shell-banners";
 import { TopBar } from "@/components/top-bar";
 import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+import {
+  OPEN_IN_APP_BROWSER_EVENT,
+  PENDING_IN_APP_BROWSER_URL_KEY,
+} from "@/lib/open-external";
 
 type WorkspaceMode = WorkspaceModeFromDaemon;
 
@@ -245,6 +249,7 @@ export function Workspace() {
   const companionBrowserPaneRef = useRef<BrowserPaneHandle>(null);
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [rightPanel, setRightPanel] = useState<RightPanelKind | null>(null);
+  const [codeRightView, setCodeRightView] = useState<"files" | "changes">("files");
   const [railTab, setRailTab] = useState<CompanionTab>(() => {
     if (typeof window === "undefined") return "chat";
     const stored = window.localStorage.getItem("cave:rail.tab");
@@ -1742,28 +1747,38 @@ export function Workspace() {
     requestAnimationFrame(() => shellRef.current?.openFamiliar());
   }, [familiarPanelOpen, railTab]);
 
-  // Open a link in the user's real system browser. On desktop (Tauri) we hand
-  // the URL to the `shell_open` Rust command so it lands in Safari/Chrome; in
-  // plain browser dev (and as a fallback if the invoke fails) we fall back to
-  // window.open. This is the path every feed/chat/board "open link" button hits
-  // via onOpenUrl.
-  const openUrlExternally = useCallback((url: string) => {
-    const openExternally = () => window.open(url, "_blank", "noopener,noreferrer");
-    // @ts-expect-error Tauri injects this at runtime
-    const inTauri = typeof window !== "undefined" && !!window.__TAURI_INTERNALS__;
-    if (!inTauri) {
-      openExternally();
-      return;
-    }
-    void (async () => {
-      try {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("shell_open", { url });
-      } catch {
-        openExternally();
-      }
-    })();
+  const openUrlInAppBrowser = useCallback((url: string) => {
+    if (!url) return;
+    setMode("browser");
+    shellRef.current?.dismissNavMobile();
+    window.setTimeout(() => browserPaneRef.current?.navigateTo(url), 0);
   }, []);
+
+  useEffect(() => {
+    const openPendingBrowserUrl = () => {
+      const pending = window.sessionStorage.getItem(PENDING_IN_APP_BROWSER_URL_KEY);
+      if (pending) {
+        window.sessionStorage.removeItem(PENDING_IN_APP_BROWSER_URL_KEY);
+        openUrlInAppBrowser(pending);
+        return;
+      }
+      if (window.location.hash === "#browser") setMode("browser");
+    };
+    const onOpenBrowserUrl = (event: Event) => {
+      const detail = (event as CustomEvent<{ url?: string }>).detail;
+      if (detail?.url) {
+        window.sessionStorage.removeItem(PENDING_IN_APP_BROWSER_URL_KEY);
+        openUrlInAppBrowser(detail.url);
+      }
+    };
+    openPendingBrowserUrl();
+    window.addEventListener(OPEN_IN_APP_BROWSER_EVENT, onOpenBrowserUrl);
+    window.addEventListener("hashchange", openPendingBrowserUrl);
+    return () => {
+      window.removeEventListener(OPEN_IN_APP_BROWSER_EVENT, onOpenBrowserUrl);
+      window.removeEventListener("hashchange", openPendingBrowserUrl);
+    };
+  }, [openUrlInAppBrowser]);
 
   const openProjectChat = useCallback((projectRoot: string) => {
     startFamiliarChat(activeId, projectRoot);
@@ -1846,6 +1861,10 @@ export function Workspace() {
         shellRef.current?.dismissNavMobile();
       }}
       onNewChat={openCodeProjectChat}
+      onDeleteSession={async (session) => {
+        await fetch(`/api/chat/conversation/${encodeURIComponent(session.id)}`, { method: "DELETE" });
+        await loadSessions();
+      }}
     />
   );
 
@@ -1890,7 +1909,7 @@ export function Workspace() {
           window.location.hash = `memory:${encodeURIComponent(path)}`;
         }}
         onOpenOnboarding={openOnboarding}
-        onOpenUrl={openUrlExternally}
+        onOpenUrl={openUrlInAppBrowser}
         onFamiliarCreated={(id) => {
           void loadFamiliars();
           selectFamiliar(id);
@@ -1924,13 +1943,13 @@ export function Workspace() {
         onInboxItemChanged={refreshInbox}
         onSessionsChanged={loadSessions}
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-        onOpenUrl={openUrlExternally}
+        onOpenUrl={openUrlInAppBrowser}
       />
     ) : mode === "groupchat" ? (
       <GroupChatView
         familiars={resolvedFamiliars}
         onSessionStarted={loadSessions}
-        onOpenUrl={openUrlExternally}
+        onOpenUrl={openUrlInAppBrowser}
       />
     ) : mode === "code" ? (
       <CodeView
@@ -1963,7 +1982,7 @@ export function Workspace() {
             onInboxItemChanged={refreshInbox}
             onSessionsChanged={loadSessions}
             onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-            onOpenUrl={openUrlExternally}
+            onOpenUrl={openUrlInAppBrowser}
           />
         }
         comux={
@@ -1971,6 +1990,8 @@ export function Workspace() {
             view="projects"
             active={mode === "code"}
             storageNamespace=":code"
+            rightView={codeRightView}
+            onRightViewChange={setCodeRightView}
             hideProjectNavigator
             hideFileTree
             sessions={sessions}
@@ -1983,7 +2004,7 @@ export function Workspace() {
       />
     ) : mode === "library" ? (
       <LibraryView
-        onOpenUrl={openUrlExternally}
+        onOpenUrl={openUrlInAppBrowser}
         sessions={sessions}
         onOpenSession={openFamiliarSession}
         onNewProjectChat={openProjectChat}
@@ -1994,7 +2015,7 @@ export function Workspace() {
         sessions={sessions}
         activeFamiliarId={activeId}
         scopeFamiliarIds={scopeIds}
-        onOpenUrl={openUrlExternally}
+        onOpenUrl={openUrlInAppBrowser}
         onJumpToSession={(sessionId, familiarId) => {
           openFamiliarSession(sessionId, familiarId);
         }}
@@ -2013,7 +2034,7 @@ export function Workspace() {
           if (item.sourceSessionKey) {
             openFamiliarSession(item.sourceSessionKey);
           } else if (item.sourceUrl) {
-            window.open(item.sourceUrl, "_blank", "noopener");
+            openUrlInAppBrowser(item.sourceUrl);
           }
         }}
         familiars={familiars}

--- a/src/lib/open-external.test.ts
+++ b/src/lib/open-external.test.ts
@@ -1,0 +1,50 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const helper = await readFile(new URL("./open-external.ts", import.meta.url), "utf8");
+const settings = await readFile(new URL("../components/settings-shell.tsx", import.meta.url), "utf8");
+
+assert.match(
+  helper,
+  /export const OPEN_IN_APP_BROWSER_EVENT = "cave:open-url-in-browser"/,
+  "shared URL helper should expose the in-app browser event name",
+);
+assert.match(
+  helper,
+  /export function openExternalUrl\(url: string\): void/,
+  "legacy openExternalUrl callers should be preserved behind the in-app browser handoff",
+);
+assert.match(
+  helper,
+  /window\.dispatchEvent\(new CustomEvent\(OPEN_IN_APP_BROWSER_EVENT, \{ detail: \{ url \} \}\)\)/,
+  "same-page callers should dispatch an in-app browser navigation event",
+);
+assert.match(
+  helper,
+  /window\.sessionStorage\.setItem\(PENDING_IN_APP_BROWSER_URL_KEY, url\)/,
+  "callers outside Workspace should persist a pending browser URL before routing home",
+);
+assert.match(
+  helper,
+  /window\.location\.assign\("\/#browser"\)/,
+  "callers outside Workspace should route to the Workspace browser surface",
+);
+assert.doesNotMatch(
+  helper,
+  /shell_open|window\.open/,
+  "shared external URL helper should not open the system browser or a new tab",
+);
+
+assert.match(
+  settings,
+  /import \{ openExternalUrl \} from "@\/lib\/open-external"/,
+  "Settings should use the shared in-app browser URL helper",
+);
+assert.doesNotMatch(
+  settings,
+  /target="_blank"/,
+  "Settings links should not bypass the app with new external tabs",
+);
+
+console.log("open-external.test.ts: ok");

--- a/src/lib/open-external.ts
+++ b/src/lib/open-external.ts
@@ -1,16 +1,13 @@
-// Open a URL in the user's *system* browser (not the embedded browser pane).
-// In the Tauri desktop shell this uses the built-in `shell_open` command; on the
-// web it falls back to window.open. Mirrors the pattern in library-doc-preview.
-export async function openExternalUrl(url: string): Promise<void> {
+export const OPEN_IN_APP_BROWSER_EVENT = "cave:open-url-in-browser";
+export const PENDING_IN_APP_BROWSER_URL_KEY = "cave:pending-in-app-browser-url";
+
+// Historical name kept for existing call sites. External destinations should
+// open inside Cave's Browser surface instead of the system browser/new tab.
+export function openExternalUrl(url: string): void {
   if (typeof window === "undefined") return;
-  if ("__TAURI_INTERNALS__" in window) {
-    try {
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("shell_open", { url });
-      return;
-    } catch {
-      // fall through to window.open
-    }
+  window.sessionStorage.setItem(PENDING_IN_APP_BROWSER_URL_KEY, url);
+  window.dispatchEvent(new CustomEvent(OPEN_IN_APP_BROWSER_EVENT, { detail: { url } }));
+  if (window.location.pathname !== "/") {
+    window.location.assign("/#browser");
   }
-  window.open(url, "_blank", "noopener,noreferrer");
 }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -150,6 +150,234 @@
   .dr-quicklinks.dash-launcher--compact { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
+/* Settings shell: desktop-native control surface for /settings. */
+.settings-shell {
+  background:
+    linear-gradient(135deg, color-mix(in oklch, var(--accent-presence) 9%, transparent), transparent 32%),
+    var(--bg-base);
+}
+
+.settings-shell__header {
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 88%, transparent), var(--bg-base));
+  -webkit-app-region: drag;
+}
+
+.settings-shell__header :is(button, a, input, select, textarea) {
+  -webkit-app-region: no-drag;
+}
+
+.settings-shell__native-badge {
+  background: color-mix(in oklch, var(--bg-raised) 82%, transparent);
+}
+
+.settings-shell__sidebar {
+  width: 248px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 96%, transparent), color-mix(in oklch, var(--bg-base) 96%, transparent));
+}
+
+.settings-shell__sidebar-head {
+  margin-bottom: 10px;
+}
+
+.settings-nav__item {
+  min-height: 48px;
+}
+
+.settings-nav__item[aria-current="page"] .settings-nav__description {
+  color: var(--accent-presence-foreground);
+  opacity: 0.78;
+}
+
+.settings-nav__description {
+  display: -webkit-box;
+  overflow: hidden;
+  margin-top: 1px;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.settings-shell__content {
+  scroll-padding-top: 18px;
+}
+
+.settings-overview {
+  margin-bottom: 24px;
+  padding: 18px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background:
+    radial-gradient(circle at top right, color-mix(in oklch, var(--accent-presence) 15%, transparent), transparent 34%),
+    color-mix(in oklch, var(--bg-raised) 88%, transparent);
+}
+
+.settings-overview__title-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.settings-overview__mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  border-radius: 12px;
+  color: #111;
+  box-shadow: inset 0 0 0 1px color-mix(in oklch, white 38%, transparent);
+}
+
+.settings-overview__kicker {
+  margin: 0 0 1px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.settings-overview__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 22px;
+  font-weight: 680;
+  line-height: 1.15;
+}
+
+.settings-overview__description {
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.settings-overview-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.settings-overview-strip__item {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-base) 68%, transparent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.25;
+}
+
+.settings-overview-strip__item span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-overview-strip__icon {
+  flex-shrink: 0;
+  color: var(--accent-presence);
+}
+
+.settings-touch-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: var(--touch-target);
+  line-height: 1.2;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.settings-mobile-switch {
+  min-width: 64px;
+  min-height: var(--touch-target);
+}
+
+.settings-addon-switch {
+  min-width: var(--touch-target);
+  min-height: var(--touch-target);
+}
+
+.settings-addon-switch__track {
+  position: relative;
+  display: inline-flex;
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.settings-addon-switch[aria-checked="true"] .settings-addon-switch__track {
+  background: var(--accent-presence);
+}
+
+.settings-addon-switch__thumb {
+  position: absolute;
+  top: 2px;
+  left: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  background: #fff;
+  box-shadow: 0 1px 4px rgb(0 0 0 / 0.28);
+  transform: translateX(2px);
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.settings-addon-switch[aria-checked="true"] .settings-addon-switch__thumb {
+  transform: translateX(18px);
+}
+
+@media (max-width: 767px) {
+  .settings-shell__sidebar {
+    width: 100%;
+    background: var(--bg-base);
+  }
+
+  .settings-shell__sidebar-head {
+    margin-bottom: 12px;
+  }
+
+  .settings-overview {
+    padding: 14px;
+    border-radius: 14px;
+  }
+
+  .settings-overview__title-row {
+    align-items: flex-start;
+  }
+
+  .settings-overview__mark {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+  }
+
+  .settings-overview__title {
+    font-size: 19px;
+  }
+
+  .settings-overview-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-overview-strip__item span {
+    white-space: normal;
+  }
+}
+
 /* ── Unified dashboard: today's daily summary, folded inline ───────────────
    The narrative panel sits beside its generated illustration on wide screens
    and stacks on narrow ones. Reuses the shared .dr-panel / .dr-cardimg look. */


### PR DESCRIPTION
## Summary
- route external HTTP controls through Cave's Browser pane instead of opening separate browser windows
- add inline close/delete affordances for Code and Projects thread rows using the existing conversation delete flow
- update source guards for browser handoff, settings/library/github links, and thread delete wiring

## Test Plan
- pnpm test:app
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check