### PR TITLE
Use nonInteractive launch mode for flow sessions

### DIFF
--- a/src/app/api/flows/run/route.test.ts
+++ b/src/app/api/flows/run/route.test.ts
@@ -18,6 +18,7 @@ assert.match(executor, /flowPartialExecutionOrder\(flow, options\.targetNodeId/,
 assert.match(executor, /options\.targetNodeId \? `Flow step:/, "partial runs get a step-specific session title");
 assert.match(executor, /flowSnapshot: flow/, "run records should persist the workflow snapshot used for retrying original executions");
 assert.match(executor, /mode: options\.mode \?\? "manual"/, "run records should persist whether execution used manual or production semantics");
+assert.match(executor, /launchMode: "nonInteractive"/, "flow sessions should launch with plain non-interactive harness output");
 assert.match(executor, /extractFlowCustomData/, "run records should persist saved custom execution data from Execution Data nodes");
 assert.match(executor, /flowRunRedactsData\(flow, options\.mode \?\? "manual"\)/, "run records should resolve execution-data redaction from the flow policy");
 assert.match(executor, /redacted: true/, "run records should mark redacted executions in history");

--- a/src/components/chat-list-panel.test.ts
+++ b/src/components/chat-list-panel.test.ts
@@ -35,6 +35,18 @@ assert.match(
 
 assert.match(
   source,
+  /import \{ EmptyState \} from "@\/components\/ui\/empty-state"/,
+  "ChatList should use the shared EmptyState primitive",
+);
+
+assert.match(
+  source,
+  /<EmptyState[\s\S]*headline="Ready for a new thread"/,
+  "ChatList empty state should render through the shared EmptyState primitive",
+);
+
+assert.match(
+  source,
   /Ready for a new thread/,
   "ChatList empty state should frame the agent as ready instead of only saying no chats exist",
 );

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -10,6 +10,8 @@ import { useIsMobile } from "@/lib/use-viewport";
 import { OriginChip } from "@/components/ui/origin-chip";
 import { SessionInitiatorChip } from "@/components/ui/session-initiator-chip";
 import { UndoToast } from "@/components/ui/undo-toast";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
@@ -929,38 +931,41 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         ) : !hasAny ? (
           /* Empty state */
           <div className="flex h-full flex-col justify-between px-4 py-4">
-            <div className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35 p-4">
-              <div className="flex items-start gap-3">
-                <span className="grid h-9 w-9 shrink-0 place-items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-muted)]">
-                  <Icon name="ph:sparkle" width={17} aria-hidden />
-                </span>
-                <div className="min-w-0">
-                  <p className="text-[13px] font-semibold text-[var(--text-primary)]">Ready for a new thread</p>
-                  <p className="mt-1 text-[12px] leading-5 text-[var(--text-muted)]">
+            <EmptyState
+              compact
+              className="rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/35"
+              icon="ph:sparkle"
+              headline="Ready for a new thread"
+              subtitle={
+                <>
+                  <span>
                     Start a focused chat with {panelTitle}. The thread will inherit the selected
                     familiar's runtime and show up here once it starts.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-4 divide-y divide-[var(--border-hairline)] border-y border-[var(--border-hairline)] text-left">
-                <div className="flex items-center justify-between gap-3 py-2">
-                  <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Runtime</p>
-                  <p className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{panelRuntime}</p>
-                </div>
-                <div className="flex items-center justify-between gap-3 py-2">
-                  <p className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Model</p>
-                  <p className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{familiar?.model ?? "default"}</p>
-                </div>
-              </div>
-              <button
-                onClick={() => onNewChat(undefined, fallbackFamiliarId)}
-                disabled={!fallbackFamiliarId}
-                className="mt-4 flex h-8 w-full items-center justify-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 text-[12px] font-medium text-white transition-opacity hover:opacity-85"
-              >
-                <Icon name="ph:plus-bold" width={12} />
-                Start with context
-              </button>
-            </div>
+                  </span>
+                  <span className="mt-4 block divide-y divide-[var(--border-hairline)] border-y border-[var(--border-hairline)] text-left">
+                    <span className="flex items-center justify-between gap-3 py-2">
+                      <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Runtime</span>
+                      <span className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{panelRuntime}</span>
+                    </span>
+                    <span className="flex items-center justify-between gap-3 py-2">
+                      <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-[var(--text-muted)]">Model</span>
+                      <span className="min-w-0 truncate font-mono text-[11px] text-[var(--text-secondary)]">{familiar?.model ?? "default"}</span>
+                    </span>
+                  </span>
+                </>
+              }
+              actions={
+                <Button
+                  variant="primary"
+                  size="sm"
+                  leadingIcon="ph:plus-bold"
+                  onClick={() => onNewChat(undefined, fallbackFamiliarId)}
+                  disabled={!fallbackFamiliarId}
+                >
+                  Start with context
+                </Button>
+              }
+            />
             <div className="rounded-md border border-dashed border-[var(--border-hairline)] px-3 py-2 text-[11px] leading-5 text-[var(--text-muted)]">
               <span className="font-medium text-[var(--text-secondary)]">Tip:</span> use {keys.mod}F
               to jump back to chat search after this list has history.

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -10,9 +10,10 @@ const source = readFileSync(new URL("./flow-executor.ts", import.meta.url), "utf
 // the daemon body must NOT include familiarId.
 assert.match(
   source,
-  /body: \{ projectRoot, harness: binding\.harness, prompt \},/,
+  /body: \{ projectRoot, harness: binding\.harness, prompt, launchMode: "nonInteractive" \},/,
   "flow session spawn must not pass familiarId natively to the daemon",
 );
+assert.match(source, /launchMode: "nonInteractive"/, "flow session output should be plain assistant text, not harness TUI output");
 assert.match(source, /recordSessionFamiliar\(sessionId, familiarId\)/, "familiar is still mirrored into cave-state");
 assert.match(
   source,

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -149,10 +149,12 @@ export async function startFlowSession(
     // chat does. Passing `familiarId` makes some daemon setups try to run the
     // session *as* that familiar and reject it with "no familiar configured for
     // this harness" when the familiar isn't registered for that harness on the
-    // daemon. The familiar is already described in the compiled prompt and is
-    // mirrored into cave-state below via recordSessionFamiliar, so attribution
+    // daemon. Use non-interactive launch mode so the event stream contains the
+    // flow prompt's assistant output and progress markers, not a fullscreen
+    // harness TUI. The familiar is already described in the compiled prompt and
+    // is mirrored into cave-state below via recordSessionFamiliar, so attribution
     // and the run→familiar link survive.
-    body: { projectRoot, harness: binding.harness, prompt },
+    body: { projectRoot, harness: binding.harness, prompt, launchMode: "nonInteractive" },
     timeoutMs: 8000,
   });
 


### PR DESCRIPTION
Moves a commit that was accidentally made directly on local `main` (the protected-branch push was correctly rejected) onto a PR branch — the required path to `main`. Commit is unchanged and signed.

## What

- Flow sessions now pass `launchMode: "nonInteractive"` to the daemon, so the event stream carries plain assistant output instead of fullscreen harness TUI output.
- Migrates the ChatList empty state to the shared `EmptyState` primitive with a `Button` CTA.

Files: `flow-executor.ts` (+ test), `flows/run/route.test.ts`, `chat-list.tsx`, `chat-list-panel.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)