### PR TITLE
feat(quick-chat): add ⌘J to toggle the quick-chat dropdown

### DIFF
--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -130,7 +130,7 @@ export function FamiliarMenuBar({
             data-quick-chat-trigger
             onClick={onOpenQuickChat}
             aria-label="Quick chat"
-            title="Quick chat"
+            title="Quick chat (⌘J)"
           >
             <Icon name="ph:chat-circle-dots" width={22} height={22} aria-hidden />
             <span>Chat</span>

--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./quick-chat-overlay.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
+const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -95,5 +96,19 @@ assert.match(
   /window\.addEventListener\("resize", measure\)/,
   "the anchor position is kept in sync on resize",
 );
+
+// ── ⌘J toggles quick chat from anywhere, and it's listed in the catalog ───────
+assert.match(
+  workspace,
+  /if \(k === "j"\) \{\s*e\.preventDefault\(\);\s*setQuickChatOpen\(\(open\) => !open\);/,
+  "⌘/Ctrl+J toggles the quick-chat dropdown globally",
+);
+assert.match(
+  shortcuts,
+  /\{ keys: "⌘J", description: "Toggle quick chat" \}/,
+  "the shortcut catalog documents ⌘J (shortcuts sheet + /help)",
+);
+// Tooltips advertise the shortcut without polluting the accessible name.
+assert.match(topBar, /aria-label="Quick chat"\s*\n\s*title="Quick chat \(⌘J\)"/, "mobile trigger tooltip shows the shortcut, aria-label stays clean");
 
 console.log("quick-chat-overlay.test.ts OK");

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -183,7 +183,7 @@ export function TopBar(props: Props) {
             data-quick-chat-trigger
             onClick={onOpenQuickChat}
             aria-label="Quick chat"
-            title="Quick chat"
+            title="Quick chat (⌘J)"
           >
             <Icon name="ph:chat-circle-dots" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
           </button>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -910,6 +910,12 @@ export function Workspace() {
           setPaletteOpen(true);
           return;
         }
+        // ⌘J (Ctrl+J off-Mac) → toggle the quick-chat dropdown, from anywhere.
+        if (k === "j") {
+          e.preventDefault();
+          setQuickChatOpen((open) => !open);
+          return;
+        }
         // ⌘/ (Ctrl+/ off-Mac) → keyboard shortcuts sheet, from anywhere.
         if (e.key === "/") {
           e.preventDefault();

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -99,6 +99,7 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
     id: "other",
     label: "Other",
     entries: [
+      { keys: "⌘J", description: "Toggle quick chat" },
       { keys: "⌘,", description: "Open Settings" },
       { keys: "⌘S", description: "Save (daily notes, journal)" },
       { keys: "⌘Z", description: "Undo the last delete (while the undo toast is showing)" },


### PR DESCRIPTION
## What

Quick chat was only reachable by clicking the menubar **Chat** icon. Adds a global **⌘/Ctrl+J** that **toggles** the quick-chat dropdown from anywhere.

## How
- `workspace.tsx` — in the existing global keydown handler (next to ⌘K palette), `⌘/Ctrl+J` → `setQuickChatOpen(o => !o)`.
- `keyboard-shortcuts.ts` — catalog entry `⌘J → Toggle quick chat` (shows in the ⌘/ sheet + `/help`).
- `familiar-menu-bar.tsx` / `top-bar.tsx` — trigger **tooltips** now read "Quick chat (⌘J)"; `aria-label` stays "Quick chat" (clean for screen readers).

## Verification
- Tests + `pnpm build` green.
- Drove the app: **⌘J opens** the dropdown, **⌘J again closes** it, and **Ctrl+J** (off-Mac path) opens it too — all confirmed.

Completes the quick-chat arc: reveal (#2185) → polish (#2197) → drop-from-menubar anchoring (#2204) → desktop trigger (#2209) → keyboard shortcut (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)