### PR TITLE
Route links in-app and polish Settings shell

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4269,17 +4269,15 @@ button:active > .edge-rail-chip {
 }
 
 /* While the chat right panel is expanded it covers the whole surface, so the
-   side-panel toggle is redundant; and the Code surface hoists its own companion
-   toggle onto its tab row (.code-panel-toggle), so suppress the shell's there
-   too — otherwise there'd be two. */
+   side-panel toggle is redundant. Code mode keeps this chrome focused on the
+   Code/Changes switch, so suppress the shell's right-panel button there too. */
 :root[data-right-panel-expanded] .shell-top-toggle--right,
 :root[data-code-inline-toolbar] .shell-top-toggle--right {
   display: none;
 }
 
-/* Code mode crowds the tab row (familiar scope + Sessions/Memory tabs + layout
-   presets + panel toggle), so tighten its padding/gaps to fit the narrowest
-   chat-pane preset (Review, ~30%) without the presets overlapping the tabs. */
+/* Code mode crowds the tab row (familiar scope + Sessions/Memory tabs +
+   Code/Changes switch), so tighten its padding/gaps. */
 :root[data-code-inline-toolbar] .chat-scope-tabs--minimal {
   padding-inline: 8px;
   gap: 8px;
@@ -4288,33 +4286,38 @@ button:active > .edge-rail-chip {
   gap: 8px;
 }
 
-/* Inline companion-panel toggle on the Code surface tab row. Mirrors the shell
-   float's affordance but sits in normal flow beside the layout presets. */
-.code-panel-toggle {
+/* Inline Code/Changes segmented toggle on the Code surface tab row. */
+.code-mode-toggle {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 6px;
+  gap: 2px;
+  height: 28px;
+  padding: 2px;
+  border-radius: 18px;
   border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-base) 52%, transparent);
+}
+
+.code-mode-toggle__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 22px;
+  border: 0;
+  border-radius: 8px;
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
   transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
 }
