### PR TITLE
fix(code): drop stale file responses, reset preview on project switch, guard the changes poll

### DIFF
--- a/src/components/comux-view-changes.test.ts
+++ b/src/components/comux-view-changes.test.ts
@@ -86,4 +86,8 @@ assert.match(
   "live diff polling keys off a running session in the selected project",
 );
 
+// ── 2026-07-03 code-surface audit (perf): changes poll content guard ─────────
+assert.match(changes, /import \{ arrayContentEqual \} from "@\/lib\/array-content-equal"/, "changes panel imports the content-equality guard");
+assert.match(changes, /setFiles\(\(prev\) => \(arrayContentEqual\(prev, nextFiles\) \? prev : nextFiles\)\)/, "the 5s changes poll keeps the previous reference when the diff is unchanged");
+
 console.log("comux-view-changes.test.ts: ok");

--- a/src/components/comux-view-edit.test.ts
+++ b/src/components/comux-view-edit.test.ts
@@ -52,4 +52,12 @@ assert.ok(source.includes("if (!previewPath || savingRef.current) return;"), "sa
 assert.ok(source.includes("savingRef.current = true;"), "saveEdit marks the in-flight ref synchronously");
 assert.ok(source.includes('<span role="alert" className="shrink-0 truncate text-[10px] text-[var(--color-danger,#f87171)]"'), "save error is announced via role=alert");
 
+// ── 2026-07-03 code-surface audit (correctness) ──────────────────────────────
+// A slow file load must not clobber a newer one (wrong file shown/edited).
+assert.match(source, /previewReqRef\.current = path;/, "openFilePreview records the latest requested path");
+assert.match(source, /if \(previewReqRef\.current !== path\) return;/, "a superseded file response is dropped");
+// Switching projects from the sidebar drops the previous project's open preview.
+assert.match(source, /if \(root !== selectedRootRef\.current\) clearFilePreview\(\);/, "a sidebar project switch clears the stale file preview");
+assert.match(source, /const clearFilePreview = useCallback/, "there is a shared file-preview reset");
+
 console.log("comux-view-edit.test.ts: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -477,6 +477,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   // flips once the user clicks a toggle or opens a file; prevChangeCount tracks
   // the 0→>0 edit transition so we surface the diff exactly once per project.
   const pinnedRightViewRef = useRef(false);
+  // Tracks the most-recent openFilePreview request so a slow response for an
+  // older file can't clobber a newer one (wrong file shown / edited).
+  const previewReqRef = useRef<string | null>(null);
   // Jump-to-diff target from a transcript edit tool (cave:open-file-diff). The
   // nonce re-triggers the focus even when the same path is clicked again.
   const [focusDiff, setFocusDiff] = useState<{ path: string; nonce: number } | null>(null);
@@ -503,6 +506,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const projectFilterRef = useRef<HTMLInputElement>(null);
   const projectListRef = useRef<HTMLDivElement>(null);
   const activeProjectRowRef = useRef<HTMLButtonElement | null>(null);
+  const selectedRootRef = useRef<string | undefined>(undefined);
   // Right-click context menu for a project row. `menuTarget` records which
   // project was right-clicked (one menu serves the whole list).
   const [projectMenu, setProjectMenu] = useState<ContextMenuState>(null);
@@ -949,6 +953,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   }, [view, active, terminalLayout, zoomedSessionId, visiblePaneSessionIds]);
 
   const openFilePreview = useCallback(async (path: string, line?: number) => {
+    previewReqRef.current = path;
     setPreviewPath(path);
     setPreviewLine(line);
     setFilePreviewCollapsed(false);
@@ -977,6 +982,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         size?: number;
         error?: string;
       };
+      // A newer file was opened while this fetch was in flight — drop the stale
+      // response so it can't paint over the current file.
+      if (previewReqRef.current !== path) return;
       if (json.ok && json.kind === "image" && typeof json.dataUrl === "string" && typeof json.mimeType === "string") {
         setPreview({ kind: "image", dataUrl: json.dataUrl, mimeType: json.mimeType, size: json.size });
       } else if (json.ok && typeof json.content === "string") {
@@ -985,9 +993,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         setPreview({ kind: "error", message: json.error ?? "Could not load this file." });
       }
     } catch (err) {
+      if (previewReqRef.current !== path) return;
       setPreview({ kind: "error", message: `Could not load this file. ${String(err)}` });
     } finally {
-      setPreviewLoading(false);
+      if (previewReqRef.current === path) setPreviewLoading(false);
     }
   }, [selectedProjectFamiliarId]);
 
