### PR TITLE
feat(quick-chat): drop the quick-chat popover from below its menubar trigger

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9933,6 +9933,19 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   animation: quick-chat-overlay-in 180ms var(--ease-emphasized, cubic-bezier(0.2, 0.8, 0.2, 1));
 }
 
+/* Caret connecting the dropdown to its menubar trigger (positioned inline). */
+.quick-chat-overlay__caret {
+  width: 12px;
+  height: 12px;
+  background: var(--bg-panel);
+  border-left: 1px solid var(--border-hairline);
+  border-top: 1px solid var(--border-hairline);
+  border-top-left-radius: 3px;
+  transform: rotate(45deg);
+  box-shadow: -2px -2px 6px -3px rgba(0, 0, 0, 0.35);
+  animation: quick-chat-backdrop-in 180ms var(--ease-standard, ease-out);
+}
+
 @keyframes quick-chat-overlay-in {
   from {
     opacity: 0;
@@ -9949,7 +9962,8 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 @media (prefers-reduced-motion: reduce) {
   .quick-chat-overlay,
-  .quick-chat-overlay-backdrop {
+  .quick-chat-overlay-backdrop,
+  .quick-chat-overlay__caret {
     animation: none;
   }
 }

--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./quick-chat-overlay.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -61,6 +62,38 @@ assert.match(
   workspace,
   /<QuickChatOverlay[\s\S]*onOpenFullSession=\{\(sid, fid\) =>/,
   "workspace renders QuickChatOverlay and routes Open-in-full-chat to openFamiliarSession",
+);
+
+// ── Dropdown-from-the-menubar: anchored under its trigger, on left click ──────
+assert.match(
+  topBar,
+  /data-quick-chat-trigger[\s\S]{0,120}onClick=\{onOpenQuickChat\}/,
+  "the menubar trigger is tagged for anchoring and opens the dropdown on (left) click",
+);
+assert.match(
+  source,
+  /querySelectorAll\("\[data-quick-chat-trigger\]"\)/,
+  "the overlay finds its menubar trigger to anchor beneath it",
+);
+assert.match(
+  source,
+  /\.find\(\(el\) => el\.getBoundingClientRect\(\)\.width > 0\)/,
+  "the overlay anchors to the visible trigger instance (top bar is rendered per-breakpoint)",
+);
+assert.match(
+  source,
+  /style=\{anchor \? \{ top: anchor\.top, right: anchor\.right \} : undefined\}/,
+  "the dropdown drops from just below the trigger (falls back to the CSS corner)",
+);
+assert.match(
+  source,
+  /className="quick-chat-overlay__caret"/,
+  "a caret connects the dropdown to the menubar trigger",
+);
+assert.match(
+  source,
+  /window\.addEventListener\("resize", measure\)/,
+  "the anchor position is kept in sync on resize",
 );
 
 console.log("quick-chat-overlay.test.ts OK");

--- a/src/components/quick-chat-overlay.tsx
+++ b/src/components/quick-chat-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 import {
   COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
@@ -49,6 +49,41 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession }: Props) {
 
   const sending = sendState === "sending";
 
+  // Anchor the popover directly beneath its menubar trigger so it reads as a
+  // dropdown from the bar (with a caret pointing up at the icon) rather than a
+  // panel pinned to the corner. Falls back to the CSS default (top-right) if the
+  // trigger can't be measured. Recomputed on resize while open.
+  const [anchor, setAnchor] = useState<{ top: number; right: number; caretRight: number } | null>(null);
+  useLayoutEffect(() => {
+    if (!open) return;
+    const measure = () => {
+      // The trigger lives in the top bar, which is rendered per-breakpoint — pick
+      // the visible instance (a hidden one reports a 0×0 rect). Its icon <svg> is
+      // a leaf that keeps a real box even if the button itself doesn't, so fall
+      // back to that to find the real on-screen position.
+      const btns = Array.from(document.querySelectorAll("[data-quick-chat-trigger]"));
+      const btn = btns.find((el) => el.getBoundingClientRect().width > 0) ?? btns[0] ?? null;
+      let rect: DOMRect | undefined = btn?.getBoundingClientRect();
+      if ((!rect || rect.width === 0) && btn) {
+        rect = (btn.querySelector("svg") ?? btn.firstElementChild)?.getBoundingClientRect();
+      }
+      if (!rect || rect.width === 0) {
+        setAnchor(null);
+        return;
+      }
+      const right = Math.max(12, Math.round(window.innerWidth - rect.right));
+      setAnchor({
+        top: Math.round(rect.bottom + 8),
+        right,
+        // Centre the caret on the trigger icon (distance from the viewport right).
+        caretRight: Math.max(14, Math.round(window.innerWidth - (rect.left + rect.width / 2) - 6)),
+      });
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [open]);
+
   // Escape closes the popover while it's open.
   useEffect(() => {
     if (!open) return;
@@ -88,11 +123,19 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession }: Props) {
         onClick={onClose}
         aria-hidden
       />
+      {anchor ? (
+        <div
+          className="quick-chat-overlay__caret"
+          aria-hidden
+          style={{ position: "fixed", top: anchor.top - 5, right: anchor.caretRight, zIndex: 1201 }}
+        />
+      ) : null}
       <div
         role="dialog"
         aria-modal="true"
         aria-label="Quick chat"
         className="quick-chat-overlay"
+        style={anchor ? { top: anchor.top, right: anchor.right } : undefined}
       >
         <header className="flex items-center justify-between border-b border-[var(--border-hairline)] px-4 py-3">
           <div className="flex min-w-0 items-center gap-2">

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -180,6 +180,7 @@ export function TopBar(props: Props) {
           <button
             type="button"
             className="top-bar__icon-btn"
+            data-quick-chat-trigger
             onClick={onOpenQuickChat}
             aria-label="Quick chat"
             title="Quick chat"


### PR DESCRIPTION
## What

The quick-chat popover opened pinned to the **top-right corner**. Now it **drops down from directly below its menubar trigger** — anchored under the chat icon with a **caret** pointing up at it, so it reads as a dropdown from the bar. It opens on **left click** (unchanged) and keeps #2197's slide-in animation.

## How
- `top-bar.tsx` — tag the trigger with `data-quick-chat-trigger`.
- `quick-chat-overlay.tsx` — on open (and on resize) measure the **visible** trigger instance and position the dialog just beneath it, right-aligned, with a caret centered on the icon. The trigger's icon `<svg>` is measured as a fallback since the top-bar button can report a 0×0 box; if nothing measurable, it falls back to the previous top-right corner.
- `globals.css` — caret styling (rotated square) + reduced-motion guard.

All existing dialog semantics (role/aria-modal/aria-label, Escape, Cmd/Ctrl+Enter, backdrop close, Open-in-full-chat) are preserved.

## Verification
- Test + `pnpm build` green.
- Drove the app at the width where the quick-chat menubar is shown: the trigger measures a real box, and the popover anchors below it (`top = bar bottom + 8`, right-aligned to the icon) with the caret in the gap. Screenshot confirms the dropdown hangs from the menubar under the (active) chat icon.

Note: builds on #2185 (reveal) and #2197 (visual polish); this is the positioning/anchoring pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)