### PR TITLE
fix(mobile): reduce input-time background work

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -213,6 +213,16 @@ assert.match(
   /persistSendModelIntent\(conv, body, modelState\)/,
   "Native transcript persistence should save direct session-scoped model intent",
 );
+assert.match(
+  chatRoute,
+  /const push = \(e: StreamEvent\) => \{[\s\S]*?if \(closed \|\| req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(e\)\);[\s\S]*?catch/,
+  "Native stream pushes should be ignored after close/abort so late child output cannot enqueue into a closed stream",
+);
+assert.match(
+  chatRoute,
+  /catch \(error\) \{[\s\S]*?closed = true;[\s\S]*?if \(!req\.signal\.aborted\) console\.warn/,
+  "Native stream enqueue failures should mark the stream closed and avoid noisy abort-path errors",
+);
 assert.doesNotMatch(
   chatRoute,
   /saveConfig\([\s\S]*modelOverride/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1092,7 +1092,16 @@ export async function POST(req: Request) {
 
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
-      const push = (e: StreamEvent) => controller.enqueue(sse(e));
+      let closed = false;
+      const push = (e: StreamEvent) => {
+        if (closed || req.signal.aborted) return;
+        try {
+          controller.enqueue(sse(e));
+        } catch (error) {
+          closed = true;
+          if (!req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);
+        }
+      };
       const pushProgress = (
         id: string,
         label: string,
@@ -1108,7 +1117,6 @@ export async function POST(req: Request) {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
-      let closed = false;
       const close = () => {
         if (closed) return;
         closed = true;

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -476,8 +476,8 @@ assert.match(
 );
 assert.match(
   source,
-  /useEffect\(\(\) => \{\s*writeComposerDraft\(input\);\s*\}, \[input\]\)/,
-  "the draft is persisted whenever the composer input changes",
+  /useEffect\(\(\) => \{\s*const timer = window\.setTimeout\(\(\) => \{\s*writeComposerDraft\(input\);\s*\}, COMPOSER_DRAFT_WRITE_DELAY_MS\);\s*return \(\) => window\.clearTimeout\(timer\);\s*\}, \[input\]\)/,
+  "the draft is debounced so mobile typing does not write localStorage on every keystroke",
 );
 assert.match(
   source,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -292,6 +292,7 @@ const COMPOSER_PREFS_KEY = "cave:chat-composer-controls:v1";
 // half-written message. The composer is a single shared input (it isn't
 // remounted per session), so one key mirrors the in-memory behaviour.
 const COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1";
+const COMPOSER_DRAFT_WRITE_DELAY_MS = 250;
 // Persisted ↑/↓ prompt-history recall stack for the chat composer.
 const COMPOSER_HISTORY_KEY = "cave:chat-composer-history:v1";
 // Initial render cap: while the reader is pinned to the newest content, only the
@@ -4031,7 +4032,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Persist the composer draft so a reload restores a half-written message.
   // Cleared (key removed) when the input empties — e.g. after a send.
   useEffect(() => {
-    writeComposerDraft(input);
+    const timer = window.setTimeout(() => {
+      writeComposerDraft(input);
+    }, COMPOSER_DRAFT_WRITE_DELAY_MS);
+    return () => window.clearTimeout(timer);
   }, [input]);
 
   // Persist the ↑/↓ prompt-history so past prompts survive a reload.

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -251,8 +251,8 @@ assert.match(
 );
 assert.match(
   source,
-  /useEffect\(\(\) => \{\s*writeHomeDraft\(text\);\s*\}, \[text\]\)/,
-  "the home draft is persisted whenever the prompt changes",
+  /useEffect\(\(\) => \{\s*const timer = window\.setTimeout\(\(\) => \{\s*writeHomeDraft\(text\);\s*\}, HOME_DRAFT_WRITE_DELAY_MS\);\s*return \(\) => window\.clearTimeout\(timer\);\s*\}, \[text\]\)/,
+  "the home draft is debounced so mobile typing does not write localStorage on every keystroke",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -67,6 +67,7 @@ type Props = {
 // Persist the in-progress prompt so a page reload doesn't eat what you were
 // typing on the home screen (mirrors the chat composer's draft persistence).
 const HOME_DRAFT_KEY = "cave:home-composer-draft:v1";
+const HOME_DRAFT_WRITE_DELAY_MS = 250;
 // Persisted ↑/↓ prompt-history recall stack for the home composer.
 const HOME_HISTORY_KEY = "cave:home-composer-history:v1";
 
@@ -289,7 +290,10 @@ export function HomeComposer({
   // Persist the draft so a reload restores it; cleared when the input empties
   // (e.g. after a send), so sent prompts don't reappear.
   useEffect(() => {
-    writeHomeDraft(text);
+    const timer = window.setTimeout(() => {
+      writeHomeDraft(text);
+    }, HOME_DRAFT_WRITE_DELAY_MS);
+    return () => window.clearTimeout(timer);
   }, [text]);
 
   // Persist the ↑/↓ prompt-history so past prompts survive a reload.

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -142,6 +142,26 @@ assert.match(
   /if \(!activeFamiliarHydrated\) return;[\s\S]*setFamiliarScope\(\[\.\.\.scopeIds\]\)/,
   "Workspace should not write scope storage until after the mount restore runs",
 );
+assert.match(
+  workspace,
+  /usePausablePoll\(\(\) => void refreshDaemonStatus\(\), 5000, \{\s*pauseWhileInputActive: true,?\s*\}\)/,
+  "Workspace pauses the daemon-status poll while a mobile text input is active",
+);
+assert.match(
+  workspace,
+  /usePausablePoll\(\(\) => void loadSessions\(\), 4000, \{\s*pauseWhileInputActive: true,?\s*\}\)/,
+  "Workspace pauses the heavy sessions poll while a mobile text input is active",
+);
+assert.match(
+  workspace,
+  /usePausablePoll\(\(\) => void refreshEscalations\(\), 30_000, \{\s*pauseWhileInputActive: true,?\s*\}\)/,
+  "Workspace pauses the escalation poll while a mobile text input is active",
+);
+assert.match(
+  workspace,
+  /usePausablePoll\(\(\) => void refreshOpenTaskCards\(\), 60_000, \{\s*pauseWhileInputActive: true,?\s*\}\)/,
+  "Workspace pauses the task-card poll while a mobile text input is active",
+);
 
 assert.doesNotMatch(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -576,7 +576,9 @@ export function Workspace() {
   useEffect(() => {
     void refreshDaemonStatus();
   }, [refreshDaemonStatus]);
-  usePausablePoll(() => void refreshDaemonStatus(), 5000);
+  usePausablePoll(() => void refreshDaemonStatus(), 5000, {
+    pauseWhileInputActive: true,
+  });
 
   // Push / dismiss the daemon-offline banner into the shared shell channel so
   // it appears at the top of every surface, not just Chat.
@@ -695,7 +697,9 @@ export function Workspace() {
     loadFamiliars();
     loadSessions();
   }, [loadFamiliars, loadSessions]);
-  usePausablePoll(() => void loadSessions(), 4000);
+  usePausablePoll(() => void loadSessions(), 4000, {
+    pauseWhileInputActive: true,
+  });
 
   const refreshPrefs = useCallback(async () => {
     try {
@@ -1004,7 +1008,9 @@ export function Workspace() {
   useEffect(() => {
     void refreshEscalations();
   }, [refreshEscalations]);
-  usePausablePoll(() => void refreshEscalations(), 30_000);
+  usePausablePoll(() => void refreshEscalations(), 30_000, {
+    pauseWhileInputActive: true,
+  });
 
   const refreshOpenTaskCards = useCallback(async () => {
     try {
@@ -1049,7 +1055,9 @@ export function Workspace() {
   useEffect(() => {
     void refreshOpenTaskCards();
   }, [refreshOpenTaskCards]);
-  usePausablePoll(() => void refreshOpenTaskCards(), 60_000);
+  usePausablePoll(() => void refreshOpenTaskCards(), 60_000, {
+    pauseWhileInputActive: true,
+  });
 
   const handleEnrichTasks = useCallback(async () => {
     if (!activeId || enrichingTasks) return;

--- a/src/lib/use-pausable-poll.test.ts
+++ b/src/lib/use-pausable-poll.test.ts
@@ -7,8 +7,8 @@ const src = readFileSync(new URL("./use-pausable-poll.ts", import.meta.url), "ut
 // ── Signature ────────────────────────────────────────────────────────────────
 assert.match(
   src,
-  /export function usePausablePoll\(\s*callback: \(\) => void,\s*intervalMs: number,\s*opts\?: \{ enabled\?: boolean \},\s*\): void/,
-  "usePausablePoll(callback, intervalMs, { enabled }) returns void",
+  /export function usePausablePoll\(\s*callback: \(\) => void,\s*intervalMs: number,\s*opts\?: \{ enabled\?: boolean; pauseWhileInputActive\?: boolean \},\s*\): void/,
+  "usePausablePoll(callback, intervalMs, { enabled, pauseWhileInputActive }) returns void",
 );
 
 // ── Recurring poll pauses while the tab is hidden ────────────────────────────
@@ -17,6 +17,21 @@ assert.match(
   /const id = setInterval\(\(\) => \{[\s\S]*?if \(typeof document !== "undefined" && document\.hidden\) return;[\s\S]*?cbRef\.current\(\);[\s\S]*?\}, intervalMs\)/,
   "the interval skips the callback while the tab is hidden",
 );
+assert.match(
+  src,
+  /function pollPausedForActiveInput\(pauseWhileInputActive: boolean\): boolean/,
+  "the shared input-focus pause helper is centralized for interval and focus refresh paths",
+);
+assert.match(
+  src,
+  /active instanceof HTMLTextAreaElement[\s\S]*active instanceof HTMLInputElement[\s\S]*active instanceof HTMLSelectElement[\s\S]*active\.isContentEditable/,
+  "active text fields, selects, and contentEditable elements can pause nonessential polls",
+);
+assert.match(
+  src,
+  /if \(pollPausedForActiveInput\(pauseWhileInputActive\)\) return;/,
+  "the interval skips nonessential callbacks while the user is composing text",
+);
 assert.match(src, /return \(\) => clearInterval\(id\)/, "the interval is cleared on cleanup");
 
 // ── Disabled stops polling entirely ──────────────────────────────────────────
@@ -24,11 +39,15 @@ assert.match(src, /if \(!enabled\) return;/, "passing { enabled: false } suspend
 
 // ── Resume reuses the existing foreground hook (no re-rolled visibilitychange) ─
 assert.match(src, /import \{ useRefreshOnFocus \} from "@\/lib\/use-refresh-on-focus"/, "composes the existing useRefreshOnFocus");
-assert.match(src, /useRefreshOnFocus\(\(\) => cbRef\.current\(\), \{ enabled \}\)/, "an immediate refresh fires when the app regains the foreground");
+assert.match(
+  src,
+  /useRefreshOnFocus\(\(\) => \{[\s\S]*?if \(pollPausedForActiveInput\(pauseWhileInputActive\)\) return;[\s\S]*?cbRef\.current\(\);[\s\S]*?\}, \{ enabled \}\)/,
+  "foreground refresh also respects active input composition",
+);
 assert.doesNotMatch(src, /addEventListener\("visibilitychange"/, "no hand-rolled visibilitychange listener — that lives in useRefreshOnFocus");
 
 // ── Stable interval across callback identity changes ─────────────────────────
 assert.match(src, /const cbRef = useRef\(callback\);\s*cbRef\.current = callback;/, "the callback is read via a ref so the interval isn't torn down each render");
-assert.match(src, /\}, \[enabled, intervalMs\]\)/, "the poll effect depends only on enabled + intervalMs");
+assert.match(src, /\}, \[enabled, intervalMs, pauseWhileInputActive\]\)/, "the poll effect depends only on enabled + intervalMs + input-pause mode");
 
 console.log("use-pausable-poll.test.ts: ok");

--- a/src/lib/use-pausable-poll.ts
+++ b/src/lib/use-pausable-poll.ts
@@ -16,16 +16,30 @@ import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
  *
  * The recurring poll is suspended while `document.hidden`, so a backgrounded tab
  * stops hitting the network. Pass `{ enabled: false }` to stop polling entirely
- * (e.g. only poll while a run is active). The initial mount load stays the
- * caller's job — this hook only schedules the recurring poll + the on-return
- * refresh.
+ * (e.g. only poll while a run is active). Pass `{ pauseWhileInputActive: true }`
+ * for nonessential shell polls that should not compete with mobile composition.
+ * The initial mount load stays the caller's job — this hook only schedules the
+ * recurring poll + the on-return refresh.
  */
+function pollPausedForActiveInput(pauseWhileInputActive: boolean): boolean {
+  if (!pauseWhileInputActive || typeof document === "undefined") return false;
+  const active = document.activeElement;
+  if (!active) return false;
+  return (
+    active instanceof HTMLTextAreaElement ||
+    active instanceof HTMLInputElement ||
+    active instanceof HTMLSelectElement ||
+    (active instanceof HTMLElement && active.isContentEditable)
+  );
+}
+
 export function usePausablePoll(
   callback: () => void,
   intervalMs: number,
-  opts?: { enabled?: boolean },
+  opts?: { enabled?: boolean; pauseWhileInputActive?: boolean },
 ): void {
   const enabled = opts?.enabled ?? true;
+  const pauseWhileInputActive = opts?.pauseWhileInputActive ?? false;
   // Read the latest callback via a ref so a changing callback identity doesn't
   // tear down and recreate the interval on every render.
   const cbRef = useRef(callback);
@@ -35,12 +49,16 @@ export function usePausablePoll(
     if (!enabled) return;
     const id = setInterval(() => {
       if (typeof document !== "undefined" && document.hidden) return;
+      if (pollPausedForActiveInput(pauseWhileInputActive)) return;
       cbRef.current();
     }, intervalMs);
     return () => clearInterval(id);
-  }, [enabled, intervalMs]);
+  }, [enabled, intervalMs, pauseWhileInputActive]);
 
   // Immediate refresh on regaining the foreground (browser focus/visibility +
   // Tauri native focus), so returning to the tab doesn't wait out the interval.
-  useRefreshOnFocus(() => cbRef.current(), { enabled });
+  useRefreshOnFocus(() => {
+    if (pollPausedForActiveInput(pauseWhileInputActive)) return;
+    cbRef.current();
+  }, { enabled });
 }


### PR DESCRIPTION
## Summary
- debounce chat and home composer draft writes so mobile typing does not hit localStorage on every keystroke
- let nonessential workspace polling pause while text/select/contentEditable input is active
- guard chat stream event enqueue after abort/close to avoid late child output writing into a closed stream

## Verification
- node --experimental-strip-types src/lib/use-pausable-poll.test.ts
- node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts
- node --experimental-strip-types src/components/workspace-familiars-landing.test.ts
- node --experimental-strip-types src/components/chat-view-lifecycle.test.ts
- node --experimental-strip-types src/components/home-composer.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app
- pnpm test:api
- pnpm test:mobile
- git diff --check origin/main...HEAD