### PR TITLE
docs(changelog): note the sharp version-skew CI guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Added
+
+- **Supply chain** - guard against `sharp` version skew with Next's pinned copy
+  in the dependency-policy test: the build now fails fast if `pnpm-lock.yaml`
+  resolves more than one `sharp` version, if `sharp` diverges from `package.json`,
+  or if any `@img/sharp-<native>` package drifts off it. This catches the skew
+  that silently breaks the Windows sidecar bundle on every OS, instead of only in
+  the Windows-only sidecar CI leg.
+
 ## [0.0.132] - 2026-07-02
 
 Patch release on top of v0.0.131. Headline: GitHub README images can be


### PR DESCRIPTION
## What

Adds an `[Unreleased]` changelog entry for the `sharp` version-skew CI guard landed in #2267.

## Entry

> **Supply chain** - guard against `sharp` version skew with Next's pinned copy in the dependency-policy test: the build now fails fast if `pnpm-lock.yaml` resolves more than one `sharp` version, if `sharp` diverges from `package.json`, or if any `@img/sharp-<native>` package drifts off it. This catches the skew that silently breaks the Windows sidecar bundle on every OS, instead of only in the Windows-only sidecar CI leg.

Docs-only change; picked up by the next `chore(release): stamp` into a versioned section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)