### PR TITLE
feat(sidebar): app version as the bottommost minimal-height sidebar line

### DIFF
--- a/docs/specs/2026-07-03-sidebar-version-line-design.md
+++ b/docs/specs/2026-07-03-sidebar-version-line-design.md
@@ -1,0 +1,44 @@
+# Sidebar version line — design
+
+- **Date:** 2026-07-03
+- **Status:** Approved (user approved design in-session)
+- **Surface:** Default nav sidebar (`src/components/sidebar-minimal.tsx`)
+
+## Problem
+
+The app version is not visible anywhere in the main chrome. The user wants it
+shown at the bottommost position of the left sidebar with minimal height.
+
+## Design
+
+Render a single muted text line `v{APP_VERSION}` as the last child of the
+sidebar nav, directly below the `.sidebar-foot` icon row (Dashboard /
+Notifications / Settings), so it is the bottommost element.
+
+- **Version source:** `APP_VERSION` from `src/lib/app-version.ts` (package.json
+  version; `app-version.test.ts` already pins it in sync with
+  `tauri.conf.json`, `Cargo.toml`, and the iOS plists — it is the real app
+  version on web and desktop).
+- **Markup:** `<div className="sidebar-version" title={`CovenCave v${APP_VERSION}`}>v{APP_VERSION}</div>`
+  — plain text, no interactivity (YAGNI; a Settings/About link can come later).
+- **Minimal height:** ~16px total — `font-size: 10.5px`, `line-height: 1`,
+  `padding: 3px 6px 4px`, centered, `color: var(--text-muted)`,
+  `user-select: none`. The footer above already has no bottom padding.
+- **Rail mode:** hidden (`.shell-nav--rail .sidebar-version { display: none }`)
+  — the 56px rail has no room for text, consistent with all other labels.
+- **Scope:** `sidebar-minimal` only; the chat/code sidebars are separate
+  components and unchanged. Mobile drawer shows it (it renders the same
+  component expanded).
+
+## Alternatives rejected
+
+- Fourth item inside the `.sidebar-foot` icon row — zero added height but
+  clutters an evenly-spaced icon row.
+- Version as a button/link — plumbing without a request behind it.
+
+## Testing
+
+Append source-text assertions to the existing `sidebar-minimal.test.ts`
+(already wired in `SUITES.app`): the `APP_VERSION` import, the
+`.sidebar-version` element rendered immediately before `</nav>` (pins
+"bottommost"), the CSS block, and the rail hide rule.

