### PR TITLE
fix(responsive): make chat/board surfaces viewable at any pane or screen width

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6688,6 +6688,31 @@ a.mobile-handoff__link:hover {
   .top-bar__actions .notification-bell {
     position: static;
   }
+  /* Phone-width top bar: the labeled familiar trigger (chat mode adds the
+     quickswitch to the actions cluster) plus the full icon set overflow the
+     actions grid track — justify-self:end anchors the right edge, so the
+     cluster bleeds LEFT over the nav toggle and search. Compact the trigger
+     to its avatar and drop the secondary Enhance shortcut (still reachable
+     from the composer) so the cluster fits a 360px bar. */
+  @media (max-width: 480px) {
+    .top-bar__actions .familiar-switcher__trigger-label {
+      display: none;
+    }
+    .top-bar__actions .familiar-switcher__trigger--labeled {
+      justify-content: center;
+      width: var(--touch-target);
+      max-width: var(--touch-target);
+      padding: 0;
+    }
+    .top-bar__actions .familiar-switcher__trigger--labeled img {
+      width: 100%;
+      height: 100%;
+      border-radius: calc(var(--radius-control) - 1px);
+    }
+    .top-bar__actions .top-bar__tasks-enrich {
+      display: none;
+    }
+  }
   .notification-bell__popover {
     position: fixed;
     left: calc(8px + var(--sai-left));
@@ -6899,6 +6924,11 @@ a.mobile-handoff__link:hover {
   container-type: inline-size;
   container-name: chatlist;
 }
+/* The date reads as one unit — "Jul 3, 2026 · just now" must never break
+   word-by-word when the pane squeezes (drag-to-split); it truncates instead. */
+.chat-list-row-time {
+  white-space: nowrap;
+}
 @container chatlist (max-width: 520px) {
   .chat-list-row-meta {
     flex-direction: column;
@@ -6910,6 +6940,12 @@ a.mobile-handoff__link:hover {
   }
   .chat-list-row-time {
     width: auto;
+    max-width: 100%;
+  }
+  .chat-list-row-time > span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { Card, CardStatus, CardPriority } from "@/lib/cave-board-types";
 import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
@@ -666,15 +667,22 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
           </div>
         );
       })}
