### PR TITLE
chore(release): stamp v0.0.136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.136] - 2026-07-03
+
+Patch release on top of v0.0.135. Headlined by the desktop browser fix — the
+embedded native webview no longer paints over onboarding, modals, or the
+command palette — plus avatar storage moving to IndexedDB (freeing the shared
+localStorage quota), a unified project picker across surfaces, a
+time-bucketed chat sidebar, and calendar/canvas hardening.
+
+### Added
+
+- **Chat** - the sidebar gains an Organize menu with a default time-bucketed
+  Recent view (#2310).
+- **Projects** - unified project picker: one selection UI and a one-step add
+  flow across surfaces (#2307).
+- **Sidebar** - the app version shows as the bottommost minimal-height line
+  (#2312).
+
+### Changed
+
+- **Avatars** - avatar images move from localStorage to IndexedDB with a
+  one-time migration, handing the shared ~5MB origin quota back to the rest of
+  the app (#2306).
+
+### Fixed
+
+- **Browser (desktop)** - the embedded native webview yields to DOM overlays:
+  it no longer paints over onboarding, modals, or the command palette, and
+  navigating while covered loads offscreen and re-seats when the overlay
+  closes (#2309).
+- **Familiars** - avatar saves report the friendly "storage full" message
+  instead of the raw browser quota error, and a refused write no longer leaves
+  a phantom avatar that vanishes on reload (#2302).
+- **Chat** - a task-linked chat opens in the task's project, not the first
+  project (#2308).
+- **Calendar** - timed events stay out of the all-day bucket, the add-day pin
+  holds, and the minute tick no longer re-packs every column (#2304).
+- **Canvas** - failed generations no longer leave blank tiles, sketch deletes
+  ask for confirmation, and the dead canvas.css/ArtifactNode pair is removed
+  (#2311).
+- **Shell** - the titlebar drag lane spans the full height again (#2301).
+
+### Accessibility
+
+- **Calendar** - view, date, and mutation changes are announced; times and
+  deadlines carry accessible names; the date popover traps focus (#2305).
+
 ## [0.0.135] - 2026-07-03
 
 Patch release on top of v0.0.134. Continues the surface-hardening and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.135",
+  "version": "0.0.136",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.135"
+version = "0.0.136"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.135"
+version = "0.0.136"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.135</string>
+	<string>0.0.136</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.135</string>
+	<string>0.0.136</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.135</string>
+	<string>0.0.136</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.135</string>
+	<string>0.0.136</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.135",
+  "version": "0.0.136",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version stamp for **v0.0.136** — the usual 7-file bump (package.json, Cargo.toml/lock, tauri.conf.json, both iOS plists) plus the CHANGELOG rollup of the 12 commits since v0.0.135.

Headliners: the desktop browser's native webview no longer paints over onboarding/modals/palette (#2309), and avatar images move from localStorage to IndexedDB with one-time migration (#2306). Full notes in the CHANGELOG entry.

Publishing is a separate manual step: after this merges, the signed `v0.0.136` tag triggers release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)