### PR TITLE
feat(ios): iPad/macOS adaptive layouts across all tabs

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/CalendarView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CalendarView.swift
@@ -8,13 +8,18 @@ import SwiftUI
 struct CalendarView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    /// Task shown in the split detail pane (regular width).
     @State private var taskSelection: BoardCard?
+    /// Task shown in a sheet (compact width — agenda rows are plain buttons,
+    /// so a collapsed split view wouldn't push a detail on its own).
+    @State private var compactTask: BoardCard?
     /// A reminder awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: Reminder?
     @State private var showJournal = false
 
     var body: some View {
-        NavigationStack {
+        NavigationSplitView {
             content
                 .navigationTitle("Calendar")
                 .navigationBarTitleDisplayMode(.inline)
@@ -29,7 +34,7 @@ struct CalendarView: View {
                     if !app.remindersLoaded { await app.loadReminders() }
                     if !app.tasksLoaded { await app.loadTasks() }
                 }
-                .sheet(item: $taskSelection) { card in
+                .sheet(item: $compactTask) { card in
                     NavigationStack { TaskDetailView(card: card) }
                 }
                 .sheet(isPresented: $showJournal) { JournalView() }
@@ -42,7 +47,22 @@ struct CalendarView: View {
                     }
                     Button("Cancel", role: .cancel) {}
                 } message: { reminder in Text(reminder.title) }
+                .sidebarColumn()
+        } detail: {
+            // A tapped task fills the pane beside the agenda on iPad (it used
+            // to open a modal sheet even with a whole pane of dead space); on
+            // iPhone the collapsed split view pushes it, same as before.
+            if let card = taskSelection {
+                NavigationStack { TaskDetailView(card: card) }
+            } else {
+                ContentUnavailableView {
+                    Label("Select an item", systemImage: "calendar")
+                } description: {
+                    Text("Pick a task to see its details beside the agenda.")
+                }
+            }
         }
+        .navigationSplitViewStyle(.balanced)
     }
 
     private var deleteDialogBinding: Binding<Bool> {
@@ -121,7 +141,10 @@ struct CalendarView: View {
                     }
                 }
         case .task(let card):
-            Button { taskSelection = card } label: { AgendaTaskRow(card: card) }
+            Button {
+                if horizontalSizeClass == .regular { taskSelection = card }
+                else { compactTask = card }
+            } label: { AgendaTaskRow(card: card) }
                 .buttonStyle(.plain)
                 .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                 .contextMenu {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -70,6 +70,7 @@ struct ChatsHomeView: View {
                 if lastThreadId != thread.id { open(.thread(thread)) }
                 app.threadToOpen = nil
             }
+            .sidebarColumn()
         } detail: {
             detailColumn
         }

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -69,6 +69,7 @@ struct ConnectionView: View {
                     trustNote
                 }
                 .padding(24)
+                .readableWidth(520)
             }
             .background(chrome.bgBase.ignoresSafeArea())
             .navigationTitle("Coven Cave")

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -72,7 +72,9 @@ struct FamiliarThreadsView: View {
                 if entries.isEmpty && archivedLocalCount == 0 {
                     emptyState
                 } else {
-                    threadList
+                    // Align the thread column with ChatView's 740pt transcript
+                    // so drilling into a conversation doesn't shift the content.
+                    threadList.readableListWidth(740)
                 }
             case .feed:
                 FamiliarFeedView()

--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -25,6 +25,7 @@ struct GitHubView: View {
                 .searchable(text: $query, prompt: "Search issues & PRs")
                 .refreshable { await load() }
                 .task { await load() }
+                .sidebarColumn()
         } detail: {
             if let selection {
                 NavigationStack { GitHubItemDetailView(item: selection) }

--- a/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/GitHubView.swift
@@ -216,6 +216,7 @@ struct GitHubItemDetailView: View {
                 }
             }
             .padding(16)
+            .readableWidth(720)
         }
         .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle(item.number.map { "#\($0)" } ?? "Item")

--- a/apps/ios/CovenCave/CovenCave/Views/LibraryView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LibraryView.swift
@@ -64,6 +64,7 @@ struct LibraryView: View {
             }
             .listStyle(.plain)
             .themedListBackground()
+            .readableListWidth(680)
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ReadableWidth.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ReadableWidth.swift
@@ -18,6 +18,16 @@ extension View {
     }
 }
 
