### PR TITLE
a11y(home): wire Escape to dismiss the inline menus; announce enhance & attach

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -311,20 +311,23 @@ for (const [name, src] of [
   );
   // menuOpen unifies the slash-command and /model listboxes (both share the
   // listbox id), so the combobox ARIA covers the /model picker too — not just
-  // the slash menu. Both composers must use it.
+  // the slash menu. Both composers must use it. (HomeComposer additionally gates
+  // the slash term on its Escape-dismiss flag: `(!slashDismissed && …)`.)
   assert.match(
     src,
-    /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| slashSuggestions\.length > 0;/,
+    /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\|[\s\S]{0,40}slashSuggestions\.length > 0/,
     `${name} combobox ARIA must reflect every inline menu (slash, /model, /skill)`,
   );
 }
 
 // ── HomeComposer combobox ARIA covers the /model picker, not just slash ──────
 // Both inline listboxes share the listbox id; menuOpen unifies them so the
-// textarea announces the /model picker too (was: slash-only).
+// textarea announces the /model picker too (was: slash-only). The slash term is
+// gated on the Escape-dismiss flag so a dismissed menu also drops the combobox
+// ARIA.
 assert.match(
   source,
-  /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| slashSuggestions\.length > 0;/,
+  /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\| \(!slashDismissed && slashSuggestions\.length > 0\);/,
   "HomeComposer combobox ARIA reflects every inline menu (slash, /model, /skill)",
 );
 
