### PR TITLE
Home composer: image attachment thumbnails

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -470,3 +470,15 @@ assert.match(
   /onPaste=\{\(e\) => \{[\s\S]*?e\.clipboardData\.items[\s\S]*?item\.kind === "file"[\s\S]*?void addFiles\(pastedFiles\)/,
   "pasting files into the composer stages them as attachments",
 );
+
+// ── Image attachment thumbnails ─────────────────────────────────────────────
+assert.match(
+  source,
+  /const isImage = \(att\.mimeType \?\? att\.type\)\?\.startsWith\("image\/"\)/,
+  "image attachments are detected for a preview thumbnail",
+);
+assert.match(
+  source,
+  /isImage && att\.dataUrl \?[\s\S]*?<img src=\{att\.dataUrl\}[\s\S]*?className="hc-attachment-thumb"/,
+  "image chips render a preview thumbnail instead of the generic icon",
+);

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -977,9 +977,16 @@ export function HomeComposer({
         {/* Staged attachments — chips with a remove control (mirrors chat). */}
         {attachments.length > 0 && (
           <ul className="hc-attachments" aria-label="Attachments">
-            {attachments.map((att) => (
+            {attachments.map((att) => {
+              const isImage = (att.mimeType ?? att.type)?.startsWith("image/");
+              return (
               <li key={att.id} className="hc-attachment">
-                <Icon name={attachmentIcon(att)} width={12} className="hc-attachment-icon" aria-hidden />
+                {isImage && att.dataUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={att.dataUrl} alt="" aria-hidden className="hc-attachment-thumb" />
+                ) : (
+                  <Icon name={attachmentIcon(att)} width={12} className="hc-attachment-icon" aria-hidden />
+                )}
                 <span className="hc-attachment-name" title={att.name}>{att.name}</span>
                 <button
                   type="button"
@@ -991,7 +998,8 @@ export function HomeComposer({
                   <Icon name="ph:x" width={10} aria-hidden />
                 </button>
               </li>
-            ))}
+              );
+            })}
           </ul>
         )}
 

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -256,6 +256,15 @@
   color: var(--text-secondary);
 }
 .hc-attachment-icon { color: var(--text-muted); flex-shrink: 0; }
+/* Image attachments show a small preview thumbnail in place of the icon. */
+.hc-attachment-thumb {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  object-fit: cover;
+  display: block;
+}
 .hc-attachment-name {
   min-width: 0;
   overflow: hidden;


### PR DESCRIPTION
Polish follow-up to the home-composer attachment set. Image attachments (via picker, drag-drop, or paste) now show a **small preview thumbnail** on the chip instead of the generic paperclip icon, using the `dataUrl` that `fileToAttachment` already captures for small images. Non-image attachments keep the icon.

**Verified in the running app:** pasting a PNG renders a `.hc-attachment-thumb` `<img>` with a `data:image/` src (generic icon not used); filename still shows. tsc clean, full `test:app` (509 files) green, prod build within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)