### PR TITLE
Home composer: drag-and-drop attachments

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -605,7 +605,7 @@ assert.match(
 
 // — CHAT-D1-03: drag-and-drop attach on the chat surface —
 assert.match(
-  source,
+  attachmentsLib,
   /function hasDraggedFiles\(types: DataTransfer\["types"\]\): boolean \{[\s\S]*Array\.from\(types\)\.includes\("Files"\)/,
   "Drag file detection must normalize DataTransfer.types before calling includes for WebKit/WebView DOMStringList compatibility",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -39,6 +39,7 @@ import {
   attachmentIcon,
   extractAgentAttachmentMarkers,
   fileToAttachment,
+  hasDraggedFiles,
   stripPreviewOnlyAttachmentFieldsKeepingImages,
   type ChatAttachment,
   type ComposerAttachment,
@@ -736,10 +737,6 @@ function fmtBytes(size?: number): string {
     value /= 1024;
   }
   return `${size} B`;
-}
-
-function hasDraggedFiles(types: DataTransfer["types"]): boolean {
-  return Array.from(types).includes("Files");
 }
 
 /**

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -446,3 +446,20 @@ assert.match(
   /enhanceOriginal != null &&[\s\S]*?onClick=\{revertEnhance\}/,
   "a one-tap Undo reverts an enhancement",
 );
+
+// ── Drag-and-drop attachments ───────────────────────────────────────────────
+assert.match(
+  source,
+  /onDrop=\{\(e\) => \{[\s\S]*?hasDraggedFiles\(e\.dataTransfer\.types\)[\s\S]*?void addFiles\(e\.dataTransfer\.files\)/,
+  "dropping files onto the composer card routes through addFiles",
+);
+assert.match(
+  source,
+  /onDragEnter=\{\(e\) => \{[\s\S]*?setDropActive\(true\)/,
+  "a file drag arms the drop overlay",
+);
+assert.match(
+  source,
+  /dropActive \? \([\s\S]*?hc-drop-overlay[\s\S]*?Drop files to attach/,
+  "an overlay prompts to drop files while dragging",
+);

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -39,6 +39,7 @@ import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
 import {
   attachmentIcon,
   fileToAttachment,
+  hasDraggedFiles,
   type ChatAttachment,
   type ComposerAttachment,
 } from "@/lib/chat-attachments";
@@ -153,6 +154,10 @@ export function HomeComposer({
   // Attachments staged in the composer; handed to the opened chat on submit.
   const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Drag-and-drop onto the composer card. dragDepthRef counts enter/leave pairs
+  // so moving across child elements doesn't flicker the overlay.
+  const [dropActive, setDropActive] = useState(false);
+  const dragDepthRef = useRef(0);
   // Prompt enhancement (mirrors the chat composer's Enhance): the pre-enhance
   // text is kept so the user can revert in one tap.
   const [enhanceStatus, setEnhanceStatus] = useState<"idle" | "loading" | "error">("idle");
@@ -871,7 +876,39 @@ export function HomeComposer({
           </div>
         ) : null}
 
-        <div className="home-composer-card">
+        <div
+          className={`home-composer-card${dropActive ? " is-drop-active" : ""}`}
+          onDragEnter={(e) => {
+            if (!hasDraggedFiles(e.dataTransfer.types)) return;
+            e.preventDefault();
+            dragDepthRef.current += 1;
+            setDropActive(true);
+          }}
+          onDragOver={(e) => {
+            if (!hasDraggedFiles(e.dataTransfer.types)) return;
+            e.preventDefault();
+          }}
+          onDragLeave={(e) => {
+            if (!hasDraggedFiles(e.dataTransfer.types)) return;
+            dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+            if (dragDepthRef.current === 0) setDropActive(false);
+          }}
+          onDrop={(e) => {
+            dragDepthRef.current = 0;
+            setDropActive(false);
+            if (!hasDraggedFiles(e.dataTransfer.types)) return;
+            e.preventDefault();
+            void addFiles(e.dataTransfer.files);
+          }}
+        >
+          {dropActive ? (
+            <div className="hc-drop-overlay" aria-hidden="true">
+              <div className="hc-drop-overlay-inner">
+                <Icon name="ph:paperclip" width={16} aria-hidden />
+                <span>Drop files to attach</span>
+              </div>
+            </div>
+          ) : null}
 
         {/* Mode strip — the composer's primary intent switch (Chat vs Task)
             leads the card, above the textarea, so it reads as the top-level

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -212,6 +212,12 @@ export function buildPromptWithAttachments(
 /** A composer-staged attachment: a ChatAttachment plus a local id for the UI. */
 export type ComposerAttachment = ChatAttachment & { id: string };
 
+/** True when a drag carries files (vs. a text selection), so a composer only
+ *  arms its drop affordance for actual file drops. */
+export function hasDraggedFiles(types: DataTransfer["types"]): boolean {
+  return Array.from(types).includes("Files");
+}
+
 /** Files we inline as text (captured into `.text`) vs. keep as metadata/image. */
 export function isTextLike(file: File): boolean {
   if (file.type.startsWith("text/")) return true;

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -89,6 +89,7 @@
 
 /* ── Composer card ───────────────────────────────────────────────────────── */
 .home-composer-card {
+  position: relative;
   width: 100%;
   max-width: 100%;
   background: color-mix(in oklch, var(--bg-raised) 70%, var(--bg-base));
@@ -98,6 +99,30 @@
   box-shadow: 0 12px 40px color-mix(in oklch, var(--text-primary) 14%, transparent),
               0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+.home-composer-card.is-drop-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong));
+}
+
+/* Drag-and-drop overlay — covers the card while a file drag hovers it. */
+.hc-drop-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  display: grid;
+  place-items: center;
+  border-radius: 22px;
+  background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base) 88%);
+  border: 2px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  pointer-events: none;
+}
+.hc-drop-overlay-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
 }
 
 .home-composer-card:focus-within {


### PR DESCRIPTION
Follow-up to #2200 (the deferred drag-drop item). The home composer card is now a drop zone.

## What
- Dragging files over the composer card arms a **"Drop files to attach"** overlay (accent dashed border + `is-drop-active`).
- Dropping routes through the existing `addFiles`, so the 10-attachment cap and text/image capture all apply — files land as the same removable chips, and thread into the started chat via the pipe #2200 already verified.
- Mirrors the chat composer's drag handling; the shared `hasDraggedFiles` helper moves into `chat-attachments.ts` so both composers use it.

## Verified in the running app
Synthetic file drag → `dragenter` arms the overlay + `is-drop-active` class; **dropping a file adds the `dropped.txt` chip**; overlay clears on drop. Screenshot confirms the dashed overlay.

## Tests
`home-composer.test` asserts the drop handler → `addFiles`, the drag-arm, and the overlay. `chat-view-polish` `hasDraggedFiles` assertion repointed to the shared lib. tsc clean, full `test:app` (508 files) green, prod build within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)