### PR TITLE
Evals UI/UX slice 3: Compare verdict chips + guided empty states

### DIFF
--- a/src/components/evals/run-compare.tsx
+++ b/src/components/evals/run-compare.tsx
@@ -27,7 +27,13 @@ export function RunCompare({ runs }: { runs: EvalRun[] }) {
   const [onlyChanged, setOnlyChanged] = useState(true);
 
   if (ordered.length < 2) {
-    return <div className="evals-empty">Need at least two runs to compare.</div>;
+    return (
+      <div className="evals-empty">
+        {ordered.length === 0
+          ? "No runs yet — run this suite twice, then compare the results here."
+          : "One run recorded. Run the suite again to compare results run-over-run."}
+      </div>
+    );
   }
 
   const before = ordered.find((r) => r.id === beforeId) ?? ordered[1];
@@ -36,6 +42,13 @@ export function RunCompare({ runs }: { runs: EvalRun[] }) {
   const shown = onlyChanged
     ? rows.filter((r) => r.status !== "pass")
     : rows;
+
+  // Headline verdict before the row detail: how many cases moved, and which way.
+  const counts = new Map<RunDiffStatus, number>();
+  for (const r of rows) counts.set(r.status, (counts.get(r.status) ?? 0) + 1);
+  const summary = (["regressed", "fixed", "added", "removed", "fail"] as RunDiffStatus[])
+    .filter((s) => (counts.get(s) ?? 0) > 0)
+    .map((s) => ({ status: s, count: counts.get(s)! }));
 
   const label = (r: EvalRun) =>
     `${new Date(r.startedAt).toLocaleString()} · ${Math.round(r.summary.passRate * 100)}%`;
@@ -63,26 +76,46 @@ export function RunCompare({ runs }: { runs: EvalRun[] }) {
           <input type="checkbox" checked={onlyChanged} onChange={(e) => setOnlyChanged(e.target.checked)} /> Only changes
         </label>
       </div>
-      <table className="evals-diff">
-        <thead>
-          <tr>
-            <th>Case</th>
-            <th>Before</th>
-            <th>After</th>
-            <th>Change</th>
-          </tr>
-        </thead>
-        <tbody>
-          {shown.map((r) => (
-            <tr key={r.caseId} className={`evals-diff__row--${r.status}`}>
-              <td>{r.name}</td>
-              <td>{r.before == null ? "—" : r.before ? "Pass" : "Fail"}</td>
-              <td>{r.after == null ? "—" : r.after ? "Pass" : "Fail"}</td>
-              <td className="evals-diff__status">{STATUS_LABEL[r.status]}</td>
+
+      {/* Verdict line: what moved between the two runs, before the row detail. */}
+      <div className="evals-compare__summary" role="status">
+        {summary.length === 0 ? (
+          <span className="evals-compare__chip is-clean">No changes · all {rows.length} case{rows.length === 1 ? "" : "s"} identical</span>
+        ) : (
+          summary.map((s) => (
+            <span key={s.status} className={`evals-compare__chip is-${s.status}`}>
+              {s.count} {STATUS_LABEL[s.status].toLowerCase()}
+            </span>
+          ))
+        )}
+      </div>
+
+      {shown.length === 0 ? (
+        <p className="evals-compare__none">
+          Untick “Only changes” to see all {rows.length} passing row{rows.length === 1 ? "" : "s"}.
+        </p>
+      ) : (
+        <table className="evals-diff">
+          <thead>
+            <tr>
+              <th>Case</th>
+              <th>Before</th>
+              <th>After</th>
+              <th>Change</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {shown.map((r) => (
+              <tr key={r.caseId} className={`evals-diff__row--${r.status}`}>
+                <td>{r.name}</td>
+                <td>{r.before == null ? "—" : r.before ? "Pass" : "Fail"}</td>
+                <td>{r.after == null ? "—" : r.after ? "Pass" : "Fail"}</td>
+                <td className="evals-diff__status">{STATUS_LABEL[r.status]}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -1682,6 +1682,23 @@
 .evals-diff__row--regressed .evals-diff__status { color: var(--color-danger); }
 .evals-diff__row--fixed .evals-diff__status { color: var(--color-success); }
 
+/* Compare verdict chips: the headline of the diff before the row detail. */
+.evals-compare__summary { display: flex; flex-wrap: wrap; gap: 6px; }
+.evals-compare__chip {
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--foreground) 7%, transparent);
+}
+.evals-compare__chip.is-regressed { color: var(--color-danger); background: color-mix(in oklch, var(--color-danger) 14%, transparent); }
+.evals-compare__chip.is-fail { color: var(--color-danger); background: color-mix(in oklch, var(--color-danger) 9%, transparent); }
+.evals-compare__chip.is-fixed { color: var(--color-success); background: color-mix(in oklch, var(--color-success) 14%, transparent); }
+.evals-compare__chip.is-clean { color: var(--color-success); background: color-mix(in oklch, var(--color-success) 10%, transparent); }
+.evals-compare__none { margin: 0; color: var(--text-muted); font-size: var(--text-sm); }
+
 @media (max-width: 720px) {
   .evals-insights,
   .evals-compare {


### PR DESCRIPTION
## What
Third slice of the Evals UI/UX optimization (follows #2228, #2231). All Compare-tab:

1. **Verdict chips above the diff** — status counts (`1 regressed` in danger red, `1 fixed` in success green, plus added/removed/fail; `No changes · all N cases identical` when the runs match). The comparison's outcome lands before the row detail.
2. **No more empty table** — with "Only changes" on and nothing changed, a one-line hint replaces the orphaned table headers.
3. **Guided empty state** — with <2 runs, the message now says how to get a comparison ("run this suite twice") instead of the bare "Need at least two runs."

## Verification
- Prod build + mocked regress/fix run pair: chips render `1 regressed · 1 fixed` above the highlighted rows (screenshot-verified); comparing a run against itself yields `1 fail` — an unchanged failure, correctly still surfaced under "Only changes".
- Typecheck clean; `evals-view.test.ts` + `eval-analytics.test.ts` pass; Frontend build green, bundle within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)