### PR TITLE
feat(chat): host chip on the home composer — shared ComposerHostChip module

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -279,23 +279,37 @@ assert.match(
 );
 assert.match(
   source,
-  /cave-composer-host-chip/,
-  "composer has a host chip (remote execution picker)",
+  /<ComposerHostChip value=\{composerHostValue\} disabled=\{busy\} onPick=\{setRuntimeHost\} \/>/,
+  "composer has a host chip (remote execution picker, shared with the home composer)",
 );
+// The chip internals moved to the shared module — pin them there.
+const hostChip = readFileSync(new URL("./composer-host-chip.tsx", import.meta.url), "utf8");
 assert.match(
-  source,
+  hostChip,
   /cave-host-status--\$\{optionStatus\}/,
   "host rows carry live status dots (popover, not a native select)",
 );
 assert.match(
-  source,
-  /\.\.\.\(runtimeHost \? \{ runtimeHost \} : \{\}\)/,
-  "an explicit host pick rides the send body; auto stays absent",
+  hostChip,
+  /Connect new host/,
+  "the host chip offers the connect-new-host flow",
 );
 assert.match(
   source,
-  /Connect new host/,
-  "the host chip offers the connect-new-host flow",
+  /\(controlsOverride\?\.runtimeHost \?\? runtimeHost\)/,
+  "an explicit host pick (or the home composer's initial pick) rides the send body; auto stays absent",
+);
+// Home composer parity: the same chip, threading the pick into the opened chat.
+const homeComposer = readFileSync(new URL("./home-composer.tsx", import.meta.url), "utf8");
+assert.match(
+  homeComposer,
+  /<ComposerHostChip[\s\S]{0,200}onPick=\{\(id\) => setRuntimeHost\(id === LOCAL_HOST_ID \? null : id\)\}/,
+  "the home composer renders the shared host chip (local pick = auto)",
+);
+assert.match(
+  homeComposer,
+  /initialControls: \{ thinkingEffort, responseSpeed, \.\.\.\(runtimeHost \? \{ runtimeHost \} : \{\}\) \}/,
+  "the home composer threads the host pick into the opened chat's first send",
 );
 assert.match(
   source,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -52,7 +52,8 @@ import {
 } from "@/lib/file-mention";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
-import { LOCAL_HOST_ID, parseConversationRuntime, type ChatHostOption } from "@/lib/chat-hosts";
+import { LOCAL_HOST_ID, parseConversationRuntime } from "@/lib/chat-hosts";
+import { ComposerHostChip } from "@/components/composer-host-chip";
 import { ThinkingIndicator } from "@/components/ui/thinking-indicator";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
@@ -708,184 +709,6 @@ function ComposerControlSelect<T extends string>({
       </select>
       <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
     </label>
-  );
-}
-
-function hostStatusKind(option: ChatHostOption): "online" | "offline" | "unknown" {
-  if (option.kind === "local" || option.online === true) return "online";
-  return option.online === false ? "offline" : "unknown";
-}
-
-/** Composer Host chip: a popover picker with live status dots per host and a
- *  connect-new-host row — a native select can't render either. */
-function ComposerHostChip({
-  value,
-  options,
-  disabled,
-  onOpen,
-  onPick,
-  onConnectNew,
-}: {
-  value: string;
-  options: ChatHostOption[];
-  disabled?: boolean;
-  onOpen: () => void;
-  onPick: (id: string) => void;
-  onConnectNew: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement | null>(null);
-  const current = options.find((option) => option.id === value);
-  const label = current?.label ?? value;
-  const status = current ? hostStatusKind(current) : "unknown";
-  return (
-    <>
-      <button
-        ref={anchorRef}
-        type="button"
-        className="cave-composer-select cave-composer-host-chip"
-        disabled={disabled}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title={`Host: ${label}`}
-        onClick={() => {
-          onOpen();
-          setOpen((v) => !v);
-        }}
-      >
-        <Icon name="ph:desktop" width={13} aria-hidden />
-        <span className="cave-composer-select__label">Host</span>
-        <span className={`cave-host-dot cave-host-dot--${status}`} aria-hidden />
-        <span className="cave-composer-select__value">{label}</span>
-        <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
-      </button>
-      <Popover
-        open={open}
-        onOpenChange={setOpen}
-        anchorRef={anchorRef}
-        placement="top-start"
-        minWidth={240}
-        ariaLabel="Chat host"
-      >
-        <PopoverBody role="menu" ariaLabel="Chat host">
-          <PopoverLabel>Run this chat on</PopoverLabel>
-          {options.map((option) => {
-            const optionStatus = hostStatusKind(option);
-            return (
-              <PopoverItem
-                key={option.id}
-                checked={option.id === value}
-                onSelect={() => {
-                  onPick(option.id);
-                  setOpen(false);
-                }}
-              >
-                <span className="cave-host-row">
-                  <Icon name="ph:desktop" width={13} aria-hidden />
-                  <span className="cave-host-row__name">{option.label}</span>
-                  <span className={`cave-host-status cave-host-status--${optionStatus}`}>
-                    <span className="cave-host-dot cave-host-dot--inline" aria-hidden />
-                    {optionStatus === "online" ? "online" : optionStatus === "offline" ? "offline" : "checking"}
-                  </span>
-                </span>
-              </PopoverItem>
-            );
-          })}
-          <PopoverSeparator />
-          <PopoverItem icon="ph:plus" onSelect={() => { setOpen(false); onConnectNew(); }}>
-            Connect new host
-          </PopoverItem>
-        </PopoverBody>
-      </Popover>
-    </>
-  );
-}
-
-/** Register a new SSH host for chat execution: probe (BatchMode, key auth)
- *  then persist to config.remoteHosts via POST /api/hosts. */
-function ConnectHostDialog({ onClose, onConnected }: { onClose: () => void; onConnected: (host: string) => void }) {
-  const [host, setHost] = useState("");
-  const [cwd, setCwd] = useState("");
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const submit = async () => {
-    if (!host.trim() || pending) return;
-    setPending(true);
-    setError(null);
-    try {
-      const res = await fetch("/api/hosts", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ host: host.trim(), ...(cwd.trim() ? { cwd: cwd.trim() } : {}) }),
-      });
-      const json = await res.json().catch(() => null);
-      if (!res.ok || !json?.ok) {
-        setError(json?.error ?? `couldn't reach the host (http ${res.status})`);
-        return;
-      }
-      onConnected(host.trim());
-      onClose();
-    } finally {
-      setPending(false);
-    }
-  };
-
-  return (
-    <Modal
-      open
-      onClose={onClose}
-      breadcrumb={["Chat", "Connect a new host"]}
-      dismissOnBackdrop={!pending}
-      footerActions={
-        <>
-          <Button variant="ghost" onClick={onClose} disabled={pending}>
-            Cancel
-          </Button>
-          <Button variant="primary" disabled={!host.trim() || pending} onClick={() => void submit()}>
-            {pending ? "Probing…" : "Connect"}
-          </Button>
-        </>
-      }
-    >
-      <div className="cave-connect-host">
-        <p className="cave-connect-host__hint">
-          Chats can run on any machine your SSH config reaches with key auth and a{" "}
-          <code>coven</code> CLI installed. Run <code>ssh &lt;host&gt;</code> once first to trust
-          the host key.
-        </p>
-        <label className="cave-connect-host__field">
-          <span>Host</span>
-          <input
-            type="text"
-            value={host}
-            autoFocus
-            placeholder="vm-1 or user@server.tailnet"
-            onChange={(event) => setHost(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") void submit();
-            }}
-          />
-        </label>
-        <label className="cave-connect-host__field">
-          <span>Remote directory (optional)</span>
-          <input
-            type="text"
-            value={cwd}
-            placeholder="~"
-            onChange={(event) => setCwd(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") void submit();
-            }}
-          />
-        </label>
-        {error && (
-          <p className="cave-connect-host__error" role="alert">
-            {error}
-          </p>
-        )}
-      </div>
-    </Modal>
   );
 }
 
