### PR TITLE
World-class marketplace + Coven & MCP plugins

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -1412,6 +1412,986 @@
         "useCases": ["Read build and runtime errors", "Inspect routes and server actions", "Trace logs from the dev server"],
         "guardrails": ["Requires a running Next.js 16+ dev server", "Treat the endpoint as local-only", "Confirm the target project before acting"]
       }
+    },
+    {
+      "name": "coven-familiars",
+      "displayName": "Coven Familiars",
+      "version": "0.1.0",
+      "description": "Spawn, configure, and roster-manage Coven familiars — identities, roles, glyphs, and lifecycle.",
+      "category": "Coven",
+      "keywords": [
+        "coven",
+        "familiars",
+        "agents",
+        "roster",
+        "identity"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Create and tend familiars from inside Coven Cave without overwriting other familiars' config.",
+        "useCases": [
+          "Draft a new familiar with role, glyph, and SOUL scaffold",
+          "Adjust an existing familiar's roles or pins",
+          "Archive or reorder the roster from Settings → Familiars"
+        ],
+        "guardrails": [
+          "Never write default familiars over a user's saved config",
+          "Confirm before archiving or deleting a familiar",
+          "Keep glyph names within the familiar glyph catalog"
+        ]
+      }
+    },
+    {
+      "name": "coven-flows",
+      "displayName": "Coven Flows",
+      "version": "0.1.0",
+      "description": "Author and run multi-step Coven flows and workflows with live per-step progress and run logs.",
+      "category": "Coven",
+      "keywords": [
+        "coven",
+        "flows",
+        "workflows",
+        "automation",
+        "orchestration"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files",
+        "shell"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Design flows and trigger runs, then read step-by-step progress and surface failures clearly.",
+        "useCases": [
+          "Compose a flow from a goal description",
+          "Run a flow and watch per-step progress",
+          "Inspect a failed step's log and propose a fix"
+        ],
+        "guardrails": [
+          "Validate the flow manifest before saving",
+          "Stop for approval before running state-changing steps",
+          "Summarize each run with outcome and step IDs"
+        ]
+      }
+    },
+    {
+      "name": "coven-memory",
+      "displayName": "Coven Memory & Knowledge",
+      "version": "0.1.0",
+      "description": "Persist and recall cross-session memory and curated knowledge-vault references for your familiars.",
+      "category": "Coven",
+      "keywords": [
+        "coven",
+        "memory",
+        "knowledge",
+        "recall",
+        "vault"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist",
+            "retrospector"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Capture durable facts to memory and reference the knowledge vault without leaking secrets.",
+        "useCases": [
+          "Save a non-obvious project fact as a memory",
+          "Recall relevant memories before acting",
+          "Add a curated reference to the knowledge vault"
+        ],
+        "guardrails": [
+          "Never store secrets or credentials in memory or knowledge",
+          "One fact per memory; update rather than duplicate",
+          "Verify a referenced file still exists before recommending it"
+        ]
+      }
+    },
+    {
+      "name": "coven-evals",
+      "displayName": "Coven Evals",
+      "version": "0.1.0",
+      "description": "Build, run, and read eval suites and scorecards to measure familiar quality over time.",
+      "category": "Coven",
+      "keywords": [
+        "coven",
+        "evals",
+        "scorecards",
+        "quality",
+        "testing"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "echo",
+          "roles": [
+            "retrospector"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Assemble evals from templates and interpret scorecards honestly, including regressions.",
+        "useCases": [
+          "Start an eval from the template gallery",
+          "Run an eval and read the scorecard",
+          "Compare runs to spot regressions"
+        ],
+        "guardrails": [
+          "Report failing scores plainly, never inflate results",
+          "Keep eval datasets free of secrets",
+          "Cite the run ID when summarizing a scorecard"
+        ]
+      }
+    },
+    {
+      "name": "coven-canvas",
+      "displayName": "Coven Canvas",
+      "version": "0.1.0",
+      "description": "Plan visually on the Coven canvas — triage incoming work and sketch ideas before building.",
+      "category": "Coven",
+      "keywords": [
+        "coven",
+        "canvas",
+        "triage",
+        "sketch",
+        "planning"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Use the canvas to triage and sketch, turning loose ideas into structured plans.",
+        "useCases": [
+          "Triage incoming items into lanes",
+          "Sketch an idea before committing to code",
+          "Promote a sketch into a board task"
+        ],
+        "guardrails": [
+          "Confirm before deleting canvas content you did not create",
+          "Keep triage decisions reversible",
+          "Summarize what moved and why"
+        ]
+      }
+    },
+    {
+      "name": "coven-automations",
+      "displayName": "Coven Automations",
+      "version": "0.1.0",
+      "description": "Schedule reminders, crons, and flows; review next-fire times and run history from one surface.",
+      "category": "Coven",
+      "keywords": [
+        "coven",
+        "automations",
+        "schedules",
+        "cron",
+        "reminders"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Create and tend scheduled automations and read their run logs without surprise side effects.",
+        "useCases": [
+          "Schedule a recurring cron or reminder",
+          "Check the next-fire summary for active automations",
+          "Read a run log and diagnose a failed automation"
+        ],
+        "guardrails": [
+          "Confirm cadence and target before enabling a schedule",
+          "Use UPPERCASE cron status (ACTIVE/PAUSED)",
+          "Stop for approval before deleting an automation"
+        ]
+      }
+    },
+    {
+      "name": "slack",
+      "displayName": "Slack",
+      "version": "0.1.0",
+      "description": "Read channels, search history, and post approved messages to Slack workspaces.",
+      "category": "Productivity",
+      "keywords": [
+        "slack",
+        "chat",
+        "messaging",
+        "notifications",
+        "team"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/modelcontextprotocol/servers"
+      ],
+      "trust": "reference-local",
+      "mcpServers": {
+        "slack": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-slack"
+          ],
+          "type": "stdio",
+          "env": {
+            "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+            "SLACK_TEAM_ID": "${SLACK_TEAM_ID}"
+          }
+        }
+      },
+      "userConfig": {
+        "slack_bot_token": {
+          "type": "string",
+          "title": "Slack Bot Token",
+          "description": "Bot user OAuth token (xoxb-…) for the Slack MCP server.",
+          "required": true,
+          "sensitive": true,
+          "env": "SLACK_BOT_TOKEN"
+        },
+        "slack_team_id": {
+          "type": "string",
+          "title": "Slack Team ID",
+          "description": "Workspace/team ID the bot is installed in.",
+          "required": true,
+          "sensitive": false,
+          "env": "SLACK_TEAM_ID"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Use Slack read-first; never post, react, or DM without explicit approval.",
+        "useCases": [
+          "Search channel history for context",
+          "Summarize a thread",
+          "Post an approved status update"
+        ],
+        "guardrails": [
+          "Do not post, react, or DM without approval",
+          "Preserve exact approved text when posting",
+          "Record message timestamps/permalinks"
+        ]
+      }
+    },
+    {
+      "name": "postgres",
+      "displayName": "PostgreSQL",
+      "version": "0.1.0",
+      "description": "Read-only SQL introspection and queries against a PostgreSQL database for analysis and debugging.",
+      "category": "Databases",
+      "keywords": [
+        "postgres",
+        "postgresql",
+        "sql",
+        "database",
+        "query"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/modelcontextprotocol/servers"
+      ],
+      "trust": "reference-local",
+      "mcpServers": {
+        "postgres": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@modelcontextprotocol/server-postgres",
+            "${POSTGRES_CONNECTION_STRING}"
+          ],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "postgres_connection_string": {
+          "type": "string",
+          "title": "Connection String",
+          "description": "postgresql://user:pass@host:5432/db connection string.",
+          "required": true,
+          "sensitive": true,
+          "env": "POSTGRES_CONNECTION_STRING"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger",
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Query Postgres read-only for analysis; never mutate data without explicit approval.",
+        "useCases": [
+          "Inspect schema and table shapes",
+          "Run read-only analytical queries",
+          "Explain a slow query plan"
+        ],
+        "guardrails": [
+          "Prefer read-only queries; no writes without approval",
+          "Never expose connection credentials",
+          "Bound result sets with LIMIT"
+        ]
+      }
+    },
+    {
+      "name": "sentry",
+      "displayName": "Sentry",
+      "version": "0.1.0",
+      "description": "Query Sentry issues, events, and traces to triage and debug production errors.",
+      "category": "Developer Tools",
+      "keywords": [
+        "sentry",
+        "errors",
+        "observability",
+        "debugging",
+        "traces"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://docs.sentry.io/product/sentry-mcp/"
+      ],
+      "trust": "official-remote",
+      "mcpServers": {
+        "sentry": {
+          "url": "https://mcp.sentry.dev/mcp",
+          "type": "http"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "retrospector"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Use Sentry to triage and explain errors; never resolve or mutate issues without approval.",
+        "useCases": [
+          "Find the most frequent unresolved issues",
+          "Read an event's stack trace and breadcrumbs",
+          "Correlate an error spike with a release"
+        ],
+        "guardrails": [
+          "Do not resolve, ignore, or assign issues without approval",
+          "Avoid leaking PII from event payloads",
+          "Cite issue IDs and permalinks"
+        ]
+      }
+    },
+    {
+      "name": "cloudflare-docs",
+      "displayName": "Cloudflare Docs",
+      "version": "0.1.0",
+      "description": "Search and read Cloudflare's developer documentation directly from the agent.",
+      "category": "Cloud & Infrastructure",
+      "keywords": [
+        "cloudflare",
+        "docs",
+        "workers",
+        "edge",
+        "reference"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://developers.cloudflare.com/agents/model-context-protocol/"
+      ],
+      "trust": "official-remote",
+      "mcpServers": {
+        "cloudflare-docs": {
+          "url": "https://docs.mcp.cloudflare.com/sse",
+          "type": "sse"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Look up Cloudflare docs to ground answers in current product behavior.",
+        "useCases": [
+          "Find the docs for a Workers API",
+          "Confirm a configuration option exists",
+          "Quote canonical guidance with a link"
+        ],
+        "guardrails": [
+          "Quote docs accurately and link the source",
+          "Flag when docs are version-specific",
+          "Do not guess beyond what the docs state"
+        ]
+      }
+    },
+    {
+      "name": "huggingface",
+      "displayName": "Hugging Face",
+      "version": "0.1.0",
+      "description": "Search models, datasets, papers, and Spaces on the Hugging Face Hub.",
+      "category": "Agents & Harnesses",
+      "keywords": [
+        "huggingface",
+        "models",
+        "datasets",
+        "papers",
+        "ml"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://hf.co/settings/mcp/"
+      ],
+      "trust": "official-remote",
+      "mcpServers": {
+        "huggingface": {
+          "url": "https://huggingface.co/mcp",
+          "type": "http"
+        }
+      },
+      "userConfig": {
+        "hf_token": {
+          "type": "string",
+          "title": "Hugging Face Token",
+          "description": "Optional token for higher rate limits and gated repos.",
+          "required": false,
+          "sensitive": true,
+          "env": "HF_TOKEN"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Search the Hub for models, datasets, and papers; cite repo IDs and arXiv references.",
+        "useCases": [
+          "Find a model for a task",
+          "Look up a dataset's card",
+          "Locate the paper behind a model"
+        ],
+        "guardrails": [
+          "Cite repo IDs and links",
+          "Note license and gating before recommending",
+          "Do not download large artifacts without approval"
+        ]
+      }
+    },
+    {
+      "name": "exa",
+      "displayName": "Exa Search",
+      "version": "0.1.0",
+      "description": "Neural and keyword web search with content retrieval for grounded research.",
+      "category": "Browser & Web",
+      "keywords": [
+        "exa",
+        "search",
+        "web",
+        "research",
+        "retrieval"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://docs.exa.ai/reference/exa-mcp"
+      ],
+      "trust": "official-remote",
+      "mcpServers": {
+        "exa": {
+          "url": "https://mcp.exa.ai/mcp",
+          "type": "http"
+        }
+      },
+      "userConfig": {
+        "exa_api_key": {
+          "type": "string",
+          "title": "Exa API Key",
+          "description": "API key for the Exa search MCP server.",
+          "required": true,
+          "sensitive": true,
+          "env": "EXA_API_KEY"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Use Exa to find and read sources for grounded, cited research.",
+        "useCases": [
+          "Find recent sources on a topic",
+          "Retrieve and summarize an article",
+          "Gather citations for a claim"
+        ],
+        "guardrails": [
+          "Cite every source with a link",
+          "Verify claims across more than one source",
+          "Note publish dates for time-sensitive facts"
+        ]
+      }
+    },
+    {
+      "name": "e2b",
+      "displayName": "E2B Code Sandbox",
+      "version": "0.1.0",
+      "description": "Run code in secure, ephemeral E2B cloud sandboxes for execution and testing.",
+      "category": "Developer Tools",
+      "keywords": [
+        "e2b",
+        "sandbox",
+        "code-execution",
+        "runtime",
+        "testing"
+      ],
+      "capabilities": [
+        "network",
+        "shell",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/e2b-dev/mcp-server"
+      ],
+      "trust": "reference-local",
+      "mcpServers": {
+        "e2b": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@e2b/mcp-server"
+          ],
+          "type": "stdio",
+          "env": {
+            "E2B_API_KEY": "${E2B_API_KEY}"
+          }
+        }
+      },
+      "userConfig": {
+        "e2b_api_key": {
+          "type": "string",
+          "title": "E2B API Key",
+          "description": "API key for E2B sandbox provisioning.",
+          "required": true,
+          "sensitive": true,
+          "env": "E2B_API_KEY"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Execute code in an isolated sandbox; treat sandbox output as untrusted.",
+        "useCases": [
+          "Run a snippet to verify behavior",
+          "Reproduce a bug in isolation",
+          "Test a fix before applying it locally"
+        ],
+        "guardrails": [
+          "Never run untrusted code against local credentials",
+          "Keep sandboxes ephemeral",
+          "Summarize stdout/stderr and exit codes"
+        ]
+      }
+    },
+    {
+      "name": "browserbase",
+      "displayName": "Browserbase",
+      "version": "0.1.0",
+      "description": "Drive cloud headless browsers for automation, scraping, and end-to-end checks.",
+      "category": "Browser & Web",
+      "keywords": [
+        "browserbase",
+        "browser",
+        "automation",
+        "scraping",
+        "headless"
+      ],
+      "capabilities": [
+        "network",
+        "shell",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/browserbase/mcp-server-browserbase"
+      ],
+      "trust": "reference-local",
+      "mcpServers": {
+        "browserbase": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@browserbasehq/mcp-server-browserbase"
+          ],
+          "type": "stdio",
+          "env": {
+            "BROWSERBASE_API_KEY": "${BROWSERBASE_API_KEY}",
+            "BROWSERBASE_PROJECT_ID": "${BROWSERBASE_PROJECT_ID}"
+          }
+        }
+      },
+      "userConfig": {
+        "browserbase_api_key": {
+          "type": "string",
+          "title": "Browserbase API Key",
+          "description": "API key for Browserbase sessions.",
+          "required": true,
+          "sensitive": true,
+          "env": "BROWSERBASE_API_KEY"
+        },
+        "browserbase_project_id": {
+          "type": "string",
+          "title": "Browserbase Project ID",
+          "description": "Project ID for Browserbase sessions.",
+          "required": true,
+          "sensitive": false,
+          "env": "BROWSERBASE_PROJECT_ID"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Automate cloud browsers carefully; never submit forms or auth without approval.",
+        "useCases": [
+          "Navigate and extract page content",
+          "Run an end-to-end flow check",
+          "Capture a screenshot of a rendered page"
+        ],
+        "guardrails": [
+          "Do not submit forms or log in without approval",
+          "Respect robots and site terms",
+          "Report URLs visited and actions taken"
+        ]
+      }
+    },
+    {
+      "name": "elevenlabs",
+      "displayName": "ElevenLabs",
+      "version": "0.1.0",
+      "description": "Text-to-speech, voice synthesis, and audio transcription via ElevenLabs.",
+      "category": "Media & Creative",
+      "keywords": [
+        "elevenlabs",
+        "tts",
+        "voice",
+        "audio",
+        "speech"
+      ],
+      "capabilities": [
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/elevenlabs/elevenlabs-mcp"
+      ],
+      "trust": "reference-local",
+      "mcpServers": {
+        "elevenlabs": {
+          "command": "uvx",
+          "args": [
+            "elevenlabs-mcp"
+          ],
+          "type": "stdio",
+          "env": {
+            "ELEVENLABS_API_KEY": "${ELEVENLABS_API_KEY}"
+          }
+        }
+      },
+      "userConfig": {
+        "elevenlabs_api_key": {
+          "type": "string",
+          "title": "ElevenLabs API Key",
+          "description": "API key for the ElevenLabs MCP server.",
+          "required": true,
+          "sensitive": true,
+          "env": "ELEVENLABS_API_KEY"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "charm",
+          "roles": [
+            "social-voice",
+            "devrel-liaison"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Generate speech and transcribe audio; confirm voice and cost before large jobs.",
+        "useCases": [
+          "Synthesize a short voice clip",
+          "Transcribe an audio file",
+          "Pick a voice for a narration"
+        ],
+        "guardrails": [
+          "Confirm voice, language, and length before generating",
+          "Do not clone voices without consent",
+          "Report output file paths and durations"
+        ]
+      }
+    },
+    {
+      "name": "sqlite",
+      "displayName": "SQLite",
+      "version": "0.1.0",
+      "description": "Query and introspect local SQLite databases for lightweight analysis.",
+      "category": "Databases",
+      "keywords": [
+        "sqlite",
+        "sql",
+        "database",
+        "local",
+        "query"
+      ],
+      "capabilities": [
+        "read_files",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/modelcontextprotocol/servers"
+      ],
+      "trust": "reference-local",
+      "mcpServers": {
+        "sqlite": {
+          "command": "uvx",
+          "args": [
+            "mcp-server-sqlite",
+            "--db-path",
+            "${SQLITE_DB_PATH}"
+          ],
+          "type": "stdio"
+        }
+      },
+      "userConfig": {
+        "sqlite_db_path": {
+          "type": "string",
+          "title": "Database Path",
+          "description": "Filesystem path to the SQLite .db file.",
+          "required": true,
+          "sensitive": false,
+          "env": "SQLITE_DB_PATH"
+        }
+      },
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Query a local SQLite file read-first; confirm before schema or data changes.",
+        "useCases": [
+          "List tables and inspect schema",
+          "Run a read-only query",
+          "Summarize row counts and shapes"
+        ],
+        "guardrails": [
+          "Prefer read-only queries; no writes without approval",
+          "Back up before any schema change",
+          "Bound result sets with LIMIT"
+        ]
+      }
     }
   ]
 }

--- a/marketplace/exports/codex/marketplace.json
+++ b/marketplace/exports/codex/marketplace.json
@@ -531,6 +531,198 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "coven-familiars",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/coven-familiars"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
+      "name": "coven-flows",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/coven-flows"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
+      "name": "coven-memory",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/coven-memory"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
+      "name": "coven-evals",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/coven-evals"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
+      "name": "coven-canvas",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/coven-canvas"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
+      "name": "coven-automations",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/coven-automations"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
+      "name": "slack",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/slack"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    },
+    {
+      "name": "postgres",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/postgres"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
+    },
+    {
+      "name": "sentry",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/sentry"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "cloudflare-docs",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/cloudflare-docs"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Cloud & Infrastructure"
+    },
+    {
+      "name": "huggingface",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/huggingface"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Agents & Harnesses"
+    },
+    {
+      "name": "exa",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/exa"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "e2b",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/e2b"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
+      "name": "browserbase",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/browserbase"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Browser & Web"
+    },
+    {
+      "name": "elevenlabs",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/elevenlabs"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Media & Creative"
+    },
+    {
+      "name": "sqlite",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/sqlite"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Databases"
     }
   ]
 }

