### PR TITLE
Skill Browser: reveal-folder + delete actions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -764,6 +764,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/session-rail-title.test.ts",
   "src/lib/server/familiar-contract-files.test.ts",
   "src/lib/server/project-paths.test.ts",
+  "src/lib/server/skill-file-paths.test.ts",
   "src/lib/server/agent-attachments.test.ts",
   "src/lib/server/session-project-roots.test.ts",
   "src/app/api/library/doc/route.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -154,7 +154,7 @@ const contracts: RouteContract[] = [
   { route: "/skills/eval-loop/[familiarId]", methods: ["GET"], kind: "json" },
   { route: "/skills/eval-loop/[familiarId]/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/skills/eval-loop/[familiarId]/run-lock", methods: ["DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
-  { route: "/skills/local", methods: ["GET"], kind: "json" },
+  { route: "/skills/local", methods: ["GET", "DELETE"], kind: "json" },
   { route: "/skills", methods: ["GET"], kind: "json" },
   { route: "/theme", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/travel/client", methods: ["GET", "PATCH"], kind: "json", readsJson: true },

--- a/src/app/api/skills/local/route.ts
+++ b/src/app/api/skills/local/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import path from "node:path";
+import { rm } from "node:fs/promises";
 import { covenHome } from "@/lib/coven-paths";
 import { scanSkillsDir, scanClaudeUserSkills, type LocalSkillEntry } from "@/lib/server/skill-scan";
+import { isRemovableSkillDir } from "@/lib/server/skill-file-paths";
+import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
 
@@ -20,4 +23,30 @@ export async function GET() {
   skills.push(...await scanClaudeUserSkills());
 
   return NextResponse.json({ ok: true, skills });
+}
+
+// Remove a scanned skill's directory. Destructive → local-origin gated and
+// hard-constrained to a direct child of a scan root (see isRemovableSkillDir).
+// The client passes the skill's SKILL.md `path`; we delete its parent folder.
+export async function DELETE(req: Request) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
+  }
+  const filePath = new URL(req.url).searchParams.get("path");
+  if (!filePath) {
+    return NextResponse.json({ ok: false, error: "path required" }, { status: 400 });
+  }
+  const dir = path.dirname(filePath);
+  if (!(await isRemovableSkillDir(dir))) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+  try {
+    await rm(dir, { recursive: true, force: true });
+  } catch (err) {
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "delete failed" },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ ok: true, deleted: true, path: dir });
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10459,7 +10459,32 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 
 .skill-browser__detail { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; min-height: 0; }
 .skill-browser__detail-head { padding: 18px 20px 12px; border-bottom: 1px solid var(--border-hairline); }
