### PR TITLE
chore(release): stamp v0.0.134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.134] - 2026-07-03
+
+Patch release on top of v0.0.133. A broad UI/UX + accessibility sweep: the
+detail split now fills and re-fits its full width reliably, the split divider
+gets a seamless magnetic even-split (no more ratio buttons), chat stops crossing
+wires when you switch threads mid-stream, and Board/Automations/GitHub get
+large accessibility batches. Also: the message action row swaps its redundant
+Share button for privacy-safe local thumbs analytics, and the Automations
+surface is lazy-loaded out of the boot shell.
+
+### Added
+
+- **Chat** - message action row mirrors 👍/👎 votes to a new local
+  `/api/feedback/message` store so votes can seed later quality analytics.
+  Whitelist-only fields, atomic writes, no message content ever egresses
+  (mirrors the Salem pathfinder-feedback privacy model) (#2289).
+- **Split view** - dragging a pane past the far edge collapses and promotes it;
+  the divider snaps magnetically to an even split (#2280, #2283).
+
+### Changed
+
+- **Chat** - removed the redundant Share button from the assistant action row
+  (it only copied text — the dedicated Copy button already does that) (#2289).
+- **Split divider** - dropped the ⅓·½·⅔ ratio buttons in favor of the magnetic
+  even-split gesture (#2283).
+- **Dashboard** - removed the "Copy link" button from report pages (#2281).
+- **Flow** - flow sessions launch in `nonInteractive` mode (#2287).
+
+### Fixed
+
+- **Shell** - the detail split now always fills the full width and re-fits when
+  its width changes, closing the desktop far-right gap (#2277, #2284).
+- **Chat** - switching threads mid-stream no longer crosses wires between
+  sessions (#2282).
+- **GitHub** - guarded the activity poll, stopped a manual refresh from eating
+  drafts, and surfaced CI passing/pending state (#2286).
+- **Board** - intent operations stop clobbering the full array on PATCH (#2275).
+- **Automations** - audit batch A: poll guards, edit-wipe fix, run-history
+  purge, and route hardening (#2278).
+
+### Performance
+
+- **Automations** - `AutomationsView` (~2500 lines) is now lazy-loaded like
+  `BoardView` instead of shipping in the boot shell; also dropped the dead
+  `workflow` automation kind (#2290).
+- **Chat** - killed per-row sibling scans and an O(n²) stream buffer, gated the
+  log, and made the artifact overlay a proper dialog (#2285).
+
+### Accessibility
+
+- **Board** - accessible names, focus restoration, scoped grab keys, and dated
+  reschedule announcements (#2276).
+- **Automations** - audit batch B: announcer, status labels, tab/menu
+  semantics, and focus handling (#2279).
+- **GitHub** - announce CRUD, label the composer, and focus-trap the action
+  popover (#2288).
+
 ## [0.0.133] - 2026-07-03
 
 Patch release on top of v0.0.132. Headline: the macOS overlay titlebar drags the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.133",
+  "version": "0.0.134",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.133"
+version = "0.0.134"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.133"
+version = "0.0.134"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.133</string>
+	<string>0.0.134</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.133</string>
+	<string>0.0.134</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.133</string>
+	<string>0.0.134</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.133</string>
+	<string>0.0.134</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.133",
+  "version": "0.0.134",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.134** across all six version locations + CHANGELOG.

## Payload — 16 PRs since v0.0.133 (#2275–#2290)

**Added**
- #2289 message thumbs → local privacy-safe feedback analytics
- #2280 / #2283 drag-to-collapse + magnetic even-split divider

**Changed**
- #2289 removed redundant Share button · #2283 dropped ⅓·½·⅔ buttons · #2281 removed dashboard Copy-link · #2287 flow sessions nonInteractive

**Fixed**
- #2277 / #2284 detail split fills + re-fits full width · #2282 no cross-wiring on mid-stream thread switch · #2286 GitHub poll guard / draft-eating / CI state · #2275 board PATCH clobber · #2278 automations audit A

**Performance**
- #2290 lazy-load AutomationsView + drop dead workflow kind · #2285 chat sibling-scan & O(n²) buffer fixes

**Accessibility**
- #2276 board batch · #2279 automations audit B · #2288 GitHub announce/label/focus-trap

## Version locations stamped
`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` (app pkg), `src-tauri/tauri.conf.json`, `src-tauri/Info.ios.plist`, `src-tauri/gen/apple/app_iOS/Info.plist` → all `0.0.134`.

Tag `v0.0.134` will be pushed after merge to trigger the release workflow.