--- a/marketplace/exports/mcp/mcp.json
+++ b/marketplace/exports/mcp/mcp.json
@@ -341,6 +341,85 @@
         "next-devtools-mcp@latest"
       ],
       "type": "stdio"
+    },
+    "slack": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-slack"
+      ],
+      "type": "stdio",
+      "env": {
+        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+        "SLACK_TEAM_ID": "${SLACK_TEAM_ID}"
+      }
+    },
+    "postgres": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "${POSTGRES_CONNECTION_STRING}"
+      ],
+      "type": "stdio"
+    },
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp",
+      "type": "http"
+    },
+    "cloudflare-docs": {
+      "url": "https://docs.mcp.cloudflare.com/sse",
+      "type": "sse"
+    },
+    "huggingface": {
+      "url": "https://huggingface.co/mcp",
+      "type": "http"
+    },
+    "exa": {
+      "url": "https://mcp.exa.ai/mcp",
+      "type": "http"
+    },
+    "e2b": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@e2b/mcp-server"
+      ],
+      "type": "stdio",
+      "env": {
+        "E2B_API_KEY": "${E2B_API_KEY}"
+      }
+    },
+    "browserbase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@browserbasehq/mcp-server-browserbase"
+      ],
+      "type": "stdio",
+      "env": {
+        "BROWSERBASE_API_KEY": "${BROWSERBASE_API_KEY}",
+        "BROWSERBASE_PROJECT_ID": "${BROWSERBASE_PROJECT_ID}"
+      }
+    },
+    "elevenlabs": {
+      "command": "uvx",
+      "args": [
+        "elevenlabs-mcp"
+      ],
+      "type": "stdio",
+      "env": {
+        "ELEVENLABS_API_KEY": "${ELEVENLABS_API_KEY}"
+      }
+    },
+    "sqlite": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite",
+        "--db-path",
+        "${SQLITE_DB_PATH}"
+      ],
+      "type": "stdio"
     }
   }
 }

