### PR TITLE
test(supply-chain): guard against sharp version skew that breaks the Windows sidecar

### DIFF
--- a/scripts/dependency-policy.test.mjs
+++ b/scripts/dependency-policy.test.mjs
@@ -45,4 +45,67 @@ assert.equal(
   "pnpm saveExact must keep future added dependencies pinned by default",
 );
 
-console.log("dependency-policy.test.mjs: ok");
+// --- sharp version-skew guard (Windows sidecar) ------------------------------
+// `next` hard-pins its own `sharp`; bumping our direct `sharp` dependency above
+// that pin makes two sharp versions coexist in the lockfile. The sidecar's
+// hoisted staging bundle then loads one version's `@img/sharp-<target>` native
+// under the other version's JS → native/JS ABI mismatch → on win32 `format()`
+// returns a table with no `heif`, so `sharp/dist/utility.cjs` throws at load and
+// the avatar route 500s. macOS/Linux tolerate the mismatch, so ONLY the
+// `Sidecar runtime (windows-latest)` CI leg catches it. This guard fails fast in
+// the required Frontend-build check instead. Fix a divergence by aligning `sharp`
+// to next's pin, or by adding `pnpm.overrides.sharp` so next's transitive copy is
+// forced to the same version. (PR #2263 dug out this root cause.)
+const lockfile = parse(await readFile(new URL("../pnpm-lock.yaml", import.meta.url), "utf8"));
+const lockPackages = lockfile.packages ?? lockfile.snapshots ?? {};
+
+const splitLockKey = (key) => {
+  const at = key.lastIndexOf("@");
+  return { name: key.slice(0, at), version: key.slice(at + 1).replace(/\(.*\)$/, "") };
+};
+
+const sharpVersions = new Set();
+const nativeVersions = new Map(); // `@img/sharp-<target>` → Set<version>
+for (const key of Object.keys(lockPackages)) {
+  const { name, version } = splitLockKey(key);
+  if (name === "sharp") sharpVersions.add(version);
+  // native ABI packages track sharp's version in lockstep; libvips packages do not.
+  if (/^@img\/sharp-(?!libvips)/.test(name)) {
+    if (!nativeVersions.has(name)) nativeVersions.set(name, new Set());
+    nativeVersions.get(name).add(version);
+  }
+}
+
+assert.ok(sharpVersions.size >= 1, "sharp must be present in pnpm-lock.yaml");
+assert.equal(
+  sharpVersions.size,
+  1,
+  `sharp must resolve to a SINGLE version in pnpm-lock.yaml, found ${[...sharpVersions].sort().join(", ")}. ` +
+    "This is the version skew that breaks the Windows sidecar bundle: next pins its own sharp, so a direct " +
+    "bump adds a second copy and the hoisted @img/sharp-<target> native mismatches sharp's JS (win32 drops " +
+    "heif). Align sharp to next's pinned version, or add pnpm.overrides.sharp to force next's transitive copy.",
+);
+
+const [resolvedSharp] = [...sharpVersions];
+assert.equal(
+  packageJson.dependencies?.sharp,
+  resolvedSharp,
+  `package.json dependencies.sharp (${packageJson.dependencies?.sharp}) must equal the single resolved ` +
+    `lockfile sharp version (${resolvedSharp})`,
+);
+
+for (const [name, versions] of nativeVersions) {
+  assert.equal(
+    versions.size,
+    1,
+    `${name} must resolve to a single version in pnpm-lock.yaml, found ${[...versions].sort().join(", ")} ` +
+      "— a native/JS ABI skew that crashes the Windows sidecar. Reconcile sharp to one version (see above).",
+  );
+  assert.ok(
+    versions.has(resolvedSharp),
+    `${name} (${[...versions][0]}) must match the resolved sharp version (${resolvedSharp}); ` +
+      "the sidecar bundle loads this native under sharp's JS.",
+  );
+}
+
+console.log(`dependency-policy.test.mjs: ok (sharp pinned coherently at ${resolvedSharp})`);


### PR DESCRIPTION
## What

Adds a CI guard so a future blind `sharp` bump can't silently reintroduce the version-skew that breaks the Windows sidecar (root-caused while closing #2263).

## Why

`next@16.2.9` hard-pins its own `sharp`. Bumping our **direct** `sharp` dep above that pin makes **two** sharp versions coexist in the lockfile; the sidecar's hoisted staging bundle then loads one version's `@img/sharp-<target>` native under the other version's JS. On win32 that ABI mismatch drops `heif` from `format()`, so `sharp/dist/utility.cjs` throws at module-load and the avatar route 500s.

It's a nasty trap because **only `Sidecar runtime (windows-latest)` catches it** — macOS/Linux tolerate the mismatch and local macOS `Frontend build` goes fully green.

## The guard

A new assertion block in `scripts/dependency-policy.test.mjs` (already wired into the required **Frontend build** via the `api` suite) parses `pnpm-lock.yaml` and fails if:

- more than one `sharp` version is resolved, **or**
- the resolved `sharp` version diverges from `package.json`, **or**
- any `@img/sharp-<native>` package drifts off the resolved sharp version (`@img/sharp-libvips-*` excluded — it versions independently).

The failure message tells the next person the fix: align `sharp` to next's pin, or add `pnpm.overrides.sharp` to force next's transitive copy to match.

## Verification

- `node scripts/dependency-policy.test.mjs` → `ok (sharp pinned coherently at 0.34.5)` on this branch.
- Synthetic two-version lockfile → guard throws as expected; `@img/sharp-libvips-*` correctly excluded from the native-ABI set.
- `check:tests-wired` green (no new file; assertion added to an already-wired test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
