### PR TITLE
ci: add sidecar runtime smoke matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,3 +168,46 @@ jobs:
             exit 1
           fi
           echo "Cross-environment matrix passed on ubuntu-latest, windows-latest, and macos-latest."
+
+  sidecar-runtime:
+    name: Sidecar runtime (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - run: pnpm install --frozen-lockfile
+
+      # Slice B runtime proof for #1990: build the OS-specific packaged Node
+      # sidecar on each target, boot the bundled server with sidecar auth, and
+      # prove a seeded raster familiar avatar transcodes through the real HTTP
+      # route. This catches native sharp/libvips prune and packaged-server boot
+      # regressions that pure conformance assertions cannot.
+      - name: Build packaged sidecar bundle
+        shell: bash
+        run: bash scripts/sidecar-bundle.sh
+
+      - run: pnpm test:sidecar-runtime
+
+  sidecar-runtime-required:
+    name: Sidecar runtime required
+    runs-on: ubuntu-latest
+    needs: sidecar-runtime
+    if: always()
+    steps:
+      - name: Require every sidecar runtime matrix leg
+        run: |
+          if [ "${{ needs.sidecar-runtime.result }}" != "success" ]; then
+            echo "::error::Sidecar runtime matrix result: ${{ needs.sidecar-runtime.result }}"
+            exit 1
+          fi
+          echo "Sidecar runtime matrix passed on ubuntu-latest, windows-latest, and macos-latest."

--- a/docs/cross-environment.md
+++ b/docs/cross-environment.md
@@ -19,16 +19,25 @@ that diverge. It pairs with the conformance suite that enforces them.
 - **Stable required check** — `Cross-environment required` depends on the
   matrix and fails unless every OS leg succeeds. Use that stable job name for
   branch protection instead of requiring each dynamic matrix leg directly.
+- **Packaged sidecar runtime matrix** — `Sidecar runtime (<os>)` builds the
+  OS-specific bundled Node sidecar on `ubuntu-latest`, `windows-latest`, and
+  `macos-latest`, boots the packaged `server.mjs` with sidecar auth, and proves
+  a seeded raster familiar avatar is transcoded through the real HTTP route.
+  `Sidecar runtime required` is the stable aggregate check for branch
+  protection.
 - **The conformance suite** — [`scripts/cross-environment.test.ts`](../scripts/cross-environment.test.ts).
   Identical assertions on every OS; branches that can only run on one platform
   run there for real and are **explicit, reasoned skips** elsewhere (printed as
   `↷ skipped: <reason>`), never silent no-ops. Run it locally with
   `pnpm test:conformance`.
+- **The sidecar runtime smoke** — [`scripts/sidecar-runtime-smoke.mjs`](../scripts/sidecar-runtime-smoke.mjs).
+  Run it after `bash scripts/sidecar-bundle.sh` with
+  `pnpm test:sidecar-runtime`.
 
-What is **not** yet covered (tracked as Slice B in #1990, surfaced as explicit
-skips): booting the packaged OS-specific sidecar and transcoding a raster
-avatar end-to-end, and mDNS / Tailscale host discovery. Both need per-OS build
-hosts / network stacks rather than a pure unit matrix.
+What is **not** yet covered (tracked as the remaining Slice B network gap in
+#1990, surfaced as an explicit skip): mDNS / Tailscale host discovery. That
+needs the platform's real networking stack and tailnet/mDNS preconditions rather
+than a pure unit matrix.
 
 ## Neutral defaults
 
@@ -84,7 +93,9 @@ source of truth shared by `scripts/sidecar-bundle.sh` (via
 Notes:
 - `sharp` must remain a **runtime** dependency (not dev) so the production
   sidecar install includes it — the familiar avatar route transcodes raster
-  avatars at request time. Root cause: #2010.
+  avatars at request time. Root cause: #2010. The `Sidecar runtime (<os>)`
+  matrix now proves this end-to-end by booting the packaged sidecar and fetching
+  a seeded JPEG avatar as PNG on every target OS.
 - `fsevents` is kept only on darwin.
 - The release DMG/installer must be built **on the matching host arch** — the
   prune keys off the build host, same as `@next/swc` and `node-pty`. Mobile

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:api:http": "node scripts/api-http-smoke.mjs",
     "test:mobile": "node scripts/run-tests.mjs mobile",
     "test:conformance": "node scripts/run-tests.mjs conformance",
+    "test:sidecar-runtime": "node scripts/sidecar-runtime-smoke.mjs",
     "e2e:install": "playwright install chromium webkit",
     "test:e2e:mobile": "pnpm e2e:install && playwright test --project=pixel-5 --project=iphone-13",
     "test:e2e": "pnpm e2e:install && playwright test",

--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -174,11 +174,11 @@ function skip(reason: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Contract D — explicit, reasoned gaps (Slice B). These are deliberately NOT
-// asserted here; they are surfaced as skips so the report shows the gap rather
-// than a falsely-green check (#1990 acceptance criterion 5).
+// Contract D — explicit, reasoned remaining network gap. Packaged sidecar boot
+// + raster-avatar transcode is covered by the Sidecar runtime matrix; mDNS /
+// Tailscale discovery still needs real network-stack preconditions rather than
+// a pure conformance assertion.
 // ---------------------------------------------------------------------------
-skip("packaged-sidecar boot + raster-avatar transcode: requires building the OS-specific sidecar bundle (Slice B)");
 skip("mDNS / Tailscale host discovery: requires the platform's networking stack (Slice B)");
 
 console.log(`cross-environment.test.ts: ok on ${process.platform}/${process.arch} (${skips.length} explicit skip(s))`);

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -50,6 +50,22 @@ assert.match(
   "sidecar must verify sharp loads from the bundle before declaring it ready (#2010)",
 );
 
+// Some Node distributions (notably Homebrew macOS builds) ship `node` as a
+// small executable that depends on a sibling libnode shared library. The
+// packaged sidecar must copy that shared runtime and verify the bundled Node
+// actually starts, otherwise release builds can assemble a server that aborts
+// before Next boots.
+assert.match(
+  src,
+  /copy_node_shared_runtime\(\)/,
+  "sidecar must copy Node's shared runtime library when the host node depends on one",
+);
+assert.match(
+  src,
+  /\$BUNDLED_NODE_DIR\/bin\/\$NODE_NAME" -e "process\.exit\(0\)"/,
+  "sidecar must verify the bundled Node runtime starts before declaring the bundle ready",
+);
+
 // The native target mapping (@img/sharp-<target>, @next/swc-<target>, …) is now
 // owned by scripts/sidecar-target.mjs and shared with the cross-environment
 // conformance suite (#1990). The prune must consume that single source of truth

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -141,6 +141,57 @@ prune_sidecar_nonruntime_files() {
   \) -delete
 }
 
+copy_node_shared_runtime() {
+  local node_bin="$1"
+  local dest_dir="$2"
+  local lib_ref=""
+
+  case "$(uname -s)" in
+    Darwin)
+      if command -v otool >/dev/null 2>&1; then
+        lib_ref="$(otool -L "$node_bin" | awk '/libnode.*\.dylib/ {print $1; exit}')"
+      fi
+      ;;
+    Linux)
+      if command -v ldd >/dev/null 2>&1; then
+        lib_ref="$(ldd "$node_bin" | awk '/libnode.*\.so/ {print $3; exit}')"
+      fi
+      ;;
+  esac
+
+  if [ -z "$lib_ref" ]; then
+    return 0
+  fi
+
+  local lib_name="${lib_ref##*/}"
+  local lib_path=""
+  if [ -f "$lib_ref" ]; then
+    lib_path="$lib_ref"
+  else
+    local dir
+    for dir in \
+      "$(dirname "$node_bin")" \
+      "$(dirname "$node_bin")/../lib" \
+      "$(dirname "$node_bin")/../../lib" \
+      "$(dirname "$node_bin")/../../../lib"; do
+      if [ -f "$dir/$lib_name" ]; then
+        lib_path="$(cd "$dir" && pwd -P)/$lib_name"
+        break
+      fi
+    done
+  fi
+
+  if [ -z "$lib_path" ]; then
+    echo "ERROR: node runtime depends on $lib_ref, but the library could not be found" >&2
+    exit 1
+  fi
+
+  mkdir -p "$dest_dir/lib"
+  cp "$lib_path" "$dest_dir/lib/$lib_name"
+  chmod +r "$dest_dir/lib/$lib_name" 2>/dev/null || true
+  echo "==> bundled Node shared runtime $lib_name"
+}
+
 echo "==> next build"
 (cd "$ROOT" && pnpm build) >&2
 
@@ -166,6 +217,8 @@ rm -rf "$BUNDLED_NODE_DIR"
 mkdir -p "$BUNDLED_NODE_DIR/bin"
 cp "$NODE_BIN" "$BUNDLED_NODE_DIR/bin/$NODE_NAME"
 chmod +x "$BUNDLED_NODE_DIR/bin/$NODE_NAME" 2>/dev/null || true
+copy_node_shared_runtime "$NODE_BIN" "$BUNDLED_NODE_DIR"
+"$BUNDLED_NODE_DIR/bin/$NODE_NAME" -e "process.exit(0)" >/dev/null
 printf "generated at release build time\n" > "$BUNDLED_NODE_DIR/placeholder.txt"
 
 # Next.js + pnpm leaves a node_modules full of pnpm-style symlinks

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { access, mkdir, mkdtemp } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sidecarRoot = path.join(root, "src-tauri", "resources", "server");
+const sidecarServer = path.join(sidecarRoot, "server.mjs");
+const bundledNode = path.join(
+  root,
+  "src-tauri",
+  "resources",
+  "node",
+  "bin",
+  process.platform === "win32" ? "node.exe" : "node",
+);
+const token = "sidecar-runtime-smoke-token";
+
+function reservePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      assert(address && typeof address === "object");
+      const port = address.port;
+      server.close((err) => err ? reject(err) : resolve(port));
+    });
+  });
+}
+
+function waitForExit(child) {
+  return new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function requestAvatar(baseUrl, output) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 1_000);
+  try {
+    return await fetch(`${baseUrl}/api/familiars/smoke/avatar?v=1&format=png`, {
+      headers: { "x-coven-cave-token": token },
+      signal: controller.signal,
+    });
+  } catch (err) {
+    output.lastFetchError = err instanceof Error ? err.message : String(err);
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function waitForAvatar(baseUrl, output) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const res = await requestAvatar(baseUrl, output);
+    if (!res) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      continue;
+    }
+    if (res.status === 200) return res;
+    const body = await res.text();
+    throw new Error(`avatar endpoint returned HTTP ${res.status}: ${body.slice(0, 300)}`);
+  }
+  throw new Error(`timed out waiting for sidecar avatar endpoint; last fetch error: ${output.lastFetchError ?? "none"}`);
+}
+
+function attachOutput(child) {
+  const lines = [];
+  const remember = (source, chunk) => {
+    for (const line of String(chunk).split(/\r?\n/).filter(Boolean)) {
+      lines.push(`${source}: ${line}`);
+      while (lines.length > 80) lines.shift();
+    }
+  };
+  child.stdout?.on("data", (chunk) => remember("stdout", chunk));
+  child.stderr?.on("data", (chunk) => remember("stderr", chunk));
+  return {
+    lines,
+    lastFetchError: null,
+    dump() {
+      return lines.join("\n");
+    },
+  };
+}
+
+async function main() {
+  await access(sidecarServer);
+  await access(bundledNode);
+
+  const covenHome = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-smoke-"));
+  const avatarDir = path.join(covenHome, "workspaces", "familiars", "smoke", "avatars");
+  await mkdir(avatarDir, { recursive: true });
+  await sharp({
+    create: {
+      width: 640,
+      height: 320,
+      channels: 3,
+      background: { r: 238, g: 33, b: 104 },
+    },
+  })
+    .jpeg({ quality: 86 })
+    .toFile(path.join(avatarDir, "smoke.jpg"));
+
+  const port = await reservePort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const child = spawn(bundledNode, [sidecarServer], {
+    cwd: sidecarRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      NODE_ENV: "production",
+      HOSTNAME: "127.0.0.1",
+      PORT: String(port),
+      COVEN_CAVE_BUNDLE: "1",
+      COVEN_CAVE_AUTH_TOKEN: token,
+      COVEN_HOME: covenHome,
+      NEXT_TELEMETRY_DISABLED: "1",
+    },
+  });
+  const output = attachOutput(child);
+
+  try {
+    const earlyExit = Promise.race([
+      waitForExit(child).then((exit) => {
+        throw new Error(`sidecar exited before smoke completed: ${JSON.stringify(exit)}\n${output.dump()}`);
+      }),
+      new Promise((_, reject) => child.once("error", reject)),
+    ]);
+    const res = await Promise.race([waitForAvatar(baseUrl, output), earlyExit]);
+    assert.equal(res.headers.get("content-type")?.split(";")[0], "image/png");
+    const bytes = Buffer.from(await res.arrayBuffer());
+    assert.equal(bytes.subarray(0, 8).toString("hex"), "89504e470d0a1a0a", "avatar response should be PNG");
+    const meta = await sharp(bytes).metadata();
+    assert.equal(meta.format, "png");
+    assert.equal(meta.width, 256, "avatar should be downscaled to the packaged route max dimension");
+    assert.equal(meta.height, 128, "avatar should preserve aspect ratio during sidecar transcode");
+    console.log(`sidecar-runtime-smoke: ok on ${process.platform}/${process.arch} (${baseUrl})`);
+  } catch (err) {
+    console.error(output.dump());
+    throw err;
+  } finally {
+    child.kill();
+    await Promise.race([
+      waitForExit(child),
+      new Promise((resolve) => setTimeout(resolve, 2_000)),
+    ]);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- add a three-OS sidecar runtime CI matrix with a required aggregate check
- add a packaged sidecar smoke that boots the bundled server over real HTTP and verifies sharp avatar raster transcode
- copy Node shared runtime libraries into the sidecar bundle and verify bundled Node startup
- update cross-environment docs and conformance coverage for the packaged sidecar proof

Refs #1990

## Test Plan
- `node --check scripts/sidecar-runtime-smoke.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci yaml ok"'`\n- `pnpm check:tests-wired`\n- `pnpm typecheck`\n- `node scripts/run-tests.mjs conformance`\n- `node scripts/sidecar-bundle-deps.test.mjs`\n- `bash scripts/sidecar-bundle.sh`\n- `pnpm test:sidecar-runtime`\n- `git diff --check`