### PR TITLE
feat(skills): 3-column Skill Browser (rail · list · rendered SKILL.md)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -129,6 +129,7 @@ export const SUITES = {
     "src/components/theme-color-editor.test.ts",
     "src/lib/theme-token-hex.test.ts",
     "src/components/roles-tools-navigation.test.ts",
+    "src/components/skill-browser.test.ts",
     "src/components/top-bar.test.ts",
     "src/components/command-palette.test.ts",
     "src/components/command-palette-a11y.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10323,3 +10323,165 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
     display: none !important;
   }
 }
+
+/* ── Skill Browser (Roles → Skills tab): rail · card list · SKILL.md detail ── */
+.skill-browser {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-base);
+}
+.skill-browser__rail {
+  flex: 0 0 190px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 10px;
+  overflow-y: auto;
+  border-right: 1px solid var(--border-hairline);
+}
+.skill-browser__cat {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 10px;
+  border-radius: 9px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.skill-browser__cat:hover { background: var(--bg-hover); color: var(--text-primary); }
+.skill-browser__cat.is-active {
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  color: var(--text-primary);
+}
+.skill-browser__cat-icon { flex: 0 0 auto; color: var(--text-muted); }
+.skill-browser__cat.is-active .skill-browser__cat-icon { color: var(--accent-presence); }
+.skill-browser__cat-label { flex: 1; min-width: 0; }
+.skill-browser__cat-count { flex: 0 0 auto; font-variant-numeric: tabular-nums; font-size: 12px; color: var(--text-muted); }
+
+.skill-browser__list {
+  flex: 0 0 300px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  overflow-y: auto;
+  border-right: 1px solid var(--border-hairline);
+}
+.skill-browser__card {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 11px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-panel, var(--bg-base));
+  cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease, transform 0.1s ease;
+}
+.skill-browser__card:hover { border-color: var(--border-strong); background: var(--bg-hover); }
+.skill-browser__card:active { transform: scale(0.995); }
+.skill-browser__card.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-panel, var(--bg-base)));
+}
+.skill-browser__card-main { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.skill-browser__card-name { font-size: 13px; font-weight: 600; color: var(--text-primary); }
+.skill-browser__card-desc {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.skill-browser__badge {
+  flex: 0 0 auto;
+  align-self: flex-start;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  border-radius: 999px;
+  padding: 2px 8px;
+  white-space: nowrap;
+}
+
+.skill-browser__detail { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; min-height: 0; }
+.skill-browser__detail-head { padding: 18px 20px 12px; border-bottom: 1px solid var(--border-hairline); }
+.skill-browser__detail-name { margin: 0; font-size: 18px; font-weight: 700; color: var(--text-primary); }
+.skill-browser__detail-path {
+  margin: 3px 0 0;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.skill-browser__detail-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.skill-browser__tag {
+  font-size: 10px;
+  color: var(--text-muted);
+  background: var(--bg-base);
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+  padding: 2px 7px;
+}
+.skill-browser__detail-body { flex: 1; min-height: 0; overflow-y: auto; padding: 16px 20px 28px; }
+.skill-browser__fallback { font-size: 13px; line-height: 1.6; color: var(--text-secondary); }
+.skill-browser__detail-empty { display: grid; place-items: center; height: 100%; color: var(--text-muted); font-size: 13px; }
+.skill-browser__note { padding: 16px; color: var(--text-muted); font-size: 13px; }
+.skill-browser__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+.skill-browser__empty svg { color: var(--accent-presence); opacity: 0.8; }
+.skill-browser__empty-action {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 35%, transparent);
+  border-radius: 8px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.skill-browser__skeleton { display: flex; flex-direction: column; gap: 10px; }
+.skill-browser__skeleton span {
+  display: block;
+  height: 12px;
+  border-radius: 6px;
+  background: var(--bg-hover);
+  animation: skill-browser-pulse 1.4s ease-in-out infinite;
+}
+@keyframes skill-browser-pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 0.9; } }
+@media (prefers-reduced-motion: reduce) { .skill-browser__skeleton span { animation: none; } }
+
+@media (max-width: 900px) {
+  .skill-browser__rail { display: none; }
+}
+@media (max-width: 680px) {
+  .skill-browser { flex-direction: column; }
+  .skill-browser__list { flex: 0 0 auto; max-height: 42%; border-right: 0; border-bottom: 1px solid var(--border-hairline); }
+}

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { SkillCard } from "@/components/skill-card";
+import { SkillBrowser } from "@/components/skill-browser";
 import {
   SkillDetailDrawer,
   type FamiliarForSkill,
@@ -236,14 +236,6 @@ export function PluginsView({
     [roles, query],
   );
 
-  const filteredSkills = useMemo(
-    () =>
-      skills.filter((skill) =>
-        includesQuery([skill.id, skill.name, skill.description, skill.kind, skill.familiar, ...(skill.tags ?? [])], query),
-      ),
-    [skills, query],
-  );
-
   const filteredWorkflows = useMemo(
     () =>
       workflows.filter((workflow) =>
@@ -432,7 +424,9 @@ export function PluginsView({
           role="tabpanel"
           id={`plugins-panel-${tab}`}
           aria-labelledby={`plugins-tab-${tab}`}
-          className="min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6"
+          // The Skills tab is a full-bleed 3-column browser that owns its own
+          // per-column scrolling; other tabs keep the padded scroll container.
+          className={`min-h-0 flex-1 ${tab === "skills" ? "overflow-hidden" : "overflow-y-auto px-4 py-4 sm:px-6"}`}
         >
           {tab === "roles" ? (
             <RolesTab
@@ -450,12 +444,11 @@ export function PluginsView({
             <WorkflowsTab workflows={filteredWorkflows} loaded={workflowsLoaded} query={query} onClearQuery={() => setQuery("")} onOpenWorkflow={onOpenWorkflow} />
           ) : (
             <SkillsTab
-              skills={filteredSkills}
+              skills={skills}
               loaded={skillsLoaded}
               query={query}
               onClearQuery={() => setQuery("")}
               onCreateSkill={openCapabilities}
-              onSelectSkill={(skill) => setSelectedSkill(toSkillDetail(skill))}
             />
           )}
         </div>
@@ -692,41 +685,22 @@ function SkillsTab({
   query,
   onClearQuery,
   onCreateSkill,
-  onSelectSkill,
 }: {
   skills: LocalSkillEntry[];
   loaded: boolean;
   query: string;
   onClearQuery: () => void;
   onCreateSkill?: () => void;
-  onSelectSkill: (skill: LocalSkillEntry) => void;
 }) {
-  if (!loaded) return <ListSkeleton />;
-  if (skills.length === 0) {
-    return query
-      ? <SearchEmpty kind="skills" query={query} onClear={onClearQuery} />
-      : <EmptyPanel icon={ICONS.tabSkills} title="No local skills found" body="Create or install skills to make them available to familiars." actionLabel="Open Capabilities" onAction={onCreateSkill} />;
-  }
-
+  // Three-column browser: category rail · card list · rendered SKILL.md detail.
   return (
-    <div className="flex flex-col gap-1.5">
-      {skills.map((skill) => (
-        <SkillCard
-          key={`${skill.familiar}:${skill.id}:${skill.path}`}
-          skill={{
-            id: skill.id,
-            name: skill.name,
-            description: skill.description,
-            version: skill.version,
-            category: skill.kind,
-            owner: skill.familiar,
-            tags: skill.tags,
-            source: skill.path,
-          }}
-          onClick={() => onSelectSkill(skill)}
-        />
-      ))}
-    </div>
+    <SkillBrowser
+      skills={skills}
+      loaded={loaded}
+      query={query}
+      onClearQuery={onClearQuery}
+      onCreateSkill={onCreateSkill}
+    />
   );
 }
 

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -1,0 +1,56 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./skill-browser.tsx", import.meta.url), "utf8");
+const plugins = readFileSync(new URL("./plugins-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── Three-column browser: rail · list · detail ───────────────────────────────
+assert.match(src, /export function SkillBrowser\(/, "exports the SkillBrowser component");
+assert.match(src, /className="skill-browser__rail"/, "renders the category rail");
+assert.match(src, /className="skill-browser__list"/, "renders the card list");
+assert.match(src, /className="skill-browser__detail"/, "renders the detail pane");
+
+// Category rail: All / Claude Code / Generic with derived counts.
+assert.match(src, /label: "All Skills"/, "rail has an All Skills entry");
+assert.match(src, /label: "Claude Code"[\s\S]*?icon: "ph:terminal-window"/, "rail has a Claude Code entry");
+assert.match(src, /label: "Generic"[\s\S]*?icon: "ph:puzzle-piece"/, "rail has a Generic entry");
+assert.match(
+  src,
+  /familiar === "user" \? "claude" : "generic"/,
+  "maps scan scope (user→Claude Code, global→Generic)",
+);
+assert.match(src, /className="skill-browser__cat-count"/, "each category shows a count");
+
+// Detail pane sources the SKILL.md body from /api/skills/file and renders it.
+assert.match(
+  src,
+  /fetch\(`\/api\/skills\/file\?path=\$\{encodeURIComponent\(selectedPath\)\}`/,
+  "detail fetches the selected skill's SKILL.md via /api/skills/file",
+);
+assert.match(src, /stripFrontmatter\(preview\.text\)/, "strips YAML frontmatter before rendering");
+assert.match(src, /<MarkdownBlock text=\{body\}/, "renders the SKILL.md body as markdown");
+assert.match(src, /selected\.description \|\| "No preview available/, "falls back to the description on error/empty (e.g. 403 outside allow-listed roots)");
+assert.match(src, /skill-browser__detail-path/, "detail shows the skill's path");
+
+// Selection is sticky-but-safe: first visible when the pick is filtered out.
+assert.match(src, /visible\.find\(\(s\) => skillKey\(s\) === selectedKey\) \?\? visible\[0\]/, "auto-selects the first visible skill");
+
+// ── plugins-view wiring: Skills tab renders the browser (no old drawer path) ──
+assert.match(plugins, /import \{ SkillBrowser \}/, "plugins-view imports SkillBrowser");
+assert.match(plugins, /<SkillBrowser\s+skills=\{skills\}/, "SkillsTab renders SkillBrowser with the full skill list");
+assert.doesNotMatch(plugins, /import \{ SkillCard \}/, "the old flat SkillCard list is retired from the Skills tab");
+// The Skills tab is full-bleed so the browser owns per-column scrolling.
+assert.match(
+  plugins,
+  /tab === "skills" \? "overflow-hidden" : "overflow-y-auto/,
+  "the Skills tabpanel is full-bleed (browser scrolls its own columns)",
+);
+
+// ── CSS present ──────────────────────────────────────────────────────────────
+assert.match(css, /\.skill-browser \{[\s\S]*?display: flex;/, "the browser is a flex 3-column layout");
+assert.match(css, /\.skill-browser__card\.is-active \{/, "the selected card is highlighted");
+assert.match(css, /@media \(max-width: 900px\)[\s\S]*?\.skill-browser__rail \{ display: none;/, "the rail collapses on small screens");
+
+console.log("skill-browser.test.ts OK");

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+// Skill Browser — a three-column view of local skills: a category rail (All /
+// Claude Code / Generic with counts), a searchable card list, and a detail pane
+// that renders the selected skill's SKILL.md. Replaces the old flat list + slide
+// -over drawer for the Roles → Skills tab.
+
+import { useEffect, useMemo, useState } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+import { MarkdownBlock } from "@/components/message-bubble";
+
+export type SkillBrowserEntry = {
+  id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  kind?: string;
+  tags?: string[];
+  /** Absolute path to the skill's SKILL.md. */
+  path: string;
+  /** Scan scope: "user" (~/.claude/skills) or "global" (Coven shared skills). */
+  familiar: string;
+};
+
+type Category = "all" | "claude" | "generic";
+type PreviewState = {
+  status: "idle" | "loading" | "loaded" | "error";
+  text: string | null;
+  error: string | null;
+};
+
+// The scan tags user skills (~/.claude/skills) as "user" and shared Coven skills
+// as "global"; surface those as "Claude Code" vs "Generic".
+function categoryOf(skill: SkillBrowserEntry): "claude" | "generic" {
+  return skill.familiar === "user" ? "claude" : "generic";
+}
+const CATEGORY_LABEL: Record<"claude" | "generic", string> = {
+  claude: "Claude Code",
+  generic: "Generic",
+};
+
+const RAIL: { id: Category; label: string; icon: IconName }[] = [
+  { id: "all", label: "All Skills", icon: "ph:squares-four" },
+  { id: "claude", label: "Claude Code", icon: "ph:terminal-window" },
+  { id: "generic", label: "Generic", icon: "ph:puzzle-piece" },
+];
+
+function skillKey(skill: SkillBrowserEntry): string {
+  return `${skill.familiar}:${skill.id}:${skill.path}`;
+}
+
+// SKILL.md opens with a YAML frontmatter block (name/description/tags) already
+// surfaced as the title/badges — strip it so the body reads as prose.
+function stripFrontmatter(text: string): string {
+  return text.replace(/^﻿?---\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n?/, "").trimStart();
+}
+
+function matchesQuery(skill: SkillBrowserEntry, query: string): boolean {
+  if (!query) return true;
+  const hay = [skill.id, skill.name, skill.description, skill.kind, skill.familiar, ...(skill.tags ?? [])]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return hay.includes(query.toLowerCase());
+}
+
+// Collapse the absolute SKILL.md path to a friendly directory (drops /SKILL.md,
+// tildes the home prefix) for the detail header.
+function displayPath(path: string): string {
+  const dir = path.replace(/\/SKILL\.md$/i, "");
+  return dir.replace(/^\/(?:Users|home)\/[^/]+/, "~");
+}
+
+export function SkillBrowser({
+  skills,
+  loaded,
+  query,
+  onClearQuery,
+  onCreateSkill,
+}: {
+  skills: SkillBrowserEntry[];
+  loaded: boolean;
+  query: string;
+  onClearQuery: () => void;
+  onCreateSkill?: () => void;
+}) {
+  const [category, setCategory] = useState<Category>("all");
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewState>({ status: "idle", text: null, error: null });
+
+  const counts = useMemo(
+    () => ({
+      all: skills.length,
+      claude: skills.filter((s) => categoryOf(s) === "claude").length,
+      generic: skills.filter((s) => categoryOf(s) === "generic").length,
+    }),
+    [skills],
+  );
+
+  const visible = useMemo(
+    () => skills.filter((s) => (category === "all" || categoryOf(s) === category) && matchesQuery(s, query)),
+    [skills, category, query],
+  );
+
+  // Keep a valid selection: fall back to the first visible skill when the
+  // current pick is filtered out (or nothing is selected yet).
+  const selected = useMemo(
+    () => visible.find((s) => skillKey(s) === selectedKey) ?? visible[0] ?? null,
+    [visible, selectedKey],
+  );
+  const selectedPath = selected?.path ?? null;
+
+  // Load the selected skill's SKILL.md for the detail pane. Only paths under the
+  // allow-listed roots return content; anything else 403s → fall back to the
+  // scanned description so the pane never goes blank.
+  useEffect(() => {
+    if (!selectedPath) {
+      setPreview({ status: "idle", text: null, error: null });
+      return;
+    }
+    let cancelled = false;
+    setPreview({ status: "loading", text: null, error: null });
+    void (async () => {
+      try {
+        const res = await fetch(`/api/skills/file?path=${encodeURIComponent(selectedPath)}`, { cache: "no-store" });
+        const json = (await res.json()) as { ok: boolean; text?: string; error?: string };
+        if (cancelled) return;
+        if (!json.ok) setPreview({ status: "error", text: null, error: json.error ?? `http ${res.status}` });
+        else setPreview({ status: "loaded", text: json.text ?? "", error: null });
+      } catch (err) {
+        if (!cancelled) setPreview({ status: "error", text: null, error: err instanceof Error ? err.message : "fetch failed" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPath]);
+
+  const body = preview.text ? stripFrontmatter(preview.text) : "";
+
+  return (
+    <div className="skill-browser" role="group" aria-label="Skill browser">
+      {/* ── Category rail ────────────────────────────────────────────── */}
+      <nav className="skill-browser__rail" aria-label="Skill categories">
+        {RAIL.map((cat) => {
+          const count = counts[cat.id === "all" ? "all" : cat.id];
+          const active = category === cat.id;
+          return (
+            <button
+              key={cat.id}
+              type="button"
+              className={`skill-browser__cat${active ? " is-active" : ""}`}
+              aria-pressed={active}
+              onClick={() => setCategory(cat.id)}
+            >
+              <Icon name={cat.icon} width={15} className="skill-browser__cat-icon" aria-hidden />
+              <span className="skill-browser__cat-label">{cat.label}</span>
+              <span className="skill-browser__cat-count">{count}</span>
+            </button>
+          );
+        })}
+      </nav>
+
+      {/* ── Card list ────────────────────────────────────────────────── */}
+      <div className="skill-browser__list" role="listbox" aria-label="Skills">
+        {!loaded ? (
+          <div className="skill-browser__note" aria-hidden>
+            Loading skills…
+          </div>
+        ) : skills.length === 0 ? (
+          <div className="skill-browser__empty">
+            <Icon name="ph:puzzle-piece" width={22} aria-hidden />
+            <p>No local skills found.</p>
+            {onCreateSkill ? (
+              <button type="button" className="skill-browser__empty-action" onClick={onCreateSkill}>
+                Open Capabilities
+              </button>
+            ) : null}
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="skill-browser__empty">
+            <p>No skills match “{query.trim()}”.</p>
+            <button type="button" className="skill-browser__empty-action" onClick={onClearQuery}>
+              Clear search
+            </button>
+          </div>
+        ) : (
+          visible.map((skill) => {
+            const key = skillKey(skill);
+            const isSel = selected != null && skillKey(selected) === key;
+            return (
+              <button
+                key={key}
+                type="button"
+                role="option"
+                aria-selected={isSel}
+                className={`skill-browser__card${isSel ? " is-active" : ""}`}
+                onClick={() => setSelectedKey(key)}
+              >
+                <span className="skill-browser__card-main">
+                  <span className="skill-browser__card-name">{skill.name}</span>
+                  {skill.description ? (
+                    <span className="skill-browser__card-desc">{skill.description}</span>
+                  ) : null}
+                </span>
+                <span className="skill-browser__badge">{CATEGORY_LABEL[categoryOf(skill)]}</span>
+              </button>
+            );
+          })
+        )}
+      </div>
+
+      {/* ── Detail pane ──────────────────────────────────────────────── */}
+      <div className="skill-browser__detail">
+        {selected ? (
+          <>
+            <div className="skill-browser__detail-head">
+              <h2 className="skill-browser__detail-name">{selected.name}</h2>
+              <p className="skill-browser__detail-path" title={selected.path}>
+                {displayPath(selected.path)}
+              </p>
+              <div className="skill-browser__detail-meta">
+                <span className="skill-browser__badge">{CATEGORY_LABEL[categoryOf(selected)]}</span>
+                {selected.version ? <span className="skill-browser__badge">v{selected.version}</span> : null}
+                {(selected.tags ?? []).slice(0, 6).map((t) => (
+                  <span key={t} className="skill-browser__tag">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <div className="skill-browser__detail-body">
+              {preview.status === "loading" ? (
+                <div className="skill-browser__skeleton" aria-hidden>
+                  {["90%", "96%", "70%", "88%", "60%"].map((w, i) => (
+                    <span key={i} style={{ width: w }} />
+                  ))}
+                </div>
+              ) : preview.status === "loaded" && body ? (
+                <MarkdownBlock text={body} className="cave-md--expanded" />
+              ) : (
+                // 403 (path outside allow-listed roots), empty file, or error —
+                // show the scanned description so the pane is never blank.
+                <p className="skill-browser__fallback">
+                  {selected.description || "No preview available for this skill."}
+                </p>
+              )}
+            </div>
+          </>
+        ) : (
+          <div className="skill-browser__detail-empty">Select a skill to view its details.</div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Redesigns the **Roles → Skills tab** into a three-column **Skill Browser** (emulating a dedicated skill-browser app):

- **Category rail** — All Skills / Claude Code / Generic, each with a live count. Derived from scan scope: `user` (`~/.claude/skills`) → "Claude Code", `global` (Coven shared) → "Generic".
- **Card list** — searchable (via the shared Roles search), each card = name + truncated description + scope badge; selected card highlighted.
- **Detail pane** — the selected skill's name, path, scope chip/tags, and its **rendered SKILL.md** (fetched from `/api/skills/file`, frontmatter stripped, rendered with `MarkdownBlock` incl. code highlighting). Falls back to the scanned description when a path is outside the allow-listed preview roots (403) or empty.

Replaces the old flat `SkillCard` list + slide-over `SkillDetailDrawer` for this tab. The role-card "open skill" chip still uses the drawer; the tabs and their a11y contract are unchanged (so `roles-tools-navigation` stays green).

## Files
- `skill-browser.tsx` (new) + `skill-browser.test.ts` (new, wired in run-tests.mjs)
- `plugins-view.tsx` — Skills tab renders `SkillBrowser`; tabpanel full-bleed for skills; dropped the unused flat-list path
- `globals.css` — `.skill-browser-*` (3-col flex, rail/cards/detail, rail collapses ≤900px, stacks ≤680px)

## Verification
- Tests + `pnpm build` green.
- Drove Roles → Skills on a real build: rail "All Skills 28 / Claude Code 18 / Generic 10", 28 cards, first auto-selected, detail pane rendered real SKILL.md ("coven-astra" → Identity/Purpose/Vibe). Screenshot matches the target layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)