### PR TITLE
Add Claude Sonnet 5 to the claude runtime

### DIFF
--- a/src/lib/context-meter.ts
+++ b/src/lib/context-meter.ts
@@ -35,6 +35,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "anthropic/claude-opus-4-8": 1_000_000,
   "anthropic/claude-opus-4-7": 1_000_000,
   "anthropic/claude-opus-4-6": 1_000_000,
+  "anthropic/claude-sonnet-5": 1_000_000,
   "anthropic/claude-sonnet-4-6": 1_000_000,
   "anthropic/claude-haiku-4-5": 200_000,
   // Nous (hermes runtime) — estimate.

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -26,6 +26,10 @@ assert.ok(
   "claude catalog should seed Claude Opus 4.8",
 );
 assert.ok(
+  catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-sonnet-5"),
+  "claude catalog should seed Claude Sonnet 5",
+);
+assert.ok(
   !catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
   "claude catalog should not offer Claude Fable 5",
 );

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -38,6 +38,7 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     models: [
       { id: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8" },
       { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
+      { id: "anthropic/claude-sonnet-5", label: "Claude Sonnet 5" },
       { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
       { id: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5" },
     ],

--- a/src/lib/slash-model.test.ts
+++ b/src/lib/slash-model.test.ts
@@ -7,9 +7,9 @@ assert.equal(modelSlashOptions("/mod", "claude"), null, "not /model arg position
 assert.equal(modelSlashOptions("/familiar researcher", "claude"), null, "ignores other commands");
 
 const all = modelSlashOptions("/model ", "claude");
-assert.ok(Array.isArray(all) && all.length === 4, "‘/model ’ lists every claude model");
+assert.ok(Array.isArray(all) && all.length === 5, "‘/model ’ lists every claude model");
 
-assert.equal(modelSlashOptions("/m ", "claude").length, 4, "the /m alias works too");
+assert.equal(modelSlashOptions("/m ", "claude").length, 5, "the /m alias works too");
 
 const opus = modelSlashOptions("/model opus", "claude");
 assert.ok(opus.every((m) => /opus/i.test(m.label)), "filters by partial label");
@@ -20,7 +20,7 @@ assert.equal(modelSlashOptions("/model haiku", "codex").length, 0, "codex catalo
 // --- resolveModelArg: id / label / substring / custom -----------------------
 assert.equal(resolveModelArg("Claude Sonnet 4.6", "claude"), "anthropic/claude-sonnet-4-6", "matches by label");
 assert.equal(resolveModelArg("anthropic/claude-haiku-4-5", "claude"), "anthropic/claude-haiku-4-5", "matches by exact id");
-assert.equal(resolveModelArg("sonnet", "claude"), "anthropic/claude-sonnet-4-6", "matches by substring");
+assert.equal(resolveModelArg("sonnet", "claude"), "anthropic/claude-sonnet-5", "substring matches the newest Sonnet first");
 assert.equal(resolveModelArg("openai/gpt-6", "claude"), "openai/gpt-6", "accepts a valid custom id");
 assert.equal(resolveModelArg("  ", "claude"), null, "empty arg → null");
 assert.equal(resolveModelArg("not a model!!", "claude"), null, "malformed custom id → null");


### PR DESCRIPTION
## What

Adds **Claude Sonnet 5** (`claude-sonnet-5`) as a selectable model in the **claude** runtime. Sonnet 5 shipped 2026-06-09 as the latest Sonnet — 1M context, 128K max output, adaptive thinking, positioned as the best speed/intelligence balance (succeeding Sonnet 4.6).

I verified the model ID against the live Anthropic model docs before adding it (the offline reference predated its release), so the id is known-good rather than guessed.

## Changes

- **`runtime-models.ts`** — new catalog entry `{ id: "anthropic/claude-sonnet-5", label: "Claude Sonnet 5" }`, placed ahead of Sonnet 4.6. Opus 4.8 remains `models[0]`, so the runtime **default is unchanged**.
- **`context-meter.ts`** — `anthropic/claude-sonnet-5` → 1,000,000 so the context meter uses the real window instead of the fallback.
- **Tests** — `slash-model.test.ts` count assertions bumped 4→5; the `sonnet` substring now resolves to the newest Sonnet (`claude-sonnet-5`); added a presence assertion in `runtime-models.test.ts`.

`model-label.ts` already derives "Sonnet 5" (the `sonnet` family is covered) and `modelIcon` returns the Claude sparkle — no change needed. No iOS/Swift mirror, no API-route or alias-table changes: the id flows verbatim to `coven run --model`, and `allowCustom` already covered it.

Ordering note: placing Sonnet 5 first among Sonnets means typing `/model sonnet` now resolves to Sonnet 5 (latest), which is the intended behavior.

## Tests

`runtime-models`, `slash-model`, `context-meter`, and `model-label` lib tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)