@@ -1049,6 +1058,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     const onSelectProject = (event: Event) => {
       const root = (event as CustomEvent<{ root?: string }>).detail?.root;
       if (!root) return;
+      // Switching to a DIFFERENT project must drop the previous project's open
+      // file preview — otherwise it keeps showing (and offering Edit/Save on)
+      // a file from the old project, with a broken absolute-path breadcrumb.
+      if (root !== selectedRootRef.current) clearFilePreview();
       setSelectedProjectRoot(root);
       setProjectDetailCollapsed(false);
     };
@@ -1242,11 +1255,20 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
     [searchRoot, openFilePreview],
   );
 
-  const selectProject = useCallback((project: ComuxProject) => {
-    setSelectedProjectRoot(project.root);
+  useEffect(() => { selectedRootRef.current = selectedProjectRoot; }, [selectedProjectRoot]);
+
+  const clearFilePreview = useCallback(() => {
+    previewReqRef.current = null;
     setPreviewPath(null);
     setPreview(null);
+    setEditing(false);
+    setSaveError(null);
   }, []);
+
+  const selectProject = useCallback((project: ComuxProject) => {
+    setSelectedProjectRoot(project.root);
+    clearFilePreview();
+  }, [clearFilePreview]);
 
   // Poll the diff while a familiar is actively working this project so the
   // Changes view reflects edits as they land.

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -460,7 +461,11 @@ export function SessionChangesInner({
       if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
       setNotARepo(json.repo === false);
       setRepoRoot(json.repoRoot ?? null);
-      setFiles(json.files ?? []);
+      // Content-guard: an unchanged 5s poll keeps the previous reference so the
+      // whole diff panel (and the expanded file's diff refetch, gated by
+      // filesSig) doesn't churn while an agent is actively editing.
+      const nextFiles = json.files ?? [];
+      setFiles((prev) => (arrayContentEqual(prev, nextFiles) ? prev : nextFiles));
       setError(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));


### PR DESCRIPTION
## What

Code-surface (comux) audit — correctness + perf half (a11y follows; they'd collide on `comux-view.tsx`). Every finding source-verified.

- **Wrong file shown/edited (stale response)** — `openFilePreview` set `previewPath` synchronously but applied the fetch result unconditionally with no staleness check. Open file A then quickly open B (tree click, search match, or ⌘P quick-open all route here) → if A's response lands after B's, A's content painted over B, and Edit/Save then wrote B's path with A's content. Now tracks the latest requested path in a ref and drops any superseded response (the same guard proven on chat/GitHub).
- **Cross-project preview bleed** — the in-column project-row switch reset the preview, but the left Sessions **sidebar** switch (`cave:code-select-project`) only set the root. Switching projects there kept the old project's file open — still offering Edit/Save, with a broken absolute-path breadcrumb. A shared `clearFilePreview()` now fires on a real (root-changed) sidebar switch, guarded so the within-project file-open path (`cave:open-project-file`) isn't wiped.
- **Changes-poll storm** — `SessionChangesInner`'s 5s poll called `setFiles` with a fresh array every tick, re-rendering the whole diff panel + refetching the expanded file's diff even when the diff was byte-identical — at the highest-traffic moment (agent actively editing). Now content-guarded with `arrayContentEqual`.

## Audit notes (verified clean)
The scariest classes are **clean**: pty/WebSocket lifecycle (disposes on unmount, `projectRoot` read via ref so a project switch doesn't re-point a live terminal — no cross-stream), path-traversal across all file/tree/changes routes (realpath containment), the file tree's expanded/selected state survives refresh, git-diff correctness. Code-split, ws buffer, syntax re-highlight all clean too.

## Verification
Render-level: the Code surface loads with these changes and zero page errors. The stale-response + project-switch resets are source-pinned; the full open-A-then-B race needs deep multi-route timing mocks, and the guard is the identical ref pattern already verified live on chat (mid-stream) and GitHub.

## Parked (P2)
~220 lines dead `.cave-code-page__env*` CSS (shared `globals.css` — a live session is editing it); `saveEdit` 403 in a sessionless project; **`/api/changes` enforces no per-familiar grant** and **`/api/projects` accepts an arbitrary `root`** (may be intentional security posture — needs a call before changing).

## Tests
`comux-view-edit.test.ts` (stale-response guard + sidebar-switch reset), `comux-view-changes.test.ts` (poll content guard). Comux test sweep + typecheck + tests-wired green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)