### PR TITLE
Polish command center controls across Home, Chat, and Code

### DIFF
--- a/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
+++ b/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
@@ -1,0 +1,1148 @@
+# Home Chat Code Command Center Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the shared command-control contract approved in `docs/superpowers/specs/2026-06-30-home-chat-code-command-center-design.md`, polish Home as the primary launch surface, and keep Chat, Code, and Quick Chat switching behavior consistent.
+
+**Architecture:** Extract the existing thinking/speed option model into a small client-safe library, add a typed initial-controls handoff from Home through Workspace/ChatSurface/ChatRouter into ChatView, and then reuse compact control semantics in Quick Chat. Server authority stays in `/api/chat/model-state`, `/api/config`, and `/api/chat/send`; the client layer only derives options, scopes, and payloads.
+
+**Tech Stack:** Next.js App Router, React client components, TypeScript, Node `node:test` source assertions, existing `scripts/run-tests.mjs`, Playwright/browser smoke checks for rendered layout.
+
+---
+
+## File Structure
+
+- Create `src/lib/command-controls.ts`: pure shared option/catalog/state helpers for thinking effort, response speed, density, and initial-control payloads.
+- Create `src/lib/command-controls.test.ts`: pure tests for option validation, defaults, payload building, and runtime-managed model labels.
+- Modify `src/components/chat-view.tsx`: import shared thinking/speed types/options/defaults, accept optional initial controls, and apply them before auto-sending a Home-started chat.
+- Modify `src/components/chat-router.tsx`: thread `initialControls` through the view state and `newChat` handle.
+- Modify `src/components/chat-surface.tsx`: thread `initialControls` through pending actions and window events.
+- Modify `src/lib/pending-chat-action.ts`: add `initialControls` to new-chat pending actions.
+- Modify `src/components/workspace.tsx`: let `startFamiliarChat` and the non-chat bridge carry `initialControls`.
+- Modify `src/components/home-composer.tsx`: add thinking/speed controls, use shared defaults/options, and pass controls through `onStartChat`.
+- Modify `src/styles/home-composer.css`: polish the Home command center execution strip and responsive grouping.
+- Modify `src/lib/familiar-stream.ts`: allow Quick Chat to pass reasoning effort, response speed, and optional model override through the existing stream helper.
+- Modify `src/components/tray-quick-chat.tsx`: add compact thinking/speed controls and pass them into `streamFamiliarText`.
+- Modify tests already present in `src/components/home-composer.test.ts`, `src/components/workspace-chat-handoff.test.ts`, `src/components/chat-surface.test.ts`, `src/components/code-view.test.ts`, `src/components/tray-quick-chat.test.ts`, `src/lib/familiar-stream.test.ts`, and `src/app/api/chat/send/harness-routing.test.ts`.
+- Modify `scripts/run-tests.mjs`: register `src/lib/command-controls.test.ts`.
+
+## Task 1: Shared Command-Control Model
+
+**Files:**
+- Create: `src/lib/command-controls.ts`
+- Create: `src/lib/command-controls.test.ts`
+- Modify: `scripts/run-tests.mjs`
+
+- [ ] **Step 1: Write the failing pure test**
+
+Create `src/lib/command-controls.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  commandControlPayload,
+  normalizeCommandControls,
+  runtimeModelSelectLabel,
+} from "./command-controls.ts";
+
+assert.deepEqual(
+  COMMAND_THINKING_OPTIONS.map((option) => option.value),
+  ["low", "medium", "high"],
+  "thinking options should preserve the Chat composer contract",
+);
+
+assert.deepEqual(
+  COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => option.value),
+  ["fast", "balanced", "careful"],
+  "response speed options should preserve the Chat composer contract",
+);
+
+assert.deepEqual(
+  normalizeCommandControls({ thinkingEffort: "wild", responseSpeed: "slow" }),
+  COMMAND_CONTROL_DEFAULTS,
+  "invalid stored controls should fall back to defaults",
+);
+
+assert.deepEqual(
+  normalizeCommandControls({ thinkingEffort: "medium", responseSpeed: "balanced" }),
+  { thinkingEffort: "medium", responseSpeed: "balanced" },
+  "valid controls should be preserved",
+);
+
+assert.deepEqual(
+  commandControlPayload({ thinkingEffort: "low", responseSpeed: "careful" }),
+  { reasoningEffort: "low", responseSpeed: "careful" },
+  "send payload maps thinkingEffort to reasoningEffort",
+);
+
+assert.equal(runtimeModelSelectLabel([]), "Runtime managed", "empty model catalogs are runtime-managed");
+assert.equal(runtimeModelSelectLabel([{ id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" }]), "Model");
+
+console.log("command-controls tests passed");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/command-controls.test.ts
+```
+
+Expected: `ERR_MODULE_NOT_FOUND` for `src/lib/command-controls.ts`.
+
+- [ ] **Step 3: Implement the pure helper**
+
+Create `src/lib/command-controls.ts`:
+
+```ts
+import type { RuntimeModelOption } from "@/lib/runtime-models";
+
+export type CommandThinkingEffort = "low" | "medium" | "high";
+export type CommandResponseSpeed = "fast" | "balanced" | "careful";
+export type CommandControlDensity = "full" | "compact";
+export type CommandControlSurface = "home" | "chat" | "code" | "quick-chat";
+
+export type CommandControls = {
+  thinkingEffort: CommandThinkingEffort;
+  responseSpeed: CommandResponseSpeed;
+};
+
+export type InitialCommandControls = Partial<CommandControls>;
+
+export const COMMAND_CONTROL_DEFAULTS: CommandControls = {
+  thinkingEffort: "high",
+  responseSpeed: "fast",
+};
+
+export const COMMAND_THINKING_OPTIONS: Array<{ value: CommandThinkingEffort; label: string }> = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+
+export const COMMAND_RESPONSE_SPEED_OPTIONS: Array<{ value: CommandResponseSpeed; label: string }> = [
+  { value: "fast", label: "Fast" },
+  { value: "balanced", label: "Balanced" },
+  { value: "careful", label: "Careful" },
+];
+
+function isThinkingEffort(value: unknown): value is CommandThinkingEffort {
+  return COMMAND_THINKING_OPTIONS.some((option) => option.value === value);
+}
+
+function isResponseSpeed(value: unknown): value is CommandResponseSpeed {
+  return COMMAND_RESPONSE_SPEED_OPTIONS.some((option) => option.value === value);
+}
+
+export function normalizeCommandControls(input: Partial<Record<keyof CommandControls, unknown>> | null | undefined): CommandControls {
+  return {
+    thinkingEffort: isThinkingEffort(input?.thinkingEffort)
+      ? input.thinkingEffort
+      : COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+    responseSpeed: isResponseSpeed(input?.responseSpeed)
+      ? input.responseSpeed
+      : COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  };
+}
+
+export function commandControlPayload(controls: CommandControls): {
+  reasoningEffort: CommandThinkingEffort;
+  responseSpeed: CommandResponseSpeed;
+} {
+  return {
+    reasoningEffort: controls.thinkingEffort,
+    responseSpeed: controls.responseSpeed,
+  };
+}
+
+export function runtimeModelSelectLabel(options: RuntimeModelOption[]): string {
+  return options.length === 0 ? "Runtime managed" : "Model";
+}
+```
+
+- [ ] **Step 4: Register the test**
+
+Add `"src/lib/command-controls.test.ts",` immediately after `"src/lib/quick-chat.test.ts",` in the app suite in `scripts/run-tests.mjs`.
+
+Add `"src/lib/command-controls.test.ts",` to `ALIAS_LOADER` beside `"src/lib/quick-chat.test.ts",`.
+
+- [ ] **Step 5: Run focused verification**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/command-controls.test.ts
+node scripts/run-tests.mjs src/lib/command-controls.test.ts
+```
+
+Expected: both commands print `command-controls tests passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/command-controls.ts src/lib/command-controls.test.ts scripts/run-tests.mjs
+git commit -m "Add shared command controls model"
+```
+
+## Task 2: Initial Controls Handoff from Home to Chat
+
+**Files:**
+- Modify: `src/lib/pending-chat-action.ts`
+- Modify: `src/components/workspace.tsx`
+- Modify: `src/components/chat-surface.tsx`
+- Modify: `src/components/chat-router.tsx`
+- Modify: `src/components/chat-view.tsx`
+- Test: `src/components/workspace-chat-handoff.test.ts`
+- Test: `src/components/chat-surface.test.ts`
+
+- [ ] **Step 1: Write source assertions for the handoff**
+
+In `src/components/workspace-chat-handoff.test.ts`, append:
+
+```ts
+assert.match(
+  pendingChatActionLib,
+  /initialControls\?: InitialCommandControls \| null/,
+  "PendingChatAction should carry initial command controls for Home-started chats",
+);
+
+assert.match(
+  workspace,
+  /startFamiliarChat = useCallback\(\(\s*familiarId\?: string \| null,[\s\S]*?initialControls\?: InitialCommandControls \| null,[\s\S]*?initialControls,[\s\S]*?setMode\("chat"\)/,
+  "Workspace should carry initial controls through the pending new-chat action",
+);
+
+assert.match(
+  chatSurface,
+  /routerRef\.current\?\.newChat\([\s\S]*?pendingChatAction\.initialControls \?\? undefined/,
+  "ChatSurface should pass pending initial controls into ChatRouter.newChat",
+);
+```
+
+In `src/components/chat-surface.test.ts`, append:
+
+```ts
+assert.match(
+  source,
+  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null, origin\?: SessionOrigin, initialControls\?: InitialCommandControls\) => void/,
+  "ChatRouterHandle.newChat should accept initial command controls",
+);
+
+assert.match(
+  source,
+  /<ChatView[\s\S]*initialControls=\{view\.kind === "chat" \? view\.initialControls : undefined\}/,
+  "ChatRouter should pass initial command controls into ChatView",
+);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/workspace-chat-handoff.test.ts
+node --experimental-strip-types src/components/chat-surface.test.ts
+```
+
+Expected: assertions fail because `initialControls` is not yet threaded.
+
+- [ ] **Step 3: Add the shared type to pending actions**
+
+Update `src/lib/pending-chat-action.ts`:
+
+```ts
+import type { InitialCommandControls } from "@/lib/command-controls";
+
+export type PendingChatAction =
+  | {
+      kind: "new";
+      familiarId?: string | null;
+      projectRoot?: string | null;
+      /** Prompt handed off from the home composer; ChatView auto-sends it so
+       *  the send runs through the normal streaming path. */
+      initialPrompt?: string | null;
+      initialControls?: InitialCommandControls | null;
+      nonce: number;
+    }
+  | { kind: "open"; sessionId: string; familiarId?: string | null; findQuery?: string; nonce: number }
+  | { kind: "list"; nonce: number }
+  | null;
+```
+
+- [ ] **Step 4: Thread the payload through Workspace**
+
+In `src/components/workspace.tsx`, import the type:
+
+```ts
+import type { InitialCommandControls } from "@/lib/command-controls";
+```
+
+Change `startFamiliarChat` to:
+
+```ts
+  const startFamiliarChat = useCallback((
+    familiarId?: string | null,
+    projectRoot?: string | null,
+    initialPrompt?: string | null,
+    initialControls?: InitialCommandControls | null,
+  ) => {
+    if (familiarId) setActiveId(familiarId);
+    setPendingProjectChatRoot(projectRoot ?? null);
+    setPendingChatAction({
+      kind: "new",
+      familiarId,
+      projectRoot,
+      initialPrompt,
+      initialControls,
+      nonce: Date.now(),
+    });
+    setMode("chat");
+  }, []);
+```
+
+Change the non-chat event bridge detail type and call:
+
+```ts
+      const d = (e as CustomEvent<{
+        familiarId?: string | null;
+        projectRoot?: string | null;
+        initialPrompt?: string | null;
+        initialControls?: InitialCommandControls | null;
+      }>).detail;
+      startFamiliarChat(
+        d?.familiarId ?? null,
+        d?.projectRoot ?? null,
+        d?.initialPrompt ?? null,
+        d?.initialControls ?? null,
+      );
+```
+
+- [ ] **Step 5: Thread through ChatSurface and ChatRouter**
+
+In `src/components/chat-surface.tsx`, import `InitialCommandControls` and update the event detail type:
+
+```ts
+import type { InitialCommandControls } from "@/lib/command-controls";
+```
+
+```ts
+      const d = (e as CustomEvent<{
+        familiarId?: string | null;
+        projectRoot?: string | null;
+        initialPrompt?: string | null;
+        origin?: SessionOrigin;
+        initialControls?: InitialCommandControls | null;
+      }>).detail;
+      if (d?.familiarId) onSetActiveFamiliar(d.familiarId);
+      setScope("conversation");
+      window.setTimeout(
+        () => routerRef.current?.newChat(
+          d?.projectRoot ?? undefined,
+          d?.initialPrompt ?? undefined,
+          d?.familiarId,
+          d?.origin,
+          d?.initialControls ?? undefined,
+        ),
+        0,
+      );
+```
+
+Update the pending action call:
+
+```ts
+        () => routerRef.current?.newChat(
+          pendingChatAction.projectRoot ?? undefined,
+          pendingChatAction.initialPrompt ?? undefined,
+          pendingChatAction.familiarId,
+          undefined,
+          pendingChatAction.initialControls ?? undefined,
+        ),
+```
+
+In `src/components/chat-router.tsx`, import the type and update `View`, `ChatRouterHandle`, and `newChat`:
+
+```ts
+import type { InitialCommandControls } from "@/lib/command-controls";
+```
+
+```ts
+type View =
+  | { kind: "list" }
+  | {
+      kind: "chat";
+      sessionId: string | null;
+      projectRoot?: string;
+      initialPrompt?: string;
+      familiarId?: string | null;
+      origin?: SessionOrigin;
+      initialControls?: InitialCommandControls;
+    };
+```
+
+```ts
+  newChat: (
+    projectRoot?: string,
+    initialPrompt?: string,
+    familiarId?: string | null,
+    origin?: SessionOrigin,
+    initialControls?: InitialCommandControls,
+  ) => void;
+```
+
+In the `newChat` implementation, include `initialControls` in the view:
+
+```ts
+      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls) => {
+        const next = selectFamiliarForChat(familiarId);
+        if (next && onSetActiveFamiliar) onSetActiveFamiliar(next.id);
+        setView({
+          kind: "chat",
+          sessionId: null,
+          projectRoot,
+          initialPrompt,
+          familiarId: next?.id ?? familiarId ?? null,
+          origin,
+          initialControls,
+        });
+      },
+```
+
+Pass it into `ChatView`:
+
+```tsx
+            initialControls={view.kind === "chat" ? view.initialControls : undefined}
+```
+
+- [ ] **Step 6: Apply controls in ChatView before auto-send**
+
+In `src/components/chat-view.tsx`, import:
+
+```ts
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  normalizeCommandControls,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+  type InitialCommandControls,
+} from "@/lib/command-controls";
+```
+
+Replace local composer types/options with aliases:
+
+```ts
+type ComposerThinkingEffort = CommandThinkingEffort;
+type ComposerResponseSpeed = CommandResponseSpeed;
+const THINKING_OPTIONS = COMMAND_THINKING_OPTIONS;
+const SPEED_OPTIONS = COMMAND_RESPONSE_SPEED_OPTIONS;
+```
+
+Change default reads to use `COMMAND_CONTROL_DEFAULTS`:
+
+```ts
+if (typeof window === "undefined") return COMMAND_CONTROL_DEFAULTS;
+```
+
+and in both `catch` branches:
+
+```ts
+return COMMAND_CONTROL_DEFAULTS;
+```
+
+Add `initialControls?: InitialCommandControls;` to the `Props` type and destructure it in `ChatView`.
+
+Before the `sendRaw(initialPrompt)` line in the initial-prompt effect, insert:
+
+```ts
+      if (initialControls) {
+        const normalized = normalizeCommandControls(initialControls);
+        setThinkingEffort(normalized.thinkingEffort);
+        setResponseSpeed(normalized.responseSpeed);
+      }
+```
+
+Change the send call to avoid waiting for React state:
+
+```ts
+      const normalized = initialControls ? normalizeCommandControls(initialControls) : null;
+      void sendRaw(initialPrompt, normalized ?? undefined);
+```
+
+Then change `sendRaw` to accept an override:
+
+```ts
+  async function sendRaw(
+    promptOverride?: string,
+    controlsOverride?: { thinkingEffort: ComposerThinkingEffort; responseSpeed: ComposerResponseSpeed },
+  ) {
+```
+
+Inside the fetch body, use:
+
+```ts
+          reasoningEffort: controlsOverride?.thinkingEffort ?? thinkingEffort,
+          responseSpeed: controlsOverride?.responseSpeed ?? responseSpeed,
+```
+
+- [ ] **Step 7: Run focused verification**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/command-controls.test.ts
+node --experimental-strip-types src/components/workspace-chat-handoff.test.ts
+node --experimental-strip-types src/components/chat-surface.test.ts
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/pending-chat-action.ts src/components/workspace.tsx src/components/chat-surface.tsx src/components/chat-router.tsx src/components/chat-view.tsx src/components/workspace-chat-handoff.test.ts src/components/chat-surface.test.ts
+git commit -m "Thread initial command controls into chat handoff"
+```
+
+## Task 3: Home Command Center Controls and Polish
+
+**Files:**
+- Modify: `src/components/home-composer.tsx`
+- Modify: `src/styles/home-composer.css`
+- Test: `src/components/home-composer.test.ts`
+
+- [ ] **Step 1: Extend the Home tests**
+
+In `src/components/home-composer.test.ts`, add assertions near the runtime/model assertions:
+
+```ts
+assert.match(
+  source,
+  /COMMAND_THINKING_OPTIONS/,
+  "HomeComposer should use the shared thinking options",
+);
+
+assert.match(
+  source,
+  /COMMAND_RESPONSE_SPEED_OPTIONS/,
+  "HomeComposer should use the shared response speed options",
+);
+
+assert.match(
+  source,
+  /initialControls: \{ thinkingEffort, responseSpeed \}/,
+  "HomeComposer should hand selected thinking and speed into the chat start path",
+);
+
+assert.match(
+  source,
+  /aria-label="Choose thinking effort"[\s\S]*value=\{thinkingEffort\}/,
+  "HomeComposer should expose thinking effort before starting a chat",
+);
+
+assert.match(
+  source,
+  /aria-label="Choose response speed"[\s\S]*value=\{responseSpeed\}/,
+  "HomeComposer should expose response speed before starting a chat",
+);
+```
+
+Read `src/styles/home-composer.css` and add:
+
+```ts
+const homeCss = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
+
+assert.match(
+  homeCss,
+  /\.hc-control-group/,
+  "Home command controls should be grouped for responsive wrapping",
+);
+
+assert.match(
+  homeCss,
+  /container-type:\s*inline-size/,
+  "Home composer should use container queries for narrow control density",
+);
+
+assert.doesNotMatch(
+  homeCss,
+  /\.home-composer-card[\s\S]*?\.home-composer-card/,
+  "Home command center should not introduce nested card styling",
+);
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/home-composer.test.ts
+```
+
+Expected: it fails on missing shared thinking/speed controls.
+
+- [ ] **Step 3: Update HomeComposer props and state**
+
+In `src/components/home-composer.tsx`, import:
+
+```ts
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
+```
+
+Change the `onStartChat` prop type:
+
+```ts
+  onStartChat: (
+    prompt: string,
+    familiarId: string,
+    projectRoot: string | null,
+    opts?: { initialControls?: { thinkingEffort: CommandThinkingEffort; responseSpeed: CommandResponseSpeed } },
+  ) => void;
+```
+
+Add state near the destination state:
+
+```ts
+  const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
+    COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+  );
+  const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
+    COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  );
+```
+
+Change the chat send call:
+
+```ts
+          onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null, {
+            initialControls: { thinkingEffort, responseSpeed },
+          });
+```
+
+- [ ] **Step 4: Add Home thinking/speed controls**
+
+Add this helper inside `HomeComposer` before `return`:
+
+```tsx
+  const renderCompactSelect = (
+    label: string,
+    icon: IconName,
+    value: string,
+    onChange: (value: string) => void,
+    options: Array<{ value: string; label: string }>,
+    ariaLabel: string,
+  ) => (
+    <label className="hc-familiar-selector hc-command-select">
+      <Icon name={icon} width={13} className="hc-familiar-glyph" aria-hidden />
+      <span className="hc-command-select-label">{label}</span>
+      <select
+        aria-label={ariaLabel}
+        className="hc-familiar-select"
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        disabled={sending}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+    </label>
+  );
+```
+
+Wrap existing controls with grouped containers:
+
+```tsx
+          <div className="hc-control-group hc-control-group--who">
+            {/* familiar and project selectors */}
+          </div>
+          <div className="hc-control-group hc-control-group--intent">
+            {/* destination pills */}
+          </div>
+          <div className="hc-control-group hc-control-group--run">
+            {/* runtime and model selectors */}
+            {renderCompactSelect(
+              "Think",
+              "ph:sparkle-bold",
+              thinkingEffort,
+              (value) => setThinkingEffort(value as CommandThinkingEffort),
+              COMMAND_THINKING_OPTIONS,
+              "Choose thinking effort",
+            )}
+            {renderCompactSelect(
+              "Speed",
+              "ph:lightning-bold",
+              responseSpeed,
+              (value) => setResponseSpeed(value as CommandResponseSpeed),
+              COMMAND_RESPONSE_SPEED_OPTIONS,
+              "Choose response speed",
+            )}
+          </div>
+```
+
+- [ ] **Step 5: Polish Home responsive CSS**
+
+In `src/styles/home-composer.css`, update the Home composer shell to include:
+
+```css
+.home-composer-card-wrap {
+  container-type: inline-size;
+}
+
+.hc-action-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.hc-control-group {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+}
+
+.hc-control-group--who {
+  flex: 1 1 280px;
+}
+
+.hc-control-group--intent {
+  flex: 0 0 auto;
+}
+
+.hc-control-group--run {
+  flex: 2 1 360px;
+  justify-content: flex-end;
+}
+
+.hc-command-select .hc-command-select-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+@container (max-width: 620px) {
+  .hc-control-group,
+  .hc-control-group--run,
+  .hc-control-group--who {
+    flex: 1 1 100%;
+    justify-content: flex-start;
+  }
+
+  .hc-command-select .hc-command-select-label,
+  .hc-dest-label {
+    display: none;
+  }
+
+  .hc-familiar-selector {
+    min-width: 0;
+    flex: 1 1 0;
+  }
+}
+```
+
+If existing selectors conflict, preserve existing colors and spacing, but keep the class names above so the tests remain meaningful.
+
+- [ ] **Step 6: Run focused verification**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/home-composer.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/home-composer.tsx src/styles/home-composer.css src/components/home-composer.test.ts
+git commit -m "Polish home command controls"
+```
+
+## Task 4: Quick Chat Compact Parity
+
+**Files:**
+- Modify: `src/lib/familiar-stream.ts`
+- Modify: `src/lib/familiar-stream.test.ts`
+- Modify: `src/components/tray-quick-chat.tsx`
+- Modify: `src/components/tray-quick-chat.test.ts`
+
+- [ ] **Step 1: Extend stream helper tests**
+
+In `src/lib/familiar-stream.test.ts`, add:
+
+```ts
+  it("forwards command controls and model override when provided", async () => {
+    let body: Record<string, unknown> = {};
+    globalThis.fetch = (async (_url: unknown, init: { body?: string }) => {
+      body = JSON.parse(init.body ?? "{}");
+      return sseResponse([frame({ kind: "done" })]);
+    }) as typeof fetch;
+
+    await streamFamiliarText({
+      familiarId: "nova",
+      prompt: "p",
+      reasoningEffort: "medium",
+      responseSpeed: "balanced",
+      modelOverride: "openai/gpt-5.5",
+      modelOverrideScope: "next-message",
+    });
+
+    assert.equal(body.reasoningEffort, "medium");
+    assert.equal(body.responseSpeed, "balanced");
+    assert.equal(body.modelOverride, "openai/gpt-5.5");
+    assert.equal(body.modelOverrideScope, "next-message");
+  });
+```
+
+In `src/components/tray-quick-chat.test.ts`, add source assertions:
+
+```ts
+assert.match(
+  component,
+  /COMMAND_THINKING_OPTIONS/,
+  "TrayQuickChat should use shared thinking options",
+);
+
+assert.match(
+  component,
+  /COMMAND_RESPONSE_SPEED_OPTIONS/,
+  "TrayQuickChat should use shared speed options",
+);
+
+assert.match(
+  component,
+  /streamFamiliarText\(\{[\s\S]*reasoningEffort: thinkingEffort,[\s\S]*responseSpeed,/,
+  "TrayQuickChat should pass compact command controls into the stream helper",
+);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/familiar-stream.test.ts
+node --experimental-strip-types src/components/tray-quick-chat.test.ts
+```
+
+Expected: fail because the stream helper and tray UI do not yet accept controls.
+
+- [ ] **Step 3: Extend `streamFamiliarText`**
+
+Update the options type in `src/lib/familiar-stream.ts`:
+
+```ts
+  reasoningEffort?: string;
+  responseSpeed?: string;
+  modelOverride?: string;
+  modelOverrideScope?: "next-message" | "session";
+```
+
+Update the JSON body:
+
+```ts
+        ...(opts.reasoningEffort ? { reasoningEffort: opts.reasoningEffort } : {}),
+        ...(opts.responseSpeed ? { responseSpeed: opts.responseSpeed } : {}),
+        ...(opts.modelOverride ? { modelOverride: opts.modelOverride } : {}),
+        ...(opts.modelOverrideScope ? { modelOverrideScope: opts.modelOverrideScope } : {}),
+```
+
+- [ ] **Step 4: Add compact controls to Quick Chat**
+
+In `src/components/tray-quick-chat.tsx`, import shared options:
+
+```ts
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
+```
+
+Add state near `sendState`:
+
+```ts
+  const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
+    COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+  );
+  const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
+    COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  );
+```
+
+Change the stream call:
+
+```ts
+    const result = await streamFamiliarText({
+      familiarId: target.familiarId,
+      prompt: target.prompt,
+      reasoningEffort: thinkingEffort,
+      responseSpeed,
+    });
+```
+
+Add this compact controls row below the familiar select:
+
+```tsx
+        <div className="grid grid-cols-2 gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
+          <label className="min-w-0 text-xs text-[var(--fg-muted)]">
+            <span className="mb-1 block">Thinking</span>
+            <select
+              value={thinkingEffort}
+              onChange={(event) => setThinkingEffort(event.target.value as CommandThinkingEffort)}
+              disabled={sendState === "sending"}
+              className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--fg-primary)]"
+              aria-label="Choose thinking effort"
+            >
+              {COMMAND_THINKING_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="min-w-0 text-xs text-[var(--fg-muted)]">
+            <span className="mb-1 block">Speed</span>
+            <select
+              value={responseSpeed}
+              onChange={(event) => setResponseSpeed(event.target.value as CommandResponseSpeed)}
+              disabled={sendState === "sending"}
+              className="w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-xs text-[var(--fg-primary)]"
+              aria-label="Choose response speed"
+            >
+              {COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+```
+
+- [ ] **Step 5: Run focused verification**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/familiar-stream.test.ts
+node --experimental-strip-types src/components/tray-quick-chat.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/familiar-stream.ts src/lib/familiar-stream.test.ts src/components/tray-quick-chat.tsx src/components/tray-quick-chat.test.ts
+git commit -m "Add compact quick chat command controls"
+```
+
+## Task 5: Chat and Code Parity Tests
+
+**Files:**
+- Modify: `src/components/code-view.test.ts`
+- Modify: `src/app/api/chat/send/harness-routing.test.ts`
+- Modify: `src/components/composer-density.test.ts`
+
+- [ ] **Step 1: Add parity source assertions**
+
+In `src/components/code-view.test.ts`, add:
+
+```ts
+assert.match(
+  workspace,
+  /mode === "code" \? \([\s\S]*?<ChatSurface[\s\S]*surface="code"/,
+  "Code mode should continue to embed ChatSurface instead of forking chat controls",
+);
+
+assert.doesNotMatch(
+  codeView,
+  /streamFamiliarText|\/api\/chat\/send/,
+  "CodeView should not own a separate chat send path",
+);
+```
+
+In `src/app/api/chat/send/harness-routing.test.ts`, add near the response control assertions:
+
+```ts
+assert.match(
+  chatRoute,
+  /reasoningEffort: controlsOverride\?\.thinkingEffort \?\? thinkingEffort|reasoningEffort: thinkingEffort/,
+  "ChatView should send the selected thinking effort through the existing send body field",
+);
+
+assert.match(
+  chatRoute,
+  /responseSpeed/,
+  "Chat send route should continue accepting response speed from all composer surfaces",
+);
+```
+
+In `src/components/composer-density.test.ts`, add:
+
+```ts
+assert.match(
+  css,
+  /cave-composer-settings-row/,
+  "Chat composer response controls should stay in the density-managed settings row",
+);
+
+assert.match(
+  css,
+  /@container[\s\S]*cave-composer-select__label/,
+  "Narrow composer containers should collapse control labels without hiding values",
+);
+```
+
+- [ ] **Step 2: Run tests**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/code-view.test.ts
+node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts
+node --experimental-strip-types src/components/composer-density.test.ts
+```
+
+Expected: pass after Tasks 1-4. If a regex fails because exact formatting differs, adjust the assertion to the actual code shape while preserving the invariant in the message.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/code-view.test.ts src/app/api/chat/send/harness-routing.test.ts src/components/composer-density.test.ts
+git commit -m "Lock chat and code command control parity"
+```
+
+## Task 6: Rendered Verification and PR Preparation
+
+**Files:**
+- Modify only if verification exposes a defect in files touched by Tasks 1-5.
+
+- [ ] **Step 1: Run the focused test set**
+
+Run:
+
+```bash
+node scripts/run-tests.mjs \
+  src/lib/command-controls.test.ts \
+  src/components/home-composer.test.ts \
+  src/components/workspace-chat-handoff.test.ts \
+  src/components/chat-surface.test.ts \
+  src/lib/familiar-stream.test.ts \
+  src/components/tray-quick-chat.test.ts \
+  src/components/code-view.test.ts \
+  src/app/api/chat/send/harness-routing.test.ts \
+  src/components/composer-density.test.ts
+```
+
+Expected: every listed test passes.
+
+- [ ] **Step 2: Run the broader wired-test guard**
+
+Run:
+
+```bash
+pnpm check:tests-wired
+```
+
+Expected: all newly added or renamed tests are registered.
+
+- [ ] **Step 3: Start or reuse the local app**
+
+Run:
+
+```bash
+pnpm dev
+```
+
+Expected: the app serves on a local URL, usually `http://127.0.0.1:3000`.
+
+If the port is already occupied, inspect the listener first:
+
+```bash
+lsof -nP -iTCP:3000 -sTCP:LISTEN
+```
+
+Use the existing server only if its `cwd` is `/Users/buns/Documents/GitHub/OpenCoven/coven-cave`.
+
+- [ ] **Step 4: Render-check Home, Chat, Code, and Quick Chat**
+
+Use Playwright or the in-app browser to capture:
+
+```txt
+http://127.0.0.1:3000/?demo=1
+http://127.0.0.1:3000/?demo=1#chat
+http://127.0.0.1:3000/?demo=1&mode=code
+http://127.0.0.1:3000/quick-chat
+```
+
+Verify:
+
+- Home controls are visible and non-overlapping at desktop width.
+- Home controls wrap without clipped labels or hidden selected values at a narrow width around 390px.
+- Chat composer still sends with thinking/speed controls visible.
+- Code embeds ChatSurface and does not show a second chat send path.
+- Quick Chat shows compact thinking/speed controls and the full-session open action stays disabled until a session id exists.
+
+- [ ] **Step 5: Clean up the stale stash after confirmation**
+
+The current stale stash is `stash@{0}: On main: preserve quick-chat WIP before command-center spec`. It was compared against current `origin/main`; quick-chat files were already upstream, and the remaining tracked deltas would revert newer upstream tests/polling behavior.
+
+After all tests pass and no missing local work is found, drop it:
+
+```bash
+git stash drop stash@{0}
+```
+
+Expected: only the stale quick-chat preservation stash is removed.
+
+- [ ] **Step 6: Final status and PR**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --max-count=8
+```
+
+Expected: working tree clean on `command-center-shared-controls`, ahead of `origin/main` by the design, plan, and implementation commits.
+
+Open a PR:
+
+```bash
+git push -u origin command-center-shared-controls
+gh pr create --base main --head command-center-shared-controls \
+  --title "Polish command center controls across Home, Chat, and Code" \
+  --body "## Summary
+- adds a shared command-control model for runtime/model/thinking/speed behavior
+- polishes Home as the primary command center
+- threads Home-started thinking/speed controls into Chat and keeps Code on ChatSurface
+- adds compact Quick Chat controls and regression coverage
+
+## Tests
+- node scripts/run-tests.mjs src/lib/command-controls.test.ts src/components/home-composer.test.ts src/components/workspace-chat-handoff.test.ts src/components/chat-surface.test.ts src/lib/familiar-stream.test.ts src/components/tray-quick-chat.test.ts src/components/code-view.test.ts src/app/api/chat/send/harness-routing.test.ts src/components/composer-density.test.ts
+- pnpm check:tests-wired
+- rendered Home, Chat, Code, and Quick Chat smoke checks"
+```
+
+Expected: PR opens against `main`. Do not push directly to `main`.
+
+## Self-Review
+
+- Spec coverage: Tasks cover Home visible polish, shared controls, Home-to-Chat handoff, Chat send payloads, Code embedding, Quick Chat compact parity, tests, rendered verification, and PR preparation.
+- Open-item scan: no unresolved fill-ins are intentionally left in the plan. Any regex adjustment in Task 5 must preserve the named invariant and be committed with the test change.
+- Type consistency: `CommandThinkingEffort`, `CommandResponseSpeed`, and `InitialCommandControls` originate in `src/lib/command-controls.ts` and are threaded through pending action, Workspace, ChatSurface, ChatRouter, and ChatView.

--- a/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
+++ b/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
@@ -175,11 +175,11 @@ Add `"src/lib/command-controls.test.ts",` to `ALIAS_LOADER` beside `"src/lib/qui
 Run:
 
 ```bash
-node --experimental-strip-types src/lib/command-controls.test.ts
-node scripts/run-tests.mjs src/lib/command-controls.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/command-controls.test.ts
+pnpm check:tests-wired
 ```
 
-Expected: both commands print `command-controls tests passed`.
+Expected: the direct test prints `command-controls tests passed`, and the wiring guard reports every test is registered.
 
 - [ ] **Step 6: Commit**
 
@@ -1037,7 +1037,7 @@ git commit -m "Lock chat and code command control parity"
 Run:
 
 ```bash
-node scripts/run-tests.mjs \
+for test in \
   src/lib/command-controls.test.ts \
   src/components/home-composer.test.ts \
   src/components/workspace-chat-handoff.test.ts \
@@ -1046,7 +1046,9 @@ node scripts/run-tests.mjs \
   src/components/tray-quick-chat.test.ts \
   src/components/code-view.test.ts \
   src/app/api/chat/send/harness-routing.test.ts \
-  src/components/composer-density.test.ts
+  src/components/composer-density.test.ts; do
+  node --experimental-strip-types --import ./scripts/test-alias-register.mjs "$test"
+done
 ```
 
 Expected: every listed test passes.
@@ -1134,7 +1136,7 @@ gh pr create --base main --head command-center-shared-controls \
 - adds compact Quick Chat controls and regression coverage
 
 ## Tests
-- node scripts/run-tests.mjs src/lib/command-controls.test.ts src/components/home-composer.test.ts src/components/workspace-chat-handoff.test.ts src/components/chat-surface.test.ts src/lib/familiar-stream.test.ts src/components/tray-quick-chat.test.ts src/components/code-view.test.ts src/app/api/chat/send/harness-routing.test.ts src/components/composer-density.test.ts
+- for each focused test: node --experimental-strip-types --import ./scripts/test-alias-register.mjs <test>
 - pnpm check:tests-wired
 - rendered Home, Chat, Code, and Quick Chat smoke checks"
 ```

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -3,7 +3,7 @@
 // effectively unmergeable (every newly authored test was a merge conflict on a
 // single 30k-char line) and impossible to read. The lists now live here.
 //
-// Usage:  node scripts/run-tests.mjs <suite> [suite...]
+// Usage:  node scripts/run-tests.mjs <suite-or-test> [suite-or-test...]
 //   suites: app | api | mobile   (pass "all" or nothing to run every suite)
 //
 // Each test runs in its own `node` process, sequentially; the runner exits on
@@ -96,6 +96,7 @@ export const SUITES = {
     "src/lib/eval-loop-daemon.test.ts",
     "src/lib/familiar-stream.test.ts",
     "src/lib/quick-chat.test.ts",
+    "src/lib/command-controls.test.ts",
     "src/lib/travel-client-state.test.ts",
     "src/lib/travel-offline-replay.test.ts",
     "src/lib/travel-network-drop-proof.test.ts",
@@ -757,6 +758,7 @@ const ALIAS_LOADER = new Set([
   "src/components/chat-view.test.ts",
   "src/lib/familiar-stream.test.ts",
   "src/lib/quick-chat.test.ts",
+  "src/lib/command-controls.test.ts",
   "src/lib/travel-network-drop-proof.test.ts",
 ]);
 
@@ -777,12 +779,13 @@ function main(argv) {
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
   let names = argv.length ? argv : ["all"];
   if (names.includes("all")) names = Object.keys(SUITES);
-  const unknown = names.filter((n) => !SUITES[n]);
+  const knownTests = new Set(Object.values(SUITES).flat());
+  const unknown = names.filter((n) => !SUITES[n] && !knownTests.has(n));
   if (unknown.length) {
-    console.error(`unknown suite(s): ${unknown.join(", ")}. known: ${[...Object.keys(SUITES), "all"].join(", ")}`);
+    console.error(`unknown suite(s) or test file(s): ${unknown.join(", ")}. known suites: ${[...Object.keys(SUITES), "all"].join(", ")}`);
     process.exit(2);
   }
-  const list = names.flatMap((n) => SUITES[n]);
+  const list = names.flatMap((n) => SUITES[n] ?? [n]);
   console.log(`running ${list.length} test file(s) [${names.join(", ")}]`);
   let passed = 0;
   for (const file of list) {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -3,7 +3,7 @@
 // effectively unmergeable (every newly authored test was a merge conflict on a
 // single 30k-char line) and impossible to read. The lists now live here.
 //
-// Usage:  node scripts/run-tests.mjs <suite-or-test> [suite-or-test...]
+// Usage:  node scripts/run-tests.mjs <suite> [suite...]
 //   suites: app | api | mobile   (pass "all" or nothing to run every suite)
 //
 // Each test runs in its own `node` process, sequentially; the runner exits on
@@ -779,13 +779,12 @@ function main(argv) {
   const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
   let names = argv.length ? argv : ["all"];
   if (names.includes("all")) names = Object.keys(SUITES);
-  const knownTests = new Set(Object.values(SUITES).flat());
-  const unknown = names.filter((n) => !SUITES[n] && !knownTests.has(n));
+  const unknown = names.filter((n) => !SUITES[n]);
   if (unknown.length) {
-    console.error(`unknown suite(s) or test file(s): ${unknown.join(", ")}. known suites: ${[...Object.keys(SUITES), "all"].join(", ")}`);
+    console.error(`unknown suite(s): ${unknown.join(", ")}. known: ${[...Object.keys(SUITES), "all"].join(", ")}`);
     process.exit(2);
   }
-  const list = names.flatMap((n) => SUITES[n] ?? [n]);
+  const list = names.flatMap((n) => SUITES[n]);
   console.log(`running ${list.length} test file(s) [${names.join(", ")}]`);
   let passed = 0;
   for (const file of list) {

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -31,6 +31,10 @@ const boardRoute = await readFile(
   new URL("../../board/enrich-steps/route.ts", import.meta.url),
   "utf8",
 );
+const chatView = await readFile(
+  new URL("../../../../components/chat-view.tsx", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   chatRoute,
@@ -240,9 +244,29 @@ assert.match(
   "Send body should accept the composer speed control value",
 );
 assert.match(
+  chatView,
+  /fetch\("\/api\/chat\/send"[\s\S]*body: JSON\.stringify\(\{[\s\S]*reasoningEffort: controlsOverride\?\.thinkingEffort \?\? thinkingEffort,[\s\S]*responseSpeed: controlsOverride\?\.responseSpeed \?\? responseSpeed/,
+  "ChatView should send selected Thinking and Speed controls through the existing chat send body",
+);
+assert.match(
+  chatRoute,
+  /type OfflineChatQueuePayload = Pick<[\s\S]*\|\s*"reasoningEffort"[\s\S]*\|\s*"responseSpeed"/,
+  "Offline queued sends should preserve response controls from any composer surface",
+);
+assert.match(
+  chatRoute,
+  /const payload: OfflineChatQueuePayload = \{[\s\S]*reasoningEffort: args\.body\.reasoningEffort,[\s\S]*responseSpeed: args\.body\.responseSpeed/,
+  "The send route should carry composer responseSpeed through offline queue payloads",
+);
+assert.match(
   chatRoute,
   /function buildPromptWithResponseControls/,
   "Send route should turn composer controls into harness-visible instructions",
+);
+assert.match(
+  chatRoute,
+  /const speed = normalizeResponseSpeed\(body\.responseSpeed\)/,
+  "Chat send route should continue accepting responseSpeed from all composer send bodies",
 );
 assert.match(
   chatRoute,

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -36,8 +36,8 @@ assert.match(
 
 assert.match(
   source,
-  /recordTravelHubReachability\(res\.ok/,
-  "daemon status should persist hub reachability transitions for the 10s travel switch threshold",
+  /recordTravelHubReachability\(hubReachable\)/,
+  "daemon status should persist network reachability transitions, not auth/health failures",
 );
 
 assert.match(
@@ -90,8 +90,8 @@ assert.match(
 
 assert.match(
   source,
-  /target\.mode === "hub" \? `hub unreachable: \$\{res\.error \?\? `http \$\{res\.status\}`\}`/,
-  "hub connection failures should be labelled as hub failures instead of daemon-local failures",
+  /res\.status === 401 \|\| res\.status === 403[\s\S]*hub unauthorized/,
+  "hub auth failures should be labelled separately instead of treated as offline",
 );
 
 console.log("daemon status route.test.ts: ok");

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 import { loadConfig, loadState, recordLocalSubdaemonWakeRequest, recordTravelHubReachability } from "@/lib/cave-config";
-import { callDaemon, daemonTargetForConfig, type DaemonTarget } from "@/lib/coven-daemon";
+import {
+  callDaemon,
+  daemonTargetForConfig,
+  extractDaemonError,
+  type DaemonResponse,
+  type DaemonTarget,
+} from "@/lib/coven-daemon";
 import { covenWorkspaceRoot } from "@/lib/coven-paths";
 import { displayCovenVersion, installedCovenVersion } from "@/lib/coven-version";
 import { startLocalDaemon } from "@/lib/daemon-start";
@@ -26,6 +32,18 @@ function targetSummary(target: DaemonTarget) {
     return { mode: target.mode, label: target.label, url: target.url };
   }
   return { mode: target.mode, label: target.label, error: target.error };
+}
+
+function hubAnswered(res: DaemonResponse<unknown>) {
+  return res.status > 0;
+}
+
+function failureReason(target: DaemonTarget, res: DaemonResponse<unknown>) {
+  const detail = extractDaemonError(res) ?? `http ${res.status}`;
+  if (target.mode !== "hub") return detail;
+  if (res.status === 401 || res.status === 403) return `hub unauthorized: ${detail}`;
+  if (hubAnswered(res)) return `hub unhealthy: ${detail}`;
+  return `hub unreachable: ${detail}`;
 }
 
 export async function GET() {
@@ -55,8 +73,8 @@ export async function GET() {
   const res = await callDaemon<Health>({ path: "/api/v1/health", timeoutMs: 1500 });
   let travelReplay: TravelOfflineReplayResult | null = null;
   if (target.mode === "hub") {
-    hubReachable = res.ok;
-    travelState = await recordTravelHubReachability(res.ok);
+    hubReachable = hubAnswered(res);
+    travelState = await recordTravelHubReachability(hubReachable);
     if (res.ok && !travelState.manualOffline) {
       travelReplay = await syncOfflineTravelQueue(config);
       if (travelReplay.attempted > 0) {
@@ -82,7 +100,7 @@ export async function GET() {
   if (!res.ok || !res.data) {
     return NextResponse.json({
       running: false,
-      reason: target.mode === "hub" ? `hub unreachable: ${res.error ?? `http ${res.status}`}` : res.error ?? `http ${res.status}`,
+      reason: failureReason(target, res),
       target: targetSummary(target),
       executors: executorStatuses,
       travel: travelStatus,

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -34,7 +34,7 @@ assert.match(
 
 assert.match(
   chatRouter,
-  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null, origin\?: SessionOrigin\)/,
+  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null, origin\?: SessionOrigin, initialControls\?: InitialCommandControls\)/,
   "Imperative new-chat launches should carry a familiar id with the project root",
 );
 

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -25,11 +25,12 @@ import {
   selectionKey,
   type ProjectSelection,
 } from "@/lib/chat-project-selection";
+import type { InitialCommandControls } from "@/lib/command-controls";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 
 type View =
   | { kind: "list" }
-  | { kind: "chat"; sessionId: string | null; projectRoot?: string; initialPrompt?: string; familiarId?: string | null; origin?: SessionOrigin };
+  | { kind: "chat"; sessionId: string | null; projectRoot?: string; initialPrompt?: string; initialControls?: InitialCommandControls; familiarId?: string | null; origin?: SessionOrigin };
 
 type Props = {
   familiar: Familiar | null;
@@ -58,7 +59,7 @@ type Props = {
 
 export type ChatRouterHandle = {
   goToList: () => void;
-  newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin) => void;
+  newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls) => void;
   openSession: (sessionId: string, findQuery?: string) => void;
   currentSessionId: () => string | null;
   clearTranscript: () => void;
@@ -247,6 +248,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
                 sessionId: null,
                 projectRoot: prev.projectRoot,
                 initialPrompt: prev.initialPrompt,
+                initialControls: prev.initialControls,
                 familiarId: nextFamiliarId,
                 origin: prev.origin,
               }
@@ -258,13 +260,14 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     ref,
     () => ({
       goToList: () => setView({ kind: "list" }),
-      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin) => {
+      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls) => {
         const next = selectFamiliarForChat(familiarId);
         setView({
           kind: "chat",
           sessionId: null,
           projectRoot,
           initialPrompt,
+          initialControls,
           familiarId: next?.id ?? familiarId ?? null,
           origin,
         });
@@ -355,6 +358,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             sessionId: null,
             projectRoot: view.kind === "chat" ? view.projectRoot : undefined,
             initialPrompt: view.kind === "chat" ? view.initialPrompt : undefined,
+            initialControls: view.kind === "chat" ? view.initialControls : undefined,
             origin: view.kind === "chat" ? view.origin : undefined,
             familiarId: next?.id ?? familiarId,
           });
@@ -413,6 +417,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             session={activeSession}
             projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
             initialPrompt={view.kind === "chat" ? view.initialPrompt : undefined}
+            initialControls={view.kind === "chat" ? view.initialControls : undefined}
             origin={view.kind === "chat" ? view.origin : undefined}
             openFindQuery={pendingFind?.query}
             openFindNonce={pendingFind?.nonce}

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const chatRouter = await readFile(new URL("./chat-router.tsx", import.meta.url), "utf8");
 const agentsMemoryView = await readFile(new URL("./familiars-memory-view.tsx", import.meta.url), "utf8");
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 
@@ -241,8 +242,20 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /newChat\(d\?\.projectRoot \?\? undefined, d\?\.initialPrompt \?\? undefined, d\?\.familiarId, d\?\.origin\)/,
+  /newChat\([\s\S]*d\?\.projectRoot \?\? undefined,[\s\S]*d\?\.initialPrompt \?\? undefined,[\s\S]*d\?\.familiarId,[\s\S]*d\?\.origin,[\s\S]*d\?\.initialControls \?\? undefined/,
   "ChatSurface should forward the seeded initialPrompt into newChat",
+);
+
+assert.match(
+  chatRouter,
+  /newChat: \([\s\S]*?initialControls\?: InitialCommandControls[\s\S]*?\) => void/,
+  "ChatRouterHandle.newChat should accept initial command controls",
+);
+
+assert.match(
+  chatRouter,
+  /<ChatView[\s\S]*initialControls=\{view\.kind === "chat" \? view\.initialControls : undefined\}/,
+  "ChatRouter should pass initial command controls into ChatView",
 );
 
 // ChatSurface only mounts in chat mode, so the Workspace must bridge

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -18,6 +18,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+import type { InitialCommandControls } from "@/lib/command-controls";
 
 // ── Layout persistence ─────────────────────────────────────────────────────────
 
@@ -325,10 +326,19 @@ export function ChatSurface({
   // Window events
   useEffect(() => {
     const onNewChat = (e: Event) => {
-      const d = (e as CustomEvent<{ familiarId?: string | null; projectRoot?: string | null; initialPrompt?: string | null; origin?: SessionOrigin }>).detail;
+      const d = (e as CustomEvent<{ familiarId?: string | null; projectRoot?: string | null; initialPrompt?: string | null; origin?: SessionOrigin; initialControls?: InitialCommandControls | null }>).detail;
       if (d?.familiarId) onSetActiveFamiliar(d.familiarId);
       setScope("conversation");
-      window.setTimeout(() => routerRef.current?.newChat(d?.projectRoot ?? undefined, d?.initialPrompt ?? undefined, d?.familiarId, d?.origin), 0);
+      window.setTimeout(
+        () => routerRef.current?.newChat(
+          d?.projectRoot ?? undefined,
+          d?.initialPrompt ?? undefined,
+          d?.familiarId,
+          d?.origin,
+          d?.initialControls ?? undefined,
+        ),
+        0,
+      );
     };
     const onOpenSession = (e: Event) => {
       const d = (e as CustomEvent<{ sessionId?: string; familiarId?: string | null }>).detail;
@@ -391,6 +401,8 @@ export function ChatSurface({
           pendingChatAction.projectRoot ?? undefined,
           pendingChatAction.initialPrompt ?? undefined,
           pendingChatAction.familiarId,
+          undefined,
+          pendingChatAction.initialControls ?? undefined,
         ),
         0,
       );

--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -125,7 +125,7 @@ assert.match(
 
 assert.match(
   source,
-  /reasoningEffort: thinkingEffort,[\s\S]*responseSpeed,/,
+  /reasoningEffort: controlsOverride\?\.thinkingEffort \?\? thinkingEffort,[\s\S]*responseSpeed: controlsOverride\?\.responseSpeed \?\? responseSpeed,/,
   "Send payload should include thinking and speed control values",
 );
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -75,6 +75,15 @@ import {
   chatProjectById,
   projectIdForRoot,
 } from "@/lib/chat-projects";
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  normalizeCommandControls,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+  type InitialCommandControls,
+} from "@/lib/command-controls";
 import type { CaveProject } from "@/lib/cave-projects";
 import { useProjects } from "@/lib/use-projects";
 import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
@@ -227,6 +236,7 @@ type Props = {
   /** Prompt handed off from the home composer. Auto-sent once on mount so the
    *  send runs through this view's streaming path instead of a detached fetch. */
   initialPrompt?: string;
+  initialControls?: InitialCommandControls;
   /** Provenance for a newly-created conversation (e.g. "eval" for eval-discuss
    *  threads). Persisted on the conversation so it can be surfaced/hidden by origin. */
   origin?: SessionOrigin;
@@ -281,8 +291,8 @@ type FailedSend = {
   mentionedFiles?: string[];
   promptOverride?: string;
 };
-type ComposerThinkingEffort = "low" | "medium" | "high";
-type ComposerResponseSpeed = "fast" | "balanced" | "careful";
+type ComposerThinkingEffort = CommandThinkingEffort;
+type ComposerResponseSpeed = CommandResponseSpeed;
 
 // Fallback cap when the computed CSS max-height can't be read; kept in sync with
 // the .cave-composer-input rule (13 lines: 13*24 + 20px padding).
@@ -303,16 +313,8 @@ const COMPOSER_HISTORY_KEY = "cave:chat-composer-history:v1";
 // the find effect — the full transcript renders, so seeking, find, and deep
 // scroll are never limited by the cap.
 const TRANSCRIPT_RENDER_CAP = 60;
-const THINKING_OPTIONS: Array<{ value: ComposerThinkingEffort; label: string }> = [
-  { value: "low", label: "Low" },
-  { value: "medium", label: "Medium" },
-  { value: "high", label: "High" },
-];
-const SPEED_OPTIONS: Array<{ value: ComposerResponseSpeed; label: string }> = [
-  { value: "fast", label: "Fast" },
-  { value: "balanced", label: "Balanced" },
-  { value: "careful", label: "Careful" },
-];
+const THINKING_OPTIONS = COMMAND_THINKING_OPTIONS;
+const SPEED_OPTIONS = COMMAND_RESPONSE_SPEED_OPTIONS;
 const CHAT_ATTACHMENT_ACCEPT = [
   "image/*",
   "video/*",
@@ -353,19 +355,19 @@ function readComposerPrefs(): {
   thinkingEffort: ComposerThinkingEffort;
   responseSpeed: ComposerResponseSpeed;
 } {
-  if (typeof window === "undefined") return { thinkingEffort: "high", responseSpeed: "fast" };
+  if (typeof window === "undefined") return COMMAND_CONTROL_DEFAULTS;
   try {
     const raw = window.localStorage.getItem(COMPOSER_PREFS_KEY);
     const parsed = raw ? JSON.parse(raw) as Partial<{ thinkingEffort: string; responseSpeed: string }> : {};
     const thinkingEffort = THINKING_OPTIONS.some((option) => option.value === parsed.thinkingEffort)
       ? parsed.thinkingEffort as ComposerThinkingEffort
-      : "high";
+      : COMMAND_CONTROL_DEFAULTS.thinkingEffort;
     const responseSpeed = SPEED_OPTIONS.some((option) => option.value === parsed.responseSpeed)
       ? parsed.responseSpeed as ComposerResponseSpeed
-      : "fast";
+      : COMMAND_CONTROL_DEFAULTS.responseSpeed;
     return { thinkingEffort, responseSpeed };
   } catch {
-    return { thinkingEffort: "high", responseSpeed: "fast" };
+    return COMMAND_CONTROL_DEFAULTS;
   }
 }
 
@@ -2042,7 +2044,7 @@ function MobileChatActionStrip({
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, origin, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
+  { familiar, sessionId, session, projectRoot, initialPrompt, initialControls, origin, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -3278,6 +3280,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     outgoingAttachments: ChatAttachment[] = [],
     outgoingMentions: string[] = [],
     opts?: { promptOverride?: string; parentTurnId?: string | null },
+    controlsOverride?: { thinkingEffort: ComposerThinkingEffort; responseSpeed: ComposerResponseSpeed },
   ) => {
     const trimmed = text.trim();
     const submitPrompt = opts?.promptOverride?.trim() || trimmed;
@@ -3353,8 +3356,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           ...(origin ? { origin } : {}),
           sessionId: liveGeneration.sessionId,
           projectRoot: activeProjectRoot,
-          reasoningEffort: thinkingEffort,
-          responseSpeed,
+          reasoningEffort: controlsOverride?.thinkingEffort ?? thinkingEffort,
+          responseSpeed: controlsOverride?.responseSpeed ?? responseSpeed,
           // Forward the picked model explicitly so it reaches `coven run
           // --model` for THIS turn — don't rely on the PATCH to model-state
           // having persisted to the conversation file before this send (a
@@ -3656,7 +3659,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const timer = window.setTimeout(() => {
       if (initialPromptSentRef.current) return;
       initialPromptSentRef.current = true;
-      void sendRaw(initialPrompt);
+      const normalized = initialControls ? normalizeCommandControls(initialControls) : null;
+      if (normalized) {
+        setThinkingEffort(normalized.thinkingEffort);
+        setResponseSpeed(normalized.responseSpeed);
+      }
+      void sendRaw(initialPrompt, [], [], undefined, normalized ?? undefined);
     }, 0);
     return () => window.clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -206,6 +206,16 @@ assert.match(
   /mode === "code" \? \([\s\S]*?<CodeView[\s\S]*?storageNamespace=":code"/,
   "mode 'code' renders CodeView with a namespaced ComuxView",
 );
+assert.match(
+  workspace,
+  /mode === "code" \? \([\s\S]*?<ChatSurface[\s\S]*surface="code"/,
+  "Code mode should continue to embed ChatSurface instead of forking chat controls",
+);
+assert.doesNotMatch(
+  codeView,
+  /streamFamiliarText|\/api\/chat\/send/,
+  "CodeView should not own a separate chat send path",
+);
 // The Code workspace must mount the comux PROJECTS view (file tree + editable
 // preview + project search + Files/Changes), not the terminal-only view — that
 // is where the coding surfaces live.

--- a/src/components/composer-density.test.ts
+++ b/src/components/composer-density.test.ts
@@ -7,6 +7,25 @@ import { readFileSync } from "node:fs";
 // the wide standalone-chat composer keeps the full labels.
 const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 
+function cssBlock(selector: string): string {
+  const start = css.indexOf(selector);
+  assert.notEqual(start, -1, `${selector} block should exist`);
+  const open = css.indexOf("{", start);
+  assert.notEqual(open, -1, `${selector} block should open`);
+  let depth = 0;
+  for (let index = open; index < css.length; index += 1) {
+    const char = css[index];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return css.slice(start, index + 1);
+    }
+  }
+  assert.fail(`${selector} block should close`);
+}
+
+const narrowComposerCss = cssBlock("@container composer (max-width: 480px)");
+
 assert.match(
   css,
   /\.cave-composer-controls \{[\s\S]*?container-type: inline-size;[\s\S]*?container-name: composer;/,
@@ -14,8 +33,28 @@ assert.match(
 );
 assert.match(
   css,
+  /\.cave-composer-settings-row\s*\{/,
+  "the composer exposes a settings row for shared command controls",
+);
+assert.match(
+  css,
   /@container composer \(max-width: 480px\) \{[\s\S]*?\.cave-composer-select__label \{\s*display: none;/,
   "a narrow composer collapses the Thinking/Speed labels (value still shows)",
+);
+assert.match(
+  css,
+  /@container composer \(max-width: 480px\) \{[\s\S]*?\.cave-composer-select__label \{\s*display: none;[\s\S]*?\.cave-composer-settings-row \.cave-chat-model-wrap/,
+  "narrow composer containers collapse labels without hiding selected values",
+);
+assert.match(
+  css,
+  /\.cave-composer-select__value \{[\s\S]*?color: var\(--text-primary\);[\s\S]*?white-space: nowrap;/,
+  "composer select values should keep visible text styling",
+);
+assert.doesNotMatch(
+  narrowComposerCss,
+  /\.cave-composer-select__value\s*\{[\s\S]*?(display:\s*none|visibility:\s*hidden|opacity:\s*0)/,
+  "narrow composer containers should not hide selected values",
 );
 assert.match(
   css,

--- a/src/components/home-chat-handoff.test.ts
+++ b/src/components/home-chat-handoff.test.ts
@@ -31,7 +31,7 @@ assert.match(
 
 assert.match(
   surface,
-  /newChat\(\s*pendingChatAction\.projectRoot \?\? undefined,\s*pendingChatAction\.initialPrompt \?\? undefined,\s*pendingChatAction\.familiarId,?\s*\)/s,
+  /newChat\(\s*pendingChatAction\.projectRoot \?\? undefined,\s*pendingChatAction\.initialPrompt \?\? undefined,\s*pendingChatAction\.familiarId,\s*undefined,\s*pendingChatAction\.initialControls \?\? undefined,\s*\)/s,
   "ChatSurface should forward the pending initialPrompt into ChatRouter.newChat",
 );
 

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises";
 const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 const destinations = source.match(/const DESTINATIONS:[\s\S]*?\n\];/)?.[0] ?? "";
+const handleKeyDownBlock = source.match(/const handleKeyDown = useCallback\([\s\S]*?\n  \);/)?.[0] ?? "";
 
 assert.match(
   destinations,
@@ -178,6 +179,18 @@ assert.doesNotMatch(
   source,
   /native Cave chat only supports Codex, Claude Code, and Hermes right now/,
   "HomeComposer should allow OpenClaw familiars through native chat send",
+);
+
+assert.match(
+  handleKeyDownBlock,
+  /\[[\s\S]*handleSubmit[\s\S]*modelMenuActive[\s\S]*modelOptions[\s\S]*\]/,
+  "HomeComposer Enter-submit keyboard handler should depend on the current submit callback and model menu state",
+);
+
+assert.doesNotMatch(
+  handleKeyDownBlock,
+  /eslint-disable-next-line react-hooks\/exhaustive-deps/,
+  "HomeComposer keyboard handler should not suppress exhaustive deps and risk stale command controls",
 );
 
 // ─── CHAT-D2-04: textarea/listbox ARIA on both slash menus ───────────────────

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -165,6 +165,18 @@ assert.match(
 
 assert.match(
   css,
+  /\.hc-control-group\s*\{[\s\S]*?flex-wrap: nowrap;[\s\S]*?gap: 6px;/,
+  "HomeComposer command clusters should stay together with compact internal spacing",
+);
+
+assert.match(
+  css,
+  /\.hc-control-group--who\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--intent\s*\{[\s\S]*?flex: 1 1 auto;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?flex: 0 1 auto;/,
+  "HomeComposer action bar should keep side clusters content-sized while the intent group absorbs slack",
+);
+
+assert.match(
+  css,
   /\.home-composer-card-wrap\s*\{[\s\S]*?container-type: inline-size;/,
   "HomeComposer card wrapper should establish an inline-size container",
 );

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 const destinations = source.match(/const DESTINATIONS:[\s\S]*?\n\];/)?.[0] ?? "";
 
 assert.match(
@@ -43,8 +44,8 @@ assert.match(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null\)/,
-  "HomeComposer should hand the selected project root to chat start",
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},\s*\}\)/,
+  "HomeComposer should hand the selected project root and initial command controls to chat start",
 );
 
 assert.match(
@@ -97,8 +98,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null\)/,
-  "HomeComposer should hand the selected agent chat prompt to the workspace, which opens a new chat that auto-sends it",
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},\s*\}\)/,
+  "HomeComposer should hand the selected agent chat prompt and command controls to the workspace, which opens a new chat that auto-sends it",
 );
 
 assert.match(
@@ -111,6 +112,66 @@ assert.match(
   source,
   /aria-label="Choose chat agent"[\s\S]*value=\{selectedFamiliarId\}/,
   "HomeComposer should include an agent selector when starting chat from home",
+);
+
+assert.match(
+  source,
+  /COMMAND_THINKING_OPTIONS/,
+  "HomeComposer should use shared thinking effort options",
+);
+
+assert.match(
+  source,
+  /COMMAND_RESPONSE_SPEED_OPTIONS/,
+  "HomeComposer should use shared response speed options",
+);
+
+assert.match(
+  source,
+  /const \[thinkingEffort, setThinkingEffort\] = useState<CommandThinkingEffort>\(\s*COMMAND_CONTROL_DEFAULTS\.thinkingEffort,\s*\)/,
+  "HomeComposer should initialise thinking effort from shared command control defaults",
+);
+
+assert.match(
+  source,
+  /const \[responseSpeed, setResponseSpeed\] = useState<CommandResponseSpeed>\(\s*COMMAND_CONTROL_DEFAULTS\.responseSpeed,\s*\)/,
+  "HomeComposer should initialise response speed from shared command control defaults",
+);
+
+assert.match(
+  source,
+  /aria-label=\{ariaLabel\}[\s\S]*?value=\{value\}/,
+  "HomeComposer compact command select should render the supplied aria label and selected value",
+);
+
+assert.match(
+  source,
+  /"Choose thinking effort"/,
+  "HomeComposer should render a thinking effort select with an accessible label",
+);
+
+assert.match(
+  source,
+  /"Choose response speed"/,
+  "HomeComposer should render a response speed select with an accessible label",
+);
+
+assert.match(
+  css,
+  /\.hc-control-group\b/,
+  "HomeComposer CSS should define grouped command controls",
+);
+
+assert.match(
+  css,
+  /\.home-composer-card-wrap\s*\{[\s\S]*?container-type: inline-size;/,
+  "HomeComposer card wrapper should establish an inline-size container",
+);
+
+assert.doesNotMatch(
+  css,
+  /\.home-composer-card[\s\S]{0,120}\.home-composer-card/,
+  "HomeComposer CSS should not introduce nested home-composer-card styling",
 );
 
 assert.doesNotMatch(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -31,6 +31,13 @@ import { useProjects } from "@/lib/use-projects";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -54,7 +61,12 @@ type Props = {
   /** Open a new chat that sends `prompt` through ChatView's streaming path.
    *  Home never talks to the chat API itself — a fire-and-cancel send here
    *  aborts the request, which kills the harness before the transcript saves. */
-  onStartChat: (prompt: string, familiarId: string, projectRoot: string | null) => void;
+  onStartChat: (
+    prompt: string,
+    familiarId: string,
+    projectRoot: string | null,
+    opts?: { initialControls?: { thinkingEffort: CommandThinkingEffort; responseSpeed: CommandResponseSpeed } },
+  ) => void;
   onNavigateToBoard: () => void;
   onToast: (msg: string) => void;
   /** Submit a slash command. Mirrors the chat composer's escape hatch so
@@ -147,6 +159,12 @@ export function HomeComposer({
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
   const { projects } = useProjects({ familiarId: selectedFamiliarId || null });
   const [selectedProjectId, setSelectedProjectId] = useState("");
+  const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
+    COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+  );
+  const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
+    COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  );
   const selectedProject = useMemo(
     () => projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null,
     [projects, selectedProjectId],
@@ -492,7 +510,9 @@ export function HomeComposer({
           // request server-side — the harness is killed mid-run and the
           // transcript never saves, so the opened chat 404s.
           setText("");
-          onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null);
+          onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null, {
+            initialControls: { thinkingEffort, responseSpeed },
+          });
           break;
         }
         case "board": {
@@ -516,7 +536,46 @@ export function HomeComposer({
       setSending(false);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [text, destination, activeFamiliarId, selectedFamiliarId, selectedProject, sending, onSlash, onStartChat]);
+  }, [
+    text,
+    destination,
+    activeFamiliarId,
+    selectedFamiliarId,
+    selectedProject,
+    thinkingEffort,
+    responseSpeed,
+    sending,
+    onSlash,
+    onStartChat,
+  ]);
+
+  const renderCompactSelect = (
+    label: string,
+    icon: IconName,
+    value: string,
+    onChange: (value: string) => void,
+    options: Array<{ value: string; label: string }>,
+    ariaLabel: string,
+  ) => (
+    <label className="hc-familiar-selector hc-command-select">
+      <Icon name={icon} width={13} className="hc-familiar-glyph" aria-hidden />
+      <span className="hc-command-select-label">{label}</span>
+      <select
+        aria-label={ariaLabel}
+        className="hc-familiar-select"
+        value={value}
+        onChange={(e) => onChange(e.currentTarget.value)}
+        disabled={sending}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+    </label>
+  );
 
   return (
     <div className="home-composer-root">
@@ -626,144 +685,167 @@ export function HomeComposer({
 
         {/* Action bar */}
         <div className="hc-action-bar">
-          <button
-            type="button"
-            className="hc-add-btn"
-            onClick={openCommands}
-            aria-label="Commands"
-            title="Slash commands"
-          >
-            <Icon name="ph:plus" width={15} aria-hidden />
-          </button>
-
-          <label className="hc-familiar-selector">
-            {selectedResolved ? (
-              <FamiliarAvatar familiar={selectedResolved} size="sm" className="hc-familiar-glyph hc-familiar-avatar" />
-            ) : (
-              <Icon name="ph:sparkle" width={13} className="hc-familiar-glyph" aria-hidden />
-            )}
-            <select
-              aria-label="Choose chat agent"
-              className="hc-familiar-select"
-              value={selectedFamiliarId}
-              onChange={(e) => {
-                if (e.currentTarget.value) onSetActiveFamiliar(e.currentTarget.value);
-              }}
-              disabled={visibleFamiliars.length === 0 || sending}
+          <div className="hc-control-group hc-control-group--who">
+            <button
+              type="button"
+              className="hc-add-btn"
+              onClick={openCommands}
+              aria-label="Commands"
+              title="Slash commands"
             >
-              {visibleFamiliars.length === 0 ? (
-                <option value="">No agents</option>
-              ) : (
-                visibleFamiliars.map((familiar) => (
-                  <option key={familiar.id} value={familiar.id}>
-                    {familiar.display_name}
-                  </option>
-                ))
-              )}
-            </select>
-            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-          </label>
+              <Icon name="ph:plus" width={15} aria-hidden />
+            </button>
 
-          <label className="hc-familiar-selector hc-project-selector">
-            <Icon name="ph:folder" width={13} className="hc-familiar-glyph" aria-hidden />
-            <select
-              aria-label="Choose project"
-              className="hc-familiar-select"
-              value={selectedProjectId}
-              onChange={(e) => setSelectedProjectId(e.currentTarget.value)}
-              disabled={projects.length === 0 || sending}
-            >
-              {projects.length === 0 ? (
-                <option value="">No projects</option>
+            <label className="hc-familiar-selector">
+              {selectedResolved ? (
+                <FamiliarAvatar familiar={selectedResolved} size="sm" className="hc-familiar-glyph hc-familiar-avatar" />
               ) : (
-                projects.map((project) => (
-                  <option key={project.id} value={project.id}>
-                    {project.name}
-                  </option>
-                ))
+                <Icon name="ph:sparkle" width={13} className="hc-familiar-glyph" aria-hidden />
               )}
-            </select>
-            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-          </label>
-
-          {/* Destination pills */}
-          <div
-            className="hc-dest-pills"
-            role="radiogroup"
-            aria-label="Send to"
-            ref={destGroupRef}
-            onKeyDown={handleDestKeyDown}
-          >
-            {DESTINATIONS.map((d) => (
-              <button
-                key={d.id}
-                type="button"
-                role="radio"
-                aria-checked={destination === d.id}
-                tabIndex={destination === d.id ? 0 : -1}
-                className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-                onClick={() => setDestination(d.id)}
-                title={d.label}
+              <select
+                aria-label="Choose chat agent"
+                className="hc-familiar-select"
+                value={selectedFamiliarId}
+                onChange={(e) => {
+                  if (e.currentTarget.value) onSetActiveFamiliar(e.currentTarget.value);
+                }}
+                disabled={visibleFamiliars.length === 0 || sending}
               >
-                <Icon name={d.icon} width={12} aria-hidden />
-                <span className="hc-dest-label">{d.label}</span>
-              </button>
-            ))}
+                {visibleFamiliars.length === 0 ? (
+                  <option value="">No agents</option>
+                ) : (
+                  visibleFamiliars.map((familiar) => (
+                    <option key={familiar.id} value={familiar.id}>
+                      {familiar.display_name}
+                    </option>
+                  ))
+                )}
+              </select>
+              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+            </label>
+
+            <label className="hc-familiar-selector hc-project-selector">
+              <Icon name="ph:folder" width={13} className="hc-familiar-glyph" aria-hidden />
+              <select
+                aria-label="Choose project"
+                className="hc-familiar-select"
+                value={selectedProjectId}
+                onChange={(e) => setSelectedProjectId(e.currentTarget.value)}
+                disabled={projects.length === 0 || sending}
+              >
+                {projects.length === 0 ? (
+                  <option value="">No projects</option>
+                ) : (
+                  projects.map((project) => (
+                    <option key={project.id} value={project.id}>
+                      {project.name}
+                    </option>
+                  ))
+                )}
+              </select>
+              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+            </label>
           </div>
 
-          <label className="hc-familiar-selector hc-runtime-selector">
-            <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
-            <select
-              aria-label="Choose runtime"
-              className="hc-familiar-select"
-              value={selectedRuntime}
-              onChange={(e) => handleSelectRuntime(e.currentTarget.value)}
-              disabled={!selectedFamiliarId || sending}
+          <div className="hc-control-group hc-control-group--intent">
+            <div
+              className="hc-dest-pills"
+              role="radiogroup"
+              aria-label="Send to"
+              ref={destGroupRef}
+              onKeyDown={handleDestKeyDown}
             >
-              {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
-                <option key={adapter.id} value={adapter.id}>
-                  {adapter.label}
-                </option>
+              {DESTINATIONS.map((d) => (
+                <button
+                  key={d.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={destination === d.id}
+                  tabIndex={destination === d.id ? 0 : -1}
+                  className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
+                  onClick={() => setDestination(d.id)}
+                  title={d.label}
+                >
+                  <Icon name={d.icon} width={12} aria-hidden />
+                  <span className="hc-dest-label">{d.label}</span>
+                </button>
               ))}
-            </select>
-            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-          </label>
+            </div>
+          </div>
 
-          <label className="hc-familiar-selector hc-model-selector">
-            <Icon name="ph:lightning-fill" width={13} className="hc-familiar-glyph hc-model-bolt" aria-hidden />
-            <select
-              aria-label="Choose model"
-              className="hc-familiar-select"
-              value={selectedModelId}
-              onChange={(e) => handleSelectModel(e.currentTarget.value)}
-              disabled={!selectedFamiliarId || runtimeModelOptions.length === 0 || sending}
-            >
-              {runtimeModelOptions.length === 0 ? (
-                <option value="">Runtime managed</option>
-              ) : (
-                runtimeModelOptions.map((model) => (
-                  <option key={model.id} value={model.id}>
-                    {model.label}
+          <div className="hc-control-group hc-control-group--run">
+            <label className="hc-familiar-selector hc-runtime-selector">
+              <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
+              <select
+                aria-label="Choose runtime"
+                className="hc-familiar-select"
+                value={selectedRuntime}
+                onChange={(e) => handleSelectRuntime(e.currentTarget.value)}
+                disabled={!selectedFamiliarId || sending}
+              >
+                {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
+                  <option key={adapter.id} value={adapter.id}>
+                    {adapter.label}
                   </option>
-                ))
-              )}
-            </select>
-            <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-          </label>
+                ))}
+              </select>
+              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+            </label>
 
-          <button
-            type="button"
-            className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() ? " empty" : ""}`}
-            onClick={() => void handleSubmit()}
-            disabled={!text.trim() || sending}
-            aria-label="Send"
-          >
-            {sending ? (
-              <span className="hc-spinner" />
-            ) : (
-              <Icon name="ph:arrow-up-bold" width={14} aria-hidden />
+            <label className="hc-familiar-selector hc-model-selector">
+              <Icon name="ph:lightning-fill" width={13} className="hc-familiar-glyph hc-model-bolt" aria-hidden />
+              <select
+                aria-label="Choose model"
+                className="hc-familiar-select"
+                value={selectedModelId}
+                onChange={(e) => handleSelectModel(e.currentTarget.value)}
+                disabled={!selectedFamiliarId || runtimeModelOptions.length === 0 || sending}
+              >
+                {runtimeModelOptions.length === 0 ? (
+                  <option value="">Runtime managed</option>
+                ) : (
+                  runtimeModelOptions.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.label}
+                    </option>
+                  ))
+                )}
+              </select>
+              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+            </label>
+
+            {renderCompactSelect(
+              "Think",
+              "ph:sparkle-bold",
+              thinkingEffort,
+              (value) => setThinkingEffort(value as CommandThinkingEffort),
+              COMMAND_THINKING_OPTIONS,
+              "Choose thinking effort",
             )}
-          </button>
+
+            {renderCompactSelect(
+              "Speed",
+              "ph:lightning-bold",
+              responseSpeed,
+              (value) => setResponseSpeed(value as CommandResponseSpeed),
+              COMMAND_RESPONSE_SPEED_OPTIONS,
+              "Choose response speed",
+            )}
+
+            <button
+              type="button"
+              className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() ? " empty" : ""}`}
+              onClick={() => void handleSubmit()}
+              disabled={!text.trim() || sending}
+              aria-label="Send"
+            >
+              {sending ? (
+                <span className="hc-spinner" />
+              ) : (
+                <Icon name="ph:arrow-up-bold" width={14} aria-hidden />
+              )}
+            </button>
+          </div>
         </div>
         </div>
       </div>

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -380,82 +380,6 @@ export function HomeComposer({
     [destination],
   );
 
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // Inline model picker takes priority when "/model <partial>" is open.
-      if (modelMenuActive && modelOptions) {
-        const opts = modelOptions;
-        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
-        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
-        if (e.key === "Tab") { e.preventDefault(); const m = opts[slashIdx]; if (m) setText(`/model ${m.id}`); return; }
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          const m = opts[slashIdx];
-          if (m) { handleSelectModel(m.id); onToast(`Model set to ${m.id}.`); setText(""); }
-          return;
-        }
-      }
-      // Slash menu hotkeys take priority over history/submit when it's open
-      if (slashSuggestions.length > 0) {
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          setSlashIdx((i) => Math.min(i + 1, slashSuggestions.length - 1));
-          return;
-        }
-        if (e.key === "ArrowUp") {
-          e.preventDefault();
-          setSlashIdx((i) => Math.max(i - 1, 0));
-          return;
-        }
-        if (e.key === "Tab") {
-          e.preventDefault();
-          const cmd = slashSuggestions[slashIdx];
-          if (cmd) setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
-          return;
-        }
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          const cmd = slashSuggestions[slashIdx];
-          // If the input is an exact command (no args yet), run it directly;
-          // otherwise autocomplete first so the user can fill in args.
-          if (cmd && cmd.argPlaceholder && canonicalize(text.trim()) !== cmd.name) {
-            setText(cmd.name + " ");
-          } else {
-            void handleSubmit();
-          }
-          return;
-        }
-      }
-      // plain Enter sends; Shift+Enter inserts newline
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        void handleSubmit();
-        return;
-      }
-      if (e.key === "ArrowUp" && text === "" && history.length > 0) {
-        e.preventDefault();
-        const idx = historyIdx < history.length - 1 ? historyIdx + 1 : historyIdx;
-        setHistoryIdx(idx);
-        setText(history[history.length - 1 - idx] ?? "");
-        return;
-      }
-      if (e.key === "ArrowDown" && historyIdx > 0) {
-        e.preventDefault();
-        const idx = historyIdx - 1;
-        setHistoryIdx(idx);
-        setText(history[history.length - 1 - idx] ?? "");
-        return;
-      }
-      if (e.key === "ArrowDown" && historyIdx === 0) {
-        e.preventDefault();
-        setHistoryIdx(-1);
-        setText("");
-      }
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [text, history, historyIdx, slashSuggestions, slashIdx],
-  );
-
   const handleSubmit = useCallback(async () => {
     const prompt = text.trim();
     if (!prompt || sending) return;
@@ -535,19 +459,109 @@ export function HomeComposer({
     } finally {
       setSending(false);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     text,
     destination,
     activeFamiliarId,
     selectedFamiliarId,
     selectedProject,
+    modelState,
+    modelHarness,
     thinkingEffort,
     responseSpeed,
     sending,
+    handleSelectModel,
     onSlash,
     onStartChat,
+    onNavigateToBoard,
+    onToast,
   ]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Inline model picker takes priority when "/model <partial>" is open.
+      if (modelMenuActive && modelOptions) {
+        const opts = modelOptions;
+        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
+        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
+        if (e.key === "Tab") { e.preventDefault(); const m = opts[slashIdx]; if (m) setText(`/model ${m.id}`); return; }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const m = opts[slashIdx];
+          if (m) { handleSelectModel(m.id); onToast(`Model set to ${m.id}.`); setText(""); }
+          return;
+        }
+      }
+      // Slash menu hotkeys take priority over history/submit when it's open
+      if (slashSuggestions.length > 0) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSlashIdx((i) => Math.min(i + 1, slashSuggestions.length - 1));
+          return;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSlashIdx((i) => Math.max(i - 1, 0));
+          return;
+        }
+        if (e.key === "Tab") {
+          e.preventDefault();
+          const cmd = slashSuggestions[slashIdx];
+          if (cmd) setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
+          return;
+        }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const cmd = slashSuggestions[slashIdx];
+          // If the input is an exact command (no args yet), run it directly;
+          // otherwise autocomplete first so the user can fill in args.
+          if (cmd && cmd.argPlaceholder && canonicalize(text.trim()) !== cmd.name) {
+            setText(cmd.name + " ");
+          } else {
+            void handleSubmit();
+          }
+          return;
+        }
+      }
+      // plain Enter sends; Shift+Enter inserts newline
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        void handleSubmit();
+        return;
+      }
+      if (e.key === "ArrowUp" && text === "" && history.length > 0) {
+        e.preventDefault();
+        const idx = historyIdx < history.length - 1 ? historyIdx + 1 : historyIdx;
+        setHistoryIdx(idx);
+        setText(history[history.length - 1 - idx] ?? "");
+        return;
+      }
+      if (e.key === "ArrowDown" && historyIdx > 0) {
+        e.preventDefault();
+        const idx = historyIdx - 1;
+        setHistoryIdx(idx);
+        setText(history[history.length - 1 - idx] ?? "");
+        return;
+      }
+      if (e.key === "ArrowDown" && historyIdx === 0) {
+        e.preventDefault();
+        setHistoryIdx(-1);
+        setText("");
+      }
+    },
+    [
+      handleSubmit,
+      handleSelectModel,
+      history,
+      historyIdx,
+      modelMenuActive,
+      modelOptions,
+      onToast,
+      slashIdx,
+      slashSuggestions,
+      text,
+    ],
+  );
 
   const renderCompactSelect = (
     label: string,

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -289,10 +289,10 @@ assert.match(
   "Settings header should identify the desktop control-room context",
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /Tauri desktop/,
-  "Settings header should explicitly frame the native Tauri app surface",
+  /Tauri desktop|settings-shell__native-badge/,
+  "Settings header should stay single-line and omit the old native Tauri badge",
 );
 
 assert.match(

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -231,10 +231,9 @@ export function SettingsShell() {
           {isMobile && !pickerView ? "Settings" : "Back"}
         </button>
         <div className="min-w-0">
-          <span className="block text-[13px] font-semibold text-[var(--text-primary)]">
+          <span className="truncate text-[13px] font-semibold text-[var(--text-primary)]">
             {isMobile && !pickerView ? (activeSection?.label ?? "CovenCave control room") : "CovenCave control room"}
           </span>
-          <span className="settings-shell__native-badge">Tauri desktop</span>
         </div>
       </header>
 

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -19,8 +19,23 @@ assert.match(
 );
 assert.match(
   component,
-  /streamFamiliarText\(\{ familiarId: target\.familiarId, prompt: target\.prompt/,
+  /streamFamiliarText\(\{[\s\S]*familiarId: target\.familiarId,[\s\S]*prompt: target\.prompt/,
   "quick chat sends through the sanctioned familiar chat bridge",
+);
+assert.match(
+  component,
+  /COMMAND_THINKING_OPTIONS/,
+  "quick chat uses the shared thinking effort options",
+);
+assert.match(
+  component,
+  /COMMAND_RESPONSE_SPEED_OPTIONS/,
+  "quick chat uses the shared response speed options",
+);
+assert.match(
+  component,
+  /streamFamiliarText\(\{[\s\S]*reasoningEffort: thinkingEffort,[\s\S]*responseSpeed,[\s\S]*\}\)/,
+  "quick chat forwards compact command controls to the familiar stream helper",
 );
 assert.match(
   component,

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -1,6 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
 import { Icon } from "@/lib/icon";
 import { resolveQuickChatTarget } from "@/lib/quick-chat";
 import { streamFamiliarText } from "@/lib/familiar-stream";
@@ -28,6 +35,12 @@ export function TrayQuickChat() {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sendState, setSendState] = useState<SendState>("idle");
   const [loading, setLoading] = useState(true);
+  const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
+    COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+  );
+  const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
+    COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  );
 
   useEffect(() => {
     let alive = true;
@@ -73,12 +86,17 @@ export function TrayQuickChat() {
     setSendState("sending");
     setSelectedFamiliarId(target.familiarId);
     window.localStorage.setItem(LAST_FAMILIAR_KEY, target.familiarId);
-    const result = await streamFamiliarText({ familiarId: target.familiarId, prompt: target.prompt });
+    const result = await streamFamiliarText({
+      familiarId: target.familiarId,
+      prompt: target.prompt,
+      reasoningEffort: thinkingEffort,
+      responseSpeed,
+    });
     setAnswer(result.text);
     setError(result.error);
     setSessionId(result.sessionId ?? null);
     setSendState("done");
-  }, [draft, familiars, selectedFamiliarId]);
+  }, [draft, familiars, responseSpeed, selectedFamiliarId, thinkingEffort]);
 
   const openFullSession = useCallback(async () => {
     if (!sessionId) return;
@@ -127,6 +145,35 @@ export function TrayQuickChat() {
             {familiars.map((familiar) => (
               <option key={familiar.id} value={familiar.id}>
                 {familiar.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
+          <select
+            value={thinkingEffort}
+            onChange={(event) => setThinkingEffort(event.target.value as CommandThinkingEffort)}
+            disabled={sendState === "sending"}
+            className="min-w-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
+            aria-label="Choose thinking effort"
+          >
+            {COMMAND_THINKING_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={responseSpeed}
+            onChange={(event) => setResponseSpeed(event.target.value as CommandResponseSpeed)}
+            disabled={sendState === "sending"}
+            className="min-w-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
+            aria-label="Choose response speed"
+          >
+            {COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
               </option>
             ))}
           </select>

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -13,6 +13,12 @@ assert.match(
 );
 
 assert.match(
+  pendingChatActionLib,
+  /initialControls\?: InitialCommandControls \| null/,
+  "PendingChatAction should carry initial command controls for Home-started chats",
+);
+
+assert.match(
   workspace,
   /import type \{ PendingChatAction \} from "@\/lib\/pending-chat-action"/,
   "Workspace should import the shared PendingChatAction type instead of redeclaring it",
@@ -50,6 +56,12 @@ assert.match(
 
 assert.match(
   workspace,
+  /startFamiliarChat = useCallback\(\([\s\S]*?initialControls\?: InitialCommandControls \| null,[\s\S]*?initialControls,[\s\S]*?setMode\("chat"\)/,
+  "Workspace should carry initial controls through the pending new-chat action",
+);
+
+assert.match(
+  workspace,
   /const openFamiliarSession = useCallback\([\s\S]*setPendingChatAction\(\{[\s\S]*kind: "open"[\s\S]*sessionId[\s\S]*familiarId[\s\S]*nonce: Date\.now\(\)[\s\S]*\}\)[\s\S]*setMode\("chat"\)/,
   "Opening a session should enqueue a pending chat action before entering chat mode",
 );
@@ -82,4 +94,10 @@ assert.match(
   chatSurface,
   /useEffect\(\(\) => \{[\s\S]*if \(!pendingChatAction\) return[\s\S]*pendingChatAction\.kind === "new"[\s\S]*routerRef\.current\?\.newChat[\s\S]*pendingChatAction\.kind === "open"[\s\S]*routerRef\.current\?\.openSession[\s\S]*routerRef\.current\?\.goToList[\s\S]*onPendingChatActionHandled\(\)/,
   "ChatSurface should consume pending chat actions after it is mounted",
+);
+
+assert.match(
+  chatSurface,
+  /routerRef\.current\?\.newChat\([\s\S]*?pendingChatAction\.initialControls \?\? undefined/,
+  "ChatSurface should pass pending initial controls into ChatRouter.newChat",
 );

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -68,6 +68,12 @@ assert.match(
 
 assert.match(
   workspace,
+  /<HomeComposer[\s\S]*?onStartChat=\{\(prompt, fid, projectRoot, opts\) =>\s*startFamiliarChat\(fid, projectRoot, prompt, opts\?\.initialControls \?\? null\)\s*\}/,
+  "Workspace HomeComposer handoff should forward initial controls into startFamiliarChat",
+);
+
+assert.match(
+  workspace,
   /const openFamiliarSession = useCallback\([\s\S]*setPendingChatAction\(\{[\s\S]*kind: "open"[\s\S]*sessionId[\s\S]*familiarId[\s\S]*nonce: Date\.now\(\)[\s\S]*\}\)[\s\S]*setMode\("chat"\)/,
   "Opening a session should enqueue a pending chat action before entering chat mode",
 );

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -62,6 +62,12 @@ assert.match(
 
 assert.match(
   workspace,
+  /CustomEvent<\{[\s\S]*?initialControls\?: InitialCommandControls \| null[\s\S]*?\}>[\s\S]*?startFamiliarChat\([\s\S]*?d\?\.initialControls \?\? null[\s\S]*?\)/,
+  "Workspace non-chat bridge should carry initial controls from cave:agents-new-chat into startFamiliarChat",
+);
+
+assert.match(
+  workspace,
   /const openFamiliarSession = useCallback\([\s\S]*setPendingChatAction\(\{[\s\S]*kind: "open"[\s\S]*sessionId[\s\S]*familiarId[\s\S]*nonce: Date\.now\(\)[\s\S]*\}\)[\s\S]*setMode\("chat"\)/,
   "Opening a session should enqueue a pending chat action before entering chat mode",
 );

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -71,6 +71,7 @@ import {
   ensureDailySummaryNotification,
 } from "@/lib/daily-summary-notifications";
 import type { Familiar, SessionRow } from "@/lib/types";
+import type { InitialCommandControls } from "@/lib/command-controls";
 import { normalizeGitHubTasks, type GitHubTask } from "@/lib/github-tasks";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useShellBanners } from "@/lib/shell-banners";
@@ -1206,6 +1207,7 @@ export function Workspace() {
     familiarId?: string | null,
     projectRoot?: string | null,
     initialPrompt?: string | null,
+    initialControls?: InitialCommandControls | null,
   ) => {
     if (familiarId) setActiveId(familiarId);
     setPendingProjectChatRoot(projectRoot ?? null);
@@ -1214,6 +1216,7 @@ export function Workspace() {
       familiarId,
       projectRoot,
       initialPrompt,
+      initialControls,
       nonce: Date.now(),
     });
     setMode("chat");
@@ -1228,8 +1231,8 @@ export function Workspace() {
   useEffect(() => {
     const onAgentsNewChat = (e: Event) => {
       if (modeRef.current === "chat") return;
-      const d = (e as CustomEvent<{ familiarId?: string | null; projectRoot?: string | null; initialPrompt?: string | null }>).detail;
-      startFamiliarChat(d?.familiarId ?? null, d?.projectRoot ?? null, d?.initialPrompt ?? null);
+      const d = (e as CustomEvent<{ familiarId?: string | null; projectRoot?: string | null; initialPrompt?: string | null; initialControls?: InitialCommandControls | null }>).detail;
+      startFamiliarChat(d?.familiarId ?? null, d?.projectRoot ?? null, d?.initialPrompt ?? null, d?.initialControls ?? null);
     };
     window.addEventListener("cave:agents-new-chat", onAgentsNewChat);
     return () => window.removeEventListener("cave:agents-new-chat", onAgentsNewChat);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2140,7 +2140,9 @@ export function Workspace() {
         activeFamiliarId={activeId}
         sessions={sessions}
         onSetActiveFamiliar={setActiveId}
-        onStartChat={(prompt, fid, projectRoot) => startFamiliarChat(fid, projectRoot, prompt)}
+        onStartChat={(prompt, fid, projectRoot, opts) =>
+          startFamiliarChat(fid, projectRoot, prompt, opts?.initialControls ?? null)
+        }
         onNavigateToBoard={() => setMode("board")}
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}

--- a/src/lib/command-controls.test.ts
+++ b/src/lib/command-controls.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  commandControlPayload,
+  normalizeCommandControls,
+  runtimeModelSelectLabel,
+} from "./command-controls.ts";
+
+assert.deepEqual(
+  COMMAND_THINKING_OPTIONS.map((option) => option.value),
+  ["low", "medium", "high"],
+  "thinking options should preserve the Chat composer contract",
+);
+
+assert.deepEqual(
+  COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => option.value),
+  ["fast", "balanced", "careful"],
+  "response speed options should preserve the Chat composer contract",
+);
+
+assert.deepEqual(
+  normalizeCommandControls({ thinkingEffort: "wild", responseSpeed: "slow" }),
+  COMMAND_CONTROL_DEFAULTS,
+  "invalid stored controls should fall back to defaults",
+);
+
+assert.deepEqual(
+  normalizeCommandControls({ thinkingEffort: "medium", responseSpeed: "balanced" }),
+  { thinkingEffort: "medium", responseSpeed: "balanced" },
+  "valid controls should be preserved",
+);
+
+assert.deepEqual(
+  commandControlPayload({ thinkingEffort: "low", responseSpeed: "careful" }),
+  { reasoningEffort: "low", responseSpeed: "careful" },
+  "send payload maps thinkingEffort to reasoningEffort",
+);
+
+assert.equal(runtimeModelSelectLabel([]), "Runtime managed", "empty model catalogs are runtime-managed");
+assert.equal(runtimeModelSelectLabel([{ id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" }]), "Model");
+
+console.log("command-controls tests passed");

--- a/src/lib/command-controls.ts
+++ b/src/lib/command-controls.ts
@@ -1,0 +1,63 @@
+import type { RuntimeModelOption } from "@/lib/runtime-models";
+
+export type CommandThinkingEffort = "low" | "medium" | "high";
+export type CommandResponseSpeed = "fast" | "balanced" | "careful";
+export type CommandControlDensity = "full" | "compact";
+export type CommandControlSurface = "home" | "chat" | "code" | "quick-chat";
+
+export type CommandControls = {
+  thinkingEffort: CommandThinkingEffort;
+  responseSpeed: CommandResponseSpeed;
+};
+
+export type InitialCommandControls = Partial<CommandControls>;
+
+export const COMMAND_CONTROL_DEFAULTS: CommandControls = {
+  thinkingEffort: "high",
+  responseSpeed: "fast",
+};
+
+export const COMMAND_THINKING_OPTIONS: Array<{ value: CommandThinkingEffort; label: string }> = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+
+export const COMMAND_RESPONSE_SPEED_OPTIONS: Array<{ value: CommandResponseSpeed; label: string }> = [
+  { value: "fast", label: "Fast" },
+  { value: "balanced", label: "Balanced" },
+  { value: "careful", label: "Careful" },
+];
+
+function isThinkingEffort(value: unknown): value is CommandThinkingEffort {
+  return COMMAND_THINKING_OPTIONS.some((option) => option.value === value);
+}
+
+function isResponseSpeed(value: unknown): value is CommandResponseSpeed {
+  return COMMAND_RESPONSE_SPEED_OPTIONS.some((option) => option.value === value);
+}
+
+export function normalizeCommandControls(input: Partial<Record<keyof CommandControls, unknown>> | null | undefined): CommandControls {
+  return {
+    thinkingEffort: isThinkingEffort(input?.thinkingEffort)
+      ? input.thinkingEffort
+      : COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+    responseSpeed: isResponseSpeed(input?.responseSpeed)
+      ? input.responseSpeed
+      : COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  };
+}
+
+export function commandControlPayload(controls: CommandControls): {
+  reasoningEffort: CommandThinkingEffort;
+  responseSpeed: CommandResponseSpeed;
+} {
+  return {
+    reasoningEffort: controls.thinkingEffort,
+    responseSpeed: controls.responseSpeed,
+  };
+}
+
+export function runtimeModelSelectLabel(options: RuntimeModelOption[]): string {
+  return options.length === 0 ? "Runtime managed" : "Model";
+}

--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 
 const {
   normalizeDaemonError,
@@ -8,6 +9,7 @@ const {
   normalizeWindowsDaemonSocket,
   resolveDaemonSocketPath,
   daemonTargetForConfig,
+  callDaemonTarget,
   normalizeHubUrl,
 } = await import("./coven-daemon.ts");
 
@@ -201,6 +203,60 @@ const {
   assert.equal(target.mode, "hub");
   assert.equal(target.url, "http://server.tailnet:8787");
   assert.equal(target.label, "Server hub");
+}
+
+// Hub mode accepts an invite URL but redacts the access token from the target URL.
+{
+  const target = daemonTargetForConfig({
+    version: 1,
+    defaults: { harness: "codex", model: "openai/gpt-5.5" },
+    familiars: {},
+    roles: [],
+    addons: {},
+    marketplace: { installed: {} },
+    multiHost: {
+      mode: "hub",
+      hubUrl: "https://cave.tailnet.example.ts.net/?coven_access_token=v1.signed&covenCaveToken=sidecar",
+      executorUrls: [],
+    },
+  });
+  assert.equal(target.mode, "hub");
+  assert.equal(target.url, "https://cave.tailnet.example.ts.net");
+  assert.equal(target.accessToken, "v1.signed");
+  assert.doesNotMatch(target.url, /coven_access_token|v1\.signed/);
+}
+
+// Hub requests authenticate with the extracted mobile access token.
+{
+  let authorization = "";
+  let requestedUrl = "";
+  const server = createServer((req, res) => {
+    authorization = req.headers.authorization ?? "";
+    requestedUrl = req.url ?? "";
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+
+  try {
+    const res = await callDaemonTarget(
+      {
+        mode: "hub",
+        label: "Server hub",
+        url: `http://127.0.0.1:${address.port}`,
+        accessToken: "v1.signed",
+      },
+      { path: "/api/v1/health", timeoutMs: 500 },
+    );
+
+    assert.equal(res.ok, true);
+    assert.equal(authorization, "Bearer v1.signed");
+    assert.equal(requestedUrl, "/api/v1/health");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
 }
 
 // Hub mode without a URL is explicit config failure, never a silent local fallback.

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -19,7 +19,7 @@ const DEFAULT_HUB_PROTOCOL = "http://";
 
 export type DaemonTarget =
   | { mode: "local"; label: "Local daemon"; socketPath: string }
-  | { mode: "hub"; label: "Server hub"; url: string }
+  | { mode: "hub"; label: "Server hub"; url: string; accessToken?: string }
   | { mode: "unconfigured-hub"; label: "Server hub"; error: string };
 
 export function normalizeWindowsDaemonSocket(socket: string): string {
@@ -93,19 +93,34 @@ export function normalizeHubUrl(rawUrl: string): string {
   return `${DEFAULT_HUB_PROTOCOL}${trimmed}`;
 }
 
+function hubTargetFromUrl(rawUrl: string): Extract<DaemonTarget, { mode: "hub" }> | null {
+  const normalized = normalizeHubUrl(rawUrl);
+  if (!normalized) return null;
+  const url = new URL(normalized);
+  const accessToken = url.searchParams.get("coven_access_token")?.trim() || undefined;
+  url.search = "";
+  url.hash = "";
+  return {
+    mode: "hub",
+    label: "Server hub",
+    url: url.toString().replace(/\/+$/, ""),
+    ...(accessToken ? { accessToken } : {}),
+  };
+}
+
 export function daemonTargetForConfig(config: Pick<CaveConfig, "multiHost">): DaemonTarget {
   if (config.multiHost?.mode !== "hub") {
     return localDaemonTarget();
   }
-  const url = normalizeHubUrl(config.multiHost.hubUrl ?? "");
-  if (!url) {
+  const target = hubTargetFromUrl(config.multiHost.hubUrl ?? "");
+  if (!target) {
     return {
       mode: "unconfigured-hub",
       label: "Server hub",
       error: "server hub URL is not configured",
     };
   }
-  return { mode: "hub", label: "Server hub", url };
+  return target;
 }
 
 export function localDaemonTarget(): Extract<DaemonTarget, { mode: "local" }> {
@@ -175,6 +190,14 @@ export async function callDaemonTarget<T = unknown>(
 
   return new Promise((resolve) => {
     const payload = body !== undefined ? JSON.stringify(body) : undefined;
+    const headers: Record<string, string> = {};
+    if (payload) {
+      headers["content-type"] = "application/json";
+      headers["content-length"] = Buffer.byteLength(payload).toString();
+    }
+    if (target.mode === "hub" && target.accessToken) {
+      headers.authorization = `Bearer ${target.accessToken}`;
+    }
     const requestOptions =
       target.mode === "hub"
         ? (() => {
@@ -186,12 +209,7 @@ export async function callDaemonTarget<T = unknown>(
               path: `${url.pathname}${url.search}`,
               method,
               timeout: timeoutMs,
-              headers: payload
-                ? {
-                    "content-type": "application/json",
-                    "content-length": Buffer.byteLength(payload).toString(),
-                  }
-                : undefined,
+              headers: Object.keys(headers).length ? headers : undefined,
             };
           })()
         : {
@@ -199,12 +217,7 @@ export async function callDaemonTarget<T = unknown>(
             method,
             path: reqPath,
             timeout: timeoutMs,
-            headers: payload
-              ? {
-                  "content-type": "application/json",
-                  "content-length": Buffer.byteLength(payload).toString(),
-                }
-              : undefined,
+            headers: Object.keys(headers).length ? headers : undefined,
           };
     const requestFn =
       target.mode === "hub" &&

--- a/src/lib/familiar-stream.test.ts
+++ b/src/lib/familiar-stream.test.ts
@@ -49,6 +49,36 @@ describe("streamFamiliarText", () => {
     assert.equal(JSON.parse(bodies[1]).sessionId, "sess-9", "resume run includes sessionId");
   });
 
+  it("forwards command controls and model override fields when provided", async () => {
+    let body = "";
+    globalThis.fetch = (async (_url: unknown, init: { body?: string }) => {
+      body = init.body ?? "";
+      return sseResponse([frame({ kind: "done" })]);
+    }) as typeof fetch;
+
+    await streamFamiliarText({
+      familiarId: "nova",
+      prompt: "p",
+      reasoningEffort: "low",
+      responseSpeed: "careful",
+      modelOverride: "gpt-test",
+      modelOverrideScope: "next-message",
+    });
+
+    assert.deepEqual(
+      JSON.parse(body),
+      {
+        familiarId: "nova",
+        prompt: "p",
+        reasoningEffort: "low",
+        responseSpeed: "careful",
+        modelOverride: "gpt-test",
+        modelOverrideScope: "next-message",
+      },
+      "provided compact controls and model override fields are forwarded",
+    );
+  });
+
   it("returns the created session id from stream frames", async () => {
     globalThis.fetch = (async () => sseResponse([
       frame({ kind: "session", sessionId: "sess-created" }),

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -14,6 +14,10 @@ export async function streamFamiliarText(opts: {
   familiarId: string;
   prompt: string;
   sessionId?: string;
+  reasoningEffort?: string;
+  responseSpeed?: string;
+  modelOverride?: string;
+  modelOverrideScope?: "next-message" | "session";
   signal?: AbortSignal;
 }): Promise<{ text: string; error: string | null; sessionId?: string }> {
   let res: Response;
@@ -25,6 +29,10 @@ export async function streamFamiliarText(opts: {
         familiarId: opts.familiarId,
         prompt: opts.prompt,
         ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
+        ...(opts.reasoningEffort ? { reasoningEffort: opts.reasoningEffort } : {}),
+        ...(opts.responseSpeed ? { responseSpeed: opts.responseSpeed } : {}),
+        ...(opts.modelOverride ? { modelOverride: opts.modelOverride } : {}),
+        ...(opts.modelOverrideScope ? { modelOverrideScope: opts.modelOverrideScope } : {}),
       }),
       signal: opts.signal,
     });

--- a/src/lib/pending-chat-action.ts
+++ b/src/lib/pending-chat-action.ts
@@ -1,3 +1,5 @@
+import type { InitialCommandControls } from "@/lib/command-controls";
+
 export type PendingChatAction =
   | {
       kind: "new";
@@ -6,6 +8,7 @@ export type PendingChatAction =
       /** Prompt handed off from the home composer; ChatView auto-sends it so
        *  the send runs through the normal streaming path. */
       initialPrompt?: string | null;
+      initialControls?: InitialCommandControls | null;
       nonce: number;
     }
   | { kind: "open"; sessionId: string; familiarId?: string | null; findQuery?: string; nonce: number }

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -84,6 +84,7 @@
   width: 100%;
   max-width: min(1200px, 100%);
   margin-inline: auto;
+  container-type: inline-size;
 }
 
 /* ── Composer card ───────────────────────────────────────────────────────── */
@@ -144,6 +145,29 @@
   flex-wrap: wrap;
   gap: 8px;
   padding: 10px 14px 14px;
+}
+
+.hc-control-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+.hc-control-group--who {
+  flex: 1 1 320px;
+}
+
+.hc-control-group--intent {
+  flex: 1 1 160px;
+  justify-content: center;
+}
+
+.hc-control-group--run {
+  flex: 1 1 420px;
+  justify-content: flex-end;
+  margin-left: auto;
 }
 
 /* ── "＋" command launcher ───────────────────────────────────────────────── */
@@ -214,6 +238,17 @@
   min-width: 0;
 }
 
+.hc-command-select {
+  gap: 6px;
+}
+
+.hc-command-select .hc-command-select-label {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 550;
+  color: var(--text-muted);
+}
+
 .hc-familiar-glyph {
   display: flex;
   align-items: center;
@@ -259,6 +294,7 @@
   gap: 3px;
   flex: 1 1 140px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .hc-dest-pill {
@@ -351,6 +387,74 @@
   }
 }
 
+@container (max-width: 620px) {
+  .hc-action-bar {
+    align-items: stretch;
+    gap: 8px;
+    padding: 10px;
+  }
+
+  .hc-control-group {
+    flex: 1 0 100%;
+    width: 100%;
+    align-items: stretch;
+    justify-content: stretch;
+  }
+
+  .hc-control-group--who,
+  .hc-control-group--run {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
+  }
+
+  .hc-control-group--intent {
+    order: 3;
+  }
+
+  .hc-control-group--run {
+    order: 4;
+    grid-template-columns: repeat(4, minmax(0, 1fr)) var(--touch-target);
+    margin-left: 0;
+  }
+
+  .hc-familiar-selector {
+    min-height: var(--touch-target);
+    padding: 0 30px 0 10px;
+  }
+
+  .hc-command-select .hc-command-select-label {
+    display: none;
+  }
+
+  .hc-familiar-select {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    min-height: var(--touch-target);
+    font-size: 13px;
+  }
+
+  .hc-dest-pills {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    width: 100%;
+    gap: 8px;
+  }
+
+  .hc-dest-pill {
+    min-height: var(--touch-target);
+    justify-content: center;
+    border-color: var(--border-hairline);
+    background: color-mix(in oklch, var(--bg-base) 72%, transparent);
+  }
+
+  .hc-send-btn {
+    min-height: var(--touch-target);
+    width: var(--touch-target);
+    height: var(--touch-target);
+  }
+}
+
 /* ── Send button (circular, icon-only — matches the Codex-style composer) ──── */
 .hc-send-btn {
   display: inline-flex;
@@ -368,6 +472,10 @@
   margin-left: auto;
   flex-shrink: 0;
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
+}
+
+.hc-control-group--run .hc-send-btn {
+  margin-left: 0;
 }
 
 .hc-send-btn:hover:not(:disabled) {

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -138,34 +138,44 @@
   opacity: 0.5;
 }
 
-/* ── Action bar ──────────────────────────────────────────────────────────── */
+/* ── Action bar ──────────────────────────────────────────────────────────────
+ *   One balanced row: a compact "who" cluster anchored left, the intent pills
+ *   centered, and the "run" config cluster anchored right. Only the centre
+ *   group grows to absorb slack, so the side clusters stay tight to the edges
+ *   instead of stretching open big interior gaps. The larger column gap (vs the
+ *   intra-group gap) reads the three clusters as distinct without a divider. */
 .hc-action-bar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 8px 14px;
   padding: 10px 14px 14px;
 }
 
+/* Groups never split internally — a cluster wraps as a whole unit (so Speed and
+ * the send button can't orphan onto their own line, as they did before). */
 .hc-control-group {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
+  flex-wrap: nowrap;
+  gap: 6px;
   min-width: 0;
 }
 
+/* Side clusters are content-sized (no grow → no trailing/leading gap). */
 .hc-control-group--who {
-  flex: 1 1 320px;
+  flex: 0 1 auto;
 }
 
+/* The intent group is the only one that grows; it absorbs all the slack and
+ * centres the destination pills between the two side clusters. */
 .hc-control-group--intent {
-  flex: 1 1 160px;
+  flex: 1 1 auto;
   justify-content: center;
 }
 
 .hc-control-group--run {
-  flex: 1 1 420px;
+  flex: 0 1 auto;
   justify-content: flex-end;
   margin-left: auto;
 }
@@ -230,6 +240,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
+  min-height: 30px;
+  box-sizing: border-box;
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
   border: 1px solid color-mix(in oklch, var(--accent-presence) 25%, transparent);
   border-radius: 8px;
@@ -291,9 +303,8 @@
 /* ── Destination pills ───────────────────────────────────────────────────── */
 .hc-dest-pills {
   display: flex;
-  gap: 3px;
-  flex: 1 1 140px;
-  flex-wrap: wrap;
+  gap: 4px;
+  flex: 0 0 auto;
   min-width: 0;
 }
 
@@ -301,10 +312,12 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  min-height: 30px;
+  box-sizing: border-box;
   font-size: 11px;
   font-weight: 450;
-  padding: 3px 9px;
-  border-radius: 7px;
+  padding: 3px 11px;
+  border-radius: 8px;
   border: 1px solid transparent;
   background: transparent;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- adds a shared command-control model for runtime/model/thinking/speed behavior
- polishes Home as the primary command center and threads Home-started thinking/speed controls into Chat
- keeps Code on ChatSurface, adds compact Quick Chat controls, and locks parity with regression coverage
- fixes server hub status/auth so mobile-access tokens are sent and unauthorized responses are not reported as offline
- simplifies the Tauri desktop settings header row

## Tests
- pnpm check:tests-wired
- pnpm exec tsc --noEmit --pretty false
- pnpm test:app
- cargo check --manifest-path src-tauri/Cargo.toml
- focused guards for daemon status/settings shell/command-control handoff paths
