### PR TITLE
fix(shell): make Marketplace + Evals adapt to split-pane width, not viewport

### DIFF
--- a/src/components/evals/evals-view.test.ts
+++ b/src/components/evals/evals-view.test.ts
@@ -100,8 +100,12 @@ assert.match(source, /id="evals-rail" className="evals-rail"/, "the rail is the 
 assert.match(source, /evals--rail-open/, "root reflects the drawer open state");
 assert.match(source, /setRailOpen\(false\); \/\/ close the drawer after picking a suite/, "picking a suite closes the drawer");
 const css = readFileSync(new URL("../../styles/evals.css", import.meta.url), "utf8");
-assert.match(css, /@media \(max-width: 720px\)[\s\S]*?\.evals-rail \{[\s\S]*?transform: translateX\(-101%\)/, "the rail slides off-canvas under the narrow breakpoint");
+// The narrow layout is keyed to the surface's own width (@container evals) so it
+// also engages inside a narrow drag-to-split pane on a wide viewport.
+assert.match(css, /\.evals-host \{[\s\S]*?container: evals \/ inline-size/, "the surface root establishes the evals query container");
+assert.match(source, /className="evals-host"/, "the view renders inside the evals-host query container");
+assert.match(css, /@container evals \(max-width: 720px\)[\s\S]*?\.evals-rail \{[\s\S]*?transform: translateX\(-101%\)/, "the rail slides off-canvas under the narrow breakpoint");
 assert.match(css, /\.evals--rail-open \.evals-rail \{ transform: translateX\(0\)/, "opening the drawer slides the rail in");
-assert.doesNotMatch(css, /@media \(max-width: 720px\)[\s\S]*?\.evals-rail \{ display: none;/, "the rail no longer just vanishes on small screens");
+assert.doesNotMatch(css, /@container evals \(max-width: 720px\)[\s\S]*?\.evals-rail \{ display: none;/, "the rail no longer just vanishes on small screens");
 
 console.log("evals-view.test.ts OK");

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -476,9 +476,12 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
   }, [activeGroup, activeGroupStates]);
 
   return (
+    // .evals-host establishes the `evals` inline-size query container so the
+    // surface collapses by PANE width (drag-to-split) rather than viewport width.
+    <div className="evals-host">
     <div className={`evals evals-unified${railOpen ? " evals--rail-open" : ""}`}>
-      {/* Small-screen drawer toggle — reveals the suite rail (which collapses
-          off-canvas below the narrow breakpoint). Hidden on desktop via CSS. */}
+      {/* Narrow-pane drawer toggle — reveals the suite rail (which collapses
+          off-canvas below the narrow container breakpoint). Hidden on desktop via CSS. */}
       <button
         type="button"
         className="evals-rail-toggle"
@@ -708,6 +711,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
         onClose={() => setShowTemplates(false)}
         onPick={createFromTemplate}
       />
+    </div>
     </div>
   );
 }

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -148,10 +148,13 @@ export function MarketplaceViewSurface() {
   }, [setInstalled]);
 
   return (
-    <section className="marketplace-view flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
+    // @container/marketplace — layout responds to the PANE width, not the
+    // viewport, so the surface also adapts inside a narrow drag-to-split pane
+    // on a wide screen (same pattern as chat's chatlist/composer containers).
+    <section className="marketplace-view @container/marketplace flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
       {/* Hero header — title, stats, search, and the kind/sort controls. */}
-      <header className="border-b border-[var(--border-hairline)] px-4 py-4 sm:px-6 sm:py-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <header className="border-b border-[var(--border-hairline)] px-4 py-4 @min-[560px]/marketplace:px-6 @min-[560px]/marketplace:py-5">
+        <div className="flex flex-col gap-4 @min-[840px]/marketplace:flex-row @min-[840px]/marketplace:items-start @min-[840px]/marketplace:justify-between">
           <div className="min-w-0">
             <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--text-muted)]">
               Marketplace
@@ -175,7 +178,7 @@ export function MarketplaceViewSurface() {
             onValueChange={setQuery}
             onClear={() => setQuery("")}
             placeholder="Search the marketplace"
-            containerClassName="lg:w-96"
+            containerClassName="@min-[840px]/marketplace:w-96"
             aria-label="Search the marketplace"
           />
         </div>
@@ -216,7 +219,7 @@ export function MarketplaceViewSurface() {
       {/* Body — vertical category rail (desktop) beside the results column. */}
       <div className="flex min-h-0 flex-1">
         <aside
-          className="hidden w-56 shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] px-3 py-4 lg:block"
+          className="hidden w-56 shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] px-3 py-4 @min-[840px]/marketplace:block"
           aria-label="Browse by category"
         >
           <p className="px-2 pb-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
@@ -252,9 +255,9 @@ export function MarketplaceViewSurface() {
           </nav>
         </aside>
 
-        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6">
-          {/* Category chips — the mobile stand-in for the desktop rail. */}
-          <div className="-mx-4 mb-4 flex gap-1 overflow-x-auto px-4 pb-1 lg:hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4 @min-[560px]/marketplace:px-6">
+          {/* Category chips — the stand-in for the rail in narrow panes/screens. */}
+          <div className="-mx-4 mb-4 flex gap-1 overflow-x-auto px-4 pb-1 @min-[840px]/marketplace:hidden">
             {categories.map((cat) => (
               <button
                 key={cat}
@@ -330,7 +333,7 @@ export function MarketplaceViewSurface() {
               subtitle={query || category !== "All" || kind !== "all" || activeCollection ? "Try a different search, type, or category." : "The catalog is empty."}
             />
           ) : (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 2xl:grid-cols-3">
+            <div className="grid grid-cols-1 gap-3 @min-[560px]/marketplace:grid-cols-2 @min-[1200px]/marketplace:grid-cols-3">
               {filtered.map((plugin) => (
                 <MarketplaceCard
                   key={plugin.id}

--- a/src/components/marketplace/collection-strip.tsx
+++ b/src/components/marketplace/collection-strip.tsx
@@ -30,7 +30,8 @@ export function CollectionStrip({ collections, plugins, onOpen }: Props) {
       <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
         Featured collections
       </p>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      {/* Container-query columns — track the marketplace pane, not the viewport. */}
+      <div className="grid grid-cols-1 gap-3 @min-[560px]/marketplace:grid-cols-2 @min-[1100px]/marketplace:grid-cols-3">
         {resolved.map(({ collection, members }) => {
           const added = members.filter((m) => m.installed).length;
           return (

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -1,6 +1,25 @@
 /* Familiar Evals surface — suite rail + editor/runs main pane.
    Minimal, token-driven; mirrors the flow / automations surface vocabulary. */
 
+/* Query container for the whole surface. The narrow-layout rules below use
+   `@container evals (...)` instead of viewport @media so they also engage when
+   the surface sits in a narrow drag-to-split pane on a wide screen. Thresholds:
+   960px container ≈ the old 1120px viewport minus the app sidebar; 720px is
+   unchanged (at mobile widths the pane spans the full viewport). */
+.evals-host {
+  container: evals / inline-size;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  height: 100%;
+  min-height: 0;
+}
+.evals-host > .evals {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 .evals {
   position: relative;
   display: grid;
@@ -1343,7 +1362,7 @@
 .evals-grader-result-label { font-weight: 600; color: var(--text-primary); }
 .evals-grader-result-detail { color: var(--text-muted); }
 
-@media (max-width: 1120px) {
+@container evals (max-width: 960px) {
   .evals-analysis-summary {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1370,9 +1389,9 @@
   }
 }
 
-@media (max-width: 720px) {
+@container evals (max-width: 720px) {
   /* The suite rail collapses to an off-canvas drawer opened by the toggle,
-     instead of vanishing — so suites stay reachable on small screens. */
+     instead of vanishing — so suites stay reachable in narrow panes/screens. */
   .evals { grid-template-columns: 1fr; }
   .evals-rail-toggle {
     display: inline-flex;
@@ -1699,7 +1718,7 @@
 .evals-compare__chip.is-clean { color: var(--color-success); background: color-mix(in oklch, var(--color-success) 10%, transparent); }
 .evals-compare__none { margin: 0; color: var(--text-muted); font-size: var(--text-sm); }
 
-@media (max-width: 720px) {
+@container evals (max-width: 720px) {
   .evals-insights,
   .evals-compare {
     padding: 12px;


### PR DESCRIPTION
## Problem

In a drag-to-split pane (#2183/#2217) the **viewport stays wide while the pane can be a third of the screen**, so viewport-keyed responsive rules never fire. From the user's screenshot:

- **Marketplace** kept its fixed 224px browse rail + desktop hero/grids inside a cramped pane.
- **Evals** kept its fixed 268px suite rail (\"No suite selec…\" truncation), the 280px-min overview side column (the \"Build repeatable cases…\" copy wrapping one word per line), and stacked skinny buttons.

## Fix

Key both surfaces to **their own width** with CSS container queries — the pattern chat already established (`chatlist`/`composer`/`chatturn` containers):

- **marketplace-view.tsx** — root becomes `@container/marketplace`; all `lg:/sm:/xl:/2xl:` viewport variants become `@min-[…]/marketplace` container variants: browse rail + hero row at **840px pane**, 2-col grids at **560px**, 3-col at **1100–1200px**. In narrow panes the existing category chips replace the rail.
- **evals** — new `.evals-host` wrapper establishes the `evals` inline-size container; the `@media (max-width: 1120px/720px)` blocks become `@container evals (max-width: 960px/720px)` (960 ≈ old 1120 viewport minus the app sidebar; 720 unchanged since mobile panes span the viewport). The suite-rail **drawer**, 1-col overview, and stacked hero now also engage in narrow panes on wide screens.
- **evals-view.test.ts** — drawer assertions updated to pin the container query + host container.

## Verification (real split, driven via Playwright at 2000×1100 viewport)

| State | Result |
|---|---|
| Marketplace full-width (1520px) | rail visible, 3-col grid — unchanged ✓ |
| Marketplace ½ pane (760px) | rail → category chips, 2-col grids, stacked hero ✓ |
| Marketplace narrow pane (221px) | clean single-column ✓ |
| Evals narrow pane (178px) | 1-col overview, suite-rail drawer toggle, rail off-canvas ✓ |

`typecheck`, `test:app` (512), `pnpm build` (bundle within budget) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)