### PR TITLE
fix(shell): make titlebar drag lane full height

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4112,10 +4112,10 @@ button:active > .edge-rail-chip {
 
   :root[data-tauri-titlebar] .shell-titlebar-drag-lane {
     position: absolute;
-    inset: 0 0 auto 0;
+    inset: 0;
     z-index: 2;
     display: block;
-    height: 10px;
+    pointer-events: none;
     -webkit-app-region: drag;
     app-region: drag;
   }

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -111,8 +111,13 @@ assert.match(
 );
 assert.match(
   css,
-  /:root\[data-tauri-titlebar\]\s+\.shell-titlebar-drag-lane\s*\{[\s\S]*?position:\s*absolute;[\s\S]*?height:\s*10px;[\s\S]*?-webkit-app-region:\s*drag;[\s\S]*?app-region:\s*drag;/,
-  "macOS Tauri titlebar mode should expose a fixed-height draggable lane above the controls",
+  /:root\[data-tauri-titlebar\]\s+\.shell-titlebar-drag-lane\s*\{[^}]*position:\s*absolute;[^}]*inset:\s*0;[^}]*-webkit-app-region:\s*drag;[^}]*app-region:\s*drag;/,
+  "macOS Tauri titlebar mode should make the full titlebar band draggable/clickable, not only a thin strip",
+);
+assert.match(
+  css,
+  /:root\[data-tauri-titlebar\]\s+\.shell-titlebar-drag-lane\s*\{[^}]*pointer-events:\s*none;/,
+  "the full-band drag lane must not intercept clicks meant for titlebar controls",
 );
 assert.match(
   css,


### PR DESCRIPTION
## Summary
- Expand the macOS/Tauri titlebar drag lane to cover the full titlebar band.
- Keep pointer events disabled so visible titlebar controls remain clickable.
- Update the shell edge rails regression test for the full-band drag lane behavior.

## Test Plan
- node --experimental-strip-types src/components/shell-edge-rails.test.ts
- pnpm test:app
- git diff --check