### PR TITLE
fix(automations): a11y label on managed Run button + drop dead group/srow

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -94,5 +94,10 @@ assert.match(
   /managed-automation-row__actions[\s\S]*?onClick=\{onRun\}[\s\S]*?onClick=\{onOpen\}/,
   "managed automation row actions render below the automation name",
 );
+assert.match(
+  source,
+  /managed-automation-row__actions[\s\S]*?aria-label=\{`Run \$\{name\} now`\}/,
+  "the managed row's Run button carries a distinct accessible name (not just \"Run\"/\"…\")",
+);
 
 console.log("automations-view.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1361,7 +1361,7 @@ function AutomationEntryRow({
   const nextFire = entry.state === "active" && entry.nextFireAt ? relTime(entry.nextFireAt) : null;
   return (
     <div
-      className="automation-list-row group/srow flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
+      className="automation-list-row flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
       style={{ border: "1px solid var(--border-hairline)" }}
     >
       <AutomationTypeChip type={entry.type} />
@@ -1453,7 +1453,7 @@ function ManagedAutomationRow({
 }) {
   return (
     <div
-      className="automation-list-row group/srow flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
+      className="automation-list-row flex items-start gap-3 rounded-lg px-3 py-2.5 transition-colors hover:bg-white/5"
       style={{ border: "1px solid var(--border-hairline)" }}
     >
       <AutomationTypeChip type={type} />
@@ -1465,6 +1465,7 @@ function ManagedAutomationRow({
             type="button"
             disabled={busy}
             onClick={onRun}
+            aria-label={`Run ${name} now`}
             className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10 disabled:opacity-50"
             style={{ color: "var(--text-secondary)" }}
           >


### PR DESCRIPTION
Two small nits surfaced during the `/code-review` of the automation-row action refactor (`2c7be2a4`).

- **A11y:** `ManagedAutomationRow`'s Run button had no `aria-label`, so its accessible name was just its text — `"Run"` (ambiguous when several managed rows are listed) or `"…"` while busy. Added `aria-label={`Run ${name} now`}`, matching the pattern `AutomationEntryRow`'s Run button already uses.
- **Dead class:** removed the now-unused `group/srow` from `AutomationEntryRow` and `ManagedAutomationRow`. The row actions moved below the name and are always visible, so no descendant consumes `group-hover/srow` in these two rows anymore (the sole consumer, at line 387, belongs to a different row component).

Added a source-text assertion pinning the managed Run button's `aria-label`.

`pnpm typecheck`, `test:app`, `check:tests-wired` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)