### PR TITLE
fix+perf(browser): preserve forward history, harden the iframe sandbox, fix the listener race, throttle the reposition loop

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -362,6 +362,11 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
   // ── Page-load + title events ──────────────────────────────────────
   useEffect(() => {
     if (!bridge || !nativeBrowserAvailable) return;
+    // If this effect is torn down (tab switch / unmount) before an async
+    // bridge.listen() resolves, unlisten the moment it does — otherwise the
+    // handler leaks and later fires with a stale activeTabId (duplicate
+    // loading / address-bar updates for the wrong tab).
+    let cancelled = false;
     let unlistenLoad: (() => void) | null = null;
     let unlistenTitle: (() => void) | null = null;
 
@@ -386,13 +391,20 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               t.id === tabId ? { ...t, url: evUrl } : t
             )
           );
-          // Push to per-tab history
+          // Push to per-tab history — but a back/forward re-navigation lands on
+          // the URL already at the current index (goBack/goForward move idx
+          // first), so skip the truncate-and-append that would otherwise
+          // permanently destroy the forward entries.
           const h = historyRef.current[tabId] ?? { stack: [evUrl], idx: 0 };
-          const next = [...h.stack.slice(0, h.idx + 1), evUrl];
-          historyRef.current[tabId] = { stack: next, idx: next.length - 1 };
+          if (h.stack[h.idx] === evUrl) {
+            historyRef.current[tabId] = h;
+          } else {
+            const next = [...h.stack.slice(0, h.idx + 1), evUrl];
+            historyRef.current[tabId] = { stack: next, idx: next.length - 1 };
+          }
         }
       },
-    ).then((fn) => { unlistenLoad = fn; });
+    ).then((fn) => { if (cancelled) fn(); else unlistenLoad = fn; });
 
     void bridge.listen<{ label: string; title: string; url: string }>(
       "browser:title",
@@ -404,9 +416,9 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
         setTabTitles((prev) => ({ ...prev, [tabId]: title }));
         if (tabId === activeTabId) setAddressBar(evUrl);
       },
-    ).then((fn) => { unlistenTitle = fn; });
+    ).then((fn) => { if (cancelled) fn(); else unlistenTitle = fn; });
 
-    return () => { unlistenLoad?.(); unlistenTitle?.(); };
+    return () => { cancelled = true; unlistenLoad?.(); unlistenTitle?.(); };
   }, [bridge, nativeBrowserAvailable, label, activeTabId]);
 
   // ── Sync active tab webview bounds ────────────────────────────────
@@ -427,6 +439,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
     let raf = 0;
     let hidden = false;
     let last = { x: 0, y: 0, w: 0, h: 0 };
+    let lastRun = 0;
 
     const hideAll = () => {
       tabIds.forEach((id) => {
@@ -434,7 +447,14 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
       });
     };
 
-    const tick = () => {
+    const tick = (now: number) => {
+      raf = requestAnimationFrame(tick);
+      // Throttle to ~10 Hz and idle while the tab is hidden. This loop
+      // otherwise runs a getBoundingClientRect + a full-document occlusion
+      // check (querySelectorAll + up to 5 elementFromPoint hit-tests)
+      // 60x/second continuously, even when nothing is moving.
+      if (document.visibilityState !== "visible" || now - lastRun < 100) return;
+      lastRun = now;
       const rect = surface.getBoundingClientRect();
       // Hide every webview when the panel is collapsed, the toolbar is open,
       // OR a DOM overlay (onboarding, a modal, the palette…) renders above
@@ -472,7 +492,6 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
           });
         }
       }
-      raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
 
@@ -959,7 +978,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
             src={activeUrl}
             title="Browser"
             className="absolute inset-0 h-full w-full border-0 bg-[var(--bg-base)]"