--- a/marketplace/exports/roles/role-affinity.json
+++ b/marketplace/exports/roles/role-affinity.json
@@ -826,5 +826,227 @@
         "debugger"
       ]
     }
+  ],
+  "coven-familiars": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator",
+        "coordination-layer"
+      ]
+    },
+    {
+      "familiar": "kitty",
+      "roles": [
+        "general-helper"
+      ]
+    }
+  ],
+  "coven-flows": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator",
+        "coordination-layer"
+      ]
+    },
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    }
+  ],
+  "coven-memory": [
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist",
+        "retrospector"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    }
+  ],
+  "coven-evals": [
+    {
+      "familiar": "echo",
+      "roles": [
+        "retrospector"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "coven-canvas": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator"
+      ]
+    },
+    {
+      "familiar": "kitty",
+      "roles": [
+        "general-helper"
+      ]
+    }
+  ],
+  "coven-automations": [
+    {
+      "familiar": "astra",
+      "roles": [
+        "coordination-layer"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist"
+      ]
+    }
+  ],
+  "slack": [
+    {
+      "familiar": "charm",
+      "roles": [
+        "devrel-liaison"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "coordination-layer"
+      ]
+    }
+  ],
+  "postgres": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "debugger",
+        "implementer"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "sentry": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "retrospector"
+      ]
+    }
+  ],
+  "cloudflare-docs": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    }
+  ],
+  "huggingface": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist"
+      ]
+    }
+  ],
+  "exa": [
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "charm",
+      "roles": [
+        "devrel-liaison"
+      ]
+    }
+  ],
+  "e2b": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger"
+      ]
+    }
+  ],
+  "browserbase": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
+  ],
+  "elevenlabs": [
+    {
+      "familiar": "charm",
+      "roles": [
+        "social-voice",
+        "devrel-liaison"
+      ]
+    }
+  ],
+  "sqlite": [
+    {
+      "familiar": "cody",
+      "roles": [
+        "debugger"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher"
+      ]
+    }
   ]
 }

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -1449,6 +1449,452 @@
           ]
         }
       ]
+    },
+    {
+      "name": "coven-familiars",
+      "displayName": "Coven Familiars",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coven-familiars"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "coven-flows",
+      "displayName": "Coven Flows",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coven-flows"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "coven-memory",
+      "displayName": "Coven Memory & Knowledge",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coven-memory"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist",
+            "retrospector"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "coven-evals",
+      "displayName": "Coven Evals",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coven-evals"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "echo",
+          "roles": [
+            "retrospector"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "coven-canvas",
+      "displayName": "Coven Canvas",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coven-canvas"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "coven-automations",
+      "displayName": "Coven Automations",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coven-automations"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "slack",
+      "displayName": "Slack",
+      "category": "Productivity",
+      "source": {
+        "source": "local",
+        "path": "./plugins/slack"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "coordination-layer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "postgres",
+      "displayName": "PostgreSQL",
+      "category": "Databases",
+      "source": {
+        "source": "local",
+        "path": "./plugins/postgres"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger",
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sentry",
+      "displayName": "Sentry",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sentry"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "retrospector"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "cloudflare-docs",
+      "displayName": "Cloudflare Docs",
+      "category": "Cloud & Infrastructure",
+      "source": {
+        "source": "local",
+        "path": "./plugins/cloudflare-docs"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "huggingface",
+      "displayName": "Hugging Face",
+      "category": "Agents & Harnesses",
+      "source": {
+        "source": "local",
+        "path": "./plugins/huggingface"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "exa",
+      "displayName": "Exa Search",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/exa"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-remote",
+      "roleAffinity": [
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "e2b",
+      "displayName": "E2B Code Sandbox",
+      "category": "Developer Tools",
+      "source": {
+        "source": "local",
+        "path": "./plugins/e2b"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "browserbase",
+      "displayName": "Browserbase",
+      "category": "Browser & Web",
+      "source": {
+        "source": "local",
+        "path": "./plugins/browserbase"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "elevenlabs",
+      "displayName": "ElevenLabs",
+      "category": "Media & Creative",
+      "source": {
+        "source": "local",
+        "path": "./plugins/elevenlabs"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "charm",
+          "roles": [
+            "social-voice",
+            "devrel-liaison"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "sqlite",
+      "displayName": "SQLite",
+      "category": "Databases",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sqlite"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": [
+        {
+          "familiar": "cody",
+          "roles": [
+            "debugger"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/marketplace/plugins/browserbase/.codex-plugin/plugin.json
+++ b/marketplace/plugins/browserbase/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "browserbase",
+  "version": "0.1.0",
+  "description": "Drive cloud headless browsers for automation, scraping, and end-to-end checks.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Browserbase",
+    "shortDescription": "Drive cloud headless browsers for automation, scraping, and end-to-end checks.",
+    "longDescription": "Automate cloud browsers carefully; never submit forms or auth without approval.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "browserbase",
+      "browser",
+      "automation",
+      "scraping",
+      "headless"
+    ],
+    "defaultPrompt": "Help me use Browserbase safely."
+  }
+}

--- a/marketplace/plugins/browserbase/plugin.json
+++ b/marketplace/plugins/browserbase/plugin.json
@@ -1,0 +1,85 @@
+{
+  "name": "browserbase",
+  "version": "0.1.0",
+  "description": "Drive cloud headless browsers for automation, scraping, and end-to-end checks.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "browserbase",
+    "browser",
+    "automation",
+    "scraping",
+    "headless"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/browserbase",
+  "x-coven": {
+    "displayName": "Browserbase",
+    "category": "Browser & Web",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/browserbase/mcp-server-browserbase"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "browserbase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@browserbasehq/mcp-server-browserbase"
+      ],
+      "type": "stdio",
+      "env": {
+        "BROWSERBASE_API_KEY": "${BROWSERBASE_API_KEY}",
+        "BROWSERBASE_PROJECT_ID": "${BROWSERBASE_PROJECT_ID}"
+      }
+    }
+  },
+  "userConfig": {
+    "browserbase_api_key": {
+      "type": "string",
+      "title": "Browserbase API Key",
+      "description": "API key for Browserbase sessions.",
+      "required": true,
+      "sensitive": true,
+      "env": "BROWSERBASE_API_KEY"
+    },
+    "browserbase_project_id": {
+      "type": "string",
+      "title": "Browserbase Project ID",
+      "description": "Project ID for Browserbase sessions.",
+      "required": true,
+      "sensitive": false,
+      "env": "BROWSERBASE_PROJECT_ID"
+    }
+  }
+}

--- a/marketplace/plugins/browserbase/skills/browserbase/SKILL.md
+++ b/marketplace/plugins/browserbase/skills/browserbase/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: browserbase
+description: Automate cloud browsers carefully; never submit forms or auth without approval.
+---
+
+# Browserbase
+
+Automate cloud browsers carefully; never submit forms or auth without approval.
+
+## Use When
+- Navigate and extract page content
+- Run an end-to-end flow check
+- Capture a screenshot of a rendered page
+
+## Guardrails
+- Do not submit forms or log in without approval
+- Respect robots and site terms
+- Report URLs visited and actions taken
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/cloudflare-docs/.codex-plugin/plugin.json
+++ b/marketplace/plugins/cloudflare-docs/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "cloudflare-docs",
+  "version": "0.1.0",
+  "description": "Search and read Cloudflare's developer documentation directly from the agent.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Cloudflare Docs",
+    "shortDescription": "Search and read Cloudflare's developer documentation directly from the agent.",
+    "longDescription": "Look up Cloudflare docs to ground answers in current product behavior.",
+    "developerName": "OpenCoven",
+    "category": "Cloud & Infrastructure",
+    "capabilities": [
+      "cloudflare",
+      "docs",
+      "workers",
+      "edge",
+      "reference"
+    ],
+    "defaultPrompt": "Help me use Cloudflare Docs safely."
+  }
+}

--- a/marketplace/plugins/cloudflare-docs/plugin.json
+++ b/marketplace/plugins/cloudflare-docs/plugin.json
@@ -1,0 +1,59 @@
+{
+  "name": "cloudflare-docs",
+  "version": "0.1.0",
+  "description": "Search and read Cloudflare's developer documentation directly from the agent.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "cloudflare",
+    "docs",
+    "workers",
+    "edge",
+    "reference"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/cloudflare-docs",
+  "x-coven": {
+    "displayName": "Cloudflare Docs",
+    "category": "Cloud & Infrastructure",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://developers.cloudflare.com/agents/model-context-protocol/"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "cloudflare-docs": {
+      "url": "https://docs.mcp.cloudflare.com/sse",
+      "type": "sse"
+    }
+  }
+}

--- a/marketplace/plugins/cloudflare-docs/skills/cloudflare-docs/SKILL.md
+++ b/marketplace/plugins/cloudflare-docs/skills/cloudflare-docs/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: cloudflare-docs
+description: Look up Cloudflare docs to ground answers in current product behavior.
+---
+
+# Cloudflare Docs
+
+Look up Cloudflare docs to ground answers in current product behavior.
+
+## Use When
+- Find the docs for a Workers API
+- Confirm a configuration option exists
+- Quote canonical guidance with a link
+
+## Guardrails
+- Quote docs accurately and link the source
+- Flag when docs are version-specific
+- Do not guess beyond what the docs state
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/coven-automations/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-automations/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "coven-automations",
+  "version": "0.1.0",
+  "description": "Schedule reminders, crons, and flows; review next-fire times and run history from one surface.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coven Automations",
+    "shortDescription": "Schedule reminders, crons, and flows; review next-fire times and run history from one surface.",
+    "longDescription": "Create and tend scheduled automations and read their run logs without surprise side effects.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "coven",
+      "automations",
+      "schedules",
+      "cron",
+      "reminders"
+    ],
+    "defaultPrompt": "Help me use Coven Automations safely."
+  }
+}

--- a/marketplace/plugins/coven-automations/plugin.json
+++ b/marketplace/plugins/coven-automations/plugin.json
@@ -1,0 +1,52 @@
+{
+  "name": "coven-automations",
+  "version": "0.1.0",
+  "description": "Schedule reminders, crons, and flows; review next-fire times and run history from one surface.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coven",
+    "automations",
+    "schedules",
+    "cron",
+    "reminders"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/coven-automations",
+  "x-coven": {
+    "displayName": "Coven Automations",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "coordination-layer"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/coven-automations/skills/coven-automations/SKILL.md
+++ b/marketplace/plugins/coven-automations/skills/coven-automations/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: coven-automations
+description: Create and tend scheduled automations and read their run logs without surprise side effects.
+---
+
+# Coven Automations
+
+Create and tend scheduled automations and read their run logs without surprise side effects.
+
+## Use When
+- Schedule a recurring cron or reminder
+- Check the next-fire summary for active automations
+- Read a run log and diagnose a failed automation
+
+## Guardrails
+- Confirm cadence and target before enabling a schedule
+- Use UPPERCASE cron status (ACTIVE/PAUSED)
+- Stop for approval before deleting an automation
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/coven-canvas/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-canvas/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "coven-canvas",
+  "version": "0.1.0",
+  "description": "Plan visually on the Coven canvas \u2014 triage incoming work and sketch ideas before building.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coven Canvas",
+    "shortDescription": "Plan visually on the Coven canvas \u2014 triage incoming work and sketch ideas before building.",
+    "longDescription": "Use the canvas to triage and sketch, turning loose ideas into structured plans.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "coven",
+      "canvas",
+      "triage",
+      "sketch",
+      "planning"
+    ],
+    "defaultPrompt": "Help me use Coven Canvas safely."
+  }
+}

--- a/marketplace/plugins/coven-canvas/plugin.json
+++ b/marketplace/plugins/coven-canvas/plugin.json
@@ -1,0 +1,52 @@
+{
+  "name": "coven-canvas",
+  "version": "0.1.0",
+  "description": "Plan visually on the Coven canvas \u2014 triage incoming work and sketch ideas before building.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coven",
+    "canvas",
+    "triage",
+    "sketch",
+    "planning"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/coven-canvas",
+  "x-coven": {
+    "displayName": "Coven Canvas",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator"
+        ]
+      },
+      {
+        "familiar": "kitty",
+        "roles": [
+          "general-helper"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/coven-canvas/skills/coven-canvas/SKILL.md
+++ b/marketplace/plugins/coven-canvas/skills/coven-canvas/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: coven-canvas
+description: Use the canvas to triage and sketch, turning loose ideas into structured plans.
+---
+
+# Coven Canvas
+
+Use the canvas to triage and sketch, turning loose ideas into structured plans.
+
+## Use When
+- Triage incoming items into lanes
+- Sketch an idea before committing to code
+- Promote a sketch into a board task
+
+## Guardrails
+- Confirm before deleting canvas content you did not create
+- Keep triage decisions reversible
+- Summarize what moved and why
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/coven-evals/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-evals/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "coven-evals",
+  "version": "0.1.0",
+  "description": "Build, run, and read eval suites and scorecards to measure familiar quality over time.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coven Evals",
+    "shortDescription": "Build, run, and read eval suites and scorecards to measure familiar quality over time.",
+    "longDescription": "Assemble evals from templates and interpret scorecards honestly, including regressions.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "coven",
+      "evals",
+      "scorecards",
+      "quality",
+      "testing"
+    ],
+    "defaultPrompt": "Help me use Coven Evals safely."
+  }
+}

--- a/marketplace/plugins/coven-evals/plugin.json
+++ b/marketplace/plugins/coven-evals/plugin.json
@@ -1,0 +1,52 @@
+{
+  "name": "coven-evals",
+  "version": "0.1.0",
+  "description": "Build, run, and read eval suites and scorecards to measure familiar quality over time.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coven",
+    "evals",
+    "scorecards",
+    "quality",
+    "testing"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/coven-evals",
+  "x-coven": {
+    "displayName": "Coven Evals",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "echo",
+        "roles": [
+          "retrospector"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/coven-evals/skills/coven-evals/SKILL.md
+++ b/marketplace/plugins/coven-evals/skills/coven-evals/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: coven-evals
+description: Assemble evals from templates and interpret scorecards honestly, including regressions.
+---
+
+# Coven Evals
+
+Assemble evals from templates and interpret scorecards honestly, including regressions.
+
+## Use When
+- Start an eval from the template gallery
+- Run an eval and read the scorecard
+- Compare runs to spot regressions
+
+## Guardrails
+- Report failing scores plainly, never inflate results
+- Keep eval datasets free of secrets
+- Cite the run ID when summarizing a scorecard
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/coven-familiars/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-familiars/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "coven-familiars",
+  "version": "0.1.0",
+  "description": "Spawn, configure, and roster-manage Coven familiars \u2014 identities, roles, glyphs, and lifecycle.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coven Familiars",
+    "shortDescription": "Spawn, configure, and roster-manage Coven familiars \u2014 identities, roles, glyphs, and lifecycle.",
+    "longDescription": "Create and tend familiars from inside Coven Cave without overwriting other familiars' config.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "coven",
+      "familiars",
+      "agents",
+      "roster",
+      "identity"
+    ],
+    "defaultPrompt": "Help me use Coven Familiars safely."
+  }
+}

--- a/marketplace/plugins/coven-familiars/plugin.json
+++ b/marketplace/plugins/coven-familiars/plugin.json
@@ -1,0 +1,53 @@
+{
+  "name": "coven-familiars",
+  "version": "0.1.0",
+  "description": "Spawn, configure, and roster-manage Coven familiars \u2014 identities, roles, glyphs, and lifecycle.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coven",
+    "familiars",
+    "agents",
+    "roster",
+    "identity"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/coven-familiars",
+  "x-coven": {
+    "displayName": "Coven Familiars",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator",
+          "coordination-layer"
+        ]
+      },
+      {
+        "familiar": "kitty",
+        "roles": [
+          "general-helper"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/coven-familiars/skills/coven-familiars/SKILL.md
+++ b/marketplace/plugins/coven-familiars/skills/coven-familiars/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: coven-familiars
+description: Create and tend familiars from inside Coven Cave without overwriting other familiars' config.
+---
+
+# Coven Familiars
+
+Create and tend familiars from inside Coven Cave without overwriting other familiars' config.
+
+## Use When
+- Draft a new familiar with role, glyph, and SOUL scaffold
+- Adjust an existing familiar's roles or pins
+- Archive or reorder the roster from Settings → Familiars
+
+## Guardrails
+- Never write default familiars over a user's saved config
+- Confirm before archiving or deleting a familiar
+- Keep glyph names within the familiar glyph catalog
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/coven-flows/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-flows/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "coven-flows",
+  "version": "0.1.0",
+  "description": "Author and run multi-step Coven flows and workflows with live per-step progress and run logs.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coven Flows",
+    "shortDescription": "Author and run multi-step Coven flows and workflows with live per-step progress and run logs.",
+    "longDescription": "Design flows and trigger runs, then read step-by-step progress and surface failures clearly.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "coven",
+      "flows",
+      "workflows",
+      "automation",
+      "orchestration"
+    ],
+    "defaultPrompt": "Help me use Coven Flows safely."
+  }
+}

