### PR TITLE
feat(chat): skill detail preview in the /skill /skills picker

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -24,6 +24,7 @@ import { resolveFamiliar } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarInlineCard } from "@/components/familiar-inline-card";
 import { ArtifactComments } from "@/components/artifact-comments";
+import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import { ChatArchiveNudge } from "@/components/chat-archive-nudge";
 import {
   isChatArchiveNudgeDismissed,
@@ -4714,7 +4715,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             </div>
           ) : skillMenuActive && skillOptions ? (
             <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
-              <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Skills">
+              <div className="flex">
+              <ul className="max-h-64 flex-1 min-w-0 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Skills">
                 {skillOptions.map((s, i) => {
                   const active = i === slashIdx;
                   return (
@@ -4745,6 +4747,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   );
                 })}
               </ul>
+              <SkillDetailPreview skill={skillOptions[slashIdx] ?? skillOptions[0] ?? null} />
+              </div>
               <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
                 {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
               </div>

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -25,6 +25,7 @@ import {
   buildSkillPrompt,
   type SkillOption,
 } from "@/lib/slash-skill";
+import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import type { ChatModelState } from "@/lib/chat-model-state";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
@@ -730,25 +731,28 @@ export function HomeComposer({
           </div>
         ) : skillMenuActive && skillOptions ? (
           <div className="hc-slash-menu">
-            <ul className="hc-slash-list" id={slashListboxId} role="listbox" aria-label="Skills">
-              {skillOptions.map((s, i) => {
-                const active = i === slashIdx;
-                return (
-                  <li key={s.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
-                    <button
-                      type="button"
-                      tabIndex={-1}
-                      onMouseEnter={() => setSlashIdx(i)}
-                      onClick={() => invokeSkill(s)}
-                      className={`hc-slash-row${active ? " active" : ""}`}
-                    >
-                      <span className="hc-slash-name">{s.name}</span>
-                      <span className="hc-slash-desc">{s.description || s.id}</span>
-                    </button>
-                  </li>
-                );
-              })}
-            </ul>
+            <div className="hc-slash-body">
+              <ul className="hc-slash-list" id={slashListboxId} role="listbox" aria-label="Skills">
+                {skillOptions.map((s, i) => {
+                  const active = i === slashIdx;
+                  return (
+                    <li key={s.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        onMouseEnter={() => setSlashIdx(i)}
+                        onClick={() => invokeSkill(s)}
+                        className={`hc-slash-row${active ? " active" : ""}`}
+                      >
+                        <span className="hc-slash-name">{s.name}</span>
+                        <span className="hc-slash-desc">{s.description || s.id}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <SkillDetailPreview skill={skillOptions[slashIdx] ?? skillOptions[0] ?? null} />
+            </div>
             <div className="hc-slash-footer">↑↓ navigate · Enter run · Tab complete · Esc cancel</div>
           </div>
         ) : slashSuggestions.length > 0 ? (

--- a/src/components/skill-detail-preview.tsx
+++ b/src/components/skill-detail-preview.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+// Detail preview for the `/skill` / `/skills` picker — shows the highlighted
+// skill's full metadata (scope, kind, version, description, tags, path) beside
+// the option list, so you can read what a skill does before running it.
+
+import { Icon } from "@/lib/icon";
+import type { SkillOption } from "@/lib/slash-skill";
+import "@/styles/skill-detail-preview.css";
+
+export function SkillDetailPreview({ skill }: { skill: SkillOption | null }) {
+  if (!skill) {
+    return (
+      <div className="skill-preview skill-preview--empty" aria-hidden>
+        Highlight a skill to preview it.
+      </div>
+    );
+  }
+  return (
+    <div className="skill-preview" role="region" aria-label={`${skill.name} details`}>
+      <div className="skill-preview__head">
+        <Icon name="ph:sparkle" width={14} className="skill-preview__icon" aria-hidden />
+        <span className="skill-preview__name">{skill.name}</span>
+      </div>
+      <div className="skill-preview__meta">
+        {skill.familiar ? <span className="skill-preview__chip">{skill.familiar}</span> : null}
+        {skill.kind ? <span className="skill-preview__chip">{skill.kind}</span> : null}
+        {skill.version ? <span className="skill-preview__chip">v{skill.version}</span> : null}
+      </div>
+      {skill.description ? (
+        <p className="skill-preview__desc">{skill.description}</p>
+      ) : (
+        <p className="skill-preview__desc skill-preview__desc--muted">No description provided.</p>
+      )}
+      {skill.tags?.length ? (
+        <div className="skill-preview__tags">
+          {skill.tags.slice(0, 8).map((t) => (
+            <span key={t} className="skill-preview__tag">
+              {t}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {skill.path ? (
+        <div className="skill-preview__path" title={skill.path}>
+          {skill.path}
+        </div>
+      ) : null}
+      <div className="skill-preview__hint">
+        <kbd>↵</kbd> run · <kbd>↹</kbd> complete
+      </div>
+    </div>
+  );
+}

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -54,4 +54,25 @@ assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill\)\)/, "chat-view invoke
 assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");
 assert.match(chatView, /fetch\("\/api\/skills\/local"/, "chat-view sources skills from the local skill scan");
 
+// ── Skill detail preview in the picker ───────────────────────────────────────
+const preview = await readFile(new URL("../components/skill-detail-preview.tsx", import.meta.url), "utf8");
+assert.match(preview, /export function SkillDetailPreview\(\{ skill \}/, "exports a SkillDetailPreview component");
+assert.match(preview, /skill\.description/, "preview shows the full description");
+assert.match(preview, /skill\.tags\?\.length/, "preview shows tags when present");
+assert.match(preview, /skill\.path/, "preview shows the skill path");
+assert.match(preview, /skill\.familiar/, "preview shows the skill scope");
+
+const homeComposer = await readFile(new URL("../components/home-composer.tsx", import.meta.url), "utf8");
+for (const [label, src] of [["chat-view", chatView], ["home-composer", homeComposer]]) {
+  assert.match(
+    src,
+    /<SkillDetailPreview skill=\{skillOptions\[slashIdx\] \?\? skillOptions\[0\] \?\? null\}/,
+    `${label} renders the detail preview for the highlighted skill`,
+  );
+}
+
+// The SkillOption type carries the metadata the preview renders.
+const lib = await readFile(new URL("./slash-skill.ts", import.meta.url), "utf8");
+assert.match(lib, /version\?: string;[\s\S]*?tags\?: string\[\];[\s\S]*?path\?: string;/, "SkillOption carries preview metadata");
+
 console.log("slash-skill.test.ts: ok");

--- a/src/lib/slash-skill.ts
+++ b/src/lib/slash-skill.ts
@@ -10,6 +10,12 @@ export type SkillOption = {
   description?: string;
   /** Scope the skill belongs to (e.g. "global", "user") — shown as a hint. */
   familiar?: string;
+  // Extra metadata from /api/skills/local, shown in the picker's detail preview.
+  version?: string;
+  kind?: string;
+  tags?: string[];
+  /** Absolute path to the skill directory (shown muted in the preview). */
+  path?: string;
 };
 
 // `/skills` is the no-arg "show everything" picker; it also accepts a trailing

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -786,6 +786,10 @@
     0 14px 32px -16px color-mix(in oklch, var(--accent-presence) 22%, transparent),
     0 4px 18px -6px rgb(0 0 0 / 0.35);
 }
+/* Skills picker: option list + detail preview side by side. */
+.hc-slash-body { display: flex; align-items: stretch; min-height: 0; }
+.hc-slash-body .hc-slash-list { flex: 1 1 auto; min-width: 0; }
+.hc-slash-body .skill-preview { max-height: 260px; }
 .hc-slash-list {
   list-style: none;
   margin: 0;

--- a/src/styles/skill-detail-preview.css
+++ b/src/styles/skill-detail-preview.css
@@ -1,0 +1,98 @@
+/* Skill detail preview pane in the /skill /skills picker (see
+   skill-detail-preview.tsx). Sits to the right of the option list. */
+
+.skill-preview {
+  flex: 0 0 244px;
+  width: 244px;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 12px 10px;
+  border-left: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 40%, transparent);
+  overflow-y: auto;
+  max-height: 16rem;
+}
+.skill-preview--empty {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 11.5px;
+  color: var(--text-muted);
+}
+.skill-preview__head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.skill-preview__icon { color: var(--accent-presence); flex: 0 0 auto; }
+.skill-preview__name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+.skill-preview__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.skill-preview__chip {
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, var(--accent-presence) 80%, var(--text-secondary));
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 24%, transparent);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+.skill-preview__desc {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+.skill-preview__desc--muted { font-style: italic; color: var(--text-muted); }
+.skill-preview__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.skill-preview__tag {
+  font-size: 10px;
+  color: var(--text-muted);
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  padding: 1px 6px;
+}
+.skill-preview__path {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.skill-preview__hint {
+  margin-top: auto;
+  font-size: 10px;
+  color: var(--text-muted);
+}
+.skill-preview__hint kbd {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  border-radius: 4px;
+  padding: 0 4px;
+}
+
+/* On narrow widths the side preview would crowd the list — hide it and let the
+   per-row description carry the detail. */
+@media (max-width: 560px) {
+  .skill-preview { display: none; }
+}


### PR DESCRIPTION
## What

Adds a **detail preview** beside the `/skill` / `/skills` picker. As you navigate (keyboard or hover), a side pane shows the highlighted skill's:
- name + scope chip (`global` / `user`), kind, version
- **full, un-truncated description**
- tags
- skill directory path

So you can read what a skill does before running it.

## How
- **`skill-detail-preview.tsx`** (shared) + `skill-detail-preview.css` — one presentational `SkillDetailPreview` used by both composers; tracks the highlighted index (`skillOptions[slashIdx]`).
- **`SkillOption`** widened with `version`/`kind`/`tags`/`path` (already returned by `/api/skills/local`).
- **chat-view** + **home-composer**: the Skills listbox becomes a two-pane row (list + preview). Hidden under 560px so narrow widths keep the full-width list.

## Files
`slash-skill.ts`, `skill-detail-preview.tsx`, `skill-detail-preview.css`, `chat-view.tsx`, `home-composer.tsx`, `home-composer.css`, `slash-skill.test.ts`.

## Verification
- Tests pass; `pnpm build` green.
- Drove a real chat session: typing `/skills` shows the list + a detail pane that updates as the highlight moves (verified coven-cody → scope chip, full doctrine description, path). Screenshot confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)