### PR TITLE
fix(chat): stop 403 "project access denied" for familiars chatting in their own workspace

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -596,6 +596,7 @@ export const SUITES = {
     "src/lib/openclaw-conversation.test.ts",
     "src/lib/session-initiator.test.ts",
     "src/lib/chat-runtime-scope.test.ts",
+    "src/lib/chat-project-access.test.ts",
     "src/lib/chat-history-fallback.test.ts",
     "src/lib/familiar-identity-scaffold.test.ts",
     "src/lib/session-list-merge.test.ts",

--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -358,14 +358,14 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /async function chatProjectAccessId\([\s\S]*projectForRoot\(projectRoot, projects\)[\s\S]*projectForRoot\(args\.resolvedCwd, projects\)[\s\S]*return explicitRoot \? `unregistered:\$\{projectRoot\}` : null;/,
-  "Chat send should resolve explicit and resumed project roots to a project access id and fail unknown explicit roots closed",
+  /import \{ chatProjectAccessId \} from "@\/lib\/chat-project-access";/,
+  "Chat send should resolve project access ids through the shared chat-project-access helper (explicit and resumed roots resolve to a project id; unknown explicit roots fail closed; the familiar's own workspace is exempt — see chat-project-access.test.ts)",
 );
 
 assert.match(
   chatRoute,
-  /const chatProjectId = sshRuntime[\s\S]*await chatProjectAccessId\(\{[\s\S]*requestedProjectRoot: body\.projectRoot,[\s\S]*resumeCwd,[\s\S]*resolvedCwd: cwd,[\s\S]*\}\);[\s\S]*await assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\);/,
-  "Local project-scoped chat must assert project access before building the harness prompt",
+  /const chatProjectId = sshRuntime[\s\S]*chatProjectAccessId\(\{[\s\S]*requestedProjectRoot: body\.projectRoot,[\s\S]*resumeCwd,[\s\S]*resolvedCwd: cwd,[\s\S]*familiarWorkspace: resolvedFamiliarWorkspace,[\s\S]*\}\);[\s\S]*await assertProjectAccess\(\{ familiarId: body\.familiarId \}, chatProjectId, "chat"\);/,
+  "Local project-scoped chat must assert project access — with the familiar's own workspace exempt — before building the harness prompt",
 );
 
 assert.doesNotMatch(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -42,7 +42,8 @@ import {
 import { parseAgentAttachments } from "@/lib/server/agent-attachments";
 import { buildNextPathsDirective } from "@/lib/next-paths";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
-import { loadProjects, projectForRoot } from "@/lib/cave-projects";
+import { loadProjects } from "@/lib/cave-projects";
+import { chatProjectAccessId } from "@/lib/chat-project-access";
 import { openClawBin, openClawNeedsShell, openClawSpawnArgs, openClawSpawnEnv } from "@/lib/openclaw-bin";
 import {
   familiarWorkspacesRoot,
@@ -196,29 +197,6 @@ async function conversationCwd(sessionId?: string): Promise<string | undefined> 
     /* fall back to the caller's default */
   }
   return undefined;
-}
-
-async function chatProjectAccessId(args: {
-  projects: Awaited<ReturnType<typeof loadProjects>>;
-  requestedProjectRoot?: string;
-  resumeCwd?: string;
-  resolvedCwd: string;
-}): Promise<string | null> {
-  const explicitRoot = args.requestedProjectRoot?.trim() || undefined;
-  const resumedRoot = !explicitRoot ? args.resumeCwd?.trim() || undefined : undefined;
-  const projectRoot = explicitRoot ?? resumedRoot;
-  if (!projectRoot) return null;
-
-  const projects = args.projects;
-  const project =
-    projectForRoot(projectRoot, projects) ??
-    projectForRoot(args.resolvedCwd, projects);
-  if (project) return project.id;
-
-  // An explicit projectRoot that is not registered is still a project-scoped
-  // chat request. Fail it closed through the shared permission chokepoint so
-  // the decision is audited and only Supreme can proceed.
-  return explicitRoot ? `unregistered:${projectRoot}` : null;
 }
 
 /** Resolve the familiar's Coven workspace dir.
@@ -1059,13 +1037,17 @@ export async function POST(req: Request) {
     throw error;
   }
   const projects = sshRuntime ? [] : await loadProjects();
+  const resolvedFamiliarWorkspace = !sshRuntime
+    ? await resolveFamiliarWorkspace(body.familiarId)
+    : undefined;
   const chatProjectId = sshRuntime
     ? null
-    : await chatProjectAccessId({
+    : chatProjectAccessId({
         projects,
         requestedProjectRoot: body.projectRoot,
         resumeCwd,
         resolvedCwd: cwd,
+        familiarWorkspace: resolvedFamiliarWorkspace,
       });
   if (chatProjectId) {
     try {
@@ -1083,9 +1065,6 @@ export async function POST(req: Request) {
   const grantedProjectRoots = sshRuntime
     ? []
     : (await filterProjectsForFamiliar(projects, body.familiarId)).map((project) => project.root);
-  const resolvedFamiliarWorkspace = !sshRuntime
-    ? await resolveFamiliarWorkspace(body.familiarId)
-    : undefined;
   // Resolve familiar workspace for identity context. When a project root is
   // explicitly set, the harness boots there (and should have the familiar's
   // AGENTS.md injected separately). When there's no project root, boot in the

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -797,8 +797,8 @@ assert.match(
 );
 assert.match(
   mentionSource,
-  /projectRoot: activeProjectRoot/,
-  "The send body must use the selected project root",
+  /projectRoot: requestProjectRoot/,
+  "The send body must use the vetted project root (selected project, minus unregistered session-cwd echoes)",
 );
 assert.match(
   mentionSource,

--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -117,3 +117,27 @@ assert.doesNotMatch(
   /native Cave chat only supports Codex, Claude Code, and Hermes right now/,
   "ChatView should allow OpenClaw familiars through native chat send",
 );
+
+// REGRESSION (2026-07-01): a no-project chat boots the harness in the
+// familiar's own workspace and the daemon records that dir as the session's
+// project_root. Echoing the recorded cwd back to /api/chat/send as an
+// explicit projectRoot made the server fail closed on the next turn
+// ("unregistered project" → 403 project access denied). The send body must
+// only assert a root that maps to a registered project or an explicit pick.
+assert.match(
+  source,
+  /const requestProjectRoot =[\s\S]{0,200}activeProjectRoot === session\?\.project_root &&[\s\S]{0,120}!projectIdForRoot\(activeProjectRoot, projects\)/,
+  "ChatView should drop a session-echoed cwd that maps to no registered project before sending",
+);
+
+assert.match(
+  source,
+  /projectRoot: requestProjectRoot,/,
+  "ChatView should send the vetted requestProjectRoot to /api/chat/send",
+);
+
+assert.doesNotMatch(
+  source,
+  /projectRoot: activeProjectRoot,/,
+  "ChatView must not echo the raw activeProjectRoot (session cwd) as an explicit projectRoot",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2199,6 +2199,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     ? chatProjectById(resolvedProjectId, projects) ?? firstProject
     : firstProject;
   const activeProjectRoot = selectedProject?.root ?? session?.project_root ?? projectRoot ?? "";
+  // Root asserted to the server on send. A session's recorded cwd is NOT an
+  // explicit project choice: a no-project chat boots in the familiar's own
+  // workspace and the daemon records that dir as project_root. Echoing it back
+  // as projectRoot makes the server treat the next turn as an
+  // unregistered-project request and fail closed (403 "project access
+  // denied"). Only assert a root that maps to a registered project or came
+  // from an explicit selection; the server derives the resume cwd from the
+  // conversation record when no root rides.
+  const requestProjectRoot =
+    activeProjectRoot &&
+    activeProjectRoot === session?.project_root &&
+    !projectIdForRoot(activeProjectRoot, projects)
+      ? ""
+      : activeProjectRoot;
   useEffect(() => {
     onProjectRootChange?.(activeProjectRoot || null);
   }, [activeProjectRoot, onProjectRootChange]);
@@ -3384,7 +3398,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(outgoingAttachments) } : {}),
           ...(origin ? { origin } : {}),
           sessionId: liveGeneration.sessionId,
-          projectRoot: activeProjectRoot,
+          projectRoot: requestProjectRoot,
           reasoningEffort: controlsOverride?.thinkingEffort ?? thinkingEffort,
           responseSpeed: controlsOverride?.responseSpeed ?? responseSpeed,
           // Advisory permission mode for the picked access level; the daemon may

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -36,8 +36,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /projectRoot: activeProjectRoot/,
-  "Every send includes the selected project's root",
+  /projectRoot: requestProjectRoot/,
+  "Every send includes the selected project's root (vetted: an unregistered session-cwd echo is dropped so the server doesn't fail it closed)",
 );
 assert.match(
   chatView,

--- a/src/lib/chat-project-access.test.ts
+++ b/src/lib/chat-project-access.test.ts
@@ -1,0 +1,123 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+import { chatProjectAccessId } from "./chat-project-access.ts";
+
+const projects = [
+  {
+    id: "proj-1",
+    name: "Cave",
+    root: "/Users/me/dev/cave",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+const codyWorkspace = "/Users/me/.coven/workspaces/familiars/cody";
+
+assert.equal(
+  chatProjectAccessId({ projects, resolvedCwd: "/Users/me" }),
+  null,
+  "a chat with no project root is not project-scoped",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: "/Users/me/dev/cave",
+    resolvedCwd: "/Users/me/dev/cave",
+  }),
+  "proj-1",
+  "an explicit registered root resolves to its project id (grant check applies)",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: "/Users/me/dev/cave/",
+    resolvedCwd: "/Users/me",
+  }),
+  "proj-1",
+  "trailing slashes still match the registered project",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    resumeCwd: "/Users/me/dev/cave",
+    resolvedCwd: "/Users/me/dev/cave",
+  }),
+  "proj-1",
+  "a resumed conversation in a registered project keeps the grant check",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: "/Users/me/somewhere-else",
+    resolvedCwd: "/Users/me/somewhere-else",
+  }),
+  "unregistered:/Users/me/somewhere-else",
+  "an explicit unregistered root fails closed through the permission chokepoint",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    resumeCwd: codyWorkspace,
+    resolvedCwd: codyWorkspace,
+  }),
+  null,
+  "a resumed unregistered cwd is not an explicit project request",
+);
+
+// REGRESSION (2026-07-01): a no-project chat boots in the familiar's own
+// workspace, the daemon records that dir as the session cwd, and the client
+// echoes it back as an explicit projectRoot on the next turn. That echo must
+// not fail closed — it denied the familiar its own home with a 403
+// "project access denied" on turn 2 of every no-project chat.
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: codyWorkspace,
+    resolvedCwd: codyWorkspace,
+    familiarWorkspace: codyWorkspace,
+  }),
+  null,
+  "a familiar chatting in its own workspace is allowed (no project scope)",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: `${codyWorkspace}/`,
+    resolvedCwd: codyWorkspace,
+    familiarWorkspace: codyWorkspace,
+  }),
+  null,
+  "the own-workspace exemption tolerates unnormalized paths",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: "/Users/me/.coven/workspaces/familiars/sage",
+    resolvedCwd: "/Users/me/.coven/workspaces/familiars/sage",
+    familiarWorkspace: codyWorkspace,
+  }),
+  "unregistered:/Users/me/.coven/workspaces/familiars/sage",
+  "another familiar's workspace still fails closed",
+);
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: "/Users/me/dev/cave",
+    resolvedCwd: "/Users/me/dev/cave",
+    familiarWorkspace: codyWorkspace,
+  }),
+  "proj-1",
+  "a registered project wins over the workspace exemption",
+);
+
+console.log("chat-project-access tests passed");

--- a/src/lib/chat-project-access.ts
+++ b/src/lib/chat-project-access.ts
@@ -1,0 +1,54 @@
+import path from "node:path";
+
+import type { CaveProject } from "./cave-projects-types.ts";
+import { projectForRoot } from "./cave-projects.ts";
+
+export type ChatProjectAccessArgs = {
+  projects: CaveProject[];
+  /** Explicit projectRoot from the request body, when the client sent one. */
+  requestedProjectRoot?: string;
+  /** Recorded cwd of the resumed conversation, when no explicit root rides. */
+  resumeCwd?: string;
+  /** The cwd the runtime scope resolved for this turn. */
+  resolvedCwd: string;
+  /** The requesting familiar's own workspace dir (realpath-resolved), when it exists. */
+  familiarWorkspace?: string;
+};
+
+function samePath(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
+
+/**
+ * Resolve the project id a chat request must hold a grant for, or null when
+ * the request is not project-scoped (no permission check applies).
+ *
+ * Registered projects win: an explicit or resumed root that maps to a project
+ * returns that project's id so the grant check runs. An explicit root that
+ * matches no project fails closed as `unregistered:<root>` — audited through
+ * the shared permission chokepoint, and only Supreme can proceed — with one
+ * exemption: the familiar's OWN workspace. Chats with no project selected
+ * boot there, the daemon records that dir as the session's cwd, and clients
+ * echo the recorded cwd back as an explicit projectRoot on later turns.
+ * Fail-closing on it denied the familiar its own home ("project access
+ * denied" 403 on turn 2 of every no-project chat).
+ */
+export function chatProjectAccessId(args: ChatProjectAccessArgs): string | null {
+  const explicitRoot = args.requestedProjectRoot?.trim() || undefined;
+  const resumedRoot = !explicitRoot ? args.resumeCwd?.trim() || undefined : undefined;
+  const projectRoot = explicitRoot ?? resumedRoot;
+  if (!projectRoot) return null;
+
+  const project =
+    projectForRoot(projectRoot, args.projects) ??
+    projectForRoot(args.resolvedCwd, args.projects);
+  if (project) return project.id;
+
+  if (!explicitRoot) return null;
+
+  if (args.familiarWorkspace && samePath(explicitRoot, args.familiarWorkspace)) {
+    return null;
+  }
+
+  return `unregistered:${projectRoot}`;
+}


### PR DESCRIPTION
## Problem

Chatting with a familiar in a **no-project** chat fails on later turns with:

```
request failed (403): project access denied
step: Chat bridge rejected the request ✗ error
```

The permission audit (`~/.coven/cave-project-permissions.json`) shows the mechanism — e.g. `familiarId: "cody"`, `projectId: "unregistered:/Users/…/workspaces/familiars/cody"`, surface `chat`, reason `missing-grant` (also hit by sage on 06-28).

**Feedback loop:** a no-project chat boots the harness in the familiar's own workspace → the daemon records that dir as the session's `project_root` → ChatView echoes the recorded cwd back to `/api/chat/send` as an *explicit* `projectRoot` → the server fail-closes on the unregistered root and denies the familiar its own home. No grant can ever fix it: `unregistered:*` pseudo-ids aren't grantable.

## Fix (two complementary halves)

- **Server** — `chatProjectAccessId` moves to `src/lib/chat-project-access.ts` and exempts the requesting familiar's **own** workspace from the fail-closed unregistered-root path. Registered projects still resolve to their id (grant check applies), other familiars' workspaces and arbitrary explicit roots still fail closed and audit exactly as before.
- **Client** — ChatView sends a vetted `requestProjectRoot`: a session's recorded cwd is only asserted as an explicit `projectRoot` when it maps to a registered project. Otherwise nothing rides and the server derives the resume cwd from the conversation record, as the route already documents.

## Tests

- `src/lib/chat-project-access.test.ts` (wired in run-tests.mjs): pins the regression ("a familiar chatting in its own workspace is allowed"), plus fail-closed unregistered roots, other-familiar workspaces, resumed-root semantics, and registered-project precedence over the exemption.
- Source-text pins updated/added in `chat-view.test.ts`, `chat-view-polish.test.ts`, `task-chat-cwd.test.ts`, `harness-routing.test.ts` so the client can't regress to echoing raw session cwds.

Verified locally: typecheck, `test:api` (112), `test:app` (512), `test:mobile` (65), production build within bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)