### PR TITLE
a11y(code): announce save/revert/commit/PR, focus-trap quick-open, aria-press the toggles

### DIFF
--- a/src/components/code-quick-open.tsx
+++ b/src/components/code-quick-open.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { filterFileMentions } from "@/lib/file-mention";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 /**
  * Quick-open file picker (⌘P) for the Code workspace. Fuzzy-jumps to any file
@@ -55,6 +56,11 @@ export function CodeQuickOpen({
     };
   }, [open, root, familiarId]);
 
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Trap focus in the palette, restore it to the trigger on close, and close on
+  // Escape (shared dialog convention) — the bare autofocus let Tab escape to the
+  // page behind the backdrop and lost the return point.
+  useFocusTrap(open, dialogRef, { onEscape: onClose, focusFirst: false });
   useEffect(() => {
     if (open) requestAnimationFrame(() => inputRef.current?.focus());
   }, [open]);
@@ -79,6 +85,7 @@ export function CodeQuickOpen({
       style={{ animation: "ui-modal-fade-in var(--duration-fast) var(--ease-decelerate)" }}
     >
       <div
+        ref={dialogRef}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"

--- a/src/components/comux-view-changes.test.ts
+++ b/src/components/comux-view-changes.test.ts
@@ -89,5 +89,14 @@ assert.match(
 // ── 2026-07-03 code-surface audit (perf): changes poll content guard ─────────
 assert.match(changes, /import \{ arrayContentEqual \} from "@\/lib\/array-content-equal"/, "changes panel imports the content-equality guard");
 assert.match(changes, /setFiles\(\(prev\) => \(arrayContentEqual\(prev, nextFiles\) \? prev : nextFiles\)\)/, "the 5s changes poll keeps the previous reference when the diff is unchanged");
+// ── 2026-07-03 code a11y batch ────────────────────────────────────────────────
+assert.match(comux, /const \{ announce \} = useAnnouncer\(\)/, "comux consumes the announcer");
+assert.match(comux, /announce\("File saved\."\)/, "saving a file announces");
+assert.match(comux, /role="group" aria-label="Right pane view"[\s\S]*?aria-pressed=\{rightView === "files"\}/, "Files/Changes toggle is a group with aria-pressed");
+assert.match(comux, /role="group" aria-label="Preview format"[\s\S]*?aria-pressed=\{!previewRaw\}/, "Rendered/Raw toggle is a group with aria-pressed");
+assert.match(changes, /const \{ announce \} = useAnnouncer\(\)/, "the changes panel consumes the announcer");
+assert.match(changes, /announce\("Changes committed\."\)/, "committing announces");
+assert.match(changes, /announce\("Pull request opened\."\)/, "opening a PR announces");
+assert.match(changes, /announce\("File reverted/, "reverting announces");
 
 console.log("comux-view-changes.test.ts: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/lib/code-layout-preset";
 import type { SearchResult } from "@/lib/project-search";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -448,6 +449,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const [saveError, setSaveError] = useState<string | null>(null);
   // Brief "Saved" confirmation after a successful write (auto-clears).
   const [justSaved, setJustSaved] = useState(false);
+  const { announce } = useAnnouncer();
   const [tabDropTargetId, setTabDropTargetId] = useState<string | null>(null);
   const [sessionsCollapsed, setSessionsCollapsed] = useState(false);
   // Projects list (the 200px column) visibility, driven by the Code workspace
@@ -1159,8 +1161,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       setPreview({ kind: "text", content: editValue, size: json.size });
       setEditing(false);
       setJustSaved(true);
+      announce("File saved.");
     } catch (err) {
       setSaveError(String(err));
+      announce(`Couldn't save the file: ${String(err)}`, "assertive");
     } finally {
       setSaving(false);
       savingRef.current = false;
@@ -2172,9 +2176,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       top-level tabs); shown for the standalone surface. */}
                   {!isControlledRightView && (
                   <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-2 py-1.5">
-                    <div className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
+                    <div role="group" aria-label="Right pane view" className="flex items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
                       <button
                         type="button"
+                        aria-pressed={rightView === "files"}
                         onClick={() => { pinnedRightViewRef.current = true; setRightView("files"); }}
                         className={`flex items-center gap-1 rounded-[4px] px-2 py-0.5 transition-colors ${rightView === "files" ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
                       >
@@ -2183,6 +2188,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       </button>
                       <button
                         type="button"
+                        aria-pressed={rightView === "changes"}
                         onClick={() => { pinnedRightViewRef.current = true; setRightView("changes"); }}
                         className={`flex items-center gap-1 rounded-[4px] px-2 py-0.5 transition-colors ${rightView === "changes" ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
                       >
@@ -2260,9 +2266,10 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                           </span>
                         )}
                         {!editing && previewIsMarkdown && (
-                          <div className="flex shrink-0 items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
+                          <div role="group" aria-label="Preview format" className="flex shrink-0 items-center rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/40 p-0.5 text-[10px]">
                             <button
                               type="button"
+                              aria-pressed={!previewRaw}
                               onClick={() => setPreviewRaw(false)}
                               className={`rounded-[4px] px-1.5 py-0.5 transition-colors ${!previewRaw ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
                             >
@@ -2270,6 +2277,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                             </button>
                             <button
                               type="button"
+                              aria-pressed={previewRaw}
                               onClick={() => setPreviewRaw(true)}
                               className={`rounded-[4px] px-1.5 py-0.5 transition-colors ${previewRaw ? "bg-[var(--bg-raised)] text-[var(--text-primary)]" : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"}`}
                             >

--- a/src/components/modal-trap-adoption.test.ts
+++ b/src/components/modal-trap-adoption.test.ts
@@ -10,6 +10,7 @@ const FILES = [
   "onboarding-overlay.tsx",
   "github-view.tsx",
   "github-action-popover.tsx",
+  "code-quick-open.tsx",
   "new-reminder-modal.tsx",
 ];
 

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -8,6 +8,7 @@ import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { openExternalUrl } from "@/lib/open-external";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 /**
  * "Changes" right-panel tab (CHAT-D8-01): a per-session review surface for the
@@ -440,6 +441,7 @@ export function SessionChangesInner({
   const [committing, setCommitting] = useState(false);
   // Set after a successful commit so the "Create PR" affordance persists even
   // though the file list is now empty.
+  const { announce } = useAnnouncer();
   const [postCommit, setPostCommit] = useState<
     { sha: string; branch: string; onDefaultBranch: boolean } | null
   >(null);
@@ -702,6 +704,7 @@ export function SessionChangesInner({
         // refresh the checkpoint list so the new snapshot shows up.
         if (json.checkpointPath) {
           setCheckpointMessage("Reverted — a checkpoint was saved first, so you can undo it below.");
+          announce("File reverted — a checkpoint was saved first.");
         }
         await Promise.all([load(), loadCheckpoints()]);
       } catch (err) {
@@ -730,6 +733,7 @@ export function SessionChangesInner({
       };
       if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
       setPostCommit({ sha: json.sha ?? "", branch: json.branch ?? "", onDefaultBranch: json.onDefaultBranch === true });
+      announce("Changes committed.");
       setPrTitle(message.split("\n")[0].slice(0, 72));
       setPrBody("");
       setPrOpen(false);
@@ -758,6 +762,7 @@ export function SessionChangesInner({
       const json = (await res.json().catch(() => ({}))) as { ok?: boolean; url?: string; error?: string };
       if (!res.ok || !json.ok) throw new Error(json.error ?? `http ${res.status}`);
       setPrUrl(json.url ?? null);
+      if (json.url) announce("Pull request opened.");
       setPrOpen(false);
       setPostCommit(null);
     } catch (err) {


### PR DESCRIPTION
## What

Code-surface (comux) audit — a11y half (correctness/perf in #2296). The file tree + diff view were already reference-quality (`role="tree"` + full keyboard nav; `+/-` diff lines + status non-visual), so this closes the familiar systemic gaps.

- **Announcer**: the surface now announces async results via the shared `useAnnouncer` — file saved/failed (comux), and file reverted / changes committed / PR opened (`session-changes-panel`). Failures assertive; errors already used `role="alert"`.
- **Quick-open focus trap**: the ⌘P palette is now `useFocusTrap`'d (trap + Escape + focus-return) instead of a bare autofocus that let Tab escape behind the backdrop and lost the return point. Added to the `modal-trap-adoption` guard.
- **Toggles**: the inline Files/Changes and Rendered/Raw controls become `role="group"` + `aria-pressed` (were background-color-only, no state exposed to AT) — matching the `code-inline-toolbar` pattern.

## Verification
Rebased cleanly onto #2296 (source in separate regions; only the test-pin block overlapped). Typecheck + full comux/changes test sweep green; `modal-trap-adoption` now enforces `useFocusTrap` in `code-quick-open`.

## Parked (P2)
Terminal-tab keyboard nav (bare `<div>` tabs → `role="tab"` conversion is a larger change); terminal pane drag-only reorder + nameless `contentEditable` rename; the resize splitter's missing `aria-valuenow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)