### PR TITLE
fix(code): cache session-pins snapshot (stop useSyncExternalStore infinite loop)

### DIFF
--- a/src/lib/session-pins.test.ts
+++ b/src/lib/session-pins.test.ts
@@ -32,6 +32,15 @@ assert.deepEqual(getPinnedSessionIds(), ["s1", "s2"], "second pin appended in or
 
 toggleSessionPin("s1");
 assert.deepEqual(getPinnedSessionIds(), ["s2"], "toggle removes existing id");
+
+// Snapshot stability: useSyncExternalStore requires getSnapshot to return the
+// SAME reference until a mutation, else React throws "getSnapshot should be
+// cached to avoid an infinite loop". Two reads with no mutation between must be
+// identical (===), and a mutation must produce a fresh reference.
+const snapA = getPinnedSessionIds();
+assert.equal(getPinnedSessionIds(), snapA, "repeated reads return the same reference (cached snapshot)");
+toggleSessionPin("s3");
+assert.notEqual(getPinnedSessionIds(), snapA, "a mutation yields a new reference");
 unsub();
 
 console.log("session-pins ok");

--- a/src/lib/session-pins.ts
+++ b/src/lib/session-pins.ts
@@ -16,12 +16,14 @@ function rawSet(key: string, value: string): void {
 const listeners = new Set<() => void>();
 function notify() { for (const fn of listeners) fn(); }
 
-export function subscribeSessionPins(fn: () => void): () => void {
-  listeners.add(fn);
-  return () => { listeners.delete(fn); };
-}
+// Snapshot cache. `useSyncExternalStore` requires getSnapshot to return a
+// STABLE reference when the underlying data is unchanged — otherwise React
+// throws "The result of getSnapshot should be cached to avoid an infinite
+// loop". We parse localStorage once and reuse the array until a mutation (or a
+// cross-tab `storage` event) invalidates it. Mirrors `familiar-quick-switch`.
+let cachedPins: string[] | null = null;
 
-export function getPinnedSessionIds(): string[] {
+function readPins(): string[] {
   const raw = rawGet(PINS_KEY);
   if (!raw) return [];
   try {
@@ -30,12 +32,24 @@ export function getPinnedSessionIds(): string[] {
   } catch { return []; }
 }
 
+export function subscribeSessionPins(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}
+
+/** Current pinned-session ids (cached; stable reference until a mutation). */
+export function getPinnedSessionIds(): string[] {
+  if (cachedPins === null) cachedPins = readPins();
+  return cachedPins;
+}
+
 export function isSessionPinned(id: string): boolean {
   return getPinnedSessionIds().includes(id);
 }
 
 export function setPinnedSessionIds(ids: string[]): void {
   const unique = Array.from(new Set(ids.filter((x) => typeof x === "string" && x.length > 0)));
+  cachedPins = unique;
   rawSet(PINS_KEY, JSON.stringify(unique));
   notify();
 }
@@ -47,6 +61,9 @@ export function toggleSessionPin(id: string): void {
 
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (e) => {
-    if (e.key === PINS_KEY) notify();
+    if (e.key === PINS_KEY) {
+      cachedPins = null; // another tab mutated pins — drop the cache before notifying
+      notify();
+    }
   });
 }


### PR DESCRIPTION
**Bugfix** for the Code sidebar shipped in #2162.

`getPinnedSessionIds()` re-parsed localStorage on every call, returning a fresh array reference each render. `useSyncExternalStore` requires a stable `getSnapshot`, so React threw **"The result of getSnapshot should be cached to avoid an infinite loop"** and the Code sidebar rendered a full error overlay on mount — for *every* visit (the no-pins path also returned a fresh `[]`).

**Fix:** cache the parsed array until a mutation (or cross-tab `storage` event) invalidates it — mirrors the proven `familiar-quick-switch` store. Regression test now asserts snapshot reference stability (`getPinnedSessionIds() === getPinnedSessionIds()` until a mutation).

**How it slipped through:** build, source-text, and CI all passed because none exercise the actual React render. Caught by visually verifying the Code surface in the running app (screenshot showed the overlay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)