### PR TITLE
ci: add cross-environment aggregate check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,17 @@ jobs:
       # Same assertions on every OS; per-OS branches run for real on their host
       # and are explicit skips elsewhere (see the suite). No silent no-ops.
       - run: pnpm test:conformance
+
+  conformance-required:
+    name: Cross-environment required
+    runs-on: ubuntu-latest
+    needs: conformance
+    if: always()
+    steps:
+      - name: Require every cross-environment matrix leg
+        run: |
+          if [ "${{ needs.conformance.result }}" != "success" ]; then
+            echo "::error::Cross-environment matrix result: ${{ needs.conformance.result }}"
+            exit 1
+          fi
+          echo "Cross-environment matrix passed on ubuntu-latest, windows-latest, and macos-latest."

--- a/docs/cross-environment.md
+++ b/docs/cross-environment.md
@@ -16,6 +16,9 @@ that diverge. It pairs with the conformance suite that enforces them.
   `macos-latest` from one matrix spec, so the *same* definition of "works" is
   executed on every target. `fail-fast: false`, so one OS failing still reports
   the others.
+- **Stable required check** — `Cross-environment required` depends on the
+  matrix and fails unless every OS leg succeeds. Use that stable job name for
+  branch protection instead of requiring each dynamic matrix leg directly.
 - **The conformance suite** — [`scripts/cross-environment.test.ts`](../scripts/cross-environment.test.ts).
   Identical assertions on every OS; branches that can only run on one platform
   run there for real and are **explicit, reasoned skips** elsewhere (printed as


### PR DESCRIPTION
## Summary
- Add a stable `Cross-environment required` aggregate job for the 3-OS conformance matrix.
- Fail the aggregate unless every matrix leg succeeds, giving branch protection one stable required check name.
- Document the required-check name in `docs/cross-environment.md`.

## Test Plan
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci yaml ok"'`
- [x] `git diff --check`

Refs #1990
