### PR TITLE
fix(familiars): stop raw "quota has been exceeded" leaking from avatar saves

### DIFF
--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -98,8 +98,13 @@ export function FamiliarsView({
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    if (selectedFamiliarId) window.localStorage.setItem(LAST_SELECTED_KEY, selectedFamiliarId);
-    else window.localStorage.removeItem(LAST_SELECTED_KEY);
+    try {
+      if (selectedFamiliarId) window.localStorage.setItem(LAST_SELECTED_KEY, selectedFamiliarId);
+      else window.localStorage.removeItem(LAST_SELECTED_KEY);
+    } catch {
+      // Full localStorage must not crash the surface; the selection just
+      // won't persist across reloads.
+    }
   }, [selectedFamiliarId]);
 
   // "/" jumps to the search (GitHub-style) while this surface is shown — but

--- a/src/lib/cave-familiar-images.test.ts
+++ b/src/lib/cave-familiar-images.test.ts
@@ -2,10 +2,17 @@
 import assert from "node:assert/strict";
 
 const storage = new Map();
+// Simulates the browser refusing the write (QuotaExceededError) — the real
+// localStorage quota (~5MB, shared across all cave:* keys) is stricter than
+// the store's own cap, so the store must survive a throwing setItem.
+let denyWrites = false;
 globalThis.window = {
   localStorage: {
     getItem: (k) => (storage.has(k) ? storage.get(k) : null),
-    setItem: (k, v) => storage.set(k, v),
+    setItem: (k, v) => {
+      if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+      storage.set(k, v);
+    },
     removeItem: (k) => storage.delete(k),
   },
   addEventListener: () => {},
@@ -30,6 +37,20 @@ assert.equal(
   assert.equal(got.cody.mime, "image/png");
   assert.equal(got.cody.dataUrl, dataUrl);
   assert.ok(Number.isFinite(Date.parse(got.cody.updatedAt)));
+}
+
+// Browser quota stricter than our own cap: the setItem throws, the store
+// reports the friendly storage-full reason (never the raw browser message),
+// and the snapshot stays unchanged — no phantom avatar that vanishes on reload.
+{
+  denyWrites = true;
+  const dataUrl = "data:image/png;base64," + "B".repeat(1000);
+  const res = mod.setFamiliarImage("astra", { dataUrl, mime: "image/png" });
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /storage full/i);
+  const got = mod.readFamiliarImagesSnapshot();
+  assert.equal(got.astra, undefined, "a refused write must not land in the in-memory cache");
+  denyWrites = false;
 }
 
 // Per-image size cap (2MB pre-encode ≈ 2*1024*1024 bytes ≈ ~2.8MB base64)

--- a/src/lib/cave-familiar-images.ts
+++ b/src/lib/cave-familiar-images.ts
@@ -5,7 +5,7 @@
  *
  * Images are stored as base64 data URLs in localStorage under
  * `cave:familiar-images:v1`. Each image is capped at 2MB pre-encode and the
- * whole store at ~20MB total. Larger uploads return `{ ok: false, reason }`
+ * whole store at ~4MB total. Larger uploads return `{ ok: false, reason }`
  * so the UI can surface a toast and refuse the write.
  */
 
@@ -13,7 +13,12 @@ import { useSyncExternalStore } from "react";
 
 const IMAGES_KEY = "cave:familiar-images:v1";
 export const MAX_FAMILIAR_IMAGE_DATAURL_BYTES = Math.floor(2 * 1024 * 1024 * 4 / 3) + 100; // ~2.8MB
