### PR TITLE
HomeFeed: tick relative ages so "pushed Nm ago" doesn't freeze

### DIFF
--- a/src/components/home/home-feed.tsx
+++ b/src/components/home/home-feed.tsx
@@ -78,6 +78,14 @@ export function HomeFeed({ onOpenUrl }: Props) {
     if (tab === "tweets" && tweetState === "idle") void loadTweets();
   }, [tab, repoState, tweetState, loadRepos, loadTweets]);
 
+  // Re-stamp `nowMs` once a minute so the "pushed Nm ago" / tweet-age labels
+  // advance instead of freezing at the value from the last load. Cheap; the
+  // feed data itself stays user-refreshed via the refresh button.
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   const refresh = useCallback(() => {
     if (tab === "repos") { setRepoState("idle"); void loadRepos(); }
     if (tab === "tweets") void loadTweets(true);


### PR DESCRIPTION
## Problem
`HomeFeed` (the home Repos/Tweets feed) stamped `nowMs` only when data loaded, so the repo "pushed Nm ago" and tweet-age labels froze between refreshes.

Final candidate (#3) from the staleness audit; the feed's actual data is external (GitHub/tweets), low time-sensitivity, and has a manual refresh — only the relative labels needed to advance.

## Fix
- Re-stamp `nowMs` once a minute so `compactAge` recomputes. Feed data stays user-refreshed via the existing refresh button; no poll needed. Zero risk (no drafts/optimistic state).

## Verification
- Typecheck clean; Frontend build green, bundle within budget; all three tests that read this file pass (`home-feed.test.ts` component + lib, `home-composer-mobile-gaps.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)