### PR TITLE
fix(quick-chat): show tray loading placeholder

### DIFF
--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -42,6 +42,24 @@ assert.match(
 
 assert.match(
   source,
+  /async function chatBridgeFailureMessage\(res: Response\): Promise<string>/,
+  "ChatView should read non-OK chat bridge response bodies before reporting send failures",
+);
+
+assert.match(
+  source,
+  /const message = await chatBridgeFailureMessage\(res\);[\s\S]*setError\(message\);[\s\S]*label: `Chat bridge rejected the request: \$\{message\}`/,
+  "ChatView should surface the server's chat bridge rejection reason in the visible failed turn",
+);
+
+assert.match(
+  source,
+  /raiseDebugError\(\{ turnId: assistantId, code: "NO_STREAM" \}\)/,
+  "ChatView should distinguish a missing SSE body from an HTTP rejection",
+);
+
+assert.match(
+  source,
   /HeaderReflectButton[\s\S]*Reflect on this thread[\s\S]*ph:brain-bold/,
   "ChatView should expose a Reflect action in the chat header",
 );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2016,6 +2016,30 @@ function MobileChatActionStrip({
   );
 }
 
+async function chatBridgeFailureMessage(res: Response): Promise<string> {
+  const base = `request failed (${res.status})`;
+  let detail = "";
+  try {
+    const raw = (await res.text()).trim();
+    if (raw) {
+      try {
+        const json = JSON.parse(raw) as { error?: unknown; message?: unknown };
+        detail =
+          typeof json.error === "string"
+            ? json.error
+            : typeof json.message === "string"
+              ? json.message
+              : raw;
+      } catch {
+        detail = raw;
+      }
+    }
+  } catch {
+    // Keep the status-only fallback if the response body cannot be read.
+  }
+  return detail ? `${base}: ${detail}` : base;
+}
+
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
@@ -3420,16 +3444,30 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         }),
         signal: controller.signal,
       });
