### PR TITLE
chore(release): v0.0.127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.127] - 2026-06-30
+
+Patch release on top of v0.0.126. Headline: Cave now has release-ready
+travel/mobile resilience, safer group chat relay context, richer review and
+automation surfaces, and stronger release CI coverage.
+
+### Added
+
+- **Travel mode** - added travel client state, offline chat/work queues, replay
+  on reconnect, local daemon wakeup, hub daemon routing config, and hub executor
+  availability so Cave can keep useful work queued across network changes.
+- **Group chat** - full-coven sends can now relay sequentially with coven roster
+  context so later familiars can see earlier replies in the same round.
+- **GitHub review artifacts** - PR reviews and diffs can render/export as
+  colored HTML artifacts, including familiar-review output.
+- **Dashboard, Evals, Research, and Code** - added the dashboard cockpit and
+  predictive signals, eval insights/groups management, the redesigned Research
+  composer, and the latest Code surface layout passes.
+- **Desktop and automations** - added tray quick chat, the header operational
+  summary, all-list automation run actions, cron working-directory picking, and
+  a release compatibility banner.
+
+### Fixed
+
+- **Mobile typing** - paused expensive shell polls while composing in inputs,
+  debounced composer draft writes, and ignored late stream pushes after
+  abort/close so cancelled sends no longer churn `Controller is already closed`
+  errors.
+- **Group chat safety** - escaped relay transcript text before embedding it in
+  prompt context so user/reply text cannot break out of the coven transcript.
+- **Navigation and polish** - fixed Evals deep links, desktop automation
+  interaction/a11y details, and several release-line UI polish issues.
+
+### Internal
+
+- **Release readiness** - added secret preflight coverage, Tailscale host
+  discovery proof, sidecar runtime smoke matrix coverage, and the
+  cross-environment aggregate CI check.
+
 ## [0.0.126] - 2026-06-28
 
 Patch release on top of v0.0.125. Headline: Cave now ships inline

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.126"
+version = "0.0.127"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.126"
+version = "0.0.127"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.126</string>
+	<string>0.0.127</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.126</string>
+	<string>0.0.127</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.126</string>
+	<string>0.0.127</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.126</string>
+	<string>0.0.127</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- Bump CovenCave desktop/iOS/Tauri/Rust versions to `0.0.127`.
- Add the `0.0.127` changelog entry covering travel/mobile resilience, group chat safety, review artifacts, automations, and release CI hardening.
- Confirm release notes render from the changelog for the tag-driven release workflow.

## Test Plan
- [x] `node -e "const fs=require('fs'); const pkg=require('./package.json'); const tauri=JSON.parse(fs.readFileSync('src-tauri/tauri.conf.json','utf8')); const cargo=fs.readFileSync('src-tauri/Cargo.toml','utf8'); const lock=fs.readFileSync('src-tauri/Cargo.lock','utf8'); const ios=fs.readFileSync('src-tauri/Info.ios.plist','utf8'); const gen=fs.readFileSync('src-tauri/gen/apple/app_iOS/Info.plist','utf8'); const v='0.0.127'; if (pkg.version!==v || tauri.version!==v || !cargo.includes('version = \\\"'+v+'\\\"') || !lock.includes('version = \\\"'+v+'\\\"') || !ios.includes('<string>'+v+'</string>') || !gen.includes('<string>'+v+'</string>')) process.exit(1); console.log('version consistency ok', v);"`
- [x] `bash scripts/release-notes.sh v0.0.127`
- [x] `node scripts/release-notes.test.mjs`
- [x] `git diff --check`
- [x] `pnpm typecheck`
- [x] `pnpm test:app`
- [x] `pnpm build`