@@ -2436,45 +2259,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // body (deliberately per-session, not a sticky global pref: a forgotten
   // sticky remote host would silently run every new chat elsewhere).
   const [runtimeHost, setRuntimeHost] = useState<string | null>(null);
-  const [hostOptions, setHostOptions] = useState<ChatHostOption[] | null>(null);
-  const hostOptionsLoading = useRef(false);
-  const [connectHostOpen, setConnectHostOpen] = useState(false);
-
-  // Lazy host registry: an instant unprobed list on first interaction, then a
-  // probed refresh so online/offline states fill in without blocking the menu.
-  const loadHostOptions = useCallback(async (force = false) => {
-    if (hostOptionsLoading.current && !force) return;
-    hostOptionsLoading.current = true;
-    try {
-      const quick = await fetch("/api/hosts?probe=0").then((res) => res.json()).catch(() => null);
-      if (quick?.ok && Array.isArray(quick.hosts)) setHostOptions(quick.hosts);
-      const probed = await fetch("/api/hosts").then((res) => res.json()).catch(() => null);
-      if (probed?.ok && Array.isArray(probed.hosts)) setHostOptions(probed.hosts);
-    } finally {
-      if (force) hostOptionsLoading.current = false;
-    }
-  }, []);
-
-  // What the Host chip displays: an explicit pick, else the host this
-  // conversation is recorded on, else the local machine.
   const sessionRuntimeHost = useMemo(() => {
     const parsed = parseConversationRuntime(session?.runtime);
     return parsed?.kind === "ssh" ? parsed.host : null;
   }, [session?.runtime]);
   const composerHostValue = runtimeHost ?? sessionRuntimeHost ?? LOCAL_HOST_ID;
