### PR TITLE
refactor(automations): dedupe schedule formatter + day-label tables

### DIFF
--- a/src/components/automation-create-dialog.tsx
+++ b/src/components/automation-create-dialog.tsx
@@ -5,6 +5,7 @@ import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import {
   RRULE_DAY_ORDER,
+  RRULE_DAY_LABEL,
   buildCodexRrule,
   composeAutomationPrompt,
   type ScheduleMode,
@@ -33,15 +34,6 @@ type Props = {
   onCreate: (input: AutomationCreateInput) => void;
 };
 
-const RRULE_DAY_LABEL: Record<string, string> = {
-  SU: "Sun",
-  MO: "Mon",
-  TU: "Tue",
-  WE: "Wed",
-  TH: "Thu",
-  FR: "Fri",
-  SA: "Sat",
-};
 
 const fieldBaseClass =
   "w-full rounded-md border bg-[var(--bg-base)] text-[var(--text-primary)] outline-none transition-colors focus:border-[var(--border-strong)]";

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -38,6 +38,7 @@ import {
   filterEntries,
   countByType,
   flowTrigger,
+  humanRecurrence,
   AUTOMATION_TYPE_META,
   type AutomationType,
   type AutomationEntry,
@@ -87,48 +88,22 @@ function navigateToMode(mode: string) {
 
 import {
   RRULE_DAY_ORDER,
+  RRULE_DAY_LABEL,
   parseCodexRrule,
   buildCodexRrule,
   splitAutomationPrompt,
   composeAutomationPrompt,
 } from "@/lib/codex-automation-form";
 
-const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const DAY_INITIALS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
-const RRULE_DAY_LABEL: Record<string, string> = {
-  SU: "Sun",
-  MO: "Mon",
-  TU: "Tue",
-  WE: "Wed",
-  TH: "Thu",
-  FR: "Fri",
-  SA: "Sat",
-};
-
-// Format a schedule's hour:minute honoring the user's 12h/24h clock pref
-// (so "Daily at 14:00" reads as "Daily at 2:00 PM" when 12-hour is selected).
+// Clock-pref-aware time formatter (12h/24h) injected into the shared
+// humanRecurrence() so the schedule line honors the user's preference — one
+// formatter, instead of a forked humanSchedule() that drifted from it.
 function scheduleTime(hour: number, minute: number): string {
   return formatClock(new Date(2000, 0, 1, hour, minute, 0).toISOString());
 }
 
-function humanSchedule(rec: Recurrence | undefined): string {
-  if (!rec || rec.type === "none") return "One-shot";
-  if (rec.type === "interval") {
-    const m = Math.round(rec.everyMs / 60000);
-    if (m < 60) return `Every ${m}m`;
-    const h = Math.round(m / 60);
-    if (h < 24) return `Every ${h}h`;
-    return `Every ${Math.round(h / 24)}d`;
-  }
-  if (rec.type === "daily")
-    return `Daily at ${scheduleTime(rec.hour, rec.minute)}`;
-  if (rec.type === "weekly") {
-    const days = rec.days.map((d) => WEEKDAY[d] ?? "?").join("/");
-    return `${days}s at ${scheduleTime(rec.hour, rec.minute)}`;
-  }
-  if (rec.type === "cron") return `Cron: ${rec.expr}`;
-  return "Scheduled";
-}
+const humanSchedule = (rec: Recurrence | undefined | null): string =>
+  humanRecurrence(rec, scheduleTime);
 
 function isScheduleInboxItem(item: InboxItem): boolean {
   return item.kind === "reminder" || item.kind === "daily-summary";

--- a/src/lib/automations/automation-entry.test.ts
+++ b/src/lib/automations/automation-entry.test.ts
@@ -18,6 +18,11 @@ assert.equal(humanRecurrence({ type: "interval", everyMs: 3 * 3600_000 }), "Ever
 assert.equal(humanRecurrence({ type: "daily", hour: 9, minute: 5 }), "Daily at 09:05");
 assert.equal(humanRecurrence({ type: "weekly", days: [1, 3], hour: 14, minute: 0 }), "Mon/Wed at 14:00");
 assert.equal(humanRecurrence({ type: "cron", expr: "0 9 * * 1" }), "Cron: 0 9 * * 1");
+// An injected time formatter (e.g. the view's clock-pref-aware one) is used for
+// the hour:minute, while the rest of the line stays identical.
+const ampm = (h: number, m: number) => `${((h + 11) % 12) + 1}:${String(m).padStart(2, "0")} ${h < 12 ? "AM" : "PM"}`;
+assert.equal(humanRecurrence({ type: "daily", hour: 14, minute: 0 }, ampm), "Daily at 2:00 PM");
+assert.equal(humanRecurrence({ type: "weekly", days: [1, 3], hour: 9, minute: 30 }, ampm), "Mon/Wed at 9:30 AM");
 
 // flowTrigger picks schedule > webhook > chat > manual, ignoring disabled nodes.
 const node = (type, extra = {}) => ({ id: type, type, name: type, position: { x: 0, y: 0 }, params: {}, ...extra });

--- a/src/lib/automations/automation-entry.ts
+++ b/src/lib/automations/automation-entry.ts
@@ -109,7 +109,20 @@ const WEEKDAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
  * clock-format agnostic (renders 24h "HH:MM"); the surface re-formats clock
  * times against the user's 12h/24h pref when it has the prefs hook.
  */
-export function humanRecurrence(rec: Recurrence | undefined | null): string {
+/** Default time formatter — fixed 24h `HH:MM`. Kept here so the pure module
+ *  stays framework-free; UIs inject a clock-pref-aware formatter instead. */
+const pad2Clock = (h: number, m: number) => `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+
+/**
+ * Human schedule line for a Recurrence — the single source of truth for this
+ * formatting. `formatTime` lets callers inject a clock-pref-aware time formatter
+ * (the Automations view passes one that honors the 12h/24h preference); it
+ * defaults to fixed 24h so this module — and its tests — stay framework-free.
+ */
+export function humanRecurrence(
+  rec: Recurrence | undefined | null,
+  formatTime: (hour: number, minute: number) => string = pad2Clock,
+): string {
   if (!rec || rec.type === "none") return "One-time";
   if (rec.type === "interval") {
     const m = Math.round(rec.everyMs / 60000);
@@ -118,11 +131,10 @@ export function humanRecurrence(rec: Recurrence | undefined | null): string {
     if (h < 24) return `Every ${h}h`;
     return `Every ${Math.round(h / 24)}d`;
   }
-  const clock = (h: number, m: number) => `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
-  if (rec.type === "daily") return `Daily at ${clock(rec.hour, rec.minute)}`;
+  if (rec.type === "daily") return `Daily at ${formatTime(rec.hour, rec.minute)}`;
   if (rec.type === "weekly") {
     const days = rec.days.map((d) => WEEKDAY[d] ?? "?").join("/");
-    return `${days} at ${clock(rec.hour, rec.minute)}`;
+    return `${days} at ${formatTime(rec.hour, rec.minute)}`;
   }
   if (rec.type === "cron") return `Cron: ${rec.expr}`;
   return "Scheduled";

--- a/src/lib/codex-automation-form.ts
+++ b/src/lib/codex-automation-form.ts
@@ -6,6 +6,17 @@ export type ScheduleMode = "daily" | "weekly" | "raw";
 
 export const RRULE_DAY_ORDER = ["SU", "MO", "TU", "WE", "TH", "FR", "SA"];
 
+/** RRULE weekday code → short label, for day-chip pickers. */
+export const RRULE_DAY_LABEL: Record<string, string> = {
+  SU: "Sun",
+  MO: "Mon",
+  TU: "Tue",
+  WE: "Wed",
+  TH: "Thu",
+  FR: "Fri",
+  SA: "Sat",
+};
+
 export function parseCodexRrule(rrule: string | null): {
   mode: ScheduleMode;
   days: string[];


### PR DESCRIPTION
Result of auditing the Automations surface for duplicated logic.

## Removed duplications
- **Schedule formatter** — `humanSchedule()` (view) was a *drifted* fork of `humanRecurrence()` (pure model): `"Mon/Weds at"` vs `"Mon/Wed at"`, `"One-shot"` vs `"One-time"`, pref-aware vs fixed-24h. `humanRecurrence()` now takes an optional `formatTime` (defaults to 24h so the pure module + its tests stay framework-free); the view passes its clock-pref-aware formatter, and `humanSchedule()` is a one-line wrapper. **One source of truth**, and the schedule line is now consistent everywhere.
- **`WEEKDAY` table** — was copied into the view (identical to the pure module's) and only used by the forked formatter → removed.
- **`RRULE_DAY_LABEL`** — byte-identical in the view **and** the create dialog → hoisted to `codex-automation-form.ts` (next to `RRULE_DAY_ORDER`), imported by both.
- **`DAY_INITIALS`** (view) — dead code → removed.

## Audit notes (not in this PR)
Lower-value items left for later: the `.split("\n").map(trim).filter(Boolean)` one-liner is re-inlined in create-dialog/cwd-picker vs the view's `parseListInput`; and a run-status→color mapping repeats. Happy to fold those in if wanted.

## Verification
- `pnpm typecheck` clean (no unused imports/locals) · `pnpm test:app` green (496 files) · `pnpm build` within budget
- New `automation-entry.test` case covers the injected `formatTime` (`"Daily at 2:00 PM"`); existing default-clock assertions unchanged. No test pinned the removed symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)