### PR TITLE
Trim Growth hero heading to "Spot growth patterns."

### DIFF
--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -189,7 +189,7 @@ export function FamiliarGrowthView({
             <Icon name="ph:chart-bar-bold" aria-hidden />
             Familiar Growth &amp; Performance
           </p>
-          <h2>Spot growth patterns before they stall.</h2>
+          <h2>Spot growth patterns.</h2>
           <p>
             Review familiar activity, retro acceptance, memory freshness, and rule-based growth opportunities in one place.
           </p>


### PR DESCRIPTION
Drops the "before they stall" clause from the Familiar Growth hero heading (`src/components/familiar-growth-view.tsx`): `Spot growth patterns before they stall.` → `Spot growth patterns.` Kept the terminal period to match the heading style. No test pins the string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)