### PR TITLE
feat(dashboard): truthful freshness + drill-throughs on every cockpit component

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -43,6 +43,39 @@ assert.match(cockpit, /deriveGrowthReport/, "confidence composes the growth repo
 assert.match(cockpit, /\/api\/retro-runs/, "confidence pulls the shared retro-runs snapshot");
 assert.match(cockpit, /\/api\/familiars\/\$\{encodeURIComponent\(f\.id\)\}\/contract/, "confidence pulls each familiar's contract");
 
+// ── Minimal-yet-powerful pass: truthful freshness + drill-throughs everywhere ──
+
+// The "Updated…" pill reflects when fetched data actually LANDED (not render
+// time), ticks between polls, and doubles as a manual refresh.
+assert.match(cockpit, /const \[lastUpdated, setLastUpdated\] = useState<Date \| null>\(null\)/, "freshness is stamped from real data arrivals");
+assert.match(cockpit, /setLastUpdated\(new Date\(\)\)/, "each landing fetch bumps the freshness stamp");
+assert.match(cockpit, /useMinuteTick\(\)/, "the freshness label ticks between polls");
+assert.match(cockpit, /className="cockpit-pill cockpit-pill--refresh"[\s\S]{0,80}onClick=\{load\}/, "the freshness pill is the manual refresh button");
+assert.doesNotMatch(cockpit, /Updated \{relativeTime\(now\.toISOString\(\)/, "the pill no longer reads the static render time (was pinned at 'just now')");
+
+// Dead links are gone: KPI tiles, panels, and quick links all deep-link to the
+// surface that owns the number (`/?mode=<WorkspaceMode>` is the SPA deep link).
+assert.doesNotMatch(cockpit, /href: "\/#card-"/, "KPI tiles no longer point at the dead bare /#card- hash");
+assert.match(cockpit, /href: "\/\?mode=board"/, "board KPIs drill into the board");
+assert.match(cockpit, /href: "\/\?mode=github"/, "the PRs KPI drills into GitHub");
+assert.match(cockpit, /href: "\/\?mode=library"/, "the reading KPI drills into the library");
+assert.match(cockpit, /href="\/\?mode=calendar"/, "the agenda panel drills into the calendar");
+assert.match(cockpit, /href="\/\?mode=agents"/, "the agents panel drills into the familiars roster");
+assert.match(cockpit, /href="\/dashboard\/familiars\/growth"/, "load/confidence drill into the growth page");
+assert.doesNotMatch(cockpit, /QuickLink href="\/" icon="ph:calendar-bold"/, "the Calendar quick link no longer dead-ends at /");
+assert.doesNotMatch(cockpit, /QuickLink href="\/" icon="ph:books-bold"/, "the Library quick link no longer dead-ends at /");
+
+// Rows are destinations, not dead ends.
+assert.match(cockpit, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(f\.id\)\}\/analytics`\}/, "agent rows open the familiar's analytics");
+assert.match(cockpit, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(r\.id\)\}\/analytics`\}/, "confidence rows open the familiar's analytics");
+assert.doesNotMatch(cockpit, /href=\{r\.url \|\| "#"\}/, "reading rows without a URL render as text, not a dead # link");
+assert.match(cockpit, /s\.href \?/, "actionable signals render as links");
+assert.match(cockpit, /openExternalUrl\(s\.href!\)/, "external signal links route through the external-URL helper");
+
+// KPI deltas carry meaning, not just direction (all metrics are workload
+// queues — rising is load, falling is relief).
+assert.match(cockpit, /cockpit-kpi__delta--\$\{delta > 0 \? "up" : "down"\}/, "delta direction is a semantic class");
+
 // Action inbox supports bulk triage: select several items → done/dismiss/snooze together.
 const inboxUrl = new URL("../components/dashboard/action-inbox.tsx", import.meta.url);
 const inbox = readFileSync(inboxUrl, "utf8");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -22,6 +22,7 @@ import { buildFamiliarCardStats, type FamiliarCardStats } from "@/components/fam
 import type { ContractReport } from "@/lib/familiar-contract";
 import type { RetroRunsSnapshot } from "@/lib/retro-runs";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
 import { TodaySummary } from "@/components/dashboard/today-summary";
 import { RecentReports } from "@/components/dashboard/recent-reports";
@@ -122,10 +123,14 @@ const STATUS_ORDER: CardStatus[] = ["running", "review", "blocked", "inbox", "ba
 
 export function DashboardCockpit({ model }: { model: DashboardModel }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
+  useMinuteTick();    // keep the "Updated Nm ago" pill honest between polls
   const [data, setData] = useState<CockpitData>(EMPTY);
   // Each source populates independently so a panel renders the moment its data
   // lands — the slow ones (sessions) never block the fast ones (board, agents).
   const [ready, setReady] = useState<ReadonlySet<keyof CockpitData>>(new Set());
+  // Truthful freshness: stamped when fetched data actually lands (not render
+  // time), so a backgrounded tab shows real staleness when you come back.
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   // Keep setState off an unmounted tree: the polled `load` may resolve after
   // unmount. A ref survives across the stable `load` identity (a plain `let`
@@ -143,6 +148,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       if (!aliveRef.current) return;
       setData((d) => ({ ...d, [key]: value }));
       setReady((r) => new Set(r).add(key));
+      setLastUpdated(new Date());
     };
     void getJson<{ cards: Card[] }>("/api/board").then((r) => put("cards", r?.cards ?? []));
     void getJson<{ familiars: Familiar[] }>("/api/familiars").then((r) => put("familiars", r?.familiars ?? []));
@@ -236,13 +242,15 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     });
   }, [confidenceRaw, data.sessions]);
 
