### PR TITLE
fix(chat): a task-linked chat opens in the task's project, not the first project

### DIFF
--- a/src/app/api/board/[id]/chat/route.ts
+++ b/src/app/api/board/[id]/chat/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { bindingFor, loadConfig, recordSessionFamiliar, setSessionTitle } from "@/lib/cave-config";
 import { loadBoard, updateCard } from "@/lib/cave-board";
+import { loadProjects, projectById } from "@/lib/cave-projects";
 import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
 import { buildInitialTaskChatPrompt } from "@/lib/task-chat-context";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
@@ -60,8 +61,21 @@ export async function POST(
   }
 
   // The UI sends the root for card.projectId when present; prefer that explicit
-  // project scope over any older cwd persisted on the card.
-  const projectRoot = normalizeProjectRoot(body.projectRoot ?? card.cwd ?? process.cwd());
+  // project scope, then the card's own project association, then its cwd.
+  // NEVER fall back to process.cwd(): that roots the task chat in the app's
+  // own checkout, records the wrong project_root on the session, and the chat
+  // picker then displays the wrong project for the task.
+  const cardProjectRoot = card.projectId
+    ? (projectById(card.projectId, await loadProjects())?.root ?? null)
+    : null;
+  const rawProjectRoot = body.projectRoot ?? cardProjectRoot ?? card.cwd;
+  if (!rawProjectRoot) {
+    return NextResponse.json(
+      { ok: false, error: "assign a project to this task before starting chat" },
+      { status: 409 },
+    );
+  }
+  const projectRoot = normalizeProjectRoot(rawProjectRoot);
   if (!projectRoot) {
     return NextResponse.json({ ok: false, error: "invalid project root" }, { status: 400 });
   }

