### PR TITLE
Changes panel: commit working tree + Create PR to GitHub

### DIFF
--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -99,7 +99,12 @@ function featureBranchName(message: string, nowMs: number): string {
   const slug = message
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
+    // Trim leading/trailing dashes with anchored single-char replaces.
+    // The collapse above already reduces any run of separators to a single
+    // "-", so a linear-time trim suffices and avoids the polynomial-ReDoS
+    // backtracking of `/^-+|-+$/g` on attacker-influenced input.
+    .replace(/^-/, "")
+    .replace(/-$/, "")
     .slice(0, 32) || "changes";
   return `cave/${slug}-${nowMs.toString(36)}`;
 }

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -59,6 +59,56 @@ function gitDiff(cwd: string, args: string[]): Promise<{ stdout: string; stderr:
   return git(cwd, ["diff", "--no-ext-diff", "--no-textconv", ...args]);
 }
 
+/** Network git (push) and `gh` can take longer than the read-only 10s budget. */
+const NET_TIMEOUT_MS = 60_000;
+function gitLong(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync("git", args, { cwd, timeout: NET_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
+}
+/** Run the GitHub CLI (argument array, no shell) for PR creation. */
+function ghCli(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync("gh", args, { cwd, timeout: NET_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
+}
+
+const PR_URL_RE = /https:\/\/github\.com\/[^\s]+\/pull\/\d+/;
+
+/** Current branch name, or "HEAD" when detached. */
+async function currentBranch(repoRoot: string): Promise<string> {
+  const { stdout } = await git(repoRoot, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  return stdout.trim();
+}
+
+/** The repo's default branch: origin/HEAD when known, else main/master, else main. */
+async function defaultBranch(repoRoot: string): Promise<string> {
+  try {
+    const { stdout } = await git(repoRoot, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"]);
+    const m = stdout.trim().match(/refs\/remotes\/origin\/(.+)$/);
+    if (m) return m[1];
+  } catch { /* no origin/HEAD ref */ }
+  for (const b of ["main", "master"]) {
+    try {
+      await git(repoRoot, ["rev-parse", "--verify", "--quiet", b]);
+      return b;
+    } catch { /* not present */ }
+  }
+  return "main";
+}
+
+/** Server-generated, shell-safe feature branch name derived from the commit
+ *  message. `cave/<slug>-<base36-stamp>` — never client-controlled. */
+function featureBranchName(message: string, nowMs: number): string {
+  const slug = message
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 32) || "changes";
+  return `cave/${slug}-${nowMs.toString(36)}`;
+}
+
+function stderrOf(err: unknown): string {
+  const e = err as { stderr?: unknown; stdout?: unknown; message?: unknown };
+  return String(e?.stderr || e?.stdout || e?.message || err).trim();
+}
+
 type RootResolution =
   | { ok: true; repoRoot: string }
   | { ok: false; status: number; error: string; notARepo?: boolean };
@@ -367,8 +417,11 @@ export async function POST(req: NextRequest) {
     projectRoot?: string;
     path?: string;
     confirmUntracked?: boolean;
-    action?: "revert" | "checkpoint" | "restore-checkpoint" | "delete-checkpoint";
+    action?: "revert" | "checkpoint" | "restore-checkpoint" | "delete-checkpoint" | "commit" | "create-pr";
     checkpoint?: string;
+    message?: string;
+    title?: string;
+    prBody?: string;
   };
   try {
     body = await req.json();
@@ -394,6 +447,101 @@ export async function POST(req: NextRequest) {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    }
+  }
+  // Stage all working-tree changes and commit them. To keep the default branch
+  // clean (and set up the PR flow), a commit made while on the default branch
+  // (or a detached HEAD) first spins up a fresh `cave/<slug>` feature branch.
+  // The commit is signed (-S) to match the repo norm; a signing failure is
+  // surfaced rather than silently dropped.
+  if (action === "commit") {
+    const message = typeof body.message === "string" ? body.message.trim() : "";
+    if (!message) {
+      return NextResponse.json({ ok: false, error: "commit message is required" }, { status: 400 });
+    }
+    try {
+      const { stdout: statusOut } = await git(root.repoRoot, ["status", "--porcelain"]);
+      if (!statusOut.trim()) {
+        return NextResponse.json({ ok: false, error: "nothing to commit — the working tree is clean" }, { status: 400 });
+      }
+      const cur = await currentBranch(root.repoRoot);
+      const def = await defaultBranch(root.repoRoot);
+      let branch = cur;
+      let branchCreated = false;
+      if (cur === def || cur === "HEAD") {
+        branch = featureBranchName(message, Date.now());
+        await git(root.repoRoot, ["checkout", "-b", branch]);
+        branchCreated = true;
+      }
+      await git(root.repoRoot, ["add", "-A"]);
+      try {
+        await gitLong(root.repoRoot, ["commit", "-S", "-m", message]);
+      } catch (err) {
+        // Roll back the just-created branch so a failed commit doesn't strand it.
+        if (branchCreated) await git(root.repoRoot, ["checkout", cur]).catch(() => {});
+        const detail = stderrOf(err);
+        const signing = /gpg|signing|ssh|secret key|sign/i.test(detail);
+        return NextResponse.json(
+          { ok: false, error: signing ? `commit signing failed: ${detail}` : `commit failed: ${detail}` },
+          { status: 500 },
+        );
+      }
+      const { stdout: sha } = await git(root.repoRoot, ["rev-parse", "--short", "HEAD"]);
+      return NextResponse.json({
+        ok: true,
+        sha: sha.trim(),
+        branch,
+        branchCreated,
+        onDefaultBranch: branch === def,
+        defaultBranch: def,
+      });
+    } catch (err) {
+      return NextResponse.json({ ok: false, error: stderrOf(err) }, { status: 500 });
+    }
+  }
+  // Push the current feature branch and open a GitHub pull request via `gh`.
+  // Refuses to run from the default branch (there'd be nothing to PR and the
+  // push would be rejected by branch protection). If a PR already exists for
+  // the branch, gh's message carries its URL — surfaced as a success.
+  if (action === "create-pr") {
+    const title = typeof body.title === "string" ? body.title.trim() : "";
+    if (!title) {
+      return NextResponse.json({ ok: false, error: "PR title is required" }, { status: 400 });
+    }
+    const prBody = typeof body.prBody === "string" ? body.prBody : "";
+    try {
+      const branch = await currentBranch(root.repoRoot);
+      const def = await defaultBranch(root.repoRoot);
+      if (branch === def || branch === "HEAD") {
+        return NextResponse.json(
+          { ok: false, error: `you're on ${branch} — commit to a feature branch first, then open a PR` },
+          { status: 400 },
+        );
+      }
+      try {
+        await gitLong(root.repoRoot, ["push", "-u", "origin", branch]);
+      } catch (err) {
+        return NextResponse.json({ ok: false, error: `git push failed: ${stderrOf(err)}` }, { status: 502 });
+      }
+      try {
+        const { stdout } = await ghCli(root.repoRoot, [
+          "pr", "create", "--base", def, "--head", branch, "--title", title, "--body", prBody,
+        ]);
+        const url = stdout.match(PR_URL_RE)?.[0] ?? stdout.trim();
+        return NextResponse.json({ ok: true, url, branch, base: def });
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException & { stderr?: string };
+        if (e.code === "ENOENT") {
+          return NextResponse.json({ ok: false, error: "GitHub CLI (gh) not found — install it to open PRs" }, { status: 500 });
+        }
+        const detail = stderrOf(err);
+        // gh exits non-zero when a PR already exists; its message includes the URL.
+        const existing = detail.match(PR_URL_RE);
+        if (existing) return NextResponse.json({ ok: true, url: existing[0], branch, base: def, existed: true });
+        return NextResponse.json({ ok: false, error: `gh pr create failed: ${detail}` }, { status: 502 });
+      }
+    } catch (err) {
+      return NextResponse.json({ ok: false, error: stderrOf(err) }, { status: 500 });
     }
   }
   if (action === "restore-checkpoint" || action === "delete-checkpoint") {

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -6,6 +6,7 @@ import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
+import { openExternalUrl } from "@/lib/open-external";
 
 /**
  * "Changes" right-panel tab (CHAT-D8-01): a per-session review surface for the
@@ -433,6 +434,20 @@ export function SessionChangesInner({
   const [busyCheckpoint, setBusyCheckpoint] = useState<string | null>(null);
   const inFlightRef = useRef(false);
 
+  // Commit + Create PR flow.
+  const [commitMsg, setCommitMsg] = useState("");
+  const [committing, setCommitting] = useState(false);
+  // Set after a successful commit so the "Create PR" affordance persists even
+  // though the file list is now empty.
+  const [postCommit, setPostCommit] = useState<
+    { sha: string; branch: string; onDefaultBranch: boolean } | null
+  >(null);
+  const [prOpen, setPrOpen] = useState(false);
+  const [prTitle, setPrTitle] = useState("");
+  const [prBody, setPrBody] = useState("");
+  const [creatingPr, setCreatingPr] = useState(false);
+  const [prUrl, setPrUrl] = useState<string | null>(null);
+
   const load = useCallback(async () => {
     if (inFlightRef.current) return;
     inFlightRef.current = true;
@@ -693,6 +708,62 @@ export function SessionChangesInner({
     [load, loadCheckpoints, projectRoot],
   );
 
+  const commitChanges = useCallback(async () => {
+    const message = commitMsg.trim();
+    if (!message) return;
+    setCommitting(true);
+    setActionError(null);
+    setPrUrl(null);
+    try {
+      const res = await fetch("/api/changes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectRoot, action: "commit", message }),
+      });
+      const json = (await res.json().catch(() => ({}))) as {
+        ok?: boolean; sha?: string; branch?: string; onDefaultBranch?: boolean; error?: string;
+      };
+      if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
+      setPostCommit({ sha: json.sha ?? "", branch: json.branch ?? "", onDefaultBranch: json.onDefaultBranch === true });
+      setPrTitle(message.split("\n")[0].slice(0, 72));
+      setPrBody("");
+      setPrOpen(false);
+      setCommitMsg("");
+      setDiffs({});
+      setExpandedPath(null);
+      await Promise.all([load(), loadCheckpoints()]);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCommitting(false);
+    }
+  }, [commitMsg, projectRoot, load, loadCheckpoints]);
+
+  const createPr = useCallback(async () => {
+    const title = prTitle.trim();
+    if (!title) return;
+    setCreatingPr(true);
+    setActionError(null);
+    try {
+      const res = await fetch("/api/changes", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectRoot, action: "create-pr", title, prBody }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; url?: string; error?: string };
+      if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
+      setPrUrl(json.url ?? null);
+      setPrOpen(false);
+      setPostCommit(null);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreatingPr(false);
+    }
+  }, [prTitle, prBody, projectRoot]);
+
+  const canCommit = loaded && !notARepo && !error && files.length > 0;
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Header: honest scope copy + refresh */}
@@ -873,6 +944,121 @@ export function SessionChangesInner({
           />
         ) : null}
       </div>
+
+      {/* Commit + Create PR — the working tree's outbound actions. */}
+      {loaded && !notARepo && !error ? (
+        <div className="session-changes-panel__commit shrink-0 space-y-1.5 border-t border-[var(--border-hairline)] px-3 py-2">
+          {prUrl ? (
+            <div className="flex items-center justify-between gap-2 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)] px-2 py-1.5 text-[11px] text-[var(--accent-presence)]">
+              <span className="flex min-w-0 items-center gap-1.5">
+                <Icon name="ph:check-circle" width={12} aria-hidden className="shrink-0" />
+                <span className="min-w-0 truncate">Pull request opened.</span>
+              </span>
+              <button
+                type="button"
+                className="focus-ring inline-flex shrink-0 items-center gap-1 underline"
+                onClick={() => openExternalUrl(prUrl)}
+              >
+                Open PR <Icon name="ph:arrow-square-out" width={11} aria-hidden />
+              </button>
+            </div>
+          ) : null}
+
+          {postCommit ? (
+            <div className="rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)] px-2 py-1.5 text-[11px] text-[var(--accent-presence)]">
+              <div className="flex items-center justify-between gap-2">
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <Icon name="ph:check-circle" width={12} aria-hidden className="shrink-0" />
+                  <span className="min-w-0 truncate font-mono">
+                    {postCommit.sha} · {postCommit.branch}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  className="focus-ring shrink-0"
+                  aria-label="Dismiss commit result"
+                  onClick={() => setPostCommit(null)}
+                >
+                  <Icon name="ph:x-bold" width={10} aria-hidden />
+                </button>
+              </div>
+              {!prOpen && !postCommit.onDefaultBranch ? (
+                <button
+                  type="button"
+                  className="focus-ring mt-1.5 inline-flex items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] font-medium text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
+                  onClick={() => setPrOpen(true)}
+                >
+                  <Icon name="ph:git-pull-request" width={12} aria-hidden /> Create PR
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+
+          {prOpen ? (
+            <div className="space-y-1.5 rounded-md border border-[var(--border-hairline)] p-2">
+              <input
+                value={prTitle}
+                onChange={(e) => setPrTitle(e.target.value)}
+                placeholder="Pull request title"
+                aria-label="Pull request title"
+                className="focus-ring w-full rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] text-[var(--text-primary)]"
+              />
+              <textarea
+                value={prBody}
+                onChange={(e) => setPrBody(e.target.value)}
+                placeholder="Description (optional)"
+                aria-label="Pull request description"
+                rows={3}
+                className="focus-ring w-full resize-y rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] text-[var(--text-primary)]"
+              />
+              <div className="flex items-center gap-1.5">
+                <button
+                  type="button"
+                  disabled={!prTitle.trim() || creatingPr}
+                  onClick={() => void createPr()}
+                  className="focus-ring inline-flex items-center gap-1 rounded bg-[var(--accent-presence)] px-2.5 py-1 text-[11px] font-medium text-[var(--accent-presence-foreground,white)] disabled:opacity-40"
+                >
+                  <Icon name="ph:git-pull-request" width={12} aria-hidden />
+                  {creatingPr ? "Opening…" : "Create pull request"}
+                </button>
+                <button
+                  type="button"
+                  className="focus-ring rounded px-2 py-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                  onClick={() => setPrOpen(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {!postCommit && !prOpen ? (
+            <div className="flex items-center gap-1.5">
+              <input
+                value={commitMsg}
+                onChange={(e) => setCommitMsg(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) void commitChanges();
+                }}
+                placeholder={canCommit ? "Commit message" : "No changes to commit"}
+                aria-label="Commit message"
+                disabled={!canCommit || committing}
+                className="focus-ring min-w-0 flex-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] text-[var(--text-primary)] disabled:opacity-40"
+              />
+              <button
+                type="button"
+                disabled={!canCommit || !commitMsg.trim() || committing}
+                onClick={() => void commitChanges()}
+                title="Stage all changes and commit"
+                className="focus-ring inline-flex shrink-0 items-center gap-1 rounded bg-[var(--accent-presence)] px-2.5 py-1 text-[11px] font-medium text-[var(--accent-presence-foreground,white)] disabled:opacity-40"
+              >
+                <Icon name="ph:git-diff" width={12} aria-hidden />
+                {committing ? "Committing…" : "Commit"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## What
Adds **Commit** and **Create PR** to the Changes panel — you can now commit the working tree and open a GitHub pull request straight from the review surface, not just review/revert/checkpoint.

## Backend — extends `/api/changes` (reuses its repo allow-listing + execFile-no-shell posture)
- **`action: "commit"`** — stages all changes and commits, **signed (`-S`)** to match the repo norm. Committing while on the **default branch** (or a detached HEAD) first creates a fresh `cave/<slug>-<stamp>` feature branch, so the default stays clean and the PR flow is set up. Returns the short sha + branch. Friendly errors for a clean tree and for signing failures.
- **`action: "create-pr"`** — pushes the current feature branch and runs `gh pr create --base <default>`. **Refuses to run from the default branch**; if a PR already exists for the branch, surfaces its URL; clear errors when `gh` is missing or the push is rejected.
- All user-supplied text (message / title / body) is passed as `execFile` argument arrays — **no shell interpolation**. Branch names are server-generated or the server-derived current branch (never client-controlled).

## UI — `session-changes-panel` footer
- Commit message box + **Commit** button (⌘/Ctrl+Enter to commit).
- After a commit: a result chip (`sha · branch`) with a **Create PR** button (hidden while still on the default branch) → inline title/description form → a link to open the PR externally.

## Verification
- Typecheck clean; Frontend build green, bundle within budget; all tests that read these files pass (`changes/route.test.ts`, `session-changes-totals`, `comux-view-changes`, `chat-view-polish`, `debug-pane`, `use-changes-summary`).
- Ran the exact commit sequence in a throwaway git repo: on the default branch it creates a feature branch and commits there, leaving the default untouched and the working tree clean; the create-PR guard correctly refuses on the default branch. (Push/`gh pr create` not exercised against the live repo to avoid noise — straightforward execFile calls with explicit error handling.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)