### PR TITLE
Queue chat sends during travel-local mode

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -548,6 +548,7 @@ export const SUITES = {
     "src/app/api/board/enrich-steps/route.test.ts",
     "src/app/api/board/[id]/chat/route.test.ts",
     "src/app/api/chat/send/harness-routing.test.ts",
+    "src/app/api/chat/send/offline-queue.test.ts",
     "src/app/api/library/route-link/route.test.ts",
     "src/app/api/onboarding/status/route.test.ts",
     "src/app/api/onboarding/install/route.test.ts",

--- a/src/app/api/chat/send/offline-queue.test.ts
+++ b/src/app/api/chat/send/offline-queue.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const chatRoute = await readFile(
+  new URL("./route.ts", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  chatRoute,
+  /import \{ deriveTravelClientStatus \} from "@\/lib\/travel-client-state";/,
+  "Chat send should derive travel authority before deciding whether to spawn a harness",
+);
+
+assert.match(
+  chatRoute,
+  /enqueueOfflineTravelItem\(\{\s*kind: "chat"/,
+  "Offline travel chat sends should persist a chat item in the travel queue",
+);
+
+assert.match(
+  chatRoute,
+  /hubReachable: state\.travel\.hubUnreachableSince \? false : null/,
+  "Chat send should respect a previously recorded hub outage without probing the hub inline",
+);
+
+assert.match(
+  chatRoute,
+  /if \(travelStatus\.authority !== "travel-local"\) return null;/,
+  "Only travel-local authority should divert chat sends into the offline queue",
+);
+
+assert.match(
+  chatRoute,
+  /attachments: args\.persistedAttachments/,
+  "Queued offline chat payloads should keep transcript-safe attachment metadata, not preview payloads",
+);
+
+assert.match(
+  chatRoute,
+  /id: "queued-offline"[\s\S]*label: "Queued for travel sync"/,
+  "The SSE response should tell the chat UI that the turn was queued offline",
+);
+
+assert.match(
+  chatRoute,
+  /"content-type": "text\/event-stream; charset=utf-8"/,
+  "Queued offline chat should preserve the /api/chat/send SSE contract",
+);
+
+const postIndex = chatRoute.indexOf("export async function POST");
+const accessIndex = chatRoute.indexOf("await assertProjectAccess", postIndex);
+const queueIndex = chatRoute.indexOf(
+  "const offlineChatResponse = await maybeQueueOfflineChat",
+  postIndex,
+);
+const imageWriteIndex = chatRoute.indexOf("writeImageAttachmentsToTemp", queueIndex);
+const harnessPromptIndex = chatRoute.indexOf("const harnessPrompt =", queueIndex);
+
+assert.ok(postIndex >= 0, "Chat send POST handler should exist");
+assert.ok(accessIndex >= 0, "Chat send should still perform project access checks");
+assert.ok(queueIndex > accessIndex, "Offline queueing must run after project access checks");
+assert.ok(
+  queueIndex < imageWriteIndex,
+  "Offline queueing should run before image temp-file writes",
+);
+assert.ok(
+  queueIndex < harnessPromptIndex,
+  "Offline queueing should run before prompt assembly and harness spawning work",
+);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { stripAnsi } from "@/lib/ansi";
 import {
   bindingFor,
+  enqueueOfflineTravelItem,
   type CaveConfig,
   type FamiliarBinding,
   loadConfig,
@@ -102,6 +103,7 @@ import {
 } from "@/lib/usage-format";
 import type { ChatResponseMetadata } from "@/lib/chat-response-metadata";
 import type { StreamEvent } from "@/lib/stream-events";
+import { deriveTravelClientStatus } from "@/lib/travel-client-state";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -133,6 +135,25 @@ type SendBody = {
 
 type ReasoningEffort = "low" | "medium" | "high";
 type ResponseSpeed = "fast" | "balanced" | "careful";
+
+type OfflineChatQueuePayload = Pick<
+  SendBody,
+  | "familiarId"
+  | "projectRoot"
+  | "modelOverride"
+  | "modelOverrideScope"
+  | "reasoningEffort"
+  | "responseSpeed"
+  | "mentionedFiles"
+  | "mentionedFilesRoot"
+  | "parentTurnId"
+  | "origin"
+> & {
+  prompt: string;
+  sessionId: string;
+  attachments: ChatAttachment[];
+  responseMetadata: ChatResponseMetadata;
+};
 
 
 // Hook-line shapes emitted by codex/claude harnesses while a tool runs.
@@ -382,6 +403,75 @@ async function setDefaultSessionTitleIfMissing(sessionId: string, title: string)
 
 function sse(event: StreamEvent): Uint8Array {
   return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+async function maybeQueueOfflineChat(args: {
+  body: SendBody;
+  config: CaveConfig;
+  promptText: string;
+  persistedAttachments: ChatAttachment[];
+  responseMetadata: ChatResponseMetadata;
+}): Promise<Response | null> {
+  const state = await loadState();
+  const travelStatus = deriveTravelClientStatus({
+    multiHost: args.config.multiHost,
+    travel: state.travel,
+    hubReachable: state.travel.hubUnreachableSince ? false : null,
+  });
+  if (travelStatus.authority !== "travel-local") return null;
+
+  const sessionId = args.body.sessionId ?? crypto.randomUUID();
+  const payload: OfflineChatQueuePayload = {
+    familiarId: args.body.familiarId,
+    prompt: args.promptText,
+    sessionId,
+    projectRoot: args.body.projectRoot,
+    modelOverride: args.body.modelOverride,
+    modelOverrideScope: args.body.modelOverrideScope,
+    reasoningEffort: args.body.reasoningEffort,
+    responseSpeed: args.body.responseSpeed,
+    attachments: args.persistedAttachments,
+    mentionedFiles: args.body.mentionedFiles,
+    mentionedFilesRoot: args.body.mentionedFilesRoot,
+    parentTurnId: args.body.parentTurnId,
+    origin: args.body.origin,
+    responseMetadata: args.responseMetadata,
+  };
+  const queued = await enqueueOfflineTravelItem({
+    kind: "chat",
+    summary: chatTitleFromPrompt(args.promptText) ?? `Offline chat with ${args.body.familiarId}`,
+    payload,
+  });
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: (controller) => {
+      const push = (event: StreamEvent) => controller.enqueue(sse(event));
+      push({ kind: "session", sessionId });
+      push({ kind: "user", text: args.promptText });
+      push({
+        kind: "progress",
+        id: "queued-offline",
+        label: "Queued for travel sync",
+        status: "done",
+        detail: `${travelStatus.reason}: ${queued.id}`,
+      });
+      push({
+        kind: "done",
+        isError: false,
+        sessionId,
+        responseMetadata: args.responseMetadata,
+      });
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    },
+  });
 }
 
 // Model parity: probe once per process whether the installed `coven run`
@@ -967,6 +1057,14 @@ export async function POST(req: Request) {
     modelApplicationState: modelState.applicationState,
     modelApplicationReason: modelState.reason,
   };
+  const offlineChatResponse = await maybeQueueOfflineChat({
+    body,
+    config,
+    promptText,
+    persistedAttachments,
+    responseMetadata,
+  });
+  if (offlineChatResponse) return offlineChatResponse;
 
   // Image delivery channel: only local coven-run harnesses can Read files on
   // this machine. The OpenClaw bridge and SSH runtimes cannot, so their


### PR DESCRIPTION
## Summary
- queue `/api/chat/send` turns into the persisted travel offline queue whenever travel-local authority owns the client
- preserve the chat SSE contract with a queued-offline progress event and done event instead of spawning a harness
- add an API contract test guarding queue placement after project access and before image/harness side effects

## Test Plan
- `node --experimental-strip-types src/app/api/chat/send/offline-queue.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/app/api/chat/send/harness-routing.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/travel-client-state.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `node scripts/run-tests.mjs app api mobile`
- `pnpm build`
- `git diff --check`

Refs #2053
