### PR TITLE
fix(mobile): polish Cave connection handoff

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -17,73 +17,21 @@ struct ConnectionView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 22) {
                     header
+                    pairingSteps
 
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Desktop address").font(.subheadline.weight(.semibold))
-                            Spacer()
-                            if canPaste {
-                                Button(action: pasteHost) {
-                                    Label("Paste", systemImage: "doc.on.clipboard")
-                                        .font(.subheadline.weight(.medium))
-                                }
-                                .buttonStyle(.borderless)
-                                .accessibilityHint("Pastes the desktop address from the clipboard")
-                            }
-                        }
-                        TextField("my-mac.tailnet.ts.net", text: $host)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .keyboardType(.URL)
-                            .focused($focused)
-                            .padding(12)
-                            .glass(.control, cornerRadius: 12)
-                            .accentGlow(active: focused)
-                        if let hostHint {
-                            Label(hostHint, systemImage: "exclamationmark.circle")
-                                .font(.caption).foregroundStyle(.orange)
-                        } else {
-                            Text("Your desktop’s Tailscale MagicDNS name or 100.x address. Found in the Cave desktop app under “Open on phone”.")
-                                .font(.footnote).foregroundStyle(.secondary)
-                        }
-                    }
+                    addressField
 
                     if case .unreachable(let message) = app.connectionState {
-                        Label(message, systemImage: "exclamationmark.triangle.fill")
-                            .font(.footnote)
-                            .foregroundStyle(.orange)
+                        connectionRecoveryCallout(message: message, systemImage: "exclamationmark.triangle.fill")
                     } else if case .needsAuth(let message) = app.connectionState {
                         // The desktop is alive but token-gated — say how to
                         // pair instead of the generic unreachable shrug.
-                        Label(message, systemImage: "qrcode.viewfinder")
-                            .font(.footnote)
-                            .foregroundStyle(.orange)
+                        connectionRecoveryCallout(message: message, systemImage: "qrcode.viewfinder")
                     }
 
