### PR TITLE
feat(board): carry card attachments into the dispatched task chat

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -746,6 +746,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/journal-memory-stats.test.ts",
   "src/lib/journal-generate.test.ts",
   "src/lib/task-archive-nudge.test.ts",
+  "src/lib/task-chat-context.test.ts",
   "src/lib/cave-config.test.ts",
   "src/lib/cave-config-state-race.test.ts",
   "src/lib/travel-client-state.test.ts",

--- a/src/lib/task-chat-context.test.ts
+++ b/src/lib/task-chat-context.test.ts
@@ -43,3 +43,24 @@ const initialPrompt = buildInitialTaskChatPrompt({
 });
 assert.match(initialPrompt, /^Task context:\nTitle: Start from board/);
 assert.match(initialPrompt, /Use this session as the working thread for the task\.$/);
+// No attachments → no "Attached files" section.
+assert.doesNotMatch(initialPrompt, /Attached files:/);
+
+// Cards with attachments fold them into the initial dispatch prompt so the
+// familiar working the task can read them. Text bodies render in full; images
+// (stored lean, dataUrl stripped) render as a metadata line.
+const promptWithAttachments = buildInitialTaskChatPrompt({
+  title: "Ship the onboarding flow",
+  status: "backlog",
+  priority: "high",
+  attachments: [
+    { name: "spec.md", type: "text/markdown", size: 24, text: "# Onboarding\n- step one" },
+    { name: "mockup.png", type: "image/png", size: 4096 },
+  ],
+});
+assert.match(promptWithAttachments, /^Task context:\nTitle: Ship the onboarding flow/);
+assert.match(promptWithAttachments, /Use this session as the working thread for the task\./);
+assert.match(promptWithAttachments, /Attached files:/);
+assert.match(promptWithAttachments, /1\. spec\.md/);
+assert.match(promptWithAttachments, /# Onboarding\n- step one/);
+assert.match(promptWithAttachments, /2\. mockup\.png/);

--- a/src/lib/task-chat-context.ts
+++ b/src/lib/task-chat-context.ts
@@ -1,3 +1,5 @@
+import { buildPromptWithAttachments, type ChatAttachment } from "@/lib/chat-attachments";
+
 type TaskContextCard = {
   title: string;
   notes?: string | null;
@@ -6,6 +8,9 @@ type TaskContextCard = {
   labels?: string[] | null;
   links?: string[] | null;
   github?: Array<{ title: string; url: string }> | null;
+  /** Files carried onto the card at creation. Folded into the initial dispatch
+   * prompt so the familiar working the task can read them. */
+  attachments?: ChatAttachment[] | null;
 };
 
 function linesForList(title: string, values: string[]): string[] {
@@ -52,7 +57,12 @@ export function buildTaskAwarePrompt(prompt: string, taskContext: string | null)
 }
 
 export function buildInitialTaskChatPrompt(card: TaskContextCard): string {
-  return `${buildTaskContext(card)}\n\nUse this session as the working thread for the task.`;
+  const base = `${buildTaskContext(card)}\n\nUse this session as the working thread for the task.`;
+  const attachments = card.attachments ?? [];
+  // Board attachments are stored lean (text inlined; image dataUrls stripped),
+  // so buildPromptWithAttachments renders text bodies in full and images as a
+  // metadata line — exactly the once-at-dispatch delivery the composer uses.
+  return attachments.length ? buildPromptWithAttachments(base, attachments) : base;
 }
 
 export async function taskContextForSession(sessionId?: string | null): Promise<string | null> {


### PR DESCRIPTION
## What

Completes the board-attachments feature (#2219). Attachments were stored on the card but **never reached the familiar** when the task was dispatched to chat (the inspector's "Start" → `/api/board/[id]/chat`). Now they do.

- `buildInitialTaskChatPrompt` folds the card's `attachments` into the dispatch prompt via the existing `buildPromptWithAttachments`.
- Text attachments (specs, CSV, notes) render their content **in full**; images — stored lean, base64 stripped at creation — render as a metadata line.
- The route already passed the full `Card`, so the only change is the prompt builder + type. Dispatched once, at session creation (not re-attached on every follow-up turn).

## Verification
Printed the actual composed dispatch prompt for a card with a `.md` + a `.png`: task context → `Use this session as the working thread…` → `Attached files:` with the spec's full text inlined and the image as a metadata line. (The route itself needs a live daemon to round-trip; the prompt builder is the behavioral surface and is unit-tested + eyeballed.)

## Tests
- `task-chat-context.test.ts`: attachments fold into the initial prompt (text body inlined, image metadata line); no attachments → no "Attached files" section.
- Added `task-chat-context.test.ts` to `ALIAS_LOADER` in `run-tests.mjs` — the module now imports `@/lib/chat-attachments`, so CI must run it with the alias loader (without it: `ERR_MODULE_NOT_FOUND`).
- `board-chat-link.test.ts` (pins the route's `buildInitialTaskChatPrompt(card)` call) still green. Typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)