### PR TITLE
perf(board): code-split BoardView via lazy-surfaces

### DIFF
--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -64,6 +64,11 @@ export const CalendarView = dynamic(
   { ssr: false, loading: SurfaceFallback },
 );
 
+export const BoardView = dynamic(
+  timed("board", () => import("@/components/board-view").then((m) => m.BoardView)),
+  { ssr: false, loading: SurfaceFallback },
+);
+
 export const MarketplaceView = dynamic(
   timed("marketplace", () => import("@/components/marketplace-view").then((m) => m.MarketplaceViewSurface)),
   { ssr: false, loading: SurfaceFallback },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -9,7 +9,6 @@ import { arrayContentEqual } from "@/lib/array-content-equal";
 import type { ChatRouterHandle } from "@/components/chat-router";
 import type { WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-mode";
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
-import { BoardView } from "@/components/board-view";
 import { JournalView } from "@/components/journal/journal-view";
 import type { CalendarDeadline } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
@@ -43,6 +42,7 @@ import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
 // their chunks (and deps like @xyflow/react, @uiw/react-codemirror) load on
 // first open instead of shipping in the main bundle. See lazy-surfaces.tsx.
 import {
+  BoardView,
   CalendarView,
   ComuxView,
   EvalsView,


### PR DESCRIPTION
## What

Board-audit P2 item: `workspace.tsx` statically imported `BoardView`, shipping the whole board surface (kanban/table/gantt/stack/inspector + transitive deps) in the boot payload for every user — against the stated `lazy-surfaces.tsx` convention that already splits Comux/GitHub/Flow/Evals/Calendar/Marketplace. BoardView now routes through the same `next/dynamic` boundary with the `timed("board", …)` perf mark (visible in `?perf=1`) and the shared skeleton fallback.

## Measured impact
- The board lands in a **116 KB async chunk** that is absent from every page's initial script set (checked `build-manifest.json`), fetched on first board open. (The bundle-budget "shell" metric is unchanged at 447 KB — it only counts `rootMainFiles`; the board previously rode in the `/` page chunk, which is also boot-loaded in this single-page app.)
- Live-verified with network capture: navigating Home → Tasks fetches the `board-view` chunk at that moment; board renders; **0 page errors**.

## Deep-link safety
The `#card-<id>` focus-card intent is unaffected by lazy mounting: workspace writes the **URL hash** (durable), and BoardView's hash effect re-applies once `cards` load after the async mount. Verified live from a cold Home surface — the inspector opened on the exact target card.

## Tests
- Bundle-budget gate green (runs as postbuild in Frontend build).
- Existing board E2E specs (`board-touch`, `board-attachments`) navigate to the board through the UI, so they exercise the lazy mount in CI.
- tests-wired + typecheck green; workspace-adjacent unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)