-                    Button(action: connect) {
-                        HStack {
-                            if busy { ProgressView().tint(.white) }
-                            Text(busy ? "Connecting…" : "Connect")
-                                .frame(maxWidth: .infinity)
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
-                    .disabled(host.trimmingCharacters(in: .whitespaces).isEmpty || busy)
-
-                    if QRScannerSheet.isSupported {
-                        Button {
-                            showScanner = true
-                        } label: {
-                            Label("Scan pairing QR code", systemImage: "qrcode.viewfinder")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.large)
-                        .disabled(busy)
-                    }
+                    actions
 
                     trustNote
                 }
@@ -113,25 +61,185 @@ struct ConnectionView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 14) {
+            heroBadge
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Connect to Cave")
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(chrome.textPrimary)
+                Text("Pair this phone with the Cave desktop running on your private Tailscale network.")
+                    .font(.callout)
+                    .foregroundStyle(chrome.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(.top, 4)
+    }
+
+    private var heroBadge: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Circle()
+                .fill(chrome.accent.opacity(0.16))
+                .frame(width: 72, height: 72)
+                .overlay {
+                    Circle()
+                        .strokeBorder(chrome.accent.opacity(0.35), lineWidth: 1)
+                }
             Image(systemName: "cat.fill")
-                .font(.system(size: 44))
-                .foregroundStyle(Color.accentColor)
-            Text("Connect to your familiars")
-                .font(.title2.bold())
-            Text("Pair with your desktop over your Tailscale network — scan the QR code from Cave’s “Open on phone” panel, paste its invite link, or type the address.")
-                .font(.subheadline).foregroundStyle(.secondary)
+                .font(.system(size: 38, weight: .semibold))
+                .foregroundStyle(chrome.accent)
+            Image(systemName: "wifi")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(.white)
+                .padding(7)
+                .background(Circle().fill(Color.green))
+                .overlay {
+                    Circle().strokeBorder(chrome.bgBase.opacity(0.9), lineWidth: 2)
+                }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Cave familiar network")
+    }
+
+    private var pairingSteps: some View {
+        HStack(spacing: 8) {
+            stepChip("Scan", systemImage: "qrcode.viewfinder", highlighted: true)
+            stepChip("Paste", systemImage: "doc.on.clipboard", highlighted: false)
+            stepChip("Connect", systemImage: "bolt.horizontal.circle", highlighted: false)
+        }
+        .padding(8)
+        .glass(.raised, cornerRadius: 18)
+    }
+
+    private func stepChip(_ title: String, systemImage: String, highlighted: Bool) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(highlighted ? chrome.accent : chrome.textSecondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.82)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 9)
+            .padding(.horizontal, 6)
+            .background(
+                Capsule()
+                    .fill(highlighted ? chrome.accent.opacity(0.16) : chrome.bgElevated.opacity(0.55))
+            )
+            .overlay {
+                Capsule()
+                    .strokeBorder(highlighted ? chrome.accent.opacity(0.45) : chrome.border.opacity(0.25), lineWidth: 1)
+            }
+    }
+
+    private var addressField: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Desktop").font(.subheadline.weight(.semibold))
+                        .foregroundStyle(chrome.textPrimary)
+                    Text("Tailscale address or invite link")
+                        .font(.caption)
+                        .foregroundStyle(chrome.textMuted)
+                }
+                Spacer()
+                if canPaste {
+                    Button(action: pasteHost) {
+                        Label("Paste", systemImage: "doc.on.clipboard")
+                            .font(.subheadline.weight(.semibold))
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityHint("Pastes the desktop address from the clipboard")
+                }
+            }
+            TextField("Cave desktop or 100.x address", text: $host)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .focused($focused)
+                .font(.body.monospaced())
+                .padding(.vertical, 14)
+                .padding(.horizontal, 14)
+                .glass(.control, cornerRadius: 16)
+                .accentGlow(active: focused)
+            if let hostHint {
+                Label(hostHint, systemImage: "exclamationmark.circle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            } else {
+                Text("Find it in Cave on the desktop under “Open on phone”. QR invite links fill this automatically.")
+                    .font(.footnote)
+                    .foregroundStyle(chrome.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .glass(.raised, cornerRadius: 20)
+    }
+
+    private var actions: some View {
+        VStack(spacing: 12) {
+            Button(action: connect) {
+                Label(busy ? "Connecting…" : "Connect desktop", systemImage: busy ? "arrow.triangle.2.circlepath" : "bolt.horizontal.circle.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(host.trimmingCharacters(in: .whitespaces).isEmpty || busy)
+
+            if QRScannerSheet.isSupported {
+                Button {
+                    showScanner = true
+                } label: {
+                    Label("Scan QR", systemImage: "qrcode.viewfinder")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .disabled(busy)
+            }
         }
     }
 
-    private var trustNote: some View {
-        HStack(alignment: .top, spacing: 10) {
-            Image(systemName: "lock.shield.fill").foregroundStyle(.green)
-            Text("This device connects directly to your desktop over Tailscale’s encrypted mesh. Nothing is exposed to the public internet.")
-                .font(.caption).foregroundStyle(.secondary)
+    private func connectionRecoveryCallout(message: String, systemImage: String) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: systemImage)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.orange)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Pairing needed")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(chrome.textPrimary)
+                Text(message)
+                    .font(.footnote)
+                    .foregroundStyle(chrome.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("Open Cave on your desktop and scan the latest QR code.")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.orange)
+            }
         }
-        .padding(12)
-        .glass(.raised, cornerRadius: 12)
+        .padding(14)
+        .glass(.raised, cornerRadius: 16)
+    }
+
+    private var trustNote: some View {
+        HStack(alignment: .center, spacing: 12) {
+            Image(systemName: "lock.shield.fill")
+                .font(.title3)
+                .foregroundStyle(Color.green)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Private Tailscale mesh")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(chrome.textPrimary)
+                Text("No public internet exposure. Traffic stays encrypted between this phone and your desktop.")
+                    .font(.footnote)
+                    .foregroundStyle(chrome.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(14)
+        .glass(.raised, cornerRadius: 16)
     }
 
     private func connect() {

--- a/scripts/ios-connect-screen-ux.test.mjs
+++ b/scripts/ios-connect-screen-ux.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The native connect screen is the first-run experience. Keep it pairing-first:
+// scan/paste/connect guidance, a branded hero, a distinct pairing-required
+// recovery callout, and a trust footer that makes the private Tailscale path
+// explicit.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const src = await read("apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift");
+
+assert.match(
+  src,
+  /private var pairingSteps: some View \{[\s\S]*?Scan[\s\S]*?Paste[\s\S]*?Connect/,
+  "connect screen should show the scan/paste/connect path as a compact step guide",
+);
+
+assert.match(
+  src,
+  /private var heroBadge: some View \{[\s\S]*?Image\(systemName: "cat\.fill"\)[\s\S]*?Image\(systemName: "wifi"\)/,
+  "hero should pair the familiar mark with a network signal cue",
+);
+
+assert.match(
+  src,
+  /private var addressField: some View \{[\s\S]*?Text\("Desktop"\)[\s\S]*?Text\("Tailscale address or invite link"\)/,
+  "address section should use concise desktop/invite labeling",
+);
+
+assert.match(
+  src,
+  /private func connectionRecoveryCallout\(message: String, systemImage: String\) -> some View \{[\s\S]*?Open Cave on your desktop and scan the latest QR code/,
+  "pairing-required state should render as a clear recovery callout",
+);
+
+assert.match(
+  src,
+  /Label\(busy \? "Connecting…" : "Connect desktop", systemImage: busy \? "arrow\.triangle\.2\.circlepath" : "bolt\.horizontal\.circle\.fill"\)/,
+  "primary action should read as connecting the desktop, not a generic form submit",
+);
+
+assert.match(
+  src,
+  /Label\("Scan QR", systemImage: "qrcode\.viewfinder"\)/,
+  "secondary scan action should stay short enough for mobile buttons",
+);
+
+assert.match(
+  src,
+  /private var trustNote: some View \{[\s\S]*?Private Tailscale mesh[\s\S]*?No public internet exposure/,
+  "trust footer should summarize the private encrypted path with scannable labels",
+);
+
+console.log("ios-connect-screen-ux: OK");

--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -410,7 +410,8 @@ try {
 } catch {
   process.exit(1);
 }
-const ips = status?.Self?.TailscaleIPs ?? status?.TailscaleIPs ?? [];
+const rawIps = status?.Self?.TailscaleIPs ?? status?.TailscaleIPs;
+const ips = Array.isArray(rawIps) ? rawIps.filter((ip) => typeof ip === "string") : [];
 const ipv4 = ips.find((ip) => /^100\.\d+\.\d+\.\d+$/.test(ip));
 if (!ipv4) process.exit(1);
 console.log(ipv4);

--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -396,6 +396,27 @@ const [backendUrl, input] = process.argv.slice(2);
 NODE
 }
 
+tailscale_ip_host() {
+  local self_json
+  if ! self_json="$(tailscale_capture status --self --json 2>/dev/null)"; then
+    return 1
+  fi
+
+  node - "$self_json" <<'NODE'
+const input = process.argv[2] || "";
+let status;
+try {
+  status = JSON.parse(input);
+} catch {
+  process.exit(1);
+}
+const ips = status?.Self?.TailscaleIPs ?? status?.TailscaleIPs ?? [];
+const ipv4 = ips.find((ip) => /^100\.\d+\.\d+\.\d+$/.test(ip));
+if (!ipv4) process.exit(1);
+console.log(ipv4);
+NODE
+}
+
 resolve_ios_device_name() {
   if [ "${CAVE_MOBILE_DEVICE:-0}" != "1" ]; then
     return 0
@@ -616,13 +637,15 @@ app_command() {
   CAVE_MOBILE_APP=1 start_next_server
 
   TAILSCALE_BACKEND="$(backend_url)"
-  tailscale_cmd serve --bg "$TAILSCALE_BACKEND" >/dev/null
-
-  status_json="$(tailscale_capture serve status --json)"
-  APP_URL="$(serve_url_from_status "$TAILSCALE_BACKEND" "$status_json")"
+  APP_URL=""
+  if tailscale_cmd serve --bg "$TAILSCALE_BACKEND" >/dev/null 2>&1; then
+    status_json="$(tailscale_capture serve status --json)"
+    APP_URL="$(serve_url_from_status "$TAILSCALE_BACKEND" "$status_json" 2>/dev/null || true)"
+  fi
   if [ -z "$APP_URL" ]; then
-    echo "Unable to resolve Tailscale Serve URL for ${TAILSCALE_BACKEND}." >&2
-    exit 1
+    APP_IP_HOST="$(tailscale_ip_host)"
+    tailscale_cmd serve --bg --http="$PORT" "$TAILSCALE_BACKEND" >/dev/null
+    APP_URL="http://${APP_IP_HOST}:${PORT}/"
   fi
 
   APP_HOST="$(node -e "process.stdout.write(new URL(process.argv[1]).host)" "$APP_URL")"

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -43,6 +43,12 @@ test("mobile tailscale app mode serves the native client with no token", () => {
   assert.match(script, /PORT="\$PORT"/);
 });
 
+test("mobile tailscale app mode falls back to Tailscale IP HTTP when MagicDNS is missing", () => {
+  assert.match(script, /tailscale_ip_host\(\)/);
+  assert.match(script, /tailscale_cmd serve --bg --http="\$PORT" "\$TAILSCALE_BACKEND"/);
+  assert.match(script, /APP_URL="http:\/\/\$\{APP_IP_HOST\}:\$\{PORT\}\/"/);
+});
+
 test("mobile tailscale app mode records tokenless ownership separately from invite tokens", () => {
   assert.match(script, /MODE_FILE=/);
   assert.match(script, /write_server_mode app/);

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -45,6 +45,8 @@ test("mobile tailscale app mode serves the native client with no token", () => {
 
 test("mobile tailscale app mode falls back to Tailscale IP HTTP when MagicDNS is missing", () => {
   assert.match(script, /tailscale_ip_host\(\)/);
+  assert.match(script, /Array\.isArray\(rawIps\)/);
+  assert.match(script, /typeof ip === "string"/);
   assert.match(script, /tailscale_cmd serve --bg --http="\$PORT" "\$TAILSCALE_BACKEND"/);
   assert.match(script, /APP_URL="http:\/\/\$\{APP_IP_HOST\}:\$\{PORT\}\/"/);
 });

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -697,6 +697,7 @@ export const SUITES = {
     "scripts/ios-auto-reconnect.test.mjs",
     "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
+    "scripts/ios-connect-screen-ux.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",
     "scripts/ios-presence-dots.test.mjs",
     "scripts/ios-swipe-reply.test.mjs",

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -141,8 +141,11 @@ async function ensureNativeAppServe(req: Request) {
           ? `${serveWarning} Using the Tailscale IP fallback for the native app.`
           : "Using the Tailscale IP fallback for the native app.";
       }
-    } else if (!serveWarning) {
-      fallbackWarning = httpServe.stderr || "Tailscale HTTP Serve could not be started.";
+    } else {
+      const httpServeError = httpServe.stderr || "Tailscale HTTP Serve could not be started.";
+      fallbackWarning = serveWarning
+        ? `${serveWarning} HTTP fallback failed: ${httpServeError}`
+        : httpServeError;
       discovery = {
         ok: false,
         reason: fallbackWarning,

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -5,6 +5,7 @@ import { stripAnsi } from "@/lib/ansi";
 import {
   createMobileInvite,
   MOBILE_INVITE_TTL_MS,
+  nativeAppDiscoveryProof,
   tailnetDiscoveryProof,
   tailscaleBin,
   tailscaleSpawnEnv,
@@ -97,6 +98,14 @@ function backendUrl(req: Request) {
   return `http://127.0.0.1:${port}`;
 }
 
+function backendPort(backend: string) {
+  try {
+    return new URL(backend).port || process.env.PORT || "3000";
+  } catch {
+    return process.env.PORT || "3000";
+  }
+}
+
 async function ensureNativeAppServe(req: Request) {
   const self = await runTailscale(["status", "--self", "--json"]);
   if (!self.ok) {
@@ -120,14 +129,33 @@ async function ensureNativeAppServe(req: Request) {
     const parsed = parseServeStatus(status.stdout);
     if (!("error" in parsed)) serveStatus = parsed.value;
   }
-  const discovery = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
+  const tailnetDiscovery = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
+  let discovery: ReturnType<typeof nativeAppDiscoveryProof> = tailnetDiscovery;
+  let fallbackWarning: string | null = null;
+  if (!tailnetDiscovery.ok) {
+    const httpServe = await runTailscale(["serve", "--bg", `--http=${backendPort(backend)}`, backend]);
+    if (httpServe.ok) {
+      discovery = nativeAppDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
+      if (discovery.ok && discovery.source === "tailscale-ip-http") {
+        fallbackWarning = serveWarning
+          ? `${serveWarning} Using the Tailscale IP fallback for the native app.`
+          : "Using the Tailscale IP fallback for the native app.";
+      }
+    } else if (!serveWarning) {
+      fallbackWarning = httpServe.stderr || "Tailscale HTTP Serve could not be started.";
+      discovery = {
+        ok: false,
+        reason: fallbackWarning,
+      };
+    }
+  }
 
   if (!discovery.ok) {
     return NextResponse.json(
       {
         ok: false,
-        error: serveWarning ?? discovery.reason,
-        stderr: serveWarning ?? status.stderr,
+        error: fallbackWarning ?? serveWarning ?? discovery.reason,
+        stderr: fallbackWarning ?? serveWarning ?? status.stderr,
         backendUrl: backend,
       },
       { status: 500 },
@@ -149,7 +177,7 @@ async function ensureNativeAppServe(req: Request) {
     nativeHost: discovery.host,
     discoverySource: discovery.source,
     qrSvg,
-    warning: serveWarning ?? undefined,
+    warning: fallbackWarning ?? serveWarning ?? undefined,
   });
 }
 

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -82,6 +82,16 @@ assert.match(
 );
 assert.match(
   handoffRoute,
+  /nativeAppDiscoveryProof\(\{\s*selfStatus,\s*serveStatus,\s*backendUrl: backend\s*\}\)/,
+  "native mobile mode should use a native-specific fallback when MagicDNS is unavailable",
+);
+assert.match(
+  handoffRoute,
+  /`--http=\$\{backendPort\(backend\)\}`/,
+  "native mobile mode should ask Tailscale Serve for a plain HTTP port fallback",
+);
+assert.match(
+  handoffRoute,
   /status", "--self", "--json"/,
   "route reads self status as JSON to source the MagicDNS fallback host",
 );

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -92,6 +92,11 @@ assert.match(
 );
 assert.match(
   handoffRoute,
+  /HTTP fallback failed:/,
+  "native mobile mode should keep the HTTP Serve fallback stderr when that fallback fails",
+);
+assert.match(
+  handoffRoute,
   /status", "--self", "--json"/,
   "route reads self status as JSON to source the MagicDNS fallback host",
 );

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -6,8 +6,10 @@ import {
   findServeUrl,
   magicDnsHost,
   magicDnsServeUrl,
+  nativeAppDiscoveryProof,
   resolveTailscaleBin,
   tailnetDiscoveryProof,
+  tailscaleIpHost,
 } from "./mobile-handoff.ts";
 import { verifyMobileAccessToken } from "./mobile-access-token.ts";
 
@@ -176,11 +178,34 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
 }
 
 {
+  const selfWithoutMagicDns = {
+    Self: {
+      TailscaleIPs: ["100.101.102.103", "fd7a:115c:a1e0::1"],
+    },
+  };
+  assert.equal(tailscaleIpHost(selfWithoutMagicDns), "100.101.102.103");
+  assert.deepEqual(
+    nativeAppDiscoveryProof({
+      selfStatus: selfWithoutMagicDns,
+      serveStatus: {},
+      backendUrl: "http://127.0.0.1:3000",
+    }),
+    {
+      ok: true,
+      host: "100.101.102.103:3000",
+      serveUrl: "http://100.101.102.103:3000/",
+      source: "tailscale-ip-http",
+    },
+  );
+}
+
+{
   // No DNSName → no fallback (caller then surfaces the serve error).
   assert.equal(magicDnsServeUrl(null), null);
   assert.equal(magicDnsServeUrl({}), null);
   assert.equal(magicDnsServeUrl({ Self: {} }), null);
   assert.equal(magicDnsHost({ Self: { DNSName: "  " } }), null);
+  assert.equal(tailscaleIpHost({ Self: { TailscaleIPs: ["fd7a:115c:a1e0::1"] } }), null);
 }
 
 console.log("mobile-handoff.test.ts OK");

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -206,6 +206,9 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.equal(magicDnsServeUrl({ Self: {} }), null);
   assert.equal(magicDnsHost({ Self: { DNSName: "  " } }), null);
   assert.equal(tailscaleIpHost({ Self: { TailscaleIPs: ["fd7a:115c:a1e0::1"] } }), null);
+  assert.equal(tailscaleIpHost({ Self: { TailscaleIPs: "100.101.102.103" } }), null);
+  assert.equal(tailscaleIpHost({ TailscaleIPs: { primary: "100.101.102.103" } }), null);
+  assert.equal(tailscaleIpHost({ TailscaleIPs: [null, 42, "100.101.102.103"] }), "100.101.102.103");
 }
 
 console.log("mobile-handoff.test.ts OK");

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -160,9 +160,11 @@ export function magicDnsServeUrl(selfStatus: unknown): string | null {
   return host ? `https://${host}/` : null;
 }
 
-function selfTailscaleIps(selfStatus: unknown) {
+function selfTailscaleIps(selfStatus: unknown): string[] {
   const status = selfStatus as TailscaleSelfStatus | null;
-  return status?.Self?.TailscaleIPs ?? status?.TailscaleIPs ?? [];
+  const ips = status?.Self?.TailscaleIPs ?? status?.TailscaleIPs;
+  if (!Array.isArray(ips)) return [];
+  return ips.filter((candidate): candidate is string => typeof candidate === "string");
 }
 
 export function tailscaleIpHost(selfStatus: unknown): string | null {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -136,7 +136,8 @@ export function tailscaleSpawnEnv(): NodeJS.ProcessEnv {
 }
 
 type TailscaleSelfStatus = {
-  Self?: { DNSName?: string };
+  TailscaleIPs?: string[];
+  Self?: { DNSName?: string; TailscaleIPs?: string[] };
 };
 
 // The device's MagicDNS name from `tailscale status --self --json`, with the
@@ -157,6 +158,30 @@ export function magicDnsHost(selfStatus: unknown): string | null {
 export function magicDnsServeUrl(selfStatus: unknown): string | null {
   const host = magicDnsHost(selfStatus);
   return host ? `https://${host}/` : null;
+}
+
+function selfTailscaleIps(selfStatus: unknown) {
+  const status = selfStatus as TailscaleSelfStatus | null;
+  return status?.Self?.TailscaleIPs ?? status?.TailscaleIPs ?? [];
+}
+
+export function tailscaleIpHost(selfStatus: unknown): string | null {
+  const ip = selfTailscaleIps(selfStatus).find((candidate) => /^100\.\d+\.\d+\.\d+$/.test(candidate));
+  return ip ?? null;
+}
+
+function backendPort(backendUrl: string) {
+  try {
+    return new URL(backendUrl).port || "3000";
+  } catch {
+    return "3000";
+  }
+}
+
+export function nativeHttpServeUrl(selfStatus: unknown, backendUrl: string): string | null {
+  const host = tailscaleIpHost(selfStatus);
+  if (!host) return null;
+  return `http://${host}:${backendPort(backendUrl)}/`;
 }
 
 export type TailnetDiscoveryProof =
@@ -204,6 +229,47 @@ export function tailnetDiscoveryProof({
   return {
     ok: false,
     reason: "tailscale serve URL not found and status --self had no MagicDNS DNSName",
+  };
+}
+
+export type NativeAppDiscoveryProof =
+  | {
+      ok: true;
+      host: string;
+      serveUrl: string;
+      source: "serve-status" | "magicdns-self-status" | "tailscale-ip-http";
+    }
+  | {
+      ok: false;
+      reason: string;
+    };
+
+export function nativeAppDiscoveryProof({
+  selfStatus,
+  serveStatus,
+  backendUrl,
+}: {
+  selfStatus: unknown;
+  serveStatus: unknown;
+  backendUrl: string;
+}): NativeAppDiscoveryProof {
+  const tailnet = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl });
+  if (tailnet.ok) return tailnet;
+
+  const serveUrl = nativeHttpServeUrl(selfStatus, backendUrl);
+  const host = tailscaleIpHost(selfStatus);
+  if (serveUrl && host) {
+    return {
+      ok: true,
+      host: `${host}:${backendPort(backendUrl)}`,
+      serveUrl,
+      source: "tailscale-ip-http",
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "tailscale serve URL not found and status --self had no MagicDNS DNSName or Tailscale IPv4",
   };
 }
 


### PR DESCRIPTION
## Summary
- polish the iOS Cave connection screen into a guided pairing flow
- add native app Tailscale IP fallback when MagicDNS is unavailable
- cover the new connect UX and app-mode fallback in mobile tests

## Test Plan
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:mobile
- pnpm test:app
- git diff --check
- xcodebuild -project apps/ios/CovenCave/CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build