### PR TITLE
test(analytics): heal-request count is 2, not 1 (fixes red main)

### DIFF
--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -357,7 +357,12 @@ describe("FamiliarAnalyticsView", () => {
     const data = await loadFamiliarAnalyticsData("cody");
     const model = buildFamiliarAnalyticsModel(data);
 
-    assert.equal(model.healRequests.length, 1);
+    // The "trusted" fixture produces two heal requests from two distinct
+    // sources: an eval-loop REVERT iteration (cody:eval-loop:revert-1) and a
+    // growth-report session-gap signal (cody:growth-signal:session-gap:all:0).
+    // deriveHealRequests aggregates eval-loop + contract + growth sources, so
+    // both legitimately surface here.
+    assert.equal(model.healRequests.length, 2);
     assert.equal(model.threadReports.length, 1);
     assert.match(source, /escalateBlockers\(model\.familiarId, threadSignalsAggregate, model\.healRequests\)/);
     assert.match(source, /healRequests\.length === 1 \? "request" : "requests"/);


### PR DESCRIPTION
## Main is currently red 🔴

`pnpm test:app` fails on `main` (and therefore the **Frontend build** CI job on every PR), on a single stale assertion in `familiar-analytics-view.test.ts`:

```
✖ renders the heal request count and keeps EvalLoopPanel present
  AssertionError: 2 !== 1
```

## Root cause

The `"trusted"` fixture legitimately produces **two** heal requests, from two distinct sources that `deriveHealRequests` aggregates:
- `cody:eval-loop:revert-1` — an eval-loop **REVERT** iteration
- `cody:growth-signal:session-gap:all:0` — a growth-report **session-gap** signal

The assertion still expected `1`. This is a stale expectation, not a regression in the derivation — 2 is the correct current behavior.

## Fix

Update the expectation `1 → 2` and add a comment documenting the two sources so it doesn't get "corrected" back.

## Verification
- `familiar-analytics-view.test.ts` → **7/7 pass**
- full `pnpm test:app` → **green, 515 test files passed**

## Why standalone
Found while stamping v0.0.133 (#2271) — its Frontend build failed here, not on the version bump. Fixing on its own so it can fast-track ahead of the release; #2271 will re-stamp on the unblocked main.