### PR TITLE
refactor(automations): share list-input parse/join helpers across the forms

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -306,6 +306,7 @@ export const SUITES = {
     "src/components/inbox-feed-a11y.test.ts",
     "src/components/schedules-tabs.test.ts",
     "src/lib/automations/automation-entry.test.ts",
+    "src/lib/automations/list-input.test.ts",
     "src/lib/inbox-feed.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/daily-summary-notifications.test.ts",

--- a/src/components/automation-create-dialog.tsx
+++ b/src/components/automation-create-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { FamiliarMultiSelect } from "@/components/automation-familiar-select";
 import { SkillSelect } from "@/components/automation-skill-select";
 import { CwdPickerField } from "@/components/cwd-picker-field";
+import { parseListInput } from "@/lib/automations/list-input";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 export type AutomationCreateInput = {
@@ -86,8 +87,8 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate }:
       name: name.trim(),
       rrule,
       prompt,
-      cwds: cwds.split("\n").map((s) => s.trim()).filter(Boolean),
-      tags: tagsText.split(",").map((s) => s.trim()).filter(Boolean),
+      cwds: parseListInput(cwds),
+      tags: parseListInput(tagsText),
       familiars: [...selected],
       model: model.trim(),
       reasoning_effort: reasoningEffort,

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -43,6 +43,7 @@ import {
   type AutomationType,
   type AutomationEntry,
 } from "@/lib/automations/automation-entry";
+import { listInput, commaInput, parseListInput } from "@/lib/automations/list-input";
 
 // AutomationsView — Schedules surface, redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
@@ -126,20 +127,6 @@ function relTime(iso: string | undefined | null): string {
   return relativeTimeSigned(iso);
 }
 
-function listInput(values: string[]): string {
-  return values.join("\n");
-}
-
-function commaInput(values: string[]): string {
-  return values.join(", ");
-}
-
-function parseListInput(value: string): string[] {
-  return value
-    .split(/\n|,/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return (

--- a/src/components/cwd-picker-field.tsx
+++ b/src/components/cwd-picker-field.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { ProjectTree } from "@/components/project-tree";
+import { parseListInput } from "@/lib/automations/list-input";
 import type { CaveProject } from "@/lib/cave-projects-types";
 
 /**
@@ -38,10 +39,7 @@ export function CwdPickerField({
   const dialogRef = useRef<HTMLDivElement>(null);
   useFocusTrap(pickerOpen, dialogRef, { onEscape: () => setPickerOpen(false) });
 
-  const list = useMemo(
-    () => value.split("\n").map((s) => s.trim()).filter(Boolean),
-    [value],
-  );
+  const list = useMemo(() => parseListInput(value), [value]);
   const selectedDirs = useMemo(() => new Set(list), [list]);
 
   const addCwd = (dir: string) => {

--- a/src/lib/automations/list-input.test.ts
+++ b/src/lib/automations/list-input.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { listInput, commaInput, parseListInput } from "./list-input.ts";
+
+// Joiners.
+assert.equal(listInput(["/a", "/b"]), "/a\n/b", "listInput joins one per line");
+assert.equal(commaInput(["x", "y"]), "x, y", "commaInput joins comma-separated");
+assert.equal(listInput([]), "", "empty list → empty string");
+
+// parseListInput accepts newline OR comma OR a mix, trims, and drops blanks.
+assert.deepEqual(parseListInput("/a\n/b"), ["/a", "/b"], "splits on newlines");
+assert.deepEqual(parseListInput("x, y, z"), ["x", "y", "z"], "splits on commas");
+assert.deepEqual(parseListInput("/a\n b , /c "), ["/a", "b", "/c"], "mixed separators + trims");
+assert.deepEqual(parseListInput("\n\n, ,\n"), [], "all-blank → empty list");
+assert.deepEqual(parseListInput(""), [], "empty input → empty list");
+
+// Round-trips.
+assert.deepEqual(parseListInput(listInput(["/a", "/b"])), ["/a", "/b"], "listInput→parse round-trips");
+assert.deepEqual(parseListInput(commaInput(["x", "y"])), ["x", "y"], "commaInput→parse round-trips");
+
+console.log("list-input.test.ts: ok");

--- a/src/lib/automations/list-input.ts
+++ b/src/lib/automations/list-input.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared <input text> ↔ string[] helpers for the automation forms (working
+ * directories, tags). One place so the create dialog, the inline cron editor,
+ * and the cwd picker parse the same way — `parseListInput` accepts newline- AND
+ * comma-separated entries, trims, and drops blanks.
+ */
+
+/** Join a list for a multi-line textarea (one entry per line). */
+export function listInput(values: string[]): string {
+  return values.join("\n");
+}
+
+/** Join a list for a single-line comma field. */
+export function commaInput(values: string[]): string {
+  return values.join(", ");
+}
+
+/** Parse a textarea/comma field into a trimmed, blank-free list. Accepts either
+ *  separator (or a mix), so paste-from-anywhere just works. */
+export function parseListInput(value: string): string[] {
+  return value
+    .split(/\n|,/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}


### PR DESCRIPTION
The audit's last item. `listInput`/`commaInput`/`parseListInput` lived only in `automations-view.tsx`, while the create dialog and the cwd picker re-inlined `.split(...).map(trim).filter(Boolean)` — and **less robustly**: the create dialog split tags on `,` only and cwds on `\n` only, whereas `parseListInput` accepts either separator (or a mix).

- Extracted the three helpers to **`src/lib/automations/list-input.ts`** (+ a behavioral test).
- Pointed the view, the create dialog, and the cwd picker at it.
- Bonus: the create dialog + picker now tolerate mixed/pasted separators for free.

## Verification
- `pnpm typecheck` clean (no unused locals) · `pnpm test:app` green (497 files) · `pnpm check:tests-wired` ✓ (new test wired) · `pnpm build` within budget

Completes the dedup audit follow-ups (after #2143). Remaining noted item — a small run-status→color mapping repeated in two row spots — is cosmetic; the status-dot components stay separate (different domains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)