### PR TITLE
fix(flow): drop dangling edges on load, stop re-parsing the run transcript every render, memoize node cards

### DIFF
--- a/src/components/flow/flow-node.tsx
+++ b/src/components/flow/flow-node.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, NodeResizer, Position, type NodeProps, type Node } from "@xyflow/react";
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { FlowNodeType } from "@/lib/flow/flow-catalog";
 import type { FlowLayoutOrientation, FlowNode } from "@/lib/flow/flow-doc";
@@ -34,7 +34,7 @@ function handleOffset(index: number, count: number): string {
 }
 
 /** The n8n-style node card: icon tile, name, type subtitle, port handles. */
-export function FlowNodeView({ data, selected }: NodeProps<FlowRFNode>) {
+function FlowNodeViewImpl({ data, selected }: NodeProps<FlowRFNode>) {
   const { node, def, phase, stale, orientation } = data;
   const accent = def?.accent ?? "#7b7f87";
   const inputs = def?.inputs ?? [];
@@ -132,7 +132,7 @@ export function FlowNodeView({ data, selected }: NodeProps<FlowRFNode>) {
 
 /** Sticky note — a non-executable canvas annotation. Double-click to edit its
  *  text inline; drag the corner handles (when selected) to resize. */
-export function FlowStickyView({ data, selected }: NodeProps<FlowStickyRFNode>) {
+function FlowStickyViewImpl({ data, selected }: NodeProps<FlowStickyRFNode>) {
   const sticky = data.node.sticky;
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(sticky?.text ?? "");
@@ -196,3 +196,10 @@ export function FlowStickyView({ data, selected }: NodeProps<FlowStickyRFNode>) 
     </div>
   );
 }
+
+// Memoized so an unrelated FlowView re-render (a run tick, a notice, a
+// keystroke in the detail panel) doesn't re-render every node card — only nodes
+// whose `data`/`selected` actually changed. Relies on the canvas keeping node
+// `data` identities stable (see the stabilized sticky callbacks in flow-view).
+export const FlowNodeView = memo(FlowNodeViewImpl);
+export const FlowStickyView = memo(FlowStickyViewImpl);

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -770,6 +770,14 @@ export function FlowView() {
     (id: string, patch: Partial<FlowStickyData>) => mutate((d) => updateSticky(d, id, patch)),
     [mutate],
   );
+  // Stable identities so FlowCanvas's docNodes memo (keyed on these) doesn't
+  // rebuild every node object on every FlowView render — that rebuild mints a
+  // fresh `data` object per node and defeats the memoized node cards.
+  const onStickyText = useCallback((id: string, text: string) => onChangeSticky(id, { text }), [onChangeSticky]);
+  const onStickySize = useCallback(
+    (id: string, width: number, height: number) => onChangeSticky(id, { width, height }),
+    [onChangeSticky],
+  );
 
   if (loaded && flows.length === 0 && !doc) {
     return (
@@ -903,8 +911,8 @@ export function FlowView() {
                   onInsertEdge={requestInsertEdge}
                   onTidy={tidy}
                   onLayoutOrientation={setAndApplyLayoutOrientation}
-                  onStickyText={(id, text) => onChangeSticky(id, { text })}
-                  onStickySize={(id, width, height) => onChangeSticky(id, { width, height })}
+                  onStickyText={onStickyText}
+                  onStickySize={onStickySize}
                 />
                 {activeRun && activeRun.steps.length > 0 && (
                   <FlowRunSteps

--- a/src/components/flow/use-flow-run.ts
+++ b/src/components/flow/use-flow-run.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { parseFlowRunProgress, type FlowRunProgress } from "@/lib/flow/flow-progress";
 import type { FlowRunRecord } from "@/lib/flows";
 
@@ -58,6 +58,12 @@ export function useFlowRun(run: FlowRunRecord | null): FlowRunProgress {
     };
   }, [sessionId, live]);
 
-  if (!run) return EMPTY;
-  return parseFlowRunProgress(transcript, run.steps);
+  // Memoize: parseFlowRunProgress regex-scans the whole transcript and mints a
+  // fresh object each call. Without this it re-ran on *every* FlowView render
+  // (keystroke, notice tick, unrelated setState) — even with no active run —
+  // and its new object identity cascaded into re-deriving all canvas nodes.
+  return useMemo(
+    () => (run ? parseFlowRunProgress(transcript, run.steps) : EMPTY),
+    [run, transcript],
+  );
 }

--- a/src/lib/server/flow-store.test.ts
+++ b/src/lib/server/flow-store.test.ts
@@ -49,6 +49,34 @@ try {
   assert.equal(loaded.nodes.find((node) => node.id === "a")?.settings, undefined, "execution-setting defaults are omitted");
   assert.equal(loaded.nodes.find((node) => node.id === "b")?.disabled, true, "disabled state persists");
   assert.equal(loaded.nodes.find((node) => node.id === "b")?.displayNote, true, "display-note enabled state persists");
+
+  // Dangling edges (source/target referencing a node that isn't in the doc) are
+  // dropped on load rather than persisted forever as references to a ghost node.
+  const danglingFlow: FlowDoc = {
+    id: "dangling",
+    name: "Dangling",
+    active: false,
+    nodes: [
+      { id: "n1", type: "trigger.manual", name: "Trigger", position: { x: 0, y: 0 }, params: {} },
+      { id: "n2", type: "familiar", name: "Do", position: { x: 240, y: 0 }, params: {} },
+    ],
+    edges: [
+      { id: "e-valid", source: "n1", sourceHandle: "main", target: "n2", targetHandle: "in" },
+      { id: "e-dangling-target", source: "n1", sourceHandle: "main", target: "ghost", targetHandle: "in" },
+      { id: "e-dangling-source", source: "ghost", sourceHandle: "main", target: "n2", targetHandle: "in" },
+    ],
+    createdAt: now,
+    updatedAt: now,
+    schema: 1,
+  };
+  await saveFlow(danglingFlow);
+  const reloaded = await loadFlow("dangling");
+  assert.ok(reloaded, "dangling flow loads");
+  assert.deepEqual(
+    reloaded.edges.map((edge) => edge.id),
+    ["e-valid"],
+    "only the edge whose source and target both exist survives coercion",
+  );
 } finally {
   await rm(dir, { recursive: true, force: true });
   delete process.env.COVEN_FLOWS_DIR;

--- a/src/lib/server/flow-store.ts
+++ b/src/lib/server/flow-store.ts
@@ -10,7 +10,7 @@ import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import path from "node:path";
 import { writeJsonAtomic } from "./atomic-write.ts";
-import { FLOW_SCHEMA_VERSION, normalizeNodeSettings, type FlowDoc, type FlowNodeSettings } from "../flow/flow-doc.ts";
+import { FLOW_SCHEMA_VERSION, normalizeNodeSettings, type FlowDoc, type FlowEdge, type FlowNodeSettings } from "../flow/flow-doc.ts";
 import type { FlowRunRecord } from "../flows.ts";
 
 export const FLOW_RUNS_CAP = 200;
@@ -44,14 +44,15 @@ function isValidDoc(value: unknown): value is FlowDoc {
 function coerceDoc(value: unknown): FlowDoc | null {
   if (!isValidDoc(value)) return null;
   const now = new Date().toISOString();
+  const nodes = coerceFlowNodes(value.nodes);
   return {
     id: value.id,
     name: typeof value.name === "string" && value.name.trim() ? value.name : value.id,
     active: Boolean(value.active),
     published: coercePublished(value.published),
     executionData: coerceExecutionData(value.executionData),
-    nodes: coerceFlowNodes(value.nodes),
-    edges: value.edges,
+    nodes,
+    edges: coerceFlowEdges(value.edges, nodes),
     createdAt: typeof value.createdAt === "string" ? value.createdAt : now,
     updatedAt: typeof value.updatedAt === "string" ? value.updatedAt : now,
     schema: typeof value.schema === "number" ? value.schema : FLOW_SCHEMA_VERSION,
@@ -85,6 +86,28 @@ function coerceFlowNodes(value: unknown): FlowDoc["nodes"] {
     ));
 }
 
+// Edges are validated against the coerced node set: an edge whose shape is
+// malformed, or whose source/target references a node that didn't survive
+// coercion, is dropped rather than persisted as a dangling reference that the
+// canvas and executor would otherwise have to skip on every load.
+function coerceFlowEdges(value: unknown, nodes: FlowDoc["nodes"]): FlowEdge[] {
+  if (!Array.isArray(value)) return [];
+  const ids = new Set(nodes.map((node) => node.id));
+  return value.filter((edge): edge is FlowEdge => {
+    if (!edge || typeof edge !== "object" || Array.isArray(edge)) return false;
+    const e = edge as Record<string, unknown>;
+    return (
+      typeof e.id === "string" &&
+      typeof e.source === "string" &&
+      typeof e.sourceHandle === "string" &&
+      typeof e.target === "string" &&
+      typeof e.targetHandle === "string" &&
+      ids.has(e.source) &&
+      ids.has(e.target)
+    );
+  });
+}
+
 function coerceNodeSettings(value: unknown): FlowNodeSettings | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   const raw = value as Partial<FlowNodeSettings>;
@@ -115,6 +138,7 @@ function coercePublished(value: unknown): FlowDoc["published"] {
   if (typeof published.publishedAt !== "string" || typeof doc.id !== "string") return undefined;
   if (!Array.isArray(doc.nodes) || !Array.isArray(doc.edges)) return undefined;
   const now = new Date().toISOString();
+  const nodes = coerceFlowNodes(doc.nodes);
   return {
     publishedAt: published.publishedAt,
     snapshot: {
@@ -122,8 +146,8 @@ function coercePublished(value: unknown): FlowDoc["published"] {
       name: typeof doc.name === "string" && doc.name.trim() ? doc.name : doc.id,
       active: Boolean(doc.active),
       executionData: coerceExecutionData(doc.executionData),
-      nodes: coerceFlowNodes(doc.nodes),
-      edges: doc.edges,
+      nodes,
+      edges: coerceFlowEdges(doc.edges, nodes),
       createdAt: typeof doc.createdAt === "string" ? doc.createdAt : now,
       updatedAt: typeof doc.updatedAt === "string" ? doc.updatedAt : now,
       schema: typeof doc.schema === "number" ? doc.schema : FLOW_SCHEMA_VERSION,


### PR DESCRIPTION
Correctness + perf batch from the **Flow surface audit** (three-lens: correctness / a11y / perf-dead-code; findings source-verified). The Flow surface is the n8n-style graph editor (`flow-view`/`flow-canvas`, nav mode "flow"). a11y ships as a follow-up PR that rebases on this one.

## Correctness
- **Dangling edges were persisted on every load/save.** `coerceDoc` / `coercePublished` in `flow-store.ts` carefully filter invalid *nodes* (`coerceFlowNodes`) but passed `edges` through with **zero validation** (`edges: value.edges`). If a node failed coercion — a hand-edited/older/partially-corrupt flow JSON, or a node written by a different client version missing a field — that node was silently dropped but every edge touching it survived, so `flowExecutionOrder` and the canvas kept referencing a `source`/`target` id with no node, and it re-saved on every write. Added `coerceFlowEdges`, which keeps only well-formed edges whose **both endpoints exist** in the coerced node set. (In-editor `removeNode` already purges edges correctly — this was purely a persistence-layer gap.)

## Perf
- **`useFlowRun` re-parsed the entire run transcript on every render.** `parseFlowRunProgress` regex-scans the whole transcript and mints a fresh `FlowRunProgress` object; it was called **unconditionally on every `FlowView` render** (any keystroke in the node detail panel, any notice tick, any unrelated `setState`) — even with no active run — and its new object identity cascaded into `displayedPhases` → `renderNodes` → re-deriving **all** canvas nodes, plus the run-steps memos. Now wrapped in `useMemo([run, transcript])`.
- **Node cards weren't memoized.** `FlowNodeView`/`FlowStickyView` are now `React.memo`, and the sticky callbacks passed into `FlowCanvas` are stabilized with `useCallback` so the canvas's `docNodes` memo (keyed on them) stops rebuilding every node object each render — otherwise the memo is defeated by fresh `data` identities. Together: an unrelated `FlowView` re-render no longer re-renders every node, only the ones whose `data`/`selected` changed.

## Deferred to P2 (noted, not in this PR)
- Undo/redo of a node **move** leaves the canvas painting the pre-undo position (the drag reconciler keeps the live position; fix touches the core drag path and warrants live drag+undo verification).
- A run that finishes without emitting terminal `@@step-*` markers leaks as perpetually `"running"` with unbounded transcript polling.
- The large **dead workflow-lib sweep** (`workflow-playback`/`workflow-draft`/`workflow-generate`/`workflow-edit` + most of `workflow-graph` — ~900 lines, superseded by `flow-doc`) — separate PR, needs careful `tsc` verification against type barrels.

## Verification
- `tsc --noEmit` clean; all flow tests pass (`flow-store`, `flow-canvas`, `flow-node-required-badge`, `node-detail-view`, `flow-doc`, `flow-progress`, …). Added a `flow-store` regression test: a save→load round-trip drops edges whose endpoints don't both exist, keeping only the valid edge.
- `pnpm build` green. Rendered the live Flow surface (9 nodes, 8 edges, an active run showing `SUCCEEDED` step phases) — nodes paint correctly under `React.memo` and the memoized transcript parse, **zero page errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)