### PR TITLE
a11y(terminal): announce connection-status transitions to the assertive live region

### DIFF
--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -6,6 +6,7 @@ import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { TerminalKeyBar } from "@/components/terminal-key-bar";
 import { PtyWsBridge } from "@/lib/pty-ws-bridge";
 import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 // Bottom terminal pane — xterm.js in the browser, hooked up to a
 // portable-pty session on the Rust side (see src-tauri/src/pty.rs).
@@ -156,6 +157,10 @@ export function BottomTerminal({
   onUserInput?: (paneId: string, data: string) => void;
 }) {
   const broadcastPaneId = paneId ?? threadId;
+  // Connection transitions are written into the terminal (and its polite
+  // mirror) as dim ANSI, where a disconnect can be buried under output — mirror
+  // them to the shared assertive live region so AT interrupts with the status.
+  const { announce: srAnnounce } = useAnnouncer();
   // Writer set by whichever transport (Tauri / WS) is live; the registered
   // wrapper reads this ref at call time so registration can precede attach.
   const writerRef = useRef<((data: string) => void) | null>(null);
@@ -622,6 +627,7 @@ export function BottomTerminal({
           announce(
             "\r\n\x1b[2m[terminal reconnect failed — press any key to retry]\x1b[0m\r\n",
           );
+          srAnnounce("Terminal reconnect failed; press any key to retry", "assertive");
         } finally {
           reconnecting = false;
         }
@@ -633,6 +639,7 @@ export function BottomTerminal({
           announce(
             "\r\n\x1b[2m[this terminal was opened in another window — view detached]\x1b[0m\r\n",
           );
+          srAnnounce("This terminal was opened in another window; this view is detached", "assertive");
           return;
         }
         if (reason === "pty exit") {
@@ -640,6 +647,7 @@ export function BottomTerminal({
           return;
         }
         announce("\r\n\x1b[2m[terminal disconnected — reconnecting…]\x1b[0m\r\n");
+        srAnnounce("Terminal disconnected, reconnecting", "assertive");
         void attemptReconnect();
       });
 


### PR DESCRIPTION
## What

The terminal surfaces its **connection lifecycle** — disconnect, reconnect-failed, and take-over-by-another-window — by writing dim ANSI notices into the pane. Those notices are mirrored into the terminal's **polite** screen-reader region, where a busy output stream buries them and a screen-reader user typing into a silently-dropped socket gets no cue that their keystrokes are going nowhere.

This mirrors the three connection transitions to the shared **assertive** live region (`useAnnouncer`) so assistive tech interrupts with the status, *alongside* the existing in-terminal write:

- disconnected → reconnecting — `"Terminal disconnected, reconnecting"`
- reconnect failed → press any key — `"Terminal reconnect failed; press any key to retry"`
- view detached (opened in another window) — `"This terminal was opened in another window; this view is detached"`

## Why assertive

Status of the input channel is exactly the case WAI-ARIA reserves `aria-live="assertive"` for: the user needs to know *now* that the terminal stopped accepting input, not after the next screen-reader queue drain. The polite mirror still carries the scrollback for review.

## Scope

- **+8 lines, one file** (`bottom-terminal.tsx`): import `useAnnouncer`, one hook call, three `srAnnounce(..., "assertive")` calls at the existing `announce(...)` sites. No behavior change to the terminal writes themselves.
- Follows the correctness/perf pass in #2338 (the 13th surface in the audit campaign — Terminal).

## Deferred (noted P2s)

- Per-pane input label on the xterm helper textarea — needs a human label prop threaded from `comux-view` (BottomTerminal only receives `threadId`).
- xterm viewport `aria-hidden` — conflicts with the still-focusable helper textarea (WCAG 4.1.2); needs input-preservation handling.
- Tab strip → `role="tablist"` — lives in `comux-view`, tangled with the in-place contentEditable rename.

## Test

- `pnpm test:app` — all 521 app test files pass (terminal source-text pins included).
- `tsc --noEmit` clean; `check:tests-wired` clean (699 wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)