### PR TITLE
style(chat): polish the session list cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6884,6 +6884,49 @@ a.mobile-handoff__link:hover {
   }
 }
 
+/* ── Session list card polish ──────────────────────────────────────────────
+   Each row reads as a tappable card: a faint leading-edge accent on hover, a
+   refined model pill, and running sessions feel LIVE (pulsing status dot +
+   accent-tinted "Active now…" preview). Purely additive over the row's inline
+   Tailwind background/active states. */
+.chat-list-row {
+  transition:
+    background var(--duration-fast, 120ms) var(--ease-standard, ease),
+    box-shadow var(--duration-fast, 120ms) var(--ease-standard, ease);
+}
+.chat-list-row:hover {
+  box-shadow: inset 2px 0 0 0 color-mix(in oklch, var(--accent-presence) 45%, transparent);
+}
+/* Active rows already show the solid absolute accent bar — no hover hairline. */
+.chat-list-row[data-active="true"]:hover {
+  box-shadow: none;
+}
+
+/* Model chip → a clean, consistent pill. */
+.chat-list-row-model {
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 80%, transparent);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
+}
+
+/* Running sessions: gentle pulsing halo on the status dot + live-tinted preview. */
+.chat-list-row[data-status="running"] .chat-list-status-dot > span {
+  animation: chat-list-dot-pulse 2s var(--ease-standard, ease-out) infinite;
+}
+.chat-list-row[data-status="running"] .chat-list-row-preview {
+  color: color-mix(in oklch, var(--color-success) 78%, var(--text-secondary));
+}
+@keyframes chat-list-dot-pulse {
+  0% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-success) 55%, transparent); }
+  70% { box-shadow: 0 0 0 5px color-mix(in oklch, var(--color-success) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in oklch, var(--color-success) 0%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .chat-list-row[data-status="running"] .chat-list-status-dot > span {
+    animation: none;
+  }
+}
+
 /* Capabilities inspector metadata collapses into one dense row whenever the
    expanded row has enough width, then wraps by whole field on narrower panes. */
 .capability-meta-row {

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -1115,6 +1115,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             }
                           }}
                           data-selected={selectMode && selectedIds.has(s.id) ? "true" : undefined}
+                          data-status={st.label}
+                          data-active={isActive ? "true" : undefined}
                           className={[
                             "chat-list-row focus-ring-inset group relative flex cursor-pointer gap-3 px-4 py-3.5 transition-colors",
                             isActive
@@ -1215,7 +1217,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                             </span>
 
                             {/* Row 3: status preview */}
-                            <span className={`truncate text-[12px] ${st.preview}`}>
+                            <span className={`chat-list-row-preview truncate text-[12px] ${st.preview}`}>
                               {s.archived_at ? <span className="text-[var(--text-muted)]">Archived · </span> : null}
                               {st.label === "running"
                                 ? "Active now…"


### PR DESCRIPTION
Visual polish for the session list cards (the Sessions rail / Code-surface center list).

- **Refined model pill**: `.chat-list-row-model` becomes a clean rounded, bordered pill.
- **Hover affordance**: a faint leading-edge accent hairline on hover (suppressed on the active row, which already shows the solid accent bar).
- **Running sessions feel live**: a gentle pulsing halo on the status dot (`prefers-reduced-motion` aware) + an accent-tinted "Active now…" preview line.

Additive only: new `data-status` / `data-active` attributes + a `chat-list-row-preview` class on `chat-list.tsx`; the rest is scoped CSS over the existing row background/active states. All existing classes kept.

Verified in the app (7 cards, 2 running rows with the live treatment, 7 refined model pills). All `chat-list-*` + `chat-rail-modern-redesign` source-text tests pass; typecheck + build + bundle-budget green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)