-  const hostChipOptions = useMemo<ChatHostOption[]>(() => {
-    const base: ChatHostOption[] = hostOptions ?? [
-      { id: LOCAL_HOST_ID, kind: "local", label: "This machine", online: true },
-      ...(sessionRuntimeHost
-        ? [{ id: sessionRuntimeHost, kind: "ssh" as const, label: sessionRuntimeHost, online: null }]
-        : []),
-    ];
-    // The current value must always be present — cover a stale pick or a host
-    // recorded on the conversation that isn't (or is no longer) registered.
-    return base.some((option) => option.id === composerHostValue)
-      ? base
-      : [...base, { id: composerHostValue, kind: "ssh", label: composerHostValue, online: null }];
-  }, [hostOptions, sessionRuntimeHost, composerHostValue]);
   const [input, setInput] = useState(() => readComposerDraft());
   // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer pattern
   const [inputHistory, setInputHistory] = useState<string[]>(() => readComposerHistory(COMPOSER_HISTORY_KEY));
@@ -3695,7 +3484,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     outgoingAttachments: ChatAttachment[] = [],
     outgoingMentions: string[] = [],
     opts?: { promptOverride?: string; parentTurnId?: string | null },
-    controlsOverride?: { thinkingEffort: ComposerThinkingEffort; responseSpeed: ComposerResponseSpeed },
+    controlsOverride?: { thinkingEffort: ComposerThinkingEffort; responseSpeed: ComposerResponseSpeed; runtimeHost?: string },
   ) => {
     const trimmed = text.trim();
     const submitPrompt = opts?.promptOverride?.trim() || trimmed;
@@ -3779,7 +3568,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           permissionMode,
           // Composer Host chip: only an explicit pick rides; the server
           // resolves it against the registered-host registry fail-closed.
-          ...(runtimeHost ? { runtimeHost } : {}),
+          ...((controlsOverride?.runtimeHost ?? runtimeHost) ? { runtimeHost: controlsOverride?.runtimeHost ?? runtimeHost } : {}),
           // Forward the picked model explicitly so it reaches `coven run
           // --model` for THIS turn — don't rely on the PATCH to model-state
           // having persisted to the conversation file before this send (a
@@ -4135,7 +3924,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         setThinkingEffort(normalized.thinkingEffort);
         setResponseSpeed(normalized.responseSpeed);
       }
