### PR TITLE
feat(marketplace): show OpenClaw skills in Cave

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -1464,6 +1464,94 @@
       }
     },
     {
+      "name": "openclaw-skills",
+      "displayName": "OpenClaw Skills",
+      "version": "0.1.0",
+      "description": "The migrated OpenClaw workspace skill library, represented in Coven so familiars can share one canonical skill surface.",
+      "category": "Coven",
+      "keywords": [
+        "openclaw",
+        "skills",
+        "familiars",
+        "migration",
+        "coven"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files",
+        "shell"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven/tree/main/skills",
+        "https://github.com/OpenCoven/coven/blob/main/skills/openclaw-skills-manifest.json"
+      ],
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "nova",
+          "roles": [
+            "operator",
+            "maintainer"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger",
+            "code-reviewer"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist",
+            "retrospector"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison",
+            "social-voice"
+          ]
+        }
+      ],
+      "skill": {
+        "description": "Use the migrated OpenClaw skill library from Coven, checking coverage before treating the migration as complete.",
+        "useCases": [
+          "Find the Coven copy of an OpenClaw workspace skill",
+          "Verify OpenClaw skill migration coverage",
+          "Update shared familiar workflows through the Coven skill library"
+        ],
+        "guardrails": [
+          "Run the Coven `sync-openclaw-skills` coverage check before claiming 100% migration",
+          "Do not overwrite richer Coven-native skills when a represented skill already exists",
+          "Keep secret-bearing examples sanitized before publishing skills"
+        ]
+      }
+    },
+    {
       "name": "coven-flows",
       "displayName": "Coven Flows",
       "version": "0.1.0",

--- a/marketplace/exports/codex/marketplace.json
+++ b/marketplace/exports/codex/marketplace.json
@@ -545,6 +545,18 @@
       "category": "Coven"
     },
     {
+      "name": "openclaw-skills",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/openclaw-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coven"
+    },
+    {
       "name": "coven-flows",
       "source": {
         "source": "local",

--- a/marketplace/exports/roles/role-affinity.json
+++ b/marketplace/exports/roles/role-affinity.json
@@ -842,6 +842,57 @@
       ]
     }
   ],
+  "openclaw-skills": [
+    {
+      "familiar": "nova",
+      "roles": [
+        "operator",
+        "maintainer"
+      ]
+    },
+    {
+      "familiar": "cody",
+      "roles": [
+        "implementer",
+        "debugger",
+        "code-reviewer"
+      ]
+    },
+    {
+      "familiar": "kitty",
+      "roles": [
+        "general-helper"
+      ]
+    },
+    {
+      "familiar": "sage",
+      "roles": [
+        "researcher",
+        "librarian"
+      ]
+    },
+    {
+      "familiar": "echo",
+      "roles": [
+        "archivist",
+        "retrospector"
+      ]
+    },
+    {
+      "familiar": "astra",
+      "roles": [
+        "strategic-navigator",
+        "coordination-layer"
+      ]
+    },
+    {
+      "familiar": "charm",
+      "roles": [
+        "devrel-liaison",
+        "social-voice"
+      ]
+    }
+  ],
   "coven-flows": [
     {
       "familiar": "astra",

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -1480,6 +1480,71 @@
       ]
     },
     {
+      "name": "openclaw-skills",
+      "displayName": "OpenClaw Skills",
+      "category": "Coven",
+      "source": {
+        "source": "local",
+        "path": "./plugins/openclaw-skills"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": [
+        {
+          "familiar": "nova",
+          "roles": [
+            "operator",
+            "maintainer"
+          ]
+        },
+        {
+          "familiar": "cody",
+          "roles": [
+            "implementer",
+            "debugger",
+            "code-reviewer"
+          ]
+        },
+        {
+          "familiar": "kitty",
+          "roles": [
+            "general-helper"
+          ]
+        },
+        {
+          "familiar": "sage",
+          "roles": [
+            "researcher",
+            "librarian"
+          ]
+        },
+        {
+          "familiar": "echo",
+          "roles": [
+            "archivist",
+            "retrospector"
+          ]
+        },
+        {
+          "familiar": "astra",
+          "roles": [
+            "strategic-navigator",
+            "coordination-layer"
+          ]
+        },
+        {
+          "familiar": "charm",
+          "roles": [
+            "devrel-liaison",
+            "social-voice"
+          ]
+        }
+      ]
+    },
+    {
       "name": "coven-flows",
       "displayName": "Coven Flows",
       "category": "Coven",

--- a/marketplace/plugins/openclaw-skills/.codex-plugin/plugin.json
+++ b/marketplace/plugins/openclaw-skills/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "openclaw-skills",
+  "version": "0.1.0",
+  "description": "The migrated OpenClaw workspace skill library, represented in Coven so familiars can share one canonical skill surface.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "OpenClaw Skills",
+    "shortDescription": "The migrated OpenClaw workspace skill library, represented in Coven so familiars can share one canonical skill surface.",
+    "longDescription": "Use the migrated OpenClaw skill library from Coven, checking coverage before treating the migration as complete.",
+    "developerName": "OpenCoven",
+    "category": "Coven",
+    "capabilities": [
+      "openclaw",
+      "skills",
+      "familiars",
+      "migration",
+      "coven"
+    ],
+    "defaultPrompt": "Help me use OpenClaw Skills safely."
+  }
+}

