### PR TITLE
a11y(library): name zoomable reader images, focus-trap the lightbox, mark reading progress, aria-current the doc list

### DIFF
--- a/src/components/library-doc-list.tsx
+++ b/src/components/library-doc-list.tsx
@@ -199,6 +199,7 @@ export function LibraryDocList({
                 <button
                   type="button"
                   className="library-doclist-item-main"
+                  aria-current={doc.id === selectedId ? "true" : undefined}
                   onClick={() => onSelect(doc)}
                 >
                   <div className="library-doclist-item-header">

--- a/src/components/library-doc-preview.tsx
+++ b/src/components/library-doc-preview.tsx
@@ -480,6 +480,10 @@ function wireMarkdownImages(container: HTMLElement, onZoom: (t: ZoomTarget) => v
     img.classList.add("cave-md-img--zoomable");
     img.setAttribute("role", "button");
     img.setAttribute("tabindex", "0");
+    // A role=button with no name is a WCAG 4.1.2 failure (an empty-alt image
+    // becomes a nameless button); name the zoom control from the alt.
+    const zoomAlt = (img.getAttribute("alt") || "").trim();
+    img.setAttribute("aria-label", zoomAlt ? `View image: ${zoomAlt}` : "View image");
     img.addEventListener("click", () => open(img.currentSrc || img.src));
     img.addEventListener("keydown", (e) => {
       if (e.key === "Enter" || e.key === " ") { e.preventDefault(); open(img.currentSrc || img.src); }
@@ -488,20 +492,21 @@ function wireMarkdownImages(container: HTMLElement, onZoom: (t: ZoomTarget) => v
 }
 
 function ImageLightbox({ target, onClose }: { target: ZoomTarget; onClose: () => void }) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // Trap focus + Escape + restore focus to the triggering image on close; the
+  // lightbox is aria-modal but previously leaked Tab to the page behind it.
+  useFocusTrap(true, dialogRef, { onEscape: onClose });
 
   if (typeof document === "undefined") return null;
   const canOpen = /^https?:\/\//i.test(target.src);
   return createPortal(
     <div
+      ref={dialogRef}
       className="cave-img-lightbox"
       role="dialog"
       aria-modal="true"
       aria-label={target.alt || "Image preview"}
+      tabIndex={-1}
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div className="cave-img-lightbox__bar" onClick={(e) => e.stopPropagation()}>

--- a/src/components/library-reading-list.tsx
+++ b/src/components/library-reading-list.tsx
@@ -582,9 +582,16 @@ export function LibraryReadingList({ selectedId, onSelect, onDelete }: Props) {
                       </td>
                       <td className="library-reading-col-progress">
                         {item.status === "done" ? (
-                          <span style={{ color: "var(--color-success)", display:"inline-flex", alignItems:"center" }}><Icon name="ph:check" width={13} /></span>
+                          <span aria-label="Read" style={{ color: "var(--color-success)", display:"inline-flex", alignItems:"center" }}><Icon name="ph:check" width={13} aria-hidden /></span>
                         ) : item.status === "reading" && item.progress != null ? (
-                          <div className="library-progress-bar library-progress-bar--lg">
+                          <div
+                            className="library-progress-bar library-progress-bar--lg"
+                            role="progressbar"
+                            aria-valuenow={item.progress}
+                            aria-valuemin={0}
+                            aria-valuemax={100}
+                            aria-label={`Reading progress: ${item.progress}%`}
+                          >
                             <div className="library-progress-fill" style={{ width: `${item.progress}%` }} />
                           </div>
                         ) : (


### PR DESCRIPTION
Accessibility batch from the **Library surface audit** — the companion to the correctness/perf PR (#2325), rebased onto it. The audit verified a lot already-clean (quick-open, reader modal, research composer, the table lists' `useTableRowKeyboardNav`, shared Tabs, heading/ToC hierarchy, reduced-motion gating, PDF iframe title), so this is well-bounded.

## Reader
- **Zoomable markdown images now have an accessible name.** `wireMarkdownImages` promotes standalone content images to `role="button" tabindex=0` for zoom, but never named them — an empty-alt image became a **nameless button** (WCAG 4.1.2 failure), and figures in briefs/READMEs announced only as "button". Now `aria-label` from the alt (`"View image: <alt>"`, or `"View image"`).
- **The image zoom-lightbox now traps focus.** It was `role="dialog" aria-modal` but — unlike every other dialog in the file — didn't call `useFocusTrap`: nothing moved focus in, Tab leaked to the page behind the modal backdrop, and focus wasn't restored on close. Now `useFocusTrap(true, dialogRef, { onEscape })` (which also replaces the ad-hoc window Escape listener) + `tabIndex={-1}`.

## Lists
- **Reading-list progress is now a real `progressbar`** (`role="progressbar"` + `aria-valuenow`/`min`/`max` + label) instead of bar-width alone; the "done" cell gets `aria-label="Read"` (the check glyph is `aria-hidden`).
- **Doc-list rows expose selection with `aria-current`**, not colour alone.

## Deferred to P2 (noted, not in this PR)
- Wire `useAnnouncer` into Library CRUD/undo (add/remove/mark-read/delete/research-complete) for parity with every other surface — real but broad (4 files).
- Roving-tabindex on the doc list; the doc-preview reading-progress bar's `progressbar` semantics.

## Verification
- `tsc --noEmit` clean; all library test suites pass (no source-text pins on the changed lightbox/image/progress code); `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)