### PR TITLE
fix(shell): re-fit the detail split when its width changes (desktop far-right gap)

### DIFF
--- a/src/components/detail-split-host.tsx
+++ b/src/components/detail-split-host.tsx
@@ -131,6 +131,7 @@ export function DetailSplitHost({
   // pointerup: if the ratio moved while a pointer was held, that was a divider
   // drag — resolve it to snap / close / collapse.
   const secRef = usePanelRef();
+  const groupElRef = React.useRef<HTMLDivElement | null>(null);
   const ratioRef = React.useRef(SPLIT_DEFAULT_RATIO);
   const pointerDownRef = React.useRef(false);
   const dragStartRatioRef = React.useRef(SPLIT_DEFAULT_RATIO);
@@ -188,6 +189,46 @@ export function DetailSplitHost({
       window.removeEventListener("pointerup", onUp, true);
     };
   }, [secondaryTiles, onClose, onPromoteTile, secRef]);
+
+  // Re-fit guard: react-resizable-panels sizes its panes in pixels from a
+  // ResizeObserver on the group. In some embedded webviews (observed on the
+  // desktop app) that observer doesn't fire when the detail area changes width
+  // *without* a window resize — e.g. the nav collapsing to its rail, or a slow
+  // first layout — so the panes stay sized for the old, narrower width and
+  // leave dead space past the last pane. We observe the group ourselves and
+  // re-apply the current ratio, which forces RRP to recompute against the live
+  // width. Re-applying the same ratio is a no-op when the panes already fill,
+  // so this never fights the user's chosen split or the divider drag.
+  React.useEffect(() => {
+    if (secondaryTiles.length !== 1) return;
+    const el = groupElRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+
+    const refit = () => {
+      if (pointerDownRef.current) return; // don't interrupt an active divider drag
+      const r = ratioRef.current;
+      if (r > 0.02 && r < 0.98) secRef.current?.resize(PCT(r));
+    };
+
+    let raf = 0;
+    let lastW = Math.round(el.getBoundingClientRect().width);
+    const ro = new ResizeObserver((entries) => {
+      const w = Math.round(entries[0]?.contentRect.width ?? 0);
+      if (w === lastW || w === 0) return;
+      lastW = w;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(refit);
+    });
+    ro.observe(el);
+    // Initial correction for a stale/late first measurement in the webview.
+    const t = window.setTimeout(refit, 200);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.clearTimeout(t);
+      ro.disconnect();
+    };
+  }, [secondaryTiles.length, secondarySide, secRef]);
 
   // Keyboard / button snap helpers shown in the pane header.
   const snapTo = (ratio: number) => secRef.current?.resize(PCT(ratio));
@@ -353,7 +394,7 @@ export function DetailSplitHost({
         secondaryTiles.length === 1 ? (
           <>
             {mobileSwitcher}
-            <Group className="split-host__group" data-variant={variant} orientation="horizontal">
+            <Group className="split-host__group" data-variant={variant} orientation="horizontal" elementRef={groupElRef}>
               {secondarySide === "left" ? (
                 <>
                   {secondaryPanel}


### PR DESCRIPTION
## What

Second, more targeted fix for the desktop far-right gap in a Code split (after #2277's CSS hardening didn't resolve it on the desktop app).

## Root cause (narrowed)

react-resizable-panels sizes its panes in **pixels**, computed from a `ResizeObserver` on the group. I confirmed the web build always re-fills — at every width, on window resize, on nav-collapse-after-split, RRP's observer fires and recomputes the panes (`gap=0`). So the desktop-only gap is that **the webview's ResizeObserver doesn't fire when the detail area changes width *without* a window resize** (e.g. the nav collapsing to its rail, or a slow first layout). The panes stay sized for the old, narrower width → dead space past the last pane, scaling proportionally "at any screen size."

## Fix

`DetailSplitHost` now observes the split group itself (RRP v4's `Group` `elementRef`) and, when the group's width changes, re-applies the **current** ratio — forcing RRP to recompute pane pixels against the live width. It:
- skips while a divider drag is active (`pointerDownRef`),
- re-applies the *current* ratio, not a reset, so a user's custom split is preserved,
- can't loop (re-applying the ratio doesn't change the group width), and
- also does one delayed re-fit on open for a stale/late first webview layout.

## Verification (web)

- `pnpm typecheck`, `pnpm test:app` (517 files), `pnpm build` all green.
- Drove the split and confirmed: keyboard resize still works (ratio 50→20→70), the panes always fill (`gap=0`), and after a nav-collapse the user's 70% ratio is **preserved** while the panes re-fill proportionally — no observer loop.

Since I can't reproduce the gap headlessly, this targets the one remaining mechanism (webview observer not firing). If the desktop app still shows it after rebuilding, the group-width overlay measurement will pin the exact element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)