### PR TITLE
style(home): make the active Chat/Task tab more prominent

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -344,11 +344,19 @@
 }
 
 .hc-dest-pill.active {
-  background: color-mix(in oklch, var(--accent-presence) 18%, var(--bg-raised));
-  border-color: color-mix(in oklch, var(--accent-presence) 45%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 32%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 80%, transparent);
   color: var(--text-primary);
   font-weight: 600;
-  box-shadow: 0 1px 2px color-mix(in oklch, var(--text-primary) 8%, transparent);
+  box-shadow:
+    0 2px 8px color-mix(in oklch, var(--accent-presence) 32%, transparent),
+    inset 0 1px 0 color-mix(in oklch, var(--foreground) 10%, transparent);
+}
+
+/* The active tab's icon picks up the accent so the selected mode reads at a
+ * glance, while the label stays high-contrast for legibility. */
+.hc-dest-pill.active svg {
+  color: var(--accent-presence);
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
Follow-up to #2159. The active mode tab read a bit subtle. This bumps its prominence:

- Stronger accent fill (18% → 32% over `--bg-raised`).
- Border becomes a clear accent ring (45% → 80% accent).
- Adds an accent glow (`0 2px 8px` accent) + a subtle inset top highlight.
- Tints the active tab's icon with the accent; the label stays high-contrast.

CSS-only (`src/styles/home-composer.css`). Verified in the web build — the selected Chat/Task tab now stands out clearly against the recessed segmented track in both states. `pnpm build` succeeds; no test pins the active-tab colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)