### PR TITLE
Fix Library GitHub README HTML rendering

### DIFF
--- a/src/app/api/library/github-repo/route.ts
+++ b/src/app/api/library/github-repo/route.ts
@@ -25,5 +25,5 @@ export async function GET(req: NextRequest) {
   if ("error" in result) {
     return NextResponse.json({ ok: false, error: result.error }, { status: result.status });
   }
-  return NextResponse.json({ ok: true, meta: result.meta, readme: result.readme });
+  return NextResponse.json({ ok: true, meta: result.meta, readme: result.readme, readmeHtml: result.readmeHtml });
 }

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -9,6 +9,7 @@ import { copyText } from "@/lib/clipboard";
 import { useCopy } from "@/lib/use-copy";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { wireDiffBlocks } from "@/lib/gh-diff";
+import { gfmAutolink } from "@/lib/gfm-autolink";
 import { parseLeadingMetadata, type MetaEntry } from "@/lib/library-metadata";
 import { isSafeGitHubUrl, isSafeHttpUrl, isSafeVscodeFileUrl } from "@/lib/url-safety";
 import { useTauriPlatform } from "@/lib/tauri-platform";
@@ -419,28 +420,35 @@ async function getMdFn(): Promise<MdFn> {
 
 interface RenderedMarkdownProps {
   text: string;
+  html?: string | null;
+  repo?: string | null;
   containerRef?: React.RefObject<HTMLDivElement | null>;
 }
 
-function RenderedMarkdown({ text, containerRef }: RenderedMarkdownProps) {
+function RenderedMarkdown({ text, html: renderedHtml, repo, containerRef }: RenderedMarkdownProps) {
   const [html, setHtml] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const internalRef = useRef<HTMLDivElement | null>(null);
   const ref = containerRef ?? internalRef;
 
   useEffect(() => {
+    if (renderedHtml?.trim()) {
+      setHtml(sanitizeHtml(renderedHtml));
+      setLoading(false);
+      return;
+    }
     if (!text) { setHtml(null); setLoading(false); return; }
     setLoading(true);
     let cancelled = false;
     void (async () => {
       const fn = await getMdFn();
-      const raw = await fn(text);
+      const raw = await fn(gfmAutolink(text, { repo }));
       if (cancelled) return;
       setHtml(sanitizeHtml(raw));
       setLoading(false);
     })();
     return () => { cancelled = true; };
-  }, [text]);
+  }, [text, renderedHtml, repo]);
 
   // Colorize any ```diff fenced blocks (e.g. a README's changelog) into a real
   // diff once the markdown lands. Idempotent + observed so a late syntax
@@ -528,7 +536,7 @@ function FieldRow({ label, children }: { label: string; children: React.ReactNod
 type RepoState =
   | { phase: "loading" }
   | { phase: "error"; error: string }
-  | { phase: "ready"; meta: GitHubRepoMeta; readme: string | null };
+  | { phase: "ready"; meta: GitHubRepoMeta; readme: string | null; readmeHtml: string | null };
 
 function GitHubRepoViewer({ item }: { item: LibraryGitHubItem }) {
   const [state, setState] = useState<RepoState>({ phase: "loading" });
@@ -540,13 +548,13 @@ function GitHubRepoViewer({ item }: { item: LibraryGitHubItem }) {
     void (async () => {
       try {
         const res = await fetch(`/api/library/github-repo?repo=${encodeURIComponent(item.repo)}`, { cache: "no-store" });
-        const json = (await res.json()) as { ok: boolean; meta?: GitHubRepoMeta; readme?: string | null; error?: string };
+        const json = (await res.json()) as { ok: boolean; meta?: GitHubRepoMeta; readme?: string | null; readmeHtml?: string | null; error?: string };
         if (cancelled) return;
         if (!res.ok || !json.ok || !json.meta) {
           setState({ phase: "error", error: json.error ?? "Could not load repository." });
           return;
         }
-        setState({ phase: "ready", meta: json.meta, readme: json.readme ?? null });
+        setState({ phase: "ready", meta: json.meta, readme: json.readme ?? null, readmeHtml: json.readmeHtml ?? null });
       } catch {
         if (!cancelled) setState({ phase: "error", error: "Could not reach GitHub." });
       }
@@ -575,6 +583,7 @@ function GitHubRepoViewer({ item }: { item: LibraryGitHubItem }) {
 
   const meta = state.phase === "ready" ? state.meta : null;
   const readme = state.phase === "ready" ? state.readme : null;
+  const readmeHtml = state.phase === "ready" ? state.readmeHtml : null;
 
   return (
     <div className="library-preview">
@@ -615,8 +624,8 @@ function GitHubRepoViewer({ item }: { item: LibraryGitHubItem }) {
               <div key={i} className="library-md-skeleton-line" style={{ width: w }} />
             ))}
           </div>
-        ) : readme ? (
-          <RenderedMarkdown text={readme} containerRef={mdRef} />
+        ) : readme || readmeHtml ? (
+          <RenderedMarkdown text={readme ?? ""} html={readmeHtml} repo={item.repo} containerRef={mdRef} />
         ) : (
           <p className="library-reading-detail__empty">This repository has no README.</p>
         )}

--- a/src/components/library-link-viewer.test.ts
+++ b/src/components/library-link-viewer.test.ts
@@ -102,6 +102,18 @@ assert.match(
   "GitHub selections should render the embedded Library link viewer",
 );
 
+assert.match(
+  preview,
+  /readmeHtml\?: string \| null/,
+  "Library GitHub repo payload should include GitHub-rendered README HTML",
+);
+
+assert.match(
+  preview,
+  /<RenderedMarkdown text=\{readme \?\? ""\} html=\{readmeHtml\} repo=\{item\.repo\} containerRef=\{mdRef\} \/>/,
+  "Library GitHub repo viewer should render sanitized GitHub HTML and keep raw markdown as fallback",
+);
+
 assert.doesNotMatch(
   view,
   /if \(onOpenUrl && item\.url\) \{ onOpenUrl\(item\.url\); return; \}/,

--- a/src/lib/github-repo.test.ts
+++ b/src/lib/github-repo.test.ts
@@ -29,9 +29,14 @@ function jsonResponse(body, init = {}) {
 
 await (async () => {
   const calls = [];
-  const fakeFetch = async (url, opts) => {
+  const acceptHeaders = [];
+  const fakeFetch = async (url, opts = {}) => {
     calls.push(String(url));
-    if (String(url).endsWith("/readme")) return new Response("# Hello\n\nbody", { status: 200 });
+    acceptHeaders.push(opts.headers?.Accept ?? opts.headers?.accept ?? "");
+    if (String(url).endsWith("/readme") && opts.headers?.Accept === "application/vnd.github.html+json") {
+      return new Response("<article><h1>Hello</h1><ul class=\"contains-task-list\"><li><input type=\"checkbox\" checked> done</li></ul></article>", { status: 200 });
+    }
+    if (String(url).endsWith("/readme")) return new Response("# Hello\n\n- [x] done", { status: 200 });
     return jsonResponse({
       full_name: "vercel/next.js",
       description: "The React Framework",
@@ -54,8 +59,14 @@ await (async () => {
   assert.equal(out.meta.defaultBranch, "canary");
   assert.equal(out.meta.license, "MIT");
   assert.deepEqual(out.meta.topics, ["react", "ssr"]);
-  assert.equal(out.readme, "# Hello\n\nbody");
-  assert.equal(calls.length, 2, "fetched meta + readme");
+  assert.equal(out.readme, "# Hello\n\n- [x] done");
+  assert.match(out.readmeHtml, /contains-task-list/, "returns GitHub-rendered README HTML for GFM features");
+  assert.equal(calls.length, 3, "fetched meta + rendered README HTML + raw README markdown");
+  assert.deepEqual(
+    acceptHeaders.slice(1),
+    ["application/vnd.github.html+json", "application/vnd.github.raw+json"],
+    "README requests should ask GitHub for rendered HTML before raw markdown fallback",
+  );
 })();
 
 await (async () => {
@@ -83,6 +94,7 @@ await (async () => {
   const out = await fetchRepoOverview("a/b", { fetchImpl: fakeFetch });
   assert.ok(!("error" in out));
   assert.equal(out.readme, null, "no readme -> null");
+  assert.equal(out.readmeHtml, null, "no readme -> null rendered HTML");
 })();
 
 assert.ok((await fetchRepoOverview("not a repo", { fetchImpl: async () => new Response("{}") })).error, "bad input -> error");

--- a/src/lib/github-repo.ts
+++ b/src/lib/github-repo.ts
@@ -32,6 +32,8 @@ export type GitHubRepoOverview = {
   meta: GitHubRepoMeta;
   /** Raw README markdown, or null when the repo has no README. */
   readme: string | null;
+  /** GitHub-rendered README HTML, or null when unavailable. */
+  readmeHtml: string | null;
 };
 
 export type GitHubRepoError = { error: string; status: number };
@@ -135,6 +137,18 @@ export async function fetchRepoOverview(
   };
 
   // README is best-effort: a repo without one still returns a useful overview.
+  let readmeHtml: string | null = null;
+  try {
+    const readmeHtmlRes = await doFetch(`${base}/readme`, {
+      headers: { ...authHeaders(token), Accept: "application/vnd.github.html+json" },
+    });
+    if (readmeHtmlRes.ok) {
+      readmeHtml = await readmeHtmlRes.text();
+    }
+  } catch {
+    /* keep readmeHtml null */
+  }
+
   let readme: string | null = null;
   try {
     const readmeRes = await doFetch(`${base}/readme`, {
@@ -147,7 +161,7 @@ export async function fetchRepoOverview(
     /* keep readme null */
   }
 
-  return { meta, readme };
+  return { meta, readme, readmeHtml };
 }
 
 /** Compact "1.2k" / "12.3k" / "1.4M" star/fork formatter. */


### PR DESCRIPTION
## Summary
- Fetch GitHub-rendered README HTML for Library repo previews while keeping raw markdown as fallback.
- Thread `readmeHtml` through `/api/library/github-repo` and prefer sanitized HTML in the Library repo viewer.
- Keep raw markdown rendering repo-aware with GFM autolinks and add regression coverage.

## Test Plan
- [x] node --experimental-strip-types src/lib/github-repo.test.ts
- [x] node --experimental-strip-types src/components/library-link-viewer.test.ts
- [x] pnpm typecheck
- [x] pnpm check:tests-wired
- [x] git diff --check origin/main...HEAD
- [x] pnpm test:app
- [x] pnpm build