--- a/docs/specs/2026-07-03-sidebar-version-line-plan.md
+++ b/docs/specs/2026-07-03-sidebar-version-line-plan.md
@@ -1,0 +1,102 @@
+# Sidebar version line — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show `v{APP_VERSION}` as the bottommost, minimal-height element of the default left sidebar.
+
+**Architecture:** One JSX line in `sidebar-minimal.tsx` (last child of the nav, below `.sidebar-foot`), one CSS block + one rail-hide rule in `sidebar-minimal.css`, assertions appended to the existing `sidebar-minimal.test.ts`. Version comes from the existing `src/lib/app-version.ts`.
+
+**Tech Stack:** Next.js client component, plain CSS, node source-text tests.
+
+**Spec:** `docs/specs/2026-07-03-sidebar-version-line-design.md`
+**Where to work:** worktree `.worktrees/sidebar-version-line`, branch `sidebar-version-line`. Worktree-relative paths only; every commit signed (`-S`) and pushed immediately after committing.
+
+---
+
+### Task 1: Failing assertions (TDD)
+
+**Files:** Modify: `src/components/sidebar-minimal.test.ts` (append before the final `console.log`)
+
+- [ ] **Step 1:** Append:
+
+```ts
+// The app version renders as the bottommost sidebar element — one
+// minimal-height muted line under the footer icon row, hidden in the rail.
+assert.match(
+  source,
+  /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
+  "SidebarMinimal should read the version from the shared app-version module",
+);
+assert.match(
+  source,
+  /className="sidebar-version"[\s\S]{0,120}?v\{APP_VERSION\}[\s\S]{0,40}?<\/div>\s*<\/nav>/,
+  "The version line should be the bottommost element of the sidebar nav",
+);
+assert.match(
+  styles,
+  /\.sidebar-version \{[^}]*line-height: 1;[^}]*color: var\(--text-muted\)/,
+  "The version line should be minimal-height muted text",
+);
+assert.match(
+  styles,
+  /\.shell-nav--rail \.sidebar-version \{[^}]*display: none/,
+  "The 56px rail has no room for text — the version line hides there",
+);
+```
+
+- [ ] **Step 2:** `node --experimental-strip-types src/components/sidebar-minimal.test.ts` → expect FAIL on the APP_VERSION import assertion.
+
+### Task 2: Implement
+
+**Files:** Modify: `src/components/sidebar-minimal.tsx` (import block + after `.sidebar-foot`'s closing `</div>` at ~line 404), `src/styles/sidebar-minimal.css` (after the `.sidebar-foot-bell,.sidebar-foot-btn` region; rail rule next to the other `.shell-nav--rail .sidebar-foot` rules ~1055)
+
+- [ ] **Step 1:** In `sidebar-minimal.tsx`, add to the imports:
+
+```ts
+import { APP_VERSION } from "@/lib/app-version";
+```
+
+- [ ] **Step 2:** Insert between the footer's closing `</div>` and `</nav>`:
+
+```tsx
+      {/* Bottommost: app version — one minimal-height muted line. */}
+      <div className="sidebar-version" title={`CovenCave v${APP_VERSION}`}>
+        v{APP_VERSION}
+      </div>
+```
+
+- [ ] **Step 3:** In `sidebar-minimal.css`, after the `.sidebar-foot` button styles:
+
+```css
+/* Bottommost element: the app version. One minimal-height line — small,
+   muted, unselectable; the footer above keeps its calm hairline boundary. */
+.sidebar-version {
+  flex-shrink: 0;
+  padding: 3px 6px 4px;
+  font-size: 10.5px;
+  line-height: 1;
+  text-align: center;
+  color: var(--text-muted);
+  user-select: none;
+}
+```
+
+and with the rail rules:
+
+```css
+/* No room for text in the 56px rail — the version returns when expanded. */
+.shell-nav--rail .sidebar-version {
+  display: none;
+}
+```
+
+- [ ] **Step 4:** Test → PASS. Commit signed, push.
+
+### Task 3: Gates + visual verify
+
+- [ ] `pnpm typecheck && pnpm check:tests-wired && pnpm test:app` (test file already wired — no run-tests.mjs change), then `pnpm build`.
+- [ ] Serve the built app on a unique port; screenshot the sidebar bottom at 1440px (version line visible under the icon row, ≤18px tall) and in rail mode (hidden). Confirm the line is the bottommost element.
+
+### Task 4: Ship
+
+- [ ] Signature sanity check; `gh pr create`; watch ALL SIX required checks; `gh pr merge --squash` (expect the worktree `fatal: 'main' is already used` quirk — verify `state==MERGED`, then delete the remote branch manually); clean up worktree + local branch.

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -364,4 +364,27 @@ assert.match(
   "title combines label + description (+ shortcut when present) + drag-to-split hint",
 );
 
+// The app version renders as the bottommost sidebar element — one
+// minimal-height muted line under the footer icon row, hidden in the rail.
+assert.match(
+  source,
+  /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
+  "SidebarMinimal should read the version from the shared app-version module",
+);
+assert.match(
+  source,
+  /className="sidebar-version"[\s\S]{0,120}?v\{APP_VERSION\}[\s\S]{0,40}?<\/div>\s*<\/nav>/,
+  "The version line should be the bottommost element of the sidebar nav",
+);
+assert.match(
+  styles,
+  /\.sidebar-version \{[^}]*line-height: 1;[^}]*color: var\(--text-muted\)/,
+  "The version line should be minimal-height muted text",
+);
+assert.match(
+  styles,
+  /\.shell-nav--rail \.sidebar-version \{[^}]*display: none/,
+  "The 56px rail has no room for text — the version line hides there",
+);
+
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -21,6 +21,7 @@ import {
   isSplittablePage,
 } from "@/lib/page-drag";
 import { RecentActivityRollup } from "@/components/recent-activity-rollup";
+import { APP_VERSION } from "@/lib/app-version";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -401,6 +402,11 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
           </span>
           <span className="sidebar-foot-label">Settings</span>
         </button>
+      </div>
+
+      {/* Bottommost: app version — one minimal-height muted line. */}
+      <div className="sidebar-version" title={`CovenCave v${APP_VERSION}`}>
+        v{APP_VERSION}
       </div>
     </nav>
   );

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -325,6 +325,18 @@
   transition: background 0.12s ease, color 0.12s ease;
 }
 
+/* Bottommost element: the app version. One minimal-height line — small,
+   muted, unselectable; the footer above keeps its calm hairline boundary. */
+.sidebar-version {
+  flex-shrink: 0;
+  padding: 3px 6px 4px;
+  font-size: 10.5px;
+  line-height: 1;
+  text-align: center;
+  color: var(--text-muted);
+  user-select: none;
+}
+
 .sidebar-foot-bell:hover,
 .sidebar-foot-btn:hover,
 .sidebar-foot-icon-btn:hover {
@@ -1056,6 +1068,11 @@
 .shell-nav--rail .sidebar-foot {
   flex-direction: column;
   align-items: center;
+}
+
+/* No room for text in the 56px rail — the version returns when expanded. */
+.shell-nav--rail .sidebar-version {
+  display: none;
 }
 
 /* Every rail control is the same centered 40px rounded square — one shared


### PR DESCRIPTION
Shows `v{APP_VERSION}` as the bottommost element of the default left sidebar — one muted 10.5px line (~17px total) under the Dashboard/Notifications/Settings footer row. Hidden in the 56px collapsed rail like all other sidebar text.

- Version comes from the existing `src/lib/app-version.ts` (package.json version, already version-sync pinned to `tauri.conf.json`/`Cargo.toml`/iOS plists by `app-version.test.ts`) — correct on web and desktop.
- Plain text, no interactivity; tooltip carries `CovenCave v…`.
- Assertions appended to `sidebar-minimal.test.ts` pin the import, the bottommost placement (element immediately before `</nav>`), the minimal-height muted CSS, and the rail hide rule.

Verified in the built app: renders `v0.0.135` at 17.5px as the nav's last child below the footer, hidden after ⌘B rail collapse.

Design: `docs/specs/2026-07-03-sidebar-version-line-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)