### PR TITLE
Queue workflow work during travel-local mode

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -534,6 +534,7 @@ export const SUITES = {
     "src/app/api/opencoven-tools/status/route.test.ts",
     "src/app/api/daemon/status/route.test.ts",
     "src/app/api/travel/client/route.test.ts",
+    "src/app/api/travel/offline-work-queue.test.ts",
     "src/lib/executor-status.test.ts",
     "src/lib/daemon-start.test.ts",
     "src/app/api/projects/route.test.ts",

--- a/src/app/api/codex-automations/[id]/run/route.ts
+++ b/src/app/api/codex-automations/[id]/run/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
+import { enqueueOfflineTravelItem, loadConfig } from "@/lib/cave-config";
 import { getCodexAutomation } from "@/lib/codex-automations";
+import { recordRun } from "@/lib/automation-runs";
 import { startAutomationRun } from "@/lib/server/automation-runner";
 import { isLocalOrigin } from "@/lib/server/local-origin";
+import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +17,40 @@ export async function POST(req: Request, { params }: Params) {
   const { id } = await params;
   const auto = await getCodexAutomation(id);
   if (!auto) return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
+  const config = await loadConfig();
+  const travelStatus = await travelLocalQueueStatus(config);
+  if (travelStatus) {
+    const queued = await enqueueOfflineTravelItem({
+      kind: "job",
+      summary: `Automation: ${auto.name}`,
+      payload: {
+        route: `/api/codex-automations/${auto.id}/run`,
+        automation: {
+          id: auto.id,
+          name: auto.name,
+          model: auto.model,
+          cwds: auto.cwds,
+          familiars: auto.familiars,
+          prompt: auto.prompt,
+        },
+      },
+    });
+    const run = await recordRun({
+      automationId: auto.id,
+      automationName: auto.name,
+      startedAt: queued.createdAt,
+      status: "queued",
+      summary: `queued offline ${queued.id}`,
+    });
+    return NextResponse.json({
+      ok: true,
+      queued: true,
+      queueItem: queued,
+      run,
+      executor: "travel-queue",
+      travel: { reason: travelStatus.reason },
+    });
+  }
   try {
     const run = await startAutomationRun(auto);
     return NextResponse.json({ ok: true, run });

--- a/src/app/api/travel/offline-work-queue.test.ts
+++ b/src/app/api/travel/offline-work-queue.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const workflowRunRoute = await readFile(new URL("../workflows/run/route.ts", import.meta.url), "utf8");
+const flowExecutor = await readFile(new URL("../../../lib/server/flow-executor.ts", import.meta.url), "utf8");
+const automationRunRoute = await readFile(
+  new URL("../codex-automations/[id]/run/route.ts", import.meta.url),
+  "utf8",
+);
+const travelHelper = await readFile(new URL("../../../lib/travel-offline-queue.ts", import.meta.url), "utf8");
+const flows = await readFile(new URL("../../../lib/flows.ts", import.meta.url), "utf8");
+const flowExecutions = await readFile(new URL("../../../components/flow/flow-executions.tsx", import.meta.url), "utf8");
+const flowRunSteps = await readFile(new URL("../../../components/flow/flow-run-steps.tsx", import.meta.url), "utf8");
+const flowFilters = await readFile(new URL("../../../lib/flow/flow-execution-filters.ts", import.meta.url), "utf8");
+const automationRuns = await readFile(new URL("../../../lib/automation-runs.ts", import.meta.url), "utf8");
+const automationsView = await readFile(new URL("../../../components/automations-view.tsx", import.meta.url), "utf8");
+
+assert.match(
+  travelHelper,
+  /deriveTravelClientStatus\(\{[\s\S]*hubReachable: state\.travel\.hubUnreachableSince \? false : null/,
+  "Travel queue helper should respect recorded hub outages without probing inline",
+);
+assert.match(
+  travelHelper,
+  /return status\.authority === "travel-local" \? status : null/,
+  "Only travel-local authority should divert work into the offline queue",
+);
+
+assert.match(workflowRunRoute, /travelLocalQueueStatus\(config\)/, "Workflow runs should check travel-local authority");
+assert.match(workflowRunRoute, /enqueueOfflineTravelItem\(\{[\s\S]*kind: "workflow"/, "Workflow runs should queue workflow work");
+assert.match(workflowRunRoute, /status:\s*"queued"/, "Workflow run history should show queued offline runs");
+assert.match(workflowRunRoute, /executor:\s*"travel-queue"/, "Workflow queue responses should name the travel queue executor");
+assert.ok(
+  workflowRunRoute.indexOf("const offlineWorkflowResponse = await maybeQueueOfflineWorkflow") <
+    workflowRunRoute.indexOf("path: \"/api/v1/workflows/run\""),
+  "Workflow queueing should run before daemon engine calls",
+);
+
+assert.match(flowExecutor, /travelLocalQueueStatus\(config\)/, "Flow execution should check travel-local authority");
+assert.match(flowExecutor, /enqueueOfflineTravelItem\(\{[\s\S]*kind: "workflow"/, "Flow execution should queue workflow work");
+assert.match(flowExecutor, /status:\s*"queued"/, "Flow run history should show queued offline runs");
+assert.match(flowExecutor, /executor:\s*"travel-queue"/, "Flow queue responses should name the travel queue executor");
+assert.ok(
+  flowExecutor.indexOf("const travelStatus = await travelLocalQueueStatus(config)") <
+    flowExecutor.indexOf("path: \"/api/v1/sessions\""),
+  "Flow queueing should run before daemon session spawning",
+);
+
+assert.match(automationRunRoute, /travelLocalQueueStatus\(config\)/, "Automation jobs should check travel-local authority");
+assert.match(automationRunRoute, /enqueueOfflineTravelItem\(\{[\s\S]*kind: "job"/, "Automation jobs should queue job work");
+assert.match(automationRunRoute, /status:\s*"queued"/, "Automation run history should show queued offline jobs");
+assert.match(automationRunRoute, /executor:\s*"travel-queue"/, "Automation queue responses should name the travel queue executor");
+assert.ok(
+  automationRunRoute.indexOf("const travelStatus = await travelLocalQueueStatus(config)") <
+    automationRunRoute.indexOf("startAutomationRun(auto)"),
+  "Automation queueing should run before codex exec spawning",
+);
+
+assert.match(flows, /FlowRunStatus = "preview" \| "queued" \| "running"/, "Flow run type should include queued");
+assert.match(flowExecutions, /queued: "Queued"/, "Flow executions list should label queued runs");
+assert.match(flowExecutions, /queued: 0/, "Flow executions list should count queued runs");
+assert.match(flowRunSteps, /queued: "Queued"/, "Flow run detail should label queued runs");
+assert.match(flowFilters, /\{ value: "queued", label: "Queued" \}/, "Flow execution filters should expose queued runs");
+assert.match(automationRuns, /AutomationRunStatus = "queued" \| "running"/, "Automation run type should include queued");
+assert.match(automationsView, /r\.status === "queued" \? "var\(--color-warning\)"/, "Automation run rows should tint queued jobs");
+
+console.log("offline-work-queue.test.ts: ok");

--- a/src/app/api/workflows/run/route.ts
+++ b/src/app/api/workflows/run/route.ts
@@ -1,8 +1,15 @@
 import { NextResponse } from "next/server";
-import { bindingFor, loadConfig, recordSessionFamiliar, setSessionTitle } from "@/lib/cave-config";
+import {
+  bindingFor,
+  enqueueOfflineTravelItem,
+  loadConfig,
+  recordSessionFamiliar,
+  setSessionTitle,
+} from "@/lib/cave-config";
 import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isAllowedHarness, MAX_SESSION_JSON_BYTES, normalizeProjectRoot } from "@/lib/server/session-security";
+import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
 import { buildWorkflowRunPrompt } from "@/lib/workflow-run-prompt";
 import { recordRun } from "@/lib/workflow-runs";
 import { loadLocalWorkflowList } from "@/lib/workflow-source";
@@ -33,8 +40,56 @@ async function resolveWorkflow(body: RunBody): Promise<WorkflowSummary | null> {
   );
 }
 
+async function maybeQueueOfflineWorkflow(body: RunBody, workflow: WorkflowSummary | null): Promise<Response | null> {
+  const config = await loadConfig();
+  const travelStatus = await travelLocalQueueStatus(config);
+  if (!travelStatus) return null;
+
+  const workflowId = workflow?.id ?? body.id ?? body.path ?? "unknown";
+  const queued = await enqueueOfflineTravelItem({
+    kind: "workflow",
+    summary: workflow?.name ? `Workflow: ${workflow.name}` : `Workflow: ${workflowId}`,
+    payload: {
+      route: "/api/workflows/run",
+      body,
+      workflow: workflow
+        ? {
+            id: workflow.id,
+            name: workflow.name,
+            version: workflow.version,
+            path: workflow.path,
+          }
+        : null,
+    },
+  });
+  const run = await recordRun({
+    workflowId,
+    version: workflow?.version,
+    kind: "execution",
+    status: "queued",
+    startedAt: queued.createdAt,
+    steps: (workflow?.steps ?? []).map((step) => ({
+      id: step.id,
+      kind: step.kind,
+      status: "ready" as const,
+    })),
+    summary: `queued offline ${queued.id}`,
+    source: "cave",
+  });
+
+  return NextResponse.json({
+    ok: true,
+    queued: true,
+    queueItem: queued,
+    run,
+    executor: "travel-queue",
+    travel: { reason: travelStatus.reason },
+  });
+}
+
 /**
- * Execute a workflow. Two executors, daemon-first:
+ * Execute a workflow. Travel-local clients queue work first; online execution
+ * still uses two executors, daemon-first:
  *
  *  1. The daemon's native workflow engine (`/api/v1/workflows/run`), if it ever
  *     lands. Forward-compatible — when present, we use it verbatim.
@@ -71,6 +126,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: blocked }, { status: 400 });
     }
   }
+  const offlineWorkflowResponse = await maybeQueueOfflineWorkflow(body, gateWorkflow);
+  if (offlineWorkflowResponse) return offlineWorkflowResponse;
 
   // 1. Native daemon engine first (forward-compatible).
   const engine = await callDaemon<DaemonRunResponse>({

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1064,7 +1064,7 @@ function CodexDetailPanel({
                     className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-[12px] hover:bg-white/5"
                   >
                     <span aria-hidden className="h-2 w-2 shrink-0 rounded-full" style={{ background:
-                      r.status === "succeeded" ? "var(--accent-presence)" : r.status === "failed" ? "var(--color-danger)" : "var(--text-muted)" }} />
+                      r.status === "succeeded" ? "var(--accent-presence)" : r.status === "failed" ? "var(--color-danger)" : r.status === "queued" ? "var(--color-warning)" : "var(--text-muted)" }} />
                     <span style={{ color: "var(--text-secondary)" }} title={r.startedAt ? formatTimestamp(r.startedAt, readDateTimePrefs()) : undefined}>{relTime(r.startedAt)}</span>
                     {r.summary && <span className="truncate" style={{ color: "var(--text-muted)" }}>{r.summary}</span>}
                     <span aria-hidden className="ml-auto shrink-0" style={{ color: "var(--text-muted)", lineHeight: 0 }}>
@@ -1190,6 +1190,7 @@ function AutomationScheduleRow({
           <span className="shrink-0 text-[11px]" title={lastRun.startedAt ? formatTimestamp(lastRun.startedAt, readDateTimePrefs()) : undefined} style={{ color:
             lastRun.status === "failed" ? "var(--color-danger)"
             : lastRun.status === "running" ? "var(--accent-presence)"
+            : lastRun.status === "queued" ? "var(--color-warning)"
             : "var(--text-muted)" }}>
             Run {relTime(lastRun.startedAt)}
           </span>

--- a/src/components/flow/flow-executions.tsx
+++ b/src/components/flow/flow-executions.tsx
@@ -17,6 +17,7 @@ import type { FlowRunRecord, FlowRunStatus } from "@/lib/flows";
 
 const STATUS_LABEL: Record<FlowRunStatus, string> = {
   preview: "Preview",
+  queued: "Queued",
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",
@@ -60,6 +61,7 @@ export function FlowExecutions({
     const next: Record<FlowExecutionStatusFilter, number> = {
       all: runs.length,
       preview: 0,
+      queued: 0,
       running: 0,
       succeeded: 0,
       failed: 0,

--- a/src/components/flow/flow-run-steps.tsx
+++ b/src/components/flow/flow-run-steps.tsx
@@ -10,6 +10,7 @@ import { stripStepMarkers } from "@/lib/workflow-step-progress";
 
 const STATUS_LABEL: Record<FlowRunRecord["status"], string> = {
   preview: "Preview",
+  queued: "Queued",
   running: "Running",
   succeeded: "Succeeded",
   failed: "Failed",

--- a/src/lib/automation-runs.ts
+++ b/src/lib/automation-runs.ts
@@ -12,7 +12,7 @@ import path from "node:path";
  */
 export const AUTOMATION_RUNS_CAP = 200;
 
-export type AutomationRunStatus = "running" | "succeeded" | "failed";
+export type AutomationRunStatus = "queued" | "running" | "succeeded" | "failed";
 export type AutomationRunRecord = {
   id: string;
   automationId: string;

--- a/src/lib/flow/flow-execution-filters.ts
+++ b/src/lib/flow/flow-execution-filters.ts
@@ -5,6 +5,7 @@ export type FlowExecutionStartedFilter = "any" | "hour" | "today" | "week";
 
 export const FLOW_EXECUTION_STATUS_FILTERS: Array<{ value: FlowExecutionStatusFilter; label: string }> = [
   { value: "all", label: "All" },
+  { value: "queued", label: "Queued" },
   { value: "running", label: "Running" },
   { value: "succeeded", label: "Succeeded" },
   { value: "failed", label: "Failed" },

--- a/src/lib/flows.ts
+++ b/src/lib/flows.ts
@@ -9,7 +9,7 @@ import type { FlowExecutionMode } from "./flow/flow-compile.ts";
 
 export type { FlowDoc, FlowNode, FlowEdge } from "./flow/flow-doc.ts";
 
-export type FlowRunStatus = "preview" | "running" | "succeeded" | "failed";
+export type FlowRunStatus = "preview" | "queued" | "running" | "succeeded" | "failed";
 
 export type FlowRunStepStatus = "pending" | "running" | "succeeded" | "failed" | "skipped";
 
@@ -48,9 +48,10 @@ export type FlowMutationResponse = { ok: boolean; error?: string };
 export type FlowRunsResponse = { ok: boolean; runs: FlowRunRecord[]; error?: string };
 export type FlowRunResponse = {
   ok: boolean;
-  executor?: "session" | "engine";
+  executor?: "session" | "engine" | "travel-queue";
   sessionId?: string;
   run?: FlowRunRecord;
+  queued?: boolean;
   unavailable?: boolean;
   error?: string;
 };

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -1,4 +1,11 @@
-import { bindingFor, loadConfig, recordSessionFamiliar, setSessionTitle } from "@/lib/cave-config";
+import {
+  bindingFor,
+  enqueueOfflineTravelItem,
+  loadConfig,
+  recordSessionFamiliar,
+  setSessionTitle,
+  type CaveTravelQueueItem,
+} from "@/lib/cave-config";
 import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
 import { catalogNode } from "@/lib/flow/flow-catalog";
 import {
@@ -18,13 +25,16 @@ import { extractFlowCustomData } from "@/lib/flow/flow-execution-data";
 import type { FlowRunRecord, FlowRunStepStatus } from "@/lib/flows";
 import { recordFlowRun } from "@/lib/server/flow-store";
 import { isAllowedHarness, normalizeProjectRoot } from "@/lib/server/session-security";
+import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
 
 export type StartFlowSessionResult = {
   ok: boolean;
   status?: number;
-  executor?: "session";
+  executor?: "session" | "travel-queue";
   sessionId?: string;
   run?: FlowRunRecord;
+  queued?: boolean;
+  queueItem?: CaveTravelQueueItem;
   unavailable?: boolean;
   error?: string;
 };
@@ -86,6 +96,44 @@ export async function startFlowSession(
       ok: false,
       error: `harness '${binding.harness}' can't run as an agent session`,
       status: 409,
+    };
+  }
+  const travelStatus = await travelLocalQueueStatus(config);
+  if (travelStatus) {
+    const order = options.targetNodeId ? flowPartialExecutionOrder(flow, options.targetNodeId) : flowExecutionOrder(flow);
+    const byId = new Map(flow.nodes.map((node) => [node.id, node]));
+    const queued = await enqueueOfflineTravelItem({
+      kind: "workflow",
+      summary: options.targetNodeId ? `Flow step: ${flow.name} / ${options.targetNodeId}` : `Flow: ${flow.name}`,
+      payload: {
+        route: "flow-session",
+        flow,
+        options,
+        familiarId,
+        harness: binding.harness,
+      },
+    });
+    const run = await recordFlowRun({
+      flowId: flow.id,
+      flowName: flow.name,
+      status: "queued",
+      mode: options.mode ?? "manual",
+      startedAt: queued.createdAt,
+      steps: order.map((stepId) => ({
+        id: stepId,
+        type: byId.get(stepId)?.type ?? "unknown",
+        status: "pending",
+      })),
+      summary: `queued offline ${queued.id}`,
+      source: "cave",
+      flowSnapshot: flow,
+    });
+    return {
+      ok: true,
+      executor: "travel-queue",
+      queued: true,
+      queueItem: queued,
+      run,
     };
   }
 

--- a/src/lib/travel-offline-queue.ts
+++ b/src/lib/travel-offline-queue.ts
@@ -1,0 +1,13 @@
+import type { CaveConfig } from "@/lib/cave-config";
+import { loadState } from "@/lib/cave-config";
+import { deriveTravelClientStatus, type TravelClientStatus } from "@/lib/travel-client-state";
+
+export async function travelLocalQueueStatus(config: CaveConfig): Promise<TravelClientStatus | null> {
+  const state = await loadState();
+  const status = deriveTravelClientStatus({
+    multiHost: config.multiHost,
+    travel: state.travel,
+    hubReachable: state.travel.hubUnreachableSince ? false : null,
+  });
+  return status.authority === "travel-local" ? status : null;
+}


### PR DESCRIPTION
## Summary
- queue Workflow Studio runs, Flow executions/webhooks, and Codex automation run-now jobs while travel-local authority owns the client
- record queued workflow/flow/automation run history so pending work is visible outside the daemon settings count
- add a shared travel-local queue-status helper and source contract coverage for queue-before-spawn behavior

## Test Plan
- `node --experimental-strip-types src/app/api/travel/offline-work-queue.test.ts`
- `node --experimental-strip-types src/app/api/workflows/run/route.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/app/api/flows/run/route.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/flow/flow-execution-filters.test.ts`
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/automation-runs.test.ts`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `node scripts/run-tests.mjs app api mobile`
- `pnpm build`
- `git diff --check`

Refs #2053
