### PR TITLE
refactor(automations): share run-status → color via runStatusColor()

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -307,6 +307,7 @@ export const SUITES = {
     "src/components/schedules-tabs.test.ts",
     "src/lib/automations/automation-entry.test.ts",
     "src/lib/automations/list-input.test.ts",
+    "src/lib/automations/run-status.test.ts",
     "src/lib/inbox-feed.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/daily-summary-notifications.test.ts",

--- a/src/app/api/travel/offline-work-queue.test.ts
+++ b/src/app/api/travel/offline-work-queue.test.ts
@@ -14,6 +14,7 @@ const flowRunSteps = await readFile(new URL("../../../components/flow/flow-run-s
 const flowFilters = await readFile(new URL("../../../lib/flow/flow-execution-filters.ts", import.meta.url), "utf8");
 const automationRuns = await readFile(new URL("../../../lib/automation-runs.ts", import.meta.url), "utf8");
 const automationsView = await readFile(new URL("../../../components/automations-view.tsx", import.meta.url), "utf8");
+const runStatusColorHelper = await readFile(new URL("../../../lib/automations/run-status.ts", import.meta.url), "utf8");
 
 assert.match(
   travelHelper,
@@ -62,6 +63,7 @@ assert.match(flowExecutions, /queued: 0/, "Flow executions list should count que
 assert.match(flowRunSteps, /queued: "Queued"/, "Flow run detail should label queued runs");
 assert.match(flowFilters, /\{ value: "queued", label: "Queued" \}/, "Flow execution filters should expose queued runs");
 assert.match(automationRuns, /AutomationRunStatus = "queued" \| "running"/, "Automation run type should include queued");
-assert.match(automationsView, /r\.status === "queued" \? "var\(--color-warning\)"/, "Automation run rows should tint queued jobs");
+assert.match(automationsView, /runStatusColor\(r\.status\)/, "Automation run rows should tint runs via the shared runStatusColor helper");
+assert.match(runStatusColorHelper, /case "queued":\s*\n\s*return "var\(--color-warning\)"/, "runStatusColor should tint queued jobs with the warning color");
 
 console.log("offline-work-queue.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -44,6 +44,7 @@ import {
   type AutomationEntry,
 } from "@/lib/automations/automation-entry";
 import { listInput, commaInput, parseListInput } from "@/lib/automations/list-input";
+import { runStatusColor } from "@/lib/automations/run-status";
 
 // AutomationsView — Schedules surface, redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
@@ -914,8 +915,7 @@ function CodexDetailPanel({
                     aria-label={`${r.status} run ${relTime(r.startedAt)}${r.summary ? ` — ${r.summary}` : ""}, ${openRunId === r.id ? "hide" : "show"} log`}
                     className="flex w-full items-center gap-2 rounded px-1 py-0.5 text-left text-[12px] hover:bg-white/5"
                   >
-                    <span aria-hidden className="h-2 w-2 shrink-0 rounded-full" style={{ background:
-                      r.status === "succeeded" ? "var(--accent-presence)" : r.status === "failed" ? "var(--color-danger)" : r.status === "queued" ? "var(--color-warning)" : "var(--text-muted)" }} />
+                    <span aria-hidden className="h-2 w-2 shrink-0 rounded-full" style={{ background: runStatusColor(r.status) }} />
                     <span style={{ color: "var(--text-secondary)" }} title={r.startedAt ? formatTimestamp(r.startedAt, readDateTimePrefs()) : undefined}>{relTime(r.startedAt)}</span>
                     {r.summary && <span className="truncate" style={{ color: "var(--text-muted)" }}>{r.summary}</span>}
                     <span aria-hidden className="ml-auto shrink-0" style={{ color: "var(--text-muted)", lineHeight: 0 }}>
@@ -1038,11 +1038,7 @@ function AutomationScheduleRow({
           </span>
         )}
         {lastRun && (
-          <span className="shrink-0 text-[11px]" title={lastRun.startedAt ? formatTimestamp(lastRun.startedAt, readDateTimePrefs()) : undefined} style={{ color:
-            lastRun.status === "failed" ? "var(--color-danger)"
-            : lastRun.status === "running" ? "var(--accent-presence)"
-            : lastRun.status === "queued" ? "var(--color-warning)"
-            : "var(--text-muted)" }}>
+          <span className="shrink-0 text-[11px]" title={lastRun.startedAt ? formatTimestamp(lastRun.startedAt, readDateTimePrefs()) : undefined} style={{ color: runStatusColor(lastRun.status, { quietSuccess: true }) }}>
             Run {relTime(lastRun.startedAt)}
           </span>
         )}

--- a/src/lib/automations/run-status.test.ts
+++ b/src/lib/automations/run-status.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { runStatusColor } from "./run-status.ts";
+
+// failed/running/queued are the same in both contexts.
+assert.equal(runStatusColor("failed"), "var(--color-danger)");
+assert.equal(runStatusColor("running"), "var(--accent-presence)");
+assert.equal(runStatusColor("queued"), "var(--color-warning)");
+assert.equal(runStatusColor("failed", { quietSuccess: true }), "var(--color-danger)");
+assert.equal(runStatusColor("running", { quietSuccess: true }), "var(--accent-presence)");
+
+// succeeded is the one intentional difference: loud (list) vs quiet (row badge).
+assert.equal(runStatusColor("succeeded"), "var(--accent-presence)", "default highlights success");
+assert.equal(runStatusColor("succeeded", { quietSuccess: true }), "var(--text-muted)", "quietSuccess keeps a healthy row calm");
+
+// Unknown status falls back to muted.
+assert.equal(runStatusColor("nope"), "var(--text-muted)");
+
+console.log("run-status.test.ts: ok");

--- a/src/lib/automations/run-status.ts
+++ b/src/lib/automations/run-status.ts
@@ -1,0 +1,28 @@
+import type { AutomationRunStatus } from "@/lib/automation-runs";
+
+/**
+ * Shared run-status → CSS-color-var mapping for the Automations surface, so the
+ * recent-runs list and the row last-run badge can't drift apart.
+ *
+ * `quietSuccess` is the one intentional difference between the two callers: the
+ * recent-runs list highlights a succeeded run (accent) to distinguish outcomes,
+ * while a row's last-run badge keeps a healthy/succeeded row calm (muted) and
+ * only colors the states worth noticing (failed/running/queued).
+ */
+export function runStatusColor(
+  status: AutomationRunStatus | string,
+  { quietSuccess = false }: { quietSuccess?: boolean } = {},
+): string {
+  switch (status) {
+    case "failed":
+      return "var(--color-danger)";
+    case "running":
+      return "var(--accent-presence)";
+    case "queued":
+      return "var(--color-warning)";
+    case "succeeded":
+      return quietSuccess ? "var(--text-muted)" : "var(--accent-presence)";
+    default:
+      return "var(--text-muted)";
+  }
+}


### PR DESCRIPTION
Last item from the dedup audit. The recent-runs list (status dot) and the row last-run badge each hand-rolled a `status → color` ternary — overlapping but **drifted**: the list highlighted `succeeded` but left `running` muted; the badge did the opposite.

Extracted one **`runStatusColor(status, { quietSuccess })`** → `src/lib/automations/run-status.ts` (+ behavioral test). `quietSuccess` captures the *one* intentional difference: the list highlights a succeeded run to distinguish outcomes; a row badge keeps a healthy row calm (muted success) and only colors `failed`/`running`/`queued`.

- Row last-run badge: **byte-equivalent** behavior (`quietSuccess: true`).
- Recent-runs list: now colors `running` runs (previously muted → visibly live), fixing the prior inconsistency.

## Verification
- `pnpm typecheck` clean · `pnpm test:app` green (498 files) · `pnpm check:tests-wired` ✓ · `pnpm build` within budget

This closes the dedup audit — the status-*dot components* (StateDot/StatusIcon/inline) stay separate by design (entry state vs inbox status vs run status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)