### PR TITLE
a11y(board): accessible names, focus restoration, scoped grab keys, dated reschedule announcements

### DIFF
--- a/src/components/board-card-stack-a11y.test.ts
+++ b/src/components/board-card-stack-a11y.test.ts
@@ -9,9 +9,12 @@ const src = readFileSync(new URL("./board-card-stack.tsx", import.meta.url), "ut
 // KanbanCard. Was: a <button> wrapping <div>/<p> and a tabIndex=-1 role=link.
 assert.match(
   src,
-  /className="board-card-stack__row-main"\s+role="button"\s+tabIndex=\{0\}\s+aria-pressed=\{isSelected\}/,
+  /className="board-card-stack__row-main"\s+role="button"\s+tabIndex=\{0\}/,
   "the card body is a keyboard-focusable role=button (not a <button> wrapping flow content)",
 );
+// Activating the row OPENS the inspector — it is not a toggle, so it must not
+// carry aria-pressed (which announced a pressed state that never matched).
+assert.doesNotMatch(src, /aria-pressed/, "the opener row does not claim toggle semantics");
 assert.match(
   src,
   /onKeyDown=\{\(e\) => \{\s*if \(e\.key === "Enter" \|\| e\.key === " "\) \{ e\.preventDefault\(\); onSelect\(\); \}/,

--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -194,7 +194,6 @@ function BoardCardStackRow({
         className="board-card-stack__row-main"
         role="button"
         tabIndex={0}
-        aria-pressed={isSelected}
         onClick={onSelect}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onSelect(); }

--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -5,6 +5,7 @@ import type { Card, CardStatus } from "@/lib/cave-board-types";
 import type { Familiar } from "@/lib/types";
 import { useDateTimePrefs, readDateTimePrefs } from "@/lib/datetime-format";
 import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
 import type { CardPatch } from "@/lib/board-card-ops";
 
 type ProjectLike = { id: string; name: string };
@@ -150,6 +151,7 @@ function cardRange(card: Card): { start: Date; end: Date } | null {
 }
 
 export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelect, onPatch, groupMode = "project" }: Props) {
+  const { announce } = useAnnouncer();
   // Click a group header to focus it (hide the others); click again to show all.
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
   const [showUnscheduled, setShowUnscheduled] = useState(false);
@@ -257,6 +259,9 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
           ],
         },
       });
