### PR TITLE
Polish startup setup and workspace layout

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -25,6 +25,7 @@ export const SUITES = {
     "src/lib/session-list-equal.test.ts",
     "src/lib/tool-edit-stat.test.ts",
     "src/lib/split-snap.test.ts",
+    "src/lib/workspace-tiles.test.ts",
     "src/lib/page-drag.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",

--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -66,6 +66,12 @@ assert.match(
 
 assert.match(
   source,
+  /tool\.outdated[\s\S]{0,240}ok: false[\s\S]{0,240}COVEN_CLI_INSTALL_COMMAND/,
+  "startup should require the latest coven CLI version, not just any installed version",
+);
+
+assert.match(
+  source,
   /openCovenTools\.find\(\(tool\) => tool\.id === "coven-cli"\)/,
   "startup identifies the coven CLI by the shared tool id",
 );

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -54,16 +54,27 @@ async function checkGit(): Promise<Step> {
 }
 
 function checkCovenCli(tool: OpenCovenToolStatus | undefined): Step {
-  if (tool?.installed) {
-    const location = tool.path ?? tool.binary;
+  if (!tool?.installed) {
     return {
-      ok: true,
-      detail: tool.current ? `${tool.current} at ${location}` : `${location} (version unknown)`,
+      ok: false,
+      hint: `Install the coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, make sure it is on PATH, then re-check.`,
     };
   }
+  if (tool.outdated) {
+    const detail =
+      tool.current && tool.latest
+        ? `Update available: ${tool.current} -> ${tool.latest}`
+        : "Update available";
+    return {
+      ok: false,
+      detail,
+      hint: `Update the coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, then re-check.`,
+    };
+  }
+  const location = tool.path ?? tool.binary;
   return {
-    ok: false,
-    hint: `Install the coven CLI with \`${COVEN_CLI_INSTALL_COMMAND}\`, make sure it is on PATH, then re-check.`,
+    ok: true,
+    detail: tool.current ? `${tool.current} at ${location}` : `${location} (version unknown)`,
   };
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10083,6 +10083,30 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   min-width: 0;
 }
 
+.split-host__mobile-switcher {
+  display: none;
+}
+
+.split-host__grid {
+  display: grid;
+  gap: 1px;
+  background: var(--border-hairline);
+}
+
+.split-host__grid[data-variant="triad"] {
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+.split-host__grid[data-variant="triad"] .split-host__tile--primary {
+  grid-row: 1 / span 2;
+}
+
+.split-host__grid[data-variant="quad"] {
+  grid-template-columns: repeat(2, minmax(320px, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+}
+
 /* Secondary pane shell — a framed "window" beside the primary surface. */
 .split-host__pane {
   display: flex;
@@ -10091,6 +10115,11 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   min-height: 0;
   min-width: 0;
   background: var(--bg-base);
+}
+.split-host__tile {
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
 }
 .split-host__pane-head {
   display: flex;
@@ -10246,4 +10275,63 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 
 @media (prefers-reduced-motion: reduce) {
   .split-host__guide { transition: none; }
+}
+
+@media (max-width: 1023px) {
+  .split-host__mobile-switcher {
+    flex: 0 0 auto;
+    display: flex;
+    gap: 6px;
+    padding: 6px 8px;
+    overflow-x: auto;
+    border-bottom: 1px solid var(--border-hairline);
+    background: color-mix(in oklch, var(--bg-panel) 92%, transparent);
+  }
+
+  .split-host__mobile-tab {
+    flex: 0 0 auto;
+    max-width: 48vw;
+    min-height: 30px;
+    padding: 0 10px;
+    border: 1px solid var(--border-hairline);
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .split-host__mobile-tab[aria-selected="true"] {
+    background: var(--bg-raised);
+    color: var(--text-primary);
+    border-color: color-mix(in oklch, var(--accent) 45%, var(--border-hairline));
+  }
+
+  .split-host__group {
+    height: calc(100% - 43px);
+  }
+
+  .split-host__grid,
+  .split-host__group[data-variant] {
+    display: block !important;
+    background: transparent;
+  }
+
+  .split-host__sep {
+    display: none !important;
+  }
+
+  .split-host__tile-panel,
+  .split-host__tile {
+    height: 100%;
+    width: 100% !important;
+  }
+
+  .split-host__tile-panel[data-active="false"],
+  .split-host__tile[data-active="false"] {
+    display: none !important;
+  }
 }

--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -84,5 +84,15 @@ assert.match(source, /onClick=\{\(e\) => \{ e\.stopPropagation\(\); onClick\(\);
 assert.match(source, /actions\.runAutomation\(auto\)/, "the automation row exposes run-now");
 assert.match(source, /actions\.togglePauseReminder\(item\)/, "the reminder row exposes pause/resume");
 assert.match(source, /item\.kind !== "daily-summary"/, "daily-summary rows get no run/pause actions");
+assert.match(
+  source,
+  /automation-entry-row__actions[\s\S]*?aria-label=\{`Run \$\{entry\.name\} now`\}/,
+  "unified automation row actions render below the automation name",
+);
+assert.match(
+  source,
+  /managed-automation-row__actions[\s\S]*?onClick=\{onRun\}[\s\S]*?onClick=\{onOpen\}/,
+  "managed automation row actions render below the automation name",
+);
 
 console.log("automations-view.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1361,42 +1361,46 @@ function AutomationEntryRow({
   const nextFire = entry.state === "active" && entry.nextFireAt ? relTime(entry.nextFireAt) : null;
   return (
     <div
-      className="automation-list-row group/srow flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
+      className="automation-list-row group/srow flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
       style={{ border: "1px solid var(--border-hairline)" }}
     >
       <AutomationTypeChip type={entry.type} />
-      <button
-        type="button"
-        onClick={() => onOpen(entry)}
-        className="focus-ring-inset min-w-0 flex-1 rounded-md text-left"
-      >
-        <span className="block truncate text-[13px] font-medium" style={{ color: "var(--text-primary)" }}>
-          {entry.name}
-        </span>
-        <span className="mt-0.5 flex items-center gap-2 text-[11px]" style={{ color: "var(--text-muted)" }}>
-          <span className="inline-flex shrink-0 items-center gap-1">
-            <Icon name={entry.scheduled ? "ph:clock" : "ph:play"} width={11} aria-hidden />
-            {entry.trigger}
+      <span className="min-w-0 flex-1">
+        <button
+          type="button"
+          onClick={() => onOpen(entry)}
+          className="focus-ring-inset block w-full rounded-md text-left"
+        >
+          <span className="block truncate text-[13px] font-medium" style={{ color: "var(--text-primary)" }}>
+            {entry.name}
           </span>
-          {nextFire && (
-            <span className="shrink-0 whitespace-nowrap" style={{ color: "var(--text-secondary)" }} title={`Next fire: ${entry.nextFireAt}`}>
-              · {nextFire}
+          <span className="mt-0.5 flex items-center gap-2 text-[11px]" style={{ color: "var(--text-muted)" }}>
+            <span className="inline-flex shrink-0 items-center gap-1">
+              <Icon name={entry.scheduled ? "ph:clock" : "ph:play"} width={11} aria-hidden />
+              {entry.trigger}
             </span>
-          )}
-          {fam && <span className="truncate">· {fam}</span>}
+            {nextFire && (
+              <span className="shrink-0 whitespace-nowrap" style={{ color: "var(--text-secondary)" }} title={`Next fire: ${entry.nextFireAt}`}>
+                · {nextFire}
+              </span>
+            )}
+            {fam && <span className="truncate">· {fam}</span>}
+          </span>
+        </button>
+        <span className="automation-entry-row__actions mt-1.5 flex items-center gap-1">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => onRun(entry)}
+            aria-label={`Run ${entry.name} now`}
+            className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10 disabled:opacity-50"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            <Icon name="ph:play" width={11} aria-hidden />
+            {busy ? "…" : "Run"}
+          </button>
         </span>
-      </button>
-      <button
-        type="button"
-        disabled={busy}
-        onClick={() => onRun(entry)}
-        aria-label={`Run ${entry.name} now`}
-        className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium opacity-0 transition-colors hover:bg-white/10 focus-visible:opacity-100 group-hover/srow:opacity-100 disabled:opacity-50"
-        style={{ color: "var(--text-secondary)" }}
-      >
-        <Icon name="ph:play" width={11} aria-hidden />
-        {busy ? "…" : "Run"}
-      </button>
+      </span>
       <StateDot state={entry.state} />
     </div>
   );
@@ -1449,33 +1453,35 @@ function ManagedAutomationRow({
 }) {
   return (
     <div
-      className="automation-list-row group/srow flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
+      className="automation-list-row group/srow flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
       style={{ border: "1px solid var(--border-hairline)" }}
     >
       <AutomationTypeChip type={type} />
       <span className="min-w-0 flex-1">
         <span className="block truncate text-[13px] font-medium" style={{ color: "var(--text-primary)" }}>{name}</span>
         <span className="mt-0.5 block truncate text-[11px]" style={{ color: "var(--text-muted)" }}>{meta}</span>
+        <span className="managed-automation-row__actions mt-1.5 flex items-center gap-1">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onRun}
+            className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10 disabled:opacity-50"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            <Icon name="ph:play" width={11} aria-hidden />
+            {busy ? "…" : "Run"}
+          </button>
+          <button
+            type="button"
+            onClick={onOpen}
+            className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10"
+            style={{ color: "var(--text-secondary)" }}
+          >
+            <Icon name="ph:arrow-square-out" width={11} aria-hidden />
+            Open
+          </button>
+        </span>
       </span>
-      <button
-        type="button"
-        disabled={busy}
-        onClick={onRun}
-        className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10 disabled:opacity-50"
-        style={{ color: "var(--text-secondary)" }}
-      >
-        <Icon name="ph:play" width={11} aria-hidden />
-        {busy ? "…" : "Run"}
-      </button>
-      <button
-        type="button"
-        onClick={onOpen}
-        className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10"
-        style={{ color: "var(--text-secondary)" }}
-      >
-        <Icon name="ph:arrow-square-out" width={11} aria-hidden />
-        Open
-      </button>
     </div>
   );
 }

--- a/src/components/detail-split-host.tsx
+++ b/src/components/detail-split-host.tsx
@@ -31,18 +31,25 @@ import {
   resolveSplitRelease,
   dividerOffset,
 } from "@/lib/split-snap";
+import { workspaceTileVariant } from "@/lib/workspace-tiles";
+
+export type DetailSplitTile = {
+  id: string;
+  title: string;
+  content: React.ReactNode;
+};
 
 export type DetailSplitHostProps = {
   /** The primary surface (current workspace mode). */
   primary: React.ReactNode;
-  /** The secondary page, or null when no split is open. */
-  secondary: React.ReactNode | null;
-  /** Title shown in the secondary pane header. */
-  secondaryTitle: string;
+  /** Secondary pages/companions shown beside the primary, capped by Workspace. */
+  secondaryTiles: DetailSplitTile[];
   /** Which side the secondary pane occupies. */
   secondarySide: "left" | "right";
-  /** Close the split. */
+  /** Close every secondary tile. */
   onClose: () => void;
+  /** Close one secondary tile. */
+  onCloseTile: (id: string) => void;
   /** A page was dropped into the main area on the given side. */
   onDropPage: (mode: string, side: "left" | "right") => void;
   /** Enable the drag-to-split drop zone (desktop only). */
@@ -53,14 +60,31 @@ const PCT = (ratio: number) => `${(ratio * 100).toFixed(2)}%`;
 
 export function DetailSplitHost({
   primary,
-  secondary,
-  secondaryTitle,
+  secondaryTiles,
   secondarySide,
   onClose,
+  onCloseTile,
   onDropPage,
   enableDrop,
 }: DetailSplitHostProps) {
-  const hasSplit = secondary != null;
+  const hasSplit = secondaryTiles.length > 0;
+  const primaryTile = React.useMemo<DetailSplitTile>(
+    () => ({ id: "primary", title: "Current", content: primary }),
+    [primary],
+  );
+  const tiles = React.useMemo(
+    () =>
+      secondaryTiles.length === 1 && secondarySide === "left"
+        ? [secondaryTiles[0]!, primaryTile]
+        : [primaryTile, ...secondaryTiles],
+    [primaryTile, secondarySide, secondaryTiles],
+  );
+  const variant = workspaceTileVariant(tiles.length);
+  const [activeTileId, setActiveTileId] = React.useState("primary");
+
+  React.useEffect(() => {
+    if (!tiles.some((tile) => tile.id === activeTileId)) setActiveTileId("primary");
+  }, [activeTileId, tiles]);
 
   // ---- Drag-to-split drop zone -------------------------------------------
   const [pageDrag, setPageDrag] = React.useState<PageDragDetail | null>(null);
@@ -100,12 +124,12 @@ export function DetailSplitHost({
 
   // Reset the live divider tracking whenever a fresh split opens.
   React.useEffect(() => {
-    if (hasSplit) {
+    if (secondaryTiles.length === 1) {
       ratioRef.current = SPLIT_DEFAULT_RATIO;
       setDragRatio(null);
       draggingRef.current = false;
     }
-  }, [hasSplit, secondarySide]);
+  }, [secondaryTiles.length, secondarySide]);
 
   const onSecondaryResize = React.useCallback(
     (size: { asPercentage: number }) => {
@@ -142,21 +166,40 @@ export function DetailSplitHost({
     </Separator>
   );
 
-  const secondaryPanel = (
+  const legacySecondaryTile = secondaryTiles[0] ?? null;
+  const mobileSwitcher = hasSplit ? (
+    <div className="split-host__mobile-switcher" role="tablist" aria-label="Open pages">
+      {tiles.map((tile) => (
+        <button
+          key={tile.id}
+          type="button"
+          role="tab"
+          aria-selected={activeTileId === tile.id}
+          className="split-host__mobile-tab"
+          onClick={() => setActiveTileId(tile.id)}
+        >
+          {tile.title}
+        </button>
+      ))}
+    </div>
+  ) : null;
+
+  const secondaryPanel = legacySecondaryTile ? (
     <Panel
       id="split-secondary"
-      className="split-host__pane-panel flex min-h-0 min-w-0"
+      className="split-host__pane-panel split-host__tile-panel flex min-h-0 min-w-0"
+      data-active={activeTileId === legacySecondaryTile.id}
       panelRef={secRef}
       defaultSize={PCT(SPLIT_DEFAULT_RATIO)}
       minSize="10%"
       maxSize={PCT(SPLIT_MAX_RATIO)}
       onResize={onSecondaryResize}
     >
-      <section className="split-host__pane" aria-label={`${secondaryTitle} (split)`}>
+      <section className="split-host__pane split-host__tile" aria-label={`${legacySecondaryTile.title} (split)`}>
         <header className="split-host__pane-head">
           <span className="split-host__pane-title">
             <Icon name="ph:columns" width={14} height={14} aria-hidden />
-            {secondaryTitle}
+            {legacySecondaryTile.title}
           </span>
           <span className="split-host__pane-actions">
             <button
@@ -191,22 +234,60 @@ export function DetailSplitHost({
               className="split-host__pane-btn split-host__pane-close"
               title="Close split"
               aria-label="Close split"
-              onClick={onClose}
+              onClick={() => onCloseTile(legacySecondaryTile.id)}
             >
               <Icon name="ph:x" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} aria-hidden />
             </button>
           </span>
         </header>
-        <div className="split-host__pane-body">{secondary}</div>
+        <div className="split-host__pane-body">{legacySecondaryTile.content}</div>
       </section>
     </Panel>
-  );
+  ) : null;
 
   const primaryPanel = (
-    <Panel id="split-primary" className="flex min-h-0 min-w-0" minSize="16%">
+    <Panel
+      id="split-primary"
+      className="split-host__tile-panel flex min-h-0 min-w-0"
+      data-active={activeTileId === "primary"}
+      minSize="16%"
+    >
       <div className="min-h-0 min-w-0 flex-1">{primary}</div>
     </Panel>
   );
+
+  const renderGridTile = (tile: DetailSplitTile) => {
+    const isPrimary = tile.id === "primary";
+    return (
+      <section
+        key={tile.id}
+        className={`split-host__pane split-host__tile${isPrimary ? " split-host__tile--primary" : ""}`}
+        data-active={activeTileId === tile.id}
+        aria-label={isPrimary ? tile.title : `${tile.title} (split)`}
+      >
+        <header className="split-host__pane-head">
+          <span className="split-host__pane-title">
+            <Icon name={isPrimary ? "ph:rows" : "ph:columns"} width={14} height={14} aria-hidden />
+            {tile.title}
+          </span>
+          {!isPrimary ? (
+            <span className="split-host__pane-actions">
+              <button
+                type="button"
+                className="split-host__pane-btn split-host__pane-close"
+                title="Close split"
+                aria-label={`Close ${tile.title} split`}
+                onClick={() => onCloseTile(tile.id)}
+              >
+                <Icon name="ph:x" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} aria-hidden />
+              </button>
+            </span>
+          ) : null}
+        </header>
+        <div className="split-host__pane-body">{tile.content}</div>
+      </section>
+    );
+  };
 
   // Live snap guide while dragging the divider.
   const snapPreview = dragRatio != null ? nearestSnap(dragRatio) : null;
@@ -233,21 +314,33 @@ export function DetailSplitHost({
   return (
     <>
       {hasSplit ? (
-        <Group className="split-host__group" orientation="horizontal">
-          {secondarySide === "left" ? (
-            <>
-              {secondaryPanel}
-              {separator}
-              {primaryPanel}
-            </>
-          ) : (
-            <>
-              {primaryPanel}
-              {separator}
-              {secondaryPanel}
-            </>
-          )}
-        </Group>
+        secondaryTiles.length === 1 ? (
+          <>
+            {mobileSwitcher}
+            <Group className="split-host__group" data-variant={variant} orientation="horizontal">
+              {secondarySide === "left" ? (
+                <>
+                  {secondaryPanel}
+                  {separator}
+                  {primaryPanel}
+                </>
+              ) : (
+                <>
+                  {primaryPanel}
+                  {separator}
+                  {secondaryPanel}
+                </>
+              )}
+            </Group>
+          </>
+        ) : (
+          <>
+            {mobileSwitcher}
+            <div className="split-host__group split-host__grid" data-variant={variant}>
+              {tiles.map(renderGridTile)}
+            </div>
+          </>
+        )
       ) : (
         primary
       )}

--- a/src/components/drag-to-split.test.ts
+++ b/src/components/drag-to-split.test.ts
@@ -29,22 +29,32 @@ test("DetailSplitHost renders drop zones + a snapping divider", () => {
   assert.match(src, /nearestSnap\(dragRatio\)/, "live snap guide");
 });
 
+test("DetailSplitHost supports optimized variants for up to four visible pages", () => {
+  const src = read("./detail-split-host.tsx");
+  assert.match(src, /secondaryTiles: DetailSplitTile\[\]/, "host receives multiple secondary tiles");
+  assert.match(src, /workspaceTileVariant\(tiles\.length\)/, "host chooses a layout variant from visible tile count");
+  assert.match(src, /data-variant=\{variant\}/, "variant is exposed to CSS");
+  assert.match(src, /split-host__mobile-switcher/, "mobile/tablet gets a tile switcher instead of cramped panes");
+  assert.match(src, /onCloseTile\(tile\.id\)/, "each secondary tile can be closed independently");
+});
+
 test("Shell hosts the split inside the detail main with a drop zone", () => {
   const src = read("./shell.tsx");
-  assert.match(src, /import \{ DetailSplitHost \}/);
-  assert.match(src, /<DetailSplitHost[\s\S]*?primary=\{detail\}[\s\S]*?secondary=\{split\}/);
+  assert.match(src, /import \{ DetailSplitHost, type DetailSplitTile \}/);
+  assert.match(src, /<DetailSplitHost[\s\S]*?primary=\{detail\}[\s\S]*?secondaryTiles=\{splitTiles\}/);
   assert.match(src, /enableDrop=\{!isMobile\}/, "drop zone is desktop-only");
 });
 
 test("workspace owns split state and the drop handler, and reuses renderSurface", () => {
   const src = read("./workspace.tsx");
-  assert.match(src, /const \[splitTarget, setSplitTarget\] = useState<SplitTarget \| null>\(null\)/);
+  assert.match(src, /const \[splitTargets, setSplitTargets\] = useState<SplitTarget\[\]>\(\[\]\)/);
   assert.match(src, /const openSplitPage = useCallback/);
+  assert.match(src, /addSecondaryWorkspaceTile/, "workspace appends split pages up to the secondary tile cap");
   assert.match(src, /const renderSurface = \(mode: WorkspaceMode\): ReactNode =>/);
   assert.match(src, /\{mode === "terminal" \? null : renderSurface\(mode\)\}/, "primary uses renderSurface");
-  assert.match(src, /renderSurface\(splitTarget\.mode\)/, "secondary reuses the same machinery");
+  assert.match(src, /renderSurface\(target\.mode\)/, "secondary tiles reuse the same machinery");
   assert.match(src, /onDropSplitPage=\{openSplitPage\}/);
-  assert.match(src, /setSplitTarget\(\{ kind: "salem" \}\)/, "Salem re-homed into the split (not the removed rail)");
+  assert.match(src, /addSplitTarget\(\{ kind: "salem" \}\)/, "Salem re-homed into the split (not the removed rail)");
 });
 
 test("the right companion (agent) panel is no longer mounted", () => {

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -128,8 +128,20 @@ assert.match(
 
 assert.match(
   source,
-  /Runs on a remote machine \(SSH\)/,
+  /remote machine over SSH/,
   "the familiar form offers a remote SSH runtime",
+);
+
+assert.match(
+  source,
+  /Optional remote runtime \(SSH\)/,
+  "SSH runtime copy should make clear it is optional",
+);
+
+assert.match(
+  source,
+  /Skip this unless you want this familiar to run on another machine/,
+  "SSH runtime copy should tell users local setup can ignore it",
 );
 
 assert.match(
@@ -224,6 +236,18 @@ assert.match(
   source,
   /Start the daemon first\. Familiar creation unlocks once Cave can reach it\./,
   "the familiar step explains why creation is unavailable while the daemon is offline",
+);
+
+assert.match(
+  source,
+  /Run this local command:[\s\S]*coven daemon start/,
+  "startup daemon step should present the exact local command plainly",
+);
+
+assert.match(
+  source,
+  /Start local daemon \(coven daemon start\)/,
+  "startup daemon CTA should name the command it runs",
 );
 
 assert.match(
@@ -350,6 +374,12 @@ assert.match(
   source,
   /tools=\{status\?\.tools \?\? \[\]\}/,
   "the startup CLI step receives OpenCoven tool status from onboarding status",
+);
+
+assert.match(
+  source,
+  /const covenCodeReady =[\s\S]{0,180}installed[\s\S]{0,80}!.*outdated/,
+  "startup should require the latest Coven Code version before treating it as ready",
 );
 
 assert.match(

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1174,8 +1174,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
 
   // Coven Code is a required OpenCoven tool, but skippable so a failed install
   // can never permanently strand onboarding (see covenCodeSkipped).
-  const covenCodeInstalled = !!status?.tools?.find((t) => t.id === "coven-code")?.installed;
-  const covenCodeSatisfied = covenCodeInstalled || covenCodeSkipped;
+  const covenCodeTool = status?.tools?.find((t) => t.id === "coven-code");
+  const covenCodeInstalled = !!covenCodeTool?.installed;
+  const covenCodeReady = !!covenCodeTool?.installed && !covenCodeTool.outdated;
+  const covenCodeSatisfied = covenCodeReady || covenCodeSkipped;
   // Server `complete` already requires every other step; AND-in the Coven Code
   // requirement so the finish CTA only appears once both tools are handled.
   const effectiveComplete = (status?.complete ?? false) && covenCodeSatisfied;
@@ -1631,11 +1633,10 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             </div>
                             <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
                               The coven daemon runs your familiars in the
-                              background. Cave starts it for you — or run{" "}
+                              background. Cave starts it for you. Run this local command:{" "}
                               <code className="font-mono">
                                 coven daemon start
-                              </code>{" "}
-                              in any terminal.
+                              </code>
                             </p>
                             <div className="flex flex-wrap items-center gap-2">
                               <button
@@ -1647,11 +1648,11 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                 title={
                                   !status?.steps.covenCli.ok
                                     ? "Install coven CLI first (step 1)"
-                                    : "coven daemon start"
+                                    : "Start local daemon (coven daemon start)"
                                 }
                               >
                                 <Icon name="ph:rocket-launch-bold" />
-                                {startingDaemon ? "Starting..." : "Start daemon"}
+                                {startingDaemon ? "Starting..." : "Start local daemon"}
                               </button>
                               {!status?.steps.covenCli.ok ? (
                                 <span className="text-[11px] text-[var(--text-muted)]">
@@ -2696,11 +2697,12 @@ function StepFamiliar(props: {
                 />
                 <span className="text-[12px] leading-5 text-[var(--text-secondary)]">
                   <span className="font-medium text-[var(--text-primary)]">
-                    Runs on a remote machine (SSH)
+                    Optional remote runtime (SSH)
                   </span>{" "}
-                  — the familiar&rsquo;s runtime uses SSH transport on another box (a
-                  build server, a homelab, a VM). Cave connects non-interactively
-                  with your SSH keys and never stores passwords or key material.
+                  — Skip this unless you want this familiar to run on another machine
+                  (a build server, a homelab, a VM). When enabled, it runs on a
+                  remote machine over SSH. Cave connects non-interactively with
+                  your SSH keys and never stores passwords or key material.
                 </span>
               </label>
               {sshEnabled ? (

--- a/src/components/salem/salem.test.ts
+++ b/src/components/salem/salem.test.ts
@@ -83,7 +83,7 @@ const workspace = await readFile(path.join(root, "src/components/workspace.tsx")
 // The right companion rail was removed; Salem was re-homed into the
 // drag-to-split pane. Its launcher event now opens Salem in the split.
 assert.match(workspace, /cave:salem-open/, "workspace must listen for Salem launcher events");
-assert.match(workspace, /setSplitTarget\(\{ kind: "salem" \}\)/, "Salem launcher must open Salem in the drag-to-split pane");
+assert.match(workspace, /addSplitTarget\(\{ kind: "salem" \}\)/, "Salem launcher must open Salem in the drag-to-split pane");
 assert.match(workspace, /import \{ SalemChatPanel \}/, "workspace should import only the Salem sidepanel surface");
 assert.doesNotMatch(workspace, /SalemWidget|salemRetreating/, "workspace must not render or compute floating Salem state");
 assert.match(workspace, /<SalemChatPanel\s+familiarId=\{/, "workspace must render Salem in the split with the local familiar id");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -16,7 +16,7 @@ import { UpdateBannerTrigger } from "@/components/update-available";
 import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-update";
 import { useIsMobile } from "@/lib/use-viewport";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
-import { DetailSplitHost } from "@/components/detail-split-host";
+import { DetailSplitHost, type DetailSplitTile } from "@/components/detail-split-host";
 import {
   getPanelShortcutBindings,
   labelPanelShortcut,
@@ -108,10 +108,10 @@ function ShellInner({
   bottom,
   topBar,
   mobileTabs,
-  split = null,
-  splitTitle = "",
+  splitTiles = [],
   splitSide = "right",
   onCloseSplit,
+  onCloseSplitTile,
   onDropSplitPage,
   onNavOpenChange,
   panelShortcutOverrides,
@@ -121,12 +121,11 @@ function ShellInner({
   detail: ReactNode;
   bottom?: ReactNode;
   topBar?: ShellTopBar;
-  /** Secondary "page" rendered beside the detail surface in a resizable split
-   *  (null = no split). Opened by dragging a sidebar page into the main area. */
-  split?: ReactNode;
-  splitTitle?: string;
+  /** Secondary pages rendered beside the detail surface, capped by Workspace. */
+  splitTiles?: DetailSplitTile[];
   splitSide?: "left" | "right";
   onCloseSplit?: () => void;
+  onCloseSplitTile?: (id: string) => void;
   onDropSplitPage?: (mode: string, side: "left" | "right") => void;
   /** Mobile/tablet-only bottom tab bar. Rendered after `.shell-body`
    *  inside `.shell-frame`, but only when the viewport matches the
@@ -432,10 +431,10 @@ function ShellInner({
           <ShellBannerStrip />
           <DetailSplitHost
             primary={detail}
-            secondary={split}
-            secondaryTitle={splitTitle}
+            secondaryTiles={splitTiles}
             secondarySide={splitSide}
             onClose={() => onCloseSplit?.()}
+            onCloseTile={(id) => onCloseSplitTile?.(id)}
             onDropPage={(mode, side) => onDropSplitPage?.(mode, side)}
             enableDrop={!isMobile}
           />

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -20,6 +20,7 @@ import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-t
 import { MagicTriggers } from "@/components/magic-triggers";
 import { FamiliarGlyphPicker } from "@/components/familiar-glyph-picker";
 import { Shell, type ShellHandle } from "@/components/shell";
+import type { DetailSplitTile } from "@/components/detail-split-host";
 import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
 import { Icon } from "@/lib/icon";
 import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
@@ -81,6 +82,10 @@ import {
   OPEN_IN_APP_BROWSER_EVENT,
   PENDING_IN_APP_BROWSER_URL_KEY,
 } from "@/lib/open-external";
+import {
+  addSecondaryWorkspaceTile,
+  removeSecondaryWorkspaceTile,
+} from "@/lib/workspace-tiles";
 
 type WorkspaceMode = WorkspaceModeFromDaemon;
 
@@ -98,6 +103,14 @@ const SPLIT_COMPANION_TITLES: Record<Exclude<SplitTarget["kind"], "page">, strin
   memory: "Memory",
   browser: "Browser",
 };
+
+function splitTargetKey(target: SplitTarget): string {
+  return target.kind === "page" ? `page:${target.mode}` : target.kind;
+}
+
+function splitTargetTitle(target: SplitTarget): string {
+  return target.kind === "page" ? WORKSPACE_MODE_TITLES[target.mode] : SPLIT_COMPANION_TITLES[target.kind];
+}
 
 // CHAT-D13-05 (axe page-has-heading-one): the shell renders no visible page
 // title, so the detail pane carries a visually-hidden h1 naming the active
@@ -264,12 +277,16 @@ export function Workspace() {
   const [inspectorOpen, setInspectorOpen] = useState(false);
   const [rightPanel, setRightPanel] = useState<RightPanelKind | null>(null);
   const [codeRightView, setCodeRightView] = useState<"files" | "changes">("files");
-  // Drag-to-split: a second surface opened beside the primary one. The target
-  // is either a draggable page (a workspace mode) or a companion surface
-  // (Salem / Memory / Browser) that used to live in the removed right rail.
-  // `splitSide` is which half it occupies (modern-desktop snap).
-  const [splitTarget, setSplitTarget] = useState<SplitTarget | null>(null);
+  // Drag-to-split: up to three secondary surfaces opened beside the primary
+  // one (four visible pages total). Targets are draggable pages or companion
+  // surfaces (Salem / Memory / Browser) re-homed from the removed right rail.
+  // `splitSide` preserves the familiar 2-page left/right snap behavior.
+  const [splitTargets, setSplitTargets] = useState<SplitTarget[]>([]);
   const [splitSide, setSplitSide] = useState<"left" | "right">("right");
+  const addSplitTarget = useCallback((target: SplitTarget, side: "left" | "right" = "right") => {
+    setSplitSide(side);
+    setSplitTargets((prev) => addSecondaryWorkspaceTile(prev, target, splitTargetKey));
+  }, []);
   const [pendingProjectChatRoot, setPendingProjectChatRoot] = useState<string | null>(null);
   const [pendingChatAction, setPendingChatAction] = useState<PendingChatAction>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
@@ -483,12 +500,11 @@ export function Workspace() {
     // Salem was re-homed from the (removed) right rail into the drag-to-split
     // pane — its launcher now opens Salem beside the current surface.
     const openSalem = () => {
-      setSplitSide("right");
-      setSplitTarget({ kind: "salem" });
+      addSplitTarget({ kind: "salem" });
     };
     window.addEventListener("cave:salem-open", openSalem);
     return () => window.removeEventListener("cave:salem-open", openSalem);
-  }, []);
+  }, [addSplitTarget]);
 
   // Cross-surface "create a familiar" bridge. The dock (and any deep surface
   // that can't reach openOnboarding directly) announces intent and the
@@ -1393,25 +1409,32 @@ export function Workspace() {
   const openSplitPage = useCallback(
     (m: string, side: "left" | "right") => {
       if (!m || m === mode) return;
-      setSplitSide(side);
-      setSplitTarget({ kind: "page", mode: m as WorkspaceMode });
+      addSplitTarget({ kind: "page", mode: m as WorkspaceMode }, side);
     },
-    [mode],
+    [addSplitTarget, mode],
   );
 
   const closeSplit = useCallback(() => {
     // Tell Salem it's undocking so it can pause, mirroring the old rail teardown.
-    setSplitTarget((prev) => {
-      if (prev?.kind === "salem") window.dispatchEvent(new CustomEvent("cave:salem-undock"));
-      return null;
+    setSplitTargets((prev) => {
+      if (prev.some((target) => target.kind === "salem")) window.dispatchEvent(new CustomEvent("cave:salem-undock"));
+      return [];
     });
   }, []);
 
-  // A page split showing the same page as the primary is redundant — clear it
-  // (e.g. the user navigated the primary surface to the page in the split).
+  const closeSplitTile = useCallback((id: string) => {
+    setSplitTargets((prev) => {
+      const closing = prev.find((target) => splitTargetKey(target) === id);
+      if (closing?.kind === "salem") window.dispatchEvent(new CustomEvent("cave:salem-undock"));
+      return removeSecondaryWorkspaceTile(prev, id, splitTargetKey);
+    });
+  }, []);
+
+  // Page splits showing the same page as the primary are redundant — clear them
+  // (e.g. the user navigated the primary surface to a page in the split).
   useEffect(() => {
-    if (splitTarget?.kind === "page" && splitTarget.mode === mode) setSplitTarget(null);
-  }, [splitTarget, mode]);
+    setSplitTargets((prev) => prev.filter((target) => target.kind !== "page" || target.mode !== mode));
+  }, [mode]);
 
   const onPaletteIntent = (intent: PaletteIntent) => {
     if (intent.kind === "switch-familiar") {
@@ -2151,35 +2174,33 @@ export function Workspace() {
     </div>
   );
 
-  // The split secondary, if any: a dragged-in page (heavy/stateful surfaces like
-  // terminal are excluded from drag, so renderSurface always has something) or a
-  // re-homed companion surface (Salem / Memory / Browser).
-  const splitDetail: ReactNode = !splitTarget
-    ? null
-    : splitTarget.kind === "page"
-      ? splitTarget.mode !== mode
-        ? (
-            <div className="cave-mode-fade relative h-full min-h-0 flex flex-col overflow-hidden">
-              {renderSurface(splitTarget.mode)}
-            </div>
-          )
-        : null
-      : splitTarget.kind === "salem"
-        ? (
-            <SalemChatPanel
-              familiarId={active?.id ?? familiars.find((f) => f.id === "salem")?.id ?? "salem"}
-              model={active?.model ?? familiars.find((f) => f.id === "salem")?.model ?? null}
-            />
-          )
-        : splitTarget.kind === "memory"
-          ? <RailInspector familiar={active} onOpenFullView={() => setMode("agents")} />
-          : <BrowserPane label="companion" activeFamiliarId={active?.id ?? null} />;
+  // Split tiles: dragged-in pages (heavy/stateful surfaces like terminal are
+  // excluded from drag) or re-homed companion surfaces (Salem / Memory / Browser).
+  const renderSplitTargetContent = (target: SplitTarget): ReactNode =>
+    target.kind === "page" ? (
+      target.mode !== mode ? (
+        <div className="cave-mode-fade relative h-full min-h-0 flex flex-col overflow-hidden">
+          {renderSurface(target.mode)}
+        </div>
+      ) : null
+    ) : target.kind === "salem" ? (
+      <SalemChatPanel
+        familiarId={active?.id ?? familiars.find((f) => f.id === "salem")?.id ?? "salem"}
+        model={active?.model ?? familiars.find((f) => f.id === "salem")?.model ?? null}
+      />
+    ) : target.kind === "memory" ? (
+      <RailInspector familiar={active} onOpenFullView={() => setMode("agents")} />
+    ) : (
+      <BrowserPane label="companion" activeFamiliarId={active?.id ?? null} />
+    );
 
-  const splitTitle = !splitTarget
-    ? ""
-    : splitTarget.kind === "page"
-      ? WORKSPACE_MODE_TITLES[splitTarget.mode]
-      : SPLIT_COMPANION_TITLES[splitTarget.kind];
+  const splitTiles: DetailSplitTile[] = splitTargets
+    .map((target) => ({
+      id: splitTargetKey(target),
+      title: splitTargetTitle(target),
+      content: renderSplitTargetContent(target),
+    }))
+    .filter((tile) => tile.content != null);
 
   const mobileTabs = (
     <MobileBottomTabs
@@ -2198,10 +2219,10 @@ export function Workspace() {
         mobileTabs={mobileTabs}
         // Drag-to-split: a sidebar page dropped into the main area opens beside
         // the current surface, resizable with desktop-style snapping.
-        split={splitDetail}
-        splitTitle={splitTitle}
+        splitTiles={splitTiles}
         splitSide={splitSide}
         onCloseSplit={closeSplit}
+        onCloseSplitTile={closeSplitTile}
         onDropSplitPage={openSplitPage}
         topBar={({ navDrawerOpen, listDrawerOpen }) => (
           <>

--- a/src/lib/workspace-tiles.test.ts
+++ b/src/lib/workspace-tiles.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  MAX_SECONDARY_WORKSPACE_TILES,
+  addSecondaryWorkspaceTile,
+  removeSecondaryWorkspaceTile,
+  workspaceTileVariant,
+} from "./workspace-tiles.ts";
+
+type Tile = { id: string };
+const keyOf = (tile: Tile) => tile.id;
+
+test("addSecondaryWorkspaceTile appends unique tiles up to the 3-secondary cap", () => {
+  const tiles = [{ id: "library" }, { id: "github" }, { id: "board" }];
+  const next = addSecondaryWorkspaceTile(tiles, { id: "journal" }, keyOf);
+
+  assert.equal(MAX_SECONDARY_WORKSPACE_TILES, 3);
+  assert.deepEqual(next.map((tile) => tile.id), ["library", "github", "journal"]);
+});
+
+test("addSecondaryWorkspaceTile moves an existing tile to the most recent position", () => {
+  const tiles = [{ id: "library" }, { id: "github" }, { id: "board" }];
+  const next = addSecondaryWorkspaceTile(tiles, { id: "library" }, keyOf);
+
+  assert.deepEqual(next.map((tile) => tile.id), ["github", "board", "library"]);
+});
+
+test("removeSecondaryWorkspaceTile removes one tile by key", () => {
+  const next = removeSecondaryWorkspaceTile(
+    [{ id: "library" }, { id: "github" }, { id: "board" }],
+    "github",
+    keyOf,
+  );
+
+  assert.deepEqual(next.map((tile) => tile.id), ["library", "board"]);
+});
+
+test("workspaceTileVariant names the optimized layout for each visible page count", () => {
+  assert.equal(workspaceTileVariant(1), "single");
+  assert.equal(workspaceTileVariant(2), "split");
+  assert.equal(workspaceTileVariant(3), "triad");
+  assert.equal(workspaceTileVariant(4), "quad");
+  assert.equal(workspaceTileVariant(7), "quad");
+});

--- a/src/lib/workspace-tiles.ts
+++ b/src/lib/workspace-tiles.ts
@@ -1,0 +1,32 @@
+export const MAX_WORKSPACE_TILES = 4;
+export const MAX_SECONDARY_WORKSPACE_TILES = MAX_WORKSPACE_TILES - 1;
+
+export type WorkspaceTileVariant = "single" | "split" | "triad" | "quad";
+
+export function addSecondaryWorkspaceTile<T>(
+  tiles: readonly T[],
+  next: T,
+  keyOf: (tile: T) => string,
+): T[] {
+  const nextKey = keyOf(next);
+  const withoutDuplicate = tiles.filter((tile) => keyOf(tile) !== nextKey);
+  if (withoutDuplicate.length >= MAX_SECONDARY_WORKSPACE_TILES) {
+    return [...withoutDuplicate.slice(0, MAX_SECONDARY_WORKSPACE_TILES - 1), next];
+  }
+  return [...withoutDuplicate, next];
+}
+
+export function removeSecondaryWorkspaceTile<T>(
+  tiles: readonly T[],
+  key: string,
+  keyOf: (tile: T) => string,
+): T[] {
+  return tiles.filter((tile) => keyOf(tile) !== key);
+}
+
+export function workspaceTileVariant(count: number): WorkspaceTileVariant {
+  if (count <= 1) return "single";
+  if (count === 2) return "split";
+  if (count === 3) return "triad";
+  return "quad";
+}


### PR DESCRIPTION
## Summary
- Require startup setup to treat outdated OpenCoven tools as not ready, while showing current/latest versions and update CTAs.
- Clarify onboarding copy for optional SSH runtime setup and the local `coven daemon start` daemon command.
- Move automation title actions below names and add the optimized multi-page workspace split layout up to four visible pages.

## Test Plan
- [x] `node --experimental-strip-types src/app/api/onboarding/status/route.test.ts`
- [x] `node --experimental-strip-types src/components/onboarding-guided-steps.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] `git diff --check origin/main...HEAD`
- [x] `pnpm test:app`
- [x] Live smoke: `curl http://127.0.0.1:3000/api/onboarding/status` reported `coven-cli` and `coven-code` current/latest/outdated fields.
