### PR TITLE
feat(quick-chat): add a desktop menubar trigger so the dropdown is reachable

### DIFF
--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -175,4 +175,18 @@ assert.match(
   "menu bar shows on desktop (≥1024px)",
 );
 
+// Desktop quick-chat entry point: the bar carries the quick-chat trigger (the
+// mobile top bar's copy is hidden ≥1024px), tagged so the popover anchors under
+// it as a dropdown from this menubar.
+assert.match(
+  source,
+  /data-quick-chat-trigger[\s\S]{0,140}onClick=\{onOpenQuickChat\}[\s\S]{0,140}aria-label="Quick chat"/,
+  "the desktop menu bar renders a data-quick-chat-trigger button wired to onOpenQuickChat",
+);
+assert.match(
+  workspace,
+  /<FamiliarMenuBar[\s\S]*?onOpenQuickChat=\{\(\) => setQuickChatOpen\(true\)\}/,
+  "workspace wires the desktop menu bar's quick-chat trigger to open the popover",
+);
+
 console.log("familiar-menu-bar.test.ts: ok");

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -34,6 +34,8 @@ type Props = {
   enrichProgress?: { done: number; total: number } | null;
   /** Jump to the inbox / schedules. */
   onViewInbox: () => void;
+  /** Open the quick-chat dropdown (anchored under its trigger in this bar). */
+  onOpenQuickChat?: () => void;
 };
 
 const ENRICH_TASKS_TITLE =
@@ -66,6 +68,7 @@ export function FamiliarMenuBar({
   enrichingTasks,
   enrichProgress,
   onViewInbox,
+  onOpenQuickChat,
 }: Props) {
   const enrichLabel = enrichingTasks
     ? enrichProgress
@@ -120,6 +123,19 @@ export function FamiliarMenuBar({
       </form>
 
       <div className="menu-bar__group menu-bar__group--tasks">
+        {onOpenQuickChat ? (
+          <button
+            type="button"
+            className="menu-bar__task focus-ring"
+            data-quick-chat-trigger
+            onClick={onOpenQuickChat}
+            aria-label="Quick chat"
+            title="Quick chat"
+          >
+            <Icon name="ph:chat-circle-dots" width={22} height={22} aria-hidden />
+            <span>Chat</span>
+          </button>
+        ) : null}
         {onEnrichTasks ? (
           <button
             type="button"

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2225,6 +2225,7 @@ export function Workspace() {
               enrichingTasks={enrichingTasks}
               enrichProgress={enrichProgress}
               onViewInbox={() => setMode("inbox")}
+              onOpenQuickChat={() => setQuickChatOpen(true)}
             />
             <TopBar
               onOpenPalette={() => setPaletteOpen(true)}


### PR DESCRIPTION
## What

Quick chat had **no entry point on desktop**: its only trigger lived in the mobile top bar (`.top-bar`, hidden ≥1024px). This adds a **"Chat" button to the desktop `FamiliarMenuBar`**, so the quick-chat dropdown (from #2204) is reachable on desktop — anchored beneath the button with its caret.

Found while shipping #2204 (the dropdown anchoring): the popover worked wherever its trigger showed, but on desktop the trigger simply wasn't rendered.

## How
- `familiar-menu-bar.tsx` — new optional `onOpenQuickChat`; renders a `menu-bar__task` "Chat" button tagged `data-quick-chat-trigger` (reuses existing menubar button styling + icon sizing).
- `workspace.tsx` — passes `onOpenQuickChat={() => setQuickChatOpen(true)}` to the desktop bar.
- The overlay (#2204) already selects the **visible** trigger among instances, so with both the mobile and desktop triggers present it anchors under whichever is shown.

## Files
`familiar-menu-bar.tsx`, `workspace.tsx`, `familiar-menu-bar.test.ts` (asserts the trigger + wiring).

## Verification
- Tests + `pnpm build` green.
- Drove the app at 1280px: 2 triggers exist, the visible desktop "Chat" button is picked; clicking it opens the popover anchored at `bar-bottom + 8` with a caret. Screenshot confirms the dropdown hangs from the desktop menubar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)