### PR TITLE
Composer: compact, content-sized control pills

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2009,12 +2009,14 @@ details[open] > .cave-tool-summary::before {
 .cave-composer-select {
   position: relative;
   display: inline-flex;
-  flex: 1 1 142px;
+  /* Content-sized (compact) pill — icon · label · value · chevron sit snug, and
+     the row's spare width falls to the trailing edge before Send. */
+  flex: 0 0 auto;
   align-items: center;
   gap: 6px;
-  min-width: 124px;
-  max-width: 190px;
-  padding: 0 9px;
+  min-width: 0;
+  max-width: 260px;
+  padding: 0 11px;
   font-size: 11px;
   line-height: 1;
   cursor: pointer;
@@ -2088,9 +2090,11 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-composer-select__chevron {
-  position: absolute;
-  right: 8px;
+  /* Inline (right after the value) so the pill hugs its content, matching the
+     reference — rather than pinned to a stretched pill's far edge. */
+  position: relative;
   z-index: 0;
+  margin-left: -1px;
   color: var(--text-muted) !important;
   pointer-events: none;
 }


### PR DESCRIPTION
Recreates the reference composer's tight control bar.

**Before:** the response-control pills (Thinking · Speed · Access · Model · Host) used `flex: 1 1 142px`, so they stretched to fill the row — each value floated with its chevron pinned to the pill's far edge, loose and uneven.

**After:** pills are content-sized (`flex: 0 0 auto`) with the chevron inline right after the value, so each hugs `icon · label · **value** · ▾` snugly, with even gaps between pills and the spare width falling to the trailing edge before Send — matching the reference.

CSS-only (`.cave-composer-select` + `__chevron` in `cave-chat.css`).

## Verification
- Live screenshot: pills now compact and snug (`Thinking High ▾  Speed Fast ▾  Access Full access ▾  Model Claude Opus 4.8 ▾`), matching the reference layout.
- `composer-density` + `chat-view-first-class` source-text tests pass; `tsc` clean; `pnpm build` clean; `test:app` + `test:mobile` (67) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)