### PR TITLE
chore(release): stamp v0.0.128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.128] - 2026-07-01
+
+Patch release on top of v0.0.127. Headline: Cave adds the first-party
+OpenClaw Skills marketplace card and changes full-coven group chat to a
+parallel roundtable first pass.
+
+### Added
+
+- **Marketplace** - added the OpenClaw Skills card to Cave's Coven collection,
+  with regenerated marketplace, Codex, and role-affinity exports so the card is
+  visible from the first-party plugin catalog.
+
+### Changed
+
+- **Group chat** - full-coven sends now fan out in parallel with shared roster
+  context, so every familiar answers the same human request from its own
+  identity and judgment instead of seeing earlier peer replies by default.
+
 ## [0.0.127] - 2026-06-30
 
 Patch release on top of v0.0.126. Headline: Cave now has release-ready

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.127"
+version = "0.0.128"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.127"
+version = "0.0.128"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.127</string>
+	<string>0.0.128</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.127</string>
+	<string>0.0.128</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.127</string>
+	<string>0.0.128</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.127</string>
+	<string>0.0.128</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.127",
+  "version": "0.0.128",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp CovenCave v0.0.128 across package, Tauri, Cargo, and iOS metadata
- add changelog notes for the OpenClaw Skills marketplace card and parallel full-coven group chat first pass

## Verification
- node scripts/release-notes.test.mjs
- node src/lib/app-version.test.ts
- node src/lib/coven-version.test.ts
- node scripts/release-macos-signing.test.mjs
- corepack pnpm exec tsc --noEmit
- git diff --check