### PR TITLE
fix(group-chat): parallelize first-pass coven replies

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -21,11 +21,11 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
   // A Stop control aborts the in-flight broadcast.
   assert.match(view, /abortRef\.current\?\.abort\(\)/, "Stop aborts the broadcast");
   // Injects the coven roster into each send so a familiar knows who else is present.
-  assert.match(view, /renderCovenRoster\(rosterParticipants, r\.familiarId\)/, "injects the per-familiar coven roster");
-  // Full-coven broadcasts relay sequentially so each familiar sees peers' fresh replies.
-  assert.match(view, /const shouldRelay = mentioned\.length === 0 && replies\.length > 1/, "gates relay to full-coven broadcasts");
-  assert.match(view, /for \(const r of replies\)/, "relays sequentially when gated on");
-  assert.match(view, /renderCovenContext\(contextTurns, r\.familiarId/, "injects peers' prior replies as transcript");
+  assert.match(view, /renderCovenRoundtablePrompt\(\{/, "builds the per-familiar roundtable prompt");
+  assert.match(view, /receivingFamiliarId: r\.familiarId/, "marks the receiving familiar in prompt context");
+  assert.match(view, /targeted: mentioned\.length > 0/, "tells the prompt whether the user targeted this reply");
+  assert.doesNotMatch(view, /renderCovenContext\(contextTurns, r\.familiarId/, "default group chat does not relay peer replies");
+  assert.doesNotMatch(view, /const shouldRelay = mentioned\.length === 0 && replies\.length > 1/, "full-coven broadcasts no longer switch to sequential relay");
   // Strips the piggybacked next-paths block (visible) and surfaces the parsed
   // lines (suggestions) so control markup never leaks and chips can render.
   assert.match(

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -39,8 +39,7 @@ import {
   setGroupSession,
   setGroupParticipants,
   parseMentions,
-  renderCovenRoster,
-  renderCovenContext,
+  renderCovenRoundtablePrompt,
   findActiveMention,
   matchMentions,
   applyMention,
@@ -95,9 +94,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // Caret to restore after we programmatically rewrite the draft (mention insert).
   const pendingCaretRef = useRef<number | null>(null);
   const groupsRef = useRef<CovenGroup[]>(groups);
-  const transcriptRef = useRef<GroupTurn[]>(transcript);
   groupsRef.current = groups;
-  transcriptRef.current = transcript;
 
   const byId = useMemo(() => {
     const m = new Map<string, ResolvedFamiliar>();
@@ -243,9 +240,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // --- broadcast send ------------------------------------------------------
   const streamOne = useCallback(
     async (group: CovenGroup, reply: GroupReply, prompt: string, signal: AbortSignal): Promise<GroupReply> => {
-      // `settled` mirrors the live React state so relay can read the final reply
-      // synchronously (transcriptRef only refreshes on re-render, which doesn't
-      // happen between sequential iterations). Apply every update to both.
+      // `settled` mirrors the live React state so callers can await the final
+      // reply state without waiting for React to render. Apply every update to both.
       let settled = reply;
       const apply = (fn: (r: GroupReply) => GroupReply) => {
         settled = fn(settled);
@@ -342,51 +338,31 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         status: "queued",
         createdAt: at,
       }));
-      // Prior rounds (before this turn) — the relay reads peers' replies from
-      // here plus the in-round accumulator. Captured before setTranscript, which
-      // flushes async (transcriptRef only refreshes on re-render).
-      const prior = transcriptRef.current;
       setTranscript((prev) => [...prev, userTurn, ...replies]);
       setDraft("");
       setMention(null);
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
-      // Full-coven broadcasts relay SEQUENTIALLY so each familiar sees the
-      // others' fresh replies this round; targeted/@mention sends stay parallel
-      // (a lone target has no peers to relay, and parallel keeps latency at 1×).
-      const shouldRelay = mentioned.length === 0 && replies.length > 1;
-      if (shouldRelay) {
-        const relayed: GroupReply[] = [];
-        for (const r of replies) {
-          if (controller.signal.aborted) {
-            updateReply(r.id, (x) => ({ ...x, status: "error", error: "cancelled", activity: undefined }));
-            continue;
-          }
-          // Strip the piggybacked next-paths block from peers' text before
-          // quoting it, so control markup never leaks into the next prompt.
-          const contextTurns = [...prior, userTurn, ...relayed].map((t) =>
-            t.role === "assistant" ? { ...t, text: extractNextPaths(t.text).visible } : t,
-          );
-          const roster = renderCovenRoster(rosterParticipants, r.familiarId);
-          const transcript = renderCovenContext(contextTurns, r.familiarId, mentionable);
-          const prompt = [roster, transcript, text].filter(Boolean).join("\n\n");
-          const done = await streamOne(group, r, prompt, controller.signal);
-          if (done.status === "done" && done.text.trim()) relayed.push(done);
-        }
-      } else {
-        await Promise.all(
-          replies.map((r) => {
-            const roster = renderCovenRoster(rosterParticipants, r.familiarId);
-            const prompt = roster ? `${roster}\n\n${text}` : text;
-            return streamOne(group, r, prompt, controller.signal);
-          }),
-        );
-      }
+      await Promise.all(
+        replies.map((r) =>
+          streamOne(
+            group,
+            r,
+            renderCovenRoundtablePrompt({
+              participants: rosterParticipants,
+              receivingFamiliarId: r.familiarId,
+              userText: text,
+              targeted: mentioned.length > 0,
+            }),
+            controller.signal,
+          ),
+        ),
+      );
       abortRef.current = null;
       setBusy(false);
     },
-    [busy, streamOne, byId, updateReply],
+    [busy, streamOne, byId],
   );
 
   // The composer and "click a next-path suggestion to send" chips both go

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -11,6 +11,7 @@ import {
   setGroupParticipants,
   parseMentions,
   renderCovenRoster,
+  renderCovenRoundtablePrompt,
   renderCovenContext,
   findActiveMention,
   matchMentions,
@@ -268,6 +269,35 @@ test("renderCovenRoster: returns '' for a degenerate roster (<= 1 participant)",
     renderCovenRoster([{ id: "nova", name: "Nova", role: "Lead", kind: "familiar" }], "nova"),
     "",
   );
+});
+
+test("renderCovenRoundtablePrompt: frames broadcast replies as independent first-pass answers", () => {
+  const out = renderCovenRoundtablePrompt({
+    participants: COVEN,
+    receivingFamiliarId: "nova",
+    userText: "What should we do?",
+    targeted: false,
+  });
+
+  assert.match(out, /<coven_roster>[\s\S]*Nova — Lead orchestrator \(you\)/);
+  assert.match(out, /<coven_roundtable>[\s\S]*independent first-pass group reply/i);
+  assert.match(out, /Other familiars receive the same human request in parallel/);
+  assert.match(out, /Answer from your own identity, role, and judgment/);
+  assert.match(out, /Do not summarize, predict, imitate, or speak for other familiars/);
+  assert.match(out, /What should we do\?$/);
+  assert.doesNotMatch(out, /<coven_transcript>/);
+});
+
+test("renderCovenRoundtablePrompt: targeted replies get direct-mention framing", () => {
+  const out = renderCovenRoundtablePrompt({
+    participants: COVEN,
+    receivingFamiliarId: "charm",
+    userText: "  @Charm check this  ",
+    targeted: true,
+  });
+
+  assert.match(out, /directly mentioned/);
+  assert.match(out, /@Charm check this$/);
 });
 
 const NAMES: MentionableFamiliar[] = [

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -353,6 +353,38 @@ export function renderCovenRoster(
   ].join("\n");
 }
 
+export type CovenRoundtablePromptArgs = {
+  participants: RosterParticipant[];
+  receivingFamiliarId: string;
+  userText: string;
+  targeted: boolean;
+};
+
+/**
+ * Build the default group-chat prompt for one familiar.
+ *
+ * The first pass through a coven should preserve distinct voices: every
+ * participant receives the same human request in parallel, plus a compact
+ * roster and explicit "answer independently" framing. Cross-familiar transcript
+ * relay is reserved for future explicit debate/synthesis modes; dumping peer
+ * replies into the default prompt makes later familiars converge toward a
+ * blended consensus voice.
+ */
+export function renderCovenRoundtablePrompt(args: CovenRoundtablePromptArgs): string {
+  const roster = renderCovenRoster(args.participants, args.receivingFamiliarId);
+  const mode = [
+    "<coven_roundtable>",
+    args.targeted
+      ? "You were directly mentioned in this coven. Answer the human's request as yourself."
+      : "This is an independent first-pass group reply. Other familiars receive the same human request in parallel.",
+    "Answer from your own identity, role, and judgment.",
+    "Do not summarize, predict, imitate, or speak for other familiars.",
+    "If useful, state what you would hand off to another familiar, but keep your answer yours.",
+    "</coven_roundtable>",
+  ].join("\n");
+  return [roster, mode, args.userText.trim()].filter(Boolean).join("\n\n");
+}
+
 // ---------------------------------------------------------------------------
 // Coven relay (pure) — what other familiars just said
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- close #2188 by changing default full-coven group chat from sequential relay to independent parallel first-pass replies
- add roundtable prompt framing so each familiar answers from its own role/judgment while still seeing compact roster context
- keep the existing relay-context helper available for a future explicit debate/synthesis mode

## Verification
- node --experimental-strip-types --test src/lib/group-chat.test.ts
- node --test src/components/group-chat-view.test.ts
- corepack pnpm exec tsc --noEmit
- corepack pnpm test:app (509 app test files)

Closes #2188