--- a/marketplace/plugins/coven-flows/plugin.json
+++ b/marketplace/plugins/coven-flows/plugin.json
@@ -1,0 +1,54 @@
+{
+  "name": "coven-flows",
+  "version": "0.1.0",
+  "description": "Author and run multi-step Coven flows and workflows with live per-step progress and run logs.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coven",
+    "flows",
+    "workflows",
+    "automation",
+    "orchestration"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell"
+  ],
+  "marketplaceId": "opencoven/coven-flows",
+  "x-coven": {
+    "displayName": "Coven Flows",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator",
+          "coordination-layer"
+        ]
+      },
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/coven-flows/skills/coven-flows/SKILL.md
+++ b/marketplace/plugins/coven-flows/skills/coven-flows/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: coven-flows
+description: Design flows and trigger runs, then read step-by-step progress and surface failures clearly.
+---
+
+# Coven Flows
+
+Design flows and trigger runs, then read step-by-step progress and surface failures clearly.
+
+## Use When
+- Compose a flow from a goal description
+- Run a flow and watch per-step progress
+- Inspect a failed step's log and propose a fix
+
+## Guardrails
+- Validate the flow manifest before saving
+- Stop for approval before running state-changing steps
+- Summarize each run with outcome and step IDs
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/coven-memory/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-memory/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "coven-memory",
+  "version": "0.1.0",
+  "description": "Persist and recall cross-session memory and curated knowledge-vault references for your familiars.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Coven Memory & Knowledge",
+    "shortDescription": "Persist and recall cross-session memory and curated knowledge-vault references for your familiars.",
+    "longDescription": "Capture durable facts to memory and reference the knowledge vault without leaking secrets.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "coven",
+      "memory",
+      "knowledge",
+      "recall",
+      "vault"
+    ],
+    "defaultPrompt": "Help me use Coven Memory & Knowledge safely."
+  }
+}

--- a/marketplace/plugins/coven-memory/plugin.json
+++ b/marketplace/plugins/coven-memory/plugin.json
@@ -1,0 +1,54 @@
+{
+  "name": "coven-memory",
+  "version": "0.1.0",
+  "description": "Persist and recall cross-session memory and curated knowledge-vault references for your familiars.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "coven",
+    "memory",
+    "knowledge",
+    "recall",
+    "vault"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/coven-memory",
+  "x-coven": {
+    "displayName": "Coven Memory & Knowledge",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist",
+          "retrospector"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/coven-memory/skills/coven-memory/SKILL.md
+++ b/marketplace/plugins/coven-memory/skills/coven-memory/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: coven-memory
+description: Capture durable facts to memory and reference the knowledge vault without leaking secrets.
+---
+
+# Coven Memory & Knowledge
+
+Capture durable facts to memory and reference the knowledge vault without leaking secrets.
+
+## Use When
+- Save a non-obvious project fact as a memory
+- Recall relevant memories before acting
+- Add a curated reference to the knowledge vault
+
+## Guardrails
+- Never store secrets or credentials in memory or knowledge
+- One fact per memory; update rather than duplicate
+- Verify a referenced file still exists before recommending it
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/e2b/.codex-plugin/plugin.json
+++ b/marketplace/plugins/e2b/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "e2b",
+  "version": "0.1.0",
+  "description": "Run code in secure, ephemeral E2B cloud sandboxes for execution and testing.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "E2B Code Sandbox",
+    "shortDescription": "Run code in secure, ephemeral E2B cloud sandboxes for execution and testing.",
+    "longDescription": "Execute code in an isolated sandbox; treat sandbox output as untrusted.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "e2b",
+      "sandbox",
+      "code-execution",
+      "runtime",
+      "testing"
+    ],
+    "defaultPrompt": "Help me use E2B Code Sandbox safely."
+  }
+}

--- a/marketplace/plugins/e2b/plugin.json
+++ b/marketplace/plugins/e2b/plugin.json
@@ -1,0 +1,71 @@
+{
+  "name": "e2b",
+  "version": "0.1.0",
+  "description": "Run code in secure, ephemeral E2B cloud sandboxes for execution and testing.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "e2b",
+    "sandbox",
+    "code-execution",
+    "runtime",
+    "testing"
+  ],
+  "capabilities": [
+    "network",
+    "shell",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/e2b",
+  "x-coven": {
+    "displayName": "E2B Code Sandbox",
+    "category": "Developer Tools",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/e2b-dev/mcp-server"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "e2b": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@e2b/mcp-server"
+      ],
+      "type": "stdio",
+      "env": {
+        "E2B_API_KEY": "${E2B_API_KEY}"
+      }
+    }
+  },
+  "userConfig": {
+    "e2b_api_key": {
+      "type": "string",
+      "title": "E2B API Key",
+      "description": "API key for E2B sandbox provisioning.",
+      "required": true,
+      "sensitive": true,
+      "env": "E2B_API_KEY"
+    }
+  }
+}

