### PR TITLE
style(home): solid accent fill for the active Chat/Task tab

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -344,19 +344,17 @@
 }
 
 .hc-dest-pill.active {
-  background: color-mix(in oklch, var(--accent-presence) 32%, var(--bg-raised));
-  border-color: color-mix(in oklch, var(--accent-presence) 80%, transparent);
-  color: var(--text-primary);
+  background: var(--accent-presence);
+  border-color: var(--accent-presence);
+  color: var(--accent-foreground);
   font-weight: 600;
-  box-shadow:
-    0 2px 8px color-mix(in oklch, var(--accent-presence) 32%, transparent),
-    inset 0 1px 0 color-mix(in oklch, var(--foreground) 10%, transparent);
+  box-shadow: 0 2px 8px color-mix(in oklch, var(--accent-presence) 38%, transparent);
 }
 
-/* The active tab's icon picks up the accent so the selected mode reads at a
- * glance, while the label stays high-contrast for legibility. */
+/* Label and icon sit on the solid accent fill, so both take the on-accent
+ * foreground colour for legibility. */
 .hc-dest-pill.active svg {
-  color: var(--accent-presence);
+  color: var(--accent-foreground);
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
Follow-up to #2160. Make the active Chat/Task tab a **fully solid accent fill** (per request) instead of the tinted thumb:

- `background`/`border` → solid `--accent-presence`.
- Label + icon → `--accent-foreground` (theme-aware on-accent colour) for legibility on the fill.
- Keep the accent glow shadow.

CSS-only (`src/styles/home-composer.css`). Verified in the web build — the selected tab now reads as a filled segmented thumb in both Chat- and Task-active states. `pnpm build` succeeds; no test pins active-tab colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)