+  // Every tile with a value that lives on another surface is a drill-down to
+  // that surface ("Needs you" stays put — its panel is right below).
   const kpis: KpiSpec[] = [
     { icon: "ph:warning-circle", value: model.needsAttention.length, label: "Needs you", accent: "rose", metric: "needs" },
-    { icon: "ph:kanban-bold", value: open.length, label: "Active tasks", accent: "lavender", src: "cards", metric: "tasks", href: "/#card-" },
-    { icon: "ph:lightning-bold", value: (byStatus.get("running") ?? 0) + runningSessions.length, label: "In progress", accent: "green", src: "cards", metric: "progress", href: "/#card-" },
-    { icon: "ph:git-merge", value: byStatus.get("review") ?? 0, label: "In review", accent: "blue", src: "cards", metric: "review", href: "/#card-" },
-    { icon: "ph:git-pull-request", value: prsToReview.length, label: "PRs to review", accent: "amber", src: "github", metric: "prs" },
-    { icon: "ph:books-bold", value: readingQueue.length, label: "To read", accent: "blue", src: "reading", metric: "reading" },
+    { icon: "ph:kanban-bold", value: open.length, label: "Active tasks", accent: "lavender", src: "cards", metric: "tasks", href: "/?mode=board" },
+    { icon: "ph:lightning-bold", value: (byStatus.get("running") ?? 0) + runningSessions.length, label: "In progress", accent: "green", src: "cards", metric: "progress", href: "/?mode=board" },
+    { icon: "ph:git-merge", value: byStatus.get("review") ?? 0, label: "In review", accent: "blue", src: "cards", metric: "review", href: "/?mode=board" },
+    { icon: "ph:git-pull-request", value: prsToReview.length, label: "PRs to review", accent: "amber", src: "github", metric: "prs", href: "/?mode=github" },
+    { icon: "ph:books-bold", value: readingQueue.length, label: "To read", accent: "blue", src: "reading", metric: "reading", href: "/?mode=library" },
   ];
 
   // ── 7-day KPI trends: load history; snapshot today once the live data is in ──
