### PR TITLE
fix(browser): stop the native webview painting over onboarding and dialogs

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -242,6 +242,44 @@ function SaveToLibraryButton({
 }
 
 
+// ── Native-overlay occlusion ─────────────────────────────────────────
+// The embedded browser webview is an OS-level layer painted ABOVE the entire
+// DOM — no z-index puts onboarding, modals, or the command palette over it.
+// Detect "something renders above the pane" two ways and yield the native
+// layer while it holds:
+//   1. any visible dialog anywhere (role=dialog / aria-modal — the shared
+//      Modal, onboarding, ⌘K palette, quick chat, lightboxes), and
+//   2. point-sampling the pane rect — when the top hit-test element at the
+//      center or an inset corner isn't inside the pane, a non-dialog overlay
+//      (drag-to-split drop targets, custom covers) sits over it. Transient
+//      live regions (toasts) are ignored so a corner toast doesn't blank the
+//      page.
+function surfaceIsCovered(surface: HTMLElement, rect: DOMRect): boolean {
+  const dialogs = document.querySelectorAll('[role="dialog"], [aria-modal="true"]');
+  for (const dialog of dialogs) {
+    if (dialog.getClientRects().length > 0) return true;
+  }
+  const inset = 12;
+  const points: Array<[number, number]> = [
+    [rect.left + rect.width / 2, rect.top + rect.height / 2],
+    [rect.left + inset, rect.top + inset],
+    [rect.right - inset, rect.top + inset],
+    [rect.left + inset, rect.bottom - inset],
+    [rect.right - inset, rect.bottom - inset],
+  ];
+  for (const [x, y] of points) {
+    const hit = document.elementFromPoint(x, y);
+    if (!hit || surface.contains(hit)) continue;
+    if (hit.closest('[role="status"], [role="alert"], [aria-live]')) continue;
+    return true;
+  }
+  return false;
+}
+
+// Mirrors OFFSCREEN_X/OFFSCREEN_Y in src-tauri/src/browser.rs — the "hidden"
+// position for a native webview.
+const WEBVIEW_OFFSCREEN = -10000;
+
 export type BrowserPaneHandle = {
   navigateTo: (url: string) => void;
 };
@@ -398,10 +436,16 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
 
     const tick = () => {
       const rect = surface.getBoundingClientRect();
-      // Hide every webview when the panel is collapsed OR the toolbar is open.
-      // The toolbar is DOM and the webview is an OS-level overlay that would
-      // cover it, so the page yields the pane while the toolbar is showing.
-      if (toolbarOpenRef.current || rect.width <= 1 || rect.height <= 1) {
+      // Hide every webview when the panel is collapsed, the toolbar is open,
+      // OR a DOM overlay (onboarding, a modal, the palette…) renders above
+      // the pane. All of those are DOM and the webview is an OS-level overlay
+      // that would cover them, so the page yields while any of them shows.
+      if (
+        toolbarOpenRef.current ||
+        rect.width <= 1 ||
+        rect.height <= 1 ||
+        surfaceIsCovered(surface, rect)
+      ) {
         if (!hidden) {
           hidden = true;
           hideAll();
@@ -449,10 +493,18 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
       const rect = surface.getBoundingClientRect();
       if (rect.width <= 1 || rect.height <= 1) return;
       setLoading(true);
+      // While an overlay covers the pane, create/load the webview OFFSCREEN:
+      // browser_navigate repositions an existing webview (and creates a new
+      // one at the given bounds), which would paint it back over the overlay
+      // — and the bounds loop above only issues IPC on transitions, so it
+      // would never re-hide it. The page still loads; the loop re-seats it
+      // at the live rect once the cover lifts.
+      const covered = toolbarOpenRef.current || surfaceIsCovered(surface, rect);
       void bridge.invoke("browser_navigate", {
         label: tabLabel(activeTab.id),
         url: activeTab.url,
-        x: rect.left, y: rect.top,
+        x: covered ? WEBVIEW_OFFSCREEN : rect.left,
+        y: covered ? WEBVIEW_OFFSCREEN : rect.top,
         w: rect.width, h: rect.height,
       });
       setAddressBar(activeTab.url);

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -101,6 +101,55 @@ assert.match(
   "Mobile browser address input should meet the shared touch target",
 );
 
+// ───────── Native webview yields to DOM overlays ─────────
+// The embedded browser webview is an OS-level layer above the whole DOM, so
+// the pane must hide it whenever an overlay renders (onboarding covered by a
+// stuck white webview was the reported bug).
+assert.match(
+  pane,
+  /function surfaceIsCovered\(surface: HTMLElement, rect: DOMRect\): boolean/,
+  "pane has an occlusion detector for the native overlay",
+);
+assert.match(
+  pane,
+  /querySelectorAll\('\[role="dialog"\], \[aria-modal="true"\]'\)/,
+  "any visible dialog (Modal, onboarding, palette, quick chat) counts as cover",
+);
+assert.match(
+  pane,
+  /dialog\.getClientRects\(\)\.length > 0/,
+  "hidden-but-mounted dialogs must not count as cover",
+);
+assert.match(
+  pane,
+  /document\.elementFromPoint\(x, y\)/,
+  "the pane rect is point-sampled for non-dialog overlays",
+);
+assert.match(
+  pane,
+  /closest\('\[role="status"\], \[role="alert"\], \[aria-live\]'\)/,
+  "transient live regions (toasts) don't blank the page",
+);
+assert.match(
+  pane,
+  /toolbarOpenRef\.current \|\|\s*\n\s*rect\.width <= 1 \|\|\s*\n\s*rect\.height <= 1 \|\|\s*\n\s*surfaceIsCovered\(surface, rect\)/,
+  "the bounds loop hides all webviews while the pane is covered",
+);
+// browser_navigate repositions/creates the webview at the given bounds, and
+// the bounds loop only issues IPC on transitions — navigating while covered
+// must therefore target the offscreen position or the webview reappears over
+// the overlay and never re-hides (the onboarding screenshot bug).
+assert.match(
+  pane,
+  /const WEBVIEW_OFFSCREEN = -10000;/,
+  "offscreen constant mirrors OFFSCREEN_X/Y in src-tauri/src/browser.rs",
+);
+assert.match(
+  pane,
+  /const covered = toolbarOpenRef\.current \|\| surfaceIsCovered\(surface, rect\);[\s\S]{0,320}x: covered \? WEBVIEW_OFFSCREEN : rect\.left,\s*\n\s*y: covered \? WEBVIEW_OFFSCREEN : rect\.top,/,
+  "navigate loads covered webviews offscreen; the bounds loop re-seats them when the cover lifts",
+);
+
 // ───────── Task 4: Quick-open backdrop ─────────
 const qo = await readFile(new URL("./browser-quick-open.tsx", import.meta.url), "utf8");
 assert.match(qo, /bg-black\/40 backdrop-blur-sm/, "Backdrop must use bg-black/40 + backdrop-blur-sm");


### PR DESCRIPTION
## What

Fixes the stuck white rectangle covering the first-run onboarding wizard (screenshot in report) — and the whole class behind it: the embedded browser's native webview painting over every DOM overlay.

**Two bugs:**
1. **No overlay awareness.** The browser pane's bounds loop only hid the native webview when the pane collapsed or its own toolbar opened. The webview is an OS-level Tauri child webview painted above the entire DOM, so onboarding (`role=dialog`, `z-50`), the shared Modal, the ⌘K palette, and quick chat all rendered *underneath* it whenever the browser surface was mounted.
2. **Navigate-while-covered race.** `browser_navigate` fires ~80ms after mount and repositions/creates the webview onscreen — after the bounds loop already recorded it hidden. The loop only issues IPC on transitions, so it never re-hid it: the webview parked over the overlay permanently. That's exactly the reported state (app restored into browser mode under first-run onboarding).

**Fix (frontend only, `browser-pane.tsx`):**
- `surfaceIsCovered()` runs in the per-frame reconcile: any *visible* `role="dialog"` / `aria-modal="true"` element anywhere counts as cover, plus point-sampling the pane rect (center + inset corners via `elementFromPoint`) for non-dialog overlays like drag-to-split drop targets. Transient live regions (`role=status/alert`, `aria-live`) are ignored so a corner toast doesn't blank the page. While covered, all webviews hide (offscreen — same mechanism as before).
- Navigating while covered targets the offscreen position (`WEBVIEW_OFFSCREEN`, mirroring `OFFSCREEN_X/Y` in `src-tauri/src/browser.rs`), so the page still loads behind the overlay and the bounds loop re-seats it once the cover lifts.

No Rust changes.

## Tests
Source pins in `browser-polish.test.ts` for the detector (dialog query, visibility check, point sampling, toast exclusion), the hide condition, and the offscreen navigate. `typecheck` · `test:app` 522 ✓ · `test:api` 114 ✓ · `test:mobile` 65 ✓.

Note: runtime behavior needs the desktop app (`nativeBrowserAvailable` is Tauri-desktop-only; the web build uses the iframe fallback and is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)