### PR TITLE
chore(release): stamp v0.0.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.129] - 2026-07-01
+
+Patch release on top of v0.0.128. Headline: Cave clarifies Hermes mode as the
+installed Hermes Agent runtime, not a bundled Hermes model selection.
+
+### Fixed
+
+- **Hermes runtime** - treated Hermes as a runtime-managed adapter in the model
+  catalog, keeping its picker label in runtime-managed mode and defaulting new
+  Hermes familiars to the synthetic `hermes-local` marker instead of a
+  Nous/Hermes model id.
+
 ## [0.0.128] - 2026-07-01
 
 Patch release on top of v0.0.127. Headline: Cave adds the first-party

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.128",
+  "version": "0.0.129",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.128"
+version = "0.0.129"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.128"
+version = "0.0.129"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.128</string>
+	<string>0.0.129</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.128</string>
+	<string>0.0.129</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.128</string>
+	<string>0.0.129</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.128</string>
+	<string>0.0.129</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.128",
+  "version": "0.0.129",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary\n- stamp CovenCave v0.0.129 after the Hermes runtime-managed correction\n- add changelog notes for the Hermes Agent runtime wording/model-catalog fix\n- update desktop/iOS version metadata\n\n## Verification\n- node scripts/release-notes.test.mjs\n- node src/lib/app-version.test.ts\n- node src/lib/coven-version.test.ts\n- node scripts/release-macos-signing.test.mjs\n- corepack pnpm exec tsc --noEmit\n- git diff --check