### PR TITLE
chore(release): stamp v0.0.130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.130] - 2026-07-01
+
+Patch release on top of v0.0.129. Headline: the Changes panel can now commit
+your working tree and open a GitHub PR, Kanban cards carry attachments through
+the whole dispatch flow, and split panes are resizable.
+
+### Added
+
+- **Changes panel** - commit the working tree and create a GitHub PR straight
+  from Cave; a server-generated, shell-safe `cave/<slug>-<stamp>` feature
+  branch is derived from the commit message when on a protected/detached HEAD.
+- **Board attachments** - carry composer attachments onto Task cards, forward
+  them into the dispatched task chat, and add/remove attachments on an existing
+  card.
+- **Resizable panes** - drag to resize split pages when two or more are opened
+  beside the primary page.
+- **Quick-chat** - `⌘J` toggles the quick-chat dropdown.
+- **Marketplace** - OpenClaw Skills are split into individual cards with
+  per-skill config defaults.
+- **Projects** - browse for a project folder when creating a new project.
+- **Home composer** - attachment count indicator with a clear-all control.
+- **Chat** - forward the composer permission mode to `coven run --permission`.
+
+### Fixed
+
+- **Dark theme** - model/familiar picker dropdown options were invisible in the
+  dark theme; restored contrast.
+- **Changes route (security)** - replaced the polynomial-ReDoS-prone
+  `/^-+|-+$/g` trim in the feature-branch slug with anchored linear-time
+  trims (CodeQL `js/polynomial-redos`).
+- **Automations** - accessible label on the managed Run button; removed dead
+  group/subrow markup.
+
 ## [0.0.129] - 2026-07-01
 
 Patch release on top of v0.0.128. Headline: Cave clarifies Hermes mode as the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.129"
+version = "0.0.130"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.129"
+version = "0.0.130"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.129</string>
+	<string>0.0.130</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.129</string>
+	<string>0.0.130</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.129</string>
+	<string>0.0.130</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.129</string>
+	<string>0.0.130</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.129",
+  "version": "0.0.130",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version stamp + CHANGELOG for v0.0.130. See CHANGELOG for the feature list (Changes-panel commit+PR, board attachments, resizable panes, quick-chat cmd-J, marketplace skill cards, project-folder browse, plus dark-theme dropdown + ReDoS + a11y fixes).