### PR TITLE
feat(code): surface Codex edit cards inline on settled turns

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -163,8 +163,18 @@ assert.match(
 
 assert.match(
   turnRow,
-  /!turn\.pending && turn\.tools\?\.length \? <ToolGroup/,
-  "every settled turn that used tools renders the designated ToolGroup section",
+  /!turn\.pending && turn\.tools\?\.length/,
+  "settled turns that used tools render a designated tool section",
+);
+assert.match(
+  turnRow,
+  /cave-edit-cards[\s\S]*editCards\.map\(\(tool\) => <ToolBlock/,
+  "edit-tool cards stay visible inline on settled turns (not buried in the collapsed rollup)",
+);
+assert.match(
+  turnRow,
+  /otherTools\.length \? <ToolGroup tools=\{otherTools\}/,
+  "non-edit tool activity still collapses into the designated ToolGroup",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5473,11 +5473,31 @@ function TurnRowImpl({
             {turn.attachments?.length ? <AttachmentList attachments={turn.attachments} /> : null}
             {turn.progress?.length ? <ProgressGroup progress={turn.progress} pending={!!turn.pending} /> : null}
             {reasoning ? <ReasoningBlock reasoning={reasoning} durationMs={turn.durationMs} /> : null}
-            {/* Designated "Tool activity" section: on every settled turn that
-                used tools, collect them into one collapsed group below the prose
-                (which renders uninterrupted above). Streaming turns show tools
-                inline instead — see renderSegments. */}
-            {!turn.pending && turn.tools?.length ? <ToolGroup tools={turn.tools} /> : null}
+            {/* Designated "Tool activity" section on settled turns. Codex
+                file-edit cards (Edit/Write/etc. with a target file) stay VISIBLE
+                inline — they're the actionable output (Review/Undo), so they must
+                not be buried in the collapsed rollup. All OTHER tool activity
+                (reads, greps, bash, …) collapses into the ToolGroup below the
+                prose. Streaming turns weave tools inline instead — see
+                renderSegments. */}
+            {!turn.pending && turn.tools?.length
+              ? (() => {
+                  const isEditCard = (t: ToolEvent) =>
+                    toolInputAsDiff(t.name, t.input) != null && toolTargetFile(t.name, t.input) != null;
+                  const editCards = turn.tools.filter(isEditCard);
+                  const otherTools = turn.tools.filter((t) => !isEditCard(t));
+                  return (
+                    <>
+                      {editCards.length ? (
+                        <div className="cave-edit-cards mt-3 space-y-2">
+                          {editCards.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
+                        </div>
+                      ) : null}
+                      {otherTools.length ? <ToolGroup tools={otherTools} /> : null}
+                    </>
+                  );
+                })()
+              : null}
             {/* Suggested follow-ups render LAST — they're the most actionable
                 element (click to send), so they sit closest to the composer and
                 aren't pushed up the turn by the tool-activity section. */}

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -227,8 +227,8 @@ assert.match(
 );
 assert.match(
   chatViewSource,
-  /\{!turn\.pending && turn\.tools\?\.length \? <ToolGroup tools=\{turn\.tools\} \/> : null\}/,
-  "every settled turn with tools renders the designated trailing ToolGroup section",
+  /!turn\.pending && turn\.tools\?\.length[\s\S]*otherTools\.length \? <ToolGroup tools=\{otherTools\} \/>/,
+  "settled turns render edit-tool cards inline and collapse other tool activity into the ToolGroup",
 );
 assert.match(
   chatViewSource,


### PR DESCRIPTION
Follow-up to #2171/#2190. Settled assistant turns rendered **all** tool calls into the collapsed "Tool activity" `ToolGroup`, so the Codex file-edit cards (Review/Undo) were buried until you expanded the rollup — they only showed inline while streaming.

Now settled turns **partition** their tools:
- **Edit/Write/MultiEdit/NotebookEdit** (with a target file) render as **visible inline edit cards** (matching the streaming behavior and the Codex reference).
- **All other tool activity** (reads, greps, bash, …) stays in the collapsed `ToolGroup` below the prose.

**Verified in the app** (settled turn with an Edit + a Read tool): edit card visible inline without expanding (`VISIBLE_WITHOUT_EXPAND: true`), Undo visible on it, the Read tool collapsed into `TOOL ACTIVITY (1 done)`, 0 console errors.

Tests: updated the two source-text assertions that pinned the old `<ToolGroup tools={turn.tools}>` settled render (`chat-view-polish.test.ts`, `session-debug.test.ts`) to the partitioned structure. Full app suite (510), typecheck, check:tests-wired (682), build + bundle-budget green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)