### PR TITLE
chore(release): stamp v0.0.135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.135] - 2026-07-03
+
+Patch release on top of v0.0.134. Continues the surface-hardening and
+accessibility sweep: the **Code** surface stops showing stale file responses and
+announces its save/revert/commit/PR actions, **Roles** folds into the
+Marketplace as one hub, the shell's left nav/list panels are now pixel-sized for
+full-width content, chat/board surfaces render at any pane or screen width, and
+**Automations** audit batch C brings a kind-aware detail panel with uniform run
+confirmation and action parity.
+
+### Added
+
+- **Shell** - the left nav and list panels are pixel-sized so content can use
+  the full available width (#2299).
+
+### Changed
+
+- **Marketplace** - Roles merged into the Marketplace as a single hub surface
+  instead of a separate view (#2295).
+- **Automations** - audit batch C: the detail panel is now kind-aware, run
+  confirmation is uniform across kinds, action parity across the list, and the
+  surface lazy-loads (#2294).
+
+### Fixed
+
+- **Code** - drop stale file responses, reset the preview on project switch, and
+  guard the changes poll so it can't race (#2296).
+- **Responsive** - chat and board surfaces stay viewable at any pane or screen
+  width (#2298).
+
+### Accessibility
+
+- **Settings** - announce async results, label the daemon inputs, and make the
+  search jump move focus (#2293).
+- **Code** - announce save/revert/commit/PR, focus-trap quick-open, and
+  `aria-pressed` the toggles (#2297).
+
 ## [0.0.134] - 2026-07-03
 
 Patch release on top of v0.0.133. A broad UI/UX + accessibility sweep: the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.134",
+  "version": "0.0.135",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.134"
+version = "0.0.135"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.134"
+version = "0.0.135"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.134</string>
+	<string>0.0.135</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.134</string>
+	<string>0.0.135</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.134</string>
+	<string>0.0.135</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.134</string>
+	<string>0.0.135</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.134",
+  "version": "0.0.135",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.135** across all six version locations + CHANGELOG.

## Payload — 7 PRs since v0.0.134 (#2293–#2299)

**Added**
- #2299 shell: pixel-size the left nav/list panels for full-width content

**Changed**
- #2295 marketplace: merge Roles into the Marketplace as one hub surface
- #2294 automations: audit batch C — kind-aware detail panel, uniform run confirm, action parity, lazy-load

**Fixed**
- #2296 code: drop stale file responses, reset preview on project switch, guard the changes poll
- #2298 responsive: chat/board surfaces viewable at any pane or screen width

**Accessibility**
- #2293 settings: announce async results, label daemon inputs, focus search jumps
- #2297 code: announce save/revert/commit/PR, focus-trap quick-open, aria-press toggles

## Version locations stamped
`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` (app pkg), `src-tauri/tauri.conf.json`, `src-tauri/Info.ios.plist`, `src-tauri/gen/apple/app_iOS/Info.plist` → all `0.0.135`.

Tag `v0.0.135` will be pushed after merge to trigger the release workflow.