### PR TITLE
a11y(evals): give the trend chart a text alternative, announce run lifecycle, name grader outcomes

### DIFF
--- a/src/components/evals/evals-insights-panel.tsx
+++ b/src/components/evals/evals-insights-panel.tsx
@@ -51,6 +51,11 @@ export function EvalsInsightsPanel({ suite, runs }: { suite: EvalSuite | null; r
           series={[{ id: suite?.id ?? "all", label: "Pass rate", color: "var(--accent-presence)", points: trend }]}
           threshold={sla}
           height={160}
+          ariaLabel={
+            trend.length
+              ? `Pass rate over ${trend.length} run${trend.length === 1 ? "" : "s"}: latest ${pct(latest ?? 0)}${trend.length > 1 ? `, ranging ${pct(Math.min(...trend.map((p) => p.y)))} to ${pct(Math.max(...trend.map((p) => p.y)))}` : ""}`
+              : "Pass rate over time: no runs yet"
+          }
         />
       </section>
 

--- a/src/components/evals/evals-view.tsx
+++ b/src/components/evals/evals-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type 
 import { Icon } from "@/lib/icon";
 import type { IconName } from "@/lib/icon";
 import { EmptyState } from "@/components/ui/empty-state";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { EvalLoopPanel } from "@/components/eval-loop-panel";
 import { RetroRunsView } from "@/components/retro-runs-view";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
@@ -446,6 +447,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     });
   }, [draft, selectSuite]);
 