-      void sendRaw(initialPrompt, initialAttachments ?? [], [], undefined, normalized ?? undefined);
+      // The home composer's host pick rides the first send explicitly (state
+      // set below lands too late for this closure) and seeds the chip.
+      if (initialControls?.runtimeHost) setRuntimeHost(initialControls.runtimeHost);
+      void sendRaw(
+        initialPrompt,
+        initialAttachments ?? [],
+        [],
+        undefined,
+        normalized
+          ? { ...normalized, runtimeHost: initialControls?.runtimeHost }
+          : undefined,
+      );
     }, 0);
     return () => window.clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -5454,24 +5254,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       onChange={(id) => handleSelectModel(id)}
                     />
                   ) : null}
-                  <ComposerHostChip
-                    value={composerHostValue}
-                    options={hostChipOptions}
-                    disabled={busy}
-                    onOpen={() => void loadHostOptions()}
-                    onPick={setRuntimeHost}
-                    onConnectNew={() => setConnectHostOpen(true)}
-                  />
+                  <ComposerHostChip value={composerHostValue} disabled={busy} onPick={setRuntimeHost} />
                 </div>
-                {connectHostOpen && (
-                  <ConnectHostDialog
-                    onClose={() => setConnectHostOpen(false)}
-                    onConnected={(host) => {
-                      setRuntimeHost(host);
-                      void loadHostOptions(true);
-                    }}
-                  />
-                )}
                 {busy ? (
                   <button
                     type="button"

--- a/src/components/composer-host-chip.tsx
+++ b/src/components/composer-host-chip.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+// Composer Host chip — shared by the chat composer and the home composer.
+// A popover picker over the registered-host registry (/api/hosts) with live
+// status dots per host and a connect-new-host flow. Self-contained: owns the
+// lazy registry fetch and the connect dialog; the parent only supplies the
+// current value and receives picks. Selection semantics stay the parent's
+// concern (per-session, fail-closed server-side resolution — see #2337).
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import {
+  Popover,
+  PopoverBody,
+  PopoverItem,
+  PopoverLabel,
+  PopoverSeparator,
+} from "@/components/ui/popover";
+import { LOCAL_HOST_ID, type ChatHostOption } from "@/lib/chat-hosts";
+import "@/styles/composer-host-chip.css";
+
+function hostStatusKind(option: ChatHostOption): "online" | "offline" | "unknown" {
+  if (option.kind === "local" || option.online === true) return "online";
+  return option.online === false ? "offline" : "unknown";
+}
+
+/** Register a new SSH host for chat execution: probe (BatchMode, key auth)
+ *  then persist to config.remoteHosts via POST /api/hosts. */
+function ConnectHostDialog({ onClose, onConnected }: { onClose: () => void; onConnected: (host: string) => void }) {
+  const [host, setHost] = useState("");
+  const [cwd, setCwd] = useState("");
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!host.trim() || pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/hosts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ host: host.trim(), ...(cwd.trim() ? { cwd: cwd.trim() } : {}) }),
+      });
+      const json = await res.json().catch(() => null);
+      if (!res.ok || !json?.ok) {
+        setError(json?.error ?? `couldn't reach the host (http ${res.status})`);
+        return;
+      }
+      onConnected(host.trim());
+      onClose();
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      breadcrumb={["Chat", "Connect a new host"]}
+      dismissOnBackdrop={!pending}
+      footerActions={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button variant="primary" disabled={!host.trim() || pending} onClick={() => void submit()}>
+            {pending ? "Probing…" : "Connect"}
+          </Button>
+        </>
+      }
+    >
+      <div className="cave-connect-host">
+        <p className="cave-connect-host__hint">
+          Chats can run on any machine your SSH config reaches with key auth and a{" "}
+          <code>coven</code> CLI installed. Run <code>ssh &lt;host&gt;</code> once first to trust
+          the host key.
+        </p>
+        <label className="cave-connect-host__field">
+          <span>Host</span>
+          <input
+            type="text"
+            value={host}
+            autoFocus
+            placeholder="vm-1 or user@server.tailnet"
+            onChange={(event) => setHost(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void submit();
+            }}
+          />
+        </label>
+        <label className="cave-connect-host__field">
+          <span>Remote directory (optional)</span>
+          <input
+            type="text"
+            value={cwd}
+            placeholder="~"
+            onChange={(event) => setCwd(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") void submit();
+            }}
+          />
+        </label>
+        {error && (
+          <p className="cave-connect-host__error" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+export function ComposerHostChip({
+  value,
+  onPick,
+  disabled,
+}: {
+  /** LOCAL_HOST_ID or an ssh host id — see chat-hosts. */
+  value: string;
+  onPick: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [connectOpen, setConnectOpen] = useState(false);
+  const [hosts, setHosts] = useState<ChatHostOption[] | null>(null);
+  const loading = useRef(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+
+  // Lazy registry: an instant unprobed list on open, then a probed refresh so
+  // online/offline states fill in without blocking the menu.
+  const load = useCallback(async (force = false) => {
+    if (loading.current && !force) return;
+    loading.current = true;
+    try {
+      const quick = await fetch("/api/hosts?probe=0").then((res) => res.json()).catch(() => null);
+      if (quick?.ok && Array.isArray(quick.hosts)) setHosts(quick.hosts);
+      const probed = await fetch("/api/hosts").then((res) => res.json()).catch(() => null);
+      if (probed?.ok && Array.isArray(probed.hosts)) setHosts(probed.hosts);
+    } finally {
+      if (force) loading.current = false;
+    }
+  }, []);
+
+  const options = useMemo<ChatHostOption[]>(() => {
+    const base: ChatHostOption[] = hosts ?? [
+      { id: LOCAL_HOST_ID, kind: "local", label: "This machine", online: true },
+    ];
+    // The current value must always be present — cover a stale pick or a host
+    // recorded on the conversation that isn't (or is no longer) registered.
+    return base.some((option) => option.id === value)
+      ? base
+      : [...base, { id: value, kind: "ssh", label: value, online: null }];
+  }, [hosts, value]);
+
+  const current = options.find((option) => option.id === value);
+  const label = current?.label ?? value;
+  const status = current ? hostStatusKind(current) : "unknown";
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="cave-composer-select cave-composer-host-chip"
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title={`Host: ${label}`}
+        onClick={() => {
+          void load();
+          setOpen((v) => !v);
+        }}
+      >
+        <Icon name="ph:desktop" width={13} aria-hidden />
+        <span className="cave-composer-select__label">Host</span>
+        <span className={`cave-host-dot cave-host-dot--${status}`} aria-hidden />
+        <span className="cave-composer-select__value">{label}</span>
+        <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        placement="top-start"
+        minWidth={240}
+        ariaLabel="Chat host"
+      >
+        <PopoverBody role="menu" ariaLabel="Chat host">
+          <PopoverLabel>Run this chat on</PopoverLabel>
+          {options.map((option) => {
+            const optionStatus = hostStatusKind(option);
+            return (
+              <PopoverItem
+                key={option.id}
+                checked={option.id === value}
+                onSelect={() => {
+                  onPick(option.id);
+                  setOpen(false);
+                }}
+              >
+                <span className="cave-host-row">
+                  <Icon name="ph:desktop" width={13} aria-hidden />
+                  <span className="cave-host-row__name">{option.label}</span>
+                  <span className={`cave-host-status cave-host-status--${optionStatus}`}>
+                    <span className="cave-host-dot cave-host-dot--inline" aria-hidden />
+                    {optionStatus === "online" ? "online" : optionStatus === "offline" ? "offline" : "checking"}
+                  </span>
+                </span>
+              </PopoverItem>
+            );
+          })}
+          <PopoverSeparator />
+          <PopoverItem
+            icon="ph:plus"
+            onSelect={() => {
+              setOpen(false);
+              setConnectOpen(true);
+            }}
+          >
+            Connect new host
+          </PopoverItem>
+        </PopoverBody>
+      </Popover>
+      {connectOpen && (
+        <ConnectHostDialog
+          onClose={() => setConnectOpen(false)}
+          onConnected={(host) => {
+            onPick(host);
+            void load(true);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -141,8 +141,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},[\s\S]*?\}\)/,
-  "HomeComposer should hand the selected agent chat prompt and command controls to the workspace, which opens a new chat that auto-sends it",
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed, \.\.\.\(runtimeHost \? \{ runtimeHost \} : \{\}\) \},[\s\S]*?\}\)/,
+  "HomeComposer should hand the selected agent chat prompt, command controls, and any host pick to the workspace, which opens a new chat that auto-sends it",
 );
 
 assert.match(

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -63,8 +63,8 @@ assert.match(
 
 assert.match(
   source,
-  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed \},[\s\S]*?\}\)/,
-  "HomeComposer should hand the selected project root and initial command controls to chat start",
+  /onStartChat\(prompt, selectedFamiliarId, selectedProject\?\.root \?\? null, \{\s*initialControls: \{ thinkingEffort, responseSpeed, \.\.\.\(runtimeHost \? \{ runtimeHost \} : \{\}\) \},[\s\S]*?\}\)/,
+  "HomeComposer should hand the selected project root, initial command controls, and any host pick to chat start",
 );
 
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -16,6 +16,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { ComposerHostChip } from "@/components/composer-host-chip";
+import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
@@ -80,7 +82,7 @@ type Props = {
     familiarId: string,
     projectRoot: string | null,
     opts?: {
-      initialControls?: { thinkingEffort: CommandThinkingEffort; responseSpeed: CommandResponseSpeed };
+      initialControls?: { thinkingEffort: CommandThinkingEffort; responseSpeed: CommandResponseSpeed; runtimeHost?: string };
       /** Files staged in the home composer; the opened chat auto-sends with them. */
       initialAttachments?: ChatAttachment[];
     },
@@ -212,6 +214,9 @@ export function HomeComposer({
   const [responseSpeed, setResponseSpeed] = useState<CommandResponseSpeed>(
     COMMAND_CONTROL_DEFAULTS.responseSpeed,
   );
+  // Host chip: where the opened chat should execute. Per-composer state, not a
+  // sticky pref — mirrors the chat composer's Host chip (#2337/#2340).
+  const [runtimeHost, setRuntimeHost] = useState<string | null>(null);
   const selectedProject = useMemo(
     () =>
       selectedProjectId === NO_PROJECT_ID
@@ -400,10 +405,10 @@ export function HomeComposer({
       }
       setText("");
       onStartChat(buildSkillPrompt(skill), selectedFamiliarId, selectedProject?.root ?? null, {
-        initialControls: { thinkingEffort, responseSpeed },
+        initialControls: { thinkingEffort, responseSpeed, ...(runtimeHost ? { runtimeHost } : {}) },
       });
     },
-    [selectedFamiliarId, selectedProject, thinkingEffort, responseSpeed, onStartChat, onToast],
+    [selectedFamiliarId, selectedProject, thinkingEffort, responseSpeed, runtimeHost, onStartChat, onToast],
   );
 
   useEffect(() => {
@@ -605,7 +610,7 @@ export function HomeComposer({
           setAttachments([]);
           setEnhanceOriginal(null);
           onStartChat(prompt, selectedFamiliarId, selectedProject?.root ?? null, {
-            initialControls: { thinkingEffort, responseSpeed },
+            initialControls: { thinkingEffort, responseSpeed, ...(runtimeHost ? { runtimeHost } : {}) },
             initialAttachments: outgoing,
           });
           break;
@@ -1173,6 +1178,12 @@ export function HomeComposer({
                   COMMAND_RESPONSE_SPEED_OPTIONS,
                   "Choose response speed",
                 )}
+
+                <ComposerHostChip
+                  value={runtimeHost ?? LOCAL_HOST_ID}
+                  disabled={sending}
+                  onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
+                />
               </>
             ) : null}
 

--- a/src/lib/command-controls.ts
+++ b/src/lib/command-controls.ts
@@ -10,7 +10,11 @@ export type CommandControls = {
   responseSpeed: CommandResponseSpeed;
 };
 
-export type InitialCommandControls = Partial<CommandControls>;
+export type InitialCommandControls = Partial<CommandControls> & {
+  /** Composer Host chip: "local" or a registered ssh host id (see chat-hosts).
+   *  Rides the opened chat's first send and seeds its Host chip. */
+  runtimeHost?: string;
+};
 
 export const COMMAND_CONTROL_DEFAULTS: CommandControls = {
   thinkingEffort: "high",

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4188,29 +4188,3 @@ details[open] > .cave-tool-summary::before {
 .cave-launch__recent-meta { font-size: 11px; color: var(--text-muted); }
 .cave-launch__recent-go { color: var(--text-muted); flex: 0 0 auto; opacity: 0; transition: opacity 140ms ease; }
 .cave-launch__recent:hover .cave-launch__recent-go { opacity: 1; }
-
-/* Connect-new-host dialog (composer Host chip) */
-.cave-connect-host { display: flex; flex-direction: column; gap: 12px; }
-.cave-connect-host__hint { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-muted); }
-.cave-connect-host__hint code { font-size: 11px; padding: 0 4px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-hairline); }
-.cave-connect-host__field { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--text-secondary); }
-.cave-connect-host__field input { width: 100%; padding: 7px 10px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-base); color: var(--text-primary); outline: none; }
-.cave-connect-host__field input:focus { border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent); }
-.cave-connect-host__error { margin: 0; font-size: 11px; line-height: 1.4; color: var(--color-danger); }
-.cave-connect-host__actions { display: flex; justify-content: flex-end; gap: 8px; }
-
-/* Host chip popover (composer) */
-.cave-composer-host-chip { cursor: pointer; background: none; border: none; font: inherit; }
-.cave-host-dot { width: 6px; height: 6px; border-radius: 50%; flex: none; }
-.cave-host-dot--online { background: var(--color-success); }
-.cave-host-dot--offline { background: var(--color-danger); }
-.cave-host-dot--unknown { background: var(--text-muted); }
-.cave-host-row { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
-.cave-host-row__name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.cave-host-status { display: inline-flex; align-items: center; gap: 4px; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
-.cave-host-status--online { color: var(--color-success); }
-.cave-host-status--online .cave-host-dot--inline { background: var(--color-success); }
-.cave-host-status--offline { color: var(--color-danger); }
-.cave-host-status--offline .cave-host-dot--inline { background: var(--color-danger); }
-.cave-host-status--unknown { color: var(--text-muted); }
-.cave-host-status--unknown .cave-host-dot--inline { background: var(--text-muted); }

--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -1,0 +1,59 @@
+/* Composer Host chip + popover — shared by the chat and home composers, so
+   the chip carries its full styling here rather than leaning on the chat
+   surface's stylesheet. Values mirror .cave-composer-select in cave-chat.css;
+   on the chat surface both apply (identical), on home these stand alone. */
+
+.cave-composer-host-chip {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 260px;
+  height: 30px;
+  padding: 0 11px;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1;
+  cursor: pointer;
+  border: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
+  color: var(--text-secondary);
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.cave-composer-host-chip:disabled { opacity: 0.5; cursor: default; }
+.cave-composer-host-chip svg { flex-shrink: 0; color: var(--accent-presence); }
+.cave-composer-host-chip .cave-composer-select__label { color: var(--text-muted); }
+.cave-composer-host-chip .cave-composer-select__value {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cave-host-dot { width: 6px; height: 6px; border-radius: 50%; flex: none; }
+.cave-host-dot--online { background: var(--color-success); }
+.cave-host-dot--offline { background: var(--color-danger); }
+.cave-host-dot--unknown { background: var(--text-muted); }
+.cave-host-row { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
+.cave-host-row__name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cave-host-status { display: inline-flex; align-items: center; gap: 4px; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; }
+.cave-host-status--online { color: var(--color-success); }
+.cave-host-status--online .cave-host-dot--inline { background: var(--color-success); }
+.cave-host-status--offline { color: var(--color-danger); }
+.cave-host-status--offline .cave-host-dot--inline { background: var(--color-danger); }
+.cave-host-status--unknown { color: var(--text-muted); }
+.cave-host-status--unknown .cave-host-dot--inline { background: var(--text-muted); }
+
+/* Connect-new-host dialog */
+.cave-connect-host { display: flex; flex-direction: column; gap: 12px; }
+.cave-connect-host__hint { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-muted); }
+.cave-connect-host__hint code { font-size: 11px; padding: 0 4px; border-radius: 4px; background: var(--bg-elevated); border: 1px solid var(--border-hairline); }
+.cave-connect-host__field { display: flex; flex-direction: column; gap: 4px; font-size: 11px; color: var(--text-secondary); }
+.cave-connect-host__field input { width: 100%; padding: 7px 10px; border-radius: 8px; border: 1px solid var(--border-strong); background: var(--bg-base); color: var(--text-primary); outline: none; }
+.cave-connect-host__field input:focus { border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent); }
+.cave-connect-host__error { margin: 0; font-size: 11px; line-height: 1.4; color: var(--color-danger); }


### PR DESCRIPTION
Completes the host-picker parity deferred from #2337/#2340: the home composer gets the same Host chip, via extraction into a shared module.

## What
- **`src/components/composer-host-chip.tsx`** (extracted from chat-view): the popover chip with live status dots, now fully self-contained — it owns the lazy `/api/hosts` fetch (instant unprobed list, probed refresh) and the connect-new-host dialog; parents supply only `value` + `onPick`. Styling moves to `composer-host-chip.css` (values mirror the chat pill recipe) so both surfaces carry it without leaning on `cave-chat.css`.
- **Home composer**: renders the chip in its chat-only controls (collapses on Task mode with Think/Speed, as built). A pick rides `initialControls.runtimeHost` (`InitialCommandControls` extended) through the workspace → chat-router → the opened chat, where it rides the **first send explicitly** (the state seed lands too late for that closure) and seeds the chat's own Host chip. Picking the local machine on home = auto (no field sent).
- **Chat view slims down**: drops the moved component/dialog/fetch state, keeps only `runtimeHost` + the session-derived display value.

## Verified live (worktree dev server)
The chip renders in home's control row styled to match the neighboring pills (999px pill, 30px, green dot: `Host ● This machine`), the popover opens with host rows, zero page errors. Chat-surface behavior unchanged.

## Tests
`chat-view-polish.test.ts` pins repointed at the shared module + new home-parity pins (chip render with local-pick-=-auto, initialControls threading); both `home-composer.test.ts` onStartChat pins updated for the host field. Full suite: 704 test files green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)