### PR TITLE
feat(avatars): move avatar image stores from localStorage to IndexedDB

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -742,6 +742,9 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/cave-familiar-images.test.ts",
+  "src/lib/user-avatar-image.test.ts",
+  "src/lib/familiar-resolve.test.ts",
   "src/lib/gh-review-html.test.ts",
   "src/lib/evals/eval-analytics.test.ts",
   "src/lib/home-digest.test.ts",

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -53,7 +53,7 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
     }
     clearAllFamiliarOverrides(familiar.id);
     clearGlyphOverride(familiar.id);
-    clearFamiliarImage(familiar.id);
+    void clearFamiliarImage(familiar.id);
     void fetch("/api/config", {
       method: "PATCH",
       headers: { "content-type": "application/json" },

--- a/src/components/user-chat-avatar.tsx
+++ b/src/components/user-chat-avatar.tsx
@@ -43,8 +43,8 @@ export function UserChatAvatar({ className, ariaLabel }: Props) {
           if (!file) return;
           setStatus(null);
           void prepareFamiliarImage(file)
-            .then((prepared) => {
-              const res = setUserAvatarImage(prepared);
+            .then(async (prepared) => {
+              const res = await setUserAvatarImage(prepared);
               setStatus(res.ok ? (prepared.downsized ? "Image was downsized for Cave." : "Chat avatar updated.") : res.reason);
             })
             .catch((err) => {

--- a/src/lib/avatar-idb.ts
+++ b/src/lib/avatar-idb.ts
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * Minimal IndexedDB driver for the Cave avatar stores.
+ *
+ * Avatars are base64 data URLs (up to ~2.8MB each) — far too big for
+ * localStorage's ~5MB origin quota, which is shared with every other cave:*
+ * key. IndexedDB's quota is effectively unbounded for this use, so the avatar
+ * stores persist here and keep localStorage free for small state.
+ *
+ * The driver is a three-method seam (`getAll` / `put` / `delete`) so the store
+ * modules stay storage-agnostic and tests can inject a Map-backed fake via
+ * `setAvatarStorageForTests`.
+ */
+
+export type AvatarRecord = { dataUrl: string; mime: string; updatedAt: string };
+
+export type AvatarStore = "familiarImages" | "userAvatar";
+
+export type AvatarStorageDriver = {
+  getAll(store: AvatarStore): Promise<Record<string, AvatarRecord>>;
+  put(store: AvatarStore, key: string, value: AvatarRecord): Promise<void>;
+  delete(store: AvatarStore, key: string): Promise<void>;
+};
+
+const DB_NAME = "cave-avatars";
+const DB_VERSION = 1;
+const STORES: readonly AvatarStore[] = ["familiarImages", "userAvatar"];
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      for (const store of STORES) {
+        if (!db.objectStoreNames.contains(store)) db.createObjectStore(store);
+      }
+    };
+    req.onsuccess = () => {
+      const db = req.result;
+      // Another tab/window upgrading the schema must not deadlock on this
+      // connection — close and let the next call reopen.
+      db.onversionchange = () => {
+        db.close();
+        dbPromise = null;
+      };
+      resolve(db);
+    };
+    req.onerror = () => reject(req.error ?? new Error("IndexedDB open failed"));
+    req.onblocked = () => reject(new Error("IndexedDB open blocked"));
+  });
+  // A failed open must not poison every later call (e.g. a transient lock).
+  dbPromise.catch(() => {
+    dbPromise = null;
+  });
+  return dbPromise;
+}
+
+function requestToPromise<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("IndexedDB request failed"));
+  });
+}
+
+const hasIdb = () => typeof indexedDB !== "undefined";
+
+const idbDriver: AvatarStorageDriver = {
+  async getAll(store) {
+    if (!hasIdb()) return {};
+    try {
+      const db = await openDb();
+      const tx = db.transaction(store, "readonly");
+      const os = tx.objectStore(store);
+      const [keys, values] = await Promise.all([
+        requestToPromise(os.getAllKeys()),
+        requestToPromise(os.getAll()),
+      ]);
+      const map: Record<string, AvatarRecord> = {};
+      keys.forEach((key, i) => {
+        const value = values[i] as AvatarRecord | undefined;
+        if (typeof key === "string" && value && typeof value.dataUrl === "string") {
+          map[key] = value;
+        }
+      });
+      return map;
+    } catch {
+      return {}; // unreadable DB reads as empty; writes will surface real errors
+    }
+  },
+
+  async put(store, key, value) {
+    if (!hasIdb()) throw new Error("IndexedDB unavailable");
+    const db = await openDb();
+    const tx = db.transaction(store, "readwrite");
+    await requestToPromise(tx.objectStore(store).put(value, key));
+  },
+
+  async delete(store, key) {
+    if (!hasIdb()) throw new Error("IndexedDB unavailable");
+    const db = await openDb();
+    const tx = db.transaction(store, "readwrite");
+    await requestToPromise(tx.objectStore(store).delete(key));
+  },
+};
+
+let driver: AvatarStorageDriver = idbDriver;
+
+export function avatarStorage(): AvatarStorageDriver {
+  return driver;
+}
+
+/** Test seam — pass null to restore the real IndexedDB driver. */
+export function setAvatarStorageForTests(next: AvatarStorageDriver | null): void {
+  driver = next ?? idbDriver;
+}