@@ -304,7 +312,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           <SignalsPanel signals={signals} />
         </Panel>);
       case "confidence": return confidence.length === 0 ? null : (
-        <Panel title="Confidence" icon="ph:seal-check">
+        <Panel title="Confidence" icon="ph:seal-check" href="/dashboard/familiars/growth">
           <ConfidencePanel rows={confidence} />
         </Panel>);
       case "needs": return model.caughtUp ? null : (
@@ -312,18 +320,18 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           <ActionInbox initialItems={model.needsAttention} />
         </Panel>);
       case "board": return (
-        <Panel title="Board" icon="ph:kanban-bold" hint={`${open.length} open`}>
+        <Panel title="Board" icon="ph:kanban-bold" hint={`${open.length} open`} href="/?mode=board">
           <BoardSnapshot byStatus={byStatus} total={data.cards.length} active={activeCards} loaded={ready.has("cards")} familiars={data.familiars} />
         </Panel>);
       case "today": return <TodaySummary summary={model.todaySummary} featured={model.featuredReport} now={now} />;
       case "agents": return (
-        <Panel title="Agents" icon="ph:sparkle" count={data.familiars.length || undefined}>
+        <Panel title="Agents" icon="ph:sparkle" count={data.familiars.length || undefined} href="/?mode=agents">
           <AgentsPanel familiars={data.familiars} sessions={data.sessions} loaded={ready.has("familiars")} />
         </Panel>);
       case "load": {
         const series = familiarLoadSeries(data.familiars, data.sessions, Date.now(), 7, 4);
         return (
-          <Panel title="Familiar load" icon="ph:chart-bar-bold">
+          <Panel title="Familiar load" icon="ph:chart-bar-bold" href="/dashboard/familiars/growth">
             {series.length > 0 ? (
               <div className="cockpit-load"><TrendChart series={series} height={150} fill={false} /></div>
             ) : (
@@ -332,15 +340,15 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           </Panel>);
       }
       case "github": return (
-        <Panel title="GitHub" icon="ph:github-logo" count={data.github.length || undefined} hint={prsToReview.length ? `${prsToReview.length} to review` : undefined}>
+        <Panel title="GitHub" icon="ph:github-logo" count={data.github.length || undefined} hint={prsToReview.length ? `${prsToReview.length} to review` : undefined} href="/?mode=github">
           <GithubPanel items={data.github} loaded={ready.has("github")} />
         </Panel>);
       case "agenda": return (
-        <Panel title="Up next" icon="ph:calendar-bold" count={upcoming.length || undefined}>
+        <Panel title="Up next" icon="ph:calendar-bold" count={upcoming.length || undefined} href="/?mode=calendar">
           <AgendaPanel items={upcoming} now={now} loaded={ready.has("upcoming")} />
         </Panel>);
       case "reading": return (
-        <Panel title="Reading" icon="ph:books-bold" count={readingQueue.length || undefined} hint={readingQueue.length ? undefined : "queue empty"}>
+        <Panel title="Reading" icon="ph:books-bold" count={readingQueue.length || undefined} hint={readingQueue.length ? undefined : "queue empty"} href="/?mode=library">
           <ReadingPanel items={readingQueue} loaded={ready.has("reading")} />
         </Panel>);
       default: return null;
@@ -360,9 +368,18 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
           </h1>
         </div>
         <div className="cockpit-head__meta">
-          <span className="cockpit-pill">
-            <Icon name="ph:clock" aria-hidden /> Updated {relativeTime(now.toISOString(), now) || "just now"}
-          </span>
+          {/* The pill doubles as a manual refresh — the label stays truthful
+              (stamped when data lands), the click re-pulls everything now. */}
+          <button
+            type="button"
+            className="cockpit-pill cockpit-pill--refresh"
+            onClick={load}
+            title="Refresh now"
+            aria-label={`Refresh now — updated ${lastUpdated ? relativeTime(lastUpdated.toISOString()) || "just now" : "…"}`}
+          >
+            <Icon name="ph:arrows-clockwise" aria-hidden />
+            {lastUpdated ? `Updated ${relativeTime(lastUpdated.toISOString()) || "just now"}` : "Loading…"}
+          </button>
         </div>
       </header>
 
@@ -392,11 +409,11 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
         <SectionHead icon="ph:squares-four" title="Jump back in" />
         <div className="cockpit-quicklinks">
           <QuickLink href="/" icon="ph:house-bold" label="Home" sub="Your cave" />
-          <QuickLink href="/#card-" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
+          <QuickLink href="/?mode=board" icon="ph:kanban-bold" label="Board" sub="Cards & tasks" />
           <QuickLink href="/dashboard/familiars/growth" icon="ph:chart-bar-bold" label="Growth" sub="Familiar performance" />
           <QuickLink href="/?mode=evals" icon="ph:flask" label="Evals" sub="Suites, loops, freshness" />
-          <QuickLink href="/" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
-          <QuickLink href="/" icon="ph:books-bold" label="Library" sub="Saved knowledge" />
+          <QuickLink href="/?mode=calendar" icon="ph:calendar-bold" label="Calendar" sub="Reminders & agenda" />
+          <QuickLink href="/?mode=library" icon="ph:books-bold" label="Library" sub="Saved knowledge" />
           <QuickLink href="/settings" icon="ph:gear-six" label="Settings" sub="Preferences" />
         </div>
       </div>
@@ -474,7 +491,12 @@ function KpiTile({ icon, value, label, accent, href, loading, series }: KpiSpec 
           <Icon name={icon} aria-hidden />
         </span>
         {!loading && delta !== 0 ? (
-          <span className="cockpit-kpi__delta" title={`${delta > 0 ? "+" : ""}${delta} over ${TREND_DAYS} days`}>
+          // Every KPI here is a workload queue, so rising is load and falling
+          // is relief — color the delta by what it means, not by direction.
+          <span
+            className={`cockpit-kpi__delta cockpit-kpi__delta--${delta > 0 ? "up" : "down"}`}
+            title={`${delta > 0 ? "+" : ""}${delta} over ${TREND_DAYS} days`}
+          >
             {delta > 0 ? "▲" : "▼"} {Math.abs(delta)}
           </span>
         ) : null}
@@ -541,17 +563,20 @@ function AgentsPanel({ familiars, sessions, loaded }: { familiars: Familiar[]; s
         const p = profiles.find((x) => x.id === f.id);
         return (
           <li key={f.id} className="cockpit-agent">
-            <span className="cockpit-agent__avatar" style={{ background: f.color || "var(--accent-presence)" }}>
-              {(f.display_name || "?").slice(0, 1).toUpperCase()}
-              {active ? <span className="cockpit-agent__on" /> : null}
-            </span>
-            <span className="cockpit-agent__body">
-              <span className="cockpit-agent__name" title={f.display_name}>{f.display_name}</span>
-              <span className="cockpit-agent__role" title={f.role || f.model || "familiar"}>{f.role || f.model || "familiar"}</span>
-            </span>
-            {p ? <span className="cockpit-agent__count">{p.sessionsLast7d}/7d</span> : null}
-            {p ? <span className="cockpit-agent__trend"><Sparkline points={p.trend} color={f.color || "var(--accent-presence)"} height={20} /></span> : null}
-            {active ? <span className="cockpit-agent__busy">{f.active_sessions} active</span> : null}
+            {/* The whole row drills into the familiar's analytics page. */}
+            <a className="cockpit-agent__link" href={`/dashboard/familiars/${encodeURIComponent(f.id)}/analytics`}>
+              <span className="cockpit-agent__avatar" style={{ background: f.color || "var(--accent-presence)" }}>
+                {f.emoji || (f.display_name || "?").slice(0, 1).toUpperCase()}
+                {active ? <span className="cockpit-agent__on" /> : null}
+              </span>
+              <span className="cockpit-agent__body">
+                <span className="cockpit-agent__name" title={f.display_name}>{f.display_name}</span>
+                <span className="cockpit-agent__role" title={f.role || f.model || "familiar"}>{f.role || f.model || "familiar"}</span>
+              </span>
+              {p ? <span className="cockpit-agent__count">{p.sessionsLast7d}/7d</span> : null}
+              {p ? <span className="cockpit-agent__trend"><Sparkline points={p.trend} color={f.color || "var(--accent-presence)"} height={20} /></span> : null}
+              {active ? <span className="cockpit-agent__busy">{f.active_sessions} active</span> : null}
+            </a>
           </li>
         );
       })}
@@ -594,7 +619,7 @@ function GithubPanel({ items, loaded }: { items: GitHubItem[]; loaded: boolean }
 function checkDot(s: GitHubItem["checkStatus"]) {
   if (!s) return null;
   const color = s === "passing" ? "var(--color-success)" : s === "failing" ? "var(--color-danger)" : "var(--color-warning)";
-  return <span className="cockpit-dot" style={{ background: color }} title={`Checks: ${s}`} />;
+  return <span className="cockpit-dot" style={{ background: color }} title={`Checks: ${s}`} role="img" aria-label={`Checks ${s}`} />;
 }
 function shortRepo(repo: string): string {
   const slash = repo.lastIndexOf("/");
@@ -636,13 +661,22 @@ function ReadingPanel({ items, loaded }: { items: ReadingItem[]; loaded: boolean
     <ul className="cockpit-reading">
       {items.slice(0, 5).map((r) => {
         const reading = r.status === "reading";
+        const inner = (
+          <>
+            <span className="cockpit-dot" style={{ background: reading ? "var(--accent-presence)" : "var(--text-muted)" }} />
+            <span className="cockpit-readrow__title" title={r.title}>{r.title}</span>
+            {host(r.url) ? <span className="cockpit-readrow__host">{host(r.url)}</span> : null}
+          </>
+        );
         return (
           <li key={r.id}>
-            <a className="cockpit-readrow" href={r.url || "#"} target={r.url ? "_blank" : undefined} rel="noreferrer">
-              <span className="cockpit-dot" style={{ background: reading ? "var(--accent-presence)" : "var(--text-muted)" }} />
-              <span className="cockpit-readrow__title" title={r.title}>{r.title}</span>
-              {host(r.url) ? <span className="cockpit-readrow__host">{host(r.url)}</span> : null}
-            </a>
+            {r.url ? (
+              <a className="cockpit-readrow" href={r.url} target="_blank" rel="noreferrer">{inner}</a>
+            ) : (
+              // No URL → nothing to open; a dead href="#" link would just
+              // scroll-jump and lie to assistive tech.
+              <span className="cockpit-readrow">{inner}</span>
+            )}
           </li>
         );
       })}
@@ -660,12 +694,31 @@ const SIGNAL_ICON: Record<DashboardSignal["severity"], IconName> = { warn: "ph:w
 function SignalsPanel({ signals }: { signals: DashboardSignal[] }) {
   return (
     <ul className="cockpit-signals">
-      {signals.map((s) => (
-        <li key={s.id} className={`cockpit-signal cockpit-signal--${s.severity}`}>
-          <Icon name={SIGNAL_ICON[s.severity]} className="cockpit-signal__icon" aria-hidden />
-          <span className="cockpit-signal__text">{s.text}</span>
-        </li>
-      ))}
+      {signals.map((s) => {
+        const inner = (
+          <>
+            <Icon name={SIGNAL_ICON[s.severity]} className="cockpit-signal__icon" aria-hidden />
+            <span className="cockpit-signal__text">{s.text}</span>
+          </>
+        );
+        return (
+          <li key={s.id}>
+            {s.href ? (
+              // An actionable signal takes you to where you can act on it —
+              // the stalled PR, the library, the familiar's analytics.
+              <a
+                className={`cockpit-signal cockpit-signal--${s.severity} cockpit-signal--link`}
+                href={s.href}
+                onClick={s.external ? (event) => { event.preventDefault(); openExternalUrl(s.href!); } : undefined}
+              >
+                {inner}
+              </a>
+            ) : (
+              <span className={`cockpit-signal cockpit-signal--${s.severity}`}>{inner}</span>
+            )}
+          </li>
+        );
+      })}
     </ul>
   );
 }
@@ -698,7 +751,13 @@ function ConfidencePanel({ rows }: { rows: ConfidenceRow[] }) {
       <div className="cockpit-confidence__grid">
         <div className="cockpit-confidence__rows">
           {rows.map((r) => (
-            <span key={r.id} title={`${r.name}: confidence ${r.score}`}>{r.name}</span>
+            <a
+              key={r.id}
+              href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}
+              title={`${r.name}: confidence ${r.score} — open analytics`}
+            >
+              {r.name}
+            </a>
           ))}
         </div>
         <Heatmap rows={rows.map((r) => r.name)} cols={cols} cells={cells} colorFor={confidenceColor} height={Math.max(72, rows.length * 26)} />

--- a/src/lib/dashboard-analytics.test.ts
+++ b/src/lib/dashboard-analytics.test.ts
@@ -79,4 +79,15 @@ assert.ok(!sigIds.includes("familiar-down-f2"), "recently-active familiar is not
 assert.equal(signals[0].severity, "warn", "warnings sort ahead of info");
 assert.equal(dashboardSignals({ github: [], reading: [], sessions: [], familiars: [], nowMs: NOW }).length, 0, "no signals when nothing is drifting");
 
+// ── Signals are actionable: each carries the destination to act on it ─
+const stalled = signals.find((s) => s.id === "pr-stalled-p1");
+assert.equal(stalled.href, "#", "stalled-PR signal links to the PR's own URL");
+assert.equal(stalled.external, true, "PR links leave the app via the external opener");
+assert.equal(signals.find((s) => s.id === "reading-large").href, "/?mode=library", "reading signal opens the library");
+assert.equal(
+  signals.find((s) => s.id === "familiar-down-f1").href,
+  "/dashboard/familiars/f1/analytics",
+  "trending-down signal opens that familiar's analytics",
+);
+
 console.log("dashboard-analytics.test.ts passed");

--- a/src/lib/dashboard-analytics.ts
+++ b/src/lib/dashboard-analytics.ts
@@ -90,6 +90,11 @@ export type DashboardSignal = {
   id: string;
   severity: "warn" | "info";
   text: string;
+  /** Where acting on the signal takes you (the stalled PR, the library, the
+   *  familiar's analytics). Signals without a destination render as plain rows. */
+  href?: string;
+  /** True when href leaves the app (opened via the external-URL helper). */
+  external?: boolean;
 };
 
 const STALE_PR_DAYS = 7;
@@ -124,6 +129,8 @@ export function dashboardSignals(input: {
         id: `pr-stalled-${g.id}`,
         severity: "warn",
         text: `PR stalled ${days}d: ${g.title}`,
+        href: g.url,
+        external: true,
       });
     }
   }
@@ -134,6 +141,7 @@ export function dashboardSignals(input: {
       id: "reading-large",
       severity: "info",
       text: `Reading queue is large (${reading.length} items)`,
+      href: "/?mode=library",
     });
   }
 
@@ -156,6 +164,7 @@ export function dashboardSignals(input: {
         id: `familiar-down-${f.id}`,
         severity: "warn",
         text: `${f.display_name} is trending down — no sessions in 3 days`,
+        href: `/dashboard/familiars/${encodeURIComponent(f.id)}/analytics`,
       });
     }
   }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -448,6 +448,10 @@
 .cockpit-head__meta { display: flex; gap: 8px; }
 .cockpit-pill { display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--text-muted);
   border: 1px solid var(--border-hairline); border-radius: 999px; padding: 4px 10px; background: var(--bg-raised); }
+/* The freshness pill doubles as the manual refresh button. */
+button.cockpit-pill--refresh { cursor: pointer; font: inherit; font-size: 11.5px; transition: border-color .15s, color .15s; }
+button.cockpit-pill--refresh:hover { border-color: var(--border-strong); color: var(--text-secondary); }
+button.cockpit-pill--refresh:hover svg { color: var(--accent-presence); }
 
 /* KPI rail */
 .cockpit-kpis { display: grid; grid-template-columns: repeat(6, 1fr); gap: 10px; }
@@ -460,6 +464,9 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-kpi__icon { width: 26px; height: 26px; display: grid; place-items: center; border-radius: 8px;
   color: var(--kpi, var(--accent-presence)); background: color-mix(in oklch, var(--kpi, var(--accent-presence)) 15%, transparent); }
 .cockpit-kpi__delta { font-size: 10px; font-weight: 700; color: var(--text-muted); font-variant-numeric: tabular-nums; letter-spacing: -0.02em; }
+/* All KPI metrics are workload queues: rising = load, falling = relief. */
+.cockpit-kpi__delta--up { color: var(--color-warning); }
+.cockpit-kpi__delta--down { color: var(--color-success); }
 .cockpit-kpi__value { font-size: 24px; font-weight: 700; line-height: 1.1; color: var(--text-primary); font-variant-numeric: tabular-nums; }
 .cockpit-kpi__label { font-size: 11.5px; color: var(--text-secondary); }
 /* Shared hover-able trend sparkline (cockpit KPIs + report metric cards) */
@@ -509,7 +516,10 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 
 /* Agents */
 .cockpit-agents { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
-.cockpit-agent { display: flex; align-items: center; gap: 10px; padding: 6px 4px; }
+.cockpit-agent { display: flex; }
+.cockpit-agent__link { display: flex; align-items: center; gap: 10px; padding: 6px 8px; flex: 1; min-width: 0;
+  border-radius: 8px; text-decoration: none; color: inherit; }
+.cockpit-agent__link:hover { background: var(--bg-hover); }
 .cockpit-agent__avatar { position: relative; width: 28px; height: 28px; border-radius: 8px; display: grid; place-items: center;
   font-size: 12px; font-weight: 700; color: #fff; flex: 0 0 auto; }
 .cockpit-agent__on { position: absolute; right: -2px; bottom: -2px; width: 9px; height: 9px; border-radius: 50%;
@@ -546,6 +556,8 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-signal--warn .cockpit-signal__icon { color: var(--color-warning); }
 .cockpit-signal--info .cockpit-signal__icon { color: var(--color-info); }
 .cockpit-signal__text { min-width: 0; }
+a.cockpit-signal--link { text-decoration: none; }
+a.cockpit-signal--link:hover { background: var(--bg-hover); }
 
 /* Confidence heatmap */
 .cockpit-confidence { display: flex; flex-direction: column; gap: 6px; }
@@ -553,7 +565,9 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
   font-size: 9.5px; color: var(--text-muted); text-align: center; }
 .cockpit-confidence__grid { display: flex; align-items: stretch; gap: 6px; }
 .cockpit-confidence__rows { display: flex; flex-direction: column; justify-content: space-around; width: 78px; flex: 0 0 auto; }
-.cockpit-confidence__rows span { font-size: 11px; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cockpit-confidence__rows a { font-size: 11px; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  text-decoration: none; }
+.cockpit-confidence__rows a:hover { color: var(--accent-presence); text-decoration: underline; }
 .cockpit-confidence .cave-chart--heatmap { flex: 1; min-width: 0; }
 
 /* Quick launch + skeleton */


### PR DESCRIPTION
## What

A minimal-yet-powerful pass over the `/dashboard` cockpit: every component either tells the truth or takes you somewhere — no decorative chrome added, several dead ends removed.

### Truthful liveness
- The **"Updated…" pill was lying**: it rendered `relativeTime(now, now)` from server-render time, so it read "just now" forever regardless of polling. It's now stamped when fetched data actually **lands**, ticks by the minute (`useMinuteTick`), and doubles as a **manual refresh button** (`onClick={load}`, labeled for AT). A backgrounded tab now shows real staleness on return.

### Drill-throughs everywhere (dead-end removal)
- **KPI tiles**: the three board tiles pointed at the dead bare `/#card-` hash and the PRs/Reading tiles weren't links at all. All five now deep-link via `/?mode=board|github|library` (the SPA's validated mode param).
- **Panel headers**: the `Panel` component's `href` affordance existed but no caller used it. Board→board, Agents→familiars roster, GitHub→github, Up next→calendar, Reading→library, Load/Confidence→growth page.
- **Agent rows** now open `/dashboard/familiars/[id]/analytics` — the original dashboard spec promised this link and it was never wired. Confidence heatmap row names link the same way.
- **Signals became actionable** (`DashboardSignal.href` + `external`): stalled-PR → the PR (via `openExternalUrl`), reading-queue → library, trending-down familiar → its analytics.
- **Quick links**: Calendar and Library both dead-ended at `/`; now `/?mode=calendar` and `/?mode=library`. Board uses `/?mode=board`.
- **Reading rows without a URL** rendered `href="#"` (scroll-jump + lies to AT) — now plain text.

### Semantics & a11y
- KPI deltas colored by **meaning**: every metric is a workload queue, so ▲ = load (warning), ▼ = relief (success) — not generic up/down.
- Agent avatars show the familiar's **emoji** when set (consistent with the rest of the app), falling back to the initial.
- The GitHub check dot carries `role="img"` + `aria-label` (was title-only).

## Verification
- `typecheck` · `check:tests-wired` (700) · `test:app` 521 ✓; `dashboard-page.test.ts` extended with pins for all of the above (including doesNotMatch on the dead `/#card-` and static-time pill); `dashboard-analytics.test.ts` asserts the new signal hrefs behaviorally.
- Live-verified on the built app: DOM checks confirm zero `/#card-` or `href="#"` links, all six panel drill-throughs, six agent analytics links, and the live refresh pill; full-page screenshots at 1440px and 620px show clean layout, correct degraded states for slow sources, and no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)