### PR TITLE
Sidebar threads: full-width rows when not hovered

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1116,6 +1116,31 @@ tr[role="checkbox"]:focus-visible {
 .cnav__thread--flat .cnav__thread-main {
   padding-left: 13px;
 }
+/* Row actions overlay the right edge so they reserve NO layout width — the title
+   and timestamp use the full row when not hovered, then the actions fade in over
+   the (now-hidden) timestamp on hover. */
+.cnav__row-actions {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 6px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--duration-fast) var(--ease-standard);
+}
+.cnav__thread:hover .cnav__row-actions,
+.cnav__row-actions:focus-within {
+  opacity: 1;
+  pointer-events: auto;
+}
+/* Only when hovered does the title reserve room for the revealed actions; when
+   not hovered the row is full-width (no dead space for hidden buttons). */
+.cnav__thread:hover .cnav__thread-main {
+  padding-right: 52px;
+}
 .cnav__thread:hover {
   background: color-mix(in oklch, var(--foreground) 5%, transparent);
   color: var(--text-primary);

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -129,7 +129,7 @@ function ThreadRow({
           </button>
         </span>
       ) : (
-        <>
+        <span className="cnav__row-actions">
           <button
             type="button"
             title={pinned ? "Unpin thread" : "Pin thread"}
@@ -149,7 +149,7 @@ function ThreadRow({
           >
             <Icon name="ph:x-bold" width={10} aria-hidden />
           </button>
-        </>
+        </span>
       )}
     </div>
   );

--- a/src/components/code-sidebar.tsx
+++ b/src/components/code-sidebar.tsx
@@ -320,7 +320,7 @@ export function CodeSidebar({
                                       </button>
                                     </span>
                                   ) : (
-                                    <>
+                                    <span className="cnav__row-actions">
                                       <button
                                         type="button"
                                         title={isPinnedRow ? "Unpin thread" : "Pin thread"}
@@ -339,7 +339,7 @@ export function CodeSidebar({
                                       >
                                         <Icon name="ph:x-bold" width={10} aria-hidden />
                                       </button>
-                                    </>
+                                    </span>
                                   )}
                                 </div>
                               </li>


### PR DESCRIPTION
The pin/delete actions on Chat + Code sidebar thread rows reserved ~44px of layout width even while hidden, leaving dead space on the right — titles and timestamps never reached the edge.

**Fix:** wrap the row actions in an absolutely-positioned `.cnav__row-actions` overlay so they take **no** layout width until hover.
- **Not hovered** → full-width rows: the title truncates right before the edge timestamp, no gap.
- **Hovered** → the timestamp hides, the actions fade in over that space, and the title reserves room (`padding-right`) only then.

Applies to both the conversation threads (chat) and the code threads (same shared `.cnav` markup + CSS).

## Verification
- Live screenshots (Chat Recent view + Code expanded project): titles now extend to the timestamp at rest (e.g. `Curl 'http://127.0.0.1:3000/…`, `Task: CovenWiki v0 Phas…`); hover cleanly reveals pin + delete.
- `tsc` clean; `pnpm build` (bundle-budget) clean; `check:tests-wired` (695), `test:app`, `test:mobile` (65), chat-sidebar-wiring + code-view source-text tests all green.