### PR TITLE
Composer pills: warm gold icon accent

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2025,7 +2025,10 @@ details[open] > .cave-tool-summary::before {
 
 .cave-composer-select svg {
   flex-shrink: 0;
-  color: var(--accent-presence);
+  /* Warm gold accent for the control-pill icons (matches the reference
+     composer) — deliberately independent of the app's accent so the pills read
+     the same across themes. */
+  color: var(--composer-pill-gold, oklch(0.81 0.105 83));
 }
 
 .cave-composer-select__label {


### PR DESCRIPTION
Matches the reference composer's gold accent — the control-pill icons (Thinking · Speed · Access · Model · Host) now render in a warm gold instead of the app's purple accent, so the pills read the same across themes.

CSS-only, one rule (`.cave-composer-select svg`), behind a `--composer-pill-gold` var for easy re-theming.

Verified live: pill icons are now gold matching the reference. composer-density + chat-view-first-class tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)