### PR TITLE
Home composer: attachment count + clear-all

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -482,3 +482,15 @@ assert.match(
   /isImage && att\.dataUrl \?[\s\S]*?<img src=\{att\.dataUrl\}[\s\S]*?className="hc-attachment-thumb"/,
   "image chips render a preview thumbnail instead of the generic icon",
 );
+
+// ── Attachment count + clear-all ────────────────────────────────────────────
+assert.match(
+  source,
+  /hc-attachments-count[\s\S]*?\{attachments\.length\}\/10 attached/,
+  "the attachments header shows a count out of the 10 cap",
+);
+assert.match(
+  source,
+  /hc-attachments-clear[\s\S]*?onClick=\{\(\) => setAttachments\(\[\]\)\}[\s\S]*?Clear all/,
+  "a Clear all control empties the staged attachments",
+);

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -974,8 +974,21 @@ export function HomeComposer({
           enterKeyHint="send"
         />
 
-        {/* Staged attachments — chips with a remove control (mirrors chat). */}
+        {/* Staged attachments — a count + clear-all header over the chips
+            (each chip has its own remove control; mirrors chat). */}
         {attachments.length > 0 && (
+          <div className="hc-attachments-wrap">
+            <div className="hc-attachments-head">
+              <span className="hc-attachments-count">{attachments.length}/10 attached</span>
+              <button
+                type="button"
+                className="hc-attachments-clear"
+                onClick={() => setAttachments([])}
+                disabled={sending}
+              >
+                Clear all
+              </button>
+            </div>
           <ul className="hc-attachments" aria-label="Attachments">
             {attachments.map((att) => {
               const isImage = (att.mimeType ?? att.type)?.startsWith("image/");
@@ -1001,6 +1014,7 @@ export function HomeComposer({
               );
             })}
           </ul>
+          </div>
         )}
 
         {/* Action bar */}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -235,13 +235,43 @@
 }
 
 /* ── Attachment chips ────────────────────────────────────────────────────── */
+.hc-attachments-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.hc-attachments-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 14px 0;
+}
+.hc-attachments-count {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.hc-attachments-clear {
+  border: none;
+  background: transparent;
+  padding: 2px 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: 5px;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.hc-attachments-clear:hover:not(:disabled) { background: var(--bg-base); color: var(--text-secondary); }
+.hc-attachments-clear:disabled { opacity: 0.5; cursor: default; }
 .hc-attachments {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   list-style: none;
   margin: 0;
-  padding: 8px 14px 0;
+  padding: 0 14px 0;
 }
 .hc-attachment {
   display: inline-flex;


### PR DESCRIPTION
Adds a small header over the staged-attachment chips: an **"N/10 attached"** count and a **Clear all** button that empties the staged files in one click. The attachments block still hides entirely when empty.

**Verified in the running app:** attaching two files shows "2/10 attached"; clicking Clear all drops the chips to zero and removes the header. tsc clean, full `test:app` (508 files) green, prod build within budget.

Completes the optional attachment polish (final item alongside #2208 thumbnails).

🤖 Generated with [Claude Code](https://claude.com/claude-code)