### PR TITLE
e2e: sweep ALL workspace surfaces for render crashes

### DIFF
--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -253,4 +253,49 @@ test.describe("mobile foundations", () => {
     const toggles = page.locator(".top-bar__mobile-toggle");
     await expect(toggles.first()).toBeVisible();
   });
+
+  // EVERY workspace surface must mount without a render crash. The
+  // "desktop shell is headerless…" test above guards the 7 primary surfaces,
+  // but a render loop / thrown effect / hook violation on any of the other
+  // surfaces (familiars, group chat, automations, github, roles, marketplace,
+  // flow, evals, retro, capabilities, journal, …) would never be seen — nothing
+  // navigates to them, and CI's build doesn't render. This sweeps ALL of
+  // WorkspaceMode and fails on any crash, daemon-less. It does NOT assert
+  // layout (some surfaces legitimately scroll); it only asserts "didn't crash".
+  test("no workspace surface crashes on navigation", async ({ page }) => {
+    // The complete WorkspaceMode set (src/lib/workspace-mode.ts). Keep in sync
+    // when a new surface is added — a new mode with a render crash should turn
+    // this red.
+    const ALL_SURFACES = [
+      "home", "agents", "chat", "groupchat", "board", "calendar", "inbox",
+      "library", "browser", "terminal", "code", "github", "roles", "marketplace",
+      "flow", "evals", "submissions", "retro", "capabilities", "journal",
+    ];
+
+    const FATAL_RENDER = /maximum update depth|too many re-?renders|minified react error|getsnapshot should be cached|rendered (more|fewer) hooks|hooks can only be called/i;
+    const errors: string[] = [];
+    let current = "(initial)";
+    page.on("pageerror", (err) => errors.push(`[${current}] pageerror: ${err.message}`));
+    page.on("console", (msg) => {
+      if (msg.type() === "error" && FATAL_RENDER.test(msg.text())) errors.push(`[${current}] ${msg.text()}`);
+    });
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await page.waitForSelector(".shell-frame");
+
+    for (const surface of ALL_SURFACES) {
+      current = surface;
+      await page.evaluate(
+        (mode) => window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } })),
+        surface,
+      );
+      await page.waitForTimeout(250);
+      // The shell frame must survive every navigation (a render crash unmounts
+      // the app to the top-level error boundary, removing it).
+      await expect(page.locator(".shell-frame"), `${surface} must keep the app shell mounted (no crash)`).toBeVisible();
+    }
+
+    expect(errors, `render crashes while sweeping surfaces:\n${errors.join("\n")}`).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Why

The render-crash guard added in #2179 covers only the **7 primary surfaces** in the existing sweep. Checking coverage showed **12 of the 20 `WorkspaceMode` surfaces are never navigated to by any e2e spec** — `agents, groupchat, inbox, github, roles, marketplace, flow, evals, submissions, retro, capabilities, journal`. A render crash on any of them (the same class as the #2162 CodeSidebar loop) would be invisible to CI: nothing renders them, and the build doesn't execute React.

## What

Adds `tests/mobile/foundations.spec.ts` → **"no workspace surface crashes on navigation"**, which navigates to **every** `WorkspaceMode` and fails on a crash. Per surface it:
- asserts the app shell (`.shell-frame`) survived — a render crash unmounts it to the top-level error boundary;
- collects uncaught `pageerror`s and the fatal React render-error class (swallowed into `console.error` by the boundary), **tagged by surface name** so a failure names the culprit.

It intentionally does **not** assert layout (some surfaces legitimately scroll) — it only catches "didn't crash", daemon-less.

## Verified locally (Playwright, `next dev` + `COVEN_CAVE_E2E=1`)

- **All 20 surfaces pass clean** — no false positives, no surface needed a mock or exclusion in the daemon-less env.
- Full `foundations.spec.ts` still green (8 tests).
- Reintroducing the #2162 bug fails the test with **`[code] must keep the app shell mounted (no crash)`** (pinpoints the surface).

Net: render crashes (loops, thrown effects, hook violations) on **any** workspace surface now turn E2E red, not just the 7 primary ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)