--- a/marketplace/plugins/e2b/skills/e2b/SKILL.md
+++ b/marketplace/plugins/e2b/skills/e2b/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: e2b
+description: Execute code in an isolated sandbox; treat sandbox output as untrusted.
+---
+
+# E2B Code Sandbox
+
+Execute code in an isolated sandbox; treat sandbox output as untrusted.
+
+## Use When
+- Run a snippet to verify behavior
+- Reproduce a bug in isolation
+- Test a fix before applying it locally
+
+## Guardrails
+- Never run untrusted code against local credentials
+- Keep sandboxes ephemeral
+- Summarize stdout/stderr and exit codes
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/elevenlabs/.codex-plugin/plugin.json
+++ b/marketplace/plugins/elevenlabs/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "elevenlabs",
+  "version": "0.1.0",
+  "description": "Text-to-speech, voice synthesis, and audio transcription via ElevenLabs.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ElevenLabs",
+    "shortDescription": "Text-to-speech, voice synthesis, and audio transcription via ElevenLabs.",
+    "longDescription": "Generate speech and transcribe audio; confirm voice and cost before large jobs.",
+    "developerName": "OpenCoven",
+    "category": "Media & Creative",
+    "capabilities": [
+      "elevenlabs",
+      "tts",
+      "voice",
+      "audio",
+      "speech"
+    ],
+    "defaultPrompt": "Help me use ElevenLabs safely."
+  }
+}

--- a/marketplace/plugins/elevenlabs/plugin.json
+++ b/marketplace/plugins/elevenlabs/plugin.json
@@ -1,0 +1,69 @@
+{
+  "name": "elevenlabs",
+  "version": "0.1.0",
+  "description": "Text-to-speech, voice synthesis, and audio transcription via ElevenLabs.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "elevenlabs",
+    "tts",
+    "voice",
+    "audio",
+    "speech"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/elevenlabs",
+  "x-coven": {
+    "displayName": "ElevenLabs",
+    "category": "Media & Creative",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/elevenlabs/elevenlabs-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "charm",
+        "roles": [
+          "social-voice",
+          "devrel-liaison"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "elevenlabs": {
+      "command": "uvx",
+      "args": [
+        "elevenlabs-mcp"
+      ],
+      "type": "stdio",
+      "env": {
+        "ELEVENLABS_API_KEY": "${ELEVENLABS_API_KEY}"
+      }
+    }
+  },
+  "userConfig": {
+    "elevenlabs_api_key": {
+      "type": "string",
+      "title": "ElevenLabs API Key",
+      "description": "API key for the ElevenLabs MCP server.",
+      "required": true,
+      "sensitive": true,
+      "env": "ELEVENLABS_API_KEY"
+    }
+  }
+}

--- a/marketplace/plugins/elevenlabs/skills/elevenlabs/SKILL.md
+++ b/marketplace/plugins/elevenlabs/skills/elevenlabs/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: elevenlabs
+description: Generate speech and transcribe audio; confirm voice and cost before large jobs.
+---
+
+# ElevenLabs
+
+Generate speech and transcribe audio; confirm voice and cost before large jobs.
+
+## Use When
+- Synthesize a short voice clip
+- Transcribe an audio file
+- Pick a voice for a narration
+
+## Guardrails
+- Confirm voice, language, and length before generating
+- Do not clone voices without consent
+- Report output file paths and durations
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/exa/.codex-plugin/plugin.json
+++ b/marketplace/plugins/exa/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "exa",
+  "version": "0.1.0",
+  "description": "Neural and keyword web search with content retrieval for grounded research.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Exa Search",
+    "shortDescription": "Neural and keyword web search with content retrieval for grounded research.",
+    "longDescription": "Use Exa to find and read sources for grounded, cited research.",
+    "developerName": "OpenCoven",
+    "category": "Browser & Web",
+    "capabilities": [
+      "exa",
+      "search",
+      "web",
+      "research",
+      "retrieval"
+    ],
+    "defaultPrompt": "Help me use Exa Search safely."
+  }
+}

--- a/marketplace/plugins/exa/plugin.json
+++ b/marketplace/plugins/exa/plugin.json
@@ -1,0 +1,69 @@
+{
+  "name": "exa",
+  "version": "0.1.0",
+  "description": "Neural and keyword web search with content retrieval for grounded research.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "exa",
+    "search",
+    "web",
+    "research",
+    "retrieval"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/exa",
+  "x-coven": {
+    "displayName": "Exa Search",
+    "category": "Browser & Web",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://docs.exa.ai/reference/exa-mcp"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "charm",
+        "roles": [
+          "devrel-liaison"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "exa": {
+      "url": "https://mcp.exa.ai/mcp",
+      "type": "http"
+    }
+  },
+  "userConfig": {
+    "exa_api_key": {
+      "type": "string",
+      "title": "Exa API Key",
+      "description": "API key for the Exa search MCP server.",
+      "required": true,
+      "sensitive": true,
+      "env": "EXA_API_KEY"
+    }
+  }
+}

--- a/marketplace/plugins/exa/skills/exa/SKILL.md
+++ b/marketplace/plugins/exa/skills/exa/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: exa
+description: Use Exa to find and read sources for grounded, cited research.
+---
+
+# Exa Search
+
+Use Exa to find and read sources for grounded, cited research.
+
+## Use When
+- Find recent sources on a topic
+- Retrieve and summarize an article
+- Gather citations for a claim
+
+## Guardrails
+- Cite every source with a link
+- Verify claims across more than one source
+- Note publish dates for time-sensitive facts
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/huggingface/.codex-plugin/plugin.json
+++ b/marketplace/plugins/huggingface/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "huggingface",
+  "version": "0.1.0",
+  "description": "Search models, datasets, papers, and Spaces on the Hugging Face Hub.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Hugging Face",
+    "shortDescription": "Search models, datasets, papers, and Spaces on the Hugging Face Hub.",
+    "longDescription": "Search the Hub for models, datasets, and papers; cite repo IDs and arXiv references.",
+    "developerName": "OpenCoven",
+    "category": "Agents & Harnesses",
+    "capabilities": [
+      "huggingface",
+      "models",
+      "datasets",
+      "papers",
+      "ml"
+    ],
+    "defaultPrompt": "Help me use Hugging Face safely."
+  }
+}

--- a/marketplace/plugins/huggingface/plugin.json
+++ b/marketplace/plugins/huggingface/plugin.json
@@ -1,0 +1,69 @@
+{
+  "name": "huggingface",
+  "version": "0.1.0",
+  "description": "Search models, datasets, papers, and Spaces on the Hugging Face Hub.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "huggingface",
+    "models",
+    "datasets",
+    "papers",
+    "ml"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/huggingface",
+  "x-coven": {
+    "displayName": "Hugging Face",
+    "category": "Agents & Harnesses",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://hf.co/settings/mcp/"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "huggingface": {
+      "url": "https://huggingface.co/mcp",
+      "type": "http"
+    }
+  },
+  "userConfig": {
+    "hf_token": {
+      "type": "string",
+      "title": "Hugging Face Token",
+      "description": "Optional token for higher rate limits and gated repos.",
+      "required": false,
+      "sensitive": true,
+      "env": "HF_TOKEN"
+    }
+  }
+}

--- a/marketplace/plugins/huggingface/skills/huggingface/SKILL.md
+++ b/marketplace/plugins/huggingface/skills/huggingface/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: huggingface
+description: Search the Hub for models, datasets, and papers; cite repo IDs and arXiv references.
+---
+
+# Hugging Face
+
+Search the Hub for models, datasets, and papers; cite repo IDs and arXiv references.
+
+## Use When
+- Find a model for a task
+- Look up a dataset's card
+- Locate the paper behind a model
+
+## Guardrails
+- Cite repo IDs and links
+- Note license and gating before recommending
+- Do not download large artifacts without approval
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/postgres/.codex-plugin/plugin.json
+++ b/marketplace/plugins/postgres/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "postgres",
+  "version": "0.1.0",
+  "description": "Read-only SQL introspection and queries against a PostgreSQL database for analysis and debugging.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "PostgreSQL",
+    "shortDescription": "Read-only SQL introspection and queries against a PostgreSQL database for analysis and debugging.",
+    "longDescription": "Query Postgres read-only for analysis; never mutate data without explicit approval.",
+    "developerName": "OpenCoven",
+    "category": "Databases",
+    "capabilities": [
+      "postgres",
+      "postgresql",
+      "sql",
+      "database",
+      "query"
+    ],
+    "defaultPrompt": "Help me use PostgreSQL safely."
+  }
+}

--- a/marketplace/plugins/postgres/plugin.json
+++ b/marketplace/plugins/postgres/plugin.json
@@ -1,0 +1,74 @@
+{
+  "name": "postgres",
+  "version": "0.1.0",
+  "description": "Read-only SQL introspection and queries against a PostgreSQL database for analysis and debugging.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "postgres",
+    "postgresql",
+    "sql",
+    "database",
+    "query"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/postgres",
+  "x-coven": {
+    "displayName": "PostgreSQL",
+    "category": "Databases",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/modelcontextprotocol/servers"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "debugger",
+          "implementer"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "${POSTGRES_CONNECTION_STRING}"
+      ],
+      "type": "stdio"
+    }
+  },
+  "userConfig": {
+    "postgres_connection_string": {
+      "type": "string",
+      "title": "Connection String",
+      "description": "postgresql://user:pass@host:5432/db connection string.",
+      "required": true,
+      "sensitive": true,
+      "env": "POSTGRES_CONNECTION_STRING"
+    }
+  }
+}

--- a/marketplace/plugins/postgres/skills/postgres/SKILL.md
+++ b/marketplace/plugins/postgres/skills/postgres/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: postgres
+description: Query Postgres read-only for analysis; never mutate data without explicit approval.
+---
+
+# PostgreSQL
+
+Query Postgres read-only for analysis; never mutate data without explicit approval.
+
+## Use When
+- Inspect schema and table shapes
+- Run read-only analytical queries
+- Explain a slow query plan
+
+## Guardrails
+- Prefer read-only queries; no writes without approval
+- Never expose connection credentials
+- Bound result sets with LIMIT
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/sentry/.codex-plugin/plugin.json
+++ b/marketplace/plugins/sentry/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "sentry",
+  "version": "0.1.0",
+  "description": "Query Sentry issues, events, and traces to triage and debug production errors.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Sentry",
+    "shortDescription": "Query Sentry issues, events, and traces to triage and debug production errors.",
+    "longDescription": "Use Sentry to triage and explain errors; never resolve or mutate issues without approval.",
+    "developerName": "OpenCoven",
+    "category": "Developer Tools",
+    "capabilities": [
+      "sentry",
+      "errors",
+      "observability",
+      "debugging",
+      "traces"
+    ],
+    "defaultPrompt": "Help me use Sentry safely."
+  }
+}

