### PR TITLE
feat(chat): "Opening chat…" takeover while a deep link awaits the sessions fetch

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2296,6 +2296,32 @@ textarea.required-inputs-control {
   to { transform: rotate(360deg); }
 }
 
+/* Chat deep-link takeover: `#chat-<id>` holds until the sessions fetch
+   settles — show intent instead of flashing Home for that beat. */
+.workspace-deeplink-pending {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+.workspace-deeplink-pending__spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in oklch, currentColor 25%, transparent);
+  border-top-color: currentColor;
+  animation: ui-btn-spin 0.7s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .workspace-deeplink-pending__spinner { animation: none; }
+}
+
 /* ---- IconButton --------------------------------------------- */
 .ui-icon-btn {
   display: inline-flex;

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -131,6 +131,25 @@ assert.match(
   "Unknown/stale deep-link ids must fall back to the chat list with the hash cleared — no crash",
 );
 
+// ── Deep-link loading hint (2026-07-04) ─────────────────────────────────────
+// The restore holds until the sessions fetch settles (~2s warm, longer under a
+// cold compile) — the shell must show intent for that beat, not flash Home.
+assert.match(
+  workspaceSource,
+  /const \[chatDeepLinkPending, setChatDeepLinkPending\] = useState<boolean>\(\s*\(\) => pendingChatDeepLinkRef\.current !== null,\s*\)/,
+  "the pending deep link mirrors into render state seeded from the mount-time hash",
+);
+assert.match(
+  restoreEffect,
+  /setChatDeepLinkPending\(false\)/,
+  "resolving the deep link (found or stale) clears the takeover",
+);
+assert.match(
+  workspaceSource,
+  /\{chatDeepLinkPending && \([\s\S]{0,200}workspace-deeplink-pending[\s\S]{0,120}role="status"[\s\S]{0,200}Opening chat…/,
+  "while pending, the shell renders an announced Opening-chat takeover",
+);
+
 const readChatHashHelper =
   workspaceSource.match(/function readChatHash\(\): string \| null \{[\s\S]*?\n\}/)?.[0] ?? "";
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -341,6 +341,12 @@ export function Workspace() {
   // Deep-link target captured at mount, held until the async sessions fetch
   // settles (loadSessions → sessionsLoaded) so the restore can resolve it.
   const pendingChatDeepLinkRef = useRef<string | null>(readChatHash());
+  // Render mirror of the ref: while the deep link awaits the sessions fetch
+  // the shell shows an "Opening chat…" takeover instead of flashing Home —
+  // that wait is ~2s warm but stretches under a cold dev-server compile.
+  const [chatDeepLinkPending, setChatDeepLinkPending] = useState<boolean>(
+    () => pendingChatDeepLinkRef.current !== null,
+  );
   // Refs for the popstate listener — sessions repoll every 4s and mode flips
   // often; the listener should not resubscribe on either.
   const sessionsRef = useRef(sessions);
@@ -1360,6 +1366,7 @@ export function Workspace() {
     const sid = pendingChatDeepLinkRef.current;
     if (!sid) return;
     pendingChatDeepLinkRef.current = null;
+    setChatDeepLinkPending(false);
     const target = sessions.find((s) => s.id === sid);
     if (target) {
       openFamiliarSession(sid, target.familiarId);
@@ -2478,6 +2485,13 @@ export function Workspace() {
           openFamiliarSession(sid, fid);
         }}
       />
+
+      {chatDeepLinkPending && (
+        <div className="workspace-deeplink-pending" role="status">
+          <span className="workspace-deeplink-pending__spinner" aria-hidden />
+          Opening chat…
+        </div>
+      )}
     </FamiliarStudioProvider>
   );
 }


### PR DESCRIPTION
A `#chat-<sessionId>` deep link holds by design until `/api/sessions/list` settles — ~2 seconds warm, but long enough under a cold dev-server compile that the shell visibly flashes Home first (this beat recently misled an e2e run into diagnosing a nonexistent regression).

## What
While the mount-time deep-link target is pending, the shell renders a fixed `role="status"` takeover — spinner + "Opening chat…" — instead of Home. It clears the moment the restore resolves, on **both** paths: a found session (opens via `openFamiliarSession`) and a stale/unknown id (existing fallback to the chat list with the hash cleared). Reduced-motion drops the spin. The pending state is a render mirror of the existing `pendingChatDeepLinkRef`, seeded from the mount-time hash; no restore logic changed.

## Verified live (worktree dev server, fresh contexts, 60ms polling to catch the window)
- Valid id: hint seen during load → cleared → chat composer ("Message Cody…").
- Stale id: hint seen → cleared → chat-list fallback, no crash.

## Tests
Three pins added to `chat-router-switching.test.ts` next to the existing deep-link contract pins (state mirror seeding, clear-on-resolve, announced takeover render). Full suite: 704 test files green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)