-.skill-browser__detail-name { margin: 0; font-size: 18px; font-weight: 700; color: var(--text-primary); }
+.skill-browser__detail-titlerow { display: flex; align-items: flex-start; gap: 12px; }
+.skill-browser__detail-name { margin: 0; font-size: 18px; font-weight: 700; color: var(--text-primary); flex: 1; min-width: 0; }
+.skill-browser__actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.skill-browser__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--surface-raised, transparent);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+.skill-browser__action:hover:not(:disabled) { color: var(--text-primary); border-color: var(--border-strong, var(--border-hairline)); }
+.skill-browser__action:disabled { opacity: 0.5; cursor: default; }
+.skill-browser__action--danger:hover:not(:disabled) { color: var(--danger, #e5484d); border-color: var(--danger, #e5484d); }
+.skill-browser__action--danger.is-confirming {
+  color: #fff;
+  background: var(--danger, #e5484d);
+  border-color: var(--danger, #e5484d);
+}
+.skill-browser__action-label { font-size: 12px; font-weight: 600; }
+.skill-browser__notice { margin: 10px 0 0; font-size: 11.5px; color: var(--text-muted); }
 .skill-browser__detail-path {
   margin: 3px 0 0;
   font-family: var(--font-mono, ui-monospace, monospace);

--- a/src/components/plugins-view.tsx
+++ b/src/components/plugins-view.tsx
@@ -449,6 +449,7 @@ export function PluginsView({
               query={query}
               onClearQuery={() => setQuery("")}
               onCreateSkill={openCapabilities}
+              onChanged={loadSkills}
             />
           )}
         </div>
@@ -685,12 +686,14 @@ function SkillsTab({
   query,
   onClearQuery,
   onCreateSkill,
+  onChanged,
 }: {
   skills: LocalSkillEntry[];
   loaded: boolean;
   query: string;
   onClearQuery: () => void;
   onCreateSkill?: () => void;
+  onChanged?: () => void;
 }) {
   // Three-column browser: category rail · card list · rendered SKILL.md detail.
   return (
@@ -700,6 +703,7 @@ function SkillsTab({
       query={query}
       onClearQuery={onClearQuery}
       onCreateSkill={onCreateSkill}
+      onChanged={onChanged}
     />
   );
 }

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -37,9 +37,26 @@ assert.match(src, /skill-browser__detail-path/, "detail shows the skill's path")
 // Selection is sticky-but-safe: first visible when the pick is filtered out.
 assert.match(src, /visible\.find\(\(s\) => skillKey\(s\) === selectedKey\) \?\? visible\[0\]/, "auto-selects the first visible skill");
 
+// ── Detail-pane actions: reveal folder + delete ─────────────────────────────
+assert.match(src, /className="skill-browser__actions"/, "detail head has an actions cluster");
+assert.match(src, /name="ph:folder-open"/, "reveal-folder action uses the folder-open icon");
+assert.match(src, /name="ph:trash"/, "delete action uses the trash icon");
+// Reveal shells out via Tauri and copies the path on the web.
+assert.match(src, /invoke\("shell_open", \{ url: dir \}\)/, "reveal opens the folder via Tauri shell_open on desktop");
+assert.match(src, /copyText\(dir\)/, "reveal copies the path to the clipboard as the web fallback");
+// Delete is a two-step confirm hitting the DELETE route, then re-scans.
+assert.match(src, /if \(!confirmingDelete\) \{[\s\S]*?setConfirmingDelete\(true\)/, "delete requires an explicit confirm step");
+assert.match(
+  src,
+  /fetch\(`\/api\/skills\/local\?path=\$\{encodeURIComponent\(selectedPath\)\}`,\s*\{\s*method: "DELETE"/,
+  "delete calls DELETE /api/skills/local with the selected path",
+);
+assert.match(src, /onChanged\?\.\(\)/, "a successful delete asks the parent to re-scan");
+
 // ── plugins-view wiring: Skills tab renders the browser (no old drawer path) ──
 assert.match(plugins, /import \{ SkillBrowser \}/, "plugins-view imports SkillBrowser");
 assert.match(plugins, /<SkillBrowser\s+skills=\{skills\}/, "SkillsTab renders SkillBrowser with the full skill list");
+assert.match(plugins, /onChanged=\{loadSkills\}/, "SkillsTab wires onChanged to re-scan after a delete");
 assert.doesNotMatch(plugins, /import \{ SkillCard \}/, "the old flat SkillCard list is retired from the Skills tab");
 // The Skills tab is full-bleed so the browser owns per-column scrolling.
 assert.match(

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { MarkdownBlock } from "@/components/message-bubble";
+import { copyText } from "@/lib/clipboard";
 
 export type SkillBrowserEntry = {
   id: string;
@@ -71,22 +72,45 @@ function displayPath(path: string): string {
   return dir.replace(/^\/(?:Users|home)\/[^/]+/, "~");
 }
 
+// Reveal a directory in the OS file manager. On desktop this shells out via
+// Tauri; on the web there is no filesystem bridge, so we copy the path to the
+// clipboard instead and report which happened so the UI can say so.
+async function revealDir(dir: string): Promise<"revealed" | "copied"> {
+  if (typeof window !== "undefined" && "__TAURI_INTERNALS__" in window) {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("shell_open", { url: dir });
+      return "revealed";
+    } catch {
+      // fall through to clipboard
+    }
+  }
+  await copyText(dir);
+  return "copied";
+}
+
 export function SkillBrowser({
   skills,
   loaded,
   query,
   onClearQuery,
   onCreateSkill,
+  onChanged,
 }: {
   skills: SkillBrowserEntry[];
   loaded: boolean;
   query: string;
   onClearQuery: () => void;
   onCreateSkill?: () => void;
+  /** Called after a skill is deleted so the parent can re-scan. */
+  onChanged?: () => void;
 }) {
   const [category, setCategory] = useState<Category>("all");
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [preview, setPreview] = useState<PreviewState>({ status: "idle", text: null, error: null });
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [busy, setBusy] = useState<"reveal" | "delete" | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
 
   const counts = useMemo(
     () => ({
@@ -137,6 +161,55 @@ export function SkillBrowser({
   }, [selectedPath]);
 
   const body = preview.text ? stripFrontmatter(preview.text) : "";
+
+  // Reset the transient action state whenever the selection changes so a stale
+  // "confirm delete" or notice never carries over to a different skill.
+  useEffect(() => {
+    setConfirmingDelete(false);
+    setNotice(null);
+  }, [selectedPath]);
+
+  async function handleReveal() {
+    if (!selectedPath || busy) return;
+    setBusy("reveal");
+    try {
+      const dir = selectedPath.replace(/\/SKILL\.md$/i, "");
+      const how = await revealDir(dir);
+      setNotice(how === "revealed" ? "Opened in file manager" : "Path copied to clipboard");
+    } catch {
+      setNotice("Could not open folder");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function handleDelete() {
+    if (!selectedPath || busy) return;
+    if (!confirmingDelete) {
+      setConfirmingDelete(true);
+      setNotice(null);
+      return;
+    }
+    setBusy("delete");
+    try {
+      const res = await fetch(`/api/skills/local?path=${encodeURIComponent(selectedPath)}`, {
+        method: "DELETE",
+        cache: "no-store",
+      });
+      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !json.ok) {
+        setNotice(json.error ? `Delete failed: ${json.error}` : `Delete failed (${res.status})`);
+        return;
+      }
+      setConfirmingDelete(false);
+      setSelectedKey(null);
+      onChanged?.();
+    } catch (err) {
+      setNotice(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed");
+    } finally {
+      setBusy(null);
+    }
+  }
 
   return (
     <div className="skill-browser" role="group" aria-label="Skill browser">
@@ -215,7 +288,32 @@ export function SkillBrowser({
         {selected ? (
           <>
             <div className="skill-browser__detail-head">
-              <h2 className="skill-browser__detail-name">{selected.name}</h2>
+              <div className="skill-browser__detail-titlerow">
+                <h2 className="skill-browser__detail-name">{selected.name}</h2>
+                <div className="skill-browser__actions">
+                  <button
+                    type="button"
+                    className="skill-browser__action"
+                    onClick={handleReveal}
+                    disabled={busy != null}
+                    title="Reveal skill folder"
+                    aria-label="Reveal skill folder"
+                  >
+                    <Icon name="ph:folder-open" width={16} aria-hidden />
+                  </button>
+                  <button
+                    type="button"
+                    className={`skill-browser__action skill-browser__action--danger${confirmingDelete ? " is-confirming" : ""}`}
+                    onClick={handleDelete}
+                    disabled={busy != null}
+                    title={confirmingDelete ? "Confirm delete" : "Delete skill"}
+                    aria-label={confirmingDelete ? "Confirm delete skill" : "Delete skill"}
+                  >
+                    <Icon name="ph:trash" width={16} aria-hidden />
+                    {confirmingDelete ? <span className="skill-browser__action-label">Delete?</span> : null}
+                  </button>
+                </div>
+              </div>
               <p className="skill-browser__detail-path" title={selected.path}>
                 {displayPath(selected.path)}
               </p>
@@ -228,6 +326,11 @@ export function SkillBrowser({
                   </span>
                 ))}
               </div>
+              {notice ? (
+                <p className="skill-browser__notice" role="status">
+                  {notice}
+                </p>
+              ) : null}
             </div>
             <div className="skill-browser__detail-body">
               {preview.status === "loading" ? (

--- a/src/lib/server/skill-file-paths.test.ts
+++ b/src/lib/server/skill-file-paths.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { isAllowedSkillFilePath, MAX_SKILL_FILE_PREVIEW_BYTES } from "./skill-file-paths.ts";
+import { isAllowedSkillFilePath, isRemovableSkillDir, MAX_SKILL_FILE_PREVIEW_BYTES } from "./skill-file-paths.ts";
 
 const home = await mkdtemp(path.join(tmpdir(), "coven-skill-paths-"));
 
@@ -117,5 +117,44 @@ assert.equal(
 );
 
 assert.equal(MAX_SKILL_FILE_PREVIEW_BYTES, 512 * 1024, "skill previews have a bounded size");
+
+// ── isRemovableSkillDir (DELETE guard) ──────────────────────────────────────
+// The guard only clears an IMMEDIATE child directory of a scan root. Exercise
+// the ~/.claude/skills root (the coven root is env-derived and not the tmp home).
+const removableSkillDir = path.join(home, ".claude", "skills", "deep-research");
+const skillsRoot = path.join(home, ".claude", "skills");
+await mkdir(path.join(removableSkillDir, "nested"), { recursive: true });
+
+assert.equal(
+  await isRemovableSkillDir(removableSkillDir, home),
+  true,
+  "an immediate child directory of ~/.claude/skills is removable",
+);
+assert.equal(
+  await isRemovableSkillDir(skillsRoot, home),
+  false,
+  "the scan root itself is never removable",
+);
+assert.equal(
+  await isRemovableSkillDir(path.join(removableSkillDir, "nested"), home),
+  false,
+  "a directory nested deeper than an immediate child is rejected",
+);
+assert.equal(
+  await isRemovableSkillDir(claudeSkill, home),
+  false,
+  "a file path (SKILL.md, not a directory) is rejected",
+);
+assert.equal(
+  await isRemovableSkillDir(claudeSkillSymlink, home),
+  false,
+  "a symlinked skill directory is rejected (never follow a symlink to rm)",
+);
+assert.equal(
+  await isRemovableSkillDir(path.join(home, "secrets"), home),
+  false,
+  "a directory outside the scan roots is rejected",
+);
+assert.equal(await isRemovableSkillDir("", home), false, "empty path is rejected");
 
 console.log("skill-file-paths.test.ts: ok");

--- a/src/lib/server/skill-file-paths.ts
+++ b/src/lib/server/skill-file-paths.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { homedir } from "node:os";
 import { lstat, realpath } from "node:fs/promises";
+import { covenHome } from "@/lib/coven-paths";
 
 /**
  * Allow-list for the Capabilities skill-preview reader (/api/skills/file).
@@ -62,5 +63,41 @@ export async function isAllowedSkillFilePath(fullPath: string, home = homedir())
     }
   }
 
+  return false;
+}
+
+/**
+ * Guard for DELETE /api/skills/local — removing a scanned skill's directory.
+ *
+ * Deleting a directory recursively from a user-supplied path is a destructive
+ * primitive, so it is constrained HARD: the target's realpath must be an
+ * IMMEDIATE child of one of the two skill scan roots (`covenHome()/skills` or
+ * `~/.claude/skills`), must be a real directory (not a symlink), and can never
+ * be a root itself or anything nested deeper/outside. This matches exactly what
+ * `/api/skills/local` enumerates, so you can only delete a skill you can see.
+ */
+export async function isRemovableSkillDir(dir: string, home = homedir()): Promise<boolean> {
+  if (!dir) return false;
+
+  let real: string;
+  try {
+    const st = await lstat(dir);
+    if (st.isSymbolicLink() || !st.isDirectory()) return false;
+    real = await realpath(dir);
+  } catch {
+    return false;
+  }
+
+  const parent = path.dirname(real);
+  const rootCandidates = [path.join(covenHome(), "skills"), path.join(home, ".claude", "skills")];
+  for (const root of rootCandidates) {
+    try {
+      const rootReal = await realpath(root);
+      // Must be a DIRECT child of a scan root — never the root itself, never nested.
+      if (parent === rootReal && real !== rootReal) return true;
+    } catch {
+      // Missing root → not a removable location.
+    }
+  }
   return false;
 }


### PR DESCRIPTION
Adds the two detail-pane header actions from the Skill Browser mock.

## What

- **Reveal folder** (`ph:folder-open`) — opens the selected skill's directory in the OS file manager via Tauri `shell_open` on desktop; on the web (no filesystem bridge) it copies the path to the clipboard and says so.
- **Delete** (`ph:trash`) — a two-step confirm (click → red "Delete?" pill → click to confirm) that removes the skill's directory and re-scans the list.

## Safety

Recursive directory deletion from a user-supplied path is a destructive primitive, so `DELETE /api/skills/local` is:

- **local-origin gated** (`isLocalOrigin` → 403 otherwise), and
- hard-constrained by the new `isRemovableSkillDir` guard — the target's realpath must be an **immediate child** of a scan root (`covenHome()/skills` or `~/.claude/skills`), never a symlink, never the root itself, never nested deeper. This matches exactly what the list route enumerates, so you can only delete a skill you can see.

## Verification

- `isRemovableSkillDir` unit tests: immediate-child ✓, root rejected, deeper-nested rejected, file-path rejected, symlink rejected, outside-root rejected, empty rejected.
- Live route against a throwaway skill: listed → `coven.json` path 403 → delete 200 → dir gone → delisted.
- Visual: folder + trash icons render top-right of the detail pane; delete click flips to the red confirm pill.
- `tsc --noEmit` clean; `pnpm build` (incl. bundle-budget gate) clean; api-contracts + skill-browser + skill-file-paths tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)