--- a/marketplace/plugins/sentry/plugin.json
+++ b/marketplace/plugins/sentry/plugin.json
@@ -1,0 +1,58 @@
+{
+  "name": "sentry",
+  "version": "0.1.0",
+  "description": "Query Sentry issues, events, and traces to triage and debug production errors.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "sentry",
+    "errors",
+    "observability",
+    "debugging",
+    "traces"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/sentry",
+  "x-coven": {
+    "displayName": "Sentry",
+    "category": "Developer Tools",
+    "trust": "official-remote",
+    "sourceRefs": [
+      "https://docs.sentry.io/product/sentry-mcp/"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "retrospector"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp",
+      "type": "http"
+    }
+  }
+}

--- a/marketplace/plugins/sentry/skills/sentry/SKILL.md
+++ b/marketplace/plugins/sentry/skills/sentry/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: sentry
+description: Use Sentry to triage and explain errors; never resolve or mutate issues without approval.
+---
+
+# Sentry
+
+Use Sentry to triage and explain errors; never resolve or mutate issues without approval.
+
+## Use When
+- Find the most frequent unresolved issues
+- Read an event's stack trace and breadcrumbs
+- Correlate an error spike with a release
+
+## Guardrails
+- Do not resolve, ignore, or assign issues without approval
+- Avoid leaking PII from event payloads
+- Cite issue IDs and permalinks
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/slack/.codex-plugin/plugin.json
+++ b/marketplace/plugins/slack/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "slack",
+  "version": "0.1.0",
+  "description": "Read channels, search history, and post approved messages to Slack workspaces.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Slack",
+    "shortDescription": "Read channels, search history, and post approved messages to Slack workspaces.",
+    "longDescription": "Use Slack read-first; never post, react, or DM without explicit approval.",
+    "developerName": "OpenCoven",
+    "category": "Productivity",
+    "capabilities": [
+      "slack",
+      "chat",
+      "messaging",
+      "notifications",
+      "team"
+    ],
+    "defaultPrompt": "Help me use Slack safely."
+  }
+}

--- a/marketplace/plugins/slack/plugin.json
+++ b/marketplace/plugins/slack/plugin.json
@@ -1,0 +1,84 @@
+{
+  "name": "slack",
+  "version": "0.1.0",
+  "description": "Read channels, search history, and post approved messages to Slack workspaces.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "slack",
+    "chat",
+    "messaging",
+    "notifications",
+    "team"
+  ],
+  "capabilities": [
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/slack",
+  "x-coven": {
+    "displayName": "Slack",
+    "category": "Productivity",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/modelcontextprotocol/servers"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "charm",
+        "roles": [
+          "devrel-liaison"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "coordination-layer"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-slack"
+      ],
+      "type": "stdio",
+      "env": {
+        "SLACK_BOT_TOKEN": "${SLACK_BOT_TOKEN}",
+        "SLACK_TEAM_ID": "${SLACK_TEAM_ID}"
+      }
+    }
+  },
+  "userConfig": {
+    "slack_bot_token": {
+      "type": "string",
+      "title": "Slack Bot Token",
+      "description": "Bot user OAuth token (xoxb-\u2026) for the Slack MCP server.",
+      "required": true,
+      "sensitive": true,
+      "env": "SLACK_BOT_TOKEN"
+    },
+    "slack_team_id": {
+      "type": "string",
+      "title": "Slack Team ID",
+      "description": "Workspace/team ID the bot is installed in.",
+      "required": true,
+      "sensitive": false,
+      "env": "SLACK_TEAM_ID"
+    }
+  }
+}

--- a/marketplace/plugins/slack/skills/slack/SKILL.md
+++ b/marketplace/plugins/slack/skills/slack/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: slack
+description: Use Slack read-first; never post, react, or DM without explicit approval.
+---
+
+# Slack
+
+Use Slack read-first; never post, react, or DM without explicit approval.
+
+## Use When
+- Search channel history for context
+- Summarize a thread
+- Post an approved status update
+
+## Guardrails
+- Do not post, react, or DM without approval
+- Preserve exact approved text when posting
+- Record message timestamps/permalinks
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/marketplace/plugins/sqlite/.codex-plugin/plugin.json
+++ b/marketplace/plugins/sqlite/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "sqlite",
+  "version": "0.1.0",
+  "description": "Query and introspect local SQLite databases for lightweight analysis.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "SQLite",
+    "shortDescription": "Query and introspect local SQLite databases for lightweight analysis.",
+    "longDescription": "Query a local SQLite file read-first; confirm before schema or data changes.",
+    "developerName": "OpenCoven",
+    "category": "Databases",
+    "capabilities": [
+      "sqlite",
+      "sql",
+      "database",
+      "local",
+      "query"
+    ],
+    "defaultPrompt": "Help me use SQLite safely."
+  }
+}

--- a/marketplace/plugins/sqlite/plugin.json
+++ b/marketplace/plugins/sqlite/plugin.json
@@ -1,0 +1,73 @@
+{
+  "name": "sqlite",
+  "version": "0.1.0",
+  "description": "Query and introspect local SQLite databases for lightweight analysis.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "sqlite",
+    "sql",
+    "database",
+    "local",
+    "query"
+  ],
+  "capabilities": [
+    "read_files",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/sqlite",
+  "x-coven": {
+    "displayName": "SQLite",
+    "category": "Databases",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/modelcontextprotocol/servers"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "cody",
+        "roles": [
+          "debugger"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": true,
+      "rolePatch": true
+    }
+  },
+  "mcpServers": {
+    "sqlite": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-sqlite",
+        "--db-path",
+        "${SQLITE_DB_PATH}"
+      ],
+      "type": "stdio"
+    }
+  },
+  "userConfig": {
+    "sqlite_db_path": {
+      "type": "string",
+      "title": "Database Path",
+      "description": "Filesystem path to the SQLite .db file.",
+      "required": true,
+      "sensitive": false,
+      "env": "SQLITE_DB_PATH"
+    }
+  }
+}

--- a/marketplace/plugins/sqlite/skills/sqlite/SKILL.md
+++ b/marketplace/plugins/sqlite/skills/sqlite/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: sqlite
+description: Query a local SQLite file read-first; confirm before schema or data changes.
+---
+
+# SQLite
+
+Query a local SQLite file read-first; confirm before schema or data changes.
+
+## Use When
+- List tables and inspect schema
+- Run a read-only query
+- Summarize row counts and shapes
+
+## Guardrails
+- Prefer read-only queries; no writes without approval
+- Back up before any schema change
+- Bound result sets with LIMIT
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -1,16 +1,37 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
 import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
+import { Tabs } from "@/components/ui/tabs";
 import { MarketplaceCard } from "@/components/marketplace/marketplace-card";
 import { MarketplaceDetail } from "@/components/marketplace/marketplace-detail";
 import { MarketplaceConfigure } from "@/components/marketplace/marketplace-configure";
+import { CollectionStrip } from "@/components/marketplace/collection-strip";
 import {
   categoriesFrom,
   filterPlugins,
+  sortPlugins,
+  countByKind,
+  resolveCollection,
+  COLLECTIONS,
+  type KindFilter,
+  type SortKey,
   type MarketplacePlugin,
 } from "@/lib/marketplace-catalog";
