### PR TITLE
chore(release): stamp v0.0.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.133] - 2026-07-03
+
 ### Fixed
 
 - **macOS titlebar drag** - the seamless overlay titlebar now actually drags the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.132"
+version = "0.0.133"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.132"
+version = "0.0.133"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Roll all six version locations `0.0.132 → 0.0.133` and cut the CHANGELOG.

## Version locations (all 6)
- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (the `app` package entry)
- `src-tauri/tauri.conf.json`
- `src-tauri/Info.ios.plist` (both `CFBundleShortVersionString` + `CFBundleVersion`)
- `src-tauri/gen/apple/app_iOS/Info.plist` (same two keys)

## CHANGELOG
`[Unreleased]` → `[0.0.133] - 2026-07-03`, fresh empty `[Unreleased]` added on top.

## Ships since v0.0.132
- **fix(desktop):** macOS titlebar drag via `startDragging()` on external URLs (#2270) — the fix that finally reaches AppKit after four CSS-only attempts.
- **test(supply-chain):** guard against `sharp` version skew that breaks the Windows sidecar (#2267).

## After merge
Signed tag `v0.0.133` on the merge commit → release workflow builds + notarizes DMG / AppImage / MSI (~17–20 min).