### PR TITLE
feat(code): inline Codex file-edit cards (Edited <file> +N −M · Review)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -23,6 +23,7 @@ export const SUITES = {
   app: [
     "src/lib/array-content-equal.test.ts",
     "src/lib/session-list-equal.test.ts",
+    "src/lib/tool-edit-stat.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10608,3 +10608,61 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 @media (prefers-reduced-motion: reduce) {
   .cave-fill-btn::before { transition: none; }
 }
+
+/* Codex inline file-edit card: a mutation tool call rendered in the chat
+   transcript as `[icon] Edited <file>  +N −M  [Review]` instead of the
+   collapsed tool block. Horizontal flex row, hairline border. */
+.cave-edit-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border-hairline);
+  border-radius: 0.625rem;
+  background: var(--bg-raised);
+  font-size: 12px;
+}
+.cave-edit-card__icon {
+  flex: none;
+  color: var(--text-muted);
+}
+.cave-edit-card__body {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 0.5rem;
+}
+.cave-edit-card__title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+.cave-edit-card__stat {
+  flex: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+}
+.cave-edit-card__ins {
+  color: var(--color-success);
+}
+.cave-edit-card__del {
+  color: var(--color-danger);
+}
+.cave-edit-card__review {
+  flex: none;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--border-hairline);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--text-secondary, var(--text-primary));
+  font-size: 11px;
+  cursor: pointer;
+}
+.cave-edit-card__review:hover {
+  background: color-mix(in oklch, var(--text-primary) 8%, transparent);
+  color: var(--text-primary);
+}

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -917,3 +917,10 @@ assert.ok(
   source.includes('e.currentTarget.value = "";') && !source.includes('fileInputRef.current.value = ""'),
   "file input resets value synchronously in onChange, not after the async attach",
 );
+
+// Codex inline file-edit card: Edit/Write/MultiEdit/NotebookEdit tool calls
+// render as a compact `Edited <file>  +N −M  Review` card in the transcript.
+assert.match(source, /cave-edit-card/, "mutation tools render as an inline Codex edit card");
+assert.match(source, /diffStat/, "edit card derives a +/- stat");
+assert.match(source, /Review/, "edit card has a Review action");
+assert.match(globalsSrc, /\.cave-edit-card/, "edit card styling exists");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -96,6 +96,7 @@ import { toolVisual } from "@/lib/tool-visual";
 import { toolReadableFields, prettyToolOutput, type ReadableField } from "@/lib/tool-readable";
 import { useShowThinking } from "@/lib/reasoning-visibility";
 import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
+import { diffStat } from "@/lib/tool-edit-stat";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
@@ -5546,6 +5547,38 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
     );
   };
   const visual = toolVisual(tool.name);
+  // Codex-style inline edit card: a mutation tool (Edit/Write/MultiEdit/
+  // NotebookEdit, i.e. `isEditTool`) with a known target file renders as a
+  // compact `[icon] Edited <basename>  +N −M  [Review]` row instead of the
+  // collapsed tool block. Review opens the comux diff via the same
+  // `cave:open-file-diff` event the default block dispatches.
+  if (isEditTool && targetFile) {
+    const stat = diffStat(inputDiff ?? "");
+    const base = targetFile.split("/").pop() || targetFile;
+    return (
+      <div className="cave-edit-card">
+        <Icon name="ph:pencil-simple" width={16} className="cave-edit-card__icon" aria-hidden />
+        <span className="cave-edit-card__body">
+          <span className="cave-edit-card__title">Edited {base}</span>
+          <span className="cave-edit-card__stat">
+            <span className="cave-edit-card__ins">+{stat.insertions}</span>{" "}
+            <span className="cave-edit-card__del">−{stat.deletions}</span>
+          </span>
+        </span>
+        <button
+          type="button"
+          className="cave-edit-card__review focus-ring"
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent("cave:open-file-diff", { detail: { path: targetFile } }),
+            )
+          }
+        >
+          Review
+        </button>
+      </div>
+    );
+  }
   return (
     <details className="cave-tool-block" data-default-collapsed="true" data-tool-category={visual.category}>
       <summary className="flex min-w-0 cursor-pointer select-none flex-wrap items-center gap-2 text-[11px]">

--- a/src/lib/tool-edit-stat.test.ts
+++ b/src/lib/tool-edit-stat.test.ts
@@ -1,0 +1,8 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+const { diffStat } = await import("./tool-edit-stat.ts");
+const diff = ["@@ -1,2 +1,3 @@", " ctx", "-old line", "+new line", "+extra line"].join("\n");
+assert.deepEqual(diffStat(diff), { insertions: 2, deletions: 1 }, "counts +/- non-header lines");
+assert.deepEqual(diffStat(""), { insertions: 0, deletions: 0 }, "empty diff is zero");
+assert.deepEqual(diffStat("+++ b/x\n--- a/x\n+real"), { insertions: 1, deletions: 0 }, "ignores +++/--- file headers");
+console.log("tool-edit-stat ok");

--- a/src/lib/tool-edit-stat.ts
+++ b/src/lib/tool-edit-stat.ts
@@ -1,0 +1,10 @@
+// Count insertions/deletions from a unified-diff string (output of toolInputAsDiff).
+export function diffStat(diff: string): { insertions: number; deletions: number } {
+  let insertions = 0, deletions = 0;
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue; // file headers
+    if (line.startsWith("+")) insertions += 1;
+    else if (line.startsWith("-")) deletions += 1;
+  }
+  return { insertions, deletions };
+}


### PR DESCRIPTION
**PR3 (final) of the Codex Code surface arc** (spec/plan: `docs/specs/2026-06-30-codex-code-surface-*.md`; follows #2162, #2167).

Renders Edit/Write/MultiEdit/NotebookEdit tool calls in the chat transcript as a Codex-style edit card instead of the default collapsed `<details>`:

- `[✎] Edited <basename>   +N −M   [Review]` — stat derived by a new pure `diffStat()` helper (`src/lib/tool-edit-stat.ts`) from the existing `toolInputAsDiff` output.
- **Review** reuses the existing `cave:open-file-diff` event (`{ path }`) to open the comux diff pane.
- **Undo** intentionally deferred (spec follow-up — needs a reliable per-file `/api/changes` revert).
- Additive change in `ToolBlock` (early return for edit tools); non-edit tools keep the `<details>` rollup, so existing tool/diff tests (`chat-header-row`, `comux-view-changes`) stay green unchanged.

Tests: new `tool-edit-stat.test.ts` (wired); added assertions to `chat-view-polish.test.ts`. App suite (504), typecheck, check:tests-wired (676), build + bundle-budget green locally.

This completes the arc: Codex sidebar (#2162) → conversation + composer (#2167) → inline edit cards (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)