### PR TITLE
Fix Code-surface crash: stable getPinnedSessionIds snapshot

### DIFF
--- a/src/lib/session-pins.test.ts
+++ b/src/lib/session-pins.test.ts
@@ -34,4 +34,21 @@ toggleSessionPin("s1");
 assert.deepEqual(getPinnedSessionIds(), ["s2"], "toggle removes existing id");
 unsub();
 
+// ── Snapshot stability (useSyncExternalStore contract) ───────────────────────
+// getPinnedSessionIds is the getSnapshot for useSessionPins. It MUST return a
+// referentially-identical array between calls when nothing changed — otherwise
+// React loops forever ("Maximum update depth exceeded") and crashes the Code
+// surface. It may only return a new reference after the value actually changes.
+assert.equal(getPinnedSessionIds(), getPinnedSessionIds(), "repeated reads return the SAME array reference");
+const before = getPinnedSessionIds();
+toggleSessionPin("s3");
+assert.notEqual(getPinnedSessionIds(), before, "a new reference appears after a real change");
+assert.equal(getPinnedSessionIds(), getPinnedSessionIds(), "stable again once settled");
+
+// The empty case must be stable too (the all-no-pins default path).
+toggleSessionPin("s2");
+toggleSessionPin("s3");
+assert.deepEqual(getPinnedSessionIds(), [], "back to empty");
+assert.equal(getPinnedSessionIds(), getPinnedSessionIds(), "empty snapshot is a stable reference");
+
 console.log("session-pins ok");

--- a/src/lib/session-pins.ts
+++ b/src/lib/session-pins.ts
@@ -21,13 +21,30 @@ export function subscribeSessionPins(fn: () => void): () => void {
   return () => { listeners.delete(fn); };
 }
 
+// useSyncExternalStore requires a referentially-stable snapshot: getSnapshot
+// must return the SAME array when the underlying value hasn't changed, or React
+// re-renders every commit and throws "Maximum update depth exceeded" (this
+// crashed the whole Code surface). Cache the parsed list keyed on the raw stored
+// string, so repeated reads return one array until it actually changes.
+const EMPTY_IDS: string[] = Object.freeze([]) as unknown as string[];
+let cachedRaw: string | null | undefined;
+let cachedIds: string[] = EMPTY_IDS;
+
 export function getPinnedSessionIds(): string[] {
   const raw = rawGet(PINS_KEY);
-  if (!raw) return [];
+  if (raw === cachedRaw) return cachedIds;
+  cachedRaw = raw;
+  if (!raw) {
+    cachedIds = EMPTY_IDS;
+    return cachedIds;
+  }
   try {
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
-  } catch { return []; }
+    cachedIds = Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : EMPTY_IDS;
+  } catch {
+    cachedIds = EMPTY_IDS;
+  }
+  return cachedIds;
 }
 
 export function isSessionPinned(id: string): boolean {


### PR DESCRIPTION
## The bug (live on `main`, from #2162)

`getPinnedSessionIds()` is the `getSnapshot` for the `useSessionPins` `useSyncExternalStore` hook that powers `CodeSidebar`'s new Pinned section. It returned a **fresh array on every call**:

```ts
export function getPinnedSessionIds(): string[] {
  const raw = rawGet(PINS_KEY);
  if (!raw) return [];                 // new [] every call
  // …parsed.filter(...)               // new array every call
}
```

`useSyncExternalStore` requires a **referentially-stable** snapshot. A new reference each call makes React think the store changed on every commit, so it re-renders forever and throws **"Maximum update depth exceeded"** — crashing the entire **Code surface** to its error boundary.

## Fix

Cache the parsed list keyed on the raw stored string, so repeated reads return the same array reference until a pin/unpin (or cross-tab `storage` write) actually changes it. Empty state returns a frozen shared `EMPTY_IDS`.

## How it was found

While verifying the Code-sidebar familiar **count scoping** (#2170) in the running app, the Code surface wouldn't render at all — it crashed with this loop. With the fix applied, the surface renders and the count scoping is confirmed (1 shared project, 3 Sage + 1 Cody chats → badge reads **3** for Sage / **1** for Cody).

## Tests

Adds snapshot-stability assertions to `session-pins.test.ts`: repeated `getPinnedSessionIds()` calls return the **same** reference; a new reference appears only after a real change; the empty default is stable too. Verified the Code surface renders cleanly in a prod build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)