### PR TITLE
feat(chat): comment on a markdown artifact + request an agent revision

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -105,6 +105,8 @@ export const SUITES = {
     "src/lib/agent-completion-report.test.ts",
     "src/lib/chat-reply.test.ts",
     "src/components/chat-reply-wiring.test.ts",
+    "src/lib/artifact-comments.test.ts",
+    "src/components/artifact-comments.test.ts",
     "src/lib/reminder-draft.test.ts",
     "src/lib/daily-report.test.ts",
     "src/lib/daily-note.test.ts",

--- a/src/components/artifact-comments.test.ts
+++ b/src/components/artifact-comments.test.ts
@@ -1,0 +1,54 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const comp = await readFile(new URL("./artifact-comments.tsx", import.meta.url), "utf8");
+const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/artifact-comments.css", import.meta.url), "utf8");
+
+// ── ArtifactComments: select-to-comment + request revision ───────────────────
+assert.match(comp, /export function ArtifactComments\(/, "exports the ArtifactComments component");
+// Selection is scoped to THIS turn's rendered markdown, not the whole document.
+assert.match(
+  comp,
+  /\[data-turn-id="\$\{CSS\.escape\(turnId\)\}"\] \.cave-artifact-content/,
+  "scopes text selection to the turn's rendered markdown content",
+);
+assert.match(comp, /document\.addEventListener\("mouseup", onMouseUp\)/, "detects selection on mouseup");
+assert.match(comp, /window\.getSelection\(\)/, "reads the live text selection");
+assert.match(comp, /className="cave-artifact-comment-fab"/, "shows a floating Comment affordance on selection");
+// The comments are folded into a prompt and sent via the chat send path.
+assert.match(comp, /buildCommentsPrompt\(comments/, "builds the revision prompt from the collected comments");
+assert.match(comp, /onRequest\(prompt\)/, "submits the synthesized prompt to the agent");
+assert.match(comp, /Request \{familiarName\}/, "labels the action with the familiar's name");
+// Per-turn persistence so a reload doesn't drop in-progress comments.
+assert.match(comp, /readComments\(turnId\)/, "initialises comments from per-turn storage");
+assert.match(comp, /writeComments\(turnId, comments\)/, "persists comments per turn");
+// Note editing + removal.
+assert.match(comp, /aria-label="Comment note"/, "each comment has an editable note field");
+assert.match(comp, /aria-label="Remove comment"/, "each comment can be removed");
+
+// ── chat-view wiring ─────────────────────────────────────────────────────────
+assert.match(chatView, /import \{ ArtifactComments \}/, "chat-view imports ArtifactComments");
+assert.match(
+  chatView,
+  /<div className="cave-artifact-content">\s*<MessageBubble/,
+  "the assistant bubble is wrapped so selection can be scoped to its markdown",
+);
+assert.match(
+  chatView,
+  /!turn\.pending && !turn\.error && visible\.trim\(\)\.length > 80 \? \(\s*<ArtifactComments/,
+  "ArtifactComments mounts only on settled, substantial assistant turns",
+);
+assert.match(
+  chatView,
+  /<ArtifactComments[\s\S]*?turnId=\{turn\.id\}[\s\S]*?onRequest=\{\(prompt\) => onSuggestion\?\.\(prompt\)\}/,
+  "the revision request is sent through the existing onSuggestion→send path",
+);
+
+// ── CSS present for the affordance + panel ───────────────────────────────────
+assert.match(css, /\.cave-artifact-comment-fab \{[\s\S]*?position: fixed/, "the floating Comment button is styled");
+assert.match(css, /\.cave-artifact-comments \{/, "the comments panel is styled");
+assert.match(css, /\.cave-artifact-comments__send \{/, "the request-revision button is styled");
+
+console.log("artifact-comments.test.ts: ok");

--- a/src/components/artifact-comments.tsx
+++ b/src/components/artifact-comments.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+/**
+ * ArtifactComments — lets a user annotate a markdown artifact an agent produced
+ * in chat (select any passage → leave a comment), then request a revision that
+ * sends every comment back to the agent as a single follow-up prompt.
+ *
+ * Selection is scoped to the turn's rendered markdown
+ * (`[data-turn-id="…"] .cave-artifact-content`); comments are held client-side
+ * (persisted per-turn to localStorage) and folded into the prompt on request —
+ * Cave only persists prompt text, never client turn metadata.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  buildCommentsPrompt,
+  normalizeExcerpt,
+  readComments,
+  writeComments,
+  type ArtifactComment,
+} from "@/lib/artifact-comments";
+import "@/styles/artifact-comments.css";
+
+type FloatingSel = { text: string; x: number; y: number };
+
+function newId(): string {
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `c_${Date.now().toString(36)}_${Math.floor(Math.random() * 1e6).toString(36)}`;
+  }
+}
+
+export function ArtifactComments({
+  turnId,
+  familiarName,
+  onRequest,
+}: {
+  turnId: string;
+  familiarName: string;
+  /** Submit the synthesized revision prompt to the agent (wired to chat send). */
+  onRequest: (prompt: string) => void;
+}) {
+  const [comments, setComments] = useState<ArtifactComment[]>(() => readComments(turnId));
+  const [sel, setSel] = useState<FloatingSel | null>(null);
+  const [requested, setRequested] = useState(false);
+  const focusIdRef = useRef<string | null>(null);
+  const noteRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map());
+
+  // Persist per-turn so an accidental reload doesn't drop in-progress comments.
+  useEffect(() => {
+    writeComments(turnId, comments);
+  }, [turnId, comments]);
+
+  // Detect a text selection inside THIS turn's rendered markdown and surface a
+  // floating "Comment" affordance anchored to it.
+  useEffect(() => {
+    const content = () =>
+      document.querySelector<HTMLElement>(`[data-turn-id="${CSS.escape(turnId)}"] .cave-artifact-content`);
+    const within = (node: Node | null, root: HTMLElement | null) =>
+      !!node && !!root && root.contains(node.nodeType === Node.TEXT_NODE ? node.parentNode : node);
+
+    const onMouseUp = () => {
+      // Defer so the selection has settled after the mouseup.
+      window.setTimeout(() => {
+        const root = content();
+        const selection = window.getSelection();
+        if (!root || !selection || selection.isCollapsed || selection.rangeCount === 0) {
+          setSel(null);
+          return;
+        }
+        const text = selection.toString().trim();
+        if (text.length < 3 || !within(selection.anchorNode, root) || !within(selection.focusNode, root)) {
+          setSel(null);
+          return;
+        }
+        const rect = selection.getRangeAt(0).getBoundingClientRect();
+        setSel({ text, x: rect.left + rect.width / 2, y: rect.top });
+      }, 0);
+    };
+    const onSelectionChange = () => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) setSel(null);
+    };
+    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("selectionchange", onSelectionChange);
+    return () => {
+      document.removeEventListener("mouseup", onMouseUp);
+      document.removeEventListener("selectionchange", onSelectionChange);
+    };
+  }, [turnId]);
+
+  // Focus the note field of a freshly added comment.
+  useEffect(() => {
+    if (!focusIdRef.current) return;
+    noteRefs.current.get(focusIdRef.current)?.focus();
+    focusIdRef.current = null;
+  }, [comments]);
+
+  const addFromSelection = useCallback(() => {
+    if (!sel) return;
+    const id = newId();
+    focusIdRef.current = id;
+    setComments((prev) => [...prev, { id, excerpt: normalizeExcerpt(sel.text), note: "" }]);
+    setRequested(false);
+    setSel(null);
+    window.getSelection()?.removeAllRanges();
+  }, [sel]);
+
+  const setNote = useCallback((id: string, note: string) => {
+    setComments((prev) => prev.map((c) => (c.id === id ? { ...c, note } : c)));
+  }, []);
+
+  const removeComment = useCallback((id: string) => {
+    noteRefs.current.delete(id);
+    setComments((prev) => prev.filter((c) => c.id !== id));
+  }, []);
+
+  const requestRevision = useCallback(() => {
+    const prompt = buildCommentsPrompt(comments, { documentLabel: "the document you produced above" });
+    if (!prompt) return;
+    onRequest(prompt);
+    setComments([]);
+    setRequested(true);
+  }, [comments, onRequest]);
+
+  return (
+    <>
+      {sel ? (
+        <button
+          type="button"
+          className="cave-artifact-comment-fab"
+          style={{ left: `${sel.x}px`, top: `${Math.max(8, sel.y - 42)}px` }}
+          // Use mouseDown so the click lands before the selection clears.
+          onMouseDown={(e) => {
+            e.preventDefault();
+            addFromSelection();
+          }}
+          aria-label="Comment on selection"
+        >
+          <Icon name="ph:chat-teardrop" width={13} aria-hidden />
+          Comment
+        </button>
+      ) : null}
+
+      {comments.length > 0 ? (
+        <div className="cave-artifact-comments" role="group" aria-label="Comments on this document">
+          <div className="cave-artifact-comments__head">
+            <Icon name="ph:chat-teardrop" width={13} aria-hidden />
+            <span>
+              {comments.length} comment{comments.length === 1 ? "" : "s"}
+            </span>
+            <span className="cave-artifact-comments__hint">select text above to add more</span>
+          </div>
+          <ul className="cave-artifact-comments__list">
+            {comments.map((c) => (
+              <li key={c.id} className="cave-artifact-comment">
+                <blockquote className="cave-artifact-comment__excerpt" title={c.excerpt}>
+                  {c.excerpt}
+                </blockquote>
+                <div className="cave-artifact-comment__row">
+                  <textarea
+                    ref={(el) => {
+                      if (el) noteRefs.current.set(c.id, el);
+                      else noteRefs.current.delete(c.id);
+                    }}
+                    className="cave-artifact-comment__note"
+                    value={c.note}
+                    onChange={(e) => setNote(c.id, e.target.value)}
+                    placeholder="Add a note (what should change?)…"
+                    aria-label="Comment note"
+                    rows={1}
+                  />
+                  <button
+                    type="button"
+                    className="cave-artifact-comment__remove"
+                    onClick={() => removeComment(c.id)}
+                    aria-label="Remove comment"
+                    title="Remove comment"
+                  >
+                    <Icon name="ph:x" width={11} aria-hidden />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <div className="cave-artifact-comments__foot">
+            <button
+              type="button"
+              className="cave-artifact-comments__send"
+              onClick={requestRevision}
+              aria-label={`Send comments to ${familiarName} and request a revision`}
+            >
+              <Icon name="ph:arrow-bend-up-left" width={13} aria-hidden />
+              Request {familiarName}&rsquo;s revision
+            </button>
+          </div>
+        </div>
+      ) : requested ? (
+        <div className="cave-artifact-comments__sent" role="status">
+          <Icon name="ph:chat-circle-dots" width={12} aria-hidden />
+          Sent your comments to {familiarName}.
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -23,6 +23,7 @@ import { useFamiliarOverrides } from "@/lib/cave-familiar-overrides";
 import { resolveFamiliar } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarInlineCard } from "@/components/familiar-inline-card";
+import { ArtifactComments } from "@/components/artifact-comments";
 import { ChatArchiveNudge } from "@/components/chat-archive-nudge";
 import {
   isChatArchiveNudgeDismissed,
@@ -5221,23 +5222,27 @@ function TurnRowImpl({
             {indicatorVisible ? (
               <ThinkingIndicator label="Thinking" startedAt={turn.createdAt ? new Date(turn.createdAt).getTime() : undefined} />
             ) : (
-              <MessageBubble
-                role="assistant"
-                content={visible || (turn.pending ? "…" : "")}
-                timestamp={turn.createdAt}
-                showTimestamp={false}
-                pending={turn.pending}
-                isError={turn.error}
-                label={familiar.display_name}
-                onRegenerate={onRegenerate}
-                onReply={onReply}
-                onOpenUrl={onOpenUrl}
-                // CHAT-D13-01: with tools hidden, fall back to plain content —
-                // the text segments concatenate to `visible` anyway, so prose
-                // renders identically with the tool blocks omitted.
-                segments={renderSegments}
-                branchNav={branchNav}
-              />
+              // `cave-artifact-content` scopes the comment-on-artifact text
+              // selection to this turn's rendered markdown (see ArtifactComments).
+              <div className="cave-artifact-content">
+                <MessageBubble
+                  role="assistant"
+                  content={visible || (turn.pending ? "…" : "")}
+                  timestamp={turn.createdAt}
+                  showTimestamp={false}
+                  pending={turn.pending}
+                  isError={turn.error}
+                  label={familiar.display_name}
+                  onRegenerate={onRegenerate}
+                  onReply={onReply}
+                  onOpenUrl={onOpenUrl}
+                  // CHAT-D13-01: with tools hidden, fall back to plain content —
+                  // the text segments concatenate to `visible` anyway, so prose
+                  // renders identically with the tool blocks omitted.
+                  segments={renderSegments}
+                  branchNav={branchNav}
+                />
+              </div>
             )}
             {/* CHAT-D4-01: tools often run BEFORE the first prose chunk
                 (research-style turns) — show them inline immediately so
@@ -5283,6 +5288,17 @@ function TurnRowImpl({
                   );
                 })}
               </div>
+            ) : null}
+            {/* Comment on the markdown artifact this turn produced: select any
+                passage above to leave a comment, then request a revision that
+                sends every comment back to the agent. Settled, substantial
+                assistant turns only (skip tiny replies and errors). */}
+            {!turn.pending && !turn.error && visible.trim().length > 80 ? (
+              <ArtifactComments
+                turnId={turn.id}
+                familiarName={familiar.display_name}
+                onRequest={(prompt) => onSuggestion?.(prompt)}
+              />
             ) : null}
           </div>
         </div>

--- a/src/lib/artifact-comments.test.ts
+++ b/src/lib/artifact-comments.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { buildCommentsPrompt, normalizeExcerpt, commentsStorageKey } from "./artifact-comments.ts";
+
+// ── normalizeExcerpt collapses whitespace and clamps long selections ─────────
+assert.equal(normalizeExcerpt("  hello   world\n\nfoo "), "hello world foo");
+const long = "x".repeat(400);
+const norm = normalizeExcerpt(long);
+assert.ok(norm.length <= 281, "long excerpts are clamped");
+assert.ok(norm.endsWith("…"), "clamped excerpts get an ellipsis");
+
+// ── buildCommentsPrompt folds comments into a revision request ───────────────
+const empty = buildCommentsPrompt([]);
+assert.equal(empty, "", "no comments → empty prompt (callers guard the send)");
+
+const blankOnly = buildCommentsPrompt([{ id: "1", excerpt: "  ", note: "  " }]);
+assert.equal(blankOnly, "", "comments with no excerpt and no note are dropped");
+
+const prompt = buildCommentsPrompt([
+  { id: "1", excerpt: "The intro paragraph", note: "Too long — tighten it" },
+  { id: "2", excerpt: "section two", note: "" },
+]);
+assert.match(prompt, /2 comments/, "counts the comments");
+assert.match(prompt, /revise it to address each one/, "asks for a revision addressing each");
+assert.match(prompt, /summarize the changes/, "asks for a change summary on completion");
+assert.match(prompt, /1\. On: “The intro paragraph”/, "quotes the first excerpt");
+assert.match(prompt, /Comment: Too long — tighten it/, "includes the note");
+assert.match(prompt, /2\. On: “section two”/, "quotes the second excerpt");
+assert.match(prompt, /Comment: \(please reconsider this passage\)/, "a note-less comment still flags the passage");
+
+const one = buildCommentsPrompt([{ id: "1", excerpt: "a", note: "b" }]);
+assert.match(one, /1 comment\b/, "singular for a single comment");
+
+// custom document label
+const labeled = buildCommentsPrompt([{ id: "1", excerpt: "a", note: "b" }], { documentLabel: "the spec" });
+assert.match(labeled, /on the spec\./, "honours a custom document label");
+
+// ── storage key is namespaced per turn ───────────────────────────────────────
+assert.equal(commentsStorageKey("t_123"), "cave:artifact-comments:v1:t_123");
+
+console.log("artifact-comments.test.ts: ok");

--- a/src/lib/artifact-comments.ts
+++ b/src/lib/artifact-comments.ts
@@ -1,0 +1,85 @@
+/**
+ * Comments on a markdown artifact an agent produced in chat.
+ *
+ * Cave persists transcripts server-side from the prompt text sent to
+ * /api/chat/send — client turn objects are never written back (see
+ * `chat-reply.ts`). So a comment can't live as turn metadata; instead the
+ * "request a revision" action folds the collected comments into a normal
+ * follow-up prompt (mirrors `buildQuotedPrompt`). Until sent, comments are held
+ * client-side and persisted to localStorage keyed by the turn id so an
+ * accidental reload doesn't drop in-progress annotations.
+ */
+
+export type ArtifactComment = {
+  id: string;
+  /** The exact excerpt the user selected within the rendered markdown. */
+  excerpt: string;
+  /** The user's note about that excerpt (may be empty — a bare flag). */
+  note: string;
+};
+
+const STORAGE_PREFIX = "cave:artifact-comments:v1:";
+// Keep excerpts readable in the synthesized prompt; a selection can be long.
+const MAX_EXCERPT = 280;
+
+export function commentsStorageKey(turnId: string): string {
+  return `${STORAGE_PREFIX}${turnId}`;
+}
+
+/** Collapse whitespace and clamp a selected excerpt to a quotable length. */
+export function normalizeExcerpt(raw: string): string {
+  const collapsed = raw.replace(/\s+/g, " ").trim();
+  return collapsed.length > MAX_EXCERPT ? `${collapsed.slice(0, MAX_EXCERPT).trimEnd()}…` : collapsed;
+}
+
+/**
+ * Build the follow-up prompt that asks the agent to revise the document it
+ * produced, addressing each comment. Returns "" when there are no usable
+ * comments so callers can guard the send.
+ */
+export function buildCommentsPrompt(
+  comments: ArtifactComment[],
+  opts?: { documentLabel?: string },
+): string {
+  const usable = comments.filter((c) => c.excerpt.trim() || c.note.trim());
+  if (usable.length === 0) return "";
+  const label = opts?.documentLabel?.trim() || "the document you produced above";
+  const lines: string[] = [
+    `I've left ${usable.length} comment${usable.length === 1 ? "" : "s"} on ${label}. Please revise it to address each one, then briefly summarize the changes you made.`,
+    "",
+  ];
+  usable.forEach((c, i) => {
+    const excerpt = normalizeExcerpt(c.excerpt);
+    lines.push(`${i + 1}. On: “${excerpt}”`);
+    const note = c.note.trim();
+    lines.push(`   Comment: ${note || "(please reconsider this passage)"}`);
+    lines.push("");
+  });
+  return lines.join("\n").trimEnd();
+}
+
+export function readComments(turnId: string): ArtifactComment[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(commentsStorageKey(turnId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (c): c is ArtifactComment =>
+        c && typeof c.id === "string" && typeof c.excerpt === "string" && typeof c.note === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function writeComments(turnId: string, comments: ArtifactComment[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (comments.length === 0) window.localStorage.removeItem(commentsStorageKey(turnId));
+    else window.localStorage.setItem(commentsStorageKey(turnId), JSON.stringify(comments));
+  } catch {
+    /* storage may be unavailable (private mode) — comments stay in memory */
+  }
+}

--- a/src/styles/artifact-comments.css
+++ b/src/styles/artifact-comments.css
@@ -1,0 +1,163 @@
+/* Comment-on-markdown-artifact UI (see artifact-comments.tsx). */
+
+/* Floating "Comment" affordance anchored to a text selection. */
+.cave-artifact-comment-fab {
+  position: fixed;
+  z-index: 1400;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent-presence);
+  border: 0;
+  border-radius: 999px;
+  box-shadow: 0 8px 22px -8px color-mix(in oklch, var(--accent-presence) 80%, transparent),
+    0 2px 8px rgb(0 0 0 / 0.35);
+  cursor: pointer;
+  animation: cave-fab-in 0.12s ease both;
+}
+.cave-artifact-comment-fab:hover { filter: brightness(1.08); }
+.cave-artifact-comment-fab svg { color: #fff; }
+@keyframes cave-fab-in {
+  from { opacity: 0; transform: translate(-50%, 4px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+/* Collected comments panel under the turn. */
+.cave-artifact-comments {
+  margin-top: 12px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 28%, var(--border-hairline));
+  border-radius: 12px;
+  background: color-mix(in oklch, var(--accent-presence) 5%, var(--bg-raised));
+}
+.cave-artifact-comments__head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+.cave-artifact-comments__head svg { color: var(--accent-presence); }
+.cave-artifact-comments__hint {
+  margin-left: auto;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-muted);
+}
+.cave-artifact-comments__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.cave-artifact-comment {
+  padding: 8px 10px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 9px;
+  background: var(--bg-base);
+}
+.cave-artifact-comment__excerpt {
+  margin: 0 0 6px;
+  padding-left: 9px;
+  border-left: 3px solid color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  font-size: 12px;
+  font-style: italic;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.cave-artifact-comment__row { display: flex; align-items: flex-start; gap: 6px; }
+.cave-artifact-comment__note {
+  flex: 1;
+  min-width: 0;
+  min-height: 32px;
+  max-height: 160px;
+  resize: vertical;
+  padding: 6px 8px;
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-primary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.12s ease;
+}
+.cave-artifact-comment__note:focus {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline));
+}
+.cave-artifact-comment__note::placeholder { color: var(--text-muted); }
+.cave-artifact-comment__remove {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+}
+.cave-artifact-comment__remove:hover {
+  color: var(--color-danger);
+  background: color-mix(in oklch, var(--color-danger) 10%, transparent);
+  border-color: color-mix(in oklch, var(--color-danger) 30%, transparent);
+}
+.cave-artifact-comments__foot {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 9px;
+}
+.cave-artifact-comments__send {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 13px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent-presence);
+  border: 0;
+  border-radius: 9px;
+  cursor: pointer;
+  transition: filter 0.12s ease, transform 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.cave-artifact-comments__send svg { color: #fff; }
+.cave-artifact-comments__send:hover { filter: brightness(1.08); }
+.cave-artifact-comments__send:active { transform: scale(0.97); }
+
+.cave-artifact-comments__sent {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+.cave-artifact-comments__sent svg { color: var(--accent-presence); }
+
+@media (prefers-reduced-motion: reduce) {
+  .cave-artifact-comment-fab,
+  .cave-artifact-comments__send { animation: none; transition: none; }
+  .cave-artifact-comment-fab { transform: translateX(-50%); }
+}


### PR DESCRIPTION
## What

A markdown artifact an agent produces in chat (an assistant turn's rendered markdown) was read-only. This lets you **annotate it and ask the agent to revise**:

1. **Select** any passage in a settled assistant turn → a floating **"Comment"** button appears.
2. Click it → the excerpt is captured into a per-turn **comments panel** with a note field.
3. **"Request {familiar}'s revision"** folds every comment into one follow-up prompt and sends it — the agent then responds addressing each comment and summarizes its changes.

## How it fits the architecture
Cave persists transcripts **server-side from prompt text** — client turn objects are never written back (see `chat-reply.ts`). So comments can't be turn metadata. Instead:
- Comments are held client-side and **persisted per-turn to `localStorage`** (so a reload doesn't drop in-progress annotations).
- On request, `buildCommentsPrompt` synthesizes a prompt (quoted excerpt + note per comment) and submits it through the **existing `onSuggestion`→`send`** channel — the same path the next-path chips use. **No new API route, no `Turn` schema change.**

Selection is scoped to the turn's own markdown via `[data-turn-id="…"] .cave-artifact-content`, so you can only comment on that artifact.

## Files
- `src/lib/artifact-comments.ts` — pure `buildCommentsPrompt` + per-turn storage helpers
- `src/components/artifact-comments.tsx` — selection→comment layer, panel, request action
- `src/styles/artifact-comments.css` — floating affordance + panel styling (reduced-motion aware)
- `src/components/chat-view.tsx` — wraps the assistant bubble in `.cave-artifact-content` and mounts `ArtifactComments` on settled, substantial assistant turns
- tests: `src/lib/artifact-comments.test.ts` (behavioral), `src/components/artifact-comments.test.ts` (component + chat-view wiring), wired in `run-tests.mjs`

## Verification
- New tests pass; `pnpm build` green (tests-wired + bundle budget).
- Drove a real chat session end-to-end: selected text in an assistant turn → "Comment" fab → panel with the excerpt + note → "Request Cody's revision" button (correct familiar name). Screenshots confirm. localStorage-only state; no real data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)