### PR TITLE
fix(quick-chat): show a loading state while the familiar roster loads

### DIFF
--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -135,3 +135,18 @@ assert.match(
 );
 
 console.log("quick-chat-overlay.test.ts OK");
+
+// ── Loading state: cold roster reads as "loading", not "no familiar" ──────────
+const tray = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
+for (const [name, src] of [["overlay", source], ["tray", tray]]) {
+  assert.match(
+    src,
+    /loading \? "Loading familiars…" : selectedFamiliar \? `@\$\{selectedFamiliar\.id\}` : "No familiar selected"/,
+    `${name} header shows a loading state while the roster loads`,
+  );
+}
+assert.match(
+  source,
+  /loading && familiars\.length === 0 \? <option value="">Loading…<\/option> : null/,
+  "the familiar select shows a Loading placeholder while empty",
+);

--- a/src/components/quick-chat-overlay.tsx
+++ b/src/components/quick-chat-overlay.tsx
@@ -146,7 +146,9 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
             <div className="min-w-0">
               <h2 className="truncate text-sm font-semibold">Quick chat</h2>
               <p className="truncate text-xs text-[var(--fg-muted)]">
-                {selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
+                {/* While the roster loads, say so — "No familiar selected" reads
+                    as an error/empty state when it's really just cold. */}
+                {loading ? "Loading familiars…" : selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
               </p>
             </div>
           </div>
@@ -170,6 +172,7 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
             className="min-w-0 flex-1 bg-transparent text-sm outline-none"
             aria-label="Familiar"
           >
+            {loading && familiars.length === 0 ? <option value="">Loading…</option> : null}
             {familiars.map((familiar) => (
               <option key={familiar.id} value={familiar.id}>
                 {familiar.display_name}

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -72,7 +72,8 @@ export function TrayQuickChat() {
             <div className="min-w-0">
               <h1 className="truncate text-sm font-semibold">Quick Chat</h1>
               <p className="truncate text-xs text-[var(--fg-muted)]">
-                {selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
+                {/* Mirror the in-app overlay: loading is not "no familiar". */}
+                {loading ? "Loading familiars…" : selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## What

While `/api/familiars` is in flight (seconds on a cold server), the quick-chat popover header said **"No familiar selected"** — error/empty framing for what's really just loading (it even fooled an automated verification recently). Now both the in-app overlay and the Tauri tray show **"Loading familiars…"**, and the familiar `<select>` shows a `Loading…` placeholder, until the roster arrives.

## Verification
- Tests + `pnpm build` green (assertions added for both surfaces).
- Drove the app with `/api/familiars` artificially delayed 4s: during load → header "Loading familiars…", select "Loading…"; after load → `@nova`. Confirmed live.

Follow-up to the quick-chat arc (#2204/#2209/#2224/#2229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)