### PR TITLE
feat(board): drop-to-attach on the inspector Attachments section

### DIFF
--- a/src/components/board-inspector-a11y.test.ts
+++ b/src/components/board-inspector-a11y.test.ts
@@ -59,4 +59,21 @@ assert.match(
 assert.match(src, /aria-label=\{`Remove \$\{att\.name\}`\}/, "each attachment's remove button is named for its file");
 assert.match(src, /disabled=\{busy \|\| atCap\}/, "the add-files button is disabled while busy or at the 10-file cap");
 
+// ── Drop-to-attach mirrors the home composer's guarded drag handling ─────────
+assert.match(
+  src,
+  /if \(atCap \|\| !hasDraggedFiles\(e\.dataTransfer\.types\)\) return;[\s\S]*?dragDepthRef\.current \+= 1;/,
+  "drag-enter only arms for real file drags, never past the attachment cap",
+);
+assert.match(
+  src,
+  /dragDepthRef\.current = Math\.max\(0, dragDepthRef\.current - 1\);\s*\n\s*if \(dragDepthRef\.current === 0\) setDropActive\(false\);/,
+  "drag-leave uses depth counting so crossing child elements doesn't flicker",
+);
+assert.match(
+  src,
+  /onDrop=\{\(e\) => \{[\s\S]*?void addFiles\(e\.dataTransfer\.files\);/,
+  "dropping files routes through the same addFiles path as the picker",
+);
+
 console.log("board-inspector-a11y.test.ts: ok");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -26,7 +26,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
 import { openExternalUrl } from "@/lib/open-external";
-import { attachmentIcon, fileToAttachment } from "@/lib/chat-attachments";
+import { attachmentIcon, fileToAttachment, hasDraggedFiles } from "@/lib/chat-attachments";
 
 const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
@@ -647,6 +647,10 @@ function AttachmentsSection({
 }) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [busy, setBusy] = useState(false);
+  // Drop-to-attach (parity with the home composer): dragDepthRef counts
+  // enter/leave pairs so crossing child elements doesn't flicker the armed state.
+  const [dropActive, setDropActive] = useState(false);
+  const dragDepthRef = useRef(0);
   const attachments = card.attachments ?? [];
   const atCap = attachments.length >= MAX_CARD_ATTACHMENTS;
 
@@ -671,7 +675,36 @@ function AttachmentsSection({
   }
 
   return (
-    <div className="board-drawer-field">
+    <div
+      className="board-drawer-field"
+      data-drop-active={dropActive || undefined}
+      style={dropActive ? { outline: "1.5px dashed var(--accent-presence)", outlineOffset: 2, borderRadius: 8 } : undefined}
+      onDragEnter={(e) => {
+        if (atCap || !hasDraggedFiles(e.dataTransfer.types)) return;
+        e.preventDefault();
+        e.stopPropagation();
+        dragDepthRef.current += 1;
+        setDropActive(true);
+      }}
+      onDragOver={(e) => {
+        if (atCap || !hasDraggedFiles(e.dataTransfer.types)) return;
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+      onDragLeave={(e) => {
+        if (!hasDraggedFiles(e.dataTransfer.types)) return;
+        dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+        if (dragDepthRef.current === 0) setDropActive(false);
+      }}
+      onDrop={(e) => {
+        dragDepthRef.current = 0;
+        setDropActive(false);
+        if (atCap || !hasDraggedFiles(e.dataTransfer.types)) return;
+        e.preventDefault();
+        e.stopPropagation();
+        void addFiles(e.dataTransfer.files);
+      }}
+    >
       <div className="board-drawer-field-label" style={{ display: "flex", alignItems: "center", gap: 6 }}>
         <Icon name="ph:paperclip" width={12} />
         Attachments
@@ -736,10 +769,10 @@ function AttachmentsSection({
         onClick={() => fileInputRef.current?.click()}
         disabled={busy || atCap}
         style={{ padding: "4px 10px", fontSize: 11 }}
-        title={atCap ? `Attachment limit reached (${MAX_CARD_ATTACHMENTS})` : "Attach files to this task"}
+        title={atCap ? `Attachment limit reached (${MAX_CARD_ATTACHMENTS})` : "Attach files to this task — or drop them onto this section"}
       >
         <Icon name="ph:paperclip" width={11} />
-        {busy ? "Adding…" : atCap ? "Limit reached" : "Add files"}
+        {busy ? "Adding…" : atCap ? "Limit reached" : dropActive ? "Drop files to attach" : "Add files"}
       </button>
     </div>
   );


### PR DESCRIPTION
## What

Input parity with the home composer: you can now **drag files onto a card's Attachments section** in the board inspector, not just click "Add files".

- Arms a dashed accent outline + the button label swaps to "Drop files to attach".
- Drop routes through the exact same `addFiles` path as the picker → `fileToAttachment` → PATCH → server-side lean normalization (unchanged).
- Guards mirror the composer: `hasDraggedFiles` (text-selection drags ignored), the 10-file cap disarms the zone, and depth-counted dragenter/leave prevents flicker when crossing child elements. `stopPropagation` keeps the drop from leaking to any outer handlers.

## Verification (live app)
- Simulated a real `DataTransfer` file drag in chromium: `dragenter` set `data-drop-active` + swapped the button label (screenshot), `drop` persisted `dropped-spec.md` with full text content via the lean pipeline, **0 page errors**.

## Tests
- `board-inspector-a11y.test.ts`: arm gated on `atCap`/`hasDraggedFiles`; depth-counted leave; drop routes through `addFiles`.
- Typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)