### PR TITLE
perf(marketplace): memoize the card + stop stale catalog loads clobbering the list

### DIFF
--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -141,52 +141,74 @@ export function MarketplaceViewSurface({
   const [skillsLoaded, setSkillsLoaded] = useState(false);
   const [skillsError, setSkillsError] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<SkillDetailEntry | null>(null);
+  // Each loader keeps its in-flight controller so a newer load (or unmount)
+  // aborts the previous one — a slow response can't land after a fresher one
+  // and clobber the list (the useProjects hygiene pattern). A superseded load
+  // bails before touching state; only the winning load flips its loaded flag.
+  const loadCtl = useRef<AbortController | null>(null);
+  const rolesCtl = useRef<AbortController | null>(null);
+  const skillsCtl = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
+    loadCtl.current?.abort();
+    const ctl = new AbortController();
+    loadCtl.current = ctl;
     setLoaded(false);
     try {
-      const res = await fetch("/api/marketplace", { cache: "no-store" });
+      const res = await fetch("/api/marketplace", { cache: "no-store", signal: ctl.signal });
       const json = (await res.json()) as { ok?: boolean; plugins?: MarketplacePlugin[]; error?: string };
+      if (ctl.signal.aborted) return;
       if (!json.ok) throw new Error(json.error ?? `marketplace http ${res.status}`);
       setPlugins(json.plugins ?? []);
       setError(null);
     } catch (err) {
+      if (ctl.signal.aborted) return;
       setPlugins([]);
       setError(err instanceof Error ? err.message : "marketplace unavailable");
     } finally {
-      setLoaded(true);
+      if (!ctl.signal.aborted) setLoaded(true);
     }
   }, []);
 
   const loadRoles = useCallback(async () => {
+    rolesCtl.current?.abort();
+    const ctl = new AbortController();
+    rolesCtl.current = ctl;
     setRolesLoaded(false);
     try {
-      const res = await fetch("/api/roles", { cache: "no-store" });
+      const res = await fetch("/api/roles", { cache: "no-store", signal: ctl.signal });
       const json = (await res.json()) as { ok?: boolean; roles?: RoleEntry[]; error?: string };
+      if (ctl.signal.aborted) return;
       if (!json.ok) throw new Error(json.error ?? `roles http ${res.status}`);
       setRoles(json.roles ?? []);
       setRolesError(null);
     } catch (err) {
+      if (ctl.signal.aborted) return;
       setRoles([]);
       setRolesError(err instanceof Error ? err.message : "roles unavailable");
     } finally {
-      setRolesLoaded(true);
+      if (!ctl.signal.aborted) setRolesLoaded(true);
     }
   }, []);
 
   const loadSkills = useCallback(async () => {
+    skillsCtl.current?.abort();
+    const ctl = new AbortController();
+    skillsCtl.current = ctl;
     setSkillsLoaded(false);
     try {
-      const res = await fetch("/api/skills/local", { cache: "no-store" });
+      const res = await fetch("/api/skills/local", { cache: "no-store", signal: ctl.signal });
       const json = (await res.json()) as { ok?: boolean; skills?: SkillBrowserEntry[]; error?: string };
+      if (ctl.signal.aborted) return;
       if (!json.ok) throw new Error(json.error ?? `skills http ${res.status}`);
       setSkills(json.skills ?? []);
       setSkillsError(null);
     } catch (err) {
+      if (ctl.signal.aborted) return;
       setSkills([]);
       setSkillsError(err instanceof Error ? err.message : "skills unavailable");
     } finally {
-      setSkillsLoaded(true);
+      if (!ctl.signal.aborted) setSkillsLoaded(true);
     }
   }, []);
 
@@ -194,6 +216,11 @@ export function MarketplaceViewSurface({
     void load();
     void loadRoles();
     void loadSkills();
+    return () => {
+      loadCtl.current?.abort();
+      rolesCtl.current?.abort();
+      skillsCtl.current?.abort();
+    };
   }, [load, loadRoles, loadSkills]);
 
   // "/" focuses the hub search from anywhere on the surface (unless typing).
