### PR TITLE
refactor(automations): CwdPickerField Escape uses shared useFocusTrap

### DIFF
--- a/src/components/cwd-picker-field.test.ts
+++ b/src/components/cwd-picker-field.test.ts
@@ -13,7 +13,10 @@ assert.match(src, /Browse projects/, "offers a Browse-projects affordance");
 assert.match(src, /fetch\("\/api\/projects"\)/, "lazy-loads the project list from /api/projects when the picker opens");
 assert.match(src, /<ProjectTree[\s\S]*?onDirSelect=\{addCwd\}[\s\S]*?selectedDirs=\{selectedDirs\}/, "browses with the shared ProjectTree, toggling dirs in/out");
 assert.match(src, /role="dialog"[\s\S]*?aria-modal="true"/, "the picker is a labelled modal dialog");
-assert.match(src, /e\.key === "Escape"/, "the picker closes on Escape");
+// Escape + Tab cycling + focus management come from the shared focus-trap hook,
+// not a bespoke inline onKeyDown.
+assert.match(src, /useFocusTrap\(pickerOpen, dialogRef, \{ onEscape: \(\) => setPickerOpen\(false\) \}\)/, "the picker dismisses via the shared useFocusTrap hook");
+assert.doesNotMatch(src, /onKeyDown=/, "no hand-rolled key handler — the focus trap owns Escape");
 assert.match(src, /list\.includes\(clean\)/, "addCwd dedupes already-listed paths");
 
 // The cron create dialog uses it (parity with the detail editor — no more

--- a/src/components/cwd-picker-field.tsx
+++ b/src/components/cwd-picker-field.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { ProjectTree } from "@/components/project-tree";
 import type { CaveProject } from "@/lib/cave-projects-types";
 
@@ -31,6 +32,11 @@ export function CwdPickerField({
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [projects, setProjects] = useState<CaveProject[]>([]);
+  // Shared focus trap: Escape-to-close, Tab cycling, and focus into/back out of
+  // the dialog — the app's one dialog-dismissal path, instead of a bespoke
+  // inline Escape handler.
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(pickerOpen, dialogRef, { onEscape: () => setPickerOpen(false) });
 
   const list = useMemo(
     () => value.split("\n").map((s) => s.trim()).filter(Boolean),
@@ -91,9 +97,9 @@ export function CwdPickerField({
           aria-modal="true"
           aria-label="Pick working directories"
           onClick={() => setPickerOpen(false)}
-          onKeyDown={(e) => { if (e.key === "Escape") { e.stopPropagation(); setPickerOpen(false); } }}
         >
           <div
+            ref={dialogRef}
             className="flex max-h-[80vh] w-[460px] max-w-full flex-col overflow-hidden rounded-lg border border-[var(--border-hairline)] shadow-xl"
             style={{ background: "var(--bg-panel)" }}
             onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
The working-directories picker hand-rolled its own inline `onKeyDown` Escape handler — duplicating the dismissal logic the app's shared **`useFocusTrap`** hook already provides (and which the cron create dialog uses). Swapped it for `useFocusTrap(pickerOpen, dialogRef, { onEscape })`.

Deduplicates the Escape path **and** upgrades the modal: focus now moves into the dialog on open and Tab cycles within it — proper modal focus management the bespoke handler lacked.

## Verification
- `pnpm typecheck` clean · `pnpm test:app` green (495 files) · `pnpm build` within budget
- Updated `cwd-picker-field.test.ts` (asserts the hook + no hand-rolled `onKeyDown`).
- Playwright on the prod build: opening the picker moves focus into the dialog (Close button); **Escape closes it**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)