### PR TITLE
feat(projects): unified project picker — one selection UI + one-step add flow across surfaces

### DIFF
--- a/docs/specs/2026-07-03-unified-project-picker-design.md
+++ b/docs/specs/2026-07-03-unified-project-picker-design.md
@@ -1,0 +1,163 @@
+# Unified project picker — design
+
+Date: 2026-07-03
+Status: approved (autonomous session — decisions recorded here for async review)
+Related: goal "update the method of project selection for a seamless UI/UX"
+
+## Problem
+
+Project selection is fragmented across the app, with four-plus independent
+picker implementations and two dead ends:
+
+1. **Four picker styles, no shared component.** Chat overflow kebab (Popover
+   list), chat empty-state (native `<select>`, hidden entirely for no-project
+   chats), home composer (native `<select>`), comux PROJECTS rail (DnD list),
+   code sidebar (event-dispatch list). Each styles and behaves differently.
+2. **Register ≠ grant.** `ProjectsView`'s "New project" form registers a root
+   (`POST /api/projects`) but never grants it to the active familiar — a
+   freshly created project can still 403 in chat. Only the 403-recovery path
+   (`addChatProject`) does both steps.
+3. **Add-project is reactive.** The main way an unregistered cwd becomes a
+   project is by *failing a send* and clicking the error-strip recovery
+   button. There is no proactive "add a project" affordance in any picker.
+4. **Code surface forgets its project.** `selectedProjectRoot` in comux-view
+   is plain React state; pins and drag order persist to localStorage but the
+   selection itself resets to `projects[0]` on every reload.
+5. **No-project empty chat has no picker.** `ChatEmptyState` hides its select
+   when the resolved project is `NO_PROJECT_ID` (`project &&` guard), so the
+   only way out is the overflow kebab.
+
+## Approaches considered
+
+- **A. Full model unification** — replace the derived-project model
+  (session-bucketed roots in code sidebar/comux/chat sidebar) with registered
+  projects everywhere. Correct long-term, but a multi-PR structural arc with
+  migration questions (unregistered roots with live sessions). Too big for
+  one coherent change; deferred as follow-up.
+- **B. Shared picker + one-step add + persistence (chosen).** Introduce one
+  shared `ProjectPicker` UI and one shared add-project flow (register +
+  grant), wire them into the chat empty state, chat overflow menu, and home
+  composer; persist the code surface's selection. Fixes every pain point
+  above that a user hits day-to-day, in one reviewable PR, without touching
+  the derived-model surfaces' data flow.
+- **C. Minimal patch** — grant-on-create + unhide the empty-state select.
+  Fixes the dead ends but leaves the fragmented UX in place; doesn't meet
+  the "seamless" bar.
+
+## Design (approach B)
+
+### New: `src/components/project-picker.tsx`
+
+Two exports, both reusing existing primitives (`Popover*`,
+`DirectoryPickerModal`, `addChatProject`, `projectNameForRoot`):
+
+- **`useAddProjectFlow({ familiarId, createProject, onAdded })`** — the one
+  shared add-project flow. `beginAddProject()` opens the native folder dialog
+  on Tauri (`shell_pick_directory`) or the web `DirectoryPickerModal`; the
+  picked directory is registered **and granted** via `addChatProject` (name
+  auto-derived from the leaf folder), then `onAdded(project)` fires so the
+  caller can select it. Returns `{ beginAddProject, addProjectModal, adding,
+  addError }`; the caller renders `addProjectModal` once.
+- **`ProjectPicker`** — a popover picker: trigger chip (folder icon + current
+  project name or "No project") opening a Popover with a filter input (shown
+  above 6 projects, mirroring `familiar-switcher`), an optional "No project"
+  row (`allowNoProject`), the project rows (name + root), and an
+  "Add project…" row wired to `useAddProjectFlow`. Props: `projects`,
+  `value` (project id / `NO_PROJECT_ID` / null), `onChange(id)`,
+  `allowNoProject?`, `familiarId?`, `createProject?`, `disabled?`,
+  `ariaLabel`, `className?`. With zero projects the trigger still renders and
+  the popover leads with "Add project…" — the empty state becomes an
+  onboarding affordance instead of a dead end.
+
+CSS: `.cave-project-picker*` block in `src/app/globals.css` (repo convention
+for shell/chat surface styles).
+
+### Chat empty state (`chat-view.tsx` `ChatEmptyState`)
+
+Replace the native `<select>` with `ProjectPicker`. Keep the
+`cave-chat-empty-project` wrapper class and `aria-label="Project for this
+chat"` (both pinned by tests; the aria-label moves to the picker trigger).
+Drop the `project &&` guard — the picker now renders for no-project chats
+("No project" shown as the value) and for zero-project installs (add flow).
+Prop names `projectId`/`onProjectChange` stay (pinned).
+
+### Chat overflow menu (`SessionOverflowMenu`)
+
+The existing Project section (PopoverLabel + "No project" row + project rows)
+stays textually intact — it already matches the picker's semantics and two
+source-text tests pin its structure. Add one "Add project…" `PopoverItem`
+after the project rows, driven by a new optional `onAddProject` prop; the
+mount site passes the shared flow's `beginAddProject`. ChatView renders the
+flow's modal once, next to the existing DirectoryPickerModal-free tree.
+
+### Home composer (`home-composer.tsx`)
+
+Keep the native select (the composer's control bar is a row of native
+selects — local idiom, and its markup is pinned), but make it complete:
+
+- A "No project" option (sentinel `NO_PROJECT_ID` value) so home chats can
+  deliberately start without a project, matching chat semantics.
+  `selectedProject` resolves to null for it; the existing null-safe handoff
+  (`selectedProject?.root ?? null`) already does the right thing.
+- An "Add project…" option (sentinel `__add-project__`). Selecting it does
+  not change the selection; it opens the shared add flow, and on success the
+  new project becomes selected. The select is no longer disabled at zero
+  projects so the flow stays reachable.
+- `aria-label="Choose project"` and `value={selectedProjectId}` unchanged
+  (pinned).
+
+### Projects view (`projects-view.tsx`)
+
+`handleCreate` routes through `addChatProject({ root, familiarId:
+activeFamiliarId, createProject, name })` instead of bare `createProject`,
+so creating a project from the management surface also grants it to the
+familiar whose scope you're looking at. No familiar in scope (operator view)
+→ behaves exactly as before. `handleCreate` stays the form's `onSubmit`
+(pinned).
+
+### Code surface persistence (`comux-view.tsx`, `comux-project-order.ts`)
+
+New `readSelectedProject()` / `writeSelectedProject(root)` pair in
+`comux-project-order.ts` (key `cave:comux:selectedProject`, same
+SSR-safe read/write helpers as order/pins). Comux seeds it in the existing
+after-mount effect (only when nothing is selected yet) and writes it whenever
+`selectedProjectRoot` changes. The existing `?? projects[0]` fallback already
+handles a persisted root that no longer exists.
+
+### Grant semantics
+
+`POST /api/project-grants` rejects agent-relayed approvals and accepts direct
+human clicks; every new grant call here happens in a click handler (add
+flow, create form), same as the existing 403-recovery path — no server
+changes needed.
+
+## Error handling
+
+- Add flow failures (register or grant) surface inline where the flow was
+  started (picker popover / composer row / error strip), never silently.
+- Grant failure after successful registration reports the grant error but
+  keeps the registered project (same behavior as `addChatProject` today).
+
+## Testing
+
+- New `src/components/project-picker.test.ts` — source-text pins for the
+  shared component: trigger aria pattern, "No project" row, "Add project…"
+  flow registering **and** granting via `addChatProject`, filter input.
+- Update `task-chat-cwd.test.ts` empty-state pins (select → picker markup);
+  its overflow-menu pins remain valid by construction.
+- `chat-surface-polish.test.ts`, `home-composer.test.ts`,
+  `projects-view.test.ts`, `chat-view.test.ts` pins are preserved by keeping
+  the pinned classes/aria/props/function names in place.
+- New pins: home composer sentinel options; comux persistence
+  (`cave:comux:selectedProject` read/write wiring); projects-view
+  grant-on-create.
+- All new test files wired into `scripts/run-tests.mjs` (app suite);
+  ALIAS_LOADER only if a test imports `@/` runtime modules.
+
+## Out of scope (follow-ups)
+
+- Merging the derived-project model (code sidebar / chat sidebar buckets)
+  into the registered-project registry (approach A).
+- Quick-chat project selection (deliberately lightweight surface).
+- Connecting the chat sidebar's folder *filter* selection to the active
+  chat's project draft.

