### PR TITLE
Add secret preflight guard

### DIFF
--- a/scripts/git-hooks-pre-commit.test.mjs
+++ b/scripts/git-hooks-pre-commit.test.mjs
@@ -64,4 +64,15 @@ function runHook(repo) {
   assert.match(result.stderr, /GitHub PAT/i);
 }
 
+{
+  const token = "sk-" + "or-v1-" + "a".repeat(64);
+  const repo = stagedRepo({
+    filePath: "src/lib/secrets.test.ts",
+    content: `const token = "${token}";\n`,
+  });
+  const result = runHook(repo);
+  assert.notEqual(result.status, 0, "OpenRouter key-shaped strings should be blocked");
+  assert.match(result.stderr, /OpenRouter/i);
+}
+
 console.log("git-hooks-pre-commit.test.mjs: ok");

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -5,7 +5,7 @@
 #   1. Files matching dangerous path patterns (env files, private keys,
 #      certificates, signing material, agent scratch state).
 #   2. Inline secret-shaped strings in staged diffs (AWS, Stripe, Slack,
-#      GitHub PAT, OpenAI, Anthropic, Telegram bot tokens, generic
+#      GitHub PAT, OpenRouter, OpenAI, Anthropic, Telegram bot tokens, generic
 #      Bearer tokens, password assignments, PEM private-key blocks).
 #
 # Bypass for genuine false positives:
@@ -79,6 +79,7 @@ scan() {
 
 # Patterns intentionally aligned with src/lib/redact.ts so contributors get
 # the same coverage at commit time as users get at render time.
+scan "OpenRouter API key"    'sk-or-v1-[A-Za-z0-9_-]{32,}'
 scan "AWS access key"        'AKIA[0-9A-Z]{16}'
 scan "AWS secret access key" 'aws_secret_access_key[[:space:]]*[:=][[:space:]]*["'\'']?[A-Za-z0-9/+=]{30,}'
 scan "GitHub PAT"            'gh[pousr]_[A-Za-z0-9]{30,}'

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -518,6 +518,7 @@ export const SUITES = {
     "scripts/dependency-policy.test.mjs",
     "scripts/build-sandbox-runtime.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",
+    "scripts/secret-preflight.test.mjs",
     "scripts/uninstall-app.test.mjs",
     "src/lib/coven-paths.test.ts",
     "src/lib/server/agent-attachments.test.ts",

--- a/scripts/secret-preflight.mjs
+++ b/scripts/secret-preflight.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const PATTERNS = [
+  ["OpenRouter API key", /sk-or-v1-[A-Za-z0-9_-]{32,}/g],
+  ["AWS access key", /AKIA[0-9A-Z]{16}/g],
+  ["AWS secret access key", /aws_secret_access_key\s*[:=]\s*["']?[A-Za-z0-9/+=]{30,}/gi],
+  ["GitHub PAT", /(?:gh[pousr]_[A-Za-z0-9_]{30,}|github_pat_[A-Za-z0-9_]{20,})/g],
+  ["Slack token", /xox[abprs]-[A-Za-z0-9-]{10,}/g],
+  ["Stripe secret", /sk_(?:live|test)_[A-Za-z0-9]{20,}/g],
+  ["OpenAI key", /sk-(?:proj-)?[A-Za-z0-9_-]{32,}/g],
+  ["Anthropic key", /sk-ant-[A-Za-z0-9_-]{20,}/g],
+  ["Google API key", /AIza[0-9A-Za-z_-]{30,}/g],
+  ["Telegram bot token", /(?:^|[^0-9])[0-9]{8,11}:[A-Za-z0-9_-]{30,}/g],
+  ["Bearer token", /Bearer\s+[A-Za-z0-9_.-]{16,}/gi],
+  ["PEM private key", /BEGIN (?:(?:RSA|EC|OPENSSH|DSA|PGP|ENCRYPTED) )?PRIVATE KEY/g],
+  [
+    "password or token assignment",
+    /(?:password|passwd|secret|api[_-]?key|access[_-]?token)\s*[:=]\s*["'][^"'\s]{8,}["']/gi,
+  ],
+  ["private Tailscale Serve host", /[A-Za-z0-9-]+\.[A-Za-z0-9-]+\.ts\.net(?::[0-9]+)?/g],
+];
+
+const SAFE_TAILSCALE_RE = /(?:^|[.])example\.ts\.net|<[^>]+>\.ts\.net|\*\.ts\.net/;
+
+function usage() {
+  console.error("usage: node scripts/secret-preflight.mjs [--stdin] [--label LABEL] [file ...]");
+}
+
+function parseArgs(argv) {
+  const files = [];
+  let stdin = false;
+  let label = "secret preflight";
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--stdin") {
+      stdin = true;
+    } else if (arg === "--label") {
+      const next = argv[i + 1];
+      if (!next) {
+        usage();
+        process.exit(2);
+      }
+      label = next;
+      i += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else if (arg.startsWith("-")) {
+      console.error(`unknown option: ${arg}`);
+      usage();
+      process.exit(2);
+    } else {
+      files.push(arg);
+    }
+  }
+
+  if (!stdin && files.length === 0) {
+    usage();
+    process.exit(2);
+  }
+
+  return { files, stdin, label };
+}
+
+function readStdin() {
+  return readFileSync(0, "utf8");
+}
+
+function lineForOffset(text, offset) {
+  let line = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (text.charCodeAt(i) === 10) line += 1;
+  }
+  return line;
+}
+
+function scanText(source, text) {
+  const hits = [];
+
+  for (const [name, pattern] of PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) {
+      const value = match[0];
+      if (name === "private Tailscale Serve host" && SAFE_TAILSCALE_RE.test(value)) continue;
+      hits.push({ name, source, line: lineForOffset(text, match.index ?? 0) });
+      if (hits.length >= 20) return hits;
+    }
+  }
+
+  return hits;
+}
+
+const { files, stdin, label } = parseArgs(process.argv.slice(2));
+const documents = [];
+if (stdin) documents.push({ source: "stdin", text: readStdin() });
+for (const file of files) {
+  documents.push({ source: file, text: readFileSync(file, "utf8") });
+}
+
+const hits = documents.flatMap((doc) => scanText(doc.source, doc.text));
+if (hits.length > 0) {
+  console.error(`[secret-preflight blocked] ${label} contains possible secrets:`);
+  for (const hit of hits.slice(0, 10)) {
+    console.error(`  - ${hit.name} at ${hit.source}:${hit.line}`);
+  }
+  console.error("Secret values are intentionally not printed. Remove or redact them before sending/committing.");
+  process.exit(1);
+}
+
+console.error(`[secret-preflight] ok (${documents.length} input${documents.length === 1 ? "" : "s"} scanned)`);

