### PR TITLE
feat(chat): host chip popover with live status dots

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -279,8 +279,13 @@ assert.match(
 );
 assert.match(
   source,
-  /label="Host"/,
+  /cave-composer-host-chip/,
   "composer has a host chip (remote execution picker)",
+);
+assert.match(
+  source,
+  /cave-host-status--\$\{optionStatus\}/,
+  "host rows carry live status dots (popover, not a native select)",
 );
 assert.match(
   source,
@@ -289,7 +294,7 @@ assert.match(
 );
 assert.match(
   source,
-  /CONNECT_HOST_OPTION/,
+  /Connect new host/,
   "the host chip offers the connect-new-host flow",
 );
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -327,8 +327,6 @@ type ComposerResponseSpeed = CommandResponseSpeed;
 // the .cave-composer-input rule (13 lines: 13*24 + 20px padding).
 const COMPOSER_MAX_HEIGHT = 332;
 const COMPOSER_PREFS_KEY = "cave:chat-composer-controls:v1";
-/** Sentinel option in the Host chip that opens the connect-new-host dialog. */
-const CONNECT_HOST_OPTION = "__connect-host__";
 // Persist the in-progress composer text so a page reload doesn't eat a
 // half-written message. The composer is a single shared input (it isn't
 // remounted per session), so one key mirrors the in-memory behaviour.
@@ -710,6 +708,96 @@ function ComposerControlSelect<T extends string>({
       </select>
       <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
     </label>
+  );
+}
+
+function hostStatusKind(option: ChatHostOption): "online" | "offline" | "unknown" {
+  if (option.kind === "local" || option.online === true) return "online";
+  return option.online === false ? "offline" : "unknown";
+}
+
+/** Composer Host chip: a popover picker with live status dots per host and a
+ *  connect-new-host row — a native select can't render either. */
+function ComposerHostChip({
+  value,
+  options,
+  disabled,
+  onOpen,
+  onPick,
+  onConnectNew,
+}: {
+  value: string;
+  options: ChatHostOption[];
+  disabled?: boolean;
+  onOpen: () => void;
+  onPick: (id: string) => void;
+  onConnectNew: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const current = options.find((option) => option.id === value);
+  const label = current?.label ?? value;
+  const status = current ? hostStatusKind(current) : "unknown";
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="cave-composer-select cave-composer-host-chip"
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={`Host: ${label}`}
+        onClick={() => {
+          onOpen();
+          setOpen((v) => !v);
+        }}
+      >
+        <Icon name="ph:desktop" width={13} aria-hidden />
+        <span className="cave-composer-select__label">Host</span>
+        <span className={`cave-host-dot cave-host-dot--${status}`} aria-hidden />
+        <span className="cave-composer-select__value">{label}</span>
+        <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        placement="top-start"
+        minWidth={240}
+        ariaLabel="Chat host"
+      >
+        <PopoverBody role="menu" ariaLabel="Chat host">
+          <PopoverLabel>Run this chat on</PopoverLabel>
+          {options.map((option) => {
+            const optionStatus = hostStatusKind(option);
+            return (
+              <PopoverItem
+                key={option.id}
+                checked={option.id === value}
+                onSelect={() => {
+                  onPick(option.id);
+                  setOpen(false);
+                }}
+              >
+                <span className="cave-host-row">
+                  <Icon name="ph:desktop" width={13} aria-hidden />
+                  <span className="cave-host-row__name">{option.label}</span>
+                  <span className={`cave-host-status cave-host-status--${optionStatus}`}>
+                    <span className="cave-host-dot cave-host-dot--inline" aria-hidden />
+                    {optionStatus === "online" ? "online" : optionStatus === "offline" ? "offline" : "checking"}
+                  </span>
+                </span>
+              </PopoverItem>
+            );
+          })}
+          <PopoverSeparator />
+          <PopoverItem icon="ph:plus" onSelect={() => { setOpen(false); onConnectNew(); }}>
+            Connect new host
+          </PopoverItem>
+        </PopoverBody>
+      </Popover>
+    </>
   );
 }
 
@@ -2374,27 +2462,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return parsed?.kind === "ssh" ? parsed.host : null;
   }, [session?.runtime]);
   const composerHostValue = runtimeHost ?? sessionRuntimeHost ?? LOCAL_HOST_ID;
