### PR TITLE
test(board): e2e attachment pipeline + by-design image note at dispatch

### DIFF
--- a/src/lib/chat-attachments.test.ts
+++ b/src/lib/chat-attachments.test.ts
@@ -44,6 +44,12 @@ assert.match(prompt, /2\. diagram\.png \(image\/png, 128 B\)\n\(image attachment
 assert.doesNotMatch(prompt, /2\. diagram\.png[^\n]*\n\(content unavailable\)/);
 assert.match(prompt, /3\. secret\.txt \(text\/plain, 12 B\)/);
 
+// Board dispatch opts into the by-design metadata-only wording: task cards strip
+// image payloads at storage, so their absence isn't a delivery failure.
+const boardPrompt = buildPromptWithAttachments("Work the task.", attachments, { imagesMetadataOnly: true });
+assert.match(boardPrompt, /2\. diagram\.png \(image\/png, 128 B\)\n\(image attached as metadata only — task cards don't store image content\)/);
+assert.doesNotMatch(boardPrompt, /was not delivered/);
+
 const mediaPrompt = buildPromptWithAttachments("Summarize these.", normalizeChatAttachments([
   {
     name: "demo.mp4",

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -8,6 +8,8 @@ export const IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE =
   "(image attachments are not supported by this harness)";
 const IMAGE_NOT_DELIVERED_NOTE =
   "(image attachment was not delivered — payload missing or over the size limit)";
+const IMAGE_METADATA_ONLY_NOTE =
+  "(image attached as metadata only — task cards don't store image content)";
 const VIDEO_METADATA_ONLY_NOTE =
   "(video attached as metadata only — frames and audio are not decoded yet)";
 const FILE_METADATA_ONLY_NOTE =
@@ -163,6 +165,10 @@ export type AttachmentPromptOptions = {
   /** When false, image entries render an explicit unsupported notice (e.g. a
    * bridge harness with no access to this machine's filesystem). */
   imagesSupported?: boolean;
+  /** When true, undelivered images render a by-design metadata-only note
+   * instead of the "not delivered" failure wording — board cards strip image
+   * payloads at storage, so their absence at dispatch is expected. */
+  imagesMetadataOnly?: boolean;
 };
 
 export function buildPromptWithAttachments(
@@ -190,6 +196,8 @@ export function buildPromptWithAttachments(
         body = IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE;
       } else if (savedPath) {
         body = `Image saved to ${savedPath} — open it with the Read tool to view.`;
+      } else if (options.imagesMetadataOnly) {
+        body = IMAGE_METADATA_ONLY_NOTE;
       } else {
         body = IMAGE_NOT_DELIVERED_NOTE;
       }

--- a/src/lib/task-chat-context.test.ts
+++ b/src/lib/task-chat-context.test.ts
@@ -82,3 +82,9 @@ assert.match(promptWithAttachments, /Attached files:/);
 assert.match(promptWithAttachments, /1\. spec\.md/);
 assert.match(promptWithAttachments, /# Onboarding\n- step one/);
 assert.match(promptWithAttachments, /2\. mockup\.png/);
+assert.match(
+  promptWithAttachments,
+  /\(image attached as metadata only — task cards don't store image content\)/,
+  "board images use the by-design metadata-only note, not the delivery-failure wording",
+);
+assert.doesNotMatch(promptWithAttachments, /was not delivered/);

--- a/src/lib/task-chat-context.ts
+++ b/src/lib/task-chat-context.ts
@@ -70,7 +70,9 @@ export function buildInitialTaskChatPrompt(card: TaskContextCard): string {
   // Board attachments are stored lean (text inlined; image dataUrls stripped),
   // so buildPromptWithAttachments renders text bodies in full and images as a
   // metadata line — exactly the once-at-dispatch delivery the composer uses.
-  return attachments.length ? buildPromptWithAttachments(base, attachments) : base;
+  return attachments.length
+    ? buildPromptWithAttachments(base, attachments, { imagesMetadataOnly: true })
+    : base;
 }
 
 export async function taskContextForSession(sessionId?: string | null): Promise<string | null> {

--- a/tests/board-attachments.spec.ts
+++ b/tests/board-attachments.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+
+// Board-destination attachments, end to end in the UI (arc #2219→#2234):
+// stage a file on the home composer → Task destination → the POST /api/board
+// body carries it → the board renders the paperclip chip → the inspector lists
+// the files. Daemon-less: every asserted route is mocked.
+
+const cardWithAttachments = {
+  id: "att-1",
+  title: "Task with files",
+  notes: "",
+  status: "backlog",
+  priority: "medium",
+  familiarId: null,
+  sessionId: null,
+  cwd: null,
+  projectId: null,
+  links: [],
+  github: [],
+  labels: [],
+  createdAt: "2026-07-02T12:00:00Z",
+  updatedAt: "2026-07-02T12:00:00Z",
+  lifecycle: "queued",
+  lifecycleAt: "2026-07-02T12:00:00Z",
+  retryCount: 0,
+  maxRetries: 3,
+  steps: [],
+  attachments: [
+    { name: "spec.md", type: "text/markdown", size: 30, text: "# Spec" },
+    { name: "shot.png", type: "image/png", size: 900 },
+  ],
+};
+
+test("home composer files ride onto a Task card and render on the board", async ({ page }) => {
+  const boardPosts: any[] = [];
+  await page.route("**/api/familiars**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, familiars: [] }) }));
+  await page.route("**/api/sessions/list**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, sessions: [] }) }));
+  await page.route("**/api/escalations**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }));
+  await page.route("**/api/board", (r) => {
+    if (r.request().method() === "POST") {
+      boardPosts.push(JSON.parse(r.request().postData() || "{}"));
+      return r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, card: cardWithAttachments }) });
+    }
+    return r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, cards: [cardWithAttachments] }) });
+  });
+  await page.addInitScript(() => window.localStorage.setItem("cave:onboarding:dismissed", "1"));
+
+  await page.goto("/");
+  await page.waitForSelector(".shell-frame", { timeout: 60000 });
+
+  // ── Stage a file on the home composer ──────────────────────────────────────
+  await page.waitForSelector(".hc-textarea", { timeout: 60000 });
+  await page.locator(".hc-file-input").setInputFiles({
+    name: "spec.md",
+    mimeType: "text/markdown",
+    buffer: Buffer.from("# Spec\n- do the thing\n"),
+  });
+  await expect(page.locator(".hc-attachment-name")).toHaveText("spec.md");
+
+  // ── Send to the Task destination ───────────────────────────────────────────
+  await page.getByRole("radio", { name: "Task" }).click();
+  await page.locator(".hc-textarea").fill("Ship the spec");
+  await page.locator(".hc-send-btn").click();
+
+  // The POST body carries the staged attachment, content included.
+  await expect.poll(() => boardPosts.length, { timeout: 15000 }).toBeGreaterThan(0);
+  expect(boardPosts[0].title).toBe("Ship the spec");
+  expect(boardPosts[0].attachments?.[0]?.name).toBe("spec.md");
+  expect(boardPosts[0].attachments?.[0]?.text).toContain("do the thing");
+
+  // ── Board renders the paperclip chip (auto-navigated after create) ─────────
+  await page.waitForSelector(".board-kanban-card", { timeout: 60000 });
+  await expect(page.locator('[title="2 attachments"]')).toBeVisible();
+
+  // ── Inspector lists the files with per-file remove affordances ─────────────
+  await page.locator('[data-card-id="att-1"]').click();
+  await expect(page.getByText("Attachments")).toBeVisible();
+  await expect(page.getByText("spec.md", { exact: true })).toBeVisible();
+  await expect(page.getByText("shot.png", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Remove spec.md" })).toBeVisible();
+});


### PR DESCRIPTION
## What

The last two residuals from the attachment arc (#2219 → #2221 → #2223 → #2234), as one small PR:

**1. E2E spec for the attachment pipeline** — `tests/board-attachments.spec.ts` pins the full UI flow in CI (previously only unit/source-text tested + manually verified):
- stage a file on the home composer (`.hc-file-input` → chip renders)
- switch destination to **Task**, submit
- assert the captured `POST /api/board` body carries `attachments` (name + content)
- board auto-navigates → kanban `📎 2` chip visible
- open inspector → both files listed, per-file `Remove` button present

Daemon-less per E2E conventions: familiars/sessions/escalations/board all route-mocked. **Passed locally (1.2s).**

**2. By-design image note at dispatch** — task cards strip image payloads at storage, so a dispatched image previously rendered the chat path's failure wording ("was not delivered — payload missing or over the size limit"). New opt-in `imagesMetadataOnly` option on `buildPromptWithAttachments`; board dispatch (`buildInitialTaskChatPrompt`) passes it, rendering "(image attached as metadata only — task cards don't store image content)". The chat path's default wording is untouched (its test pin still passes verbatim).

## Tests
- `chat-attachments.test.ts`: metadata-only note under the flag; default "not delivered" wording unchanged.
- `task-chat-context.test.ts`: dispatch prompt uses the by-design note, never the failure wording.
- New e2e spec auto-discovered by the desktop Playwright project.
- Typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)