### PR TITLE
Home composer: paste-to-attach

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -463,3 +463,10 @@ assert.match(
   /dropActive \? \([\s\S]*?hc-drop-overlay[\s\S]*?Drop files to attach/,
   "an overlay prompts to drop files while dragging",
 );
+
+// ── Paste-to-attach ─────────────────────────────────────────────────────────
+assert.match(
+  source,
+  /onPaste=\{\(e\) => \{[\s\S]*?e\.clipboardData\.items[\s\S]*?item\.kind === "file"[\s\S]*?void addFiles\(pastedFiles\)/,
+  "pasting files into the composer stages them as attachments",
+);

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -947,6 +947,19 @@ export function HomeComposer({
           rows={3}
           value={text}
           onChange={(e) => { setText(e.target.value); autoGrow(); if (enhanceOriginal != null) setEnhanceOriginal(null); }}
+          onPaste={(e) => {
+            // Paste-to-attach: clipboard files (screenshots, copied files) stage
+            // as attachments. Only preventDefault when files were consumed so a
+            // plain-text paste is untouched.
+            const pastedFiles = Array.from(e.clipboardData.items)
+              .filter((item) => item.kind === "file")
+              .map((item) => item.getAsFile())
+              .filter((file): file is File => file !== null);
+            if (pastedFiles.length > 0) {
+              e.preventDefault();
+              void addFiles(pastedFiles);
+            }
+          }}
           onKeyDown={handleKeyDown}
           disabled={sending}
           aria-label="Ask anything"


### PR DESCRIPTION
Final follow-up to #2200 / #2202 — completes the attachment set.

Pasting files (screenshots, copied files) into the home composer textarea now stages them as attachments via the existing `addFiles` path. `preventDefault` fires **only** when files are consumed, so a plain-text paste is untouched. Mirrors the chat composer's paste handler.

**Verified in the running app:** dispatching a file paste adds the `pasted.txt` chip and leaves the textarea text empty. Pasted files thread into the started chat via the pipe #2200 verified. tsc clean, full `test:app` (508 files) green, prod build within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)