### PR TITLE
fix+perf(evals): honor the judge's pass/fail, don't record stopped runs, cap runs per-suite, guard the poll, floor sub-100%

### DIFF
--- a/src/components/evals/evals-insights-panel.tsx
+++ b/src/components/evals/evals-insights-panel.tsx
@@ -26,7 +26,7 @@ export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; r
   const sla = suite?.slaMinPassRate;
   const latest = trend.length ? trend[trend.length - 1].y : null;
   const breached = sla != null && latest != null && latest < sla;
-  const pct = (n: number) => `${Math.round(n * 100)}%`;
+  const pct = (n: number) => `${n >= 1 ? 100 : Math.min(99, Math.round(n * 100))}%`;
 
   const failBars = clusters.byCase
     .filter((c) => c.failures > 0)

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/lib/evals/eval-model";
 import { runSuite, type RunProgress } from "@/lib/evals/eval-runner";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import {
   instantiateTemplate,
@@ -297,19 +298,36 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
       if (r.status !== "fulfilled") return null;
       try { return await r.value.json(); } catch { return null; }
     };
+    // Each poll rebuilds fresh arrays from JSON; guard every setter with a
+    // structural equality check so an unchanged snapshot returns the previous
+    // reference and doesn't re-render the whole surface + re-aggregate every
+    // tick (this poll runs every 30s even when idle).
     const runsData = (await readJson(runsR)) as { ok?: boolean; runs?: EvalRun[] } | null;
-    if (runsData?.ok && Array.isArray(runsData.runs)) setAllRuns(runsData.runs);
+    if (runsData?.ok && Array.isArray(runsData.runs)) {
+      const next = runsData.runs;
+      setAllRuns((prev) => (arrayContentEqual(prev, next) ? prev : next));
+    }
     const groupsData = (await readJson(groupsR)) as { ok?: boolean; groups?: EvalGroup[] } | null;
-    if (groupsData?.ok && Array.isArray(groupsData.groups)) setGroups(groupsData.groups);
+    if (groupsData?.ok && Array.isArray(groupsData.groups)) {
+      const next = groupsData.groups;
+      setGroups((prev) => (arrayContentEqual(prev, next) ? prev : next));
+    }
     const threadsData = (await readJson(threadsR)) as { ok?: boolean; snapshots?: ThreadEvalSnapshot[] } | null;
-    if (threadsData?.ok && Array.isArray(threadsData.snapshots)) setThreadSnapshots(threadsData.snapshots);
+    if (threadsData?.ok && Array.isArray(threadsData.snapshots)) {
+      const next = threadsData.snapshots;
+      setThreadSnapshots((prev) => (arrayContentEqual(prev, next) ? prev : next));
+    }
     const queueData = (await readJson(queueR)) as { ok?: boolean; queue?: ManualEvalQueueItem[] } | null;
-    if (queueData?.ok && Array.isArray(queueData.queue)) setQueue(queueData.queue);
+    if (queueData?.ok && Array.isArray(queueData.queue)) {
+      const next = queueData.queue;
+      setQueue((prev) => (arrayContentEqual(prev, next) ? prev : next));
+    }
     const retroData = (await readJson(retroR)) as RetroApiResponse | null;
     if (retroData?.ok && retroData.snapshot) setRetroSnapshot(retroData.snapshot);
     const sessionsData = (await readJson(sessionsR)) as { ok?: boolean; sessions?: SessionRow[] } | null;
     if (sessionsData?.ok && Array.isArray(sessionsData.sessions)) {
-      setEvalThreads(sessionsData.sessions.filter((s) => s.origin === "eval"));
+      const next = sessionsData.sessions.filter((s) => s.origin === "eval");
+      setEvalThreads((prev) => (arrayContentEqual(prev, next) ? prev : next));
     }
   }, []);
 
@@ -444,6 +462,9 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
         signal: controller.signal,
         onProgress: setProgress,
       });
+      // A stopped run is a truncated/partial result — don't record it or its
+      // depressed pass rate into history (trends / compare / insights).
+      if (controller.signal.aborted) return;
       setRuns((prev) => [result, ...prev]);
       setAllRuns((prev) => [result, ...prev.filter((run) => run.id !== result.id)]);
       setExpandedRunId(result.id);