-      {ghost && (
-        <div
-          className="board-kanban-touch-ghost"
-          style={{ left: ghost.x, top: ghost.y }}
-          aria-hidden
-        >
-          {ghost.title}
-        </div>
-      )}
+      {/* Portaled like the task drawer (#537): .board-shell is a size query
+          container, whose layout containment would otherwise trap this
+          fixed-position clone inside the pane (wrong origin + clipped by the
+          shell's overflow:hidden). Ghost coords are viewport-based. */}
+      {ghost &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            className="board-kanban-touch-ghost"
+            style={{ left: ghost.x, top: ghost.y }}
+            aria-hidden
+          >
+            {ghost.title}
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -38,10 +38,17 @@ assert.match(
   /\.board-search-wrap\s*\{[\s\S]*min-width:\s*0/,
   "Desktop board search should be allowed to shrink before forcing toolbar wrapping",
 );
+// The stacked layout is keyed to the surface's own width (@container board) so
+// it also engages inside a narrow drag-to-split pane on a wide viewport.
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.board-header\s*\{[\s\S]*flex-wrap:\s*wrap/,
-  "Mobile board header should keep its stacked layout",
+  /\.board-shell\s*\{[^}]*container:\s*board \/ inline-size/,
+  "the board shell establishes the board query container",
+);
+assert.match(
+  styles,
+  /@container board \(max-width: 767px\) \{[\s\S]*\.board-header\s*\{[\s\S]*flex-wrap:\s*wrap/,
+  "Narrow board header should keep its stacked layout",
 );
 
 // ───────── Crash-guard + card a11y ─────────
@@ -63,9 +70,13 @@ assert.match(kanban, /board-kanban-card--grabbed/, "Grabbed visual affordance pr
 // ───────── Mobile board chrome ─────────
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.board-search-input\s*\{[\s\S]*height:\s*44px[\s\S]*\.board-view-toggle\s*\{[\s\S]*display:\s*none[\s\S]*\.board-toolbar-btn,\s*\n\s*\.board-new-card-btn\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
-  "Mobile board search and toolbar controls should meet thumb-sized touch targets",
+  /@container board \(max-width: 767px\) \{[\s\S]*\.board-search-input\s*\{[\s\S]*height:\s*44px[\s\S]*\.board-view-toggle\s*\{[\s\S]*display:\s*none[\s\S]*\.board-toolbar-btn,\s*\n\s*\.board-new-card-btn\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "Narrow board search and toolbar controls should meet thumb-sized touch targets",
 );
+
+// The touch ghost is fixed-position with viewport coords — the board container's
+// layout containment would trap it in the pane, so it portals to document.body.
+assert.match(kanban, /createPortal\(\s*<div\s*\n?\s*className="board-kanban-touch-ghost"/, "the kanban touch ghost renders through a portal");
 
 assert.match(
   styles,

--- a/src/components/chat-surface-mobile-command-center.test.ts
+++ b/src/components/chat-surface-mobile-command-center.test.ts
@@ -7,8 +7,8 @@ const styles = readFileSync(new URL("../app/globals.css", import.meta.url), "utf
 
 assert.match(
   source,
-  /<section className="chat-surface /,
-  "ChatSurface should expose a mobile-targetable root class",
+  /<section ref=\{surfaceRef\} className="chat-surface /,
+  "ChatSurface should expose a mobile-targetable root class (and the ref that measures pane width)",
 );
 
 assert.match(
@@ -48,19 +48,22 @@ assert.match(
 );
 
 // The Inspector/Debug/Changes panels live in a 230px right sidebar that is
-// hidden below the desktop shell breakpoint (no room beside the chat thread).
-// On mobile they must remain reachable — rendered in a right-edge sheet over a
-// dismissible scrim — instead of silently vanishing.
+// hidden when there's no room beside the chat thread — a phone viewport OR a
+// narrow drag-to-split pane on a wide screen. In both cases they must remain
+// reachable — rendered in a right-edge sheet over a dismissible scrim —
+// instead of silently vanishing.
 assert.match(
   source,
-  /scope === "conversation" && rightPanel !== null && isMobile && \(/,
-  "ChatSurface should render the session panels as a mobile sheet when the inline sidebar is hidden",
+  /scope === "conversation" && rightPanel !== null && \(isMobile \|\| paneNarrow\) && \(/,
+  "ChatSurface should render the session panels as a sheet when the inline sidebar is hidden",
 );
 
+// The sheet's visibility is JS-gated (isMobile || paneNarrow) — a viewport
+// lg:hidden here would wrongly hide it inside a narrow split pane on desktop.
 assert.match(
   source,
-  /className="chat-right-sheet fixed inset-0 z-\[200\] flex justify-end lg:hidden"/,
-  "Mobile session-panel sheet should be a fixed right-edge overlay, hidden once the desktop sidebar fits (lg)",
+  /className="chat-right-sheet fixed inset-0 z-\[200\] flex justify-end"/,
+  "Session-panel sheet should be a fixed right-edge overlay without a viewport-gated lg:hidden",
 );
 
 assert.match(
@@ -69,12 +72,19 @@ assert.match(
   "Mobile session-panel sheet should close on scrim tap",
 );
 
-// Gate the inline desktop sidebar on !isMobile so only one RightPanel mounts per
-// breakpoint — otherwise InspectorPane double-fetches and duplicates DOM ids.
+// Gate the inline desktop sidebar as the exact complement of the sheet so only
+// one RightPanel mounts at a time — otherwise InspectorPane double-fetches and
+// duplicates DOM ids. paneNarrow tracks the surface's own measured width so a
+// narrow drag-to-split pane on a wide viewport also swaps to the sheet.
 assert.match(
   source,
-  /const showRightSidebar = rightPanel !== null && !isMobile/,
-  "Inline desktop right sidebar should not also mount on mobile (avoids duplicate RightPanel)",
+  /const showRightSidebar = rightPanel !== null && !isMobile && !paneNarrow/,
+  "Inline desktop right sidebar should not mount when the pane or viewport is narrow (avoids duplicate RightPanel)",
+);
+assert.match(
+  source,
+  /const paneNarrow = paneWidth === null \? isMobile : paneWidth < 680/,
+  "paneNarrow falls back to the viewport heuristic until the first ResizeObserver measurement",
 );
 
 console.log("chat-surface-mobile-command-center.test.ts: ok");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -224,6 +224,24 @@ export function ChatSurface({
   // (no room beside the chat thread), so the Inspector/Debug/Changes panels would
   // be unreachable. On mobile we render them in a right-edge sheet overlay instead.
   const isMobile = useIsMobile();
+  // A drag-to-split pane can be far narrower than the viewport, so the
+  // inline-vs-sheet decision also tracks the surface's own measured width —
+  // below ~680px the inline sidebar (200px min) would crush the chat thread's
+  // 45% minSize. Until the first measurement lands, fall back to the viewport
+  // heuristic so SSR and first paint agree with the CSS.
+  const surfaceRef = useRef<HTMLElement | null>(null);
+  const [paneWidth, setPaneWidth] = useState<number | null>(null);
+  useEffect(() => {
+    const el = surfaceRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? el.clientWidth;
+      setPaneWidth((prev) => (prev === width ? prev : width));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const paneNarrow = paneWidth === null ? isMobile : paneWidth < 680;
   const consumedPendingActionNonce = useRef<number | null>(null);
 
   // Right panel — prefer new prop, fall back to legacy bool
@@ -235,8 +253,9 @@ export function ChatSurface({
     onSetInspectorOpen(next === "inspector");
   }
 
-  // The inspector/debug/changes sidebar shares the chat thread's row on desktop.
-  const showRightSidebar = rightPanel !== null && !isMobile;
+  // The inspector/debug/changes sidebar shares the chat thread's row on desktop
+  // — only when the pane itself is wide enough to host both.
+  const showRightSidebar = rightPanel !== null && !isMobile && !paneNarrow;
 
   // Persist the chat / right-area split. panelIds tracks which panels are
   // actually mounted so the with-sidebar and bare layouts persist separately.
@@ -373,7 +392,7 @@ export function ChatSurface({
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
-    <section className="chat-surface relative flex h-full min-w-0 bg-[var(--bg-base)]">
+    <section ref={surfaceRef} className="chat-surface relative flex h-full min-w-0 bg-[var(--bg-base)]">
       {/* Main content */}
       <div className="flex min-w-0 flex-1 flex-col">
         {/* ── Header ──────────────────────────────────────────────────────
@@ -493,14 +512,16 @@ export function ChatSurface({
           </Group>
         )}
       </div>
-      {/* Mobile: the inline 230px right sidebar can't fit beside the chat thread,
-          so the Inspector/Debug/Changes panels open in a right-edge sheet over a
-          dismissible scrim. Gated on isMobile so only one RightPanel mounts per
-          breakpoint — the InspectorPane won't double-fetch or duplicate DOM ids.
-          Scoped to the conversation tab to mirror the desktop placement. */}
-      {scope === "conversation" && rightPanel !== null && isMobile && (
+      {/* Narrow: the inline 230px right sidebar can't fit beside the chat thread
+          (phone viewport OR a narrow drag-to-split pane on a wide screen), so the
+          Inspector/Debug/Changes panels open in a right-edge sheet over a
+          dismissible scrim. The gate is the exact complement of showRightSidebar
+          so only one RightPanel mounts at a time — the InspectorPane won't
+          double-fetch or duplicate DOM ids. Scoped to the conversation tab to
+          mirror the desktop placement. */}
+      {scope === "conversation" && rightPanel !== null && (isMobile || paneNarrow) && (
         <div
-          className="chat-right-sheet fixed inset-0 z-[200] flex justify-end lg:hidden"
+          className="chat-right-sheet fixed inset-0 z-[200] flex justify-end"
           role="presentation"
           onKeyDown={(e) => {
             if (e.key === "Escape") setRightPanel(null);

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -5,7 +5,12 @@
 
 /* board.css — Board v2 */
 
-.board-shell { display:flex; flex-direction:column; height:100%; overflow:hidden; background:var(--bg-base); color:var(--text-primary); }
+/* container: board — the narrow-layout rules below query the surface's own
+   width instead of the viewport, so they also engage when the board sits in a
+   narrow drag-to-split pane on a wide screen (same pattern as evals /
+   marketplace, #2249). At phone widths the pane spans the viewport, so the
+   same rules fire there too. */
+.board-shell { display:flex; flex-direction:column; height:100%; overflow:hidden; background:var(--bg-base); color:var(--text-primary); container:board / inline-size; }
 
 .board-header { display:flex; align-items:center; gap:10px; padding:10px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; flex-wrap:nowrap; }
 .board-header-title { flex:0 0 auto; font-size:14px; font-weight:600; color:var(--text-primary); }
@@ -49,7 +54,7 @@
 .board-new-card-btn:hover { background:color-mix(in oklch, var(--accent-presence) 85%, #000); transform:scale(1.02); }
 .board-new-card-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:2px; }
 
-@media (max-width: 767px) {
+@container board (max-width: 767px) {
   .board-header {
     align-items: stretch;
     flex-wrap: wrap;
@@ -115,11 +120,15 @@
   .board-new-card-btn {
     flex: 0 0 auto;
   }
+}
 
+@media (max-width: 767px) {
   /* The task inspector goes full-screen on phones (.board-drawer is
      max-width:100vw), so its interactive controls are primary touch targets
      and must meet --touch-target — the desktop-dense 24-28px sizes are too
-     small to hit reliably with a thumb.
+     small to hit reliably with a thumb. It renders through a portal outside
+     .board-shell, where the board container query can't reach it — so these
+     rules stay keyed to the viewport.
      Use min-* (not width/height): this mobile block sits earlier in the file
      than the base .board-drawer-close rule, so an
      equal-specificity width/height would LOSE the cascade to them (verified:

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -46,6 +46,40 @@ test.describe("mobile foundations", () => {
     expect(overflow, "no horizontal overflow at 360px viewport").toBeLessThanOrEqual(0);
   });
 
+  test("chat and tasks surfaces fit 360px without horizontal scroll", async ({ page }) => {
+    await page.setViewportSize({ width: 360, height: 720 });
+    await page.goto("/");
+    await page.waitForSelector(".shell-frame");
+
+    // Re-dispatch navigate-mode inside the poll: on a cold mobile load the
+    // Workspace listener can attach AFTER .shell-frame appears, so a single
+    // early dispatch is silently dropped and the check would measure Home.
+    const targets: Array<[string, string]> = [
+      ["chat", ".chat-surface"],
+      ["board", ".board-shell"],
+    ];
+    for (const [surface, selector] of targets) {
+      await page.waitForFunction(
+        ({ mode, sel }) => {
+          window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode } }));
+          return document.querySelector(sel) !== null;
+        },
+        { mode: surface, sel: selector },
+        // Generous: the dev webServer compiles the chat/board chunks on first
+        // hit, which can take >15s under CI's parallel project load.
+        { timeout: 25000 },
+      );
+      await page.waitForTimeout(200);
+      const overflow = await page.evaluate(() => {
+        return (
+          document.documentElement.scrollWidth -
+          document.documentElement.clientWidth
+        );
+      });
+      expect(overflow, `no horizontal overflow on ${surface} at 360px viewport`).toBeLessThanOrEqual(0);
+    }
+  });
+
   test("home route does not create window-level vertical scroll", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");


### PR DESCRIPTION
## Problem

The chat page (and the surfaces beside it in a drag-to-split) broke when squeezed — screenshot from a live session showed session dates word-wrapping into vertical stacks in the Familiars pane, the Tasks toolbar clipping its controls, and the composer's Enhance button cut off. At phone widths, the top bar's labeled familiar trigger overflowed its grid track and bled over the nav toggle and search.

Root cause for most of it: these surfaces adapt to **viewport** width (`@media`, Tailwind `lg:`) but not **pane** width, so a narrow split pane on a wide screen never triggers the narrow layouts.

## Changes

- **Chat sessions list** — `.chat-list-row-time` is now `nowrap` + ellipsis, so "Jul 3, 2026 · just now" truncates as a unit instead of stacking word-by-word (`globals.css`).
- **Board toolbar** — header reflow keys to `@container board (max-width: 767px)` on `.board-shell` instead of viewport `@media`, engaging inside narrow split panes too (same pattern as evals/marketplace, #2249). The portaled task-drawer touch-target rules stay viewport-gated (a container query can't reach a portal).
- **Board kanban touch ghost** — portals to `document.body`: the new query container's layout containment would otherwise re-parent the fixed-position clone and clip it under the shell's `overflow:hidden` (same precedent as the drawer, #537).
- **Chat surface** — the inline right-sidebar vs sheet decision now also tracks the surface's own ResizeObserver width (<680px → sheet), exactly complementary to `showRightSidebar` so only one RightPanel ever mounts. A narrow split pane on desktop now gets the sheet instead of a crushed thread.
- **Top bar ≤480px** — familiar trigger compacts to its avatar, the secondary Enhance shortcut hides (still reachable from the composer), so chat mode's action cluster fits a 360px bar without overlapping the nav toggle/search.
- **e2e** — new check: chat + board fit a 360px viewport with no horizontal scroll. The `cave:navigate-mode` dispatch retries inside the poll — a single early dispatch is silently dropped when the Workspace listener attaches late on cold mobile loads.

## Verification

- Typecheck, app (519), api (113), mobile (65) suites, production build + bundle budget all green.
- Playwright foundations spec green on desktop (new test included).
- Visually verified in the running app: chat/board/home at 360/768px (0px horizontal overflow); sessions list at an emulated 250px pane renders dates on one line; board at an emulated 520px pane wraps its toolbar with zero clipped controls; 360px top bar shows a compact avatar trigger with no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)