### PR TITLE
feat(code): Undo on inline Codex file-edit cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10666,6 +10666,52 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   background: color-mix(in oklch, var(--text-primary) 8%, transparent);
   color: var(--text-primary);
 }
+.cave-edit-card__actions {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.cave-edit-card__undo {
+  flex: none;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--border-hairline);
+  border-radius: 0.5rem;
+  background: transparent;
+  color: var(--text-secondary, var(--text-primary));
+  font-size: 11px;
+  cursor: pointer;
+}
+.cave-edit-card__undo:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--text-primary) 8%, transparent);
+  color: var(--text-primary);
+}
+.cave-edit-card__undo:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.cave-edit-card__undo--confirm {
+  color: var(--color-danger);
+  border-color: color-mix(in oklch, var(--color-danger) 45%, transparent);
+}
+.cave-edit-card__undo--confirm:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--color-danger) 12%, transparent);
+  color: var(--color-danger);
+}
+.cave-edit-card__reverted {
+  flex: none;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.cave-edit-card__error {
+  flex: 0 1 auto;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--color-danger);
+}
 
 /* Quick-chat reveal: an in-app popover anchored top-right under the top bar,
    opened by the top-bar chat-circle icon. The Tauri standalone window

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -947,3 +947,12 @@ assert.match(source, /cave-edit-card/, "mutation tools render as an inline Codex
 assert.match(source, /diffStat/, "edit card derives a +/- stat");
 assert.match(source, /Review/, "edit card has a Review action");
 assert.match(globalsSrc, /\.cave-edit-card/, "edit card styling exists");
+
+// Inline "Undo" reverts the edited file to its last committed state via the
+// changes revert API, resolving the repo-relative path through a context, and
+// pings the Changes panel to refresh.
+assert.match(source, /cave-edit-card__undo/, "edit card has an Undo action");
+assert.match(source, /ToolProjectRootContext/, "edit card resolves project root via context for revert");
+assert.match(source, /"\/api\/changes"/, "Undo posts to the changes revert API");
+assert.match(source, /cave:changes-refresh/, "Undo notifies the changes panel to refresh");
+assert.match(globalsSrc, /\.cave-edit-card__undo/, "Undo button styling exists");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { forwardRef, Fragment, memo, useCallback, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { createContext, forwardRef, Fragment, memo, useCallback, useContext, useEffect, useId, useImperativeHandle, useLayoutEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
 import { createPortal } from "react-dom";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
@@ -4398,6 +4398,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         />
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
+      <ToolProjectRootContext.Provider value={session?.project_root ?? projectRoot ?? null}>
       <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
         <div
           className="cave-chat-thread"
@@ -4600,6 +4601,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           </button>
         )}
       </div>
+      </ToolProjectRootContext.Provider>
 
       {reflectError ? (
         <div
@@ -5670,6 +5672,88 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
   );
 }
 
+// The active session's project root, provided by ChatView so the inline edit
+// card can convert an absolute target path into the repo-relative path that the
+// `/api/changes` revert endpoint requires — without prop-threading through the
+// five ToolBlock/ToolGroup render sites.
+const ToolProjectRootContext = createContext<string | null>(null);
+
+// Review + Undo actions for the Codex-style inline edit card. Review opens the
+// comux diff (unchanged behavior); Undo reverts the edited file to its last
+// committed state via `/api/changes` (which auto-snapshots the tree to a
+// checkpoint first, so the revert is itself recoverable). Undo requires a
+// two-step arm→confirm to avoid an accidental one-click revert, and is only
+// offered when the target resolves to a repo-relative path under the project
+// root.
+function EditCardActions({ targetFile }: { targetFile: string }) {
+  const projectRoot = useContext(ToolProjectRootContext);
+  const relPath =
+    projectRoot && targetFile.startsWith(projectRoot)
+      ? targetFile.slice(projectRoot.length).replace(/^\/+/, "")
+      : null;
+  const [state, setState] = useState<"idle" | "armed" | "reverting" | "reverted" | "error">("idle");
+  const [err, setErr] = useState<string | null>(null);
+
+  const review = () =>
+    window.dispatchEvent(new CustomEvent("cave:open-file-diff", { detail: { path: targetFile } }));
+
+  const doUndo = async () => {
+    if (!projectRoot || !relPath) return;
+    setState("reverting");
+    setErr(null);
+    try {
+      const res = await fetch("/api/changes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectRoot, path: relPath, confirmUntracked: true }),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json?.ok) throw new Error(json?.error || `revert failed (${res.status})`);
+      setState("reverted");
+      window.dispatchEvent(new CustomEvent("cave:changes-refresh"));
+    } catch (e) {
+      setErr((e as Error)?.message ?? "revert failed");
+      setState("error");
+    }
+  };
+
+  return (
+    <span className="cave-edit-card__actions">
+      {err ? <span className="cave-edit-card__error" title={err}>{err}</span> : null}
+      <button type="button" className="cave-edit-card__review focus-ring" onClick={review}>
+        Review
+      </button>
+      {relPath ? (
+        state === "reverted" ? (
+          <span className="cave-edit-card__reverted">Reverted</span>
+        ) : state === "reverting" ? (
+          <button type="button" className="cave-edit-card__undo focus-ring" disabled>
+            Undoing…
+          </button>
+        ) : state === "armed" ? (
+          <>
+            <button type="button" className="cave-edit-card__undo focus-ring" onClick={() => setState("idle")}>
+              Cancel
+            </button>
+            <button type="button" className="cave-edit-card__undo cave-edit-card__undo--confirm focus-ring" onClick={doUndo}>
+              Confirm undo
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="cave-edit-card__undo focus-ring"
+            onClick={() => setState("armed")}
+            title="Revert this file to its last committed state (a checkpoint is saved first)"
+          >
+            Undo
+          </button>
+        )
+      ) : null}
+    </span>
+  );
+}
+
 function ToolBlock({ tool }: { tool: ToolEvent }) {
   const argSummary = toolArgSummary(tool.name, tool.input);
   // CHAT-D8-02: Edit/Write/MultiEdit/NotebookEdit inputs render as a
@@ -5713,17 +5797,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
             <span className="cave-edit-card__del">−{stat.deletions}</span>
           </span>
         </span>
-        <button
-          type="button"
-          className="cave-edit-card__review focus-ring"
-          onClick={() =>
-            window.dispatchEvent(
-              new CustomEvent("cave:open-file-diff", { detail: { path: targetFile } }),
-            )
-          }
-        >
-          Review
-        </button>
+        <EditCardActions targetFile={targetFile} />
       </div>
     );
   }

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -493,6 +493,19 @@ export function SessionChangesInner({
     return () => window.clearInterval(id);
   }, [load, running]);
 
+  // An inline "Undo" on a transcript edit card reverts a file via /api/changes
+  // and fires `cave:changes-refresh` so this panel reflects the reverted file
+  // (and the fresh checkpoint) without waiting for the poll — mirroring the
+  // load()+loadCheckpoints() refresh that revertFile does after its own revert.
+  useEffect(() => {
+    const onRefresh = () => {
+      void load();
+      void loadCheckpoints();
+    };
+    window.addEventListener("cave:changes-refresh", onRefresh);
+    return () => window.removeEventListener("cave:changes-refresh", onRefresh);
+  }, [load, loadCheckpoints]);
+
   const fetchDiff = useCallback(
     // `silent` re-fetches without flashing the "Loading diff…" state or wiping
     // the visible diff on error — used by the poll refresh so an open diff for


### PR DESCRIPTION
Completes the deferred **Undo** on the inline Codex file-edit cards (follow-up to #2171, where Undo was deferred pending a reliable per-file revert).

The card `Edited <file>  +N −M` now offers **Review** + **Undo**:
- **Undo** is a two-step arm → confirm (mirrors the Changes panel's revert guard), then `POST /api/changes` to revert the file to HEAD (server auto-snapshots the tree to a checkpoint first, so it's recoverable; `confirmUntracked` handles newly-created files).
- `toolTargetFile` is absolute but the revert API needs a **repo-relative** path — the card relativizes against the effective project root and only shows Undo when the file is under it (else Review-only, render-but-inert).
- On success it dispatches `cave:changes-refresh`; `session-changes-panel` now listens and reloads (diff + checkpoints) so an open Changes view reflects the undo.
- States: idle / armed / Undoing… / Reverted / error (inline).

Plumbing: the effective project root (`session?.project_root ?? projectRoot`) reaches `ToolBlock` via a new `ToolProjectRootContext` (wraps the transcript container) — no prop-threading through the tool render sites.

Tests: `chat-view-polish.test.ts` (+Undo/context/api/refresh assertions); Review/diffStat/card assertions preserved. Full app suite (510), typecheck, check:tests-wired (682), build + bundle-budget green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)