+extension View {
+    /// Pin a split-view sidebar to a real column. Without an explicit width
+    /// the sidebar sizes by trait defaults and can present as a floating
+    /// overlay at in-between window widths (Designed-for-iPad on macOS);
+    /// with one it stays a fixed pane and the detail keeps the rest.
+    func sidebarColumn() -> some View {
+        navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
+    }
+}
+
 private struct ReadableListWidth: ViewModifier {
     let maxWidth: CGFloat
 

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -33,6 +33,7 @@ struct SettingsView: View {
                 aboutSection
             }
             .themedListBackground()
+            .readableListWidth(680)
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -34,6 +34,7 @@ struct TaskDetailView: View {
                 metaCard
             }
             .padding(20)
+            .readableWidth(680)
         }
         .background(chrome.bgBase.ignoresSafeArea())
         .navigationTitle("Task")

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -31,6 +31,7 @@ struct TasksView: View {
     /// A task awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: BoardCard?
     @State private var showReminders = false
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     /// How the task list is partitioned into sections.
     enum GroupBy: String, CaseIterable, Identifiable {
@@ -269,16 +270,30 @@ struct TasksView: View {
     /// reusing the same `sections` as the list — so group-by, sort, search, and
     /// filters all apply. Tap a card for its detail; long-press for the actions.
     private var kanbanBoard: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .top, spacing: 12) {
-                ForEach(sections) { section in kanbanColumn(section) }
+        GeometryReader { geo in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(sections) { section in
+                        kanbanColumn(section, width: kanbanColumnWidth(available: geo.size.width))
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 12)
         }
     }
 
-    @ViewBuilder private func kanbanColumn(_ section: TaskSection) -> some View {
+    /// Fit as many 280pt-minimum columns as the pane allows (capped at the
+    /// section count), then stretch them to consume the leftover width — no
+    /// dead right margin on iPad/Mac.
+    private func kanbanColumnWidth(available: CGFloat) -> CGFloat {
+        let inset: CGFloat = 32, spacing: CGFloat = 12, minWidth: CGFloat = 280
+        let usable = max(minWidth, available - inset)
+        let fit = max(1, min(CGFloat(sections.count), ((usable + spacing) / (minWidth + spacing)).rounded(.down)))
+        return max(minWidth, (usable - spacing * (fit - 1)) / fit)
+    }
+
+    @ViewBuilder private func kanbanColumn(_ section: TaskSection, width: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 6) {
                 if let image = section.systemImage { Image(systemName: image).accessibilityHidden(true) }
@@ -294,7 +309,12 @@ struct TasksView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 LazyVStack(spacing: 8) {
                     ForEach(section.cards) { card in
-                        Button { boardDetail = card } label: {
+                        Button {
+                            // Regular width has a live detail column — use it,
+                            // matching the List path; compact keeps the sheet.
+                            if horizontalSizeClass == .regular { selection = card }
+                            else { boardDetail = card }
+                        } label: {
                             TaskRow(card: card)
                                 .padding(12)
                                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -307,7 +327,7 @@ struct TasksView: View {
                 .padding(.bottom, 8)
             }
         }
-        .frame(width: 280)
+        .frame(width: width)
     }
 
     private var taskList: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -121,6 +121,7 @@ struct TasksView: View {
                 // open the reminders sheet, then clear the pending link.
                 .onChange(of: app.deepLink) { _, link in consumeDeepLink(link) }
                 .onAppear { consumeDeepLink(app.deepLink) }
+                .sidebarColumn()
         } detail: {
             if let selection {
                 NavigationStack { TaskDetailView(card: selection) }

--- a/docs/specs/2026-07-03-ios-ipad-mac-onboarding-design.md
+++ b/docs/specs/2026-07-03-ios-ipad-mac-onboarding-design.md
@@ -1,0 +1,154 @@
+# iOS app: iPad/macOS screen adaptivity + seamless onboarding — design
+
+Date: 2026-07-03
+Status: approved (autonomous session — decisions recorded for async review)
+Related: goal screenshot (floating overlay sidebar + misaligned composer on a
+wide "Designed for iPad" window), `apps/ios/CovenCave/README.md:38-40` (known
+connection gap).
+
+## Problems
+
+The native SwiftUI app (`apps/ios/CovenCave`, iPhone+iPad device families,
+runs on Apple Silicon Macs as "Designed for iPad") has two distinct gaps:
+
+### A. Wide-screen layout (iPad landscape, macOS windows)
+
+1. The three `NavigationSplitView(.balanced)` surfaces (Chats, Tasks,
+   Developer→GitHub) set **no column widths** anywhere, so sidebar sizing is
+   left to defaults and the sidebar can present as a floating overlay at
+   in-between window widths (the screenshot) instead of a pinned column.
+2. **Calendar** and **Settings** are single-column `NavigationStack`s —
+   an iPad-landscape/Mac window is mostly dead space, and Calendar opens task
+   detail in a modal sheet even when a detail pane would fit.
+3. `readableWidth`/`readableListWidth` (Views/ReadableWidth.swift) exists but
+   is used **only by ChatView** — Tasks detail, Settings, Library, Journal,
+   and GitHub detail stretch edge-to-edge on wide screens.
+4. The Tasks **board** opens card detail in a sheet even on regular width,
+   while the Tasks **list** uses the split detail column — inconsistent.
+5. Zero size-class awareness in the app (no `horizontalSizeClass` usage), so
+   compact-vs-regular decisions (sheet vs detail pane) can't be made.
+
+### B. Onboarding & connection
+
+1. **Blocking bug:** the server enforces a signed mobile access token on all
+   `/api/*` when `COVEN_CAVE_ACCESS_TOKEN` is set (src/proxy.ts
+   mobileAccessGate), and mints QR invites carrying `coven_access_token` via
+   `/api/mobile-handoff` — but the iOS client **never attaches any
+   credential** (CaveClient/SSE/PTY WebSocket), stores no token, and its
+   `probe()` treats 401 as "unreachable". Pairing only works in the special
+   tokenless `COVEN_CAVE_TAILNET_TRUST=1` mode.
+2. Onboarding is manual host entry only — no invite-URL paste, no QR path,
+   no deep link (the `covencave://` scheme exists but only routes widget
+   tabs).
+3. Credentials live in UserDefaults (bare host), not Keychain; signed tokens
+   expire (invite TTL 8h) with no renewal path, so even a fixed client would
+   silently rot within a working day.
+
+## Approaches considered
+
+- **Full Mac Catalyst / SwiftUI-multiplatform target** — real Mac windowing,
+  menus, resizability. Rejected for now: new target, signing, AppKit
+  divergence; the app already runs on macOS as Designed-for-iPad, and every
+  regular-width fix below improves that mode directly. Revisit later.
+- **Per-screen adaptive fixes on the existing architecture (chosen for A)** —
+  pin split-view columns with explicit widths, convert Calendar to a split
+  view, spread `readableWidth` to every stretched surface, make sheet-vs-pane
+  decisions size-class-aware. One reviewable PR, no architectural rewrite.
+- **Tokenless trust everywhere (rejected for B)** — running the desktop with
+  the gate relaxed forever is the current workaround, not a fix.
+- **Full token pairing + rolling renewal (chosen for B)** — client attaches
+  the signed token; onboarding accepts invite URLs (paste/QR/deep link);
+  server gains a token-refresh endpoint so a paired device renews silently.
+
+## Design — Part A: adaptive screens (PR 1, Swift-only)
+
+New `Views/AdaptiveColumns.swift`:
+- `sidebarColumn()` = `.navigationSplitViewColumnWidth(min: 300, ideal: 340,
+  max: 420)` — applied to the sidebar column of Chats, Tasks, and GitHub
+  split views so the list pins as a real column instead of a floating
+  overlay, and the detail pane keeps the remaining width (fixes the
+  screenshot's overlay + off-center composer).
+- Each split view gets `@State columnVisibility:
+  NavigationSplitViewVisibility = .automatic` threaded through so behavior
+  stays standard but is explicit and testable.
+
+Per surface:
+- **Calendar** → `NavigationSplitView`: sidebar = existing agenda list
+  (`readableListWidth` not needed at ≤420pt); detail = selected task
+  (`TaskDetailView`) or journal entry; compact width keeps the current
+  stack + sheet behavior via `horizontalSizeClass`.
+- **Tasks board** → on regular width, tapping a card selects it into the
+  split detail column (same as the list path); the sheet remains for compact.
+  Kanban columns scale with the pane (`min 280`, growing to fill available
+  width instead of the hardcoded 280).
+- **Settings** → `readableListWidth(680)` on the Form; the connection hero
+  and theme grid stay centered instead of stretching.
+- **Tasks detail, GitHub detail, Library, Journal** → `readableWidth`/
+  `readableListWidth` (680) so text surfaces read as centered columns.
+- **ConnectionView / ConnectingView** → `readableWidth(520)` so onboarding
+  is a centered card on iPad/Mac rather than full-bleed.
+
+Not in scope for A: Info.plist windowing keys, multi-window scenes, Catalyst.
+
+## Design — Part B: onboarding + connection (PR 2, Swift + server)
+
+Server (`src/`):
+- `POST /api/mobile-token/refresh` — requires a currently-valid credential
+  (the existing gate already enforces this before the route runs); returns a
+  fresh signed token with a **rolling TTL of 30 days**
+  (`MOBILE_APP_TOKEN_TTL_MS` override), so a device that connects at least
+  monthly never re-pairs. Unit-tested; wired into run-tests.
+- `/api/mobile-handoff` gains an `appInvite` field in its response payload:
+  a `covencave://connect?host=<serveHost>&token=<signed 30-day token>` URL
+  (and the existing QR keeps working — the QR's https invite URL is ALSO
+  accepted by the app via paste/scan).
+
+iOS:
+- **`Networking/KeychainStore.swift`** — minimal Keychain wrapper; the access
+  token moves there (host string stays in UserDefaults; it's not secret).
+- **`CaveClient.request` / SSE / PTY WebSocket** attach
+  `Authorization: Bearer <token>` when a token exists.
+- **Invite parsing** (`Networking/CaveInvite.swift`, pure + unit-testable):
+  accepts `covencave://connect?host=&token=`, any https invite URL carrying
+  `coven_access_token` (+ optional `covenCaveToken`), or a bare host; returns
+  `{host, token?}`.
+- **ConnectionView**: the existing field accepts a pasted invite URL (parsed
+  through CaveInvite, token captured automatically); a "Scan QR" button
+  (camera devices; `NSCameraUsageDescription` added) scans the same invite;
+  `.onOpenURL` routes `covencave://connect` through the same path so tapping
+  the invite link pairs with zero typing.
+- **Auth-aware connection state**: `probe()` distinguishes 401/403 from
+  network failure; new `.needsAuth` connection state renders an actionable
+  screen ("This desktop requires pairing — scan the QR from Cave's Connect
+  Phone panel") instead of the generic "unreachable".
+- **Silent renewal**: on foreground/refresh, if the stored token's expiry
+  (readable client-side from the `v1.<expiresAt>.<nonce>.<sig>` shape) is
+  within 7 days, call `/api/mobile-token/refresh` and rotate the Keychain
+  copy. A 401 with reason=expired routes to `.needsAuth`.
+- **Swift unit tests**: new test target (XcodeGen `project.yml`) covering
+  CaveInvite parsing and token-expiry extraction. CI doesn't build iOS, so
+  these run locally (`xcodebuild test`), but they pin the pure logic.
+
+## Error handling
+
+- Every connection failure now lands in one of three explicit states:
+  `unreachable` (network), `needsAuth` (401/403), `connected` — each with its
+  own copy and recovery affordance.
+- Refresh failures are non-fatal (token keeps working until expiry); expiry
+  routes to `.needsAuth` with the pairing instructions.
+
+## Testing / verification
+
+- Part A: build for iPad simulator (`Cave iPad Verify`, iOS 26.5) +
+  screenshot every tab in landscape; compare against the goal screenshot.
+  Web CI unaffected (Swift-only).
+- Part B: server routes unit-tested (web CI); iOS side verified against a
+  local Cave server run WITH `COVEN_CAVE_ACCESS_TOKEN` set — confirm 401 →
+  `.needsAuth` UX, paste-invite pairing, authorized requests, and refresh
+  rotation. Swift unit tests for the pure parsing.
+
+## Out of scope (follow-ups)
+
+- Mac Catalyst target / multi-window scenes.
+- iOS CI (Xcode build in GitHub Actions).
+- Bonjour LAN discovery of the desktop.

--- a/docs/specs/2026-07-03-ios-ipad-mac-onboarding-plan.md
+++ b/docs/specs/2026-07-03-ios-ipad-mac-onboarding-plan.md
@@ -1,0 +1,216 @@
+# iOS iPad/macOS Adaptivity + Seamless Onboarding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every screen of the native app lays out properly on iPad landscape and macOS ("Designed for iPad") windows, and pairing a device with a token-gated desktop is a paste/scan/tap affair with actionable errors and silent renewal.
+
+**Architecture:** Part A (PR 1, Swift-only): explicit split-view column widths, Calendar converted to a split view, size-class-aware sheet-vs-pane decisions, `readableWidth` spread to all stretched surfaces. Part B (PR 2, Swift + server): signed-token capture (invite URL paste / QR / `covencave://connect` deep link) → Keychain → `Authorization: Bearer` on every transport, 401-aware connection states, and a rolling 30-day refresh endpoint.
+
+**Tech Stack:** SwiftUI (iOS 18 target, XcodeGen), Next.js API routes (node:test source-text/unit tests, run-tests.mjs suites).
+
+**Spec:** `docs/specs/2026-07-03-ios-ipad-mac-onboarding-design.md`
+
+Verification environment: iPad simulator "Cave iPad Verify" (iPad Pro 13-inch, iOS 26.5, udid 104E9408-B20F-45BE-B9D7-F315D9364AF9); local Cave server; tab navigation in the sim via the existing `covencave://tasks|calendar` deep links. CI does not build Swift — every Swift task must end with a local `xcodebuild build` pass.
+
+---
+
+## Part A — adaptive screens (branch `feat/ipad-mac-adaptive-screens`)
+
+### Task A1: Sidebar column widths (Chats, Tasks, GitHub)
+
+**Files:**
+- Modify: `apps/ios/CovenCave/CovenCave/Views/ReadableWidth.swift` (append)
+- Modify: `apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift` (sidebar Group, ~line 37)
+- Modify: `apps/ios/CovenCave/CovenCave/Views/TasksView.swift` (sidebar `content`, ~line 71)
+- Modify: `apps/ios/CovenCave/CovenCave/Views/GitHubView.swift` (sidebar `content`, ~line 21)
+
+- [ ] **Step 1:** Append to `ReadableWidth.swift`:
+
+```swift
+extension View {
+    /// Pin a split-view sidebar to a real column. Without an explicit width
+    /// the sidebar sizes by trait defaults and can present as a floating
+    /// overlay at in-between window widths (Designed-for-iPad on macOS);
+    /// with one it stays a fixed pane and the detail keeps the rest.
+    func sidebarColumn() -> some View {
+        navigationSplitViewColumnWidth(min: 300, ideal: 340, max: 420)
+    }
+}
+```
+
+- [ ] **Step 2:** In each of the three split views, add `.sidebarColumn()` as the LAST modifier of the sidebar content (after `.onChange`/`.onAppear` chains, inside the `NavigationSplitView { … }` first closure).
+- [ ] **Step 3:** `cd apps/ios/CovenCave && xcodegen generate && xcodebuild -project CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,name=Cave iPad Verify' build` → BUILD SUCCEEDED.
+- [ ] **Step 4:** Commit -S "feat(ios): pin split-view sidebars to real columns on wide screens"; push.
+
+### Task A2: Calendar becomes a split view (detail pane instead of sheets on iPad)
+
+**Files:**
+- Modify: `apps/ios/CovenCave/CovenCave/Views/CalendarView.swift:16-46` (body)
+
+- [ ] **Step 1:** Replace the `NavigationStack { content … }` body with a `NavigationSplitView`: sidebar = existing `content` chain (title, toolbar, refreshable, task, confirmationDialog, `.sidebarColumn()`); detail = selected task or placeholder. Delete the task-detail `.sheet` (the collapsed split view pushes detail on iPhone, so one code path serves both); keep the Journal sheet.
+
+```swift
+    var body: some View {
+        NavigationSplitView {
+            content
+                .navigationTitle("Calendar")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button { showJournal = true } label: { Image(systemName: "book") }
+                            .accessibilityLabel("Journal")
+                    }
+                }
+                .refreshable { await reload() }
+                .task {
+                    if !app.remindersLoaded { await app.loadReminders() }
+                    if !app.tasksLoaded { await app.loadTasks() }
+                }
+                .sheet(isPresented: $showJournal) { JournalView() }
+                .confirmationDialog("Delete this reminder?",
+                                    isPresented: deleteDialogBinding,
+                                    titleVisibility: .visible,
+                                    presenting: pendingDelete) { reminder in
+                    Button("Delete", role: .destructive) {
+                        Task { await app.deleteReminders([reminder.id]) }
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: { reminder in Text(reminder.title) }
+                .sidebarColumn()
+        } detail: {
+            if let card = taskSelection {
+                NavigationStack { TaskDetailView(card: card) }
+            } else {
+                ContentUnavailableView {
+                    Label("Select an item", systemImage: "calendar")
+                } description: {
+                    Text("Pick a task to see its details beside the agenda.")
+                }
+            }
+        }
+        // Agenda stays visible beside the detail on iPad; iPhone collapses to
+        // the familiar single-column push.
+        .navigationSplitViewStyle(.balanced)
+    }
+```
+
+Check how agenda rows set `taskSelection` (the `row(item)` builder further down) — taps must keep setting `taskSelection`; only the presentation changes.
+
+- [ ] **Step 2:** Build (same xcodebuild) → SUCCEEDED. Commit -S "feat(ios): Calendar detail pane on iPad instead of modal sheets"; push.
+
+### Task A3: Tasks board — detail column on regular width + columns that fill the pane
+
+**Files:**
+- Modify: `apps/ios/CovenCave/CovenCave/Views/TasksView.swift` (board `Button { boardDetail = card }` ~line 295; `kanbanBoard` ~line 270; add `@Environment(\.horizontalSizeClass)`)
+
+- [ ] **Step 1:** Add `@Environment(\.horizontalSizeClass) private var horizontalSizeClass` to `TasksView`. Change the card tap:
+
+```swift
+                        Button {
+                            // Regular width has a live detail column — use it,
+                            // matching the List path; compact keeps the sheet.
+                            if horizontalSizeClass == .regular { selection = card }
+                            else { boardDetail = card }
+                        } label: {
+```
+
+- [ ] **Step 2:** Make column widths fill the pane:
+
+```swift
+    private var kanbanBoard: some View {
+        GeometryReader { geo in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(sections) { section in
+                        kanbanColumn(section, width: kanbanColumnWidth(available: geo.size.width))
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            }
+        }
+    }
+
+    /// Fit as many 280pt-minimum columns as the pane allows (capped at the
+    /// section count), then stretch them to consume the leftover width — no
+    /// dead right margin on iPad/Mac.
+    private func kanbanColumnWidth(available: CGFloat) -> CGFloat {
+        let inset: CGFloat = 32, spacing: CGFloat = 12, minWidth: CGFloat = 280
+        let usable = max(minWidth, available - inset)
+        let fit = max(1, min(CGFloat(sections.count), ((usable + spacing) / (minWidth + spacing)).rounded(.down)))
+        return max(minWidth, (usable - spacing * (fit - 1)) / fit)
+    }
+```
+
+`kanbanColumn(_:)` gains a `width: CGFloat` parameter and its `.frame(width: 280)` becomes `.frame(width: width)`.
+
+- [ ] **Step 3:** Build → SUCCEEDED. Commit -S "feat(ios): board cards open the detail pane on iPad; kanban columns fill the width"; push.
+
+### Task A4: Readable columns everywhere text stretches
+
+**Files:**
+- Modify: `SettingsView.swift` (Form, after `.themedListBackground()`): `.readableListWidth(680)`
+- Modify: `TaskDetailView.swift` (root container — List/Form → `.readableListWidth(680)`; ScrollView → `.readableWidth(680)`)
+- Modify: `GitHubView.swift` (`GitHubItemDetailView` root): `.readableListWidth(720)` (or `readableWidth` per container)
+- Modify: `LibraryView.swift`, `JournalView.swift` (lists): `.readableListWidth(680)`
+- Modify: `FamiliarThreadsView.swift` (thread list): `.readableListWidth(740)` to align with ChatView's 740
+- Modify: `ConnectionView.swift` (onboarding card): `.readableWidth(520)`
+
+- [ ] **Step 1:** Apply each modifier at the screen's outermost scroll container; inspect each file's root first and put the modifier where the container is greedy (List/Form → `readableListWidth`, ScrollView/VStack → `readableWidth`).
+- [ ] **Step 2:** Build → SUCCEEDED. Commit -S "feat(ios): readable centered columns for wide-screen text surfaces"; push.
+
+### Task A5: iPad simulator verification + PR
+
+- [ ] **Step 1:** Start the Cave web server from the worktree (build once: `pnpm build`; then `rm -rf .next/dev && PORT=3496 node server.mjs &`). NOTE: the iOS app hardcodes port 3000 for bare hosts (`CaveConnection.swift:16-35`) — run on PORT=3000 instead if free, else temporarily seed the host as `localhost:3496`? The connection host accepts `host:port`? CHECK `CaveConnection` parsing first; if it doesn't accept an explicit port, use PORT=3000 (check `lsof -ti tcp:3000` first — another session may own it).
+- [ ] **Step 2:** Boot + seed the sim:
+
+```bash
+xcrun simctl boot 104E9408-B20F-45BE-B9D7-F315D9364AF9 || true
+xcrun simctl spawn 104E9408-B20F-45BE-B9D7-F315D9364AF9 defaults write ai.opencoven.cave cave.connection.host -string "localhost"
+xcrun simctl install 104E9408-B20F-45BE-B9D7-F315D9364AF9 <DerivedData .app path>
+xcrun simctl launch 104E9408-B20F-45BE-B9D7-F315D9364AF9 ai.opencoven.cave
+```
+
+- [ ] **Step 3:** Screenshot Chats (default), then `xcrun simctl openurl … covencave://tasks` and `covencave://calendar` for those tabs; `xcrun simctl io … screenshot /tmp/ios-<tab>.png` each time; READ the images — sidebar must be a pinned column, composer centered, no dead panes.
+- [ ] **Step 4:** PR `feat(ios): iPad/macOS adaptive layouts across all tabs`; six required checks (all web — should be green quickly since no web files change); verify MERGED; clean worktree.
+
+## Part B — onboarding + connection (branch `feat/mobile-pairing-auth`)
+
+### Task B1: Server — rolling refresh endpoint + app invite
+
+**Files:**
+- Create: `src/app/api/mobile-token/refresh/route.ts`
+- Modify: `src/lib/mobile-handoff.ts` (add `appInviteUrl` to invite payload)
+- Modify: `src/app/api/mobile-handoff/route.ts` (include `appInvite` in responses)
+- Test: `src/app/api/mobile-token/refresh/route.test.ts` (new), extend `src/lib/mobile-handoff.test.ts` if present
+- Modify: `scripts/run-tests.mjs` (wire new test into the `api` suite)
+
+- [ ] **Step 1:** Failing test: POST with valid credential returns `{ok:true, token, expiresAt}` where `expiresAt - now ≈ 30d` (override via `MOBILE_APP_TOKEN_TTL_MS`); GET rejected 405. The route itself can trust the proxy gate for auth (it never runs unauthenticated), but still re-verify the supplied credential to bind the response to it.
+- [ ] **Step 2:** Implement route with `signMobileAccessToken({secret: process.env.COVEN_CAVE_ACCESS_TOKEN, expiresAt: Date.now() + TTL})`; return 503 `{ok:false, error:"token gate disabled"}` when no secret configured. `appInviteUrl`: `covencave://connect?host=<serve host>&token=<30-day signed token>` built beside the https invite in `createMobileInvite`.
+- [ ] **Step 3:** Wire tests, `pnpm run check:tests-wired`, `pnpm run test:api`, typecheck, build. Commit -S; push.
+
+### Task B2: iOS — credential capture, storage, attachment, auth-aware states
+
+**Files:**
+- Create: `apps/ios/CovenCave/CovenCave/Networking/KeychainStore.swift` (kSecClassGenericPassword get/set/delete for `cave.access-token`)
+- Create: `apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift` — pure parser: `covencave://connect?host&token` | https URL with `coven_access_token`/`covenCaveToken` query | bare host → `struct CaveInvite { let host: String; let token: String? }`; plus `tokenExpiry(_ token: String) -> Date?` reading the `v1.<expiresAt>.<nonce>.<sig>` shape.
+- Modify: `Networking/CaveConnection.swift` — token accessor via KeychainStore (host stays in UserDefaults).
+- Modify: `Networking/CaveClient.swift:22-48` request builder + `:260-307` SSE: `if let token { request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization") }`.
+- Modify: `Networking/PtyTerminal.swift` — same header on the WebSocket URLRequest.
+- Modify: `State/AppModel.swift` — `probe()` returns an enum (`ok | unauthorized | unreachable`); new `.needsAuth` connection state; `configure(host:token:)`; silent renewal on foreground when expiry < 7 days via `api/mobile-token/refresh`.
+- Modify: `Views/ConnectionView.swift` — paste/typed input routed through `CaveInvite`; "Scan QR" button (`DataScannerViewController` availability-gated; `NSCameraUsageDescription` in Info.plist); `.needsAuth` copy with pairing instructions.
+- Modify: `Views/RootView.swift` — route `.needsAuth` to ConnectionView with the auth message.
+- Modify: `CovenCaveApp.swift` / `AppModel.handleDeepLink` — accept `covencave://connect?host&token` → configure + connect.
+- Modify: `project.yml` — add a unit-test target `CovenCaveTests`; tests for CaveInvite parsing + expiry extraction.
+
+- [ ] Steps: failing Swift tests for CaveInvite → implement parser → wire storage/attachment → states/UI → `xcodegen generate && xcodebuild test -destination 'platform=iOS Simulator,name=Cave iPad Verify'` → commit -S per coherent slice; push each.
+
+### Task B3: End-to-end verification + PR
+
+- [ ] Run the local server WITH `COVEN_CAVE_ACCESS_TOKEN=<random>`: fresh app shows `.needsAuth` (not "unreachable"); mint a signed token via a node one-liner using `signMobileAccessToken`; `xcrun simctl openurl … "covencave://connect?host=localhost&token=…"` → app pairs, familiars load; screenshot the flow. Kill server; confirm `.unreachable` copy still distinct. PR `feat(mobile): seamless pairing — QR/deep-link invites, Bearer auth, rolling renewal`; six checks; merge; clean up.
+
+## Self-review notes
+
+- Spec coverage: A1→pain 1, A2→pain 2, A3→pains 4/5 (board+size class), A4→pain 3, B1→token TTL/renewal, B2→pains B1-B3 (attach/capture/states/Keychain), B3→verified end-to-end. Out-of-scope items have no tasks by design.
+- Line anchors are from today's exploration of `origin/main`; re-locate by content before editing.
+- `CaveConnection` port handling must be confirmed before A5 step 1 (bare-host port hardcode).


### PR DESCRIPTION
## Why

On iPad landscape and macOS ("Designed for iPad") windows, the app's list panes floated as overlay panels on top of content instead of pinning as split-view columns, the Calendar and Settings tabs wasted the whole right pane, board/agenda taps opened modal sheets beside dead space, and most text surfaces stretched edge-to-edge. Design doc: `docs/specs/2026-07-03-ios-ipad-mac-onboarding-design.md` (Part A).

## What

- **`sidebarColumn()`** (ReadableWidth.swift): explicit `navigationSplitViewColumnWidth(min 300 / ideal 340 / max 420)` applied to the Chats, Tasks, and GitHub split-view sidebars — the list pins as a real column and the detail keeps the rest.
- **Calendar** becomes a `NavigationSplitView`: tapped tasks fill the detail pane on regular width; compact keeps the sheet (agenda rows are plain buttons, so a collapsed split wouldn't push on its own).
- **Tasks board**: on regular width a card tap selects into the split detail column (same as the List path); compact keeps the sheet. Kanban columns now fit-and-fill the pane (280pt minimum, stretching to consume leftover width).
- **Readable centered columns** for wide-screen text surfaces: Task detail (680), GitHub item detail (720), Library list (680), Settings form (680), familiar thread list (740 — aligned with ChatView's transcript), onboarding ConnectionView (520).

## Verification

- `xcodebuild build` (iPad Pro 13-inch simulator, iOS 26.5) green after every task.
- Live in the simulator against a local Cave server: the Chats sidebar renders as a pinned column beside the detail pane (previously a floating overlay — see goal screenshot), familiars list loads, onboarding renders as a centered card.
- No web files changed; CI checks are unaffected by content.

Part B (seamless onboarding/connection: token pairing, QR/deep-link invites, auth-aware errors, rolling renewal) follows in a separate PR per the same design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)