-  const composerHostOptions = useMemo(() => {
+  const hostChipOptions = useMemo<ChatHostOption[]>(() => {
     const base: ChatHostOption[] = hostOptions ?? [
       { id: LOCAL_HOST_ID, kind: "local", label: "This machine", online: true },
       ...(sessionRuntimeHost
         ? [{ id: sessionRuntimeHost, kind: "ssh" as const, label: sessionRuntimeHost, online: null }]
         : []),
     ];
-    const rows = base.map((option) => ({
-      value: option.id,
-      label:
-        option.kind === "ssh"
-          ? `${option.label}${option.online === true ? " — online" : option.online === false ? " — offline" : ""}`
-          : option.label,
-    }));
-    // A native select must contain its value — cover a stale pick or a host
+    // The current value must always be present — cover a stale pick or a host
     // recorded on the conversation that isn't (or is no longer) registered.
-    if (!rows.some((row) => row.value === composerHostValue)) {
-      rows.push({ value: composerHostValue, label: composerHostValue });
-    }
-    rows.push({ value: CONNECT_HOST_OPTION, label: "＋ Connect new host…" });
-    return rows;
+    return base.some((option) => option.id === composerHostValue)
+      ? base
+      : [...base, { id: composerHostValue, kind: "ssh", label: composerHostValue, online: null }];
   }, [hostOptions, sessionRuntimeHost, composerHostValue]);
   const [input, setInput] = useState(() => readComposerDraft());
   // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer pattern
@@ -5375,22 +5454,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       onChange={(id) => handleSelectModel(id)}
                     />
                   ) : null}
-                  <span onPointerDown={() => void loadHostOptions()} onFocusCapture={() => void loadHostOptions()}>
-                    <ComposerControlSelect
-                      label="Host"
-                      icon="ph:desktop"
-                      value={composerHostValue}
-                      options={composerHostOptions}
-                      disabled={busy}
-                      onChange={(id) => {
-                        if (id === CONNECT_HOST_OPTION) {
-                          setConnectHostOpen(true);
-                          return;
-                        }
-                        setRuntimeHost(id);
-                      }}
-                    />
-                  </span>
+                  <ComposerHostChip
+                    value={composerHostValue}
+                    options={hostChipOptions}
+                    disabled={busy}
+                    onOpen={() => void loadHostOptions()}
+                    onPick={setRuntimeHost}
+                    onConnectNew={() => setConnectHostOpen(true)}
+                  />
                 </div>
                 {connectHostOpen && (
                   <ConnectHostDialog

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4194,3 +4194,19 @@ details[open] > .cave-tool-summary::before {
 .cave-connect-host__field input:focus { border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent); }
 .cave-connect-host__error { margin: 0; font-size: 11px; line-height: 1.4; color: var(--color-danger); }
 .cave-connect-host__actions { display: flex; justify-content: flex-end; gap: 8px; }
+
+/* Host chip popover (composer) */
+.cave-composer-host-chip { cursor: pointer; background: none; border: none; font: inherit; }
+.cave-host-dot { width: 6px; height: 6px; border-radius: 50%; flex: none; }
+.cave-host-dot--online { background: var(--color-success); }
+.cave-host-dot--offline { background: var(--color-danger); }
+.cave-host-dot--unknown { background: var(--text-muted); }
+.cave-host-row { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
+.cave-host-row__name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cave-host-status { display: inline-flex; align-items: center; gap: 4px; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
+.cave-host-status--online { color: var(--color-success); }
+.cave-host-status--online .cave-host-dot--inline { background: var(--color-success); }
+.cave-host-status--offline { color: var(--color-danger); }
+.cave-host-status--offline .cave-host-dot--inline { background: var(--color-danger); }
+.cave-host-status--unknown { color: var(--text-muted); }
+.cave-host-status--unknown .cave-host-dot--inline { background: var(--text-muted); }


### PR DESCRIPTION
Follow-up to #2337: upgrades the composer Host chip from a native `<select>` (which can't render per-option status) to the shared `Popover` primitives, matching the reference design.

## What
- **Chip**: keeps the composer-select styling but is now a popover trigger showing the current host's live status dot (green/red/muted) next to its name.
- **Menu**: `menuitemradio` rows — monitor glyph, host name, and a live **● online / offline / checking** status per host from the registry probes; check glyph on the current selection; a real **Connect new host** row after a separator (opens the existing probe-then-persist dialog).
- Escape / outside-click / focus-return and the upward auto-flip above the composer come from the shared `Popover` (same primitives as the session overflow menu).
- Selection semantics unchanged from #2337: per-session `runtimeHost`, fail-closed server-side registry resolution.

## Verified live (worktree dev server)
Chip renders with the online dot; opening the menu lazy-loads the registry (row shows the real hostname `MB-Black-1684.local` with ● ONLINE and the check on the current selection); the Connect row is present; Escape closes; zero page errors. Screenshot taken.

## Tests
`chat-view-polish.test.ts` pins updated: chip class, per-row live status class, Connect-new-host row (replacing the native-select sentinel pin). Send-body and harness-routing pins unchanged and green.

(While verifying: the disk hit ENOSPC mid-compile — freed ~4GB via `pnpm store prune` + my own worktree's `.next`; other sessions' caches untouched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)