-.code-panel-toggle:hover {
+.code-mode-toggle__button:hover {
   color: var(--text-secondary);
 }
-.code-panel-toggle[aria-pressed="true"] {
+.code-mode-toggle__button[aria-pressed="true"] {
   color: var(--text-primary);
-  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
-  border-color: color-mix(in oklch, var(--accent-presence) 58%, var(--border-hairline));
-}
-/* The sidebar glyph points at the left rail by default; mirror it so it reads
-   as the RIGHT companion panel, matching the shell float. */
-.code-panel-toggle > svg {
-  transform: scaleX(-1);
+  background: color-mix(in oklch, var(--bg-raised) 92%, var(--foreground) 8%);
 }
 
 /* Codex-like Code page shell. The underlying chat and comux components keep
@@ -4469,7 +4472,7 @@ button:active > .edge-rail-chip {
     color-mix(in oklch, var(--code-page-pane) 92%, transparent);
 }
 
-.cave-code-page .code-panel-toggle,
+.cave-code-page .code-mode-toggle,
 .cave-code-page :is(.comux-terminal-add-button, .comux-terminal-toolbar-button, .comux-preview-copypath) {
   border-color: color-mix(in oklch, var(--foreground) 12%, transparent);
   background: color-mix(in oklch, var(--bg-base) 54%, transparent);
@@ -10069,55 +10072,150 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   border-color: color-mix(in oklch, var(--color-warning) 50%, var(--border-hairline));
   color: var(--color-warning);
 }
-.fa-thread-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-.fa-thread-panel {
+.fa-thread-table-wrap {
   min-width: 0;
-  padding: 12px;
+  overflow: auto;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
   background: var(--bg-base);
 }
-.fa-thread-panel h3 {
-  margin: 0 0 8px;
+.fa-thread-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 13px;
+}
+.fa-thread-table__col-signal { width: 25%; }
+.fa-thread-table__col-type { width: 18%; }
+.fa-thread-table__col-state { width: 15%; }
+.fa-thread-table__col-detail { width: 34%; }
+.fa-thread-table__col-count { width: 8%; }
+.fa-thread-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--bg-base);
+  color: var(--text-muted);
   font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+  white-space: nowrap;
 }
-.fa-thread-panel p,
-.fa-thread-panel li {
-  color: var(--text-secondary);
+.fa-thread-table tbody tr {
+  border-bottom: 1px solid var(--border-hairline);
+}
+.fa-thread-table tbody tr:not(.fa-thread-table__group):not(.fa-thread-table__empty):hover {
+  background: var(--bg-hover);
+}
+.fa-thread-table tbody tr.board-table-row--alt td {
+  background: color-mix(in oklch, var(--foreground) 3.5%, transparent);
+}
+.fa-thread-table td {
+  min-width: 0;
+  padding: 9px 10px;
+  vertical-align: middle;
+}
+.fa-thread-table__group td {
+  padding: 8px 10px 7px;
+  border-top: 1px solid var(--border-strong);
+  border-bottom: 1px solid var(--border-strong);
+  background: color-mix(in oklch, var(--bg-base) 82%, var(--foreground) 18%);
+  color: var(--text-primary);
   font-size: 12px;
-  line-height: 1.45;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
 }
-.fa-thread-panel ul {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+.fa-thread-table__group:first-child td {
+  border-top: 0;
 }
-.fa-thread-panel li {
+.fa-thread-table .board-table-group-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  margin-left: 6px;
+  padding: 0 5px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-base);
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 500;
+  vertical-align: middle;
+}
+.fa-thread-table__signal-cell {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 8px;
   min-width: 0;
 }
-.fa-thread-panel li > span {
+.fa-thread-table__severity {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 3px color-mix(in oklch, currentColor 14%, transparent);
+}
+.fa-thread-table__severity--critical { background: var(--color-danger); color: var(--color-danger); }
+.fa-thread-table__severity--warning { background: var(--color-warning); color: var(--color-warning); }
+.fa-thread-table__severity--info { background: var(--accent-presence); color: var(--accent-presence); }
+.fa-thread-table .board-table-title {
+  display: inline-block;
   min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.fa-thread-table .board-table-muted,
+.fa-thread-table .board-table-cell-time {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+.fa-thread-table__state {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 2px 7px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+  text-transform: capitalize;
+}
+.fa-thread-table__state--critical {
+  border-color: color-mix(in oklch, var(--color-danger) 42%, var(--border-hairline));
+  color: var(--color-danger);
+}
+.fa-thread-table__state--warning {
+  border-color: color-mix(in oklch, var(--color-warning) 46%, var(--border-hairline));
+  color: var(--color-warning);
+}
+.fa-thread-table__state--info {
+  border-color: color-mix(in oklch, var(--accent-presence) 42%, var(--border-hairline));
+  color: var(--text-secondary);
+}
+.fa-thread-table__detail {
+  display: block;
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
   overflow-wrap: anywhere;
 }
-.fa-thread-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  flex: 0 0 auto;
-  color: var(--color-danger);
-  font-size: 10px;
-  text-transform: uppercase;
+.fa-thread-table__empty td {
+  color: var(--text-muted);
+  font-size: 12px;
 }
 .fa-contract-grid {
   display: grid;

--- a/src/components/code-inline-toolbar.tsx
+++ b/src/components/code-inline-toolbar.tsx
@@ -5,100 +5,58 @@ import { Icon } from "@/lib/icon";
 import {
   CODE_PRESETS,
   CODE_PRESET_EVENT,
-  CODE_PRESET_HIDES_PROJECT_LIST,
   CODE_PRESET_HINTS,
   CODE_PRESET_ICONS,
   CODE_PRESET_LABELS,
-  CODE_PROJECT_LIST_EVENT,
   readCodePreset,
   writeCodePreset,
-  writeProjectListCollapsed,
   type CodePreset,
 } from "@/lib/code-layout-preset";
 
-/** The inline toggle asks the Shell to show/hide the companion panel (the Shell
- *  owns the panel ref, so we go over an event rather than reaching into it). */
-export const TOGGLE_RIGHT_PANEL_EVENT = "cave:toggle-right-panel";
-/** The Shell broadcasts the companion (familiar) panel's open state so this
- *  toggle can mirror it. `detail.open: boolean`; the Shell also sets the
- *  matching `:root[data-familiar-open]` attribute for the initial read. */
-export const FAMILIAR_OPEN_EVENT = "cave:familiar-open";
-
-/** Persist + broadcast a preset pick. The chat-pane resize (code-view) and the
- *  comux right-pane (comux-view) both listen for CODE_PRESET_EVENT, so this
- *  toolbar never has to reach into either pane. */
+/** Persist + broadcast a preset pick. Comux listens for CODE_PRESET_EVENT and
+ *  applies both the right-pane target and the Code/Changes column weighting. */
 function applyPreset(next: CodePreset) {
   writeCodePreset(next);
-  const collapsed = CODE_PRESET_HIDES_PROJECT_LIST[next];
-  writeProjectListCollapsed(collapsed);
-  window.dispatchEvent(new CustomEvent(CODE_PROJECT_LIST_EVENT, { detail: { collapsed } }));
   window.dispatchEvent(new CustomEvent(CODE_PRESET_EVENT, { detail: { preset: next } }));
 }
 
 /**
- * Code workspace layout controls — Chat/Split/Review presets + the companion
- * panel toggle — hoisted onto the Sessions/Memory tab row so the Code surface
- * no longer needs a separate toolbar row above the split.
+ * Code workspace view toggle — Code / Changes — hoisted onto the
+ * Sessions/Memory tab row so the Code surface no longer needs a separate
+ * toolbar row above the split.
  */
 export function CodeInlineToolbar() {
   const [preset, setPreset] = useState<CodePreset>(() => readCodePreset());
-  const [panelOpen, setPanelOpen] = useState(false);
 
   useEffect(() => {
     const onPreset = (e: Event) => {
       const p = (e as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
       if (p) setPreset(p);
     };
-    const onPanel = (e: Event) => {
-      const open = (e as CustomEvent<{ open?: boolean }>).detail?.open;
-      if (typeof open === "boolean") setPanelOpen(open);
-    };
     window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
-    window.addEventListener(FAMILIAR_OPEN_EVENT, onPanel as EventListener);
-    setPanelOpen(document.documentElement.hasAttribute("data-familiar-open"));
     return () => {
       window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
-      window.removeEventListener(FAMILIAR_OPEN_EVENT, onPanel as EventListener);
     };
   }, []);
 
   return (
-    <div className="flex shrink-0 items-center gap-1.5">
-      <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[11px]">
-        {CODE_PRESETS.map((p) => (
-          <button
-            key={p}
-            type="button"
-            onClick={() => {
-              setPreset(p);
-              applyPreset(p);
-            }}
-            aria-pressed={preset === p}
-            aria-label={CODE_PRESET_LABELS[p]}
-            title={`${CODE_PRESET_LABELS[p]} — ${CODE_PRESET_HINTS[p]}`}
-            className={`flex items-center justify-center rounded-[5px] px-1.5 py-1 transition-colors ${
-              preset === p
-                ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
-                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-            }`}
-          >
-            {/* Icon-only: the chat pane (esp. the Review preset) is too narrow
-                for labels alongside the familiar scope + Sessions/Memory tabs.
-                The active chip is highlighted; tooltips name each layout. */}
-            <Icon name={CODE_PRESET_ICONS[p]} width={14} />
-          </button>
-        ))}
-      </div>
-      <button
-        type="button"
-        className="code-panel-toggle focus-ring"
-        aria-label={panelOpen ? "Hide side panel" : "Show side panel"}
-        aria-pressed={panelOpen}
-        title={panelOpen ? "Hide side panel" : "Show side panel"}
-        onClick={() => window.dispatchEvent(new CustomEvent(TOGGLE_RIGHT_PANEL_EVENT))}
-      >
-        <Icon name={panelOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={14} />
-      </button>
+    <div className="code-mode-toggle" role="group" aria-label="Code workspace view">
+      {CODE_PRESETS.map((p) => (
+        <button
+          key={p}
+          type="button"
+          onClick={() => {
+            setPreset(p);
+            applyPreset(p);
+          }}
+          aria-pressed={preset === p}
+          aria-label={CODE_PRESET_LABELS[p]}
+          title={`${CODE_PRESET_LABELS[p]} - ${CODE_PRESET_HINTS[p]}`}
+          className="code-mode-toggle__button focus-ring"
+        >
+          <Icon name={CODE_PRESET_ICONS[p]} width={15} />
+        </button>
+      ))}
     </div>
   );
 }

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -214,18 +214,18 @@ assert.match(
   /mode === "code" \? \([\s\S]*?<ComuxView\s+view="projects"[\s\S]*?storageNamespace=":code"/,
   "the Code workspace comux uses the projects view (coding surfaces), not terminal-only",
 );
-// Code is the 8th sidebar surface (⌘8), reached via the SURFACE_ORDER lookup.
+// Code is the 7th sidebar surface (⌘7), reached via the SURFACE_ORDER lookup.
 assert.match(
   workspace,
   /const SURFACE_ORDER: WorkspaceMode\[\] = \[[\s\S]*?"terminal", "code",/,
-  "Cmd/Ctrl+8 switches to the Code workspace (last entry in SURFACE_ORDER)",
+  "Cmd/Ctrl+7 switches to the Code workspace (last entry in SURFACE_ORDER)",
 );
 
-// ── sidebar exposes a Code entry (⌘8) ────────────────────────────────────────
+// ── sidebar exposes a Code entry (⌘7) ────────────────────────────────────────
 assert.match(
   sidebar,
-  /id: "code", label: "Code"[\s\S]*?kbd: "⌘8"/,
-  "sidebar has a Code nav entry bound to ⌘8",
+  /id: "code", label: "Code"[\s\S]*?kbd: "⌘7"/,
+  "sidebar has a Code nav entry bound to ⌘7",
 );
 
 console.log("code-view.test.ts: ok");

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -245,7 +245,7 @@ assert.match(
   // guard, hence the doubled `))}` closing the tree-column ternary; the optional
   // centerSlot (the Code workspace's conversation column) then sits between the
   // tree and the preview/Changes column, before `{filePreviewCollapsed`.
-  /ProjectTree[\s\S]*?<\/div>\s*<\/div>\s*<\/div>\s*\)\)\}[\s\S]*?\{filePreviewCollapsed \? \([\s\S]*?<div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">[\s\S]*?previewPath/,
+  /ProjectTree[\s\S]*?<\/div>\s*<\/div>\s*<\/div>\s*\)\)\}[\s\S]*?\{filePreviewCollapsed \? \([\s\S]*?<div[\s\S]{0,180}className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden"[\s\S]*?previewPath/,
   "Projects preview pane should be the right full-height half of the layout",
 );
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -15,10 +15,11 @@ import { useChangesSummary } from "@/lib/use-changes-summary";
 import { CodeEditor } from "@/components/code-editor";
 import { resolveLangLabel } from "@/lib/code-lang";
 import {
+  CODE_PRESET_COLUMN_FLEX,
   CODE_PRESET_EVENT,
   CODE_PRESET_RIGHT_VIEW,
-  CODE_PROJECT_LIST_EVENT,
   readProjectListCollapsed,
+  readCodePreset,
   writeProjectListCollapsed,
   type CodePreset,
 } from "@/lib/code-layout-preset";
@@ -455,6 +456,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [projectListCollapsed, setProjectListCollapsed] = useState(false);
   const [projectDetailCollapsed, setProjectDetailCollapsed] = useState(false);
   const [filePreviewCollapsed, setFilePreviewCollapsed] = useState(false);
+  const [codePreset, setCodePreset] = useState<CodePreset>(() => readCodePreset());
   // Right pane view: the file preview, or the project's git changes/diff review.
   // Controllable: when the parent passes onRightViewChange (the Code workspace's
   // top-level Files/Changes tabs), the prop wins and every setRightView call is
@@ -1054,39 +1056,33 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     return () => window.removeEventListener("cave:code-select-project", onSelectProject as EventListener);
   }, [active, view]);
 
-  // Code workspace toolbar wiring (projects view only): the Projects toggle
-  // shows/hides this column, and a layout preset additionally switches the
-  // right pane (Review → Changes, Split → Files). Sync the initial collapse
-  // state from storage so a reload remembers it.
+  // Code workspace toolbar wiring (projects view only): the Code/Changes toggle
+  // switches the right pane and applies the matching 2/3 column weighting. Sync
+  // initial persisted state so a reload remembers the selected mode.
   useEffect(() => {
     if (view !== "projects") return;
     setProjectListCollapsed(readProjectListCollapsed());
-    const onProjectList = (event: Event) => {
-      const detail = (event as CustomEvent<{ collapsed?: boolean }>).detail;
-      setProjectListCollapsed(Boolean(detail?.collapsed));
-    };
+    const initialPreset = readCodePreset();
+    setCodePreset(initialPreset);
+    setRightView(CODE_PRESET_RIGHT_VIEW[initialPreset]);
     const onPreset = (event: Event) => {
       const preset = (event as CustomEvent<{ preset?: CodePreset }>).detail?.preset;
       if (!preset) return;
+      setCodePreset(preset);
       const nextRight = CODE_PRESET_RIGHT_VIEW[preset];
-      if (nextRight) {
-        // An explicit preset is a deliberate view choice — pin it so diff-first
-        // auto-switch doesn't override.
-        pinnedRightViewRef.current = true;
-        setRightView(nextRight);
-      }
+      // An explicit preset is a deliberate view choice — pin it so diff-first
+      // auto-switch doesn't override.
+      pinnedRightViewRef.current = true;
+      setRightView(nextRight);
     };
-    window.addEventListener(CODE_PROJECT_LIST_EVENT, onProjectList as EventListener);
     window.addEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
     return () => {
-      window.removeEventListener(CODE_PROJECT_LIST_EVENT, onProjectList as EventListener);
       window.removeEventListener(CODE_PRESET_EVENT, onPreset as EventListener);
     };
-  }, [view]);
+  }, [setRightView, view]);
 
   // Show/hide the projects list from its own header (and the collapsed rail).
