### PR TITLE
feat(chat): add Projects tab quick create

### DIFF
--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -69,6 +69,36 @@ assert.match(
 );
 
 assert.match(
+  chatProjectSidebar,
+  /onOpenProjectsTab\?: \(\) => void/,
+  "Chat project rail should accept a Projects-tab jump callback",
+);
+
+assert.match(
+  chatProjectSidebar,
+  /aria-label="Open Projects tab"[\s\S]{0,180}onClick=\{openProjectsTab\}/,
+  "Chat project rail should expose a keyboard-accessible Projects-tab button",
+);
+
+assert.match(
+  chatProjectSidebar,
+  /CHAT_OPEN_PROJECTS_EVENT/,
+  "Chat project rail should know how to route the shortcut through the shared Projects event",
+);
+
+assert.match(
+  chatProjectSidebar,
+  /function openProjectsTab\(\) \{[\s\S]*?onOpenProjectsTab\(\);[\s\S]*?window\.dispatchEvent\(new CustomEvent\(CHAT_OPEN_PROJECTS_EVENT\)\);[\s\S]*?\}/,
+  "Chat project rail should supply a Projects-tab fallback when the parent callback is absent",
+);
+
+assert.match(
+  chatRouter,
+  /onOpenProjectsTab=\{openProjectsTab\}/,
+  "ChatRouter should pass the concrete Projects-tab handler to the rail",
+);
+
+assert.match(
   workspace,
   /normalizeGitHubTasks/,
   "Workspace should normalize GitHub task context when refreshing sessions",

--- a/src/components/chat-project-sidebar.tsx
+++ b/src/components/chat-project-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   writeSessionOrder,
 } from "@/lib/chat-session-order";
 import { Icon, type IconName } from "@/lib/icon";
+import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import {
   DndContext,
   PointerSensor,
@@ -62,6 +63,7 @@ type Props = {
   onToggleExpanded: (key: string) => void;
   onOpenSession: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
+  onOpenProjectsTab?: () => void;
 };
 
 function statusDotClass(status: string): string {
@@ -301,6 +303,7 @@ export function ChatProjectSidebar({
   onToggleExpanded,
   onOpenSession,
   onNewChat,
+  onOpenProjectsTab,
 }: Props) {
   const [search, setSearch] = useState("");
   const [pinnedIds, setPinnedIds] = useState<string[]>([]);
@@ -350,6 +353,14 @@ export function ChatProjectSidebar({
 
   const displayIds = useMemo(() => display.map((s) => s.id), [display]);
   const hasSearch = search.trim().length > 0;
+
+  function openProjectsTab() {
+    if (onOpenProjectsTab) {
+      onOpenProjectsTab();
+      return;
+    }
+    window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT));
+  }
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -460,6 +471,15 @@ export function ChatProjectSidebar({
           ].join(" ")}
         >
           All sessions
+        </button>
+        <button
+          type="button"
+          title="Open Projects tab"
+          aria-label="Open Projects tab"
+          onClick={openProjectsTab}
+          className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)]/40 hover:text-[var(--text-primary)]"
+        >
+          <Icon name="ph:folder-open-bold" width={13} aria-hidden />
         </button>
         <button
           type="button"

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -17,6 +17,7 @@ import { applyProjectOverrides } from "@/lib/chat-project-overrides";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
+import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import {
   normalizeSelection,
   projectSelectionKeys,
@@ -55,6 +56,8 @@ type Props = {
   /** Compact mode for the narrow companion sidepanel (FamiliarPanel). Hides the
    *  project sidebar in both list and chat views to reclaim the limited width. */
   compact?: boolean;
+  /** Jump from the in-chat project rail to the dedicated Projects tab. */
+  onOpenProjectsTab?: () => void;
 };
 
 export type ChatRouterHandle = {
@@ -96,6 +99,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onOpenUrl,
     syncUrlHash,
     compact = false,
+    onOpenProjectsTab,
   },
   ref,
 ) {
@@ -105,6 +109,13 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   const [pendingFind, setPendingFind] = useState<{ query: string; nonce: number } | null>(null);
   const viewHandle = useRef<ChatViewHandle | null>(null);
   const previousFamiliarIdRef = useRef<string | null | undefined>(undefined);
+  const openProjectsTab = useCallback(() => {
+    if (onOpenProjectsTab) {
+      onOpenProjectsTab();
+      return;
+    }
+    window.dispatchEvent(new CustomEvent(CHAT_OPEN_PROJECTS_EVENT));
+  }, [onOpenProjectsTab]);
   const sidebarPrefsLoadedRef = useRef(false);
   const sidebarDefaultExpandedRef = useRef(false);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -404,6 +415,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             familiarId: next?.id ?? nextFamiliarId ?? null,
           });
         }}