@@ -1321,7 +1342,9 @@ function GraderRow({ grader, onChange, onRemove }: { grader: Grader; onChange: (
 // ---- Runs ------------------------------------------------------------------
 
 function pct(n: number): string {
-  return `${Math.round(n * 100)}%`;
+  // Only show 100% when it truly is: Math.round would render 99.5% as "100%"
+  // on a run that actually failed a case.
+  return `${n >= 1 ? 100 : Math.min(99, Math.round(n * 100))}%`;
 }
 
 function RunsPanel({

--- a/src/components/evals/run-compare.tsx
+++ b/src/components/evals/run-compare.tsx
@@ -51,7 +51,7 @@ export function RunCompare({ runs }: { runs: EvalRun[] }) {
     .map((s) => ({ status: s, count: counts.get(s)! }));
 
   const label = (r: EvalRun) =>
-    `${new Date(r.startedAt).toLocaleString()} · ${Math.round(r.summary.passRate * 100)}%`;
+    `${new Date(r.startedAt).toLocaleString()} · ${r.summary.passRate >= 1 ? 100 : Math.min(99, Math.round(r.summary.passRate * 100))}%`;
 
   return (
     <div className="evals-compare">

--- a/src/lib/evals/eval-model.test.ts
+++ b/src/lib/evals/eval-model.test.ts
@@ -68,6 +68,10 @@ function mkCase(over: Partial<EvalCase> = {}): EvalCase {
   assert.equal(judged.pass, true, "judge verdict >= 0.5 passes");
   assert.equal(judged.score, 0.8);
   assert.equal(applyJudgeVerdict(g, 0.3, "rude").pass, false, "judge verdict < 0.5 fails");
+  // An explicit judge boolean wins over the score threshold (a judge may return
+  // a high score but pass:false, or vice-versa).
+  assert.equal(applyJudgeVerdict(g, 0.9, "high score, explicit fail", false).pass, false, "explicit pass:false overrides a >=0.5 score");
+  assert.equal(applyJudgeVerdict(g, 0.2, "low score, explicit pass", true).pass, true, "explicit pass:true overrides a <0.5 score");
   assert.equal(graderNeedsModel({ kind: "contains", value: "x" }), false, "deterministic graders need no model");
 }
 

--- a/src/lib/evals/eval-model.ts
+++ b/src/lib/evals/eval-model.ts
@@ -314,14 +314,18 @@ export function graderNeedsModel(g: Grader): boolean {
  * Fold a judge verdict (produced by the client via the chat pipeline) into a
  * judge grader result. `verdictScore` is 0..1; pass threshold is 0.5.
  */
-export function applyJudgeVerdict(g: Grader, verdictScore: number, detail: string): GraderResult {
+export function applyJudgeVerdict(g: Grader, verdictScore: number, detail: string, pass?: boolean): GraderResult {
   const score = clamp01(verdictScore);
+  // Honor the judge's explicit boolean when it gave one; only fall back to the
+  // score threshold when it didn't. A judge can legitimately return score 0.9
+  // with pass:false (or vice-versa) and its own decision must win.
+  const passed = pass ?? score >= 0.5;
   return {
     kind: "llm_judge",
     label: graderLabel(g),
-    pass: score >= 0.5,
+    pass: passed,
     score,
-    detail: detail || (score >= 0.5 ? "judge passed" : "judge failed"),
+    detail: detail || (passed ? "judge passed" : "judge failed"),
   };
 }
 
@@ -359,10 +363,6 @@ export function summarizeResults(results: EvalCaseResult[]): EvalRunSummary {
     avgScore: mean(results.map((r) => r.score)),
     avgLatencyMs: mean(results.map((r) => r.latencyMs)),
   };
-}
-
-export function emptySummary(): EvalRunSummary {
-  return { ...EMPTY_SUMMARY };
 }
 
 /** Reasons a suite cannot be run, for surfacing a disabled Run button. */

--- a/src/lib/evals/eval-runner.ts
+++ b/src/lib/evals/eval-runner.ts
@@ -119,7 +119,7 @@ async function gradeCase(
       continue;
     }
     const verdict = parseJudgeVerdict(text);
-    out.push(applyJudgeVerdict(g, verdict.score, verdict.reason));
+    out.push(applyJudgeVerdict(g, verdict.score, verdict.reason, verdict.pass));
   }
   return out;
 }

--- a/src/lib/server/eval-store.ts
+++ b/src/lib/server/eval-store.ts
@@ -406,11 +406,19 @@ export async function deleteRun(id: string): Promise<boolean> {
   }
 }
 
-/** Keep the newest EVAL_RUNS_CAP run files; drop the rest. */
+/** Keep the newest EVAL_RUNS_CAP run files *per suite*; drop the rest. Capping
+ *  globally let one busy suite silently evict another suite's run history. */
 async function pruneRuns(): Promise<void> {
-  const all = await listRuns();
-  if (all.length <= EVAL_RUNS_CAP) return;
-  for (const run of all.slice(EVAL_RUNS_CAP)) {
-    await rm(path.join(runsDir(), fileName(run.id, "run")), { force: true }).catch(() => {});
+  const bySuite = new Map<string, EvalRun[]>();
+  for (const run of await listRuns()) {
+    const list = bySuite.get(run.suiteId);
+    if (list) list.push(run);
+    else bySuite.set(run.suiteId, [run]);
+  }
+  for (const list of bySuite.values()) {
+    // listRuns is newest-first, so slice(CAP) is the oldest beyond the per-suite cap.
+    for (const run of list.slice(EVAL_RUNS_CAP)) {
+      await rm(path.join(runsDir(), fileName(run.id, "run")), { force: true }).catch(() => {});
+    }
   }
 }


### PR DESCRIPTION
Correctness + perf batch from the **Evals surface audit** (three-lens; findings source-verified). **No High-severity security bugs** — the store is per-file atomic, path-safe, and validated; compare matches by stable id (not index); errored runs can't count as pass.

## Correctness
- **The LLM judge's explicit pass/fail is now honored.** `applyJudgeVerdict` recomputed `pass` purely from the score (`>= 0.5`) and threw away the judge's boolean, so a reply `{"score":0.9,"pass":false}` was recorded **PASS** (and `{"score":0.2,"pass":true}` → **FAIL**) whenever score and pass land on opposite sides of 0.5. The runner now threads `verdict.pass` through; the judge's own decision wins. (+ regression test.)
- **Stopping a run no longer records the partial/errored result.** An aborted run was persisted like a completed one — fewer cases, the interrupted case counted as a hard fail — and its depressed pass rate polluted trends / compare / insights. A stopped run is now discarded (`signal.aborted` guard).
- **Run-history cap is per-suite, not global.** The 200-run cap spanned *every* suite, so one busy suite silently evicted another suite's older runs (and its trend history). `pruneRuns` now caps per `suiteId`.
- **"100%" is only shown when it truly is.** `pct()` used `Math.round`, so `199/200` (99.5%) rendered "100%" on a run that actually failed a case — now floored to 99 for the sub-100 band (three call sites).

## Perf
- **Pass-rate poll no longer re-renders + re-aggregates the whole surface every tick.** `refreshSnapshot` re-set fresh JSON-parsed arrays **unconditionally** every 30s (idle) / 5s (running), cascading through every memo (`scopedAllRuns` → `analysis`, group states, rollups). Each setter is now guarded with `arrayContentEqual` — the exact pattern `board-view`/`workspace`/`automations-view`/`github-view`/`session-changes-panel` already use, which Evals was the only poll-heavy surface missing.

## Dead code
- Removed the dead `emptySummary()` export (grep incl. defining file + tests: zero callers).

## Deferred to P2 (noted)
- The transient poll-vs-optimistic-run drop (self-heals in one interval); `coerceRun` NaN-hardening for hand-edited legacy run files; dead `.evals-familiar-pick` CSS (shares a responsive selector with a live class); test-only exports (`BarChart`, `failureClusters.byGrader`, `CATEGORY_LABELS`/`findEvalTemplate`).

## Verification
- `tsc --noEmit` clean; all 10 eval test suites pass (added the judge score/pass-disagree regression test); `pnpm build` green, bundle within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)