### PR TITLE
chore(workspace): remove inert companion-rail wiring left after the rail removal

### DIFF
--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -198,11 +198,8 @@ assert.match(
   "Mobile bottom tab focus ring should use the shared inset offset token",
 );
 
-assert.match(
-  workspace,
-  /railTab === "browser" \|\| railTab === "salem" \|\| \(mode !== "browser" && mode !== "agents"\)/,
-  "Browser and Agents modes suppress the default companion pane unless a floating Browser or Salem tab is selected",
-);
+// The right companion rail was removed in favour of drag-to-split, so the
+// workspace no longer computes companion-pane visibility (showCompanionRail).
 assert.match(
   workspace,
   /const openUrlInAppBrowser = useCallback\(\(url: string\) => \{/,

--- a/src/components/sidepanel-badges.test.ts
+++ b/src/components/sidepanel-badges.test.ts
@@ -20,12 +20,10 @@ assert.match(workspace, /scheduleNeedsCount=\{scheduleNeedsCount\}/, "schedules 
 assert.match(workspace, /githubAssignedCount=\{githubAssignedCount\}/, "github count passed");
 assert.match(workspace, /groupInboxFeed\(inboxItemsWithEphemeral\)\.needsYou\.length/, "schedules badge = needs-you group");
 
-// ── Per-familiar rail tab ──────────────────────────────────────────────────────
-assert.match(workspace, /const persistRailTab = useCallback/, "explicit tab choices persist per familiar");
-assert.match(workspace, /"cave:rail\.tab:" \+ \(activeIdRef\.current \?\? "all"\)/, "tab stored under the active familiar");
-assert.match(workspace, /"cave:rail\.tab:" \+ \(activeId \?\? "all"\)/, "tab restored for the active familiar");
-// The right companion rail was removed (drag-to-split replaces it); rail tab
-// clicks no longer have an onTabChange to wire.
+// Per-familiar rail-tab persistence was dropped with the right companion rail
+// (drag-to-split replaces it) — the workspace no longer stores cave:rail.tab.
+// `workspace` is still read above for the nav-badge assertions.
+void workspace;
 
 // ── Video split persistence ────────────────────────────────────────────────────
 assert.match(rail, /useDefaultLayout/, "rail split uses the layout-persistence hook");

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -48,20 +48,9 @@ assert.match(
   "Workspace passes the selected familiar into the Familiars page",
 );
 
-assert.match(
-  workspace,
-  /railTab === "browser" \|\| railTab === "salem" \|\| \(mode !== "browser" && mode !== "agents"\)/,
-  "Companion rail is hidden on Familiars and Browser unless a floating rail tab is selected",
-);
-
-// The right companion rail (and its Chat tab) was removed in favour of
-// drag-to-split, so there is no rail Chat tab to hide on the Familiars surface.
-
-assert.match(
-  workspace,
-  /if \(!activeId\) \{\s*queueMicrotask\(\(\) => shellRef\.current\?\.closeFamiliar\(\)\);\s*return;\s*\}/,
-  "Workspace collapses the companion panel when no familiar is selected so empty rails do not crowd every surface",
-);
+// The right companion rail was removed in favour of drag-to-split, so the
+// workspace no longer computes rail visibility (showCompanionRail), a rail Chat
+// tab, or a per-familiar rail-open restore effect.
 
 assert.match(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -23,7 +23,6 @@ import { Shell, type ShellHandle } from "@/components/shell";
 import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
 import { Icon } from "@/lib/icon";
 import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
-import { type CompanionTab } from "@/components/companion-rail";
 import { RailInspector } from "@/components/inspector-pane";
 import { SalemChatPanel } from "@/components/salem/salem-widget";
 import { FamiliarsView } from "@/components/familiars-view";
@@ -33,8 +32,6 @@ import {
   setFamiliarScope,
   getLastSurface,
   setLastSurface,
-  getRailOpen,
-  setRailOpen,
 } from "@/lib/familiar-memory";
 import { recordFamiliarUsed } from "@/lib/familiar-quick-switch";
 import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
@@ -272,15 +269,6 @@ export function Workspace() {
   // `splitSide` is which half it occupies (modern-desktop snap).
   const [splitTarget, setSplitTarget] = useState<SplitTarget | null>(null);
   const [splitSide, setSplitSide] = useState<"left" | "right">("right");
-  const [railTab, setRailTab] = useState<CompanionTab>(() => {
-    if (typeof window === "undefined") return "chat";
-    const stored = window.localStorage.getItem("cave:rail.tab");
-    // The standalone "inspector" (magnifier) tab folded into "memory" (brain);
-    // remap any persisted value so a stale key doesn't select a removed tab.
-    if (stored === "inspector") return "memory";
-    return (stored as CompanionTab) ?? "chat";
-  });
-  const [familiarPanelOpen, setFamiliarPanelOpen] = useState(false);
   const [pendingProjectChatRoot, setPendingProjectChatRoot] = useState<string | null>(null);
   const [pendingChatAction, setPendingChatAction] = useState<PendingChatAction>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
@@ -491,44 +479,6 @@ export function Workspace() {
   }, [scopeIds, activeFamiliarHydrated]);
 
   useEffect(() => {
-    if (!activeId) {
-      queueMicrotask(() => shellRef.current?.closeFamiliar());
-      return;
-    }
-    const desired = getRailOpen(activeId);
-    queueMicrotask(() => {
-      if (desired) shellRef.current?.openFamiliar();
-      else shellRef.current?.closeFamiliar();
-    });
-  }, [activeId]);
-
-  // Per-familiar rail tab. persistRailTab handles explicit tab choices: it
-  // writes the active familiar slot (plus a global fallback for first paint).
-  // Restoring a familiar tab on scope change uses plain setRailTab so it never
-  // rewrites. Keyed on activeId ("all" when no familiar scope).
-  const persistRailTab = useCallback((next: CompanionTab) => {
-    setRailTab(next);
-    try {
-      window.localStorage.setItem("cave:rail.tab:" + (activeIdRef.current ?? "all"), next);
-      window.localStorage.setItem("cave:rail.tab", next);
-    } catch {
-      /* ignore storage failures */
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!activeFamiliarHydrated || typeof window === "undefined") return;
-    try {
-      const stored =
-        window.localStorage.getItem("cave:rail.tab:" + (activeId ?? "all")) ??
-        window.localStorage.getItem("cave:rail.tab");
-      if (stored) setRailTab(stored === "inspector" ? "memory" : (stored as CompanionTab));
-    } catch {
-      /* ignore storage failures */
-    }
-  }, [activeId, activeFamiliarHydrated]);
-
-  useEffect(() => {
     // Salem was re-homed from the (removed) right rail into the drag-to-split
     // pane — its launcher now opens Salem beside the current surface.
     const openSalem = () => {
@@ -591,12 +541,6 @@ export function Workspace() {
     window.addEventListener("cave:open-project-file", onOpenFile as EventListener);
     return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
   }, []);
-
-  useEffect(() => {
-    if (railTab !== "salem") {
-      window.dispatchEvent(new CustomEvent("cave:salem-undock"));
-    }
-  }, [railTab]);
 
   useEffect(() => {
     fetch("/api/config", { cache: "no-store" })
@@ -1822,18 +1766,6 @@ export function Workspace() {
   // primary Inbox surface). "new" + "acknowledged" + "snoozed-due" all
   // count as needing attention; resolved/dismissed do not.
   const inboxBadgeCount = escalationsUnresolved;
-
-  const showCompanionRail =
-    railTab === "browser" || railTab === "salem" || (mode !== "browser" && mode !== "agents");
-
-  const openCompanionTab = useCallback((tab: CompanionTab) => {
-    persistRailTab(tab);
-    if (familiarPanelOpen && railTab === tab) {
-      shellRef.current?.closeFamiliar();
-      return;
-    }
-    requestAnimationFrame(() => shellRef.current?.openFamiliar());
-  }, [familiarPanelOpen, railTab]);
 
   const openUrlInAppBrowser = useCallback((url: string) => {
     if (!url) return;

--- a/src/lib/familiar-memory.test.ts
+++ b/src/lib/familiar-memory.test.ts
@@ -8,11 +8,8 @@ assert.match(source, /export function getActiveFamiliar\(\)/);
 assert.match(source, /export function setActiveFamiliar\(id: string \| null\)/);
 assert.match(source, /export function getLastSurface\(familiarId: string\)/);
 assert.match(source, /export function setLastSurface\(familiarId: string, surface: string\)/);
-assert.match(source, /export function getRailOpen\(familiarId: string\)/);
-assert.match(source, /export function setRailOpen\(familiarId: string, open: boolean\)/);
 assert.match(source, /cave:active-familiar/);
 assert.match(source, /cave:familiar:\$\{familiarId\}:last-surface/);
-assert.match(source, /cave:familiar:\$\{familiarId\}:rail\.open/);
 assert.match(
   source,
   /typeof window === "undefined"/,

--- a/src/lib/familiar-memory.ts
+++ b/src/lib/familiar-memory.ts
@@ -61,12 +61,3 @@ export function getLastSurface(familiarId: string): string | null {
 export function setLastSurface(familiarId: string, surface: string): void {
   safeSet(`cave:familiar:${familiarId}:last-surface`, surface);
 }
-
-export function getRailOpen(familiarId: string): boolean {
-  const raw = safeGet(`cave:familiar:${familiarId}:rail.open`);
-  return raw === "1"; // default closed
-}
-
-export function setRailOpen(familiarId: string, open: boolean): void {
-  safeSet(`cave:familiar:${familiarId}:rail.open`, open ? "1" : "0");
-}


### PR DESCRIPTION
Follow-up to #2183 (drag-to-split / right-rail removal).

When #2183 removed the right companion rail, its workspace plumbing was intentionally left **inert** so the source-text tests kept passing. This deletes that now-dead code.

## Removed
- **`workspace.tsx`** (−68 lines): `railTab`/`familiarPanelOpen` state, `persistRailTab`, `showCompanionRail`, `openCompanionTab`, the per-familiar rail-open restore effect, the rail-tab restore effect, and the dead `railTab !== "salem"` salem-undock effect (the real undock now lives in `closeSplit`). Dropped the now-unused `CompanionTab` / `getRailOpen` / `setRailOpen` imports.
- **`familiar-memory.ts`**: the now-unused `getRailOpen` / `setRailOpen` helpers (workspace was their only consumer).
- Updated the source-text tests that pinned the removed wiring (`sidepanel-badges`, `workspace-familiars-landing`, `mobile-shell-smoke`, `familiar-memory`).

**Net −96 lines.**

## Intentionally left as-is
`companion-rail.tsx` / `youtube-viewer.tsx` and the Shell's generic right-panel **peek** scaffolding (`rightPanelPeek`, `right-panel-expand`). Fully deleting them would tear out the Shell's reusable right-panel/peek/video feature (~450 lines of CSS + several tests) — a separate structural concern from this inert-wiring cleanup, and worth its own PR if desired.

## Verification
`pnpm typecheck`, `test:app`, `test:api`, `test:mobile`, `check:tests-wired`, `pnpm build` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)