### PR TITLE
feat(chat): enforce composer permission mode via coven run --permission

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -66,6 +66,25 @@ assert.doesNotMatch(
   "OpenClaw should not be special-cased inside the generic coven run argv builder",
 );
 
+// Permission enforcement: Read-only forwards `coven run --permission read-only`
+// (mapped to the harness's native sandbox flag), gated on the CLI advertising
+// the flag; "full" stays implicit so the harness keeps its default sandbox.
+assert.match(
+  chatRoute,
+  /covenRunSupportsPermission\(\)/,
+  "route capability-probes coven run --permission before forwarding",
+);
+assert.match(
+  chatRoute,
+  /body\.permissionMode === "read" \? "read-only" : null/,
+  "only Read-only is forwarded; Full access stays implicit (harness default sandbox)",
+);
+assert.match(
+  chatRoute,
+  /a\.push\("--permission", forwardPermission\)/,
+  "coven run argv forwards --permission when enabled",
+);
+
 assert.match(
   chatRoute,
   /if \(binding\.harness === "openclaw" && !sshRuntime\)/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -57,7 +57,7 @@ import {
   resolveOpenClawAgentBinding,
   type OpenClawAgentJson,
 } from "@/lib/openclaw-bridge";
-import { isTrustedChatHarness, covenRunSupportsModelFlag, canonicalHarnessId } from "@/lib/harness-adapters";
+import { isTrustedChatHarness, covenRunSupportsModelFlag, covenRunSupportsPermissionFlag, canonicalHarnessId } from "@/lib/harness-adapters";
 import {
   type ConversationFile,
   type ChatTurn,
@@ -117,6 +117,11 @@ type SendBody = {
   modelOverrideScope?: "next-message" | "session";
   reasoningEffort?: string;
   responseSpeed?: string;
+  /** Composer Access chip: "full" (default) or "read". Forwarded to
+   *  `coven run --permission` (mapped to the harness's native sandbox flag)
+   *  only when the installed CLI advertises it; "full" is left implicit so the
+   *  harness keeps its default sandbox rather than being widened. */
+  permissionMode?: string;
   attachments?: ChatAttachment[];
   /** Repo-relative paths the user @-mentioned in the composer (CHAT-D1-04). */
   mentionedFiles?: string[];
@@ -518,6 +523,52 @@ function covenRunSupportsModel(): Promise<boolean> {
     });
   }
   return covenRunModelFlagProbe;
+}
+
+// Parallel capability probe for `coven run --permission` (the sandbox flag added
+// in @opencoven/cli). Same shape/caching as the model probe; a CLI that predates
+// the flag rejects unknown flags, so forwarding must stay gated to a no-op.
+let covenRunPermissionFlagProbe: Promise<boolean> | null = null;
+function covenRunSupportsPermission(): Promise<boolean> {
+  if (!covenRunPermissionFlagProbe) {
+    covenRunPermissionFlagProbe = new Promise<boolean>((resolve) => {
+      let out = "";
+      let settled = false;
+      const done = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        resolve(value);
+      };
+      try {
+        const { command, fixedArgs } = covenLaunchCommand();
+        const child = spawn(command, [...fixedArgs, "run", "--help"], {
+          env: covenSpawnEnv(),
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        child.stdout.on("data", (d) => (out += d.toString()));
+        child.stderr.on("data", (d) => (out += d.toString()));
+        const t = setTimeout(() => {
+          try {
+            child.kill("SIGTERM");
+          } catch {
+            /* ignore */
+          }
+          done(false);
+        }, 2500);
+        child.on("close", () => {
+          clearTimeout(t);
+          done(covenRunSupportsPermissionFlag(out));
+        });
+        child.on("error", () => {
+          clearTimeout(t);
+          done(false);
+        });
+      } catch {
+        done(false);
+      }
+    });
+  }
+  return covenRunPermissionFlagProbe;
 }
 
 function resolveSendModelMetadata(args: {
@@ -937,6 +988,11 @@ export async function POST(req: Request) {
   // probe so this stays a no-op until the companion CLI ships the flag.
   const modelForwardingEnabled =
     binding.harness !== "openclaw" && (await covenRunSupportsModel());
+  // Same gating for the sandbox/permission flag. Only "read" is forwarded
+  // (→ `--permission read-only`); "full" stays implicit so the harness keeps
+  // its own default sandbox instead of being widened to danger-full-access.
+  const permissionForwardingEnabled =
+    binding.harness !== "openclaw" && (await covenRunSupportsPermission());
   const { desiredModel, modelState } = resolveSendModelMetadata({
     body,
     config,
@@ -1138,6 +1194,8 @@ export async function POST(req: Request) {
   // Emitted BEFORE the `--` separator for the same reason every other flag is.
   const forwardModel =
     modelForwardingEnabled && cleanModelId(desiredModel) ? desiredModel : null;
+  const forwardPermission =
+    permissionForwardingEnabled && body.permissionMode === "read" ? "read-only" : null;
   // `promptOverride` lets the transparent resume-retry (below) prime a fresh
   // harness session with replayed conversation history — without it the retry
   // forks a context-free session and the familiar loses the thread.
@@ -1159,6 +1217,10 @@ export async function POST(req: Request) {
     const a = ["run", binding.harness, "--stream-json"];
     if (resumeSessionId) a.push("--continue", resumeSessionId);
     if (forwardModel) a.push("--model", forwardModel);
+    // Enforce Read-only by mapping to the harness's native sandbox flag via
+    // `coven run --permission read-only` (codex --sandbox read-only / claude
+    // --permission-mode plan). Gated on the CLI advertising the flag.
+    if (forwardPermission) a.push("--permission", forwardPermission);
     // Inject identity preamble. coven-cli renders this through the best
     // available identity channel for the chosen harness. Without this, the
     // harness answers as its generic CLI identity instead of as the familiar.

--- a/src/lib/command-controls.test.ts
+++ b/src/lib/command-controls.test.ts
@@ -44,7 +44,8 @@ assert.equal(runtimeModelSelectLabel([]), "Runtime managed", "empty model catalo
 assert.equal(runtimeModelSelectLabel([{ id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" }]), "Model");
 
 assert.equal(PERMISSION_MODES.find((m) => m.value === "full")?.value, "full", "full access is a permission mode");
+assert.equal(PERMISSION_MODES.find((m) => m.value === "read")?.value, "read", "read-only is a permission mode");
 assert.equal(DEFAULT_PERMISSION_MODE, "full", "defaults to full access (matches Codex reference)");
-assert.equal(PERMISSION_MODES.length, 3, "three permission modes");
+assert.equal(PERMISSION_MODES.length, 2, "two enforceable permission modes (Ask-first dropped — no interactive approval in the one-shot bridge)");
 
 console.log("command-controls tests passed");

--- a/src/lib/command-controls.ts
+++ b/src/lib/command-controls.ts
@@ -29,12 +29,15 @@ export const COMMAND_RESPONSE_SPEED_OPTIONS: Array<{ value: CommandResponseSpeed
   { value: "careful", label: "Careful" },
 ];
 
-export type CommandPermissionMode = "full" | "read" | "ask";
+// Only the two modes the non-interactive chat bridge can actually enforce via
+// the harness's native sandbox flag (coven run --permission full|read-only).
+// "Ask first" (interactive approval) is intentionally omitted — the harness runs
+// one-shot with no channel to prompt for approval, so it would hang.
+export type CommandPermissionMode = "full" | "read";
 
 export const PERMISSION_MODES: { value: CommandPermissionMode; label: string; icon: string }[] = [
   { value: "full", label: "Full access", icon: "ph:shield-warning" },
   { value: "read", label: "Read only", icon: "ph:eye" },
-  { value: "ask", label: "Ask first", icon: "ph:hand" },
 ];
 
 export const DEFAULT_PERMISSION_MODE: CommandPermissionMode = "full";

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -159,6 +159,14 @@ export function covenRunSupportsModelFlag(helpText: string): boolean {
   return /(^|\s)--model(?![\w-])/m.test(helpText);
 }
 
+// Same gated-forwarding probe for `coven run --permission <full|read-only>` (the
+// sandbox/permission flag added in @opencoven/cli). Forwarding stays a no-op on
+// CLIs that predate the flag, since `coven run` rejects unknown flags.
+export function covenRunSupportsPermissionFlag(helpText: string): boolean {
+  if (typeof helpText !== "string" || !helpText) return false;
+  return /(^|\s)--permission(?![\w-])/m.test(helpText);
+}
+
 export function mergeAdapterReports(
   localReports: Array<
     Partial<AdapterReport> & {


### PR DESCRIPTION
Makes the composer **Access** chip actually enforce (was advisory). Pairs with **OpenCoven/coven#289**, which adds `coven run --permission <full|read-only>` mapping to each harness's native sandbox flag (codex `--sandbox`, claude `--permission-mode`).

**This PR (coven-cave):**
- `/api/chat/send` capability-probes `coven run --help` for `--permission` (mirrors the existing `--model` probe) and forwards **`--permission read-only`** for the Read-only mode. **Full access stays implicit** — we don't forward `--permission full`, so the harness keeps its own default sandbox instead of being widened to `danger-full-access`.
- Drops **"Ask first"** from `PERMISSION_MODES` — interactive approval can't work in the non-interactive one-shot chat bridge (the harness would hang with no channel to approve). Composer now offers **Full access + Read only**.

**Safe to merge independently:** forwarding is gated on the `--help` probe, so it's a **no-op** until the installed `@opencoven/cli` ships the flag (`coven run` rejects unknown flags). No lockstep release needed.

Tests: `command-controls.test.ts` (2 modes), new `harness-routing.test.ts` assertions (probe + `--permission read-only` gating + argv push), `harness-adapters` has `covenRunSupportsPermissionFlag`. Typecheck, app suite (509), check:tests-wired (681), build + bundle-budget green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)