### PR TITLE
feat(evals): collapse the suite rail into a drawer on small screens

### DIFF
--- a/src/components/evals/evals-view.test.ts
+++ b/src/components/evals/evals-view.test.ts
@@ -88,4 +88,16 @@ assert.match(source, /"insights"/, "has an insights tab");
 assert.match(source, /"compare"/, "has a compare tab");
 assert.match(source, /slaMinPassRate/, "suite editor wires the SLA field");
 
+// Suite rail collapses to a drawer on small screens (toggle + backdrop).
+assert.match(source, /const \[railOpen, setRailOpen\] = useState\(false\)/, "tracks the suite-rail drawer open state");
+assert.match(source, /className="evals-rail-toggle"/, "renders the small-screen Suites drawer toggle");
+assert.match(source, /aria-controls="evals-rail"/, "the toggle is associated with the rail");
+assert.match(source, /id="evals-rail" className="evals-rail"/, "the rail is the toggle's controlled region");
+assert.match(source, /evals--rail-open/, "root reflects the drawer open state");
+assert.match(source, /setRailOpen\(false\); \/\/ close the drawer after picking a suite/, "picking a suite closes the drawer");
+const css = readFileSync(new URL("../../styles/evals.css", import.meta.url), "utf8");
+assert.match(css, /@media \(max-width: 720px\)[\s\S]*?\.evals-rail \{[\s\S]*?transform: translateX\(-101%\)/, "the rail slides off-canvas under the narrow breakpoint");
+assert.match(css, /\.evals--rail-open \.evals-rail \{ transform: translateX\(0\)/, "opening the drawer slides the rail in");
+assert.doesNotMatch(css, /@media \(max-width: 720px\)[\s\S]*?\.evals-rail \{ display: none;/, "the rail no longer just vanishes on small screens");
+
 console.log("evals-view.test.ts OK");

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -114,6 +114,10 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
   const [suites, setSuites] = useState<EvalSuite[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // On small screens the suite rail collapses into a drawer; this tracks whether
+  // it's open. It's a no-op on desktop (the CSS only reacts to it under the
+  // narrow breakpoint), so it can be toggled freely.
+  const [railOpen, setRailOpen] = useState(false);
   const [draft, setDraft] = useState<EvalSuite | null>(null);
   const [savedJson, setSavedJson] = useState<string>("");
   const [runs, setRuns] = useState<EvalRun[]>([]);
@@ -263,6 +267,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
 
   const selectSuite = useCallback((suite: EvalSuite) => {
     setSelectedId(suite.id);
+    setRailOpen(false); // close the drawer after picking a suite (small screens)
     setDraft(structuredClone(suite));
     setSavedJson(JSON.stringify(suite));
     setExpandedRunId(null);
@@ -415,8 +420,27 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
   }, [activeGroup, activeGroupStates]);
 
   return (
-    <div className="evals evals-unified">
-      <aside className="evals-rail">
+    <div className={`evals evals-unified${railOpen ? " evals--rail-open" : ""}`}>
+      {/* Small-screen drawer toggle — reveals the suite rail (which collapses
+          off-canvas below the narrow breakpoint). Hidden on desktop via CSS. */}
+      <button
+        type="button"
+        className="evals-rail-toggle"
+        onClick={() => setRailOpen((open) => !open)}
+        aria-expanded={railOpen}
+        aria-controls="evals-rail"
+      >
+        <Icon name={railOpen ? "ph:x" : "ph:list-bullets-bold"} width={14} aria-hidden />
+        <span>Suites</span>
+        <span className="evals-rail-toggle-count">{suites.length}</span>
+      </button>
+      {/* Backdrop closes the drawer; only interactive while open on small screens. */}
+      <div
+        className="evals-rail-backdrop"
+        onClick={() => setRailOpen(false)}
+        aria-hidden
+      />
+      <aside id="evals-rail" className="evals-rail">
         <div className="evals-rail-head">
           <div>
             <span className="evals-rail-title">Evals</span>

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -2,6 +2,7 @@
    Minimal, token-driven; mirrors the flow / automations surface vocabulary. */
 
 .evals {
+  position: relative;
   display: grid;
   grid-template-columns: 268px minmax(0, 1fr);
   height: 100%;
@@ -15,6 +16,11 @@
   display: grid;
   place-items: center;
 }
+
+/* Suite-rail drawer toggle + backdrop — inert on desktop (the rail is a fixed
+   grid column there); they only come alive under the narrow breakpoint below. */
+.evals-rail-toggle { display: none; }
+.evals-rail-backdrop { display: none; }
 
 /* ---- Rail ---------------------------------------------------------------- */
 .evals-rail {
@@ -1310,8 +1316,56 @@
 }
 
 @media (max-width: 720px) {
+  /* The suite rail collapses to an off-canvas drawer opened by the toggle,
+     instead of vanishing — so suites stay reachable on small screens. */
   .evals { grid-template-columns: 1fr; }
-  .evals-rail { display: none; }
+  .evals-rail-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    margin: 12px 12px 0;
+    padding: 7px 12px;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: var(--bg-raised);
+    border: 1px solid var(--border-hairline);
+    border-radius: 999px;
+    cursor: pointer;
+  }
+  .evals-rail-toggle:hover { color: var(--text-primary); border-color: var(--border-strong); }
+  .evals-rail-toggle-count {
+    font-variant-numeric: tabular-nums;
+    color: var(--text-muted);
+    background: var(--bg-base);
+    border-radius: 999px;
+    padding: 0 6px;
+  }
+  .evals-rail {
+    position: absolute;
+    inset: 0 auto 0 0;
+    z-index: 45;
+    width: min(300px, 84%);
+    transform: translateX(-101%);
+    transition: transform 0.2s ease;
+    box-shadow: 0 18px 50px -12px rgb(0 0 0 / 0.55);
+  }
+  .evals--rail-open .evals-rail { transform: translateX(0); }
+  .evals-rail-backdrop {
+    position: absolute;
+    inset: 0;
+    z-index: 44;
+    background: rgb(0 0 0 / 0.4);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+  .evals--rail-open .evals-rail-backdrop {
+    display: block;
+    opacity: 1;
+    pointer-events: auto;
+  }
   .evals-toolbar {
     align-items: stretch;
     flex-direction: column;


### PR DESCRIPTION
## What

The Evals **"N suites tracked" rail** was hard-hidden (`display: none`) below 720px — so on small screens you couldn't reach any suite. Now it **collapses into an off-canvas drawer**: a **"Suites N"** toggle chip reveals it (sliding in over a backdrop), and picking a suite or tapping the backdrop closes it.

Desktop is unchanged — the toggle and backdrop are inert above the breakpoint (the rail stays a fixed grid column).

## How
- `evals-view.tsx` — `railOpen` state, a `.evals-rail-toggle` (small-screen only), a `.evals-rail-backdrop`, root reflects `evals--rail-open`, and `selectSuite` closes the drawer.
- `evals.css` — replaced the `≤720px { .evals-rail { display:none } }` with an off-canvas drawer (`translateX(-101%)` → `translateX(0)` when open) + backdrop; `.evals` is now `position: relative`.
- `evals-view.test.ts` — asserts the toggle/drawer wiring and that the rail no longer just vanishes.

## Verification
- Test passes; `pnpm build` green.
- Drove the app: **wide** → normal 2-col rail, no toggle; **640px** → rail off-canvas + "Suites 2" chip; **toggle** → drawer slides in with the suite list. Screenshots confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)