### PR TITLE
Polish in-app update recovery

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -15,7 +15,16 @@ assert.match(src, /relaunch\(\)/, "relaunches the app after install");
 
 // Graceful fallback when no updater-enabled release exists yet.
 assert.match(src, /\/api\/app\/latest-release/, "falls back to the server release check");
-assert.match(src, /openExternalUrl/, "fallback opens the download in the system browser");
+assert.match(
+  src,
+  /import \{ openInAppBrowserUrl \} from "@\/lib\/open-external"/,
+  "update fallback should use the explicit Cave Browser URL handoff",
+);
+assert.doesNotMatch(
+  src,
+  /openExternalUrl/,
+  "update fallback must not use the legacy external-browser name",
+);
 
 // Fallback "Download" resolves a direct platform installer (DMG/MSI/AppImage)
 // via the OS plugin instead of dead-ending on the release page.
@@ -32,23 +41,31 @@ assert.match(src, /async function resolveUpdate/, "resolves native-first, then f
 assert.match(src, /pushBanner\(/, "pushes a shell banner when an update is available");
 assert.match(src, /cave:update:dismissed:/, "persists dismissal keyed by version");
 assert.match(src, /onDismiss:\s*\(\)\s*=>\s*markDismissed/, "dismissing the banner records it for that version");
+assert.match(
+  src,
+  /installNativeUpdate\(r\.update,\s*\(pct\) => \{[\s\S]*Downloading update v\$\{r\.version\}… \$\{pct\}%/,
+  "banner native install should surface download progress instead of a static loading state",
+);
 
-// Settings row exposes install / download / progress / manual recheck.
+// Settings row exposes install / in-app fallback / progress / manual recheck.
 assert.match(src, /Install &amp; restart/, "native path offers install + restart");
 assert.match(src, /Downloading…/, "shows download progress");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
+assert.match(src, /Open installer in Browser/, "fallback keeps installer recovery inside Cave's Browser surface");
 
 // A failed native install must not dead-end: it captures the reason and offers
-// a working manual download plus a retry, so the update is always reachable
-// even when downloadAndInstall/relaunch throws. The manual path should resolve
-// the platform installer through the same fallback route instead of hardcoding
-// the releases page.
+// in-app recovery plus a retry, so the update is always reachable even when
+// downloadAndInstall/relaunch throws. The recovery path should resolve the
+// platform installer through the same fallback route instead of hardcoding the
+// releases page or sending the user outside Cave.
 assert.match(src, /phase: "failed"/, "tracks a dedicated failed state for a thrown install");
 assert.match(src, /message: err instanceof Error \? err\.message/, "captures the real failure reason instead of swallowing it");
-assert.match(src, /async function openManualDownload/, "centralizes manual-download fallback resolution");
-assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "manual download resolves a direct platform installer when release metadata is reachable");
-assert.match(src, /onClick=\{\(\) => void openManualDownload\(\)\}/, "failed state offers the same direct manual download path as fallback updates");
-assert.doesNotMatch(src, /onClick=\{\(\) => void openExternalUrl\(RELEASES_PAGE\)\}/, "failed state must not dead-end on the generic release page when a direct installer can be resolved");
+assert.match(src, /async function openFallbackUpdateInBrowser/, "centralizes in-app fallback recovery resolution");
+assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "in-app recovery resolves a direct platform installer when release metadata is reachable");
+assert.match(src, /onClick=\{\(\) => void openFallbackUpdateInBrowser\(\)\}/, "failed state offers the same in-app installer path as fallback updates");
+assert.match(src, /openInAppBrowserUrl\(url\)/, "fallback recovery opens in Cave's Browser surface");
+assert.doesNotMatch(src, /download manually/i, "failed updater copy should not imply leaving the app for manual recovery");
+assert.doesNotMatch(src, /onClick=\{\(\) => void openInAppBrowserUrl\(RELEASES_PAGE\)\}/, "failed state must not dead-end on the generic release page when a direct installer can be resolved");
 assert.match(src, />\s*Retry\s*</, "failed state offers a retry");
 
 console.log("update-available.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { Icon } from "@/lib/icon";
 import { isTauri, useIsTauriDesktop } from "@/lib/tauri-platform";
 import { useShellBanners } from "@/lib/shell-banners";
-import { openExternalUrl } from "@/lib/open-external";
+import { openInAppBrowserUrl } from "@/lib/open-external";
 import { pickDownloadUrl, type UpdateStatus } from "@/lib/app-update";
 
 const BANNER_ID = "update-available";
@@ -107,15 +107,15 @@ async function resolveDownloadUrl(status: UpdateStatus): Promise<string> {
 }
 
 /**
- * Open the easiest reachable installer for the running desktop platform. This
- * is used when the native updater cannot finish, so a broken install attempt
- * still leaves the user one click from the DMG/MSI/AppImage when release
- * metadata is available.
+ * Open the easiest reachable installer for the running desktop platform in
+ * Cave's Browser surface. This is used when the native updater cannot finish,
+ * so a broken install attempt still leaves the user one click from the
+ * DMG/MSI/AppImage when release metadata is available.
  */
-async function openManualDownload(): Promise<void> {
+async function openFallbackUpdateInBrowser(): Promise<void> {
   const fb = await fetchFallbackStatus();
   const url = fb ? await resolveDownloadUrl(fb) : RELEASES_PAGE;
-  await openExternalUrl(url);
+  openInAppBrowserUrl(url);
 }
 
 type Resolved =
@@ -155,24 +155,30 @@ export function UpdateBannerTrigger() {
         severity: "info",
         title: `Update available — v${r.version}`,
         cta: {
-          label: r.kind === "native" ? "Install & restart" : "Download",
+          label: r.kind === "native" ? "Install & restart" : "Open installer in Browser",
           onClick: () => {
             if (r.kind === "native") {
-              pushBanner({ id: BANNER_ID, severity: "info", title: `Downloading update v${r.version}…` });
-              void installNativeUpdate(r.update, () => {}).catch((err) => {
+              pushBanner({ id: BANNER_ID, severity: "info", title: `Preparing update v${r.version}…` });
+              void installNativeUpdate(r.update, (pct) => {
+                pushBanner({
+                  id: BANNER_ID,
+                  severity: "info",
+                  title: `Downloading update v${r.version}… ${pct}%`,
+                });
+              }).catch((err) => {
                 const reason = err instanceof Error ? err.message : "";
                 pushBanner({
                   id: BANNER_ID,
                   severity: "warning",
                   title: reason
-                    ? `Update failed (${reason}) — download manually`
-                    : "Update failed — download manually",
-                  cta: { label: "Download", onClick: () => void openManualDownload() },
+                    ? `Update failed (${reason})`
+                    : "Update failed",
+                  cta: { label: "Open installer in Browser", onClick: () => void openFallbackUpdateInBrowser() },
                   onDismiss: () => markDismissed(r.version),
                 });
               });
             } else {
-              void openExternalUrl(r.url);
+              openInAppBrowserUrl(r.url);
             }
           },
         },
@@ -198,7 +204,8 @@ type RowState =
 
 /**
  * Desktop-only row for Settings ▸ About. Native updater when available
- * (Install & restart with progress), else a Download link to the release page.
+ * (Install & restart with progress), else opens the release installer in Cave's
+ * Browser surface.
  */
 export function UpdateSettingsRow() {
   const isDesktop = useIsTauriDesktop();
@@ -263,17 +270,17 @@ export function UpdateSettingsRow() {
             Install &amp; restart
           </button>
         ) : (
-          <button type="button" onClick={() => void openExternalUrl(r.url)} className={accentBtn}>
+          <button type="button" onClick={() => openInAppBrowserUrl(r.url)} className={accentBtn}>
             <Icon name="ph:arrow-square-out" width={12} />
-            Download
+            Open installer in Browser
           </button>
         )}
       </>
     );
   } else if (state.phase === "failed") {
     // The native install threw (e.g. unsigned/dev build, app translocation, or
-    // a network/verification error). Don't dead-end: surface the reason and a
-    // working manual download so the update is always reachable.
+    // a network/verification error). Don't dead-end: surface the reason and
+    // keep recovery inside Cave.
     control = (
       <>
         <span
@@ -282,9 +289,9 @@ export function UpdateSettingsRow() {
         >
           Update failed
         </span>
-        <button type="button" onClick={() => void openManualDownload()} className={accentBtn}>
+        <button type="button" onClick={() => void openFallbackUpdateInBrowser()} className={accentBtn}>
           <Icon name="ph:arrow-square-out" width={12} />
-          Download
+          Open installer in Browser
         </button>
         <button
           type="button"

--- a/src/lib/open-external.test.ts
+++ b/src/lib/open-external.test.ts
@@ -12,6 +12,11 @@ assert.match(
 );
 assert.match(
   helper,
+  /export function openInAppBrowserUrl\(url: string\): void/,
+  "shared URL helper should expose an explicitly named in-app browser opener",
+);
+assert.match(
+  helper,
   /export function openExternalUrl\(url: string\): void/,
   "legacy openExternalUrl callers should be preserved behind the in-app browser handoff",
 );

--- a/src/lib/open-external.ts
+++ b/src/lib/open-external.ts
@@ -1,13 +1,17 @@
 export const OPEN_IN_APP_BROWSER_EVENT = "cave:open-url-in-browser";
 export const PENDING_IN_APP_BROWSER_URL_KEY = "cave:pending-in-app-browser-url";
 
-// Historical name kept for existing call sites. External destinations should
-// open inside Cave's Browser surface instead of the system browser/new tab.
-export function openExternalUrl(url: string): void {
+export function openInAppBrowserUrl(url: string): void {
   if (typeof window === "undefined") return;
   window.sessionStorage.setItem(PENDING_IN_APP_BROWSER_URL_KEY, url);
   window.dispatchEvent(new CustomEvent(OPEN_IN_APP_BROWSER_EVENT, { detail: { url } }));
   if (window.location.pathname !== "/") {
     window.location.assign("/#browser");
   }
+}
+
+// Historical name kept for existing call sites. External destinations should
+// open inside Cave's Browser surface instead of the system browser/new tab.
+export function openExternalUrl(url: string): void {
+  openInAppBrowserUrl(url);
 }


### PR DESCRIPTION
## Summary
- add an explicit Cave Browser URL handoff helper while preserving the legacy openExternalUrl API
- keep updater fallback and failed-install recovery inside Cave with clearer "Open installer in Browser" CTAs
- surface native updater download progress in the shell banner instead of a static downloading state

## Verification
- node --experimental-strip-types src/components/update-available.test.ts
- node --experimental-strip-types src/lib/open-external.test.ts
- node --experimental-strip-types src/lib/app-update.test.ts
- node --experimental-strip-types src/app/api/app/latest-release/route.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:app
- git diff --check
- Playwright smoke: http://127.0.0.1:3009/settings#about loaded with title "Settings — CovenCave", no framework overlay, no console errors

## Notes
- The updater controls are gated to Tauri desktop; browser-dev smoke verifies import/render health for Settings/About, while source tests cover the desktop update flow.