-  // Persists so a reload remembers; the Code presets also drive this over the
-  // event above.
+  // Persists so a reload remembers.
   const setProjectListVisible = useCallback((visible: boolean) => {
     setProjectListCollapsed(!visible);
     writeProjectListCollapsed(!visible);
@@ -1290,6 +1286,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // now actually colorizes.
   const previewExt = previewPath ? previewPath.split(".").pop() : undefined;
   const previewLangLabel = preview?.kind === "text" ? resolveLangLabel(previewExt) : null;
+  const codeColumnFlex = CODE_PRESET_COLUMN_FLEX[codePreset];
   const visiblePaneCount = visiblePaneSessionIds.length;
   const sessionById = useMemo(
     () => new Map(sessions.map((session) => [session.id, session])),
@@ -2119,7 +2116,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                     the right). Only the Code workspace passes a centerSlot; the
                     Library projects browser stays two-column. */}
                 {centerSlot ? (
-                  <div className="comux-center-column flex min-w-0 min-h-0 flex-[2.4] flex-col overflow-hidden border-b border-[var(--border-hairline)] xl:border-b-0 xl:border-r">
+                  <div
+                    className="comux-center-column flex min-w-0 min-h-0 flex-col overflow-hidden border-b border-[var(--border-hairline)] xl:border-b-0 xl:border-r"
+                    style={{ flex: codeColumnFlex.chat }}
+                  >
                     {centerSlot}
                   </div>
                 ) : null}
@@ -2140,7 +2140,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                     </span>
                   </button>
                 ) : (
-                  <div className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden">
+                  <div
+                    className="min-w-0 min-h-0 flex flex-1 flex-col overflow-hidden"
+                    style={{ flex: codeColumnFlex.worktree }}
+                  >
                   {/* Files / Changes toggle — review the familiar's working-tree
                       diffs (revert + checkpoints) without leaving the surface.
                       Hidden when a parent owns the selection (Code workspace's

--- a/src/components/debug-pane.test.ts
+++ b/src/components/debug-pane.test.ts
@@ -90,6 +90,21 @@ assert.match(
   /CheckpointSection|CheckpointRow/,
   "Panel should render a saved-checkpoints list (restore/delete), not just write-only snapshots",
 );
+assert.match(
+  changesPanel,
+  /session-changes-table-wrap[\s\S]*?<table[\s\S]*?className="session-changes-table/,
+  "Changes file list should use the compact table-style rail layout instead of stacked cards",
+);
+assert.match(
+  changesPanel,
+  /<thead[\s\S]*?File[\s\S]*?Diff[\s\S]*?<\/thead>/,
+  "Changes table should expose File and Diff columns like the task tables",
+);
+assert.match(
+  changesPanel,
+  /function splitFilePath[\s\S]*?basename[\s\S]*?dirname/,
+  "Changes rows should split basename and parent path so narrow rails preserve the useful file name",
+);
 
 const changesRoute = await readFile(
   new URL("../app/api/changes/route.ts", import.meta.url),

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -62,6 +62,15 @@ function formatBytes(n: number): string {
   return `${(n / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function splitFilePath(path: string): { basename: string; dirname: string } {
+  const idx = path.lastIndexOf("/");
+  if (idx < 0) return { basename: path, dirname: "" };
+  return {
+    basename: path.slice(idx + 1) || path,
+    dirname: path.slice(0, idx),
+  };
+}
+
 const STATUS_META: Record<FileStatus, { letter: string; label: string; color: string }> = {
   modified: { letter: "M", label: "modified", color: "var(--color-warning)" },
   added: { letter: "A", label: "added", color: "var(--accent-presence)" },
@@ -92,19 +101,35 @@ function StatusChip({ status }: { status: FileStatus }) {
 // "Loading changes…" string.
 function ChangesSkeleton() {
   return (
-    <div className="flex flex-col gap-1" aria-hidden>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="rounded-md border border-[var(--border-hairline)]">
-          <div className="flex items-center gap-2 px-2 py-1.5">
-            <Skeleton variant="text" width={10} height={10} />
-            <Skeleton variant="text" width={20} height={12} />
-            <div className="min-w-0 flex-1">
-              <Skeleton variant="text" width={`${62 - i * 7}%`} />
-            </div>
-            <Skeleton variant="text" width={34} height={10} />
-          </div>
-        </div>
-      ))}
+    <div className="session-changes-table-wrap overflow-hidden rounded-md border border-[var(--border-hairline)]" aria-hidden>
+      <table className="session-changes-table w-full table-fixed border-collapse text-[11px]">
+        <colgroup>
+          <col />
+          <col className="w-[70px]" />
+          <col className="w-[32px]" />
+        </colgroup>
+        <tbody className="divide-y divide-[var(--border-hairline)]">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <tr key={i}>
+              <td className="px-2 py-1.5">
+                <div className="flex min-w-0 items-center gap-2">
+                  <Skeleton variant="text" width={10} height={10} />
+                  <Skeleton variant="text" width={16} height={16} />
+                  <div className="min-w-0 flex-1">
+                    <Skeleton variant="text" width={`${62 - i * 7}%`} />
+                  </div>
+                </div>
+              </td>
+              <td className="px-2 py-1.5">
+                <Skeleton variant="text" width={34} height={10} />
+              </td>
+              <td className="px-2 py-1.5">
+                <Skeleton variant="text" width={18} height={14} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
@@ -132,76 +157,96 @@ function FileRow({
   // reverting one deletes it — it has no committed version to restore.
   const [confirmRevert, setConfirmRevert] = useState(false);
   const untracked = file.status === "untracked" || file.status === "added";
+  const { basename, dirname } = splitFilePath(file.path);
+  const diffCounts =
+    typeof file.insertions === "number" || typeof file.deletions === "number" ? (
+      <>
+        <span className="text-[var(--accent-presence)]">+{file.insertions ?? 0}</span>{" "}
+        <span className="text-[var(--color-danger)]">−{file.deletions ?? 0}</span>
+      </>
+    ) : (
+      <span className="text-[var(--text-muted)]">--</span>
+    );
 
   return (
-    <div className="rounded-md border border-[var(--border-hairline)]">
-      <div className="flex items-center gap-2 px-2 py-1.5">
-        <button
-          type="button"
-          className="focus-ring flex min-w-0 flex-1 items-center gap-2 rounded text-left text-[11px]"
-          onClick={onToggle}
-          aria-expanded={expanded}
-          title={file.renamedFrom ? `${file.renamedFrom} → ${file.path}` : file.path}
-        >
-          <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden />
-          <StatusChip status={file.status} />
-          <span className="min-w-0 flex-1 truncate font-mono text-[var(--text-secondary)]">
-            {file.path}
-          </span>
-          {typeof file.insertions === "number" || typeof file.deletions === "number" ? (
-            <span className="shrink-0 font-mono text-[10px]">
-              <span className="text-[var(--accent-presence)]">+{file.insertions ?? 0}</span>{" "}
-              <span className="text-[var(--color-danger)]">−{file.deletions ?? 0}</span>
-            </span>
-          ) : null}
-        </button>
-
-        {confirmRevert ? (
-          <span
-            className="flex shrink-0 items-center gap-1.5"
-            role="group"
-            aria-label={untracked ? "Confirm untracked file deletion" : "Confirm file revert"}
-          >
-            <span className="text-[10px] font-medium text-[var(--color-danger)]">
-              {untracked ? "Delete file?" : "Revert file?"}
-            </span>
-            <button
-              type="button"
-              onClick={() => setConfirmRevert(false)}
-              className="focus-ring rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setConfirmRevert(false);
-                onRevert();
-              }}
-              disabled={reverting}
-              aria-label={untracked ? `Confirm delete ${file.path}` : `Confirm revert ${file.path}`}
-              className="focus-ring inline-flex items-center gap-1 rounded border border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_18%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-danger)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-danger)_30%,transparent)] disabled:opacity-40"
-            >
-              <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={10} aria-hidden />
-              {reverting ? "…" : untracked ? "Delete" : "Revert"}
-            </button>
-          </span>
-        ) : (
+    <>
+      <tr className="session-changes-table-row group align-middle transition-colors hover:bg-[var(--bg-hover)]">
+        <td className="min-w-0 overflow-hidden px-2 py-1.5">
           <button
             type="button"
-            onClick={() => setConfirmRevert(true)}
-            disabled={reverting}
-            title={untracked ? `Delete ${file.path}` : `Revert ${file.path}`}
-            aria-label={untracked ? `Delete untracked file ${file.path}` : `Revert ${file.path}`}
-            className="focus-ring shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] disabled:opacity-40"
+            className="focus-ring flex w-full min-w-0 items-center gap-2 rounded text-left text-[11px]"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            title={file.renamedFrom ? `${file.renamedFrom} → ${file.path}` : file.path}
           >
-            <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={11} aria-hidden />
+            <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={10} aria-hidden className="shrink-0" />
+            <StatusChip status={file.status} />
+            <span className="min-w-0 flex-1">
+              <span className="block truncate font-mono text-[11px] font-medium text-[var(--text-secondary)]">
+                {basename}
+              </span>
+              {dirname ? (
+                <span className="block truncate font-mono text-[9.5px] leading-tight text-[var(--text-muted)]">
+                  {dirname}
+                </span>
+              ) : null}
+            </span>
           </button>
-        )}
-      </div>
-
+        </td>
+        <td className="whitespace-nowrap px-2 py-1.5 text-right font-mono text-[10px] tabular-nums">{diffCounts}</td>
+        <td className="px-2 py-1.5 text-right">
+          {confirmRevert ? null : (
+            <button
+              type="button"
+              onClick={() => setConfirmRevert(true)}
+              disabled={reverting}
+              title={untracked ? `Delete ${file.path}` : `Revert ${file.path}`}
+              aria-label={untracked ? `Delete untracked file ${file.path}` : `Revert ${file.path}`}
+              className="focus-ring inline-flex h-6 w-6 items-center justify-center rounded border border-[var(--border-hairline)] text-[var(--text-muted)] transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] disabled:opacity-40"
+            >
+              <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={11} aria-hidden />
+            </button>
+          )}
+        </td>
+      </tr>
+      {confirmRevert ? (
+        <tr className="bg-[color-mix(in_oklch,var(--color-danger)_7%,transparent)]">
+          <td colSpan={3} className="px-2 py-1.5">
+            <span
+              className="flex min-w-0 items-center justify-end gap-1.5"
+              role="group"
+              aria-label={untracked ? "Confirm untracked file deletion" : "Confirm file revert"}
+            >
+              <span className="min-w-0 flex-1 truncate text-[10px] font-medium text-[var(--color-danger)]">
+                {untracked ? "Delete file?" : "Revert file?"}
+              </span>
+              <button
+                type="button"
+                onClick={() => setConfirmRevert(false)}
+                className="focus-ring rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setConfirmRevert(false);
+                  onRevert();
+                }}
+                disabled={reverting}
+                aria-label={untracked ? `Confirm delete ${file.path}` : `Confirm revert ${file.path}`}
+                className="focus-ring inline-flex items-center gap-1 rounded border border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_18%,transparent)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-danger)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-danger)_30%,transparent)] disabled:opacity-40"
+              >
+                <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={10} aria-hidden />
+                {reverting ? "…" : untracked ? "Delete" : "Revert"}
+              </button>
+            </span>
+          </td>
+        </tr>
+      ) : null}
       {expanded ? (
-        <div className="border-t border-[var(--border-hairline)] p-2">
+        <tr>
+          <td colSpan={3} className="border-t border-[var(--border-hairline)] p-2">
           {!diffState || diffState.loading ? (
             <div className="py-1 text-[10px] text-[var(--text-muted)]">Loading diff…</div>
           ) : diffState.error ? (
@@ -222,9 +267,10 @@ function FileRow({
               ) : null}
             </>
           )}
-        </div>
+          </td>
+        </tr>
       ) : null}
-    </div>
+    </>
   );
 }
 
@@ -637,24 +683,31 @@ export function SessionChangesInner({
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Header: honest scope copy + refresh */}
-      <div className="shrink-0 border-b border-[var(--border-hairline)] px-3 py-2">
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
-            Working tree changes
-            {loaded && !notARepo && !error ? (
-              <>
-                <span className="ml-1.5 font-mono font-normal normal-case text-[var(--text-muted)]">
+      <div className="session-changes-panel__toolbar shrink-0 border-b border-[var(--border-hairline)] px-3 py-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="shrink-0 text-[10px] font-semibold uppercase tracking-wider text-[var(--text-secondary)]">
+                Worktree
+              </span>
+              {loaded && !notARepo && !error ? (
+                <span className="inline-flex h-4 shrink-0 items-center rounded border border-[var(--border-hairline)] px-1.5 font-mono text-[9.5px] text-[var(--text-muted)]">
                   {files.length}
                 </span>
-                {totalInsertions + totalDeletions > 0 ? (
-                  <span className="ml-1.5 font-mono font-normal normal-case">
-                    <span className="text-[var(--accent-presence)]">+{totalInsertions}</span>{" "}
-                    <span className="text-[var(--color-danger)]">−{totalDeletions}</span>
-                  </span>
-                ) : null}
-              </>
-            ) : null}
-          </span>
+              ) : null}
+              {loaded && !notARepo && !error && totalInsertions + totalDeletions > 0 ? (
+                <span className="min-w-0 truncate font-mono text-[10px]">
+                  <span className="text-[var(--accent-presence)]">+{totalInsertions}</span>{" "}
+                  <span className="text-[var(--color-danger)]">−{totalDeletions}</span>
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]" title={repoRoot ?? projectRoot}>
+              {notARepo
+                ? <>No git working tree at {repoRoot ?? projectRoot}.</>
+                : <>All uncommitted changes in {repoRoot ?? projectRoot} — not only this session&rsquo;s edits.</>}
+            </p>
+          </div>
           <span className="flex shrink-0 items-center gap-1">
             <button
               type="button"
@@ -662,10 +715,10 @@ export function SessionChangesInner({
               disabled={checkpointing || notARepo || !!error}
               title="Save patch checkpoint"
               aria-label="Save patch checkpoint"
-              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)] disabled:opacity-40"
+              className="focus-ring inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-transparent text-[var(--text-muted)] transition-colors hover:border-[var(--border-hairline)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
             >
               <Icon name="ph:archive" width={11} aria-hidden />
-              {checkpointing ? "Saving" : "Checkpoint"}
+              <span className="sr-only">{checkpointing ? "Saving checkpoint" : "Checkpoint"}</span>
             </button>
             <button
               type="button"
@@ -673,18 +726,13 @@ export function SessionChangesInner({
               disabled={refreshing}
               title="Refresh"
               aria-label="Refresh working tree changes"
-              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded px-1 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)] disabled:opacity-40"
+              className="focus-ring inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-transparent text-[var(--text-muted)] transition-colors hover:border-[var(--border-hairline)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
             >
               <Icon name="ph:arrows-clockwise" width={11} aria-hidden className={refreshing ? "animate-spin" : undefined} />
-              Refresh
+              <span className="sr-only">Refresh</span>
             </button>
           </span>
         </div>
-        <p className="mt-0.5 truncate text-[10px] text-[var(--text-muted)]" title={repoRoot ?? projectRoot}>
-          {notARepo
-            ? <>No git working tree at {repoRoot ?? projectRoot}.</>
-            : <>All uncommitted changes in {repoRoot ?? projectRoot} — not only this session&rsquo;s edits.</>}
-        </p>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto p-2">
@@ -763,18 +811,40 @@ export function SessionChangesInner({
             <p className="mt-1">Edits the agent makes to this project will show up here.</p>
           </div>
         ) : (
-          <div className="flex flex-col gap-1">
-            {files.map((file) => (
-              <FileRow
-                key={file.path}
-                file={file}
-                expanded={expandedPath === file.path}
-                diffState={diffs[file.path]}
-                reverting={revertingPath === file.path}
-                onToggle={() => toggleFile(file)}
-                onRevert={() => void revertFile(file)}
-              />
-            ))}
+          <div className="session-changes-table-wrap overflow-hidden rounded-md border border-[var(--border-hairline)]">
+            <table className="session-changes-table w-full table-fixed border-collapse text-[11px]">
+              <colgroup>
+                <col />
+                <col className="w-[70px]" />
+                <col className="w-[32px]" />
+              </colgroup>
+              <thead className="sticky top-0 z-10 bg-[var(--bg-base)] text-[9.5px] uppercase tracking-wider text-[var(--text-muted)]">
+                <tr className="border-b border-[var(--border-hairline)]">
+                  <th scope="col" className="px-2 py-1.5 text-left font-medium">
+                    File
+                  </th>
+                  <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                    Diff
+                  </th>
+                  <th scope="col" className="px-2 py-1.5 text-right font-medium">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[var(--border-hairline)]">
+                {files.map((file) => (
+                  <FileRow
+                    key={file.path}
+                    file={file}
+                    expanded={expandedPath === file.path}
+                    diffState={diffs[file.path]}
+                    reverting={revertingPath === file.path}
+                    onToggle={() => toggleFile(file)}
+                    onRevert={() => void revertFile(file)}
+                  />
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
 

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -113,10 +113,16 @@ assert.match(
   "the Tasks surface (mode id 'board') sits on the ⌘3 Work shortcut",
 );
 
+assert.doesNotMatch(
+  source,
+  /\{ id: "calendar", label: "Calendar"/,
+  "Calendar should not appear as a standalone sidebar row after merging into Automations",
+);
+
 assert.match(
   source,
-  /\{ id: "inbox", label: "Automations", iconName: "ph:lightning-bold", group: "work", kbd: "⌘5", description:/,
-  "Automations should stay on the inbox route as the ⌘5 Work surface",
+  /\{ id: "inbox", label: "Automations", iconName: "ph:lightning-bold", group: "work", kbd: "⌘4", description:/,
+  "Automations should own the old Calendar shortcut as the unified schedule surface",
 );
 
 assert.match(
@@ -144,14 +150,14 @@ assert.match(
 
 assert.match(
   source,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘6", description:/,
-  "Browser is the first Tools surface, on ⌘6",
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘5", description:/,
+  "Browser is the first Tools surface after Automations, on ⌘5",
 );
 
 assert.match(
   source,
-  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘7", description:/,
-  "Terminal follows Browser on ⌘7",
+  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘6", description:/,
+  "Terminal follows Browser on ⌘6",
 );
 
 assert.match(

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -6,7 +6,7 @@
  * Layout (top to bottom):
  *   1. Familiar scope selector + New chat CTA
  *   2. App destinations grouped by purpose:
- *      Work  (Home / Familiars / Board / Calendar / Schedules)
+ *      Work  (Home / Chat / Tasks / Automations)
  *      Tools (Browser / Terminal / Code / Library / Roles / Flow / GitHub)
  *   3. Footer: Notifications, Settings
  */
@@ -102,12 +102,11 @@ const FOLDER_MODES: Array<{
   { id: "groupchat", label: "Group", iconName: "ph:users-three", group: "work", description: "Group chat — broadcast to a coven of familiars at once" },
   { id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
-  { id: "calendar", label: "Calendar", iconName: "ph:calendar-blank", group: "work", kbd: "⌘4", description: "Schedule and timeline of work" },
-  { id: "inbox", label: "Automations", iconName: "ph:lightning-bold", group: "work", kbd: "⌘5", description: "Reminders, crons, and flows in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
+  { id: "inbox", label: "Automations", iconName: "ph:lightning-bold", group: "work", kbd: "⌘4", description: "Calendar, reminders, crons, and flows in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
   // Tools
-  { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘6", description: "Built-in web browser" },
-  { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘7", description: "Shell session in your project" },
-  { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘8", description: "Chat with a familiar beside your files and terminal" },
+  { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘5", description: "Built-in web browser" },
+  { id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘6", description: "Shell session in your project" },
+  { id: "code", label: "Code", iconName: "ph:code", group: "tools", kbd: "⌘7", description: "Chat with a familiar beside your files and terminal" },
   { id: "library", label: "Library", iconName: "ph:books", group: "tools", kbd: "⌘0", description: "Saved docs, links, and reading" },
   { id: "roles", label: "Roles", iconName: "ph:mask-happy", group: "tools", description: "Agent personas, skills, and the capabilities your familiars can use" },
   { id: "flow", label: "Flow", iconName: "ph:flow-arrow", group: "tools", description: "Freeform n8n-style automation editor — wire nodes on a canvas" },
@@ -245,7 +244,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
   // Gated surfaces are hidden from the nav until enabled in Settings → Add-ons
   // (all default off). This keeps the default Cave to a simple core — Home, Chat,
-  // Board, Calendar, Schedules — with everything else opt-in.
+  // Board, Automations — with everything else opt-in.
   const visibleFolderModes = FOLDER_MODES.filter((fm) => {
     if (fm.id === "github") return addons?.github === true;
     if (fm.id === "library") return addons?.library === true;

--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -131,6 +131,16 @@ describe("aggregateThreadSignals", () => {
     assert.match(source, /Latest report/, "component shows recency for the summary");
   });
 
+  it("renders thread signal categories as a task-style grouped table", () => {
+    assert.match(source, /tableSections\(aggregate\)/, "component normalizes signal categories into table sections");
+    assert.match(source, /className="board-table board-table--grid fa-thread-table"/, "component reuses the task table class stack");
+    assert.match(source, /aria-label="Thread signal summary"/, "table has a stable accessible label");
+    assert.match(source, /className="board-table-group-row fa-thread-table__group"/, "sections render as task-style grouped rows");
+    assert.match(source, /className="fa-thread-table__col-detail"/, "column sizing classes stay separate from cell content classes");
+    assert.match(source, /No access gaps\./, "empty category states remain visible inside the table");
+    assert.match(source, /<th>Signal<\/th>[\s\S]*<th>Type<\/th>[\s\S]*<th>Status<\/th>[\s\S]*<th>Detail<\/th>[\s\S]*<th>Reports<\/th>/, "table exposes scan-friendly columns");
+  });
+
   it("lets you select a review item to unlock a discussion on the topic", () => {
     assert.match(source, /buildThreadSignalDiscussionPrompt/, "seeds the chat with a topic-specific prompt");
     assert.match(source, /new CustomEvent\("cave:agents-new-chat"/, "opens a new chat with the familiar");

--- a/src/components/thread-signals-section.tsx
+++ b/src/components/thread-signals-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Fragment } from "react";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Icon } from "@/lib/icon";
 import {
@@ -14,6 +15,22 @@ import {
 
 const CONTEXTS = ["adequate", "tight", "excess", "critical"] as const;
 
+type ThreadSignalTableRow = {
+  id: string;
+  signal: string;
+  type: string;
+  state: string;
+  detail: string;
+  count?: number;
+  severity?: "critical" | "warning" | "info";
+};
+
+type ThreadSignalTableSection = {
+  id: string;
+  title: string;
+  empty: string;
+  rows: ThreadSignalTableRow[];
+};
 
 function ScoreBar({ label, value }: { label: string; value: number }) {
   return (
@@ -34,27 +51,89 @@ function latestReportDate(reports: ThreadSelfReport[]): string {
   return latest ? new Date(latest.reportedAt).toLocaleString() : "Unknown";
 }
 
-function ListBlock<T>({
-  title,
-  items,
-  empty,
-  render,
-}: {
-  title: string;
-  items: T[];
-  empty: string;
-  render: (item: T) => string;
-}) {
-  return (
-    <div className="fa-thread-panel">
-      <h3>{title}</h3>
-      {items.length === 0 ? <p>{empty}</p> : (
-        <ul>
-          {items.map((item, index) => <li key={`${title}-${index}`}>{render(item)}</li>)}
-        </ul>
-      )}
-    </div>
-  );
+function tableSections(aggregate: ThreadSignalsAggregate): ThreadSignalTableSection[] {
+  return [
+    {
+      id: "skills-used",
+      title: "Skills used most",
+      empty: "No skills reported.",
+      rows: aggregate.skillsUsedMost.map((item) => ({
+        id: `skill-used-${item.skillId}`,
+        signal: item.skillId,
+        type: "Used most",
+        state: "reported",
+        detail: "Appeared in thread self-reports.",
+        count: item.count,
+        severity: "info",
+      })),
+    },
+    {
+      id: "skills-clarity",
+      title: "Skills needing clarity",
+      empty: "No clarity gaps.",
+      rows: aggregate.skillsNeedingClarity.map((item) => ({
+        id: `skill-clarity-${item.skillId}`,
+        signal: item.skillId,
+        type: "Clarity gap",
+        state: "needs definition",
+        detail: item.reason,
+        severity: "warning",
+      })),
+    },
+    {
+      id: "skills-access",
+      title: "Skills needing access",
+      empty: "No access gaps.",
+      rows: aggregate.skillsNeedingAccess.map((item) => ({
+        id: `skill-access-${item.skillId}`,
+        signal: item.skillId,
+        type: "Access gap",
+        state: "blocked",
+        detail: item.reason,
+        severity: "critical",
+      })),
+    },
+    {
+      id: "capabilities-vital",
+      title: "Capabilities vital",
+      empty: "No vital capabilities reported.",
+      rows: aggregate.capabilitiesVital.map((item) => ({
+        id: `capability-vital-${item.name}`,
+        signal: item.name,
+        type: "Vital capability",
+        state: item.currentState,
+        detail: item.notes || "Reported as necessary for successful work.",
+        severity: item.currentState === "missing" ? "critical" : item.currentState === "degraded" ? "warning" : "info",
+      })),
+    },
+    {
+      id: "capabilities-lacking",
+      title: "Capabilities lacking",
+      empty: "No lacking capabilities reported.",
+      rows: aggregate.capabilitiesLacking.map((item) => ({
+        id: `capability-lacking-${item.name}`,
+        signal: item.name,
+        type: "Lacking capability",
+        state: item.importance,
+        detail: item.detail,
+        severity: item.importance === "blocking" ? "critical" : "warning",
+      })),
+    },
+    {
+      id: "persistent-blockers",
+      title: "Persistent blockers",
+      empty: "No persistent blockers.",
+      rows: aggregate.persistentBlockers.map((blocker) => ({
+        id: `blocker-${blocker.id}`,
+        signal: blocker.title,
+        type: blocker.category,
+        state: blocker.impact,
+        detail: blocker.detail || "Reported as a repeated blocker.",
+        count: blocker.frequency,
+        severity: blocker.crit || blocker.impact === "blocking" ? "critical" : blocker.impact === "high" ? "warning" : "info",
+      })),
+    },
+  ];
 }
 
 /** Open a new chat with this familiar, primed to discuss the selected topic. */
@@ -79,6 +158,7 @@ export function ThreadSignalsSection({ familiarId, reports }: { familiarId: stri
 
   const aggregate = aggregateThreadSignals(reports);
   const reviewQueue = buildThreadSignalReviewQueue(aggregate);
+  const sections = tableSections(aggregate);
 
   return (
     <div className="fa-thread-signals" data-familiar-id={familiarId}>
@@ -128,25 +208,57 @@ export function ThreadSignalsSection({ familiarId, reports }: { familiarId: stri
           </span>
         ))}
       </div>
-      <div className="fa-thread-grid">
-        <ListBlock title="Skills used most" items={aggregate.skillsUsedMost} empty="No skills reported." render={(item) => `${item.skillId} (${item.count})`} />
-        <ListBlock title="Skills needing clarity" items={aggregate.skillsNeedingClarity} empty="No clarity gaps." render={(item) => `${item.skillId}: ${item.reason}`} />
-        <ListBlock title="Skills needing access" items={aggregate.skillsNeedingAccess} empty="No access gaps." render={(item) => `${item.skillId}: ${item.reason}`} />
-        <ListBlock title="Capabilities vital" items={aggregate.capabilitiesVital} empty="No vital capabilities reported." render={(item) => `${item.name}: ${item.currentState}${item.notes ? ` - ${item.notes}` : ""}`} />
-        <ListBlock title="Capabilities lacking" items={aggregate.capabilitiesLacking} empty="No lacking capabilities reported." render={(item) => `${item.name}: ${item.importance} - ${item.detail}`} />
-        <div className="fa-thread-panel">
-          <h3>Persistent blockers</h3>
-          {aggregate.persistentBlockers.length === 0 ? <p>No persistent blockers.</p> : (
-            <ul>
-              {aggregate.persistentBlockers.map((blocker) => (
-                <li key={blocker.id}>
-                  <span>{blocker.title}: {blocker.frequency}x - {blocker.impact}</span>
-                  {blocker.crit ? <b className="fa-thread-badge"><Icon name="ph:warning-circle" aria-hidden />crit</b> : null}
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
+      <div className="fa-thread-table-wrap">
+        <table className="board-table board-table--grid fa-thread-table" aria-label="Thread signal summary">
+          <colgroup>
+            <col className="fa-thread-table__col-signal" />
+            <col className="fa-thread-table__col-type" />
+            <col className="fa-thread-table__col-state" />
+            <col className="fa-thread-table__col-detail" />
+            <col className="fa-thread-table__col-count" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Signal</th>
+              <th>Type</th>
+              <th>Status</th>
+              <th>Detail</th>
+              <th>Reports</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sections.map((section) => (
+              <Fragment key={section.id}>
+                <tr className="board-table-group-row fa-thread-table__group">
+                  <td colSpan={5}>
+                    {section.title}
+                    <span className="board-table-group-badge">{section.rows.length}</span>
+                  </td>
+                </tr>
+                {section.rows.length === 0 ? (
+                  <tr className="fa-thread-table__empty">
+                    <td colSpan={5}>{section.empty}</td>
+                  </tr>
+                ) : (
+                  section.rows.map((row, index) => (
+                    <tr key={row.id} className={index % 2 === 1 ? "board-table-row--alt" : undefined}>
+                      <td>
+                        <span className="fa-thread-table__signal-cell">
+                          <span className={`fa-thread-table__severity fa-thread-table__severity--${row.severity ?? "info"}`} aria-hidden />
+                          <span className="board-table-title" title={row.signal}>{row.signal}</span>
+                        </span>
+                      </td>
+                      <td><span className="board-table-muted">{row.type}</span></td>
+                      <td><span className={`fa-thread-table__state fa-thread-table__state--${row.severity ?? "info"}`}>{row.state}</span></td>
+                      <td><span className="fa-thread-table__detail">{row.detail}</span></td>
+                      <td><span className="board-table-cell-time">{row.count ? `${row.count}x` : "-"}</span></td>
+                    </tr>
+                  ))
+                )}
+              </Fragment>
+            ))}
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -68,8 +68,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /const SURFACE_ORDER: WorkspaceMode\[\] = \[\s*"home", "chat", "board", "calendar", "inbox", "browser", "terminal", "code",/,
-  "SURFACE_ORDER ascends with the sidebar top-to-bottom order (⌘1..⌘8)",
+  /const SURFACE_ORDER: WorkspaceMode\[\] = \[\s*"home", "chat", "board", "inbox", "browser", "terminal", "code",/,
+  "SURFACE_ORDER ascends with the merged sidebar top-to-bottom order (⌘1..⌘7)",
 );
 
 // ⌘[ / ⌘] cycle to the previous / next surface through SURFACE_ORDER (wraps).
@@ -157,14 +157,14 @@ assert.match(
 
 assert.match(
   sidebar,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘6", description:/,
-  "Sidebar Browser is the first Tools shortcut, on ⌘6",
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘5", description:/,
+  "Sidebar Browser is the first Tools shortcut, on ⌘5",
 );
 
 assert.match(
   sidebar,
-  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘7", description:/,
-  "Sidebar Terminal follows Browser on ⌘7",
+  /\{ id: "terminal", label: "Terminal", iconName: "ph:terminal-window", group: "tools", kbd: "⌘6", description:/,
+  "Sidebar Terminal follows Browser on ⌘6",
 );
 
 console.log("workspace-familiars-landing: all assertions passed");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -93,7 +93,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   chat: "Familiars",
   groupchat: "Group Chat",
   board: "Tasks",
-  calendar: "Calendar",
+  calendar: "Automations",
   inbox: "Automations",
   library: "Library",
   browser: "Browser",
@@ -1209,11 +1209,11 @@ export function Workspace() {
   }, [startFamiliarChat]);
 
   useEffect(() => {
-    // ⌘1..⌘8 in the order surfaces appear top-to-bottom in the left sidebar
+    // ⌘1..⌘7 in the order surfaces appear top-to-bottom in the left sidebar
     // (Work group, then Tools group). ⌘9 is Projects and ⌘0 is Library (handled
     // below); Journal/Roles/Workflows are unshortcut.
     const SURFACE_ORDER: WorkspaceMode[] = [
-      "home", "chat", "board", "calendar", "inbox", "browser", "terminal", "code",
+      "home", "chat", "board", "inbox", "browser", "terminal", "code",
     ];
 
     const onKey = (e: KeyboardEvent) => {
@@ -2022,7 +2022,7 @@ export function Workspace() {
     ) : mode === "journal" ? (
       <JournalView familiars={familiars} activeFamiliarId={activeId} scopeFamiliarIds={scopeIds} />
     ) : mode === "inbox" || mode === "calendar" ? (
-      // Calendar and Automations are one "Schedule" surface: Calendar is the
+      // Calendar and Automations are one Automations surface: Calendar is the
       // leading tab of the Automations view. The "calendar" mode still resolves
       // here (nav button / deep links) but opens that tab; keying on the mode
       // remounts so the deep link lands on it.

--- a/src/lib/code-layout-preset.test.ts
+++ b/src/lib/code-layout-preset.test.ts
@@ -1,17 +1,18 @@
 import assert from "node:assert/strict";
 import {
-  CODE_PRESET_CHAT_SIZE,
+  CODE_PRESET_COLUMN_FLEX,
   CODE_PRESET_ICONS,
   CODE_PRESET_LABELS,
   CODE_PRESET_KEY,
+  CODE_PRESET_RIGHT_VIEW,
   CODE_PRESETS,
   DEFAULT_CODE_PRESET,
   normalizeCodePreset,
   readCodePreset,
 } from "./code-layout-preset.ts";
 
-assert.deepEqual([...CODE_PRESETS], ["chat", "split", "review"], "three presets, ordered");
-assert.equal(DEFAULT_CODE_PRESET, "split", "default is the balanced split");
+assert.deepEqual([...CODE_PRESETS], ["code", "changes"], "two Code workspace toggles, ordered");
+assert.equal(DEFAULT_CODE_PRESET, "code", "default is the chat-forward Code view");
 assert.equal(CODE_PRESET_KEY, "cave.code.preset.v1", "stable storage key");
 
 // normalizeCodePreset: pass through known, fall back to default otherwise.
@@ -22,21 +23,23 @@ assert.equal(normalizeCodePreset("bogus"), DEFAULT_CODE_PRESET, "unknown → def
 assert.equal(normalizeCodePreset(undefined), DEFAULT_CODE_PRESET, "undefined → default");
 assert.equal(normalizeCodePreset(null), DEFAULT_CODE_PRESET, "null → default");
 
-// Every preset has a chat-pane width within the code-chat panel's 28%–75% band,
-// a label, and a whitelisted icon name.
+// Every preset has a label, a whitelisted icon name, a right-pane target, and
+// a 2:1 column weighting between chat and the worktree pane.
 for (const p of CODE_PRESETS) {
-  const size = CODE_PRESET_CHAT_SIZE[p];
-  assert.match(size, /^\d+%$/, `${p} chat size is a percent string`);
-  const pct = Number.parseInt(size, 10);
-  assert.ok(pct >= 28 && pct <= 75, `${p} chat size ${size} is within the panel min/max band`);
   assert.ok(CODE_PRESET_LABELS[p].length > 0, `${p} has a label`);
   assert.match(CODE_PRESET_ICONS[p], /^ph:/, `${p} has a phosphor icon`);
+  assert.match(CODE_PRESET_RIGHT_VIEW[p], /^(files|changes)$/, `${p} has a concrete right-pane target`);
+  assert.equal(
+    CODE_PRESET_COLUMN_FLEX[p].chat + CODE_PRESET_COLUMN_FLEX[p].worktree,
+    3,
+    `${p} keeps a 3-part layout`,
+  );
 }
 
-// review gives comux the most room; chat the least; split sits between.
-const chatPct = (p: (typeof CODE_PRESETS)[number]) => Number.parseInt(CODE_PRESET_CHAT_SIZE[p], 10);
-assert.ok(chatPct("chat") > chatPct("split"), "chat preset is wider than split");
-assert.ok(chatPct("split") > chatPct("review"), "split is wider than review");
+assert.deepEqual(CODE_PRESET_COLUMN_FLEX.code, { chat: 2, worktree: 1 }, "Code gives chat 2/3 of the two-pane surface");
+assert.deepEqual(CODE_PRESET_COLUMN_FLEX.changes, { chat: 1, worktree: 2 }, "Changes gives diffs 2/3 of the two-pane surface");
+assert.equal(CODE_PRESET_RIGHT_VIEW.code, "files", "Code opens the code/file preview pane");
+assert.equal(CODE_PRESET_RIGHT_VIEW.changes, "changes", "Changes opens the git diff pane");
 
 // SSR / no-window: readCodePreset must not throw and returns the default.
 assert.equal(readCodePreset(), DEFAULT_CODE_PRESET, "readCodePreset is SSR-safe");

--- a/src/lib/code-layout-preset.ts
+++ b/src/lib/code-layout-preset.ts
@@ -1,78 +1,59 @@
 /**
- * Layout presets for the Code workspace (mode "code"): quick re-weightings of
- * the chat | comux split so the user can jump between conversation-heavy,
- * balanced, and review-heavy layouts without dragging the separator.
+ * Layout modes for the Code workspace (mode "code"): a two-option switch
+ * between the code/files pane and the git changes pane. The selected mode also
+ * re-weights the chat | worktree columns to keep the active task at 2/3 width.
  *
  * Mirrors src/lib/reading-width.ts: a small enum persisted in localStorage. The
- * preset only records *which chip is selected*; the actual pane sizes live in
- * react-resizable-panels' own persisted layout ("cave.code.widths.v1"), applied
- * by resizing the chat panel to CODE_PRESET_CHAT_SIZE. Values stay inside the
- * code-chat panel's min/max band (the comux pane fills the remainder, clamped to
- * its own minSize), so a preset never produces an impossible layout.
+ * preset records which chip is selected; Comux maps that to the visible
+ * right-pane and column flex weights.
  */
 import type { IconName } from "@/lib/icon";
 
 export const CODE_PRESET_KEY = "cave.code.preset.v1";
 
-export const CODE_PRESETS = ["chat", "split", "review"] as const;
+export const CODE_PRESETS = ["code", "changes"] as const;
 
 export type CodePreset = (typeof CODE_PRESETS)[number];
 
-export const DEFAULT_CODE_PRESET: CodePreset = "split";
+export const DEFAULT_CODE_PRESET: CodePreset = "code";
 
-/** Chat-pane width per preset; the comux pane fills what's left. */
-export const CODE_PRESET_CHAT_SIZE: Record<CodePreset, string> = {
-  chat: "65%", // conversation-forward (comux at its 35% min)
-  split: "45%", // balanced
-  review: "30%", // comux-forward for diff review
+/** Two-pane Code workspace weights: chat column | worktree column. */
+export const CODE_PRESET_COLUMN_FLEX: Record<CodePreset, { chat: number; worktree: number }> = {
+  code: { chat: 2, worktree: 1 },
+  changes: { chat: 1, worktree: 2 },
 };
 
 export const CODE_PRESET_LABELS: Record<CodePreset, string> = {
-  chat: "Chat",
-  split: "Split",
-  review: "Review",
+  code: "Code",
+  changes: "Changes",
 };
 
 export const CODE_PRESET_ICONS: Record<CodePreset, IconName> = {
-  chat: "ph:chats",
-  split: "ph:columns",
-  review: "ph:git-diff",
+  code: "ph:code",
+  changes: "ph:git-diff",
 };
 
 /** One-line hint shown in each preset chip's tooltip — what the mode is *for*. */
 export const CODE_PRESET_HINTS: Record<CodePreset, string> = {
-  chat: "Focus the conversation — widen chat, hide the projects list",
-  split: "Balanced — chat beside the file tree & preview",
-  review: "Review changes — widen code and open the git diff",
+  code: "Focus the chat with the code preview available",
+  changes: "Focus the git diff and uncommitted changes",
 };
 
 /**
  * A preset is more than a width: it sets up the whole Code workspace for a task.
- * These maps let the chat-pane toolbar (code-view) and the coding surface
+ * These maps let the chat-pane toolbar (CodeInlineToolbar) and the coding surface
  * (comux-view) agree on the *context* each preset implies, dispatched over the
  * events below so neither component has to reach into the other.
  */
 
-/** Whether a preset hides the comux projects list (Chat focuses the chat). */
-export const CODE_PRESET_HIDES_PROJECT_LIST: Record<CodePreset, boolean> = {
-  chat: true,
-  split: false,
-  review: false,
-};
-
 /** Which comux right-pane a preset switches to, or null to leave it untouched. */
-export const CODE_PRESET_RIGHT_VIEW: Record<CodePreset, "files" | "changes" | null> = {
-  chat: null, // conversation-forward: don't disturb whatever's open
-  split: "files", // balanced working layout → file tree & preview
-  review: "changes", // review-forward → the git diff
+export const CODE_PRESET_RIGHT_VIEW: Record<CodePreset, "files" | "changes"> = {
+  code: "files",
+  changes: "changes",
 };
 
 /** localStorage key for whether the comux projects list is collapsed. */
 export const CODE_PROJECT_LIST_KEY = "cave.code.projectListCollapsed.v1";
-
-/** Fired by the Code toolbar (code-view) → consumed by comux-view to show/hide
- *  the projects list. `detail.collapsed: boolean`. */
-export const CODE_PROJECT_LIST_EVENT = "cave:code-project-list";
 
 /** Fired when a preset is chosen → comux-view switches its right pane to match.
  *  `detail.preset: CodePreset`. */


### PR DESCRIPTION
## Summary
- route affected external-link actions through Cave's in-app Browser handoff instead of direct system browser launches
- move Settings search/index ownership into settings-sections and polish Settings navigation/search accessibility/hash sync
- update Code/sidebar/workspace source guards for the layout and shell behavior covered by this commit

## Test Plan
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app
- git diff --check HEAD~1 HEAD