### PR TITLE
feat: add release compatibility banner

### DIFF
--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -4,15 +4,23 @@ import { readFile } from "node:fs/promises";
 
 const src = await readFile(new URL("./open-coven-tools-update.tsx", import.meta.url), "utf8");
 const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
+const status = await readFile(new URL("../lib/opencoven-tools-status.ts", import.meta.url), "utf8");
 const runner = await readFile(new URL("../../scripts/run-tests.mjs", import.meta.url), "utf8");
 
 assert.match(src, /\/api\/opencoven-tools\/status/, "component fetches OpenCoven tool version status");
 assert.match(src, /\/api\/onboarding\/install/, "component reuses the allowlisted background installer");
 assert.match(src, /tool\.outdated/, "update buttons are gated to outdated tools");
+assert.match(src, /tool\.compatible/, "tool rows distinguish update availability from Cave compatibility");
+assert.match(src, /tool\.minimumVersion/, "tool rows expose the minimum compatible version");
+assert.match(src, /tool\.installCommand/, "tool rows expose a copyable install/update command");
+assert.match(src, /Copy command/, "tool rows can copy the exact update command");
 assert.match(src, /Update \{tool\.label\}/, "outdated tools expose a clear update button");
 assert.match(src, /function toolVersionText\(tool: ToolStatus\): string/, "tool version text is centralized");
 assert.match(src, /if \(!tool\.current\) return "Installed, version unknown"/, "installed tools with unknown versions should say the version is unknown");
 assert.match(src, /function toolStatusText\(tool: ToolStatus\): string/, "tool status text is centralized");
+assert.match(src, /function toolCompatibilityText\(tool: ToolStatus\): string \| null/, "tool compatibility copy is centralized");
+assert.match(src, /return `Requires >= \$\{tool\.minimumVersion\}`/, "below-minimum tools show the compatibility floor");
 assert.match(src, /if \(!tool\.current\) return "Version unknown"/, "installed tools with unknown versions must not claim to be up to date");
 assert.match(src, /tool\.outdated \? `\$\{tool\.current\} -> \$\{tool\.latest\}` : tool\.current/, "version line should show an arrow only for actual upgrades");
 assert.doesNotMatch(src, /tool\.latest\s*\?\s*` -> \$\{tool\.latest\}`/, "version line must not advertise latest when npm latest is older than installed");
