### PR TITLE
docs(release): note chat workspace fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ on the workspace's active familiar.
 
 - **Evals** - keyed failure rows by stable case id and preserved non-zero
   proportional bar widths for small failure ratios.
+- **Chat** - stopped `project access denied` 403s when a familiar continues
+  chatting from its own workspace in a no-project thread.
 
 ## [0.0.130] - 2026-07-01
 


### PR DESCRIPTION
## Summary
- add the merged familiar workspace chat 403 fix to the v0.0.131 changelog before tagging

## Test Plan
- node --test scripts/release-notes.test.mjs
- git diff --check