### PR TITLE
Fix Tauri titlebar drag region

### DIFF
--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -38,8 +38,18 @@ assert.match(
 );
 assert.match(
   shell,
-  /<div className="shell-top">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar">\{renderedTopBar\}<\/div>[\s\S]*?\{rightToggles\}/,
+  /<div className="shell-top" data-tauri-drag-region="">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="">\{renderedTopBar\}<\/div>[\s\S]*?\{rightToggles\}/,
   "the top bar row flanks the rendered top bar with the nav (left) and side-panel (right) toggles",
+);
+assert.equal(
+  shell.match(/<div className="shell-top" data-tauri-drag-region="">/g)?.length,
+  2,
+  "both shell top bars should expose the Tauri drag region on the titlebar container",
+);
+assert.equal(
+  shell.match(/<div className="shell-top__bar" data-tauri-drag-region="">/g)?.length,
+  2,
+  "both rendered top-bar wrappers should remain draggable when their empty chrome is clicked",
 );
 assert.match(
   shell,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -432,9 +432,9 @@ function ShellInner({
   if (!mounted) {
     return (
       <div className="shell-frame flex h-full w-full flex-col">
-        <div className="shell-top">
+        <div className="shell-top" data-tauri-drag-region="">
           <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
-          <div className="shell-top__bar">{renderedTopBar}</div>
+          <div className="shell-top__bar" data-tauri-drag-region="">{renderedTopBar}</div>
         </div>
         <div className="shell-body flex flex-1 min-h-0">
           <div className="shell-root flex-1 min-h-0" />
@@ -623,10 +623,10 @@ function ShellInner({
       {/* Keyboard/SR users can jump straight past the chrome to the active
           surface. Visually hidden until focused (see .skip-link in globals). */}
       <a className="skip-link" href="#shell-main-content">Skip to main content</a>
-      <div className="shell-top">
+      <div className="shell-top" data-tauri-drag-region="">
         <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
         {navToggle}
-        <div className="shell-top__bar">{renderedTopBar}</div>
+        <div className="shell-top__bar" data-tauri-drag-region="">{renderedTopBar}</div>
         {rightToggles}
       </div>
       <div className="shell-body flex flex-1 min-h-0">


### PR DESCRIPTION
## Summary
- mark the shell top bar containers as Tauri drag regions in both shell render paths
- keep the existing dedicated drag lane and interactive-control no-drag CSS contract intact
- extend the shell edge regression test to require drag-region coverage on the titlebar containers and wrappers

## Verification
- `node --experimental-strip-types src/components/shell-edge-rails.test.ts` (red before fix, green after)
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm test:app`
- `git diff --check`

Note: the first `pnpm test:app` attempt in the fresh worktree stopped after 37 passing files because `node_modules` was not installed (`ERR_MODULE_NOT_FOUND: Cannot find package 'yaml'`). After `pnpm install --frozen-lockfile`, the rerun passed all 495 app test files.