### PR TITLE
perf(flow): index branch label sources

### DIFF
--- a/src/components/flow/flow-canvas.test.ts
+++ b/src/components/flow/flow-canvas.test.ts
@@ -65,6 +65,16 @@ assert.match(view, /target\.isContentEditable/, "shortcuts stand down while typi
 assert.match(canvas, /node\.selected === true \|\| node\.id === selectedNodeId/, "canvas selection is a union of internal multi-select and the detail-panel node");
 // Branch labels: fan-out edges (router/if/loop) name their branch on the wire.
 const edge = readFileSync(new URL("./flow-edge.tsx", import.meta.url), "utf8");
+assert.match(
+  canvas,
+  /new Map\(docNodes\.map\(\(node\) => \[node\.id, node\.data\.def\]\)\)/,
+  "edge source definitions are indexed once per node change",
+);
+assert.doesNotMatch(
+  canvas,
+  /docNodes\.find\(\(node\) => node\.id === edge\.source\)/,
+  "edge rendering must not scan all nodes once per edge",
+);
 assert.match(canvas, /sourceDef\.outputs\.length > 1/, "only true fan-outs get branch labels");
 assert.match(edge, /branchLabel/, "the edge renders its branch name");
 assert.match(styles, /\.flow-edge-branch-label/, "branch labels are styled");

--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -179,6 +179,11 @@ if (syncedViewKey !== viewKey) {
     [nodes, phases, selectedNodeId, staleNodeIds],
   );
 
+  const nodeDefinitionsById = useMemo(
+    () => new Map(docNodes.map((node) => [node.id, node.data.def])),
+    [docNodes],
+  );
+
   const edges = useMemo<Edge[]>(
     () =>
       doc.edges.map((edge) => {
@@ -186,7 +191,7 @@ if (syncedViewKey !== viewKey) {
         // Branch label: when the source node fans out over several labeled
         // ports (router/if/loop), name the branch on the wire itself — the
         // tiny port badge alone doesn't survive a glance at a busy canvas.
-        const sourceDef = docNodes.find((node) => node.id === edge.source)?.data.def;
+        const sourceDef = nodeDefinitionsById.get(edge.source);
         const branchLabel =
           sourceDef && sourceDef.outputs.length > 1
             ? sourceDef.outputs.find((port) => port.id === edge.sourceHandle)?.label
@@ -204,7 +209,7 @@ if (syncedViewKey !== viewKey) {
           data: { onInsert: () => onInsertEdge(edge.id), branchLabel },
         } satisfies Edge;
       }),
-    [doc.edges, docNodes, activeNodeId, onInsertEdge],
+    [doc.edges, nodeDefinitionsById, activeNodeId, onInsertEdge],
   );
 
   const handleNodesChange = useCallback((changes: NodeChange<Node<FlowNodeData>>[]) => {


### PR DESCRIPTION
## Summary
- build a memoized node definition map for Flow edge branch-label lookup
- avoid scanning every node once per edge when rendering fan-out labels
- add a guard that keeps per-edge node scans from coming back

## Verification
- node --experimental-strip-types src/components/flow/flow-canvas.test.ts
- pnpm typecheck
- git diff --check
- pnpm test:app