+        onOpenProjectsTab={openProjectsTab}
       />
       )}
       <div className="min-h-0 min-w-0 flex-1">

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -10,26 +10,30 @@ assert.match(events, /CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects"/, "ev
 assert.match(surface, /import \{ ProjectsView \} from "@\/components\/projects-view"/, "chat-surface imports ProjectsView");
 assert.match(surface, /CHAT_OPEN_PROJECTS_EVENT/, "chat-surface references the reroute event");
 assert.match(surface, /type FamiliarsScope = "conversation" \| "memory" \| "projects"/, "scope union still includes memory (Code surface) + projects");
-// The standalone chat's Chat/Code toggle was removed — the chat page is just the
-// conversation; Code is its own sidebar surface. Projects still renders as a
-// sub-state of Chat (scope === "projects") reached via ⌘9 / board / the
-// /projects slash. No mode-switch segments remain.
+// The standalone chat keeps a narrow Sessions / Projects tab pair so project
+// creation is discoverable without slash commands. Code keeps its own
+// Sessions / Memory pair because the comux pane owns project/file navigation.
 assert.doesNotMatch(surface, /\{\s*id:\s*"chat",\s*label:\s*"Chat"\s*\}/, "the Chat toggle segment is gone");
 assert.doesNotMatch(surface, /\{\s*id:\s*"code",\s*label:\s*"Code"\s*\}/, "the Code toggle segment is gone");
-assert.doesNotMatch(
+assert.match(
   surface,
   /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
-  "Projects is not a mode-switch segment (merged into Chat)",
+  "standalone Chat exposes Projects as a dedicated tab",
+);
+assert.match(
+  surface,
+  /!isCodeSurface\s*\?\s*\([\s\S]*?<Tabs<FamiliarsScope>[\s\S]*?\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
+  "standalone Chat tab list is Sessions + Projects",
 );
 assert.match(surface, /scope === "projects" && !isCodeSurface \? \(/, "projects browse still renders ProjectsView as a sub-state of Chat (standalone chat only)");
 assert.match(surface, /<ProjectsView[\s\S]*?sessions=\{sessions\}/, "projects panel renders ProjectsView with sessions");
 assert.match(surface, /onNewChat=\{startProjectChat\}/, "projects panel wires onNewChat to startProjectChat");
 assert.match(surface, /addEventListener\(CHAT_OPEN_PROJECTS_EVENT/, "listens for the reroute event");
+assert.match(surface, /onOpenProjectsTab=\{\(\) => setScope\("projects"\)\}/, "chat project rail can jump directly to the Projects tab");
 
 // Code surface keeps its own Sessions + Memory underline tab pair (the comux
 // pane owns project/file navigation there, so it has no Projects tab), gated
-// behind isCodeSurface. The standalone chat renders no header strip at all now
-// (the Chat/Code toggle was removed), so the header is `isCodeSurface ? … : null`.
+// behind isCodeSurface.
 assert.match(
   surface,
   /isCodeSurface\s*\?\s*\([\s\S]*?<Tabs<FamiliarsScope>[\s\S]*?\{\s*id:\s*"conversation",\s*label:\s*"Sessions"\s*\},\s*\{\s*id:\s*"memory",\s*label:\s*"Memory"\s*\},?\s*\][\s\S]*?\)\s*:\s*null/,

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -496,12 +496,9 @@ export function ChatSurface({
       {/* Main content */}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* ── Header ──────────────────────────────────────────────────────
-            Only the Code surface needs a header row: a Sessions/Memory tab pair
-            (the comux pane owns file nav) plus the layout/companion toolbar. The
-            standalone chat is just the conversation — no Chat/Code toggle, so it
-            renders no header strip. Code is reached from its own sidebar
-            surface; Projects open as a sub-state of Chat via ⌘9 / the board /
-            the /projects slash. */}
+            Standalone Chat keeps Projects discoverable as a first-class tab.
+            Code keeps its Sessions/Memory pair because the comux pane owns
+            project/file navigation there. */}
         {isCodeSurface ? (
           <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4">
             <div className="flex min-w-0 items-center gap-3">
@@ -521,6 +518,23 @@ export function ChatSurface({
               />
             </div>
             <CodeInlineToolbar />
+          </div>
+        ) : !isCodeSurface ? (
+          <div className="chat-scope-tabs chat-scope-tabs--minimal flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4">
+            <Tabs<FamiliarsScope>
+              bordered={false}
+              value={scope}
+              onChange={(s) => {
+                setScope(s);
+                if (s === "conversation") {
+                  window.setTimeout(() => routerRef.current?.goToList(), 0);
+                }
+              }}
+              items={[
+                { id: "conversation", label: "Sessions" },
+                { id: "projects", label: "Projects" },
+              ]}
+            />
           </div>
         ) : null}
 
@@ -561,6 +575,7 @@ export function ChatSurface({
                   pendingProjectRoot={pendingProjectRoot}
                   onOpenTask={onOpenTask}
                   onOpenUrl={onOpenUrl}
+                  onOpenProjectsTab={() => setScope("projects")}
                   syncUrlHash
                 />
               </div>

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -14,6 +14,7 @@ const projectsView = [
 ].join("\n\n");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const chatProjectSidebar = readFileSync(new URL("./chat-project-sidebar.tsx", import.meta.url), "utf8");
 const workspaceMode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const iconSource = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8");
 const globalsCss = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
@@ -21,6 +22,13 @@ const globalsCss = readFileSync(new URL("../app/globals.css", import.meta.url), 
 assert.match(projectsView, /export function ProjectsView/, "ProjectsView should export the workspace surface");
 assert.match(projectsView, /useProjects\(\{ familiarId: activeFamiliarId \}\)/, "ProjectsView should scope the live projects hook to the active familiar");
 assert.match(projectsView, /createProject\(name, root\)/, "ProjectsView should create projects through the hook");
+assert.match(projectsView, /const rootInputRef = useRef<HTMLInputElement>\(null\)/, "new-project flow keeps a root input ref for quick focus");
+assert.match(projectsView, /function openCreateProjectForm/, "ProjectsView should centralize opening the quick-create form");
+assert.match(projectsView, /rootInputRef\.current\?\.focus\(\)/, "quick-create can focus the path field directly");
+assert.match(projectsView, /const \[createdProject, setCreatedProject\] = useState/, "ProjectsView should remember the just-created project");
+assert.match(projectsView, /setCreatedProject\(project\)/, "successful creation should mark the new project for follow-up actions");
+assert.match(projectsView, /onNewChat\?\.?\(createdProject\.root\)/, "created-project success state should offer immediate chat launch");
+assert.match(projectsView, /Start chat in \{createdProject\.name\}/, "created-project success state should label the immediate chat action");
 assert.match(projectsView, /onRename=\{renameProject\}/, "ProjectsView should wire inline rename");
 assert.match(projectsView, /onUpdateRoot=\{updateRoot\}/, "ProjectsView should wire root updates");
 assert.match(projectsView, /onDelete=\{deleteProject\}/, "ProjectsView should wire deletion");
@@ -138,7 +146,7 @@ assert.match(chatTabEvents, /CHAT_OPEN_PROJECTS_EVENT/, "reroute event exists");
 assert.match(workspace, /case "\/projects":[\s\S]*?setMode\("chat"\)[\s\S]*?CHAT_OPEN_PROJECTS_EVENT/, "/projects reroutes: setMode(chat) + chat-open-projects event");
 
 assert.doesNotMatch(sidebar, /id: "projects"/, "Sidebar no longer shows a Projects entry — Projects lives only in the Chat tab");
-assert.doesNotMatch(sidebar, /CHAT_OPEN_PROJECTS_EVENT/, "Sidebar no longer imports the chat-tab reroute event (entry removed)");
+assert.match(chatProjectSidebar, /CHAT_OPEN_PROJECTS_EVENT/, "Chat rail can jump to the dedicated Projects tab through the shared reroute event");
 
 for (const icon of [
   "ph:folders-bold",

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { Icon } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { useMinuteTick } from "@/lib/use-minute-tick";
-import { normalizeProjectRoot } from "@/lib/cave-projects-types";
+import { normalizeProjectRoot, type CaveProject } from "@/lib/cave-projects-types";
 import type { SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { stripTaskPrefix } from "@/lib/projects/session-glyph";
@@ -64,9 +64,11 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   const [showForm, setShowForm] = useState(false);
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const rootInputRef = useRef<HTMLInputElement>(null);
   const [nameDraft, setNameDraft] = useState("");
   const [rootDraft, setRootDraft] = useState("");
   const [creating, setCreating] = useState(false);
+  const [createdProject, setCreatedProject] = useState<CaveProject | null>(null);
   const [sessionError, setSessionError] = useState<string | null>(null);
   const [moveToast, setMoveToast] = useState<{ sessionId: string; prevRoot: string | null; label: string } | null>(null);
   // Bulk delete is deferred + undoable: the rows hide immediately, the actual
@@ -246,6 +248,12 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     setMoveToast(null);
   };
 
+  function openCreateProjectForm() {
+    setCreatedProject(null);
+    setShowForm(true);
+    window.setTimeout(() => rootInputRef.current?.focus(), 0);
+  }
+
   const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const name = nameDraft.trim();
@@ -258,6 +266,9 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     setNameDraft("");
     setRootDraft("");
     setShowForm(false);
+    setCreatedProject(project);
+    setExpanded(project.id, true);
+    setQuery("");
   };
 
   // Delete one chat, mirroring the Chats list delete (DELETE
@@ -351,7 +362,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
             </button>
             <button
               type="button"
-              onClick={() => setShowForm((value) => !value)}
+              onClick={showForm ? () => setShowForm(false) : openCreateProjectForm}
               className="focus-ring flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--accent-presence)]/10 px-2.5 text-[12px] text-[var(--accent-presence)] hover:bg-[var(--accent-presence)]/15"
             >
               <Icon name="ph:plus-bold" width={12} aria-hidden />
@@ -411,6 +422,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
               className="focus-ring h-9 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 text-[13px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
             />
             <input
+              ref={rootInputRef}
               value={rootDraft}
               onChange={(event) => setRootDraft(event.target.value)}
               placeholder="/absolute/path/to/project"
@@ -434,6 +446,34 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
             </div>
           </div>
         </form>
+      ) : null}
+
+      {createdProject && !showForm ? (
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/50 px-4 py-2 text-[12px] sm:px-6">
+          <span className="min-w-0 truncate text-[var(--text-secondary)]">
+            Created <span className="font-medium text-[var(--text-primary)]">{createdProject.name}</span>
+          </span>
+          <div className="flex shrink-0 items-center gap-2">
+            {onNewChat ? (
+              <button
+                type="button"
+                onClick={() => onNewChat?.(createdProject.root)}
+                className="focus-ring inline-flex h-8 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-2.5 text-[12px] font-medium text-[var(--text-primary)]"
+              >
+                <Icon name="ph:chat-circle-dots-bold" width={13} aria-hidden />
+                Start chat in {createdProject.name}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => setCreatedProject(null)}
+              aria-label="Dismiss created project action"
+              className="focus-ring grid h-8 w-8 place-items-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-secondary)]"
+            >
+              <Icon name="ph:x" width={12} aria-hidden />
+            </button>
+          </div>
+        </div>
       ) : null}
 
       <main ref={listRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
@@ -465,7 +505,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
               <>
                 <button
                   type="button"
-                  onClick={() => setShowForm(true)}
+                  onClick={openCreateProjectForm}
                   className="focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)]"
                 >
                   New project


### PR DESCRIPTION
## Summary
- add a standalone Chat `Sessions / Projects` tab pair so project creation is discoverable in chat
- add a rail shortcut into the Projects tab from the chat project sidebar
- make `New project` focus the root/path field and show a post-create `Start chat in …` action

## Test Plan
- `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/chat-surface-projects-tab.test.ts && node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/chat-all-familiars-project-list.test.ts && node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/projects-view.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm test:app`
- Playwright smoke: Chat shows Sessions/Projects tabs; rail `Open Projects tab` selects Projects; `New project` opens the form and focuses `/absolute/path/to/project`

## Notes
- local unstaged eval-loop edits were preserved and are not part of this PR
