### PR TITLE
fix(chat): treat Hermes as runtime-managed

### DIFF
--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -19,7 +19,6 @@ for (const runtime of ["codex", "claude", "hermes", "openclaw"]) {
 // Provider-backed runtimes expose a menu sourced from their provider.
 assert.equal(catalogForRuntime("codex").provider, "openai");
 assert.equal(catalogForRuntime("claude").provider, "anthropic");
-assert.equal(catalogForRuntime("hermes").provider, "nous");
 assert.ok(catalogForRuntime("claude").models.length > 0, "claude should seed a menu");
 assert.ok(
   catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-opus-4-8"),
@@ -42,13 +41,20 @@ for (const catalog of Object.values(RUNTIME_MODEL_CATALOG)) {
   }
 }
 
+// Runtime-managed adapters are free-text only (no model menu). Hermes here means
+// the installed Hermes Agent runtime, not a Nous/Hermes model selection.
+const hermes = catalogForRuntime("hermes");
+assert.equal(hermes.provider, null);
+assert.equal(hermes.models.length, 0, "hermes is runtime-managed, not a Hermes model menu");
+assert.equal(hermes.allowCustom, true, "runtime-managed Hermes still accepts explicit user model ids");
+
 // null-provider runtimes are free-text only (no menu).
 const openclaw = catalogForRuntime("openclaw");
 assert.equal(openclaw.provider, null);
 assert.equal(openclaw.models.length, 0, "openclaw renders free-text only");
 assert.equal(openclaw.allowCustom, true, "free-text must stay allowed when there is no menu");
 assert.equal(defaultModelForRuntime("codex"), "openai/gpt-5.5");
-assert.equal(defaultModelForRuntime("hermes"), "nous/hermes-4");
+assert.equal(defaultModelForRuntime("hermes"), "hermes-local", "Hermes should default to the runtime marker, not a Hermes model");
 assert.equal(defaultModelForRuntime("openclaw"), "openai/gpt-5.5", "OpenClaw should inherit a real global default, not openclaw-local");
 
 // Unknown runtimes have no catalog.
@@ -57,6 +63,7 @@ assert.equal(catalogForRuntime("nonexistent"), null);
 // isModelInCatalog only matches curated ids; allowCustom covers the rest.
 assert.equal(isModelInCatalog("claude", "anthropic/claude-opus-4-7"), true);
 assert.equal(isModelInCatalog("claude", "anthropic/not-listed-yet"), false);
+assert.equal(isModelInCatalog("hermes", "nous/hermes-4"), false);
 assert.equal(isModelInCatalog("openclaw", "anything"), false);
 assert.equal(isModelInCatalog("nonexistent", "openai/gpt-5.5"), false);
 

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -7,9 +7,10 @@
 //
 // The curated lists below are a seed. They are intentionally a one-line edit as
 // providers ship new models, and `allowCustom` is the safety valve so the menu
-// never blocks an id that isn't listed yet. Runtimes with no clean provider
-// (e.g. OpenClaw) get `provider: null` and render a free-text field only — the
-// literal "else the runtime's CLI" branch.
+// never blocks an id that isn't listed yet. Runtime-managed adapters get
+// `provider: null` and render a free-text field only — the literal "else the
+// runtime's CLI" branch. That includes Hermes: Cave's Hermes mode means the
+// installed Hermes Agent runtime, not a bundled Nous/Hermes model selection.
 
 export type RuntimeProvider = "openai" | "anthropic" | "nous" | null;
 
@@ -21,6 +22,8 @@ export type RuntimeModelCatalog = {
   provider: RuntimeProvider;
   /** Curated seed; empty ⇒ no menu, free-text only. */
   models: RuntimeModelOption[];
+  /** Fallback when no curated model exists. Runtime markers are synthetic. */
+  defaultModel?: string;
   /** User may type any model id not present in `models`. */
   allowCustom: boolean;
 };
@@ -46,8 +49,9 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
   },
   hermes: {
     runtime: "hermes",
-    provider: "nous",
-    models: [{ id: "nous/hermes-4", label: "Hermes 4" }],
+    provider: null,
+    models: [],
+    defaultModel: "hermes-local",
     allowCustom: true,
   },
   // No clean provider → defer to the runtime's own CLI: free-text only, no menu.
@@ -66,7 +70,8 @@ export function catalogForRuntime(runtime: string): RuntimeModelCatalog | null {
 }
 
 export function defaultModelForRuntime(runtime: string): string {
-  return catalogForRuntime(runtime)?.models[0]?.id ?? GLOBAL_DEFAULT_MODEL;
+  const catalog = catalogForRuntime(runtime);
+  return catalog?.models[0]?.id ?? catalog?.defaultModel ?? GLOBAL_DEFAULT_MODEL;
 }
 
 export function isModelInCatalog(runtime: string, modelId: string): boolean {


### PR DESCRIPTION
## Summary\n- treat Cave's Hermes runtime as runtime-managed instead of provider-backed by a Nous/Hermes model catalog\n- keep the model selector in runtime-managed mode for Hermes\n- default new Hermes familiars to the synthetic hermes-local marker instead of a Hermes model id\n\n## Verification\n- node --experimental-strip-types src/lib/runtime-models.test.ts\n- node --experimental-strip-types src/lib/onboarding-familiars.test.ts\n- node src/lib/command-controls.test.ts\n- corepack pnpm exec tsc --noEmit\n- git diff --check