### PR TITLE
ActionInbox: tick relative-time labels so they don't freeze

### DIFF
--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/lib/daily-report";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
@@ -28,6 +29,8 @@ function minutesUntilTomorrowMorning(): number {
 
 export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  useMinuteTick();    // keep the per-item "Nm ago" labels current; the parent
+                      // cockpit re-fetches the list itself every 30s.
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
   const [snoozeOpenId, setSnoozeOpenId] = useState<string | null>(null);


### PR DESCRIPTION
## Problem
The dashboard action inbox rendered per-item "Nm ago" labels that never advanced — the component only re-rendered on user actions. (Its parent cockpit already re-fetches the list every 30s, so the list itself stays fresh; only the relative-time labels drifted.)

Candidate #2 from the staleness audit; continues the live-progress arc (#2152, #2165, #2168, #2174, #2180).

## Fix
- Add `useMinuteTick` so the "ago" labels stay current.
- **Deliberately does NOT** re-sync `items` from `initialItems` on prop change — that would clobber optimistic done/dismiss/snooze removes. List freshness stays the parent's job; this only fixes the time labels.

## Verification
- Typecheck clean; Frontend build green, bundle within budget; both source-text tests that read this file pass (`dashboard-page.test.ts`, `a11y-audit-fixes.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)