### PR TITLE
feat(board): nudge to set a project on projectless task cards

### DIFF
--- a/src/components/board-card-stack.tsx
+++ b/src/components/board-card-stack.tsx
@@ -204,6 +204,14 @@ function BoardCardStackRow({
             {card.priority}
           </span>
           <LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} />
+          {!card.projectId && !card.cwd && (
+            <span
+              className="board-card-stack__row-no-project"
+              title="No project set — pick one in the card's Project field so task chats open in the right place"
+            >
+              No project
+            </span>
+          )}
         </div>
         <div className="board-card-stack__row-title">{card.title}</div>
         {card.notes ? (

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -1206,6 +1206,12 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
                   No projects yet. Open Projects to add one, then choose it here.
                 </p>
               ) : null}
+              {projects.length > 0 && !card.projectId && !card.cwd ? (
+                <p className="board-drawer-field-hint board-drawer-field-hint--nudge">
+                  No project set — task chats can't start, and linked chats won't open in the
+                  right project, until you pick one.
+                </p>
+              ) : null}
             </div>
           </div>
 

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -707,6 +707,9 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
   const urgency = scheduleUrgency(card.endDate, card.status, todayMs);
   const attachmentCount = card.attachments?.length ?? 0;
   const hasChips = !!schedule || !!card.cwd || card.links.length > 0 || card.labels.length > 0 || attachmentCount > 0 || !!session;
+  // A card with neither a project nor a cwd can't root its task chats — new
+  // chat starts are refused and linked chats can't inherit a project. Nudge.
+  const missingProject = !card.projectId && !card.cwd;
   // The metadata chips below are visual-only (title-attribute spans); fold the
   // same state into the card's accessible name so AT users hear it.
   const ariaMeta = [
@@ -718,6 +721,7 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
         : `scheduled ${schedule}`
       : null,
     session ? "linked chat" : null,
+    missingProject ? "no project set" : null,
     attachmentCount > 0 ? `${attachmentCount} attachment${attachmentCount === 1 ? "" : "s"}` : null,
     card.labels.length > 0 ? `labels ${card.labels.join(", ")}` : null,
   ].filter(Boolean).join(", ");
@@ -764,6 +768,14 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
       <div className="board-kanban-card-top">
         <span className={`board-kanban-priority-pill board-kanban-priority-pill--${card.priority}`}>{pri.label}</span>
         <LifecycleBadge lifecycle={card.lifecycle} needsHuman={card.needsHuman} />
+        {missingProject && (
+          <span
+            className="board-kanban-card-chip board-kanban-card-chip--no-project"
+            title="No project set — pick one in the card's Project field so task chats open in the right place"
+          >
+            <Icon name="ph:folder" width={9} aria-hidden /> No project
+          </span>
+        )}
       </div>
       <div className="board-kanban-card-title">{card.title}</div>
       {card.notes && <p className="board-kanban-card-notes">{card.notes}</p>}

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -194,4 +194,41 @@ assert.match(
   "The draft-init effect re-seeds when the linked task arrives (it loads async with the conversation)",
 );
 
+// ── Projectless task cards get a "set a project" nudge (2026-07-03) ──────────
+// A card with neither projectId nor cwd can't root its task chats: new starts
+// are refused (409) and linked chats can't inherit a project. Surface that on
+// the card face (desktop + mobile) and under the inspector's Project field.
+const boardKanban = readFileSync(new URL("./board-kanban.tsx", import.meta.url), "utf8");
+const boardCardStack = readFileSync(new URL("./board-card-stack.tsx", import.meta.url), "utf8");
+assert.match(
+  boardKanban,
+  /const missingProject = !card\.projectId && !card\.cwd;/,
+  "the kanban card derives its projectless state from both project fields",
+);
+assert.match(
+  boardKanban,
+  /board-kanban-card-chip--no-project/,
+  "a projectless kanban card shows a No-project chip",
+);
+assert.match(
+  boardKanban,
+  /missingProject \? "no project set" : null,/,
+  "the nudge is folded into the card's accessible name so AT users hear it",
+);
+assert.match(
+  boardCardStack,
+  /board-card-stack__row-no-project/,
+  "the mobile card face mirrors the No-project nudge",
+);
+assert.match(
+  boardInspector,
+  /projects\.length > 0 && !card\.projectId && !card\.cwd \? \(/,
+  "the inspector nudge shows only when a project could actually be picked (the empty-roster case has its own hint)",
+);
+assert.match(
+  boardInspector,
+  /board-drawer-field-hint--nudge/,
+  "the inspector Project field carries the set-a-project nudge",
+);
+
 console.log("task-chat-cwd.test.ts: ok");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -377,6 +377,8 @@
 .board-kanban-card-chip--due-soon svg { color:var(--color-warning); }
 .board-kanban-card-chip--overdue { color:var(--color-danger); background:color-mix(in oklch,var(--color-danger) 14%,transparent); border-color:color-mix(in oklch,var(--color-danger) 38%,var(--border-hairline)); font-weight:600; }
 .board-kanban-card-chip--overdue svg { color:var(--color-danger); }
+.board-kanban-card-chip--no-project { color:var(--color-warning); background:color-mix(in oklch,var(--color-warning) 12%,transparent); border-color:color-mix(in oklch,var(--color-warning) 32%,var(--border-hairline)); }
+.board-kanban-card-chip--no-project svg { color:var(--color-warning); }
 
 .board-kanban-card-footer { display:flex; align-items:center; justify-content:space-between; gap:6px; padding-top:6px; border-top:1px dashed var(--border-hairline); }
 .board-kanban-card-familiar { display:inline-flex; align-items:center; gap:5px; min-width:0; flex:1; }
@@ -413,6 +415,7 @@
 .board-drawer-inline-link { display:inline-flex; align-items:center; gap:4px; border:0; background:transparent; padding:0; color:var(--accent-presence); font-size:10px; font-weight:600; text-transform:none; letter-spacing:0; cursor:pointer; }
 .board-drawer-inline-link:hover { color:var(--text-primary); }
 .board-drawer-field-hint { margin:0; color:var(--text-muted); font-size:11px; line-height:1.35; }
+.board-drawer-field-hint--nudge { color:var(--color-warning); }
 .board-drawer-count-pill { display:inline-flex; align-items:center; justify-content:center; min-width:16px; height:14px; padding:0 5px; border-radius:7px; background:var(--bg-elevated); border:1px solid var(--border-hairline); color:var(--text-secondary); font-size:9.5px; font-weight:600; letter-spacing:0; text-transform:none; }
 .board-drawer-field-select,.board-drawer-field-input { width:100%; padding:6px 9px; border-radius:8px; border:1px solid var(--border-strong); background:var(--bg-base); color:var(--text-primary); line-height:1.25; outline:none; transition:border-color .12s,box-shadow .12s; }
 .board-drawer-field-select:focus,.board-drawer-field-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 60%,transparent); box-shadow:0 0 0 3px color-mix(in oklch,var(--accent-presence) 16%,transparent); }
