### PR TITLE
chore(release): stamp v0.0.133

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.133] - 2026-07-03
+
+Patch release on top of v0.0.132. Headline: the macOS overlay titlebar drags the
+window again on external-URL webviews, and the build now fails fast on `sharp`
+version skew with Next's pinned copy instead of only tripping the Windows-only
+sidecar CI leg.
+
+### Added
+
+- **Supply chain** - guard against `sharp` version skew with Next's pinned copy
+  in the dependency-policy test: the build now fails fast if `pnpm-lock.yaml`
+  resolves more than one `sharp` version, if `sharp` diverges from `package.json`,
+  or if any `@img/sharp-<native>` package drifts off it. This catches the skew
+  that silently breaks the Windows sidecar bundle on every OS, instead of only in
+  the Windows-only sidecar CI leg.
+
 ### Fixed
 
 - **macOS titlebar drag** - the seamless overlay titlebar now actually drags the
@@ -19,15 +35,6 @@ breaking config changes; patch releases stay additive.
   the platform check that gated the whole titlebar mode: `navigator.platform` is
   deprecated and empty on newer WebKit, so it now prefers
   `navigator.userAgentData.platform` before falling back to the UA string.
-
-### Added
-
-- **Supply chain** - guard against `sharp` version skew with Next's pinned copy
-  in the dependency-policy test: the build now fails fast if `pnpm-lock.yaml`
-  resolves more than one `sharp` version, if `sharp` diverges from `package.json`,
-  or if any `@img/sharp-<native>` package drifts off it. This catches the skew
-  that silently breaks the Windows sidecar bundle on every OS, instead of only in
-  the Windows-only sidecar CI leg.
 
 ## [0.0.132] - 2026-07-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.132"
+version = "0.0.133"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.132"
+version = "0.0.133"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.132</string>
+	<string>0.0.133</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.132",
+  "version": "0.0.133",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamp the accumulated `[Unreleased]` changelog into a dated **v0.0.133** patch section and bump the version across the desktop/iOS manifests.

## What's in this release

- **Supply chain** — the `dependency-policy` test now fails fast on `sharp` version skew with Next's pinned copy (guard added in #2267). The build breaks on _every_ OS if `pnpm-lock.yaml` resolves more than one `sharp` version, if `sharp` diverges from `package.json`, or if any `@img/sharp-<native>` package drifts off it — instead of only tripping the Windows-only sidecar CI leg.
- **macOS titlebar drag** — the overlay titlebar drives `startDragging()` on external-URL webviews so the window drags again (#2270).

## Mechanics

- Version bumped `0.0.132 → 0.0.133` across `package.json`, `src-tauri/{tauri.conf.json,Cargo.toml,Cargo.lock}`, and both iOS `Info.plist` files.
- `CHANGELOG.md`: `[Unreleased]` entries moved under `## [0.0.133] - 2026-07-03` (canonical Added-before-Fixed order); `[Unreleased]` left empty.

This is a **stamp only** — a normal PR merge, not a publish. The public DMG + GitHub Release build fires from a manual signed `v*` tag push, which is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)