### PR TITLE
docs(evals): describe Insights failure breakdown as labeled bars

### DIFF
--- a/src/components/evals/evals-insights-panel.tsx
+++ b/src/components/evals/evals-insights-panel.tsx
@@ -7,8 +7,9 @@ import type { EvalRun, EvalSuite } from "@/lib/evals/eval-model";
 
 /**
  * Insights tab body. Shows, for the selected suite's run history: a pass-rate
- * trend (with the SLA floor as a threshold line + a breach/ok badge) and a
- * failure-frequency bar with a flaky-case list. Empty until the suite has runs.
+ * trend (with the SLA floor as a threshold line + a breach/ok badge), a
+ * per-case failure breakdown as labeled bars (name · count · proportional
+ * track), and a flaky-case list. Empty until the suite has runs.
  */
 export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; runs: EvalRun[] }) {
   const suiteRuns = useMemo(


### PR DESCRIPTION
## What

The Evals **Insights** panel body already renders per-case failures as labeled horizontal bars (`evals-fail-bars`: name · count · proportional track) — shipped in #2228. But the `EvalsInsightsPanel` docstring still described it as a "failure-frequency bar". This updates the comment to match the actual rendering.

## Scope

Comment-only, one file (`src/components/evals/evals-insights-panel.tsx`). No behavior change.

## Verification

Confirmed the live rendering matches the new wording by driving the Insights tab with route-mocked failing runs (labeled bars sorted most-failures-first, proportional widths, `N/M runs` counts). No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)