### PR TITLE
fix(calendar): keep timed events out of the all-day bucket, pin the add-day, stop the minute-tick re-packing every column

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -46,7 +46,7 @@ assert.doesNotMatch(view, /minHeight: 20/, "Old fixed 20px event height must be 
 // re-ticks each minute, so today-highlights + the now-line don't mismatch SSR
 // and the current-time indicator tracks the clock.
 assert.match(view, /function useNow\(\): Date \| null \{[\s\S]*?setInterval\(\(\) => setNow\(new Date\(\)\), 60_000\)/, "useNow ticks every minute");
-assert.match(view, /col\.isToday && now &&/, "the now-line only renders once `now` resolves");
+assert.match(view, /now && isSameDay\(col\.date, now\) &&/, "the now-line only renders once `now` resolves, derived from TimeGrid's own clock");
 // The grid sub-views derive "today" from useNow (hydration-safe + live), not a
 // render-time `new Date()` (Agenda, Day, Week, Month, TimeGrid).
 assert.ok((view.match(/const now = useNow\(\)/g) ?? []).length >= 5, "every grid sub-view uses useNow for today");
@@ -74,7 +74,7 @@ assert.match(view, /aria-pressed=\{viewMode === id\}/, "each view-mode button an
 assert.match(view, /target\.isContentEditable/, "Single-key shortcuts must not fire inside contenteditable");
 
 // ───────── No render-time array mutation in AgendaView ─────────
-assert.match(view, /\[\.\.\.groupItems\]\s*\n\s*\.sort/, "AgendaView must sort a copy, not the memoized array");
+assert.match(view, /\[\.\.\.groupItems\][\s\S]*?\.sort\(\(a, b\) => \(itemDate\(a\)\?\.getTime\(\) \?\? 0\) - \(itemDate\(b\)\?\.getTime\(\) \?\? 0\)\)/, "AgendaView sorts a copy by the itemDate key (fireAt ?? firedAt ?? createdAt), not the memoized array");
 
 // ───────── Workspace wires optimistic mutations to the inbox routes ─────────
 assert.match(ws, /\/api\/inbox\/\$\{id\}\/done/, "completeInboxItem must POST the done route");

--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -50,7 +50,7 @@ assert.match(
 // ───────── Task 4: Today indicator ─────────
 assert.match(
   source,
-  /col\.isToday \? "bg-\[color-mix\(in_oklch,var\(--accent-presence\)_6%,transparent\)\]" : ""/,
+  /now && isSameDay\(col\.date, now\) \? "bg-\[color-mix\(in_oklch,var\(--accent-presence\)_6%,transparent\)\]" : ""/,
   "TimeGrid column body must tint today's column with accent-presence at 6%",
 );
 assert.match(

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -157,11 +157,18 @@ function fmtHourLabel(h: number): string {
 function defaultEntryFireAt(day: Date): string {
   const target = new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0, 0, 0);
   const now = new Date();
+  // Future 9 AM on the clicked day → use it directly.
   if (target.getTime() > now.getTime()) return target.toISOString();
-
-  const fallback = new Date(now);
-  fallback.setMinutes(Math.ceil((fallback.getMinutes() + 5) / 15) * 15, 0, 0);
-  return fallback.toISOString();
+  // 9 AM has already passed. Keep the *clicked day* rather than silently
+  // jumping to today: when the day is today, round up to the next 15-min slot
+  // so the default isn't in the past; a past day keeps its 9 AM so the modal
+  // opens on the day the user actually clicked.
+  if (isSameDay(day, now)) {
+    const slot = new Date(now);
+    slot.setMinutes(Math.ceil((slot.getMinutes() + 5) / 15) * 15, 0, 0);
+    return slot.toISOString();
+  }
+  return target.toISOString();
 }
 
 // A reminder still pending after its fire time never fired — flag it so it
@@ -279,7 +286,6 @@ function AgendaView({
   anchor,
   onAddEntry,
   onOpenItem,
-  onReschedule,
   onOpenDeadline,
 }: {
   items: InboxItem[];
@@ -287,7 +293,6 @@ function AgendaView({
   anchor: Date;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onOpenItem?: (item: InboxItem) => void;
-  onReschedule?: (id: string, fireAtIso: string) => void;
   onOpenDeadline?: (id: string) => void;
 }) {
   const [showPast, setShowPast] = useState(false);
@@ -390,11 +395,10 @@ function AgendaView({
               <DeadlineChip key={d.id} deadline={d} onOpen={onOpenDeadline} />
             ))}
             {[...groupItems]
-              .sort((a, b) => {
-                const ta = new Date(a.fireAt ?? a.createdAt).getTime();
-                const tb = new Date(b.fireAt ?? b.createdAt).getTime();
-                return ta - tb;
-              })
+              // Order by the same key the day bucket uses (itemDate: fireAt ??
+              // firedAt ?? createdAt) so fired items with no fireAt stay in
+              // chronological order instead of falling back to createdAt.
+              .sort((a, b) => (itemDate(a)?.getTime() ?? 0) - (itemDate(b)?.getTime() ?? 0))
               .map((item) => (
                 <ItemChip
                   key={item.id}
@@ -573,6 +577,15 @@ function isAllDay(item: InboxItem): boolean {
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT = 56;
+// Timed-grid interactions snap to 15-min slots. Floor to the first slot (and
+// cap at the last) so an event placed / dragged / nudged to the very top of the
+// day never lands on exact local midnight — isAllDay() treats 00:00:00 as an
+// all-day marker, which would yank the event out of the hourly grid into the
+// all-day strip.
+const SNAP_MIN = 15;
+const MAX_TIMED_MIN = 24 * 60 - SNAP_MIN;
+const clampTimedMinutes = (min: number) =>
+  Math.min(MAX_TIMED_MIN, Math.max(SNAP_MIN, min));
 
 function TimeGrid({
   columns,
@@ -580,7 +593,7 @@ function TimeGrid({
   onAddEntry,
   onReschedule,
 }: {
-  columns: { label: string; date: Date; isToday: boolean; items: InboxItem[] }[];
+  columns: { label: string; date: Date; items: InboxItem[] }[];
   onOpenItem?: (item: InboxItem) => void;
   onAddEntry?: (defaults?: { fireAt?: string; title?: string; whenText?: string }) => void;
   onReschedule?: (id: string, fireAtIso: string) => void;
@@ -647,7 +660,7 @@ function TimeGrid({
           <div
             key={ci}
             className={`flex-1 relative min-w-[80px] ${
-              col.isToday ? "bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)]" : ""
+              now && isSameDay(col.date, now) ? "bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)]" : ""
             } ${onAddEntry ? "cursor-pointer" : ""}`}
             style={{ height: totalHeight }}
             title={onAddEntry ? "Click an empty slot to add an event" : undefined}
@@ -659,7 +672,7 @@ function TimeGrid({
                     const rect = e.currentTarget.getBoundingClientRect();
                     const hour = Math.max(0, Math.min(23, Math.floor((e.clientY - rect.top) / HOUR_HEIGHT)));
                     const slot = new Date(col.date);
-                    slot.setHours(hour, 0, 0, 0);
+                    slot.setHours(0, clampTimedMinutes(hour * 60), 0, 0);
                     onAddEntry({ fireAt: slot.toISOString() });
                   }
                 : undefined
@@ -682,10 +695,7 @@ function TimeGrid({
                     const rect = e.currentTarget.getBoundingClientRect();
                     // Snap the block's start to the nearest 15 minutes at the drop.
                     const topPx = e.clientY - rect.top - drag.grabY;
-                    const minutes = Math.max(
-                      0,
-                      Math.min(24 * 60 - 15, Math.round((topPx / HOUR_HEIGHT) * 4) * 15),
-                    );
+                    const minutes = clampTimedMinutes(Math.round((topPx / HOUR_HEIGHT) * 4) * 15);
                     const slot = new Date(col.date);
                     slot.setHours(0, minutes, 0, 0);
                     onReschedule(drag.id, slot.toISOString());
@@ -703,7 +713,7 @@ function TimeGrid({
             ))}
 
             {/* Current time indicator (today's column only, once `now` resolves) */}
-            {col.isToday && now && (
+            {now && isSameDay(col.date, now) && (
               <div
                 ref={nowRef}
                 className="absolute left-0 right-0 flex items-center z-10"
@@ -747,7 +757,7 @@ function TimeGrid({
                           if (!e.altKey || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
                           e.preventDefault();
                           const step = (e.shiftKey ? 60 : 15) * (e.key === "ArrowDown" ? 1 : -1);
-                          const minutes = Math.max(0, Math.min(24 * 60 - 15, ev.start + step));
+                          const minutes = clampTimedMinutes(ev.start + step);
                           if (minutes === ev.start) return;
                           const slot = new Date(col.date);
                           slot.setHours(0, minutes, 0, 0);
@@ -830,12 +840,14 @@ function DayView({
     [deadlines, anchor],
   );
 
+  // `isToday` is derived inside TimeGrid from its own clock, so the 60s
+  // now-tick never invalidates this memo (which would otherwise re-pack the
+  // column every minute).
   const columns = useMemo(() => [{
     label: fmtDateHeading(anchor),
     date: anchor,
-    isToday: now ? isSameDay(anchor, now) : false,
     items: timedItems,
-  }], [anchor, timedItems, now]);
+  }], [anchor, timedItems]);
 
   const rel = now ? relDayWord(anchor, now) : null;
 
@@ -905,17 +917,20 @@ function WeekView({
     [weekStartMs],
   );
 
+  // `isToday` is derived per-column at render time (here for the header, in
+  // TimeGrid for the grid) rather than baked into this memo, so the 60s
+  // now-tick doesn't mint a new columns array and force TimeGrid to re-pack
+  // every column each minute.
   const columns = useMemo(() => {
     return days.map((day) => ({
       label: `${WEEKDAYS[day.getDay()]} ${day.getDate()}`,
       date: day,
-      isToday: now ? isSameDay(day, now) : false,
       items: items.filter((it) => {
         const d = itemDate(it);
         return d && isSameDay(d, day) && !isAllDay(it);
       }),
     }));
-  }, [items, days, now]);
+  }, [items, days]);
 
   const allDayColumns = useMemo(() => {
     return days.map((day) => ({
@@ -949,7 +964,7 @@ function WeekView({
             <div
               key={i}
               className={`group relative flex-1 min-w-[80px] px-2 py-2 text-center ${
-                col.isToday ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]" : ""
+                now && isSameDay(col.date, now) ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]" : ""
               }`}
             >
               {onAddEntry && (
@@ -968,7 +983,7 @@ function WeekView({
               </div>
               <div
                 className={`text-sm font-semibold ${
-                  col.isToday ? "text-[var(--accent-presence)]" : "text-[var(--text-primary)]"
+                  now && isSameDay(col.date, now) ? "text-[var(--accent-presence)]" : "text-[var(--text-primary)]"
                 }`}
               >
                 {col.date.getDate()}
@@ -1692,7 +1707,6 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
             deadlines={scopedDeadlines}
             anchor={anchor}
             onAddEntry={onAddEntry}
-            onReschedule={onReschedule}
             onOpenItem={(item) => setSelectedItem(item)}
             onOpenDeadline={onOpenDeadline}
           />

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -3962,35 +3962,10 @@ details[open] > .cave-tool-summary::before {
   animation: ui-modal-fade-in var(--duration-fast) var(--ease-decelerate);
 }
 
-.cave-cal-detail-panel {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: 280px;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-panel);
-  border-left: 1px solid var(--border-hairline);
-  box-shadow: -4px 0 16px oklch(0 0 0 / 20%);
-  z-index: 20;
-  animation: cave-slide-in-right 0.18s ease;
-}
-
-@keyframes cave-slide-in-right {
-  from { transform: translateX(20px); opacity: 0; }
-  to   { transform: translateX(0);    opacity: 1; }
-}
-
-.cave-cal-detail-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 12px 16px;
-  border-bottom: 1px solid var(--border-hairline);
-  min-height: 48px;
-}
+/* The .cave-cal-detail-panel / -header rules (and their slide keyframe) live in
+   globals.css, which is loaded after this file and wins at equal specificity —
+   the copies that used to sit here were dead. Only the backdrop above is unique
+   to this file. */
 
 .cave-chat-voice-call-group {
   border-left: 2px solid var(--accent-presence, #6aa);


### PR DESCRIPTION
Correctness + perf batch from the **Calendar** surface audit (three-lens: correctness / a11y / perf-dead-code). Findings were source-verified; the a11y batch ships as a follow-up PR that rebases on this one.

## Correctness
- **Timed → all-day reclassification (top bug).** Dragging, `Alt+↑/↓`-nudging, or click-creating an event at the very top of the day produced a local-midnight `fireAt`, which `isAllDay()` treats as an all-day marker — the event vanished from the hourly grid and reappeared in the "All day" strip. Timed-grid interactions now floor to the 15-min snap (`clampTimedMinutes`), so a deliberately-placed timed event never collapses to exact `00:00:00`.
- **"Add on this day" pinned to the wrong day.** `defaultEntryFireAt` fell back to *today* for any day whose 9 AM had already passed (a past day, or today after 09:00), so clicking an empty past cell pre-filled today's date. It now keeps the clicked day: future 9 AM → that 9 AM; today after 9 AM → next 15-min slot (still today); a past day → that day's 9 AM (the modal lets the user adjust).
- **Agenda within-day ordering.** The sort used `fireAt ?? createdAt` while the day bucket keys on `itemDate` (`fireAt ?? firedAt ?? createdAt`), so fired items with no `fireAt` (e.g. `agent`/`daily-summary` rows) sorted by `createdAt`. Sort now uses the same `itemDate` key.

## Perf / dead code
- **60s now-tick re-packed every column.** `useNow()`'s minute tick flowed into the Week/Day `columns` memo via `isToday`, minting a new array each minute and defeating `TimeGrid`'s `packedColumns` memo → `packEventColumns` re-ran for all 7 columns every minute. `isToday` is now derived per-column at render time (headers and TimeGrid both read their own `now`), so the tick only moves the now-line.
- Removed the dead `onReschedule` prop threaded to `AgendaView` (unused).
- Deleted the dead duplicate `.cave-cal-detail-panel` / `-header` rules and the orphaned `@keyframes cave-slide-in-right` in `cave-chat.css` — `globals.css` holds the live copies (loaded later, wins at equal specificity).

## Deferred to P2 (noted, not in this PR)
- Detail panel keeps a stale item snapshot across SSE reconciles.
- An externally-sourced midnight-timed event still classifies as all-day (data-model ambiguity — needs an explicit all-day flag).
- Full ARIA grid roles + 2D roving; keyboard create on empty time slots.

## Verification
- `tsc --noEmit` clean; `check:tests-wired` (695 files) green; calendar test suites pass (two source-text pins repointed for the `isToday` derivation + one for the `itemDate` sort).
- `pnpm build` green; rendered the live surface (Week + Day) with mocked inbox items: today-column tint and the now-line render correctly, zero console/page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)