### PR TITLE
Lock in Code-surface thread filtering by selected familiar

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -318,6 +318,7 @@ export const SUITES = {
     "src/components/board-table-familiar-select.test.ts",
     "src/components/board-table-keyboard.test.ts",
     "src/components/board-view-familiar-scope.test.ts",
+    "src/components/code-surface-familiar-scope.test.ts",
     "src/components/browser-pane-default-tabs.test.ts",
     "src/components/browser-pane-hooks.test.ts",
     "src/components/browser-pane-save.test.ts",

--- a/src/components/code-surface-familiar-scope.test.ts
+++ b/src/components/code-surface-familiar-scope.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Locks the guarantee that the Code surface's thread list is filtered by the
+// selected familiar. The Code page (mode "code") renders a `ChatSurface
+// surface="code"` whose thread rail + list come from `filterVisibleChatSessions`
+// keyed off the active familiar. This is a multi-component prop chain, so this
+// test pins each load-bearing seam — a regression at any one of them would let
+// another familiar's threads leak into the Code page. Mirrors the idiom in
+// board-view-familiar-scope.test.ts. (`filterVisibleChatSessions` itself is
+// behaviorally tested in chat-projects.test.ts.)
+
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const chatRouter = await readFile(new URL("./chat-router.tsx", import.meta.url), "utf8");
+const chatList = await readFile(new URL("./chat-list.tsx", import.meta.url), "utf8");
+
+// 1. Workspace feeds the *selected* familiar into the Code surface's chat pane.
+//    `active` is the single-selected familiar (null for All / multiselect).
+assert.match(
+  workspace,
+  /surface="code"[\s\S]*?activeFamiliar=\{active\}/,
+  "workspace must pass the active (selected) familiar into the Code surface ChatSurface",
+);
+
+// 2. ChatSurface forwards that familiar (and the sessions) into ChatRouter on the
+//    Code surface (compact) path — without the familiar prop the list can't scope.
+assert.match(
+  chatSurface,
+  /<ChatRouter[\s\S]*?familiar=\{activeFamiliar\}[\s\S]*?sessions=\{sessions\}[\s\S]*?compact=\{isCodeSurface\}/,
+  "ChatSurface must forward activeFamiliar + sessions into ChatRouter (compact on the Code surface)",
+);
+
+// 3. ChatRouter scopes the sidebar/thread list to the familiar (null = show all,
+//    the deliberate escape hatch for the All-familiars scope).
+assert.match(
+  chatRouter,
+  /filterVisibleChatSessions\(sessions, familiar\?\.id \?\? null\)/,
+  "ChatRouter must derive the thread rail via filterVisibleChatSessions keyed on the familiar",
+);
+
+// 4. ChatList (the rendered thread list) re-applies the same familiar scope, so
+//    even a directly-mounted list can't show another familiar's threads.
+assert.match(
+  chatList,
+  /return filterVisibleChatSessions\(rows, familiar\?\.id \?\? null\);/,
+  "ChatList must filter its visible rows by the familiar",
+);
+
+console.log("code-surface-familiar-scope.test.ts: ok");


### PR DESCRIPTION
## Context

Asked to ensure the Code page's threads are filtered by the selected familiar. **Investigation found this already works for the common case** — when a single familiar is selected, the Code page (mode `code`) filters its thread list to that familiar at three layers:

1. **Server fetch** — `workspace.tsx` scopes `/api/sessions/list?familiarId=…` to the active familiar.
2. **Router** — `ChatRouter` derives the rail via `filterVisibleChatSessions(sessions, familiar?.id ?? null)`.
3. **List** — `ChatList` re-applies the same `filterVisibleChatSessions(rows, familiar?.id ?? null)`.

The selected familiar flows in as `activeFamiliar={active}` on the `surface="code"` `ChatSurface`. When **no single familiar is selected** ("All familiars" / multiselect), `familiar?.id` is `null` and the list intentionally shows everything — that escape-hatch behavior is being kept as-is (per product decision).

## What this PR does

No behavior change. The filtering guarantee spans four components, so a regression at any seam (a dropped `familiar` prop, an unfiltered list) could silently leak another familiar's threads into the Code page while still building green. This adds a **source-text regression test** (`code-surface-familiar-scope.test.ts`) pinning each load-bearing seam:

- `workspace.tsx` passes `activeFamiliar={active}` into the `surface="code"` ChatSurface
- `ChatSurface` forwards `familiar={activeFamiliar}` + `sessions` into `ChatRouter` (compact path)
- `ChatRouter` and `ChatList` both scope via `filterVisibleChatSessions(…, familiar?.id ?? null)`

Mirrors the existing `board-view-familiar-scope.test.ts` idiom. The filter helper itself is already behaviorally tested in `chat-projects.test.ts`. Wired into the `app` suite.

> If you're seeing unfiltered threads with **exactly one** familiar selected, that would be a real leak not covered by the static trace — tell me the repro and I'll hunt it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)