### PR TITLE
a11y(board): announce CRUD outcomes to assistive tech

### DIFF
--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -199,11 +199,10 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
               ?.dataset?.kanbanColumn as CardStatus | undefined;
           const card = cards.find((c) => c.id === grabbedCardId);
           if (card && dropTargetStatus && card.status !== dropTargetStatus) {
-            const col = COLUMNS.find((c) => c.id === dropTargetStatus);
+            // The final "Moved …" announcement comes from BoardView's
+            // moveCardToStatus so every view (kanban/table/stack/inspector)
+            // announces identically and drops never announce twice.
             onMoveStatus(grabbedCardId, dropTargetStatus);
-            announce(
-              `Moved '${card.title}' to ${col?.label ?? dropTargetStatus}.`,
-            );
           } else if (card) {
             announce("Drop cancelled — same column.");
           }
@@ -436,9 +435,7 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
       setTouchDragId(null);
       setGhost(null);
       if (target && card.status !== target) {
-        const col = COLUMNS.find((c) => c.id === target);
-        onMoveStatus(card.id, target);
-        announce(`Moved '${card.title}' to ${col?.label ?? target}.`);
+        onMoveStatus(card.id, target); // BoardView announces the move
       } else {
         announce("Drop cancelled.");
       }

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -181,4 +181,16 @@ assert.doesNotMatch(stack, /familiars\.find\(/, "card-stack rows use O(1) map lo
 assert.match(stack, /board-card-stack__row-attachments/, "the mobile stack shows an attachment count");
 assert.match(gantt, /cg-attach/, "the gantt task label shows an attachment count");
 
+// ── Board CRUD announces for AT (2026-07-02 audit follow-up) ─────────────────
+assert.match(view, /const \{ announce \} = useAnnouncer\(\)/, "BoardView consumes the shared announcer");
+assert.match(view, /announce\(`Created task '\$\{draft\.title\.trim\(\)\}'\.`\)/, "create announces");
+assert.match(view, /announce\(`Deleted \$\{toRemove\.length\} task/, "delete announces with undo hint");
+assert.match(view, /announce\(`Cleared \$\{cleared\.length\} done task/, "clear-done announces");
+assert.match(view, /announce\(`Moved '\$\{title\}' to /, "moveCardToStatus announces for every view");
+assert.match(view, /announce\(`Rescheduled '\$\{before\.title\}'\. Undo available\.`\)/, "reschedule announces");
+assert.match(view, /announce\(`Restored /, "undo paths announce restoration");
+// The final "Moved" message is BoardView's alone — kanban's drop paths must not
+// double-announce it (they keep their grab/over/cancel narration).
+assert.doesNotMatch(kanban, /announce\(`Moved '/, "kanban no longer announces the final move");
+
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -11,6 +11,7 @@ import { Icon } from "@/lib/icon";
 import { type Card, type CardStatus, type CardPriority, STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import { cardMatchesBoardSearch } from "@/lib/board-search";
 import { arrayContentEqual } from "@/lib/array-content-equal";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
 import { UndoToast } from "@/components/ui/undo-toast";
@@ -115,6 +116,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const [clearedBanner, setClearedBanner] = useState<{ snapshot: Card[] } | null>(null);
   // Transient undo for a gantt drag/drop reschedule — snapshots the prior dates
   // so an accidental drag is one click to revert.
+  // Async CRUD results are announced for AT: the visual toasts/banners are
+  // aria-silent, and only kanban's drag flow had an announcer before.
+  const { announce } = useAnnouncer();
   const [rescheduleUndo, setRescheduleUndo] = useState<{ id: string; title: string; prev: Partial<Card> } | null>(null);
 
   // `quiet` is for background polls: a transient poll failure must not blank
@@ -309,6 +313,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 title: before.title,
                 prev: { startDate: before.startDate ?? null, endDate: before.endDate ?? null },
               });
+        announce(`Rescheduled '${before.title}'. Undo available.`);
       }
     }
     setCards((prev) => prev.map((c) => (c.id === id ? { ...c, ...patch } : c)));
@@ -332,6 +337,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const moveCardToStatus = (id: string, status: CardStatus) => {
     const patch: Partial<Card> = { status, lifecycle: lifecycleForStatus(status), needsHuman: status === "blocked" };
     if (status === "running") (patch as Record<string, unknown>).runningSince = new Date().toISOString();
+    const title = cards.find((c) => c.id === id)?.title;
+    if (title) announce(`Moved '${title}' to ${status.charAt(0).toUpperCase()}${status.slice(1)}.`);
     void patchCard(id, patch);
   };
 
@@ -339,6 +346,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     const res = await fetch("/api/board", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(draft) });
     const json = await res.json();
     if (!json.ok) throw new Error(json.error ?? "create failed");
+    announce(`Created task '${draft.title.trim()}'.`);
     await load();
   };
 
@@ -375,6 +383,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     const idSet = new Set(toRemove.map((c) => c.id));
     if (selectedCardId && idSet.has(selectedCardId)) setSelectedCardId(null);
     setClearedBanner(null); // one bottom undo affordance at a time
+    announce(`Deleted ${toRemove.length} task${toRemove.length === 1 ? "" : "s"}. Undo available.`);
     scheduleCardDelete(
       toRemove,
       `${toRemove.length} task${toRemove.length === 1 ? "" : "s"}`,
@@ -509,13 +518,17 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     } else {
       setActionError(null);
     }
-    if (cleared.length > 0) setClearedBanner({ snapshot: cleared });
+    if (cleared.length > 0) {
+      setClearedBanner({ snapshot: cleared });
+      announce(`Cleared ${cleared.length} done task${cleared.length === 1 ? "" : "s"}. Undo available.`);
+    }
   };
 
   const handleUndoClear = async () => {
     const banner = clearedBanner;
     if (!banner) return;
     setClearedBanner(null);
+    announce(`Restored ${banner.snapshot.length} cleared task${banner.snapshot.length === 1 ? "" : "s"}.`);
     try {
       await Promise.all(
         banner.snapshot.map((c) =>
@@ -553,6 +566,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     const u = rescheduleUndo;
     if (!u) return;
     setRescheduleUndo(null);
+    announce(`Restored '${u.title}' to its previous dates.`);
     void patchCard(u.id, u.prev, false);
   };
 
@@ -1073,7 +1087,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           key={deletePending.id}
           message={`Deleted ${deletePending.label}`}
           undoAriaLabel="Undo delete"
-          onUndo={undoCardDelete}
+          onUndo={() => { announce(`Restored ${deletePending.label}.`); undoCardDelete(); }}
           onDismiss={commitCardDelete}
         />
       ) : null}


### PR DESCRIPTION
## What

Board-audit follow-up (P1 #5, the last cheap item): board mutations were **aria-silent** — only kanban's drag flow had announcer coverage. A screen-reader user got no feedback when a card was created, deleted, cleared, moved via the inspector/table/stack, or rescheduled.

- `BoardView` now consumes the shared `useAnnouncer` and announces: **create** ("Created task '…'."), **delete** ("Deleted N tasks. Undo available."), **clear-done**, **move** ("Moved '…' to Review."), **reschedule** ("Rescheduled '…'. Undo available."), and every **undo restoration**.
- The final "Moved …" message is centralized in `moveCardToStatus`, so all four views announce identically — kanban's two drop-site duplicates are removed (its grab/over/cancel narration is untouched, and its keyboard test still passes).
- Failures were already covered (visual `role="alert"` banners) — unchanged.

## Verification (live app)
The live region self-clears after 250ms (so identical messages re-announce), so a plain DOM read misses it — verified with a MutationObserver on `[aria-live]` during real interactions: inspector status change captured `"Moved 'Announcer probe' to Review."`, inspector delete captured `"Deleted 1 task. Undo available."`. Zero page errors.

## Tests
`board-ux-polish.test.ts` pins each announce site + the kanban dedupe; full board suite green; typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)