### PR TITLE
fix(security): avoid self-report json ReDoS

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -293,6 +293,7 @@ export const SUITES = {
     "src/lib/familiar-analytics-insight.test.ts",
     "src/lib/familiar-heal-requests.test.ts",
     "src/lib/thread-self-report.test.ts",
+    "src/app/api/familiar-self-report-route.test.ts",
     "src/components/familiar-analytics-view.test.ts",
     "src/components/familiar-analytics-navigation.test.ts",
     "src/lib/server/familiar-self-reports.test.ts",

--- a/src/app/api/familiar-self-report-route.test.ts
+++ b/src/app/api/familiar-self-report-route.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  parseSelfReportJsonObject,
+  stripSelfReportJsonFence,
+} from "../../lib/server/self-report-json.ts";
+
+const routeSource = readFileSync(
+  fileURLToPath(new URL("./familiars/[id]/self-report/route.ts", import.meta.url)),
+  "utf8",
+);
+
+describe("self-report route JSON parsing", () => {
+  it("parses fenced JSON without using an ambiguous closing-fence regex in the route", () => {
+    assert.doesNotMatch(
+      routeSource,
+      /replace\(\s*\/\\s\*```\\\$\/[gimsyu]*/,
+      "closing code-fence cleanup must not use a backtracking \\s* end-anchor regex on user input",
+    );
+
+    const parsed = parseSelfReportJsonObject("```json\n{\"overallConfidence\":80}\n\t\t```");
+
+    assert.deepEqual(parsed, { overallConfidence: 80 });
+  });
+
+  it("strips code fences with linear string operations", () => {
+    assert.equal(stripSelfReportJsonFence("```JSON\t\n{\"ok\":true}\n\t```"), "{\"ok\":true}");
+    assert.equal(stripSelfReportJsonFence("```\n{\"ok\":true}\n```"), "{\"ok\":true}");
+    assert.equal(stripSelfReportJsonFence("{\"ok\":true}\t\t"), "{\"ok\":true}");
+  });
+});

--- a/src/app/api/familiars/[id]/self-report/route.ts
+++ b/src/app/api/familiars/[id]/self-report/route.ts
@@ -6,6 +6,7 @@ import {
   SELF_REPORT_SESSION_ID_RE,
 } from "@/lib/server/familiar-self-reports";
 import { isValidFamiliarId } from "@/lib/server/familiar-id";
+import { parseSelfReportJsonObject } from "@/lib/server/self-report-json";
 import type {
   BlockerCategory,
   BlockerImpact,
@@ -65,13 +66,6 @@ function enumValue<T extends string>(value: unknown, allowed: Set<T>, field: str
 
 function objectArray(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.filter(isRecord) : [];
-}
-
-function parseJsonObject(raw: string): Record<string, unknown> {
-  const trimmed = raw.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
-  const parsed = JSON.parse(trimmed) as unknown;
-  if (!isRecord(parsed)) throw new Error("response was not an object");
-  return parsed;
 }
 
 function normalizePayload(payload: Record<string, unknown>, meta: {
@@ -161,7 +155,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
   }
 
   try {
-    const report = redactSecretsDeep(normalizePayload(parseJsonObject(raw), {
+    const report = redactSecretsDeep(normalizePayload(parseSelfReportJsonObject(raw), {
       familiarId: id,
       sessionId,
       threadTitle: optionalText(body.threadTitle),

--- a/src/lib/server/self-report-json.ts
+++ b/src/lib/server/self-report-json.ts
@@ -1,0 +1,27 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function stripSelfReportJsonFence(raw: string): string {
+  let text = raw.trim();
+
+  if (text.startsWith("```")) {
+    let body = text.slice(3);
+    if (body.slice(0, 4).toLowerCase() === "json") {
+      body = body.slice(4);
+    }
+    text = body.trimStart();
+  }
+
+  if (text.endsWith("```")) {
+    text = text.slice(0, -3).trimEnd();
+  }
+
+  return text;
+}
+
+export function parseSelfReportJsonObject(raw: string): Record<string, unknown> {
+  const parsed = JSON.parse(stripSelfReportJsonFence(raw)) as unknown;
+  if (!isRecord(parsed)) throw new Error("response was not an object");
+  return parsed;
+}


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #73 by removing the ambiguous closing code-fence cleanup regex from the familiar self-report route.

The route now parses model-returned fenced JSON through a small server helper that uses bounded string operations (`startsWith`, `endsWith`, `slice`, `trimStart`, `trimEnd`) instead of a backtracking `\s*```$` regex on user-controlled input.

## Validation

- `node --experimental-strip-types src/app/api/familiar-self-report-route.test.ts`
- `node --experimental-strip-types src/lib/thread-self-report.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `git diff --check`
- `pnpm test:api`
- `pnpm test:app`

Security alert: https://github.com/OpenCoven/coven-cave/security/code-scanning/73