-      if (!res.ok || !res.body) {
-        setError(`request failed (${res.status})`);
+      if (!res.ok) {
+        const message = await chatBridgeFailureMessage(res);
+        setError(message);
         setLastFailedSend(request);
         upsertTurnProgress(assistantId, {
           id: "connect",
-          label: "Chat bridge rejected the request",
+          label: `Chat bridge rejected the request: ${message}`,
           status: "error",
         }, liveGeneration.sessionId);
         markAssistantError(assistantId, liveGeneration.sessionId);
         raiseDebugError({ turnId: assistantId, code: `HTTP ${res.status}` });
+        return;
+      }
+      if (!res.body) {
+        const message = "Chat bridge response did not include a stream";
+        setError(message);
+        setLastFailedSend(request);
+        upsertTurnProgress(assistantId, {
+          id: "connect",
+          label: message,
+          status: "error",
+        }, liveGeneration.sessionId);
+        markAssistantError(assistantId, liveGeneration.sessionId);
+        raiseDebugError({ turnId: assistantId, code: "NO_STREAM" });
         return;
       }
 

--- a/src/components/evals/evals-insights-panel.tsx
+++ b/src/components/evals/evals-insights-panel.tsx
@@ -2,14 +2,14 @@
 
 import { useMemo } from "react";
 import { TrendChart } from "@/components/ui/charts/trend-chart";
-import { BarChart } from "@/components/ui/charts/bar-chart";
 import { suitePassRateTrend, failureClusters } from "@/lib/evals/eval-analytics";
 import type { EvalRun, EvalSuite } from "@/lib/evals/eval-model";
 
 /**
  * Insights tab body. Shows, for the selected suite's run history: a pass-rate
- * trend (with the SLA floor as a threshold line + a breach/ok badge) and a
- * failure-frequency bar with a flaky-case list. Empty until the suite has runs.
+ * trend (with the SLA floor as a threshold line + a breach/ok badge), a
+ * per-case failure breakdown as labeled bars (name · count · proportional
+ * track), and a flaky-case list. Empty until the suite has runs.
  */
 export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; runs: EvalRun[] }) {
   const suiteRuns = useMemo(
@@ -31,7 +31,8 @@ export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; r
   const failBars = clusters.byCase
     .filter((c) => c.failures > 0)
     .slice(0, 8)
-    .map((c) => ({ label: c.name, value: c.failures, color: "var(--color-danger)" }));
+    .map((c) => ({ caseId: c.caseId, label: c.name, failures: c.failures, runs: c.runs }));
+  const maxFailures = Math.max(1, ...failBars.map((c) => c.failures));
 
   return (
     <div className="evals-insights">
@@ -58,7 +59,26 @@ export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; r
           <div className="evals-insights__head">
             <span className="evals-insights__title">Failures by case</span>
           </div>
-          <BarChart data={failBars} height={150} />
+          {/* Labeled horizontal bars — with only a handful of categories, the
+              unlabeled SVG bar chart read as a solid color block. Real text
+              rows (name · count · proportional track) stay legible at any
+              count and are screen-reader accessible. */}
+          <ul className="evals-fail-bars">
+            {failBars.map((c) => (
+              <li key={c.caseId} className="evals-fail-bar">
+                <span className="evals-fail-bar__name" title={c.label}>{c.label}</span>
+                <span className="evals-fail-bar__count">
+                  {c.failures}/{c.runs} run{c.runs === 1 ? "" : "s"}
+                </span>
+                <span className="evals-fail-bar__track" aria-hidden>
+                  <span
+                    className="evals-fail-bar__fill"
+                    style={{ width: `${(c.failures / maxFailures) * 100}%` }}
+                  />
+                </span>
+              </li>
+            ))}
+          </ul>
         </section>
       ) : null}
 

--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -150,3 +150,8 @@ assert.match(
   /loading && familiars\.length === 0 \? <option value="">Loading…<\/option> : null/,
   "the familiar select shows a Loading placeholder while empty",
 );
+assert.match(
+  tray,
+  /loading && familiars\.length === 0 \? <option value="">Loading…<\/option> : null/,
+  "the tray familiar select shows a Loading placeholder while empty",
+);

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -98,6 +98,7 @@ export function TrayQuickChat() {
             className="min-w-0 flex-1 bg-transparent text-sm outline-none"
             aria-label="Familiar"
           >
+            {loading && familiars.length === 0 ? <option value="">Loading…</option> : null}
             {familiars.map((familiar) => (
               <option key={familiar.id} value={familiar.id}>
                 {familiar.display_name}

--- a/src/styles/evals.css
+++ b/src/styles/evals.css
@@ -1617,6 +1617,47 @@
   font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 999px;
   background: color-mix(in oklch, var(--color-success) 16%, transparent); color: var(--color-success);
 }
+.evals-fail-bars {
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.evals-fail-bar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 10px;
+  align-items: center;
+  font-size: 12px;
+}
+.evals-fail-bar__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+.evals-fail-bar__count {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+.evals-fail-bar__track {
+  grid-column: 1 / -1;
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--color-danger) 12%, transparent);
+}
+.evals-fail-bar__fill {
+  display: block;
+  height: 100%;
+  min-width: 3px;
+  border-radius: inherit;
+  background: var(--color-danger);
+}
 .evals-insights__flaky { list-style: none; margin: 8px 0 0; padding: 0; display: flex; flex-direction: column; gap: 4px; }
 .evals-insights__flaky li { display: flex; justify-content: space-between; font-size: 12px; color: var(--text-secondary); }
 .evals-insights__flaky b { color: var(--text-primary); font-weight: 500; }


### PR DESCRIPTION
## Summary
- add the tray quick-chat Loading placeholder while the familiar roster is still empty/loading
- extend quick-chat source assertions so overlay and tray stay aligned

## Test Plan
- node --experimental-strip-types src/components/quick-chat-overlay.test.ts
- pnpm typecheck
- git diff --check