+
+const KIND_TABS: ReadonlyArray<{ id: KindFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "mcp", label: "MCP servers" },
+  { id: "skill", label: "Skills" },
+];
+
+const SORT_OPTIONS: ReadonlyArray<{ id: SortKey; label: string }> = [
+  { id: "recommended", label: "Recommended" },
+  { id: "name", label: "Name (A–Z)" },
+  { id: "installed", label: "Installed first" },
+];
 
 export function MarketplaceViewSurface() {
   const [plugins, setPlugins] = useState<MarketplacePlugin[]>([]);
@@ -18,6 +39,9 @@ export function MarketplaceViewSurface() {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("All");
+  const [kind, setKind] = useState<KindFilter>("all");
+  const [sort, setSort] = useState<SortKey>("recommended");
+  const [collectionId, setCollectionId] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [configuringId, setConfiguringId] = useState<string | null>(null);
@@ -43,9 +67,33 @@ export function MarketplaceViewSurface() {
   }, [load]);
 
   const categories = useMemo(() => categoriesFrom(plugins), [plugins]);
-  const filtered = useMemo(() => filterPlugins(plugins, { query, category }), [plugins, query, category]);
+  const kindCounts = useMemo(() => countByKind(plugins), [plugins]);
+  const installedCount = useMemo(() => plugins.filter((p) => p.installed).length, [plugins]);
+
+  const activeCollection = useMemo(
+    () => COLLECTIONS.find((c) => c.id === collectionId) ?? null,
+    [collectionId],
+  );
+  const collectionIds = useMemo(
+    () => (activeCollection ? resolveCollection(plugins, activeCollection).map((p) => p.id) : undefined),
+    [plugins, activeCollection],
+  );
+
+  const filtered = useMemo(() => {
+    const matched = filterPlugins(plugins, {
+      query,
+      category: activeCollection ? "All" : category,
+      kind,
+      ids: collectionIds,
+    });
+    return sortPlugins(matched, sort);
+  }, [plugins, query, category, kind, sort, collectionIds, activeCollection]);
+
   const selectedPlugin = useMemo(() => plugins.find((p) => p.id === selected) ?? null, [plugins, selected]);
   const configuringPlugin = useMemo(() => plugins.find((p) => p.id === configuringId) ?? null, [plugins, configuringId]);
+
+  // The featured strip only makes sense on the unfiltered default landing.
+  const showFeatured = !activeCollection && !query && category === "All" && kind === "all";
 
   const setInstalled = useCallback((id: string, installed: boolean) => {
     setPlugins((prev) => prev.map((p) => (p.id === id ? { ...p, installed } : p)));
@@ -96,7 +144,19 @@ export function MarketplaceViewSurface() {
           <div>
             <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">Marketplace</p>
             <h2 className="text-[20px] font-semibold text-[var(--text-primary)]">Add tools to your familiars</h2>
-            <p className="mt-1 text-[12px] text-[var(--text-muted)]">{filtered.length} of {plugins.length} plugins</p>
+            <p className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-[var(--text-muted)]">
+              <span>{plugins.length} plugins</span>
+              <span aria-hidden>·</span>
+              <span>{kindCounts.mcp} MCP servers</span>
+              <span aria-hidden>·</span>
+              <span>{kindCounts.skill} skills</span>
+              {installedCount > 0 ? (
+                <>
+                  <span aria-hidden>·</span>
+                  <span className="text-[var(--text-primary)]">{installedCount} added</span>
+                </>
+              ) : null}
+            </p>
           </div>
           <SearchInput
             value={query}
@@ -107,14 +167,44 @@ export function MarketplaceViewSurface() {
             aria-label="Search plugins"
           />
         </div>
-        <div className="mt-4 flex flex-wrap gap-1">
+
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <Tabs
+            items={KIND_TABS}
+            value={kind}
+            onChange={setKind}
+            variant="segment"
+            size="sm"
+            bordered={false}
+            ariaLabel="Filter plugins by type"
+          />
+          <label className="flex items-center gap-2 text-[12px] text-[var(--text-muted)]">
+            <span className="sr-only">Sort plugins</span>
+            <Icon name="ph:sort-ascending" width={14} aria-hidden />
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value as SortKey)}
+              aria-label="Sort plugins"
+              className="focus-ring cursor-pointer rounded-md border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-2 py-1 text-[12px] text-[var(--text-primary)]"
+            >
+              {SORT_OPTIONS.map((o) => (
+                <option key={o.id} value={o.id}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="mt-3 flex flex-wrap gap-1">
           {categories.map((cat) => (
             <button
               key={cat}
               type="button"
-              onClick={() => setCategory(cat)}
+              onClick={() => {
+                setCategory(cat);
+                setCollectionId(null);
+              }}
               className={`focus-ring rounded-md px-3 py-1.5 text-[12px] transition-colors ${
-                category === cat
+                !activeCollection && category === cat
                   ? "bg-[var(--text-primary)] text-[var(--bg-base)]"
                   : "text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
               }`}
@@ -123,6 +213,7 @@ export function MarketplaceViewSurface() {
             </button>
           ))}
         </div>
+
         {error ? (
           <p className="mt-3 rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
             {error}
@@ -131,13 +222,46 @@ export function MarketplaceViewSurface() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+        {showFeatured && plugins.length > 0 ? (
+          <CollectionStrip
+            collections={COLLECTIONS}
+            plugins={plugins}
+            onOpen={(id) => {
+              setCollectionId(id);
+              setCategory("All");
+              setKind("all");
+            }}
+          />
+        ) : null}
+
+        {activeCollection ? (
+          <div className="mb-4 flex items-start justify-between gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-4 py-3">
+            <div className="flex items-start gap-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+                <Icon name={activeCollection.icon} width={18} className="text-[var(--text-primary)]" />
+              </span>
+              <div>
+                <p className="text-[14px] font-semibold text-[var(--text-primary)]">{activeCollection.title}</p>
+                <p className="text-[12px] text-[var(--text-muted)]">{activeCollection.description}</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setCollectionId(null)}
+              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[12px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            >
+              <Icon name="ph:arrow-left" width={12} aria-hidden /> All plugins
+            </button>
+          </div>
+        ) : null}
+
         {!loaded ? (
           <p className="text-[12px] text-[var(--text-muted)]">Loading…</p>
         ) : filtered.length === 0 ? (
           <EmptyState
             icon="ph:puzzle-piece-bold"
-            headline={query || category !== "All" ? "No matching plugins" : "No plugins available"}
-            subtitle={query || category !== "All" ? "Try a different search or category." : "The catalog is empty."}
+            headline={query || category !== "All" || kind !== "all" || activeCollection ? "No matching plugins" : "No plugins available"}
+            subtitle={query || category !== "All" || kind !== "all" || activeCollection ? "Try a different search, type, or category." : "The catalog is empty."}
           />
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">

--- a/src/components/marketplace/collection-strip.tsx
+++ b/src/components/marketplace/collection-strip.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Icon } from "@/lib/icon";
+import {
+  resolveCollection,
+  type Collection,
+  type MarketplacePlugin,
+} from "@/lib/marketplace-catalog";
+
+type Props = {
+  collections: readonly Collection[];
+  plugins: MarketplacePlugin[];
+  onOpen: (id: string) => void;
+};
+
+/**
+ * Featured-collections strip shown on the marketplace landing. Each card is a
+ * curated bundle; clicking it filters the grid to that collection's members.
+ * Collections that resolve to nothing (ids absent from the catalog) are hidden.
+ */
+export function CollectionStrip({ collections, plugins, onOpen }: Props) {
+  const resolved = collections
+    .map((c) => ({ collection: c, members: resolveCollection(plugins, c) }))
+    .filter((r) => r.members.length > 0);
+
+  if (resolved.length === 0) return null;
+
+  return (
+    <div className="mb-5">
+      <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
+        Featured collections
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {resolved.map(({ collection, members }) => {
+          const added = members.filter((m) => m.installed).length;
+          return (
+            <button
+              key={collection.id}
+              type="button"
+              onClick={() => onOpen(collection.id)}
+              className="focus-ring group flex flex-col gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-4 text-left transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)]"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
+                  <Icon name={collection.icon} width={18} className="text-[var(--text-primary)]" />
+                </span>
+                <Icon
+                  name="ph:caret-right"
+                  width={14}
+                  aria-hidden
+                  className="text-[var(--text-muted)] transition-transform group-hover:translate-x-0.5"
+                />
+              </div>
+              <span className="text-[14px] font-semibold text-[var(--text-primary)]">{collection.title}</span>
+              <span className="line-clamp-2 text-[12px] text-[var(--text-muted)]">{collection.description}</span>
+              <span className="mt-1 text-[11px] text-[var(--text-muted)]">
+                {members.length} {members.length === 1 ? "plugin" : "plugins"}
+                {added > 0 ? ` · ${added} added` : ""}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -62,6 +62,10 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfi
       <p className="line-clamp-2 text-[12px] text-[var(--text-muted)]">{plugin.description}</p>
       <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
         <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5">
+          <Icon name={plugin.kind === "mcp" ? "ph:plug-bold" : "ph:sparkle-bold"} width={11} aria-hidden />{" "}
+          {plugin.kind === "mcp" ? "MCP" : "Skill"}
+        </span>
+        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5">
           <Icon name="ph:seal-check" width={11} aria-hidden /> {TRUST_LABEL[plugin.trust] ?? plugin.trust}
         </span>
         <span className="rounded-full border border-[var(--border-hairline)] px-2 py-0.5">{plugin.category}</span>

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -61,7 +61,7 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-              <Icon name="ph:plug-bold" width={18} className="text-[var(--text-muted)]" />
+              <Icon name={plugin.kind === "mcp" ? "ph:plug-bold" : "ph:sparkle-bold"} width={18} className="text-[var(--text-muted)]" />
             </span>
             <div className="min-w-0">
               <h2 className="truncate text-[16px] font-semibold text-[var(--text-primary)]">{plugin.displayName}</h2>
@@ -76,6 +76,10 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
         {plugin.description ? <p className="text-[13px] text-[var(--text-primary)]">{plugin.description}</p> : null}
 
         <div className="flex flex-wrap gap-2 text-[11px] text-[var(--text-muted)]">
+          <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5">
+            <Icon name={plugin.kind === "mcp" ? "ph:plug-bold" : "ph:sparkle-bold"} width={11} aria-hidden />{" "}
+            {plugin.kind === "mcp" ? "MCP server" : "Skill"}
+          </span>
           <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5">
             <Icon name="ph:seal-check" width={11} aria-hidden /> {TRUST_LABEL[plugin.trust] ?? plugin.trust}
           </span>

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -3,11 +3,16 @@ import assert from "node:assert/strict";
 import {
   mergeCatalog,
   deriveRequiresSetup,
+  deriveKind,
   pluginBadgeState,
   filterPlugins,
+  sortPlugins,
+  countByKind,
   categoriesFrom,
   requiredConfigFromManifest,
   remoteUrlFromManifest,
+  resolveCollection,
+  COLLECTIONS,
 } from "./marketplace-catalog.ts";
 
 const marketplacePlugins = [
@@ -16,9 +21,9 @@ const marketplacePlugins = [
   { name: "legacy", displayName: "Legacy", category: "Other", trust: "preview-local", policy: { installation: "UNAVAILABLE", authentication: "NONE" } },
 ];
 const manifests = {
-  github: { version: "0.1.0", description: "Repos, issues, PRs.", author: { name: "OpenCoven" }, keywords: ["git", "pull-requests"], capabilities: ["network", "mcp"], homepage: "https://opencoven.ai", userConfig: { github_token: { required: true, sensitive: true, env: "GITHUB_PERSONAL_ACCESS_TOKEN" } } },
-  fetch: { version: "0.2.0", description: "HTTP fetch.", author: "Anthropic", keywords: ["http"], capabilities: ["network"] },
-  // legacy: intentionally no manifest -> degraded card
+  github: { version: "0.1.0", description: "Repos, issues, PRs.", author: { name: "OpenCoven" }, keywords: ["git", "pull-requests"], capabilities: ["network", "mcp"], homepage: "https://opencoven.ai", mcpServers: { github: { command: "npx", type: "stdio" } }, userConfig: { github_token: { required: true, sensitive: true, env: "GITHUB_PERSONAL_ACCESS_TOKEN" } } },
+  fetch: { version: "0.2.0", description: "HTTP fetch.", author: "Anthropic", keywords: ["http"], capabilities: ["network"], mcpServers: { fetch: { command: "npx", type: "stdio" } } },
+  // legacy: intentionally no manifest -> degraded card, no mcpServers -> kind "skill"
 };
 const installed = { fetch: { version: "0.2.0", source: "catalog", installedAt: "2026-06-24T00:00:00.000Z" } };
 
@@ -124,6 +129,48 @@ const remoteMerged = mergeCatalog(
 assert.equal(remoteMerged[0].remoteUrl, "https://mcp.linear.app/mcp");
 
 const ghRow = merged.find((p) => p.id === "github");
-assert.equal(ghRow.remoteUrl, undefined); // github fixture has no mcpServers -> undefined
+assert.equal(ghRow.remoteUrl, undefined); // command-only mcpServer (no url) -> undefined
+
+// --- deriveKind ---
+assert.equal(deriveKind({ mcpServers: { x: { command: "npx" } } }), "mcp");
+assert.equal(deriveKind({ mcpServers: { x: { url: "https://e.x/mcp" } } }), "mcp");
+assert.equal(deriveKind({ mcpServers: {} }), "skill");
+assert.equal(deriveKind({}), "skill");
+assert.equal(merged.find((p) => p.id === "legacy").kind, "skill"); // no manifest -> skill
+
+// --- filterPlugins: kind + ids ---
+assert.deepEqual(filterPlugins(merged, { kind: "mcp" }).map((p) => p.id), ["fetch", "github"]);
+assert.deepEqual(filterPlugins(merged, { kind: "skill" }).map((p) => p.id), ["legacy"]);
+assert.deepEqual(filterPlugins(merged, { ids: ["github", "legacy"] }).map((p) => p.id), ["github", "legacy"]);
+assert.deepEqual(filterPlugins(merged, { ids: ["github"], kind: "skill" }).map((p) => p.id), []);
+
+// --- countByKind ---
+assert.deepEqual(countByKind(merged), { mcp: 2, skill: 1 });
+
+// --- sortPlugins (returns a new array, never mutates) ---
+const before = merged.map((p) => p.id);
+const byName = sortPlugins(merged, "name");
+assert.deepEqual(byName.map((p) => p.id), ["fetch", "github", "legacy"]);
+assert.deepEqual(merged.map((p) => p.id), before); // input untouched
+// installed: fetch is installed -> first
+assert.equal(sortPlugins(merged, "installed")[0].id, "fetch");
+// recommended: trust rank reference-local(2) < preview-local(3) -> legacy last
+assert.equal(sortPlugins(merged, "recommended").at(-1).id, "legacy");
+
+// --- collections ---
+const essentials = COLLECTIONS.find((c) => c.id === "essentials");
+assert.ok(essentials);
+// resolve keeps collection id order and skips ids absent from the catalog
+assert.deepEqual(
+  resolveCollection(merged, { id: "t", title: "t", description: "", icon: "", ids: ["legacy", "missing", "github"] }).map((p) => p.id),
+  ["legacy", "github"],
+);
+// category-based collection returns every plugin in the category
+assert.deepEqual(
+  resolveCollection(merged, { id: "t", title: "t", description: "", icon: "", category: "Other" }).map((p) => p.id),
+  ["legacy"],
+);
+// coven-native collection is category-driven so it always tracks first-party plugins
+assert.equal(COLLECTIONS.find((c) => c.id === "coven-native").category, "Coven");
 
 console.log("marketplace-catalog.test.ts: ok");

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -4,6 +4,8 @@
  * passes already-parsed inputs here so this stays unit-testable.
  */
 
+import type { IconName } from "@/lib/icon";
+
 export type RoleAffinity = { familiar: string; roles: string[] };
 
 export type MarketplaceJsonPlugin = {
@@ -69,6 +71,8 @@ export function remoteUrlFromManifest(manifest: PluginManifest): string | undefi
 
 export type InstalledMap = Record<string, { version: string; source: string; installedAt: string }>;
 
+export type PluginKind = "mcp" | "skill";
+
 export type MarketplacePlugin = {
   id: string;
   displayName: string;
@@ -82,7 +86,7 @@ export type MarketplacePlugin = {
   homepage?: string;
   repository?: string;
   roleAffinity: RoleAffinity[];
-  kind: "mcp";
+  kind: PluginKind;
   version: string;
   installed: boolean;
   requiresSetup: boolean;
@@ -91,6 +95,16 @@ export type MarketplacePlugin = {
   configured: boolean;
   remoteUrl?: string;
 };
+
+/**
+ * "mcp" when the manifest declares any MCP server (stdio command or remote
+ * url); otherwise "skill" — a first-party capability that runs inside Coven
+ * Cave without an external server.
+ */
+export function deriveKind(manifest: PluginManifest): PluginKind {
+  const servers = manifest.mcpServers ?? {};
+  return Object.keys(servers).length > 0 ? "mcp" : "skill";
+}
 
 export function deriveRequiresSetup(userConfig: PluginManifest["userConfig"]): boolean {
   if (!userConfig) return false;
@@ -129,7 +143,7 @@ export function mergeCatalog(
         homepage: manifest.homepage,
         repository: manifest.repository,
         roleAffinity: p.roleAffinity ?? [],
-        kind: "mcp" as const,
+        kind: deriveKind(manifest),
         version: manifest.version ?? "0.0.0",
         installed: Boolean(installed[p.name]),
         requiresSetup: requiredConfig.length > 0,
@@ -153,20 +167,148 @@ export function pluginBadgeState(
   return "add";
 }
 
+export type KindFilter = "all" | PluginKind;
+
 export function filterPlugins(
   plugins: MarketplacePlugin[],
-  opts: { query?: string; category?: string },
+  opts: { query?: string; category?: string; kind?: KindFilter; ids?: readonly string[] },
 ): MarketplacePlugin[] {
   const q = (opts.query ?? "").trim().toLowerCase();
   const category = opts.category ?? "All";
+  const kind = opts.kind ?? "all";
+  const idSet = opts.ids ? new Set(opts.ids) : null;
   return plugins.filter((p) => {
+    if (idSet && !idSet.has(p.id)) return false;
     if (category !== "All" && p.category !== category) return false;
+    if (kind !== "all" && p.kind !== kind) return false;
     if (!q) return true;
     const haystack = [p.displayName, p.description, p.author, p.category, ...p.keywords]
       .join(" ")
       .toLowerCase();
     return haystack.includes(q);
   });
+}
+
+export type SortKey = "recommended" | "name" | "installed";
+
+const TRUST_RANK: Record<string, number> = {
+  "official-remote": 0,
+  "official-local": 1,
+  "reference-local": 2,
+  "preview-local": 3,
+  "local-tool": 4,
+};
+
+function trustRank(trust: string): number {
+  return TRUST_RANK[trust] ?? 9;
+}
+
+/** Returns a new, sorted array — never mutates the input. */
+export function sortPlugins(plugins: MarketplacePlugin[], sort: SortKey): MarketplacePlugin[] {
+  const byName = (a: MarketplacePlugin, b: MarketplacePlugin) =>
+    a.displayName.localeCompare(b.displayName);
+  const copy = [...plugins];
+  if (sort === "name") return copy.sort(byName);
+  if (sort === "installed") {
+    return copy.sort(
+      (a, b) => Number(b.installed) - Number(a.installed) || byName(a, b),
+    );
+  }
+  // recommended: official trust first, then needs-setup demoted, then name
+  return copy.sort(
+    (a, b) =>
+      trustRank(a.trust) - trustRank(b.trust) ||
+      Number(a.requiresSetup && !a.configured) - Number(b.requiresSetup && !b.configured) ||
+      byName(a, b),
+  );
+}
+
+export function countByKind(plugins: MarketplacePlugin[]): { mcp: number; skill: number } {
+  let mcp = 0;
+  let skill = 0;
+  for (const p of plugins) {
+    if (p.kind === "mcp") mcp += 1;
+    else skill += 1;
+  }
+  return { mcp, skill };
+}
+
+export type Collection = {
+  id: string;
+  title: string;
+  description: string;
+  icon: IconName;
+  /** Explicit member ids; resolved against the live catalog (missing ids skipped). */
+  ids?: readonly string[];
+  /** When set, members are every plugin in this category (ids ignored). */
+  category?: string;
+};
+
+/**
+ * Curated bundles surfaced as a "Featured collections" strip. Order matters —
+ * it is the on-screen order. Coven-native uses a category match so it always
+ * reflects every first-party plugin; the rest are hand-picked id lists.
+ */
+export const COLLECTIONS: readonly Collection[] = [
+  {
+    id: "coven-native",
+    title: "Coven native",
+    description: "First-party capabilities that run inside Coven Cave.",
+    icon: "ph:sparkle-bold",
+    category: "Coven",
+  },
+  {
+    id: "essentials",
+    title: "Essentials",
+    description: "The core toolkit every familiar should start with.",
+    icon: "ph:cube-bold",
+    ids: ["filesystem", "git", "github", "fetch", "memory", "time", "sequential-thinking"],
+  },
+  {
+    id: "research",
+    title: "Research stack",
+    description: "Search, retrieve, and ground answers in real sources.",
+    icon: "ph:magnifying-glass-bold",
+    ids: ["exa", "tavily", "firecrawl", "context7", "huggingface", "fetch"],
+  },
+  {
+    id: "web-automation",
+    title: "Web & browser",
+    description: "Drive browsers and crawl the live web.",
+    icon: "ph:globe-bold",
+    ids: ["playwright", "browserbase", "chrome-devtools", "firecrawl", "searxng"],
+  },
+  {
+    id: "data",
+    title: "Data & databases",
+    description: "Query and inspect your data sources.",
+    icon: "ph:database-bold",
+    ids: ["postgres", "sqlite", "supabase", "mongodb", "dbhub"],
+  },
+  {
+    id: "devops",
+    title: "Ship & operate",
+    description: "Deploy, observe, and manage infrastructure.",
+    icon: "ph:rocket-launch-bold",
+    ids: ["vercel", "azure", "terraform", "cloudflare-docs", "sentry"],
+  },
+];
+
+/** Member plugins of a collection, in collection order, present in the catalog. */
+export function resolveCollection(
+  plugins: MarketplacePlugin[],
+  collection: Collection,
+): MarketplacePlugin[] {
+  if (collection.category) {
+    return plugins.filter((p) => p.category === collection.category);
+  }
+  const byId = new Map(plugins.map((p) => [p.id, p]));
+  const out: MarketplacePlugin[] = [];
+  for (const id of collection.ids ?? []) {
+    const p = byId.get(id);
+    if (p) out.push(p);
+  }
+  return out;
 }
 
 export function categoriesFrom(plugins: MarketplacePlugin[]): string[] {


### PR DESCRIPTION
## What

Turns the Marketplace tab into a world-class plugin storefront and grows the catalog from **44 → 60 plugins** with first-party Coven capabilities and 10 more MCP servers.

### Surface uplift
- **Featured collections** strip — curated bundles (Coven native, Essentials, Research stack, Web & browser, Data & databases, Ship & operate) that filter the grid on click, with a banner + "← All plugins" back affordance.
- **Kind filter** segmented control: All · MCP servers · Skills.
- **Sort** control: Recommended (official-trust first, needs-setup demoted) · Name (A–Z) · Installed first.
- Header stat line: `N plugins · N MCP servers · N skills · N added`.
- Cards and the detail drawer show a **kind badge** (MCP / Skill); the detail header icon is kind-aware.

### Pure-lib additions (`src/lib/marketplace-catalog.ts`, unit-tested)
- `deriveKind()` — a plugin is `mcp` when its manifest declares any MCP server, else `skill`. `mergeCatalog` now derives `kind` instead of hardcoding `"mcp"`, so first-party skills render correctly.
- `filterPlugins()` gains `kind` + `ids` filters; new `sortPlugins()`, `countByKind()`, `COLLECTIONS`, and `resolveCollection()`.

### Catalog (regenerated via `scripts/sync-marketplace.py`)
- **6 first-party Coven skills** (new "Coven" category): familiars, flows, memory & knowledge, evals, canvas, automations.
- **10 MCP servers**: slack, postgres, sentry, cloudflare-docs, huggingface, exa, e2b, browserbase, elevenlabs, sqlite.

## Verification
- `marketplace-catalog.test.ts` extended (deriveKind, kind/ids filter, sortPlugins, countByKind, collections) — green.
- `sync-marketplace.py --check` clean (184 files / 60 plugins).
- Frontend build green, bundle within budget; `check-tests-wired` (666 files) and `api-contracts` (152) pass.
- Visually verified the landing strip, kind/sort controls, stat line, and the Coven-native collection filter in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)