### PR TITLE
Drag-to-split: dragging a pane wide collapses & promotes it

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2300,10 +2300,15 @@ textarea.required-inputs-control {
 }
 .ui-sep-handle--col {
   width: 1px;
+  /* Fill the separator's height so the handle is actually clickable — a block
+     child otherwise collapses to 0 height, leaving the drag handler (and its
+     hover affordance / hit area) unreachable. */
+  height: 100%;
   cursor: col-resize;
 }
 .ui-sep-handle--row {
   height: 1px;
+  width: 100%;
   cursor: row-resize;
 }
 .ui-sep-handle::before {
@@ -10235,6 +10240,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
     0 0 12px color-mix(in oklch, var(--accent) 55%, transparent);
 }
 .split-host__guide--close { background: var(--color-danger, #e5484d); }
+/* Far-edge "Fill" state — promoting the secondary to the whole surface. Uses
+   the accent (a positive/constructive action) with a stronger glow than snap. */
+.split-host__guide--collapse {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--accent) 55%, transparent),
+    0 0 16px color-mix(in oklch, var(--accent) 70%, transparent);
+}
 .split-host__guide-chip {
   position: absolute;
   top: 10px;

--- a/src/components/detail-split-host.tsx
+++ b/src/components/detail-split-host.tsx
@@ -27,6 +27,7 @@ import {
   SPLIT_DEFAULT_RATIO,
   SPLIT_MAX_RATIO,
   SPLIT_CLOSE_RATIO,
+  SPLIT_COLLAPSE_RATIO,
   nearestSnap,
   resolveSplitRelease,
   dividerOffset,
@@ -50,6 +51,11 @@ export type DetailSplitHostProps = {
   onClose: () => void;
   /** Close one secondary tile. */
   onCloseTile: (id: string) => void;
+  /**
+   * Promote a secondary tile to the sole surface — invoked when its divider is
+   * dragged past the far edge (collapsing the primary).
+   */
+  onPromoteTile?: (id: string) => void;
   /** A page was dropped into the main area on the given side. */
   onDropPage: (mode: string, side: "left" | "right") => void;
   /** Enable the drag-to-split drop zone (desktop only). */
@@ -64,6 +70,7 @@ export function DetailSplitHost({
   secondarySide,
   onClose,
   onCloseTile,
+  onPromoteTile,
   onDropPage,
   enableDrop,
 }: DetailSplitHostProps) {
@@ -117,9 +124,16 @@ export function DetailSplitHost({
   };
 
   // ---- Resizable split with snapping -------------------------------------
+  // The divider is react-resizable-panels' own <Separator>, which owns the
+  // pointer drag and resizes freely. It swallows the pointerdown, so we can't
+  // hang a "drag started" handler off the visible handle. Instead we track the
+  // live ratio from RRP's onResize and detect the *release* from a global
+  // pointerup: if the ratio moved while a pointer was held, that was a divider
+  // drag — resolve it to snap / close / collapse.
   const secRef = usePanelRef();
   const ratioRef = React.useRef(SPLIT_DEFAULT_RATIO);
-  const draggingRef = React.useRef(false);
+  const pointerDownRef = React.useRef(false);
+  const dragStartRatioRef = React.useRef(SPLIT_DEFAULT_RATIO);
   const [dragRatio, setDragRatio] = React.useState<number | null>(null);
 
   // Reset the live divider tracking whenever a fresh split opens.
@@ -127,7 +141,7 @@ export function DetailSplitHost({
     if (secondaryTiles.length === 1) {
       ratioRef.current = SPLIT_DEFAULT_RATIO;
       setDragRatio(null);
-      draggingRef.current = false;
+      pointerDownRef.current = false;
     }
   }, [secondaryTiles.length, secondarySide]);
 
@@ -135,34 +149,52 @@ export function DetailSplitHost({
     (size: { asPercentage: number }) => {
       const ratio = size.asPercentage / 100;
       ratioRef.current = ratio;
-      if (draggingRef.current) setDragRatio(ratio);
+      // A live resize under a held pointer is a divider drag → show the guide.
+      if (pointerDownRef.current) setDragRatio(ratio);
     },
     [],
   );
 
-  const beginDividerDrag = React.useCallback(() => {
-    draggingRef.current = true;
-    setDragRatio(ratioRef.current);
-    const finish = () => {
-      window.removeEventListener("mouseup", finish);
-      window.removeEventListener("pointerup", finish);
-      if (!draggingRef.current) return;
-      draggingRef.current = false;
+  // Divider release detection for the 2-pane (snap-assisted) split. Capture
+  // pointer up/down at the window so it works regardless of RRP eating the
+  // event on the separator itself.
+  React.useEffect(() => {
+    if (secondaryTiles.length !== 1) return;
+    const onDown = () => {
+      pointerDownRef.current = true;
+      dragStartRatioRef.current = ratioRef.current;
+    };
+    const onUp = () => {
+      if (!pointerDownRef.current) return;
+      pointerDownRef.current = false;
       setDragRatio(null);
+      // Only a real divider drag moves the ratio; ignore unrelated clicks.
+      if (Math.abs(ratioRef.current - dragStartRatioRef.current) < 0.002) return;
       const release = resolveSplitRelease(ratioRef.current);
       if (release.action === "close") onClose();
-      else if (release.action === "snap") secRef.current?.resize(PCT(release.ratio));
+      else if (release.action === "collapse") {
+        // Dragged past the far edge — collapse the primary and let the secondary
+        // fill. If it can't be promoted (e.g. a companion with no primary mode),
+        // fall back to sitting at the max width rather than snapping shut.
+        const tile = secondaryTiles[0];
+        if (tile && onPromoteTile) onPromoteTile(tile.id);
+        else secRef.current?.resize(PCT(SPLIT_MAX_RATIO));
+      } else if (release.action === "snap") secRef.current?.resize(PCT(release.ratio));
     };
-    window.addEventListener("mouseup", finish);
-    window.addEventListener("pointerup", finish);
-  }, [onClose, secRef]);
+    window.addEventListener("pointerdown", onDown, true);
+    window.addEventListener("pointerup", onUp, true);
+    return () => {
+      window.removeEventListener("pointerdown", onDown, true);
+      window.removeEventListener("pointerup", onUp, true);
+    };
+  }, [secondaryTiles, onClose, onPromoteTile, secRef]);
 
   // Keyboard / button snap helpers shown in the pane header.
   const snapTo = (ratio: number) => secRef.current?.resize(PCT(ratio));
 
   const separator = (
     <Separator className="shell-separator split-host__sep">
-      <SeparatorHandle orientation="col" onMouseDown={beginDividerDrag} />
+      <SeparatorHandle orientation="col" />
     </Separator>
   );
 
@@ -250,7 +282,9 @@ export function DetailSplitHost({
       id="split-primary"
       className="split-host__tile-panel flex min-h-0 min-w-0"
       data-active={activeTileId === "primary"}
-      minSize="16%"
+      // Mirrors the secondary's 10% min so the divider can be dragged wide
+      // enough to enter the far-edge collapse zone (secondary → SPLIT_MAX_RATIO).
+      minSize="10%"
     >
       <div className="min-h-0 min-w-0 flex-1">{primary}</div>
     </Panel>
@@ -291,18 +325,20 @@ export function DetailSplitHost({
 
   // Live snap guide while dragging the divider.
   const snapPreview = dragRatio != null ? nearestSnap(dragRatio) : null;
+  const inCloseZone = dragRatio != null && dragRatio < SPLIT_CLOSE_RATIO;
+  const inCollapseZone = dragRatio != null && dragRatio > SPLIT_COLLAPSE_RATIO;
   const guideRatio = snapPreview ? snapPreview.ratio : dragRatio;
   const guide =
     dragRatio != null && guideRatio != null ? (
       <div
         className={`split-host__guide${snapPreview ? " split-host__guide--snap" : ""}${
-          dragRatio < SPLIT_CLOSE_RATIO ? " split-host__guide--close" : ""
-        }`}
+          inCloseZone ? " split-host__guide--close" : ""
+        }${inCollapseZone ? " split-host__guide--collapse" : ""}`}
         style={{ left: PCT(dividerOffset(guideRatio, secondarySide)) }}
         aria-hidden
       >
         <span className="split-host__guide-chip">
-          {dragRatio < SPLIT_CLOSE_RATIO ? "Close" : snapPreview ? snapPreview.label : null}
+          {inCloseZone ? "Close" : inCollapseZone ? "Fill" : snapPreview ? snapPreview.label : null}
         </span>
       </div>
     ) : null;

--- a/src/components/drag-to-split.test.ts
+++ b/src/components/drag-to-split.test.ts
@@ -24,9 +24,13 @@ test("DetailSplitHost renders drop zones + a snapping divider", () => {
   assert.match(src, /onDropPage\(drag\.mode, side\)/, "drop opens the page on a side");
   // Snapping on divider release goes through the pure resolver.
   assert.match(src, /resolveSplitRelease\(ratioRef\.current\)/);
-  assert.match(src, /release\.action === "close"/, "drag past the edge closes the split");
+  assert.match(src, /release\.action === "close"/, "drag past the near edge closes the split");
   assert.match(src, /secRef\.current\?\.resize\(PCT\(release\.ratio\)\)/, "snaps via imperative resize");
   assert.match(src, /nearestSnap\(dragRatio\)/, "live snap guide");
+  // Dragging past the FAR edge collapses the primary and promotes the secondary.
+  assert.match(src, /release\.action === "collapse"/, "drag past the far edge collapses the primary");
+  assert.match(src, /onPromoteTile\(tile\.id\)/, "collapse promotes the secondary tile to the sole surface");
+  assert.match(src, /split-host__guide--collapse/, "far-edge drag shows the fill guide");
 });
 
 test("DetailSplitHost supports optimized variants for up to four visible pages", () => {
@@ -42,6 +46,7 @@ test("Shell hosts the split inside the detail main with a drop zone", () => {
   const src = read("./shell.tsx");
   assert.match(src, /import \{ DetailSplitHost, type DetailSplitTile \}/);
   assert.match(src, /<DetailSplitHost[\s\S]*?primary=\{detail\}[\s\S]*?secondaryTiles=\{splitTiles\}/);
+  assert.match(src, /onPromoteTile=\{\(id\) => onPromoteSplitTile\?\.\(id\)\}/, "forwards the promote handler");
   assert.match(src, /enableDrop=\{!isMobile\}/, "drop zone is desktop-only");
 });
 
@@ -55,6 +60,10 @@ test("workspace owns split state and the drop handler, and reuses renderSurface"
   assert.match(src, /renderSurface\(target\.mode\)/, "secondary tiles reuse the same machinery");
   assert.match(src, /onDropSplitPage=\{openSplitPage\}/);
   assert.match(src, /addSplitTarget\(\{ kind: "salem" \}\)/, "Salem re-homed into the split (not the removed rail)");
+  // Far-edge collapse promotes a page split to the primary via setMode.
+  assert.match(src, /const promoteSplitTile = useCallback/, "workspace owns the promote handler");
+  assert.match(src, /if \(target\?\.kind === "page"\) setMode\(target\.mode\)/, "promoting a page switches the primary mode");
+  assert.match(src, /onPromoteSplitTile=\{promoteSplitTile\}/, "promote handler is passed to Shell");
 });
 
 test("the right companion (agent) panel is no longer mounted", () => {

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -112,6 +112,7 @@ function ShellInner({
   splitSide = "right",
   onCloseSplit,
   onCloseSplitTile,
+  onPromoteSplitTile,
   onDropSplitPage,
   onNavOpenChange,
   panelShortcutOverrides,
@@ -126,6 +127,7 @@ function ShellInner({
   splitSide?: "left" | "right";
   onCloseSplit?: () => void;
   onCloseSplitTile?: (id: string) => void;
+  onPromoteSplitTile?: (id: string) => void;
   onDropSplitPage?: (mode: string, side: "left" | "right") => void;
   /** Mobile/tablet-only bottom tab bar. Rendered after `.shell-body`
    *  inside `.shell-frame`, but only when the viewport matches the
@@ -484,6 +486,7 @@ function ShellInner({
             secondarySide={splitSide}
             onClose={() => onCloseSplit?.()}
             onCloseTile={(id) => onCloseSplitTile?.(id)}
+            onPromoteTile={(id) => onPromoteSplitTile?.(id)}
             onDropPage={(mode, side) => onDropSplitPage?.(mode, side)}
             enableDrop={!isMobile}
           />

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1450,6 +1450,19 @@ export function Workspace() {
     });
   }, []);
 
+  // Promote a split tile to the sole surface (its divider was dragged past the
+  // far edge, collapsing the primary). Only page tiles map to a primary mode —
+  // switching to it makes the redundant-split effect below clear the tile.
+  // Companion tiles (Salem / Memory / Browser) have no primary mode, so they
+  // stay put (the host leaves them at max width instead).
+  const promoteSplitTile = useCallback(
+    (id: string) => {
+      const target = splitTargets.find((t) => splitTargetKey(t) === id);
+      if (target?.kind === "page") setMode(target.mode);
+    },
+    [splitTargets],
+  );
+
   // Page splits showing the same page as the primary are redundant — clear them
   // (e.g. the user navigated the primary surface to a page in the split).
   useEffect(() => {
@@ -2266,6 +2279,7 @@ export function Workspace() {
         splitSide={splitSide}
         onCloseSplit={closeSplit}
         onCloseSplitTile={closeSplitTile}
+        onPromoteSplitTile={promoteSplitTile}
         onDropSplitPage={openSplitPage}
         topBar={({ navDrawerOpen, listDrawerOpen }) => (
           <>

--- a/src/lib/split-snap.test.ts
+++ b/src/lib/split-snap.test.ts
@@ -6,6 +6,7 @@ import {
   clampSplitRatio,
   dividerOffset,
   SPLIT_CLOSE_RATIO,
+  SPLIT_COLLAPSE_RATIO,
   SPLIT_MAX_RATIO,
   SPLIT_SNAP_THRESHOLD,
 } from "./split-snap.ts";
@@ -29,6 +30,21 @@ test("nearestSnap returns null in free space between snap points", () => {
 test("resolveSplitRelease closes when dragged past the near edge", () => {
   const r = resolveSplitRelease(SPLIT_CLOSE_RATIO - 0.02);
   assert.equal(r.action, "close");
+});
+
+test("resolveSplitRelease collapses the primary when dragged past the far edge", () => {
+  const r = resolveSplitRelease(SPLIT_COLLAPSE_RATIO + 0.02);
+  assert.equal(r.action, "collapse");
+});
+
+test("the collapse edge mirrors the close edge (symmetric past-the-edge margins)", () => {
+  // The pane panels clamp to 10%/90% min/max. Close fires 0.06 above the 10%
+  // floor; collapse fires the same 0.06 below the 90% ceiling.
+  const PANEL_MIN = 0.1;
+  const closeMargin = SPLIT_CLOSE_RATIO - PANEL_MIN;
+  const collapseMargin = SPLIT_MAX_RATIO - SPLIT_COLLAPSE_RATIO;
+  assert.ok(Math.abs(closeMargin - collapseMargin) < 1e-9, "close and collapse margins match");
+  assert.ok(SPLIT_COLLAPSE_RATIO < SPLIT_MAX_RATIO, "the divider can enter the collapse zone before the max");
 });
 
 test("resolveSplitRelease snaps to a clean ratio near a snap point", () => {

--- a/src/lib/split-snap.ts
+++ b/src/lib/split-snap.ts
@@ -4,9 +4,11 @@
  * The detail area can host a second "page" beside the primary surface. The
  * secondary pane is resizable, and — like a modern desktop window manager —
  * the divider *snaps* to a set of clean ratios (a third, a half, two thirds)
- * when the user drags close to them, and the pane closes entirely when dragged
- * past the near edge. All sizes are expressed as the **secondary pane's**
- * fraction of the split group (0..1), independent of which side it sits on.
+ * when the user drags close to them. Dragging past *either* edge collapses the
+ * pane on that side: past the near edge closes the secondary (the primary
+ * fills), and past the far edge collapses the primary (the secondary fills).
+ * All sizes are expressed as the **secondary pane's** fraction of the split
+ * group (0..1), independent of which side it sits on.
  */
 
 export type SnapPoint = {
@@ -29,8 +31,19 @@ export const SPLIT_DEFAULT_RATIO = 1 / 2;
 /** Below this secondary fraction, releasing the drag closes the split. */
 export const SPLIT_CLOSE_RATIO = 0.16;
 
-/** Secondary cannot grow beyond this (the primary keeps a usable column). */
-export const SPLIT_MAX_RATIO = 0.84;
+/**
+ * Above this secondary fraction, releasing the drag collapses the *primary* and
+ * promotes the secondary to fill the surface — the mirror image of
+ * SPLIT_CLOSE_RATIO on the far edge (same 0.06 past-the-edge margin).
+ */
+export const SPLIT_COLLAPSE_RATIO = 0.84;
+
+/**
+ * Secondary cannot grow beyond this while resizing. It sits past
+ * SPLIT_COLLAPSE_RATIO so the divider can enter the collapse zone (mirroring
+ * how the 10% panel min lets it enter the close zone below SPLIT_CLOSE_RATIO).
+ */
+export const SPLIT_MAX_RATIO = 0.9;
 
 /** Snap engages when the divider is within this fraction of a snap point. */
 export const SPLIT_SNAP_THRESHOLD = 0.04;
@@ -63,16 +76,20 @@ export function nearestSnap(
 
 export type SplitRelease =
   | { action: "close" }
+  | { action: "collapse" }
   | { action: "snap"; ratio: number; label: string }
   | { action: "keep"; ratio: number };
 
 /**
  * Resolve what should happen when the user *releases* the divider at `ratio`:
- * close the split if it was dragged past the near edge, snap to the nearest
- * clean ratio if within the threshold, otherwise keep the freely-chosen size.
+ * close the split if it was dragged past the near edge, collapse the primary
+ * (promote the secondary to full) if dragged past the far edge, snap to the
+ * nearest clean ratio if within the threshold, otherwise keep the freely-chosen
+ * size.
  */
 export function resolveSplitRelease(ratio: number): SplitRelease {
   if (ratio < SPLIT_CLOSE_RATIO) return { action: "close" };
+  if (ratio > SPLIT_COLLAPSE_RATIO) return { action: "collapse" };
   const snap = nearestSnap(ratio);
   if (snap) return { action: "snap", ratio: snap.ratio, label: snap.label };
   return { action: "keep", ratio: clampSplitRatio(ratio) };


### PR DESCRIPTION
The resizable split divider already closed the secondary when dragged past the near edge; this adds the mirror on the far edge — dragging a pane wide collapses the *other* pane. A page split promoted this way becomes the sole surface (via setMode); a companion (no primary mode) just sits at max width. The live guide shows a "Fill" chip in the far-edge zone, mirroring the "Close" chip near the near edge.

Two fixes were needed to make this (and the pre-existing snap/close) actually reachable at runtime:

1. `.ui-sep-handle` rendered at height 0 (a block child that never stretched), so the divider handle was unclickable — the component's promised hit area didn't exist. It now fills the separator.

2. react-resizable-panels' <Separator> owns the pointer drag and swallows the pointerdown, so the handle's onMouseDown never fired and the snap/close release logic was dead. Release is now detected from a global pointerup + RRP's live onResize ratio, independent of who owns the pointerdown.

Symmetric edges: panels clamp to 10%/90%; close fires 0.06 above the floor, collapse 0.06 below the ceiling.

<!--
Heads up before you fill this out:

  Coven Cave is NOT accepting external pull requests through July 1st, 2026.

  PRs opened from outside the OpenCoven organization will be closed without
  review during the freeze. The intent will be captured as an issue so the
  work isn't lost. See CONTRIBUTING.md for the full policy.

  If you are an OpenCoven maintainer, please replace this template with the
  PR description below.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

<!-- Why is this change needed? Link the issue, plan, or release notes if any. -->

## Changes

<!-- Bullet list of the meaningful changes in this PR. -->

-

## Verification

<!--
What did you run locally to convince yourself this works?
Tests, builds, manual repro steps, screenshots, anything that matters.
-->

## Risk + rollout notes

<!--
Anything reviewers should look at carefully?
Anything that needs a release-note line, migration, or follow-up issue?
-->
