### PR TITLE
Polish eval groups UX

### DIFF
--- a/src/components/evals/eval-groups-panel.test.ts
+++ b/src/components/evals/eval-groups-panel.test.ts
@@ -17,10 +17,18 @@ assert.match(source, /onChanged/, "calls back to refetch groups after a mutation
 
 // Rollup summary per group.
 assert.match(source, /rollupEvalGroup\(/, "rolls each group's state into status counts");
+assert.match(source, /groupTotals/, "derives a page-level groups summary");
+assert.match(source, /evals-groups-hero/, "renders a dedicated Groups tab header");
+assert.match(source, /Tracked groups/, "shows tracked group count");
+assert.match(source, /Runnable threads/, "shows runnable thread count");
+assert.match(source, /Stale or never run/, "shows stale work needing attention");
+assert.match(source, /No tracked groups/, "distinguishes an empty groups list from the editor");
+assert.match(source, /Group set/, "labels the group list region");
 assert.match(source, /freshThreads/, "shows fresh thread count");
 assert.match(source, /staleThreads/, "shows stale thread count");
 assert.match(source, /neverRunThreads/, "shows never-run thread count");
 assert.match(source, /aria-label="Toggle group debug details"/, "each group exposes a debug details toggle");
+assert.match(source, /is-active/, "debug action exposes its active state visually");
 assert.match(source, /Group debug details/, "labels the inline debug payload");
 assert.match(source, /statesById\.get\(group\.id\)/, "debug payload uses the exact derived states for the group");
 assert.match(source, /JSON\.stringify\(\s*\{\s*group:/, "renders copyable JSON debug data");

--- a/src/components/evals/eval-groups-panel.tsx
+++ b/src/components/evals/eval-groups-panel.tsx
@@ -37,6 +37,14 @@ const TRACK_OPTIONS: Array<{ value: EvalTrack; label: string }> = [
 
 const HOUR_MS = 60 * 60 * 1000;
 
+function groupStatusLabel(rollup: ReturnType<typeof rollupEvalGroup> | undefined): string {
+  if (!rollup || rollup.totalThreads === 0) return "No threads";
+  if (rollup.blockedThreads > 0) return `${rollup.blockedThreads} blocked`;
+  const staleTotal = rollup.staleThreads + rollup.neverRunThreads;
+  if (staleTotal > 0) return `${staleTotal} need review`;
+  return "Fresh";
+}
+
 function newGroup(rubricVersion: string): EvalGroup {
   const now = new Date().toISOString();
   let id: string;
@@ -75,6 +83,31 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
   const rollups = useMemo(
     () => new Map(groups.map((group) => [group.id, rollupEvalGroup(group, statesById.get(group.id) ?? [])])),
     [groups, statesById],
+  );
+
+  const groupTotals = useMemo(
+    () =>
+      groups.reduce(
+        (totals, group) => {
+          const rollup = rollups.get(group.id);
+          totals.members += group.members.length;
+          totals.tracks += group.tracks.length;
+          totals.totalThreads += rollup?.totalThreads ?? 0;
+          totals.runnableThreads += rollup?.runnableThreadIds.length ?? 0;
+          totals.staleOrNeverRun += (rollup?.staleThreads ?? 0) + (rollup?.neverRunThreads ?? 0);
+          totals.blockedThreads += rollup?.blockedThreads ?? 0;
+          return totals;
+        },
+        {
+          members: 0,
+          tracks: 0,
+          totalThreads: 0,
+          runnableThreads: 0,
+          staleOrNeverRun: 0,
+          blockedThreads: 0,
+        },
+      ),
+    [groups, rollups],
   );
 
   const existingRubric = groups[0]?.rubricVersion ?? "v1";
@@ -172,18 +205,42 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
 
   return (
     <div className="evals-groups">
-      <div className="evals-section-head">
-        <span className="evals-group-kicker">Eval groups</span>
-        <button type="button" className="evals-btn" onClick={startCreate}>
-          <Icon name="ph:plus" width={13} /> New group
-        </button>
+      <div className="evals-groups-hero">
+        <div className="evals-groups-hero-copy">
+          <span className="evals-group-kicker">Eval groups</span>
+          <h3>Thread freshness sets</h3>
+          <p>Group related threads and familiars, track stale coverage, and queue the exact work that needs another eval pass.</p>
+        </div>
+        <div className="evals-groups-hero-actions">
+          <button type="button" className="evals-btn evals-btn-primary" onClick={startCreate}>
+            <Icon name="ph:plus" width={13} /> New group
+          </button>
+        </div>
+        <div className="evals-groups-stats" aria-label="Eval group summary">
+          <div className="evals-groups-stat">
+            <span>Tracked groups</span>
+            <b>{groups.length}</b>
+          </div>
+          <div className="evals-groups-stat">
+            <span>Total threads</span>
+            <b>{groupTotals.totalThreads}</b>
+          </div>
+          <div className="evals-groups-stat">
+            <span>Runnable threads</span>
+            <b>{groupTotals.runnableThreads}</b>
+          </div>
+          <div className="evals-groups-stat">
+            <span>Stale or never run</span>
+            <b>{groupTotals.staleOrNeverRun}</b>
+          </div>
+        </div>
       </div>
 
       {groups.length === 0 && !draft ? (
         <EmptyState
           icon="ph:squares-four"
-          headline="No eval groups yet"
-          subtitle="Group threads and familiars into a tracked eval set, choose which tracks to run, and watch freshness roll up across the group."
+          headline="No tracked groups"
+          subtitle="Create a group when a thread set needs its own freshness policy, track mix, and manual queue."
           actions={
             <button type="button" className="evals-btn evals-btn-primary" onClick={startCreate}>
               <Icon name="ph:plus" width={14} /> New group
@@ -194,213 +251,238 @@ export function EvalGroupsPanel({ groups, statesById, familiars, onChanged }: Pr
 
       {draft ? (
         <article className="evals-group-editor" aria-label="Edit eval group">
-          <label className="evals-field">
-            <span>Name</span>
-            <input
-              className="evals-group-name-input"
-              value={draft.name}
-              onChange={(e) => patch({ name: e.target.value })}
-              aria-label="Group name"
-            />
-          </label>
-          <label className="evals-field">
-            <span>Description</span>
-            <textarea
-              className="evals-desc"
-              value={draft.description ?? ""}
-              placeholder="What does this group track? (optional)"
-              onChange={(e) => patch({ description: e.target.value })}
-              rows={2}
-              aria-label="Group description"
-            />
-          </label>
-          <label className="evals-field">
-            <span>Scope</span>
-            <select
-              className="evals-grader-kind"
-              value={draft.scope}
-              onChange={(e) => patch({ scope: e.target.value as EvalGroupScope })}
-              aria-label="Group scope"
-            >
-              {SCOPE_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <div className="evals-field">
-            <span>Tracks</span>
-            <div className="evals-track-toggles" role="group" aria-label="Eval tracks">
-              {TRACK_OPTIONS.map((o) => {
-                const on = draft.tracks.includes(o.value);
-                return (
-                  <button
-                    key={o.value}
-                    type="button"
-                    className={`evals-toggle-chip${on ? " is-on" : ""}`}
-                    aria-pressed={on}
-                    onClick={() => toggleTrack(o.value)}
-                  >
-                    {o.label}
-                  </button>
-                );
-              })}
+          <div className="evals-section-head">
+            <div>
+              <span className="evals-group-kicker">{isNew ? "New group" : "Edit group"}</span>
+              <b>{draft.name.trim() || "Untitled group"}</b>
             </div>
+            <span className="evals-group-muted">{draft.members.length} members · {draft.tracks.length} tracks</span>
           </div>
+          <div className="evals-group-editor-body">
+            <label className="evals-field">
+              <span>Name</span>
+              <input
+                className="evals-group-name-input"
+                value={draft.name}
+                onChange={(e) => patch({ name: e.target.value })}
+                aria-label="Group name"
+              />
+            </label>
+            <label className="evals-field evals-field-stack">
+              <span>Description</span>
+              <textarea
+                className="evals-desc"
+                value={draft.description ?? ""}
+                placeholder="What does this group track? (optional)"
+                onChange={(e) => patch({ description: e.target.value })}
+                rows={3}
+                aria-label="Group description"
+              />
+            </label>
+            <label className="evals-field">
+              <span>Scope</span>
+              <select
+                className="evals-grader-kind"
+                value={draft.scope}
+                onChange={(e) => patch({ scope: e.target.value as EvalGroupScope })}
+                aria-label="Group scope"
+              >
+                {SCOPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
 
-          <label className="evals-field">
-            <span>Stale after (hours)</span>
-            <input
-              type="number"
-              min={0}
-              value={draft.stalePolicy.ttlMs != null ? Math.round(draft.stalePolicy.ttlMs / HOUR_MS) : ""}
-              placeholder="never"
-              onChange={(e) => {
-                const hours = e.target.value === "" ? undefined : Number(e.target.value);
-                patch({
-                  stalePolicy: {
-                    ttlMs: hours == null || Number.isNaN(hours) || hours <= 0 ? undefined : Math.round(hours * HOUR_MS),
-                  },
-                });
-              }}
-              aria-label="Stale policy TTL in hours"
-            />
-          </label>
-
-          <div className="evals-field">
-            <span>Familiar members</span>
-            {familiars.length === 0 ? (
-              <small className="evals-group-muted">No familiars available</small>
-            ) : (
-              <div className="evals-member-toggles" role="group" aria-label="Familiar members">
-                {familiars.map((f) => {
-                  const on = draft.members.some((m) => m.kind === "familiar" && m.id === f.id);
+            <div className="evals-field evals-field-stack">
+              <span>Tracks</span>
+              <div className="evals-track-toggles" role="group" aria-label="Eval tracks">
+                {TRACK_OPTIONS.map((o) => {
+                  const on = draft.tracks.includes(o.value);
                   return (
                     <button
-                      key={f.id}
+                      key={o.value}
                       type="button"
                       className={`evals-toggle-chip${on ? " is-on" : ""}`}
                       aria-pressed={on}
-                      onClick={() => toggleFamiliar(f.id)}
+                      onClick={() => toggleTrack(o.value)}
                     >
-                      {f.display_name}
+                      {o.label}
                     </button>
                   );
                 })}
               </div>
-            )}
-          </div>
+            </div>
 
-          {error ? <p className="evals-group-error">{error}</p> : null}
+            <label className="evals-field">
+              <span>Stale after (hours)</span>
+              <input
+                type="number"
+                min={0}
+                value={draft.stalePolicy.ttlMs != null ? Math.round(draft.stalePolicy.ttlMs / HOUR_MS) : ""}
+                placeholder="never"
+                onChange={(e) => {
+                  const hours = e.target.value === "" ? undefined : Number(e.target.value);
+                  patch({
+                    stalePolicy: {
+                      ttlMs: hours == null || Number.isNaN(hours) || hours <= 0 ? undefined : Math.round(hours * HOUR_MS),
+                    },
+                  });
+                }}
+                aria-label="Stale policy TTL in hours"
+              />
+            </label>
 
-          <div className="evals-toolbar-actions">
-            <button type="button" className="evals-btn evals-btn-primary" onClick={save} disabled={saving || !draft.name.trim()}>
-              <Icon name="ph:check" width={13} /> {isNew ? "Create group" : "Save group"}
-            </button>
-            <button type="button" className="evals-btn" onClick={cancel} disabled={saving}>
-              Cancel
-            </button>
+            <div className="evals-field evals-field-stack">
+              <span>Familiar members</span>
+              {familiars.length === 0 ? (
+                <small className="evals-group-muted">No familiars available</small>
+              ) : (
+                <div className="evals-member-toggles" role="group" aria-label="Familiar members">
+                  {familiars.map((f) => {
+                    const on = draft.members.some((m) => m.kind === "familiar" && m.id === f.id);
+                    return (
+                      <button
+                        key={f.id}
+                        type="button"
+                        className={`evals-toggle-chip${on ? " is-on" : ""}`}
+                        aria-pressed={on}
+                        onClick={() => toggleFamiliar(f.id)}
+                      >
+                        {f.display_name}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {error ? <p className="evals-group-error">{error}</p> : null}
+
+            <div className="evals-toolbar-actions">
+              <button type="button" className="evals-btn evals-btn-primary" onClick={save} disabled={saving || !draft.name.trim()}>
+                <Icon name="ph:check" width={13} /> {isNew ? "Create group" : "Save group"}
+              </button>
+              <button type="button" className="evals-btn" onClick={cancel} disabled={saving}>
+                Cancel
+              </button>
+            </div>
           </div>
         </article>
       ) : null}
 
-      <ul className="evals-group-list">
-        {groups.map((group) => {
-          const rollup = rollups.get(group.id);
-          const states = statesById.get(group.id) ?? [];
-          const debugOpen = debugGroupIds.has(group.id);
-          const debugPanelId = `eval-group-debug-${group.id}`;
-          const memberFamiliars = group.members.filter((m) => m.kind === "familiar");
-          return (
-            <li key={group.id} className="evals-group-card">
-              <div className="evals-group-card-head">
-                <div className="evals-group-summary">
-                  <b>{group.name}</b>
-                  <span className="evals-group-muted">
-                    {group.scope} · {group.tracks.length ? group.tracks.join(", ") : "no tracks"}
-                  </span>
-                </div>
-                <div className="evals-group-card-actions">
-                  <button
-                    type="button"
-                    className="evals-icon-btn"
-                    onClick={() => toggleGroupDebug(group.id)}
-                    title="Debug group"
-                    aria-label="Toggle group debug details"
-                    aria-expanded={debugOpen}
-                    aria-controls={debugPanelId}
-                  >
-                    <Icon name="ph:bug-bold" width={13} />
-                  </button>
-                  <button type="button" className="evals-icon-btn" onClick={() => startEdit(group)} title="Edit group" aria-label="Edit group">
-                    <Icon name="ph:pencil-simple" width={13} />
-                  </button>
-                  <button type="button" className="evals-icon-btn" onClick={() => void remove(group)} title="Delete group" aria-label="Delete group">
-                    <Icon name="ph:trash" width={13} />
-                  </button>
-                </div>
-              </div>
-              {group.description ? <p className="evals-group-desc">{group.description}</p> : null}
-              {rollup ? (
-                <div className="evals-group-rollup" aria-label="Group freshness rollup">
-                  <span className="evals-chip">{rollup.totalThreads} threads</span>
-                  <span className="evals-chip is-pass">{rollup.freshThreads} fresh</span>
-                  <span className="evals-chip is-fail">{rollup.staleThreads} stale</span>
-                  <span className="evals-chip">{rollup.neverRunThreads} never run</span>
-                </div>
-              ) : null}
-              {memberFamiliars.length ? (
-                <div className="evals-group-members">
-                  {memberFamiliars.map((m) => (
-                    <span key={m.id} className="evals-toggle-chip is-on">
-                      {familiarName(m.familiarId ?? m.id)}
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-              {debugOpen ? (
-                <div id={debugPanelId} className="evals-group-debug" aria-label="Group debug details">
-                  <div className="evals-group-debug-title">Group debug details</div>
-                  <pre>
-                    {JSON.stringify(
-                      {
-                        group: {
-                          id: group.id,
-                          name: group.name,
-                          scope: group.scope,
-                          tracks: group.tracks,
-                          rubricVersion: group.rubricVersion,
-                          stalePolicy: group.stalePolicy,
-                          schedulePolicy: group.schedulePolicy,
-                          createdAt: group.createdAt,
-                          updatedAt: group.updatedAt,
-                          members: group.members.map((member) => ({
-                            ...member,
-                            label: member.kind === "familiar" ? familiarName(member.familiarId ?? member.id) : member.id,
-                          })),
-                        },
-                        rollup: rollup ?? null,
-                        states: states.map((state) => ({
-                          threadId: state.threadId,
-                          familiarId: state.familiarId,
-                          status: state.status,
-                          staleReasons: state.staleReasons,
-                          evaluatedAt: state.evaluatedAt,
-                          details: state.details,
-                        })),
-                      },
-                      null,
-                      2,
-                    )}
-                  </pre>
-                </div>
-              ) : null}
-            </li>
-          );
-        })}
-      </ul>
+      {groups.length ? (
+        <section className="evals-group-set" aria-label="Group set">
+          <div className="evals-section-head">
+            <div>
+              <span className="evals-group-kicker">Group set</span>
+              <b>{groups.length} tracked</b>
+            </div>
+            <span className="evals-group-muted">
+              {groupTotals.members} members · {groupTotals.tracks} tracks · {groupTotals.blockedThreads} blocked
+            </span>
+          </div>
+          <ul className="evals-group-list">
+            {groups.map((group) => {
+              const rollup = rollups.get(group.id);
+              const states = statesById.get(group.id) ?? [];
+              const debugOpen = debugGroupIds.has(group.id);
+              const debugPanelId = `eval-group-debug-${group.id}`;
+              const memberFamiliars = group.members.filter((m) => m.kind === "familiar");
+              return (
+                <li key={group.id} className="evals-group-card">
+                  <div className="evals-group-card-head">
+                    <div className="evals-group-summary">
+                      <div className="evals-group-title-row">
+                        <b>{group.name}</b>
+                        <span className="evals-group-status">{groupStatusLabel(rollup)}</span>
+                      </div>
+                      <span className="evals-group-muted">
+                        {group.scope} · {group.tracks.length ? group.tracks.join(", ") : "no tracks"}
+                      </span>
+                    </div>
+                    <div className="evals-group-card-actions">
+                      <button
+                        type="button"
+                        className={`evals-icon-btn${debugOpen ? " is-active" : ""}`}
+                        onClick={() => toggleGroupDebug(group.id)}
+                        title="Debug group"
+                        aria-label="Toggle group debug details"
+                        aria-expanded={debugOpen}
+                        aria-controls={debugPanelId}
+                      >
+                        <Icon name="ph:bug-bold" width={13} />
+                      </button>
+                      <button type="button" className="evals-icon-btn" onClick={() => startEdit(group)} title="Edit group" aria-label="Edit group">
+                        <Icon name="ph:pencil-simple" width={13} />
+                      </button>
+                      <button type="button" className="evals-icon-btn" onClick={() => void remove(group)} title="Delete group" aria-label="Delete group">
+                        <Icon name="ph:trash" width={13} />
+                      </button>
+                    </div>
+                  </div>
+                  {group.description ? <p className="evals-group-desc">{group.description}</p> : null}
+                  {rollup ? (
+                    <div className="evals-group-rollup" aria-label="Group freshness rollup">
+                      <span className="evals-chip">{rollup.totalThreads} threads</span>
+                      <span className="evals-chip is-pass">{rollup.freshThreads} fresh</span>
+                      <span className="evals-chip is-fail">{rollup.staleThreads} stale</span>
+                      <span className="evals-chip">{rollup.neverRunThreads} never run</span>
+                    </div>
+                  ) : null}
+                  {memberFamiliars.length ? (
+                    <div className="evals-group-members">
+                      {memberFamiliars.map((m) => (
+                        <span key={m.id} className="evals-toggle-chip is-on">
+                          {familiarName(m.familiarId ?? m.id)}
+                        </span>
+                      ))}
+                    </div>
+                  ) : null}
+                  {debugOpen ? (
+                    <div id={debugPanelId} className="evals-group-debug" aria-label="Group debug details">
+                      <div className="evals-group-debug-title">Group debug details</div>
+                      <pre>
+                        {JSON.stringify(
+                          {
+                            group: {
+                              id: group.id,
+                              name: group.name,
+                              scope: group.scope,
+                              tracks: group.tracks,
+                              rubricVersion: group.rubricVersion,
+                              stalePolicy: group.stalePolicy,
+                              schedulePolicy: group.schedulePolicy,
+                              createdAt: group.createdAt,
+                              updatedAt: group.updatedAt,
+                              members: group.members.map((member) => ({
+                                ...member,
+                                label: member.kind === "familiar" ? familiarName(member.familiarId ?? member.id) : member.id,
+                              })),
+                            },
+                            rollup: rollup ?? null,
+                            states: states.map((state) => ({
+                              threadId: state.threadId,
+                              familiarId: state.familiarId,
+                              status: state.status,
+                              staleReasons: state.staleReasons,
+                              evaluatedAt: state.evaluatedAt,
+                              details: state.details,
+                            })),
+                          },
+                          null,
+                          2,
+                        )}
+                      </pre>
+                    </div>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -373,19 +373,24 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     <div className="evals evals-unified">
       <aside className="evals-rail">
         <div className="evals-rail-head">
-          <span className="evals-rail-title">Evals</span>
-          <button
-            type="button"
-            className="evals-icon-btn"
-            onClick={() => setShowTemplates(true)}
-            title="New suite from template"
-            aria-label="New suite from template"
-          >
-            <Icon name="ph:sparkle" width={14} />
-          </button>
-          <button type="button" className="evals-icon-btn" onClick={createSuite} title="New blank eval suite" aria-label="New blank eval suite">
-            <Icon name="ph:plus" width={14} />
-          </button>
+          <div>
+            <span className="evals-rail-title">Evals</span>
+            <span className="evals-rail-subtitle">{suites.length} suite{suites.length === 1 ? "" : "s"} tracked</span>
+          </div>
+          <div className="evals-rail-actions">
+            <button
+              type="button"
+              className="evals-icon-btn"
+              onClick={() => setShowTemplates(true)}
+              title="New suite from template"
+              aria-label="New suite from template"
+            >
+              <Icon name="ph:sparkle" width={14} />
+            </button>
+            <button type="button" className="evals-icon-btn" onClick={createSuite} title="New blank eval suite" aria-label="New blank eval suite">
+              <Icon name="ph:plus" width={14} />
+            </button>
+          </div>
         </div>
         <ul className="evals-suite-list">
           {suites.map((s) => (
@@ -396,7 +401,10 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
                 onClick={() => selectSuite(s)}
               >
                 <span className="evals-suite-name">{s.name}</span>
-                <span className="evals-suite-meta">{s.cases.length} case{s.cases.length === 1 ? "" : "s"}</span>
+                <span className="evals-suite-meta">
+                  <Icon name="ph:list-bullets-bold" width={12} aria-hidden />
+                  {s.cases.length} case{s.cases.length === 1 ? "" : "s"}
+                </span>
               </button>
             </li>
           ))}
@@ -429,7 +437,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
       <section className="evals-main">
         <header className="evals-toolbar evals-unified-toolbar">
           <div className="evals-title-block">
-            <span className="evals-group-kicker">Unified Evals</span>
+            <span className="evals-group-kicker">Evaluation cockpit</span>
             {draft ? (
               <input
                 className="evals-name-input"
@@ -440,42 +448,49 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
             ) : (
               <h2>Evals</h2>
             )}
+            <span className="evals-title-meta">
+              {draft
+                ? `${draft.cases.length} case${draft.cases.length === 1 ? "" : "s"} · ${runs.length} selected-suite run${runs.length === 1 ? "" : "s"}`
+                : loaded ? "Create or choose a suite to begin." : "Loading suites and run history."}
+            </span>
           </div>
-          <label className="evals-familiar-pick">
-            <span className="evals-familiar-label">Familiar</span>
-            <select
-              value={familiarId}
-              onChange={(e) => patchDraft({ familiarId: e.target.value })}
-              aria-label="Familiar to evaluate"
-              disabled={!draft}
-            >
-              {familiars.length === 0 && <option value="">No familiars</option>}
-              {familiars.map((f) => (
-                <option key={f.id} value={f.id}>
-                  {f.display_name}
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="evals-toolbar-actions">
-            <button type="button" className="evals-btn" onClick={save} disabled={!draft || saving || !dirty}>
-              {saving ? "Saving…" : dirty ? "Save" : "Saved"}
-            </button>
-            {running ? (
-              <button type="button" className="evals-btn evals-btn-stop" onClick={stop}>
-                <span className="evals-spinner" aria-hidden /> Stop
-              </button>
-            ) : (
-              <button
-                type="button"
-                className="evals-btn evals-btn-primary"
-                onClick={run}
-                disabled={!draft || Boolean(blockReason)}
-                title={blockReason ?? "Run this suite against the familiar"}
+          <div className="evals-command-stack">
+            <label className="evals-familiar-pick">
+              <span className="evals-familiar-label">Familiar</span>
+              <select
+                value={familiarId}
+                onChange={(e) => patchDraft({ familiarId: e.target.value })}
+                aria-label="Familiar to evaluate"
+                disabled={!draft}
               >
-                <Icon name="ph:play" width={13} /> Run
+                {familiars.length === 0 && <option value="">No familiars</option>}
+                {familiars.map((f) => (
+                  <option key={f.id} value={f.id}>
+                    {f.display_name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="evals-toolbar-actions">
+              <button type="button" className="evals-btn" onClick={save} disabled={!draft || saving || !dirty}>
+                {saving ? "Saving…" : dirty ? "Save" : "Saved"}
               </button>
-            )}
+              {running ? (
+                <button type="button" className="evals-btn evals-btn-stop" onClick={stop}>
+                  <span className="evals-spinner" aria-hidden /> Stop
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className="evals-btn evals-btn-primary"
+                  onClick={run}
+                  disabled={!draft || Boolean(blockReason)}
+                  title={blockReason ?? "Run this suite against the familiar"}
+                >
+                  <Icon name="ph:play" width={13} /> Run
+                </button>
+              )}
+            </div>
           </div>
         </header>
 
@@ -498,68 +513,74 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
           ))}
         </div>
 
-        {tab === "overview" ? (
-          <EvalsOverview
-            analysis={analysis}
-            recentLoopRuns={retroSnapshot.runs.slice(0, 5)}
-            activeLoopState={activeLoopState}
-            activeGroupRollup={activeGroupRollup}
-          />
-        ) : tab === "insights" ? (
-          <EvalsInsightsPanel suite={draft} runs={allRuns} />
-        ) : tab === "suites" ? (
-          draft ? (
-            <SuiteEditor draft={draft} patchDraft={patchDraft} patchCase={patchCase} patchGrader={patchGrader} setDraft={setDraft} />
-          ) : (
-            <EmptyState
-              icon="ph:flask"
-              headline="Run evals on your familiars"
-              subtitle="Build a suite of test cases, grade each answer with deterministic checks or an LLM judge, and track pass rates over time."
-              actions={
-                <>
-                  <button type="button" className="evals-btn evals-btn-primary" onClick={() => setShowTemplates(true)}>
-                    <Icon name="ph:sparkle" width={14} /> Start from template
-                  </button>
-                  <button type="button" className="evals-btn" onClick={createSuite}>
-                    <Icon name="ph:plus" width={14} /> Blank suite
-                  </button>
-                </>
-              }
+        <div className="evals-tab-panel">
+          {tab === "overview" ? (
+            <EvalsOverview
+              analysis={analysis}
+              draft={draft}
+              runs={runs}
+              recentLoopRuns={retroSnapshot.runs.slice(0, 5)}
+              activeLoopState={activeLoopState}
+              activeGroupRollup={activeGroupRollup}
+              onOpenSuite={() => setTab("suites")}
+              onOpenRuns={() => setTab("runs")}
             />
-          )
-        ) : tab === "runs" ? (
-          <RunsPanel
-            runs={runs}
-            progress={progress}
-            running={running}
-            expandedRunId={expandedRunId}
-            onToggle={(id) => setExpandedRunId((cur) => (cur === id ? null : id))}
-          />
-        ) : tab === "compare" ? (
-          <RunCompare runs={draft ? allRuns.filter((r) => r.suiteId === draft.id) : allRuns} />
-        ) : tab === "loops" ? (
-          <LoopAnalysisPanel
-            familiarId={familiarId}
-            familiarName={familiarName}
-            snapshot={retroSnapshot}
-            activeLoopState={activeLoopState}
-          />
-        ) : tab === "threads" ? (
-          <ThreadFreshnessPanel
-            group={activeGroup}
-            states={activeGroupStates}
-            rollup={activeGroupRollup}
-            queuedCount={queue.length}
-            onQueue={queueStaleGroup}
-          />
-        ) : (
-          <EvalGroupsPanel
-            groups={groups}
-            statesById={groupStatesById}
-            familiars={familiars}
-            onChanged={reloadGroups}
-          />
-        )}
+          ) : tab === "insights" ? (
+            <EvalsInsightsPanel suite={draft} runs={allRuns} />
+          ) : tab === "suites" ? (
+            draft ? (
+              <SuiteEditor draft={draft} patchDraft={patchDraft} patchCase={patchCase} patchGrader={patchGrader} setDraft={setDraft} />
+            ) : (
+              <EmptyState
+                icon="ph:flask"
+                headline="Run evals on your familiars"
+                subtitle="Build a suite of test cases, grade each answer with deterministic checks or an LLM judge, and track pass rates over time."
+                actions={
+                  <>
+                    <button type="button" className="evals-btn evals-btn-primary" onClick={() => setShowTemplates(true)}>
+                      <Icon name="ph:sparkle" width={14} /> Start from template
+                    </button>
+                    <button type="button" className="evals-btn" onClick={createSuite}>
+                      <Icon name="ph:plus" width={14} /> Blank suite
+                    </button>
+                  </>
+                }
+              />
+            )
+          ) : tab === "runs" ? (
+            <RunsPanel
+              runs={runs}
+              progress={progress}
+              running={running}
+              expandedRunId={expandedRunId}
+              onToggle={(id) => setExpandedRunId((cur) => (cur === id ? null : id))}
+            />
+          ) : tab === "compare" ? (
+            <RunCompare runs={draft ? allRuns.filter((r) => r.suiteId === draft.id) : allRuns} />
+          ) : tab === "loops" ? (
+            <LoopAnalysisPanel
+              familiarId={familiarId}
+              familiarName={familiarName}
+              snapshot={retroSnapshot}
+              activeLoopState={activeLoopState}
+            />
+          ) : tab === "threads" ? (
+            <ThreadFreshnessPanel
+              group={activeGroup}
+              states={activeGroupStates}
+              rollup={activeGroupRollup}
+              queuedCount={queue.length}
+              onQueue={queueStaleGroup}
+            />
+          ) : (
+            <EvalGroupsPanel
+              groups={groups}
+              statesById={groupStatesById}
+              familiars={familiars}
+              onChanged={reloadGroups}
+            />
+          )}
+        </div>
       </section>
 
       <TemplateGallery
@@ -746,21 +767,60 @@ function AnalysisCard({ icon, label, value, detail }: { icon: IconName; label: s
 
 function EvalsOverview({
   analysis,
+  draft,
+  runs,
   recentLoopRuns,
   activeLoopState,
   activeGroupRollup,
+  onOpenSuite,
+  onOpenRuns,
 }: {
   analysis: EvalsAnalysis;
+  draft: EvalSuite | null;
+  runs: EvalRun[];
   recentLoopRuns: RetroRun[];
   activeLoopState: RetroRunsSnapshot["familiars"][number] | null;
   activeGroupRollup: EvalGroupRollup | null;
+  onOpenSuite: () => void;
+  onOpenRuns: () => void;
 }) {
+  const latestRun = runs[0] ?? null;
   return (
     <div className="evals-overview">
+      <section className="evals-analysis-panel evals-overview-hero">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Evaluation focus</span>
+          <b>{draft?.name ?? "No suite selected"}</b>
+          <button type="button" className="evals-btn" onClick={onOpenSuite}>
+            <Icon name="ph:pencil-simple" width={13} /> Edit suite
+          </button>
+        </div>
+        <div className="evals-overview-hero-grid">
+          <div className="evals-focus-score">
+            <span>Latest pass rate</span>
+            <b>{passRateLabel(analysis.latestPassRate)}</b>
+            <small>{analysis.passTrend == null ? "Run twice to establish a trend." : `${trendLabel(analysis.passTrend)} since previous run.`}</small>
+          </div>
+          <div className="evals-focus-copy">
+            <p>
+              {draft?.description?.trim()
+                ? draft.description
+                : "Build repeatable cases, run them against a familiar, then compare regressions before promoting behavior changes."}
+            </p>
+            <div className="evals-focus-actions">
+              <button type="button" className="evals-btn evals-btn-primary" onClick={onOpenRuns}>
+                <Icon name="ph:chart-bar-bold" width={13} /> Review runs
+              </button>
+              <span className="evals-focus-pill">{draft ? `${draft.cases.length} case${draft.cases.length === 1 ? "" : "s"}` : "No suite"}</span>
+              <span className="evals-focus-pill">{latestRun ? `${latestRun.summary.passed}/${latestRun.summary.total} passed` : "No run history"}</span>
+            </div>
+          </div>
+        </div>
+      </section>
       <section className="evals-analysis-panel">
         <div className="evals-section-head">
-          <span className="evals-group-kicker">Analysis</span>
-          <b>What needs attention</b>
+          <span className="evals-group-kicker">Attention queue</span>
+          <b>{analysis.staleThreads + analysis.blockedThreads + analysis.runningFamiliars} active signals</b>
         </div>
         <ul className="evals-insight-list">
           <li>{analysis.latestPassRate == null ? "No suite runs yet." : `Latest selected-suite pass rate is ${passRateLabel(analysis.latestPassRate)}.`}</li>
@@ -768,13 +828,6 @@ function EvalsOverview({
           <li>{analysis.staleThreads > 0 ? `${analysis.staleThreads} thread eval snapshots need review.` : "Grouped thread eval snapshots are fresh where configured."}</li>
           <li>{activeLoopState?.running ? `${activeLoopState.familiarName} has an eval loop running.` : "No selected familiar eval loop is currently running."}</li>
         </ul>
-      </section>
-      <section className="evals-analysis-panel">
-        <div className="evals-section-head">
-          <span className="evals-group-kicker">Recent eval-loop runs</span>
-          <b>{recentLoopRuns.length ? `${recentLoopRuns.length} newest` : "No loop runs"}</b>
-        </div>
-        <LoopRunList runs={recentLoopRuns} />
       </section>
       <section className="evals-analysis-panel">
         <div className="evals-section-head">
@@ -786,6 +839,13 @@ function EvalsOverview({
             ? `${activeGroupRollup.freshThreads} fresh, ${activeGroupRollup.staleThreads} stale, ${activeGroupRollup.neverRunThreads} never run, ${activeGroupRollup.blockedThreads} blocked.`
             : "Create an eval group to connect thread freshness, stale reasons, and manual queueing."}
         </p>
+      </section>
+      <section className="evals-analysis-panel evals-overview-wide">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Recent eval-loop runs</span>
+          <b>{recentLoopRuns.length ? `${recentLoopRuns.length} newest` : "No loop runs"}</b>
+        </div>
+        <LoopRunList runs={recentLoopRuns} />
       </section>
     </div>
   );
@@ -993,31 +1053,55 @@ function SuiteEditor({
 
   return (
     <div className="evals-editor">
-      <textarea
-        className="evals-desc"
-        value={draft.description ?? ""}
-        placeholder="What does this suite check? (optional)"
-        onChange={(e) => patchDraft({ description: e.target.value })}
-        rows={2}
-        aria-label="Suite description"
-      />
-      <label className="evals-field">
-        <span>Pass-rate SLA (%)</span>
-        <input
-          type="number"
-          min={0}
-          max={100}
-          value={draft.slaMinPassRate != null ? Math.round(draft.slaMinPassRate * 100) : ""}
-          onChange={(e) => {
-            const pct = e.target.value === "" ? undefined : Number(e.target.value);
-            patchDraft({
-              slaMinPassRate: pct == null || Number.isNaN(pct) ? undefined : Math.min(1, Math.max(0, pct / 100)),
-            });
-          }}
-          aria-label="Pass-rate SLA percent"
-        />
-      </label>
+      <section className="evals-suite-config" aria-label="Suite configuration">
+        <div className="evals-section-head">
+          <span className="evals-group-kicker">Suite contract</span>
+          <b>Readiness</b>
+        </div>
+        <div className="evals-suite-config-body">
+          <label className="evals-field evals-field-stack">
+            <span>Description</span>
+            <textarea
+              className="evals-desc"
+              value={draft.description ?? ""}
+              placeholder="What does this suite check? (optional)"
+              onChange={(e) => patchDraft({ description: e.target.value })}
+              rows={4}
+              aria-label="Suite description"
+            />
+          </label>
+          <label className="evals-field">
+            <span>Pass-rate SLA (%)</span>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={draft.slaMinPassRate != null ? Math.round(draft.slaMinPassRate * 100) : ""}
+              onChange={(e) => {
+                const pct = e.target.value === "" ? undefined : Number(e.target.value);
+                patchDraft({
+                  slaMinPassRate: pct == null || Number.isNaN(pct) ? undefined : Math.min(1, Math.max(0, pct / 100)),
+                });
+              }}
+              aria-label="Pass-rate SLA percent"
+            />
+          </label>
+          <div className="evals-contract-stats" aria-label="Suite contract summary">
+            <ThreadEvalDetail label="Cases" value={String(draft.cases.length)} />
+            <ThreadEvalDetail label="Checks" value={String(draft.cases.reduce((total, item) => total + item.graders.length, 0))} />
+          </div>
+        </div>
+      </section>
       <div className="evals-cases">
+        <div className="evals-cases-head">
+          <div>
+            <span className="evals-group-kicker">Cases</span>
+            <b>Prompt checks</b>
+          </div>
+          <button type="button" className="evals-add-case" onClick={addCase}>
+            <Icon name="ph:plus" width={14} /> Add case
+          </button>
+        </div>
         {draft.cases.map((c, ci) => (
           <article className="evals-case" key={c.id}>
             <div className="evals-case-head">
@@ -1056,9 +1140,6 @@ function SuiteEditor({
           </article>
         ))}
       </div>
-      <button type="button" className="evals-add-case" onClick={addCase}>
-        <Icon name="ph:plus" width={14} /> Add case
-      </button>
     </div>
   );
 }

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -3,10 +3,12 @@
 
 .evals {
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr);
+  grid-template-columns: 268px minmax(0, 1fr);
   height: 100%;
   min-height: 0;
-  background: var(--bg-base);
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--bg-panel) 78%, black), var(--bg-base) 360px),
+    var(--bg-base);
   color: var(--text-primary);
 }
 .evals-empty {
@@ -20,29 +22,43 @@
   flex-direction: column;
   min-height: 0;
   border-right: 1px solid var(--border-hairline);
-  background: var(--bg-panel);
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--bg-raised) 58%, transparent), transparent 220px),
+    var(--bg-panel);
 }
 .evals-rail-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--space-3) var(--space-3) var(--space-2);
+  gap: var(--space-2);
+  padding: 18px 16px 12px;
 }
 .evals-rail-title {
+  display: block;
   font-size: var(--text-sm);
   font-weight: 700;
   letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   color: var(--text-muted);
 }
+.evals-rail-subtitle {
+  display: block;
+  margin-top: 3px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+.evals-rail-actions {
+  display: inline-flex;
+  gap: 5px;
+}
 .evals-suite-list {
   list-style: none;
   margin: 0;
-  padding: 0 var(--space-2) var(--space-3);
+  padding: 0 10px 16px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
 
 /* Migrated eval-discuss threads — surfaced here instead of the chat list. */
@@ -106,24 +122,28 @@
 .evals-suite-row {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 5px;
   width: 100%;
   text-align: left;
-  padding: 7px 9px;
+  padding: 10px 11px;
   border: 1px solid transparent;
-  border-radius: var(--radius-control);
+  border-radius: 9px;
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
+  transition: background 140ms var(--ease-decelerate, ease), border-color 140ms var(--ease-decelerate, ease), color 140ms var(--ease-decelerate, ease);
 }
 .evals-suite-row:hover {
   background: var(--bg-hover);
   color: var(--text-primary);
 }
 .evals-suite-row.is-active {
-  background: var(--bg-elevated);
-  border-color: color-mix(in oklch, var(--accent-presence) 35%, var(--border));
+  background:
+    linear-gradient(135deg, color-mix(in oklch, var(--accent-presence) 12%, transparent), transparent 62%),
+    var(--bg-elevated);
+  border-color: color-mix(in oklch, var(--accent-presence) 42%, var(--border));
   color: var(--text-primary);
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 5%, transparent);
 }
 .evals-suite-name {
   font-size: var(--text-base);
@@ -133,6 +153,9 @@
   text-overflow: ellipsis;
 }
 .evals-suite-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-size: var(--text-2xs);
   color: var(--text-muted);
 }
@@ -148,12 +171,15 @@
 .evals-toolbar {
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-3);
+  gap: 16px;
+  padding: 16px 18px 14px;
   border-bottom: 1px solid var(--border-hairline);
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--foreground) 3%, transparent), transparent),
+    color-mix(in oklch, var(--bg-panel) 72%, var(--bg-base));
 }
 .evals-unified-toolbar {
-  align-items: stretch;
+  align-items: center;
 }
 .evals-title-block {
   display: flex;
@@ -165,24 +191,43 @@
 }
 .evals-title-block h2 {
   margin: 0;
-  font-size: var(--text-md);
+  font-size: 20px;
   line-height: 1.2;
 }
 .evals-name-input {
   flex: 0 1 auto;
   min-width: 8ch;
-  max-width: 26ch;
-  padding: 5px 8px;
+  max-width: min(50vw, 34ch);
+  padding: 4px 0;
   border: 1px solid transparent;
-  border-radius: var(--radius-control);
+  border-radius: 0;
   background: transparent;
   color: var(--text-primary);
-  font-size: var(--text-md);
-  font-weight: 600;
+  font-size: 20px;
+  line-height: 1.15;
+  font-weight: 720;
   outline: none;
 }
-.evals-name-input:hover { border-color: var(--border-hairline); }
-.evals-name-input:focus { border-color: var(--accent-presence); }
+.evals-name-input:hover { color: color-mix(in oklch, var(--text-primary) 86%, var(--accent-presence)); }
+.evals-name-input:focus {
+  padding-inline: 8px;
+  border: 1px solid var(--accent-presence);
+  border-radius: var(--radius-control);
+}
+.evals-title-meta {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.evals-command-stack {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: auto;
+}
 .evals-familiar-pick {
   display: inline-flex;
   align-items: center;
@@ -191,7 +236,8 @@
   color: var(--text-muted);
 }
 .evals-familiar-pick select {
-  padding: 5px 8px;
+  min-height: 32px;
+  padding: 5px 30px 5px 10px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
   background: var(--bg-elevated);
@@ -208,7 +254,7 @@
   background: var(--bg-base);
 }
 .evals-tab {
-  padding: 4px 12px;
+  padding: 6px 12px;
   font-size: var(--text-sm);
   font-weight: 500;
   border: 0;
@@ -223,18 +269,26 @@
 .evals-section-tabs {
   flex: 0 0 auto;
   margin: 0;
-  padding: var(--space-2) var(--space-3);
+  padding: 10px 18px;
   border-bottom: 1px solid var(--border-hairline);
   border-radius: 0;
-  background: var(--bg-panel);
+  background: color-mix(in oklch, var(--bg-panel) 82%, var(--bg-base));
   overflow-x: auto;
+}
+.evals-tab-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .evals-btn {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  min-height: 30px;
+  min-height: 32px;
   padding: 5px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
@@ -248,7 +302,9 @@
 .evals-btn:disabled { opacity: var(--opacity-disabled, 0.5); cursor: default; }
 .evals-btn-primary {
   border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent);
-  background: color-mix(in oklch, var(--accent-presence) 26%, var(--bg-elevated));
+  background:
+    linear-gradient(180deg, color-mix(in oklch, white 6%, transparent), transparent),
+    color-mix(in oklch, var(--accent-presence) 30%, var(--bg-elevated));
 }
 .evals-btn-primary:hover:not(:disabled) { background: color-mix(in oklch, var(--accent-presence) 38%, var(--bg-elevated)); }
 .evals-btn-stop {
@@ -258,8 +314,8 @@
 .evals-icon-btn {
   display: inline-grid;
   place-items: center;
-  width: 26px;
-  height: 26px;
+  width: 30px;
+  height: 30px;
   border: 1px solid transparent;
   border-radius: var(--radius-control);
   background: transparent;
@@ -280,20 +336,21 @@
 .evals-analysis-summary {
   display: grid;
   grid-template-columns: repeat(5, minmax(120px, 1fr));
-  gap: var(--space-2);
-  padding: 10px 16px;
+  gap: 10px;
+  padding: 12px 18px;
   border-bottom: 1px solid var(--border-hairline);
   background:
-    linear-gradient(180deg, color-mix(in oklch, var(--accent-presence) 5%, var(--bg-base)), var(--bg-base));
+    linear-gradient(90deg, color-mix(in oklch, var(--accent-presence) 7%, transparent), transparent 38%),
+    color-mix(in oklch, var(--bg-base) 82%, var(--bg-panel));
 }
 .evals-analysis-card {
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   gap: 2px 8px;
   min-width: 0;
-  padding: 11px 12px;
+  padding: 12px 13px;
   border: 1px solid var(--border-hairline);
-  border-radius: 10px;
+  border-radius: 8px;
   background:
     linear-gradient(180deg, color-mix(in oklch, var(--foreground) 4%, transparent), transparent),
     color-mix(in oklch, var(--bg-raised) 88%, var(--bg-base));
@@ -330,12 +387,82 @@
 .evals-thread-freshness {
   min-height: 0;
   overflow: auto;
-  padding: var(--space-3);
+  padding: 18px;
 }
 .evals-overview {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: var(--space-3);
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  align-content: start;
+  gap: 14px;
+}
+.evals-overview-hero,
+.evals-overview-wide {
+  grid-column: 1 / -1;
+}
+.evals-overview-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 260px) minmax(0, 1fr);
+  gap: 18px;
+  padding: 18px;
+}
+.evals-focus-score {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  min-height: 150px;
+  padding: 18px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 100% 0%, color-mix(in oklch, var(--accent-presence) 20%, transparent), transparent 150px),
+    color-mix(in oklch, var(--bg-panel) 72%, var(--bg-base));
+}
+.evals-focus-score span {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-weight: 800;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+}
+.evals-focus-score b {
+  font-size: clamp(34px, 5vw, 58px);
+  line-height: 0.95;
+}
+.evals-focus-score small,
+.evals-focus-copy p {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+.evals-focus-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  justify-content: center;
+  gap: 16px;
+}
+.evals-focus-copy p {
+  max-width: 78ch;
+  margin: 0;
+}
+.evals-focus-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+.evals-focus-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  font-size: var(--text-xs);
+  font-weight: 650;
 }
 .evals-loop-analysis {
   display: grid;
@@ -367,7 +494,7 @@
 .evals-analysis-panel {
   min-width: 0;
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-panel);
+  border-radius: 10px;
   background:
     linear-gradient(180deg, color-mix(in oklch, var(--foreground) 3%, transparent), transparent),
     color-mix(in oklch, var(--bg-raised) 82%, var(--bg-base));
@@ -380,7 +507,7 @@
   align-items: center;
   gap: var(--space-2);
   min-width: 0;
-  padding: 14px 16px;
+  padding: 13px 15px;
   border-bottom: 1px solid var(--border-hairline);
 }
 .evals-section-head b {
@@ -401,13 +528,16 @@
 .evals-insight-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 9px;
   color: var(--text-secondary);
   font-size: var(--text-sm);
 }
 .evals-insight-list li {
-  padding-left: var(--space-2);
-  border-left: 2px solid color-mix(in oklch, var(--accent-presence) 45%, var(--border));
+  padding: 9px 10px;
+  border: 1px solid var(--border-hairline);
+  border-left: 3px solid color-mix(in oklch, var(--accent-presence) 48%, var(--border));
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--bg-base) 74%, transparent);
 }
 .evals-analysis-copy {
   margin: 0;
@@ -689,19 +819,99 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: var(--space-3);
+  padding: 18px;
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 14px;
+}
+.evals-groups-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: start;
+  padding: 16px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 10px;
+  background:
+    linear-gradient(135deg, color-mix(in oklch, var(--accent-presence) 10%, transparent), transparent 56%),
+    color-mix(in oklch, var(--bg-raised) 86%, var(--bg-base));
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+.evals-groups-hero-copy {
+  min-width: 0;
+}
+.evals-groups-hero-copy h3 {
+  margin: 3px 0 0;
+  font-size: 20px;
+  line-height: 1.15;
+}
+.evals-groups-hero-copy p {
+  max-width: 74ch;
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+.evals-groups-hero-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.evals-groups-stats {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+}
+.evals-groups-stat {
+  min-width: 0;
+  padding: 10px 11px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--bg-base) 78%, transparent);
+}
+.evals-groups-stat span {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-weight: 800;
+  letter-spacing: var(--tracking-wide);
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.evals-groups-stat b {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-primary);
+  font-size: 24px;
+  line-height: 1;
 }
 .evals-group-editor {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  padding: var(--space-3);
+  overflow: hidden;
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
-  background: var(--bg-raised);
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--foreground) 3%, transparent), transparent),
+    color-mix(in oklch, var(--bg-raised) 82%, var(--bg-base));
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+.evals-group-editor .evals-section-head > div,
+.evals-group-set .evals-section-head > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+.evals-group-editor-body {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.72fr) minmax(260px, 1fr);
+  gap: 12px 14px;
+  padding: 14px;
+}
+.evals-group-editor-body .evals-field-stack {
+  grid-column: 1 / -1;
 }
 .evals-group-name-input {
   width: 100%;
@@ -727,26 +937,37 @@
   color: var(--text-primary);
 }
 .evals-group-error {
+  grid-column: 1 / -1;
   margin: 0;
   color: var(--color-danger);
   font-size: var(--text-xs);
 }
+.evals-group-set {
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--foreground) 2%, transparent), transparent),
+    color-mix(in oklch, var(--bg-raised) 78%, var(--bg-base));
+}
 .evals-group-list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 10px;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 8px;
 }
 .evals-group-card {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: var(--space-2) var(--space-3);
+  gap: 8px;
+  padding: 12px;
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
-  background: var(--bg-raised);
+  border-radius: 9px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--foreground) 2.5%, transparent), transparent),
+    var(--bg-raised);
 }
 .evals-group-card-head {
   display: flex;
@@ -754,15 +975,44 @@
   justify-content: space-between;
   gap: var(--space-2);
 }
+.evals-group-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.evals-group-title-row b {
+  min-width: 0;
+  overflow: hidden;
+  font-size: var(--text-base);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.evals-group-status {
+  flex: 0 0 auto;
+  padding: 2px 7px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  border-radius: var(--radius-pill, 999px);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+  font-weight: 800;
+}
 .evals-group-card-actions {
   display: flex;
   gap: 4px;
   flex-shrink: 0;
 }
+.evals-icon-btn.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  color: var(--text-primary);
+}
 .evals-group-desc {
   margin: 0;
   color: var(--text-secondary);
   font-size: var(--text-xs);
+  line-height: 1.45;
 }
 .evals-group-rollup,
 .evals-group-members {
@@ -771,9 +1021,9 @@
   gap: 5px;
 }
 .evals-group-debug {
-  margin-top: 2px;
+  margin-top: 4px;
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
+  border-radius: 8px;
   background: color-mix(in oklch, var(--bg-base) 82%, var(--foreground) 18%);
   overflow: hidden;
 }
@@ -802,10 +1052,60 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: var(--space-3);
+  padding: 18px;
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+  align-content: start;
+  gap: 14px;
+}
+.evals-suite-config {
+  align-self: start;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--foreground) 3%, transparent), transparent),
+    color-mix(in oklch, var(--bg-raised) 82%, var(--bg-base));
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 5%, transparent);
+}
+.evals-suite-config-body {
   display: flex;
   flex-direction: column;
-  gap: var(--space-3);
+  gap: 12px;
+  padding: 14px;
+}
+.evals-field {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(88px, auto);
+  align-items: center;
+  gap: 10px;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+.evals-field-stack {
+  grid-template-columns: 1fr;
+  align-items: stretch;
+}
+.evals-field input {
+  width: 100%;
+  min-height: 32px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: var(--text-sm);
+  outline: none;
+}
+.evals-field input:focus {
+  border-color: var(--accent-presence);
+}
+.evals-contract-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
 .evals-desc,
 .evals-case-input,
@@ -820,26 +1120,47 @@
   border-radius: var(--radius-control);
   outline: none;
 }
-.evals-desc { width: 100%; resize: vertical; padding: 7px 9px; }
+.evals-desc { width: 100%; resize: vertical; padding: 9px 10px; }
 .evals-desc:focus,
 .evals-case-input:focus,
 .evals-grader-value:focus { border-color: var(--accent-presence); }
 
-.evals-cases { display: flex; flex-direction: column; gap: var(--space-2); }
+.evals-cases {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 10px;
+}
+.evals-cases-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding: 2px 1px 4px;
+}
+.evals-cases-head b {
+  display: block;
+  margin-top: 2px;
+  font-size: 15px;
+}
 .evals-case {
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-card);
-  background: var(--bg-raised);
-  padding: var(--space-2);
+  border-radius: 10px;
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--foreground) 2.5%, transparent), transparent),
+    var(--bg-raised);
+  padding: 12px;
   display: flex;
   flex-direction: column;
-  gap: var(--space-2);
+  gap: 10px;
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent);
 }
 .evals-case-head { display: flex; align-items: center; gap: var(--space-2); }
 .evals-case-num {
   display: inline-grid; place-items: center;
-  width: 20px; height: 20px;
-  border-radius: 999px;
+  width: 24px; height: 24px;
+  border-radius: 8px;
   background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-elevated));
   color: var(--text-primary);
   font-size: var(--text-2xs); font-weight: 700;
@@ -849,8 +1170,8 @@
 .evals-case-name:focus { border-color: var(--accent-presence); background: var(--bg-base); }
 .evals-case-input { width: 100%; resize: vertical; padding: 7px 9px; }
 
-.evals-graders { display: flex; flex-direction: column; gap: 5px; }
-.evals-grader { display: flex; align-items: center; gap: 6px; }
+.evals-graders { display: flex; flex-direction: column; gap: 6px; }
+.evals-grader { display: flex; align-items: center; gap: 6px; min-width: 0; }
 .evals-grader-kind { padding: 5px 7px; flex: 0 0 auto; min-width: 124px; }
 .evals-grader-value { flex: 1; padding: 5px 8px; }
 .evals-grader-ci {
@@ -861,6 +1182,7 @@
 .evals-add-case {
   display: inline-flex; align-items: center; gap: 5px;
   align-self: flex-start;
+  min-height: 30px;
   padding: 5px 10px;
   border: 1px dashed var(--border);
   border-radius: var(--radius-control);
@@ -878,7 +1200,7 @@
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: var(--space-3);
+  padding: 18px;
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -887,7 +1209,7 @@
 
 .evals-progress {
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-card);
+  border-radius: 10px;
   background: var(--bg-raised);
   padding: var(--space-3);
   display: flex; flex-direction: column; gap: var(--space-2);
@@ -898,7 +1220,7 @@
 
 .evals-run {
   border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-card);
+  border-radius: 10px;
   background: var(--bg-raised);
   overflow: hidden;
 }
@@ -968,6 +1290,20 @@
   .evals-loop-analysis {
     grid-template-columns: 1fr;
   }
+  .evals-overview-hero,
+  .evals-overview-wide {
+    grid-column: auto;
+  }
+  .evals-editor {
+    display: flex;
+    flex-direction: column;
+    grid-template-columns: none;
+  }
+  .evals-suite-config,
+  .evals-cases {
+    flex: 0 0 auto;
+    width: 100%;
+  }
   .evals-loop-analysis > .retro-surface {
     grid-column: auto;
   }
@@ -980,12 +1316,77 @@
     align-items: stretch;
     flex-direction: column;
   }
+  .evals-command-stack {
+    align-items: stretch;
+    flex-direction: column;
+    margin-left: 0;
+  }
+  .evals-familiar-pick,
+  .evals-toolbar-actions {
+    justify-content: space-between;
+    width: 100%;
+  }
+  .evals-familiar-pick select {
+    min-width: 0;
+    flex: 1;
+  }
+  .evals-section-tabs {
+    padding-inline: 12px;
+  }
   .evals-analysis-summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    padding-inline: 12px;
+  }
+  .evals-overview,
+  .evals-editor,
+  .evals-runs,
+  .evals-loop-analysis,
+  .evals-thread-freshness,
+  .evals-groups,
+  .evals-insights,
+  .evals-compare {
+    padding: 12px;
   }
   .evals-overview,
   .evals-loop-analysis {
     grid-template-columns: 1fr;
+  }
+  .evals-overview-hero-grid {
+    grid-template-columns: 1fr;
+    padding: 12px;
+  }
+  .evals-focus-score {
+    min-height: 120px;
+  }
+  .evals-groups {
+    padding: 12px;
+  }
+  .evals-groups-hero {
+    grid-template-columns: 1fr;
+    padding: 12px;
+  }
+  .evals-groups-hero-actions {
+    justify-content: flex-start;
+  }
+  .evals-groups-stats,
+  .evals-group-editor-body {
+    grid-template-columns: 1fr;
+  }
+  .evals-group-editor-body .evals-field-stack {
+    grid-column: auto;
+  }
+  .evals-group-title-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 5px;
+  }
+  .evals-grader {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+  .evals-grader-kind,
+  .evals-grader-value {
+    min-width: min(100%, 170px);
   }
   .evals-loop-analysis {
     overflow-x: hidden;
@@ -1102,6 +1503,13 @@
 
 /* Insights tab — trend + failure analysis. */
 .evals-insights { display: flex; flex-direction: column; gap: 18px; }
+.evals-insights,
+.evals-compare {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 18px;
+}
 .evals-insights__card {
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control, 10px);
@@ -1138,3 +1546,10 @@
 .evals-diff__row--regressed { background: color-mix(in oklch, var(--color-danger) 10%, transparent); }
 .evals-diff__row--regressed .evals-diff__status { color: var(--color-danger); }
 .evals-diff__row--fixed .evals-diff__status { color: var(--color-success); }
+
+@media (max-width: 720px) {
+  .evals-insights,
+  .evals-compare {
+    padding: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Groups tab hero with aggregate freshness stats and clearer empty state.
- Rework group editor/list cards for stronger hierarchy, responsive layout, and visible debug active state.
- Polish the broader Evals surface around the tab panel, suite overview, and suite editor to match the new Groups treatment.
- Fix editor section header crowding found during rendered QA.

## Verification
- node --experimental-strip-types src/components/evals/eval-groups-panel.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check
- Rendered QA at http://127.0.0.1:3000/?mode=evals with system Chrome: Groups tab, New group editor, no console errors, no horizontal overflow.