### PR TITLE
test: prove tailscale host discovery

### DIFF
--- a/docs/cross-environment.md
+++ b/docs/cross-environment.md
@@ -33,11 +33,13 @@ that diverge. It pairs with the conformance suite that enforces them.
 - **The sidecar runtime smoke** — [`scripts/sidecar-runtime-smoke.mjs`](../scripts/sidecar-runtime-smoke.mjs).
   Run it after `bash scripts/sidecar-bundle.sh` with
   `pnpm test:sidecar-runtime`.
-
-What is **not** yet covered (tracked as the remaining Slice B network gap in
-#1990, surfaced as an explicit skip): mDNS / Tailscale host discovery. That
-needs the platform's real networking stack and tailnet/mDNS preconditions rather
-than a pure unit matrix.
+- **Tailscale/MagicDNS discovery** — the conformance suite checks live
+  `tailscale status --self --json` when a runner has a connected Tailscale
+  daemon, then proves the MagicDNS host and derived Serve URL through the same
+  [`tailnetDiscoveryProof`](../src/lib/mobile-handoff.ts) helper used by the
+  mobile handoff API. GitHub-hosted runners are not joined to the private
+  tailnet, so they print an explicit skip for the missing Tailscale precondition
+  rather than a silent pass.
 
 ## Neutral defaults
 

--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -16,12 +16,14 @@
 // Neutral defaults and per-OS deltas are documented in docs/cross-environment.md.
 
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
 import { resolveSidecarTarget } from "./sidecar-target.mjs";
 import { covenLaunchCommandForBinary } from "../src/lib/coven-bin.ts";
+import { tailnetDiscoveryProof } from "../src/lib/mobile-handoff.ts";
 
 const skips: string[] = [];
 function skip(reason: string): void {
@@ -174,11 +176,42 @@ function skip(reason: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Contract D — explicit, reasoned remaining network gap. Packaged sidecar boot
-// + raster-avatar transcode is covered by the Sidecar runtime matrix; mDNS /
-// Tailscale discovery still needs real network-stack preconditions rather than
-// a pure conformance assertion.
+// Contract D — live Tailscale/MagicDNS host discovery when the runner has a
+// connected Tailscale daemon. CI runners are not joined to a private tailnet, so
+// they print an explicit skip; developer/release hosts that have Tailscale
+// available prove the real platform network stack instead of silently no-oping.
 // ---------------------------------------------------------------------------
-skip("mDNS / Tailscale host discovery: requires the platform's networking stack (Slice B)");
+{
+  const tailscale = spawnSync(
+    process.env.TAILSCALE_BIN || "tailscale",
+    ["status", "--self", "--json"],
+    { encoding: "utf8", timeout: 8000 },
+  );
+
+  if (tailscale.error) {
+    skip(`Tailscale/MagicDNS host discovery: tailscale CLI unavailable (${tailscale.error.message})`);
+  } else if (tailscale.status !== 0) {
+    const detail = (tailscale.stderr || tailscale.stdout || `exit ${tailscale.status}`).trim().split(/\r?\n/)[0];
+    skip(`Tailscale/MagicDNS host discovery: tailscale status unavailable (${detail || `exit ${tailscale.status}`})`);
+  } else {
+    let selfStatus: unknown;
+    try {
+      selfStatus = JSON.parse(tailscale.stdout);
+    } catch (err) {
+      assert.fail(`tailscale status --self --json returned invalid JSON: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    const proof = tailnetDiscoveryProof({
+      selfStatus,
+      serveStatus: {},
+      backendUrl: "http://127.0.0.1:3000",
+    });
+    assert.equal(proof.ok, true, proof.ok ? undefined : proof.reason);
+    assert.equal(proof.source, "magicdns-self-status", "live Tailscale proof should derive from status --self MagicDNS");
+    assert.match(proof.host, /\.ts\.net$/i, "live MagicDNS host must be a Tailscale .ts.net name");
+    assert.equal(proof.serveUrl, `https://${proof.host}/`, "MagicDNS serve URL is derived from the live host");
+    console.log("  ✓ Tailscale/MagicDNS host discovery: live status --self proof");
+  }
+}
 
 console.log(`cross-environment.test.ts: ok on ${process.platform}/${process.arch} (${skips.length} explicit skip(s))`);

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -4,9 +4,8 @@ import QRCode from "qrcode";
 import { stripAnsi } from "@/lib/ansi";
 import {
   createMobileInvite,
-  findServeUrl,
-  magicDnsServeUrl,
   MOBILE_INVITE_TTL_MS,
+  tailnetDiscoveryProof,
   tailscaleBin,
   tailscaleSpawnEnv,
 } from "@/lib/mobile-handoff";
@@ -98,14 +97,6 @@ function backendUrl(req: Request) {
   return `http://127.0.0.1:${port}`;
 }
 
-function nativeHostFromUrl(value: string) {
-  try {
-    return new URL(value).host;
-  } catch {
-    return null;
-  }
-}
-
 async function ensureNativeAppServe(req: Request) {
   const self = await runTailscale(["status", "--self", "--json"]);
   if (!self.ok) {
@@ -123,19 +114,19 @@ async function ensureNativeAppServe(req: Request) {
     ? null
     : serve.stderr || "Tailscale Serve could not be (re)started.";
 
-  let serveUrl: string | null = null;
+  let serveStatus: unknown = {};
   const status = await runTailscale(["serve", "status", "--json"]);
   if (status.ok) {
     const parsed = parseServeStatus(status.stdout);
-    if (!("error" in parsed)) serveUrl = findServeUrl(parsed.value, backend);
+    if (!("error" in parsed)) serveStatus = parsed.value;
   }
-  if (!serveUrl) serveUrl = magicDnsServeUrl(selfStatus);
+  const discovery = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
 
-  if (!serveUrl) {
+  if (!discovery.ok) {
     return NextResponse.json(
       {
         ok: false,
-        error: serveWarning ?? "tailscale serve URL not found",
+        error: serveWarning ?? discovery.reason,
         stderr: serveWarning ?? status.stderr,
         backendUrl: backend,
       },
@@ -143,7 +134,7 @@ async function ensureNativeAppServe(req: Request) {
     );
   }
 
-  const qrSvg = await QRCode.toString(serveUrl, {
+  const qrSvg = await QRCode.toString(discovery.serveUrl, {
     type: "svg",
     margin: 1,
     width: 256,
@@ -153,9 +144,10 @@ async function ensureNativeAppServe(req: Request) {
   return NextResponse.json({
     ok: true,
     backendUrl: backend,
-    serveUrl,
-    nativeUrl: serveUrl,
-    nativeHost: nativeHostFromUrl(serveUrl),
+    serveUrl: discovery.serveUrl,
+    nativeUrl: discovery.serveUrl,
+    nativeHost: discovery.host,
+    discoverySource: discovery.source,
     qrSvg,
     warning: serveWarning ?? undefined,
   });
@@ -202,23 +194,21 @@ async function mobileHandoff(req: Request) {
     : serve.stderr || "Tailscale Serve could not be (re)started.";
 
   // Prefer the real serve config when it's readable.
-  let serveUrl: string | null = null;
+  let serveStatus: unknown = {};
   const status = await runTailscale(["serve", "status", "--json"]);
   if (status.ok) {
     const parsed = parseServeStatus(status.stdout);
-    if (!("error" in parsed)) serveUrl = findServeUrl(parsed.value, backend);
+    if (!("error" in parsed)) serveStatus = parsed.value;
   }
 
-  // Fallback to the device's MagicDNS host so the invite link + QR still work
-  // when the serve config can't be read (the case the user hit).
-  if (!serveUrl) serveUrl = magicDnsServeUrl(selfStatus);
+  const discovery = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
 
-  if (!serveUrl) {
+  if (!discovery.ok) {
     // Nothing usable — surface the most actionable error we have.
     return NextResponse.json(
       {
         ok: false,
-        error: serveWarning ?? "tailscale serve URL not found",
+        error: serveWarning ?? discovery.reason,
         stderr: serveWarning ?? status.stderr,
         backendUrl: backend,
       },
@@ -227,7 +217,7 @@ async function mobileHandoff(req: Request) {
   }
 
   const invite = await createMobileInvite({
-    baseUrl: serveUrl,
+    baseUrl: discovery.serveUrl,
     accessSecret,
     sidecarToken: process.env.COVEN_CAVE_AUTH_TOKEN,
     ttlMs: MOBILE_INVITE_TTL_MS,
@@ -242,10 +232,11 @@ async function mobileHandoff(req: Request) {
   return NextResponse.json({
     ok: true,
     backendUrl: backend,
-    serveUrl,
+    serveUrl: discovery.serveUrl,
     inviteUrl: invite.url,
     url: invite.url,
     appUrl: invite.url,
+    discoverySource: discovery.source,
     expiresAt: invite.expiresAt,
     expiresAtIso: invite.expiresAtIso,
     qrSvg,

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -77,8 +77,8 @@ assert.doesNotMatch(
 );
 assert.match(
   handoffRoute,
-  /magicDnsServeUrl\(selfStatus\)/,
-  "route falls back to the MagicDNS host when the serve config can't be read",
+  /tailnetDiscoveryProof\(\{\s*selfStatus,\s*serveStatus,\s*backendUrl: backend\s*\}\)/,
+  "route falls back through the shared Tailscale discovery proof when the serve config can't be read",
 );
 assert.match(
   handoffRoute,

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -7,6 +7,7 @@ import {
   magicDnsHost,
   magicDnsServeUrl,
   resolveTailscaleBin,
+  tailnetDiscoveryProof,
 } from "./mobile-handoff.ts";
 import { verifyMobileAccessToken } from "./mobile-access-token.ts";
 
@@ -128,6 +129,35 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   // The fallback host matches what findServeUrl would have produced, so the
   // invite link is well-formed either way.
   assert.equal(magicDnsServeUrl(self), findServeUrl(status, "http://127.0.0.1:3000"));
+}
+
+{
+  const self = { Self: { DNSName: "cave.tailnet.example.ts.net." } };
+  assert.deepEqual(
+    tailnetDiscoveryProof({ selfStatus: self, serveStatus: status, backendUrl: "http://127.0.0.1:3000" }),
+    {
+      ok: true,
+      host: "cave.tailnet.example.ts.net",
+      serveUrl,
+      source: "serve-status",
+    },
+  );
+  assert.deepEqual(
+    tailnetDiscoveryProof({ selfStatus: self, serveStatus: {}, backendUrl: "http://127.0.0.1:3000" }),
+    {
+      ok: true,
+      host: "cave.tailnet.example.ts.net",
+      serveUrl,
+      source: "magicdns-self-status",
+    },
+  );
+  assert.deepEqual(
+    tailnetDiscoveryProof({ selfStatus: {}, serveStatus: {}, backendUrl: "http://127.0.0.1:3000" }),
+    {
+      ok: false,
+      reason: "tailscale serve URL not found and status --self had no MagicDNS DNSName",
+    },
+  );
 }
 
 {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -158,6 +158,54 @@ export function magicDnsServeUrl(selfStatus: unknown): string | null {
   return host ? `https://${host}/` : null;
 }
 
+export type TailnetDiscoveryProof =
+  | {
+      ok: true;
+      host: string;
+      serveUrl: string;
+      source: "serve-status" | "magicdns-self-status";
+    }
+  | {
+      ok: false;
+      reason: string;
+    };
+
+export function tailnetDiscoveryProof({
+  selfStatus,
+  serveStatus,
+  backendUrl,
+}: {
+  selfStatus: unknown;
+  serveStatus: unknown;
+  backendUrl: string;
+}): TailnetDiscoveryProof {
+  const fromServe = findServeUrl(serveStatus, backendUrl);
+  const host = magicDnsHost(selfStatus);
+  if (fromServe) {
+    return {
+      ok: true,
+      host: host ?? new URL(fromServe).host,
+      serveUrl: fromServe,
+      source: "serve-status",
+    };
+  }
+
+  const fromMagicDns = magicDnsServeUrl(selfStatus);
+  if (fromMagicDns && host) {
+    return {
+      ok: true,
+      host,
+      serveUrl: fromMagicDns,
+      source: "magicdns-self-status",
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "tailscale serve URL not found and status --self had no MagicDNS DNSName",
+  };
+}
+
 export function findServeUrl(status: unknown, backendUrl: string) {
   const web = (status as TailscaleServeStatus | null)?.Web;
   if (!web || typeof web !== "object") return null;


### PR DESCRIPTION
## Summary
- factor Tailscale Serve/MagicDNS URL selection into `tailnetDiscoveryProof`
- route mobile handoff and native app handoff through the shared discovery proof
- replace the permanent #1990 network-gap skip with a live Tailscale/MagicDNS conformance check when a runner has a connected daemon
- document that GitHub-hosted runners explicitly skip only because they are not joined to the private tailnet

Refs #1990

## Test Plan
- `node --experimental-strip-types src/lib/mobile-handoff.test.ts`
- `node scripts/run-tests.mjs conformance`
- `node scripts/run-tests.mjs mobile`
- `node scripts/run-tests.mjs api`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`