### PR TITLE
feat(flow): world-class pass 2 — working multi-select + branch labels on fan-out edges

### DIFF
--- a/src/components/flow/flow-canvas.test.ts
+++ b/src/components/flow/flow-canvas.test.ts
@@ -60,5 +60,13 @@ assert.match(view, /if \(dirty && !saving\) void save\(\)/, "Cmd+S saves only wh
 assert.match(view, /onDuplicateNode\(selectedNodeId\)/, "Cmd+D duplicates the selected node");
 assert.match(view, /catalogOpen \|\| templateGalleryOpen \|\| requiredInputsPrompt/, "shortcuts stand down while any dialog owns focus");
 assert.match(view, /target\.isContentEditable/, "shortcuts stand down while typing");
+// Multi-select: React Flow's marquee/shift-click selection must survive the
+// detail-panel selection — a plain override killed it.
+assert.match(canvas, /node\.selected === true \|\| node\.id === selectedNodeId/, "canvas selection is a union of internal multi-select and the detail-panel node");
+// Branch labels: fan-out edges (router/if/loop) name their branch on the wire.
+const edge = readFileSync(new URL("./flow-edge.tsx", import.meta.url), "utf8");
+assert.match(canvas, /sourceDef\.outputs\.length > 1/, "only true fan-outs get branch labels");
+assert.match(edge, /branchLabel/, "the edge renders its branch name");
+assert.match(styles, /\.flow-edge-branch-label/, "branch labels are styled");
 
 console.log("flow-canvas.test.ts OK");

--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -168,7 +168,11 @@ if (syncedViewKey !== viewKey) {
         const stale = staleNodeIds?.[node.id] === true;
         return {
           ...node,
-          selected: node.id === selectedNodeId,
+          // Union, not override: React Flow's own selection state (shift-drag
+          // marquee, shift-click multi) must survive alongside the detail-panel
+          // selection — forcing `selected` from selectedNodeId alone silently
+          // killed multi-select.
+          selected: node.selected === true || node.id === selectedNodeId,
           data: phase || stale ? { ...node.data, ...(phase ? { phase } : {}), ...(stale ? { stale } : {}) } : node.data,
         };
       }),
@@ -179,6 +183,14 @@ if (syncedViewKey !== viewKey) {
     () =>
       doc.edges.map((edge) => {
         const isActive = activeNodeId != null && edge.target === activeNodeId;
+        // Branch label: when the source node fans out over several labeled
+        // ports (router/if/loop), name the branch on the wire itself — the
+        // tiny port badge alone doesn't survive a glance at a busy canvas.
+        const sourceDef = docNodes.find((node) => node.id === edge.source)?.data.def;
+        const branchLabel =
+          sourceDef && sourceDef.outputs.length > 1
+            ? sourceDef.outputs.find((port) => port.id === edge.sourceHandle)?.label
+            : undefined;
         return {
           id: edge.id,
           source: edge.source,
@@ -189,10 +201,10 @@ if (syncedViewKey !== viewKey) {
           animated: isActive,
           className: isActive ? "flow-edge-active" : undefined,
           markerEnd: { type: MarkerType.ArrowClosed, width: 14, height: 14, color: "#7d83a8" },
-          data: { onInsert: () => onInsertEdge(edge.id) },
+          data: { onInsert: () => onInsertEdge(edge.id), branchLabel },
         } satisfies Edge;
       }),
-    [doc.edges, activeNodeId, onInsertEdge],
+    [doc.edges, docNodes, activeNodeId, onInsertEdge],
   );
 
   const handleNodesChange = useCallback((changes: NodeChange<Node<FlowNodeData>>[]) => {

--- a/src/components/flow/flow-edge.tsx
+++ b/src/components/flow/flow-edge.tsx
@@ -11,6 +11,9 @@ import {
 export type FlowEdgeData = {
   /** Open the node catalog to splice a node into this edge. */
   onInsert?: () => void;
+  /** Named branch this edge leaves from (router "a", if "true", loop "done") —
+   *  shown on the wire so fan-outs stay legible at a glance. */
+  branchLabel?: string;
 } & Record<string, unknown>;
 
 export type FlowRFEdge = Edge<FlowEdgeData, "flowEdge">;
@@ -43,6 +46,19 @@ export function FlowEdge({
   return (
     <>
       <BaseEdge id={id} path={path} markerEnd={markerEnd} />
+      {data?.branchLabel && (
+        <EdgeLabelRenderer>
+          <span
+            className="flow-edge-branch-label nodrag nopan"
+            style={{
+              position: "absolute",
+              transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY - 16}px)`,
+            }}
+          >
+            {data.branchLabel}
+          </span>
+        </EdgeLabelRenderer>
+      )}
       {data?.onInsert && (
         <EdgeLabelRenderer>
           <button

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -217,6 +217,8 @@
 
 .flow-node-failed-badge { position: absolute; bottom: -8px; right: 10px; padding: 1px 6px; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; border-radius: 999px; background: color-mix(in oklch, var(--color-danger) 20%, var(--bg-elevated)); color: var(--color-danger); border: 1px solid color-mix(in oklch, var(--color-danger) 55%, var(--border)); }
 
+.flow-edge-branch-label { padding: 1px 6px; font-size: 9px; font-weight: 600; letter-spacing: 0.03em; border-radius: 999px; background: var(--bg-elevated); color: var(--text-secondary); border: 1px solid var(--border); pointer-events: none; }
+
 .flow-canvas-coach { position: absolute; bottom: 72px; left: 50%; transform: translateX(-50%); z-index: 5; display: flex; flex-direction: column; align-items: center; gap: 8px; max-width: 340px; padding: 16px 22px; border-radius: var(--radius-lg, 12px); background: color-mix(in oklch, var(--bg-elevated) 88%, transparent); border: 1px dashed var(--border); text-align: center; backdrop-filter: blur(4px); }
 .flow-canvas-coach-title { margin: 0; font-size: 14px; font-weight: 600; color: var(--text-primary); }
 .flow-canvas-coach-sub { margin: 0; font-size: var(--text-xs); line-height: 1.5; color: var(--text-muted); }


### PR DESCRIPTION
Second batch of the flow-page world-class pass (pass 1 = #2327).

## Multi-select actually works now
React Flow ships marquee (shift-drag) and multi-click (⌘-click) selection, and the canvas already handled group ops — `onNodeDragStop` writes every node position, `onNodesDelete` loops all deleted nodes. But none of it was reachable: `renderNodes` **overrode** every node's `selected` with the single detail-panel selection, silently killing internal multi-selection each render. Selection is now the union of React Flow's own state and the detail-panel node.

Verified live on a worktree server: ⌘-click selects two nodes (both ringed), shift-drag marquee engages and selects contained nodes, group drag + bulk delete work as already built.

## Branch labels on fan-out edges
Router `a/b/c`, if `true/false`, loop `loop/done`, gate `approved/rejected` — an edge leaving a labeled port of a multi-output node now carries its branch name as a small pill on the wire (above the splice `+`). The tiny port badge alone didn't survive a glance at a busy canvas. Labels render only for true fan-outs (source def has >1 outputs). Verified live: the PR-review template's gate edges read `approved` / `rejected` on the canvas.

## Tests
Pins in `flow-canvas.test.ts`: the selection union expression, the >1-outputs gate, the edge `branchLabel` render, and the label styles. Full suite: 701 test files green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)