### PR TITLE
perf(automations): lazy-load the surface + drop dead workflow plumbing

### DIFF
--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { AutomationsView } from "@/components/automations-view";
+import { AutomationsView } from "@/components/lazy-surfaces";
 import type { Escalation } from "@/lib/escalations-types";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -73,3 +73,8 @@ export const MarketplaceView = dynamic(
   timed("marketplace", () => import("@/components/marketplace-view").then((m) => m.MarketplaceViewSurface)),
   { ssr: false, loading: SurfaceFallback },
 );
+
+export const AutomationsView = dynamic(
+  timed("automations", () => import("@/components/automations-view").then((m) => m.AutomationsView)),
+  { ssr: false, loading: SurfaceFallback },
+);

--- a/src/lib/automations/automation-entry.test.ts
+++ b/src/lib/automations/automation-entry.test.ts
@@ -37,7 +37,7 @@ assert.deepEqual(
   { trigger: "On webhook", scheduled: false },
 );
 
-// buildAutomationEntries normalizes all four sources into one typed list.
+// buildAutomationEntries normalizes all three sources into one typed list.
 const entries = buildAutomationEntries({
   reminders: [
     {
@@ -65,9 +65,6 @@ const entries = buildAutomationEntries({
       cwds: [], tags: [], skillPath: null,
     },
   ],
-  workflows: [
-    { id: "w1", version: "1", name: "Research brief", summary: "Fan out", validation_state: "invalid", familiar: "fam-c" },
-  ],
   flows: [
     {
       id: "f1",
@@ -82,7 +79,7 @@ const entries = buildAutomationEntries({
   ],
 });
 
-assert.equal(entries.length, 4);
+assert.equal(entries.length, 3);
 const byType = Object.fromEntries(entries.map((e) => [e.type, e]));
 
 assert.equal(byType.reminder.key, "reminder:r1");
@@ -100,27 +97,24 @@ assert.equal(byType.cron.trigger, "Every day at 7am");
 assert.equal(byType.cron.summary, "Summarize my inbox");
 assert.equal(byType.cron.familiarId, "fam-b");
 
-assert.equal(byType.workflow.state, "draft", "invalid workflow is a draft");
-assert.equal(byType.workflow.trigger, "Manual");
-
 assert.equal(byType.flow.state, "active");
 assert.equal(byType.flow.trigger, "On webhook");
 
-// Dated entries (reminder, flow) sort ahead of undated (cron, workflow).
+// Dated entries (reminder, flow) sort ahead of undated (cron).
 assert.ok(["reminder", "flow"].includes(entries[0].type));
-assert.ok(["cron", "workflow"].includes(entries[3].type));
+assert.equal(entries[2].type, "cron");
 
 // countByType + filterEntries.
-assert.deepEqual(countByType(entries), { reminder: 1, cron: 1, workflow: 1, flow: 1 });
-assert.equal(filterEntries(entries, "research").length, 1);
+assert.deepEqual(countByType(entries), { reminder: 1, cron: 1, flow: 1 });
+assert.equal(filterEntries(entries, "digest").length, 1, "matches on name");
 assert.equal(filterEntries(entries, "webhook").length, 1, "matches on trigger text");
-assert.equal(filterEntries(entries, "").length, 4);
+assert.equal(filterEntries(entries, "").length, 3);
 
 // Type metadata is complete and well-formed.
 for (const t of AUTOMATION_TYPES) {
   const meta = AUTOMATION_TYPE_META[t];
   assert.ok(meta.label && meta.plural && meta.icon && meta.accent && meta.blurb, `meta complete for ${t}`);
-  assert.ok(["inbox", "roles", "flow"].includes(meta.editorMode));
+  assert.ok(["inbox", "flow"].includes(meta.editorMode));
 }
 
 console.log("automation-entry.test.ts: ok");

--- a/src/lib/automations/automation-entry.ts
+++ b/src/lib/automations/automation-entry.ts
@@ -1,26 +1,24 @@
 // Unified automation model.
 //
-// Coven Cave grew four separate "make something happen later / automatically"
+// Coven Cave grew three separate "make something happen later / automatically"
 // primitives, each with its own surface, store, and vocabulary:
 //
 //   • reminder — a nudge (one-shot or recurring) in the inbox store
 //   • cron     — a familiar run on an rrule schedule (Codex automation, TOML)
-//   • workflow — a multi-step agent pipeline with an I/O contract (manifest)
 //   • flow     — a freeform node graph wired on a canvas
 //
 // To a user these are all just "automations": a thing that runs, on a trigger,
 // maybe on a schedule, maybe tied to a familiar. This module normalizes all
-// four into one `AutomationEntry` so a single surface can list, filter, count,
+// three into one `AutomationEntry` so a single surface can list, filter, count,
 // and route them together. It is pure / framework-free / client-safe (no node
 // imports) so the surface component and any server aggregator can share it.
 
 import type { InboxItem } from "../cave-inbox";
 import type { Recurrence } from "../inbox-recurrence";
 import type { CodexAutomation } from "../codex-automations-types";
-import type { WorkflowSummary } from "../workflows";
 import type { FlowDoc } from "../flow/flow-doc.ts";
 
-export type AutomationType = "reminder" | "cron" | "workflow" | "flow";
+export type AutomationType = "reminder" | "cron" | "flow";
 
 /** Whether the entry is armed, idle, or unfinished. */
 export type AutomationState = "active" | "paused" | "draft";
@@ -50,7 +48,7 @@ export type AutomationEntry = {
   nextFireAt?: string;
 };
 
-export const AUTOMATION_TYPES: AutomationType[] = ["reminder", "cron", "workflow", "flow"];
+export const AUTOMATION_TYPES: AutomationType[] = ["reminder", "cron", "flow"];
 
 export type AutomationTypeMeta = {
   /** Singular noun. */
@@ -64,7 +62,7 @@ export type AutomationTypeMeta = {
   /** One-line description for the "New" menu and empty states. */
   blurb: string;
   /** Which surface mode owns deep editing for this type (for "Open"). */
-  editorMode: "inbox" | "roles" | "flow";
+  editorMode: "inbox" | "flow";
 };
 
 export const AUTOMATION_TYPE_META: Record<AutomationType, AutomationTypeMeta> = {
@@ -83,14 +81,6 @@ export const AUTOMATION_TYPE_META: Record<AutomationType, AutomationTypeMeta> = 
     accent: "var(--color-success)",
     blurb: "Run a familiar on a recurring schedule",
     editorMode: "inbox",
-  },
-  workflow: {
-    label: "Workflow",
-    plural: "Workflows",
-    icon: "ph:graph",
-    accent: "var(--accent-presence)",
-    blurb: "Multi-step agent pipeline with an input/output contract",
-    editorMode: "roles",
   },
   flow: {
     label: "Flow",
@@ -186,22 +176,6 @@ export function cronToEntry(auto: CodexAutomation): AutomationEntry {
   };
 }
 
-export function workflowToEntry(wf: WorkflowSummary): AutomationEntry {
-  const blocked = wf.validation_state === "invalid";
-  return {
-    key: `workflow:${wf.id}`,
-    type: "workflow",
-    nativeId: wf.id,
-    name: wf.name || wf.id,
-    summary: wf.summary || undefined,
-    state: blocked ? "draft" : "active",
-    trigger: "Manual",
-    scheduled: false,
-    familiarId: wf.familiar ?? null,
-    sortAt: "",
-  };
-}
-
 export function flowToEntry(flow: FlowDoc): AutomationEntry {
   const { trigger, scheduled } = flowTrigger(flow);
   return {
@@ -221,20 +195,18 @@ export function flowToEntry(flow: FlowDoc): AutomationEntry {
 export type AutomationSources = {
   reminders?: InboxItem[];
   crons?: CodexAutomation[];
-  workflows?: WorkflowSummary[];
   flows?: FlowDoc[];
 };
 
 /**
- * Normalize the four native source lists into one recency-sorted entry list.
+ * Normalize the three native source lists into one recency-sorted entry list.
  * Entries with a `sortAt` timestamp sort newest-first ahead of the undated
- * ones (crons/workflows), which fall back to alphabetical by name.
+ * ones (crons), which fall back to alphabetical by name.
  */
 export function buildAutomationEntries(sources: AutomationSources): AutomationEntry[] {
   const entries: AutomationEntry[] = [
     ...(sources.reminders ?? []).map(reminderToEntry),
     ...(sources.crons ?? []).map(cronToEntry),
-    ...(sources.workflows ?? []).map(workflowToEntry),
     ...(sources.flows ?? []).map(flowToEntry),
   ];
   return entries.sort((a, b) => {
@@ -247,7 +219,7 @@ export function buildAutomationEntries(sources: AutomationSources): AutomationEn
 
 /** Count entries per type (for tab badges). */
 export function countByType(entries: AutomationEntry[]): Record<AutomationType, number> {
-  const counts: Record<AutomationType, number> = { reminder: 0, cron: 0, workflow: 0, flow: 0 };
+  const counts: Record<AutomationType, number> = { reminder: 0, cron: 0, flow: 0 };
   for (const e of entries) counts[e.type] += 1;
   return counts;
 }


### PR DESCRIPTION
## What

Two independent cleanups to the Automations surface:

### 1. Lazy-load AutomationsView
`AutomationsView` (~2500 lines) was **statically imported** through `inbox-escalations-view`, so it shipped in the boot shell. Route it through `lazy-surfaces` like `BoardView` — it now loads on first open instead of at startup.

### 2. Delete the dead "workflow" automation kind
`automation-entry.ts` carried a `workflow` automation kind that **no prod caller ever supplies**:
- both `buildAutomationEntries` call sites pass only `{ reminders, crons, flows }`
- no tab or New-menu entry exists for it
- no route emits `WorkflowSummary` through this module

Removed `workflowToEntry`, the union member, its meta entry, and the now-unused `"roles"` `editorMode`; trimmed the workflow assertions from the behavioral test.

## Net
`+22 / -51` across 4 files — smaller boot bundle, less dead code.

## Verification (local)
- `tsc --noEmit` → clean
- `automation-entry.test.ts` → ok