@@ -1634,6 +1637,17 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   font-variant-numeric: tabular-nums;
 }
 .board-card-stack__row-schedule--overdue { color: var(--color-danger); font-weight: 600; }
+.board-card-stack__row-no-project {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 5px;
+  border-radius: 5px;
+  font-size: 10px;
+  color: var(--color-warning);
+  background: color-mix(in oklch, var(--color-warning) 12%, transparent);
+  border: 1px solid color-mix(in oklch, var(--color-warning) 32%, var(--border-hairline));
+  white-space: nowrap;
+}
 .board-card-stack__row-action {
   margin-left: auto;
   display: inline-flex;


### PR DESCRIPTION
Follow-up to #2308 (task-linked chats inherit the task's project). A card with neither `projectId` nor `cwd` can't root its task chats — new starts are refused with a 409 and linked chats have no project to inherit — but nothing surfaced that until the failed chat attempt.

## What

- **Kanban card face**: a warning-tinted `No project` chip in the always-rendered top row (deliberately clear of the `hasChips` gate and the schedule-chip ordering pin in `board-schedule-window.test.ts`), with "no project set" folded into the card's accessible name for AT users.
- **Mobile card stack**: the row-top mirrors the chip (`board-card-stack__row-no-project`; needs no new props — both fields are on the card).
- **Board inspector**: a one-line warning hint under the Project field when the roster has projects but the card has none picked — placed after the select shell, outside the `{0,1100}` pin window in `task-chat-cwd.test.ts`. The empty-roster case keeps its existing "No projects yet…" hint.
- **CSS**: chip + hint variants in `src/styles/board.css`, cloning the existing `--due-soon` warning recipe.

## Tests

New pin section in `task-chat-cwd.test.ts` (the task-chat project arc's home): chip condition, accessible-name entry, mobile mirror, and the inspector gating. All ordering-sensitive board pins verified green (`board-ux-polish`, `board-card-stack-a11y`, `board-schedule-window`, `board-project-picker`, `board-chat-link`, `board-inspector-a11y`, `mobile-shell-smoke`); full suite 704 files green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)