### PR TITLE
fix(board): audit batch — inspector remount, poll guard, hoisted resolution, undo snapshot, chips, dead code

### DIFF
--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -10,7 +10,7 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel } from "@/components/ui/popover";
 import { Tabs, type TabItem } from "@/components/ui/tabs";
-import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 // Order mirrors BoardKanban's COLUMNS so users get a consistent left-to-
 // right reading on desktop translating to top-to-bottom on phone.
@@ -59,6 +59,11 @@ export function BoardCardStack({
   chatLinkingId,
 }: Props) {
   const [filter, setFilter] = useState<FilterValue>("all");
+  // Resolve familiars ONCE (5 hook subscriptions) and use O(1) lookups per row —
+  // replaces the per-row linear familiar/session scans + per-row resolution.
+  const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
+  const familiarById = useMemo(() => new Map(resolvedFamiliars.map((f) => [f.id, f])), [resolvedFamiliars]);
+  const sessionById = useMemo(() => new Map(sessions.map((sess) => [sess.id, sess])), [sessions]);
   // Resolved after mount so schedule-urgency colors stay hydration-safe.
   const [todayMs, setTodayMs] = useState<number | null>(null);
   useEffect(() => setTodayMs(Date.now()), []);
@@ -126,8 +131,8 @@ export function BoardCardStack({
                 <BoardCardStackRow
                   key={card.id}
                   card={card}
-                  familiars={familiars}
-                  sessions={sessions}
+                  familiarById={familiarById}
+                  sessionById={sessionById}
                   isSelected={card.id === selectedCardId}
                   onSelect={() => onSelect(card.id)}
                   onMoveStatus={(status) => onMoveStatus(card.id, status)}
@@ -147,8 +152,8 @@ export function BoardCardStack({
 
 function BoardCardStackRow({
   card,
-  familiars,
-  sessions,
+  familiarById,
+  sessionById,
   isSelected,
   onSelect,
   onMoveStatus,
@@ -158,8 +163,8 @@ function BoardCardStackRow({
   chatLinking,
 }: {
   card: Card;
-  familiars: Familiar[];
-  sessions: SessionRow[];
+  familiarById: Map<string, ResolvedFamiliar>;
+  sessionById: Map<string, SessionRow>;
   isSelected: boolean;
   todayMs: number | null;
   onSelect: () => void;
@@ -171,13 +176,8 @@ function BoardCardStackRow({
   const [menuOpen, setMenuOpen] = useState(false);
   const menuButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  const rawFamiliar = familiars.find((f) => f.id === card.familiarId) ?? null;
-  const resolvedFamiliars = useResolvedFamiliars(
-    rawFamiliar ? [rawFamiliar] : [],
-    { includeArchived: true },
-  );
-  const resolvedFamiliar = resolvedFamiliars[0] ?? null;
-  const session = sessions.find((s) => s.id === card.sessionId) ?? null;
+  const resolvedFamiliar = card.familiarId ? familiarById.get(card.familiarId) ?? null : null;
+  const session = card.sessionId ? sessionById.get(card.sessionId) ?? null : null;
   const schedule = scheduleLabel(card.startDate, card.endDate);
   const urgency = scheduleUrgency(card.endDate, card.status, todayMs);
 
@@ -223,6 +223,15 @@ function BoardCardStackRow({
               {resolvedFamiliar?.display_name ?? "Unassigned"}
             </span>
           </span>
+          {(card.attachments?.length ?? 0) > 0 && (
+            <span
+              className="board-card-stack__row-attachments"
+              title={`${card.attachments!.length} attachment${card.attachments!.length === 1 ? "" : "s"}`}
+            >
+              <Icon name="ph:paperclip" width={11} />
+              {card.attachments!.length}
+            </span>
+          )}
           {schedule ? (
             <span
               className={`board-card-stack__row-schedule${

--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -37,6 +37,8 @@ type GanttRow = {
   category: GanttCategory;
   /** Per-familiar bar colour, set only when grouping by familiar. */
   color?: string;
+  /** Attachment count on the underlying card (task rows only). */
+  attachmentCount?: number;
   /**
    * Task mode only: the step had no dates of its own, so its position is an
    * equal slice of the task's range (a waterfall by step order) rather than a
@@ -399,6 +401,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           end: cr.end,
           category: statusCategory(card.status),
           color: byFamiliar ? (familiarColor(card.familiarId) ?? "var(--text-muted)") : undefined,
+          attachmentCount: card.attachments?.length || undefined,
         });
         group.firstStart = Math.min(group.firstStart, cr.start.getTime());
       }
@@ -796,7 +799,15 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                       title={`${row.label} · ${formatLabel(previewStart)}–${formatLabel(previewEnd)}${row.inferred ? " · inferred from task range — drag to set real dates" : ""}${draggable ? " · drag to move, drag edges to resize · ←/→ to reschedule" : ""}`}
                     >
                       <span className="cg-left">
-                        <span className="cg-c-task">{row.label}</span>
+                        <span className="cg-c-task">
+                          {row.label}
+                          {(row.attachmentCount ?? 0) > 0 && (
+                            <span className="cg-attach" title={`${row.attachmentCount} attachment${row.attachmentCount === 1 ? "" : "s"}`}>
+                              <Icon name="ph:paperclip" width={10} />
+                              {row.attachmentCount}
+                            </span>
+                          )}
+                        </span>
                         <span className="cg-c-date">{formatLabel(previewStart)}</span>
                         <span className="cg-c-date">{formatLabel(previewEnd)}</span>
                         <span className="cg-c-st"><span className={`cg-dot cg-dot--${cat}`} aria-hidden /></span>

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -11,7 +11,7 @@ import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Icon } from "@/lib/icon";
 import type { GroupBy } from "@/components/board-table";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
-import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Popover } from "@/components/ui/popover";
 import { type WipLimits, wipState } from "@/lib/board-wip";
@@ -276,7 +276,10 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
 
   const groups = useMemo(() => getGroups(cards, groupBy, familiars, projects), [cards, groupBy, familiars, projects]);
   // O(1) per-card lookups — replaces familiars.find()/sessions.find() inside every KanbanCard.
-  const familiarById = useMemo(() => new Map(familiars.map((f) => [f.id, f])), [familiars]);
+  // Resolution (overrides/images/glyphs — 5 hook subscriptions) runs ONCE here,
+  // not once per card: same pattern as board-table's resolvedByIdMap.
+  const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
+  const familiarById = useMemo(() => new Map(resolvedFamiliars.map((f) => [f.id, f])), [resolvedFamiliars]);
   const sessionById = useMemo(() => new Map(sessions.map((s) => [s.id, s])), [sessions]);
   const showSwimlanes = true;
 
@@ -659,7 +662,7 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
 }
 
 function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSelected, isGrabbed, selectMode = false, onSelect, onDragStart, onDragEnd, onPointerDownTouch, onJumpToSession, onOpenTaskChat, chatLinking = false }: {
-  card: Card; familiarById: Map<string, Familiar>; sessionById: Map<string, SessionRow>; todayMs: number | null;
+  card: Card; familiarById: Map<string, ResolvedFamiliar>; sessionById: Map<string, SessionRow>; todayMs: number | null;
   isDragging: boolean; isSelected: boolean; isGrabbed: boolean; selectMode?: boolean;
   onSelect: () => void; onDragStart: (e: React.DragEvent) => void; onDragEnd: () => void;
   onPointerDownTouch?: (e: React.PointerEvent) => void;
@@ -668,9 +671,7 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
   chatLinking?: boolean;
 }) {
   const draggedRef = useRef(false);
-  const rawFamiliar = card.familiarId ? familiarById.get(card.familiarId) ?? null : null;
-  const resolvedFamiliars = useResolvedFamiliars(rawFamiliar ? [rawFamiliar] : [], { includeArchived: true });
-  const resolvedFamiliar = resolvedFamiliars[0] ?? null;
+  const resolvedFamiliar = card.familiarId ? familiarById.get(card.familiarId) ?? null : null;
   const session = card.sessionId ? sessionById.get(card.sessionId) ?? null : null;
   // Fallback rather than a non-null assertion: an unexpected priority value
   // must not crash the whole board render.

--- a/src/components/board-project-picker.test.ts
+++ b/src/components/board-project-picker.test.ts
@@ -53,7 +53,7 @@ assert.match(
 // ── board-view threads the projects list into both surfaces ────────────────
 assert.match(
   view,
-  /<BoardInspector[\s\S]{0,200}projects=\{projects\}/,
+  /<BoardInspector[\s\S]{0,600}projects=\{projects\}/,
   "board-view passes projects to the inspector",
 );
 assert.match(

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -73,10 +73,12 @@ assert.match(
   "Mobile BoardCardStack filters should reserve full touch-sized chip height instead of clipping to a scrollbar sliver",
 );
 
-assert.match(
+// The bespoke filter chips were replaced by the shared Tabs component (which
+// owns its own touch sizing); their orphaned CSS must stay deleted.
+assert.doesNotMatch(
   styles,
-  /\.board-card-stack__chip\s*\{[\s\S]*height:\s*var\(--touch-target\)/,
-  "Mobile BoardCardStack filter chips should meet the shared touch target",
+  /\.board-card-stack__chip\b/,
+  "dead BoardCardStack filter-chip CSS must not return (filters render via Tabs)",
 );
 
 assert.match(
@@ -87,10 +89,12 @@ assert.match(
 
 // The task inspector goes full-screen on phones, so its controls are primary
 // touch targets — the desktop-dense 24-28px close/action sizes must scale up.
+// (.board-drawer-path-open was dead CSS — no JSX renders it — and was removed
+// from this selector list in the 2026-07-02 board audit.)
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.board-drawer-close,\s*\n\s*\.board-drawer-path-open\s*\{[\s\S]*min-width:\s*var\(--touch-target\)[\s\S]*min-height:\s*var\(--touch-target\)/,
-  "Mobile inspector close/open-path controls should meet the shared touch target via min-* (so the 44px hit area wins the cascade over the earlier-in-file base width/height)",
+  /@media \(max-width: 767px\) \{[\s\S]*\.board-drawer-close\s*\{[\s\S]*min-width:\s*var\(--touch-target\)[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Mobile inspector close control should meet the shared touch target via min-* (so the 44px hit area wins the cascade over the earlier-in-file base width/height)",
 );
 assert.match(
   styles,
@@ -138,5 +142,43 @@ assert.match(kanban, /\{limit != null \? `\$\{count\}\/\$\{limit\}` : count\}/, 
 assert.match(styles, /\.board-kanban-column-count--over\s*\{[^}]*--color-danger/, "over-limit count badge turns danger");
 assert.match(view, /onSetWipLimit=\{setWipLimitFor\}/, "BoardView wires the WIP-limit setter");
 assert.match(view, /writeWipLimits\(next\)/, "WIP limits persist on change");
+
+// ── Board-audit fixes (2026-07-02) ───────────────────────────────────────────
+const gantt = await readFile(new URL("./board-gantt.tsx", import.meta.url), "utf8");
+const stack = await readFile(new URL("./board-card-stack.tsx", import.meta.url), "utf8");
+
+// 1. The inspector remounts per card: its title/notes are uncontrolled
+//    (defaultValue + save-on-blur), so switching cards while the drawer is open
+//    must reset them — otherwise a blur writes card A's text onto card B.
+assert.match(view, /key=\{selectedCard\.id\}/, "BoardInspector is keyed by card id so uncontrolled fields reset on card switch");
+
+// 2. Poll ticks keep the previous cards reference when content is unchanged —
+//    an idle board must not re-render every card/row/bar every 15s.
+assert.match(
+  view,
+  /setCards\(\(prev\) => \(arrayContentEqual\(prev, loaded\) \? prev : loaded\)\)/,
+  "the board poll guards setCards with arrayContentEqual",
+);
+
+// 3. A second reschedule inside the undo window must not clobber the snapshot —
+//    Undo restores the ORIGINAL dates, not the intermediate position.
+assert.match(
+  view,
+  /pending && pending\.id === id\s*\n?\s*\? pending/,
+  "a pending reschedule-undo for the same card is never re-armed",
+);
+
+// 4. The dead stats memo (computed every render, rendered nowhere) stays gone.
+assert.doesNotMatch(view, /const stats = useMemo/, "the unused stats memo must not return");
+
+// 5. Familiar resolution is hoisted — resolve once per view, never per card/row.
+assert.match(kanban, /const resolvedFamiliars = useResolvedFamiliars\(familiars, \{ includeArchived: true \}\)/, "kanban resolves familiars once at the board level");
+assert.doesNotMatch(kanban, /useResolvedFamiliars\(rawFamiliar/, "kanban must not resolve familiars per card");
+assert.match(stack, /const resolvedFamiliars = useResolvedFamiliars\(familiars, \{ includeArchived: true \}\)/, "card-stack resolves familiars once at the top");
+assert.doesNotMatch(stack, /familiars\.find\(/, "card-stack rows use O(1) map lookups, not per-row find()");
+
+// 6. Attachment count renders in ALL four views (kanban/table already pinned).
+assert.match(stack, /board-card-stack__row-attachments/, "the mobile stack shows an attachment count");
+assert.match(gantt, /cg-attach/, "the gantt task label shows an attachment count");
 
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view-familiar-scope.test.ts
+++ b/src/components/board-view-familiar-scope.test.ts
@@ -26,18 +26,13 @@ assert.match(
   "BoardView filters by the multiselect scope set when provided",
 );
 
-// Stats must reflect the visible (filtered) set, not the full unfiltered
-// cards array — otherwise "Total: 2" would render next to "Running: 15".
-assert.match(
+// The header stats object these pins guarded was dead code (computed every
+// render, rendered nowhere — its board-header-stats CSS was orphaned too) and
+// was removed in the 2026-07-02 board audit. Keep it gone.
+assert.doesNotMatch(
   source,
-  /running:\s*filtered\.filter/,
-  "BoardView running count must derive from filtered, not cards",
-);
-
-assert.match(
-  source,
-  /blocked:\s*filtered\.filter/,
-  "BoardView blocked count must derive from filtered, not cards",
+  /const stats = useMemo/,
+  "the unused BoardView stats memo must not return",
 );
 
 assert.match(

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -10,6 +10,7 @@ import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus, type CardPriority, STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { UndoToast } from "@/components/ui/undo-toast";
@@ -127,7 +128,11 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
       const json = await res.json();
       if (json.ok) {
         const loaded = json.cards as Card[];
-        setCards(loaded);
+        // Poll ticks rebuild an identical array most of the time; keep the
+        // previous reference when content is unchanged so an idle board
+        // doesn't re-render every card/row/bar for nothing (same convention
+        // as workspace.tsx's poll over this endpoint).
+        setCards((prev) => (arrayContentEqual(prev, loaded) ? prev : loaded));
         setError(null);
       } else if (!quiet) {
         setCards([]);
@@ -242,12 +247,6 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     );
   }, [cards, familiarsById, searchQuery, activeFamiliarId, scopeFamiliarIds, deletePending]);
 
-  const stats = useMemo(() => ({
-    total: filtered.length,
-    running: filtered.filter((c) => c.status === "running").length,
-    blocked: filtered.filter((c) => c.status === "blocked" || c.needsHuman).length,
-  }), [filtered]);
-
   // Done cards in the CURRENT scope (the filtered set the user is viewing) —
   // the exact set "Clear done" operates on.
   const doneCards = useMemo(() => filtered.filter((c) => c.status === "done"), [filtered]);
@@ -299,11 +298,17 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     if (isReschedule) {
       const before = cards.find((c) => c.id === id);
       if (before) {
-        setRescheduleUndo({
-          id,
-          title: before.title,
-          prev: { startDate: before.startDate ?? null, endDate: before.endDate ?? null },
-        });
+        // A second reschedule of the same card inside the 5s banner window must
+        // NOT overwrite the snapshot — Undo should restore the ORIGINAL dates,
+        // not the intermediate position.
+        setRescheduleUndo((pending) =>
+          pending && pending.id === id
+            ? pending
+            : {
+                id,
+                title: before.title,
+                prev: { startDate: before.startDate ?? null, endDate: before.endDate ?? null },
+              });
       }
     }
     setCards((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
@@ -1040,7 +1045,12 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
 
       {/* Inspector drawer */}
       {selectedCard && (
-        <BoardInspector card={selectedCard} familiars={familiars} sessions={sessions} projects={projects}
+        <BoardInspector
+          // Remount per card: the drawer's title/notes are uncontrolled
+          // (defaultValue + save-on-blur), so switching cards while open must
+          // reset them — otherwise a blur writes card A's text onto card B.
+          key={selectedCard.id}
+          card={selectedCard} familiars={familiars} sessions={sessions} projects={projects}
           onClose={() => setSelectedCardId(null)}
           onPatch={patchCard}
           onMoveStatus={moveCardToStatus}

--- a/src/lib/board-schedule.ts
+++ b/src/lib/board-schedule.ts
@@ -7,7 +7,7 @@ export type ScheduleUrgency = "overdue" | "due-soon" | "none";
  * Compact board date from an ISO date string ("2026-06-19"), ordered by the
  * user's date preference: "06/19" (month-first) or "19/06" (day-first).
  */
-export function formatBoardDate(value: string | null | undefined): string {
+function formatBoardDate(value: string | null | undefined): string {
   if (!value) return "";
   const [year, month, day] = value.split("-");
   if (!year || !month || !day) return value;

--- a/src/lib/board-wip.ts
+++ b/src/lib/board-wip.ts
@@ -48,7 +48,7 @@ export function setWipLimit(limits: WipLimits, status: CardStatus, limit: number
   return next;
 }
 
-export type WipState = "none" | "ok" | "over";
+type WipState = "none" | "ok" | "over";
 
 /** Classify a column's count against its limit (for styling). Pure. */
 export function wipState(count: number, limit: number | undefined): WipState {

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -9,9 +9,6 @@
 
 .board-header { display:flex; align-items:center; gap:10px; padding:10px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; flex-wrap:nowrap; }
 .board-header-title { flex:0 0 auto; font-size:14px; font-weight:600; color:var(--text-primary); }
-.board-header-stats { font-size:11px; color:var(--text-muted); display:flex; align-items:center; gap:6px; }
-.board-header-stats-sep { opacity:0.4; }
-.board-header-stats--blocked { color:var(--color-danger); }
 .board-header-controls { display:flex; align-items:center; gap:6px; margin-left:auto; flex:0 0 auto; flex-wrap:nowrap; }
 .board-search-wrap { position:relative; display:flex; align-items:center; flex:1 1 auto; min-width:0; max-width:620px; margin-left:8px; }
 .board-search-icon { position:absolute; left:9px; color:var(--text-muted); pointer-events:none; }
@@ -31,12 +28,6 @@
 .board-toolbar-btn--danger:hover { background:color-mix(in oklch,var(--color-danger) 12%,var(--bg-raised)); color:var(--text-primary); border-color:color-mix(in oklch,var(--color-danger) 55%,transparent); }
 
 .board-clear-confirm { display:flex; gap:6px; }
-
-
-.board-multiselect-btn { display:inline-flex; align-items:center; gap:5px; padding:0 8px; height:28px; white-space:nowrap; }
-.board-multiselect-caret { color:var(--text-muted); transition:transform .15s; flex-shrink:0; }
-.board-multiselect-caret--open { transform:rotate(180deg); }
-.board-multiselect-popover { min-width:180px; }
 
 .board-group-toggle { display:flex; border:1px solid var(--border-strong); border-radius:7px; overflow:hidden; }
 /* Leading zoom glyph so the compact D/W/M reads as a timeline zoom, not a range filter. */
@@ -130,12 +121,11 @@
      and must meet --touch-target — the desktop-dense 24-28px sizes are too
      small to hit reliably with a thumb.
      Use min-* (not width/height): this mobile block sits earlier in the file
-     than the base .board-drawer-close/.board-drawer-path-open rules, so an
+     than the base .board-drawer-close rule, so an
      equal-specificity width/height would LOSE the cascade to them (verified:
      the close button measured 28px). min-* clamps the base size up regardless
      of source order. */
-  .board-drawer-close,
-  .board-drawer-path-open {
+  .board-drawer-close {
     min-width: var(--touch-target);
     min-height: var(--touch-target);
   }
@@ -148,26 +138,6 @@
     min-height: var(--touch-target);
   }
 }
-
-.board-filter-chips { display:flex; flex-wrap:wrap; align-items:center; gap:5px; padding:6px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
-.board-filter-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:20px; border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:11px; cursor:default; }
-.board-filter-chip-remove { display:flex; align-items:center; justify-content:center; width:14px; height:14px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; margin-left:1px; transition:background .1s,color .1s; }
-.board-filter-chip-remove:hover { background:var(--bg-hover); color:var(--text-primary); }
-.board-filter-chip-remove:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
-.board-filter-chip--clear-all { background:transparent; border:none; color:var(--text-muted); cursor:pointer; font-size:11px; padding:2px 6px; border-radius:5px; }
-.board-filter-chip--clear-all:hover { color:var(--text-primary); }
-.board-filter-chip--clear-all:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
-
-.board-filter-popover-anchor { position:relative; }
-.board-filter-popover { position:absolute; top:calc(100% + 6px); right:0; z-index:200; width:260px; background:var(--bg-raised); border:1px solid var(--border-strong); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,.25); overflow:hidden; }
-.board-filter-popover-section { padding:10px 12px 6px; }
-.board-filter-popover-section+.board-filter-popover-section { border-top:1px solid var(--border-hairline); }
-.board-filter-popover-label { font-size:10px; font-weight:600; letter-spacing:.06em; text-transform:uppercase; color:var(--text-secondary); margin-bottom:6px; }
-.board-filter-option { display:flex; align-items:center; gap:7px; padding:4px 2px; border-radius:5px; cursor:pointer; font-size:12px; color:var(--text-secondary); background:transparent; border:none; width:100%; text-align:left; transition:background .1s,color .1s; }
-.board-filter-option:hover { background:var(--bg-hover); color:var(--text-primary); }
-.board-filter-check { width:14px; height:14px; border-radius:4px; border:1px solid var(--border-strong); background:var(--bg-base); display:flex; align-items:center; justify-content:center; flex-shrink:0; transition:background .1s,border-color .1s; }
-.board-filter-check--on { background:var(--accent-presence); border-color:var(--accent-presence); }
-.board-filter-popover-footer { display:flex; align-items:center; justify-content:space-between; padding:8px 12px; border-top:1px solid var(--border-hairline); }
 
 .board-table-wrap { flex:1; min-height:0; overflow:auto; }
 .board-table { width:100%; border-collapse:collapse; font-size:12px; }
@@ -213,13 +183,8 @@
 .board-table-familiar-avatar { display:flex; align-items:center; justify-content:center; width:16px; height:16px; border-radius:5px; background:var(--bg-elevated); border:1px solid var(--border-hairline); color:var(--text-primary); overflow:hidden; flex-shrink:0; }
 .board-table-familiar-avatar > * { display:flex; }
 .board-table-familiar-avatar--empty { color:var(--text-muted); }
-.board-table-cell-familiar-name { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; min-width:0; }
 .board-table-familiar-select { width:100%; min-width:0; max-width:112px; height:24px; border:1px solid transparent; border-radius:5px; background:transparent; color:var(--text-primary); font:inherit; font-size:11.5px; font-weight:450; cursor:pointer; outline:none; }
 .board-table-familiar-select:hover,.board-table-familiar-select:focus-visible { border-color:var(--border-hairline); background:var(--bg-elevated); }
-.board-table-cell-path { display:inline-block; max-width:100%; padding:1px 6px; border-radius:4px; background:var(--bg-elevated); border:1px solid var(--border-hairline); color:var(--text-secondary); font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace); font-size:10.5px; letter-spacing:-.01em; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; vertical-align:middle; }
-.board-table-cell-links { display:inline-flex; align-items:center; gap:4px; color:var(--text-secondary); font-size:11px; }
-.board-table-cell-links svg { color:var(--text-muted); }
-.board-table-cell-empty { color:color-mix(in oklch,var(--text-muted) 50%,transparent); font-size:11px; }
 .board-table-cell-date { color:var(--text-secondary); font-size:11px; font-variant-numeric:tabular-nums; white-space:nowrap; }
 .board-table-cell-time { color:var(--text-muted); font-size:11px; font-variant-numeric:tabular-nums; }
 
@@ -425,7 +390,6 @@
    landscape rounded corner so the title and close button are never occluded;
    --sai-* fall back to 0px off-device so desktop is unaffected. */
 .board-drawer-header { display:flex; align-items:center; justify-content:space-between; gap:8px; padding:14px 16px; padding-top:calc(14px + var(--sai-top)); padding-right:calc(16px + var(--sai-right)); border-bottom:1px solid var(--border-hairline); flex-shrink:0; }
-.board-drawer-title { font-size:13px; font-weight:600; color:var(--text-primary); flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .board-drawer-title-input { flex:1; min-width:0; background:transparent; border:1px solid transparent; border-radius:7px; padding:4px 8px; margin-left:-8px; font:600 15px/1.3 var(--font-sans,inherit); color:var(--text-primary); outline:none; text-overflow:ellipsis; transition:background .12s,border-color .12s,box-shadow .12s; }
 .board-drawer-title-input:hover { border-color:var(--border-hairline); background:color-mix(in oklch,var(--bg-hover) 50%,transparent); }
 .board-drawer-title-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 60%,transparent); background:var(--bg-base); box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 16%,transparent); }
@@ -511,13 +475,6 @@
 .board-drawer-chat-unlink:hover { background:var(--bg-hover); border-color:color-mix(in oklch,var(--color-danger,#ef4444) 50%,var(--border-hairline)); color:var(--color-danger,#ef4444); }
 
 /* CWD path field */
-.board-drawer-path-shell { position:relative; display:block; width:100%; }
-.board-drawer-path-open { position:absolute; left:6px; top:50%; transform:translateY(-50%); display:inline-flex; align-items:center; justify-content:center; width:24px; height:24px; border-radius:6px; border:0; background:transparent; color:var(--text-muted); cursor:pointer; transition:background .12s,color .12s; z-index:1; }
-.board-drawer-path-open:hover { background:var(--bg-hover); color:var(--text-primary); }
-.board-drawer-path-open:focus-visible { outline:2px solid color-mix(in oklch,var(--accent-presence) 65%,transparent); outline-offset:1px; }
-.board-drawer-path-input { padding-left:32px; font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace); font-size:12px; letter-spacing:-.01em; }
-.board-drawer-path-preview { min-height:20px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; border:1px solid var(--border-hairline); border-radius:6px; background:var(--bg-raised); padding:4px 7px; font-family:var(--font-mono,ui-monospace,SFMono-Regular,Menlo,monospace); font-size:10.5px; line-height:1.2; color:var(--text-muted); }
-.board-drawer-field-error { margin:6px 0 0; color:var(--color-danger); font-size:10.5px; line-height:1.35; }
 
 /* Lifecycle card */
 .board-drawer-lifecycle-card { display:flex; flex-direction:column; gap:10px; padding:11px 12px; border-radius:10px; border:1px solid var(--border-hairline); background:var(--bg-base); }
@@ -549,9 +506,6 @@
 .board-label-chip:hover { background:color-mix(in oklch,var(--accent-presence) 10%,var(--bg-base)); border-color:color-mix(in oklch,var(--accent-presence) 30%,var(--border-strong)); color:var(--text-primary); }
 .board-label-chip-remove { display:flex; align-items:center; justify-content:center; width:12px; height:12px; border-radius:4px; border:none; background:transparent; color:var(--text-muted); cursor:pointer; padding:0; transition:color .1s; }
 .board-label-chip-remove:hover { color:var(--text-primary); }
-.board-task-links { display:flex; flex-wrap:wrap; gap:5px; margin-bottom:6px; }
-.board-task-link { display:inline-flex; max-width:100%; min-width:0; align-items:center; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; padding:2px 8px; border-radius:7px; border:1px solid var(--border-strong); background:var(--bg-base); color:var(--text-secondary); font-size:11px; text-decoration:none; }
-.board-task-link:hover { background:var(--bg-hover); color:var(--text-primary); }
 
 .board-empty { display:flex; flex-direction:column; align-items:center; justify-content:center; flex:1; gap:8px; padding:48px 24px; color:var(--text-muted); font-size:13px; }
 
@@ -1480,41 +1434,6 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   z-index: 2;
 }
 .board-card-stack__filters::-webkit-scrollbar { display: none; }
-.board-card-stack__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  height: var(--touch-target);
-  padding: 0 14px;
-  border-radius: 999px;
-  border: 1px solid var(--border-strong);
-  background: var(--bg-raised);
-  color: var(--text-secondary);
-  font-size: 12px;
-  white-space: nowrap;
-  cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-standard),
-              border-color var(--duration-fast) var(--ease-standard),
-              color var(--duration-fast) var(--ease-standard);
-}
-.board-card-stack__chip:hover { background: var(--bg-hover); }
-.board-card-stack__chip:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 2px;
-}
-.board-card-stack__chip--active {
-  background: color-mix(in oklch, var(--accent-presence) 22%, var(--bg-raised));
-  border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong));
-  color: var(--text-primary);
-}
-.board-card-stack__chip-count {
-  font-size: 10px;
-  color: var(--text-muted);
-  font-variant-numeric: tabular-nums;
-}
-.board-card-stack__chip--active .board-card-stack__chip-count {
-  color: var(--text-secondary);
-}
 
 .board-card-stack__section {
   display: flex;
@@ -1696,6 +1615,14 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   font-variant-numeric: tabular-nums;
 }
 .board-card-stack__row-schedule--due-soon { color: var(--color-warning); }
+.board-card-stack__row-attachments {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
 .board-card-stack__row-schedule--overdue { color: var(--color-danger); font-weight: 600; }
 .board-card-stack__row-action {
   margin-left: auto;
@@ -1885,6 +1812,15 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .cg-row:hover .cg-left { background: color-mix(in oklch, var(--accent-presence) 9%, var(--bg-base)); }
 .cg-row:hover .cg-track { background-color: color-mix(in oklch, var(--accent-presence) 5%, transparent); }
 .cg-row--sel .cg-left { background: color-mix(in oklch, var(--accent-presence) 15%, var(--bg-base)); }
+.cg-attach {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 6px;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
 .cg-c-task { font-size: 12px; font-weight: 600; padding-left: 18px !important; }
 
 /* bars (redefines the legacy .board-gantt-row__bar by status category) */


### PR DESCRIPTION
## What

Fix batch from the 2026-07-02 board-surface audit (3-lens: correctness / a11y-UX / perf-dead-code; every finding verified in source before fixing). All verified live in the running app across all four board views with zero page errors.

### Correctness
- **Inspector remount per card** (`key={selectedCard.id}`): title/notes are uncontrolled (`defaultValue` + save-on-blur), so switching cards while the drawer is open must reset them — otherwise a blur writes card A's text onto card B. Verified live: open Alpha → title "Audit card Alpha"; open Beta → "Audit card Beta".
- **Undo-reschedule snapshot**: a second reschedule of the same card inside the 5s banner window no longer clobbers the snapshot — Undo restores the *original* dates, not the intermediate position.

### Performance
- **Poll guard**: the 15s `/api/board` poll now guards `setCards` with `arrayContentEqual` — an idle board no longer re-renders every card/row/bar per tick. (Same convention `workspace.tsx` already applies to this endpoint.)
- **Hoisted familiar resolution**: kanban and card-stack resolved familiars *per card* (5 context/localStorage hook subscriptions × N cards, fresh-array literal defeating the memo). Both now resolve once per view and do O(1) map lookups per row — `board-table`'s existing `resolvedByIdMap` pattern. Stack rows also drop O(cards×familiars/sessions) linear scans.

### Parity
- **Attachment count in all four views**: gantt task labels (`cg-attach`) and mobile stack rows join the kanban/table `📎 N` chips. Verified live in both (count "2" renders, screenshots taken).

### Dead code
- Unused `stats` memo in BoardView (computed every render, rendered nowhere).
- ~80 lines of orphaned `board.css`: filter-chip/popover family, multiselect dropdown, header stats, drawer path/title leftovers, table-cell leftovers, the stack filter-chip family (replaced by `Tabs`), task-links. Every selector verified zero JSX references (incl. template-interpolation check) before deletion.
- Dead exports: `formatBoardDate` (board-schedule; only internal callers — the table has its own local copy), `WipState` type.
- Two stale test pins repointed: one guarded the dead `stats` memo itself, one pinned the deleted `.board-drawer-path-open` (also dead) in the touch-target media block.

## Tests
- `board-ux-polish.test.ts`: new assertions pin every fix (key remount, poll guard, undo re-arm guard, once-per-view resolution, chips in gantt/stack, stats stays gone).
- Full board test suite green; typecheck + tests-wired green.

## Note
This PR is a cherry-pick of the original signed commit onto a fresh branch — the original worktree's HEAD was hijacked by a concurrent session's checkout mid-flow (see `reference_another_session_hijacks_worktree_head`). Content is identical (10 files, +140/−136).

🤖 Generated with [Claude Code](https://claude.com/claude-code)