### PR TITLE
feat(quick-chat): reveal quick chat from a top-bar icon + comprehensive composer enhancements

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -490,6 +490,7 @@ export const SUITES = {
     "src/components/familiar-menu-bar.test.ts",
     "src/components/menu-bar-icon-size.test.ts",
     "src/components/tray-quick-chat.test.ts",
+    "src/components/quick-chat-overlay.test.ts",
     "src/components/familiar-quick-switch.test.ts",
     "src/components/familiar-pin-order.test.ts",
     "src/lib/familiar-quick-switch.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10666,3 +10666,30 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   background: color-mix(in oklch, var(--text-primary) 8%, transparent);
   color: var(--text-primary);
 }
+
+/* Quick-chat reveal: an in-app popover anchored top-right under the top bar,
+   opened by the top-bar chat-circle icon. The Tauri standalone window
+   (TrayQuickChat) reuses the same useQuickChat hook but renders full-screen. */
+.quick-chat-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1190;
+  background: transparent;
+}
+
+.quick-chat-overlay {
+  position: fixed;
+  top: 52px;
+  right: 12px;
+  z-index: 1200;
+  width: 360px;
+  max-width: calc(100vw - 24px);
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--radius-panel, 12px);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-panel);
+  color: var(--fg-primary);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}

--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./quick-chat-overlay.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /useQuickChat\(\)/,
+  "overlay shares the quick-chat state/send logic via the useQuickChat hook",
+);
+assert.match(
+  source,
+  /role="dialog"/,
+  "overlay panel is a dialog",
+);
+assert.match(
+  source,
+  /aria-modal="true"/,
+  "overlay dialog is modal",
+);
+assert.match(
+  source,
+  /aria-label="Quick chat"/,
+  "overlay dialog is accessibly labeled",
+);
+assert.match(
+  source,
+  /event\.key === "Escape"[\s\S]*onClose\(\)/,
+  "Escape closes the overlay via a window keydown listener",
+);
+assert.match(
+  source,
+  /window\.addEventListener\("keydown"/,
+  "overlay listens for keydown while open",
+);
+assert.match(
+  source,
+  /onOpenFullSession\?\.\(sessionId, selectedFamiliarId\)/,
+  "overlay opens the saved session in the full app",
+);
+assert.match(
+  source,
+  /aria-live="polite"/,
+  "overlay answer pane announces streamed text",
+);
+assert.match(
+  source,
+  /\(event\.metaKey \|\| event\.ctrlKey\) && event\.key === "Enter"/,
+  "overlay textarea sends on Cmd/Ctrl+Enter",
+);
+assert.match(
+  source,
+  /onClick=\{onClose\}/,
+  "overlay backdrop / close button calls onClose",
+);
+
+// Workspace wires the overlay to its open state and the full-session opener.
+assert.match(
+  workspace,
+  /<QuickChatOverlay[\s\S]*onOpenFullSession=\{\(sid, fid\) =>/,
+  "workspace renders QuickChatOverlay and routes Open-in-full-chat to openFamiliarSession",
+);
+
+console.log("quick-chat-overlay.test.ts OK");

--- a/src/components/quick-chat-overlay.tsx
+++ b/src/components/quick-chat-overlay.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import {
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
+import { Icon } from "@/lib/icon";
+import { useQuickChat } from "@/lib/use-quick-chat";
+import type { Familiar } from "@/lib/types";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onOpenFullSession?: (sessionId: string, familiarId?: string | null) => void;
+};
+
+function initials(familiar: Familiar): string {
+  return (familiar.display_name || familiar.id)
+    .split(/\s+/)
+    .map((part) => part[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export function QuickChatOverlay({ open, onClose, onOpenFullSession }: Props) {
+  const {
+    familiars,
+    selectedFamiliarId,
+    setSelectedFamiliarId,
+    selectedFamiliar,
+    draft,
+    setDraft,
+    answer,
+    error,
+    sessionId,
+    sendState,
+    loading,
+    thinkingEffort,
+    setThinkingEffort,
+    responseSpeed,
+    setResponseSpeed,
+    send,
+    cancel,
+  } = useQuickChat();
+
+  const sending = sendState === "sending";
+
+  // Escape closes the popover while it's open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const onTextareaKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        if (!sending) void send();
+      }
+    },
+    [send, sending],
+  );
+
+  const openFull = useCallback(() => {
+    if (!sessionId) return;
+    onOpenFullSession?.(sessionId, selectedFamiliarId);
+    onClose();
+  }, [onClose, onOpenFullSession, selectedFamiliarId, sessionId]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        className="quick-chat-overlay-backdrop"
+        style={{ position: "fixed", inset: 0 }}
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Quick chat"
+        className="quick-chat-overlay"
+      >
+        <header className="flex items-center justify-between border-b border-[var(--border-hairline)] px-4 py-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Icon name="ph:chat-circle-dots" width={18} aria-hidden />
+            <div className="min-w-0">
+              <h2 className="truncate text-sm font-semibold">Quick chat</h2>
+              <p className="truncate text-xs text-[var(--fg-muted)]">
+                {selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close quick chat"
+            title="Close"
+            className="ui-icon-btn ui-icon-btn--sm"
+          >
+            <Icon name="ph:x" width={14} aria-hidden />
+          </button>
+        </header>
+
+        <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
+          <Icon name="ph:at" width={14} aria-hidden />
+          <select
+            value={selectedFamiliarId ?? ""}
+            onChange={(event) => setSelectedFamiliarId(event.target.value || null)}
+            disabled={loading || familiars.length === 0}
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+            aria-label="Familiar"
+          >
+            {familiars.map((familiar) => (
+              <option key={familiar.id} value={familiar.id}>
+                {familiar.display_name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
+          <select
+            value={thinkingEffort}
+            onChange={(event) => setThinkingEffort(event.target.value as CommandThinkingEffort)}
+            disabled={sending}
+            className="min-w-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
+            aria-label="Choose thinking effort"
+          >
+            {COMMAND_THINKING_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <select
+            value={responseSpeed}
+            onChange={(event) => setResponseSpeed(event.target.value as CommandResponseSpeed)}
+            disabled={sending}
+            className="min-w-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
+            aria-label="Choose response speed"
+          >
+            {COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="px-4 py-3">
+          {selectedFamiliar ? (
+            <div className="mb-3 flex items-center gap-2 text-xs text-[var(--fg-muted)]">
+              {selectedFamiliar.avatarUrl ? (
+                <img
+                  src={selectedFamiliar.avatarUrl}
+                  alt=""
+                  className="h-6 w-6 rounded-sm object-cover"
+                />
+              ) : (
+                <span className="grid h-6 w-6 place-items-center rounded-sm bg-[var(--bg-elevated)] text-[10px] font-semibold text-[var(--fg-primary)]">
+                  {initials(selectedFamiliar)}
+                </span>
+              )}
+              <span className="min-w-0 truncate">{selectedFamiliar.role}</span>
+            </div>
+          ) : null}
+
+          <label className="block text-xs font-medium text-[var(--fg-muted)]" htmlFor="quick-chat-overlay-draft">
+            Message
+          </label>
+          <textarea
+            id="quick-chat-overlay-draft"
+            value={draft}
+            autoFocus
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={onTextareaKeyDown}
+            placeholder="@sage summarize what needs attention"
+            className="mt-2 h-24 w-full resize-none rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-sm outline-none focus:border-[var(--accent-presence)]"
+          />
+
+          {error ? (
+            <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--fg-primary)]">
+              <span className="min-w-0 truncate">{error}</span>
+              <button
+                type="button"
+                onClick={() => void send()}
+                disabled={sending}
+                className="shrink-0 rounded-md border border-[var(--border-hairline)] px-2 py-1 text-xs font-medium disabled:opacity-50"
+              >
+                Retry
+              </button>
+            </div>
+          ) : null}
+
+          <div
+            className="mt-3 max-h-48 min-h-24 overflow-auto rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 text-sm"
+            aria-live="polite"
+          >
+            {answer ? (
+              <p className="whitespace-pre-wrap leading-6">{answer}</p>
+            ) : sending ? (
+              <p className="text-[var(--fg-muted)]">Thinking...</p>
+            ) : (
+              <p className="text-[var(--fg-muted)]">The reply will appear here.</p>
+            )}
+          </div>
+        </div>
+
+        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-3">
+          <button
+            type="button"
+            onClick={openFull}
+            disabled={!sessionId}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2.5 py-2 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Icon name="ph:arrow-square-out" width={12} aria-hidden />
+            Open in full chat
+          </button>
+          <div className="flex items-center gap-2">
+            {sending ? (
+              <button
+                type="button"
+                onClick={cancel}
+                className="inline-flex items-center gap-2 rounded-md border border-[var(--border-hairline)] px-3 py-2 text-sm font-medium"
+              >
+                Cancel
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void send()}
+              disabled={sending || loading}
+              className="inline-flex items-center gap-2 rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[var(--accent-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Icon name="ph:sparkle" width={14} aria-hidden />
+              Send
+            </button>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -182,4 +182,21 @@ assert.match(
   "Tasks button shows an open-task count badge, hidden at zero",
 );
 
+// Quick-chat reveal: a single top-bar icon button opens the in-app popover.
+assert.match(
+  source,
+  /onOpenQuickChat\?: \(\) => void/,
+  "Top bar accepts an onOpenQuickChat handler to reveal the in-app quick chat",
+);
+assert.match(
+  source,
+  /onClick=\{onOpenQuickChat\}/,
+  "Top bar wires the quick-chat button to the onOpenQuickChat handler",
+);
+assert.match(
+  source,
+  /aria-label="Quick chat"/,
+  "Quick-chat top-bar button is accessibly labeled",
+);
+
 console.log("top-bar.test.ts: ok");

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -35,6 +35,9 @@ type Props = {
    *  `FamiliarMenuBar` carries these), so these render only on mobile. Omit
    *  either handler to hide that button. */
   onEnrichTasks?: () => void;
+  /** Reveal the in-app quick-chat popover (anchored under the top bar). When
+   *  provided, the top bar renders a chat icon button that toggles it open. */
+  onOpenQuickChat?: () => void;
   enrichingTasks?: boolean;
   enrichProgress?: { done: number; total: number } | null;
   onViewTasks?: () => void;
@@ -84,6 +87,7 @@ export function TopBar(props: Props) {
     familiarOptions,
     onSelectFamiliar,
     onEnrichTasks,
+    onOpenQuickChat,
     enrichingTasks,
     enrichProgress,
     onViewTasks,
@@ -175,6 +179,17 @@ export function TopBar(props: Props) {
             placement="bottom-end"
             labeled={familiarSwitcherLabeled}
           />
+        ) : null}
+        {onOpenQuickChat ? (
+          <button
+            type="button"
+            className="top-bar__icon-btn"
+            onClick={onOpenQuickChat}
+            aria-label="Quick chat"
+            title="Quick chat"
+          >
+            <Icon name="ph:chat-circle-dots" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
+          </button>
         ) : null}
         {onEnrichTasks ? (
           <button

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -5,20 +5,24 @@ import { readFileSync } from "node:fs";
 const component = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
 const page = readFileSync(new URL("../app/quick-chat/page.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+// Quick-chat state + send logic now lives in the shared useQuickChat hook,
+// consumed by both the Tauri window (this component) and the in-app overlay.
+const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
 
 assert.match(
   page,
   /import \{ TrayQuickChat \} from "@\/components\/tray-quick-chat"/,
   "quick-chat route renders the tray quick chat component",
 );
-assert.match(component, /fetch\("\/api\/familiars"\)/, "quick chat loads the familiar roster");
+assert.match(component, /useQuickChat\(\)/, "tray quick chat consumes the shared useQuickChat hook");
+assert.match(hook, /fetch\("\/api\/familiars"\)/, "quick chat loads the familiar roster");
 assert.match(
-  component,
+  hook,
   /resolveQuickChatTarget\(draft, familiars, selectedFamiliarId\)/,
   "quick chat resolves @familiar mentions before sending",
 );
 assert.match(
-  component,
+  hook,
   /streamFamiliarText\(\{[\s\S]*familiarId: target\.familiarId,[\s\S]*prompt: target\.prompt/,
   "quick chat sends through the sanctioned familiar chat bridge",
 );
@@ -33,9 +37,19 @@ assert.match(
   "quick chat uses the shared response speed options",
 );
 assert.match(
-  component,
+  hook,
   /streamFamiliarText\(\{[\s\S]*reasoningEffort: thinkingEffort,[\s\S]*responseSpeed,[\s\S]*\}\)/,
   "quick chat forwards compact command controls to the familiar stream helper",
+);
+assert.match(
+  component,
+  /onKeyDown=\{onKeyDown\}/,
+  "tray textarea sends on Cmd/Ctrl+Enter via onKeyDown",
+);
+assert.match(
+  component,
+  /\(event\.metaKey \|\| event\.ctrlKey\) && event\.key === "Enter"/,
+  "tray Cmd/Ctrl+Enter handler sends the draft",
 );
 assert.match(
   component,

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -1,21 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback } from "react";
 import {
-  COMMAND_CONTROL_DEFAULTS,
   COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
   type CommandResponseSpeed,
   type CommandThinkingEffort,
 } from "@/lib/command-controls";
 import { Icon } from "@/lib/icon";
-import { resolveQuickChatTarget } from "@/lib/quick-chat";
-import { streamFamiliarText } from "@/lib/familiar-stream";
+import { useQuickChat } from "@/lib/use-quick-chat";
 import type { Familiar } from "@/lib/types";
-
-const LAST_FAMILIAR_KEY = "cave.quick-chat.last-familiar";
-
-type SendState = "idle" | "sending" | "done";
 
 function initials(familiar: Familiar): string {
   return (familiar.display_name || familiar.id)
@@ -27,76 +21,37 @@ function initials(familiar: Familiar): string {
 }
 
 export function TrayQuickChat() {
-  const [familiars, setFamiliars] = useState<Familiar[]>([]);
-  const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
-  const [draft, setDraft] = useState("");
-  const [answer, setAnswer] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [sessionId, setSessionId] = useState<string | null>(null);
-  const [sendState, setSendState] = useState<SendState>("idle");
-  const [loading, setLoading] = useState(true);
-  const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
-    COMMAND_CONTROL_DEFAULTS.thinkingEffort,
-  );
-  const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
-    COMMAND_CONTROL_DEFAULTS.responseSpeed,
-  );
+  const {
+    familiars,
+    selectedFamiliarId,
+    setSelectedFamiliarId,
+    selectedFamiliar,
+    draft,
+    setDraft,
+    answer,
+    error,
+    sessionId,
+    sendState,
+    loading,
+    thinkingEffort,
+    setThinkingEffort,
+    responseSpeed,
+    setResponseSpeed,
+    send,
+    cancel,
+  } = useQuickChat();
 
-  useEffect(() => {
-    let alive = true;
-    void (async () => {
-      try {
-        const res = await fetch("/api/familiars");
-        const json = await res.json();
-        if (!alive) return;
-        const next = (json?.familiars ?? []) as Familiar[];
-        const stored =
-          typeof window !== "undefined"
-            ? window.localStorage.getItem(LAST_FAMILIAR_KEY)
-            : null;
-        setFamiliars(next);
-        setSelectedFamiliarId(
-          (stored && next.some((familiar) => familiar.id === stored) ? stored : null) ??
-            next[0]?.id ??
-            null,
-        );
-      } catch (err) {
-        if (alive) setError((err as Error)?.message ?? "Failed to load familiars.");
-      } finally {
-        if (alive) setLoading(false);
+  const sending = sendState === "sending";
+
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+        event.preventDefault();
+        if (!sending) void send();
       }
-    })();
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  const selectedFamiliar = useMemo(
-    () => familiars.find((familiar) => familiar.id === selectedFamiliarId) ?? familiars[0] ?? null,
-    [familiars, selectedFamiliarId],
+    },
+    [send, sending],
   );
-
-  const send = useCallback(async () => {
-    const target = resolveQuickChatTarget(draft, familiars, selectedFamiliarId);
-    setError(target.error);
-    setAnswer("");
-    setSessionId(null);
-    if (target.error || !target.familiarId) return;
-
-    setSendState("sending");
-    setSelectedFamiliarId(target.familiarId);
-    window.localStorage.setItem(LAST_FAMILIAR_KEY, target.familiarId);
-    const result = await streamFamiliarText({
-      familiarId: target.familiarId,
-      prompt: target.prompt,
-      reasoningEffort: thinkingEffort,
-      responseSpeed,
-    });
-    setAnswer(result.text);
-    setError(result.error);
-    setSessionId(result.sessionId ?? null);
-    setSendState("done");
-  }, [draft, familiars, responseSpeed, selectedFamiliarId, thinkingEffort]);
 
   const openFullSession = useCallback(async () => {
     if (!sessionId) return;
@@ -154,7 +109,7 @@ export function TrayQuickChat() {
           <select
             value={thinkingEffort}
             onChange={(event) => setThinkingEffort(event.target.value as CommandThinkingEffort)}
-            disabled={sendState === "sending"}
+            disabled={sending}
             className="min-w-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
             aria-label="Choose thinking effort"
           >
@@ -167,7 +122,7 @@ export function TrayQuickChat() {
           <select
             value={responseSpeed}
             onChange={(event) => setResponseSpeed(event.target.value as CommandResponseSpeed)}
-            disabled={sendState === "sending"}
+            disabled={sending}
             className="min-w-0 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
             aria-label="Choose response speed"
           >
@@ -203,22 +158,35 @@ export function TrayQuickChat() {
           <textarea
             id="quick-chat-draft"
             value={draft}
+            autoFocus
             onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={onKeyDown}
             placeholder="@sage summarize what needs attention"
             className="mt-2 h-28 w-full resize-none rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-sm outline-none focus:border-[var(--accent-presence)]"
           />
 
           {error ? (
-            <p className="mt-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--fg-primary)]">
-              {error}
-            </p>
+            <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--fg-primary)]">
+              <span className="min-w-0 truncate">{error}</span>
+              <button
+                type="button"
+                onClick={() => void send()}
+                disabled={sending}
+                className="shrink-0 rounded-md border border-[var(--border-hairline)] px-2 py-1 text-xs font-medium disabled:opacity-50"
+              >
+                Retry
+              </button>
+            </div>
           ) : null}
 
-          <div className="mt-3 min-h-32 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 text-sm">
-            {sendState === "sending" ? (
-              <p className="text-[var(--fg-muted)]">Thinking...</p>
-            ) : answer ? (
+          <div
+            className="mt-3 min-h-32 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 text-sm"
+            aria-live="polite"
+          >
+            {answer ? (
               <p className="whitespace-pre-wrap leading-6">{answer}</p>
+            ) : sending ? (
+              <p className="text-[var(--fg-muted)]">Thinking...</p>
             ) : (
               <p className="text-[var(--fg-muted)]">The reply will appear here.</p>
             )}
@@ -227,17 +195,28 @@ export function TrayQuickChat() {
 
         <footer className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-3">
           <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
-            Use @id to switch familiars.
+            Use @id to switch familiars. ⌘↵ to send.
           </p>
-          <button
-            type="button"
-            onClick={send}
-            disabled={sendState === "sending" || loading}
-            className="inline-flex items-center gap-2 rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[var(--accent-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <Icon name="ph:sparkle" width={14} aria-hidden />
-            Send
-          </button>
+          <div className="flex items-center gap-2">
+            {sending ? (
+              <button
+                type="button"
+                onClick={cancel}
+                className="inline-flex items-center gap-2 rounded-md border border-[var(--border-hairline)] px-3 py-2 text-sm font-medium"
+              >
+                Cancel
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void send()}
+              disabled={sending || loading}
+              className="inline-flex items-center gap-2 rounded-md bg-[var(--accent)] px-3 py-2 text-sm font-medium text-[var(--accent-foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Icon name="ph:sparkle" width={14} aria-hidden />
+              Send
+            </button>
+          </div>
         </footer>
       </section>
     </main>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -77,6 +77,7 @@ import { normalizeGitHubTasks, type GitHubTask } from "@/lib/github-tasks";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useShellBanners } from "@/lib/shell-banners";
 import { TopBar } from "@/components/top-bar";
+import { QuickChatOverlay } from "@/components/quick-chat-overlay";
 import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
 import {
@@ -295,6 +296,7 @@ export function Workspace() {
   const [glyphPickerFor, setGlyphPickerFor] = useState<Familiar | null>(null);
   const [addChooserOpen, setAddChooserOpen] = useState(false);
   const [mobileHandoffOpen, setMobileHandoffOpen] = useState(false);
+  const [quickChatOpen, setQuickChatOpen] = useState(false);
   const [mobileModeEnabled, setMobileModeEnabledState] = useState(readMobileModeEnabled);
   const [mobileModeHost, setMobileModeHost] = useState<string | null>(null);
   const [mobileModeError, setMobileModeError] = useState<string | null>(null);
@@ -2228,6 +2230,7 @@ export function Workspace() {
               onOpenInbox={() => setMode("inbox")}
               onOpenSettings={() => nextRouter.push("/settings")}
               onOpenMobileHandoff={() => setMobileHandoffOpen(true)}
+              onOpenQuickChat={() => setQuickChatOpen(true)}
               inboxItems={inboxItemsWithEphemeral}
               familiars={familiars}
               activeFamiliar={resolvedFamiliars.find((f) => f.id === activeId) ?? null}
@@ -2441,6 +2444,15 @@ export function Workspace() {
         nativeHost={mobileModeHost}
         mobileModeError={mobileModeError}
         onMobileModeChange={setMobileModeEnabled}
+      />
+
+      <QuickChatOverlay
+        open={quickChatOpen}
+        onClose={() => setQuickChatOpen(false)}
+        onOpenFullSession={(sid, fid) => {
+          setQuickChatOpen(false);
+          openFamiliarSession(sid, fid);
+        }}
       />
     </FamiliarStudioProvider>
   );

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -19,6 +19,9 @@ export async function streamFamiliarText(opts: {
   modelOverride?: string;
   modelOverrideScope?: "next-message" | "session";
   signal?: AbortSignal;
+  /** Called with the accumulated assistant text after each streamed chunk,
+   *  so callers can render the reply incrementally as it arrives. */
+  onText?: (text: string) => void;
 }): Promise<{ text: string; error: string | null; sessionId?: string }> {
   let res: Response;
   try {
@@ -57,7 +60,10 @@ export async function streamFamiliarText(opts: {
       buffer = buffer.slice(idx + 2);
       const ev = parseSseFrame(frame);
       if (!ev) continue;
-      if (ev.kind === "assistant_chunk") text += ev.text ?? "";
+      if (ev.kind === "assistant_chunk") {
+        text += ev.text ?? "";
+        opts.onText?.(text);
+      }
       else if (ev.kind === "session") sessionId = ev.sessionId;
       else if (ev.kind === "done") {
         if (ev.sessionId) sessionId = ev.sessionId;

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -1,0 +1,155 @@
+"use client";
+
+// Shared quick-chat state + send logic, used by both the Tauri standalone
+// window (`TrayQuickChat`) and the in-app popover (`QuickChatOverlay`). It
+// loads the familiar roster, resolves @mentions, and streams a one-shot reply
+// through the sanctioned familiar chat bridge — with incremental token
+// streaming, in-flight abort, and unmount cleanup.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  COMMAND_CONTROL_DEFAULTS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
+import { resolveQuickChatTarget } from "@/lib/quick-chat";
+import { streamFamiliarText } from "@/lib/familiar-stream";
+import type { Familiar } from "@/lib/types";
+
+const LAST_FAMILIAR_KEY = "cave.quick-chat.last-familiar";
+
+export type QuickChatSendState = "idle" | "sending" | "done";
+
+export type UseQuickChat = {
+  familiars: Familiar[];
+  selectedFamiliarId: string | null;
+  setSelectedFamiliarId: (id: string | null) => void;
+  selectedFamiliar: Familiar | null;
+  draft: string;
+  setDraft: (value: string) => void;
+  answer: string;
+  error: string | null;
+  sessionId: string | null;
+  sendState: QuickChatSendState;
+  loading: boolean;
+  thinkingEffort: CommandThinkingEffort;
+  setThinkingEffort: (value: CommandThinkingEffort) => void;
+  responseSpeed: CommandResponseSpeed;
+  setResponseSpeed: (value: CommandResponseSpeed) => void;
+  send: () => Promise<void>;
+  cancel: () => void;
+};
+
+export function useQuickChat(): UseQuickChat {
+  const [familiars, setFamiliars] = useState<Familiar[]>([]);
+  const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
+  const [draft, setDraft] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sendState, setSendState] = useState<QuickChatSendState>("idle");
+  const [loading, setLoading] = useState(true);
+  const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
+    COMMAND_CONTROL_DEFAULTS.thinkingEffort,
+  );
+  const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
+    COMMAND_CONTROL_DEFAULTS.responseSpeed,
+  );
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch("/api/familiars");
+        const json = await res.json();
+        if (!alive) return;
+        const next = (json?.familiars ?? []) as Familiar[];
+        const stored =
+          typeof window !== "undefined"
+            ? window.localStorage.getItem(LAST_FAMILIAR_KEY)
+            : null;
+        setFamiliars(next);
+        setSelectedFamiliarId(
+          (stored && next.some((familiar) => familiar.id === stored) ? stored : null) ??
+            next[0]?.id ??
+            null,
+        );
+      } catch (err) {
+        if (alive) setError((err as Error)?.message ?? "Failed to load familiars.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Abort any in-flight stream when the consumer unmounts.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  const selectedFamiliar = useMemo(
+    () => familiars.find((familiar) => familiar.id === selectedFamiliarId) ?? familiars[0] ?? null,
+    [familiars, selectedFamiliarId],
+  );
+
+  const send = useCallback(async () => {
+    const target = resolveQuickChatTarget(draft, familiars, selectedFamiliarId);
+    setError(target.error);
+    setAnswer("");
+    setSessionId(null);
+    if (target.error || !target.familiarId) return;
+
+    setSendState("sending");
+    setSelectedFamiliarId(target.familiarId);
+    window.localStorage.setItem(LAST_FAMILIAR_KEY, target.familiarId);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const result = await streamFamiliarText({
+      familiarId: target.familiarId,
+      prompt: target.prompt,
+      reasoningEffort: thinkingEffort,
+      responseSpeed,
+      signal: controller.signal,
+      onText: (t) => setAnswer(t),
+    });
+    if (abortRef.current === controller) abortRef.current = null;
+    setAnswer(result.text);
+    setError(result.error);
+    setSessionId(result.sessionId ?? null);
+    setSendState("done");
+  }, [draft, familiars, responseSpeed, selectedFamiliarId, thinkingEffort]);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setSendState("idle");
+  }, []);
+
+  return {
+    familiars,
+    selectedFamiliarId,
+    setSelectedFamiliarId,
+    selectedFamiliar,
+    draft,
+    setDraft,
+    answer,
+    error,
+    sessionId,
+    sendState,
+    loading,
+    thinkingEffort,
+    setThinkingEffort,
+    responseSpeed,
+    setResponseSpeed,
+    send,
+    cancel,
+  };
+}


### PR DESCRIPTION
Quick chat was previously **only** reachable as a Tauri tray window (`/quick-chat` → `TrayQuickChat`) with no in-app entry point. This makes it **revealable in-app from a single click on a new top-bar icon**, and comprehensively patches/enhances the composer for both the in-app overlay and the Tauri window.

**Reveal on the top icon**
- New `ph:chat-circle-dots` button in `top-bar__actions` (`onOpenQuickChat`), wired in `workspace.tsx` to toggle a new `QuickChatOverlay`.
- `QuickChatOverlay` — an in-app popover (`role="dialog"`, `aria-modal`, anchored top-right) with backdrop click-away, Escape-to-close, and a header close button. "Open in full chat" hands off to `openFamiliarSession`.

**Comprehensive composer enhancements (shared by overlay + tray)**
- Extracted shared `useQuickChat()` hook (roster load + last-familiar persistence, `resolveQuickChatTarget`, send) so the Tauri window and the in-app overlay share one implementation.
- **Incremental token streaming** — `streamFamiliarText` gained an `onText` callback; the answer now streams live instead of appearing only on completion.
- **Cmd/Ctrl+Enter to send**, **autofocus** on open.
- **Cancel** in-flight (AbortController; aborts on close/unmount) and **Retry** on error.
- **`aria-live="polite"`** answer pane for screen readers.

**Verified in the running app:** clicking the top icon reveals the overlay (confirmed via the real click handler → dialog visible), Escape closes it, the textarea is interactive, **0 console errors**.

Tests: `top-bar.test.ts` (+ new button), `tray-quick-chat.test.ts` (repointed shared-logic assertions to `use-quick-chat.ts` + Cmd+Enter), new `quick-chat-overlay.test.ts` (wired). Full app suite (508), typecheck, check:tests-wired (680), build + bundle-budget green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)