### PR TITLE
Seamless split divider: magnetic even-split, drop the ⅓·½·⅔ buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10228,6 +10228,48 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   min-width: 0;
 }
 
+/* ── Split divider: a calm hairline that reveals a grip on hover/drag ──────── */
+.split-host__sep {
+  position: relative;
+  /* Sit above the panes so the whole seam is grabbable — pane content otherwise
+     overlaps the hit strip on one side and steals the pointer. */
+  z-index: 5;
+}
+/* Widen the invisible grab strip so the seam is an easy target. */
+.split-host__sep .ui-sep-handle--col::after {
+  left: -7px;
+  right: -7px;
+}
+/* The grip: a short rounded bar centered on the seam, hidden until hover/drag,
+   then it fades and grows in. Pure affordance — no layout impact. */
+.split-host__grip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scaleY(0.55);
+  width: 4px;
+  height: 36px;
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--text-muted) 60%, transparent);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard);
+}
+.split-host__sep:hover .split-host__grip,
+.split-host__group[data-resizing] .split-host__grip {
+  opacity: 1;
+  transform: translate(-50%, -50%) scaleY(1);
+}
+.split-host__group[data-resizing] .split-host__grip {
+  background: var(--accent);
+  box-shadow: 0 0 10px color-mix(in oklch, var(--accent) 55%, transparent);
+}
+@media (prefers-reduced-motion: reduce) {
+  .split-host__grip { transition: opacity var(--duration-fast) var(--ease-standard); }
+}
+
 /* Live snap guide drawn while dragging the divider. */
 .split-host__guide {
   position: absolute;

--- a/src/components/detail-split-host.tsx
+++ b/src/components/detail-split-host.tsx
@@ -181,20 +181,32 @@ export function DetailSplitHost({
         else secRef.current?.resize(PCT(SPLIT_MAX_RATIO));
       } else if (release.action === "snap") secRef.current?.resize(PCT(release.ratio));
     };
+    // Double-click the divider → reset to an even split (replaces the ½ button).
+    // Captured at the window so it fires even though RRP owns the separator.
+    const onDblClick = (e: MouseEvent) => {
+      const target = e.target;
+      if (target instanceof Element && target.closest(".split-host__sep")) {
+        secRef.current?.resize(PCT(SPLIT_DEFAULT_RATIO));
+      }
+    };
     window.addEventListener("pointerdown", onDown, true);
     window.addEventListener("pointerup", onUp, true);
+    window.addEventListener("dblclick", onDblClick, true);
     return () => {
       window.removeEventListener("pointerdown", onDown, true);
       window.removeEventListener("pointerup", onUp, true);
+      window.removeEventListener("dblclick", onDblClick, true);
     };
   }, [secondaryTiles, onClose, onPromoteTile, secRef]);
 
-  // Keyboard / button snap helpers shown in the pane header.
-  const snapTo = (ratio: number) => secRef.current?.resize(PCT(ratio));
-
   const separator = (
     <Separator className="shell-separator split-host__sep">
-      <SeparatorHandle orientation="col" />
+      <SeparatorHandle
+        orientation="col"
+        title="Drag to resize · double-click for an even split"
+      >
+        <span className="split-host__grip" aria-hidden />
+      </SeparatorHandle>
     </Separator>
   );
 
