### PR TITLE
feat: show hub executor availability

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -532,6 +532,7 @@ export const SUITES = {
     "src/app/api/app/latest-release/route.test.ts",
     "src/app/api/opencoven-tools/status/route.test.ts",
     "src/app/api/daemon/status/route.test.ts",
+    "src/lib/executor-status.test.ts",
     "src/app/api/projects/route.test.ts",
     "src/app/api/coven/exec/route.test.ts",
     "src/lib/coven-daemon.test.ts",

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -24,6 +24,18 @@ assert.match(
 
 assert.match(
   source,
+  /executorStatusesForConfig\(config\)/,
+  "daemon status should check configured executor node availability from Cave config",
+);
+
+assert.match(
+  source,
+  /executors: executorStatuses/,
+  "daemon status response should include executor node availability",
+);
+
+assert.match(
+  source,
   /reason: target\.error/,
   "an unconfigured hub should be reported as an explicit status failure",
 );

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "@/lib/cave-config";
 import { callDaemon, daemonTargetForConfig, type DaemonTarget } from "@/lib/coven-daemon";
 import { covenWorkspaceRoot } from "@/lib/coven-paths";
 import { displayCovenVersion, installedCovenVersion } from "@/lib/coven-version";
+import { executorStatusesForConfig } from "@/lib/executor-status";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -27,12 +28,14 @@ function targetSummary(target: DaemonTarget) {
 export async function GET() {
   const config = await loadConfig();
   const target = daemonTargetForConfig(config);
+  const executorStatuses = await executorStatusesForConfig(config);
   if (target.mode === "unconfigured-hub") {
     const root = covenWorkspaceRoot();
     return NextResponse.json({
       running: false,
       reason: target.error,
       target: targetSummary(target),
+      executors: executorStatuses,
       workspacePath: root,
       projectRoot: root,
     });
@@ -45,6 +48,7 @@ export async function GET() {
       running: false,
       reason: target.mode === "hub" ? `hub unreachable: ${res.error ?? `http ${res.status}`}` : res.error ?? `http ${res.status}`,
       target: targetSummary(target),
+      executors: executorStatuses,
       workspacePath: root,
       projectRoot: root,
     });
@@ -62,6 +66,7 @@ export async function GET() {
     }),
     daemon: res.data.daemon,
     target: targetSummary(target),
+    executors: executorStatuses,
     workspacePath: root,
     projectRoot: root,
   });

--- a/src/app/api/onboarding/setup/route.test.ts
+++ b/src/app/api/onboarding/setup/route.test.ts
@@ -49,6 +49,27 @@ assert.match(
   "setup route should preserve existing.marketplace (installed plugins) when writing the next config",
 );
 
+// 5. Multi-host daemon routing is part of onboarding now: setup may receive
+//    hub/executor config, and rerunning setup must preserve the existing value
+//    when the user does not provide one.
+assert.match(
+  source,
+  /multiHost\?:\s*Partial<CaveMultiHostConfig>/,
+  "setup route should accept optional multi-host config from onboarding",
+);
+
+assert.match(
+  source,
+  /multiHost:\s*normalizeMultiHostConfig\(\{/,
+  "setup route should normalize onboarding multi-host config before writing it",
+);
+
+assert.match(
+  source,
+  /\.\.\.\(body\.multiHost \?\? \{\}\)/,
+  "setup route should preserve existing multi-host config when onboarding does not send an update",
+);
+
 // 5. Defensive guard: ensure nextConfig is NOT a literal that only enumerates
 //    {version, defaults, familiars} — i.e. block the regression. We assert
 //    the pre-fix shape doesn't appear verbatim.

--- a/src/app/api/onboarding/setup/route.ts
+++ b/src/app/api/onboarding/setup/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
-import { loadConfig } from "@/lib/cave-config";
+import {
+  loadConfig,
+  normalizeMultiHostConfig,
+  type CaveMultiHostConfig,
+} from "@/lib/cave-config";
 import {
   buildFamiliarsToml,
   familiarsTomlContainsId,
@@ -23,6 +27,7 @@ type SetupBody = {
   harness?: string;
   model?: string;
   familiar?: OnboardingFamiliarInput;
+  multiHost?: Partial<CaveMultiHostConfig>;
 };
 
 async function pathExists(p: string): Promise<boolean> {
@@ -137,6 +142,10 @@ export async function POST(req: Request) {
     roles: existing.roles,
     addons: existing.addons,
     marketplace: existing.marketplace,
+    multiHost: normalizeMultiHostConfig({
+      ...existing.multiHost,
+      ...(body.multiHost ?? {}),
+    }),
   };
   await writeFile(configJson, JSON.stringify(nextConfig, null, 2), "utf8");
   wrote.push("cave-config.json");

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -204,6 +204,24 @@ assert.match(
 
 assert.match(
   source,
+  /saveOnboardingConnection/,
+  "onboarding should provide a setup-time save path for local/server hub routing",
+);
+
+assert.match(
+  source,
+  /body: JSON\.stringify\(\{ multiHost: \{ mode: onboardingMultiHostMode, hubUrl: onboardingHubUrl, executorUrls: parseOnboardingExecutorUrls\(onboardingExecutorText\) \} \}\)/,
+  "onboarding should persist hub URL and executor addresses through /api/onboarding/setup",
+);
+
+assert.match(
+  source,
+  /Server hub URL/,
+  "onboarding daemon step should expose the server hub URL field",
+);
+
+assert.match(
+  source,
   /Start the daemon first\. Familiar creation unlocks once Cave can reach it\./,
   "the familiar step explains why creation is unavailable while the daemon is offline",
 );

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -329,6 +329,19 @@ type GuidedStep = {
   icon: IconName;
 };
 
+type MultiHostMode = "local" | "hub";
+
+function parseOnboardingExecutorUrls(text: string): string[] {
+  return Array.from(
+    new Set(
+      text
+        .split(/\r?\n|,/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
 export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [status, setStatus] = useState<OnboardingStatus | null>(null);
   const [platform, setPlatform] = useState<PlatformId>("unknown");
@@ -383,6 +396,12 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [sshCwd, setSshCwd] = useState("");
   const [sshCommand, setSshCommand] = useState("");
   const [sshCheck, setSshCheck] = useState<SshCheckState>({ state: "idle" });
+  const [onboardingMultiHostMode, setOnboardingMultiHostMode] =
+    useState<MultiHostMode>("local");
+  const [onboardingHubUrl, setOnboardingHubUrl] = useState("");
+  const [onboardingExecutorText, setOnboardingExecutorText] = useState("");
+  const [savingOnboardingConnection, setSavingOnboardingConnection] =
+    useState(false);
   // Created familiars (final step lists them with Edit affordances)
   const [familiarsList, setFamiliarsList] = useState<CaveFamiliar[]>([]);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -409,6 +428,20 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   }, []);
 
   useEffect(() => setPlatform(detectPlatform()), []);
+
+  useEffect(() => {
+    if (!open) return;
+    fetch("/api/config", { cache: "no-store" })
+      .then((res) => res.json())
+      .then((json: { ok?: boolean; config?: { multiHost?: { mode?: MultiHostMode; hubUrl?: string; executorUrls?: string[] } } }) => {
+        const multiHost = json.config?.multiHost;
+        if (!json.ok || !multiHost) return;
+        setOnboardingMultiHostMode(multiHost.mode === "hub" ? "hub" : "local");
+        setOnboardingHubUrl(multiHost.hubUrl ?? "");
+        setOnboardingExecutorText((multiHost.executorUrls ?? []).join("\n"));
+      })
+      .catch(() => {});
+  }, [open]);
 
   const loadOpenClawAgents = useCallback(async () => {
     setAgentsLoading(true);
@@ -1094,6 +1127,25 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   };
 
+  const saveOnboardingConnection = async () => {
+    setSavingOnboardingConnection(true);
+    setSetupError(null);
+    try {
+      const res = await fetch("/api/onboarding/setup", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ multiHost: { mode: onboardingMultiHostMode, hubUrl: onboardingHubUrl, executorUrls: parseOnboardingExecutorUrls(onboardingExecutorText) } }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.ok === false) throw new Error(json.error ?? "connection setup failed");
+      await refresh();
+    } catch (err) {
+      setSetupError(err instanceof Error ? err.message : "connection setup failed");
+    } finally {
+      setSavingOnboardingConnection(false);
+    }
+  };
+
   const editFamiliar = (id: string) => {
     // The studio renders under this overlay, so close the overlay first.
     onDismiss();
@@ -1520,6 +1572,63 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                           />
                         ) : step.key === "daemon" ? (
                           <div className="flex flex-col gap-3">
+                            <div className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/45 p-3">
+                              <div className="mb-2 flex flex-wrap items-center gap-2">
+                                <span className="text-[12px] font-medium text-[var(--text-primary)]">Daemon connection</span>
+                                <button
+                                  type="button"
+                                  onClick={() => setOnboardingMultiHostMode("local")}
+                                  className={`focus-ring rounded-md border px-2 py-1 text-[11px] ${
+                                    onboardingMultiHostMode === "local"
+                                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-white"
+                                      : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                                  }`}
+                                >
+                                  Local
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() => setOnboardingMultiHostMode("hub")}
+                                  className={`focus-ring rounded-md border px-2 py-1 text-[11px] ${
+                                    onboardingMultiHostMode === "hub"
+                                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-white"
+                                      : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+                                  }`}
+                                >
+                                  Server hub
+                                </button>
+                              </div>
+                              <label className="grid gap-1 text-[11px] text-[var(--text-secondary)]">
+                                Server hub URL
+                                <input
+                                  value={onboardingHubUrl}
+                                  onChange={(event) => setOnboardingHubUrl(event.target.value)}
+                                  placeholder="http://server.tailnet:8787"
+                                  disabled={onboardingMultiHostMode !== "hub"}
+                                  className="rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-primary)] outline-none disabled:opacity-50"
+                                />
+                              </label>
+                              <label className="mt-2 grid gap-1 text-[11px] text-[var(--text-secondary)]">
+                                Executor addresses
+                                <textarea
+                                  value={onboardingExecutorText}
+                                  onChange={(event) => setOnboardingExecutorText(event.target.value)}
+                                  placeholder={"executor-1.tailnet:8787\nexecutor-2.tailnet:8787"}
+                                  disabled={onboardingMultiHostMode !== "hub"}
+                                  rows={2}
+                                  className="resize-y rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-1.5 font-mono text-[11px] text-[var(--text-primary)] outline-none disabled:opacity-50"
+                                />
+                              </label>
+                              <button
+                                type="button"
+                                onClick={() => void saveOnboardingConnection()}
+                                disabled={savingOnboardingConnection}
+                                className="focus-ring mt-2 inline-flex items-center gap-2 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-60"
+                              >
+                                <Icon name="ph:floppy-disk-bold" width={12} />
+                                {savingOnboardingConnection ? "Saving..." : "Save connection"}
+                              </button>
+                            </div>
                             <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
                               The coven daemon runs your familiars in the
                               background. Cave starts it for you — or run{" "}

--- a/src/components/settings-daemon-multihost.test.ts
+++ b/src/components/settings-daemon-multihost.test.ts
@@ -42,6 +42,18 @@ assert.match(
 );
 
 assert.match(
+  shell,
+  /Executor nodes/,
+  "Daemon status UI should label configured executor node availability",
+);
+
+assert.match(
+  shell,
+  /status\?\.executors\?\.map/,
+  "Daemon status UI should render every executor availability row returned by /api/daemon/status",
+);
+
+assert.match(
   sections,
   /daemon: \["Runtime health", "Local\/hub routing", "Socket & version"\]/,
   "Daemon settings overview should advertise local/hub routing",

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -65,6 +65,13 @@ type DaemonStatus = {
   apiVersion?: string;
   workspacePath?: string;
   daemon?: { pid: number; startedAt: string; socket: string };
+  executors?: Array<{
+    url: string;
+    healthUrl: string;
+    ok: boolean;
+    state: "available" | "unreachable";
+    detail: string;
+  }>;
   target?: {
     mode: "local" | "hub" | "unconfigured-hub";
     label: string;
@@ -570,6 +577,25 @@ function DaemonSection() {
             <p className="basis-full text-[11px] text-[var(--color-danger)]">
               {status.target.url} is not reachable from this Cave.
             </p>
+          )}
+          {mode === "hub" && (status?.executors?.length ?? 0) > 0 && (
+            <div className="basis-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2">
+              <div className="mb-1 flex items-center gap-2 text-[11px] font-medium text-[var(--text-secondary)]">
+                <Icon name="ph:terminal-window" width={12} />
+                Executor nodes
+              </div>
+              <div className="space-y-1">
+                {status?.executors?.map((executor) => (
+                  <div key={executor.url} className="flex min-w-0 flex-wrap items-center gap-2 text-[11px]">
+                    <span className={`h-2 w-2 rounded-full ${executor.ok ? "bg-[var(--color-success)]" : "bg-red-400"}`} />
+                    <span className="min-w-0 truncate font-mono text-[var(--text-primary)]">{executor.url}</span>
+                    <span className={executor.ok ? "text-[var(--color-success)]" : "text-[var(--color-danger)]"}>
+                      {executor.detail}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
           )}
         </div>
       </SettingsGroup>

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -175,7 +175,7 @@ export async function loadConfig(): Promise<CaveConfig> {
   }
 }
 
-function normalizeMultiHostConfig(input: Partial<CaveMultiHostConfig> | undefined): CaveMultiHostConfig {
+export function normalizeMultiHostConfig(input: Partial<CaveMultiHostConfig> | undefined): CaveMultiHostConfig {
   const mode = input?.mode === "hub" ? "hub" : "local";
   const hubUrl = typeof input?.hubUrl === "string" ? input.hubUrl.trim() : "";
   const executorUrls = Array.from(

--- a/src/lib/executor-status.test.ts
+++ b/src/lib/executor-status.test.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+const {
+  checkExecutorAvailability,
+  normalizeExecutorUrl,
+} = await import("./executor-status.ts");
+
+assert.equal(
+  normalizeExecutorUrl(" executor-1.tailnet:8787/ "),
+  "http://executor-1.tailnet:8787",
+  "executor address shorthand should normalize to an HTTP private-network target",
+);
+
+assert.equal(
+  normalizeExecutorUrl("https://executor-2.tailnet:9443/"),
+  "https://executor-2.tailnet:9443",
+  "executor HTTPS targets should preserve their scheme",
+);
+
+{
+  const calls = [];
+  const statuses = await checkExecutorAvailability(
+    [
+      "executor-1.tailnet:8787",
+      "executor-1.tailnet:8787",
+      "https://executor-2.tailnet:9443/",
+      "",
+      "executor-3.tailnet:8787",
+    ],
+    {
+      timeoutMs: 25,
+      fetchImpl: async (url) => {
+        calls.push(String(url));
+        if (String(url).startsWith("http://executor-1.tailnet:8787/")) {
+          return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }
+        if (String(url).startsWith("https://executor-2.tailnet:9443/")) {
+          return new Response(JSON.stringify({ ok: false }), { status: 200 });
+        }
+        throw Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+      },
+    },
+  );
+
+  assert.deepEqual(calls, [
+    "http://executor-1.tailnet:8787/api/v1/health",
+    "https://executor-2.tailnet:9443/api/v1/health",
+    "http://executor-3.tailnet:8787/api/v1/health",
+  ]);
+  assert.deepEqual(statuses, [
+    {
+      url: "http://executor-1.tailnet:8787",
+      healthUrl: "http://executor-1.tailnet:8787/api/v1/health",
+      ok: true,
+      state: "available",
+      detail: "executor reachable",
+    },
+    {
+      url: "https://executor-2.tailnet:9443",
+      healthUrl: "https://executor-2.tailnet:9443/api/v1/health",
+      ok: false,
+      state: "unreachable",
+      detail: "executor reported unhealthy",
+    },
+    {
+      url: "http://executor-3.tailnet:8787",
+      healthUrl: "http://executor-3.tailnet:8787/api/v1/health",
+      ok: false,
+      state: "unreachable",
+      detail: "executor offline",
+    },
+  ]);
+}
+
+console.log("executor-status.test.ts: ok");

--- a/src/lib/executor-status.ts
+++ b/src/lib/executor-status.ts
@@ -1,0 +1,116 @@
+import type { CaveConfig } from "./cave-config.ts";
+import { normalizeHubUrl } from "./coven-daemon.ts";
+
+export type ExecutorAvailability = {
+  url: string;
+  healthUrl: string;
+  ok: boolean;
+  state: "available" | "unreachable";
+  detail: string;
+};
+
+type FetchLike = (
+  input: string,
+  init?: { signal?: AbortSignal },
+) => Promise<Response>;
+
+type CheckExecutorOptions = {
+  timeoutMs?: number;
+  fetchImpl?: FetchLike;
+};
+
+export function normalizeExecutorUrl(rawUrl: string): string {
+  return normalizeHubUrl(rawUrl);
+}
+
+function executorHealthUrl(rawUrl: string): string {
+  const url = normalizeExecutorUrl(rawUrl);
+  return new URL("/api/v1/health", `${url}/`).toString();
+}
+
+function normalizeExecutorError(err: unknown): string {
+  if (err instanceof DOMException && err.name === "AbortError") {
+    return "executor timeout";
+  }
+  const code = err && typeof err === "object" ? (err as { code?: unknown }).code : null;
+  if (code === "ENOENT" || code === "ECONNREFUSED" || code === "EHOSTUNREACH") {
+    return "executor offline";
+  }
+  if (err instanceof Error && err.message === "timeout") return "executor timeout";
+  return err instanceof Error && err.message.trim() ? err.message : "executor unreachable";
+}
+
+async function fetchWithTimeout(
+  fetchImpl: FetchLike,
+  url: string,
+  timeoutMs: number,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkExecutorAvailability(
+  urls: string[],
+  options: CheckExecutorOptions = {},
+): Promise<ExecutorAvailability[]> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 800;
+  const normalizedUrls = Array.from(
+    new Set(urls.map(normalizeExecutorUrl).filter(Boolean)),
+  );
+
+  return Promise.all(
+    normalizedUrls.map(async (url) => {
+      const healthUrl = executorHealthUrl(url);
+      try {
+        const res = await fetchWithTimeout(fetchImpl, healthUrl, timeoutMs);
+        if (!res.ok) {
+          return {
+            url,
+            healthUrl,
+            ok: false,
+            state: "unreachable" as const,
+            detail: `executor http ${res.status}`,
+          };
+        }
+        const data = await res.json().catch(() => null);
+        if (data && typeof data === "object" && (data as { ok?: unknown }).ok === false) {
+          return {
+            url,
+            healthUrl,
+            ok: false,
+            state: "unreachable" as const,
+            detail: "executor reported unhealthy",
+          };
+        }
+        return {
+          url,
+          healthUrl,
+          ok: true,
+          state: "available" as const,
+          detail: "executor reachable",
+        };
+      } catch (err) {
+        return {
+          url,
+          healthUrl,
+          ok: false,
+          state: "unreachable" as const,
+          detail: normalizeExecutorError(err),
+        };
+      }
+    }),
+  );
+}
+
+export function executorStatusesForConfig(
+  config: Pick<CaveConfig, "multiHost">,
+): Promise<ExecutorAvailability[]> {
+  if (config.multiHost.mode !== "hub") return Promise.resolve([]);
+  return checkExecutorAvailability(config.multiHost.executorUrls);
+}


### PR DESCRIPTION
## Summary
- add executor availability checks for configured hub executor nodes
- include executor status rows in /api/daemon/status and Settings -> Daemon
- let onboarding save local/server hub mode, hub URL, and executor addresses through /api/onboarding/setup

## Verification
- node --experimental-strip-types src/lib/executor-status.test.ts
- node --experimental-strip-types src/app/api/daemon/status/route.test.ts
- node --experimental-strip-types src/components/settings-daemon-multihost.test.ts
- node --experimental-strip-types src/app/api/onboarding/setup/route.test.ts
- node --experimental-strip-types src/components/onboarding-guided-steps.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app
- pnpm test:api
- pnpm test:mobile
- pnpm build
- git diff --check

Closes the remaining executor/onboarding/status slice of #2052.