--- a/src/app/api/board/[id]/chat/route.ts
+++ b/src/app/api/board/[id]/chat/route.ts
@@ -62,9 +62,9 @@ export async function POST(
 
   // The UI sends the root for card.projectId when present; prefer that explicit
   // project scope, then the card's own project association, then its cwd.
-  // NEVER fall back to process.cwd(): that roots the task chat in the app's
-  // own checkout, records the wrong project_root on the session, and the chat
-  // picker then displays the wrong project for the task.
+  // NEVER fall back to the app's own working directory: that roots the task
+  // chat in the coven-cave checkout, records the wrong project_root on the
+  // session, and the chat picker then displays the wrong project for the task.
   const cardProjectRoot = card.projectId
     ? (projectById(card.projectId, await loadProjects())?.root ?? null)
     : null;

--- a/src/components/board-chat-link.test.ts
+++ b/src/components/board-chat-link.test.ts
@@ -49,8 +49,13 @@ assert.match(
 );
 assert.match(
   route,
-  /normalizeProjectRoot\(body\.projectRoot \?\? card\.cwd \?\? process\.cwd\(\)\)/,
-  "Board chat endpoint should prefer the explicitly assigned project root over stale card cwd",
+  /normalizeProjectRoot\(rawProjectRoot\)/,
+  "Board chat endpoint normalizes the resolved project root",
+);
+assert.match(
+  route,
+  /body\.projectRoot \?\? cardProjectRoot \?\? card\.cwd/,
+  "Board chat endpoint prefers the explicitly assigned root, then the card's project, then stale card cwd — never the app's own working directory",
 );
 assert.match(
   route,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1851,6 +1851,9 @@ function LinkedContextRow({
       lifecycle: card.lifecycle,
       labels: card.labels,
       cwd: card.cwd,
+      // Carrying the card's project re-scopes the picker the moment a task is
+      // linked — the chat belongs in the task's project from then on.
+      projectId: card.projectId ?? null,
       notes: card.notes.trim() || null,
     };
     onLinkedContextChange?.((prev) => {

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2265,11 +2265,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // A session whose recorded cwd maps to no registered project resolves to
   // NO_PROJECT_ID here — never to the first project, whose root would re-root
   // the next turn's cwd and fork the harness session (`--continue` misses).
+  // A linked task's project (card projectId/cwd) outranks the recorded cwd: a
+  // chat tied to a task opens in — and runs in — the task's project.
   const projectSelection = resolveChatProjectSelection({
     draftId: projectIdDraft,
     hasSession: Boolean(session),
     sessionProjectRoot: session?.project_root,
     fallbackProjectRoot: projectRoot,
+    taskProjectId: linkedContext?.task?.projectId,
+    taskCwd: linkedContext?.task?.cwd,
     projects,
   });
   const resolvedProjectId = projectSelection.projectId;
@@ -4292,15 +4296,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // delete confirm resets itself — HeaderDeleteButton is keyed on sessionId.)
   useEffect(() => {
     setProjectIdDraft((prev) => {
-      // Mirrors resolveChatProjectSelection: a registered project mapped from
-      // the session/opener root, then NO_PROJECT_ID for an existing session in
-      // an unregistered cwd, then the first project only for brand-new chats.
+      // Mirrors resolveChatProjectSelection: the linked task's project first
+      // (a task chat belongs in its task's project), then a registered project
+      // mapped from the session/opener root, then NO_PROJECT_ID for an
+      // existing session in an unregistered cwd, then the first project only
+      // for brand-new chats. linkedContext loads async with the conversation,
+      // so its deps re-seed the draft once the task arrives.
       const resolved =
         resolveChatProjectSelection({
           draftId: null,
           hasSession: Boolean(session),
           sessionProjectRoot: session?.project_root,
           fallbackProjectRoot: projectRoot,
+          taskProjectId: linkedContext?.task?.projectId,
+          taskCwd: linkedContext?.task?.cwd,
           projects,
         }).projectId ??
         firstProject?.id ??
@@ -4310,7 +4319,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     });
     setMentionedFiles([]);
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, session?.project_root, projectRoot, firstProject?.id]);
+  }, [sessionId, session?.project_root, projectRoot, firstProject?.id, linkedContext?.task?.projectId, linkedContext?.task?.cwd]);
 
   // Re-read the per-session dismiss flag whenever the active chat changes, so
   // dismissing one chat doesn't silently hide the nudge on a different chat.

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -21,8 +21,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
-  "ChatView resolves the selected project through resolveChatProjectSelection (sessions in unregistered cwds are No project — behaviorally pinned in chat-projects.test.ts)",
+  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
+  "ChatView resolves the selected project through resolveChatProjectSelection, feeding the linked task's project (sessions in unregistered cwds are No project — behaviorally pinned in chat-projects.test.ts)",
 );
 // REGRESSION (2026-07-02): a session in an unregistered cwd must NOT default
 // the picker to the first project — sending that root re-roots the next
@@ -87,8 +87,26 @@ assert.doesNotMatch(
 
 assert.match(
   taskChatRoute,
-  /body\.projectRoot \?\? card\.cwd \?\? process\.cwd\(\)/,
-  "Task chat sessions start in the assigned project root when one is supplied",
+  /body\.projectRoot \?\? cardProjectRoot \?\? card\.cwd/,
+  "Task chat sessions start in the assigned project root, then the card's own project, then its cwd",
+);
+// REGRESSION (2026-07-03): the route must never root a task chat in the app's
+// own process.cwd() — that records coven-cave as the session's project_root
+// and the chat picker then shows the wrong project for the task.
+assert.doesNotMatch(
+  taskChatRoute,
+  /process\.cwd\(\)/,
+  "The process.cwd() fallback for task-chat roots must stay gone",
+);
+assert.match(
+  taskChatRoute,
+  /projectById\(card\.projectId, await loadProjects\(\)\)/,
+  "A card's stable projectId resolves server-side when the UI didn't send a root",
+);
+assert.match(
+  taskChatRoute,
+  /assign a project to this task before starting chat/,
+  "A projectless task chat start is refused instead of silently mis-rooted",
 );
 assert.match(
   taskChatRoute,
@@ -149,6 +167,31 @@ assert.doesNotMatch(
   boardView,
   /TaskChatCwdPrompt|setCwdPromptCardId|aria-label="Select a project for this task chat"/,
   "Task chat project selection should live in the task CWD field, not a follow-up dialog",
+);
+
+// ── Chat side: the linked task's project drives the picker (2026-07-03) ──────
+// A chat tied to a board card must open in the card's project — not the first
+// registered project, and not whatever cwd the session happened to be recorded
+// in (a mis-rooted task chat displayed "Coven Cave" for a task belonging to a
+// different project).
+const linkedContextLib = readFileSync(
+  new URL("../lib/chat-linked-context.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  linkedContextLib,
+  /projectId: card\.projectId \?\? null/,
+  "The linked-task context carries the card's stable projectId through to the chat",
+);
+assert.match(
+  chatView,
+  /taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*projects,\s*\}\)\.projectId \?\?/,
+  "The draft-init effect seeds the picker from the linked task's project once the context loads",
+);
+assert.match(
+  chatView,
+  /firstProject\?\.id, linkedContext\?\.task\?\.projectId, linkedContext\?\.task\?\.cwd\]/,
+  "The draft-init effect re-seeds when the linked task arrives (it loads async with the conversation)",
 );
 
 console.log("task-chat-cwd.test.ts: ok");

--- a/src/lib/chat-linked-context.ts
+++ b/src/lib/chat-linked-context.ts
@@ -9,6 +9,9 @@ type LinkedTask = {
   lifecycle: string;
   labels: string[];
   cwd: string | null;
+  /** Stable project id from the card — the task's project association, which
+   *  the chat picker prefers over the session's recorded cwd. */
+  projectId: string | null;
   notes: string | null;
 };
 
@@ -25,6 +28,7 @@ export type ChatLinkedContext = {
         lifecycle: string;
         labels: string[];
         cwd: string | null;
+        projectId: string | null;
         notes: string | null;
       }
     | null;
@@ -54,6 +58,7 @@ export async function linkedContextForSession(sessionId: string): Promise<ChatLi
     lifecycle: card.lifecycle,
     labels: card.labels,
     cwd: card.cwd,
+    projectId: card.projectId ?? null,
     notes: card.notes.trim() || null,
   }));
 

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -198,4 +198,78 @@ console.log("chat-projects.test.ts: ok");
     { projectId: NO_PROJECT_ID, project: null },
     "an empty roster resolves existing sessions to No project, not undefined state",
   );
