### PR TITLE
feat(board): add/remove attachments on an existing card

### DIFF
--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -8,6 +8,7 @@ import {
 } from "@/lib/cave-board";
 import type { CardStep } from "@/lib/cave-board-types";
 import type { CardGitHubLink } from "@/lib/cave-board-types";
+import type { ChatAttachment } from "@/lib/chat-attachments";
 
 export const dynamic = "force-dynamic";
 
@@ -35,6 +36,7 @@ export async function PATCH(
     needsHuman: boolean;
     runningSince: string | undefined;
     steps: CardStep[];
+    attachments: ChatAttachment[];
   }>;
   try {
     body = await req.json();

--- a/src/components/board-inspector-a11y.test.ts
+++ b/src/components/board-inspector-a11y.test.ts
@@ -44,4 +44,19 @@ assert.match(src, /import \{ openExternalUrl \} from "@\/lib\/open-external"/, "
 assert.match(src, /onClick=\{\(\) => void openExternalUrl\(GITHUB_PAT_URL\)\}/, "inline PAT setup opens GitHub token creation outside the local app");
 assert.doesNotMatch(src, /href="https:\/\/github\.com\/settings\/tokens\/new/, "inline PAT setup no longer uses a plain localhost-bound anchor");
 
+// ── Attachments section: add/remove are accessible and go through onPatch ────
+assert.match(src, /function AttachmentsSection\(/, "the inspector has an editable AttachmentsSection");
+assert.match(
+  src,
+  /const converted = await Promise\.all\(picked\.map\(\(file\) => fileToAttachment\(file\)\)\)/,
+  "added files are converted client-side via the shared fileToAttachment helper",
+);
+assert.match(
+  src,
+  /onPatch\(card\.id, \{ attachments: attachments\.filter\(\(_, i\) => i !== index\) \}\)/,
+  "removing an attachment PATCHes the filtered array",
+);
+assert.match(src, /aria-label=\{`Remove \$\{att\.name\}`\}/, "each attachment's remove button is named for its file");
+assert.match(src, /disabled=\{busy \|\| atCap\}/, "the add-files button is disabled while busy or at the 10-file cap");
+
 console.log("board-inspector-a11y.test.ts: ok");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -26,7 +26,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
 import { openExternalUrl } from "@/lib/open-external";
-import { attachmentIcon } from "@/lib/chat-attachments";
+import { attachmentIcon, fileToAttachment } from "@/lib/chat-attachments";
 
 const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
@@ -630,6 +630,121 @@ function LinksSection({
   );
 }
 
+// ── Attachments ───────────────────────────────────────────────────────────────
+// Files staged in a composer ride onto a card at creation; this section lets you
+// add/remove them afterward. New files are converted client-side (fileToAttachment)
+// and PATCHed — the server re-normalizes them lean (base64 image payloads stripped),
+// so the same file → attachment pipeline as the composer, and an edit can't bloat
+// cave-board.json.
+const MAX_CARD_ATTACHMENTS = 10;
+
+function AttachmentsSection({
+  card,
+  onPatch,
+}: {
+  card: Card;
+  onPatch: (id: string, patch: Partial<Card>) => void;
+}) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const attachments = card.attachments ?? [];
+  const atCap = attachments.length >= MAX_CARD_ATTACHMENTS;
+
+  async function addFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    const room = Math.max(0, MAX_CARD_ATTACHMENTS - attachments.length);
+    if (room === 0) return;
+    setBusy(true);
+    try {
+      const picked = Array.from(files).slice(0, room);
+      const converted = await Promise.all(picked.map((file) => fileToAttachment(file)));
+      // Drop the composer-only `id`; the server re-normalizes to the lean shape.
+      const next = [...attachments, ...converted.map(({ id: _id, ...rest }) => rest)];
+      onPatch(card.id, { attachments: next });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function removeAt(index: number) {
+    onPatch(card.id, { attachments: attachments.filter((_, i) => i !== index) });
+  }
+
+  return (
+    <div className="board-drawer-field">
+      <div className="board-drawer-field-label" style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <Icon name="ph:paperclip" width={12} />
+        Attachments
+        {attachments.length > 0 && (
+          <span style={{
+            fontSize: 10,
+            color: "var(--text-muted)",
+            background: "var(--bg-elevated)",
+            borderRadius: 8,
+            padding: "1px 6px",
+          }}>
+            {attachments.length}
+          </span>
+        )}
+      </div>
+      {attachments.length > 0 && (
+        <ul style={{ display: "flex", flexDirection: "column", gap: 2, marginBottom: 8 }}>
+          {attachments.map((att, i) => (
+            <li
+              key={`${att.name}-${i}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "5px 8px",
+                borderRadius: 6,
+                background: "var(--bg-elevated)",
+                border: "1px solid var(--border-hairline)",
+              }}
+            >
+              <Icon name={attachmentIcon(att)} width={11} className="shrink-0 text-[var(--text-muted)]" />
+              <span style={{ flex: 1, fontSize: 12, color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={att.name}>
+                {att.name}
+              </span>
+              <span style={{ fontSize: 10, color: "var(--text-muted)", flexShrink: 0 }}>
+                {formatAttachmentSize(att.size)}
+              </span>
+              <button
+                type="button"
+                className="board-toolbar-btn"
+                style={{ padding: "1px 4px", color: "var(--color-danger)", flexShrink: 0 }}
+                onClick={() => removeAt(i)}
+                title={`Remove ${att.name}`}
+                aria-label={`Remove ${att.name}`}
+              >
+                <Icon name="ph:x-bold" width={9} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        hidden
+        onChange={(e) => { void addFiles(e.target.files); e.target.value = ""; }}
+      />
+      <button
+        type="button"
+        className="board-toolbar-btn"
+        onClick={() => fileInputRef.current?.click()}
+        disabled={busy || atCap}
+        style={{ padding: "4px 10px", fontSize: 11 }}
+        title={atCap ? `Attachment limit reached (${MAX_CARD_ATTACHMENTS})` : "Attach files to this task"}
+      >
+        <Icon name="ph:paperclip" width={11} />
+        {busy ? "Adding…" : atCap ? "Limit reached" : "Add files"}
+      </button>
+    </div>
+  );
+}
+
 // ── Steps ─────────────────────────────────────────────────────────────────────
 function StepsSection({
   card,
@@ -1136,47 +1251,7 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
 
           <GitHubAttachSection card={card} familiars={familiars} onPatch={onPatch} onOpenUrl={onOpenUrl} />
 
-          {(card.attachments?.length ?? 0) > 0 && (
-            <div className="board-drawer-field">
-              <div className="board-drawer-field-label" style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <Icon name="ph:paperclip" width={12} />
-                Attachments
-                <span style={{
-                  fontSize: 10,
-                  color: "var(--text-muted)",
-                  background: "var(--bg-elevated)",
-                  borderRadius: 8,
-                  padding: "1px 6px",
-                }}>
-                  {card.attachments!.length}
-                </span>
-              </div>
-              <ul style={{ display: "flex", flexDirection: "column", gap: 2 }}>
-                {card.attachments!.map((att, i) => (
-                  <li
-                    key={`${att.name}-${i}`}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      padding: "5px 8px",
-                      borderRadius: 6,
-                      background: "var(--bg-elevated)",
-                      border: "1px solid var(--border-hairline)",
-                    }}
-                  >
-                    <Icon name={attachmentIcon(att)} width={11} className="shrink-0 text-[var(--text-muted)]" />
-                    <span style={{ flex: 1, fontSize: 12, color: "var(--text-primary)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }} title={att.name}>
-                      {att.name}
-                    </span>
-                    <span style={{ fontSize: 10, color: "var(--text-muted)", flexShrink: 0 }}>
-                      {formatAttachmentSize(att.size)}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
+          <AttachmentsSection card={card} onPatch={onPatch} />
 
           <div className="board-drawer-field">
             <div className="board-drawer-field-label"><Icon name="ph:note-bold" width={11} /> Notes</div>

--- a/src/lib/cave-board-attachments.test.ts
+++ b/src/lib/cave-board-attachments.test.ts
@@ -56,5 +56,34 @@ assert.equal(stored.attachments[1].dataUrl, undefined, "stored image stays lean 
 const bare = await board.createCard({ title: "No files here" });
 assert.equal(bare.attachments, undefined, "cards with no staged files omit the attachments field");
 
+// ── Inspector edit path: updateCard applies the same lean pipeline ──────────
+// Add a fresh file (with a fat image dataUrl) to a card that had none — it must
+// be stored lean, exactly like createCard.
+const added = await board.updateCard(bare.id, {
+  attachments: [
+    { name: "later.txt", type: "text/plain", size: 5, text: "hi" },
+    { name: "diagram.png", type: "image/png", mimeType: "image/png", size: 68, dataUrl: pngDataUrl },
+  ],
+});
+assert.ok(added, "updateCard returns the updated card");
+assert.equal(added.attachments.length, 2, "updateCard stores added attachments");
+assert.equal(added.attachments[0].text, "hi", "added text attachment keeps its content");
+assert.equal(added.attachments[1].dataUrl, undefined, "updateCard strips the added image dataUrl lean");
+
+// Remove one attachment (PATCH the filtered array).
+const removed = await board.updateCard(bare.id, {
+  attachments: added.attachments.filter((a) => a.name !== "diagram.png"),
+});
+assert.equal(removed.attachments.length, 1, "updateCard removes an attachment");
+assert.equal(removed.attachments[0].name, "later.txt", "the surviving attachment is the right one");
+
+// A patch that does NOT mention attachments leaves them untouched.
+const untouched = await board.updateCard(bare.id, { title: "Renamed" });
+assert.equal(untouched.attachments.length, 1, "an unrelated patch preserves attachments");
+
+// Clearing to an empty array drops the field entirely.
+const cleared = await board.updateCard(bare.id, { attachments: [] });
+assert.equal(cleared.attachments, undefined, "clearing to [] removes the attachments field");
+
 await rm(tmpHome, { recursive: true, force: true });
 console.log("cave-board-attachments: ok");

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -320,6 +320,12 @@ export async function updateCard(
     startDate: "startDate" in patch ? normalizeBoardDate(patch.startDate) : current.startDate ?? null,
     endDate: "endDate" in patch ? normalizeBoardDate(patch.endDate) : current.endDate ?? null,
     steps: patch.steps ?? current.steps,
+    // Attachments patched from the inspector go through the same lean pipeline as
+    // createCard — normalize + strip base64 image payloads — so an edit can never
+    // fatten cave-board.json. An empty array clears them (field dropped).
+    attachments: "attachments" in patch
+      ? boardAttachments(patch.attachments ?? undefined)
+      : current.attachments,
   };
   if (next.lifecycle === "running" && !next.runningSince) {
     next.runningSince = next.updatedAt;


### PR DESCRIPTION
## What

Makes the board inspector's **Attachments** section editable (it was read-only after #2219/#2221).

- **Add**: an "Add files" button (hidden file input) converts picked files client-side via the shared `fileToAttachment`, respects the 10-file cap, and PATCHes the card.
- **Remove**: a per-row `×` PATCHes the filtered array; clearing the last one drops the field.
- **Lean storage on edit**: `updateCard` now runs patched `attachments` through the same `boardAttachments()` pipeline as `createCard` (normalize + strip base64 image `dataUrl`), so an inspector edit can never fatten `cave-board.json`. Patches that don't mention attachments leave them untouched.

## Verification (live app)
- Seeded an attachment-less card → opened inspector → "Add files" a `.md`: persisted lean (`{name,type,size,text}`), UI showed the file + count, **0 page errors**.
- Clicked remove `×`: field dropped (`attachments` absent), empty-state shows just the "Add files" button, **0 page errors**.

## Tests
- `cave-board-attachments.test.ts`: `updateCard` add (lean, image dataUrl stripped), remove-one, unrelated-patch-preserves, clear-to-`[]`-drops-field.
- `board-inspector-a11y.test.ts`: `AttachmentsSection` exists; add uses `fileToAttachment`; remove PATCHes filtered array; remove button named per file; add button disabled while busy / at cap.
- Typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)