### PR TITLE
fix(chat): keep explicit no-project chats rootless

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2248,7 +2248,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   });
   const resolvedProjectId = projectSelection.projectId;
   const selectedProject = projectSelection.project;
-  const activeProjectRoot = selectedProject?.root ?? session?.project_root ?? projectRoot ?? "";
+  const activeProjectRoot =
+    resolvedProjectId === NO_PROJECT_ID ? "" : (selectedProject?.root ?? session?.project_root ?? projectRoot ?? "");
   // Root asserted to the server on send. A session's recorded cwd is NOT an
   // explicit project choice: a no-project chat boots in the familiar's own
   // workspace and the daemon records that dir as project_root. Echoing it back

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -39,8 +39,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const activeProjectRoot = selectedProject\?\.root \?\? session\?\.project_root \?\? projectRoot \?\? ""/,
-  "ChatView sends the selected project's configured root",
+  /const activeProjectRoot =\s*resolvedProjectId === NO_PROJECT_ID \? "" : \(selectedProject\?\.root \?\? session\?\.project_root \?\? projectRoot \?\? ""\)/,
+  "ChatView keeps an explicit No-project selection rootless instead of falling back to the opener/session root",
 );
 assert.match(
   chatView,


### PR DESCRIPTION
## Summary
- keep explicit No project chat selections from falling back to the opener/session root
- pin the request-root behavior in the chat cwd source regression test

## Verification
- node --experimental-strip-types src/components/task-chat-cwd.test.ts
- node --experimental-strip-types src/lib/chat-projects.test.ts
- pnpm install --frozen-lockfile && pnpm typecheck
- git diff --check