+
+  // ── Linked task project (2026-07-03) ────────────────────────────────────────
+  // A chat tied to a board card belongs in that card's project — even when the
+  // session was recorded elsewhere (a task chat mis-rooted in the app's own
+  // cwd displayed the wrong project in the picker).
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/work/alpha",
+      taskProjectId: "p2",
+    }),
+    { projectId: "p2", project: roster[1] },
+    "the linked task's projectId outranks the session's recorded cwd",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/work/alpha",
+      taskProjectId: null,
+      taskCwd: "/work/beta",
+    }),
+    { projectId: "p2", project: roster[1] },
+    "a task without a stable projectId still maps through its cwd",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: true,
+      sessionProjectRoot: "/work/alpha",
+      taskProjectId: "deleted-project",
+      taskCwd: "/somewhere/unregistered",
+    }),
+    { projectId: "p1", project: roster[0] },
+    "a task whose project no longer resolves falls through to the session mapping",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      draftId: "p1",
+      hasSession: true,
+      sessionProjectRoot: "/work/alpha",
+      taskProjectId: "p2",
+    }),
+    { projectId: "p1", project: roster[0] },
+    "an explicit user pick still beats the linked task's project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      draftId: NO_PROJECT_ID,
+      hasSession: true,
+      sessionProjectRoot: "/work/alpha",
+      taskProjectId: "p2",
+    }),
+    { projectId: NO_PROJECT_ID, project: null },
+    "an explicit No-project pick also beats the linked task's project",
+  );
+
+  assert.deepEqual(
+    resolveChatProjectSelection({
+      ...base,
+      hasSession: false,
+      sessionProjectRoot: undefined,
+      taskProjectId: "p2",
+    }),
+    { projectId: "p2", project: roster[1] },
+    "a brand-new task chat opens scoped to the task's project, not the first project",
+  );
 }

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -60,19 +60,27 @@ export type ChatProjectSelection = {
  * Resolve which project a chat is scoped to, for both the picker display and
  * the projectRoot asserted on send.
  *
- * A user-set draft wins. Otherwise the session's recorded cwd (or the opener
- * surface's root) maps to its registered project. An EXISTING session whose
- * recorded cwd maps to no registered project is "No project" — it runs in the
- * familiar's own workspace or another unregistered dir, and defaulting it to
- * the first registered project would re-root the next turn's cwd there and
- * fork the harness session (`--continue` misses in the new dir). Only a brand
- * new chat (no session yet) defaults to the first project.
+ * A user-set draft wins. Then the linked task's project: a chat tied to a
+ * board card belongs in that card's project even when the session was first
+ * recorded elsewhere (a task chat mis-rooted in the app's own cwd otherwise
+ * displays — and keeps running in — the wrong project). Otherwise the
+ * session's recorded cwd (or the opener surface's root) maps to its
+ * registered project. An EXISTING session whose recorded cwd maps to no
+ * registered project is "No project" — it runs in the familiar's own
+ * workspace or another unregistered dir, and defaulting it to the first
+ * registered project would re-root the next turn's cwd there and fork the
+ * harness session (`--continue` misses in the new dir). Only a brand new chat
+ * (no session yet) defaults to the first project.
  */
 export function resolveChatProjectSelection(args: {
   draftId: string | null;
   hasSession: boolean;
   sessionProjectRoot: string | null | undefined;
   fallbackProjectRoot: string | null | undefined;
+  /** Project association of the chat's linked task (board card), when any:
+   *  the card's stable projectId, with its cwd as a fallback mapping. */
+  taskProjectId?: string | null;
+  taskCwd?: string | null;
   projects: CaveProject[];
 }): ChatProjectSelection {
   const firstProject = args.projects[0] ?? null;
@@ -83,6 +91,9 @@ export function resolveChatProjectSelection(args: {
       project: chatProjectById(args.draftId, args.projects) ?? firstProject,
     };
   }
+  const taskProject =
+    chatProjectById(args.taskProjectId, args.projects) ?? projectForRoot(args.taskCwd, args.projects);
+  if (taskProject) return { projectId: taskProject.id, project: taskProject };
   const mappedId = projectIdForRoot(
     args.sessionProjectRoot ?? args.fallbackProjectRoot,
     args.projects,


### PR DESCRIPTION
## Bug

A chat tied to a board card opened showing the wrong project (screenshot repro: a task chat for "Ship: 'The Protected Surface'…" displayed PROJECT **Coven Cave**). Two layers:

1. **Chat side:** the project picker (`resolveChatProjectSelection`, #2252) consulted only the session's recorded cwd and the opener root — never the linked task. A task chat mis-rooted anywhere displayed (and kept running in) that root's project.
2. **Server side:** `/api/board/[id]/chat` fell back to `process.cwd()` when the UI sent no root and the card had no cwd — recording **the app's own checkout** as the session's `project_root`. That's how the wrong project got onto the session in the first place.

## Fix

- `chat-linked-context` now carries the card's stable `projectId` through to the chat alongside `cwd`.
- `resolveChatProjectSelection` gains optional `taskProjectId`/`taskCwd` inputs that outrank the session-cwd mapping. Explicit user picks (including the No-project sentinel) still win; the #2252 no-fork semantics for unregistered cwds are unchanged.
- `chat-view` feeds `linkedContext.task` into both the selection and the draft-init effect; the effect re-seeds when the linked context loads (it arrives async with the conversation), so linking a task re-scopes the picker too.
- The board-chat route resolves `card.projectId → root` server-side (`projectById(card.projectId, await loadProjects())`), then falls to `card.cwd`, and **refuses a projectless start (409)** instead of silently rooting in the app dir. The board UI already blocks this path client-side ("Choose a project for this task…"), so the 409 is defense in depth.

## Tests

- `chat-projects.test.ts`: six new behavioral cases — task projectId outranks session cwd, taskCwd fallback, stale task project falls through, explicit pick and No-project still win, brand-new task chat scopes to the task.
- `task-chat-cwd.test.ts`: pins updated for the new call shape + a `doesNotMatch(/process\.cwd\(\)/)` regression pin on the route + new pins for the linked-context projectId and the effect deps.
- `board-chat-link.test.ts`: root-chain pin repointed.
- Full suite: 700 test files green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)