### PR TITLE
fix(home): credit the shown familiar on new tasks; stop sent drafts resurrecting

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -69,8 +69,8 @@ assert.match(
 
 assert.match(
   source,
-  /body: JSON\.stringify\(\{[\s\S]*?title: prompt,[\s\S]*?familiarId: activeFamiliarId \?\? null,[\s\S]*?cwd: selectedProject\?\.root \?\? null,[\s\S]*?projectId: selectedProject\?\.id \?\? null,[\s\S]*?\}\)/,
-  "HomeComposer should attach the selected project to task creation",
+  /body: JSON\.stringify\(\{[\s\S]*?title: prompt,[\s\S]*?familiarId: selectedFamiliarId \|\| null,[\s\S]*?cwd: selectedProject\?\.root \?\? null,[\s\S]*?projectId: selectedProject\?\.id \?\? null,[\s\S]*?\}\)/,
+  "HomeComposer should attach the selected project to task creation, crediting the selector's resolved familiar (not the raw active id)",
 );
 
 assert.match(
@@ -153,8 +153,8 @@ assert.match(
 
 assert.match(
   source,
-  /if \(json\.ok\) \{ setText\(""\); setAttachments\(\[\]\); setEnhanceOriginal\(null\); onNavigateToBoard\(\); \}/,
-  "HomeComposer should clear staged attachments after a successful board card creation",
+  /if \(json\.ok\) \{ setText\(""\); writeHomeDraft\(""\); setAttachments\(\[\]\); setEnhanceOriginal\(null\); onNavigateToBoard\(\); \}/,
+  "HomeComposer should clear staged attachments (and the persisted draft) after a successful board card creation",
 );
 
 assert.match(
@@ -420,6 +420,15 @@ assert.match(
   source,
   /useEffect\(\(\) => \{\s*const timer = window\.setTimeout\(\(\) => \{\s*writeHomeDraft\(text\);\s*\}, HOME_DRAFT_WRITE_DELAY_MS\);\s*return \(\) => window\.clearTimeout\(timer\);\s*\}, \[text\]\)/,
   "the home draft is debounced so mobile typing does not write localStorage on every keystroke",
+);
+// A send unmounts the composer (mode switches to chat/board), which cancels the
+// debounced draft-write before it can flush the cleared text — so the submit
+// path must clear the persisted draft synchronously, or the sent prompt
+// resurrects on the next Home visit.
+assert.match(
+  source,
+  /setText\(""\);\s*(?:\/\/[^\n]*\n\s*)*writeHomeDraft\(""\);/,
+  "the chat send path clears the persisted draft synchronously (not only via the debounced effect)",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -602,6 +602,11 @@ export function HomeComposer({
           // it's harmless downstream (normalized away before persistence).
           const outgoing: ChatAttachment[] | undefined = attachments.length ? attachments : undefined;
           setText("");
+          // Clear the persisted draft synchronously: onStartChat unmounts this
+          // composer, which cancels the debounced draft-write effect before it
+          // can flush the empty text — otherwise the sent prompt resurrects on
+          // the next Home visit.
+          writeHomeDraft("");
           setAttachments([]);
           setEnhanceOriginal(null);
           onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null, {
@@ -617,7 +622,11 @@ export function HomeComposer({
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               title: prompt,
-              familiarId: activeFamiliarId ?? null,
+              // Attribute the card to the familiar the selector actually shows
+              // (selectedFamiliarId falls through to the first visible familiar
+              // when the active one is unset or archived) — not the raw active
+              // id, which could be null or point at the hidden/archived one.
+              familiarId: selectedFamiliarId || null,
               cwd: selectedProject?.root ?? null,
               projectId: selectedProject?.id ?? null,
               // Files staged on the composer ride onto the task card. The route
@@ -626,7 +635,7 @@ export function HomeComposer({
             }),
           });
           const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean };
-          if (json.ok) { setText(""); setAttachments([]); setEnhanceOriginal(null); onNavigateToBoard(); }
+          if (json.ok) { setText(""); writeHomeDraft(""); setAttachments([]); setEnhanceOriginal(null); onNavigateToBoard(); }
           else onToast("Board card creation failed.");
           break;
         }


### PR DESCRIPTION
Correctness pass on the **Home surface** (`home-composer.tsx`) — the 14th surface in the audit campaign. Two verified bugs:

## 1. New tasks credited to the wrong (or null) familiar — P1
The board/task path posted `familiarId: activeFamiliarId ?? null`, but the chat path and the visible familiar selector both use `selectedFamiliarId`. `selectedFamiliarId` deliberately diverges (`home-composer.tsx:183-186`): when the active familiar is unset (cold start) or archived, it falls through to the first *visible* familiar so the `<select>`'s value matches a real option. Result: the dropdown shows familiar **X**, but the created card is attributed to **null** or to the hidden/archived familiar. Now the card is credited to the same `selectedFamiliarId` the UI shows.

## 2. Sent prompt resurrects on the next Home visit — P1
The draft is persisted only by a 250ms-**debounced** effect (`:415-420`), and the textarea seeds from that draft on mount (`:146`). On send, `onStartChat` flips the workspace mode and **unmounts** the composer, whose cleanup `clearTimeout`s the freshly-scheduled `writeHomeDraft("")` before it fires. The pre-send text was almost always already persisted (the user paused ≥250ms while typing), so the key never cleared — and the already-sent prompt reappeared next time Home mounted (directly contradicting the code comment at `:413-414`). Fixed by clearing the persisted draft **synchronously** in the submit path (both chat and board).

## Scope / deferred
- The a11y findings (Escape-to-dismiss for the slash/model/skill menus — the footers already say "Esc cancel" but nothing wires it — plus announcing enhance/attach) ship as a **follow-up a11y PR** (they collide with this file).
- P2 correctness (enhance can overwrite newer typing while in-flight) deferred — it mirrors the chat composer, so it's a pre-existing sibling-consistent edge, not a home regression.
- The perf lens found **no high-severity issue** (the digest carousel correctly uses a CSS marquee + visibility-gated `usePausablePoll`); the only cleanup is the fully-dead `/api/youtube` route + its `VideoItem`/`parseYoutubeVideoId`/`youtubeThumbnail`/`youtube-feeds` chain, which belongs to the (now familiars-view) feed and is deferred to a separate cleanup.

## Test
- `pnpm test:app` — all 521 app test files pass (`fail 0`); the three affected source-text pins in `home-composer.test.ts` updated + a new pin for the synchronous draft-clear.
- `tsc --noEmit` clean; `check:tests-wired` clean (700 wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)