### PR TITLE
Fix invisible dropdown options in the model/familiar pickers (dark theme)

### DIFF
--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -456,6 +456,20 @@
   max-width: 132px;
 }
 
+/* The dropdown popup of a native <select> is drawn on the OS's own surface
+   (white on macOS), but its <option>/<optgroup> text inherits the control's
+   light dark-theme color — leaving every item invisible until the OS hover
+   highlight lands on it. Pin an explicit, theme-aware background + color so the
+   model / familiar / project menus stay readable in every theme. */
+.hc-familiar-select option,
+.hc-familiar-select optgroup {
+  background-color: var(--bg-elevated);
+  color: var(--text-primary);
+}
+.hc-familiar-select optgroup {
+  font-weight: 600;
+}
+
 .hc-select-caret {
   position: absolute;
   right: 5px;


### PR DESCRIPTION
## Problem
The home composer's model / familiar / project pickers are native `<select>`s styled with the theme's light text color. A native `<select>`'s dropdown popup is drawn on the OS surface (white on macOS), so the `<option>` text **inherited that light color** — every item was invisible until the OS hover highlight landed on it.

(Reported: the model picker's open menu showed only "Claude Sonnet 5" under the cursor; the rest of the list was blank.)

## Fix
Pin an explicit, theme-aware `background-color` + `color` on the options/optgroups (`.hc-familiar-select option, optgroup`) so the menus are readable in every theme:
- dark theme → `--bg-elevated` (oklch 0.20) + light foreground
- light theme → `--bg-elevated` (oklch 0.93) + dark foreground

CSS-only; scoped to the composer selects (`.hc-familiar-select`), which covers the model, familiar, and project pickers.

## Verification
- Frontend build green, bundle within budget.
- Confirmed the tokens resolve to real contrast in both themes (dark bg + light text / light bg + dark text). Native `<select>` popups render outside the page DOM so they can't be screenshotted, but the inherited-color mechanism and the token contrast confirm the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)