### PR TITLE
fix(automations): audit batch C — kind-aware detail panel, uniform run confirm, action parity, lazy-load

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -72,16 +72,18 @@ assert.match(source, /const mountedRef = useRef\(true\)/, "tracks mounted state 
 assert.match(source, /const runsReqRef = useRef\(0\)/, "refreshRuns tracks a request id");
 assert.match(source, /if \(reqId !== runsReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late runs fetch is dropped");
 
-// ── Per-row quick actions (run-now + pause/resume), revealed on hover ──
+// ── Per-row quick actions (run-now + pause/resume), always visible ──
 assert.match(source, /const ScheduleActionsContext = createContext/, "row actions are provided via context (no prop threading)");
 assert.match(source, /<ScheduleActionsContext\.Provider/, "AutomationsView provides the row actions");
 assert.match(source, /runReminder: runNow/, "reminder run-now is wired");
 assert.match(source, /togglePauseReminder: togglePaused/, "reminder pause/resume is wired");
 assert.match(source, /runAutomation: runCodexNow/, "automation run-now is wired");
 assert.match(source, /togglePauseAutomation: toggleCodex/, "automation pause/resume is wired");
-// Hidden actions must not steal clicks meant for the row's detail panel.
-assert.match(source, /pointer-events-none[\s\S]*?group-hover\/srow:pointer-events-auto/, "hidden row actions keep pointer-events:none until hover/focus");
-assert.match(source, /onClick=\{\(e\) => \{ e\.stopPropagation\(\); onClick\(\); \}\}/, "a row action stops the click from opening the detail panel");
+// Actions are labeled, always-visible siblings of the row button (never a
+// hover-revealed overlay, and never nested inside the row's own button).
+assert.doesNotMatch(source, /group-hover\/srow/, "row actions are always visible — no hover reveal remains");
+assert.match(source, /text=\{paused \? "Resume" : "Pause"\}/, "the reminder row's pause action is a labeled button");
+assert.match(source, /text=\{isActive \? "Pause" : "Resume"\}/, "the cron row's pause action is a labeled button");
 assert.match(source, /actions\.runAutomation\(auto\)/, "the automation row exposes run-now");
 assert.match(source, /actions\.togglePauseReminder\(item\)/, "the reminder row exposes pause/resume");
 assert.match(source, /item\.kind !== "daily-summary"/, "daily-summary rows get no run/pause actions");
@@ -127,3 +129,22 @@ assert.match(source, /idPrefix="automations"/, "tabs get ids so the panel can re
 assert.match(source, /role="tabpanel"[\s\S]{0,120}aria-labelledby=\{`automations-tab-\$\{activeTab\}`\}/, "the content region is a labelled tabpanel");
 assert.match(source, /if \(e\.key === "Escape"\) \{[\s\S]{0,120}setNewMenuOpen\(false\);[\s\S]{0,60}newBtnRef\.current\?\.focus\(\)/, "the New menu closes on Escape and returns focus to its trigger");
 assert.match(source, /window\.setTimeout\(\(\) => newBtnRef\.current\?\.focus\(\), 0\)/, "deletes hand focus somewhere stable instead of dropping it on <body>");
+
+// ── 2026-07-03 audit batch C ──────────────────────────────────────────────────
+// The Activity tab opens this panel for agent/response items too — those are
+// records, not schedules, so the run/pause/edit mutations are reminder-only.
+assert.match(source, /const isReminder = item\.kind === "reminder"/, "the detail panel derives the selected item's kind");
+assert.match(source, /isReminder \? "Reminder details" : "Activity details"/, "non-reminder activity gets an honest panel heading");
+assert.match(source, /\{onEdit && isReminder && \(/, "Edit only renders for reminders");
+assert.match(source, /\{isRecurring && isReminder && \(/, "Stop-repeating only renders for reminders");
+assert.doesNotMatch(source, /\{onEdit && !isDailySummary && \(/, "the old summary-only action gate is gone");
+// Reminder run-now confirms like crons and flows — identical Run buttons on the
+// All tab must not behave differently per type.
+assert.match(source, /This fires the reminder immediately\./, "reminder run-now is confirm-gated");
+assert.match(source, /every type confirms before running/, "runEntry documents the uniform confirm");
+// Pause/resume reaches every tab: flows gain a mutation, the All list dispatches.
+assert.match(source, /const toggleFlowActive = useCallback/, "flows have a pause/resume mutation");
+assert.match(source, /saveFlow\(setFlowActive\(flow, !pausing\)\)/, "flow pause persists via the editor's full-doc save convention");
+assert.match(source, /announce\(`\$\{pausing \? "Paused" : "Resumed"\} '\$\{flow\.name\}'\.`\)/, "flow pause/resume announces");
+assert.match(source, /const togglePauseEntry = useCallback/, "the All list dispatches pause per type");
+assert.match(source, /onTogglePause=\{pausable\(entry\) \? onTogglePause : undefined\}/, "non-pausable entries (daily summaries) hide the control");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -35,7 +35,8 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { automationMatchesFilter } from "@/lib/familiar-multiselect";
 import { AutomationCreateDialog, type AutomationCreateInput } from "@/components/automation-create-dialog";
-import { listFlows, runFlow, type FlowDoc } from "@/lib/flows";
+import { listFlows, runFlow, saveFlow, type FlowDoc } from "@/lib/flows";
+import { setActive as setFlowActive } from "@/lib/flow/flow-doc";
 import {
   buildAutomationEntries,
   filterEntries,
@@ -211,6 +212,10 @@ function DetailPanel({
   const paused = item.status === "dismissed" && item.recurrence?.type !== "none";
   const isRecurring = item.recurrence && item.recurrence.type !== "none";
   const isDailySummary = item.kind === "daily-summary";
+  // Agent / response-needed items open this panel from the Activity tab too.
+  // Those are records, not schedules — the schedule fields and the
+  // Run/Pause/Edit mutations only make sense for actual reminders.
+  const isReminder = item.kind === "reminder";
   const busy = busyId === item.id;
 
   return (
@@ -220,7 +225,7 @@ function DetailPanel({
       <div className="flex items-center justify-between border-b px-5 py-3"
         style={{ borderColor: "var(--border-hairline)" }}>
         <h2 className="text-[13px] font-semibold" style={{ color: "var(--text-primary)" }}>
-          {isDailySummary ? "Daily summary details" : "Reminder details"}
+          {isDailySummary ? "Daily summary details" : isReminder ? "Reminder details" : "Activity details"}
         </h2>
         <button type="button" onClick={onClose} aria-label="Close"
           className="focus-ring rounded p-1 transition-colors hover:bg-white/5"
@@ -250,7 +255,7 @@ function DetailPanel({
         )}
 
         <div className="grid grid-cols-1 gap-4">
-          {!isDailySummary && (
+          {isReminder && (
             <div>
               <FieldLabel>Schedule</FieldLabel>
               <p className="text-[12px]" style={{ color: "var(--text-primary)" }}>
@@ -264,7 +269,7 @@ function DetailPanel({
               {paused ? "Paused" : item.status}
             </p>
           </div>
-          {!isDailySummary && (
+          {isReminder && (
             <div>
               <FieldLabel>Next run</FieldLabel>
               <p
@@ -277,13 +282,13 @@ function DetailPanel({
             </div>
           )}
           <div>
-            <FieldLabel>{isDailySummary ? "Sent" : "Last run"}</FieldLabel>
+            <FieldLabel>{isDailySummary ? "Sent" : isReminder ? "Last run" : "Received"}</FieldLabel>
             <p
               className="text-[12px]"
               style={{ color: item.firedAt ? "oklch(0.75 0.1 150)" : "var(--text-muted)" }}
               title={item.firedAt ? formatTimestamp(item.firedAt, readDateTimePrefs()) : undefined}
             >
-              {item.firedAt ? relTime(item.firedAt) : "Never"}
+              {item.firedAt ? relTime(item.firedAt) : isReminder ? "Never" : "—"}
             </p>
           </div>
         </div>
@@ -319,7 +324,7 @@ function DetailPanel({
       {/* Actions */}
       <div className="border-t px-5 py-4 space-y-2"
         style={{ borderColor: "var(--border-hairline)" }}>
-        {onEdit && !isDailySummary && (
+        {onEdit && isReminder && (
           <button type="button" disabled={busy} onClick={() => onEdit(item)}
             className="flex w-full items-center justify-center gap-1.5 rounded-lg border py-2 text-[12px] font-medium transition-colors hover:bg-white/5 disabled:opacity-40"
             style={{ borderColor: "var(--border-hairline)", color: "var(--text-secondary)" }}>
@@ -327,7 +332,7 @@ function DetailPanel({
             Edit
           </button>
         )}
-        {!isDailySummary && (
+        {isReminder && (
           <>
             <button type="button" disabled={busy || paused} onClick={() => runNow(item.id)}
               className="w-full rounded-lg py-2 text-[12px] font-medium text-white transition-colors disabled:opacity-40"
@@ -341,7 +346,7 @@ function DetailPanel({
             </button>
           </>
         )}
-        {isRecurring && !isDailySummary && (
+        {isRecurring && isReminder && (
           <button type="button" disabled={busy} onClick={() => stopRecurrence(item.id)}
             className="w-full rounded-lg border py-2 text-[12px] font-medium transition-colors hover:bg-white/5 disabled:opacity-40"
             style={{ borderColor: "var(--border-hairline)", color: "var(--text-secondary)" }}>
@@ -359,9 +364,9 @@ function DetailPanel({
 }
 
 // Row quick-actions (run-now, pause/resume) are wired once at the top of the
-// view and read by each leaf row — so the most-used actions are one hover away
-// instead of buried in the detail panel. Avoids threading callbacks through the
-// list/section components.
+// view and read by each leaf row — so the most-used actions sit right on the
+// row instead of buried in the detail panel. Avoids threading callbacks through
+// the list/section components.
 type ScheduleActions = {
   runReminder: (id: string) => void;
   togglePauseReminder: (item: InboxItem) => void;
@@ -370,32 +375,26 @@ type ScheduleActions = {
 };
 const ScheduleActionsContext = createContext<ScheduleActions | null>(null);
 
-function RowActionButton({ icon, label, onClick }: { icon: IconName; label: string; onClick: () => void }) {
+// Always-visible labeled row action — the same affordance the All/Flows rows
+// use, so every tab exposes identical controls. Rendered as a sibling of the
+// row's own button (never nested), so a click can't also open the detail panel.
+function RowActionButton({ icon, label, text, onClick }: { icon: IconName; label: string; text: string; onClick: () => void }) {
   return (
     <button
       type="button"
-      title={label}
       aria-label={label}
-      onClick={(e) => { e.stopPropagation(); onClick(); }}
-      className="focus-ring grid h-6 w-6 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-white/10 hover:text-[var(--text-primary)]"
+      onClick={onClick}
+      className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10"
+      style={{ color: "var(--text-secondary)" }}
     >
-      <Icon name={icon} width={12} />
+      <Icon name={icon} width={11} aria-hidden />
+      {text}
     </button>
   );
 }
 
-// Hover/focus-revealed action cluster pinned to the right of a schedule row.
-// Hidden rows keep `pointer-events:none` so a non-hover click still opens the
-// row's detail panel rather than landing on an invisible action.
 function RowActions({ children }: { children: ReactNode }) {
-  return (
-    <div
-      className="pointer-events-none absolute right-1.5 top-1/2 z-10 flex -translate-y-1/2 items-center gap-0.5 rounded-md border border-[var(--border-hairline)] px-0.5 py-0.5 opacity-0 transition-opacity group-hover/srow:pointer-events-auto group-hover/srow:opacity-100 group-focus-within/srow:pointer-events-auto group-focus-within/srow:opacity-100 motion-reduce:transition-none"
-      style={{ background: "var(--bg-elevated)" }}
-    >
-      {children}
-    </div>
-  );
+  return <span className="flex shrink-0 items-center gap-0.5 pl-1">{children}</span>;
 }
 
 function ReminderTaskRow({
@@ -439,13 +438,13 @@ function ReminderTaskRow({
   const showActions = !selectMode && item.kind !== "daily-summary" && !!actions;
 
   return (
-    <li className="group/srow relative">
+    <li className="flex items-center">
       <button
         type="button"
         role={selectMode ? "checkbox" : undefined}
         aria-checked={selectMode ? checked : undefined}
         onClick={activate}
-        className="focus-ring-inset automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
+        className="focus-ring-inset automation-list-row group flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors"
         style={{
           background: active ? "rgba(255,255,255,0.05)" : "transparent",
         }}
@@ -487,11 +486,12 @@ function ReminderTaskRow({
       {showActions && actions && (
         <RowActions>
           {!paused && (
-            <RowActionButton icon="ph:lightning-bold" label={`Run ${item.title} now`} onClick={() => actions.runReminder(item.id)} />
+            <RowActionButton icon="ph:play" label={`Run ${item.title} now`} text="Run" onClick={() => actions.runReminder(item.id)} />
           )}
           <RowActionButton
-            icon={paused ? "ph:play-fill" : "ph:pause-fill"}
+            icon={paused ? "ph:play" : "ph:pause"}
             label={`${paused ? "Resume" : "Pause"} ${item.title}`}
+            text={paused ? "Resume" : "Pause"}
             onClick={() => actions.togglePauseReminder(item)}
           />
         </RowActions>
@@ -1004,12 +1004,12 @@ function AutomationScheduleRow({
   const isActive = auto.status === "ACTIVE";
   const actions = useContext(ScheduleActionsContext);
   return (
-    <li className="group/srow relative">
+    <li className="flex items-center">
       <button
         type="button"
         onClick={() => onSelect(auto)}
         aria-current={selected ? "true" : undefined}
-        className={`focus-ring-inset automation-list-row group flex w-full items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors ${selected ? "bg-white/5" : "hover:bg-white/5"}`}
+        className={`focus-ring-inset automation-list-row group flex min-w-0 flex-1 items-center gap-3 rounded-lg px-2 py-2.5 text-left transition-colors ${selected ? "bg-white/5" : "hover:bg-white/5"}`}
       >
         {/* Status dot */}
         {isActive ? (
@@ -1055,10 +1055,11 @@ function AutomationScheduleRow({
       </button>
       {actions && (
         <RowActions>
-          <RowActionButton icon="ph:lightning-bold" label={`Run ${auto.name} now`} onClick={() => actions.runAutomation(auto)} />
+          <RowActionButton icon="ph:play" label={`Run ${auto.name} now`} text="Run" onClick={() => actions.runAutomation(auto)} />
           <RowActionButton
-            icon={isActive ? "ph:pause-fill" : "ph:play-fill"}
-            label={`${isActive ? "Pause" : "Activate"} ${auto.name}`}
+            icon={isActive ? "ph:pause" : "ph:play"}
+            label={`${isActive ? "Pause" : "Resume"} ${auto.name}`}
+            text={isActive ? "Pause" : "Resume"}
             onClick={() => actions.togglePauseAutomation(auto)}
           />
         </RowActions>
@@ -1356,14 +1357,17 @@ function AutomationEntryRow({
   busy,
   onRun,
   onOpen,
+  onTogglePause,
 }: {
   entry: AutomationEntry;
   familiarLabel: (id?: string | null) => string | null;
   busy: boolean;
   onRun: (entry: AutomationEntry) => void;
   onOpen: (entry: AutomationEntry) => void;
+  onTogglePause?: (entry: AutomationEntry) => void;
 }) {
   const fam = familiarLabel(entry.familiarId);
+  const entryPaused = entry.state === "paused";
   // Next fire (reminders only, for now) as a friendly relative time alongside the
   // schedule string — so the unified list answers "when next?" at a glance.
   const nextFire = entry.state === "active" && entry.nextFireAt ? relTime(entry.nextFireAt) : null;
@@ -1407,6 +1411,19 @@ function AutomationEntryRow({
             <Icon name="ph:play" width={11} aria-hidden />
             {busy ? "…" : "Run"}
           </button>
+          {onTogglePause && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onTogglePause(entry)}
+              aria-label={`${entryPaused ? "Resume" : "Pause"} ${entry.name}`}
+              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10 disabled:opacity-50"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              <Icon name={entryPaused ? "ph:play" : "ph:pause"} width={11} aria-hidden />
+              {entryPaused ? "Resume" : "Pause"}
+            </button>
+          )}
         </span>
       </span>
       <StateDot state={entry.state} />
@@ -1420,12 +1437,16 @@ function AutomationAllList({
   familiarLabel,
   onRun,
   onOpen,
+  onTogglePause,
+  pausable,
 }: {
   entries: AutomationEntry[];
   busyId: string | null;
   familiarLabel: (id?: string | null) => string | null;
   onRun: (entry: AutomationEntry) => void;
   onOpen: (entry: AutomationEntry) => void;
+  onTogglePause: (entry: AutomationEntry) => void;
+  pausable: (entry: AutomationEntry) => boolean;
 }) {
   return (
     <div className="space-y-1.5 pt-1">
@@ -1437,6 +1458,7 @@ function AutomationAllList({
           busy={busyId === entryBusyKey(entry)}
           onRun={onRun}
           onOpen={onOpen}
+          onTogglePause={pausable(entry) ? onTogglePause : undefined}
         />
       ))}
     </div>
@@ -1449,15 +1471,19 @@ function ManagedAutomationRow({
   name,
   meta,
   busy,
+  paused,
   onRun,
   onOpen,
+  onTogglePause,
 }: {
   type: AutomationType;
   name: string;
   meta: string;
   busy: boolean;
+  paused?: boolean;
   onRun: () => void;
   onOpen: () => void;
+  onTogglePause?: () => void;
 }) {
   return (
     <div
@@ -1480,6 +1506,19 @@ function ManagedAutomationRow({
             <Icon name="ph:play" width={11} aria-hidden />
             {busy ? "…" : "Run"}
           </button>
+          {onTogglePause && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={onTogglePause}
+              aria-label={`${paused ? "Resume" : "Pause"} ${name}`}
+              className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-white/10 disabled:opacity-50"
+              style={{ color: "var(--text-secondary)" }}
+            >
+              <Icon name={paused ? "ph:play" : "ph:pause"} width={11} aria-hidden />
+              {paused ? "Resume" : "Pause"}
+            </button>
+          )}
           <button
             type="button"
             onClick={onOpen}
@@ -1501,12 +1540,14 @@ function FlowList({
   busyId,
   onRun,
   onOpen,
+  onTogglePause,
 }: {
   flows: FlowDoc[];
   query: string;
   busyId: string | null;
   onRun: (flow: FlowDoc) => void;
   onOpen: (flow: FlowDoc) => void;
+  onTogglePause: (flow: FlowDoc) => void;
 }) {
   const visible = flows.filter((f) => !query || (f.name || "").toLowerCase().includes(query));
   return (
@@ -1521,8 +1562,10 @@ function FlowList({
             name={flow.name || "Untitled flow"}
             meta={`${trigger} · ${nodeCount} node${nodeCount === 1 ? "" : "s"}${flow.active ? "" : " · paused"}`}
             busy={busyId === `flow:${flow.id}`}
+            paused={!flow.active}
             onRun={() => onRun(flow)}
             onOpen={() => onOpen(flow)}
+            onTogglePause={() => onTogglePause(flow)}
           />
         );
       })}
@@ -1765,9 +1808,13 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     });
   }, [items, scheduleDelete, load]);
 
-  const runNow = (id: string) => {
+  // Confirm before firing — crons and flows already do, and the identical Run
+  // buttons on the All tab must not behave differently per type.
+  const runNow = async (id: string) => {
     const target = items.find((i) => i.id === id);
-    announce(`Running ${target?.title ? `'${target.title}'` : "reminder"} now.`);
+    const name = target?.title;
+    if (!(await confirm({ title: name ? `Run “${name}” now?` : "Run reminder now?", body: "This fires the reminder immediately.", confirmLabel: "Run now" }))) return;
+    announce(`Running ${name ? `'${name}'` : "reminder"} now.`);
     return patchItem(id, { fireAt: new Date().toISOString(), status: "pending" });
   };
 
@@ -1887,6 +1934,23 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     }
   }, [confirm, onOpenSession]);
 
+  // Pause/resume a flow. Production triggers only fire while `active`; the flow
+  // editor persists the same full-doc save, so this mirrors its convention.
+  const toggleFlowActive = useCallback(async (flow: FlowDoc) => {
+    const pausing = flow.active;
+    setBusyId(`flow:${flow.id}`);
+    try {
+      const res = await saveFlow(setFlowActive(flow, !pausing));
+      if (!res.ok || !res.flow) throw new Error(res.error ?? "save failed");
+      announce(`${pausing ? "Paused" : "Resumed"} '${flow.name}'.`);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "flow save failed");
+    } finally {
+      setBusyId(null);
+    }
+  }, [load]);
+
   // "Open" routes to each type's dedicated editor surface.
   const openEntry = useCallback((entry: AutomationEntry) => {
     if (entry.type === "flow") { navigateToMode("flow"); return; }
@@ -1901,7 +1965,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   }, [items, codexAutos]);
 
   // Run any entry straight from the unified "All" list, dispatching to the right
-  // per-type handler (crons + flows confirm first; reminders fire immediately).
+  // per-type handler (every type confirms before running).
   const runEntry = useCallback((entry: AutomationEntry) => {
     if (entry.type === "reminder") { void runNow(entry.nativeId); return; }
     if (entry.type === "cron") {
@@ -1914,6 +1978,31 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
       if (flow) void runFlowNow(flow);
     }
   }, [codexAutos, flows, runNow, runCodexNow, runFlowNow]);
+
+  // Pause/resume any entry from the "All" list, mirroring runEntry's dispatch.
+  const togglePauseEntry = useCallback((entry: AutomationEntry) => {
+    if (entry.type === "reminder") {
+      const item = items.find((i) => i.id === entry.nativeId);
+      if (item) void togglePaused(item);
+      return;
+    }
+    if (entry.type === "cron") {
+      const auto = codexAutos.find((a) => a.id === entry.nativeId);
+      if (auto) void toggleCodex(auto);
+      return;
+    }
+    if (entry.type === "flow") {
+      const flow = flows.find((f) => f.id === entry.nativeId);
+      if (flow) void toggleFlowActive(flow);
+    }
+  }, [items, codexAutos, flows, togglePaused, toggleCodex, toggleFlowActive]);
+
+  // Daily summaries ride the reminder pipeline into the All list but aren't
+  // pausable (the Reminders tab applies the same gate) — hide the control.
+  const entryPausable = useCallback((entry: AutomationEntry) => {
+    if (entry.type !== "reminder") return true;
+    return items.find((i) => i.id === entry.nativeId)?.kind === "reminder";
+  }, [items]);
 
   // Ids whose delete is pending in the undo window — hidden everywhere until the
   // window lapses (committing the delete) or Undo restores them.
@@ -2355,6 +2444,8 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   familiarLabel={familiarLabel}
                   onRun={runEntry}
                   onOpen={openEntry}
+                  onTogglePause={togglePauseEntry}
+                  pausable={entryPausable}
                 />
               ) : activeTab === "reminders" ? (
                 <>
@@ -2421,6 +2512,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
                   busyId={busyId}
                   onRun={runFlowNow}
                   onOpen={() => navigateToMode("flow")}
+                  onTogglePause={toggleFlowActive}
                 />
               ) : (
                 <>

--- a/src/components/inbox-escalations-view.tsx
+++ b/src/components/inbox-escalations-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { AutomationsView } from "@/components/automations-view";
+import { AutomationsView } from "@/components/lazy-surfaces";
 import type { Escalation } from "@/lib/escalations-types";
 import type { Familiar } from "@/lib/types";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -73,3 +73,8 @@ export const MarketplaceView = dynamic(
   timed("marketplace", () => import("@/components/marketplace-view").then((m) => m.MarketplaceViewSurface)),
   { ssr: false, loading: SurfaceFallback },
 );
+
+export const AutomationsView = dynamic(
+  timed("automations", () => import("@/components/automations-view").then((m) => m.AutomationsView)),
+  { ssr: false, loading: SurfaceFallback },
+);

--- a/src/lib/automations/automation-entry.test.ts
+++ b/src/lib/automations/automation-entry.test.ts
@@ -37,7 +37,7 @@ assert.deepEqual(
   { trigger: "On webhook", scheduled: false },
 );
 
-// buildAutomationEntries normalizes all four sources into one typed list.
+// buildAutomationEntries normalizes all three sources into one typed list.
 const entries = buildAutomationEntries({
   reminders: [
     {
@@ -65,9 +65,6 @@ const entries = buildAutomationEntries({
       cwds: [], tags: [], skillPath: null,
     },
   ],
-  workflows: [
-    { id: "w1", version: "1", name: "Research brief", summary: "Fan out", validation_state: "invalid", familiar: "fam-c" },
-  ],
   flows: [
     {
       id: "f1",
@@ -82,7 +79,7 @@ const entries = buildAutomationEntries({
   ],
 });
 
-assert.equal(entries.length, 4);
+assert.equal(entries.length, 3);
 const byType = Object.fromEntries(entries.map((e) => [e.type, e]));
 
 assert.equal(byType.reminder.key, "reminder:r1");
@@ -100,27 +97,24 @@ assert.equal(byType.cron.trigger, "Every day at 7am");
 assert.equal(byType.cron.summary, "Summarize my inbox");
 assert.equal(byType.cron.familiarId, "fam-b");
 
-assert.equal(byType.workflow.state, "draft", "invalid workflow is a draft");
-assert.equal(byType.workflow.trigger, "Manual");
-
 assert.equal(byType.flow.state, "active");
 assert.equal(byType.flow.trigger, "On webhook");
 
-// Dated entries (reminder, flow) sort ahead of undated (cron, workflow).
+// Dated entries (reminder, flow) sort ahead of undated (cron).
 assert.ok(["reminder", "flow"].includes(entries[0].type));
-assert.ok(["cron", "workflow"].includes(entries[3].type));
+assert.equal(entries[2].type, "cron");
 
 // countByType + filterEntries.
-assert.deepEqual(countByType(entries), { reminder: 1, cron: 1, workflow: 1, flow: 1 });
-assert.equal(filterEntries(entries, "research").length, 1);
+assert.deepEqual(countByType(entries), { reminder: 1, cron: 1, flow: 1 });
+assert.equal(filterEntries(entries, "digest").length, 1, "matches on name");
 assert.equal(filterEntries(entries, "webhook").length, 1, "matches on trigger text");
-assert.equal(filterEntries(entries, "").length, 4);
+assert.equal(filterEntries(entries, "").length, 3);
 
 // Type metadata is complete and well-formed.
 for (const t of AUTOMATION_TYPES) {
   const meta = AUTOMATION_TYPE_META[t];
   assert.ok(meta.label && meta.plural && meta.icon && meta.accent && meta.blurb, `meta complete for ${t}`);
-  assert.ok(["inbox", "roles", "flow"].includes(meta.editorMode));
+  assert.ok(["inbox", "flow"].includes(meta.editorMode));
 }
 
 console.log("automation-entry.test.ts: ok");

--- a/src/lib/automations/automation-entry.ts
+++ b/src/lib/automations/automation-entry.ts
@@ -1,26 +1,24 @@
 // Unified automation model.
 //
-// Coven Cave grew four separate "make something happen later / automatically"
+// Coven Cave grew three separate "make something happen later / automatically"
 // primitives, each with its own surface, store, and vocabulary:
 //
 //   • reminder — a nudge (one-shot or recurring) in the inbox store
 //   • cron     — a familiar run on an rrule schedule (Codex automation, TOML)
-//   • workflow — a multi-step agent pipeline with an I/O contract (manifest)
 //   • flow     — a freeform node graph wired on a canvas
 //
 // To a user these are all just "automations": a thing that runs, on a trigger,
 // maybe on a schedule, maybe tied to a familiar. This module normalizes all
-// four into one `AutomationEntry` so a single surface can list, filter, count,
+// three into one `AutomationEntry` so a single surface can list, filter, count,
 // and route them together. It is pure / framework-free / client-safe (no node
 // imports) so the surface component and any server aggregator can share it.
 
 import type { InboxItem } from "../cave-inbox";
 import type { Recurrence } from "../inbox-recurrence";
 import type { CodexAutomation } from "../codex-automations-types";
-import type { WorkflowSummary } from "../workflows";
 import type { FlowDoc } from "../flow/flow-doc.ts";
 
-export type AutomationType = "reminder" | "cron" | "workflow" | "flow";
+export type AutomationType = "reminder" | "cron" | "flow";
 
 /** Whether the entry is armed, idle, or unfinished. */
 export type AutomationState = "active" | "paused" | "draft";
@@ -50,7 +48,7 @@ export type AutomationEntry = {
   nextFireAt?: string;
 };
 
-export const AUTOMATION_TYPES: AutomationType[] = ["reminder", "cron", "workflow", "flow"];
+export const AUTOMATION_TYPES: AutomationType[] = ["reminder", "cron", "flow"];
 
 export type AutomationTypeMeta = {
   /** Singular noun. */
@@ -64,7 +62,7 @@ export type AutomationTypeMeta = {
   /** One-line description for the "New" menu and empty states. */
   blurb: string;
   /** Which surface mode owns deep editing for this type (for "Open"). */
-  editorMode: "inbox" | "roles" | "flow";
+  editorMode: "inbox" | "flow";
 };
 
 export const AUTOMATION_TYPE_META: Record<AutomationType, AutomationTypeMeta> = {
@@ -83,14 +81,6 @@ export const AUTOMATION_TYPE_META: Record<AutomationType, AutomationTypeMeta> = 
     accent: "var(--color-success)",
     blurb: "Run a familiar on a recurring schedule",
     editorMode: "inbox",
-  },
-  workflow: {
-    label: "Workflow",
-    plural: "Workflows",
-    icon: "ph:graph",
-    accent: "var(--accent-presence)",
-    blurb: "Multi-step agent pipeline with an input/output contract",
-    editorMode: "roles",
   },
   flow: {
     label: "Flow",
@@ -186,22 +176,6 @@ export function cronToEntry(auto: CodexAutomation): AutomationEntry {
   };
 }
 
-export function workflowToEntry(wf: WorkflowSummary): AutomationEntry {
-  const blocked = wf.validation_state === "invalid";
-  return {
-    key: `workflow:${wf.id}`,
-    type: "workflow",
-    nativeId: wf.id,
-    name: wf.name || wf.id,
-    summary: wf.summary || undefined,
-    state: blocked ? "draft" : "active",
-    trigger: "Manual",
-    scheduled: false,
-    familiarId: wf.familiar ?? null,
-    sortAt: "",
-  };
-}
-
 export function flowToEntry(flow: FlowDoc): AutomationEntry {
   const { trigger, scheduled } = flowTrigger(flow);
   return {
@@ -221,20 +195,18 @@ export function flowToEntry(flow: FlowDoc): AutomationEntry {
 export type AutomationSources = {
   reminders?: InboxItem[];
   crons?: CodexAutomation[];
-  workflows?: WorkflowSummary[];
   flows?: FlowDoc[];
 };
 
 /**
- * Normalize the four native source lists into one recency-sorted entry list.
+ * Normalize the three native source lists into one recency-sorted entry list.
  * Entries with a `sortAt` timestamp sort newest-first ahead of the undated
- * ones (crons/workflows), which fall back to alphabetical by name.
+ * ones (crons), which fall back to alphabetical by name.
  */
 export function buildAutomationEntries(sources: AutomationSources): AutomationEntry[] {
   const entries: AutomationEntry[] = [
     ...(sources.reminders ?? []).map(reminderToEntry),
     ...(sources.crons ?? []).map(cronToEntry),
-    ...(sources.workflows ?? []).map(workflowToEntry),
     ...(sources.flows ?? []).map(flowToEntry),
   ];
   return entries.sort((a, b) => {
@@ -247,7 +219,7 @@ export function buildAutomationEntries(sources: AutomationSources): AutomationEn
 
 /** Count entries per type (for tab badges). */
 export function countByType(entries: AutomationEntry[]): Record<AutomationType, number> {
-  const counts: Record<AutomationType, number> = { reminder: 0, cron: 0, workflow: 0, flow: 0 };
+  const counts: Record<AutomationType, number> = { reminder: 0, cron: 0, flow: 0 };
   for (const e of entries) counts[e.type] += 1;
   return counts;
 }


### PR DESCRIPTION
Ships the parked P2 items from the automations-surface audit (#2278 batch A, #2279 batch B).

## Activity detail panel is now kind-aware
The Activity tab opened the reminder `DetailPanel` for `agent`/`response-needed` items — mislabeled **"Reminder details"**, with Run now / Pause / Edit / Stop-repeating happily mutating non-reminders (`patchItem` re-firing an agent notification, "pausing" a response request). The panel now derives `isReminder` and:
- heading: `Reminder details` / `Daily summary details` / **`Activity details`**
- Schedule + Next-run fields and the Run/Pause/Edit/Stop-repeating mutations render for reminders only; other kinds are read-only records (Delete stays — it's valid for any inbox item)
- Last-run label becomes `Received` for activity kinds

## Run-now confirms uniformly
Crons and flows confirmed before run-now; reminders fired instantly from visually identical buttons (the All tab even documented the inconsistency in a comment). `runNow` now uses the same `useConfirm()` gate, so every Run button behaves the same.

## Per-tab action parity
- Reminders/Crons rows: hover-only icon overlays → the same **always-visible labeled** Run/Pause buttons the All/Flows rows use, rendered as siblings of the row button (no nested buttons, no stopPropagation needed, keyboard-reachable without focus tricks)
- Flows rows + All-tab flow entries gain **Pause/Resume** via a new `toggleFlowActive` (full-doc `saveFlow(setActive(...))` — the flow editor's own persistence convention), announced via the shared announcer
- All-tab entries gain Pause/Resume dispatched per type; daily summaries (which ride the reminder pipeline) hide the control, mirroring the Reminders-tab gate

## Perf + dead code
- `AutomationsView` (~2,500 lines) was statically imported through `inbox-escalations-view`, shipping in the boot shell — now routed through `lazy-surfaces` like BoardView
- `automation-entry.ts` carried a `"workflow"` automation kind no prod caller ever supplies (no tab, no New-menu entry, no route emits it) — deleted `workflowToEntry`, the union member, its meta entry, and the now-unused `"roles"` editorMode

## Tests
- `automations-view.test.ts`: hover-reveal pins replaced with always-visible pins + a new batch-C section (kind gates, confirm, flow pause, All-list dispatch)
- `automation-entry.test.ts`: workflow assertions trimmed
- Full suite: 695 test files green locally; typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)