### PR TITLE
Eval Loops (retro-runs) view: live refresh, no longer stale

### DIFF
--- a/src/components/retro-runs-view.tsx
+++ b/src/components/retro-runs-view.tsx
@@ -8,6 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Tabs } from "@/components/ui/tabs";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import { RelativeTime } from "@/components/ui/relative-time";
 import type { RetroOutcome, RetroRun, RetroRunsSnapshot, RetroTrack } from "@/lib/retro-runs";
 
@@ -122,6 +124,7 @@ export function RetroRunsView({
   embedded?: boolean;
 }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  useMinuteTick();    // keep "last run … ago" / "never" labels current between polls
   const [snapshot, setSnapshot] = useState<RetroRunsSnapshot>(EMPTY_SNAPSHOT);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -131,16 +134,24 @@ export function RetroRunsView({
   const [outcome, setOutcome] = useState<OutcomeFilter>("all");
   const apiPath = familiarId ? `/api/retro-runs?familiarId=${encodeURIComponent(familiarId)}` : "/api/retro-runs";
 
-  async function load({ quiet = false } = {}) {
+  // `silentError` is for background polls: a transient poll failure must not
+  // replace a good snapshot with an error callout. Explicit loads/refreshes
+  // keep surfacing errors as before.
+  async function load({ quiet = false, silentError = false } = {}) {
     if (quiet) setRefreshing(true);
     else setLoading(true);
     try {
       const res = await fetch(apiPath, { cache: "no-store" });
       const json = (await res.json()) as RetroApiResponse;
-      setSnapshot(json.snapshot ?? EMPTY_SNAPSHOT);
-      setError(json.ok ? null : json.error ?? "retro runs unavailable");
+      if (json.ok) {
+        setSnapshot(json.snapshot ?? EMPTY_SNAPSHOT);
+        setError(null);
+      } else if (!silentError) {
+        setSnapshot(json.snapshot ?? EMPTY_SNAPSHOT);
+        setError(json.error ?? "retro runs unavailable");
+      }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "retro runs unavailable");
+      if (!silentError) setError(err instanceof Error ? err.message : "retro runs unavailable");
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -150,6 +161,12 @@ export function RetroRunsView({
   useEffect(() => {
     void load();
   }, [apiPath]);
+
+  // Live refresh so "running" indicators and "last run" labels stay current
+  // without a manual reload: poll fast while any familiar is mid-run, slower
+  // when idle. usePausablePoll suspends on hidden tabs and refreshes on focus.
+  const anyRunning = snapshot.summary.runningFamiliars > 0;
+  usePausablePoll(() => { void load({ quiet: true, silentError: true }); }, anyRunning ? 5000 : 30_000);
 
   const filteredRuns = useMemo(() => {
     const q = query.trim().toLowerCase();


### PR DESCRIPTION
## Problem
`RetroRunsView` (the "Eval Loops" / retro-runs surface, embedded in the Evals → Loops tab) fetched once on mount and only refreshed via the manual button. So per-familiar **"running"** indicators and **"last run … ago"** labels went stale while loops were actively running.

A direct follow-up to #2152 (eval-loop-panel live progress) — same surface, same anti-pattern.

## Fix
- **Live polling** via `usePausablePoll`: every 5s while any familiar is mid-run, every 30s when idle. Suspends on hidden tabs, refreshes on focus.
- **Silent background-poll failures** (new `silentError` flag): a transient poll error never replaces a good snapshot with an error callout; explicit loads/refreshes still surface errors.
- `useMinuteTick` keeps relative-time labels current between polls.

## Verification
- `retro-runs-view.test.ts` passes; typecheck clean; Frontend build green, bundle within budget.
- Drove the real app (prod server) with `/api/retro-runs` mocked to a **running** snapshot and counted requests: the view issued additional polls over time (2 → 4 across ~12s at the 5s running interval), confirming live refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)