### PR TITLE
fix(shell): harden the detail split so it always fills the full width

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10100,11 +10100,16 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
  * ====================================================================== */
 .shell-detail { position: relative; }
 
-/* The resizable split group fills the detail panel like the solo surface. */
+/* The resizable split group fills the detail panel like the solo surface.
+ * `width: 100%` is belt-and-suspenders: react-resizable-panels normally sets
+ * it inline, but if that inline style is missing/late (observed in the desktop
+ * webview) the group must still span the full detail width so the panes never
+ * leave a trailing gap on the far edge. */
 .split-host__group {
   flex: 1 1 auto;
   min-height: 0;
   min-width: 0;
+  width: 100%;
 }
 
 .split-host__mobile-switcher {
@@ -10215,6 +10220,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 .split-host__pane-body > * {
   flex: 1 1 auto;
   min-height: 0;
+  min-width: 0;
 }
 
 /* Live snap guide drawn while dragging the divider. */

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -41,18 +41,28 @@ const shellStorage = {
     try {
       const raw = window.localStorage.getItem(key);
       if (raw) {
-        // Guard: clear corrupted layouts where detail panel (id="detail") is ≤5%.
+        // Guard against corrupt/stale saved layouts that would leave dead space
+        // in the detail area. react-resizable-panels v4 persists each group as a
+        // flat `{ "<panelId>": <percent>, … }` map (e.g. {"nav":26.5,"detail":73.5}).
+        // Drop the layout — falling back to the default — when a panel is
+        // collapsed to ~0 or the panels don't sum to ~100% (a leftover layout
+        // from an old panel set under-fills the group and never re-expands).
         try {
-          const parsed = JSON.parse(raw) as Record<string, { layout?: number[] }>;
-          for (const entry of Object.values(parsed)) {
-            if (!Array.isArray(entry?.layout)) continue;
-            // detail is last non-bottom panel; if any panel is suspiciously ≤2%, nuke the layout.
-            if (entry.layout.some((v, i) => i > 0 && v <= 2)) {
-              window.localStorage.removeItem(key);
-              return null;
+          const parsed = JSON.parse(raw) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            const values = Object.values(parsed as Record<string, unknown>).filter(
+              (v): v is number => typeof v === "number" && Number.isFinite(v),
+            );
+            if (values.length >= 2) {
+              const sum = values.reduce((a, b) => a + b, 0);
+              const anyCollapsed = values.some((v) => v > 0 && v <= 2);
+              if (anyCollapsed || sum < 98 || sum > 102) {
+                window.localStorage.removeItem(key);
+                return null;
+              }
             }
           }
-        } catch { /* not JSON layout, pass through */ }
+        } catch { /* not a layout object, pass through */ }
       }
       return raw;
     } catch {


### PR DESCRIPTION
## What

Reported on the **desktop app**: a Code split beside a broken/empty primary surface left a large empty gap on the **far right** of the detail area (the two panes only filled ~⅔ of the width, at any window size).

## Investigation

I could **not** reproduce it in the web build — I drove real splits across 1024–2400px, every primary surface, both DPRs, window resizes, and stale persisted layouts, and the split group fills the detail panel to the viewport edge in every case (`gap=0`). react-resizable-panels sets the group's `width:100%` inline and normalizes panel sizes to 100%. So the gap is specific to the desktop webview (measurement timing / a broken primary surface that renders nothing) and/or a stale persisted layout that a fresh browser session never has.

Rather than change behavior that tests as correct, this hardens the fill so the desktop path can't leave dead space:

## Changes

- **`.split-host__group { width: 100% }`** — belt-and-suspenders. RRP normally sets this inline; if that inline style is missing/late in the desktop webview, the group still spans the full detail width.
- **`.split-host__pane-body > * { min-width: 0 }`** — a wide or broken surface can't force horizontal overflow that skews the split.
- **Fixed a dead layout guard in `shell.tsx`** — it was written for an older RRP shape (`{group:{layout:[]}}`) and never fired against v4's flat `{ "<panelId>": <percent> }` maps (e.g. `{"nav":26.5,"detail":73.5}`). It now drops corrupt/stale saved layouts (a collapsed panel, or sizes not summing to ~100%) that would under-fill the group and persist across desktop sessions — the most plausible cause of a desktop-only gap.

## Verification

- `pnpm typecheck`, `pnpm test:app` (515 files), `pnpm build` (within budget) all green.
- Re-drove the split at 1024/1100/1200/1279px after the change: still `gap=0`, resize/divider drag unaffected.

Note: the fix lands on `main`; the desktop app will pick it up on its next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)