### PR TITLE
chore(release): stamp v0.0.132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.132] - 2026-07-02
+
+Patch release on top of v0.0.131. Headline: GitHub README images can be
+inspected without leaving Cave, the board UI gets a focused audit pass, and the
+desktop TypeScript toolchain is aligned with the Node 24 runtime.
+
+### Changed
+
+- **Library** - zoom GitHub README images in Cave instead of following GitHub's
+  image link.
+- **Toolchain** - aligned TypeScript and `@types/node` with the Node 24 runtime.
+
+### Fixed
+
+- **Board** - tightened card inspector remount behavior, polling guards, hoisted
+  resolution state, undo snapshots, chips, and dead board UI paths.
+
 ## [0.0.131] - 2026-07-02
 
 Patch release on top of v0.0.130. Headline: eval analysis is easier to scan,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.131"
+version = "0.0.132"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.131"
+version = "0.0.132"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.131</string>
+	<string>0.0.132</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.131</string>
+	<string>0.0.132</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.131</string>
+	<string>0.0.132</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.131</string>
+	<string>0.0.132</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.131",
+  "version": "0.0.132",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Summary
- stamp Coven Cave v0.0.132 across package, Tauri, Cargo, and iOS plist version sources
- add v0.0.132 changelog notes for post-v0.0.131 library, toolchain, and board updates

## Verification
- node --test scripts/release-notes.test.mjs
- node --experimental-strip-types src/lib/app-version.test.ts
- corepack pnpm typecheck
- corepack pnpm check:tests-wired
- corepack pnpm test:app
- corepack pnpm test:api
- corepack pnpm test:mobile
- corepack pnpm build
- cargo check --locked
- git diff --check