### PR TITLE
Evals UI/UX slice 2: run-trend deltas + quiet attention rows

### DIFF
--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -1359,15 +1359,30 @@ function RunsPanel({
 
   return (
     <div className="evals-runs">
-      {runs.map((r) => {
+      {runs.map((r, i) => {
         const open = r.id === expandedRunId;
         const passed = r.summary.passRate >= 0.999;
+        // Runs render newest-first, so the chronologically previous run is the
+        // NEXT list entry. Surfaces the trend at a glance without opening
+        // Insights; the oldest run has no baseline so it gets no chip.
+        const prev = runs[i + 1];
+        const deltaPts = prev ? Math.round((r.summary.passRate - prev.summary.passRate) * 100) : null;
         return (
           <article className={`evals-run${open ? " is-open" : ""}`} key={r.id}>
             <button type="button" className="evals-run-head" onClick={() => onToggle(r.id)} aria-expanded={open}>
               <span className={`evals-run-rate${passed ? " is-pass" : r.summary.passRate >= 0.5 ? " is-mid" : " is-fail"}`}>{pct(r.summary.passRate)}</span>
               <span className="evals-run-meta">
-                <span className="evals-run-count">{r.summary.passed}/{r.summary.total} passed</span>
+                <span className="evals-run-count">
+                  {r.summary.passed}/{r.summary.total} passed
+                  {deltaPts !== null ? (
+                    <span
+                      className={`evals-run-delta${deltaPts > 0 ? " is-up" : deltaPts < 0 ? " is-down" : " is-flat"}`}
+                      title="Pass-rate change vs the previous run"
+                    >
+                      {deltaPts > 0 ? `+${deltaPts}` : deltaPts} pts
+                    </span>
+                  ) : null}
+                </span>
                 <span className="evals-run-sub">{r.familiarName ?? r.familiarId} · {new Date(r.startedAt).toLocaleString()} · {Math.round(r.summary.avgLatencyMs)}ms avg</span>
               </span>
               <Icon name={open ? "ph:caret-up" : "ph:caret-down"} width={14} />

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -575,16 +575,17 @@
 .evals-insight-list {
   display: flex;
   flex-direction: column;
-  gap: 9px;
+  gap: 4px;
   color: var(--text-secondary);
   font-size: var(--text-sm);
 }
+/* Quiet list rows: a slim left accent on a faint wash. The previous full
+   1px border box made these read as a stack of input fields. */
 .evals-insight-list li {
-  padding: 9px 10px;
-  border: 1px solid var(--border-hairline);
-  border-left: 3px solid color-mix(in oklch, var(--accent-presence) 48%, var(--border));
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--bg-base) 74%, transparent);
+  padding: 7px 10px;
+  border-left: 2px solid color-mix(in oklch, var(--accent-presence) 42%, transparent);
+  border-radius: 0 6px 6px 0;
+  background: color-mix(in oklch, var(--foreground) 3%, transparent);
 }
 .evals-analysis-copy {
   margin: 0;
@@ -1290,6 +1291,19 @@
 .evals-run-rate.is-fail { color: var(--color-danger); border: 1px solid color-mix(in oklch, var(--color-danger) 40%, transparent); }
 .evals-run-meta { display: flex; flex-direction: column; gap: 1px; margin-right: auto; min-width: 0; }
 .evals-run-count { font-size: var(--text-sm); font-weight: 600; }
+/* Pass-rate delta vs the previous run, inline after the passed count. */
+.evals-run-delta {
+  margin-left: 8px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  vertical-align: 1px;
+}
+.evals-run-delta.is-up { color: var(--color-success); background: color-mix(in oklch, var(--color-success) 14%, transparent); }
+.evals-run-delta.is-down { color: var(--color-danger); background: color-mix(in oklch, var(--color-danger) 14%, transparent); }
+.evals-run-delta.is-flat { color: var(--text-muted); background: color-mix(in oklch, var(--foreground) 7%, transparent); }
 .evals-run-sub { font-size: var(--text-2xs); color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 /* ---- Result list -------------------------------------------------------- */


### PR DESCRIPTION
## What
Second slice of the Evals UI/UX optimization (follows #2228).

1. **Runs tab — trend at a glance:** each run row gets a `±N pts` chip comparing its pass rate to the chronologically previous run (green up / red down / muted flat, tabular numerals). The oldest run has no baseline, so no chip. No need to open Insights to see whether the suite is improving.
2. **Overview — quiet attention rows:** the attention-queue items had a full 1px border box that made them read as a stack of input fields. Now minimal list rows — a slim left accent on a faint wash — matching the surface's minimalist direction.

## Verification
- Prod build + mocked run history (100%→67%→67%→100%): chips render `+33 pts`, `0 pts`, `-33 pts`, none on the oldest run (screenshot-verified).
- Compiled CSS carries only the `border-left` accent for the attention rows — the full border is gone.
- Typecheck clean; `evals-view.test.ts` + `eval-groups-panel.test.ts` pass; Frontend build green, bundle within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)