### PR TITLE
chore(release): stamp v0.0.131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.131] - 2026-07-01
+
+Patch release on top of v0.0.130. Headline: eval failure analysis is easier
+to read, and quick chat now opens on the workspace's active familiar.
+
+### Added
+
+- **Quick-chat** - default the popover to the active familiar for the current
+  workspace, so `⌘J` lands on the familiar already in focus.
+
+### Changed
+
+- **Evals** - replaced the failures-by-case SVG block with labeled horizontal
+  rows, untruncated stat cards, and readable failure counts.
+
+### Fixed
+
+- **Evals** - keyed failure rows by stable case id and preserved non-zero
+  proportional bar widths for small failure ratios.
+
 ## [0.0.130] - 2026-07-01
 
 Patch release on top of v0.0.129. Headline: the Changes panel can now commit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.130"
+version = "0.0.131"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.130"
+version = "0.0.131"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.130</string>
+	<string>0.0.131</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.130</string>
+	<string>0.0.131</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.130</string>
+	<string>0.0.131</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.130</string>
+	<string>0.0.131</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.130",
+  "version": "0.0.131",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- bump Cave version metadata to 0.0.131
- add changelog notes for evals readability and quick-chat active familiar release

## Test Plan
- node --experimental-strip-types src/lib/app-version.test.ts
- node --test scripts/release-notes.test.mjs
- git diff --check