### PR TITLE
fix(desktop): drive macOS titlebar drag via startDragging() on external URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS titlebar drag** - the seamless overlay titlebar now actually drags the
+  window. The webview loads from an external `http://127.0.0.1` URL, and WebKit
+  only honors the `-webkit-app-region: drag` CSS hint on the native `tauri://`
+  scheme — so the CSS-only approach (four prior attempts) was silently inert.
+  The shell now calls the Tauri window API's `startDragging()` on pointer-down
+  over empty titlebar chrome, which drives AppKit directly regardless of URL
+  scheme, while interactive controls still fall through as no-drag. Also fixed
+  the platform check that gated the whole titlebar mode: `navigator.platform` is
+  deprecated and empty on newer WebKit, so it now prefers
+  `navigator.userAgentData.platform` before falling back to the UA string.
+
 ### Added
 
 - **Supply chain** - guard against `sharp` version skew with Next's pinned copy

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -32,13 +32,18 @@ assert.match(
 );
 assert.match(
   shell,
-  /<div className="shell-top" data-tauri-drag-region="">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="">\{renderedTopBar\}<\/div>/,
+  /<div className="shell-top" data-tauri-drag-region=""(?: onPointerDown=\{onTitlebarPointerDown\})?>[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="">\{renderedTopBar\}<\/div>/,
   "the top bar row leads with the nav toggle before the rendered top bar",
 );
 assert.equal(
-  shell.match(/<div className="shell-top" data-tauri-drag-region="">/g)?.length,
+  shell.match(/<div className="shell-top" data-tauri-drag-region=""(?: onPointerDown=\{onTitlebarPointerDown\})?>/g)?.length,
   2,
-  "both shell top bars should expose the Tauri drag region on the titlebar container",
+  "both shell top bars (placeholder + desktop) should expose the Tauri drag region on the titlebar container",
+);
+assert.equal(
+  shell.match(/onPointerDown=\{onTitlebarPointerDown\}/g)?.length,
+  2,
+  "every shell-top wires the native startDragging handler so the window drags on external-URL webviews",
 );
 assert.equal(
   shell.match(/<div className="shell-top__bar" data-tauri-drag-region="">/g)?.length,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -162,17 +162,66 @@ function ShellInner({
   // mark <html> to reserve room for the traffic lights and make the top bar a
   // drag handle (see [data-tauri-titlebar] in globals.css). Browser, Windows,
   // Linux, and Tauri-mobile keep their normal chrome.
+  //
+  // We track this in state (not just the <html> dataset) because the CSS
+  // `-webkit-app-region: drag` hint is INERT here: the webview loads from an
+  // external `http://127.0.0.1` URL (see lib.rs WebviewUrl::External), and
+  // WebKit only bridges `app-region: drag` into a real NSWindow drag on the
+  // native `tauri://` scheme. On external URLs the hint is silently ignored,
+  // which is why the CSS-only approach never actually dragged the window.
+  // So when `tauriTitlebar` is on we also attach a mousedown handler that calls
+  // the Tauri window API's startDragging(), which drives AppKit directly and
+  // works regardless of URL scheme. The CSS stays as a progressive-
+  // enhancement fallback for any bundled-scheme build.
+  const [tauriTitlebar, setTauriTitlebar] = useState(false);
   useEffect(() => {
     if (typeof window === "undefined") return;
     const isTauri = "__TAURI_INTERNALS__" in window;
-    const isMac = /Mac/i.test(navigator.platform || navigator.userAgent || "");
+    // navigator.platform is deprecated and empty on newer WebKit, which made
+    // isMac fall through to false and skip the titlebar mode entirely. Prefer
+    // the modern userAgentData.platform, then fall back to the UA string.
+    const platform =
+      (navigator as unknown as { userAgentData?: { platform?: string } })
+        .userAgentData?.platform ||
+      navigator.userAgent ||
+      navigator.platform ||
+      "";
+    const isMac = /Mac/i.test(platform);
     if (!isTauri || !isMac) return;
     const root = document.documentElement;
     root.dataset.tauriTitlebar = "";
+    setTauriTitlebar(true);
     return () => {
       delete root.dataset.tauriTitlebar;
+      setTauriTitlebar(false);
     };
   }, []);
+
+  // Native window drag for the macOS overlay titlebar. Fires only in the Tauri
+  // macOS shell (tauriTitlebar). Ignores anything but a primary-button press
+  // that lands on empty chrome — clicks on interactive controls fall through
+  // so buttons/inputs keep working. Double-click still zooms the window via
+  // the OS, so we only handle single-press drags.
+  const onTitlebarPointerDown = useMemo(() => {
+    if (!tauriTitlebar) return undefined;
+    return (event: import("react").PointerEvent<HTMLElement>) => {
+      if (event.button !== 0) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target?.closest(
+          "button, a, input, select, textarea, kbd, label, [role='button'], [role='textbox'], [contenteditable], .menu-bar__search, .top-bar__search, .top-bar__account",
+        )
+      ) {
+        return;
+      }
+      void import("@tauri-apps/api/window")
+        .then(({ getCurrentWindow }) => getCurrentWindow().startDragging())
+        .catch(() => {
+          // Best-effort: if the API isn't available we simply fall back to the
+          // CSS app-region hint (a no-op on external URLs, but harmless).
+        });
+    };
+  }, [tauriTitlebar]);
   const mobileChromeState: ShellMobileChromeState = {
     navDrawerOpen: isMobile && mobileDrawer === "nav",
     listDrawerOpen: isMobile && mobileDrawer === "list",
@@ -361,7 +410,7 @@ function ShellInner({
   if (!mounted) {
     return (
       <div className="shell-frame flex h-full w-full flex-col">
-        <div className="shell-top" data-tauri-drag-region="">
+        <div className="shell-top" data-tauri-drag-region="" onPointerDown={onTitlebarPointerDown}>
           <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
           <div className="shell-top__bar" data-tauri-drag-region="">{renderedTopBar}</div>
         </div>
@@ -491,7 +540,7 @@ function ShellInner({
       {/* Keyboard/SR users can jump straight past the chrome to the active
           surface. Visually hidden until focused (see .skip-link in globals). */}
       <a className="skip-link" href="#shell-main-content">Skip to main content</a>
-      <div className="shell-top" data-tauri-drag-region="">
+      <div className="shell-top" data-tauri-drag-region="" onPointerDown={onTitlebarPointerDown}>
         <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
         {navToggle}
         <div className="shell-top__bar" data-tauri-drag-region="">{renderedTopBar}</div>


### PR DESCRIPTION
## Why the titlebar drag never stuck (after ~4 attempts)

The seamless macOS overlay titlebar (`TitleBarStyle::Overlay` in `lib.rs`) has had four prior fixes (#1927, #1972, #2063, #2139) — all correct at the CSS/DOM layer, all inert in practice.

**Root cause:** the webview loads from an **external URL** — `WebviewUrl::External(http://127.0.0.1:PORT)` (see `src-tauri/src/lib.rs`). WebKit only translates the `-webkit-app-region: drag` CSS hint into a real `NSWindow` drag on the **native `tauri://` scheme**. On an external `http://` URL the hint is silently ignored, so no amount of correct CSS or `data-tauri-drag-region` markup could ever move the window.

That's why each PR "fixed" a layer that was already fine and the window still wouldn't drag.

## The fix (A + B)

**A — native drag via the window API.** On pointer-down over empty titlebar chrome, call `getCurrentWindow().startDragging()` (Tauri v2 window API), which drives AppKit directly regardless of URL scheme. Interactive controls (`button, a, input, select, textarea, [role=button], [role=textbox], [contenteditable], .menu-bar__search, .top-bar__search, .top-bar__account`) fall through as no-drag so they keep working. Only primary-button single presses are handled, so OS double-click-to-zoom is untouched. The existing CSS `app-region` rules remain as a progressive-enhancement fallback for any bundled-scheme build.

**B — fix the platform gate.** `navigator.platform` is deprecated and returns empty on newer WebKit, which made `isMac` fall through to `false` and skip titlebar mode entirely (so on some builds the drag rules never even applied). Detection now prefers `navigator.userAgentData.platform`, then the UA string, then legacy `navigator.platform`.

## Files
- `src/components/shell.tsx` — state-tracked titlebar mode, `startDragging()` pointer handler wired onto every `.shell-top`, fixed platform detection.
- `src/components/shell-edge-rails.test.ts` — updated drag-region assertions + new guard that every `shell-top` wires the native handler.
- `CHANGELOG.md` — Fixed entry under Unreleased.

## Verification
- `tsc --noEmit` clean on changed files (project-wide typecheck passes; only pre-existing `tests/mobile` + `vitest.config` noise remains, unchanged from `main`).
- `node --import ./scripts/test-alias-register.mjs --experimental-strip-types src/components/shell-edge-rails.test.ts` → **OK**.

## Manual test after merge
Build the macOS desktop app, grab the empty titlebar area (not a control), and drag — the window should move. Buttons/search/account in the bar still click normally. Double-click still zooms.