### PR TITLE
fix(mobile): pause Home-surface polls during input composition

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -63,4 +63,11 @@ assert.match(css, /\.home-digest__card--media[\s\S]*?padding-left/, "media cards
 assert.match(composer, /import \{ HomeDigestCarousel \}/, "home composer imports the carousel");
 assert.match(composer, /<HomeDigestCarousel/, "home composer renders the carousel");
 
+// ── Ambient refresh pauses during composition (sits right below the composer) ──
+assert.match(
+  view,
+  /usePausablePoll\(\(\) => \{ void loadDigest\(\); \}, 60_000, \{ pauseWhileInputActive: true \}\)/,
+  "the once-a-minute digest refresh pauses while the user is typing",
+);
+
 console.log("home-digest-carousel.test.ts passed");

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -58,8 +58,10 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
   }, [loadDigest]);
 
   // Ambient "Daily summary" — refresh once a minute so reminder/session counts
-  // and relative ages advance. Suspends on hidden tabs and refreshes on focus.
-  usePausablePoll(() => { void loadDigest(); }, 60_000);
+  // and relative ages advance. Suspends on hidden tabs and refreshes on focus,
+  // and pauses while the user is typing so this ambient refresh (+ its re-render)
+  // doesn't compete with composition in the Home composer just below.
+  usePausablePoll(() => { void loadDigest(); }, 60_000, { pauseWhileInputActive: true });
 
   const cards = useMemo(
     () => buildDigestCards({ items, sessions, rssItems: rss, familiarNameById, nowMs }),

--- a/src/components/recent-activity-rollup.test.ts
+++ b/src/components/recent-activity-rollup.test.ts
@@ -27,4 +27,13 @@ assert.match(
   "the header toggle writes through the persisting handler",
 );
 
+// This rollup polls the same heavy /api/sessions/list as the shell, so it must
+// pause while the user is typing — otherwise it re-introduces the mobile typing
+// lag the shell polls were gated to avoid.
+assert.match(
+  source,
+  /usePausablePoll\(\(\) => void load\(\), POLL_MS, \{ pauseWhileInputActive: true \}\)/,
+  "the sessions poll pauses during active input composition",
+);
+
 console.log("recent-activity-rollup.test.ts: ok");

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -82,8 +82,10 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
   useEffect(() => {
     void load();
   }, [load]);
-  // Pauses in a hidden tab; refreshes on return.
-  usePausablePoll(() => void load(), POLL_MS);
+  // Pauses in a hidden tab; refreshes on return. Also pauses while the user is
+  // typing — this polls the same heavy /api/sessions/list the shell does, so it
+  // must not compete with mobile composition.
+  usePausablePoll(() => void load(), POLL_MS, { pauseWhileInputActive: true });
 
   const rows = useMemo(() => sessions, [sessions]);
 


### PR DESCRIPTION
## Why

Follow-up to `b201b4c5` ("fix(mobile): reduce input-time background work"), which gated the four heavy **workspace shell** polls (daemon status, `/api/sessions/list`, escalations, task cards) + `board-view` with `pauseWhileInputActive: true`.

Two **Home-surface** polls were missed and still fired while the user typed:

- **`RecentActivityRollup`** (left panel) polls the *same* heavy `/api/sessions/list` (~262KB, 2.4–4.6s in mobile logs) every **15s** — independently of the shell, so it re-introduced the exact typing lag the shell polls were gated to avoid.
- **`HomeDigestCarousel`** refreshes `/api/inbox` + `/api/rss` every **60s** and calls `setNowMs(Date.now())` (a re-render) directly below the Home composer — the "Home/digest renders during composition" the mobile investigation explicitly flagged.

## What

Gate both with `{ pauseWhileInputActive: true }`. The existing `usePausablePoll` machinery already skips a tick whenever `document.activeElement` is a text field / contentEditable, so ambient refreshes no longer compete with mobile composition. Added a source assertion to each component's test to lock the behavior.

No behavior change off the typing path: polls still run on their normal cadence, still pause on hidden tabs, and still refresh on focus.

## Verification

- `node --experimental-strip-types` on both focused tests — pass
- `pnpm typecheck` — clean
- `pnpm check:tests-wired` — 680 files wired
- `pnpm test:app` — 508 files passed
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)