-            sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-top-navigation"
+            sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
           />
         ) : (
           <div ref={surfaceRef} className="absolute inset-0" />

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -156,4 +156,20 @@ assert.match(qo, /bg-black\/40 backdrop-blur-sm/, "Backdrop must use bg-black/40
 assert.match(qo, /onClick=\{onClose\}/, "Outer container must handle onClick={onClose}");
 assert.match(qo, /onClick=\{\(e\) => e\.stopPropagation\(\)\}/, "Inner card must stopPropagation on click");
 
+// ───────── Security: iframe fallback sandbox ─────────
+// allow-top-navigation lets framed arbitrary content navigate the whole app
+// window away — it must never be in the fallback sandbox.
+assert.doesNotMatch(pane, /allow-top-navigation/, "iframe sandbox must not grant allow-top-navigation");
+assert.match(pane, /sandbox="allow-same-origin allow-scripts allow-forms allow-popups"/, "iframe fallback keeps a scoped sandbox");
+
+// ───────── Correctness: back/forward preserves forward history ─────────
+// A back/forward re-navigation lands on the URL already at the current index;
+// the page-load handler must skip the truncate-and-append that would destroy
+// the forward entries.
+assert.match(pane, /if \(h\.stack\[h\.idx\] === evUrl\) \{/, "page-load history push guards against clobbering forward entries");
+
+// ───────── Correctness: listen() unlisten race + perf throttle ─────────
+assert.match(pane, /then\(\(fn\) => \{ if \(cancelled\) fn\(\); else unlisten/, "async listen() unlistens if the effect was already torn down");
+assert.match(pane, /if \(document\.visibilityState !== "visible" \|\| now - lastRun < 100\) return;/, "the bounds-reconcile rAF loop is throttled + idle-gated");
+
 console.log("browser-polish.test.ts: ok");


### PR DESCRIPTION
Correctness + perf batch from the **Browser surface audit** (three-lens; findings source-verified, cross-checked against the Rust `browser.rs`). The audit verified a lot clean (no webview label collisions between the main/companion instances, no double-close, occlusion/visibility handled, URL normalization on the UI path, **no dead code**).

## Correctness
- **Back/Forward no longer destroys forward history.** `goBack`/`goForward` move the JS history index and set the tab URL, which re-triggers a native navigation; the `browser:page-load` handler then pushed that URL back onto history **with no guard**, truncating everything after the current index — so `[A,B,C]` + Back became `[A,B,B]` and **C was gone forever** (back/forward effectively broken on desktop). The push now skips when the load lands on the URL already at the current index (a back/forward re-navigation).
- **Security: the iframe fallback sandbox no longer grants `allow-top-navigation`.** Framed arbitrary content could do `top.location = "https://evil"` and **navigate the whole app window away**, replacing Coven Cave (web / Tauri-mobile fallback path). Dropped it; the desktop path uses a real separate webview and is unaffected.
- **The Tauri `listen()` unlisten race is fixed.** The page-load/title listeners re-subscribe on every tab switch; if the effect tore down before the async `bridge.listen()` resolved, the unlisten fn was orphaned → duplicate handlers firing with a stale `activeTabId` (loading/address-bar flicker for the wrong tab). The `.then` now unlistens immediately if the effect was already cancelled.

## Perf
- **The webview bounds-reconcile loop is throttled.** It ran a `getBoundingClientRect` **+ a full-document occlusion check** (`querySelectorAll('[role="dialog"]')` + up to 5 `elementFromPoint` hit-tests) **60×/second continuously** while the Browser was visible — even when idle, and doubled when the companion split pane is open. Now ~10 Hz + gated on `document.visibilityState` (desktop path).

## Deferred to P2 (noted)
- Lazy-load `BrowserPane` (static import → boot bundle, like Library was — but it's a `forwardRef` with an imperative handle, so the dynamic wrapper needs ref forwarding, and its heavy Tauri deps are already dynamically imported); **close** (not just hide) tab webviews on unmount so audio stops after leaving Browser mode; memoize the tab strip (address-bar keystroke re-renders it); gate the localhost probe to the main instance; validate persisted tabs against a bad/empty localStorage value.

## Verification
- `tsc --noEmit` clean; all 5 browser test suites pass + new source-text regression guards (no `allow-top-navigation`, the history-clobber guard, the listener-cancel, the rAF throttle). `pnpm build` green. Rendered the web fallback — pane mounts, **iframe `sandbox` = `"allow-same-origin allow-scripts allow-forms allow-popups"`** (no `allow-top-navigation`) confirmed in the live DOM, zero errors from app code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)