### PR TITLE
feat(automations): folder-picker for working dirs in the cron create dialog

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -301,6 +301,7 @@ export const SUITES = {
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",
     "src/components/automations-view.test.ts",
+    "src/components/cwd-picker-field.test.ts",
     "src/components/inbox-feed-a11y.test.ts",
     "src/components/schedules-tabs.test.ts",
     "src/lib/automations/automation-entry.test.ts",

--- a/src/components/automation-create-dialog.tsx
+++ b/src/components/automation-create-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/codex-automation-form";
 import { FamiliarMultiSelect } from "@/components/automation-familiar-select";
 import { SkillSelect } from "@/components/automation-skill-select";
+import { CwdPickerField } from "@/components/cwd-picker-field";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 export type AutomationCreateInput = {
@@ -285,16 +286,16 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate }:
           </select>
         </label>
 
-        {/* Working directories */}
+        {/* Working directories — type paths or browse projects (parity with the
+            cron detail editor). */}
         <label className="workflow-field">
           <span>Working directories</span>
-          <textarea
+          <CwdPickerField
             value={cwds}
-            onChange={(event) => setCwds(event.target.value)}
-            rows={3}
-            placeholder="/path/to/repo (one per line)"
-            className={monoTextareaClass}
-            style={fieldStyle}
+            onChange={setCwds}
+            familiarId={[...selected][0] ?? ""}
+            textareaClass={monoTextareaClass}
+            fieldStyle={fieldStyle}
           />
         </label>
 

--- a/src/components/cwd-picker-field.test.ts
+++ b/src/components/cwd-picker-field.test.ts
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./cwd-picker-field.tsx", import.meta.url), "utf8");
+const dialog = readFileSync(new URL("./automation-create-dialog.tsx", import.meta.url), "utf8");
+
+// Reusable working-directories field: free-text list + a Browse-projects modal
+// that walks ProjectTree and toggles directories into the list.
+assert.match(src, /export function CwdPickerField/, "exports a reusable field component");
+assert.match(src, /<textarea[\s\S]*?value=\{value\}[\s\S]*?onChange=\{\(event\) => onChange\(event\.target\.value\)\}/, "the textarea edits the raw newline value (free typing, no eaten blank lines)");
+assert.match(src, /Browse projects/, "offers a Browse-projects affordance");
+assert.match(src, /fetch\("\/api\/projects"\)/, "lazy-loads the project list from /api/projects when the picker opens");
+assert.match(src, /<ProjectTree[\s\S]*?onDirSelect=\{addCwd\}[\s\S]*?selectedDirs=\{selectedDirs\}/, "browses with the shared ProjectTree, toggling dirs in/out");
+assert.match(src, /role="dialog"[\s\S]*?aria-modal="true"/, "the picker is a labelled modal dialog");
+assert.match(src, /e\.key === "Escape"/, "the picker closes on Escape");
+assert.match(src, /list\.includes\(clean\)/, "addCwd dedupes already-listed paths");
+
+// The cron create dialog uses it (parity with the detail editor — no more
+// raw-path-only textarea).
+assert.match(dialog, /import \{ CwdPickerField \} from "@\/components\/cwd-picker-field"/, "the create dialog imports the field");
+assert.match(dialog, /<CwdPickerField[\s\S]*?value=\{cwds\}[\s\S]*?onChange=\{setCwds\}/, "the create dialog wires its cwds state through the field");
+
+console.log("cwd-picker-field.test.ts: ok");

--- a/src/components/cwd-picker-field.tsx
+++ b/src/components/cwd-picker-field.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Icon } from "@/lib/icon";
+import { ProjectTree } from "@/components/project-tree";
+import type { CaveProject } from "@/lib/cave-projects-types";
+
+/**
+ * Working-directories field: a free-text list (one path per line) plus a
+ * "Browse projects" modal that walks the user's projects with the shared
+ * ProjectTree and toggles directories in/out of the list. Reusable so the
+ * cron create dialog and the cron detail editor offer the same picker rather
+ * than the create dialog's old type-a-raw-path-only textarea.
+ *
+ * `value` is the raw newline-separated text (so typing stays unsurprising —
+ * blank lines aren't eaten mid-edit); the picker appends resolved paths.
+ */
+export function CwdPickerField({
+  value,
+  onChange,
+  familiarId = "",
+  textareaClass,
+  fieldStyle,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  /** Scopes ProjectTree reads to a familiar's workspace, when known. */
+  familiarId?: string;
+  textareaClass: string;
+  fieldStyle?: CSSProperties;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [projects, setProjects] = useState<CaveProject[]>([]);
+
+  const list = useMemo(
+    () => value.split("\n").map((s) => s.trim()).filter(Boolean),
+    [value],
+  );
+  const selectedDirs = useMemo(() => new Set(list), [list]);
+
+  const addCwd = (dir: string) => {
+    const clean = dir.trim();
+    if (!clean || list.includes(clean)) return;
+    onChange([...list, clean].join("\n"));
+  };
+
+  // Lazy-load the project list the first time the picker opens.
+  useEffect(() => {
+    if (!pickerOpen || projects.length > 0) return;
+    let alive = true;
+    void fetch("/api/projects")
+      .then((res) => res.json())
+      .then((data: { ok?: boolean; projects?: CaveProject[] }) => {
+        if (alive && data.ok && Array.isArray(data.projects)) setProjects(data.projects);
+      })
+      .catch(() => undefined);
+    return () => { alive = false; };
+  }, [pickerOpen, projects.length]);
+
+  return (
+    <>
+      <textarea
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rows={3}
+        placeholder="/path/to/repo (one per line)"
+        className={textareaClass}
+        style={fieldStyle}
+        spellCheck={false}
+      />
+      <div className="mt-1 flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name="ph:folder-open" width={12} aria-hidden />
+          Browse projects…
+        </button>
+        {list.length > 0 && (
+          <span className="text-[10px] text-[var(--text-muted)]">
+            {list.length} {list.length === 1 ? "directory" : "directories"}
+          </span>
+        )}
+      </div>
+
+      {pickerOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Pick working directories"
+          onClick={() => setPickerOpen(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") { e.stopPropagation(); setPickerOpen(false); } }}
+        >
+          <div
+            className="flex max-h-[80vh] w-[460px] max-w-full flex-col overflow-hidden rounded-lg border border-[var(--border-hairline)] shadow-xl"
+            style={{ background: "var(--bg-panel)" }}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
+              <span className="text-[13px] font-semibold text-[var(--text-primary)]">Working directories</span>
+              <button
+                type="button"
+                onClick={() => setPickerOpen(false)}
+                aria-label="Close"
+                className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:x" width={14} />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-2">
+              {projects.length === 0 ? (
+                <p className="px-2 py-4 text-[12px] text-[var(--text-muted)]">
+                  No projects found. Add a project in the Code workspace first, or type a path into the field.
+                </p>
+              ) : (
+                projects.map((proj) => (
+                  <div key={proj.root} className="mb-2">
+                    <div className="flex items-center justify-between gap-2 px-1 py-1">
+                      <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                        {proj.name}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => addCwd(proj.root)}
+                        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
+                          selectedDirs.has(proj.root)
+                            ? "text-[var(--accent-presence)]"
+                            : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                        }`}
+                      >
+                        {selectedDirs.has(proj.root) ? "Added" : "Use root"}
+                      </button>
+                    </div>
+                    <ProjectTree
+                      root={proj.root}
+                      familiarId={familiarId}
+                      onDirSelect={addCwd}
+                      selectedDirs={selectedDirs}
+                    />
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-3 py-2">
+              <span className="text-[11px] text-[var(--text-muted)]">
+                {list.length} {list.length === 1 ? "directory" : "directories"} selected
+              </span>
+              <button
+                type="button"
+                onClick={() => setPickerOpen(false)}
+                className="rounded-md px-3 py-1 text-[12px] font-medium text-white"
+                style={{ background: "var(--accent-presence)" }}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
The cron **create** dialog only let you type raw paths into a textarea, while the cron **detail** editor had a real "browse projects" folder picker — so creating a cron meant remembering exact paths.

- New reusable **`CwdPickerField`**: a free-text list (one path per line, free typing — blank lines aren't eaten) + a **Browse projects** modal that walks the user's projects with the shared `ProjectTree`, toggling directories in/out (de-duped), `role=dialog`/`aria-modal`, Escape-to-close.
- Wired into the create dialog for **parity** with the detail editor. The raw textarea still works for typing/pasting; Browse just appends resolved paths.
- The detail editor keeps its own inline picker for now (to avoid touching its pinned source-text test); the component is ready for it to adopt later.

## Verification
- `pnpm typecheck` clean · `pnpm test:app` green (495 files) · `pnpm check:tests-wired` ✓ (new `cwd-picker-field.test.ts` wired) · `pnpm build` within budget
- Playwright on the prod build: create dialog shows the **Browse projects…** button; clicking opens the picker modal listing projects + their dirs (screenshot in thread).

Final item in the Automations enhancement pass (after #2113 run-actions, #2116 a11y, #2118 header summary).