### PR TITLE
refactor(automations): cron detail editor adopts shared CwdPickerField (-111 lines)

### DIFF
--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -25,8 +25,7 @@ import { SearchInput } from "@/components/ui/search-input";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { useMultiSelect } from "@/lib/use-multi-select";
-import { ProjectTree } from "@/components/project-tree";
-import type { CaveProject } from "@/lib/cave-projects-types";
+import { CwdPickerField } from "@/components/cwd-picker-field";
 import { FamiliarMultiSelect } from "@/components/automation-familiar-select";
 import { SkillSelect } from "@/components/automation-skill-select";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
@@ -673,9 +672,6 @@ function CodexDetailPanel({
   const [tagsText, setTagsText] = useState(commaInput(auto.tags));
   const [cwdsText, setCwdsText] = useState(listInput(auto.cwds));
   const [skillPath, setSkillPath] = useState(auto.skillPath ?? "");
-  // Folder-picker ("browse") state for the Working directories field.
-  const [cwdPickerOpen, setCwdPickerOpen] = useState(false);
-  const [cwdProjects, setCwdProjects] = useState<CaveProject[]>([]);
   const [scheduleMode, setScheduleMode] = useState<"daily" | "weekly" | "raw">(parsedSchedule.mode);
   const [scheduleTime, setScheduleTime] = useState(parsedSchedule.time);
   const [scheduleDays, setScheduleDays] = useState(parsedSchedule.days);
@@ -702,28 +698,6 @@ function CodexDetailPanel({
   const nextRrule = buildCodexRrule(scheduleMode, scheduleTime, scheduleDays, rawRrule);
   const tags = parseListInput(tagsText);
   const cwds = parseListInput(cwdsText);
-  const cwdSet = useMemo(() => new Set(cwds), [cwdsText]); // eslint-disable-line react-hooks/exhaustive-deps
-  const addCwd = useCallback((dir: string) => {
-    const clean = dir.trim();
-    if (!clean) return;
-    setCwdsText((prev) => {
-      const list = parseListInput(prev);
-      if (list.includes(clean)) return prev;
-      return listInput([...list, clean]);
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!cwdPickerOpen || cwdProjects.length > 0) return;
-    let alive = true;
-    void fetch("/api/projects")
-      .then((res) => res.json())
-      .then((data: { ok?: boolean; projects?: CaveProject[] }) => {
-        if (alive && data.ok && Array.isArray(data.projects)) setCwdProjects(data.projects);
-      })
-      .catch(() => undefined);
-    return () => { alive = false; };
-  }, [cwdPickerOpen, cwdProjects.length]);
   const promptDirty = goals !== promptParts.goals || deliverables !== promptParts.deliverables;
   const nextPrompt = promptDirty
     ? composeAutomationPrompt(goals, deliverables, promptParts.hasStructuredSections || deliverables.trim().length > 0)
@@ -940,99 +914,14 @@ function CodexDetailPanel({
           </div>
           <div>
             <FieldLabel>Working directories</FieldLabel>
-            <div className="flex items-start gap-2">
-              <textarea
-                value={cwdsText}
-                onChange={(event) => setCwdsText(event.target.value)}
-                rows={3}
-                className={`${automationMonoTextareaClass} min-w-0 flex-1`}
-                style={fieldStyle}
-              />
-              <button
-                type="button"
-                onClick={() => setCwdPickerOpen(true)}
-                className="inline-flex shrink-0 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 py-1.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-              >
-                <Icon name="ph:folder-open" width={12} /> Browse…
-              </button>
-            </div>
+            <CwdPickerField
+              value={cwdsText}
+              onChange={setCwdsText}
+              familiarId={auto.familiars[0] ?? ""}
+              textareaClass={automationMonoTextareaClass}
+              fieldStyle={fieldStyle}
+            />
           </div>
-
-          {cwdPickerOpen && (
-            <div
-              className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Pick working directories"
-              onClick={() => setCwdPickerOpen(false)}
-              onKeyDown={(e) => { if (e.key === "Escape") { e.stopPropagation(); setCwdPickerOpen(false); } }}
-            >
-              <div
-                className="flex max-h-[80vh] w-[460px] max-w-full flex-col overflow-hidden rounded-lg border border-[var(--border-hairline)] shadow-xl"
-                style={{ background: "var(--bg-panel)" }}
-                onClick={(event) => event.stopPropagation()}
-              >
-                <div className="flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
-                  <span className="text-[13px] font-semibold text-[var(--text-primary)]">Working directories</span>
-                  <button
-                    type="button"
-                    onClick={() => setCwdPickerOpen(false)}
-                    aria-label="Close"
-                    className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-                  >
-                    <Icon name="ph:x" width={14} />
-                  </button>
-                </div>
-                <div className="min-h-0 flex-1 overflow-y-auto p-2">
-                  {cwdProjects.length === 0 ? (
-                    <p className="px-2 py-4 text-[12px] text-[var(--text-muted)]">
-                      No projects found. Add a project in the Code workspace first, or type a path into the field.
-                    </p>
-                  ) : (
-                    cwdProjects.map((proj) => (
-                      <div key={proj.root} className="mb-2">
-                        <div className="flex items-center justify-between gap-2 px-1 py-1">
-                          <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
-                            {proj.name}
-                          </span>
-                          <button
-                            type="button"
-                            onClick={() => addCwd(proj.root)}
-                            className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
-                              cwdSet.has(proj.root)
-                                ? "text-[var(--accent-presence)]"
-                                : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-                            }`}
-                          >
-                            {cwdSet.has(proj.root) ? "Added" : "Use root"}
-                          </button>
-                        </div>
-                        <ProjectTree
-                          root={proj.root}
-                          familiarId={auto.familiars[0] ?? ""}
-                          onDirSelect={addCwd}
-                          selectedDirs={cwdSet}
-                        />
-                      </div>
-                    ))
-                  )}
-                </div>
-                <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-3 py-2">
-                  <span className="text-[11px] text-[var(--text-muted)]">
-                    {cwds.length} {cwds.length === 1 ? "directory" : "directories"} selected
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setCwdPickerOpen(false)}
-                    className="rounded-md px-3 py-1 text-[12px] font-medium text-white"
-                    style={{ background: "var(--accent-presence)" }}
-                  >
-                    Done
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
 
           <div>
             <FieldLabel>Tags</FieldLabel>


### PR DESCRIPTION
Follow-up dedup. The cron **detail** editor carried its own ~110-line copy of the working-directories folder picker (textarea + Browse modal + `ProjectTree` + `/api/projects` fetch + add/dedupe state). That logic now lives in the reusable **`CwdPickerField`** (added with the create dialog in #2134), so the detail editor adopts it too — **one picker, used in both places**.

- Removes the duplicated modal JSX, `cwdPickerOpen`/`cwdProjects` state, `addCwd`, `cwdSet`, the `/api/projects` fetch effect, and the now-unused `ProjectTree`/`CaveProject` imports.
- **Net −111 lines**; behavior unchanged. `cwds` (the parsed list `save` uses) is retained.

## Verification
- `pnpm typecheck` clean (no unused locals/imports) · `pnpm test:app` green (495 files) · `pnpm build` within budget
- No test pinned the old cwd markup (`automations-detail-inputs.test` has no cwd assertions) — nothing to update.
- Playwright on the prod build: the detail editor's **Browse projects…** still opens the picker, walks the project tree, and marks the cron's existing root as "Added" (screenshot in thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)