### PR TITLE
a11y(flow): announce lifecycle events, name the nodes, trap the add-node & template dialogs

### DIFF
--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -108,6 +108,11 @@ function FlowCanvasInner(props: FlowCanvasProps) {
         return {
           id: node.id,
           type: isSticky ? "flowSticky" : "flowNode",
+          // Accessible name — without it every node announces only "node" and a
+          // screen-reader user can't tell them apart.
+          ariaLabel: isSticky
+            ? "Sticky note"
+            : `${node.name}, ${def?.label ?? node.type}${node.disabled ? ", disabled" : ""}`,
           position: node.position,
           data: isSticky
             ? {

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -5,6 +5,8 @@ import "@/styles/flow.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Icon } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import { catalogNode, createNode } from "@/lib/flow/flow-catalog";
@@ -108,6 +110,8 @@ export function FlowView() {
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
   const [templateGalleryOpen, setTemplateGalleryOpen] = useState(false);
+  const templateOverlayRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(templateGalleryOpen, templateOverlayRef, { onEscape: () => setTemplateGalleryOpen(false) });
   const [layoutOrientation, setLayoutOrientation] = useState<FlowLayoutOrientation>("horizontal");
   // The run currently overlaid on the canvas (live session, or a finished run
   // whose final state we keep painted until the user switches flows).
@@ -144,11 +148,14 @@ export function FlowView() {
     };
   }, []);
 
+  const { announce } = useAnnouncer();
   const showNotice = useCallback((message: string) => {
     setNotice(message);
+    announce(message); // the visual toast is conditionally mounted; route through
+                       // the always-present live region so AT actually hears it.
     if (noticeTimer.current) clearTimeout(noticeTimer.current);
     noticeTimer.current = setTimeout(() => setNotice(null), 6000);
-  }, []);
+  }, [announce]);
 
   const dispatchDraft = useCallback((action: FlowDraftAction) => {
     setDraftState((current) => {
@@ -841,7 +848,7 @@ export function FlowView() {
       />
 
       {templateGalleryOpen && (
-        <div className="flow-template-overlay" role="dialog" aria-modal aria-label="Flow templates">
+        <div className="flow-template-overlay" role="dialog" aria-modal aria-label="Flow templates" ref={templateOverlayRef} tabIndex={-1}>
           <div className="flow-template-overlay-backdrop" onClick={() => setTemplateGalleryOpen(false)} />
           <div className="flow-template-overlay-panel">
             <FlowTemplateGallery

--- a/src/components/flow/node-catalog-panel.tsx
+++ b/src/components/flow/node-catalog-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { searchCatalog } from "@/lib/flow/flow-catalog";
 
 export type NodeCatalogPanelProps = {
@@ -14,6 +15,12 @@ export type NodeCatalogPanelProps = {
 export function NodeCatalogPanel({ open, onPick, onClose }: NodeCatalogPanelProps) {
   const [query, setQuery] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
+
+  // Trap focus + Escape + restore focus to the trigger on close. Tab used to
+  // escape to the canvas behind this dialog. focusFirst:false keeps the search
+  // autofocus below in charge of the initial target.
+  useFocusTrap(open, panelRef, { onEscape: onClose, focusFirst: false });
 
   useEffect(() => {
     if (open) {
@@ -24,15 +31,6 @@ export function NodeCatalogPanel({ open, onPick, onClose }: NodeCatalogPanelProp
     }
   }, [open]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
   const groups = useMemo(() => searchCatalog(query), [query]);
   const empty = groups.length === 0;
 
@@ -41,9 +39,12 @@ export function NodeCatalogPanel({ open, onPick, onClose }: NodeCatalogPanelProp
   return (
     <div className="flow-catalog-scrim" onClick={onClose}>
       <aside
+        ref={panelRef}
         className="flow-catalog"
         role="dialog"
+        aria-modal="true"
         aria-label="Add a node"
+        tabIndex={-1}
         onClick={(event) => event.stopPropagation()}
       >
         <header className="flow-catalog-head">


### PR DESCRIPTION
Accessibility batch from the **Flow surface audit** — the companion to #2314 (correctness + perf), rebased onto it.

## Announcements (shared `useAnnouncer`)
`showNotice` — the funnel for flow **save / run-finish / create / create-from-prompt / duplicate / delete / template** — now also routes through the always-present live region. Previously those events only set a `flow-notice` toast that is **conditionally mounted**, which AT frequently misses (a `role="status"` region must exist before its text changes to announce reliably).

## Node accessible names
React Flow makes custom nodes focusable (`tabIndex=0`, `role="group"`), but the node objects set **no `ariaLabel`**, so a screen-reader user Tabbing the canvas heard N indistinguishable "node" groups. Nodes now carry `"<name>, <type>[, disabled]"` (sticky notes announce "Sticky note").

## Focus-trapped dialogs
The **add-node catalog** (`NodeCatalogPanel`) and the **flow-template overlay** are `role="dialog"` but didn't trap focus — Tab fell straight through to the canvas behind them, and neither restored focus to its trigger on close. Both now use the shared `useFocusTrap` (trap + Escape + focus restore) and gain `aria-modal`. The catalog's ad-hoc `window` Escape listener is replaced by the hook's `onEscape`; its search autofocus is preserved (`focusFirst: false`).

## Deferred to P2 (noted, not in this PR)
- Keyboard "open node config" — React Flow selects a node on Enter but there's no activate/open path (needs node-data plumbing + an Enter handler).
- Reduced-motion gating of React Flow's `fitView`/zoom/minimap — the global CSS reset can't touch d3's programmatic transforms; needs custom `<Controls>`.
- Editor/Executions tabs → real `role="tablist"` (currently ad-hoc `<button>`s with `aria-current`).
- Node-detail form required/error semantics (`aria-required`/`aria-invalid`/`aria-describedby`).

## Verification
- `tsc --noEmit` clean; all 6 flow component tests pass (source-text pins intact). `pnpm build` green.
- The correctness/perf PR (#2314) already rendered this surface live (9 nodes, 8 edges, active run) with zero errors; these changes are additive attributes + the standard `useFocusTrap` hook (same pattern as the calendar mini-month popover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)