### PR TITLE
feat(chat): swap the message Share button for privacy-safe thumbs analytics

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -537,6 +537,7 @@ export const SUITES = {
     "src/lib/server/automation-runner.test.ts",
     "src/lib/session-pins.test.ts",
     "src/lib/message-feedback.test.ts",
+    "src/lib/server/message-feedback-store.test.ts",
     "src/components/detail-split-host.test.ts",
   ],
   api: [
@@ -640,6 +641,7 @@ export const SUITES = {
     "src/app/api/library/doc/route.test.ts",
     "src/app/api/library/chat/chat-doc-path.test.ts",
     "src/app/api/salem/pathfinder/feedback/route.test.ts",
+    "src/app/api/feedback/message/route.test.ts",
     "src/app/api/launch/route.test.ts",
     "scripts/sidecar-bundle.test.mjs",
     "src/app/api/library/pdf/route.test.ts",
@@ -765,6 +767,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/cave-board-attachments.test.ts",
   "src/lib/cave-board-schedule.test.ts",
   "src/lib/salem/pathfinder-feedback.test.ts",
+  "src/lib/server/message-feedback-store.test.ts",
   "src/lib/session-rail-title.test.ts",
   "src/lib/server/familiar-contract-files.test.ts",
   "src/lib/server/project-paths.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -52,6 +52,7 @@ const contracts: RouteContract[] = [
   { route: "/familiars/[id]/self-reports", methods: ["GET"], kind: "json", pathGuard: true },
   { route: "/familiars/[id]/response-confidence", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
   { route: "/familiars", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/feedback/message", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/fs-browse", methods: ["GET"], kind: "json", pathGuard: true, localOriginGuard: true },
   { route: "/github/activity", methods: ["GET"], kind: "json" },
   { route: "/github/assigned", methods: ["GET"], kind: "json" },

--- a/src/app/api/feedback/message/route.test.ts
+++ b/src/app/api/feedback/message/route.test.ts
@@ -1,0 +1,15 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(route, /export async function POST/, "POST handler");
+assert.doesNotMatch(route, /export async function GET/, "no read endpoint (local-only traces)");
+assert.match(route, /NextResponse\.json/, "returns JSON");
+assert.match(route, /recordMessageFeedback\(/, "records via the local store");
+assert.match(route, /invalid json/i, "guards invalid JSON");
+assert.match(route, /status:\s*400/, "rejects invalid input/JSON with 400");
+assert.doesNotMatch(route, /\bfetch\(|spawn\(|https?:/i, "feedback never leaves the machine");
+
+console.log("feedback/message route test: ok");

--- a/src/app/api/feedback/message/route.ts
+++ b/src/app/api/feedback/message/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { recordMessageFeedback } from "@/lib/server/message-feedback-store";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Records LOCAL per-message thumbs feedback (up / down / toggled-off) for later
+ * quality analytics. The store whitelists fields and never egresses — see
+ * message-feedback-store.ts. POST-only; no read endpoint (local traces are not
+ * served back to the client).
+ */
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  const entry = await recordMessageFeedback(body as Parameters<typeof recordMessageFeedback>[0]);
+  if (!entry) {
+    return NextResponse.json({ ok: false, error: "invalid feedback" }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5580,13 +5580,7 @@ function TurnRowImpl({
                   isError={turn.error}
                   label={familiar.display_name}
                   messageId={turn.id}
-                  onShare={() => {
-                    try {
-                      void navigator.clipboard?.writeText(typeof visible === "string" ? visible : "");
-                    } catch {
-                      /* clipboard unavailable */
-                    }
-                  }}
+                  feedbackContext={{ familiarId: familiar.id }}
                   onRegenerate={onRegenerate}
                   onReply={onReply}
                   onOpenUrl={onOpenUrl}

--- a/src/components/message-bubble-rewire.test.ts
+++ b/src/components/message-bubble-rewire.test.ts
@@ -17,6 +17,7 @@ assert.match(bubble, /const wireAll = \(\) => \{[\s\S]*?wireCopyButtons\(el\)[\s
 
 assert.match(bubble, /ph:thumbs-up/, "assistant action row has thumbs-up");
 assert.match(bubble, /ph:thumbs-down/, "assistant action row has thumbs-down");
-assert.match(bubble, /ph:share-network/, "assistant action row has share");
+assert.doesNotMatch(bubble, /ph:share-network/, "share action removed from assistant row");
+assert.match(bubble, /recordFeedbackAnalytics\(/, "thumbs votes are mirrored to the analytics store");
 
 console.log("message-bubble-rewire.test.ts: ok");

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -30,7 +30,7 @@ import type { PreviewPlugin } from "@create-markdown/preview";
 import type { Highlighter } from "shiki";
 import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 import { Icon } from "@/lib/icon";
-import { getFeedback, setFeedback, type Feedback } from "@/lib/message-feedback";
+import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -1027,8 +1027,9 @@ export type MessageBubbleProps = {
   /** Stable id for this message — enables local thumbs-up/down persistence
    *  (assistant role only). Without it the thumbs buttons are not rendered. */
   messageId?: string;
-  /** Share this turn — renders a Share action in the assistant action row. */
-  onShare?: () => void;
+  /** Non-identifying context (e.g. the familiar id) stamped alongside a thumbs
+   *  vote when it's mirrored to the local analytics store. */
+  feedbackContext?: FeedbackContext;
   /** CHAT-D4-01: ordered segments — prose spans interleaved with tool blocks
    *  at their chronological position. Assistant role only; when present they
    *  replace the single MarkdownContent render. `content` must still carry
@@ -1046,10 +1047,16 @@ export type MessageBubbleProps = {
   };
 };
 
-export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, messageId, onShare, segments, branchNav }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, messageId, feedbackContext, segments, branchNav }: MessageBubbleProps) {
   const [tsVisible, setTsVisible] = useState(false);
   const [vote, setVote] = useState<Feedback | null>(() => (messageId ? getFeedback(messageId) : null));
-  const applyVote = (v: Feedback) => { if (!messageId) return; setFeedback(messageId, v); setVote(getFeedback(messageId)); };
+  const applyVote = (v: Feedback) => {
+    if (!messageId) return;
+    setFeedback(messageId, v);
+    const next = getFeedback(messageId);
+    setVote(next);
+    recordFeedbackAnalytics(messageId, v, next === null, feedbackContext);
+  };
   const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleMouseEnter = () => {
@@ -1235,16 +1242,6 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
                 <Icon name="ph:thumbs-down" width={13} aria-hidden />
               </button>
             </>
-          ) : null}
-          {onShare ? (
-            <button
-              type="button"
-              aria-label="Share"
-              onClick={onShare}
-              className="cave-copy-btn cave-copy-btn-bubble cave-copy-btn--icon"
-            >
-              <Icon name="ph:share-network" width={13} aria-hidden />
-            </button>
           ) : null}
         </div>
       ) : null}

--- a/src/lib/message-feedback.ts
+++ b/src/lib/message-feedback.ts
@@ -1,6 +1,12 @@
-// Local-only per-message feedback (thumbs). UI affordance; no server persistence (spec follow-up).
+// Per-message feedback (thumbs). `setFeedback` persists the vote LOCALLY for an
+// instant UI toggle; `recordFeedbackAnalytics` additionally mirrors it to the
+// local `/api/feedback/message` store (best-effort, fire-and-forget) so votes
+// can seed later quality analytics. No message content is ever sent.
 const KEY = "cave:msg-feedback:v1";
 export type Feedback = "up" | "down";
+
+/** Extra, non-identifying context stamped alongside an analytics vote. */
+export type FeedbackContext = { familiarId?: string };
 
 function read(): Record<string, Feedback> {
   if (typeof window === "undefined") return {};
@@ -19,4 +25,27 @@ export function setFeedback(messageId: string, vote: Feedback): void {
   if (map[messageId] === vote) delete map[messageId];   // toggle off
   else map[messageId] = vote;
   write(map);
+}
+
+/**
+ * Mirror a thumbs vote to the local analytics store. Best-effort and
+ * fire-and-forget — never blocks the UI, swallows all errors, and no-ops under
+ * SSR / when `fetch` is unavailable. `cleared` is true when the vote was toggled
+ * back off (i.e. the local vote is now null after `setFeedback`).
+ */
+export function recordFeedbackAnalytics(
+  messageId: string,
+  vote: Feedback,
+  cleared: boolean,
+  ctx?: FeedbackContext,
+): void {
+  if (typeof fetch !== "function") return;
+  try {
+    void fetch("/api/feedback/message", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messageId, vote, cleared, familiarId: ctx?.familiarId }),
+      keepalive: true,
+    }).catch(() => { /* best-effort analytics */ });
+  } catch { /* fetch unavailable */ }
 }

--- a/src/lib/server/message-feedback-store.test.ts
+++ b/src/lib/server/message-feedback-store.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Local feedback store — isolated to a temp COVEN_HOME so it never touches the
+// real ~/.coven/cave-message-feedback.json.
+const tmpHome = await mkdtemp(path.join(tmpdir(), "msg-fb-"));
+process.env.HOME = tmpHome;
+process.env.COVEN_HOME = path.join(tmpHome, ".coven");
+
+const fb = await import("./message-feedback-store.ts");
+
+// SAFETY GATE — never write outside the temp home.
+assert.ok(
+  fb.MESSAGE_FEEDBACK_PATH.startsWith(tmpHome),
+  `refusing: MESSAGE_FEEDBACK_PATH ${fb.MESSAGE_FEEDBACK_PATH} not under temp home`,
+);
+
+// sanitizeMessageFeedback: whitelist only; drops arbitrary keys; stamps `at`.
+{
+  const dirty = {
+    messageId: "  turn-42  ",
+    vote: "up",
+    cleared: false,
+    familiarId: "sage",
+    content: "the raw prompt text",
+    secretToken: "abc",
+  };
+  const clean = fb.sanitizeMessageFeedback(dirty, "2026-07-03T00:00:00Z");
+  assert.equal(clean.messageId, "turn-42", "trims the message id");
+  assert.equal(clean.vote, "up");
+  assert.equal(clean.cleared, false);
+  assert.equal(clean.familiarId, "sage");
+  assert.equal(clean.at, "2026-07-03T00:00:00Z");
+  assert.ok(
+    !("content" in clean) && !("secretToken" in clean),
+    "drops non-whitelisted keys (no content/secret leakage)",
+  );
+}
+assert.equal(fb.sanitizeMessageFeedback({ messageId: "x" }, "t"), null, "no vote → rejected");
+assert.equal(fb.sanitizeMessageFeedback({ vote: "up" }, "t"), null, "no messageId → rejected");
+assert.equal(fb.sanitizeMessageFeedback({ messageId: "x", vote: "sideways" }, "t"), null, "bad vote → rejected");
+
+// recordMessageFeedback persists; familiarId only when provided; cleared flag survives.
+const a = await fb.recordMessageFeedback({ messageId: "m1", vote: "down", familiarId: "sage" });
+assert.equal(a.vote, "down");
+assert.equal(a.familiarId, "sage");
+const b = await fb.recordMessageFeedback({ messageId: "m2", vote: "up", cleared: true });
+assert.equal(b.cleared, true, "toggle-off is recorded");
+assert.equal(b.familiarId, undefined, "no familiarId unless supplied");
+
+const all = await fb.loadMessageFeedback();
+assert.equal(all.length, 2, "both entries persisted");
+assert.equal(all[0].messageId, "m1");
+assert.equal(all[1].messageId, "m2");
+
+assert.equal(await fb.recordMessageFeedback({ messageId: "m3" }), null, "invalid input is not recorded");
+
+await rm(tmpHome, { recursive: true, force: true });
+console.log("message-feedback-store.test.ts OK");

--- a/src/lib/server/message-feedback-store.ts
+++ b/src/lib/server/message-feedback-store.ts
@@ -1,0 +1,78 @@
+// Per-message thumbs feedback — LOCAL ONLY, for later quality analytics.
+// Records which assistant message got a thumbs up/down (or had its vote toggled
+// off), which familiar produced it, and when. Privacy (mirrors
+// salem/pathfinder-feedback.ts §"Privacy And Logging"): nothing leaves the
+// machine; only the whitelisted fields below are stored — arbitrary keys
+// (message content, prompts, secrets) are dropped, so nothing sensitive can
+// leak in. These local traces can later seed a sanitized analytics set after
+// review.
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
+
+export const MESSAGE_FEEDBACK_PATH = path.join(covenHome(), "cave-message-feedback.json");
+
+export type MessageFeedbackVote = "up" | "down";
+
+export type MessageFeedback = {
+  messageId: string;
+  vote: MessageFeedbackVote;
+  cleared: boolean; // true when the user toggled the vote back off
+  familiarId?: string;
+  at: string;
+};
+
+/** Client-supplied fields. The store stamps `at` itself. */
+export type MessageFeedbackInput = {
+  messageId?: string;
+  vote?: string;
+  cleared?: boolean;
+  familiarId?: string;
+};
+
+type FeedbackFile = { entries: MessageFeedback[] };
+
+/**
+ * Keep ONLY the whitelisted fields (privacy). Returns null without a valid
+ * messageId + vote. `at` is stamped here, never trusted from input.
+ */
+export function sanitizeMessageFeedback(input: MessageFeedbackInput, at: string): MessageFeedback | null {
+  if (!input || typeof input.messageId !== "string" || !input.messageId.trim()) return null;
+  if (input.vote !== "up" && input.vote !== "down") return null;
+  const fb: MessageFeedback = {
+    messageId: input.messageId.trim().slice(0, 200),
+    vote: input.vote,
+    cleared: input.cleared === true,
+    at,
+  };
+  if (typeof input.familiarId === "string" && input.familiarId.trim()) {
+    fb.familiarId = input.familiarId.trim().slice(0, 120);
+  }
+  return fb;
+}
+
+export async function loadMessageFeedback(): Promise<MessageFeedback[]> {
+  try {
+    const raw = await readFile(MESSAGE_FEEDBACK_PATH, "utf8");
+    const parsed = JSON.parse(raw) as FeedbackFile;
+    return Array.isArray(parsed.entries) ? parsed.entries : [];
+  } catch {
+    return [];
+  }
+}
+
+let feedbackTmpCounter = 0;
+
+/** Append one sanitized feedback entry. Returns the stored entry, or null if invalid. */
+export async function recordMessageFeedback(input: MessageFeedbackInput): Promise<MessageFeedback | null> {
+  const entry = sanitizeMessageFeedback(input, new Date().toISOString());
+  if (!entry) return null;
+  await mkdir(path.dirname(MESSAGE_FEEDBACK_PATH), { recursive: true });
+  const entries = await loadMessageFeedback();
+  entries.push(entry);
+  const tmp = `${MESSAGE_FEEDBACK_PATH}.${process.pid}.${feedbackTmpCounter++}.tmp`;
+  await writeFile(tmp, JSON.stringify({ entries }, null, 2), "utf8");
+  await rename(tmp, MESSAGE_FEEDBACK_PATH);
+  return entry;
+}


### PR DESCRIPTION
## What

The assistant message action row's **Share** button only copied the turn text to the clipboard — redundant with the dedicated **Copy** button right next to it. This removes it and repurposes the space: **thumbs up/down votes are now mirrored to a local analytics store** so they can seed later quality analysis.

## Changes
- **Remove** `onShare`/Share affordance from `MessageBubble` + its `chat-view` wiring
- **Add** `recordFeedbackAnalytics()` — best-effort, fire-and-forget `POST /api/feedback/message`; **no message content is ever sent**, uses `keepalive`, no-ops under SSR / when `fetch` is unavailable
- **New** `/api/feedback/message` route — POST-only, guarded JSON body, no read-back endpoint
- **New** `message-feedback-store` — whitelist-only fields (drops arbitrary keys so nothing sensitive leaks), atomic tmp+rename write, mirrors the existing `salem/pathfinder-feedback` privacy model
- Wire the `api-contracts` gate entry + both new tests into `run-tests` suites & alias loader

## Privacy
Local-only. Stores just `{ messageId, vote, cleared, familiarId?, at }` in `~/.coven/cave-message-feedback.json`. Nothing egresses; message text/prompts/secrets are never captured.

## Verification (local)
- `tsc --noEmit` → clean
- `api-contracts.test.ts` → 154 route contracts passed
- `feedback/message/route.test.ts` → ok
- `message-feedback-store.test.ts` → ok
- `message-bubble-rewire.test.ts` → ok (asserts share removed + analytics mirrored)
- `message-feedback.test.ts` → ok