### PR TITLE
feat(chat): /skill + /skills slash commands to invoke skills

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -89,6 +89,14 @@ enum SlashCatalog {
                      description: "Pick or set the model for this chat. Pass an id/name or open the picker.",
                      argPlaceholder: "model", section: .chat,
                      availability: .native, action: .switchModel),
+        SlashCommand(name: "/skill", hint: "run a skill",
+                     description: "Invoke a skill — pass a name or pick from the menu as you type.",
+                     argPlaceholder: "name", section: .chat,
+                     availability: .desktopOnly, action: .desktopOnly("Skills")),
+        SlashCommand(name: "/skills", hint: "browse skills",
+                     description: "Show every available skill to pick from.",
+                     section: .chat,
+                     availability: .desktopOnly, action: .desktopOnly("Skills")),
 
         // MARK: Familiar
         SlashCommand(name: "/familiar", aliases: ["/agent"], hint: "switch",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -211,6 +211,7 @@ export const SUITES = {
     "src/lib/canvas-generate.test.ts",
     "src/lib/slash-commands.test.ts",
     "src/lib/slash-model.test.ts",
+    "src/lib/slash-skill.test.ts",
     "src/lib/cave-canvas.test.ts",
     "src/components/journal/journal-view.test.ts",
     "src/lib/journal.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -52,6 +52,13 @@ import { ThinkingIndicator } from "@/components/ui/thinking-indicator";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
 import { modelSlashOptions, resolveModelArg, formatModelList } from "@/lib/slash-model";
+import {
+  skillSlashOptions,
+  resolveSkillArg,
+  formatSkillList,
+  buildSkillPrompt,
+  type SkillOption,
+} from "@/lib/slash-skill";
 import { catalogForRuntime } from "@/lib/runtime-models";
 import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
@@ -2646,6 +2653,23 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // Esc hides the menu for the current input; any edit brings it back.
   const [slashDismissed, setSlashDismissed] = useState(false);
   const slashSuggestions: SlashCommand[] = slashDismissed ? [] : slashMatches;
+  // Skills for the inline `/skill` / `/skills` picker — fetched once from the
+  // local skill scan (Coven skills + ~/.claude/skills).
+  const [skills, setSkills] = useState<SkillOption[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/skills/local", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (alive && j?.ok && Array.isArray(j.skills)) setSkills(j.skills as SkillOption[]);
+      })
+      .catch(() => {
+        /* offline → no inline skill picker (the command menu still works) */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
   // While typing "/model <partial>", the menu shows model options instead of
   // commands (an inline picker). null ⇒ not in /model arg position.
   const modelHarness = modelState?.harness ?? familiar.harness ?? "claude";
@@ -2664,10 +2688,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ? modelState.effectiveModel
       : composerModelOptions[0]?.id ?? "";
   const modelMenuActive = (modelOptions?.length ?? 0) > 0;
-  // The slash-command and /model pickers are mutually exclusive inline listboxes
-  // sharing one listbox id, so the composer's combobox ARIA tracks whichever is
-  // open (was: slash-only, leaving the /model picker unannounced).
-  const menuOpen = modelMenuActive || slashSuggestions.length > 0;
+  // Inline `/skill` / `/skills` picker — null ⇒ not in a skill-picker position.
+  const skillOptions = useMemo(
+    () => (slashDismissed ? null : skillSlashOptions(input, skills)),
+    [input, skills, slashDismissed],
+  );
+  const skillMenuActive = (skillOptions?.length ?? 0) > 0;
+  // The slash-command, /model and /skill pickers are mutually exclusive inline
+  // listboxes sharing one listbox id, so the composer's combobox ARIA tracks
+  // whichever is open (was: slash-only, leaving the pickers unannounced).
+  const menuOpen = modelMenuActive || skillMenuActive || slashSuggestions.length > 0;
   // Stable per-mount listbox id — the home composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
@@ -3223,6 +3253,26 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       handleSelectModel(id);
       appendSystem(`Model set to ${id}.`);
       setInput("");
+      return true;
+    }
+    if (command === "/skill" || command === "/skills") {
+      if (!args.trim()) {
+        // Bare /skill or /skills: list everything (the inline picker shows the
+        // same list while typing; this is the submitted fallback).
+        appendSystem(formatSkillList(skills));
+        setInput("");
+        return true;
+      }
+      const skill = resolveSkillArg(args, skills);
+      if (!skill) {
+        appendSystem(`Unknown skill "${args.trim()}". Type /skills to list the options.`);
+        setInput("");
+        return true;
+      }
+      setInput("");
+      // Invoke by sending a directive to the active familiar's harness, which
+      // owns Skill execution (mirrors the /run prompt-send pattern).
+      setTimeout(() => sendRaw(buildSkillPrompt(skill)), 0);
       return true;
     }
     if (command === "/doctor" || command === "/daemon") {
@@ -3993,6 +4043,35 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
     }
+    if (skillMenuActive && skillOptions) {
+      const opts = skillOptions;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSlashIdx((i) => Math.min(i + 1, opts.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSlashIdx((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const s = opts[slashIdx];
+        if (s) setInput(`/skill ${s.id}`);
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const s = opts[slashIdx];
+        if (s) {
+          setInput("");
+          setSlashIdx(0);
+          setTimeout(() => sendRaw(buildSkillPrompt(s)), 0);
+        }
+        return;
+      }
+    }
     if (slashSuggestions.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -4630,6 +4709,43 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               </ul>
               <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
                 {keys.up}{keys.down} navigate · {keys.enter} switch · esc cancel
+              </div>
+            </div>
+          ) : skillMenuActive && skillOptions ? (
+            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
+              <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Skills">
+                {skillOptions.map((s, i) => {
+                  const active = i === slashIdx;
+                  return (
+                    <li key={s.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        ref={active ? activeSlashOptionRef : null}
+                        onMouseEnter={() => setSlashIdx(i)}
+                        onClick={() => {
+                          setInput("");
+                          setSlashIdx(0);
+                          const skill = s;
+                          setTimeout(() => sendRaw(buildSkillPrompt(skill)), 0);
+                          inputRef.current?.focus();
+                        }}
+                        className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                          active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
+                        }`}
+                      >
+                        <Icon name="ph:sparkle" width={13} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
+                        <span className="text-[var(--text-primary)]">{s.name}</span>
+                        <span className="flex-1 truncate text-[11px] text-[var(--text-muted)]">
+                          {s.description || s.id}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
+                {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
               </div>
             </div>
           ) : slashSuggestions.length > 0 ? (

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -284,8 +284,8 @@ for (const [name, src] of [
   // the slash menu. Both composers must use it.
   assert.match(
     src,
-    /const menuOpen = modelMenuActive \|\| slashSuggestions\.length > 0;/,
-    `${name} combobox ARIA must reflect either inline menu (slash or /model)`,
+    /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| slashSuggestions\.length > 0;/,
+    `${name} combobox ARIA must reflect every inline menu (slash, /model, /skill)`,
   );
 }
 
@@ -294,9 +294,15 @@ for (const [name, src] of [
 // textarea announces the /model picker too (was: slash-only).
 assert.match(
   source,
-  /const menuOpen = modelMenuActive \|\| slashSuggestions\.length > 0;/,
-  "HomeComposer combobox ARIA reflects either inline menu (slash or /model)",
+  /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| slashSuggestions\.length > 0;/,
+  "HomeComposer combobox ARIA reflects every inline menu (slash, /model, /skill)",
 );
+
+// ── /skill + /skills inline picker (mirrors /model) ──────────────────────────
+assert.match(source, /skillSlashOptions\(text, skills\)/, "HomeComposer offers inline /skill autocomplete");
+assert.match(source, /command === "\/skill" \|\| command === "\/skills"/, "HomeComposer handles the /skill and /skills commands");
+assert.match(source, /role="listbox" aria-label="Skills"/, "HomeComposer renders a Skills picker listbox");
+assert.match(source, /buildSkillPrompt\(skill\)/, "HomeComposer invokes a skill by starting a chat with the skill prompt");
 
 // ── Destination pills are an accessible single-select radiogroup ─────────────
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -19,6 +19,12 @@ import {
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
+import {
+  skillSlashOptions,
+  resolveSkillArg,
+  buildSkillPrompt,
+  type SkillOption,
+} from "@/lib/slash-skill";
 import type { ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
@@ -326,9 +332,42 @@ export function HomeComposer({
     modelState?.harness ?? selectedFamiliar?.harness ?? "claude";
   const modelOptions = useMemo(() => modelSlashOptions(text, modelHarness), [text, modelHarness]);
   const modelMenuActive = (modelOptions?.length ?? 0) > 0;
-  // Either inline listbox (slash commands or the /model picker) shares the same
-  // listbox id, so the textarea's combobox ARIA tracks whichever is open.
-  const menuOpen = modelMenuActive || slashSuggestions.length > 0;
+  // Inline skill picker: "/skill <partial>" / "/skills" shows skill options.
+  const [skills, setSkills] = useState<SkillOption[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/skills/local", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (alive && j?.ok && Array.isArray(j.skills)) setSkills(j.skills as SkillOption[]);
+      })
+      .catch(() => {
+        /* offline → no inline skill picker */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const skillOptions = useMemo(() => skillSlashOptions(text, skills), [text, skills]);
+  const skillMenuActive = (skillOptions?.length ?? 0) > 0;
+  // The inline listboxes (slash commands, /model, /skill) share the same listbox
+  // id, so the textarea's combobox ARIA tracks whichever is open.
+  const menuOpen = modelMenuActive || skillMenuActive || slashSuggestions.length > 0;
+
+  // Invoke a skill from home = open a new chat that asks the familiar to run it.
+  const invokeSkill = useCallback(
+    (skill: SkillOption) => {
+      if (!selectedFamiliarId) {
+        onToast("No familiar selected — add one in Settings.");
+        return;
+      }
+      setText("");
+      onStartChat(buildSkillPrompt(skill), selectedFamiliarId, selectedProject?.root ?? null, {
+        initialControls: { thinkingEffort, responseSpeed },
+      });
+    },
+    [selectedFamiliarId, selectedProject, thinkingEffort, responseSpeed, onStartChat, onToast],
+  );
 
   useEffect(() => {
     setSlashIdx(0);
@@ -430,6 +469,23 @@ export function HomeComposer({
         onToast(`Model set to ${id}.`);
         return;
       }
+      if (command === "/skill" || command === "/skills") {
+        setHistory((prev) => [...prev, prompt]);
+        setHistoryIdx(-1);
+        if (!args.trim()) {
+          setText("");
+          onToast("Type /skill <name>, or pick one from the menu.");
+          return;
+        }
+        const skill = resolveSkillArg(args, skills);
+        if (!skill) {
+          setText("");
+          onToast(`Unknown skill "${args.trim()}".`);
+          return;
+        }
+        invokeSkill(skill);
+        return;
+      }
       if (onSlash) {
         setHistory((prev) => [...prev, prompt]);
         setHistoryIdx(-1);
@@ -494,6 +550,8 @@ export function HomeComposer({
     onStartChat,
     onNavigateToBoard,
     onToast,
+    skills,
+    invokeSkill,
   ]);
 
   const handleKeyDown = useCallback(
@@ -508,6 +566,19 @@ export function HomeComposer({
           e.preventDefault();
           const m = opts[slashIdx];
           if (m) { handleSelectModel(m.id); onToast(`Model set to ${m.id}.`); setText(""); }
+          return;
+        }
+      }
+      // Inline skill picker ("/skill <partial>" or "/skills").
+      if (skillMenuActive && skillOptions) {
+        const opts = skillOptions;
+        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
+        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
+        if (e.key === "Tab") { e.preventDefault(); const s = opts[slashIdx]; if (s) setText(`/skill ${s.id}`); return; }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const s = opts[slashIdx];
+          if (s) invokeSkill(s);
           return;
         }
       }
@@ -575,6 +646,9 @@ export function HomeComposer({
       historyIdx,
       modelMenuActive,
       modelOptions,
+      skillMenuActive,
+      skillOptions,
+      invokeSkill,
       onToast,
       slashIdx,
       slashSuggestions,
@@ -653,6 +727,29 @@ export function HomeComposer({
               })}
             </ul>
             <div className="hc-slash-footer">↑↓ navigate · Enter switch · Esc cancel</div>
+          </div>
+        ) : skillMenuActive && skillOptions ? (
+          <div className="hc-slash-menu">
+            <ul className="hc-slash-list" id={slashListboxId} role="listbox" aria-label="Skills">
+              {skillOptions.map((s, i) => {
+                const active = i === slashIdx;
+                return (
+                  <li key={s.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      onMouseEnter={() => setSlashIdx(i)}
+                      onClick={() => invokeSkill(s)}
+                      className={`hc-slash-row${active ? " active" : ""}`}
+                    >
+                      <span className="hc-slash-name">{s.name}</span>
+                      <span className="hc-slash-desc">{s.description || s.id}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            <div className="hc-slash-footer">↑↓ navigate · Enter run · Tab complete · Esc cancel</div>
           </div>
         ) : slashSuggestions.length > 0 ? (
           <div className="hc-slash-menu">

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -26,6 +26,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/shortcuts", aliases: ["/keys"], hint: "open ⌘/ sheet", description: "Open the keyboard shortcuts sheet.", section: "chat" },
   { name: "/new", hint: "new chat", description: "Start a fresh chat with the active familiar.", section: "chat" },
   { name: "/model", aliases: ["/m"], hint: "switch model", description: "Switch the active model — pass an id or pick from the menu; bare /model lists them.", argPlaceholder: "model", section: "chat" },
+  { name: "/skill", hint: "run a skill", description: "Invoke a skill — pass a name or pick from the menu as you type.", argPlaceholder: "name", section: "chat" },
+  { name: "/skills", hint: "browse skills", description: "Show every available skill to pick from.", section: "chat" },
 
   // Familiar
   { name: "/familiar", aliases: ["/agent"], hint: "switch", description: "Open the familiar picker. Pass a name to switch directly.", argPlaceholder: "name", section: "familiar" },

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  skillSlashOptions,
+  resolveSkillArg,
+  buildSkillPrompt,
+  formatSkillList,
+} from "./slash-skill.ts";
+
+const SKILLS = [
+  { id: "deep-research", name: "deep-research", description: "Fan-out web research" },
+  { id: "code-review", name: "code-review", description: "Review the current diff" },
+  { id: "verify", name: "verify", description: "Run the app and check a change" },
+];
+
+// ── skillSlashOptions: null outside picker position, list/filter inside ───────
+assert.equal(skillSlashOptions("hello", SKILLS), null, "plain text → null (command menu)");
+assert.equal(skillSlashOptions("/skill", SKILLS), null, "bare /skill (no space) → null so both commands show in the menu");
+assert.deepEqual(skillSlashOptions("/skill ", SKILLS), SKILLS, "/skill <space> → full list");
+assert.deepEqual(skillSlashOptions("/skills", SKILLS), SKILLS, "/skills → full list (show all)");
+assert.deepEqual(skillSlashOptions("/skills ", SKILLS), SKILLS, "/skills <space> → full list");
+const filtered = skillSlashOptions("/skill rev", SKILLS);
+assert.equal(filtered.length, 1, "/skill rev filters to one");
+assert.equal(filtered[0].id, "code-review", "filter matches description/name");
+assert.equal(skillSlashOptions("/skills verify", SKILLS).length, 1, "/skills also accepts a trailing filter");
+assert.equal(skillSlashOptions("/skill nomatch", SKILLS).length, 0, "no match → empty (not null)");
+assert.equal(skillSlashOptions("/model gpt", SKILLS), null, "a different command → null");
+
+// ── resolveSkillArg: exact then substring ────────────────────────────────────
+assert.equal(resolveSkillArg("verify", SKILLS)?.id, "verify", "exact name");
+assert.equal(resolveSkillArg("CODE-REVIEW", SKILLS)?.id, "code-review", "case-insensitive exact");
+assert.equal(resolveSkillArg("research", SKILLS)?.id, "deep-research", "substring");
+assert.equal(resolveSkillArg("", SKILLS), null, "empty → null");
+assert.equal(resolveSkillArg("zzz", SKILLS), null, "unknown → null");
+
+// ── buildSkillPrompt / formatSkillList ───────────────────────────────────────
+assert.equal(buildSkillPrompt(SKILLS[0]), 'Use the "deep-research" skill.', "invocation prompt names the skill");
+const list = formatSkillList(SKILLS);
+assert.match(list, /Available skills/, "list has a header");
+assert.match(list, /deep-research/, "list includes each skill");
+assert.match(formatSkillList([]), /No skills found/, "empty list is explained");
+
+// ── Catalog + composer wiring (source-text) ──────────────────────────────────
+const slashCmds = await readFile(new URL("./slash-commands.ts", import.meta.url), "utf8");
+assert.match(slashCmds, /name: "\/skill",[\s\S]*?argPlaceholder: "name"/, "/skill is registered with an arg placeholder");
+assert.match(slashCmds, /name: "\/skills"/, "/skills is registered");
+
+const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+assert.match(chatView, /skillSlashOptions\(input, skills\)/, "chat-view computes the inline /skill options");
+assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| slashSuggestions\.length > 0;/, "chat-view menuOpen includes the skill picker");
+assert.match(chatView, /command === "\/skill" \|\| command === "\/skills"/, "chat-view dispatches /skill and /skills");
+assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill\)\)/, "chat-view invokes a skill by sending the skill prompt");
+assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");
+assert.match(chatView, /fetch\("\/api\/skills\/local"/, "chat-view sources skills from the local skill scan");
+
+console.log("slash-skill.test.ts: ok");

--- a/src/lib/slash-skill.ts
+++ b/src/lib/slash-skill.ts
@@ -1,0 +1,70 @@
+// Helpers for the `/skill` and `/skills` slash commands — the inline
+// autocomplete options shown while typing, resolving a typed skill argument to
+// a concrete skill, and the invocation prompt. Pure + client-safe: the skills
+// list is passed in (fetched from /api/skills/local) so this never pulls server
+// code into the bundle. Mirrors slash-model.ts.
+
+export type SkillOption = {
+  id: string;
+  name: string;
+  description?: string;
+  /** Scope the skill belongs to (e.g. "global", "user") — shown as a hint. */
+  familiar?: string;
+};
+
+// `/skills` is the no-arg "show everything" picker; it also accepts a trailing
+// filter. `/skill ` (with a space) is the per-arg autocomplete. Bare `/skill`
+// (no space) matches neither so the command menu shows both commands first.
+const SKILLS_RE = /^\/skills\s*(.*)$/i;
+const SKILL_ARG_RE = /^\/skill\s+(.*)$/i;
+
+function filterSkills(skills: SkillOption[], partial: string): SkillOption[] {
+  const q = partial.trim().toLowerCase();
+  if (!q) return skills;
+  return skills.filter(
+    (s) =>
+      s.id.toLowerCase().includes(q) ||
+      s.name.toLowerCase().includes(q) ||
+      (s.description?.toLowerCase().includes(q) ?? false),
+  );
+}
+
+/** Skill options for the inline autocomplete when the composer is in `/skill
+ *  <partial>` or `/skills [<partial>]` position. Returns null when the text
+ *  isn't a skill picker, so callers fall back to the normal command menu. */
+export function skillSlashOptions(text: string, skills: SkillOption[]): SkillOption[] | null {
+  const t = text.trimStart();
+  const m = t.match(SKILLS_RE) ?? t.match(SKILL_ARG_RE);
+  if (!m) return null;
+  return filterSkills(skills, m[1]);
+}
+
+/** Resolve a typed /skill argument to a concrete skill: exact id/name match
+ *  first, then a substring match. Returns null for an empty/unknown argument. */
+export function resolveSkillArg(arg: string, skills: SkillOption[]): SkillOption | null {
+  const a = arg.trim().toLowerCase();
+  if (!a) return null;
+  const exact = skills.find((s) => s.id.toLowerCase() === a || s.name.toLowerCase() === a);
+  if (exact) return exact;
+  const partial = skills.find(
+    (s) => s.id.toLowerCase().includes(a) || s.name.toLowerCase().includes(a),
+  );
+  return partial ?? null;
+}
+
+/** The message sent to the active familiar to invoke a skill. The harness owns
+ *  Skill execution, so this is a plain directive naming the skill. */
+export function buildSkillPrompt(skill: SkillOption): string {
+  return `Use the "${skill.name}" skill.`;
+}
+
+/** One-line-per-skill list for the bare `/skill` / `/skills` system message. */
+export function formatSkillList(skills: SkillOption[]): string {
+  if (skills.length === 0) {
+    return "No skills found. Add skills under your Coven skills directory or ~/.claude/skills, then try `/skill` again.";
+  }
+  const lines = skills.map(
+    (s) => `  ○ ${s.name} — \`${s.id}\`${s.description ? ` — ${s.description}` : ""}`,
+  );
+  return `Available skills (type \`/skill <name>\` or pick from the menu):\n${lines.join("\n")}`;
+}


### PR DESCRIPTION
## What

Two new slash commands in the chat **and** home composers, mirroring the existing inline `/model` picker:

- **`/skill <partial>`** — typing it opens an **inline autocomplete** that filters the available skills as you type; Enter or click invokes the highlighted skill.
- **`/skills`** — shows **every** available skill to select from.

Invoking a skill sends a directive (`Use the "<name>" skill.`) to the active familiar, whose harness owns Skill execution (mirrors the `/run` prompt-send pattern). From the home composer it opens a new chat with that prompt.

## How
- **`src/lib/slash-skill.ts`** (new, pure/client-safe, parallel to `slash-model.ts`): `skillSlashOptions(text, skills)` (null outside picker position → command menu falls back), `resolveSkillArg`, `buildSkillPrompt`, `formatSkillList`.
- **`src/lib/slash-commands.ts`**: register `/skill` (arg `name`) and `/skills`.
- **`chat-view.tsx` + `home-composer.tsx`**: fetch skills once from **`/api/skills/local`** (Coven skills + `~/.claude/skills`), add a third inline listbox keyed off `skillMenuActive`, a keyboard branch (↑/↓/Tab/Enter), and dispatch in the submit path. `menuOpen` now unifies slash + `/model` + `/skill` for the composer's combobox ARIA.

`/skill` (no space) shows both commands in the menu; `/skill ` filters; `/skills` shows all — the same arg-position contract `/model` uses.

## Files
`slash-skill.ts`, `slash-skill.test.ts` (behavioral + wiring), `slash-commands.ts`, `chat-view.tsx`, `home-composer.tsx`, `home-composer.test.ts` (updated the pinned `menuOpen` assertions for both composers), `run-tests.mjs`.

## Verification
- New + existing slash tests pass; `pnpm build` green.
- Drove a real chat session: `/skill rev` → filtered list (review-related skills); `/skills` → all 28 local skills in a "Skills" listbox above the composer. Screenshots confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)