+      // Step reschedules bypass board-view's card-level reschedule announcement
+      // — without this, a keyboard ←/→ commit is silent for AT.
+      announce(`Rescheduled '${row.label}': ${formatLabel(addDays(row.start, mode === "resize-end" ? 0 : delta))} to ${formatLabel(addDays(row.end, mode === "resize-start" ? 0 : delta))}.`);
     } else {
       // Project mode: a move shifts whichever of the task's own dates are set;
       // a resize sets the dragged end explicitly.

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -179,6 +179,10 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
   const { announce } = useAnnouncer();
   const draggingIdRef = useRef<string | null>(null);
   const railRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  // Scopes the grab-and-move keydown handling to this board (the listener is
+  // on window; without containment a grab session captured Space/Escape/Arrows
+  // app-wide, even with focus in the sidebar or another surface).
+  const rootRef = useRef<HTMLDivElement | null>(null);
 
   const columnIndex = useCallback(
     (id: string) => COLUMNS.findIndex((c) => c.id === id),
@@ -188,6 +192,17 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       const target = document.activeElement as HTMLElement | null;
+      const inBoard = Boolean(target && rootRef.current?.contains(target));
+      // A grab is a focus-coupled mode: if focus leaves the board (Tab to the
+      // sidebar, a dialog opens), release it and let the key act normally
+      // instead of consuming Space/Escape/Arrows app-wide.
+      if (grabbedCardId && !inBoard) {
+        const card = cards.find((c) => c.id === grabbedCardId);
+        setGrabbedCardId(null);
+        announce(card ? `Cancelled moving '${card.title}'.` : "Cancelled.");
+        return;
+      }
+      if (!inBoard) return;
       const focusedCardId = target?.dataset?.cardId ?? null;
 
       // Toggle grab on Space.
@@ -203,6 +218,12 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
             // moveCardToStatus so every view (kanban/table/stack/inspector)
             // announces identically and drops never announce twice.
             onMoveStatus(grabbedCardId, dropTargetStatus);
+            // The card re-renders under its new column; without this, focus
+            // falls to <body> and the keyboard user is lost.
+            const movedId = grabbedCardId;
+            window.setTimeout(() => {
+              document.querySelector<HTMLElement>(`[data-card-id="${movedId}"]`)?.focus();
+            }, 0);
           } else if (card) {
             announce("Drop cancelled — same column.");
           }
@@ -459,7 +480,7 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
     setCollapsedGroups((prev) => { const n = new Set(prev); if (n.has(key)) n.delete(key); else n.add(key); return n; });
 
   return (
-    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflowY: showSwimlanes ? "auto" : "hidden" }}>
+    <div ref={rootRef} style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflowY: showSwimlanes ? "auto" : "hidden" }}>
       {groups.map(({ key, label, cards: gc }) => {
         const isCollapsed = collapsedGroups.has(key);
         const grpGrouped = grouped(gc);
@@ -678,13 +699,27 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
   const urgency = scheduleUrgency(card.endDate, card.status, todayMs);
   const attachmentCount = card.attachments?.length ?? 0;
   const hasChips = !!schedule || !!card.cwd || card.links.length > 0 || card.labels.length > 0 || attachmentCount > 0 || !!session;
+  // The metadata chips below are visual-only (title-attribute spans); fold the
+  // same state into the card's accessible name so AT users hear it.
+  const ariaMeta = [
+    schedule
+      ? urgency === "overdue"
+        ? `overdue, was due ${schedule}`
+        : urgency === "due-soon"
+        ? `due soon, ${schedule}`
+        : `scheduled ${schedule}`
+      : null,
+    session ? "linked chat" : null,
+    attachmentCount > 0 ? `${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}` : null,
+    card.labels.length > 0 ? `labels ${card.labels.join(", ")}` : null,
+  ].filter(Boolean).join(", ");
 
   return (
     <li draggable={!selectMode}
       data-card-id={card.id}
       role={selectMode ? "checkbox" : "button"}
       aria-checked={selectMode ? isSelected : undefined}
-      aria-label={`${card.title} — ${pri.label} priority, ${statusLabel}${isSelected ? ", selected" : ""}${isGrabbed ? ", grabbed" : ""}.${selectMode ? " Space to toggle selection." : " Enter to open; Space to move."}`}
+      aria-label={`${card.title} — ${pri.label} priority, ${statusLabel}${ariaMeta ? `, ${ariaMeta}` : ""}${isSelected ? ", selected" : ""}${isGrabbed ? ", grabbed" : ""}.${selectMode ? " Space to toggle selection." : " Enter to open; Space to move."}`}
       aria-keyshortcuts={selectMode ? undefined : "Enter Space"}
       onDragStart={(e) => { if (selectMode) { e.preventDefault(); return; } draggedRef.current = true; onDragStart(e); }}
       onDragEnd={() => { setTimeout(() => { draggedRef.current = false; }, 0); onDragEnd(); }}

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -377,6 +377,7 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                     data-card-id={card.id}
                     role={selectMode ? "checkbox" : undefined}
                     aria-checked={selectMode ? rowChecked : undefined}
+                    aria-label={selectMode ? `${card.title}${rowChecked ? ", selected" : ""}. Space to toggle selection.` : undefined}
                     className={`${isSel ? "selected" : ""}${rowIdx % 2 === 1 ? " board-table-row--alt" : ""}`.trim()}
                     onClick={() => (selectMode ? onToggleSelect?.(card.id) : onSelect(card.id))}>
                     {orderedCols.map((col) => {

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -187,7 +187,7 @@ assert.match(view, /announce\(`Created task '\$\{draft\.title\.trim\(\)\}'\.`\)/
 assert.match(view, /announce\(`Deleted \$\{toRemove\.length\} task/, "delete announces with undo hint");
 assert.match(view, /announce\(`Cleared \$\{cleared\.length\} done task/, "clear-done announces");
 assert.match(view, /announce\(`Moved '\$\{title\}' to /, "moveCardToStatus announces for every view");
-assert.match(view, /announce\(`Rescheduled '\$\{before\.title\}'\. Undo available\.`\)/, "reschedule announces");
+assert.match(view, /announce\(`Rescheduled '\$\{before\.title\}'\$\{range \? ` — \$\{range\}` : ""\}\. Undo available\.`\)/, "reschedule announces with the committed dates");
 assert.match(view, /announce\(`Restored /, "undo paths announce restoration");
 // The final "Moved" message is BoardView's alone — kanban's drop paths must not
 // double-announce it (they keep their grab/over/cancel narration).
@@ -203,5 +203,15 @@ assert.doesNotMatch(inspector, /onPatch\(card\.id, \{ steps: steps\.(map|filter)
 assert.match(gantt, /op: "setDate", id: row\.stepId/, "gantt step drag sends setDate ops, not the whole steps array");
 assert.match(view, /applyCardOps\(c, ops, new Date\(\)\.toISOString\(\)\)/, "the optimistic render resolves ops with the same shared function the server uses");
 assert.match(view, /if \(json\.card\) setCards\(\(prev\) => prev\.map\(\(c\) => \(c\.id === id \? \(json\.card as Card\) : c\)\)\)/, "a successful PATCH adopts the server card");
+
+// ── A11y batch (2026-07-03) ───────────────────────────────────────────────────
+const table = await readFile(new URL("./board-table.tsx", import.meta.url), "utf8");
+assert.match(kanban, /const ariaMeta = \[/, "kanban folds chip metadata into the card's accessible name");
+assert.match(kanban, /\$\{ariaMeta \? `, \$\{ariaMeta\}` : ""\}/, "the accessible name carries schedule/chat/attachments/labels");
+assert.match(table, /aria-label=\{selectMode \? `\$\{card\.title\}/, "table select-mode rows are named by their card title");
+assert.match(kanban, /rootRef\.current\?\.contains\(target\)/, "grab keydown handling is scoped to the board");
+assert.match(kanban, /if \(grabbedCardId && !inBoard\)/, "a grab releases when focus leaves the board");
+assert.match(kanban, /document\.querySelector<HTMLElement>\(`\[data-card-id="\$\{movedId\}"\]`\)\?\.focus\(\)/, "keyboard drop refocuses the moved card");
+assert.match(gantt, /announce\(`Rescheduled '\$\{row\.label\}':/, "gantt step reschedules announce the committed range");
 
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -314,7 +314,8 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
                 title: before.title,
                 prev: { startDate: before.startDate ?? null, endDate: before.endDate ?? null },
               });
-        announce(`Rescheduled '${before.title}'. Undo available.`);
+        const range = [patch.startDate, patch.endDate].filter(Boolean).join(" to ");
+        announce(`Rescheduled '${before.title}'${range ? ` — ${range}` : ""}. Undo available.`);
       }
     }
     setCards((prev) => prev.map((c) => {


### PR DESCRIPTION
## What

Closes the board audit's remaining a11y findings (the last audit items):

1. **Kanban card accessible names carry the chip metadata.** The schedule/chat/attachments/labels chips are `title`-only spans AT never reads; that state now folds into the card's `aria-label`. Live-verified name: `"A11y probe — High priority, Backlog, due soon, Ends 07/05, 1 attachment, labels audit. Enter to open; Space to move."`
2. **Table select-mode rows get an `aria-label`** (kanban parity) — the checkbox's name was previously the concatenation of every cell.
3. **Keyboard grab-and-move refocuses the moved card after a drop** — focus used to fall to `<body>`. Live-verified: after Space-grab → ArrowRight → Space-drop, `document.activeElement` is the moved card **in its new column**.
4. **The grab session's window keydown is scoped to the board.** Focus leaving the board releases the grab (announced) instead of consuming Space/Escape/Arrows app-wide.
5. **Gantt reschedules announce committed dates.** Step-row commits (keyboard ←/→ and drag) were fully silent; card reschedule announcements now include the date range too.
6. **Card-stack rows drop `aria-pressed`** — activating opens the inspector; the toggle semantics never matched the action (kanban's opener pattern).

## Verification (live app)
Full keyboard flow with `aria-live` MutationObserver capture: `"Picked up 'A11y probe'…"` → `"Moving 'A11y probe' over Inbox."` → `"Moved 'A11y probe' to Inbox."`, move persisted (`status: inbox`), focus restored on the moved card, zero page errors.

## Tests
New pins in `board-ux-polish.test.ts` (ariaMeta, table label, root scoping, grab release, focus restore, gantt announce) + `board-card-stack-a11y.test.ts` repointed (no `aria-pressed`). Full board suite + typecheck + tests-wired green. Rebased on #2275 (both touch `board-gantt.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)