### PR TITLE
feat(journal): click-to-automate suggested next steps + engaging buttons

### DIFF
--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -30,25 +30,185 @@ type JournalDay = {
   context: string;
 };
 
+type NoticeAction = { label: string; mode: string };
+type NoticeFn = (text: string, action?: NoticeAction) => void;
+
+/** One-click "automate" actions for a suggested next step. Each turns the
+ *  familiar's suggestion into a real action with no typing:
+ *   • Run now    → opens a chat that acts on it immediately (cave:agents-new-chat)
+ *   • Add task   → files it on the task board (POST /api/board)
+ *   • Remind me  → schedules a reminder for tomorrow 9am (POST /api/inbox)
+ *  All self-contained — no prop threading through the workspace shell. */
+const AUTOMATIONS = [
+  { action: "run", icon: "ph:play", label: "Run now", doneLabel: "Started" },
+  { action: "task", icon: "ph:kanban", label: "Add task", doneLabel: "Added" },
+  { action: "remind", icon: "ph:bell", label: "Remind me", doneLabel: "Reminder set" },
+] as const;
+type AutoAction = (typeof AUTOMATIONS)[number]["action"];
+
+function NextPaths({
+  suggestions,
+  familiarId,
+  onNotice,
+  onError,
+}: {
+  suggestions: string[];
+  familiarId: string | null;
+  onNotice: NoticeFn;
+  onError: (text: string) => void;
+}) {
+  // The recommended (first) step is expanded by default so the automate
+  // affordances are discoverable without a hunt.
+  const [open, setOpen] = useState<number | null>(0);
+  const [pending, setPending] = useState<string | null>(null); // `${i}:${action}`
+  const [done, setDone] = useState<string | null>(null);
+  const doneTimer = useRef<number | undefined>(undefined);
+  useEffect(() => () => window.clearTimeout(doneTimer.current), []);
+
+  // Collapse back to the first step whenever the day's suggestions change.
+  useEffect(() => { setOpen(suggestions.length ? 0 : null); }, [suggestions]);
+
+  const flashDone = useCallback((key: string) => {
+    setDone(key);
+    window.clearTimeout(doneTimer.current);
+    doneTimer.current = window.setTimeout(() => setDone((d) => (d === key ? null : d)), 1800);
+  }, []);
+
+  const automate = useCallback(
+    async (i: number, action: AutoAction, text: string) => {
+      const key = `${i}:${action}`;
+      if (action === "run") {
+        if (!familiarId) {
+          onError("Pick a familiar first — actions run as a familiar.");
+          return;
+        }
+        window.dispatchEvent(
+          new CustomEvent("cave:agents-new-chat", { detail: { familiarId, initialPrompt: text } }),
+        );
+        flashDone(key);
+        onNotice("Opened a chat to act on this step.");
+        return;
+      }
+      setPending(key);
+      try {
+        if (action === "task") {
+          const res = await fetch("/api/board", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ title: text, familiarId: familiarId ?? null }),
+          });
+          const json = await res.json().catch(() => ({ ok: false }));
+          if (!res.ok || !json.ok) throw new Error();
+          flashDone(key);
+          onNotice("Added to your task board.", { label: "View tasks", mode: "board" });
+        } else {
+          // Reminder: default to tomorrow 9:00am local; the user can retime it
+          // from Automations. One click should never demand a date picker.
+          const when = new Date();
+          when.setDate(when.getDate() + 1);
+          when.setHours(9, 0, 0, 0);
+          const res = await fetch("/api/inbox", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              kind: "reminder",
+              title: text,
+              fireAt: when.toISOString(),
+              recurrence: { type: "none" },
+              familiarId: familiarId ?? null,
+              source: "user",
+            }),
+          });
+          const json = await res.json().catch(() => ({ ok: false }));
+          if (!res.ok || !json.ok) throw new Error();
+          flashDone(key);
+          onNotice("Reminder set for tomorrow, 9:00 AM.", { label: "View automations", mode: "inbox" });
+        }
+      } catch {
+        onError(action === "task" ? "Couldn't add the task." : "Couldn't set the reminder.");
+      } finally {
+        setPending((p) => (p === key ? null : p));
+      }
+    },
+    [familiarId, flashDone, onNotice, onError],
+  );
+
+  if (suggestions.length === 0) return null;
+  return (
+    <div className="journal-entry__next">
+      <span className="journal-entry__next-label">
+        <Icon name="ph:lightning-fill" width={11} aria-hidden /> Suggested next steps
+        <span className="journal-next__hint">click to automate</span>
+      </span>
+      <ul className="journal-next__list">
+        {suggestions.map((s, i) => {
+          const isOpen = open === i;
+          const recommended = i === 0;
+          return (
+            <li key={i} className="journal-next__item">
+              <button
+                type="button"
+                className={`journal-next__chip${recommended ? " journal-next__chip--rec" : ""}${isOpen ? " is-open" : ""}`}
+                aria-expanded={isOpen}
+                onClick={() => setOpen(isOpen ? null : i)}
+              >
+                <Icon name="ph:sparkle" width={13} className="journal-next__chip-icon" aria-hidden />
+                <span className="journal-next__chip-text">{s}</span>
+                <Icon name="ph:caret-down" width={11} className="journal-next__caret" aria-hidden />
+              </button>
+              {isOpen ? (
+                <div className="journal-next__tray" role="group" aria-label={`Automate: ${s}`}>
+                  {AUTOMATIONS.map((a) => {
+                    const key = `${i}:${a.action}`;
+                    const isPending = pending === key;
+                    const isDone = done === key;
+                    return (
+                      <button
+                        key={a.action}
+                        type="button"
+                        className={`journal-next__act journal-next__act--${a.action}${isDone ? " is-done" : ""}`}
+                        disabled={isPending}
+                        aria-label={`${a.label}: ${s}`}
+                        onClick={() => void automate(i, a.action, s)}
+                      >
+                        <Icon name={isDone ? "ph:check" : a.icon} width={12} aria-hidden />
+                        <span>{isPending ? "Working…" : isDone ? a.doneLabel : a.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 /** Render a journal reflection. The reflection is generated through the chat
  *  pipeline, which appends a `<coven:next-paths>` suggestions block; lift it out
- *  (as chat-view does) so the tags don't leak into the markdown, and show the
- *  suggestions as a quiet "Next" list below the reflection. */
-function JournalReflection({ text }: { text: string }) {
-  const { visible, suggestions } = extractNextPaths(text);
+ *  (as chat-view does) so the tags don't leak into the markdown, and surface the
+ *  suggestions as one-click "automate" steps below the reflection. */
+function JournalReflection({
+  text,
+  familiarId,
+  onNotice,
+  onError,
+}: {
+  text: string;
+  familiarId: string | null;
+  onNotice: NoticeFn;
+  onError: (text: string) => void;
+}) {
+  // Memoize so `suggestions` keeps a stable identity across parent re-renders
+  // (e.g. the notice toast updating) — otherwise NextPaths' open-step effect
+  // would reset the expanded step on every render.
+  const { visible, suggestions } = useMemo(() => extractNextPaths(text), [text]);
   return (
     <>
       <MarkdownBlock text={visible} className="journal-entry__reflection" />
-      {suggestions.length > 0 ? (
-        <div className="journal-entry__next">
-          <span className="journal-entry__next-label">Next</span>
-          <ul className="journal-entry__next-list">
-            {suggestions.map((s, i) => (
-              <li key={i}>{s}</li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
+      <NextPaths suggestions={suggestions} familiarId={familiarId} onNotice={onNotice} onError={onError} />
     </>
   );
 }
@@ -81,6 +241,16 @@ export function JournalEntries({
   // fires only after the undo window, and Undo restores the reflection.
   const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<string>();
   const [error, setError] = useState<string | null>(null);
+  // Transient confirmation toast for one-click "automate" actions on the
+  // suggested next steps (Add task / Remind me / Run now).
+  const [notice, setNotice] = useState<{ text: string; action?: { label: string; mode: string } } | null>(null);
+  const noticeTimer = useRef<number | undefined>(undefined);
+  const showNotice = useCallback((text: string, action?: { label: string; mode: string }) => {
+    setNotice({ text, action });
+    window.clearTimeout(noticeTimer.current);
+    noticeTimer.current = window.setTimeout(() => setNotice(null), 6000);
+  }, []);
+  useEffect(() => () => window.clearTimeout(noticeTimer.current), []);
   const [filter, setFilter] = useState("");
   const selectedFamiliarId = activeFamiliarId ?? familiars[0]?.id ?? null;
   // Guard async setState after unmount, and ignore a stale day fetch when the
@@ -305,7 +475,7 @@ export function JournalEntries({
       <aside className="journal-list__rail">
         <button
           type="button"
-          className="journal-entry-gen"
+          className={`journal-entry-gen${generating ? " is-generating" : ""}`}
           disabled={!canGenerate || generating || selected !== today}
           onClick={generate}
           title={selected !== today ? "Select today to generate" : undefined}
@@ -464,7 +634,12 @@ export function JournalEntries({
                     autoFocus
                   />
                 ) : (
-                  <JournalReflection text={day.entry.reflection} />
+                  <JournalReflection
+                    text={day.entry.reflection}
+                    familiarId={selectedFamiliarId}
+                    onNotice={showNotice}
+                    onError={setError}
+                  />
                 )}
                 <div className="journal-entry__by">
                   <Icon name="ph:sparkle" aria-hidden />
@@ -499,6 +674,26 @@ export function JournalEntries({
           <div className="journal-empty journal-empty--pane"><SkeletonRows count={5} /></div>
         )}
       </section>
+      {notice ? (
+        <div className="journal-notice" role="status" aria-live="polite">
+          <Icon name="ph:check-circle" width={16} aria-hidden className="journal-notice__icon" />
+          <span className="journal-notice__text">{notice.text}</span>
+          {notice.action ? (
+            <button
+              type="button"
+              className="journal-notice__act"
+              onClick={() => {
+                window.dispatchEvent(
+                  new CustomEvent("cave:navigate-mode", { detail: { mode: notice.action!.mode } }),
+                );
+                setNotice(null);
+              }}
+            >
+              {notice.action.label}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
       {deletePending ? (
         <UndoToast
           key={deletePending.id}

--- a/src/components/journal/journal-view.test.ts
+++ b/src/components/journal/journal-view.test.ts
@@ -173,4 +173,47 @@ assert.match(list, /return \(\) => \{ mountedRef\.current = false; \}/, "canvas 
 assert.match(list, /await generateArtifactCode\([\s\S]{0,80}?if \(!mountedRef\.current\) return;/, "runGeneration bails after the LLM call if unmounted");
 assert.match(list, /const json = await res\.json\(\)[\s\S]{0,80}?if \(!mountedRef\.current\) return;/, "load bails after the fetch if unmounted");
 
+// ── Click-to-automate: suggested next steps become one-click actions ─────────
+// The familiar's `<coven:next-paths>` suggestions are no longer static text —
+// each opens an automate tray (Run now / Add task / Remind me) that turns the
+// step into a real action with no typing.
+assert.match(entries, /function NextPaths\(/, "JournalEntries renders an interactive NextPaths component for suggested steps");
+assert.match(entries, /aria-expanded=\{isOpen\}/, "each suggested step is an expandable automate chip");
+assert.match(
+  entries,
+  /new CustomEvent\("cave:agents-new-chat", \{ detail: \{ familiarId, initialPrompt: text \} \}\)/,
+  "Run now opens a chat that acts on the suggestion (self-contained, no prop threading)",
+);
+assert.match(
+  entries,
+  /fetch\("\/api\/board",\s*\{[\s\S]*?method:\s*"POST"[\s\S]*?title: text/,
+  "Add task files the suggestion on the task board via /api/board POST",
+);
+assert.match(
+  entries,
+  /fetch\("\/api\/inbox",\s*\{[\s\S]*?kind:\s*"reminder"[\s\S]*?title: text[\s\S]*?fireAt: when\.toISOString\(\)/,
+  "Remind me schedules the suggestion as a reminder via /api/inbox POST",
+);
+assert.match(entries, /aria-label=\{`\$\{a\.label\}: \$\{s\}`\}/, "each automate action exposes an accessible label naming the step");
+assert.match(entries, /className=\{`journal-next__act[\s\S]*?\$\{isDone \? " is-done" : ""\}/, "automate actions flash a success state when they land");
+// One-click confirmation toast, with a deep-link to the surface the action wrote to.
+assert.match(entries, /className="journal-notice"[\s\S]*?role="status"[\s\S]*?aria-live="polite"/, "an automate action shows an aria-live confirmation toast");
+assert.match(
+  entries,
+  /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: notice\.action!\.mode \} \}\)/,
+  "the toast's action deep-links to the surface the automation landed on",
+);
+assert.match(entries, /className=\{`journal-entry-gen\$\{generating \? " is-generating" : ""\}`\}/, "the generate button animates while reflecting");
+
+// Engaging click feedback: chips/actions/buttons have press + transition styling,
+// with a reduced-motion fallback.
+assert.match(css, /\.journal-next__chip \{[\s\S]*?cursor: pointer;/, "suggested-step chips are styled, interactive controls");
+assert.match(css, /\.journal-next__act\b/, "automate tray action buttons are styled");
+assert.match(css, /\.journal-next__act\.is-done \{[\s\S]*?animation: journal-act-pop/, "a landed automate action pops with a success animation");
+assert.match(css, /\.journal-notice \{[\s\S]*?position: fixed/, "the automate confirmation toast is styled");
+assert.match(css, /\.journal-entry-gen:active:not\(:disabled\) \{ transform:/, "the generate button has a tactile press");
+assert.match(css, /\.journal-day:active \{ transform:/, "day rows have a tactile press");
+assert.match(css, /\.journal-entry__action:active:not\(:disabled\) \{ transform: scale/, "entry action icons have a tactile press");
+assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.journal-next__chip,/, "the new interactions respect prefers-reduced-motion");
+
 console.log("journal-view.test.ts: ok");

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -339,6 +339,8 @@
 
 /* Journal entries (Journal tab) — reuses .journal-list / .journal-detail rails. */
 .journal-entry-gen {
+  position: relative;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -352,8 +354,41 @@
   background: var(--accent-presence);
   color: var(--bg-base);
   cursor: pointer;
+  transition: filter 0.15s ease, transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1),
+    box-shadow 0.15s ease;
 }
+.journal-entry-gen:hover:not(:disabled) {
+  filter: brightness(1.07);
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px -8px color-mix(in oklch, var(--accent-presence) 80%, transparent);
+}
+.journal-entry-gen:active:not(:disabled) { transform: translateY(0) scale(0.98); }
 .journal-entry-gen:disabled { opacity: 0.5; cursor: default; }
+/* While reflecting, a light sweep travels across the button so the wait reads
+   as active work rather than a dead, dimmed control. */
+.journal-entry-gen.is-generating { opacity: 0.85; cursor: progress; }
+.journal-entry-gen.is-generating::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    color-mix(in oklch, #fff 38%, transparent) 50%,
+    transparent 80%
+  );
+  transform: translateX(-100%);
+  animation: journal-gen-sweep 1.1s ease-in-out infinite;
+}
+.journal-entry-gen.is-generating svg { animation: journal-gen-spin 1.4s linear infinite; }
+@keyframes journal-gen-sweep { to { transform: translateX(100%); } }
+@keyframes journal-gen-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .journal-entry-gen { transition: none; }
+  .journal-entry-gen:hover:not(:disabled) { transform: none; }
+  .journal-entry-gen.is-generating::after,
+  .journal-entry-gen.is-generating svg { animation: none; }
+}
 .journal-day {
   width: 100%;
   text-align: left;
@@ -366,9 +401,15 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
+  transition: border-color 0.14s ease, background 0.14s ease,
+    transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
-.journal-day:hover { border-color: var(--border-strong); }
-.journal-day.is-selected { border-color: var(--accent-presence); }
+.journal-day:hover { border-color: var(--border-strong); transform: translateX(2px); }
+.journal-day:active { transform: translateX(2px) scale(0.99); }
+.journal-day.is-selected {
+  border-color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-base));
+}
 .journal-day__top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .journal-day__date { font-size: 12.5px; font-weight: 600; }
 .journal-day__by {
@@ -426,12 +467,16 @@
   background: var(--bg-panel, var(--bg-base));
   color: var(--text-muted);
   cursor: pointer;
+  transition: border-color 0.13s ease, color 0.13s ease, background 0.13s ease,
+    transform 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .journal-entry__action:hover:not(:disabled),
 .journal-entry__action:focus-visible {
   border-color: var(--border-strong);
   color: var(--text-primary);
+  background: var(--bg-hover, var(--bg-base));
 }
+.journal-entry__action:active:not(:disabled) { transform: scale(0.9); }
 .journal-entry__action:disabled {
   opacity: 0.5;
   cursor: default;
@@ -469,23 +514,198 @@
   background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
 }
 .journal-entry__next-label {
-  display: block;
-  margin-bottom: 6px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: 9px;
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
-.journal-entry__next-list {
+.journal-entry__next-label svg { color: var(--accent-presence); }
+.journal-next__hint {
+  margin-left: auto;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: color-mix(in oklch, var(--accent-presence) 80%, var(--text-muted));
+  opacity: 0.85;
+}
+
+/* Suggested next steps — one click turns each into a real action. */
+.journal-next__list {
   margin: 0;
-  padding-left: 18px;
+  padding: 0;
+  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  font-size: 12px;
-  line-height: 1.5;
+  gap: 7px;
+}
+.journal-next__item { display: flex; flex-direction: column; }
+
+.journal-next__chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 9px 11px;
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.4;
   color: var(--text-secondary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease,
+    transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.15s ease;
+}
+.journal-next__chip:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 14px -8px color-mix(in oklch, var(--accent-presence) 60%, transparent);
+}
+.journal-next__chip:active { transform: translateY(0) scale(0.985); }
+.journal-next__chip:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus);
+  outline-offset: 2px;
+}
+.journal-next__chip.is-open {
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 7%, var(--bg-base));
+}
+.journal-next__chip-icon { color: var(--accent-presence); flex: 0 0 auto; }
+.journal-next__chip-text { flex: 1; min-width: 0; }
+.journal-next__caret {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  transition: transform 0.18s ease, color 0.15s ease;
+}
+.journal-next__chip.is-open .journal-next__caret { transform: rotate(180deg); color: var(--accent-presence); }
+
+/* The recommended (first) step gets a gentle attention pulse. */
+.journal-next__chip--rec {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
+  animation: journal-next-pulse 2.8s ease-in-out infinite;
+}
+.journal-next__chip--rec.is-open { animation: none; }
+@keyframes journal-next-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--accent-presence) 30%, transparent); }
+  50% { box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent-presence) 14%, transparent); }
+}
+
+/* Automate action tray — slides open under its step. */
+.journal-next__tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 7px 2px 2px;
+  animation: journal-tray-in 0.18s ease both;
+}
+@keyframes journal-tray-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.journal-next__act {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 11px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.13s ease, color 0.13s ease, border-color 0.13s ease,
+    transform 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.journal-next__act svg { flex: 0 0 auto; }
+.journal-next__act:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-raised));
+  transform: translateY(-1px);
+}
+.journal-next__act:active:not(:disabled) { transform: scale(0.94); }
+.journal-next__act:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus);
+  outline-offset: 2px;
+}
+.journal-next__act:disabled { opacity: 0.6; cursor: progress; }
+.journal-next__act--run:hover:not(:disabled) { color: var(--accent-presence); }
+/* Satisfying success state: green fill + a quick pop when an action lands. */
+.journal-next__act.is-done {
+  color: var(--color-success, #36b37e);
+  border-color: color-mix(in oklch, var(--color-success, #36b37e) 55%, transparent);
+  background: color-mix(in oklch, var(--color-success, #36b37e) 16%, var(--bg-raised));
+  animation: journal-act-pop 0.34s ease;
+}
+@keyframes journal-act-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.12); }
+  100% { transform: scale(1); }
+}
+
+/* One-click confirmation toast (Add task / Remind me / Run now). */
+.journal-notice {
+  position: fixed;
+  left: 50%;
+  bottom: 22px;
+  transform: translateX(-50%);
+  z-index: 1300;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  max-width: min(92vw, 460px);
+  padding: 10px 12px 10px 13px;
+  font-size: 12.5px;
+  color: var(--text-primary);
+  background: var(--bg-elevated, var(--bg-raised));
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-strong));
+  border-radius: 12px;
+  box-shadow: 0 18px 50px -18px rgba(0, 0, 0, 0.6);
+  animation: journal-notice-in 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+@keyframes journal-notice-in {
+  from { opacity: 0; transform: translate(-50%, 12px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+.journal-notice__icon { color: var(--color-success, #36b37e); flex: 0 0 auto; }
+.journal-notice__text { flex: 1; min-width: 0; }
+.journal-notice__act {
+  flex: 0 0 auto;
+  padding: 5px 11px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, transparent);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.12s ease, transform 0.1s ease;
+}
+.journal-notice__act:hover { background: color-mix(in oklch, var(--accent-presence) 20%, transparent); }
+.journal-notice__act:active { transform: scale(0.95); }
+
+@media (prefers-reduced-motion: reduce) {
+  .journal-next__chip,
+  .journal-next__act,
+  .journal-next__caret,
+  .journal-next__tray,
+  .journal-notice,
+  .journal-entry-gen,
+  .journal-entry__action,
+  .journal-day { transition: none; animation: none; }
+  .journal-next__chip:hover,
+  .journal-next__act:hover:not(:disabled) { transform: none; }
 }
 .journal-entry__by {
   display: flex;


### PR DESCRIPTION
## What

The journal page's daily reflection ends with the familiar's suggested **next steps** (`<coven:next-paths>`). Those were static bullet text. This makes each one **click-to-automate** — one click turns a suggestion into a real action, no typing:

- **Run now** → opens a chat that acts on it (`cave:agents-new-chat` with `initialPrompt`)
- **Add task** → files it on the task board (`POST /api/board`)
- **Remind me** → schedules a reminder for tomorrow 9 AM (`POST /api/inbox`)

A confirmation toast appears and deep-links to the surface the action landed on (Tasks / Automations) via `cave:navigate-mode`.

It's fully **self-contained in the journal surface** — no prop threading through the hot `workspace.tsx` (lowest collision risk with other in-flight work).

## Engaging clicks

Every journal button now has tactile feedback: press (scale/translate), hover lift, the recommended step **pulses** for attention, landed actions flash a **green success pop** ("✓ Added"), day rows nudge on hover, and the generate button runs a **light sweep + sparkle spin** while reflecting. All motion respects `prefers-reduced-motion`.

## Files
- `src/components/journal/journal-entries.tsx` — interactive `NextPaths` component + automate handlers + confirmation toast
- `src/styles/journal.css` — chip/tray/toast styling + button micro-interactions
- `src/components/journal/journal-view.test.ts` — assertions for the new affordances

## Verification
- `journal-view.test.ts` passes; `pnpm build` green (tests-wired + bundle budget).
- Ran the app and drove the journal end-to-end: chips render under "⚡ Suggested next steps — click to automate"; clicking **Add task** showed the "✓ Added" success state and the "Added to your task board · View tasks" toast. Seeded/created test data was cleaned up afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)