### PR TITLE
Sidebar header: uncramp the ⋯ options button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -767,7 +767,10 @@ tr[role="checkbox"]:focus-visible {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px var(--cnav-pad) 6px;
+  /* Extra right padding so the trailing options (⋯) button isn't jammed against
+     the panel edge; the left stays at --cnav-pad to align with the New-chat and
+     search fields below. */
+  padding: 12px 15px 6px var(--cnav-pad);
 }
 .cnav__back {
   display: grid;


### PR DESCRIPTION
The chat sidebar's Sidebar-options (⋯) button sat ~10px from the panel edge and read cramped.

**Fix:** bump the `.cnav__header` right padding to 15px so the ⋯ button has breathing room from the edge (verified: gap 10px → 15px). The left stays at `--cnav-pad` so the back arrow keeps aligning with the New-chat and search fields below.

CSS-only, one rule. `pnpm build` clean; screenshotted before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)