### PR TITLE
feat(home): Chat/Task as a mode strip above the composer

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -195,8 +195,8 @@ assert.match(
 
 assert.match(
   css,
-  /\.hc-control-group--who\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--intent\s*\{[\s\S]*?flex: 1 1 auto;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?flex: 0 1 auto;/,
-  "HomeComposer action bar should keep side clusters content-sized while the intent group absorbs slack",
+  /\.hc-control-group--who\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?margin-left: auto;/,
+  "HomeComposer action bar should keep the who cluster content-sized and pin the run cluster to the right edge",
 );
 
 assert.match(
@@ -313,6 +313,27 @@ assert.match(
   source,
   /const nav = \["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"\];/,
   "The radiogroup supports arrow/Home/End keyboard selection per the ARIA radio pattern",
+);
+
+// ── Chat/Task lead the card as a mode strip above the textarea ───────────────
+assert.match(
+  source,
+  /hc-mode-strip[\s\S]*?className="hc-dest-pills"[\s\S]*?className="hc-textarea"/,
+  "The Chat/Task switch renders in a mode strip above the textarea, not in the action bar",
+);
+assert.match(
+  css,
+  /\.hc-mode-strip\s*\{/,
+  "HomeComposer CSS should define the mode strip that seats the Chat/Task switch atop the card",
+);
+
+// ── Chat-only send config collapses when Task is the destination ─────────────
+// Runtime/model, Think, and Speed configure a chat send and are meaningless for
+// creating a board task, so they render only while the Chat mode is selected.
+assert.match(
+  source,
+  /destination === "chat" \? \(\s*<>[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/>\s*\) : null/,
+  "Runtime/model, Think, and Speed controls collapse out of the action bar when Task is selected",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -694,6 +694,35 @@ export function HomeComposer({
 
         <div className="home-composer-card">
 
+        {/* Mode strip — the composer's primary intent switch (Chat vs Task)
+            leads the card, above the textarea, so it reads as the top-level
+            mode rather than one control buried among the per-send config. */}
+        <div className="hc-mode-strip">
+          <div
+            className="hc-dest-pills"
+            role="radiogroup"
+            aria-label="Send to"
+            ref={destGroupRef}
+            onKeyDown={handleDestKeyDown}
+          >
+            {DESTINATIONS.map((d) => (
+              <button
+                key={d.id}
+                type="button"
+                role="radio"
+                aria-checked={destination === d.id}
+                tabIndex={destination === d.id ? 0 : -1}
+                className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
+                onClick={() => setDestination(d.id)}
+                title={d.label}
+              >
+                <Icon name={d.icon} width={12} aria-hidden />
+                <span className="hc-dest-label">{d.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
         {/* Textarea */}
         <textarea
           ref={textareaRef}
@@ -780,78 +809,59 @@ export function HomeComposer({
             </label>
           </div>
 
-          <div className="hc-control-group hc-control-group--intent">
-            <div
-              className="hc-dest-pills"
-              role="radiogroup"
-              aria-label="Send to"
-              ref={destGroupRef}
-              onKeyDown={handleDestKeyDown}
-            >
-              {DESTINATIONS.map((d) => (
-                <button
-                  key={d.id}
-                  type="button"
-                  role="radio"
-                  aria-checked={destination === d.id}
-                  tabIndex={destination === d.id ? 0 : -1}
-                  className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-                  onClick={() => setDestination(d.id)}
-                  title={d.label}
-                >
-                  <Icon name={d.icon} width={12} aria-hidden />
-                  <span className="hc-dest-label">{d.label}</span>
-                </button>
-              ))}
-            </div>
-          </div>
-
           <div className="hc-control-group hc-control-group--run">
-            <label className="hc-familiar-selector hc-runtime-model-selector">
-              <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
-              <select
-                aria-label="Choose runtime and model"
-                className="hc-familiar-select"
-                value={selectedRuntimeModelValue}
-                onChange={(e) => handleSelectRuntimeModel(e.currentTarget.value)}
-                disabled={!selectedFamiliarId || sending}
-              >
-                {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
-                  <optgroup key={adapter.id} label={adapter.label}>
-                    {runtimeModelOptionsFor(adapter.id).length === 0 ? (
-                      <option value={runtimeModelValue(adapter.id, "")}>
-                        Runtime managed
-                      </option>
-                    ) : (
-                      runtimeModelOptionsFor(adapter.id).map((model) => (
-                        <option key={model.id} value={runtimeModelValue(adapter.id, model.id)}>
-                          {model.label}
-                        </option>
-                      ))
-                    )}
-                  </optgroup>
-                ))}
-              </select>
-              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-            </label>
+            {/* Runtime/model, Think, and Speed configure a chat send — they're
+                meaningless for creating a board task, so they collapse out when
+                the Task mode is selected, leaving just the submit affordance. */}
+            {destination === "chat" ? (
+              <>
+                <label className="hc-familiar-selector hc-runtime-model-selector">
+                  <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
+                  <select
+                    aria-label="Choose runtime and model"
+                    className="hc-familiar-select"
+                    value={selectedRuntimeModelValue}
+                    onChange={(e) => handleSelectRuntimeModel(e.currentTarget.value)}
+                    disabled={!selectedFamiliarId || sending}
+                  >
+                    {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
+                      <optgroup key={adapter.id} label={adapter.label}>
+                        {runtimeModelOptionsFor(adapter.id).length === 0 ? (
+                          <option value={runtimeModelValue(adapter.id, "")}>
+                            Runtime managed
+                          </option>
+                        ) : (
+                          runtimeModelOptionsFor(adapter.id).map((model) => (
+                            <option key={model.id} value={runtimeModelValue(adapter.id, model.id)}>
+                              {model.label}
+                            </option>
+                          ))
+                        )}
+                      </optgroup>
+                    ))}
+                  </select>
+                  <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+                </label>
 
-            {renderCompactSelect(
-              "Think",
-              "ph:sparkle-bold",
-              thinkingEffort,
-              (value) => setThinkingEffort(value as CommandThinkingEffort),
-              COMMAND_THINKING_OPTIONS,
-              "Choose thinking effort",
-            )}
+                {renderCompactSelect(
+                  "Think",
+                  "ph:sparkle-bold",
+                  thinkingEffort,
+                  (value) => setThinkingEffort(value as CommandThinkingEffort),
+                  COMMAND_THINKING_OPTIONS,
+                  "Choose thinking effort",
+                )}
 
-            {renderCompactSelect(
-              "Speed",
-              "ph:lightning-bold",
-              responseSpeed,
-              (value) => setResponseSpeed(value as CommandResponseSpeed),
-              COMMAND_RESPONSE_SPEED_OPTIONS,
-              "Choose response speed",
-            )}
+                {renderCompactSelect(
+                  "Speed",
+                  "ph:lightning-bold",
+                  responseSpeed,
+                  (value) => setResponseSpeed(value as CommandResponseSpeed),
+                  COMMAND_RESPONSE_SPEED_OPTIONS,
+                  "Choose response speed",
+                )}
+              </>
+            ) : null}
 
             <button
               type="button"

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -139,11 +139,11 @@
 }
 
 /* ── Action bar ──────────────────────────────────────────────────────────────
- *   One balanced row: a compact "who" cluster anchored left, the intent pills
- *   centered, and the "run" config cluster anchored right. Only the centre
- *   group grows to absorb slack, so the side clusters stay tight to the edges
- *   instead of stretching open big interior gaps. The larger column gap (vs the
- *   intra-group gap) reads the three clusters as distinct without a divider. */
+ *   One balanced row: a compact "who" cluster anchored left and the "run"
+ *   config cluster anchored right (pushed there with margin-left:auto). The
+ *   intent switch (Chat/Task) no longer lives here — it leads the card as a
+ *   mode strip above the textarea — so the bar reads as pure send config. The
+ *   larger column gap (vs the intra-group gap) keeps the clusters distinct. */
 .hc-action-bar {
   display: flex;
   align-items: center;
@@ -167,13 +167,7 @@
   flex: 0 1 auto;
 }
 
-/* The intent group is the only one that grows; it absorbs all the slack and
- * centres the destination pills between the two side clusters. */
-.hc-control-group--intent {
-  flex: 1 1 auto;
-  justify-content: center;
-}
-
+/* The run cluster is content-sized and pinned to the right edge. */
 .hc-control-group--run {
   flex: 0 1 auto;
   justify-content: flex-end;
@@ -304,23 +298,37 @@
   flex-shrink: 0;
 }
 
-/* ── Destination pills ───────────────────────────────────────────────────── */
-.hc-dest-pills {
+/* ── Mode strip (Chat / Task) ──────────────────────────────────────────────────
+ *   The composer's primary intent switch, seated at the top of the card above
+ *   the textarea. A compact segmented control so the Chat-vs-Task choice reads
+ *   as the top-level mode, distinct from the per-send config in the action bar. */
+.hc-mode-strip {
   display: flex;
-  gap: 4px;
+  align-items: center;
+  padding: 12px 14px 2px;
+}
+
+/* Destination pills — a segmented toggle inside the mode strip. */
+.hc-dest-pills {
+  display: inline-flex;
+  gap: 2px;
   flex: 0 0 auto;
   min-width: 0;
+  padding: 3px;
+  border-radius: 11px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
 }
 
 .hc-dest-pill {
   display: flex;
   align-items: center;
-  gap: 4px;
-  min-height: 30px;
+  gap: 5px;
+  min-height: 28px;
   box-sizing: border-box;
-  font-size: 11px;
-  font-weight: 450;
-  padding: 3px 11px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 14px;
   border-radius: 8px;
   border: 1px solid transparent;
   background: transparent;
@@ -331,16 +339,16 @@
 }
 
 .hc-dest-pill:hover {
-  background: var(--bg-base);
+  background: var(--bg-raised);
   color: var(--text-secondary);
-  border-color: var(--border-hairline);
 }
 
 .hc-dest-pill.active {
-  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
-  border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, transparent);
   color: var(--text-primary);
-  font-weight: 500;
+  font-weight: 600;
+  box-shadow: 0 1px 2px color-mix(in oklch, var(--text-primary) 8%, transparent);
 }
 
 @media (max-width: 520px) {
@@ -422,10 +430,6 @@
   .hc-control-group--run {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
-  }
-
-  .hc-control-group--intent {
-    order: 3;
   }
 
   .hc-control-group--run {


### PR DESCRIPTION
## What

The home composer's **Chat vs Task** destination toggle was buried in the middle of a crowded action bar, equal-weight with the per-send config (runtime/model, Think, Speed) — even though it's the composer's *primary intent switch* (it changes the placeholder and what submit does).

This lifts it into a **segmented mode strip directly above the textarea**, and collapses the chat-only config when **Task** is selected.

## Changes
- **Move:** the destination radiogroup leaves the action bar's `--intent` group and renders as a mode strip atop the card (`.hc-mode-strip`). Same `role="radiogroup"`/`radio` markup + arrow-key handler — a11y/keyboard nav unchanged.
- **Collapse on Task:** runtime/model, Think, and Speed configure a *chat* send and are meaningless for creating a board card, so they render only while Chat is selected. The bar simplifies to `[+][Familiar▾][Project▾] … [↑]`.
- **Bar cleanup:** drop the now-empty `--intent` group (two clusters: who-left, run-right). Restyle `.hc-dest-pills` as a lifted segmented control. Mobile keeps the full-width 2-up toggle.
- **Tests:** updated `home-composer*` source-text tests for the new placement, the Task-collapse behavior, and the two-cluster bar.

## Verification
- `pnpm typecheck` — clean
- `home-composer`, `-polish`, `-centering`, `-mobile-gaps` tests — all pass
- `pnpm build` — succeeds
- Visual check (web build): **Chat** shows the mode strip + full config; **Task** collapses runtime/model/Think/Speed and swaps the placeholder; **mobile** renders a full-width 2-up segmented toggle with thumb-sized controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)