@@ -532,4 +535,51 @@ assert.match(
   source,
   /hc-attachments-clear[\s\S]*?onClick=\{\(\) => setAttachments\(\[\]\)\}[\s\S]*?Clear all/,
   "a Clear all control empties the staged attachments",
+);
+
+// ─── a11y: Escape dismisses the inline menus; enhance/attach announce ─────────
+// The slash/model/skill menu footers advertise "Esc cancel", but nothing wired
+// Escape — the menus re-open purely as a function of the text. A dismissed flag
+// (reset on text change) closes them; and the genuinely-silent state changes
+// (enhance success, attachment add — neither raises a toast) announce to the
+// shared live region so screen-reader users aren't left guessing.
+assert.match(
+  source,
+  /const \[slashDismissed, setSlashDismissed\] = useState\(false\)/,
+  "a slashDismissed flag backs Escape-to-dismiss for the inline menus",
+);
+assert.match(
+  source,
+  /if \(e\.key === "Escape" && menuOpen\) \{[\s\S]{0,120}setSlashDismissed\(true\);[\s\S]{0,40}return;/,
+  "Escape closes any open inline menu (the footers advertise Esc cancel)",
+);
+assert.match(
+  source,
+  /setSlashIdx\(0\);\s*setSlashDismissed\(false\);/,
+  "the dismissed flag resets when the text changes so a fresh token re-opens the menu",
+);
+assert.match(
+  source,
+  /const modelMenuActive = !slashDismissed &&/,
+  "the model menu respects the dismissed flag",
+);
+assert.match(
+  source,
+  /const skillMenuActive = !slashDismissed &&/,
+  "the skill menu respects the dismissed flag",
+);
+assert.match(
+  source,
+  /const \{ announce \} = useAnnouncer\(\)/,
+  "HomeComposer wires the shared live-region announcer",
+);
+assert.match(
+  source,
+  /setText\(json\.enhanced\);\s*announce\("Prompt enhanced", "polite"\)/,
+  "a successful enhance is announced (the textarea swap is otherwise silent to AT)",
+);
+assert.match(
+  source,
+  /Attached \$\{next\.length\} file/,
+  "adding attachments is announced (there is no toast on the success path)",
 );

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -38,6 +38,7 @@ import { ADD_PROJECT_ID, useAddProjectFlow } from "@/components/project-picker";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
+import { useAnnouncer } from "@/components/ui/live-region";
 import {
   attachmentIcon,
   fileToAttachment,
@@ -149,6 +150,11 @@ export function HomeComposer({
   const [history, setHistory] = useState<string[]>(() => readComposerHistory(HOME_HISTORY_KEY));
   const [historyIdx, setHistoryIdx] = useState<number>(-1);
   const [slashIdx, setSlashIdx] = useState(0);
+  // Escape dismisses the inline slash/model/skill menus (they otherwise stay
+  // open purely as a function of the text). Reset whenever the text changes so
+  // typing a fresh command token re-opens them.
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  const { announce } = useAnnouncer();
   // Stable per-mount listbox id — the chat composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
@@ -368,7 +374,7 @@ export function HomeComposer({
   const modelHarness =
     modelState?.harness ?? selectedFamiliar?.harness ?? "claude";
   const modelOptions = useMemo(() => modelSlashOptions(text, modelHarness), [text, modelHarness]);
-  const modelMenuActive = (modelOptions?.length ?? 0) > 0;
+  const modelMenuActive = !slashDismissed && (modelOptions?.length ?? 0) > 0;
   // Inline skill picker: "/skill <partial>" / "/skills" shows skill options.
   const [skills, setSkills] = useState<SkillOption[]>([]);
   useEffect(() => {
@@ -386,10 +392,11 @@ export function HomeComposer({
     };
   }, []);
   const skillOptions = useMemo(() => skillSlashOptions(text, skills), [text, skills]);
-  const skillMenuActive = (skillOptions?.length ?? 0) > 0;
+  const skillMenuActive = !slashDismissed && (skillOptions?.length ?? 0) > 0;
   // The inline listboxes (slash commands, /model, /skill) share the same listbox
   // id, so the textarea's combobox ARIA tracks whichever is open.
-  const menuOpen = modelMenuActive || skillMenuActive || slashSuggestions.length > 0;
+  const menuOpen =
+    modelMenuActive || skillMenuActive || (!slashDismissed && slashSuggestions.length > 0);
 
   // Invoke a skill from home = open a new chat that asks the familiar to run it.
   const invokeSkill = useCallback(
@@ -408,6 +415,7 @@ export function HomeComposer({
 
   useEffect(() => {
     setSlashIdx(0);
+    setSlashDismissed(false);
   }, [text]);
 
   // Persist the draft so a reload restores it; cleared when the input empties
@@ -458,8 +466,9 @@ export function HomeComposer({
     }
     const next = await Promise.all(selected.map(fileToAttachment));
     setAttachments((prev) => [...prev, ...next]);
+    announce(`Attached ${next.length} file${next.length === 1 ? "" : "s"}`, "polite");
     setTimeout(() => textareaRef.current?.focus(), 0);
-  }, [attachments.length, onToast]);
+  }, [attachments.length, onToast, announce]);
   const removeAttachment = useCallback((id: string) => {
     setAttachments((prev) => prev.filter((a) => a.id !== id));
   }, []);
@@ -485,13 +494,14 @@ export function HomeComposer({
       }
       setEnhanceOriginal(text);
       setText(json.enhanced);
+      announce("Prompt enhanced", "polite");
       setEnhanceStatus("idle");
       setTimeout(() => { textareaRef.current?.focus(); autoGrow(); }, 0);
     } catch {
       setEnhanceStatus("error");
       onToast("Couldn't enhance the prompt.");
     }
-  }, [text, sending, enhanceStatus, onToast, autoGrow]);
+  }, [text, sending, enhanceStatus, onToast, autoGrow, announce]);
   const revertEnhance = useCallback(() => {
     setEnhanceOriginal((original) => {
       if (original == null) return null;
@@ -666,6 +676,13 @@ export function HomeComposer({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Escape closes any open inline menu — the menu footers advertise
+      // "Esc cancel", and typing re-opens it (slashDismissed resets on text).
+      if (e.key === "Escape" && menuOpen) {
+        e.preventDefault();
+        setSlashDismissed(true);
+        return;
+      }
       // Inline model picker takes priority when "/model <partial>" is open.
       if (modelMenuActive && modelOptions) {
         const opts = modelOptions;
@@ -693,7 +710,7 @@ export function HomeComposer({
         }
       }
       // Slash menu hotkeys take priority over history/submit when it's open
-      if (slashSuggestions.length > 0) {
+      if (!slashDismissed && slashSuggestions.length > 0) {
         if (e.key === "ArrowDown") {
           e.preventDefault();
           setSlashIdx((i) => Math.min(i + 1, slashSuggestions.length - 1));
@@ -760,6 +777,8 @@ export function HomeComposer({
       skillOptions,
       invokeSkill,
       onToast,
+      menuOpen,
+      slashDismissed,
       slashIdx,
       slashSuggestions,
       text,
@@ -864,7 +883,7 @@ export function HomeComposer({
             </div>
             <div className="hc-slash-footer">↑↓ navigate · Enter run · Tab complete · Esc cancel</div>
           </div>
-        ) : slashSuggestions.length > 0 ? (
+        ) : !slashDismissed && slashSuggestions.length > 0 ? (
           <div className="hc-slash-menu">
             <ul className="hc-slash-list" id={slashListboxId} role="listbox" aria-label="Slash commands">
               {slashSuggestions.map((cmd, i) => {


### PR DESCRIPTION
Accessibility follow-up to #2344 on the **Home surface** (`home-composer.tsx`).

## 1. Escape now dismisses the inline slash / model / skill menus
The three inline listboxes (`/`, `/model`, `/skill`) are derived purely from the composer text, and their footers literally read **"Esc cancel"** — but `handleKeyDown` had no Escape branch, so a keyboard/SR user who opened a menu couldn't dismiss it without deleting characters. Added a `slashDismissed` flag (reset on every text change, so a fresh command token re-opens the menu) that Escape sets, gating all three menu-active checks, `menuOpen`, and the combobox `aria-expanded`/`aria-controls`/`aria-activedescendant` uniformly. This mirrors `chat-view.tsx`'s existing `slashDismissed` pattern.

## 2. Announce the two genuinely-silent state changes
Enhance-success (`setText(json.enhanced)` swaps the textarea content) and adding attachments both change state **without raising a toast**, so assistive tech got no cue. Both now `announce(..., "polite")` via the shared `useAnnouncer`. Error paths already ride the polite toast live region (`InboxToastStack` is `role="status" aria-live="polite"`), so they're intentionally left as-is — no double-announce.

## Why this is separate from #2344
Both touch `home-composer.tsx` heavily, so per the audit-campaign convention the correctness fix (#2344) and this a11y pass ship as two PRs; this branch was rebased onto main after #2344 merged.

## Already-correct (verified, not touched)
The digest carousel's motion is a pure CSS marquee with a `prefers-reduced-motion` off-path; the destination pills are a proper `role="radiogroup"` with roving arrow-key handling; every icon-only control (attach, enhance, send, remove, refresh) and every `<select>` is already labelled; the slash listbox already exposes full `role="listbox"`/`role="option"`/`aria-selected` + `aria-activedescendant` semantics. The only gap was the missing Escape wiring and the two silent announces.

## Deferred
The feed tabs (`role="tab"` without tabpanel/roving) and the tweets error-vs-empty-state confusion live in `home-feed.tsx`, which now renders in **familiars-view**, not Home — out of scope for this surface.

## Test
- `pnpm test:app` — all 521 app test files pass; new pins for the `slashDismissed` flag + Escape branch + the two announces, and the shared combobox-ARIA pin loosened to accept the gated `menuOpen` (it runs against both HomeComposer and ChatView).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)