+  const { announce } = useAnnouncer();
   const run = useCallback(async () => {
     if (!draft || blockReason) return;
     const controller = new AbortController();
@@ -453,6 +455,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
     setRunning(true);
     setTab("runs");
     setProgress({ index: 0, total: draft.cases.length, results: [], phase: "running" });
+    announce(`Running suite ${draft.name}, ${draft.cases.length} cases`);
     try {
       const famName = familiars.find((f) => f.id === familiarId)?.display_name;
       const result = await runSuite({
@@ -468,6 +471,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
       setRuns((prev) => [result, ...prev]);
       setAllRuns((prev) => [result, ...prev.filter((run) => run.id !== result.id)]);
       setExpandedRunId(result.id);
+      announce(`Run complete: ${result.summary.passed} of ${result.summary.total} passed, ${pct(result.summary.passRate)}`);
       // Persist (best-effort; desktop-only route).
       void fetch("/api/evals/runs", {
         method: "POST",
@@ -479,7 +483,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
       setProgress(null);
       abortRef.current = null;
     }
-  }, [draft, blockReason, familiarId, familiars]);
+  }, [draft, blockReason, familiarId, familiars, announce]);
 
   const stop = useCallback(() => {
     abortRef.current?.abort();
@@ -550,6 +554,7 @@ export function EvalsView({ familiars, activeFamiliarId }: Props) {
                 <button
                   type="button"
                   className={`evals-suite-row${s.id === selectedId ? " is-active" : ""}`}
+                  aria-current={s.id === selectedId ? "true" : undefined}
                   onClick={() => selectSuite(s)}
                 >
                   <span className="evals-suite-name">{s.name}</span>
@@ -1367,7 +1372,7 @@ function RunsPanel({
           <div className="evals-progress-head">
             <span className="evals-spinner" aria-hidden /> Running case {Math.min(progress.index + 1, progress.total)} of {progress.total}
           </div>
-          <div className="evals-progress-bar" role="progressbar" aria-valuemin={0} aria-valuemax={progress.total} aria-valuenow={progress.results.length}>
+          <div className="evals-progress-bar" role="progressbar" aria-label="Suite run progress" aria-valuemin={0} aria-valuemax={progress.total} aria-valuenow={progress.results.length}>
             <span style={{ width: pct(progress.total ? progress.results.length / progress.total : 0) }} />
           </div>
           {progress.results.length > 0 && <ResultTable results={progress.results} />}
@@ -1440,7 +1445,7 @@ function ResultTable({ results }: { results: EvalRun["results"] }) {
               <ul className="evals-grader-results">
                 {res.graders.map((g, i) => (
                   <li key={i} className={g.pass ? "is-pass" : "is-fail"}>
-                    <Icon name={g.pass ? "ph:check" : "ph:x"} width={11} />
+                    <Icon name={g.pass ? "ph:check" : "ph:x"} width={11} aria-label={g.pass ? "passed" : "failed"} />
                     <span className="evals-grader-result-label">{g.label}</span>
                     <span className="evals-grader-result-detail">{g.detail}</span>
                   </li>

--- a/src/components/ui/charts/trend-chart.tsx
+++ b/src/components/ui/charts/trend-chart.tsx
@@ -20,17 +20,21 @@ export function TrendChart({
   height = 160,
   threshold,
   fill = true,
+  ariaLabel,
 }: {
   series: TrendSeries[];
   height?: number;
   threshold?: number;
   fill?: boolean;
+  /** When set, the chart SVG is exposed to AT as role="img" with this label (a
+   *  text summary of the data). Without it the SVG stays aria-hidden. */
+  ariaLabel?: string;
 }) {
   return (
     <div className="cave-chart cave-chart--trend" style={{ height }}>
       <ParentSize>
         {({ width }) => (
-          <TrendInner width={width} height={height} series={series} threshold={threshold} fill={fill} />
+          <TrendInner width={width} height={height} series={series} threshold={threshold} fill={fill} ariaLabel={ariaLabel} />
         )}
       </ParentSize>
     </div>
@@ -43,12 +47,14 @@ function TrendInner({
   series,
   threshold,
   fill,
+  ariaLabel,
 }: {
   width: number;
   height: number;
   series: TrendSeries[];
   threshold?: number;
   fill: boolean;
+  ariaLabel?: string;
 }) {
   const margin = { top: 8, right: 8, bottom: 8, left: 8 };
   const iw = Math.max(0, width - margin.left - margin.right);
@@ -65,7 +71,7 @@ function TrendInner({
   const yScale = scaleLinear({ domain: [0, yMax], range: [ih, 0], nice: true });
 
   return (
-    <svg width={width} height={height} aria-hidden>
+    <svg width={width} height={height} {...(ariaLabel ? { role: "img", "aria-label": ariaLabel } : { "aria-hidden": true })}>
       <Group left={margin.left} top={margin.top}>
         {threshold != null ? (
           <line className="cave-chart__threshold" x1={0} x2={iw} y1={yScale(threshold)} y2={yScale(threshold)} />


### PR DESCRIPTION
Accessibility batch from the **Evals surface audit** — the companion to the correctness/perf PR (#2333), rebased onto it. The audit verified a lot already-clean (failures-by-case text bars, stat cards, compare verdict chips, the TemplateGallery `Modal` focus-trap, and — notably — **no ungated chart motion**: the visx primitives use no react-spring, only a CSS hover transition already covered by the reduced-motion reset).

## The big one
- **The trend chart had no text alternative.** `TrendChart`'s `<svg>` is hard-`aria-hidden`, and the Insights "Pass rate over time" card had no adjacent table / `aria-describedby` — so for a screen-reader user the entire trend (values, direction, history) was invisible. `TrendChart` now takes an optional `ariaLabel` prop → `role="img"` + label on the svg when provided (stays `aria-hidden` by default, so the dashboard usage is unchanged), and the insights panel passes a data summary: *"Pass rate over N runs: latest X%, ranging Y% to Z%"*.

## The rest
- **Run lifecycle is announced** (`useAnnouncer`): "Running suite X, N cases" on start, "Run complete: N of M passed, P%" on completion. Evals was the only run/poll surface not announcing.
- **Per-grader pass/fail is named.** It was an icon + color only, and the shared `Icon` defaults to `aria-hidden` without a label — so the outcome was invisible to AT. Added `aria-label={passed|failed}`.
- **Suite-rail rows expose selection with `aria-current`** (was class/color only).
- **The run progressbar gets an `aria-label`** (it had `valuemin`/`max`/`now` but no name).

## Deferred to P2 (noted, not in this PR)
- The section tabs are a hand-rolled `role="tab"` with **no** tabpanel/roving/arrow-key model (declaring the role while breaking its keyboard contract) — swap to the shared `ui/tabs`. Bigger structural change.
- eval-loop track filter `aria-pressed`; eval-loop error `role="alert"`; compare `<th scope="col">`.

## Verification
- `tsc --noEmit` clean; all eval + chart test suites pass (the charts test is intact — the svg stays `aria-hidden` by default); `pnpm build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)