--- a/src/lib/cave-familiar-images.test.ts
+++ b/src/lib/cave-familiar-images.test.ts
@@ -1,25 +1,49 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 
+// Legacy localStorage payload pre-seeded so the import exercises the one-time
+// migration into IndexedDB.
 const storage = new Map();
-// Simulates the browser refusing the write (QuotaExceededError) — the real
-// localStorage quota (~5MB, shared across all cave:* keys) is stricter than
-// the store's own cap, so the store must survive a throwing setItem.
-let denyWrites = false;
+const legacyImage = {
+  dataUrl: "data:image/png;base64," + "L".repeat(500),
+  mime: "image/png",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+storage.set("cave:familiar-images:v1", JSON.stringify({ legacyfam: legacyImage }));
 globalThis.window = {
   localStorage: {
     getItem: (k) => (storage.has(k) ? storage.get(k) : null),
-    setItem: (k, v) => {
-      if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
-      storage.set(k, v);
-    },
+    setItem: (k, v) => storage.set(k, v),
     removeItem: (k) => storage.delete(k),
   },
   addEventListener: () => {},
   removeEventListener: () => {},
 };
 
+// Map-backed fake IndexedDB driver with a write-failure toggle (simulates the
+// browser refusing a write — quota, private mode, etc.).
+const idb = { familiarImages: new Map(), userAvatar: new Map() };
+let denyWrites = false;
+const fakeDriver = {
+  async getAll(store) {
+    return Object.fromEntries(idb[store]);
+  },
+  async put(store, key, value) {
+    if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+    idb[store].set(key, value);
+  },
+  async delete(store, key) {
+    idb[store].delete(key);
+  },
+};
+
+// Inject the fake BEFORE the store module loads — its import-time hydration
+// must already go through the driver seam.
+const { setAvatarStorageForTests } = await import("./avatar-idb.ts");
+setAvatarStorageForTests(fakeDriver);
+
 const mod = await import("./cave-familiar-images.ts");
+await mod.whenFamiliarImagesHydrated();
 
 assert.equal(
   typeof mod.MAX_FAMILIAR_IMAGE_DATAURL_BYTES,
@@ -27,25 +51,36 @@ assert.equal(
   "store should expose the cap so upload UI can downsize before saving",
 );
 
+// Migration: the legacy localStorage image lands in IndexedDB and in the
+// snapshot, and the legacy key is removed (freeing the shared origin quota).
+{
+  const got = mod.readFamiliarImagesSnapshot();
+  assert.ok(got.legacyfam, "legacy image is available after hydration");
+  assert.equal(got.legacyfam.dataUrl, legacyImage.dataUrl);
+  assert.ok(idb.familiarImages.has("legacyfam"), "legacy image persisted to IndexedDB");
+  assert.equal(storage.has("cave:familiar-images:v1"), false, "legacy localStorage key removed after migration");
+}
+
 // Set + read
 {
   const dataUrl = "data:image/png;base64," + "A".repeat(1000);
-  const res = mod.setFamiliarImage("cody", { dataUrl, mime: "image/png" });
+  const res = await mod.setFamiliarImage("cody", { dataUrl, mime: "image/png" });
   assert.equal(res.ok, true);
   const got = mod.readFamiliarImagesSnapshot();
   assert.ok(got.cody);
   assert.equal(got.cody.mime, "image/png");
   assert.equal(got.cody.dataUrl, dataUrl);
   assert.ok(Number.isFinite(Date.parse(got.cody.updatedAt)));
+  assert.ok(idb.familiarImages.has("cody"), "write reached IndexedDB");
 }
 
-// Browser quota stricter than our own cap: the setItem throws, the store
-// reports the friendly storage-full reason (never the raw browser message),
-// and the snapshot stays unchanged — no phantom avatar that vanishes on reload.
+// Refused write (quota/private mode): the store reports the friendly
+// storage-full reason (never the raw browser message), and the snapshot stays
+// unchanged — no phantom avatar that vanishes on reload.
 {
   denyWrites = true;
   const dataUrl = "data:image/png;base64," + "B".repeat(1000);
-  const res = mod.setFamiliarImage("astra", { dataUrl, mime: "image/png" });
+  const res = await mod.setFamiliarImage("astra", { dataUrl, mime: "image/png" });
   assert.equal(res.ok, false);
   assert.match(res.reason, /storage full/i);
   const got = mod.readFamiliarImagesSnapshot();
@@ -56,7 +91,7 @@ assert.equal(
 // Per-image size cap (2MB pre-encode ≈ 2*1024*1024 bytes ≈ ~2.8MB base64)
 {
   const huge = "data:image/png;base64," + "A".repeat(3 * 1024 * 1024);
-  const res = mod.setFamiliarImage("nova", { dataUrl: huge, mime: "image/png" });
+  const res = await mod.setFamiliarImage("nova", { dataUrl: huge, mime: "image/png" });
   assert.equal(res.ok, false);
   assert.match(res.reason, /too large/i);
 }
@@ -64,16 +99,17 @@ assert.equal(
 // Disallowed mime
 {
   const dataUrl = "data:image/gif;base64,AAA";
-  const res = mod.setFamiliarImage("nova", { dataUrl, mime: "image/gif" });
+  const res = await mod.setFamiliarImage("nova", { dataUrl, mime: "image/gif" });
   assert.equal(res.ok, false);
   assert.match(res.reason, /unsupported|format/i);
 }
 
 // Clear
 {
-  mod.clearFamiliarImage("cody");
+  await mod.clearFamiliarImage("cody");
   const got = mod.readFamiliarImagesSnapshot();
   assert.equal(got.cody, undefined);
+  assert.equal(idb.familiarImages.has("cody"), false, "clear reached IndexedDB");
 }
 
 console.log("cave-familiar-images.test.ts: ok");

--- a/src/lib/cave-familiar-images.ts
+++ b/src/lib/cave-familiar-images.ts
@@ -3,21 +3,23 @@
 /**
  * Cave-local per-familiar avatar image store.
  *
- * Images are stored as base64 data URLs in localStorage under
- * `cave:familiar-images:v1`. Each image is capped at 2MB pre-encode and the
- * whole store at ~4MB total. Larger uploads return `{ ok: false, reason }`
- * so the UI can surface a toast and refuse the write.
+ * Images are base64 data URLs persisted in IndexedDB (see avatar-idb.ts) with
+ * an in-memory map as the render source: components read synchronously via
+ * useSyncExternalStore while hydration/writes happen async. Images from the
+ * old localStorage store (`cave:familiar-images:v1`) are migrated to IndexedDB
+ * on first load and the legacy key is removed — those payloads were eating the
+ * ~5MB origin quota shared with every other cave:* key.
+ *
+ * Each image is capped at 2MB pre-encode; oversized/invalid uploads resolve to
+ * `{ ok: false, reason }` so the UI can surface a toast and refuse the write.
  */
 
 import { useSyncExternalStore } from "react";
+import { avatarStorage } from "@/lib/avatar-idb";
 
-const IMAGES_KEY = "cave:familiar-images:v1";
+const LEGACY_IMAGES_KEY = "cave:familiar-images:v1";
+const CHANNEL_NAME = "cave:familiar-images";
 export const MAX_FAMILIAR_IMAGE_DATAURL_BYTES = Math.floor(2 * 1024 * 1024 * 4 / 3) + 100; // ~2.8MB
-// Browsers give the whole origin ~5MB of localStorage (WKWebView in the
-// desktop app), shared with every other cave:* key — so this store's own cap
-// must sit below that or the pre-check passes while the write itself throws.
-// The write is still guarded (writeMap) for when other keys hold the quota.
-const MAX_TOTAL_BYTES = 4 * 1024 * 1024;
 const STORAGE_FULL_REASON = "Cave avatar storage full. Remove an image to free space.";
 const ALLOWED_MIMES = new Set([
   "image/png",
@@ -35,90 +37,118 @@ export type FamiliarImage = {
 type ImageMap = Record<string, FamiliarImage>;
 type SetResult = { ok: true } | { ok: false; reason: string };
 
-let cached: ImageMap | null = null;
+const EMPTY: ImageMap = Object.freeze({});
+
+let cached: ImageMap = EMPTY;
+let hydration: Promise<void> | null = null;
 const listeners = new Set<() => void>();
 
 function notify() { for (const fn of listeners) fn(); }
 
-function readFromStorage(): ImageMap {
-  if (typeof window === "undefined") return {};
+// Cross-window sync (e.g. the Tauri tray quick-chat webview): localStorage
+// `storage` events are gone with the localStorage store, so writes broadcast
+// and other windows re-read IndexedDB.
+let channel: BroadcastChannel | null = null;
+function ensureChannel(): void {
+  if (channel || typeof BroadcastChannel === "undefined") return;
+  channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.onmessage = () => {
+    hydration = null;
+    void ensureHydrated();
+  };
+  // Node's global BroadcastChannel holds the event loop open — unref so test
+  // processes can exit. Browsers have no unref; the optional call is a no-op.
+  (channel as { unref?: () => void }).unref?.();
+}
+function broadcast(): void {
+  ensureChannel();
+  channel?.postMessage("changed");
+}
+
+function readLegacyLocalStorage(): ImageMap | null {
   try {
-    const raw = window.localStorage.getItem(IMAGES_KEY);
-    if (!raw) return {};
+    const raw = window.localStorage.getItem(LEGACY_IMAGES_KEY);
+    if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       return parsed as ImageMap;
     }
-  } catch { /* corrupt — discard */ }
-  return {};
+  } catch { /* corrupt/unreadable — ignore */ }
+  return null;
 }
 
-function getMap(): ImageMap {
-  if (cached === null) cached = readFromStorage();
-  return cached;
-}
+async function hydrate(): Promise<void> {
+  if (typeof window === "undefined") return;
+  ensureChannel();
+  const map = await avatarStorage().getAll("familiarImages");
 
-// Persist first, then commit to memory. A quota-exceeded setItem must not
-// leave the cache claiming an image that storage never accepted — the avatar
-// would render until the next reload, then silently vanish.
-function writeMap(next: ImageMap): boolean {
-  if (typeof window !== "undefined") {
-    try {
-      window.localStorage.setItem(IMAGES_KEY, JSON.stringify(next));
-    } catch {
-      return false; // QuotaExceededError — the browser's cap is stricter than ours
+  // One-time migration from the legacy localStorage store. Entries always
+  // reach the in-memory map (so existing avatars keep rendering even if
+  // IndexedDB is unavailable), but the legacy key is only removed once every
+  // entry actually persisted.
+  const legacy = readLegacyLocalStorage();
+  if (legacy) {
+    let allPersisted = true;
+    for (const [id, image] of Object.entries(legacy)) {
+      if (map[id]) continue; // an IndexedDB copy is newer — it wins
+      map[id] = image;
+      try {
+        await avatarStorage().put("familiarImages", id, image);
+      } catch {
+        allPersisted = false;
+      }
+    }
+    if (allPersisted) {
+      try { window.localStorage.removeItem(LEGACY_IMAGES_KEY); } catch { /* ignore */ }
     }
   }
-  cached = next;
+
+  cached = Object.keys(map).length > 0 ? map : EMPTY;
   notify();
-  return true;
 }
 
-function totalBytes(map: ImageMap): number {
-  let sum = 0;
-  for (const v of Object.values(map)) sum += v.dataUrl.length;
-  return sum;
+function ensureHydrated(): Promise<void> {
+  if (!hydration) hydration = hydrate();
+  return hydration;
 }
 
-export function setFamiliarImage(id: string, image: { dataUrl: string; mime: string }): SetResult {
+if (typeof window !== "undefined") void ensureHydrated();
+
+export async function setFamiliarImage(id: string, image: { dataUrl: string; mime: string }): Promise<SetResult> {
   if (!ALLOWED_MIMES.has(image.mime)) {
     return { ok: false, reason: "Unsupported format. Use PNG, JPEG, WebP, or SVG." };
   }
   if (image.dataUrl.length > MAX_FAMILIAR_IMAGE_DATAURL_BYTES) {
     return { ok: false, reason: "Image too large (max 2MB)." };
   }
-  const curr = getMap();
-  const previousEntry = curr[id];
-  const projected =
-    totalBytes(curr) - (previousEntry?.dataUrl.length ?? 0) + image.dataUrl.length;
-  if (projected > MAX_TOTAL_BYTES) {
+  await ensureHydrated();
+  const entry: FamiliarImage = { dataUrl: image.dataUrl, mime: image.mime, updatedAt: new Date().toISOString() };
+  // Persist first, then commit to memory — a refused write must not leave the
+  // cache claiming an image that storage never accepted.
+  try {
+    await avatarStorage().put("familiarImages", id, entry);
+  } catch {
     return { ok: false, reason: STORAGE_FULL_REASON };
   }
-  const next = {
-    ...curr,
-    [id]: { dataUrl: image.dataUrl, mime: image.mime, updatedAt: new Date().toISOString() },
-  };
-  if (!writeMap(next)) {
-    return { ok: false, reason: STORAGE_FULL_REASON };
-  }
+  cached = { ...cached, [id]: entry };
+  notify();
+  broadcast();
   return { ok: true };
 }
 
-export function clearFamiliarImage(id: string): void {
-  const curr = getMap();
-  if (!(id in curr)) return;
-  const next = { ...curr };
+export async function clearFamiliarImage(id: string): Promise<void> {
+  await ensureHydrated();
+  if (!(id in cached)) return;
+  try {
+    await avatarStorage().delete("familiarImages", id);
+  } catch {
+    return; // keep memory and storage consistent — the image simply stays
+  }
+  const next = { ...cached };
   delete next[id];
-  writeMap(next);
-}
-
-if (typeof window !== "undefined") {
-  window.addEventListener("storage", (e) => {
-    if (e.key === IMAGES_KEY) {
-      cached = null;
-      notify();
-    }
-  });
+  cached = Object.keys(next).length > 0 ? next : EMPTY;
+  notify();
+  broadcast();
 }
 
 function subscribe(fn: () => void): () => void {
@@ -126,13 +156,18 @@ function subscribe(fn: () => void): () => void {
   return () => listeners.delete(fn);
 }
 
-const EMPTY: ImageMap = Object.freeze({});
+const getSnapshot = () => cached;
 const getServerSnapshot = () => EMPTY;
 
 export function useFamiliarImages(): ImageMap {
-  return useSyncExternalStore(subscribe, getMap, getServerSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
 
 export function readFamiliarImagesSnapshot(): ImageMap {
-  return getMap();
+  return cached;
+}
+
+/** Resolves once the store has loaded (and migrated) persisted images. */
+export function whenFamiliarImagesHydrated(): Promise<void> {
+  return ensureHydrated();
 }

--- a/src/lib/familiar-image-upload.ts
+++ b/src/lib/familiar-image-upload.ts
@@ -110,7 +110,7 @@ export function useFamiliarImageUpload(familiarId: string) {
       setToast(null);
       try {
         const prepared = await prepareFamiliarImage(file);
-        const res = setFamiliarImage(familiarId, prepared);
+        const res = await setFamiliarImage(familiarId, prepared);
         if (!res.ok) {
           setToast(res.reason);
           return;
@@ -123,7 +123,7 @@ export function useFamiliarImageUpload(familiarId: string) {
     [familiarId],
   );
 
-  const clear = useCallback(() => clearFamiliarImage(familiarId), [familiarId]);
+  const clear = useCallback(() => void clearFamiliarImage(familiarId), [familiarId]);
 
   return { onFile, clear, toast, setToast };
 }

--- a/src/lib/user-avatar-image.test.ts
+++ b/src/lib/user-avatar-image.test.ts
@@ -1,28 +1,63 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 
+// Legacy localStorage record pre-seeded so the import exercises the one-time
+// migration into IndexedDB.
 const storage = new Map();
-// Simulates the browser refusing the write (QuotaExceededError) — localStorage
-// is shared across all cave:* keys, so the write can fail even under our caps.
-let denyWrites = false;
+const legacyAvatar = {
+  dataUrl: "data:image/png;base64," + "L".repeat(500),
+  mime: "image/png",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+storage.set("cave:user-avatar-image:v1", JSON.stringify(legacyAvatar));
 globalThis.window = {
   localStorage: {
     getItem: (k) => (storage.has(k) ? storage.get(k) : null),
-    setItem: (k, v) => {
-      if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
-      storage.set(k, v);
-    },
+    setItem: (k, v) => storage.set(k, v),
     removeItem: (k) => storage.delete(k),
   },
   addEventListener: () => {},
   removeEventListener: () => {},
 };
 
-const mod = await import("./user-avatar-image.ts");
+// Map-backed fake IndexedDB driver with a write-failure toggle.
+const idb = { familiarImages: new Map(), userAvatar: new Map() };
+let denyWrites = false;
+const fakeDriver = {
+  async getAll(store) {
+    return Object.fromEntries(idb[store]);
+  },
+  async put(store, key, value) {
+    if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+    idb[store].set(key, value);
+  },
+  async delete(store, key) {
+    idb[store].delete(key);
+  },
+};
 
+// Inject the fake BEFORE the store module loads — its import-time hydration
+// must already go through the driver seam.
+const { setAvatarStorageForTests } = await import("./avatar-idb.ts");
+setAvatarStorageForTests(fakeDriver);
+
+const mod = await import("./user-avatar-image.ts");
+await mod.whenUserAvatarHydrated();
+
+// Migration: the legacy record lands in IndexedDB and in the snapshot, and
+// the legacy key is removed.
+{
+  const got = mod.readUserAvatarImageSnapshot();
+  assert.ok(got, "legacy avatar is available after hydration");
+  assert.equal(got.dataUrl, legacyAvatar.dataUrl);
+  assert.ok(idb.userAvatar.has("user"), "legacy avatar persisted to IndexedDB");
+  assert.equal(storage.has("cave:user-avatar-image:v1"), false, "legacy localStorage key removed after migration");
+}
+
+// Set + read
 {
   const dataUrl = "data:image/png;base64," + "A".repeat(1000);
-  const res = mod.setUserAvatarImage({ dataUrl, mime: "image/png" });
+  const res = await mod.setUserAvatarImage({ dataUrl, mime: "image/png" });
   assert.equal(res.ok, true);
   const got = mod.readUserAvatarImageSnapshot();
   assert.equal(got.mime, "image/png");
@@ -30,26 +65,29 @@ const mod = await import("./user-avatar-image.ts");
   assert.ok(Number.isFinite(Date.parse(got.updatedAt)));
 }
 
+// Disallowed mime
 {
-  const res = mod.setUserAvatarImage({ dataUrl: "data:image/gif;base64,AAA", mime: "image/gif" });
+  const res = await mod.setUserAvatarImage({ dataUrl: "data:image/gif;base64,AAA", mime: "image/gif" });
   assert.equal(res.ok, false);
   assert.match(res.reason, /unsupported|format/i);
 }
 
-// Quota-refused write: friendly storage-full reason, snapshot unchanged.
+// Refused write: friendly storage-full reason, snapshot unchanged.
 {
   const before = mod.readUserAvatarImageSnapshot();
   denyWrites = true;
-  const res = mod.setUserAvatarImage({ dataUrl: "data:image/png;base64," + "B".repeat(1000), mime: "image/png" });
+  const res = await mod.setUserAvatarImage({ dataUrl: "data:image/png;base64," + "B".repeat(1000), mime: "image/png" });
   assert.equal(res.ok, false);
   assert.match(res.reason, /storage full/i);
   assert.deepEqual(mod.readUserAvatarImageSnapshot(), before, "a refused write must not land in the cache");
   denyWrites = false;
 }
 
+// Clear
 {
-  mod.clearUserAvatarImage();
+  await mod.clearUserAvatarImage();
   assert.equal(mod.readUserAvatarImageSnapshot(), null);
+  assert.equal(idb.userAvatar.has("user"), false, "clear reached IndexedDB");
 }
 
 console.log("user-avatar-image.test.ts: ok");

--- a/src/lib/user-avatar-image.ts
+++ b/src/lib/user-avatar-image.ts
@@ -6,12 +6,20 @@
  * This intentionally mirrors the familiar avatar store shape, but keeps the
  * human image separate from any familiar id so "You" can have one avatar across
  * regular chat and group chat without polluting familiar state.
+ *
+ * Persisted in IndexedDB (see avatar-idb.ts) with an in-memory snapshot as the
+ * render source; the old localStorage record (`cave:user-avatar-image:v1`) is
+ * migrated over on first load and its key removed.
  */
 
 import { useSyncExternalStore } from "react";
+import { avatarStorage } from "@/lib/avatar-idb";
 import { MAX_FAMILIAR_IMAGE_DATAURL_BYTES } from "./cave-familiar-images.ts";
 
-const USER_AVATAR_KEY = "cave:user-avatar-image:v1";
+const LEGACY_USER_AVATAR_KEY = "cave:user-avatar-image:v1";
+const USER_AVATAR_ID = "user";
+const CHANNEL_NAME = "cave:user-avatar-image";
+const STORAGE_FULL_REASON = "Cave avatar storage full. Remove an image to free space.";
 const ALLOWED_MIMES = new Set([
   "image/png",
   "image/jpeg",
@@ -27,83 +35,120 @@ export type UserAvatarImage = {
 
 type SetResult = { ok: true } | { ok: false; reason: string };
 
-let cached: UserAvatarImage | null | undefined;
+let cached: UserAvatarImage | null = null;
+let hydration: Promise<void> | null = null;
 const listeners = new Set<() => void>();
 
 function notify() {
   for (const fn of listeners) fn();
 }
 
-function readFromStorage(): UserAvatarImage | null {
-  if (typeof window === "undefined") return null;
+// Cross-window sync — writes broadcast and other windows re-read IndexedDB.
+let channel: BroadcastChannel | null = null;
+function ensureChannel(): void {
+  if (channel || typeof BroadcastChannel === "undefined") return;
+  channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.onmessage = () => {
+    hydration = null;
+    void ensureHydrated();
+  };
+  // Node's global BroadcastChannel holds the event loop open — unref so test
+  // processes can exit. Browsers have no unref; the optional call is a no-op.
+  (channel as { unref?: () => void }).unref?.();
+}
+function broadcast(): void {
+  ensureChannel();
+  channel?.postMessage("changed");
+}
+
+function isUserAvatarImage(value: unknown): value is UserAvatarImage {
+  return Boolean(
+    value &&
+      typeof value === "object" &&
+      "dataUrl" in value &&
+      "mime" in value &&
+      typeof (value as UserAvatarImage).dataUrl === "string" &&
+      typeof (value as UserAvatarImage).mime === "string",
+  );
+}
+
+function readLegacyLocalStorage(): UserAvatarImage | null {
   try {
-    const raw = window.localStorage.getItem(USER_AVATAR_KEY);
+    const raw = window.localStorage.getItem(LEGACY_USER_AVATAR_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as unknown;
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      "dataUrl" in parsed &&
-      "mime" in parsed &&
-      typeof parsed.dataUrl === "string" &&
-      typeof parsed.mime === "string"
-    ) {
-      return parsed as UserAvatarImage;
-    }
-  } catch {
-    /* corrupt — discard */
-  }
+    if (isUserAvatarImage(parsed)) return parsed;
+  } catch { /* corrupt/unreadable — ignore */ }
   return null;
 }
 
-function getSnapshot(): UserAvatarImage | null {
-  if (cached === undefined) cached = readFromStorage();
-  return cached;
-}
+async function hydrate(): Promise<void> {
+  if (typeof window === "undefined") return;
+  ensureChannel();
+  const map = await avatarStorage().getAll("userAvatar");
+  let next: UserAvatarImage | null = isUserAvatarImage(map[USER_AVATAR_ID]) ? map[USER_AVATAR_ID] : null;
 
-// Persist first, then commit to memory — a quota-exceeded setItem must not
-// leave the cache claiming an avatar that storage never accepted.
-function writeSnapshot(next: UserAvatarImage | null): boolean {
-  if (typeof window !== "undefined") {
-    if (next) {
+  // One-time migration from the legacy localStorage record. It always reaches
+  // the in-memory snapshot; the legacy key is only removed once it persisted.
+  if (!next) {
+    const legacy = readLegacyLocalStorage();
+    if (legacy) {
+      next = legacy;
       try {
-        window.localStorage.setItem(USER_AVATAR_KEY, JSON.stringify(next));
-      } catch {
-        return false; // QuotaExceededError — localStorage is full
-      }
-    } else {
-      window.localStorage.removeItem(USER_AVATAR_KEY);
+        await avatarStorage().put("userAvatar", USER_AVATAR_ID, legacy);
+        window.localStorage.removeItem(LEGACY_USER_AVATAR_KEY);
+      } catch { /* keep the legacy key; retry next load */ }
     }
+  } else {
+    // IndexedDB copy wins — drop a leftover legacy record so it can't shadow
+    // a future clear.
+    try { window.localStorage.removeItem(LEGACY_USER_AVATAR_KEY); } catch { /* ignore */ }
   }
+
   cached = next;
   notify();
-  return true;
 }
 
-export function setUserAvatarImage(image: { dataUrl: string; mime: string }): SetResult {
+function ensureHydrated(): Promise<void> {
+  if (!hydration) hydration = hydrate();
+  return hydration;
+}
+
+if (typeof window !== "undefined") void ensureHydrated();
+
+export async function setUserAvatarImage(image: { dataUrl: string; mime: string }): Promise<SetResult> {
   if (!ALLOWED_MIMES.has(image.mime)) {
     return { ok: false, reason: "Unsupported format. Use PNG, JPEG, WebP, or SVG." };
   }
   if (image.dataUrl.length > MAX_FAMILIAR_IMAGE_DATAURL_BYTES) {
     return { ok: false, reason: "Image too large (max 2MB)." };
   }
-  if (!writeSnapshot({ ...image, updatedAt: new Date().toISOString() })) {
-    return { ok: false, reason: "Cave avatar storage full. Remove an image to free space." };
+  await ensureHydrated();
+  const entry: UserAvatarImage = { ...image, updatedAt: new Date().toISOString() };
+  // Persist first, then commit to memory — a refused write must not leave the
+  // cache claiming an avatar that storage never accepted.
+  try {
+    await avatarStorage().put("userAvatar", USER_AVATAR_ID, entry);
+  } catch {
+    return { ok: false, reason: STORAGE_FULL_REASON };
   }
+  cached = entry;
+  notify();
+  broadcast();
   return { ok: true };
 }
 
-export function clearUserAvatarImage(): void {
-  writeSnapshot(null);
-}
-
-if (typeof window !== "undefined") {
-  window.addEventListener("storage", (e) => {
-    if (e.key === USER_AVATAR_KEY) {
-      cached = undefined;
-      notify();
-    }
-  });
+export async function clearUserAvatarImage(): Promise<void> {
+  await ensureHydrated();
+  if (!cached) return;
+  try {
+    await avatarStorage().delete("userAvatar", USER_AVATAR_ID);
+  } catch {
+    return; // keep memory and storage consistent
+  }
+  cached = null;
+  notify();
+  broadcast();
 }
 
 function subscribe(fn: () => void): () => void {
@@ -111,6 +156,7 @@ function subscribe(fn: () => void): () => void {
   return () => listeners.delete(fn);
 }
 
+const getSnapshot = () => cached;
 const getServerSnapshot = () => null;
 
 export function useUserAvatarImage(): UserAvatarImage | null {
@@ -118,5 +164,10 @@ export function useUserAvatarImage(): UserAvatarImage | null {
 }
 
 export function readUserAvatarImageSnapshot(): UserAvatarImage | null {
-  return getSnapshot();
+  return cached;
+}
+
+/** Resolves once the store has loaded (and migrated) the persisted avatar. */
+export function whenUserAvatarHydrated(): Promise<void> {
+  return ensureHydrated();
 }


### PR DESCRIPTION
## What

Moves both Cave-local avatar stores — per-familiar images (`cave-familiar-images.ts`) and the chat "You" avatar (`user-avatar-image.ts`) — from localStorage to **IndexedDB**, with a one-time migration.

**Why:** avatar images are base64 data URLs up to ~2.8MB each; two of them could fill localStorage's ~5MB origin quota, which is shared with every other `cave:*` key. #2302 made the failure friendly; this removes the ceiling entirely and hands the localStorage quota back to the rest of the app.

### How
- **`src/lib/avatar-idb.ts` (new):** minimal IndexedDB driver (`cave-avatars` DB, `familiarImages` + `userAvatar` stores) behind a three-method seam (`getAll`/`put`/`delete`) with a test-injection hook. Handles `onversionchange`, non-poisoning open failures, and missing-IDB environments (reads as empty, writes reject).
- **Stores:** in-memory snapshot stays the render source, so all `useSyncExternalStore` consumers are untouched; hydration happens async at module load. Setters are now async (both call sites were already in async flows) and keep the #2302 semantics: persist first, commit to memory only on success, map refused writes to the friendly storage-full reason.
- **Migration:** legacy localStorage records are copied into IndexedDB on first load; the legacy keys are removed only after every entry persisted. Entries always reach the in-memory map so existing avatars keep rendering even if IndexedDB is unavailable.
- **Cross-window sync:** `storage` events → `BroadcastChannel` (unref'd so node test processes can exit — Node's global BroadcastChannel otherwise holds the event loop open).
- The artificial 4MB total cap is dropped (IndexedDB's quota makes it moot); the 2MB per-image cap stays.

### Tests
Both behavioral tests rewritten for the async API with a Map-backed fake driver injected before the store modules load (so import-time hydration goes through the seam): migration (legacy → IDB, key removed), set/read, refused-write (friendly reason + no phantom cache), caps, clear. `familiar-resolve.test.ts` joined ALIAS_LOADER (its module graph now reaches `@/lib/avatar-idb`).

## Verification
- `typecheck` · `check:tests-wired` (696) · `test:app` 520 ✓ · `test:api` 114 ✓ · `test:mobile` 65 ✓ · `pnpm build` ✓ (bundle within budget).
- Live on the built app (Playwright): seeded legacy localStorage keys migrate into `cave-avatars` and are removed; the migrated image renders through FamiliarAvatar's workspace→Cave fallback chain (workspace avatar route blocked to force degradation); avatars survive a reload served from IndexedDB alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)