### PR TITLE
feat(mobile): seamless pairing — QR/deep-link invites, Bearer auth, rolling renewal

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Info.plist
+++ b/apps/ios/CovenCave/CovenCave/Info.plist
@@ -44,6 +44,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Coven Cave uses the camera to scan the pairing QR code shown on your desktop.</string>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Coven Cave connects to your desktop over your private Tailscale network to chat with your familiars.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 /// REST + streaming client for the Coven Cave desktop API.
-/// No auth header — trust is the Tailscale tailnet boundary.
+/// When the desktop is token-gated (COVEN_CAVE_ACCESS_TOKEN), every request —
+/// REST and SSE alike — carries the paired credential as a Bearer header; in
+/// tokenless tailnet-trust mode no header is sent and the tailnet boundary is
+/// the trust anchor, as before.
 struct CaveClient {
     var connection: CaveConnection
 
@@ -40,11 +43,36 @@ struct CaveClient {
         var req = URLRequest(url: url)
         req.httpMethod = method
         req.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let token = CaveConnection.accessToken {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         if let body {
             req.httpBody = body
             req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         }
         return req
+    }
+
+    // MARK: - Pairing
+
+    private struct TokenRefreshResponse: Decodable {
+        var ok: Bool
+        var token: String?
+        var expiresAt: Double?
+    }
+
+    /// Rolling renewal: exchange the current credential for a fresh 30-day
+    /// token. Returns the new token, or nil when the desktop runs tokenless
+    /// (503) or the credential can't refresh — callers treat nil as "keep
+    /// using what we have".
+    func refreshAccessToken() async -> String? {
+        guard let req = try? request("api/mobile-token/refresh", method: "POST") else { return nil }
+        guard let (data, resp) = try? await session.data(for: req),
+              let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let decoded = try? JSONDecoder().decode(TokenRefreshResponse.self, from: data),
+              decoded.ok, let token = decoded.token, !token.isEmpty
+        else { return nil }
+        return token
     }
 
     // MARK: - Health

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -79,6 +79,7 @@ struct CaveConnection: Codable, Equatable {
     }
 
     static let storageKey = "cave.connection.host"
+    static let tokenKey = "cave.access-token"
 
     static func load() -> CaveConnection? {
         guard let host = UserDefaults.standard.string(forKey: storageKey),
@@ -92,6 +93,22 @@ struct CaveConnection: Codable, Equatable {
 
     static func clear() {
         UserDefaults.standard.removeObject(forKey: storageKey)
+        KeychainStore.remove(tokenKey)
+    }
+
+    /// The mobile access credential, when this desktop's API is token-gated
+    /// (COVEN_CAVE_ACCESS_TOKEN on the server). Kept in the Keychain — the
+    /// host string above is not a secret, this is.
+    static var accessToken: String? {
+        KeychainStore.string(forKey: tokenKey)
+    }
+
+    static func saveAccessToken(_ token: String?) {
+        if let token, !token.isEmpty {
+            KeychainStore.set(token, forKey: tokenKey)
+        } else {
+            KeychainStore.remove(tokenKey)
+        }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveInvite.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// A parsed pairing input: where the desktop lives and (optionally) the
+/// credential that unlocks its API. Pure + unit-tested. Accepts, in order:
+/// - `covencave://connect?host=…&token=…` — the desktop's app invite link
+///   (tap on device, or scan its QR)
+/// - any http(s) invite URL carrying `coven_access_token`/`covenCaveToken` —
+///   the browser-invite QR payload, pasted or scanned
+/// - a bare host / host:port / full URL, with no credential (tokenless mode)
+struct CaveInvite: Equatable {
+    var host: String
+    var token: String?
+
+    static func parse(_ input: String) -> CaveInvite? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let lower = trimmed.lowercased()
+
+        if lower.hasPrefix("covencave://") {
+            guard let comps = URLComponents(string: trimmed),
+                  let host = queryValue(comps, "host"), !host.isEmpty else { return nil }
+            return CaveInvite(host: host, token: queryValue(comps, "token"))
+        }
+
+        if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
+            guard let comps = URLComponents(string: trimmed),
+                  let hostname = comps.host, !hostname.isEmpty else { return nil }
+            let token = queryValue(comps, "coven_access_token") ?? queryValue(comps, "covenCaveToken")
+            // Keep scheme + host + port (CaveConnection trusts full URLs
+            // verbatim); drop the path/query — the token is captured here.
+            var normalized = "\(comps.scheme ?? "https")://\(hostname)"
+            if let port = comps.port { normalized += ":\(port)" }
+            return CaveInvite(host: normalized, token: token)
+        }
+
+        return CaveInvite(host: trimmed, token: nil)
+    }
+
+    /// Expiry baked into a signed token (`v1.<expiresAtMs>.<nonce>.<sig>`);
+    /// nil for the legacy raw secret (which never expires). Client-side only —
+    /// drives renewal timing and the re-pair message.
+    static func tokenExpiry(_ token: String) -> Date? {
+        let parts = token.split(separator: ".")
+        guard parts.count == 4, parts[0] == "v1", let ms = Double(parts[1]) else { return nil }
+        return Date(timeIntervalSince1970: ms / 1000)
+    }
+
+    private static func queryValue(_ comps: URLComponents, _ name: String) -> String? {
+        let value = comps.queryItems?.first(where: { $0.name == name })?.value
+        return (value?.isEmpty == false) ? value : nil
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/KeychainStore.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/KeychainStore.swift
@@ -25,7 +25,10 @@ enum KeychainStore {
         if status == errSecItemNotFound {
             var add = query
             add[kSecValueData as String] = data
-            SecItemAdd(add as CFDictionary, nil)
+            let addStatus = SecItemAdd(add as CFDictionary, nil)
+            if addStatus != errSecSuccess { assertionFailure("Keychain add failed: \(addStatus)") }
+        } else if status != errSecSuccess {
+            assertionFailure("Keychain update failed: \(status)")
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/KeychainStore.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/KeychainStore.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Security
+
+/// Minimal Keychain wrapper for the mobile access credential. The desktop
+/// host stays in UserDefaults (it isn't a secret); the token that authorizes
+/// every API call belongs in the Keychain.
+enum KeychainStore {
+    private static let service = "ai.opencoven.cave"
+
+    static func string(forKey key: String) -> String? {
+        var query = baseQuery(key)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
+              let data = item as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func set(_ value: String, forKey key: String) {
+        let data = Data(value.utf8)
+        let query = baseQuery(key)
+        let update: [String: Any] = [kSecValueData as String: data]
+        let status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+        if status == errSecItemNotFound {
+            var add = query
+            add[kSecValueData as String] = data
+            SecItemAdd(add as CFDictionary, nil)
+        }
+    }
+
+    static func remove(_ key: String) {
+        SecItemDelete(baseQuery(key) as CFDictionary)
+    }
+
+    private static func baseQuery(_ key: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+        ]
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
@@ -47,7 +47,13 @@ final class PtyTerminal {
         guard let url = comps.url else { error = "Bad terminal URL."; return }
 
         let session = URLSession(configuration: .default)
-        let ws = session.webSocketTask(with: url)
+        // Same credential as the REST client — the pty-ws upgrade passes
+        // through the token gate too on a paired desktop.
+        var wsRequest = URLRequest(url: url)
+        if let token = CaveConnection.accessToken {
+            wsRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let ws = session.webSocketTask(with: wsRequest)
         task = ws
         ws.resume()
         connected = true

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -664,18 +664,20 @@ final class AppModel {
     }
 
     /// Probe candidate base URLs in order; adopt the first that answers as a
-    /// real Cave server. A 401/403 anywhere is remembered so a token-gated
-    /// desktop reads as "needs pairing" instead of "unreachable".
+    /// real Cave server. A 401/403 is TERMINAL, not a cue to keep walking:
+    /// it's a live Cave token gate talking, and the fix is pairing. Probing
+    /// past it can silently adopt a different instance on a sibling port
+    /// (e.g. a dev server on :3000) — the user thinks they're talking to the
+    /// desktop they paired with, but they aren't.
     static func discoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
-        var sawUnauthorized = false
         for base in candidates {
             switch await probe(base) {
             case .ok: return .found(base)
-            case .unauthorized: sawUnauthorized = true
+            case .unauthorized: return .unauthorized
             case .failed: continue
             }
         }
-        return sawUnauthorized ? .unauthorized : .none
+        return .none
     }
 
     private enum ProbeResult { case ok, unauthorized, failed }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -626,7 +626,8 @@ final class AppModel {
               let token = CaveConnection.accessToken,
               let expiry = CaveInvite.tokenExpiry(token) else { return }
         let renewalWindow: TimeInterval = 7 * 24 * 3600
-        guard expiry.timeIntervalSinceNow < renewalWindow else { return }
+        let secondsUntilExpiry = expiry.timeIntervalSinceNow
+        guard secondsUntilExpiry > 0 && secondsUntilExpiry < renewalWindow else { return }
         if let fresh = await client.refreshAccessToken() {
             CaveConnection.saveAccessToken(fresh)
         }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -23,6 +23,10 @@ final class AppModel {
         case checking
         case connected
         case unreachable(String)
+        /// The desktop answered but rejected our credential (401/403) — the
+        /// device needs pairing, not a different address. Distinct from
+        /// `unreachable` so onboarding can say what to actually do.
+        case needsAuth(String)
     }
 
     var connection: CaveConnection?
@@ -456,7 +460,16 @@ final class AppModel {
     var deepLink: DeepLink?
 
     func handleDeepLink(_ url: URL) {
-        guard url.scheme == "covencave", let target = DeepLink(rawValue: url.host ?? "") else { return }
+        guard url.scheme == "covencave" else { return }
+        // covencave://connect?host=…&token=… — the desktop's pairing invite.
+        // Tapping it (or scanning its QR) configures host + credential in one
+        // step, replacing any previous pairing.
+        if url.host == "connect" {
+            guard let invite = CaveInvite.parse(url.absoluteString) else { return }
+            Task { await configure(host: invite.host, token: invite.token) }
+            return
+        }
+        guard let target = DeepLink(rawValue: url.host ?? "") else { return }
         switch target {
         case .tasks, .reminders: selectedTab = .tasks
         case .calendar: selectedTab = .calendar
@@ -556,7 +569,8 @@ final class AppModel {
 
     // MARK: - Connection lifecycle
 
-    func configure(host: String) async {
+    func configure(host: String, token: String? = nil) async {
+        if let token { CaveConnection.saveAccessToken(token) }
         let conn = CaveConnection(host: host)
         connection = conn
         conn.save()
@@ -577,23 +591,45 @@ final class AppModel {
         // Try the configured endpoint first, then auto-relocate to a working
         // port (e.g. the user typed a `.ts.net` host without `:8443`).
         let configured = connection.baseURL
-        guard let working = await Self.discoverBaseURL(connection.candidateBaseURLs) else {
-            connectionState = .unreachable("Couldn’t reach the desktop. Is it on the tailnet and running?")
-            return
-        }
-
-        if working != configured {
-            // Relocate: persist the working URL so future launches connect directly.
-            let relocated = CaveConnection(host: working.absoluteString)
-            self.connection = relocated
-            relocated.save()
-            if let port = working.port {
-                showToast("Connected on port \(port)", systemImage: "antenna.radiowaves.left.and.right")
+        switch await Self.discoverBaseURL(connection.candidateBaseURLs) {
+        case .found(let working):
+            if working != configured {
+                // Relocate: persist the working URL so future launches connect directly.
+                let relocated = CaveConnection(host: working.absoluteString)
+                self.connection = relocated
+                relocated.save()
+                if let port = working.port {
+                    showToast("Connected on port \(port)", systemImage: "antenna.radiowaves.left.and.right")
+                }
             }
+            connectionState = .connected
+            await loadFamiliars()
+            await loadTheme()
+            await refreshAccessTokenIfNeeded()
+        case .unauthorized:
+            connectionState = .needsAuth(
+                CaveConnection.accessToken == nil
+                    ? "This desktop requires pairing. Open Cave on the desktop → “Open on phone”, then scan the QR code or paste the invite link here."
+                    : "Your pairing has expired. Open Cave on the desktop → “Open on phone” and scan the QR code (or paste the invite link) to pair again."
+            )
+        case .none:
+            connectionState = .unreachable("Couldn’t reach the desktop. Is it on the tailnet and running?")
         }
-        connectionState = .connected
-        await loadFamiliars()
-        await loadTheme()
+    }
+
+    /// Rolling renewal: when the stored signed token is within a week of
+    /// expiry, exchange it for a fresh 30-day one. Failures are non-fatal —
+    /// the current token keeps working until it actually expires, at which
+    /// point refreshConnection lands in `.needsAuth` with re-pair guidance.
+    private func refreshAccessTokenIfNeeded() async {
+        guard let client,
+              let token = CaveConnection.accessToken,
+              let expiry = CaveInvite.tokenExpiry(token) else { return }
+        let renewalWindow: TimeInterval = 7 * 24 * 3600
+        guard expiry.timeIntervalSinceNow < renewalWindow else { return }
+        if let fresh = await client.refreshAccessToken() {
+            CaveConnection.saveAccessToken(fresh)
+        }
     }
 
     /// Connect with a few backoff retries before surfacing the "unreachable" setup
@@ -619,31 +655,56 @@ final class AppModel {
         }
     }
 
-    /// Probe candidate base URLs in order; return the first that answers. Uses a
-    /// short per-candidate timeout so trying a few ports stays snappy.
-    static func discoverBaseURL(_ candidates: [URL]) async -> URL? {
-        for base in candidates where await probe(base) { return base }
-        return nil
+    enum DiscoveryOutcome: Equatable {
+        case found(URL)
+        /// At least one candidate was a live Cave server that rejected our
+        /// credential — pairing is the fix, not another address.
+        case unauthorized
+        case none
     }
+
+    /// Probe candidate base URLs in order; adopt the first that answers as a
+    /// real Cave server. A 401/403 anywhere is remembered so a token-gated
+    /// desktop reads as "needs pairing" instead of "unreachable".
+    static func discoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
+        var sawUnauthorized = false
+        for base in candidates {
+            switch await probe(base) {
+            case .ok: return .found(base)
+            case .unauthorized: sawUnauthorized = true
+            case .failed: continue
+            }
+        }
+        return sawUnauthorized ? .unauthorized : .none
+    }
+
+    private enum ProbeResult { case ok, unauthorized, failed }
 
     /// Reachability check that requires a *real* Cave API response — a 2xx whose
     /// body decodes as the familiars payload. A bare status check would accept
     /// the wrong endpoint: another `tailscale serve` target (e.g. `:443`) can
     /// answer `/api/familiars` with a 404 or some other app's 200, and the old
     /// `200..<500` test latched onto it. Decoding the payload guarantees we only
-    /// adopt an actual Cave server.
-    private static func probe(_ base: URL) async -> Bool {
+    /// adopt an actual Cave server. Sends the paired credential when one exists
+    /// and reports a 401/403 distinctly — that's a Cave token gate talking.
+    private static func probe(_ base: URL) async -> ProbeResult {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 6
         config.waitsForConnectivity = false
         var req = URLRequest(url: base.appendingPathComponent("api/familiars"))
         req.timeoutInterval = 6
         req.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let token = CaveConnection.accessToken {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         guard let (data, resp) = try? await URLSession(configuration: config).data(for: req),
-              let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+              let http = resp as? HTTPURLResponse
+        else { return .failed }
+        if http.statusCode == 401 || http.statusCode == 403 { return .unauthorized }
+        guard (200..<300).contains(http.statusCode),
               (try? JSONDecoder().decode(FamiliarsResponse.self, from: data)) != nil
-        else { return false }
-        return true
+        else { return .failed }
+        return .ok
     }
 
     func loadFamiliars() async {

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -11,6 +11,7 @@ struct ConnectionView: View {
     /// READ the clipboard when the user taps Paste, so there's no surprise
     /// "pasted from" banner just for showing the button.
     @State private var canPaste = false
+    @State private var showScanner = false
     @FocusState private var focused: Bool
 
     var body: some View {
@@ -53,6 +54,12 @@ struct ConnectionView: View {
                         Label(message, systemImage: "exclamationmark.triangle.fill")
                             .font(.footnote)
                             .foregroundStyle(.orange)
+                    } else if case .needsAuth(let message) = app.connectionState {
+                        // The desktop is alive but token-gated — say how to
+                        // pair instead of the generic unreachable shrug.
+                        Label(message, systemImage: "qrcode.viewfinder")
+                            .font(.footnote)
+                            .foregroundStyle(.orange)
                     }
 
                     Button(action: connect) {
@@ -65,6 +72,18 @@ struct ConnectionView: View {
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
                     .disabled(host.trimmingCharacters(in: .whitespaces).isEmpty || busy)
+
+                    if QRScannerSheet.isSupported {
+                        Button {
+                            showScanner = true
+                        } label: {
+                            Label("Scan pairing QR code", systemImage: "qrcode.viewfinder")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.large)
+                        .disabled(busy)
+                    }
 
                     trustNote
                 }
@@ -83,6 +102,13 @@ struct ConnectionView: View {
             .onChange(of: scenePhase) { _, phase in
                 if phase == .active { canPaste = UIPasteboard.general.hasStrings }
             }
+            .sheet(isPresented: $showScanner) {
+                QRScannerSheet { payload in
+                    showScanner = false
+                    apply(payload)
+                }
+                .ignoresSafeArea()
+            }
         }
     }
 
@@ -93,7 +119,7 @@ struct ConnectionView: View {
                 .foregroundStyle(Color.accentColor)
             Text("Connect to your familiars")
                 .font(.title2.bold())
-            Text("Chat with your Coven familiars from anywhere on your Tailscale network. No password, no token — your tailnet is the key.")
+            Text("Pair with your desktop over your Tailscale network — scan the QR code from Cave’s “Open on phone” panel, paste its invite link, or type the address.")
                 .font(.subheadline).foregroundStyle(.secondary)
         }
     }
@@ -110,20 +136,37 @@ struct ConnectionView: View {
 
     private func connect() {
         focused = false
-        host = cleanHost(host)
+        guard let invite = CaveInvite.parse(cleanHost(host)) else { return }
+        host = invite.host
         busy = true
         Task {
-            await app.configure(host: host)
+            await app.configure(host: invite.host, token: invite.token)
             busy = false
         }
     }
 
-    /// Fill the field from the clipboard (only read on this explicit tap), cleaned.
+    /// Fill the field from the clipboard (only read on this explicit tap).
     private func pasteHost() {
         guard let pasted = UIPasteboard.general.string else { return }
-        host = cleanHost(pasted)
-        focused = true
+        apply(pasted)
         Haptics.tap()
+    }
+
+    /// Route any input — typed, pasted, or scanned — through the invite
+    /// parser. A credential-carrying invite connects immediately (the
+    /// seamless path); a bare host just fills the field for review.
+    private func apply(_ input: String) {
+        guard let invite = CaveInvite.parse(cleanHost(input)) else { return }
+        host = invite.host
+        if invite.token != nil {
+            busy = true
+            Task {
+                await app.configure(host: invite.host, token: invite.token)
+                busy = false
+            }
+        } else {
+            focused = true
+        }
     }
 
     /// Tidy a pasted/typed address: trim whitespace, drop wrapping quotes/brackets

--- a/apps/ios/CovenCave/CovenCave/Views/QRScannerSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/QRScannerSheet.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+import VisionKit
+
+/// Live-camera QR scanner for the desktop's pairing invite. Availability-gated:
+/// hidden on hardware without a camera / without Data Scanner support (older
+/// devices, the simulator, Designed-for-iPad on Mac) — those paths pair via
+/// paste or the covencave:// link instead.
+struct QRScannerSheet: UIViewControllerRepresentable {
+    let onScan: (String) -> Void
+
+    static var isSupported: Bool {
+        DataScannerViewController.isSupported && DataScannerViewController.isAvailable
+    }
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let scanner = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            qualityLevel: .balanced,
+            isHighlightingEnabled: true
+        )
+        scanner.delegate = context.coordinator
+        try? scanner.startScanning()
+        return scanner
+    }
+
+    func updateUIViewController(_ controller: DataScannerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onScan: onScan) }
+
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        private let onScan: (String) -> Void
+        private var delivered = false
+
+        init(onScan: @escaping (String) -> Void) { self.onScan = onScan }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            didAdd addedItems: [RecognizedItem],
+            allItems: [RecognizedItem]
+        ) {
+            guard !delivered else { return }
+            for item in addedItems {
+                if case .barcode(let barcode) = item, let payload = barcode.payloadStringValue {
+                    delivered = true
+                    onScan(payload)
+                    return
+                }
+            }
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/QRScannerSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/QRScannerSheet.swift
@@ -23,6 +23,11 @@ struct QRScannerSheet: UIViewControllerRepresentable {
         return scanner
     }
 
+    static func dismantleUIViewController(_ controller: DataScannerViewController, coordinator: Coordinator) {
+        try? controller.stopScanning()
+        controller.delegate = nil
+    }
+
     func updateUIViewController(_ controller: DataScannerViewController, context: Context) {}
 
     func makeCoordinator() -> Coordinator { Coordinator(onScan: onScan) }

--- a/apps/ios/CovenCave/CovenCave/Views/QRScannerSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/QRScannerSheet.swift
@@ -42,6 +42,7 @@ struct QRScannerSheet: UIViewControllerRepresentable {
             for item in addedItems {
                 if case .barcode(let barcode) = item, let payload = barcode.payloadStringValue {
                     delivered = true
+                    try? dataScanner.stopScanning()
                     onScan(payload)
                     return
                 }

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -11,7 +11,7 @@ struct RootView: View {
                 ConnectionView()
             case .checking where app.connection != nil && app.familiars.isEmpty:
                 ConnectingView()
-            case .unreachable:
+            case .unreachable, .needsAuth:
                 ConnectionView()
             default:
                 MainTabView()

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -246,6 +246,8 @@ struct SettingsView: View {
                 Label("Checking…", systemImage: "clock").foregroundStyle(.secondary)
             case .unreachable:
                 Label("Unreachable", systemImage: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+            case .needsAuth:
+                Label("Needs pairing", systemImage: "qrcode.viewfinder").foregroundStyle(.orange)
             case .unconfigured:
                 Label("Not set up", systemImage: "circle").foregroundStyle(.secondary)
             }

--- a/apps/ios/CovenCave/CovenCaveTests/CaveInviteTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/CaveInviteTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+@testable import CovenCave
+
+final class CaveInviteTests: XCTestCase {
+    // MARK: - covencave:// app invites
+
+    func testParsesAppInviteLink() {
+        let invite = CaveInvite.parse("covencave://connect?host=cave.tailnet.example.ts.net&token=v1.123.n.sig")
+        XCTAssertEqual(invite, CaveInvite(host: "cave.tailnet.example.ts.net", token: "v1.123.n.sig"))
+    }
+
+    func testAppInviteWithoutTokenStillConfiguresHost() {
+        let invite = CaveInvite.parse("covencave://connect?host=my-mac.local")
+        XCTAssertEqual(invite, CaveInvite(host: "my-mac.local", token: nil))
+    }
+
+    func testAppInviteWithoutHostIsRejected() {
+        XCTAssertNil(CaveInvite.parse("covencave://connect?token=v1.123.n.sig"))
+    }
+
+    // MARK: - https QR invite URLs
+
+    func testParsesBrowserInviteUrlCapturingToken() {
+        let invite = CaveInvite.parse(
+            "https://cave.tailnet.example.ts.net/?coven_access_token=v1.99.nonce.sig&covenCaveToken=sidecar"
+        )
+        XCTAssertEqual(invite?.host, "https://cave.tailnet.example.ts.net")
+        XCTAssertEqual(invite?.token, "v1.99.nonce.sig")
+    }
+
+    func testHttpUrlKeepsExplicitPort() {
+        let invite = CaveInvite.parse("http://localhost:3496/?coven_access_token=v1.5.n.s")
+        XCTAssertEqual(invite, CaveInvite(host: "http://localhost:3496", token: "v1.5.n.s"))
+    }
+
+    func testSidecarTokenIsFallbackCredential() {
+        let invite = CaveInvite.parse("https://cave.example.ts.net/?covenCaveToken=raw-sidecar")
+        XCTAssertEqual(invite?.token, "raw-sidecar")
+    }
+
+    // MARK: - bare hosts
+
+    func testBareHostPassesThrough() {
+        XCTAssertEqual(CaveInvite.parse("my-mac.tailnet.example.ts.net"),
+                       CaveInvite(host: "my-mac.tailnet.example.ts.net", token: nil))
+        XCTAssertEqual(CaveInvite.parse("  100.101.102.103  "),
+                       CaveInvite(host: "100.101.102.103", token: nil))
+    }
+
+    func testEmptyInputIsRejected() {
+        XCTAssertNil(CaveInvite.parse("   "))
+    }
+
+    // MARK: - token expiry extraction
+
+    func testTokenExpiryReadsSignedTokenMilliseconds() {
+        let expiry = CaveInvite.tokenExpiry("v1.1800000000000.nonce.sig")
+        XCTAssertEqual(expiry, Date(timeIntervalSince1970: 1_800_000_000))
+    }
+
+    func testTokenExpiryNilForLegacyRawSecret() {
+        XCTAssertNil(CaveInvite.tokenExpiry("some-raw-shared-secret"))
+        XCTAssertNil(CaveInvite.tokenExpiry("v2.123.n.sig"))
+        XCTAssertNil(CaveInvite.tokenExpiry("v1.notanumber.n.sig"))
+    }
+}

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -56,6 +56,23 @@ targets:
     dependencies:
       - target: CovenCaveWidgets
 
+  # Unit tests for the pure pairing logic (CaveInvite parsing, token-expiry
+  # extraction). CI doesn't build Swift, so these run locally:
+  #   xcodebuild test -project CovenCave.xcodeproj -scheme CovenCave \
+  #     -destination 'platform=iOS Simulator,name=<sim>'
+  CovenCaveTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: CovenCaveTests
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        PRODUCT_BUNDLE_IDENTIFIER: ai.opencoven.cave.tests
+        IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+    dependencies:
+      - target: CovenCave
+
   # Widget extension hosting the "task running" Live Activity (Lock Screen +
   # Dynamic Island) and the home-screen "Up Next" widget. Shares
   # TaskActivityAttributes.swift + WidgetSnapshot.swift with the app target;
@@ -76,3 +93,14 @@ targets:
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
         SKIP_INSTALL: YES
         CODE_SIGN_ENTITLEMENTS: CovenCaveWidgets/CovenCaveWidgets.entitlements
+
+schemes:
+  CovenCave:
+    build:
+      targets:
+        CovenCave: all
+    test:
+      targets:
+        - CovenCaveTests
+    run:
+      config: Debug

--- a/scripts/ios-connect-paste.test.mjs
+++ b/scripts/ios-connect-paste.test.mjs
@@ -22,8 +22,13 @@ assert.match(
 );
 assert.match(
   src,
-  /func pasteHost\(\) \{[\s\S]*?UIPasteboard\.general\.string[\s\S]*?host = cleanHost\(pasted\)/,
-  "pasteHost should read the clipboard only on the explicit tap and clean it",
+  /func pasteHost\(\) \{[\s\S]*?UIPasteboard\.general\.string[\s\S]*?apply\(pasted\)/,
+  "pasteHost should read the clipboard only on the explicit tap and route it through the invite parser",
+);
+assert.match(
+  src,
+  /func apply\(_ input: String\) \{[\s\S]*?CaveInvite\.parse\(cleanHost\(input\)\)/,
+  "any input — typed, pasted, or scanned — is cleaned then parsed as an invite (host + optional credential)",
 );
 
 // --- Cleanup: trim + strip wrapping quotes/trailing slash, KEEP the scheme ----
@@ -32,7 +37,11 @@ assert.match(
   /func cleanHost\(_ raw: String\) -> String \{[\s\S]*?trimmingCharacters\(in: \.whitespacesAndNewlines\)[\s\S]*?hasSuffix\("\/"\)/,
   "cleanHost should trim whitespace and strip a trailing slash",
 );
-assert.match(src, /host = cleanHost\(host\)/, "connect should clean the host before configuring");
+assert.match(
+  src,
+  /CaveInvite\.parse\(cleanHost\(host\)\)/,
+  "connect should clean and invite-parse the host before configuring",
+);
 
 // --- Gentle, non-blocking malformed hint -------------------------------------
 assert.match(

--- a/scripts/mobile-tailscale-native.test.mjs
+++ b/scripts/mobile-tailscale-native.test.mjs
@@ -35,8 +35,8 @@ assert.match(libRs, /WebviewUrl::App\("index\.html"\.into\(\)\)/);
 const swiftRootView = read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
 assert.match(
   swiftRootView,
-  /case \.unreachable:\s*\n\s*ConnectionView\(\)/,
-  "native SwiftUI app should return unreachable saved hosts to the connection screen",
+  /case \.unreachable, \.needsAuth:\s*\n\s*ConnectionView\(\)/,
+  "native SwiftUI app should return unreachable AND pairing-required hosts to the connection screen",
 );
 
 const swiftChatThread = read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -660,6 +660,7 @@ export const SUITES = {
   mobile: [
     "src/lib/mobile-access-token.test.ts",
     "src/lib/mobile-handoff.test.ts",
+    "src/lib/mobile-token-refresh.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-code-browser-files.test.mjs",
     "scripts/ios-code-viewer.test.mjs",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -106,6 +106,7 @@ const contracts: RouteContract[] = [
   { route: "/library/route-link", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/library", methods: ["GET"], kind: "json" },
   { route: "/mobile-handoff", methods: ["GET", "POST"], kind: "json", readsJson: true },
+  { route: "/mobile-token/refresh", methods: ["POST"], kind: "json" },
   { route: "/mcp", methods: ["GET"], kind: "json" },
   { route: "/marketplace", methods: ["GET"], kind: "json" },
   { route: "/marketplace/install", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -236,6 +236,10 @@ async function mobileHandoff(req: Request) {
     inviteUrl: invite.url,
     url: invite.url,
     appUrl: invite.url,
+    // Native-app pairing: covencave:// deep link with a long-lived token —
+    // shown beside the QR so the iOS/iPadOS app pairs without typing.
+    appInviteUrl: invite.appInviteUrl,
+    appTokenExpiresAt: invite.appTokenExpiresAt,
     discoverySource: discovery.source,
     expiresAt: invite.expiresAt,
     expiresAtIso: invite.expiresAtIso,

--- a/src/app/api/mobile-token/refresh/route.ts
+++ b/src/app/api/mobile-token/refresh/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { refreshMobileAccessToken } from "@/lib/mobile-token-refresh";
+import { ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_QUERY_PARAM } from "@/proxy-helpers";
+
+export const dynamic = "force-dynamic";
+
+/** The credential the caller actually presented — same sources, same order,
+ *  as the proxy's mobileAccessGate (Bearer header, cookie, query param). */
+function suppliedCredential(req: NextRequest): string | null {
+  const header = req.headers.get("authorization");
+  const prefix = "Bearer ";
+  if (header?.startsWith(prefix)) {
+    const token = header.slice(prefix.length).trim();
+    if (token) return token;
+  }
+  const cookie = req.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+  if (cookie) return cookie;
+  return req.nextUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM);
+}
+
+/**
+ * Rolling renewal for paired mobile devices: exchange a currently-valid
+ * credential for a fresh 30-day signed token. Unauthenticated callers never
+ * reach this route while the gate is enabled (the proxy 401s first); the
+ * re-verification inside refreshMobileAccessToken binds the minted token to
+ * the presented credential and makes the route safe even in tokenless modes,
+ * where it reports the gate as disabled instead of minting anything.
+ */
+export async function POST(req: NextRequest) {
+  const result = await refreshMobileAccessToken({
+    supplied: suppliedCredential(req),
+    secret: process.env.COVEN_CAVE_ACCESS_TOKEN?.trim() || null,
+  });
+  if (!result.ok) {
+    return NextResponse.json({ ok: false, error: result.error }, { status: result.status });
+  }
+  return NextResponse.json({
+    ok: true,
+    token: result.token,
+    expiresAt: result.expiresAt,
+    expiresAtIso: new Date(result.expiresAt).toISOString(),
+  });
+}

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -116,6 +116,21 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.ok(token);
   const verification = await verifyMobileAccessToken(token, signingKey, now);
   assert.equal(verification.ok, true);
+
+  // The native-app invite is a covencave:// deep link carrying the SERVE host
+  // and a LONG-lived token (30d default, not the 8h QR TTL) — tapping it on
+  // the device pairs with zero typing, and the device renews from there.
+  assert.ok(invite.appInviteUrl.startsWith("covencave://connect?"));
+  const app = new URL(invite.appInviteUrl);
+  assert.equal(app.searchParams.get("host"), "cave.tailnet.example.ts.net");
+  const appToken = app.searchParams.get("token");
+  assert.ok(appToken);
+  const appVerification = await verifyMobileAccessToken(appToken, signingKey, now);
+  assert.equal(appVerification.ok, true);
+  if (appVerification.ok) {
+    assert.equal(appVerification.expiresAt, invite.appTokenExpiresAt);
+    assert.ok(invite.appTokenExpiresAt > invite.expiresAt, "app token outlives the QR invite");
+  }
 }
 
 {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import { signMobileAccessToken } from "./mobile-access-token.ts";
+import { appTokenTtlMs } from "./mobile-token-refresh.ts";
 
 export const MOBILE_INVITE_TTL_MS = 8 * 60 * 60 * 1000;
 
@@ -240,11 +241,27 @@ export function buildInviteUrl({
   return url.toString();
 }
 
+/** Deep link the native app registers (`covencave://connect`) — tapping it on
+ *  the device configures host + credential in one step, no typing. */
+export function buildAppInviteUrl({
+  host,
+  mobileAccessToken,
+}: {
+  host: string;
+  mobileAccessToken: string;
+}) {
+  const url = new URL("covencave://connect");
+  url.searchParams.set("host", host);
+  url.searchParams.set("token", mobileAccessToken);
+  return url.toString();
+}
+
 export async function createMobileInvite({
   baseUrl,
   accessSecret,
   sidecarToken,
   ttlMs = MOBILE_INVITE_TTL_MS,
+  appTtlMs,
   now = Date.now(),
   nonce,
 }: {
@@ -252,6 +269,9 @@ export async function createMobileInvite({
   accessSecret: string;
   sidecarToken?: string | null;
   ttlMs?: number;
+  /** Lifetime of the native-app deep-link token (defaults to the rolling
+   *  30-day app TTL — see mobile-token-refresh.ts). */
+  appTtlMs?: number;
   now?: number;
   nonce?: string;
 }) {
@@ -261,9 +281,22 @@ export async function createMobileInvite({
     expiresAt,
     nonce,
   });
+  // The app link carries its own longer-lived token: a QR on screen is easy
+  // to re-scan every 8h, but a paired device should renew silently instead.
+  const appTokenExpiresAt = now + (appTtlMs ?? appTokenTtlMs());
+  const appAccessToken = await signMobileAccessToken({
+    secret: accessSecret,
+    expiresAt: appTokenExpiresAt,
+    nonce: nonce ? `${nonce}-app` : undefined,
+  });
   return {
     expiresAt,
     expiresAtIso: new Date(expiresAt).toISOString(),
     url: buildInviteUrl({ baseUrl, mobileAccessToken, sidecarToken }),
+    appInviteUrl: buildAppInviteUrl({
+      host: new URL(baseUrl).host,
+      mobileAccessToken: appAccessToken,
+    }),
+    appTokenExpiresAt,
   };
 }

--- a/src/lib/mobile-token-refresh.test.ts
+++ b/src/lib/mobile-token-refresh.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+
+import {
+  MOBILE_APP_TOKEN_TTL_MS,
+  appTokenTtlMs,
+  refreshMobileAccessToken,
+} from "./mobile-token-refresh.ts";
+import { signMobileAccessToken, verifyMobileAccessToken } from "./mobile-access-token.ts";
+
+const secret = ["refresh", "test", "secret"].join("-");
+const now = 1_800_000_000_000;
+
+// A valid signed credential rolls into a fresh 30-day token.
+{
+  const supplied = await signMobileAccessToken({
+    secret,
+    expiresAt: now + 60_000,
+    nonce: "nonce-live",
+  });
+  const result = await refreshMobileAccessToken({ supplied, secret, now });
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.expiresAt, now + MOBILE_APP_TOKEN_TTL_MS);
+    const verification = await verifyMobileAccessToken(result.token, secret, now);
+    assert.equal(verification.ok, true);
+    if (verification.ok) assert.equal(verification.expiresAt, result.expiresAt);
+  }
+}
+
+// The legacy raw secret also refreshes (it's a valid credential today), giving
+// a device a path OFF the never-expiring raw secret onto expiring tokens.
+{
+  const result = await refreshMobileAccessToken({ supplied: secret, secret, now });
+  assert.equal(result.ok, true);
+}
+
+// An expired token cannot refresh — the device must re-pair.
+{
+  const supplied = await signMobileAccessToken({
+    secret,
+    expiresAt: now - 1,
+    nonce: "nonce-expired",
+  });
+  const result = await refreshMobileAccessToken({ supplied, secret, now });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.status, 401);
+}
+
+// A token signed with a different secret is rejected.
+{
+  const supplied = await signMobileAccessToken({
+    secret: ["other", "signing", "key"].join("-"),
+    expiresAt: now + 60_000,
+  });
+  const result = await refreshMobileAccessToken({ supplied, secret, now });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.status, 401);
+}
+
+// Missing credential and disabled gate are distinct failures.
+{
+  const missing = await refreshMobileAccessToken({ supplied: null, secret, now });
+  assert.equal(missing.ok, false);
+  if (!missing.ok) assert.equal(missing.status, 401);
+
+  const disabled = await refreshMobileAccessToken({ supplied: "anything", secret: null, now });
+  assert.equal(disabled.ok, false);
+  if (!disabled.ok) assert.equal(disabled.status, 503);
+}
+
+// TTL override: explicit ttlMs wins; the env fallback parses positive numbers only.
+{
+  const supplied = await signMobileAccessToken({ secret, expiresAt: now + 60_000 });
+  const result = await refreshMobileAccessToken({ supplied, secret, now, ttlMs: 1_000 });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.expiresAt, now + 1_000);
+
+  assert.equal(appTokenTtlMs({}), MOBILE_APP_TOKEN_TTL_MS);
+  assert.equal(appTokenTtlMs({ MOBILE_APP_TOKEN_TTL_MS: "5000" }), 5_000);
+  assert.equal(appTokenTtlMs({ MOBILE_APP_TOKEN_TTL_MS: "-1" }), MOBILE_APP_TOKEN_TTL_MS);
+  assert.equal(appTokenTtlMs({ MOBILE_APP_TOKEN_TTL_MS: "junk" }), MOBILE_APP_TOKEN_TTL_MS);
+}
+
+console.log("mobile-token-refresh.test.ts OK");

--- a/src/lib/mobile-token-refresh.ts
+++ b/src/lib/mobile-token-refresh.ts
@@ -1,0 +1,59 @@
+import {
+  isValidMobileAccessCredential,
+  signMobileAccessToken,
+} from "./mobile-access-token.ts";
+
+/** Default lifetime for tokens minted for the NATIVE app (pairing + refresh).
+ *  Invites shown as QR codes stay short-lived (MOBILE_INVITE_TTL_MS, 8h) — a
+ *  QR on screen is easy to re-scan. A paired device, though, should renew
+ *  silently: 30 days rolling means a device that connects at least monthly
+ *  never re-pairs, while a lost device ages out. */
+export const MOBILE_APP_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export function appTokenTtlMs(env: Record<string, string | undefined> = process.env): number {
+  const raw = Number(env.MOBILE_APP_TOKEN_TTL_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : MOBILE_APP_TOKEN_TTL_MS;
+}
+
+export type MobileTokenRefreshResult =
+  | { ok: true; token: string; expiresAt: number }
+  | { ok: false; status: 401 | 503; error: string };
+
+/**
+ * Exchange a currently-valid mobile credential for a fresh signed token with a
+ * rolling TTL. The proxy's mobileAccessGate already rejects unauthenticated
+ * callers before the route runs; verifying again here binds the minted token
+ * to the supplied credential rather than to "whatever got through".
+ *
+ * The legacy raw secret is accepted on purpose — refreshing is how a device
+ * that paired against the raw secret migrates onto expiring signed tokens.
+ */
+export async function refreshMobileAccessToken({
+  supplied,
+  secret,
+  ttlMs,
+  now = Date.now(),
+}: {
+  supplied: string | null;
+  secret: string | null;
+  ttlMs?: number;
+  now?: number;
+}): Promise<MobileTokenRefreshResult> {
+  if (!secret) {
+    return { ok: false, status: 503, error: "mobile access token gate is not enabled" };
+  }
+  if (!supplied) {
+    return { ok: false, status: 401, error: "missing credential" };
+  }
+  const verification = await isValidMobileAccessCredential({
+    supplied,
+    expectedSecret: secret,
+    now,
+  });
+  if (!verification.ok) {
+    return { ok: false, status: 401, error: `invalid credential (${verification.reason})` };
+  }
+  const expiresAt = now + (ttlMs ?? appTokenTtlMs());
+  const token = await signMobileAccessToken({ secret, expiresAt });
+  return { ok: true, token, expiresAt };
+}


### PR DESCRIPTION
## Why

The iOS app could not connect to a token-gated desktop at all: the server enforces a signed mobile access token on every `/api/*` route when `COVEN_CAVE_ACCESS_TOKEN` is set and mints QR invites at `/api/mobile-handoff` — but the client never attached any credential, stored no token, had no invite/QR/deep-link path, and rendered every 401 as "Couldn't reach the desktop." Pairing only worked in the special tokenless `COVEN_CAVE_TAILNET_TRUST=1` mode (a gap the iOS README itself flagged). Signed tokens also expire (8h invite TTL) with no renewal path. Design doc: `docs/specs/2026-07-03-ios-ipad-mac-onboarding-design.md` (Part B).

## Server

- **`POST /api/mobile-token/refresh`** — exchanges a currently-valid credential (Bearer/cookie/query, same sources as the proxy gate) for a fresh signed token with a rolling **30-day** TTL (`MOBILE_APP_TOKEN_TTL_MS` override); 503 when the gate is disabled; legacy raw-secret credentials accepted so paired devices migrate onto expiring tokens. Pure logic in `src/lib/mobile-token-refresh.ts`, unit-tested.
- **`/api/mobile-handoff`** responses now include `appInviteUrl` — a `covencave://connect?host=…&token=…` deep link carrying its own 30-day token (the on-screen QR invite keeps its short 8h TTL; a paired device renews silently instead).

## iOS

- **Credential capture**: `CaveInvite` (pure, 10 XCTest cases) parses `covencave://connect` links, https QR-invite URLs (`coven_access_token`/`covenCaveToken`), or bare hosts. ConnectionView routes typed/pasted/scanned input through it — a credential-carrying invite pairs in one tap; a "Scan pairing QR code" button (VisionKit, availability-gated, camera permission added) scans the desktop's QR; `covencave://connect` deep links pair with zero typing.
- **Storage**: token lives in the Keychain (`KeychainStore`); cleared on disconnect.
- **Attachment**: `Authorization: Bearer` on every transport — REST + SSE (shared builder) and the PTY WebSocket.
- **Auth-aware states**: probes distinguish 401/403; new `.needsAuth` connection state renders actionable pairing instructions instead of the generic "unreachable" (Settings shows a "Needs pairing" badge).
- **Discovery fix**: a 401 now STOPS endpoint discovery — previously the port-walker would probe past a token gate and silently adopt a different Cave instance on a sibling port (reproduced live: gated `:3512` + tokenless dev server on `:3000`).
- **Silent renewal**: on connect, a token within 7 days of expiry is exchanged via the refresh endpoint and rotated in place.
- New `CovenCaveTests` unit-test target (XcodeGen) — CI doesn't build Swift, so they run locally.

## Verification

- Web: `test:app` 519 / `test:api` 114 / `test:mobile` 66 files green; typecheck; tests-wired; new route registered in `api-contracts`.
- Swift: `xcodebuild test` green (10/10) on the iPad Pro 13-inch simulator.
- Live end-to-end against a gated server: bare request → 401; signed Bearer → 200; refresh → fresh token expiring +30d; fresh app install → the new pairing screen with actionable copy (screenshot verified, not "unreachable"); sibling-port hijack no longer occurs.
- Residual (needs a human tap): the `covencave://connect` flow shows iOS's one-time "Open in Coven Cave?" confirm in the simulator, which CLI automation can't accept — the parse→configure glue behind it is unit-tested.