--- a/scripts/secret-preflight.test.mjs
+++ b/scripts/secret-preflight.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const script = path.join(root, "scripts", "secret-preflight.mjs");
+
+function run(args, input) {
+  return spawnSync(process.execPath, [script, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    input,
+  });
+}
+
+{
+  const token = "sk-" + "or-v1-" + "a".repeat(64);
+  const result = run(["--stdin", "--label", "github issue comment"], `progress update ${token}\n`);
+  assert.notEqual(result.status, 0, "OpenRouter key-shaped strings should fail outbound preflight");
+  assert.match(result.stderr, /OpenRouter API key/i);
+  assert.doesNotMatch(result.stderr, new RegExp(token), "secret value should not be echoed");
+}
+
+{
+  const token = "ghp_" + "a".repeat(36);
+  const dir = mkdtempSync(path.join(tmpdir(), "coven-cave-secret-preflight-"));
+  const file = path.join(dir, "comment.md");
+  writeFileSync(file, `ship note ${token}\n`);
+  const result = run([file]);
+  assert.notEqual(result.status, 0, "file preflight should catch GitHub PAT-shaped strings");
+  assert.match(result.stderr, /GitHub PAT/i);
+  assert.doesNotMatch(result.stderr, new RegExp(token), "secret value should not be echoed");
+}
+
+{
+  const result = run(["--stdin", "--label", "safe comment"], "Final Phase 1C slice landed in #2122.\n");
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stderr, /ok/i);
+}
+
+console.log("secret-preflight.test.mjs: ok");

--- a/src/lib/secret-redaction.test.ts
+++ b/src/lib/secret-redaction.test.ts
@@ -16,6 +16,7 @@ const raw = {
   },
   rows: [
     "OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz1234567890",
+    `OPENROUTER_API_KEY=${"sk-" + "or-v1-" + "a".repeat(64)}`,
     "nothing private here",
   ],
 };
@@ -24,7 +25,11 @@ const redacted = redactSecretsDeep(raw);
 const serialized = JSON.stringify(redacted);
 
 assert.equal(redacted.authToken, REDACTED_SECRET, "suspicious object keys are replaced wholesale");
-assert.doesNotMatch(serialized, /ghp_|sk-ant-api03|sk-proj-|supersecret/, "known secret forms are removed");
+assert.doesNotMatch(
+  serialized,
+  /ghp_|sk-ant-api03|sk-proj-|sk-or-v1-|supersecret/,
+  "known secret forms are removed",
+);
 assert.match(serialized, /metric_before stayed visible/, "ordinary eval metadata remains readable");
 assert.match(serialized, /nothing private here/, "safe strings survive redaction");
 assert.match(

--- a/src/lib/secret-redaction.ts
+++ b/src/lib/secret-redaction.ts
@@ -5,6 +5,7 @@ const SECRET_KEY_PATTERN =
 
 const WHOLE_SECRET_PATTERNS: RegExp[] = [
   /\bBearer\s+[A-Za-z0-9._~+/=-]{20,}\b/gi,
+  /\bsk-or-v1-[A-Za-z0-9_-]{32,}\b/g,
   /\b(?:sk|rk)-(?:proj-)?[A-Za-z0-9_-]{20,}\b/g,
   /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
   /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/g,


### PR DESCRIPTION
## Summary
- add a standalone secret preflight script for outbound text/files without echoing matched values
- block OpenRouter API key shapes in the pre-commit hook
- align secret redaction coverage and wire the new preflight test into CI

## Test Plan
- [x] node scripts/secret-preflight.test.mjs && node scripts/git-hooks-pre-commit.test.mjs && node --experimental-strip-types src/lib/secret-redaction.test.ts
- [x] pnpm typecheck
- [x] pnpm check:tests-wired
- [x] node scripts/run-tests.mjs app api
- [x] pnpm build
- [x] git diff --check