### PR TITLE
feat(desktop): add tray quick chat

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -95,6 +95,7 @@ export const SUITES = {
     "src/lib/retro-runs.test.ts",
     "src/lib/eval-loop-daemon.test.ts",
     "src/lib/familiar-stream.test.ts",
+    "src/lib/quick-chat.test.ts",
     "src/lib/role-manifest.test.ts",
     "src/lib/chat-cwd-root.test.ts",
     "src/lib/agent-completion-report.test.ts",
@@ -473,6 +474,7 @@ export const SUITES = {
     "src/components/familiar-switcher.test.ts",
     "src/components/familiar-menu-bar.test.ts",
     "src/components/menu-bar-icon-size.test.ts",
+    "src/components/tray-quick-chat.test.ts",
     "src/components/familiar-quick-switch.test.ts",
     "src/components/familiar-pin-order.test.ts",
     "src/lib/familiar-quick-switch.test.ts",
@@ -741,6 +743,7 @@ const ALIAS_LOADER = new Set([
   "src/components/thread-signals-section.test.ts",
   "src/components/chat-view.test.ts",
   "src/lib/familiar-stream.test.ts",
+  "src/lib/quick-chat.test.ts",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -86,6 +86,51 @@ test("packaged sidecar bootstraps mobile handoff tokens", async () => {
   );
 });
 
+test("macOS tray exposes quick chat as a separate floating window", async () => {
+  const launcher = await readFile(new URL("./src/lib.rs", import.meta.url), "utf8");
+
+  assert.match(
+    launcher,
+    /const QUICK_CHAT_WINDOW_LABEL: &str = "quick-chat"/,
+    "launcher must use a stable window label for the menubar quick chat",
+  );
+  assert.match(
+    launcher,
+    /MenuItem::with_id\(app, "quick_chat", "Quick Chat…"/,
+    "tray menu must expose Quick Chat separately from the main app actions",
+  );
+  assert.match(
+    launcher,
+    /show_quick_chat_window\(app, &quick_chat_url_for_menu\)/,
+    "the Quick Chat menu item must open the dedicated quick chat window",
+  );
+  assert.match(
+    launcher,
+    /WebviewWindowBuilder::new\([\s\S]*QUICK_CHAT_WINDOW_LABEL[\s\S]*WebviewUrl::External\(quick_chat_url\.clone\(\)\)/,
+    "quick chat must be its own webview window, not the main window",
+  );
+  assert.match(
+    launcher,
+    /const QUICK_CHAT_WIDTH: f64 = 390\.0[\s\S]*const QUICK_CHAT_HEIGHT: f64 = 520\.0/,
+    "quick chat dimensions should stay small enough for a menubar panel",
+  );
+  assert.match(
+    launcher,
+    /\.inner_size\(QUICK_CHAT_WIDTH, QUICK_CHAT_HEIGHT\)[\s\S]*\.decorations\(false\)[\s\S]*\.always_on_top\(true\)[\s\S]*\.skip_taskbar\(true\)[\s\S]*\.position\(x, y\)/,
+    "quick chat window should be a small floating menubar-style panel",
+  );
+  assert.match(
+    launcher,
+    /app\.listen\("quick-chat:open-session"/,
+    "quick chat should be able to ask the native shell to reveal the full app",
+  );
+  assert.match(
+    launcher,
+    /if window\.label\(\) == "main"[\s\S]*try_state::<SidecarState>/,
+    "closing the quick chat window must not stop the desktop sidecar",
+  );
+});
+
 test("Windows packaged sidecar starts without a console window", async () => {
   const launcher = await readFile(new URL("./src/lib.rs", import.meta.url), "utf8");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,8 +23,15 @@ use tauri::{
     image::Image,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    Emitter, Manager, Url, WebviewUrl, WebviewWindowBuilder,
+    Emitter, Listener, Manager, Url, WebviewUrl, WebviewWindowBuilder,
 };
+
+#[cfg(desktop)]
+const QUICK_CHAT_WINDOW_LABEL: &str = "quick-chat";
+#[cfg(desktop)]
+const QUICK_CHAT_WIDTH: f64 = 390.0;
+#[cfg(desktop)]
+const QUICK_CHAT_HEIGHT: f64 = 520.0;
 
 #[cfg(desktop)]
 fn coven_tray_icon() -> Image<'static> {
@@ -53,6 +60,62 @@ fn coven_tray_icon() -> Image<'static> {
     }
 
     Image::new_owned(rgba, SIZE, SIZE)
+}
+
+#[cfg(desktop)]
+fn focus_main_window(app: &tauri::AppHandle) {
+    if let Some(w) = app.get_webview_window("main") {
+        let _ = w.show();
+        let _ = w.set_focus();
+    }
+}
+
+#[cfg(desktop)]
+fn quick_chat_position(app: &tauri::AppHandle) -> (f64, f64) {
+    if let Ok(Some(monitor)) = app.primary_monitor() {
+        let scale = monitor.scale_factor();
+        let position = monitor.position();
+        let size = monitor.size();
+        let screen_x = position.x as f64 / scale;
+        let screen_y = position.y as f64 / scale;
+        let screen_w = size.width as f64 / scale;
+        return (screen_x + screen_w - QUICK_CHAT_WIDTH - 14.0, screen_y + 34.0);
+    }
+    (24.0, 40.0)
+}
+
+#[cfg(desktop)]
+fn show_quick_chat_window(app: &tauri::AppHandle, quick_chat_url: &Url) {
+    if let Some(window) = app.get_webview_window(QUICK_CHAT_WINDOW_LABEL) {
+        let _ = window.show();
+        let _ = window.set_focus();
+        return;
+    }
+
+    let (x, y) = quick_chat_position(app);
+    match WebviewWindowBuilder::new(
+        app,
+        QUICK_CHAT_WINDOW_LABEL,
+        WebviewUrl::External(quick_chat_url.clone()),
+    )
+    .title("CovenCave Quick Chat")
+    .inner_size(QUICK_CHAT_WIDTH, QUICK_CHAT_HEIGHT)
+    .min_inner_size(340.0, 420.0)
+    .resizable(false)
+    .decorations(false)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .position(x, y)
+    .shadow(true)
+    .disable_drag_drop_handler()
+    .build()
+    {
+        Ok(window) => {
+            let _ = window.show();
+            let _ = window.set_focus();
+        }
+        Err(e) => log::warn!("[cave] failed to open quick chat window: {}", e),
+    }
 }
 
 /// Surface a fatal startup error to the user. Platform-specific: macOS uses
@@ -1083,6 +1146,8 @@ pub fn run() {
             };
 
             pty::trust_main_origin(&main_url);
+            let mut quick_chat_url = main_url.clone();
+            quick_chat_url.set_path("/quick-chat");
             let mut main_window = WebviewWindowBuilder::new(
                 app,
                 "main",
@@ -1142,6 +1207,8 @@ pub fn run() {
                 true,
                 None::<&str>,
             )?;
+            let quick_chat =
+                MenuItem::with_id(app, "quick_chat", "Quick Chat…", true, None::<&str>)?;
             let show_app =
                 MenuItem::with_id(app, "show_app", "Show CovenCave", true, None::<&str>)?;
             let separator = PredefinedMenuItem::separator(app)?;
@@ -1151,6 +1218,7 @@ pub fn run() {
                 &[
                     &open_inbox,
                     &new_reminder,
+                    &quick_chat,
                     &separator,
                     &show_app,
                     &separator,
@@ -1161,32 +1229,23 @@ pub fn run() {
             // `icon_as_template(true)` is a macOS-only concept (renders the
             // icon as a template image so the system can adapt it to dark/light
             // menu bar). On other platforms the call doesn't exist — guard it.
+            let quick_chat_url_for_menu = quick_chat_url.clone();
             let tray_builder = TrayIconBuilder::with_id("cave-tray")
                 .icon(coven_tray_icon())
                 .menu(&tray_menu)
                 .show_menu_on_left_click(false)
                 .tooltip("CovenCave")
-                .on_menu_event(|app, event| match event.id.as_ref() {
+                .on_menu_event(move |app, event| match event.id.as_ref() {
                     "open_inbox" => {
-                        if let Some(w) = app.get_webview_window("main") {
-                            let _ = w.show();
-                            let _ = w.set_focus();
-                        }
+                        focus_main_window(app);
                         let _ = app.emit("tray:open-inbox", ());
                     }
                     "new_reminder" => {
-                        if let Some(w) = app.get_webview_window("main") {
-                            let _ = w.show();
-                            let _ = w.set_focus();
-                        }
+                        focus_main_window(app);
                         let _ = app.emit("tray:new-reminder", ());
                     }
-                    "show_app" => {
-                        if let Some(w) = app.get_webview_window("main") {
-                            let _ = w.show();
-                            let _ = w.set_focus();
-                        }
-                    }
+                    "quick_chat" => show_quick_chat_window(app, &quick_chat_url_for_menu),
+                    "show_app" => focus_main_window(app),
                     "quit" => app.exit(0),
                     _ => {}
                 })
@@ -1199,10 +1258,7 @@ pub fn run() {
                         ..
                     } = event
                     {
-                        if let Some(w) = tray.app_handle().get_webview_window("main") {
-                            let _ = w.show();
-                            let _ = w.set_focus();
-                        }
+                        focus_main_window(tray.app_handle());
                     }
                 });
 
@@ -1213,14 +1269,21 @@ pub fn run() {
 
             let _tray = tray_builder.build(app)?;
 
+            let app_handle = app.handle().clone();
+            app.listen("quick-chat:open-session", move |_| {
+                focus_main_window(&app_handle);
+            });
+
             Ok(())
         })
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::Destroyed = event {
-                if let Some(state) = window.app_handle().try_state::<SidecarState>() {
-                    if let Some(mut child) = state.0.lock().expect("sidecar lock").take() {
-                        let _ = child.kill();
-                        let _ = child.wait();
+                if window.label() == "main" {
+                    if let Some(state) = window.app_handle().try_state::<SidecarState>() {
+                        if let Some(mut child) = state.0.lock().expect("sidecar lock").take() {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                        }
                     }
                 }
             }

--- a/src/app/quick-chat/page.tsx
+++ b/src/app/quick-chat/page.tsx
@@ -1,0 +1,5 @@
+import { TrayQuickChat } from "@/components/tray-quick-chat";
+
+export default function QuickChatPage() {
+  return <TrayQuickChat />;
+}

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const component = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
+const page = readFileSync(new URL("../app/quick-chat/page.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+assert.match(
+  page,
+  /import \{ TrayQuickChat \} from "@\/components\/tray-quick-chat"/,
+  "quick-chat route renders the tray quick chat component",
+);
+assert.match(component, /fetch\("\/api\/familiars"\)/, "quick chat loads the familiar roster");
+assert.match(
+  component,
+  /resolveQuickChatTarget\(draft, familiars, selectedFamiliarId\)/,
+  "quick chat resolves @familiar mentions before sending",
+);
+assert.match(
+  component,
+  /streamFamiliarText\(\{ familiarId: target\.familiarId, prompt: target\.prompt/,
+  "quick chat sends through the sanctioned familiar chat bridge",
+);
+assert.match(
+  component,
+  /emit\("quick-chat:open-session"/,
+  "quick chat emits an event that opens the saved session in the full app",
+);
+assert.match(
+  workspace,
+  /listen\("quick-chat:open-session"/,
+  "the main workspace listens for quick chat open-session events",
+);
+
+console.log("tray-quick-chat.test.ts OK");

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { resolveQuickChatTarget } from "@/lib/quick-chat";
+import { streamFamiliarText } from "@/lib/familiar-stream";
+import type { Familiar } from "@/lib/types";
+
+const LAST_FAMILIAR_KEY = "cave.quick-chat.last-familiar";
+
+type SendState = "idle" | "sending" | "done";
+
+function initials(familiar: Familiar): string {
+  return (familiar.display_name || familiar.id)
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function TrayQuickChat() {
+  const [familiars, setFamiliars] = useState<Familiar[]>([]);
+  const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sendState, setSendState] = useState<SendState>("idle");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/familiars");
+        const json = await res.json();
+        if (!alive) return;
+        const next = (json?.familiars ?? []) as Familiar[];
+        const stored =
+          typeof window !== "undefined"
+            ? window.localStorage.getItem(LAST_FAMILIAR_KEY)
+            : null;
+        setFamiliars(next);
+        setSelectedFamiliarId(
+          (stored && next.some((familiar) => familiar.id === stored) ? stored : null) ??
+            next[0]?.id ??
+            null,
+        );
+      } catch (err) {
+        if (alive) setError((err as Error)?.message ?? "Failed to load familiars.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const selectedFamiliar = useMemo(
+    () => familiars.find((familiar) => familiar.id === selectedFamiliarId) ?? familiars[0] ?? null,
+    [familiars, selectedFamiliarId],
+  );
+
+  const send = useCallback(async () => {
+    const target = resolveQuickChatTarget(draft, familiars, selectedFamiliarId);
+    setError(target.error);
+    setAnswer("");
+    setSessionId(null);
+    if (target.error || !target.familiarId) return;
+
+    setSendState("sending");
+    setSelectedFamiliarId(target.familiarId);
+    window.localStorage.setItem(LAST_FAMILIAR_KEY, target.familiarId);
+    const result = await streamFamiliarText({ familiarId: target.familiarId, prompt: target.prompt });
+    setAnswer(result.text);
+    setError(result.error);
+    setSessionId(result.sessionId ?? null);
+    setSendState("done");
+  }, [draft, familiars, selectedFamiliarId]);
+
+  const openFullSession = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      const { emit } = await import("@tauri-apps/api/event");
+      await emit("quick-chat:open-session", { sessionId, familiarId: selectedFamiliarId });
+    } catch {
+      window.location.href = `/#chat-${encodeURIComponent(sessionId)}`;
+    }
+  }, [selectedFamiliarId, sessionId]);
+
+  return (
+    <main className="min-h-screen bg-[var(--bg-base)] text-[var(--fg-primary)]">
+      <section className="flex min-h-screen flex-col border border-[var(--border-hairline)] bg-[var(--bg-panel)]">
+        <header className="flex items-center justify-between border-b border-[var(--border-hairline)] px-4 py-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Icon name="ph:chat-circle-dots" width={18} aria-hidden />
+            <div className="min-w-0">
+              <h1 className="truncate text-sm font-semibold">Quick Chat</h1>
+              <p className="truncate text-xs text-[var(--fg-muted)]">
+                {selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={openFullSession}
+            disabled={!sessionId}
+            aria-label="Open in CovenCave"
+            title="Open in CovenCave"
+            className="ui-icon-btn ui-icon-btn--sm disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Icon name="ph:arrow-square-out" width={12} aria-hidden />
+          </button>
+        </header>
+
+        <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
+          <Icon name="ph:at" width={14} aria-hidden />
+          <select
+            value={selectedFamiliarId ?? ""}
+            onChange={(event) => setSelectedFamiliarId(event.target.value || null)}
+            disabled={loading || familiars.length === 0}
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+            aria-label="Familiar"
+          >
+            {familiars.map((familiar) => (
+              <option key={familiar.id} value={familiar.id}>
+                {familiar.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex-1 overflow-auto px-4 py-3">
+          {selectedFamiliar ? (
+            <div className="mb-3 flex items-center gap-2 text-xs text-[var(--fg-muted)]">
+              {selectedFamiliar.avatarUrl ? (
+                <img
+                  src={selectedFamiliar.avatarUrl}
+                  alt=""
+                  className="h-6 w-6 rounded-sm object-cover"
+                />
+              ) : (
+                <span className="grid h-6 w-6 place-items-center rounded-sm bg-[var(--bg-elevated)] text-[10px] font-semibold text-[var(--fg-primary)]">
+                  {initials(selectedFamiliar)}
+                </span>
+              )}
+              <span className="min-w-0 truncate">{selectedFamiliar.role}</span>
+            </div>
+          ) : null}
+
+          <label className="block text-xs font-medium text-[var(--fg-muted)]" htmlFor="quick-chat-draft">
+            Message
+          </label>
+          <textarea
+            id="quick-chat-draft"
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            placeholder="@sage summarize what needs attention"
+            className="mt-2 h-28 w-full resize-none rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-sm outline-none focus:border-[var(--accent-presence)]"
+          />
+
+          {error ? (
+            <p className="mt-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--fg-primary)]">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="mt-3 min-h-32 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 text-sm">
+            {sendState === "sending" ? (
+              <p className="text-[var(--fg-muted)]">Thinking...</p>
+            ) : answer ? (
+              <p className="whitespace-pre-wrap leading-6">{answer}</p>
+            ) : (
+              <p className="text-[var(--fg-muted)]">The reply will appear here.</p>
+            )}
+          </div>
+        </div>
+
+        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-3">
+          <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
+            Use @id to switch familiars.
+          </p>
+          <button
+            type="button"
+            onClick={send}
+            disabled={sendState === "sending" || loading}
+            className="inline-flex items-center gap-2 rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[var(--accent-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Icon name="ph:sparkle" width={14} aria-hidden />
+            Send
+          </button>
+        </footer>
+      </section>
+    </main>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1147,6 +1147,25 @@ export function Workspace() {
     setMode("chat");
   }, []);
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    // @ts-expect-error Tauri injects this at runtime
+    if (!window.__TAURI_INTERNALS__) return;
+    let unlisten: (() => void) | undefined;
+    void (async () => {
+      try {
+        const { listen } = await import("@tauri-apps/api/event");
+        unlisten = await listen("quick-chat:open-session", (event) => {
+          const payload = event.payload as { sessionId?: string; familiarId?: string | null };
+          if (payload?.sessionId) openFamiliarSession(payload.sessionId, payload.familiarId);
+        });
+      } catch {
+        /* harmless in browser dev */
+      }
+    })();
+    return () => unlisten?.();
+  }, [openFamiliarSession]);
+
   const openReminderLink = useCallback((link: LinkRef) => {
     if (link.kind === "url") {
       if (!link.ref) return;

--- a/src/lib/familiar-stream.test.ts
+++ b/src/lib/familiar-stream.test.ts
@@ -49,6 +49,19 @@ describe("streamFamiliarText", () => {
     assert.equal(JSON.parse(bodies[1]).sessionId, "sess-9", "resume run includes sessionId");
   });
 
+  it("returns the created session id from stream frames", async () => {
+    globalThis.fetch = (async () => sseResponse([
+      frame({ kind: "session", sessionId: "sess-created" }),
+      frame({ kind: "assistant_chunk", text: "saved" }),
+      frame({ kind: "done", sessionId: "sess-created" }),
+    ])) as typeof fetch;
+
+    const { text, sessionId, error } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
+    assert.equal(text, "saved");
+    assert.equal(sessionId, "sess-created");
+    assert.equal(error, null);
+  });
+
   it("surfaces an error frame", async () => {
     globalThis.fetch = (async () => sseResponse([
       frame({ kind: "assistant_chunk", text: "partial" }),

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -15,7 +15,7 @@ export async function streamFamiliarText(opts: {
   prompt: string;
   sessionId?: string;
   signal?: AbortSignal;
-}): Promise<{ text: string; error: string | null }> {
+}): Promise<{ text: string; error: string | null; sessionId?: string }> {
   let res: Response;
   try {
     res = await fetch("/api/chat/send", {
@@ -38,6 +38,7 @@ export async function streamFamiliarText(opts: {
   let buffer = "";
   let text = "";
   let error: string | null = null;
+  let sessionId: string | undefined;
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
@@ -49,9 +50,13 @@ export async function streamFamiliarText(opts: {
       const ev = parseSseFrame(frame);
       if (!ev) continue;
       if (ev.kind === "assistant_chunk") text += ev.text ?? "";
-      else if (ev.kind === "done" && ev.isError) error = error ?? "the familiar reported an error";
+      else if (ev.kind === "session") sessionId = ev.sessionId;
+      else if (ev.kind === "done") {
+        if (ev.sessionId) sessionId = ev.sessionId;
+        if (ev.isError) error = error ?? "the familiar reported an error";
+      }
       else if (ev.kind === "error") error = ev.message ?? "generation error";
     }
   }
-  return { text, error };
+  return { text, error, sessionId };
 }

--- a/src/lib/quick-chat.test.ts
+++ b/src/lib/quick-chat.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { resolveQuickChatTarget } from "./quick-chat.ts";
+import type { Familiar } from "./types.ts";
+
+const familiars: Familiar[] = [
+  { id: "nova", display_name: "Nova", role: "research" },
+  { id: "sage", display_name: "Sage Counsel", name: "Sage", role: "review" },
+];
+
+describe("resolveQuickChatTarget", () => {
+  it("uses a leading @mention as the familiar and strips it from the prompt", () => {
+    const result = resolveQuickChatTarget("@sage summarize this", familiars, "nova");
+
+    assert.equal(result.familiarId, "sage");
+    assert.equal(result.prompt, "summarize this");
+    assert.equal(result.error, null);
+  });
+
+  it("matches @mentions against display names, names, and ids", () => {
+    const result = resolveQuickChatTarget("@sage-counsel check the plan", familiars, "nova");
+
+    assert.equal(result.familiarId, "sage");
+    assert.equal(result.prompt, "check the plan");
+  });
+
+  it("falls back to the selected familiar when there is no @mention", () => {
+    const result = resolveQuickChatTarget("what should I do next?", familiars, "nova");
+
+    assert.equal(result.familiarId, "nova");
+    assert.equal(result.prompt, "what should I do next?");
+    assert.equal(result.error, null);
+  });
+
+  it("returns an explicit error for unknown @mentions", () => {
+    const result = resolveQuickChatTarget("@ghost ping", familiars, "nova");
+
+    assert.equal(result.familiarId, null);
+    assert.equal(result.prompt, "ping");
+    assert.match(result.error ?? "", /Unknown familiar @ghost/);
+  });
+
+  it("requires prompt text after the familiar target", () => {
+    const result = resolveQuickChatTarget("@sage", familiars, "nova");
+
+    assert.equal(result.familiarId, "sage");
+    assert.equal(result.prompt, "");
+    assert.match(result.error ?? "", /prompt/i);
+  });
+});

--- a/src/lib/quick-chat.ts
+++ b/src/lib/quick-chat.ts
@@ -1,0 +1,81 @@
+import type { Familiar } from "@/lib/types";
+
+export type QuickChatTarget = {
+  familiarId: string | null;
+  prompt: string;
+  mention: string | null;
+  error: string | null;
+};
+
+function slug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function aliasesFor(familiar: Familiar): string[] {
+  return [
+    familiar.id,
+    familiar.name ?? "",
+    familiar.display_name,
+  ]
+    .filter(Boolean)
+    .flatMap((name) => {
+      const normalized = slug(name);
+      return normalized ? [normalized, normalized.replace(/-/g, "")] : [];
+    });
+}
+
+export function resolveQuickChatTarget(
+  input: string,
+  familiars: Familiar[],
+  fallbackFamiliarId?: string | null,
+): QuickChatTarget {
+  const trimmed = input.trim();
+  const mentionMatch = trimmed.match(/^@([A-Za-z0-9][A-Za-z0-9_-]*)(?:\s+|$)/);
+  const mention = mentionMatch?.[1] ?? null;
+  const prompt = mentionMatch ? trimmed.slice(mentionMatch[0].length).trim() : trimmed;
+
+  if (mention) {
+    const wanted = slug(mention);
+    const familiar = familiars.find((candidate) => aliasesFor(candidate).includes(wanted));
+    if (!familiar) {
+      return {
+        familiarId: null,
+        prompt,
+        mention,
+        error: `Unknown familiar @${mention}`,
+      };
+    }
+    return {
+      familiarId: familiar.id,
+      prompt,
+      mention,
+      error: prompt ? null : "Enter a prompt for the familiar.",
+    };
+  }
+
+  const fallback =
+    (fallbackFamiliarId && familiars.find((familiar) => familiar.id === fallbackFamiliarId)) ??
+    familiars[0] ??
+    null;
+
+  if (!fallback) {
+    return {
+      familiarId: null,
+      prompt,
+      mention: null,
+      error: "No familiars are available.",
+    };
+  }
+
+  return {
+    familiarId: fallback.id,
+    prompt,
+    mention: null,
+    error: prompt ? null : "Enter a prompt for the familiar.",
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated macOS tray Quick Chat window at /quick-chat with familiar selection, @mention targeting, and send/open-full-session actions
- wire the desktop tray menu to open the floating quick chat panel without treating it as the main app window
- return created chat session ids from the familiar stream and listen for quick-chat open-session events in the main workspace

## Test Plan
- pnpm install --frozen-lockfile
- node src-tauri/release-runtime.test.mjs
- pnpm test:app
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check
- cargo check --manifest-path src-tauri/Cargo.toml