### PR TITLE
chore(release): stamp v0.0.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.137] - 2026-07-03
+
+Patch release on top of v0.0.136. A big **Flow** and **mobile** slice: Flow gets
+a multi-pass world-class overhaul (config summaries, empty-canvas coaching,
+keyboard shortcuts, working multi-select, branch labels on fan-out edges, plus
+lifecycle accessibility and a ~1,600-line dead-code purge), the native iOS app
+gains iPad/macOS adaptive layouts and a self-healing connection with seamless
+QR/deep-link pairing, and the Library surface is faster and more accessible.
+The desktop Chat and Code sidebars also land their world-class redesign.
+
+### Added
+
+- **Flow** - world-class overhaul across two passes: config summaries, an
+  empty-canvas coach, keyboard shortcuts, memoized rails (#2327), plus working
+  multi-select and branch labels on fan-out edges (#2329).
+- **iOS** - iPad and macOS adaptive layouts across all tabs (#2317).
+- **Mobile** - seamless pairing: QR / deep-link invites, Bearer auth, and
+  rolling token renewal (#2320).
+- **Board** - nudge to set a project on projectless task cards (#2319).
+
+### Changed
+
+- **Chat / Code** - world-class redesign of the Chat and Code sidebars (#2313).
+- **Sidebar** - thread rows go full-width when not hovered (#2321).
+- **Flow** - sessions launch in non-interactive mode (#2324).
+
+### Fixed
+
+- **iOS** - the cave connection is now self-healing (#2328).
+- **Library** - fix reading-status rollback (#2325).
+
+### Performance
+
+- **Library** - lazy-load the surface (CodeMirror out of boot), memoize
+  read-time, drop a dead type (#2325).
+- **Flow** - index branch-label sources (#2330).
+
+### Accessibility
+
+- **Flow** - announce lifecycle events, name the nodes, and focus-trap the
+  add-node & template dialogs (#2316).
+- **Library** - name zoomable reader images, focus-trap the lightbox, mark
+  reading progress, and `aria-current` the doc list (#2326).
+
+### Removed
+
+- **Flow** - purge ~1,600 lines of dead superseded workflow libs and dead
+  flow-doc / workflow-graph exports (#2318).
+
 ## [0.0.136] - 2026-07-03
 
 Patch release on top of v0.0.135. Headlined by the desktop browser fix — the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.136"
+version = "0.0.137"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.136"
+version = "0.0.137"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.136</string>
+	<string>0.0.137</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.136</string>
+	<string>0.0.137</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.136</string>
+	<string>0.0.137</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.136</string>
+	<string>0.0.137</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.137** across all six version locations + CHANGELOG.

## Payload — 14 PRs since v0.0.136 (#2313, #2316–#2330)

**Added**
- #2327/#2329 Flow world-class overhaul (config summaries, empty-canvas coach, shortcuts, multi-select, branch labels)
- #2317 iOS iPad/macOS adaptive layouts · #2320 mobile seamless pairing (QR/deep-link, Bearer, rolling renewal) · #2319 board projectless nudge

**Changed**
- #2313 worldclass Chat+Code sidebar redesign · #2321 full-width thread rows · #2324 flow noninteractive launch

**Fixed**
- #2328 iOS self-healing connection · #2325 library reading-status rollback

**Performance**
- #2325 library lazy-load (CodeMirror out of boot) · #2330 flow branch-label indexing

**Accessibility**
- #2316 flow lifecycle announce/name/trap · #2326 library reader images/lightbox/progress

**Removed**
- #2318 ~1,600 lines of dead flow workflow libs

## Version locations stamped
`package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` (app pkg), `src-tauri/tauri.conf.json`, `src-tauri/Info.ios.plist`, `src-tauri/gen/apple/app_iOS/Info.plist` → all `0.0.137`.

Signed tag `v0.0.137` pushed after merge to trigger the release workflow.