### PR TITLE
a11y(github): announce CRUD, label the composer, focus-trap the action popover

### DIFF
--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -11,6 +11,7 @@ import {
   itemToContext,
 } from "@/lib/github-tasks";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
@@ -326,14 +327,10 @@ export function GitHubActionPopover({
     };
   }, [onClose]);
 
-  // Close on Escape
-  useEffect(() => {
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
-    }
-    document.addEventListener("keydown", handleKey);
-    return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  // Trap focus inside the popover, close on Escape, and return focus to the
+  // trigger on close (the shared dialog convention). Replaces a bare keydown
+  // listener that left Tab escaping into the page and lost the return point.
+  useFocusTrap(true, ref, { onEscape: onClose });
 
   const TITLES: Record<PopoverMode, string> = {
     board: "Add to board",
@@ -350,6 +347,10 @@ export function GitHubActionPopover({
   return (
     <div
       ref={ref}
+      role="dialog"
+      aria-modal="true"
+      aria-label={TITLES[mode]}
+      tabIndex={-1}
       className="absolute right-0 top-full z-50 mt-1 w-64 rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] p-3 shadow-xl"
       onClick={(e) => e.stopPropagation()}
     >

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -372,5 +372,12 @@ assert.doesNotMatch(source, /onClick=\{\(\) => void fetchActivity\(\)\}/, "no ma
 assert.match(source, /item\.checkStatus === "passing"/, "CI passing state renders a badge");
 assert.match(source, /item\.checkStatus === "pending"/, "CI pending state renders a badge");
 assert.match(boardCss, /\.gh-badge--success \{/, "the success badge has a style");
+// ── 2026-07-03 GitHub a11y batch ──────────────────────────────────────────────
+assert.match(source, /const \{ announce \} = useAnnouncer\(\)/, "the GitHub surface consumes the shared announcer");
+assert.match(source, /announce\("Comment posted\."\)/, "posting a comment announces");
+assert.match(source, /announce\(next \? "Thread resolved\." : "Thread unresolved\."\)/, "resolving a thread announces");
+assert.match(source, /announce\(`Worktree \$\{json\.created \? "created" : "reused"\} for the safe merge\.`\)/, "the safe-merge worktree announces");
+assert.match(source, /aria-label="Reply to this thread"/, "the comment composer textarea is labelled");
+assert.match(source, /className="gh-composer-error" role="alert"/, "a failed post is announced via role=alert");
 
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { arrayContentEqual } from "@/lib/array-content-equal";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { useCopy } from "@/lib/use-copy";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
@@ -517,6 +518,7 @@ function SafeMergeAction({
   onJumpToSession?: (sessionId: string, familiarId?: string | null) => void;
 }) {
   const [busy, setBusy] = useState(false);
+  const { announce } = useAnnouncer();
   const [error, setError] = useState<string | null>(null);
   if (item.kind !== "pr" && item.kind !== "review_request") return null;
 
@@ -553,6 +555,7 @@ function SafeMergeAction({
           throw new Error(json?.error ?? `worktree HTTP ${res.status}`);
         }
         worktreeLine = `Worktree: ${json.worktree} (${json.created ? "created" : "reused"}). Branch: ${json.branch}.`;
+        announce(`Worktree ${json.created ? "created" : "reused"} for the safe merge.`);
       }
 
       const context = [
@@ -838,6 +841,7 @@ function GitHubComments({
   const [tick, setTick] = useState(0);
   const [draft, setDraft] = useState("");
   const [posting, setPosting] = useState(false);
+  const { announce } = useAnnouncer();
   const [postError, setPostError] = useState<string | null>(null);
   const [showResolved, setShowResolved] = useState(false);
   const [familiarPickerOpen, setFamiliarPickerOpen] = useState(false);
@@ -890,6 +894,7 @@ function GitHubComments({
   async function toggleResolve(thread: GhReviewThread) {
     if (!canResolve || state.status !== "ready") return;
     const next = !thread.isResolved;
+    announce(next ? "Thread resolved." : "Thread unresolved.");
     // Optimistic flip — revert on failure.
     setState({
       status: "ready",
@@ -955,6 +960,7 @@ function GitHubComments({
       }
       setDraft("");
       setTick((n) => n + 1);
+      announce("Comment posted.");
     } catch (e) {
       setPostError(e instanceof Error ? e.message : "Network error");
     } finally {
@@ -1065,7 +1071,9 @@ function GitHubComments({
               <textarea
                 ref={textareaRef}
                 className="gh-composer-input"
-                placeholder="Reply… use @ to tag a familiar"
+                aria-label="Reply to this thread"
+                aria-keyshortcuts="Meta+Enter Control+Enter"
+                placeholder="Reply… use @ to tag a familiar (⌘↵ to send)"
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
                 onKeyDown={(e) => {
@@ -1076,7 +1084,7 @@ function GitHubComments({
                 }}
                 rows={2}
               />
-              {postError && <p className="gh-composer-error">{postError}</p>}
+              {postError && <p className="gh-composer-error" role="alert">{postError}</p>}
               <div className="gh-composer-actions">
                 <div className="gh-composer-tag">
                   <button

--- a/src/components/modal-trap-adoption.test.ts
+++ b/src/components/modal-trap-adoption.test.ts
@@ -9,6 +9,7 @@ const FILES = [
   "library-github-list.tsx",
   "onboarding-overlay.tsx",
   "github-view.tsx",
+  "github-action-popover.tsx",
   "new-reminder-modal.tsx",
 ];
 


### PR DESCRIPTION
## What

GitHub-surface audit — the a11y half (correctness/perf shipped in #2286). The surface never used the shared announcer and had hand-rolled popovers with no focus management.

- **Announcer**: comment posted, thread resolved/unresolved, and safe-merge worktree created/reused now announce via the shared `useAnnouncer` (`GitHubComments` + `SafeMergeAction`).
- **Composer**: the reply `<textarea>` gets an `aria-label` + `aria-keyshortcuts` (⌘↵, previously undiscoverable), and a failed post announces via `role="alert"`.
- **Action popover** (`GitHubActionPopover` — the Board/Chat popover): now a real modal dialog via `useFocusTrap` (trap + Escape + focus return) + `role="dialog"`/`aria-modal`/label, replacing a bare `window` keydown listener that let Tab escape into the page and dropped the focus return point. Added to the `modal-trap-adoption` guard list.

## Verification
Surface renders with a live region present, zero page errors (live-checked). The announce sites + composer label + `role=alert` are source-pinned; the popover's focus-trap adoption is enforced by `modal-trap-adoption.test.ts`.

## Parked (P2)
Diff line-level added/removed text alternative; focus restoration when a selected row disappears on refresh; the three other hand-rolled pickers (`OpenChatAction` and the wide wrappers) — same trap pattern, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)