### PR TITLE
feat(board): attachment polish — table paperclip count + follow-up context line

### DIFF
--- a/src/components/board-table-familiar-select.test.ts
+++ b/src/components/board-table-familiar-select.test.ts
@@ -26,4 +26,11 @@ assert.match(
   "BoardView should wire BoardTable inline edits to the existing patchCard flow",
 );
 
+// ── Title cell shows a paperclip count when the card carries attachments ─────
+assert.match(
+  boardTable,
+  /className="board-table-attach-count"[\s\S]*?ph:paperclip[\s\S]*?card\.attachments!\.length/,
+  "the table's title cell surfaces a paperclip + attachment count (kanban parity)",
+);
+
 console.log("board table familiar select guard passed");

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -399,6 +399,16 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                                 </span>
                               )}
                               <span className="board-table-title" title={card.title}>{card.title}</span>
+                              {(card.attachments?.length ?? 0) > 0 && (
+                                <span
+                                  className="board-table-attach-count"
+                                  title={`${card.attachments!.length} attachment${card.attachments!.length === 1 ? "" : "s"}`}
+                                  style={{ display: "inline-flex", alignItems: "center", gap: 2, flexShrink: 0, fontSize: 10, color: "var(--text-muted)" }}
+                                >
+                                  <Icon name="ph:paperclip" width={10} />
+                                  {card.attachments!.length}
+                                </span>
+                              )}
                             </span>
                           );
                           break;

--- a/src/lib/task-chat-context.test.ts
+++ b/src/lib/task-chat-context.test.ts
@@ -30,6 +30,24 @@ assert.match(context, /Labels: chat, tasks/);
 assert.match(context, /Notes:\nFollow-up chat turns need the task details\./);
 assert.match(context, /Links:\n- https:\/\/github\.com\/OpenCoven\/coven-cave\/pull\/1/);
 assert.match(context, /GitHub:\n- Task chat bug: https:\/\/github\.com\/OpenCoven\/coven-cave\/issues\/2/);
+// No attachments on this card → no summary line.
+assert.doesNotMatch(context, /Attachments:/);
+
+// Follow-up-turn context names the card's attachments (content rides only on the
+// initial dispatch prompt — this keeps later turns aware without the bulk).
+const contextWithAttachments = buildTaskContext({
+  title: "Ship the onboarding flow",
+  attachments: [
+    { name: "spec.md", type: "text/markdown", size: 24, text: "# Onboarding" },
+    { name: "mockup.png", type: "image/png", size: 4096 },
+  ],
+});
+assert.match(contextWithAttachments, /Attachments: spec\.md, mockup\.png/);
+assert.doesNotMatch(
+  contextWithAttachments,
+  /# Onboarding/,
+  "the summary line must not inline attachment content",
+);
 
 const prompt = buildTaskAwarePrompt("What should I do next?", context);
 assert.match(prompt, /^Task context:/);

--- a/src/lib/task-chat-context.ts
+++ b/src/lib/task-chat-context.ts
@@ -47,6 +47,14 @@ export function buildTaskContext(card: TaskContextCard): string {
     ),
   );
 
+  // Name the card's attachments so follow-up turns know files exist. Only the
+  // initial dispatch prompt carries their full content (buildInitialTaskChatPrompt);
+  // here a summary line keeps every later turn's context small.
+  const attachmentNames = (card.attachments ?? [])
+    .map((attachment) => attachment.name.trim())
+    .filter(Boolean);
+  if (attachmentNames.length) lines.push(`Attachments: ${attachmentNames.join(", ")}`);
+
   return lines.join("\n");
 }
 


### PR DESCRIPTION
## What

Closes the last two gaps from the attachment arc (#2219 → #2221 → #2223):

1. **Table view parity** — `board-table` title cells show a paperclip + count when a card carries attachments, matching the kanban chip.
2. **Follow-up-turn awareness** — `buildTaskContext` now names the card's attachments (`Attachments: spec.md, mockup.png`), so every follow-up task-chat turn knows files exist. Full content still rides only on the initial dispatch prompt (`buildInitialTaskChatPrompt`) — the summary line keeps later turns' context small, and is asserted not to inline content.

## Verification (live app)
- Seeded a card with 2 attachments → Table view row shows `📎 2` next to the title, 0 page errors.
- Printed the actual follow-up prompt: `Task context: … Attachments: onboarding-spec.md, mockup.png` above `Current user message:` — names only, no bodies.

## Tests
- `task-chat-context.test.ts`: attachments line present with names, absent when no attachments, never inlines content.
- `board-table-familiar-select.test.ts`: title cell surfaces the paperclip count.
- Typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)