### PR TITLE
perf+fix(terminal): stop re-rendering the SR mirror on hidden panes; reset the decoder on reconnect

### DIFF
--- a/src/components/bottom-terminal-sr-mirror.test.ts
+++ b/src/components/bottom-terminal-sr-mirror.test.ts
@@ -63,4 +63,11 @@ assert.match(source, /const \{ term, fit, search \} = await createXterm\(wrap, \
 // Search decoration colors are a module constant, not rebuilt each render.
 assert.match(source, /^const SEARCH_DECORATIONS = \{/m, "SEARCH_DECORATIONS is hoisted to module scope");
 
+// The mirror must not re-render while the pane is backgrounded/hidden — a busy
+// background stream otherwise re-renders the 50-line mirror every 250ms
+// off-screen. pushToMirror keeps decoding (decoder stays consistent) but skips
+// the flush when the pane isn't active, and drains on becoming active.
+assert.match(source, /if \(!activeRef\.current\) \{[\s\S]{0,180}return;/, "the SR mirror doesn't re-render while the pane is hidden");
+assert.match(source, /if \(active\) \{\s*\n\s*flushMirror\(\);/, "buffered output is drained into the mirror when the pane becomes active");
+
 console.log("bottom-terminal-sr-mirror.test.ts OK");

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -25,7 +25,8 @@ assert.match(
   /if \(!bridge\.isOpen\) \{[\s\S]{0,260}attemptReconnect\(\);[\s\S]{0,80}return;[\s\S]{0,120}bridge\.write\(new TextEncoder\(\)\.encode\(data\)\)/,
   "typing on a dead socket revives the terminal instead of vanishing into a no-op write",
 );
-assert.match(src, /term\.reset\(\);[\s\S]{0,120}await bridge\.reconnect\(\)/, "screen resets before reattach so the server replay paints clean");
+assert.match(src, /term\.reset\(\);[\s\S]{0,400}await bridge\.reconnect\(\)/, "screen resets before reattach so the server replay paints clean");
+assert.match(src, /term\.reset\(\);[\s\S]{0,300}decoderRef\.current = new TextDecoder/, "the streaming decoder is reset on reconnect so replayed scrollback decodes cleanly");
 assert.match(src, /reason === "replaced"/, "a take-over by another window is announced, not fought with reconnects");
 
 // ── PTY lifetime is decoupled from view lifetime ──────────────────────────────

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -21,6 +21,10 @@ import { Icon } from "@/lib/icon";
 // (e.g. `cargo build`) don't flood SR or thrash React.
 const MIRROR_LINES = 50;
 const MIRROR_DEBOUNCE_MS = 250;
+// While the pane is backgrounded the mirror isn't re-rendered; cap the buffered
+// text so a busy background stream can't grow it without bound before the pane
+// is next active (the flush trims to MIRROR_LINES anyway).
+const MIRROR_PENDING_CAP = 16384;
 // The xterm lazy-import + PTY handshake is "a few seconds"; well past that with
 // no connection means startup hung (a wedged native command, a transport await
 // that never settled, or `platform` never resolving off "unknown"). Surface a
@@ -251,6 +255,10 @@ export function BottomTerminal({
   if (!decoderRef.current) {
     decoderRef.current = new TextDecoder("utf-8", { fatal: false });
   }
+  // Mirror `active` into a ref so the byte handlers (registered once per mount)
+  // can read the current value without re-subscribing.
+  const activeRef = useRef(active);
+  activeRef.current = active;
 
   const flushMirror = useCallback(() => {
     flushTimerRef.current = null;
@@ -266,11 +274,22 @@ export function BottomTerminal({
   const pushToMirror = useCallback(
     (bytes: Uint8Array) => {
       if (!decoderRef.current) return;
+      // Keep decoding even while hidden so the streaming decoder state stays
+      // consistent — but don't re-render the (aria-hidden) mirror off-screen: a
+      // busy background stream otherwise re-rendered the 50-line mirror every
+      // 250ms while the terminal wasn't even visible. Buffer (bounded) and drain
+      // when the pane is next active.
       const text = stripAnsi(
         decoderRef.current.decode(bytes, { stream: true }),
       );
       if (!text) return;
       pendingMirrorRef.current += text;
+      if (!activeRef.current) {
+        if (pendingMirrorRef.current.length > MIRROR_PENDING_CAP) {
+          pendingMirrorRef.current = pendingMirrorRef.current.slice(-MIRROR_PENDING_CAP);
+        }
+        return;
+      }
       if (flushTimerRef.current == null) {
         flushTimerRef.current = setTimeout(flushMirror, MIRROR_DEBOUNCE_MS);
       }
@@ -303,13 +322,14 @@ export function BottomTerminal({
   // Re-fit + refocus whenever this terminal becomes the active tab.
   useEffect(() => {
     if (active) {
+      flushMirror(); // drain output buffered while the pane was hidden
       const id = requestAnimationFrame(() => {
         fitRef.current?.();
         termRef.current?.focus();
       });
       return () => cancelAnimationFrame(id);
     }
-  }, [active]);
+  }, [active, flushMirror]);
 
   // Startup watchdog: covers every way the terminal can stall before `ready` —
   // a native pty_* command that never returns, a transport await that throws/
@@ -588,6 +608,10 @@ export function BottomTerminal({
               // first so the replay paints a clean screen instead of
               // appending a duplicate of what's already visible.
               term.reset();
+              // Reset the streaming decoder (+ pending buffer) too: a mid-char
+              // socket drop left partial bytes that would corrupt the mirror.
+              decoderRef.current = new TextDecoder("utf-8", { fatal: false });
+              pendingMirrorRef.current = "";
               await bridge.reconnect();
               bridge.resize(term.cols, term.rows);
               return;


### PR DESCRIPTION
Correctness + perf batch from the **Terminal surface audit** (three-lens; findings source-verified, cross-checked against the Rust `server.ts` `/api/pty-ws`). The **screen-reader mirror itself — the hard part — was verified done right** (ANSI-stripped, 250ms-debounced, 50-line FIFO, `role="region"`+`aria-live="polite"`+label, timer cleanup). No dead-code false-flagging (agents correctly kept internal-only exports). These fix work happening *around* the mirror.

## Perf
- **The SR mirror no longer re-renders while the pane is hidden.** The terminal is **persistently mounted** (hidden when `mode !== "terminal"`, plus keepalive panes in a split), and the `active` prop was used at *exactly one place*. So a busy background stream (a running dev server, `cat`/`tail`) kept decoding + ANSI-stripping + re-rendering the 50-line mirror **every 250ms off-screen** — the same "always-mounted does work while hidden" class the Browser surface had. `pushToMirror` now keeps decoding (so the streaming decoder stays consistent) but **skips the flush/re-render when the pane isn't active**, buffers (bounded), and drains when it next becomes active.

## Correctness
- **The streaming `TextDecoder` is reset on reconnect.** A socket dropped mid-multibyte-character left partial bytes in the decoder; the server's replayed scrollback was then prepended to that stale state, **corrupting the mirror's first character after every reconnect**.

## Deferred to P2 (noted)
- **iOS foreground re-dials hidden/keepalive panes** — `onForeground` re-dials on every foreground for iOS (the socket suspends without a close event) but doesn't consult `active`, so background panes thundering-herd a scrollback replay. The safe fix needs a *coordinated* reconnect-on-becoming-active and is iOS-only / untestable in this env.
- Debounce resize + skip the PTY push for hidden panes (SIGWINCH churn on background TUIs); `cursorBlink` off when hidden; the **terminal tab strip isn't a real tablist** (`comux-view`, complicated by in-place rename); dead exports `terminalLayoutSessionIds` / `broadcastIsActionable`. The rest of a11y (aria-hidden the xterm viewport, connection-status announcer) ships as a follow-up PR.

## Verification
- `tsc --noEmit` clean. Ran **all 12 test files that read the terminal source** (SR-mirror, ws-bridge, startup-watchdog, comux wiring ×3, server-pty-ws, mobile-shell-smoke, key-bar, layout/nav/broadcast) — all pass; added source-text guards for the visibility gate + decoder reset (and widened the reset-before-reconnect pin). `pnpm build` green. (No live render — the terminal needs a real PTY the daemon-less env can't provide.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)