### PR TITLE
Evals UI/UX: untruncated stat cards + readable Failures-by-case

### DIFF
--- a/src/components/evals/evals-insights-panel.tsx
+++ b/src/components/evals/evals-insights-panel.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import { TrendChart } from "@/components/ui/charts/trend-chart";
-import { BarChart } from "@/components/ui/charts/bar-chart";
 import { suitePassRateTrend, failureClusters } from "@/lib/evals/eval-analytics";
 import type { EvalRun, EvalSuite } from "@/lib/evals/eval-model";
 
@@ -31,7 +30,8 @@ export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; r
   const failBars = clusters.byCase
     .filter((c) => c.failures > 0)
     .slice(0, 8)
-    .map((c) => ({ label: c.name, value: c.failures, color: "var(--color-danger)" }));
+    .map((c) => ({ label: c.name, failures: c.failures, runs: c.runs }));
+  const maxFailures = Math.max(1, ...failBars.map((c) => c.failures));
 
   return (
     <div className="evals-insights">
@@ -58,7 +58,26 @@ export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; r
           <div className="evals-insights__head">
             <span className="evals-insights__title">Failures by case</span>
           </div>
-          <BarChart data={failBars} height={150} />
+          {/* Labeled horizontal bars — with only a handful of categories, the
+              unlabeled SVG bar chart read as a solid color block. Real text
+              rows (name · count · proportional track) stay legible at any
+              count and are screen-reader accessible. */}
+          <ul className="evals-fail-bars">
+            {failBars.map((c) => (
+              <li key={c.label} className="evals-fail-bar">
+                <span className="evals-fail-bar__name" title={c.label}>{c.label}</span>
+                <span className="evals-fail-bar__count">
+                  {c.failures}/{c.runs} run{c.runs === 1 ? "" : "s"}
+                </span>
+                <span className="evals-fail-bar__track" aria-hidden>
+                  <span
+                    className="evals-fail-bar__fill"
+                    style={{ width: `${Math.round((c.failures / maxFailures) * 100)}%` }}
+                  />
+                </span>
+              </li>
+            ))}
+          </ul>
         </section>
       ) : null}
 

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -376,7 +376,9 @@
 /* ---- Unified analysis --------------------------------------------------- */
 .evals-analysis-summary {
   display: grid;
-  grid-template-columns: repeat(5, minmax(120px, 1fr));
+  /* Auto-fit so cards wrap to a second row instead of squeezing all five into
+     one line and ellipsizing their labels ("LATEST SUITE PA…"). */
+  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
   gap: 10px;
   padding: 12px 18px;
   border-bottom: 1px solid var(--border-hairline);
@@ -404,9 +406,13 @@
 .evals-analysis-card span,
 .evals-analysis-card small {
   min-width: 0;
+  /* Let the label/detail wrap to a second line (clamped) instead of
+     ellipsizing — a truncated metric label is worse than a taller card. */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 .evals-analysis-card span {
   color: var(--text-muted);
@@ -1620,6 +1626,32 @@
 .evals-insights__flaky { list-style: none; margin: 8px 0 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
 .evals-insights__flaky li { display: flex; justify-content: space-between; font-size: 12px; color: var(--text-secondary); }
 .evals-insights__flaky b { color: var(--text-primary); font-weight: 500; }
+
+/* Failures-by-case: labeled horizontal bars (name · count · track). */
+.evals-fail-bars { list-style: none; margin: 10px 0 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.evals-fail-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2px 10px;
+  align-items: baseline;
+  font-size: 12px;
+}
+.evals-fail-bar__name {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  color: var(--text-primary); font-weight: 500;
+}
+.evals-fail-bar__count { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.evals-fail-bar__track {
+  grid-column: 1 / -1;
+  height: 6px; border-radius: 999px;
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+  overflow: hidden;
+}
+.evals-fail-bar__fill {
+  display: block; height: 100%; border-radius: inherit;
+  background: color-mix(in oklch, var(--color-danger) 72%, var(--bg-base));
+  min-width: 6px;
+}
 
 /* Run comparison. */
 .evals-compare { display: flex; flex-direction: column; gap: 12px; }


### PR DESCRIPTION
## What
First slice of the Evals UI/UX optimization (done locally after the cloud ultraplan sessions failed). Fixes the two defects visible when screenshotting every tab with realistic data:

1. **Stat-card labels truncated on every tab** — the five analysis cards were forced into a single row (`repeat(5, minmax(120px,1fr))`) with `nowrap`+ellipsis, rendering "LATEST SUITE PA…", "LOOP ACCEPT/R…", "THREAD FRESHN…". Now an auto-fit grid (min 168px) that wraps to a second row, with labels/details clamped to two lines instead of ellipsized.

2. **Insights → "Failures by case" rendered as a giant solid red block** — 1–2 categories fed into the unlabeled `aria-hidden` SVG BarChart produce near-full-width bands that read as a color blob. Replaced with **labeled horizontal bars** (case name · failures/runs count · proportional track): legible at any category count, real text for screen readers. The shared `BarChart` primitive is untouched (kept for the planned Dashboard use; its source-text test still passes).

## Verification
- Screenshot-compared all 8 tabs before/after with realistic mocked data (suites, 3 runs with regressions, live loop, groups + thread snapshots): labels now read in full and the failure bars show names + counts ("No fabricated citation · 2/3 runs").
- Programmatic check: no `.evals-analysis-card span` has `scrollWidth > clientWidth` (nothing truncates).
- Typecheck clean; `evals-view.test.ts` + `charts.test.ts` pass; Frontend build green, bundle within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)