@@ -234,33 +246,6 @@ export function DetailSplitHost({
             {legacySecondaryTile.title}
           </span>
           <span className="split-host__pane-actions">
-            <button
-              type="button"
-              className="split-host__pane-btn"
-              title="Snap to a third"
-              aria-label="Snap split to a third"
-              onClick={() => snapTo(1 / 3)}
-            >
-              ⅓
-            </button>
-            <button
-              type="button"
-              className="split-host__pane-btn"
-              title="Snap to half"
-              aria-label="Snap split to half"
-              onClick={() => snapTo(1 / 2)}
-            >
-              ½
-            </button>
-            <button
-              type="button"
-              className="split-host__pane-btn"
-              title="Snap to two thirds"
-              aria-label="Snap split to two thirds"
-              onClick={() => snapTo(2 / 3)}
-            >
-              ⅔
-            </button>
             <button
               type="button"
               className="split-host__pane-btn split-host__pane-close"
@@ -323,23 +308,25 @@ export function DetailSplitHost({
     );
   };
 
-  // Live snap guide while dragging the divider.
-  const snapPreview = dragRatio != null ? nearestSnap(dragRatio) : null;
+  // Live guide while dragging. Minimalist: the even-split detent is signalled by
+  // a soft accent glow on the line (no numeric chip); only the two edge zones
+  // surface a one-word pill (Close / Fill).
+  const atEvenSplit = dragRatio != null && nearestSnap(dragRatio) != null;
   const inCloseZone = dragRatio != null && dragRatio < SPLIT_CLOSE_RATIO;
   const inCollapseZone = dragRatio != null && dragRatio > SPLIT_COLLAPSE_RATIO;
-  const guideRatio = snapPreview ? snapPreview.ratio : dragRatio;
+  const guideRatio = atEvenSplit ? SPLIT_DEFAULT_RATIO : dragRatio;
   const guide =
     dragRatio != null && guideRatio != null ? (
       <div
-        className={`split-host__guide${snapPreview ? " split-host__guide--snap" : ""}${
+        className={`split-host__guide${atEvenSplit ? " split-host__guide--snap" : ""}${
           inCloseZone ? " split-host__guide--close" : ""
         }${inCollapseZone ? " split-host__guide--collapse" : ""}`}
         style={{ left: PCT(dividerOffset(guideRatio, secondarySide)) }}
         aria-hidden
       >
-        <span className="split-host__guide-chip">
-          {inCloseZone ? "Close" : inCollapseZone ? "Fill" : snapPreview ? snapPreview.label : null}
-        </span>
+        {inCloseZone || inCollapseZone ? (
+          <span className="split-host__guide-chip">{inCloseZone ? "Close" : "Fill"}</span>
+        ) : null}
       </div>
     ) : null;
 
@@ -353,7 +340,7 @@ export function DetailSplitHost({
         secondaryTiles.length === 1 ? (
           <>
             {mobileSwitcher}
-            <Group className="split-host__group" data-variant={variant} orientation="horizontal">
+            <Group className="split-host__group" data-variant={variant} data-resizing={dragRatio != null ? "" : undefined} orientation="horizontal">
               {secondarySide === "left" ? (
                 <>
                   {secondaryPanel}

--- a/src/components/drag-to-split.test.ts
+++ b/src/components/drag-to-split.test.ts
@@ -33,6 +33,20 @@ test("DetailSplitHost renders drop zones + a snapping divider", () => {
   assert.match(src, /split-host__guide--collapse/, "far-edge drag shows the fill guide");
 });
 
+test("the divider is seamless: no ratio buttons, magnetic even-split, double-click reset", () => {
+  const src = read("./detail-split-host.tsx");
+  // The clumsy ⅓ · ½ · ⅔ button row is gone — the divider itself is the control.
+  assert.doesNotMatch(src, /Snap to a third/, "no ⅓ button");
+  assert.doesNotMatch(src, /Snap to two thirds/, "no ⅔ button");
+  assert.doesNotMatch(src, /snapTo\(/, "no per-ratio snap button handler");
+  // Double-click the divider resets to an even split (replaces the ½ button).
+  assert.match(src, /addEventListener\("dblclick"/, "double-click handled");
+  assert.match(src, /closest\(".split-host__sep"\)[\s\S]*resize\(PCT\(SPLIT_DEFAULT_RATIO\)\)/, "double-click resets to even");
+  // A hover/drag grip affordance on the seam.
+  assert.match(src, /split-host__grip/, "divider shows a grip affordance");
+  assert.match(src, /data-resizing=/, "group flags an active resize for grip feedback");
+});
+
 test("DetailSplitHost supports optimized variants for up to four visible pages", () => {
   const src = read("./detail-split-host.tsx");
   assert.match(src, /secondaryTiles: DetailSplitTile\[\]/, "host receives multiple secondary tiles");

--- a/src/lib/split-snap.test.ts
+++ b/src/lib/split-snap.test.ts
@@ -11,19 +11,20 @@ import {
   SPLIT_SNAP_THRESHOLD,
 } from "./split-snap.ts";
 
-test("nearestSnap returns the half point when dragged near the middle", () => {
+test("nearestSnap engages the even-split detent near the middle", () => {
   const snap = nearestSnap(0.5 + SPLIT_SNAP_THRESHOLD / 2);
   assert.ok(snap);
-  assert.equal(snap?.label, "½");
+  assert.equal(snap?.ratio, 0.5);
 });
 
-test("nearestSnap returns the third points within threshold", () => {
-  assert.equal(nearestSnap(1 / 3 + 0.01)?.label, "⅓");
-  assert.equal(nearestSnap(2 / 3 - 0.01)?.label, "⅔");
+test("the clumsy ⅓ / ⅔ ratios are no longer snap points", () => {
+  // The old three-button snap is gone — only the even split is magnetic now.
+  assert.equal(nearestSnap(1 / 3), null);
+  assert.equal(nearestSnap(2 / 3), null);
 });
 
-test("nearestSnap returns null in free space between snap points", () => {
-  // Midway between ⅓ (.333) and ½ (.5) is ~.417 — outside every threshold.
+test("nearestSnap returns null in free space away from the even split", () => {
+  // 0.42 is ~0.08 from ½ — outside the detent threshold, so free.
   assert.equal(nearestSnap(0.42), null);
 });
 

--- a/src/lib/split-snap.ts
+++ b/src/lib/split-snap.ts
@@ -2,9 +2,9 @@
  * split-snap — pure geometry for the drag-to-split secondary pane.
  *
  * The detail area can host a second "page" beside the primary surface. The
- * secondary pane is resizable, and — like a modern desktop window manager —
- * the divider *snaps* to a set of clean ratios (a third, a half, two thirds)
- * when the user drags close to them. Dragging past *either* edge collapses the
+ * secondary pane resizes freely, with a single *magnetic* detent at the even
+ * split (½) so a balanced layout is effortless to find without cluttering the
+ * chrome with discrete ratio buttons. Dragging past *either* edge collapses the
  * pane on that side: past the near edge closes the secondary (the primary
  * fills), and past the far edge collapses the primary (the secondary fills).
  * All sizes are expressed as the **secondary pane's** fraction of the split
@@ -18,12 +18,12 @@ export type SnapPoint = {
   label: string;
 };
 
-/** The clean ratios the divider snaps to (secondary-pane fraction). */
-export const SPLIT_SNAP_POINTS: readonly SnapPoint[] = [
-  { ratio: 1 / 3, label: "⅓" },
-  { ratio: 1 / 2, label: "½" },
-  { ratio: 2 / 3, label: "⅔" },
-];
+/**
+ * The single magnetic detent: an even split. Free-dragging everywhere else,
+ * with a gentle pull toward ½ so a balanced layout falls into place on its own.
+ * (Replaces the old ⅓ · ½ · ⅔ button row — the divider itself is the control.)
+ */
+export const SPLIT_SNAP_POINTS: readonly SnapPoint[] = [{ ratio: 1 / 2, label: "Even" }];
 
 /** The ratio the secondary opens at when a page is first dropped in. */
 export const SPLIT_DEFAULT_RATIO = 1 / 2;
@@ -45,8 +45,12 @@ export const SPLIT_COLLAPSE_RATIO = 0.84;
  */
 export const SPLIT_MAX_RATIO = 0.9;
 
-/** Snap engages when the divider is within this fraction of a snap point. */
-export const SPLIT_SNAP_THRESHOLD = 0.04;
+/**
+ * Snap engages within this fraction of the even-split detent. A touch wider
+ * than a hairline so ½ feels magnetic — but narrow enough that off-center
+ * ratios still feel free.
+ */
+export const SPLIT_SNAP_THRESHOLD = 0.06;
 
 /** Clamp a secondary fraction into the open/usable range. */
 export function clampSplitRatio(ratio: number): number {


### PR DESCRIPTION
The ⅓ · ½ · ⅔ button row was clumsy. This makes the **divider itself the only control** — a minimalist, world-class splitscreen.

## The experience

- **Free-drag anywhere**, with a single **magnetic detent at the even split (½)** — a balanced layout falls into place on its own, no discrete buttons.
- **Double-click the divider → reset to even** (replaces the ½ button). Captured at the window so it fires even though react-resizable-panels owns the seam.
- **Refined seam**: a soft **grip** fades in on hover/drag; the divider now sits above the panes so its *whole width* is grabbable (not just one side), with a widened hit strip.
- **Minimal feedback**: a gentle accent glow at the even-split detent (no numeric chip), a single one-word pill only in the edge zones (`Close` / `Fill`).
- **Edge gestures unchanged**: near edge → Close the secondary; far edge → Fill (promote the secondary, collapse the primary).

The secondary pane header is now just its title + a close button.

## Under the hood

- `split-snap.ts`: the snap set collapses from `⅓ · ½ · ⅔` to a single `½` detent with a slightly wider (0.06), magnetic threshold. `resolveSplitRelease` is otherwise unchanged (close / collapse / snap / keep).
- `detail-split-host.tsx`: fraction buttons + `snapTo` removed; a window-captured `dblclick` on `.split-host__sep` resets to `SPLIT_DEFAULT_RATIO`; the group flags `data-resizing` for grip feedback; the guide drops the numeric chip.
- `globals.css`: `.split-host__grip` affordance + `z-index` so the seam is fully grabbable; reduced-motion aware.

## Verification

- Unit: `split-snap` 10/10 (even-split detent; asserts ⅓·⅔ are no longer snap points), `drag-to-split` 7/7 (adds a seamless-divider test), `detail-split-host` ok.
- `tsc --noEmit` clean; `pnpm build` (incl. bundle-budget) clean.
- Live (Playwright, real divider drags): header shows only `Close split`; grip opacity → 1 on hover; drag to 52.6% shows the snap-glow and releases to exactly **50%** (magnet); off-center 57.9% stays free; **double-click** resets 26% → 50%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)