### PR TITLE
feat(shell): resizable panes when 2+ pages are split beside the primary

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -530,6 +530,7 @@ export const SUITES = {
     "src/lib/server/automation-runner.test.ts",
     "src/lib/session-pins.test.ts",
     "src/lib/message-feedback.test.ts",
+    "src/components/detail-split-host.test.ts",
   ],
   api: [
     "scripts/dependency-policy.test.mjs",

--- a/src/components/detail-split-host.test.ts
+++ b/src/components/detail-split-host.test.ts
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// DetailSplitHost hosts the drag-to-split secondary pages beside the primary
+// surface. Both the 2-pane and the 3+-pane cases must be RESIZABLE — every
+// divider between panes drags freely (min-size clamped), never a fixed grid.
+const src = await readFile(new URL("./detail-split-host.tsx", import.meta.url), "utf8");
+
+// The single-secondary (2-pane) case keeps its snap-assisted resizable group.
+assert.match(
+  src,
+  /secondaryTiles\.length === 1 \?[\s\S]*<Group className="split-host__group"/,
+  "2-pane split renders a resizable Group",
+);
+
+// 2+ secondary pages (3+ panes) render a resizable Group — one Panel per tile
+// with a Separator between — NOT the old fixed equal-width grid.
+assert.doesNotMatch(src, /split-host__grid/, "multi-pane split no longer uses the fixed grid layout");
+assert.match(
+  src,
+  /tiles\.map\(\(tile, i\) =>[\s\S]*<Separator[\s\S]*<Panel[\s\S]*minSize="12%"[\s\S]*renderGridTile\(tile\)/,
+  "3+ panes render each tile in a resizable Panel with a draggable Separator between them",
+);
+
+console.log("detail-split-host ok");

--- a/src/components/detail-split-host.tsx
+++ b/src/components/detail-split-host.tsx
@@ -334,11 +334,32 @@ export function DetailSplitHost({
             </Group>
           </>
         ) : (
+          // 2+ secondary pages (3+ panes total): a resizable group so every
+          // divider between panes drags freely (min-size clamped), instead of a
+          // fixed equal-width grid. react-resizable-panels distributes the panes
+          // evenly by default and its Separators resize the adjacent panes
+          // natively (no custom snap tracking — that's the 2-pane path above).
           <>
             {mobileSwitcher}
-            <div className="split-host__group split-host__grid" data-variant={variant}>
-              {tiles.map(renderGridTile)}
-            </div>
+            <Group className="split-host__group" data-variant={variant} orientation="horizontal">
+              {tiles.map((tile, i) => (
+                <React.Fragment key={tile.id}>
+                  {i > 0 ? (
+                    <Separator className="shell-separator split-host__sep">
+                      <SeparatorHandle orientation="col" />
+                    </Separator>
+                  ) : null}
+                  <Panel
+                    id={`split-tile-${tile.id}`}
+                    className="split-host__pane-panel split-host__tile-panel flex min-h-0 min-w-0"
+                    data-active={activeTileId === tile.id}
+                    minSize="12%"
+                  >
+                    {renderGridTile(tile)}
+                  </Panel>
+                </React.Fragment>
+              ))}
+            </Group>
           </>
         )
       ) : (


### PR DESCRIPTION
Extends the drag-to-split host (#2183) so **3–4 panes are resizable**, not just 2.

- **Before:** primary + **one** secondary = a resizable `Group` with a draggable, snap-assisted divider ✓. But opening a 2nd/3rd secondary (3–4 panes) fell back to a **fixed equal-width grid** — no resizing.
- **After:** the multi-tile case renders the same `react-resizable-panels` `Group` — one `Panel` per tile with a draggable `Separator` between each — so **every divider resizes freely** (min-size 12% clamp). Reuses the exact primitives the 2-pane path already uses; the polished 2-pane snap divider is untouched.

The workspace cap already allows up to 4 panes (`MAX_WORKSPACE_TILES`), so this lights up the existing multi-pane path.

Tests: new `detail-split-host.test.ts` (source-text) asserts the multi-tile branch renders `Group`/`Panel`/`Separator` and no longer the fixed grid; 2-pane resizable path still asserted. typecheck, check:tests-wired (682), build + bundle-budget green.

Note: the drag-to-split *open* flow is HTML5 drag-drop (hard to drive headlessly), so this was verified statically + reuses proven primitives; the required E2E crash-sweep exercises the split surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)