### PR TITLE
fix(github): guard activity poll, stop manual refresh eating drafts, show CI passing/pending

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -269,7 +269,7 @@ assert.match(source, /\}, \[sorted\.length\]\);/, "row-nav listeners rebind when
 // the manual/⌘R refresh keeps the linked-task chips in sync.
 assert.match(source, /function schedulePoll\(ms: number\)[\s\S]{0,160}?document\.hidden\) return/, "polling is skipped while the tab is hidden");
 assert.match(source, /addEventListener\("visibilitychange", onVis\)/, "polling resumes when the tab returns to the foreground");
-assert.match(source, /void fetchActivity\(\);\s*\n\s*reloadCards\(\);/, "⌘R refreshes activity AND reloads the linked-task cards");
+assert.match(source, /refreshActivity\(\);\s*\n\s*reloadCards\(\);/, "⌘R refreshes activity (via refreshActivity) AND reloads the linked-task cards");
 
 // Memoised so a re-render doesn't re-filter the (potentially large) item set.
 assert.match(source, /const filtered = useMemo\(/, "the kind-filtered set is memoised");
@@ -356,5 +356,21 @@ assert.doesNotMatch(
   /href="https:\/\/github\.com\/settings\/tokens\/new/,
   "PAT setup no longer relies on a plain anchor that can stay inside localhost",
 );
+
+// ── 2026-07-03 GitHub audit fixes ─────────────────────────────────────────────
+// The activity poll is content-guarded — an unchanged response keeps the prior
+// reference so the whole table + detail panel don't re-render every 90s.
+assert.match(source, /setActivity\(\(prev\) =>[\s\S]*?arrayContentEqual\(prev\.items, nextActivity\.items\)[\s\S]*?\? prev/, "the activity poll guards setActivity with arrayContentEqual");
+// A manual refresh with data already on screen keeps the list mounted (so an
+// open composer draft isn't destroyed) — skeleton is initial-load only.
+assert.match(source, /if \(!silent && !activity\) setLoading\(true\)/, "non-silent refresh only skeletons the initial load, preserving the composer");
+// One refresh helper cancels the pending poll first, so Retry can't leak a
+// second timer chain.
+assert.match(source, /function refreshActivity\(\) \{[\s\S]*?clearTimeout\(timerRef\.current\)[\s\S]*?void fetchActivity\(\)/, "refreshActivity cancels the scheduled poll before refetching");
+assert.doesNotMatch(source, /onClick=\{\(\) => void fetchActivity\(\)\}/, "no manual site refetches without cancelling the pending poll (Retry leak fixed)");
+// CI status shows passing/pending, not only failing (a green PR was invisible).
+assert.match(source, /item\.checkStatus === "passing"/, "CI passing state renders a badge");
+assert.match(source, /item\.checkStatus === "pending"/, "CI pending state renders a badge");
+assert.match(boardCss, /\.gh-badge--success \{/, "the success badge has a style");
 
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -7,6 +7,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import { useCopy } from "@/lib/use-copy";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
@@ -1409,7 +1410,9 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
   }
 
   async function fetchActivity(silent = false) {
-    if (!silent) setLoading(true);
+    // Skeleton only on the first load — a manual refresh with data already on
+    // screen must not unmount the list (and any open composer draft with it).
+    if (!silent && !activity) setLoading(true);
     setError(null);
     try {
       const res = await fetch("/api/github/activity");
@@ -1429,9 +1432,13 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
         return;
       }
 
-      setActivity(data as ActivityResult);
+      const nextActivity = data as ActivityResult;
+      setActivity((prev) =>
+        prev && prev.authed === nextActivity.authed && arrayContentEqual(prev.items, nextActivity.items)
+          ? prev
+          : nextActivity);
       setError(null);
-      schedulePoll((data as ActivityResult).authed ? 90_000 : 120_000);
+      schedulePoll(nextActivity.authed ? 90_000 : 120_000);
     } catch (e) {
       if (!mountedRef.current) return;
       setError(e instanceof Error ? e.message : "Failed to load GitHub activity");
@@ -1439,6 +1446,14 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
     } finally {
       if (mountedRef.current) setLoading(false);
     }
+  }
+
+  // Manual refresh: cancel the pending scheduled poll first so we never spawn a
+  // second self-scheduling timer chain (the error-state Retry used to skip this
+  // and leak a chain, doubling the poll rate — and the GitHub rate-limit spend).
+  function refreshActivity() {
+    if (timerRef.current !== null) { window.clearTimeout(timerRef.current); timerRef.current = null; }
+    void fetchActivity();
   }
 
   useEffect(() => {
@@ -1471,8 +1486,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
       const tag = target?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
       e.preventDefault();
-      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-      void fetchActivity();
+      refreshActivity();
       reloadCards(); // keep the linked-task chips fresh too (parity with the toolbar refresh)
     };
     window.addEventListener("keydown", onKey);
@@ -1664,8 +1678,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
           onSaved={(login, hasPat) => {
             setPatStatus({ hasPat, login });
             setShowPatModal(false);
-            if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-            void fetchActivity();
+            refreshActivity();
           }}
           onClose={() => setShowPatModal(false)}
         />
@@ -1796,8 +1809,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
           <button
             type="button"
             onClick={() => {
-              if (timerRef.current !== null) window.clearTimeout(timerRef.current);
-              void fetchActivity();
+              refreshActivity();
               reloadCards();
             }}
             title="Refresh (⌘R)"
@@ -1838,7 +1850,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
               headline="Couldn't load GitHub"
               subtitle={error}
               actions={
-                <Button variant="secondary" leadingIcon="ph:arrow-clockwise" onClick={() => void fetchActivity()}>
+                <Button variant="secondary" leadingIcon="ph:arrow-clockwise" onClick={refreshActivity}>
                   Retry
                 </Button>
               }
@@ -1979,6 +1991,26 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                             title="CI checks failing"
                           >
                             checks failed
+                          </span>
+                        )}
+                        {item.checkStatus === "passing" && (
+                          <span
+                            className="gh-badge gh-badge--success"
+                            role="img"
+                            aria-label="CI checks passing"
+                            title="CI checks passing"
+                          >
+                            checks pass
+                          </span>
+                        )}
+                        {item.checkStatus === "pending" && (
+                          <span
+                            className="gh-badge gh-badge--muted"
+                            role="img"
+                            aria-label="CI checks running"
+                            title="CI checks running"
+                          >
+                            checks…
                           </span>
                         )}
                       </td>

--- a/src/lib/github-tasks.ts
+++ b/src/lib/github-tasks.ts
@@ -141,25 +141,7 @@ export type GitHubTask = {
   checkRunUrl?: string;
 };
 
-export type GitHubTasksResult = {
-  ok: true;
-  tasks: GitHubTask[];
-};
-
 type WireTask = Record<string, unknown>;
-
-export async function loadGitHubTasks(): Promise<GitHubTasksResult> {
-  const res = await fetch("/api/github/tasks", { cache: "no-store" });
-  const data = await res.json().catch(() => null);
-  if (!res.ok || !data || data.ok === false) {
-    throw new Error(
-      (data && typeof data.error === "string" && data.error) ||
-        `GitHub tasks unavailable (${res.status})`,
-    );
-  }
-
-  return { ok: true, tasks: normalizeGitHubTasks(data) };
-}
 
 export function normalizeGitHubTasks(data: unknown): GitHubTask[] {
   const rawTasks = Array.isArray(data)

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -676,6 +676,7 @@
 .gh-badge { display:inline-flex; align-items:center; padding:1px 6px; margin-left:6px; border-radius:9999px; font-size:9.5px; line-height:1.4; vertical-align:middle; }
 .gh-badge--muted { background:var(--bg-raised); color:var(--text-muted); }
 .gh-badge--danger { background:color-mix(in oklch,var(--color-danger) 16%,transparent); color:var(--color-danger); font-weight:560; }
+.gh-badge--success { background:color-mix(in oklch,var(--color-success) 16%,transparent); color:var(--color-success); font-weight:560; }
 .gh-empty-cell { color:color-mix(in oklch,var(--text-muted) 55%,transparent); font-size:11px; }
 
 .gh-task-chip-list { display:inline-flex; align-items:center; gap:4px; flex-wrap:wrap; max-width:230px; }


### PR DESCRIPTION
## What

GitHub-surface audit — the correctness + perf half (a11y ships as a follow-up PR; they collide on `github-view.tsx`). Every finding source-verified.

- **Unguarded poll re-render storm** — the 90s activity poll called `setActivity` with a fresh object every tick, no content guard, so `filtered → scoped → linkedMap → sorted → grouped` all recomputed and the whole table + detail panel re-rendered even on byte-identical data. Now guarded with `arrayContentEqual` (board/automations/chat convention).
- **Manual refresh destroyed an open composer draft** — a non-silent refresh (`⌘R` / toolbar / Retry) set `loading=true`, swapping the list for a skeleton and unmounting any open comment composer with it. `⌘R` is a reflex; the draft was gone. Skeleton is now **initial-load only** (`if (!silent && !activity)`); a refresh with data on screen keeps the list mounted.
- **Retry leaked a poll-timer chain** — the error-state Retry refetched without cancelling the pending scheduled poll, spawning a second self-scheduling chain (double poll rate + rate-limit spend). All manual refreshes now route through one `refreshActivity()` that cancels first.
- **CI status invisible unless failing** — the badge rendered only for `checkStatus === "failing"`; `"passing"` and `"pending"` showed nothing, so a green or in-progress PR was indistinguishable from one with no CI (affects everyone, not just AT). Added passing/pending badges + `.gh-badge--success`. **Verified live: all three states render** (`CI checks passing/failing/running`), zero page errors.
- **Dead code** — removed `loadGitHubTasks` + `GitHubTasksResult` (zero callers).

## Audit notes
The poll-**wipes-edits** data-loss class (found in automations) is **clean for background polling** here — composer/thread state lives in a child keyed by `[repo, number]` with its own fetch, so the poll only swapped list refs. The related-but-distinct *explicit-refresh* draft loss (fixed above) was the real bug. Envelope double-unwrap, `.json()`-on-non-ok, PAT/path injection, HTML-export XSS all verified **clean**.

## Tests
Source-text pins in `github-view-polish.test.ts` (poll guard, initial-load-only skeleton, `refreshActivity` cancels-first, no leaky Retry, passing/pending badges, success CSS); one stale `⌘R` pin repointed. Typecheck + tests-wired green; github test sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)