### PR TITLE
feat(marketplace): default the netdata + nuxt-dev MCP URL fields

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -2615,6 +2615,7 @@
           "title": "Netdata MCP URL",
           "description": "MCP endpoint: a local agent/parent (http://YOUR_IP:19999/mcp, Netdata v2.7.2+) or Netdata Cloud (https://app.netdata.cloud/api/v1/mcp).",
           "required": true,
+          "default": "http://localhost:19999/mcp",
           "sensitive": false,
           "env": "NETDATA_MCP_URL"
         },
@@ -2866,6 +2867,7 @@
           "title": "Nuxt Dev MCP URL",
           "description": "SSE endpoint exposed by the nuxt-mcp-dev module or vite-plugin-mcp (e.g. http://localhost:3000/__mcp/sse).",
           "required": true,
+          "default": "http://localhost:3000/__mcp/sse",
           "sensitive": false,
           "env": "NUXT_MCP_URL"
         }

--- a/marketplace/plugins/netdata/plugin.json
+++ b/marketplace/plugins/netdata/plugin.json
@@ -69,6 +69,7 @@
       "title": "Netdata MCP URL",
       "description": "MCP endpoint: a local agent/parent (http://YOUR_IP:19999/mcp, Netdata v2.7.2+) or Netdata Cloud (https://app.netdata.cloud/api/v1/mcp).",
       "required": true,
+      "default": "http://localhost:19999/mcp",
       "sensitive": false,
       "env": "NETDATA_MCP_URL"
     },

--- a/marketplace/plugins/nuxt-dev/plugin.json
+++ b/marketplace/plugins/nuxt-dev/plugin.json
@@ -56,6 +56,7 @@
       "title": "Nuxt Dev MCP URL",
       "description": "SSE endpoint exposed by the nuxt-mcp-dev module or vite-plugin-mcp (e.g. http://localhost:3000/__mcp/sse).",
       "required": true,
+      "default": "http://localhost:3000/__mcp/sse",
       "sensitive": false,
       "env": "NUXT_MCP_URL"
     }


### PR DESCRIPTION
Follow-up to #2225. Adds the two config-field defaults I deliberately skipped there, now that the canonical local values are confirmed from each field's own description in the catalog:

- `netdata.netdata_mcp_url` → `http://localhost:19999/mcp` (local agent/parent, Netdata v2.7.2+)
- `nuxt-dev.nuxt_mcp_url` → `http://localhost:3000/__mcp/sse` (nuxt-mcp dev SSE endpoint)

Both are non-sensitive required fields, so the Set up modal pre-fills them. netdata's Bearer **API key** is sensitive and correctly stays unset.

Data-only change (catalog + regenerated plugin manifests); `sync-marketplace.py --check` green, `marketplace-catalog.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)