### PR TITLE
feat(code): collapsed sessions rail shows a "Sessions" label, not a bare icon

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -799,6 +799,43 @@ tr[role="checkbox"]:focus-visible {
   to { opacity: 1; transform: translateX(0); }
 }
 
+/* Code sidebar collapsed rail — when the nav panel collapses to the 56px rail,
+   show a vertical "Sessions" label instead of a bare clipped icon (mirrors the
+   comux Details/Preview rails). The full sidebar is hidden; the rail reopens the
+   panel on click. The peek overlay drops the `--rail` class, so the full sidebar
+   still shows on hover. */
+.code-sidebar__rail {
+  display: none;
+}
+.shell-nav--rail .code-sidebar__full {
+  display: none;
+}
+.shell-nav--rail .code-sidebar__rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  height: 100%;
+  padding: 12px 0;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.13s ease, background 0.13s ease;
+}
+.shell-nav--rail .code-sidebar__rail:hover {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--bg-hover) 60%, transparent);
+}
+.code-sidebar__rail-label {
+  writing-mode: vertical-rl;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .shell-nav-header {
   display: flex;
   align-items: center;

--- a/src/components/code-sidebar.tsx
+++ b/src/components/code-sidebar.tsx
@@ -73,6 +73,22 @@ export function CodeSidebar({
 
   return (
     <div className="code-sidebar flex h-full min-h-0 flex-col bg-[color-mix(in_oklch,var(--bg-raised)_88%,transparent)]">
+      {/* Collapsed rail — when the nav panel is collapsed the shell adds
+          `.shell-nav--rail`, which CSS uses to hide the full sidebar and show
+          this vertical "Sessions" label instead of a bare clipped icon (mirrors
+          the comux Details/Preview rails). Clicking it reopens the panel. */}
+      <button
+        type="button"
+        className="code-sidebar__rail focus-ring"
+        aria-label="Expand sessions"
+        title="Expand sessions"
+        onClick={() => window.dispatchEvent(new CustomEvent("cave:toggle-left-panel"))}
+      >
+        <Icon name="ph:sidebar-simple" width={15} aria-hidden />
+        <span className="code-sidebar__rail-label">Sessions</span>
+      </button>
+
+      <div className="code-sidebar__full flex min-h-0 flex-1 flex-col">
       <header className="code-sidebar__header flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-2 py-2">
         <button
           type="button"
@@ -243,6 +259,7 @@ export function CodeSidebar({
           </ul>
         )}
       </nav>
+      </div>
     </div>
   );
 }

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -17,6 +17,7 @@ const globals = await readFile(new URL("../app/globals.css", import.meta.url), "
 // Sessions/Memory tab row, in a self-contained toolbar.
 const toolbar = await readFile(new URL("./code-inline-toolbar.tsx", import.meta.url), "utf8");
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 
 // ── CodeView is the Codex 3-column shell — Files · Chat · Changes ────────────
 // Three columns side by side: the file-tree explorer (left), the familiar
@@ -237,5 +238,38 @@ assert.match(
   /id: "code", label: "Code"[\s\S]*?kbd: "⌘7"/,
   "sidebar has a Code nav entry bound to ⌘7",
 );
+
+// ── Collapsed nav rail shows a "Sessions" label, not a bare clipped icon ─────
+// When the Code surface's nav panel collapses to the 56px rail, the CodeSidebar
+// renders a vertical "Sessions" label (mirrors the comux Details/Preview rails)
+// that reopens the panel on click via the symmetric cave:toggle-left-panel hook.
+assert.match(codeSidebar, /className="code-sidebar__rail focus-ring"/, "CodeSidebar renders a collapsed rail control");
+assert.match(codeSidebar, /aria-label="Expand sessions"/, "the collapsed rail is an accessible expand affordance");
+assert.match(
+  codeSidebar,
+  /new CustomEvent\("cave:toggle-left-panel"\)/,
+  "the collapsed rail reopens the nav panel via the cave:toggle-left-panel event",
+);
+assert.match(
+  codeSidebar,
+  /<span className="code-sidebar__rail-label">Sessions<\/span>/,
+  "the collapsed rail shows a 'Sessions' label instead of a bare icon",
+);
+assert.match(codeSidebar, /className="code-sidebar__full/, "the full sidebar is wrapped so CSS can hide it when collapsed");
+// Shell honours the symmetric left-panel toggle event (mirror of the right one).
+assert.match(
+  shell,
+  /window\.addEventListener\("cave:toggle-left-panel", onToggleLeft\)/,
+  "the shell listens for cave:toggle-left-panel to reopen the nav panel",
+);
+assert.match(
+  shell,
+  /const onToggleLeft = \(\) => \{[\s\S]*?togglePanel\(navRef\.current\)/,
+  "cave:toggle-left-panel toggles the nav panel (desktop)",
+);
+// CSS hides the full sidebar and shows the rotated label only in the collapsed rail.
+assert.match(globals, /\.shell-nav--rail \.code-sidebar__full \{\s*display: none;/, "collapsed rail hides the full sidebar");
+assert.match(globals, /\.shell-nav--rail \.code-sidebar__rail \{[\s\S]*?display: flex;/, "collapsed rail shows the Sessions control");
+assert.match(globals, /\.code-sidebar__rail-label \{[\s\S]*?writing-mode: vertical-rl;/, "the Sessions rail label reads vertically");
 
 console.log("code-view.test.ts: ok");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -419,13 +419,21 @@ function ShellInner({
     const onToggleRight = () => {
       if (hasFamiliar) toggleFamiliarPanel();
     };
+    // Symmetric hook for the left nav panel — lets a collapsed-rail label (e.g.
+    // the Code sidebar's "Sessions" rail) reopen the panel without a panel ref.
+    const onToggleLeft = () => {
+      if (isMobile) toggleDrawerSlot("nav");
+      else togglePanel(navRef.current);
+    };
     window.addEventListener("keydown", handler);
     window.addEventListener("keydown", bottomToggle);
     window.addEventListener("cave:toggle-right-panel", onToggleRight);
+    window.addEventListener("cave:toggle-left-panel", onToggleLeft);
     return () => {
       window.removeEventListener("keydown", handler);
       window.removeEventListener("keydown", bottomToggle);
       window.removeEventListener("cave:toggle-right-panel", onToggleRight);
+      window.removeEventListener("cave:toggle-left-panel", onToggleLeft);
     };
   }, [twoPane, hasFamiliar, hasBottom, isMobile, panelShortcuts]);
 


### PR DESCRIPTION
## What

On the Code surface, collapsing the left nav panel left a 56px rail that just **clipped the sidebar to a bare icon**. This gives it a proper collapsed state matching the pattern used elsewhere (the comux **Details / Preview** rails): a vertical **"Sessions"** label that reopens the panel on click.

| Before | After |
|---|---|
| Collapsed rail = clipped sidebar showing a bare toggle glyph | Collapsed rail = `▢` icon + vertical **"Sessions"** label, clickable to reopen |

## How
- **`code-sidebar.tsx`** — wraps the sidebar content in `.code-sidebar__full` and adds a `.code-sidebar__rail` button (icon + vertical "Sessions" label) that dispatches a new `cave:toggle-left-panel` event.
- **`shell.tsx`** — listens for `cave:toggle-left-panel` (a symmetric mirror of the existing `cave:toggle-right-panel`) and toggles the nav panel via its ref — no prop threading.
- **`globals.css`** — hides the full sidebar and shows the rotated label only under the shell's `.shell-nav--rail` collapsed class. Hover-peek still shows full content (it drops that class and floats a 232px overlay), so peek is unaffected.

It reuses the live `writing-mode: vertical-rl` rail-label convention already used by the comux Details/Preview rails.

## Files
- `src/components/code-sidebar.tsx`
- `src/components/shell.tsx`
- `src/app/globals.css`
- `src/components/code-view.test.ts` — assertions for the rail, the toggle event, the shell listener, and the CSS

## Verification
- `code-view.test.ts` passes; `pnpm build` green.
- Drove the app: navigated to Code, collapsed the nav → rail renders the vertical **"Sessions"** label (full sidebar hidden); clicking the rail reopened the panel (full round-trip confirmed). Expanded sidebar unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)