### PR TITLE
feat: wake local daemon for travel mode

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -535,6 +535,7 @@ export const SUITES = {
     "src/app/api/daemon/status/route.test.ts",
     "src/app/api/travel/client/route.test.ts",
     "src/lib/executor-status.test.ts",
+    "src/lib/daemon-start.test.ts",
     "src/app/api/projects/route.test.ts",
     "src/app/api/coven/exec/route.test.ts",
     "src/lib/coven-daemon.test.ts",

--- a/src/app/api/daemon/start/route.test.ts
+++ b/src/app/api/daemon/start/route.test.ts
@@ -4,17 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 
-assert.match(
-  source,
-  /isMissingExecutableError\(err\)[\s\S]*covenCliMissingError\(\)/,
-  "daemon start should not surface raw spawn coven ENOENT on new installs",
-);
-
-assert.match(
-  source,
-  /shell: process\.platform === "win32"/,
-  "daemon start runs Windows npm .cmd shims through shell mode",
-);
+assert.match(source, /startLocalDaemon\(\{ restart \}\)/, "daemon start should use the shared local daemon starter");
 
 assert.match(
   source,
@@ -30,8 +20,8 @@ assert.match(
 
 assert.match(
   source,
-  /if \(!restart\) \{[\s\S]*callDaemon\(\{ path: "\/api\/v1\/health", timeoutMs: 1500 \}\)[\s\S]*alreadyRunning: true[\s\S]*\}/,
-  "plain start should stay idempotent while restart bypasses the healthy-daemon guard",
+  /NextResponse\.json\(result, \{ status: "status" in result \? result\.status : 200 \}\)/,
+  "daemon start route should preserve helper-provided error statuses",
 );
 
 console.log("daemon start route.test.ts: ok");

--- a/src/app/api/daemon/start/route.ts
+++ b/src/app/api/daemon/start/route.ts
@@ -1,8 +1,5 @@
 import { NextResponse } from "next/server";
-import { spawn } from "node:child_process";
-import { callDaemon } from "@/lib/coven-daemon";
-import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
-import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
+import { startLocalDaemon } from "@/lib/daemon-start";
 
 export const dynamic = "force-dynamic";
 
@@ -15,56 +12,6 @@ export async function POST(request: Request) {
   // (e.g. a launchd KeepAlive agent) for the socket — the supervisor relaunches
   // its copy while the restart spawns another, churning the socket. A healthy
   // daemon means "start" has nothing to do, so report it as already running.
-  if (!restart) {
-    const health = await callDaemon({ path: "/api/v1/health", timeoutMs: 1500 });
-    if (health.ok) {
-      return NextResponse.json({ ok: true, alreadyRunning: true });
-    }
-  }
-
-  return new Promise<Response>((resolve) => {
-    const child = spawn(covenBin(), ["daemon", "start"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: false,
-      env: covenSpawnEnv(),
-      // Windows npm exposes CLI shims as .cmd files. The daemon-start argv is
-      // fixed by this route, so shell mode is safe here and lets Node launch
-      // those shims instead of raising ENOENT after status already found them.
-      shell: process.platform === "win32",
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve(
-        NextResponse.json(
-          { ok: false, error: "timeout", stdout, stderr },
-          { status: 504 },
-        ),
-      );
-    }, 8000);
-
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      resolve(
-        NextResponse.json(
-          isMissingExecutableError(err)
-            ? covenCliMissingError()
-            : { ok: false, error: err.message },
-          { status: 500 },
-        ),
-      );
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve(
-        NextResponse.json({ ok: code === 0, exitCode: code, restart, stdout, stderr }),
-      );
-    });
-  });
+  const result = await startLocalDaemon({ restart });
+  return NextResponse.json(result, { status: "status" in result ? result.status : 200 });
 }

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -54,6 +54,18 @@ assert.match(
 
 assert.match(
   source,
+  /startLocalDaemon\(\)/,
+  "daemon status should wake the laptop-local daemon when travel mode takes authority",
+);
+
+assert.match(
+  source,
+  /recordLocalSubdaemonWakeRequest\(\)/,
+  "daemon status should persist that travel mode requested a local sub-daemon wake",
+);
+
+assert.match(
+  source,
   /reason: target\.error/,
   "an unconfigured hub should be reported as an explicit status failure",
 );

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
-import { loadConfig, loadState, recordTravelHubReachability } from "@/lib/cave-config";
+import { loadConfig, loadState, recordLocalSubdaemonWakeRequest, recordTravelHubReachability } from "@/lib/cave-config";
 import { callDaemon, daemonTargetForConfig, type DaemonTarget } from "@/lib/coven-daemon";
 import { covenWorkspaceRoot } from "@/lib/coven-paths";
 import { displayCovenVersion, installedCovenVersion } from "@/lib/coven-version";
+import { startLocalDaemon } from "@/lib/daemon-start";
 import { executorStatusesForConfig } from "@/lib/executor-status";
 import { deriveTravelClientStatus } from "@/lib/travel-client-state";
 
@@ -55,11 +56,20 @@ export async function GET() {
     hubReachable = res.ok;
     travelState = await recordTravelHubReachability(res.ok);
   }
-  const travelStatus = deriveTravelClientStatus({
+  let travelStatus = deriveTravelClientStatus({
     multiHost: config.multiHost,
     travel: travelState,
     hubReachable,
   });
+  if (target.mode === "hub" && travelStatus.wakeLocalSubdaemon) {
+    await startLocalDaemon();
+    travelState = await recordLocalSubdaemonWakeRequest();
+    travelStatus = deriveTravelClientStatus({
+      multiHost: config.multiHost,
+      travel: travelState,
+      hubReachable,
+    });
+  }
   const root = covenWorkspaceRoot();
   if (!res.ok || !res.data) {
     return NextResponse.json({

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -492,6 +492,16 @@ export async function recordTravelHubReachability(reachable: boolean, now = new 
   });
 }
 
+export async function recordLocalSubdaemonWakeRequest(now = new Date()): Promise<CaveTravelState> {
+  return updateState((state) => {
+    state.travel = normalizeTravelState(state.travel);
+    state.travel.localSubdaemonWakeRequestedAt = nowIso(now);
+    state.travel.localBindHost = "127.0.0.1";
+    state.travel.staleCache = true;
+    return state.travel;
+  });
+}
+
 export async function enqueueOfflineTravelItem(
   item: {
     kind: CaveTravelQueueItem["kind"];

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -95,7 +95,7 @@ export function normalizeHubUrl(rawUrl: string): string {
 
 export function daemonTargetForConfig(config: Pick<CaveConfig, "multiHost">): DaemonTarget {
   if (config.multiHost?.mode !== "hub") {
-    return { mode: "local", label: "Local daemon", socketPath: socketPath() };
+    return localDaemonTarget();
   }
   const url = normalizeHubUrl(config.multiHost.hubUrl ?? "");
   if (!url) {
@@ -106,6 +106,10 @@ export function daemonTargetForConfig(config: Pick<CaveConfig, "multiHost">): Da
     };
   }
   return { mode: "hub", label: "Server hub", url };
+}
+
+export function localDaemonTarget(): Extract<DaemonTarget, { mode: "local" }> {
+  return { mode: "local", label: "Local daemon", socketPath: socketPath() };
 }
 
 async function loadDaemonTarget(): Promise<DaemonTarget> {
@@ -148,6 +152,18 @@ export async function callDaemon<T = unknown>({
   timeoutMs = 4000,
 }: DaemonRequest): Promise<DaemonResponse<T>> {
   const target = await loadDaemonTarget();
+  return callDaemonTarget<T>(target, { method, path: reqPath, body, timeoutMs });
+}
+
+export async function callDaemonTarget<T = unknown>(
+  target: DaemonTarget,
+  {
+    method = "GET",
+    path: reqPath,
+    body,
+    timeoutMs = 4000,
+  }: DaemonRequest,
+): Promise<DaemonResponse<T>> {
   if (target.mode === "unconfigured-hub") {
     return {
       ok: false,

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -1,0 +1,44 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const daemonStart = await readFile(new URL("./daemon-start.ts", import.meta.url), "utf8");
+const covenDaemon = await readFile(new URL("./coven-daemon.ts", import.meta.url), "utf8");
+
+assert.match(
+  covenDaemon,
+  /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/,
+  "coven-daemon should expose an explicit local target even when Cave is configured for a hub",
+);
+
+assert.match(
+  covenDaemon,
+  /export async function callDaemonTarget/,
+  "coven-daemon should let callers invoke a specific daemon target",
+);
+
+assert.match(
+  daemonStart,
+  /callDaemonTarget\(localDaemonTarget\(\), \{ path: "\/api\/v1\/health", timeoutMs: healthTimeoutMs \}\)/,
+  "local daemon wake should check the laptop-local socket before spawning",
+);
+
+assert.match(
+  daemonStart,
+  /spawn\(covenBin\(\), \["daemon", "start"\]/,
+  "local daemon wake should start the Coven daemon through the existing CLI command",
+);
+
+assert.match(
+  daemonStart,
+  /shell: process\.platform === "win32"/,
+  "local daemon wake should preserve Windows npm shim support",
+);
+
+assert.match(
+  daemonStart,
+  /isMissingExecutableError\(err\)[\s\S]*covenCliMissingError\(\)/,
+  "local daemon wake should keep the missing-CLI error contract",
+);
+
+console.log("daemon-start.test.ts: ok");

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -1,0 +1,60 @@
+import { spawn } from "node:child_process";
+import { callDaemonTarget, localDaemonTarget } from "@/lib/coven-daemon";
+import { covenBin, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
+
+export type DaemonStartResult =
+  | { ok: true; alreadyRunning: true }
+  | { ok: boolean; exitCode: number | null; restart: boolean; stdout: string; stderr: string }
+  | { ok: false; error: string; stdout?: string; stderr?: string; status?: number };
+
+type StartLocalDaemonOptions = {
+  restart?: boolean;
+  healthTimeoutMs?: number;
+  startTimeoutMs?: number;
+};
+
+export async function startLocalDaemon({
+  restart = false,
+  healthTimeoutMs = 1500,
+  startTimeoutMs = 8000,
+}: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
+  if (!restart) {
+    const health = await callDaemonTarget(localDaemonTarget(), { path: "/api/v1/health", timeoutMs: healthTimeoutMs });
+    if (health.ok) return { ok: true, alreadyRunning: true };
+  }
+
+  return new Promise<DaemonStartResult>((resolve) => {
+    const child = spawn(covenBin(), ["daemon", "start"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: false,
+      env: covenSpawnEnv(),
+      shell: process.platform === "win32",
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d.toString()));
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolve({ ok: false, error: "timeout", stdout, stderr, status: 504 });
+    }, startTimeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      if (isMissingExecutableError(err)) {
+        const missing = covenCliMissingError();
+        resolve({ ...missing, ok: false, status: 500 });
+        return;
+      }
+      resolve({ ok: false, error: err.message, status: 500 });
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ ok: code === 0, exitCode: code, restart, stdout, stderr });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extract local daemon startup into a shared server helper that can check the laptop-local socket even when Cave is configured for a hub.
- Have /api/daemon/status start the local daemon when travel mode takes authority after hub loss, then persist the local wake request timestamp.
- Keep /api/daemon/start on the same helper and add guard tests for the travel wake contract.

## Verification
- pnpm install --frozen-lockfile
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/daemon-start.test.ts
- node --experimental-strip-types src/app/api/daemon/status/route.test.ts
- node --experimental-strip-types src/app/api/daemon/start/route.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/travel-client-state.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- node scripts/run-tests.mjs app api mobile
- pnpm build
- git diff --check

Refs #2053