-const MAX_TOTAL_BYTES = 20 * 1024 * 1024;
+// Browsers give the whole origin ~5MB of localStorage (WKWebView in the
+// desktop app), shared with every other cave:* key — so this store's own cap
+// must sit below that or the pre-check passes while the write itself throws.
+// The write is still guarded (writeMap) for when other keys hold the quota.
+const MAX_TOTAL_BYTES = 4 * 1024 * 1024;
+const STORAGE_FULL_REASON = "Cave avatar storage full. Remove an image to free space.";
 const ALLOWED_MIMES = new Set([
   "image/png",
   "image/jpeg",
@@ -53,12 +58,20 @@ function getMap(): ImageMap {
   return cached;
 }
 
-function writeMap(next: ImageMap) {
-  cached = next;
+// Persist first, then commit to memory. A quota-exceeded setItem must not
+// leave the cache claiming an image that storage never accepted — the avatar
+// would render until the next reload, then silently vanish.
+function writeMap(next: ImageMap): boolean {
   if (typeof window !== "undefined") {
-    window.localStorage.setItem(IMAGES_KEY, JSON.stringify(next));
+    try {
+      window.localStorage.setItem(IMAGES_KEY, JSON.stringify(next));
+    } catch {
+      return false; // QuotaExceededError — the browser's cap is stricter than ours
+    }
   }
+  cached = next;
   notify();
+  return true;
 }
 
 function totalBytes(map: ImageMap): number {
@@ -79,13 +92,15 @@ export function setFamiliarImage(id: string, image: { dataUrl: string; mime: str
   const projected =
     totalBytes(curr) - (previousEntry?.dataUrl.length ?? 0) + image.dataUrl.length;
   if (projected > MAX_TOTAL_BYTES) {
-    return { ok: false, reason: "Cave avatar storage full. Remove an image to free space." };
+    return { ok: false, reason: STORAGE_FULL_REASON };
   }
   const next = {
     ...curr,
     [id]: { dataUrl: image.dataUrl, mime: image.mime, updatedAt: new Date().toISOString() },
   };
-  writeMap(next);
+  if (!writeMap(next)) {
+    return { ok: false, reason: STORAGE_FULL_REASON };
+  }
   return { ok: true };
 }
 

--- a/src/lib/user-avatar-image.test.ts
+++ b/src/lib/user-avatar-image.test.ts
@@ -2,10 +2,16 @@
 import assert from "node:assert/strict";
 
 const storage = new Map();
+// Simulates the browser refusing the write (QuotaExceededError) — localStorage
+// is shared across all cave:* keys, so the write can fail even under our caps.
+let denyWrites = false;
 globalThis.window = {
   localStorage: {
     getItem: (k) => (storage.has(k) ? storage.get(k) : null),
-    setItem: (k, v) => storage.set(k, v),
+    setItem: (k, v) => {
+      if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+      storage.set(k, v);
+    },
     removeItem: (k) => storage.delete(k),
   },
   addEventListener: () => {},
@@ -28,6 +34,17 @@ const mod = await import("./user-avatar-image.ts");
   const res = mod.setUserAvatarImage({ dataUrl: "data:image/gif;base64,AAA", mime: "image/gif" });
   assert.equal(res.ok, false);
   assert.match(res.reason, /unsupported|format/i);
+}
+
+// Quota-refused write: friendly storage-full reason, snapshot unchanged.
+{
+  const before = mod.readUserAvatarImageSnapshot();
+  denyWrites = true;
+  const res = mod.setUserAvatarImage({ dataUrl: "data:image/png;base64," + "B".repeat(1000), mime: "image/png" });
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /storage full/i);
+  assert.deepEqual(mod.readUserAvatarImageSnapshot(), before, "a refused write must not land in the cache");
+  denyWrites = false;
 }
 
 {

--- a/src/lib/user-avatar-image.ts
+++ b/src/lib/user-avatar-image.ts
@@ -61,13 +61,23 @@ function getSnapshot(): UserAvatarImage | null {
   return cached;
 }
 
-function writeSnapshot(next: UserAvatarImage | null) {
-  cached = next;
+// Persist first, then commit to memory — a quota-exceeded setItem must not
+// leave the cache claiming an avatar that storage never accepted.
+function writeSnapshot(next: UserAvatarImage | null): boolean {
   if (typeof window !== "undefined") {
-    if (next) window.localStorage.setItem(USER_AVATAR_KEY, JSON.stringify(next));
-    else window.localStorage.removeItem(USER_AVATAR_KEY);
+    if (next) {
+      try {
+        window.localStorage.setItem(USER_AVATAR_KEY, JSON.stringify(next));
+      } catch {
+        return false; // QuotaExceededError — localStorage is full
+      }
+    } else {
+      window.localStorage.removeItem(USER_AVATAR_KEY);
+    }
   }
+  cached = next;
   notify();
+  return true;
 }
 
 export function setUserAvatarImage(image: { dataUrl: string; mime: string }): SetResult {
@@ -77,7 +87,9 @@ export function setUserAvatarImage(image: { dataUrl: string; mime: string }): Se
   if (image.dataUrl.length > MAX_FAMILIAR_IMAGE_DATAURL_BYTES) {
     return { ok: false, reason: "Image too large (max 2MB)." };
   }
-  writeSnapshot({ ...image, updatedAt: new Date().toISOString() });
+  if (!writeSnapshot({ ...image, updatedAt: new Date().toISOString() })) {
+    return { ok: false, reason: "Cave avatar storage full. Remove an image to free space." };
+  }
   return { ok: true };
 }
 


### PR DESCRIPTION
## What

Fixes the raw **"The quota has been exceeded."** toast on the familiar page when saving an avatar image.

**Root cause:** the Cave-local avatar stores (`cave-familiar-images.ts`, `user-avatar-image.ts`) keep base64 data URLs in localStorage and pre-check against an internal **20MB** cap — but the browser's real origin quota is **~5MB** (WKWebView in the desktop app), shared with every other `cave:*` key. So the pre-check passed, the unguarded `localStorage.setItem` threw `QuotaExceededError`, and WebKit's raw message surfaced via the upload hook's catch-all toast (`familiar-image-upload.ts`). Bonus bug: the in-memory cache was updated *before* the throwing write, so the avatar appeared saved until the next reload, then silently vanished.

**Fix:**
- `writeMap`/`writeSnapshot` now **persist first and only commit to memory on success**; a refused write returns the existing friendly reason — "Cave avatar storage full. Remove an image to free space." — through the normal `SetResult` path both callers already render.
- `MAX_TOTAL_BYTES` drops **20MB → 4MB** so the store's own pre-check can actually fire before the browser's.
- The `familiars-view` last-selected-familiar write is wrapped so a completely full localStorage can't crash the surface.

## Tests
Extended both behavioral tests with a quota-throwing localStorage mock: refused writes return the `storage full` reason and never land in the in-memory snapshot. `typecheck` · `check:tests-wired` (695) · `test:app` 520 ✓ · `test:api` 113 ✓ · `test:mobile` 65 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)