### PR TITLE
fix(chat): stop mid-stream thread switch from crossing wires between sessions

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -498,4 +498,20 @@ assert.match(
   "input history is persisted when it changes",
 );
 
+// ── Mid-stream thread switch must not cross wires (2026-07-03 audit P0) ───────
+// A background stream updates its OWN registry snapshot, never the displayed
+// transcript — otherwise switching threads renders/persists the wrong session.
+assert.match(
+  source,
+  /if \(targetSessionId && targetSessionId !== currentSessionRef\.current\) \{[\s\S]*?const snap = readLiveChatGeneration\(targetSessionId\);[\s\S]*?recordLiveChatGeneration\(\{[\s\S]*?turns: updater\(snap\.turns\)/,
+  "updateLiveTurns routes background-stream updates to the streaming session's snapshot, not setTurns",
+);
+// Switching threads releases the previous thread's streaming lock so its busy
+// state / Esc-cancel don't bleed onto the newly displayed thread.
+assert.match(
+  source,
+  /release streaming state owned by the PREVIOUS thread[\s\S]{0,400}?setBusy\(false\);\s*\n\s*abortRef\.current = null;/,
+  "the history-load effect clears streaming state inherited from the previous thread",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2476,6 +2476,23 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     controller: AbortController | null = abortRef.current,
     targetSessionId: string | null = currentSessionRef.current,
   ) {
+    // Background stream: the user navigated to a DIFFERENT thread while this
+    // session is still generating. Update that session's OWN registry snapshot
+    // (its turns, its controller) — calling setTurns here would splice the
+    // streaming session's messages into the thread now on screen AND persist
+    // the on-screen thread's turns back into the streaming session's snapshot
+    // (returning to it then shows the wrong conversation, stuck "Streaming…").
+    if (targetSessionId && targetSessionId !== currentSessionRef.current) {
+      const snap = readLiveChatGeneration(targetSessionId);
+      if (!snap) return; // stream already settled / snapshot evicted
+      recordLiveChatGeneration({
+        ...snap,
+        turns: updater(snap.turns),
+        activeLeafId: nextActiveLeafId,
+        updatedAt: Date.now(),
+      });
+      return;
+    }
     setTurns((prev) => {
       const next = updater(prev);
       turnsRef.current = next;
@@ -2946,6 +2963,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
     currentSessionRef.current = sessionId;
     liveSessionIdRef.current = null;
+    // Thread switch: release streaming state owned by the PREVIOUS thread so its
+    // busy lock / Esc-cancel don't bleed onto this one. A background stream
+    // keeps running via its registry snapshot + controller; the live-snapshot
+    // branch below re-arms busy/abortRef if THIS thread is the one streaming.
+    setBusy(false);
+    abortRef.current = null;
     setLinkedContext(null);
     setFlowTranscriptFallback(null);
     if (!sessionId) {


### PR DESCRIPTION
## What

The two **P0** findings from the Chat-surface audit — both from one root cause. The streaming SSE loop mutates the component's single `setTurns`/`busy`/`abortRef`, which belong to whatever thread is **displayed**, not the streaming session. Switching threads mid-stream crossed the wires:

1. **Wrong conversation shown, stuck "Streaming…"** — `updateLiveTurns` called `setTurns` against the on-screen thread's turns, then persisted *those* into the streaming session's registry snapshot. Return to the streaming thread → it showed the other conversation's messages, stuck streaming, until reload. **Fix:** when the target session isn't the displayed one, update that session's **own** registry snapshot (its turns + its controller) and never call `setTurns`.
2. **Wrong thread's composer locked; Esc aborts the other thread** — switching to a non-streaming thread left `busy=true` and `abortRef` pointing at the background stream, so the newly-viewed composer was disabled and Esc there killed the *other* thread's generation. **Fix:** the history-load effect releases streaming state on switch; the live-snapshot branch re-arms `busy`/`abortRef` only when THIS thread is the streaming one.

This preserves the intended "a stream survives navigating between threads" behavior — background streams keep running via their registry snapshot + controller.

## Verification (live, real incremental SSE)
Proxied `/api/chat/send` to a local slow-SSE helper for a genuine mid-stream window:
- Stream in A → switch to B mid-stream: **B shows its own content, composer unlocked**.
- Switch back to A → **A shows its full own stream (`ALPHA MID STREAM FINISHED`), not B's**, composer re-enabled.
- Zero page errors. (Also confirmed the normal no-switch streaming path is unchanged.)

## Scope
The audit's other correctness findings are deferred: new-chat-cancel-before-`session_id` loses the turn (needs up-front session-id design — P2), SIGTERM-only harness kill (LOW). Verified still-handled and untouched: resume-amnesia replay, stuck-zombie 90s TTL, partial-frame SSE parsing, tool-call pairing, attachment threading, StrictMode double-send. **Perf + a11y findings ship as a follow-up PR** (they collide on chat-view.tsx).

## Tests
Two source-text pins in `chat-view-lifecycle.test.ts` (the background-snapshot route + the on-switch streaming-state release). Full chat-view suite + typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)