### PR TITLE
feat(quick-chat): default the popover to the workspace's active familiar

### DIFF
--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -9,8 +9,8 @@ const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.me
 
 assert.match(
   source,
-  /useQuickChat\(\)/,
-  "overlay shares the quick-chat state/send logic via the useQuickChat hook",
+  /useQuickChat\(\{ preferredFamiliarId: activeFamiliarId \?\? null \}\)/,
+  "overlay shares the quick-chat state/send logic via useQuickChat, preferring the workspace's active familiar",
 );
 assert.match(
   source,
@@ -110,5 +110,28 @@ assert.match(
 );
 // Tooltips advertise the shortcut without polluting the accessible name.
 assert.match(topBar, /aria-label="Quick chat"\s*\n\s*title="Quick chat \(⌘J\)"/, "mobile trigger tooltip shows the shortcut, aria-label stays clean");
+
+// ── Familiar default: workspace-active > last-used > first ───────────────────
+const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
+assert.match(
+  hook,
+  /\(preferred && next\.some\(\(familiar\) => familiar\.id === preferred\) \? preferred : null\) \?\?\s*\(stored && next\.some\(\(familiar\) => familiar\.id === stored\) \? stored : null\) \?\?\s*next\[0\]\?\.id/,
+  "the initial default prefers the workspace-active familiar, then last-used, then first",
+);
+assert.match(
+  hook,
+  /if \(!preferredFamiliarId \|\| userPickedRef\.current\) return;/,
+  "the popover follows the active familiar only until the user manually picks one",
+);
+assert.match(
+  hook,
+  /setSelectedFamiliarId: pickFamiliar/,
+  "manual picks flow through pickFamiliar so they override the active-familiar default",
+);
+assert.match(
+  workspace,
+  /<QuickChatOverlay[\s\S]*?activeFamiliarId=\{activeId\}/,
+  "workspace passes its active familiar to the quick-chat popover",
+);
 
 console.log("quick-chat-overlay.test.ts OK");

--- a/src/components/quick-chat-overlay.tsx
+++ b/src/components/quick-chat-overlay.tsx
@@ -15,6 +15,9 @@ type Props = {
   open: boolean;
   onClose: () => void;
   onOpenFullSession?: (sessionId: string, familiarId?: string | null) => void;
+  /** The workspace's active familiar — the popover defaults to it (a manual
+   *  pick in the popover still wins once made). */
+  activeFamiliarId?: string | null;
 };
 
 function initials(familiar: Familiar): string {
@@ -26,7 +29,7 @@ function initials(familiar: Familiar): string {
     .toUpperCase();
 }
 
-export function QuickChatOverlay({ open, onClose, onOpenFullSession }: Props) {
+export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamiliarId }: Props) {
   const {
     familiars,
     selectedFamiliarId,
@@ -45,7 +48,7 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession }: Props) {
     setResponseSpeed,
     send,
     cancel,
-  } = useQuickChat();
+  } = useQuickChat({ preferredFamiliarId: activeFamiliarId ?? null });
 
   const sending = sendState === "sending";
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2427,6 +2427,7 @@ export function Workspace() {
       <QuickChatOverlay
         open={quickChatOpen}
         onClose={() => setQuickChatOpen(false)}
+        activeFamiliarId={activeId}
         onOpenFullSession={(sid, fid) => {
           setQuickChatOpen(false);
           openFamiliarSession(sid, fid);

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -40,9 +40,24 @@ export type UseQuickChat = {
   cancel: () => void;
 };
 
-export function useQuickChat(): UseQuickChat {
+export type UseQuickChatOptions = {
+  /** Prefer this familiar (e.g. the workspace's active scope) over the
+   *  last-used/first fallback. The user's manual pick in the popover still
+   *  wins once made. */
+  preferredFamiliarId?: string | null;
+};
+
+export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
+  const preferredFamiliarId = options?.preferredFamiliarId ?? null;
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
+  // Once the user explicitly picks a familiar in the UI, stop following the
+  // preferred (workspace-active) familiar — their choice is stickier.
+  const userPickedRef = useRef(false);
+  const pickFamiliar = useCallback((id: string | null) => {
+    userPickedRef.current = true;
+    setSelectedFamiliarId(id);
+  }, []);
   const [draft, setDraft] = useState("");
   const [answer, setAnswer] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -57,6 +72,9 @@ export function useQuickChat(): UseQuickChat {
   );
 
   const abortRef = useRef<AbortController | null>(null);
+  // Latest preferred id for the one-shot roster load below (no effect re-run).
+  const preferredRef = useRef<string | null>(preferredFamiliarId);
+  preferredRef.current = preferredFamiliarId;
 
   useEffect(() => {
     let alive = true;
@@ -70,9 +88,13 @@ export function useQuickChat(): UseQuickChat {
           typeof window !== "undefined"
             ? window.localStorage.getItem(LAST_FAMILIAR_KEY)
             : null;
+        const preferred = preferredRef.current;
         setFamiliars(next);
+        // Default priority: the workspace's active familiar, then the last
+        // familiar used in quick chat, then the first in the roster.
         setSelectedFamiliarId(
-          (stored && next.some((familiar) => familiar.id === stored) ? stored : null) ??
+          (preferred && next.some((familiar) => familiar.id === preferred) ? preferred : null) ??
+            (stored && next.some((familiar) => familiar.id === stored) ? stored : null) ??
             next[0]?.id ??
             null,
         );
@@ -86,6 +108,14 @@ export function useQuickChat(): UseQuickChat {
       alive = false;
     };
   }, []);
+
+  // Follow the workspace's active familiar as it changes — until the user has
+  // explicitly picked one in the popover (their choice then sticks).
+  useEffect(() => {
+    if (!preferredFamiliarId || userPickedRef.current) return;
+    if (!familiars.some((familiar) => familiar.id === preferredFamiliarId)) return;
+    setSelectedFamiliarId(preferredFamiliarId);
+  }, [preferredFamiliarId, familiars]);
 
   // Abort any in-flight stream when the consumer unmounts.
   useEffect(() => {
@@ -136,7 +166,9 @@ export function useQuickChat(): UseQuickChat {
   return {
     familiars,
     selectedFamiliarId,
-    setSelectedFamiliarId,
+    // Manual picks flow through pickFamiliar so they override the
+    // workspace-active default from then on.
+    setSelectedFamiliarId: pickFamiliar,
     selectedFamiliar,
     draft,
     setDraft,


### PR DESCRIPTION
## What

The quick-chat popover opened on the **last-used-or-first** familiar, ignoring the one you're actually scoped to in the workspace. Now it **defaults to the workspace's active familiar** — hit ⌘J while scoped to Sage and you're talking to Sage.

Priority: **workspace-active → last-used → first**. A **manual pick in the popover still wins** once made (it stops following the workspace scope), and the Tauri tray window keeps its existing bare `useQuickChat()` behavior (no workspace context there).

## How
- `use-quick-chat.ts` — `useQuickChat({ preferredFamiliarId })`: the roster-load default prefers it; a follow-effect adopts workspace-scope changes until the user manually picks (`pickFamiliar` marks `userPickedRef`, and the exposed `setSelectedFamiliarId` routes through it).
- `quick-chat-overlay.tsx` — new `activeFamiliarId` prop → passed to the hook.
- `workspace.tsx` — passes `activeFamiliarId={activeId}`.

## Verification
- Tests + `pnpm build` green.
- Drove the app with active familiar seeded to `sage` (roster first = `nova`, last-used cleared): **⌘J → popover opens on `@sage`** ✓. Manually picked `echo`, closed and reopened: **stays `echo`** (manual pick sticks) ✓.

Quick-chat arc: #2185 → #2197 → #2204 → #2209 → #2224 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)