--- a/marketplace/plugins/openclaw-skills/plugin.json
+++ b/marketplace/plugins/openclaw-skills/plugin.json
@@ -1,0 +1,91 @@
+{
+  "name": "openclaw-skills",
+  "version": "0.1.0",
+  "description": "The migrated OpenClaw workspace skill library, represented in Coven so familiars can share one canonical skill surface.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "openclaw",
+    "skills",
+    "familiars",
+    "migration",
+    "coven"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell"
+  ],
+  "marketplaceId": "opencoven/openclaw-skills",
+  "x-coven": {
+    "displayName": "OpenClaw Skills",
+    "category": "Coven",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven/tree/main/skills",
+      "https://github.com/OpenCoven/coven/blob/main/skills/openclaw-skills-manifest.json"
+    ],
+    "roleAffinity": [
+      {
+        "familiar": "nova",
+        "roles": [
+          "operator",
+          "maintainer"
+        ]
+      },
+      {
+        "familiar": "cody",
+        "roles": [
+          "implementer",
+          "debugger",
+          "code-reviewer"
+        ]
+      },
+      {
+        "familiar": "kitty",
+        "roles": [
+          "general-helper"
+        ]
+      },
+      {
+        "familiar": "sage",
+        "roles": [
+          "researcher",
+          "librarian"
+        ]
+      },
+      {
+        "familiar": "echo",
+        "roles": [
+          "archivist",
+          "retrospector"
+        ]
+      },
+      {
+        "familiar": "astra",
+        "roles": [
+          "strategic-navigator",
+          "coordination-layer"
+        ]
+      },
+      {
+        "familiar": "charm",
+        "roles": [
+          "devrel-liaison",
+          "social-voice"
+        ]
+      }
+    ],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": true
+    }
+  }
+}

--- a/marketplace/plugins/openclaw-skills/skills/openclaw-skills/SKILL.md
+++ b/marketplace/plugins/openclaw-skills/skills/openclaw-skills/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: openclaw-skills
+description: Use the migrated OpenClaw skill library from Coven, checking coverage before treating the migration as complete.
+---
+
+# OpenClaw Skills
+
+Use the migrated OpenClaw skill library from Coven, checking coverage before treating the migration as complete.
+
+## Use When
+- Find the Coven copy of an OpenClaw workspace skill
+- Verify OpenClaw skill migration coverage
+- Update shared familiar workflows through the Coven skill library
+
+## Guardrails
+- Run the Coven `sync-openclaw-skills` coverage check before claiming 100% migration
+- Do not overwrite richer Coven-native skills when a represented skill already exists
+- Keep secret-bearing examples sanitized before publishing skills
+
+## Default Flow
+
+1. Confirm the user intent and whether the action is read-only or state-changing.
+2. Use the narrowest available tool scope and collect only the context needed for the task.
+3. For state-changing or external actions, stop for explicit approval before acting.
+4. Summarize what changed or what was learned, including relevant object IDs or links.

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   mergeCatalog,
   deriveRequiresSetup,
@@ -172,5 +173,21 @@ assert.deepEqual(
 );
 // coven-native collection is category-driven so it always tracks first-party plugins
 assert.equal(COLLECTIONS.find((c) => c.id === "coven-native").category, "Coven");
+
+// --- production marketplace: OpenClaw skill migration is visible in Cave ---
+const productionMarketplace = JSON.parse(
+  readFileSync(new URL("../../marketplace/marketplace.json", import.meta.url), "utf8"),
+);
+const productionOpenClawSkills = productionMarketplace.plugins.find(
+  (p) => p.name === "openclaw-skills",
+);
+assert.ok(productionOpenClawSkills, "OpenClaw Skills card should be present in Cave marketplace");
+assert.equal(productionOpenClawSkills.displayName, "OpenClaw Skills");
+assert.equal(productionOpenClawSkills.category, "Coven");
+assert.equal(
+  COLLECTIONS.find((c) => c.id === "coven-native").category,
+  productionOpenClawSkills.category,
+  "OpenClaw Skills should appear in the Cave Coven native collection",
+);
 
 console.log("marketplace-catalog.test.ts: ok");


### PR DESCRIPTION
## Summary
- add a first-party `OpenClaw Skills` Marketplace plugin/card in category `Coven`
- regenerate marketplace, Codex, and role-affinity exports so the card appears in Cave's Coven-native collection
- add a marketplace regression assertion that keeps the OpenClaw Skills card visible in the Coven collection

## Verification
- `python3 scripts/sync-marketplace.py --check`
- `node --experimental-strip-types src/lib/marketplace-catalog.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck` using the primary checkout dependency symlink, then removed
- `/Users/buns/.openclaw/workspace/bin/secret-preflight` on changed marketplace/test files
- `git diff --check`