### PR TITLE
style(home): make the mode-strip divider even fainter

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -306,8 +306,8 @@
   display: flex;
   align-items: center;
   padding: 12px 14px 10px;
-  /* A faint hairline separates the mode switch from the prompt area below. */
-  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+  /* A whisper-faint hairline separates the mode switch from the prompt area. */
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 40%, transparent);
 }
 
 /* Destination pills — a segmented toggle inside the mode strip. */


### PR DESCRIPTION
Follow-up to #2169. Soften the hairline below the Chat/Task mode strip further — `--border-hairline` mixed **70% → 40%** toward transparent — so it reads as a whisper-faint separation rather than a visible rule.

CSS-only (`src/styles/home-composer.css`). Verified in the web build. `pnpm build` succeeds; no test pins the strip styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)