### PR TITLE
Home composer: Enhance button + attachments (paperclip)

### DIFF
--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -34,7 +34,7 @@ assert.match(
 
 assert.match(
   chatRouter,
-  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null, origin\?: SessionOrigin, initialControls\?: InitialCommandControls\)/,
+  /newChat: \(projectRoot\?: string, initialPrompt\?: string, familiarId\?: string \| null, origin\?: SessionOrigin, initialControls\?: InitialCommandControls, initialAttachments\?: ChatAttachment\[\]\)/,
   "Imperative new-chat launches should carry a familiar id with the project root",
 );
 

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -14,6 +14,7 @@ import {
   normalizeChatProjectRoot,
 } from "@/lib/chat-projects";
 import { applyProjectOverrides } from "@/lib/chat-project-overrides";
+import type { ChatAttachment } from "@/lib/chat-attachments";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
@@ -31,7 +32,7 @@ import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 
 type View =
   | { kind: "list" }
-  | { kind: "chat"; sessionId: string | null; projectRoot?: string; initialPrompt?: string; initialControls?: InitialCommandControls; familiarId?: string | null; origin?: SessionOrigin };
+  | { kind: "chat"; sessionId: string | null; projectRoot?: string; initialPrompt?: string; initialAttachments?: ChatAttachment[]; initialControls?: InitialCommandControls; familiarId?: string | null; origin?: SessionOrigin };
 
 type Props = {
   familiar: Familiar | null;
@@ -65,7 +66,7 @@ type Props = {
 
 export type ChatRouterHandle = {
   goToList: () => void;
-  newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls) => void;
+  newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls, initialAttachments?: ChatAttachment[]) => void;
   openSession: (sessionId: string, findQuery?: string) => void;
   currentSessionId: () => string | null;
   clearTranscript: () => void;
@@ -263,6 +264,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
                 sessionId: null,
                 projectRoot: prev.projectRoot,
                 initialPrompt: prev.initialPrompt,
+                initialAttachments: prev.initialAttachments,
                 initialControls: prev.initialControls,
                 familiarId: nextFamiliarId,
                 origin: prev.origin,
@@ -275,13 +277,14 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     ref,
     () => ({
       goToList: () => setView({ kind: "list" }),
-      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls) => {
+      newChat: (projectRoot?: string, initialPrompt?: string, familiarId?: string | null, origin?: SessionOrigin, initialControls?: InitialCommandControls, initialAttachments?: ChatAttachment[]) => {
         const next = selectFamiliarForChat(familiarId);
         setView({
           kind: "chat",
           sessionId: null,
           projectRoot,
           initialPrompt,
+          initialAttachments,
           initialControls,
           familiarId: next?.id ?? familiarId ?? null,
           origin,
@@ -373,6 +376,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             sessionId: null,
             projectRoot: view.kind === "chat" ? view.projectRoot : undefined,
             initialPrompt: view.kind === "chat" ? view.initialPrompt : undefined,
+            initialAttachments: view.kind === "chat" ? view.initialAttachments : undefined,
             initialControls: view.kind === "chat" ? view.initialControls : undefined,
             origin: view.kind === "chat" ? view.origin : undefined,
             familiarId: next?.id ?? familiarId,
@@ -434,6 +438,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
             session={activeSession}
             projectRoot={view.kind === "chat" ? view.projectRoot : undefined}
             initialPrompt={view.kind === "chat" ? view.initialPrompt : undefined}
+            initialAttachments={view.kind === "chat" ? view.initialAttachments : undefined}
             initialControls={view.kind === "chat" ? view.initialControls : undefined}
             origin={view.kind === "chat" ? view.origin : undefined}
             openFindQuery={pendingFind?.query}

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -403,6 +403,7 @@ export function ChatSurface({
           pendingChatAction.familiarId,
           undefined,
           pendingChatAction.initialControls ?? undefined,
+          pendingChatAction.initialAttachments ?? undefined,
         ),
         0,
       );

--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -4,6 +4,9 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+// attachmentIcon (and fileToAttachment/isTextLike) moved to the shared lib so
+// the home composer can reuse the exact same capture + glyph logic.
+const attachmentsLib = readFileSync(new URL("../lib/chat-attachments.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -90,7 +93,7 @@ assert.match(
 );
 
 assert.match(
-  source,
+  attachmentsLib,
   /function attachmentIcon[\s\S]*startsWith\("image\/"\)[\s\S]*"ph:camera"[\s\S]*startsWith\("video\/"\)[\s\S]*"ph:video"[\s\S]*"ph:paperclip"/,
   "Attachment chips should distinguish images and videos from generic files",
 );

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const styles = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 const globalsSrc = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+// fileToAttachment moved to the shared lib (reused by the home composer).
+const attachmentsLib = readFileSync(new URL("../lib/chat-attachments.ts", import.meta.url), "utf8");
 
 assert.match(
   globalsSrc,
@@ -21,7 +23,7 @@ assert.match(
 );
 
 assert.match(
-  source,
+  attachmentsLib,
   /if \(file\.size > MAX_ATTACHMENT_IMAGE_BYTES\) \{[\s\S]*?attachment\.truncated = true;/,
   "Oversized image attachments should be capped at capture time and marked like truncated text",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -36,11 +36,12 @@ import type { Card } from "@/lib/cave-board-types";
 import { TaskLinkPicker } from "@/components/task-link-picker";
 import { openExternalUrl } from "@/lib/open-external";
 import {
+  attachmentIcon,
   extractAgentAttachmentMarkers,
-  MAX_ATTACHMENT_IMAGE_BYTES,
-  MAX_ATTACHMENT_TEXT_CHARS,
+  fileToAttachment,
   stripPreviewOnlyAttachmentFieldsKeepingImages,
   type ChatAttachment,
+  type ComposerAttachment,
 } from "@/lib/chat-attachments";
 import {
   FILE_MENTION_RESULT_LIMIT,
@@ -251,6 +252,9 @@ type Props = {
   /** Prompt handed off from the home composer. Auto-sent once on mount so the
    *  send runs through this view's streaming path instead of a detached fetch. */
   initialPrompt?: string;
+  /** Files handed off from the home composer alongside `initialPrompt`; included
+   *  in the auto-sent first message. */
+  initialAttachments?: ChatAttachment[];
   initialControls?: InitialCommandControls;
   /** Provenance for a newly-created conversation (e.g. "eval" for eval-discuss
    *  threads). Persisted on the conversation so it can be surfaced/hidden by origin. */
@@ -281,7 +285,6 @@ export type ChatViewHandle = {
   runSlash: (command: string) => void;
 };
 
-type ComposerAttachment = ChatAttachment & { id: string };
 type ChatHistoryState = "idle" | "loading" | "loaded" | "missing" | "error";
 
 function isFlowBackedSession(session: SessionRow | null | undefined): boolean {
@@ -735,56 +738,8 @@ function fmtBytes(size?: number): string {
   return `${size} B`;
 }
 
-function isTextLike(file: File): boolean {
-  if (file.type.startsWith("text/")) return true;
-  if (/\/(json|xml|yaml|toml|javascript|typescript|x-sh|csv)$/i.test(file.type)) return true;
-  return /\.(txt|md|markdown|json|yaml|yml|toml|csv|ts|tsx|js|jsx|css|scss|html|xml|rs|go|py|rb|swift|java|kt|sh|zsh|fish|sql|log)$/i.test(file.name);
-}
-
-function attachmentIcon(attachment: Pick<ChatAttachment, "mimeType" | "type">): IconName {
-  const mimeType = attachment.mimeType ?? attachment.type ?? "";
-  if (mimeType.startsWith("image/")) return "ph:camera";
-  if (mimeType.startsWith("video/")) return "ph:video";
-  if (mimeType.startsWith("text/") || /json|xml|yaml|toml|csv|javascript|typescript/.test(mimeType)) {
-    return "ph:file-text";
-  }
-  return "ph:paperclip";
-}
-
 function hasDraggedFiles(types: DataTransfer["types"]): boolean {
   return Array.from(types).includes("Files");
-}
-
-async function fileToAttachment(file: File): Promise<ComposerAttachment> {
-  const attachment: ComposerAttachment = {
-    id: crypto.randomUUID(),
-    name: file.name,
-    type: file.type || undefined,
-    mimeType: file.type || undefined,
-    size: file.size,
-  };
-  if (isTextLike(file)) {
-    const text = await file.slice(0, MAX_ATTACHMENT_TEXT_CHARS).text();
-    attachment.text = text;
-    if (file.size > new Blob([text]).size) attachment.truncated = true;
-  } else if (file.type.startsWith("image/")) {
-    if (file.size > MAX_ATTACHMENT_IMAGE_BYTES) {
-      // Mirror the text-truncation idiom: keep the attachment listed but
-      // skip capturing an oversized payload, surfacing the same chip.
-      attachment.truncated = true;
-      return attachment;
-    }
-    await new Promise<void>((resolve) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        if (typeof reader.result === "string") attachment.dataUrl = reader.result;
-        resolve();
-      };
-      reader.onerror = () => resolve();
-      reader.readAsDataURL(file);
-    });
-  }
-  return attachment;
 }
 
 /**
@@ -2067,7 +2022,7 @@ function MobileChatActionStrip({
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, initialControls, origin, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange, surface },
+  { familiar, sessionId, session, projectRoot, initialPrompt, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, daemonRunning, onSessionStarted, onSessionsChanged, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange, surface },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -3744,7 +3699,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         setThinkingEffort(normalized.thinkingEffort);
         setResponseSpeed(normalized.responseSpeed);
       }
-      void sendRaw(initialPrompt, [], [], undefined, normalized ?? undefined);
+      void sendRaw(initialPrompt, initialAttachments ?? [], [], undefined, normalized ?? undefined);
     }, 0);
     return () => window.clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/home-chat-handoff.test.ts
+++ b/src/components/home-chat-handoff.test.ts
@@ -31,8 +31,8 @@ assert.match(
 
 assert.match(
   surface,
-  /newChat\(\s*pendingChatAction\.projectRoot \?\? undefined,\s*pendingChatAction\.initialPrompt \?\? undefined,\s*pendingChatAction\.familiarId,\s*undefined,\s*pendingChatAction\.initialControls \?\? undefined,\s*\)/s,
-  "ChatSurface should forward the pending initialPrompt into ChatRouter.newChat",
+  /newChat\(\s*pendingChatAction\.projectRoot \?\? undefined,\s*pendingChatAction\.initialPrompt \?\? undefined,\s*pendingChatAction\.familiarId,\s*undefined,\s*pendingChatAction\.initialControls \?\? undefined,\s*pendingChatAction\.initialAttachments \?\? undefined,\s*\)/s,
+  "ChatSurface should forward the pending initialPrompt + attachments into ChatRouter.newChat",
 );
 
 assert.match(

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -45,7 +45,7 @@ assert.match(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},\s*\}\)/,
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},[\s\S]*?\}\)/,
   "HomeComposer should hand the selected project root and initial command controls to chat start",
 );
 
@@ -123,7 +123,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},\s*\}\)/,
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},[\s\S]*?\}\)/,
   "HomeComposer should hand the selected agent chat prompt and command controls to the workspace, which opens a new chat that auto-sends it",
 );
 
@@ -407,4 +407,42 @@ assert.match(
   source,
   /writeComposerHistory\(HOME_HISTORY_KEY, history\)/,
   "home prompt history is persisted when it changes",
+);
+
+// ── Attachments + Enhance (added to the home composer) ──────────────────────
+assert.match(
+  source,
+  /className="hc-add-btn"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:paperclip/,
+  "the + launcher is now a paperclip that opens the file picker",
+);
+assert.match(
+  source,
+  /<input[\s\S]*?type="file"[\s\S]*?multiple[\s\S]*?onChange=\{\(e\) => \{ void addFiles\(e\.target\.files\)/,
+  "a hidden multi-file input feeds addFiles",
+);
+assert.match(
+  source,
+  /attachments\.map\(\(att\) =>[\s\S]*?attachmentIcon\(att\)[\s\S]*?removeAttachment\(att\.id\)/,
+  "staged attachments render as removable chips",
+);
+assert.doesNotMatch(source, /const openCommands =/, "the old slash-launcher click handler is retired (slash still opens on typing '/')");
+assert.match(
+  source,
+  /initialAttachments: outgoing/,
+  "staged attachments are threaded into the started chat",
+);
+assert.match(
+  source,
+  /className=\{`hc-enhance-btn[\s\S]*?onClick=\{\(\) => void enhancePrompt\(\)\}/,
+  "an Enhance button invokes prompt enhancement",
+);
+assert.match(
+  source,
+  /fetch\("\/api\/prompt\/enhance"/,
+  "Enhance calls the prompt-enhance endpoint",
+);
+assert.match(
+  source,
+  /enhanceOriginal != null &&[\s\S]*?onClick=\{revertEnhance\}/,
+  "a one-tap Undo reverts an enhancement",
 );

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -37,6 +37,12 @@ import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models"
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
 import {
+  attachmentIcon,
+  fileToAttachment,
+  type ChatAttachment,
+  type ComposerAttachment,
+} from "@/lib/chat-attachments";
+import {
   COMMAND_CONTROL_DEFAULTS,
   COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
@@ -70,7 +76,11 @@ type Props = {
     prompt: string,
     familiarId: string,
     projectRoot: string | null,
-    opts?: { initialControls?: { thinkingEffort: CommandThinkingEffort; responseSpeed: CommandResponseSpeed } },
+    opts?: {
+      initialControls?: { thinkingEffort: CommandThinkingEffort; responseSpeed: CommandResponseSpeed };
+      /** Files staged in the home composer; the opened chat auto-sends with them. */
+      initialAttachments?: ChatAttachment[];
+    },
   ) => void;
   onNavigateToBoard: () => void;
   onToast: (msg: string) => void;
@@ -140,6 +150,13 @@ export function HomeComposer({
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Attachments staged in the composer; handed to the opened chat on submit.
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  // Prompt enhancement (mirrors the chat composer's Enhance): the pre-enhance
+  // text is kept so the user can revert in one tap.
+  const [enhanceStatus, setEnhanceStatus] = useState<"idle" | "loading" | "error">("idle");
+  const [enhanceOriginal, setEnhanceOriginal] = useState<string | null>(null);
   const archivedFamiliars = useArchivedFamiliars();
   // Hide archived familiars from the "new session" picker. Starting a new
   // chat against an archived agent is a footgun — the user can't tell from
@@ -393,12 +410,6 @@ export function HomeComposer({
     setTimeout(() => textareaRef.current?.focus(), 80);
   }, []);
 
-  // The "＋" affordance reveals the slash-command menu (board/remind/model/…).
-  const openCommands = useCallback(() => {
-    setText((t) => (t.trim() ? t : "/"));
-    setTimeout(() => textareaRef.current?.focus(), 0);
-  }, []);
-
   // Maps a familiar id to its display name for the daily-summary carousel.
   const familiarNameById = useMemo(() => {
     const m = new Map<string, string>();
@@ -413,6 +424,63 @@ export function HomeComposer({
     el.style.height = "auto";
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   }, []);
+
+  // ── Attachments ──────────────────────────────────────────────────────────
+  // Paperclip stages picked files (cap 10, mirroring the chat composer); they
+  // ride along to the opened chat on submit. Slash commands still open by
+  // typing "/" in the composer, so the retired "+" launcher loses nothing.
+  const addFiles = useCallback(async (files: FileList | File[] | null) => {
+    if (!files?.length) return;
+    const room = Math.max(0, 10 - attachments.length);
+    const selected = Array.from(files).slice(0, room);
+    if (selected.length === 0) {
+      onToast("Attachment limit reached (10).");
+      return;
+    }
+    const next = await Promise.all(selected.map(fileToAttachment));
+    setAttachments((prev) => [...prev, ...next]);
+    setTimeout(() => textareaRef.current?.focus(), 0);
+  }, [attachments.length, onToast]);
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  // ── Enhance ──────────────────────────────────────────────────────────────
+  // Rewrite the draft via /api/prompt/enhance (mirrors the chat composer),
+  // stashing the original for a one-tap revert.
+  const enhancePrompt = useCallback(async () => {
+    const draft = text.trim();
+    if (!draft || sending || enhanceStatus === "loading") return;
+    setEnhanceStatus("loading");
+    try {
+      const res = await fetch("/api/prompt/enhance", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ draft, mode: "chat" }),
+      });
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; enhanced?: string } | null;
+      if (!res.ok || !json?.ok || typeof json.enhanced !== "string" || !json.enhanced.trim()) {
+        setEnhanceStatus("error");
+        onToast("Couldn't enhance the prompt.");
+        return;
+      }
+      setEnhanceOriginal(text);
+      setText(json.enhanced);
+      setEnhanceStatus("idle");
+      setTimeout(() => { textareaRef.current?.focus(); autoGrow(); }, 0);
+    } catch {
+      setEnhanceStatus("error");
+      onToast("Couldn't enhance the prompt.");
+    }
+  }, [text, sending, enhanceStatus, onToast, autoGrow]);
+  const revertEnhance = useCallback(() => {
+    setEnhanceOriginal((original) => {
+      if (original == null) return null;
+      setText(original);
+      setTimeout(() => { textareaRef.current?.focus(); autoGrow(); }, 0);
+      return null;
+    });
+  }, [autoGrow]);
 
   // Destination pills behave as a single-select radiogroup: arrow/Home/End
   // move the selection and the roving focus, matching the ARIA radio pattern.
@@ -441,7 +509,9 @@ export function HomeComposer({
 
   const handleSubmit = useCallback(async () => {
     const prompt = text.trim();
-    if (!prompt || sending) return;
+    // Allow an attachments-only send (chat can carry files with no text); every
+    // other path still needs a prompt and is guarded per-destination below.
+    if ((!prompt && attachments.length === 0) || sending) return;
 
     // Slash commands bypass the destination model entirely — same contract
     // as the chat composer's slash dispatch.
@@ -509,13 +579,20 @@ export function HomeComposer({
           // the send here and canceling on the session event aborts the
           // request server-side — the harness is killed mid-run and the
           // transcript never saves, so the opened chat 404s.
+          // ComposerAttachment carries a local `id` (extra vs ChatAttachment);
+          // it's harmless downstream (normalized away before persistence).
+          const outgoing: ChatAttachment[] | undefined = attachments.length ? attachments : undefined;
           setText("");
+          setAttachments([]);
+          setEnhanceOriginal(null);
           onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null, {
             initialControls: { thinkingEffort, responseSpeed },
+            initialAttachments: outgoing,
           });
           break;
         }
         case "board": {
+          if (!prompt) { onToast("Add a task title."); break; }
           const res = await fetch("/api/board", {
             method: "POST",
             headers: { "content-type": "application/json" },
@@ -546,6 +623,7 @@ export function HomeComposer({
     thinkingEffort,
     responseSpeed,
     sending,
+    attachments,
     handleSelectModel,
     onSlash,
     onStartChat,
@@ -831,7 +909,7 @@ export function HomeComposer({
           placeholder={PLACEHOLDERS[destination]}
           rows={3}
           value={text}
-          onChange={(e) => { setText(e.target.value); autoGrow(); }}
+          onChange={(e) => { setText(e.target.value); autoGrow(); if (enhanceOriginal != null) setEnhanceOriginal(null); }}
           onKeyDown={handleKeyDown}
           disabled={sending}
           aria-label="Ask anything"
@@ -846,17 +924,48 @@ export function HomeComposer({
           enterKeyHint="send"
         />
 
+        {/* Staged attachments — chips with a remove control (mirrors chat). */}
+        {attachments.length > 0 && (
+          <ul className="hc-attachments" aria-label="Attachments">
+            {attachments.map((att) => (
+              <li key={att.id} className="hc-attachment">
+                <Icon name={attachmentIcon(att)} width={12} className="hc-attachment-icon" aria-hidden />
+                <span className="hc-attachment-name" title={att.name}>{att.name}</span>
+                <button
+                  type="button"
+                  className="hc-attachment-remove"
+                  onClick={() => removeAttachment(att.id)}
+                  aria-label={`Remove ${att.name}`}
+                  title="Remove"
+                >
+                  <Icon name="ph:x" width={10} aria-hidden />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
         {/* Action bar */}
         <div className="hc-action-bar">
           <div className="hc-control-group hc-control-group--who">
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="hc-file-input"
+              onChange={(e) => { void addFiles(e.target.files); e.target.value = ""; }}
+              tabIndex={-1}
+              aria-hidden
+            />
             <button
               type="button"
               className="hc-add-btn"
-              onClick={openCommands}
-              aria-label="Commands"
-              title="Slash commands"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={sending}
+              aria-label="Attach files"
+              title="Attach files"
             >
-              <Icon name="ph:plus" width={15} aria-hidden />
+              <Icon name="ph:paperclip" width={15} aria-hidden />
             </button>
 
             <label className="hc-familiar-selector">
@@ -964,11 +1073,38 @@ export function HomeComposer({
               </>
             ) : null}
 
+            {enhanceOriginal != null && (
+              <button
+                type="button"
+                className="hc-enhance-undo"
+                onClick={revertEnhance}
+                disabled={sending}
+                title="Undo enhance"
+              >
+                Undo
+              </button>
+            )}
             <button
               type="button"
-              className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() ? " empty" : ""}`}
+              className={`hc-enhance-btn${enhanceStatus === "loading" ? " loading" : ""}`}
+              onClick={() => void enhancePrompt()}
+              disabled={!text.trim() || sending || enhanceStatus === "loading"}
+              aria-label="Enhance prompt"
+              title="Enhance prompt"
+            >
+              {enhanceStatus === "loading" ? (
+                <span className="hc-spinner" />
+              ) : (
+                <Icon name="ph:sparkle" width={13} aria-hidden />
+              )}
+              <span className="hc-enhance-label">Enhance</span>
+            </button>
+
+            <button
+              type="button"
+              className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() && attachments.length === 0 ? " empty" : ""}`}
               onClick={() => void handleSubmit()}
-              disabled={!text.trim() || sending}
+              disabled={(!text.trim() && attachments.length === 0) || sending}
               aria-label="Send"
             >
               {sending ? (

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -68,8 +68,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /<HomeComposer[\s\S]*?onStartChat=\{\(prompt, fid, projectRoot, opts\) =>\s*startFamiliarChat\(fid, projectRoot, prompt, opts\?\.initialControls \?\? null\)\s*\}/,
-  "Workspace HomeComposer handoff should forward initial controls into startFamiliarChat",
+  /<HomeComposer[\s\S]*?onStartChat=\{\(prompt, fid, projectRoot, opts\) =>\s*startFamiliarChat\(fid, projectRoot, prompt, opts\?\.initialControls \?\? null, opts\?\.initialAttachments \?\? null\)\s*\}/,
+  "Workspace HomeComposer handoff should forward initial controls + attachments into startFamiliarChat",
 );
 
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -76,6 +76,7 @@ import { TopBar } from "@/components/top-bar";
 import { QuickChatOverlay } from "@/components/quick-chat-overlay";
 import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+import type { ChatAttachment } from "@/lib/chat-attachments";
 import {
   OPEN_IN_APP_BROWSER_EVENT,
   PENDING_IN_APP_BROWSER_URL_KEY,
@@ -1187,6 +1188,7 @@ export function Workspace() {
     projectRoot?: string | null,
     initialPrompt?: string | null,
     initialControls?: InitialCommandControls | null,
+    initialAttachments?: ChatAttachment[] | null,
   ) => {
     if (familiarId) setActiveId(familiarId);
     setPendingProjectChatRoot(projectRoot ?? null);
@@ -1195,6 +1197,7 @@ export function Workspace() {
       familiarId,
       projectRoot,
       initialPrompt,
+      initialAttachments,
       initialControls,
       nonce: Date.now(),
     });
@@ -2131,7 +2134,7 @@ export function Workspace() {
         sessions={sessions}
         onSetActiveFamiliar={setActiveId}
         onStartChat={(prompt, fid, projectRoot, opts) =>
-          startFamiliarChat(fid, projectRoot, prompt, opts?.initialControls ?? null)
+          startFamiliarChat(fid, projectRoot, prompt, opts?.initialControls ?? null, opts?.initialAttachments ?? null)
         }
         onNavigateToBoard={() => setMode("board")}
         onToast={pushToast}

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -1,3 +1,5 @@
+import type { IconName } from "@/lib/icon";
+
 export const MAX_ATTACHMENT_TEXT_CHARS = 64_000;
 /** Hard cap on a decoded image payload, enforced on capture (client) and on
  * normalize (server) — the server never trusts the client-side check. */
@@ -200,4 +202,62 @@ export function buildPromptWithAttachments(
   });
 
   return `${header}\n\nAttached files:\n${parts.join("\n\n")}`;
+}
+
+// ── Composer-side file → attachment capture ──────────────────────────────────
+// Shared by the chat composer (ChatView) and the home composer so both convert
+// picked files identically. Browser-only (FileReader/Blob/crypto) but safe to
+// import server-side — nothing runs at module load.
+
+/** A composer-staged attachment: a ChatAttachment plus a local id for the UI. */
+export type ComposerAttachment = ChatAttachment & { id: string };
+
+/** Files we inline as text (captured into `.text`) vs. keep as metadata/image. */
+export function isTextLike(file: File): boolean {
+  if (file.type.startsWith("text/")) return true;
+  if (/\/(json|xml|yaml|toml|javascript|typescript|x-sh|csv)$/i.test(file.type)) return true;
+  return /\.(txt|md|markdown|json|yaml|yml|toml|csv|ts|tsx|js|jsx|css|scss|html|xml|rs|go|py|rb|swift|java|kt|sh|zsh|fish|sql|log)$/i.test(file.name);
+}
+
+/** Phosphor glyph for an attachment chip, by mime/type. */
+export function attachmentIcon(attachment: Pick<ChatAttachment, "mimeType" | "type">): IconName {
+  const mimeType = attachment.mimeType ?? attachment.type ?? "";
+  if (mimeType.startsWith("image/")) return "ph:camera";
+  if (mimeType.startsWith("video/")) return "ph:video";
+  if (mimeType.startsWith("text/") || /json|xml|yaml|toml|csv|javascript|typescript/.test(mimeType)) {
+    return "ph:file-text";
+  }
+  return "ph:paperclip";
+}
+
+/** Convert a picked File into a ComposerAttachment: inline text bodies, embed
+ *  small images as data URLs, keep everything else as metadata (truncated). */
+export async function fileToAttachment(file: File): Promise<ComposerAttachment> {
+  const attachment: ComposerAttachment = {
+    id: crypto.randomUUID(),
+    name: file.name,
+    type: file.type || undefined,
+    mimeType: file.type || undefined,
+    size: file.size,
+  };
+  if (isTextLike(file)) {
+    const text = await file.slice(0, MAX_ATTACHMENT_TEXT_CHARS).text();
+    attachment.text = text;
+    if (file.size > new Blob([text]).size) attachment.truncated = true;
+  } else if (file.type.startsWith("image/")) {
+    if (file.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+      attachment.truncated = true;
+      return attachment;
+    }
+    await new Promise<void>((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result === "string") attachment.dataUrl = reader.result;
+        resolve();
+      };
+      reader.onerror = () => resolve();
+      reader.readAsDataURL(file);
+    });
+  }
+  return attachment;
 }

--- a/src/lib/pending-chat-action.ts
+++ b/src/lib/pending-chat-action.ts
@@ -1,4 +1,5 @@
 import type { InitialCommandControls } from "@/lib/command-controls";
+import type { ChatAttachment } from "@/lib/chat-attachments";
 
 export type PendingChatAction =
   | {
@@ -8,6 +9,8 @@ export type PendingChatAction =
       /** Prompt handed off from the home composer; ChatView auto-sends it so
        *  the send runs through the normal streaming path. */
       initialPrompt?: string | null;
+      /** Files handed off with the prompt; included in the auto-sent message. */
+      initialAttachments?: ChatAttachment[] | null;
       initialControls?: InitialCommandControls | null;
       nonce: number;
     }

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -174,7 +174,7 @@
   margin-left: auto;
 }
 
-/* ── "＋" command launcher ───────────────────────────────────────────────── */
+/* ── Attach button (paperclip) ───────────────────────────────────────────── */
 .hc-add-btn {
   display: inline-flex;
   align-items: center;
@@ -189,10 +189,112 @@
   cursor: pointer;
   transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
 }
-.hc-add-btn:hover {
+.hc-add-btn:hover:not(:disabled) {
   background: var(--bg-base);
   border-color: var(--border-hairline);
   color: var(--text-secondary);
+}
+.hc-add-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* Hidden native file input driven by the paperclip button. */
+.hc-file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* ── Attachment chips ────────────────────────────────────────────────────── */
+.hc-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 8px 14px 0;
+}
+.hc-attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 220px;
+  padding: 3px 6px 3px 8px;
+  border-radius: 8px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+.hc-attachment-icon { color: var(--text-muted); flex-shrink: 0; }
+.hc-attachment-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hc-attachment-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.hc-attachment-remove:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+/* ── Enhance button ──────────────────────────────────────────────────────── */
+.hc-enhance-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 9px;
+  border: 1px solid var(--border-hairline);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.hc-enhance-btn:hover:not(:disabled) {
+  background: var(--bg-base);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+.hc-enhance-btn:disabled { opacity: 0.5; cursor: default; }
+.hc-enhance-btn.loading { color: var(--accent-presence); }
+.hc-enhance-label { line-height: 1; }
+.hc-enhance-undo {
+  flex-shrink: 0;
+  height: 30px;
+  padding: 0 8px;
+  border-radius: 9px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.hc-enhance-undo:hover:not(:disabled) { background: var(--bg-base); color: var(--text-secondary); }
+.hc-enhance-undo:disabled { opacity: 0.5; cursor: default; }
+
+@media (max-width: 640px) {
+  .hc-enhance-label { display: none; }
 }
 
 /* ── Model chip ──────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Adds prompt **enhancement** and file **attachments** to the home-page chat composer, mirroring the chat composer end to end. Design was brainstormed + approved: full attachment pipe, and the `+` becomes a paperclip (slash still opens on `/`).

## What

- **Enhance button** — rewrites the draft via `/api/prompt/enhance` (mode `"chat"`), keeps the original for a one-tap **Undo**. No-ops on empty draft / while sending.
- **Paperclip → attachments** — replaces the old `+` slash launcher: opens a multi-file picker; files stage as removable chips (cap 10). Slash commands still open by typing `/`, so nothing is lost.
- **Full attachment pipe** — staged files thread `onStartChat → startFamiliarChat → PendingChatAction → ChatRouter.newChat → ChatView`, whose initial-send effect includes them, so the opened chat sends the prompt **with** the files. Attachments-only sends are allowed.
- **Shared refactor** — `fileToAttachment` / `isTextLike` / `attachmentIcon` / `ComposerAttachment` moved from `chat-view.tsx` into `chat-attachments.ts` so both composers use identical capture logic (no behavior change).

## Scope (YAGNI, per the approved design)

No drag-and-drop, paste-to-attach, or image thumbnails on home this pass — just picker + chips + threading (the chat renders rich attachments once open). CSV special-casing stays chat-only.

## Tests

`home-composer.test` covers the paperclip, hidden file input, chips, Enhance button, Undo, and attachment threading. Existing `newChat` / `startFamiliarChat` / `attachmentIcon` / `fileToAttachment` source-text assertions were updated for the new signatures + lib locations. **Local: tsc clean, full `test:app` suite (508 files) green, prod build within budget.** The all-surface E2E crash sweep (#2184) renders the home surface, so a render regression here would go red too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)