### PR TITLE
e2e: fail the surface-sweep test on render crashes

### DIFF
--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -68,6 +68,23 @@ test.describe("mobile foundations", () => {
   });
 
   test("desktop shell is headerless and non-scrollable across primary surfaces", async ({ page }) => {
+    // Guard against render crashes on any surface. The chrome/layout assertions
+    // below all PASS when a surface infinite-loops or throws, because React
+    // tears the app down to its error boundary — and a centered "couldn't load"
+    // view has a hidden top bar, no overflow, and fits the viewport. So without
+    // this, a surface can be fully broken and the test stays green (exactly how
+    // the #2162 CodeSidebar `useSyncExternalStore` infinite loop reached main).
+    // Catch both uncaught exceptions and the fatal React render-error class
+    // (which an error boundary swallows into a console.error rather than a
+    // pageerror). Benign console noise (failed daemon-less fetches) is ignored.
+    const pageErrors: string[] = [];
+    const fatalConsole: string[] = [];
+    const FATAL_RENDER = /maximum update depth|too many re-?renders|minified react error|getsnapshot should be cached|rendered (more|fewer) hooks|hooks can only be called/i;
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && FATAL_RENDER.test(msg.text())) fatalConsole.push(msg.text());
+    });
+
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.waitForSelector(".shell-frame");
@@ -102,6 +119,11 @@ test.describe("mobile foundations", () => {
       expect(metrics.bodyOverflow, `${surface} should not create body vertical scroll`).toBeLessThanOrEqual(1);
       expect(metrics.frameBottom, `${surface} app frame should fit the viewport`).toBeLessThanOrEqual(metrics.viewportHeight + 1);
     }
+
+    // No surface may crash the app. (These would be invisible to the layout
+    // assertions above — see the note at the top of this test.)
+    expect(pageErrors, `uncaught page errors while sweeping surfaces:\n${pageErrors.join("\n")}`).toEqual([]);
+    expect(fatalConsole, `fatal React render errors while sweeping surfaces:\n${fatalConsole.join("\n")}`).toEqual([]);
   });
 
   test("library document rail scrolls inside the right panel", async ({ page }) => {


### PR DESCRIPTION
## Why

Follow-up to the #2162 Code-surface crash (fixed in #2175). That infinite-render loop reached `main` with **green E2E** even though the E2E suite *does* navigate to the Code surface.

The reason: `tests/mobile/foundations.spec.ts` → "desktop shell is headerless…" sweeps every primary surface (`home/chat/board/calendar/browser/terminal/code` at 1280×720) but only asserts **chrome/layout** invariants — top bar hidden, no overflow, frame fits viewport. When a surface crashes, React renders the top-level error boundary, and that minimal "couldn't load" view *satisfies all three* (top bar absent, no overflow, `.shell-frame` gone so `frameBottom` is 0). So a fully-broken surface passes. The suite has **no `pageerror`/console-error guard** anywhere.

## What

Add an error guard to the sweep:
- collect uncaught `pageerror`s (any surface),
- collect the **fatal React render-error class** via a tight regex (`maximum update depth`, `too many re-renders`, `minified react error`, `getSnapshot should be cached`, `rendered more/fewer hooks`, …) — these get swallowed into a `console.error` by the error boundary rather than surfacing as a pageerror,
- assert both empty after the loop.

Benign daemon-less fetch noise doesn't match the regex, so it's ignored.

## Verified locally (Playwright, `next dev` + `COVEN_CAVE_E2E=1`)

- **Passes** on current `main` across all 7 surfaces (no false positives).
- **Fails** when the #2162 bug is reintroduced: `uncaught page errors while sweeping surfaces: Maximum update depth exceeded`.

This turns render crashes (loops, thrown effects, hook violations) into a red E2E for the whole primary-surface set, instead of an invisible pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)