### PR TITLE
fix(chat): "No project" state for unregistered-cwd sessions (stop first-project cwd fork)

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -85,8 +85,10 @@ import {
 import type { StreamEvent } from "@/lib/stream-events";
 import { extractNextPaths } from "@/lib/next-paths";
 import {
+  NO_PROJECT_ID,
   chatProjectById,
   projectIdForRoot,
+  resolveChatProjectSelection,
 } from "@/lib/chat-projects";
 import {
   COMMAND_CONTROL_DEFAULTS,
@@ -825,7 +827,10 @@ function ChatEmptyState({
   /** True when the chat knows a project root, so `@` opens the file picker (CHAT-D1-04). */
   fileMentions?: boolean;
 }) {
-  const project = (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
+  const project =
+    projectId === NO_PROJECT_ID
+      ? null
+      : (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
   // App-contextual starters; the last is project-aware when a root is known.
   const prompts = [
     ...STARTER_PROMPTS,
@@ -922,7 +927,10 @@ function SessionOverflowMenu({
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const activeProject = (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
+  const activeProject =
+    projectId === NO_PROJECT_ID
+      ? null
+      : (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
   const voiceConfigured = Boolean(familiar.voiceProvider);
 
   const close = () => setOpen(false);
@@ -960,9 +968,19 @@ function SessionOverflowMenu({
             Rename chat
           </PopoverItem>
           <PopoverSeparator />
-          {projects.length > 1 ? (
+          {projects.length > 0 ? (
             <>
               <PopoverLabel>Project</PopoverLabel>
+              <PopoverItem
+                icon={activeProject ? "ph:folder" : "ph:check"}
+                active={!activeProject}
+                onSelect={() => {
+                  onProjectChange(NO_PROJECT_ID);
+                  close();
+                }}
+              >
+                No project
+              </PopoverItem>
               {projects.map((entry) => (
                 <PopoverItem
                   key={entry.id}
@@ -2194,10 +2212,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const { projects } = useProjects();
   const firstProject = projects[0] ?? null;
   const [projectIdDraft, setProjectIdDraft] = useState<string | null>(null);
-  const resolvedProjectId = projectIdDraft ?? projectIdForRoot(session?.project_root ?? projectRoot, projects);
-  const selectedProject = resolvedProjectId
-    ? chatProjectById(resolvedProjectId, projects) ?? firstProject
-    : firstProject;
+  // A session whose recorded cwd maps to no registered project resolves to
+  // NO_PROJECT_ID here — never to the first project, whose root would re-root
+  // the next turn's cwd and fork the harness session (`--continue` misses).
+  const projectSelection = resolveChatProjectSelection({
+    draftId: projectIdDraft,
+    hasSession: Boolean(session),
+    sessionProjectRoot: session?.project_root,
+    fallbackProjectRoot: projectRoot,
+    projects,
+  });
+  const resolvedProjectId = projectSelection.projectId;
+  const selectedProject = projectSelection.project;
   const activeProjectRoot = selectedProject?.root ?? session?.project_root ?? projectRoot ?? "";
   // Root asserted to the server on send. A session's recorded cwd is NOT an
   // explicit project choice: a no-project chat boots in the familiar's own
@@ -2210,7 +2236,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const requestProjectRoot =
     activeProjectRoot &&
     activeProjectRoot === session?.project_root &&
-    !projectIdForRoot(activeProjectRoot, projects)
+    (resolvedProjectId === NO_PROJECT_ID || !projectIdForRoot(activeProjectRoot, projects))
       ? ""
       : activeProjectRoot;
   useEffect(() => {
@@ -4133,8 +4159,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // delete confirm resets itself — HeaderDeleteButton is keyed on sessionId.)
   useEffect(() => {
     setProjectIdDraft((prev) => {
+      // Mirrors resolveChatProjectSelection: a registered project mapped from
+      // the session/opener root, then NO_PROJECT_ID for an existing session in
+      // an unregistered cwd, then the first project only for brand-new chats.
       const resolved =
-        projectIdForRoot(session?.project_root ?? projectRoot, projects) ??
+        resolveChatProjectSelection({
+          draftId: null,
+          hasSession: Boolean(session),
+          sessionProjectRoot: session?.project_root,
+          fallbackProjectRoot: projectRoot,
+          projects,
+        }).projectId ??
         firstProject?.id ??
         null;
       // Initialise when unset, or always resync on session switch.

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -21,8 +21,21 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const resolvedProjectId = projectIdDraft \?\? projectIdForRoot\(session\?\.project_root \?\? projectRoot, projects\);[\s\S]*const selectedProject = resolvedProjectId\s*\?\s*chatProjectById\(resolvedProjectId, projects\) \?\? firstProject\s*:\s*firstProject/,
-  "ChatView resolves the selected project from the session/root before falling back to the first persisted project",
+  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
+  "ChatView resolves the selected project through resolveChatProjectSelection (sessions in unregistered cwds are No project — behaviorally pinned in chat-projects.test.ts)",
+);
+// REGRESSION (2026-07-02): a session in an unregistered cwd must NOT default
+// the picker to the first project — sending that root re-roots the next
+// turn's cwd and forks the harness session (`--continue` misses).
+assert.doesNotMatch(
+  chatView,
+  /const selectedProject = resolvedProjectId\s*\?\s*chatProjectById\(resolvedProjectId, projects\) \?\? firstProject\s*:\s*firstProject/,
+  "The unconditional first-project fallback for existing sessions must stay gone",
+);
+assert.match(
+  chatView,
+  /<PopoverLabel>Project<\/PopoverLabel>[\s\S]*?onProjectChange\(NO_PROJECT_ID\);[\s\S]*?No project[\s\S]*?projects\.map\(\(entry\) => \(/,
+  "The overflow menu offers an explicit No-project row so a workspace session can stay (or become) project-less",
 );
 assert.match(
   chatView,

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -106,3 +106,96 @@ assert.deepEqual(
 }
 
 console.log("chat-projects.test.ts: ok");
+
+// ── resolveChatProjectSelection ───────────────────────────────────────────────
+// REGRESSION (2026-07-02): an existing session whose recorded cwd maps to no
+// registered project (typically the familiar's own workspace) must resolve to
+// "No project" — NOT default to the first registered project, whose root would
+// re-root the next turn's cwd and fork the harness session.
+{
+  const { NO_PROJECT_ID, resolveChatProjectSelection } = await import("./chat-projects.ts");
+  const roster = [
+    { id: "p1", name: "Alpha", root: "/work/alpha", createdAt: "", updatedAt: "" },
+    { id: "p2", name: "Beta", root: "/work/beta", createdAt: "", updatedAt: "" },
+  ];
+  const base = { draftId: null, fallbackProjectRoot: null, projects: roster };
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/Users/me/.coven/workspaces/familiars/cody",
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "a session in an unregistered cwd (familiar workspace) is No project — never the first project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({ ...base, hasSession: true, sessionProjectRoot: "" }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "a session with no recorded cwd is also No project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({ ...base, hasSession: true, sessionProjectRoot: "/work/beta" }),
+    { projectId: "p2", project: roster[1] },
+    "a session recorded in a registered project keeps resolving to that project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({ ...base, hasSession: false, sessionProjectRoot: undefined }),
+    { projectId: null, project: roster[0] },
+    "a brand-new chat still defaults to the first project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      fallbackProjectRoot: "/work/beta",
+    }),
+    { projectId: "p2", project: roster[1] },
+    "a new chat opened with a registered root scopes to that project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      draftId: "p2",
+      hasSession: true,
+      sessionProjectRoot: "/Users/me/.coven/workspaces/familiars/cody",
+    }),
+    { projectId: "p2", project: roster[1] },
+    "an explicit user pick overrides the No-project default",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      draftId: NO_PROJECT_ID,
+      hasSession: true,
+      sessionProjectRoot: "/work/beta",
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "an explicit No-project pick sticks even when the session cwd is registered",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({ ...base, draftId: "gone", hasSession: true, sessionProjectRoot: "/work/beta" }),
+    { projectId: "gone", project: roster[0] },
+    "a stale draft id keeps the legacy first-project display fallback",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      draftId: null,
+      hasSession: true,
+      sessionProjectRoot: "/Users/me/.coven/workspaces/familiars/cody",
+      fallbackProjectRoot: null,
+      projects: [],
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "an empty roster resolves existing sessions to No project, not undefined state",
+  );
+}

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -44,6 +44,54 @@ export function projectIdForRoot(
   return projectForRoot(projectRoot, projects)?.id ?? null;
 }
 
+/** Sentinel picker id for "this chat runs outside every registered project"
+ *  (typically the familiar's own workspace). A real id so it can live in the
+ *  same draft-state slot as project ids, distinct from null = "unresolved". */
+export const NO_PROJECT_ID = "__no-project__";
+
+export type ChatProjectSelection = {
+  /** NO_PROJECT_ID, a registered project id, or null (new chat, nothing picked yet). */
+  projectId: string | null;
+  /** The registered project the chat is scoped to; null for no-project. */
+  project: CaveProject | null;
+};
+
+/**
+ * Resolve which project a chat is scoped to, for both the picker display and
+ * the projectRoot asserted on send.
+ *
+ * A user-set draft wins. Otherwise the session's recorded cwd (or the opener
+ * surface's root) maps to its registered project. An EXISTING session whose
+ * recorded cwd maps to no registered project is "No project" — it runs in the
+ * familiar's own workspace or another unregistered dir, and defaulting it to
+ * the first registered project would re-root the next turn's cwd there and
+ * fork the harness session (`--continue` misses in the new dir). Only a brand
+ * new chat (no session yet) defaults to the first project.
+ */
+export function resolveChatProjectSelection(args: {
+  draftId: string | null;
+  hasSession: boolean;
+  sessionProjectRoot: string | null | undefined;
+  fallbackProjectRoot: string | null | undefined;
+  projects: CaveProject[];
+}): ChatProjectSelection {
+  const firstProject = args.projects[0] ?? null;
+  if (args.draftId === NO_PROJECT_ID) return { projectId: NO_PROJECT_ID, project: null };
+  if (args.draftId) {
+    return {
+      projectId: args.draftId,
+      project: chatProjectById(args.draftId, args.projects) ?? firstProject,
+    };
+  }
+  const mappedId = projectIdForRoot(
+    args.sessionProjectRoot ?? args.fallbackProjectRoot,
+    args.projects,
+  );
+  if (mappedId) return { projectId: mappedId, project: chatProjectById(mappedId, args.projects) };
+  if (args.hasSession) return { projectId: NO_PROJECT_ID, project: null };
+  return { projectId: null, project: firstProject };
+}
+
 function sessionTimestamp(session: SessionRow): string {
   return session.updated_at || session.created_at;
 }


### PR DESCRIPTION
## Problem (follow-up to #2238)

#2238 stopped the 403 for familiars chatting in their own workspace, but left a second head of the same echo problem: once the projects list loads, a session whose recorded cwd maps to **no registered project** has its picker default to the **first** registered project. The next send then carries that project's root as `projectRoot`, the server re-roots the turn's cwd there, `--continue <id>` misses in the new directory, and the transparent retry forks the chat into a fresh session — the context-loss/amnesia class.

## Fix

- New pure helper `resolveChatProjectSelection` + `NO_PROJECT_ID` sentinel in `src/lib/chat-projects.ts`. An **existing** session in an unregistered cwd resolves to "No project": picker shows none, the empty-state project select hides, and the send carries no `projectRoot` (the server resumes in the recorded cwd from the conversation record). Brand-new chats keep defaulting to the first project; registered-cwd sessions keep resolving to their project; an explicit user pick still overrides everything.
- The session overflow menu gains a **"No project"** row (and now shows the Project section for single-project rosters) so the state is user-reachable and reversible.
- `requestProjectRoot` additionally honors an explicit No-project pick.

## Tests

- Behavioral coverage for `resolveChatProjectSelection` in `chat-projects.test.ts` (already wired): workspace-cwd session → No project, empty-roster and no-recorded-cwd cases, new-chat default preserved, explicit picks (both directions), stale-draft fallback.
- `task-chat-cwd.test.ts`: pins the new resolution path, `doesNotMatch` on the old unconditional first-project fallback, and pins the No-project menu row.

Verified locally: typecheck, `test:app` (512), `test:api` (112), `test:mobile` (65), production build within bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)