### PR TITLE
Add eval group debug details

### DIFF
--- a/src/components/evals/eval-groups-panel.test.ts
+++ b/src/components/evals/eval-groups-panel.test.ts
@@ -20,6 +20,12 @@ assert.match(source, /rollupEvalGroup\(/, "rolls each group's state into status 
 assert.match(source, /freshThreads/, "shows fresh thread count");
 assert.match(source, /staleThreads/, "shows stale thread count");
 assert.match(source, /neverRunThreads/, "shows never-run thread count");
+assert.match(source, /aria-label="Toggle group debug details"/, "each group exposes a debug details toggle");
+assert.match(source, /Group debug details/, "labels the inline debug payload");
+assert.match(source, /statesById\.get\(group\.id\)/, "debug payload uses the exact derived states for the group");
+assert.match(source, /JSON\.stringify\(\s*\{\s*group:/, "renders copyable JSON debug data");
+assert.match(source, /rollup:/, "includes rollup status counts in debug data");
+assert.match(source, /states:/, "includes thread state diagnostics in debug data");
 
 // CRUD wiring against the API.
 assert.match(source, /fetch\("\/api\/evals\/groups"/, "saves a group via POST /api/evals/groups");

--- a/src/components/evals/eval-groups-panel.tsx
+++ b/src/components/evals/eval-groups-panel.tsx
@@ -65,6 +65,7 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
   const [isNew, setIsNew] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [debugGroupIds, setDebugGroupIds] = useState<Set<string>>(() => new Set());
 
   const familiarName = useCallback(
     (id: string) => familiars.find((f) => f.id === id)?.display_name ?? id,
@@ -93,6 +94,18 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
   const cancel = useCallback(() => {
     setDraft(null);
     setError(null);
+  }, []);
+
+  const toggleGroupDebug = useCallback((groupId: string) => {
+    setDebugGroupIds((current) => {
+      const next = new Set(current);
+      if (next.has(groupId)) {
+        next.delete(groupId);
+      } else {
+        next.add(groupId);
+      }
+      return next;
+    });
   }, []);
 
   const patch = useCallback((p: Partial<EvalGroup>) => {
@@ -296,6 +309,9 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
       <ul className="evals-group-list">
         {groups.map((group) => {
           const rollup = rollups.get(group.id);
+          const states = statesById.get(group.id) ?? [];
+          const debugOpen = debugGroupIds.has(group.id);
+          const debugPanelId = `eval-group-debug-${group.id}`;
           const memberFamiliars = group.members.filter((m) => m.kind === "familiar");
           return (
             <li key={group.id} className="evals-group-card">
@@ -307,6 +323,17 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
                   </span>
                 </div>
                 <div className="evals-group-card-actions">
+                  <button
+                    type="button"
+                    className="evals-icon-btn"
+                    onClick={() => toggleGroupDebug(group.id)}
+                    title="Debug group"
+                    aria-label="Toggle group debug details"
+                    aria-expanded={debugOpen}
+                    aria-controls={debugPanelId}
+                  >
+                    <Icon name="ph:bug-bold" width={13} />
+                  </button>
                   <button type="button" className="evals-icon-btn" onClick={() => startEdit(group)} title="Edit group" aria-label="Edit group">
                     <Icon name="ph:pencil-simple" width={13} />
                   </button>
@@ -331,6 +358,43 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
                       {familiarName(m.familiarId ?? m.id)}
                     </span>
                   ))}
+                </div>
+              ) : null}
+              {debugOpen ? (
+                <div id={debugPanelId} className="evals-group-debug" aria-label="Group debug details">
+                  <div className="evals-group-debug-title">Group debug details</div>
+                  <pre>
+                    {JSON.stringify(
+                      {
+                        group: {
+                          id: group.id,
+                          name: group.name,
+                          scope: group.scope,
+                          tracks: group.tracks,
+                          rubricVersion: group.rubricVersion,
+                          stalePolicy: group.stalePolicy,
+                          schedulePolicy: group.schedulePolicy,
+                          createdAt: group.createdAt,
+                          updatedAt: group.updatedAt,
+                          members: group.members.map((member) => ({
+                            ...member,
+                            label: member.kind === "familiar" ? familiarName(member.familiarId ?? member.id) : member.id,
+                          })),
+                        },
+                        rollup: rollup ?? null,
+                        states: states.map((state) => ({
+                          threadId: state.threadId,
+                          familiarId: state.familiarId,
+                          status: state.status,
+                          staleReasons: state.staleReasons,
+                          evaluatedAt: state.evaluatedAt,
+                          details: state.details,
+                        })),
+                      },
+                      null,
+                      2,
+                    )}
+                  </pre>
                 </div>
               ) : null}
             </li>

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -770,6 +770,32 @@
   flex-wrap: wrap;
   gap: 5px;
 }
+.evals-group-debug {
+  margin-top: 2px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-base) 82%, var(--foreground) 18%);
+  overflow: hidden;
+}
+.evals-group-debug-title {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+.evals-group-debug pre {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: 8px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
 
 /* ---- Editor ------------------------------------------------------------- */
 .evals-editor {


### PR DESCRIPTION
## Summary
- Add a per-group debug button on eval group cards.
- Render inline JSON diagnostics for group metadata, rollup counts, members, and derived thread states.
- Pin the debug affordance in the existing eval groups source-text test.

## Verification
- node --experimental-strip-types src/components/evals/eval-groups-panel.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check