@@ -21,6 +29,12 @@ assert.match(src, /coven-code/, "coven-code is included in the client install ta
 assert.match(src, /function buildDiagnosticsText/, "tool diagnostics text is centralized");
 assert.match(src, /navigator\.clipboard\.writeText/, "component can copy tool diagnostics for debugging");
 assert.match(src, /Copy diagnostics/, "About tools exposes a copy diagnostics action");
+assert.match(src, /export function OpenCovenToolsBannerTrigger/, "exports a shell banner trigger for stale OpenCoven tools");
+assert.match(src, /coven-cave:tool-update:dismissed:/, "tool update banners persist dismissal per released tool version");
+assert.match(src, /pushBanner\(/, "tool update trigger publishes through the shared shell banner system");
+assert.match(src, /severity: incompatibleTools\.length > 0 \? "warning" : "info"/, "compatibility failures get stronger warning severity than ordinary updates");
+assert.match(src, /Review tools/, "tool update banner sends users to the settings tool surface");
+assert.match(shell, /OpenCovenToolsBannerTrigger/, "Shell imports and mounts the OpenCoven tools banner trigger");
 assert.match(src, /sidecarTokenPresent/, "diagnostics include whether the sidecar auth bridge captured a token");
 assert.match(src, /Check tools/, "component offers a manual re-check");
 assert.match(
@@ -28,6 +42,11 @@ assert.match(
   /const ghostBtn =[\s\S]*settings-touch-action/,
   "About tools footer buttons should use the shared Settings action touch target",
 );
+assert.match(status, /minimumVersion: "0\.0\.49"/, "coven CLI compatibility floor is explicit in the status source");
+assert.match(status, /minimumVersion: "0\.0\.22"/, "coven-code compatibility floor is explicit in the status source");
+assert.match(status, /installCommand: "npm i -g @opencoven\/cli@latest"/, "coven CLI exposes the exact update command");
+assert.match(status, /installCommand: "npm i -g coven-code@latest"/, "coven-code exposes the exact update command");
+assert.match(status, /const compatible =[\s\S]*!!installed\?\.version && compareSemver\(installed\.version, tool\.minimumVersion\) >= 0/, "compatibility compares installed version against the Cave minimum");
 assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");
 assert.match(settings, /<SettingsGroup label="OpenCoven tools">[\s\S]*<OpenCovenToolsUpdate \/>/, "About settings renders the OpenCoven tools group");
 assert.match(runner, /src\/components\/open-coven-tools-update\.test\.ts/, "OpenCoven tools update test is wired into the test:app suite (scripts/run-tests.mjs)");

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -19,7 +19,10 @@ assert.match(src, /Update \{tool\.label\}/, "outdated tools expose a clear updat
 assert.match(src, /function toolVersionText\(tool: ToolStatus\): string/, "tool version text is centralized");
 assert.match(src, /if \(!tool\.current\) return "Installed, version unknown"/, "installed tools with unknown versions should say the version is unknown");
 assert.match(src, /function toolStatusText\(tool: ToolStatus\): string/, "tool status text is centralized");
+assert.match(src, /function toolNeedsCompatibilityUpdate\(tool: ToolStatus\): boolean/, "tool compatibility failures ignore missing or unknown-version installs");
+assert.match(src, /return tool\.installed && Boolean\(tool\.current\) && !tool\.compatible/, "only installed tools with known stale versions trigger compatibility warnings");
 assert.match(src, /function toolCompatibilityText\(tool: ToolStatus\): string \| null/, "tool compatibility copy is centralized");
+assert.match(src, /if \(!toolNeedsCompatibilityUpdate\(tool\)\) return null/, "missing tools do not render a compatibility floor warning");
 assert.match(src, /return `Requires >= \$\{tool\.minimumVersion\}`/, "below-minimum tools show the compatibility floor");
 assert.match(src, /if \(!tool\.current\) return "Version unknown"/, "installed tools with unknown versions must not claim to be up to date");
 assert.match(src, /tool\.outdated \? `\$\{tool\.current\} -> \$\{tool\.latest\}` : tool\.current/, "version line should show an arrow only for actual upgrades");
@@ -32,6 +35,7 @@ assert.match(src, /Copy diagnostics/, "About tools exposes a copy diagnostics ac
 assert.match(src, /export function OpenCovenToolsBannerTrigger/, "exports a shell banner trigger for stale OpenCoven tools");
 assert.match(src, /coven-cave:tool-update:dismissed:/, "tool update banners persist dismissal per released tool version");
 assert.match(src, /pushBanner\(/, "tool update trigger publishes through the shared shell banner system");
+assert.match(src, /const incompatibleTools = tools\.filter\(toolNeedsCompatibilityUpdate\)/, "global banner only warns for installed tools below the Cave floor");
 assert.match(src, /severity: incompatibleTools\.length > 0 \? "warning" : "info"/, "compatibility failures get stronger warning severity than ordinary updates");
 assert.match(src, /Review tools/, "tool update banner sends users to the settings tool surface");
 assert.match(shell, /OpenCovenToolsBannerTrigger/, "Shell imports and mounts the OpenCoven tools banner trigger");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useShellBanners } from "@/lib/shell-banners";
 
 type InstallTarget = "coven-cli" | "coven-code";
 
@@ -15,6 +16,9 @@ type ToolStatus = {
   current: string | null;
   latest: string | null;
   outdated: boolean;
+  compatible: boolean;
+  minimumVersion: string;
+  installCommand: string;
 };
 
 type InstallJobView = {
@@ -32,6 +36,12 @@ type InstallResult = {
 };
 
 const SIDECAR_TOKEN_STORAGE_KEY = "coven-cave:sidecar-auth-token";
+const TOOL_UPDATE_BANNER_ID = "opencoven-tools-update";
+const TOOL_DISMISS_KEY = (tools: ToolStatus[]) =>
+  `coven-cave:tool-update:dismissed:${tools
+    .map((tool) => `${tool.id}:${tool.latest ?? tool.current ?? tool.minimumVersion}`)
+    .sort()
+    .join("|")}`;
 
 function formatElapsed(ms: number): string {
   const seconds = Math.max(0, Math.floor(ms / 1000));
@@ -53,7 +63,31 @@ function toolVersionText(tool: ToolStatus): string {
 function toolStatusText(tool: ToolStatus): string {
   if (!tool.installed) return "Not found";
   if (!tool.current) return "Version unknown";
+  if (!tool.compatible) return "Needs update";
   return "Up to date";
+}
+
+function toolCompatibilityText(tool: ToolStatus): string | null {
+  if (tool.compatible) return null;
+  return `Requires >= ${tool.minimumVersion}`;
+}
+
+function dismissedToolBanner(tools: ToolStatus[]): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(TOOL_DISMISS_KEY(tools)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function dismissToolBanner(tools: ToolStatus[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(TOOL_DISMISS_KEY(tools), "1");
+  } catch {
+    /* private mode */
+  }
 }
 
 function buildDiagnosticsText({
@@ -96,6 +130,53 @@ function buildDiagnosticsText({
   );
 }
 
+export function OpenCovenToolsBannerTrigger() {
+  const { pushBanner, dismissBanner } = useShellBanners();
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/opencoven-tools/status", { cache: "no-store" })
+      .then(async (res) => {
+        if (!res.ok) return null;
+        return (await res.json()) as { ok?: boolean; tools?: ToolStatus[] };
+      })
+      .then((json) => {
+        if (cancelled || !json?.ok) return;
+        const tools = (json.tools ?? []).filter((tool) => isInstallTarget(tool.id));
+        const incompatibleTools = tools.filter((tool) => !tool.compatible);
+        const outdatedTools = tools.filter((tool) => tool.compatible && tool.outdated);
+        const bannerTools = incompatibleTools.length > 0 ? incompatibleTools : outdatedTools;
+        if (bannerTools.length === 0 || dismissedToolBanner(bannerTools)) return;
+        const label = bannerTools.map((tool) => tool.label).join(", ");
+        const detail =
+          incompatibleTools.length > 0
+            ? `${label} must be updated for this Cave build.`
+            : `New ${label} release available.`;
+        pushBanner({
+          id: TOOL_UPDATE_BANNER_ID,
+          severity: incompatibleTools.length > 0 ? "warning" : "info",
+          title: detail,
+          cta: {
+            label: "Review tools",
+            onClick: () => {
+              window.location.assign("/settings#about");
+            },
+          },
+          onDismiss: () => dismissToolBanner(bannerTools),
+        });
+      })
+      .catch(() => {
+        /* Update checks are best-effort. */
+      });
+    return () => {
+      cancelled = true;
+      dismissBanner(TOOL_UPDATE_BANNER_ID);
+    };
+  }, [pushBanner, dismissBanner]);
+
+  return null;
+}
+
 export function OpenCovenToolsUpdate() {
   const [tools, setTools] = useState<ToolStatus[]>([]);
   const [checking, setChecking] = useState(true);
@@ -103,6 +184,7 @@ export function OpenCovenToolsUpdate() {
   const [diagnosticsStatus, setDiagnosticsStatus] = useState<
     "idle" | "copied" | "failed"
   >("idle");
+  const [copiedCommand, setCopiedCommand] = useState<InstallTarget | null>(null);
   const [installJobs, setInstallJobs] = useState<
     Partial<Record<InstallTarget, InstallJobView>>
   >({});
@@ -256,6 +338,19 @@ export function OpenCovenToolsUpdate() {
     }
   };
 
+  const copyCommand = async (tool: ToolStatus) => {
+    try {
+      await navigator.clipboard.writeText(tool.installCommand);
+      setCopiedCommand(tool.id);
+      window.setTimeout(() => setCopiedCommand(null), 1800);
+    } catch {
+      setInstallResults((prev) => ({
+        ...prev,
+        [tool.id]: { ok: false, detail: "command copy failed" },
+      }));
+    }
+  };
+
   const copyDiagnostics = async () => {
     try {
       const text = buildDiagnosticsText({
@@ -308,6 +403,11 @@ export function OpenCovenToolsUpdate() {
               <p className="truncate font-mono text-[11px] text-[var(--text-muted)]">
                 {toolVersionText(tool)}
               </p>
+              {toolCompatibilityText(tool) ? (
+                <p className="mt-1 text-[11px] text-[var(--color-warning)]">
+                  {toolCompatibilityText(tool)}
+                </p>
+              ) : null}
               {result ? (
                 <p
                   className={`mt-1 text-[11px] ${
@@ -343,6 +443,17 @@ export function OpenCovenToolsUpdate() {
                   {toolStatusText(tool)}
                 </span>
               )}
+              {!busy ? (
+                <button
+                  type="button"
+                  onClick={() => void copyCommand(tool)}
+                  className={ghostBtn}
+                  aria-live="polite"
+                >
+                  <Icon name={copiedCommand === tool.id ? "ph:check-bold" : "ph:terminal-window"} width={12} />
+                  {copiedCommand === tool.id ? "Copied" : "Copy command"}
+                </button>
+              ) : null}
             </div>
           </div>
         );

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -67,8 +67,12 @@ function toolStatusText(tool: ToolStatus): string {
   return "Up to date";
 }
 
+function toolNeedsCompatibilityUpdate(tool: ToolStatus): boolean {
+  return tool.installed && Boolean(tool.current) && !tool.compatible;
+}
+
 function toolCompatibilityText(tool: ToolStatus): string | null {
-  if (tool.compatible) return null;
+  if (!toolNeedsCompatibilityUpdate(tool)) return null;
   return `Requires >= ${tool.minimumVersion}`;
 }
 
@@ -143,7 +147,7 @@ export function OpenCovenToolsBannerTrigger() {
       .then((json) => {
         if (cancelled || !json?.ok) return;
         const tools = (json.tools ?? []).filter((tool) => isInstallTarget(tool.id));
-        const incompatibleTools = tools.filter((tool) => !tool.compatible);
+        const incompatibleTools = tools.filter(toolNeedsCompatibilityUpdate);
         const outdatedTools = tools.filter((tool) => tool.compatible && tool.outdated);
         const bannerTools = incompatibleTools.length > 0 ? incompatibleTools : outdatedTools;
         if (bannerTools.length === 0 || dismissedToolBanner(bannerTools)) return;
@@ -429,7 +433,7 @@ export function OpenCovenToolsUpdate() {
                   <Icon name="ph:circle-notch-bold" className="animate-spin" width={12} />
                   Updating... {formatElapsed(job.elapsedMs)}
                 </span>
-              ) : tool.outdated ? (
+              ) : tool.outdated || toolNeedsCompatibilityUpdate(tool) ? (
                 <button
                   type="button"
                   onClick={() => void updateTool(tool.id)}

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -13,6 +13,7 @@ import {
 import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
 import { useShellBanners } from "@/lib/shell-banners";
 import { UpdateBannerTrigger } from "@/components/update-available";
+import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-update";
 import { useIsMobile } from "@/lib/use-viewport";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
 import {
@@ -497,6 +498,7 @@ function ShellInner({
       <Panel id="detail" className="shell-detail-panel">
         <main className="shell-detail" id="shell-main-content" tabIndex={-1} ref={detailElRef}>
           <UpdateBannerTrigger />
+          <OpenCovenToolsBannerTrigger />
           <ShellBannerStrip />
           {detail}
         </main>

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -12,6 +12,8 @@ export const OPEN_COVEN_TOOLS = [
     packageName: "@opencoven/cli",
     binary: "coven",
     versionArgs: ["--version"],
+    minimumVersion: "0.0.49",
+    installCommand: "npm i -g @opencoven/cli@latest",
   },
   {
     id: "coven-code",
@@ -19,6 +21,8 @@ export const OPEN_COVEN_TOOLS = [
     packageName: "coven-code",
     binary: "coven-code",
     versionArgs: ["--version"],
+    minimumVersion: "0.0.22",
+    installCommand: "npm i -g coven-code@latest",
   },
 ] as const;
 
@@ -40,6 +44,9 @@ export type OpenCovenToolStatus = {
   current: string | null;
   latest: string | null;
   outdated: boolean;
+  compatible: boolean;
+  minimumVersion: string;
+  installCommand: string;
   checkedAt: string;
 };
 
@@ -104,6 +111,8 @@ async function toolStatus(tool: ToolSpec): Promise<OpenCovenToolStatus> {
   ]);
   const outdated =
     !!installed?.version && !!latest && compareSemver(latest, installed.version) > 0;
+  const compatible =
+    !!installed?.version && compareSemver(installed.version, tool.minimumVersion) >= 0;
 
   return {
     id: tool.id,
@@ -115,6 +124,9 @@ async function toolStatus(tool: ToolSpec): Promise<OpenCovenToolStatus> {
     current: installed?.version ?? null,
     latest,
     outdated,
+    compatible,
+    minimumVersion: tool.minimumVersion,
+    installCommand: tool.installCommand,
     checkedAt: new Date().toISOString(),
   };
 }


### PR DESCRIPTION
## Summary

- add explicit Cave compatibility floors for `@opencoven/cli` and `coven-code`
- return `minimumVersion`, `compatible`, and `installCommand` from `/api/opencoven-tools/status`
- add a global shell banner for stale OpenCoven tool versions, with warning severity for compatibility failures and info severity for ordinary updates
- add copyable install/update commands in Settings -> About -> OpenCoven tools

## Verification

- `node --experimental-strip-types src/components/open-coven-tools-update.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app` (488 app test files)
- `git diff --check`