--- a/docs/specs/2026-07-03-unified-project-picker-plan.md
+++ b/docs/specs/2026-07-03-unified-project-picker-plan.md
@@ -1,0 +1,771 @@
+# Unified Project Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** One shared project-selection UI and one shared add-project (register **and** grant) flow across chat, home, and the projects management surface; the code surface remembers its selected project.
+
+**Architecture:** A new `src/components/project-picker.tsx` exports `useAddProjectFlow` (folder dialog → `addChatProject` register+grant) and `ProjectPicker` (Popover-based picker with filter, "No project", and "Add project…" rows). Chat empty state swaps its native select for the picker; the chat overflow menu and home composer gain "Add project…" via the shared flow; `projects-view` grants on create; comux persists `selectedProjectRoot` to localStorage.
+
+**Tech Stack:** Next.js/React client components, existing `Popover*` primitives, `DirectoryPickerModal`, `addChatProject`, node:test source-text pin tests, `scripts/run-tests.mjs` suites.
+
+**Spec:** `docs/specs/2026-07-03-unified-project-picker-design.md`
+
+Constraints from pinned tests (do NOT break):
+- `chat-surface-polish.test.ts:47` — class `cave-chat-empty-project` must stay in chat-view.tsx.
+- `task-chat-cwd.test.ts:37,62` — `SessionOverflowMenu` must textually keep `<PopoverLabel>Project</PopoverLabel>` … `onProjectChange(NO_PROJECT_ID);` … `No project` … `projects.map((entry) => (` … `onSelect={() => {\n onProjectChange(entry.id)` inside the function.
+- `task-chat-cwd.test.ts:72,77` — pins the empty-state `<option>` markup + `aria-label="Project for this chat"`: **update these pins** to the new picker markup, keep the aria-label.
+- `home-composer.test.ts:42` — keep `aria-label="Choose project"` and `value={selectedProjectId}`.
+- `projects-view.test.ts:188` — keep `onSubmit={handleCreate}`.
+- `chat-view-polish.test.ts:345,350` — keep header order and `Debug session`/`Delete chat` inside `SessionOverflowMenu`.
+
+---
+
+### Task 1: Comux selected-project persistence
+
+**Files:**
+- Modify: `src/lib/comux-project-order.ts` (append after `writePinnedProjects`)
+- Modify: `src/components/comux-view.tsx:503` state + `:520-523` mount effect
+- Test: `src/components/comux-view-selected-project.test.ts` (new)
+
+- [ ] **Step 1: Write the failing source-text test**
+
+```ts
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const comux = readFileSync(join(here, "comux-view.tsx"), "utf8");
+const order = readFileSync(join(here, "../lib/comux-project-order.ts"), "utf8");
+
+test("selected project persists to localStorage (cave:comux:selectedProject)", () => {
+  assert.match(order, /cave:comux:selectedProject/, "storage key exists");
+  assert.match(order, /export function readSelectedProject\(\)/, "read helper exported");
+  assert.match(order, /export function writeSelectedProject\(/, "write helper exported");
+});
+
+test("comux restores the stored selection after mount and writes on change", () => {
+  assert.match(
+    comux,
+    /readSelectedProject\(\)/,
+    "comux seeds selectedProjectRoot from storage (SSR-safe, after mount)",
+  );
+  assert.match(
+    comux,
+    /setSelectedProjectRoot\(\(current\) => current \?\? storedSelected\)/,
+    "restore never clobbers a selection made before the effect ran",
+  );
+  assert.match(
+    comux,
+    /if \(selectedProjectRoot\) writeSelectedProject\(selectedProjectRoot\);/,
+    "every selection change persists",
+  );
+});
+
+console.log("comux-view-selected-project.test.ts OK");
+```
+
+- [ ] **Step 2: Run to verify it fails** — `node --test --experimental-strip-types src/components/comux-view-selected-project.test.ts` → FAIL (helpers missing).
+
+- [ ] **Step 3: Implement helpers in `comux-project-order.ts`** (append; mirrors the file's read/write idiom):
+
+```ts
+// Last-selected project root — comux state was ephemeral, so a reload bounced
+// the code surface back to projects[0] while pins/order survived. One root,
+// same SSR-safe read-after-mount contract as the order/pins above.
+const SELECTED_KEY = "cave:comux:selectedProject";
+
+export function readSelectedProject(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(SELECTED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeSelectedProject(root: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SELECTED_KEY, root);
+  } catch {
+    /* quota / private mode — non-fatal */
+  }
+}
+```
+
+- [ ] **Step 4: Wire comux-view.** Extend the existing import from `@/lib/comux-project-order` with `readSelectedProject, writeSelectedProject`. In the mount effect (currently `setPinnedProjects(readPinnedProjects()); setProjectOrder(readProjectOrder());`):
+
+```tsx
+  useEffect(() => {
+    setPinnedProjects(readPinnedProjects());
+    setProjectOrder(readProjectOrder());
+    const storedSelected = readSelectedProject();
+    if (storedSelected) setSelectedProjectRoot((current) => current ?? storedSelected);
+  }, []);
+  useEffect(() => {
+    if (selectedProjectRoot) writeSelectedProject(selectedProjectRoot);
+  }, [selectedProjectRoot]);
+```
+
+Check the reconcile effect around comux-view.tsx:654-664 first — if it resets `selectedProjectRoot` when the root is absent from `projects`, leave it; the `?? projects[0]` fallback at :633 already tolerates a stale stored root.
+
+- [ ] **Step 5: Run test to verify it passes.**
+- [ ] **Step 6: Wire into `scripts/run-tests.mjs`** — add `"src/components/comux-view-selected-project.test.ts",` to the `app` array next to the other comux/code entries (inside `SUITES`, NOT the `ALIAS_LOADER` set — this test only reads files). Run `pnpm run check:tests-wired` (or the equivalent script) to confirm.
+- [ ] **Step 7: Commit** — `git commit -S -m "feat(code): remember the selected project across reloads"` (verify `[feat/unified-project-picker <sha>]` in output; push -u immediately).
+
+### Task 2: Shared `ProjectPicker` + `useAddProjectFlow`
+
+**Files:**
+- Create: `src/components/project-picker.tsx`
+- Modify: `src/app/globals.css` (append `.cave-project-picker*` block)
+- Test: `src/components/project-picker.test.ts` (new)
+
+- [ ] **Step 1: Write the failing source-text test**
+
+```ts
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, "project-picker.tsx"), "utf8");
+const css = readFileSync(join(here, "../app/globals.css"), "utf8");
+
+test("add flow registers AND grants in one step via addChatProject", () => {
+  assert.match(src, /export function useAddProjectFlow\(/, "shared flow exported");
+  assert.match(src, /addChatProject\(\{/, "register+grant goes through the tested helper");
+  assert.match(src, /shell_pick_directory/, "native folder dialog on desktop");
+  assert.match(src, /DirectoryPickerModal/, "web fallback directory browser");
+});
+
+test("picker offers No project, the project list, and Add project…", () => {
+  assert.match(src, /export function ProjectPicker\(/, "picker exported");
+  assert.match(src, /onChange\(NO_PROJECT_ID\);/, "explicit No-project row");
+  assert.match(src, /Add project…/, "proactive add affordance");
+  assert.match(src, /aria-label="Filter projects"/, "filter input for long lists");
+  assert.match(src, /aria-haspopup="dialog"/, "trigger announces the popover");
+});
+
+test("picker styles exist", () => {
+  assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");
+  assert.match(css, /\.cave-project-picker__option-root/, "root subtitle styled");
+});
+
+console.log("project-picker.test.ts OK");
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Create `src/components/project-picker.tsx`:**
+
+```tsx
+"use client";
+
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  Popover,
+  PopoverBody,
+  PopoverItem,
+  PopoverLabel,
+  PopoverSeparator,
+} from "@/components/ui/popover";
+import { DirectoryPickerModal } from "@/components/directory-picker-modal";
+import { addChatProject } from "@/lib/chat-add-project";
+import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import type { CaveProject } from "@/lib/cave-projects";
+import { isTauri } from "@/lib/tauri-platform";
+
+/** Sentinel `<option>` value for native selects that embed the add flow. */
+export const ADD_PROJECT_ID = "__add-project__";
+
+export type AddProjectFlow = {
+  /** Open the folder chooser — native dialog on desktop, in-app browser on web. */
+  beginAddProject: () => void;
+  /** Render once near the caller's root: the web-fallback directory browser. */
+  addProjectModal: ReactNode;
+  adding: boolean;
+  addError: string | null;
+};
+
+/**
+ * The one shared add-project flow. Registering a root only makes the access
+ * check resolve to a project id; the familiar still needs a grant — so this
+ * always goes through addChatProject (register + grant, already unit-tested),
+ * the same helper the chat 403-recovery uses. Every entry point is a direct
+ * human click, which is what the grant route requires.
+ */
+export function useAddProjectFlow(args: {
+  familiarId: string | null;
+  createProject: (name: string, root: string) => Promise<CaveProject | null>;
+  projects: CaveProject[];
+  onAdded: (projectId: string) => void;
+}): AddProjectFlow {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const registerRoot = async (dir: string) => {
+    const root = dir.trim();
+    if (!root) return;
+    setAdding(true);
+    setAddError(null);
+    const existing = args.projects.find((project) => project.root === root);
+    const result = await addChatProject({
+      root,
+      familiarId: args.familiarId,
+      createProject: args.createProject,
+      existingProjectId: existing?.id ?? null,
+    });
+    setAdding(false);
+    if (result.ok) args.onAdded(result.projectId);
+    else setAddError(result.error);
+  };
+
+  const beginAddProject = () => {
+    if (isTauri()) {
+      void (async () => {
+        try {
+          const { invoke } = await import("@tauri-apps/api/core");
+          const picked = await invoke<string | null>("shell_pick_directory");
+          if (picked) await registerRoot(picked);
+        } catch {
+          // Native dialog unavailable on this build — fall back to the web browser.
+          setPickerOpen(true);
+        }
+      })();
+      return;
+    }
+    setPickerOpen(true);
+  };
+
+  const addProjectModal = (
+    <DirectoryPickerModal
+      open={pickerOpen}
+      onClose={() => setPickerOpen(false)}
+      onSelect={(dir) => {
+        setPickerOpen(false);
+        void registerRoot(dir);
+      }}
+    />
+  );
+
+  return { beginAddProject, addProjectModal, adding, addError };
+}
+
+/**
+ * Shared project picker: one trigger chip + popover for every surface that
+ * lets the user choose the project a conversation runs in. Replaces the
+ * per-surface mix of native selects and ad-hoc lists so selection reads the
+ * same everywhere, and folds the add flow in so an empty registry is an
+ * onboarding affordance instead of a dead end.
+ */
+export function ProjectPicker({
+  projects,
+  value,
+  onChange,
+  allowNoProject = false,
+  familiarId = null,
+  createProject,
+  disabled = false,
+  ariaLabel,
+  className,
+}: {
+  projects: CaveProject[];
+  /** Project id, NO_PROJECT_ID, or null (null falls back to the first project). */
+  value: string | null;
+  onChange: (id: string) => void;
+  allowNoProject?: boolean;
+  familiarId?: string | null;
+  /** From the caller's useProjects(); presence enables the "Add project…" row. */
+  createProject?: (name: string, root: string) => Promise<CaveProject | null>;
+  disabled?: boolean;
+  ariaLabel: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const selected =
+    value === NO_PROJECT_ID
+      ? null
+      : (value ? projects.find((project) => project.id === value) ?? projects[0] : projects[0]) ??
+        null;
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return projects;
+    return projects.filter(
+      (project) =>
+        project.name.toLowerCase().includes(q) || project.root.toLowerCase().includes(q),
+    );
+  }, [projects, query]);
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
+  const addFlow = useAddProjectFlow({
+    familiarId,
+    createProject: createProject ?? (async () => null),
+    projects,
+    onAdded: onChange,
+  });
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`cave-project-picker__trigger focus-ring${className ? ` ${className}` : ""}`}
+        onClick={() => (open ? close() : setOpen(true))}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        title={selected ? selected.root : "No project"}
+      >
+        <Icon name={selected ? "ph:folder-open" : "ph:folder"} width={14} aria-hidden />
+        <span className="cave-project-picker__trigger-label">
+          {selected ? selected.name : "No project"}
+        </span>
+        <Icon name="ph:caret-up-down-bold" width={10} aria-hidden />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={(next) => (next ? setOpen(true) : close())}
+        anchorRef={triggerRef}
+        placement="bottom-start"
+        minWidth={260}
+        className="cave-project-picker__popover"
+        ariaLabel={ariaLabel}
+      >
+        <PopoverBody>
+          {projects.length > 6 ? (
+            <input
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter projects…"
+              aria-label="Filter projects"
+              className="cave-project-picker__filter focus-ring-inset"
+            />
+          ) : null}
+          <PopoverLabel>Project</PopoverLabel>
+          {allowNoProject ? (
+            <PopoverItem
+              icon={selected ? "ph:folder" : "ph:check"}
+              active={!selected}
+              onSelect={() => {
+                onChange(NO_PROJECT_ID);
+                close();
+              }}
+            >
+              No project
+            </PopoverItem>
+          ) : null}
+          {visible.map((entry) => (
+            <PopoverItem
+              key={entry.id}
+              icon={entry.id === selected?.id ? "ph:check" : "ph:folder"}
+              active={entry.id === selected?.id}
+              onSelect={() => {
+                onChange(entry.id);
+                close();
+              }}
+            >
+              <span className="cave-project-picker__option">
+                <span className="cave-project-picker__option-name">{entry.name}</span>
+                <span className="cave-project-picker__option-root">{entry.root}</span>
+              </span>
+            </PopoverItem>
+          ))}
+          {query.trim() && visible.length === 0 ? (
+            <div className="cave-project-picker__none">No projects match</div>
+          ) : null}
+          {createProject ? (
+            <>
+              <PopoverSeparator />
+              <PopoverItem
+                icon="ph:plus"
+                disabled={addFlow.adding}
+                onSelect={() => {
+                  close();
+                  addFlow.beginAddProject();
+                }}
+              >
+                {addFlow.adding ? "Adding project…" : "Add project…"}
+              </PopoverItem>
+            </>
+          ) : null}
+        </PopoverBody>
+      </Popover>
+      {addFlow.addError ? (
+        <span className="cave-project-picker__error" role="alert">
+          {addFlow.addError}
+        </span>
+      ) : null}
+      {createProject ? addFlow.addProjectModal : null}
+    </>
+  );
+}
+```
+
+- [ ] **Step 4: Append styles to `src/app/globals.css`:**
+
+```css
+/* ---- Shared project picker (chat empty state, and any surface that adopts it) —
+   one trigger-chip + popover treatment for project selection; see
+   docs/specs/2026-07-03-unified-project-picker-design.md ---- */
+.cave-project-picker__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 260px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-2);
+  color: var(--foreground);
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.cave-project-picker__trigger:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: var(--surface-3);
+}
+.cave-project-picker__trigger:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.cave-project-picker__trigger-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cave-project-picker__filter {
+  width: calc(100% - 12px);
+  margin: 4px 6px 6px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface-1);
+  color: var(--foreground);
+  font-size: 12px;
+}
+.cave-project-picker__option {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.cave-project-picker__option-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cave-project-picker__option-root {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10.5px;
+  color: var(--muted-foreground);
+}
+.cave-project-picker__none {
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--muted-foreground);
+}
+.cave-project-picker__error {
+  display: block;
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--danger, #e5484d);
+}
+```
+
+Verify the CSS custom properties used (`--border`, `--surface-2`, `--muted-foreground`, …) against the tokens actually defined in globals.css and substitute the project's real token names.
+
+- [ ] **Step 5: Run the test to verify it passes.** Also `pnpm exec tsc --noEmit -p tsconfig.json` (or the repo's `typecheck` script) for the new file.
+- [ ] **Step 6: Wire `"src/components/project-picker.test.ts",` into `SUITES.app` in `scripts/run-tests.mjs`** (next to `chat-add-project` / chat component tests; NOT in ALIAS_LOADER — it only reads files).
+- [ ] **Step 7: Commit + push** — `git commit -S -m "feat(projects): shared ProjectPicker + one-step add-project flow"`.
+
+### Task 3: Chat — empty state picker, overflow "Add project…"
+
+**Files:**
+- Modify: `src/components/chat-view.tsx` (`ChatEmptyState` ~L833-925, `SessionOverflowMenu` ~L932-1044, mount sites ~L4511-4579)
+- Modify: `src/components/task-chat-cwd.test.ts` (~L72-83 empty-state pins)
+
+- [ ] **Step 1: Update the pins in `task-chat-cwd.test.ts`** (the select-markup pin ~L72 and around): replace the `projects.map((project) => ( <option …` assertion with:
+
+```ts
+  assert.match(
+    src,
+    /<ProjectPicker[\s\S]*?value=\{projectId \?\? null\}[\s\S]*?onChange=\{onProjectChange\}[\s\S]*?allowNoProject/,
+    "empty state renders the shared picker with an explicit No-project choice",
+  );
+```
+
+Keep the `aria-label="Project for this chat"` pin (~L77) — it moves onto the picker trigger via `ariaLabel`. Adjust its regex if it anchored on `<select`. Run the file → expect FAIL (chat-view unchanged yet).
+
+- [ ] **Step 2: Edit `ChatEmptyState`.** Add `createProject` to props; replace the `{onProjectChange && project && (…<select>…)}` block with the shared picker (keeps the pinned `cave-chat-empty-project` class; drops the `project &&` guard so no-project and zero-project states get the affordance):
+
+```tsx
+        {onProjectChange && (
+          <div className="cave-chat-empty-project">
+            <span className="cave-chat-empty-project-head">
+              <Icon name="ph:folder-open" width={14} aria-hidden />
+              <span className="cave-chat-empty-project-label">Project</span>
+              <ProjectPicker
+                projects={projects}
+                value={projectId ?? null}
+                onChange={onProjectChange}
+                allowNoProject
+                familiarId={familiar.id}
+                createProject={createProject}
+                ariaLabel="Project for this chat"
+              />
+            </span>
+            {project ? <span className="cave-chat-empty-project-root">{project.root}</span> : null}
+          </div>
+        )}
+```
+
+Props type additions:
+
+```tsx
+  /** From useProjects() — enables the picker's "Add project…" row. */
+  createProject?: (name: string, root: string) => Promise<CaveProject | null>;
+```
+
+Import `{ ProjectPicker, useAddProjectFlow }` from `@/components/project-picker` at the top of chat-view.tsx.
+
+- [ ] **Step 3: Edit `SessionOverflowMenu`.** Add `onAddProject?: () => void` to props. Restructure the project section so "Add project…" shows even with zero projects, WITHOUT breaking the two pinned regexes (label→No-project→map order stays):
+
+```tsx
+          {projects.length > 0 || onAddProject ? (
+            <>
+              <PopoverLabel>Project</PopoverLabel>
+              {projects.length > 0 ? (
+                <>
+                  <PopoverItem
+                    icon={activeProject ? "ph:folder" : "ph:check"}
+                    active={!activeProject}
+                    onSelect={() => {
+                      onProjectChange(NO_PROJECT_ID);
+                      close();
+                    }}
+                  >
+                    No project
+                  </PopoverItem>
+                  {projects.map((entry) => (
+                    <PopoverItem
+                      key={entry.id}
+                      icon={entry.id === activeProject?.id ? "ph:check" : "ph:folder"}
+                      active={entry.id === activeProject?.id}
+                      onSelect={() => {
+                        onProjectChange(entry.id);
+                        close();
+                      }}
+                    >
+                      {entry.name}
+                    </PopoverItem>
+                  ))}
+                </>
+              ) : null}
+              {onAddProject ? (
+                <PopoverItem
+                  icon="ph:plus"
+                  onSelect={() => {
+                    onAddProject();
+                    close();
+                  }}
+                >
+                  Add project…
+                </PopoverItem>
+              ) : null}
+              <PopoverSeparator />
+            </>
+          ) : null}
+```
+
+- [ ] **Step 4: Instantiate the shared flow in ChatView** (near the `useProjects()` call ~L2262):
+
+```tsx
+  // Shared add-project flow for the overflow menu: register + grant, then make
+  // the new project this chat's next-send selection.
+  const overflowAddProject = useAddProjectFlow({
+    familiarId: familiar?.id ?? null,
+    createProject,
+    projects,
+    onAdded: (projectId) => {
+      setProjectIdDraft(projectId);
+      reloadProjects();
+    },
+  });
+```
+
+Mount-site changes: pass `onAddProject={overflowAddProject.beginAddProject}` to `<SessionOverflowMenu>`, `createProject={createProject}` to `<ChatEmptyState>`, and render `{overflowAddProject.addProjectModal}` adjacent to the overflow-menu mount (inside the same fragment). Keep the pinned `projectId={projectIdDraft}` / `onProjectChange={setProjectIdDraft}` props untouched.
+
+- [ ] **Step 5: Run the chat pin suites:**
+`node --test --experimental-strip-types src/components/task-chat-cwd.test.ts src/components/chat-surface-polish.test.ts src/components/chat-view-polish.test.ts src/components/chat-sidebar-wiring.test.ts` → all PASS. (`chat-view.test.ts` needs the alias loader: run it via `node scripts/run-tests.mjs app` later or with `--import ./scripts/test-alias-register.mjs`.)
+- [ ] **Step 6: Commit + push** — `git commit -S -m "feat(chat): shared project picker in empty state + proactive add-project in overflow"`.
+
+### Task 4: Home composer — No-project + Add-project options
+
+**Files:**
+- Modify: `src/components/home-composer.tsx` (~L197 hook, ~L205-207 selectedProject, ~L224-227 reset effect, ~L1074-1094 select)
+- Modify: `src/components/home-composer.test.ts` (add pins)
+
+- [ ] **Step 1: Add failing pins to `home-composer.test.ts`:**
+
+```ts
+test("project select offers No project and Add project…", () => {
+  assert.match(src, /<option value=\{NO_PROJECT_ID\}>No project<\/option>/, "explicit no-project choice");
+  assert.match(src, /ADD_PROJECT_ID/, "add-project sentinel option");
+  assert.match(src, /beginAddProject\(\)/, "sentinel opens the shared add flow");
+});
+```
+
+(Match the file's existing test/assert idiom; `src` there already reads `./home-composer.tsx`.) Run → FAIL.
+
+- [ ] **Step 2: Implement.** Imports: `NO_PROJECT_ID` from `@/lib/chat-projects`; `ADD_PROJECT_ID, useAddProjectFlow` from `@/components/project-picker`. Destructure `createProject` from the existing `useProjects({ familiarId: … })` call. Add the flow:
+
+```tsx
+  const addProjectFlow = useAddProjectFlow({
+    familiarId: selectedFamiliarId || null,
+    createProject,
+    projects,
+    onAdded: setSelectedProjectId,
+  });
+```
+
+`selectedProject` derivation becomes null-aware (keep the `?? projects[0] ?? null` fallback for ordinary ids):
+
+```tsx
+  const selectedProject =
+    selectedProjectId === NO_PROJECT_ID
+      ? null
+      : projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null;
+```
+
+The reset effect (~L224-227) must treat the sentinel as valid — do not reset `selectedProjectId` when it equals `NO_PROJECT_ID`.
+
+Select block: keep `aria-label="Choose project"` + `value={selectedProjectId}` (pinned); intercept the sentinel; stay enabled at zero projects so the add flow is reachable:
+
+```tsx
+              <select
+                aria-label="Choose project"
+                className="hc-familiar-select"
+                value={selectedProjectId}
+                onChange={(e) => {
+                  const value = e.currentTarget.value;
+                  if (value === ADD_PROJECT_ID) {
+                    addProjectFlow.beginAddProject();
+                    return;
+                  }
+                  setSelectedProjectId(value);
+                }}
+                disabled={sending}
+              >
+                {projects.length === 0 ? (
+                  <option value="">No projects yet</option>
+                ) : (
+                  <>
+                    <option value={NO_PROJECT_ID}>No project</option>
+                    {projects.map((project) => (
+                      <option key={project.id} value={project.id}>
+                        {project.name}
+                      </option>
+                    ))}
+                  </>
+                )}
+                <option value={ADD_PROJECT_ID}>＋ Add project…</option>
+              </select>
+```
+
+Render `{addProjectFlow.addProjectModal}` once near the composer's other modals/overlays.
+
+- [ ] **Step 3: Run `home-composer.test.ts`** → PASS (old pins included).
+- [ ] **Step 4: Commit + push** — `git commit -S -m "feat(home): No-project choice + inline add-project in the composer"`.
+
+### Task 5: Projects view — grant on create
+
+**Files:**
+- Modify: `src/components/projects-view.tsx` (`handleCreate` ~L265-280; import)
+- Modify: `src/components/projects-view.test.ts` (add pin)
+
+- [ ] **Step 1: Add failing pin:**
+
+```ts
+test("creating a project also grants it to the scoped familiar", () => {
+  assert.match(
+    src,
+    /addChatProject\(\{[\s\S]*?familiarId: activeFamiliarId,[\s\S]*?existingProjectId: project\.id/,
+    "register-then-grant goes through the tested helper, keyed to the fresh project",
+  );
+});
+```
+
+Run → FAIL.
+
+- [ ] **Step 2: Implement.** `import { addChatProject } from "@/lib/chat-add-project";` and extend `handleCreate` (name stays — pinned as the form's onSubmit):
+
+```tsx
+  const handleCreate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const name = nameDraft.trim();
+    const root = rootDraft.trim();
+    if (!name || !root) return;
+    setCreating(true);
+    const project = await createProject(name, root);
+    if (project && activeFamiliarId) {
+      // Register alone leaves the project 403ing in chat for this familiar —
+      // grant it here so "New project" is usable the moment it's created.
+      const granted = await addChatProject({
+        root,
+        familiarId: activeFamiliarId,
+        createProject,
+        existingProjectId: project.id,
+      });
+      if (!granted.ok) setSessionError(`Project created, but grant failed: ${granted.error}`);
+    }
+    setCreating(false);
+    if (!project) return;
+    setNameDraft("");
+    setRootDraft("");
+    setShowForm(false);
+    setCreatedProject(project);
+    setExpanded(project.id, true);
+    setQuery("");
+  };
+```
+
+- [ ] **Step 3: Run `projects-view.test.ts`** → PASS.
+- [ ] **Step 4: Commit + push** — `git commit -S -m "fix(projects): grant on create so new projects work in chat immediately"`.
+
+### Task 6: Full verification
+
+- [ ] `node scripts/run-tests.mjs app && node scripts/run-tests.mjs api && node scripts/run-tests.mjs mobile` (or the repo's `pnpm test:app` etc. — match `Frontend build`'s sequence: typecheck → check:tests-wired → test:app/api/mobile → build).
+- [ ] `pnpm build` in the worktree.
+- [ ] Visual sanity via the run-cave-app skill if time permits: chat empty state shows the picker (incl. a no-project chat), overflow menu shows "Add project…", home select lists No project / Add project.
+- [ ] Fix anything found; commit + push each fix signed.
+
+### Task 7: PR
+
+- [ ] `git log origin/feat/unified-project-picker..HEAD --pretty='%H %G?'` — nothing unsigned; branch name verified in every commit output.
+- [ ] `gh pr create --base main --head feat/unified-project-picker` with a body covering the five pain points fixed; wait for ALL SIX required checks (Frontend build, Rust check, CodeQL aggregate, E2E, Cross-environment required, Sidecar runtime required — aggregates report late); `gh pr view --json state` must be MERGED before any cleanup; then `git worktree remove` + `git branch -D`.
+
+## Self-review notes
+
+- Spec coverage: empty-state picker (T3), overflow add (T3), home options (T4), grant-on-create (T5), comux persistence (T1), shared component+flow (T2) — all design sections have tasks; "out of scope" items have none, by design.
+- Types: `useAddProjectFlow` returns `AddProjectFlow`; `ProjectPicker.value: string | null`; `createProject` signature `(name, root) => Promise<CaveProject | null>` matches `use-projects.ts` everywhere it's threaded.
+- Line numbers are anchors, not gospel — main moved (#2301-#2303); re-locate blocks by content before editing.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -277,6 +277,7 @@ export const SUITES = {
     "src/components/comux-view-edit.test.ts",
     "src/components/comux-view-changes.test.ts",
     "src/components/comux-view-search-options.test.ts",
+    "src/components/comux-view-selected-project.test.ts",
     "src/components/code-editor.test.ts",
     "src/components/code-view.test.ts",
     "src/components/chat-prompt-enhance.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -349,6 +349,7 @@ export const SUITES = {
     "src/lib/group-chat.test.ts",
     "src/components/chat-send-routes-links.test.ts",
     "src/components/chat-surface-polish.test.ts",
+    "src/components/project-picker.test.ts",
     "src/components/directory-picker.test.ts",
     "src/components/chat-view.test.ts",
     "src/components/drag-to-split.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10642,3 +10642,75 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .skill-browser { flex-direction: column; }
   .skill-browser__list { flex: 0 0 auto; max-height: 42%; border-right: 0; border-bottom: 1px solid var(--border-hairline); }
 }
+
+/* ---- Shared project picker — one trigger-chip + popover treatment for
+   project selection across surfaces (chat empty state today; see
+   docs/specs/2026-07-03-unified-project-picker-design.md). ---- */
+.cave-project-picker__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 260px;
+  min-height: 26px;
+  padding: 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.cave-project-picker__trigger:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
+}
+.cave-project-picker__trigger:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.cave-project-picker__trigger-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cave-project-picker__filter {
+  width: calc(100% - 12px);
+  margin: 6px 6px 4px;
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+.cave-project-picker__option {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  text-align: left;
+}
+.cave-project-picker__option-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cave-project-picker__option-root {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10.5px;
+  color: var(--text-secondary);
+}
+.cave-project-picker__none {
+  padding: 6px 10px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+.cave-project-picker__error {
+  display: block;
+  margin-top: 4px;
+  font-size: 11.5px;
+  color: var(--color-danger-soft);
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -105,6 +105,7 @@ import {
 } from "@/lib/command-controls";
 import type { CaveProject } from "@/lib/cave-projects";
 import { useProjects } from "@/lib/use-projects";
+import { ProjectPicker, useAddProjectFlow } from "@/components/project-picker";
 import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolVisual } from "@/lib/tool-visual";
 import { toolReadableFields, prettyToolOutput, type ReadableField } from "@/lib/tool-readable";
@@ -836,6 +837,7 @@ function ChatEmptyState({
   projectId,
   onProjectChange,
   projects,
+  createProject,
   fileMentions = false,
 }: {
   familiar: Familiar;
@@ -845,6 +847,8 @@ function ChatEmptyState({
   /** Updates the project used for the next send. */
   onProjectChange?: (value: string) => void;
   projects: CaveProject[];
+  /** From useProjects() — enables the picker's "Add project…" row. */
+  createProject?: (name: string, root: string) => Promise<CaveProject | null>;
   /** True when the chat knows a project root, so `@` opens the file picker (CHAT-D1-04). */
   fileMentions?: boolean;
 }) {
@@ -876,28 +880,27 @@ function ChatEmptyState({
           </div>
         </div>
 
-        {onProjectChange && project && (
-          <label className="cave-chat-empty-project">
+        {onProjectChange && (
+          <div className="cave-chat-empty-project">
             <span className="cave-chat-empty-project-head">
               <Icon name="ph:folder-open" width={14} aria-hidden />
               <span className="cave-chat-empty-project-label">Project</span>
-              <select
-                value={project.id}
-                onChange={(e) => onProjectChange(e.target.value)}
-                aria-label="Project for this chat"
-                className="cave-chat-empty-project-select"
-              >
-                {projects.map((project) => (
-                  <option key={project.id} value={project.id}>
-                    {project.name}
-                  </option>
-                ))}
-              </select>
+              <ProjectPicker
+                projects={projects}
+                value={projectId ?? null}
+                onChange={onProjectChange}
+                allowNoProject
+                familiarId={familiar.id}
+                createProject={createProject}
+                ariaLabel="Project for this chat"
+              />
             </span>
-            <span className="cave-chat-empty-project-root">
-              {project.root}
-            </span>
-          </label>
+            {project ? (
+              <span className="cave-chat-empty-project-root">
+                {project.root}
+              </span>
+            ) : null}
+          </div>
         )}
 
         {onPrompt && (
@@ -933,6 +936,7 @@ function SessionOverflowMenu({
   projects,
   projectId,
   onProjectChange,
+  onAddProject,
   familiar,
   voiceActive,
   onOpenVoice,
@@ -941,6 +945,8 @@ function SessionOverflowMenu({
   projects: CaveProject[];
   projectId: string | null;
   onProjectChange: (value: string) => void;
+  /** Opens the shared add-project flow (register + grant) — proactive, not 403-recovery-only. */
+  onAddProject?: () => void;
   familiar: Familiar;
   voiceActive: boolean;
   onOpenVoice: () => void;
@@ -989,32 +995,47 @@ function SessionOverflowMenu({
             Rename chat
           </PopoverItem>
           <PopoverSeparator />
-          {projects.length > 0 ? (
+          {projects.length > 0 || onAddProject ? (
             <>
               <PopoverLabel>Project</PopoverLabel>
-              <PopoverItem
-                icon={activeProject ? "ph:folder" : "ph:check"}
-                active={!activeProject}
-                onSelect={() => {
-                  onProjectChange(NO_PROJECT_ID);
-                  close();
-                }}
-              >
-                No project
-              </PopoverItem>
-              {projects.map((entry) => (
+              {projects.length > 0 ? (
+                <>
+                  <PopoverItem
+                    icon={activeProject ? "ph:folder" : "ph:check"}
+                    active={!activeProject}
+                    onSelect={() => {
+                      onProjectChange(NO_PROJECT_ID);
+                      close();
+                    }}
+                  >
+                    No project
+                  </PopoverItem>
+                  {projects.map((entry) => (
+                    <PopoverItem
+                      key={entry.id}
+                      icon={entry.id === activeProject?.id ? "ph:check" : "ph:folder"}
+                      active={entry.id === activeProject?.id}
+                      onSelect={() => {
+                        onProjectChange(entry.id);
+                        close();
+                      }}
+                    >
+                      {entry.name}
+                    </PopoverItem>
+                  ))}
+                </>
+              ) : null}
+              {onAddProject ? (
                 <PopoverItem
-                  key={entry.id}
-                  icon={entry.id === activeProject?.id ? "ph:check" : "ph:folder"}
-                  active={entry.id === activeProject?.id}
+                  icon="ph:plus"
                   onSelect={() => {
-                    onProjectChange(entry.id);
+                    onAddProject();
                     close();
                   }}
                 >
-                  {entry.name}
+                  Add project…
                 </PopoverItem>
-              ))}
+              ) : null}
               <PopoverSeparator />
             </>
           ) : null}
@@ -2290,6 +2311,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     (resolvedProjectId === NO_PROJECT_ID || !projectIdForRoot(activeProjectRoot, projects))
       ? ""
       : activeProjectRoot;
+  // Shared add-project flow for the overflow menu: register + grant in one
+  // click, then make the new project this chat's next-send selection.
+  const overflowAddProject = useAddProjectFlow({
+    familiarId: familiar?.id ?? null,
+    createProject,
+    projects,
+    onAdded: (newProjectId) => {
+      setProjectIdDraft(newProjectId);
+      reloadProjects();
+    },
+  });
   useEffect(() => {
     onProjectRootChange?.(activeProjectRoot || null);
   }, [activeProjectRoot, onProjectRootChange]);
@@ -4513,12 +4545,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 projects={projects}
                 projectId={projectIdDraft}
                 onProjectChange={setProjectIdDraft}
+                onAddProject={overflowAddProject.beginAddProject}
                 familiar={familiar}
                 voiceActive={voiceCallOpen}
                 onOpenVoice={() => setVoiceCallOpen(true)}
                 onOpenDebug={openDebug}
               />
             )}
+            {overflowAddProject.addProjectModal}
             {sessionId && familiar.id ? (
               <HeaderReflectButton reflecting={reflecting} onReflect={() => void reflectOnThread()} />
             ) : null}
@@ -4575,6 +4609,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 projectId={projectIdDraft}
                 onProjectChange={setProjectIdDraft}
                 projects={projects}
+                createProject={createProject}
                 fileMentions={Boolean(mentionRoot)}
               />
             )

--- a/src/components/comux-view-selected-project.test.ts
+++ b/src/components/comux-view-selected-project.test.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// The code surface's selected project was ephemeral React state: pins and drag
+// order persisted, but a reload bounced you back to projects[0]. The selection
+// now persists to localStorage (cave:comux:selectedProject) and is restored
+// inside the projects-reconcile effect — a separate mount-restore would lose
+// the race against the async projects fetch, whose empty-list reset wipes the
+// state before the list populates.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const comux = readFileSync(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const order = readFileSync(new URL("../lib/comux-project-order.ts", import.meta.url), "utf8");
+
+// ── Storage helpers live with the other explorer prefs ─────────────────────
+assert.match(order, /cave:comux:selectedProject/, "storage key exists");
+assert.match(order, /export function readSelectedProject\(\)/, "read helper exported");
+assert.match(order, /export function writeSelectedProject\(/, "write helper exported");
+
+// ── Restore happens inside the reconcile effect, not a mount effect ────────
+assert.match(
+  comux,
+  /const stored = current \?\? readSelectedProject\(\) \?\? undefined;/,
+  "reconcile prefers live selection, then the stored root, before projects[0]",
+);
+assert.match(
+  comux,
+  /projects\.some\(\(project\) => project\.root === stored\)/,
+  "a stale stored root falls back instead of selecting a ghost project",
+);
+
+// ── Every selection change persists ─────────────────────────────────────────
+assert.match(
+  comux,
+  /if \(selectedProjectRoot\) writeSelectedProject\(selectedProjectRoot\);/,
+  "selection writes through; the transient empty-list reset does not erase it",
+);
+
+console.log("comux-view-selected-project.test.ts OK");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -60,6 +60,8 @@ import {
   writeProjectOrder,
   readPinnedProjects,
   writePinnedProjects,
+  readSelectedProject,
+  writeSelectedProject,
   toggleProjectPin,
   isProjectPinned,
   orderProjects,
@@ -656,12 +658,19 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       setSelectedProjectRoot(undefined);
       return;
     }
-    setSelectedProjectRoot((current) =>
-      current && projects.some((project) => project.root === current)
-        ? current
-        : projects[0].root,
-    );
+    // Restore happens here rather than in a mount effect: projects arrive
+    // async, and the empty-list reset above would wipe a mount-time restore
+    // before the list ever populated.
+    setSelectedProjectRoot((current) => {
+      const stored = current ?? readSelectedProject() ?? undefined;
+      return stored && projects.some((project) => project.root === stored)
+        ? stored
+        : projects[0].root;
+    });
   }, [projects]);
+  useEffect(() => {
+    if (selectedProjectRoot) writeSelectedProject(selectedProjectRoot);
+  }, [selectedProjectRoot]);
 
   const addSession = useCallback((rootOverride?: string, placement: SessionPlacement = "replace") => {
     const id = uid();

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -45,6 +45,24 @@ assert.match(
 
 assert.match(
   source,
+  /<option value=\{NO_PROJECT_ID\}>No project<\/option>/,
+  "HomeComposer should offer an explicit No-project choice, matching chat semantics",
+);
+
+assert.match(
+  source,
+  /value === ADD_PROJECT_ID[\s\S]{0,120}?beginAddProject\(\);/,
+  "The Add-project option should open the shared register+grant flow instead of changing the selection",
+);
+
+assert.match(
+  source,
+  /selectedProjectId === NO_PROJECT_ID\s*\?\s*null/,
+  "An explicit No-project selection should resolve to a null project (not fall back to projects[0])",
+);
+
+assert.match(
+  source,
   /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},[\s\S]*?\}\)/,
   "HomeComposer should hand the selected project root and initial command controls to chat start",
 );

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -33,6 +33,8 @@ import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
+import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import { ADD_PROJECT_ID, useAddProjectFlow } from "@/components/project-picker";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
@@ -194,8 +196,16 @@ export function HomeComposer({
     [resolvedFamiliars, selectedFamiliarId],
   );
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
-  const { projects } = useProjects({ familiarId: selectedFamiliarId || null });
+  const { projects, createProject } = useProjects({ familiarId: selectedFamiliarId || null });
   const [selectedProjectId, setSelectedProjectId] = useState("");
+  // Shared register+grant flow behind the select's "Add project…" option —
+  // the composer no longer dead-ends when the wanted root isn't registered.
+  const addProjectFlow = useAddProjectFlow({
+    familiarId: selectedFamiliarId || null,
+    createProject,
+    projects,
+    onAdded: setSelectedProjectId,
+  });
   const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
     COMMAND_CONTROL_DEFAULTS.thinkingEffort,
   );
@@ -203,7 +213,10 @@ export function HomeComposer({
     COMMAND_CONTROL_DEFAULTS.responseSpeed,
   );
   const selectedProject = useMemo(
-    () => projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null,
+    () =>
+      selectedProjectId === NO_PROJECT_ID
+        ? null
+        : projects.find((project) => project.id === selectedProjectId) ?? projects[0] ?? null,
     [projects, selectedProjectId],
   );
   const selectedRuntime =
@@ -222,6 +235,7 @@ export function HomeComposer({
   const selectedRuntimeModelValue = runtimeModelValue(selectedRuntime, selectedModelId);
 
   useEffect(() => {
+    if (selectedProjectId === NO_PROJECT_ID) return; // an explicit No-project choice is valid
     if (selectedProjectId && projects.some((project) => project.id === selectedProjectId)) return;
     setSelectedProjectId(projects[0]?.id ?? "");
   }, [projects, selectedProjectId]);
@@ -1077,21 +1091,35 @@ export function HomeComposer({
                 aria-label="Choose project"
                 className="hc-familiar-select"
                 value={selectedProjectId}
-                onChange={(e) => setSelectedProjectId(e.currentTarget.value)}
-                disabled={projects.length === 0 || sending}
+                onChange={(e) => {
+                  const value = e.currentTarget.value;
+                  // The add row is an action, not a selection — keep the
+                  // current value and open the shared register+grant flow.
+                  if (value === ADD_PROJECT_ID) {
+                    addProjectFlow.beginAddProject();
+                    return;
+                  }
+                  setSelectedProjectId(value);
+                }}
+                disabled={sending}
               >
                 {projects.length === 0 ? (
-                  <option value="">No projects</option>
+                  <option value="">No projects yet</option>
                 ) : (
-                  projects.map((project) => (
-                    <option key={project.id} value={project.id}>
-                      {project.name}
-                    </option>
-                  ))
+                  <>
+                    <option value={NO_PROJECT_ID}>No project</option>
+                    {projects.map((project) => (
+                      <option key={project.id} value={project.id}>
+                        {project.name}
+                      </option>
+                    ))}
+                  </>
                 )}
+                <option value={ADD_PROJECT_ID}>＋ Add project…</option>
               </select>
               <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
             </label>
+            {addProjectFlow.addProjectModal}
           </div>
 
           <div className="hc-control-group hc-control-group--run">

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+// Project selection used to be four unrelated widgets (chat overflow popover,
+// chat empty-state <select>, home-composer <select>, comux rail), and the only
+// way to register a new root was to fail a send and click the 403 recovery.
+// ProjectPicker is the one shared picker, and useAddProjectFlow the one shared
+// add flow — folder dialog → addChatProject, which registers AND grants, so a
+// freshly added project is immediately usable instead of 403ing in chat.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./project-picker.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── One shared add flow: register + grant in a single human-initiated step ──
+assert.match(src, /export function useAddProjectFlow\(/, "shared flow exported");
+assert.match(src, /addChatProject\(\{/, "register+grant goes through the tested helper");
+assert.match(src, /shell_pick_directory/, "native folder dialog on desktop builds");
+assert.match(src, /DirectoryPickerModal/, "web fallback directory browser");
+
+// ── One shared picker: No project, project list, proactive Add project ──────
+assert.match(src, /export function ProjectPicker\(/, "picker exported");
+assert.match(src, /onChange\(NO_PROJECT_ID\);/, "explicit No-project row");
+assert.match(src, /Add project…/, "proactive add affordance (not 403-recovery-only)");
+assert.match(src, /aria-label="Filter projects"/, "filter input for long lists");
+assert.match(src, /aria-haspopup="dialog"/, "trigger announces the popover");
+assert.match(src, /role="alert"/, "add-flow failures surface inline, not silently");
+
+// ── Sentinel for native selects that embed the same flow (home composer) ────
+assert.match(src, /export const ADD_PROJECT_ID = "__add-project__";/, "select sentinel exported");
+
+// ── Styled ──────────────────────────────────────────────────────────────────
+assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");
+assert.match(css, /\.cave-project-picker__option-root/, "root subtitle styled");
+
+console.log("project-picker.test.ts OK");

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  Popover,
+  PopoverBody,
+  PopoverItem,
+  PopoverLabel,
+  PopoverSeparator,
+} from "@/components/ui/popover";
+import { DirectoryPickerModal } from "@/components/directory-picker-modal";
+import { addChatProject } from "@/lib/chat-add-project";
+import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import type { CaveProject } from "@/lib/cave-projects";
+import { isTauri } from "@/lib/tauri-platform";
+
+/** Sentinel `<option>` value for native selects that embed the add flow. */
+export const ADD_PROJECT_ID = "__add-project__";
+
+export type AddProjectFlow = {
+  /** Open the folder chooser — native dialog on desktop, in-app browser on web. */
+  beginAddProject: () => void;
+  /** Render once near the caller's root: the web-fallback directory browser. */
+  addProjectModal: ReactNode;
+  adding: boolean;
+  addError: string | null;
+};
+
+/**
+ * The one shared add-project flow. Registering a root only makes the access
+ * check resolve to a project id; the familiar still needs a grant — so this
+ * always goes through addChatProject (register + grant, already unit-tested),
+ * the same helper the chat 403-recovery uses. Every entry point is a direct
+ * human click, which is what the grant route requires.
+ */
+export function useAddProjectFlow(args: {
+  familiarId: string | null;
+  createProject: (name: string, root: string) => Promise<CaveProject | null>;
+  projects: CaveProject[];
+  onAdded: (projectId: string) => void;
+}): AddProjectFlow {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+
+  const registerRoot = async (dir: string) => {
+    const root = dir.trim();
+    if (!root) return;
+    setAdding(true);
+    setAddError(null);
+    const existing = args.projects.find((project) => project.root === root);
+    const result = await addChatProject({
+      root,
+      familiarId: args.familiarId,
+      createProject: args.createProject,
+      existingProjectId: existing?.id ?? null,
+    });
+    setAdding(false);
+    if (result.ok) args.onAdded(result.projectId);
+    else setAddError(result.error);
+  };
+
+  const beginAddProject = () => {
+    if (isTauri()) {
+      void (async () => {
+        try {
+          const { invoke } = await import("@tauri-apps/api/core");
+          const picked = await invoke<string | null>("shell_pick_directory");
+          if (picked) await registerRoot(picked);
+        } catch {
+          // Native dialog unavailable on this build — fall back to the web browser.
+          setPickerOpen(true);
+        }
+      })();
+      return;
+    }
+    setPickerOpen(true);
+  };
+
+  const addProjectModal = (
+    <DirectoryPickerModal
+      open={pickerOpen}
+      onClose={() => setPickerOpen(false)}
+      onSelect={(dir) => {
+        setPickerOpen(false);
+        void registerRoot(dir);
+      }}
+    />
+  );
+
+  return { beginAddProject, addProjectModal, adding, addError };
+}
+
+/**
+ * Shared project picker: one trigger chip + popover for every surface that
+ * lets the user choose the project a conversation runs in. Replaces the
+ * per-surface mix of native selects and ad-hoc lists so selection reads the
+ * same everywhere, and folds the add flow in so an empty registry is an
+ * onboarding affordance instead of a dead end.
+ */
+export function ProjectPicker({
+  projects,
+  value,
+  onChange,
+  allowNoProject = false,
+  familiarId = null,
+  createProject,
+  disabled = false,
+  ariaLabel,
+  className,
+}: {
+  projects: CaveProject[];
+  /** Project id, NO_PROJECT_ID, or null (null falls back to the first project). */
+  value: string | null;
+  onChange: (id: string) => void;
+  allowNoProject?: boolean;
+  familiarId?: string | null;
+  /** From the caller's useProjects(); presence enables the "Add project…" row. */
+  createProject?: (name: string, root: string) => Promise<CaveProject | null>;
+  disabled?: boolean;
+  ariaLabel: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const selected =
+    value === NO_PROJECT_ID
+      ? null
+      : (value ? projects.find((project) => project.id === value) ?? projects[0] : projects[0]) ??
+        null;
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return projects;
+    return projects.filter(
+      (project) =>
+        project.name.toLowerCase().includes(q) || project.root.toLowerCase().includes(q),
+    );
+  }, [projects, query]);
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+  };
+
+  const addFlow = useAddProjectFlow({
+    familiarId,
+    createProject: createProject ?? (async () => null),
+    projects,
+    onAdded: onChange,
+  });
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`cave-project-picker__trigger focus-ring${className ? ` ${className}` : ""}`}
+        onClick={() => (open ? close() : setOpen(true))}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        disabled={disabled}
+        title={selected ? selected.root : "No project"}
+      >
+        <Icon name={selected ? "ph:folder-open" : "ph:folder"} width={14} aria-hidden />
+        <span className="cave-project-picker__trigger-label">
+          {selected ? selected.name : "No project"}
+        </span>
+        <Icon name="ph:caret-up-down-bold" width={10} aria-hidden />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={(next) => (next ? setOpen(true) : close())}
+        anchorRef={triggerRef}
+        placement="bottom-start"
+        minWidth={260}
+        className="cave-project-picker__popover"
+        ariaLabel={ariaLabel}
+      >
+        <PopoverBody>
+          {projects.length > 6 ? (
+            <input
+              type="text"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter projects…"
+              aria-label="Filter projects"
+              className="cave-project-picker__filter focus-ring-inset"
+            />
+          ) : null}
+          <PopoverLabel>Project</PopoverLabel>
+          {allowNoProject ? (
+            <PopoverItem
+              icon={selected ? "ph:folder" : "ph:check"}
+              active={!selected}
+              onSelect={() => {
+                onChange(NO_PROJECT_ID);
+                close();
+              }}
+            >
+              No project
+            </PopoverItem>
+          ) : null}
+          {visible.map((entry) => (
+            <PopoverItem
+              key={entry.id}
+              icon={entry.id === selected?.id ? "ph:check" : "ph:folder"}
+              active={entry.id === selected?.id}
+              onSelect={() => {
+                onChange(entry.id);
+                close();
+              }}
+            >
+              <span className="cave-project-picker__option">
+                <span className="cave-project-picker__option-name">{entry.name}</span>
+                <span className="cave-project-picker__option-root">{entry.root}</span>
+              </span>
+            </PopoverItem>
+          ))}
+          {query.trim() && visible.length === 0 ? (
+            <div className="cave-project-picker__none">No projects match</div>
+          ) : null}
+          {createProject ? (
+            <>
+              <PopoverSeparator />
+              <PopoverItem
+                icon="ph:plus"
+                disabled={addFlow.adding}
+                onSelect={() => {
+                  close();
+                  addFlow.beginAddProject();
+                }}
+              >
+                {addFlow.adding ? "Adding project…" : "Add project…"}
+              </PopoverItem>
+            </>
+          ) : null}
+        </PopoverBody>
+      </Popover>
+      {addFlow.addError ? (
+        <span className="cave-project-picker__error" role="alert">
+          {addFlow.addError}
+        </span>
+      ) : null}
+      {createProject ? addFlow.addProjectModal : null}
+    </>
+  );
+}

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -22,6 +22,11 @@ const globalsCss = readFileSync(new URL("../app/globals.css", import.meta.url), 
 assert.match(projectsView, /export function ProjectsView/, "ProjectsView should export the workspace surface");
 assert.match(projectsView, /useProjects\(\{ familiarId: activeFamiliarId \}\)/, "ProjectsView should scope the live projects hook to the active familiar");
 assert.match(projectsView, /createProject\(name, root\)/, "ProjectsView should create projects through the hook");
+assert.match(
+  projectsView,
+  /addChatProject\(\{[\s\S]{0,160}?familiarId: activeFamiliarId,[\s\S]{0,160}?existingProjectId: project\.id/,
+  "Creating a project should also grant it to the scoped familiar — register alone left it 403ing in chat",
+);
 assert.match(projectsView, /const rootInputRef = useRef<HTMLInputElement>\(null\)/, "new-project flow keeps a root input ref for quick focus");
 assert.match(projectsView, /function openCreateProjectForm/, "ProjectsView should centralize opening the quick-create form");
 assert.match(projectsView, /rootInputRef\.current\?\.focus\(\)/, "quick-create can focus the path field directly");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -6,6 +6,7 @@ import { Icon } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { normalizeProjectRoot, type CaveProject } from "@/lib/cave-projects-types";
+import { addChatProject } from "@/lib/chat-add-project";
 import type { SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { stripTaskPrefix } from "@/lib/projects/session-glyph";
@@ -269,6 +270,17 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     if (!name || !root) return;
     setCreating(true);
     const project = await createProject(name, root);
+    if (project && activeFamiliarId) {
+      // Register alone leaves the project 403ing in chat for this familiar —
+      // grant it here so "New project" is usable the moment it's created.
+      const granted = await addChatProject({
+        root,
+        familiarId: activeFamiliarId,
+        createProject,
+        existingProjectId: project.id,
+      });
+      if (!granted.ok) setSessionError(`Project created, but grant failed: ${granted.error}`);
+    }
     setCreating(false);
     if (!project) return;
     setNameDraft("");

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -69,12 +69,12 @@ assert.match(
 );
 assert.match(
   chatView,
-  /projects\.map\(\(project\) => \([\s\S]*?<option key=\{project\.id\} value=\{project\.id\}>[\s\S]*?\{project\.name\}/,
-  "Empty state renders the live project list",
+  /<ProjectPicker[\s\S]*?value=\{projectId \?\? null\}[\s\S]*?onChange=\{onProjectChange\}[\s\S]*?allowNoProject/,
+  "Empty state renders the shared picker with an explicit No-project choice (a no-project chat is no longer a picker-less dead end)",
 );
 assert.match(
   chatView,
-  /aria-label="Project for this chat"/,
+  /ariaLabel="Project for this chat"/,
   "Empty state exposes a labeled project selector",
 );
 assert.doesNotMatch(

--- a/src/lib/comux-project-order.ts
+++ b/src/lib/comux-project-order.ts
@@ -42,6 +42,29 @@ export function writePinnedProjects(pinned: readonly string[]): void {
   writeRoots(PINNED_KEY, pinned);
 }
 
+// Last-selected project root. Pins and drag order survived reloads but the
+// selection itself didn't, so the code surface always reopened on projects[0].
+// Same SSR-safe read-after-mount contract as the order/pins above.
+const SELECTED_KEY = "cave:comux:selectedProject";
+
+export function readSelectedProject(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(SELECTED_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeSelectedProject(root: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(SELECTED_KEY, root);
+  } catch {
+    /* quota / private mode — non-fatal */
+  }
+}
+
 export function isProjectPinned(pinned: readonly string[], root: string): boolean {
   return pinned.includes(root);
 }


### PR DESCRIPTION
## Why

Project selection was fragmented and full of dead ends (design doc: `docs/specs/2026-07-03-unified-project-picker-design.md`):

1. **Four+ picker styles, no shared component** — chat overflow popover, chat empty-state native `<select>`, home composer native `<select>`, comux rail.
2. **Register ≠ grant** — `ProjectsView`'s "New project" registered a root but never granted it, so a freshly created project still 403'd in chat.
3. **Add-project was reactive** — the main way to register a cwd was to *fail a send* and click the 403-recovery button.
4. **Code surface forgot its project** — `selectedProjectRoot` reset to `projects[0]` on every reload (pins/order persisted, selection didn't).
5. **No-project empty chat had no picker at all** (`project &&` guard hid the select).

## What

- **New `src/components/project-picker.tsx`** — `ProjectPicker` (trigger chip + popover: filter input >6 projects, "No project" row, name+root rows, "Add project…" row) and `useAddProjectFlow` (native folder dialog on Tauri / `DirectoryPickerModal` on web → `addChatProject`, which registers **and** grants in one human click).
- **Chat empty state** swaps the native select for the shared picker; renders for no-project and zero-project chats too (add flow becomes onboarding).
- **Chat overflow menu** gains a proactive "Add project…" item wired to the shared flow; new project becomes the next-send selection.
- **Home composer** select gains "No project" (matching chat semantics) and "＋ Add project…" options; stays enabled at zero projects.
- **Projects view** grants on create (`addChatProject` with `existingProjectId`), surfacing a grant failure without losing the created project.
- **Comux** persists the selected project (`cave:comux:selectedProject`), restored inside the projects-reconcile effect (a mount-restore would lose the race against the async fetch's empty-list reset).

## Testing

- New source-text suites: `project-picker.test.ts`, `comux-view-selected-project.test.ts`; new pins in `home-composer.test.ts` / `projects-view.test.ts`; `task-chat-cwd.test.ts` empty-state pins updated to the picker markup (overflow-menu pins unchanged by construction).
- Full `test:app` (522 files) / `test:api` (114) / `test:mobile` (65) green; typecheck + `check:tests-wired` + `pnpm build` green (bundle within budget).
- Verified in a real browser (prod server + Playwright): populated picker lists all 14 registered projects with filter + checkmark; demo/empty registry shows the actionable "Add project…" empty state; home select shows the new options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)