### PR TITLE
fix(ios): make cave connection self-healing

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -22,6 +22,7 @@ struct CovenCaveApp: App {
                 .tint(resolved.chrome.accent)
                 .preferredColorScheme(resolved.scheme)
                 .task {
+                    app.startConnectionSupervisor()
                     // Route notification taps to the reminders list, and show
                     // reminder banners while the app is foregrounded.
                     notificationDelegate.onOpen = { app.handleDeepLink($0) }

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
@@ -8,7 +8,8 @@ extension CaveClient {
     private var devSession: URLSession {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 25
-        config.waitsForConnectivity = false
+        config.timeoutIntervalForResource = 60
+        config.waitsForConnectivity = true
         return URLSession(configuration: config)
     }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -18,8 +18,37 @@ struct CaveClient {
     private var session: URLSession {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 20
-        config.waitsForConnectivity = false
+        config.timeoutIntervalForResource = 60
+        config.waitsForConnectivity = true
         return URLSession(configuration: config)
+    }
+
+    func data(for req: URLRequest) async throws -> (Data, URLResponse) {
+        let method = (req.httpMethod ?? "GET").uppercased()
+        let retryDelays: [Duration] = ["GET", "HEAD"].contains(method)
+            ? [.milliseconds(350), .seconds(1)]
+            : []
+        for attempt in 0...retryDelays.count {
+            do {
+                return try await session.data(for: req)
+            } catch {
+                guard attempt < retryDelays.count, Self.isTransient(error) else { throw error }
+                try await Task.sleep(for: retryDelays[attempt])
+            }
+        }
+        throw CaveError.transport("Network request failed.")
+    }
+
+    private static func isTransient(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .timedOut, .cannotFindHost, .cannotConnectToHost, .networkConnectionLost,
+             .dnsLookupFailed, .notConnectedToInternet, .internationalRoamingOff,
+             .callIsActive, .dataNotAllowed:
+            return true
+        default:
+            return false
+        }
     }
 
     private func request(_ path: String, method: String = "GET", body: Data? = nil) throws -> URLRequest {
@@ -67,7 +96,7 @@ struct CaveClient {
     /// using what we have".
     func refreshAccessToken() async -> String? {
         guard let req = try? request("api/mobile-token/refresh", method: "POST") else { return nil }
-        guard let (data, resp) = try? await session.data(for: req),
+        guard let (data, resp) = try? await data(for: req),
               let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode),
               let decoded = try? JSONDecoder().decode(TokenRefreshResponse.self, from: data),
               decoded.ok, let token = decoded.token, !token.isEmpty
@@ -81,8 +110,8 @@ struct CaveClient {
     func ping() async -> Bool {
         guard let req = try? request("api/familiars") else { return false }
         do {
-            let (_, resp) = try await session.data(for: req)
-            return (resp as? HTTPURLResponse).map { (200..<500).contains($0.statusCode) } ?? false
+            let (_, resp) = try await data(for: req)
+            return (resp as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? false
         } catch {
             return false
         }
@@ -92,7 +121,7 @@ struct CaveClient {
 
     func familiars() async throws -> [Familiar] {
         let req = try request("api/familiars")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(FamiliarsResponse.self, from: data).familiars
@@ -111,7 +140,7 @@ struct CaveClient {
 
     func sessions(includeArchived: Bool = false) async throws -> [SessionRow] {
         let req = try request("api/sessions/list\(includeArchived ? "?includeArchived=1" : "")")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(SessionsResponse.self, from: data).sessions
@@ -124,7 +153,7 @@ struct CaveClient {
 
     func tasks() async throws -> [BoardCard] {
         let req = try request("api/board")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(BoardResponse.self, from: data).cards
@@ -207,13 +236,13 @@ struct CaveClient {
     /// `DELETE /api/board/{id}` — remove a task.
     func deleteTask(cardId: String) async throws {
         let req = try request("api/board/\(cardId)", method: "DELETE")
-        let (_, resp) = try await session.data(for: req)
+        let (_, resp) = try await data(for: req)
         try Self.check(resp)
     }
 
     private func patchTask(cardId: String, payload: Data) async throws -> BoardCard {
         let req = try request("api/board/\(cardId)", method: "PATCH", body: payload)
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         let decoded = try JSONDecoder().decode(BoardPatchResponse.self, from: data)
         if let card = decoded.card { return card }
@@ -222,7 +251,7 @@ struct CaveClient {
 
     func conversation(sessionId: String) async throws -> Conversation? {
         let req = try request("api/chat/conversation/\(sessionId)")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ConversationResponse.self, from: data).conversation
@@ -242,7 +271,7 @@ struct CaveClient {
         var path = "api/chat/model-state?familiarId=\(urlQuery(familiarId))"
         if let sessionId, !sessionId.isEmpty { path += "&sessionId=\(urlQuery(sessionId))" }
         let req = try request(path)
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ChatModelStateResponse.self, from: data)
@@ -258,7 +287,7 @@ struct CaveClient {
         if let sessionId, !sessionId.isEmpty { body["sessionId"] = sessionId }
         let payload = try JSONEncoder().encode(body)
         let req = try request("api/chat/model-state", method: "PATCH", body: payload)
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ChatModelStateResponse.self, from: data)
@@ -347,7 +376,7 @@ struct CaveClient {
     /// `/daemon` — desktop daemon health (`GET /api/daemon/status`).
     func daemonStatus() async throws -> DaemonStatus {
         let req = try request("api/daemon/status")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         return try JSONDecoder().decode(DaemonStatus.self, from: data)
     }
@@ -375,7 +404,7 @@ struct CaveClient {
         let payload = try JSONEncoder().encode(["command": command])
         var req = try request("api/coven/exec", method: "POST", body: payload)
         req.timeoutInterval = 30
-        let (data, _) = try await session.data(for: req)
+        let (data, _) = try await data(for: req)
         return try JSONDecoder().decode(CovenExecResult.self, from: data)
     }
 
@@ -405,7 +434,7 @@ struct CaveClient {
     func routeLink(_ body: RouteLinkBody) async throws -> RouteLinkResult {
         let payload = try JSONEncoder().encode(body)
         let req = try request("api/library/route-link", method: "POST", body: payload)
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         return try JSONDecoder().decode(RouteLinkResult.self, from: data)
     }
@@ -417,7 +446,7 @@ struct CaveClient {
     /// `api/familiars` etc.
     func fetchTheme() async throws -> ThemeSnapshot {
         let req = try request("api/theme")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ThemeResponse.self, from: data).theme
@@ -437,7 +466,7 @@ struct CaveClient {
         struct Body: Encodable { let themeId: String; let mode: String }
         let payload = try JSONEncoder().encode(Body(themeId: themeId, mode: mode))
         let req = try request("api/theme", method: "PUT", body: payload)
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(ThemeResponse.self, from: data).theme
@@ -451,7 +480,7 @@ struct CaveClient {
     /// `GET /api/inbox` — the reminders/inbox feed, filtered to reminders.
     func reminders() async throws -> [Reminder] {
         let req = try request("api/inbox")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(InboxResponse.self, from: data).items
@@ -464,7 +493,7 @@ struct CaveClient {
     /// `GET /api/journal` — the list of days that have a reflection.
     func journalDays() async throws -> [JournalDay] {
         let req = try request("api/journal")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(JournalDaysResponse.self, from: data).days
@@ -476,7 +505,7 @@ struct CaveClient {
     /// `GET /api/journal?date=yyyy-MM-dd` — one day's reflection.
     func journalDay(date: String) async throws -> JournalEntry {
         let req = try request("api/journal?date=\(urlQuery(date))")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(JournalDayResponse.self, from: data).entry
@@ -488,7 +517,7 @@ struct CaveClient {
     /// `GET /api/library/reading` — saved reading list, mapped for display.
     func libraryReading() async throws -> [LibraryItem] {
         let req = try request("api/library/reading")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(LibraryReadingResponse.self, from: data).items.map {
@@ -504,7 +533,7 @@ struct CaveClient {
     /// `GET /api/library/bookmarks` — saved bookmarks, mapped for display.
     func libraryBookmarks() async throws -> [LibraryItem] {
         let req = try request("api/library/bookmarks")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(LibraryBookmarksResponse.self, from: data).items.map {
@@ -524,7 +553,7 @@ struct CaveClient {
             "kind": "reminder", "title": title, "fireAt": iso, "source": "user",
         ])
         let req = try request("api/inbox", method: "POST", body: payload)
-        let (_, resp) = try await session.data(for: req)
+        let (_, resp) = try await data(for: req)
         try Self.check(resp)
     }
 
@@ -532,7 +561,7 @@ struct CaveClient {
     func deleteReminder(id: String) async throws {
         let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
         let req = try request("api/inbox/\(escaped)", method: "DELETE")
-        let (_, resp) = try await session.data(for: req)
+        let (_, resp) = try await data(for: req)
         try Self.check(resp)
     }
 
@@ -544,7 +573,7 @@ struct CaveClient {
     private func inboxAction(_ id: String, _ action: String, body: Data? = nil) async throws -> Reminder? {
         let escaped = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
         let req = try request("api/inbox/\(escaped)/\(action)", method: "POST", body: body)
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         return try? JSONDecoder().decode(ReminderActionResponse.self, from: data).item
     }
@@ -593,7 +622,7 @@ struct CaveClient {
     /// desktop has no GitHub token yet (the list query needs one).
     func repos() async throws -> (items: [RepoFeedItem], configured: Bool) {
         let req = try request("api/github/repos")
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             let decoded = try JSONDecoder().decode(ReposResponse.self, from: data)
@@ -606,7 +635,7 @@ struct CaveClient {
     /// Latest OpenCoven posts. `refresh` bypasses the desktop's short cache.
     func homeTweets(refresh: Bool = false) async throws -> [TweetFeedItem] {
         let req = try request("api/home-tweets" + (refresh ? "?refresh=1" : ""))
-        let (data, resp) = try await session.data(for: req)
+        let (data, resp) = try await data(for: req)
         try Self.check(resp)
         do {
             return try JSONDecoder().decode(TweetsResponse.self, from: data).items ?? []

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -118,6 +118,11 @@ enum CaveError: LocalizedError {
     case decoding(String)
     case transport(String)
 
+    static func isAuthFailure(_ error: Error) -> Bool {
+        guard case CaveError.badResponse(let code) = error else { return false }
+        return code == 401 || code == 403
+    }
+
     var errorDescription: String? {
         switch self {
         case .notConfigured: return "No host configured."

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import Observation
 import WidgetKit
 
@@ -31,6 +32,9 @@ final class AppModel {
 
     var connection: CaveConnection?
     var connectionState: ConnectionState = .unconfigured
+    private let connectionMonitor = NWPathMonitor()
+    private let connectionMonitorQueue = DispatchQueue(label: "ai.opencoven.cave.connection-monitor")
+    private var connectionMonitorStarted = false
 
     var familiars: [Familiar] = []
     var familiarsError: String?
@@ -217,7 +221,7 @@ final class AppModel {
             tasks = try await client.tasks()
             tasksError = nil
         } catch {
-            tasksError = error.localizedDescription
+            tasksError = handleSurfaceError(error)
         }
         tasksLoaded = true
         // A task that finished on the desktop should drop its Lock Screen activity.
@@ -398,7 +402,7 @@ final class AppModel {
             projects = try await client.projects()
             projectsError = nil
         } catch {
-            projectsError = error.localizedDescription
+            projectsError = handleSurfaceError(error)
         }
         projectsLoaded = true
     }
@@ -411,7 +415,7 @@ final class AppModel {
             reminders = try await client.reminders()
             remindersError = nil
         } catch {
-            remindersError = error.localizedDescription
+            remindersError = handleSurfaceError(error)
         }
         remindersLoaded = true
         publishWidgetSnapshot()
@@ -483,7 +487,7 @@ final class AppModel {
             journalDays = try await client.journalDays()
             journalError = nil
         } catch {
-            journalError = error.localizedDescription
+            journalError = handleSurfaceError(error)
         }
         journalLoaded = true
     }
@@ -584,7 +588,52 @@ final class AppModel {
         connectionState = .unconfigured
     }
 
-    func refreshConnection() async {
+    func startConnectionSupervisor() {
+        guard !connectionMonitorStarted else { return }
+        connectionMonitorStarted = true
+        connectionMonitor.pathUpdateHandler = { [weak self] path in
+            guard path.status == .satisfied else { return }
+            Task { @MainActor [weak self] in
+                guard let self, self.connection != nil else { return }
+                await self.recoverConnectionInBackground()
+            }
+        }
+        connectionMonitor.start(queue: connectionMonitorQueue)
+    }
+
+    func recoverConnectionInBackground() async {
+        guard connection != nil else { connectionState = .unconfigured; return }
+        await refreshConnection(reloadLoadedSurfaces: true)
+    }
+
+    private var shouldReloadLoadedSurfaces: Bool {
+        !familiars.isEmpty || sessionsLoaded || tasksLoaded || remindersLoaded || projectsLoaded || journalLoaded
+    }
+
+    private func pairingMessage() -> String {
+        CaveConnection.accessToken == nil
+            ? "This desktop requires pairing. Open Cave on the desktop → “Open on phone”, then scan the QR code or paste the invite link here."
+            : "Your pairing has expired. Open Cave on the desktop → “Open on phone” and scan the QR code (or paste the invite link) to pair again."
+    }
+
+    private func handleSurfaceError(_ error: Error) -> String {
+        if CaveError.isAuthFailure(error) {
+            connectionState = .needsAuth(pairingMessage())
+        }
+        return error.localizedDescription
+    }
+
+    private func refreshLoadedSurfaces() async {
+        await loadFamiliars()
+        if sessionsLoaded { await loadSessions() }
+        if tasksLoaded { await loadTasks() }
+        if remindersLoaded { await loadReminders() }
+        if projectsLoaded { await loadProjects() }
+        if journalLoaded { await loadJournal() }
+        await loadTheme()
+    }
+
+    func refreshConnection(reloadLoadedSurfaces: Bool = false) async {
         guard let connection else { connectionState = .unconfigured; return }
         connectionState = .checking
 
@@ -603,15 +652,15 @@ final class AppModel {
                 }
             }
             connectionState = .connected
-            await loadFamiliars()
-            await loadTheme()
             await refreshAccessTokenIfNeeded()
+            if reloadLoadedSurfaces {
+                await refreshLoadedSurfaces()
+            } else {
+                await loadFamiliars()
+                await loadTheme()
+            }
         case .unauthorized:
-            connectionState = .needsAuth(
-                CaveConnection.accessToken == nil
-                    ? "This desktop requires pairing. Open Cave on the desktop → “Open on phone”, then scan the QR code or paste the invite link here."
-                    : "Your pairing has expired. Open Cave on the desktop → “Open on phone” and scan the QR code (or paste the invite link) to pair again."
-            )
+            connectionState = .needsAuth(pairingMessage())
         case .none:
             connectionState = .unreachable("Couldn’t reach the desktop. Is it on the tailnet and running?")
         }
@@ -643,7 +692,7 @@ final class AppModel {
         guard connection != nil else { connectionState = .unconfigured; return }
         // Delays BETWEEN attempts (4 attempts total, ~7s before giving up).
         let backoffSeconds: [UInt64] = [1, 2, 4]
-        await refreshConnection()
+        await refreshConnection(reloadLoadedSurfaces: shouldReloadLoadedSurfaces)
         var attempt = 0
         while connectionState != .connected, attempt < backoffSeconds.count {
             connectionState = .checking
@@ -651,7 +700,7 @@ final class AppModel {
             if Task.isCancelled { return }
             // The user may have disconnected/reconfigured during the wait.
             guard connection != nil else { connectionState = .unconfigured; return }
-            await refreshConnection()
+            await refreshConnection(reloadLoadedSurfaces: shouldReloadLoadedSurfaces)
             attempt += 1
         }
     }
@@ -717,7 +766,7 @@ final class AppModel {
             seedFamiliarViews(familiars.map(\.id))
             familiarsError = nil
         } catch {
-            familiarsError = error.localizedDescription
+            familiarsError = handleSurfaceError(error)
         }
     }
 
@@ -788,7 +837,7 @@ final class AppModel {
             serverSessions = try await client.sessions()
             sessionsError = nil
         } catch {
-            sessionsError = error.localizedDescription
+            sessionsError = handleSurfaceError(error)
         }
         sessionsLoaded = true
     }

--- a/scripts/ios-auto-reconnect.test.mjs
+++ b/scripts/ios-auto-reconnect.test.mjs
@@ -22,7 +22,7 @@ assert.match(
 );
 assert.match(
   model,
-  /func connectWithRetry[\s\S]*?while connectionState != \.connected[\s\S]*?connectionState = \.checking[\s\S]*?Task\.sleep[\s\S]*?await refreshConnection\(\)/,
+  /func connectWithRetry[\s\S]*?while connectionState != \.connected[\s\S]*?connectionState = \.checking[\s\S]*?Task\.sleep[\s\S]*?await refreshConnection\(reloadLoadedSurfaces: shouldReloadLoadedSurfaces\)/,
   "connectWithRetry should retry refreshConnection while held at .checking (no unreachable flash)",
 );
 assert.match(

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The native app should feel like a modern companion client: transient network
+// loss waits/retries instead of immediately failing, reconnects happen on real
+// network recovery, and already-open surfaces refresh after the desktop comes
+// back without throwing the user back through setup.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const client = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
+const devClient = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift");
+const connection = await read("apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift");
+const app = await read("apps/ios/CovenCave/CovenCave/CovenCaveApp.swift");
+
+// --- Network supervision: real connectivity changes trigger a background recover
+assert.match(model, /import Network/, "AppModel should watch iOS network reachability");
+assert.match(model, /private let connectionMonitor = NWPathMonitor\(\)/, "AppModel should own an NWPathMonitor");
+assert.match(model, /func startConnectionSupervisor\(\)/, "AppModel should expose a connection supervisor starter");
+assert.match(
+  model,
+  /pathUpdateHandler = \{[\s\S]*?path\.status == \.satisfied[\s\S]*?recoverConnectionInBackground\(\)/,
+  "a satisfied network path should trigger background connection recovery",
+);
+assert.match(
+  app,
+  /\.task \{[\s\S]*?app\.startConnectionSupervisor\(\)[\s\S]*?await app\.connectWithRetry\(\)/,
+  "app launch should start the connection supervisor before the initial retry",
+);
+
+// --- Reconnect convergence: keep stale UI, then refresh any surface the user opened
+assert.match(model, /func recoverConnectionInBackground\(\) async/, "AppModel should expose background recovery");
+assert.match(
+  model,
+  /func recoverConnectionInBackground[\s\S]*?await refreshConnection\(reloadLoadedSurfaces: true\)/,
+  "background recovery should ask refreshConnection to reload opened surfaces",
+);
+assert.match(
+  model,
+  /private func refreshLoadedSurfaces\(\) async \{[\s\S]*?await loadFamiliars\(\)[\s\S]*?if sessionsLoaded \{ await loadSessions\(\) \}[\s\S]*?if tasksLoaded \{ await loadTasks\(\) \}[\s\S]*?if remindersLoaded \{ await loadReminders\(\) \}[\s\S]*?if projectsLoaded \{ await loadProjects\(\) \}[\s\S]*?if journalLoaded \{ await loadJournal\(\) \}[\s\S]*?await loadTheme\(\)/,
+  "reconnect should refresh all already-opened surfaces plus familiars/theme",
+);
+assert.match(
+  model,
+  /func connectWithRetry[\s\S]*?await refreshConnection\(reloadLoadedSurfaces: shouldReloadLoadedSurfaces\)/,
+  "foreground retry should also converge loaded surfaces after a successful reconnect",
+);
+
+// --- Auth failures: expired pairing goes to pairing guidance, not generic offline
+assert.match(model, /private func handleSurfaceError\(_ error: Error\) -> String/, "surface loads should share error handling");
+assert.match(
+  model,
+  /handleSurfaceError[\s\S]*?CaveError\.isAuthFailure\(error\)[\s\S]*?connectionState = \.needsAuth\(pairingMessage\(\)\)/,
+  "401/403 from an opened surface should route to the pairing-expired state",
+);
+assert.match(
+  connection,
+  /static func isAuthFailure\(_ error: Error\) -> Bool/,
+  "CaveError should expose an auth-failure classifier",
+);
+
+// --- Transport resilience: waits for connectivity and retries transient request failures
+assert.match(
+  client,
+  /config\.waitsForConnectivity = true/,
+  "core API requests should wait briefly for connectivity instead of failing instantly",
+);
+assert.match(
+  devClient,
+  /config\.waitsForConnectivity = true/,
+  "developer API requests should wait briefly for connectivity too",
+);
+assert.match(client, /func data\(for req: URLRequest\) async throws -> \(Data, URLResponse\)/, "CaveClient should centralize resilient request data loading");
+assert.match(
+  client,
+  /for attempt in 0\.\.\.retryDelays\.count[\s\S]*?session\.data\(for: req\)[\s\S]*?Task\.sleep/,
+  "resilient data loading should retry transient failures with bounded backoff",
+);
+
+console.log("ios-self-healing-sync: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -694,6 +694,7 @@ export const SUITES = {
     "scripts/ios-github-comment-attach.test.mjs",
     "scripts/ios-theme.test.mjs",
     "scripts/ios-auto-reconnect.test.mjs",
+    "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",


### PR DESCRIPTION
## Summary
- add an iOS network-path supervisor that retries Cave reconnects when connectivity returns
- keep stale connected UI visible while reconnecting, then refresh already-opened iOS surfaces after recovery
- make core iOS API requests wait for connectivity and retry transient GET/HEAD failures with bounded backoff
- classify 401/403 surface-load failures as pairing/auth expiration instead of generic offline errors

## Verification
- node scripts/ios-auto-reconnect.test.mjs && node scripts/ios-self-healing-sync.test.mjs
- pnpm test:mobile
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check
- xcodebuild -project apps/ios/CovenCave/CovenCave.xcodeproj -scheme CovenCave -destination "generic/platform=iOS Simulator" -configuration Debug build
- pnpm test:app → 519 app test files passed
