### PR TITLE
a11y(marketplace): announce install / remove / role-toggle / configure to AT

### DIFF
--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -12,6 +12,7 @@ import { Icon, type IconName } from "@/lib/icon";
 import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Tabs } from "@/components/ui/tabs";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { MarketplaceCard } from "@/components/marketplace/marketplace-card";
 import { MarketplaceDetail } from "@/components/marketplace/marketplace-detail";
 import { MarketplaceConfigure } from "@/components/marketplace/marketplace-configure";
@@ -148,6 +149,10 @@ export function MarketplaceViewSurface({
   const loadCtl = useRef<AbortController | null>(null);
   const rolesCtl = useRef<AbortController | null>(null);
   const skillsCtl = useRef<AbortController | null>(null);
+  // Install / remove / role-toggle / configure surface their outcome as
+  // visual-only <p> banners (not toasts), so mirror success + errors to the
+  // shared live region — otherwise these core actions are silent to AT.
+  const { announce } = useAnnouncer();
 
   const load = useCallback(async () => {
     loadCtl.current?.abort();
@@ -309,13 +314,16 @@ export function MarketplaceViewSurface({
       });
       const json = (await res.json()) as { ok?: boolean; error?: string };
       if (!json.ok) throw new Error(json.error ?? "install failed");
+      announce("Added to your setup", "polite");
     } catch (err) {
       setInstalled(id, false);
-      setError(err instanceof Error ? err.message : "install failed");
+      const msg = err instanceof Error ? err.message : "install failed";
+      setError(msg);
+      announce(msg, "assertive");
     } finally {
       setBusyId(null);
     }
-  }, [setInstalled]);
+  }, [setInstalled, announce]);
 
   const remove = useCallback(async (id: string) => {
     setBusyId(id);
@@ -328,13 +336,16 @@ export function MarketplaceViewSurface({
       });
       const json = (await res.json()) as { ok?: boolean; error?: string };
       if (!json.ok) throw new Error(json.error ?? "uninstall failed");
+      announce("Removed from your setup", "polite");
     } catch (err) {
       setInstalled(id, true);
-      setError(err instanceof Error ? err.message : "uninstall failed");
+      const msg = err instanceof Error ? err.message : "uninstall failed";
+      setError(msg);
+      announce(msg, "assertive");
     } finally {
       setBusyId(null);
     }
-  }, [setInstalled]);
+  }, [setInstalled, announce]);
 
   const toggleRole = useCallback(async (role: RoleEntry) => {
     const key = `${role.familiar}:${role.id}`;
@@ -351,17 +362,20 @@ export function MarketplaceViewSurface({
       });
       const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
       if (!res.ok || json.ok === false) throw new Error(json.error ?? `roles http ${res.status}`);
+      announce(next ? "Role enabled" : "Role disabled", "polite");
     } catch (err) {
       setRoles((current) =>
         current.map((item) =>
           item.id === role.id && item.familiar === role.familiar ? { ...item, active: role.active } : item,
         ),
       );
-      setRolesError(err instanceof Error ? err.message : "role update failed");
+      const msg = err instanceof Error ? err.message : "role update failed";
+      setRolesError(msg);
+      announce(msg, "assertive");
     } finally {
       setBusyRoleKey(null);
     }
-  }, []);
+  }, [announce]);
 
   // A role-card skill chip opens that skill's detail drawer (resolving the
   // chip's name against the scanned local skills). Unknown/not-yet-loaded

--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 type FieldStatus = {
   key: string;
@@ -36,6 +37,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
   type ValidationResult = { state: "idle" | "testing" | "valid" | "invalid"; message?: string };
   const [results, setResults] = useState<Record<string, ValidationResult>>({});
   const [error, setError] = useState<string | null>(null);
+  const { announce } = useAnnouncer();
 
   const load = useCallback(async (seedDefaults = false) => {
     setLoaded(false);
@@ -118,13 +120,16 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
       setDrafts((d) => ({ ...d, [field.key]: "" }));
       await load();
       onChanged();
+      announce(`${field.title} saved`, "polite");
       if (field.validatable) void validate(field);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "save failed");
+      const msg = err instanceof Error ? err.message : "save failed";
+      setError(msg);
+      announce(msg, "assertive");
     } finally {
       setBusyKey(null);
     }
-  }, [drafts, pluginId, load, onChanged, validate]);
+  }, [drafts, pluginId, load, onChanged, validate, announce]);
 
   return (
     <Modal

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -228,4 +228,22 @@ assert.match(
 );
 // The right companion (agent) panel was removed with the drag-to-split change.
 
+// ── Marketplace hub actions announce to the shared live region ───────────────
+// Install / remove / role-toggle surface their outcome as visual-only <p>
+// banners (not toasts), so they mirror to the assertive/polite live region —
+// otherwise these core actions are silent to screen-reader users.
+assert.match(
+  marketplaceView,
+  /import \{ useAnnouncer \} from "@\/components\/ui\/live-region"/,
+  "the marketplace hub wires the shared announcer",
+);
+assert.match(marketplaceView, /announce\("Added to your setup", "polite"\)/, "installing a plugin is announced");
+assert.match(marketplaceView, /announce\("Removed from your setup", "polite"\)/, "removing a plugin is announced");
+assert.match(
+  marketplaceView,
+  /announce\(next \? "Role enabled" : "Role disabled", "polite"\)/,
+  "toggling a role announces the new state",
+);
+assert.match(marketplaceView, /announce\(msg, "assertive"\)/, "a failed hub action is announced assertively");
+
 console.log("roles-tools-navigation.test.ts OK");


### PR DESCRIPTION
Accessibility follow-up to #2349 on the **Marketplace / Roles / Capabilities hub**.

The hub's core actions report their outcome as visual-only `<p>` banners — and crucially **not** through a toast (which would be a `role="status"` live region), so they were completely silent to screen-reader users. Installing a plugin, removing one, toggling a role, or saving a configure field all completed with no AT feedback, and their errors were equally silent.

Wired the shared `useAnnouncer`:
- **install** → `"Added to your setup"` (polite)
- **remove** → `"Removed from your setup"` (polite)
- **role toggle** → `"Role enabled"` / `"Role disabled"` (polite)
- **configure save** → `"<field> saved"` (polite)
- every failure path → the error message (assertive)

The `announce` callback is stable, so adding it to the `add`/`remove` deps doesn't destabilise the id-based handlers the memoized card relies on (from #2349).

## Why separate from #2349
Both touch `marketplace-view.tsx`, so per the audit-campaign convention the perf/correctness fix (#2349) and this a11y pass ship as two PRs; this branch was rebased onto main after #2349 merged.

## Already-correct (verified, not touched)
The section tablist already has full `role="tablist"`/`tab`/`tabpanel` + `aria-labelledby` wiring and an arrow-key handler; the detail panel uses `useFocusTrap` + `role="dialog"`; the configure modal uses the shared `Modal` with labelled inputs; icon-only controls and selects are labelled. The one gap was the silent action feedback.

## Test
- `pnpm test:app` — all 521 app test files pass; new announcer pins added to `roles-tools-navigation.test.ts` (which already reads the marketplace-view source).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)