### PR TITLE
style(home): subtle divider below the Chat/Task mode strip

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -305,7 +305,9 @@
 .hc-mode-strip {
   display: flex;
   align-items: center;
-  padding: 12px 14px 2px;
+  padding: 12px 14px 10px;
+  /* A faint hairline separates the mode switch from the prompt area below. */
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
 
 /* Destination pills — a segmented toggle inside the mode strip. */


### PR DESCRIPTION
Follow-up to #2166. Add a faint full-width hairline below the mode strip to separate the Chat/Task switch from the prompt area:

- `border-bottom` on `.hc-mode-strip` using `--border-hairline` mixed 70% toward transparent (subtle).
- Bottom padding 2px → 10px so the divider has room to breathe.

CSS-only (`src/styles/home-composer.css`). Verified in the web build. `pnpm build` succeeds; no test pins the strip styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)