@@ -648,10 +675,10 @@ export function MarketplaceViewSurface({
                     key={plugin.id}
                     plugin={plugin}
                     busy={busyId === plugin.id}
-                    onOpen={() => setSelected(plugin.id)}
-                    onAdd={() => void add(plugin.id)}
-                    onRemove={() => void remove(plugin.id)}
-                    onConfigure={() => setConfiguringId(plugin.id)}
+                    onOpen={setSelected}
+                    onAdd={add}
+                    onRemove={remove}
+                    onConfigure={setConfiguringId}
                   />
                 ))}
               </div>

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { memo } from "react";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { pluginBadgeState, type MarketplacePlugin } from "@/lib/marketplace-catalog";
@@ -15,20 +16,30 @@ const TRUST_LABEL: Record<string, string> = {
 type Props = {
   plugin: MarketplacePlugin;
   busy: boolean;
-  onOpen: () => void;
-  onAdd: () => void;
-  onRemove: () => void;
-  onConfigure: () => void;
+  // id-based so the parent can pass stable handlers (add/remove/setSelected/
+  // setConfiguringId) directly — without per-card lambdas the memo below lets
+  // unchanged cards skip re-render while the search box re-renders the surface.
+  onOpen: (id: string) => void;
+  onAdd: (id: string) => void;
+  onRemove: (id: string) => void;
+  onConfigure: (id: string) => void;
 };
 
-export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfigure }: Props) {
+export const MarketplaceCard = memo(function MarketplaceCard({
+  plugin,
+  busy,
+  onOpen,
+  onAdd,
+  onRemove,
+  onConfigure,
+}: Props) {
   const state = pluginBadgeState(plugin);
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-4">
       <div className="flex items-start justify-between gap-3">
         <button
           type="button"
-          onClick={onOpen}
+          onClick={() => onOpen(plugin.id)}
           className="focus-ring flex min-w-0 items-center gap-3 rounded-md text-left"
         >
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
@@ -42,11 +53,11 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfi
           </span>
         </button>
         {state === "needs-setup" ? (
-          <Button variant="primary" size="sm" leadingIcon="ph:warning" onClick={onConfigure}>
+          <Button variant="primary" size="sm" leadingIcon="ph:warning" onClick={() => onConfigure(plugin.id)}>
             Set up
           </Button>
         ) : state === "added" ? (
-          <Button variant="secondary" size="sm" leadingIcon="ph:check" loading={busy} onClick={onRemove}>
+          <Button variant="secondary" size="sm" leadingIcon="ph:check" loading={busy} onClick={() => onRemove(plugin.id)}>
             Added
           </Button>
         ) : state === "unavailable" ? (
@@ -54,7 +65,7 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfi
             Unavailable
           </Button>
         ) : (
-          <Button variant="primary" size="sm" leadingIcon="ph:plus" loading={busy} onClick={onAdd}>
+          <Button variant="primary" size="sm" leadingIcon="ph:plus" loading={busy} onClick={() => onAdd(plugin.id)}>
             Add
           </Button>
         )}
@@ -72,7 +83,7 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfi
         {plugin.requiresSetup && plugin.configured ? (
           <button
             type="button"
-            onClick={onConfigure}
+            onClick={() => onConfigure(plugin.id)}
             className="focus-ring inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:check-circle" width={11} aria-hidden /> Configured
@@ -86,4 +97,4 @@ export function MarketplaceCard({ plugin, busy, onOpen, onAdd, onRemove, onConfi
       </div>
     </div>
   );
-}
+});

--- a/src/components/marketplace/roles-section.tsx
+++ b/src/components/marketplace/roles-section.tsx
@@ -68,7 +68,6 @@ type Props = {
   busyRoleKey: string | null;
   onToggleRole: (role: RoleEntry) => void;
   onOpenChat?: (familiarId: string) => void;
-  onOpenWorkflow?: (id: string) => void;
   onOpenSkill?: (name: string) => void;
   /** Jumps to the hub's Browse section — the empty state's "get more" CTA. */
   onBrowseMarketplace?: () => void;
@@ -82,7 +81,6 @@ export function RolesSection({
   busyRoleKey,
   onToggleRole,
   onOpenChat,
-  onOpenWorkflow,
   onOpenSkill,
   onBrowseMarketplace,
 }: Props) {
@@ -202,8 +200,6 @@ export function RolesSection({
                 items={role.workflows}
                 emptyText="No workflows"
                 icon={ICONS.workflow}
-                onOpen={onOpenWorkflow}
-                openHint="Open workflow"
               />
             </dl>
           </article>


### PR DESCRIPTION
Perf + correctness pass on the **Marketplace / Roles / Capabilities hub** (`marketplace-view.tsx`) — the 15th surface in the audit campaign.

## 1. `MarketplaceCard` re-renders the whole catalog on every keystroke — P1 perf
The grid passed a **fresh lambda per card** for `onOpen`/`onAdd`/`onRemove`/`onConfigure`, and the card wasn't memoized — so every character typed in the hub search (which lives on the surface) re-rendered every visible card. The install/remove handlers were already stable `useCallback`s and `setSelected`/`setConfiguringId` are raw setters, so the fix is clean: `MarketplaceCard` now takes **id-based** handlers, is wrapped in `React.memo`, and the grid passes those stable handlers directly. Unchanged cards now bail out of re-render.

## 2. A stale catalog load can clobber a fresher list — correctness
`load` / `loadRoles` / `loadSkills` had no cancellation (unlike `useProjects` elsewhere). A slow response could land after a newer one — e.g. a configure-modal `onChanged` reload resolving after the user moved on — and overwrite the list, and an unmount mid-flight hit the setState-after-unmount path. Each loader now keeps an in-flight `AbortController`; a newer load or unmount aborts the previous one, and a superseded response bails before touching state.

## 3. Dead code
Removed the `onOpenWorkflow` prop from `RolesSection` — nothing ever passed it (grep: 3 refs, all self-references inside `roles-section.tsx`), so the Workflows chips always rendered as non-interactive `<span>`s. Leftover from the retired standalone roles page.

## Deferred (noted)
- A11y (install/remove/enable/configure are silent to AT — no `useAnnouncer`) ships as a **follow-up a11y PR** (collides with this file).
- The narrower install-vs-load reconciliation (an in-flight load started *before* an optimistic install resolving after it) and the per-field configure-modal `load()` race are left as P2 — extremely narrow on localhost and fiddly around the `loaded` flag.
- The section tablist is already accessible (`role="tablist"`/`tab`/`tabpanel` + arrow handler, pinned in `roles-tools-navigation.test.ts`); the "arrow-keys reset search" nuance is deferred as debatable UX.

## Test
- `pnpm test:app` — all 521 app test files pass; `tsc --noEmit` clean. No test pins the card callsite or loader internals (broad-grepped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)