### PR TITLE
perf+fix(library): lazy-load the surface (CodeMirror out of boot), fix reading-status rollback, memoize read-time

### DIFF
--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -78,3 +78,10 @@ export const AutomationsView = dynamic(
   timed("automations", () => import("@/components/automations-view").then((m) => m.AutomationsView)),
   { ssr: false, loading: SurfaceFallback },
 );
+
+// LibraryView statically pulls ComuxView → CodeMirror (+ dnd-kit,
+// react-resizable-panels); lazy-loading keeps all of it out of the boot bundle.
+export const LibraryView = dynamic(
+  timed("library", () => import("@/components/library-view").then((m) => m.LibraryView)),
+  { ssr: false, loading: SurfaceFallback },
+);

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -1194,9 +1194,12 @@ function DocDetail({ doc, docNav }: { doc: LibraryDocBody; docNav?: DocNav }) {
     });
   };
 
-  // Reading time estimate
-  const wordCount = doc.body.split(/\s+/).filter(Boolean).length;
-  const readMins = Math.max(1, Math.ceil(wordCount / 200));
+  // Reading time estimate — memoized so this full-body regex scan isn't rerun
+  // on every scroll-tick re-render (setScrollPct fires unthrottled).
+  const readMins = useMemo(
+    () => Math.max(1, Math.ceil(doc.body.split(/\s+/).filter(Boolean).length / 200)),
+    [doc.body],
+  );
 
   // Scroll progress
   const [scrollPct, setScrollPct] = useState(0);

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -284,7 +284,6 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
   }
 
   async function handleStatusChange(item: LibraryReadingItem, status: ReadingStatus) {
-    const previous = items;
     setItems((prev) => prev.map((i) => (i.id === item.id ? { ...i, status } : i)));
     try {
       const res = await fetch("/api/library/reading", {
@@ -296,7 +295,10 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
       if (!json.ok) throw new Error("status update failed");
       setItems((prev) => prev.map((i) => (i.id === item.id ? json.item : i)));
     } catch {
-      setItems(previous);
+      // Roll back only this row functionally — restoring a whole snapshot
+      // captured at click time would clobber any other edit/delete that landed
+      // while this PATCH was in flight.
+      setItems((prev) => prev.map((i) => (i.id === item.id ? { ...i, status: item.status } : i)));
     }
   }
 

--- a/src/components/library-view.tsx
+++ b/src/components/library-view.tsx
@@ -11,7 +11,7 @@ import { LibraryGitHubList } from "@/components/library-github-list";
 import { LibraryDocPreview, type SelectedItem } from "@/components/library-doc-preview";
 import { LibraryQuickOpen, type LibraryQuickItem } from "@/components/library-quick-open";
 import { LibraryTimeline } from "@/components/library-timeline";
-import { ComuxView } from "@/components/comux-view";
+import { ComuxView } from "@/components/lazy-surfaces";
 import type { TimelineEntry } from "@/app/api/library/all/route";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -48,12 +48,12 @@ import {
   EvalsView,
   FlowView,
   GitHubView,
+  LibraryView,
   MarketplaceView,
 } from "@/components/lazy-surfaces";
 import { CodeSidebar } from "@/components/code-sidebar";
 import { ChatSidebar } from "@/components/chat-sidebar";
 import { CodeView } from "@/components/code-view";
-import { LibraryView } from "@/components/library-view";
 import { OpenCovenSubmissionPage } from "@/components/opencoven-submission-page";
 import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";

--- a/src/lib/library-store.ts
+++ b/src/lib/library-store.ts
@@ -124,5 +124,3 @@ export function createLibraryStore(root: string = DEFAULT_ROOT) {
     paths,
   };
 }
-
-export type LibraryStore = ReturnType<typeof createLibraryStore>;


### PR DESCRIPTION
Correctness + perf batch from the **Library surface audit** (three-lens; findings source-verified). **No High-severity correctness/security bugs** were found (store writes are mutex-serialized, research composer can't half-write, path-traversal is thoroughly defended) — but a genuine **HIGH perf** finding: the Library surface shipped in the boot bundle.

## Perf
- **LibraryView is now code-split like every other surface.** It statically imported `ComuxView` -> CodeMirror (+ dnd-kit, react-resizable-panels), so the *entire* Library surface plus those heavy deps parsed at app boot for **every** user, even those who never open Library — the one surface bypassing the `lazy-surfaces.tsx` boundary. Routed `LibraryView` through `lazy-surfaces` (`next/dynamic`) and switched `library-view`'s `ComuxView` to the lazy one (so it isn't duplicated across chunks). Boot shell = 447 KB / 650 KB budget; CodeMirror now in the on-demand Library chunk.
- **Reader read-time is memoized.** The full-body `doc.body.split` regex scan ran on *every* `DocDetail` render — including every unthrottled scroll-tick re-render (`setScrollPct`). Now `useMemo([doc.body])`.

## Correctness
- **Reading-list status rollback no longer clobbers concurrent edits.** On a failed PATCH, `handleStatusChange` restored a whole-array snapshot captured at click time, discarding any other edit/delete that landed while the request was in flight. Now it rolls back only that row functionally.

## Dead code
- Removed the dead `LibraryStore` type export (grep-confirmed zero references; the `createLibraryStore` function stays live).

## Deferred to P2 (noted, not in this PR)
- Timeline per-row familiar `.find` -> memoized `familiarsById` map + `React.memo` rows; GitHub README client-side fetch cache + memoize the `absolutizeGitHubReadme` call; the latent `familiar` query param on the two doc fetches (single-familiar today via `workspaces[0]`).

## Correction to the audit
The audit flagged an `absolutizeGitHubReadme` sentinel-collision bug (a space-delimited code-mask token colliding with prose). **False positive** — the code already uses a **NUL-delimited** sentinel; the Read tool renders the NUL byte as a space, which misled the audit agent. Verified via hexdump. No change made.

## Verification
- `tsc --noEmit` clean (lazy-load imports resolve, no circular-import break); all 11 library test suites pass; `pnpm build` green with **bundle-budget within budget**. Rendered the live Library surface — collection rail + timeline render, the lazy chunk mounts, **zero page errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)