### PR TITLE
docs: announce Independence Day PR event

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,18 @@
 
 Thank you for your interest in Coven Cave.
 
-## Pull request freeze (through July 1st, 2026)
+## Pull request freeze (through July 3, 2026)
 
 **We are not accepting external pull requests at this time.**
 
-This freeze runs through **July 1st, 2026**, while we work through internal
-architecture and release-stability work. Any PRs opened from outside the
-OpenCoven organization will be closed without review. The intent and any
-attached technical context will be filed as an issue so the work isn't lost,
-and an OpenCoven maintainer may re-implement the change in-house when the
-freeze lifts (or sooner, at maintainer discretion).
+This freeze runs through **Friday, July 3, 2026**, while we work through
+internal architecture and release-stability work. External PRs open starting
+**Saturday, July 4, 2026**, for the OpenCoven Independence Day PR Event.
+Until then, any PRs opened from outside the OpenCoven organization may be
+closed without review. The intent and any attached technical context will be
+filed as an issue so the work isn't lost, and an OpenCoven maintainer may
+re-implement the change in-house when the event opens (or sooner, at maintainer
+discretion).
 
 This is not a comment on the quality of contributions — we appreciate the
 care that goes into PRs against this repo. It is purely a coordination
@@ -19,7 +21,8 @@ choice while internal work consolidates.
 
 ## What is in scope right now
 
-Until the freeze lifts, the most helpful things outside contributors can do:
+Until the Independence Day PR Event opens, the most helpful things outside
+contributors can do:
 
 - **Open a clear bug report or feature request** as a GitHub Issue. Include
   reproduction steps, environment, and the smallest possible example.
@@ -28,10 +31,11 @@ Until the freeze lifts, the most helpful things outside contributors can do:
   [SECURITY.md](./SECURITY.md). Do not open public PRs or public issues for
   security reports.
 
-## After the freeze lifts
+## Independence Day PR Event
 
-When external PRs reopen, this file will be updated with the full contribution
-flow: branch hygiene, test requirements, sign-off, and review expectations.
+External PRs reopen starting **Saturday, July 4, 2026**. When the event opens,
+this file will be updated with the full contribution flow: branch hygiene, test
+requirements, sign-off, and review expectations.
 For the in-house workflow that is in effect today, see
 [AGENTS.md](./AGENTS.md).
 


### PR DESCRIPTION
## Summary
- update the pull request freeze date to run through Friday, July 3, 2026
- announce the OpenCoven Independence Day PR Event opening Saturday, July 4, 2026
- keep issues and security reports as the preferred path until the event opens

## Verification
- `git diff --check`
- searched `CONTRIBUTING.md` for stale PR-freeze wording
