### PR TITLE
fix(familiars): cancel stale daily-notes loads; stop the poll resurrecting a deleted memory row

### DIFF
--- a/src/components/familiar-daily-notes.tsx
+++ b/src/components/familiar-daily-notes.tsx
@@ -40,6 +40,10 @@ export function FamiliarDailyNotes({ familiar }: Props) {
   const [savedAt, setSavedAt] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const dirtyRef = useRef(false);
+  // Monotonic token so a slow notes fetch can't apply after a newer date- or
+  // familiar-switch: a late response would otherwise overwrite the editor with
+  // the wrong day's body AND silently clear the unsaved-edit dirty flag.
+  const loadSeq = useRef(0);
 
   const loadDates = useCallback(async () => {
     try {
@@ -53,22 +57,25 @@ export function FamiliarDailyNotes({ familiar }: Props) {
 
   const loadDay = useCallback(
     async (slug: string) => {
+      const seq = ++loadSeq.current;
       setLoaded(false);
       setError(null);
       try {
         const res = await fetch(`/api/familiars/${familiar.id}/notes?date=${slug}`);
         const data = await res.json();
+        if (seq !== loadSeq.current) return; // superseded by a newer day/familiar load
         if (!data?.ok) throw new Error(data?.error || "Failed to load notes");
         setNotes(typeof data.note?.notes === "string" ? data.note.notes : "");
         setReflection(typeof data.note?.reflection === "string" ? data.note.reflection : "");
         setSavedAt(data.modified ?? null);
         dirtyRef.current = false;
       } catch (err) {
+        if (seq !== loadSeq.current) return; // stale failure — leave the current day intact
         setError(err instanceof Error ? err.message : "Failed to load notes");
         setNotes("");
         setReflection("");
       } finally {
-        setLoaded(true);
+        if (seq === loadSeq.current) setLoaded(true);
       }
     },
     [familiar.id],

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -136,6 +136,11 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   const [staleOnly, setStaleOnly] = useState(false);
   const [expandRow, setExpandRow] = useState<MemoryRow | null>(null);
   const { pending: undoPending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<{ key: string }>();
+  // The real DELETE is deferred 4s for undo, but the 30s poll / on-focus refresh
+  // re-fetches during that window and would resurrect the optimistically-removed
+  // row. Track the one pending path (useUndoDelete is single-pending) and filter
+  // it out of anything load() applies until the delete commits or is undone.
+  const pendingDeletePathRef = useRef<string | null>(null);
   const [lastLoadedAt, setLastLoadedAt] = useState<string | null>(null);
   const effectiveLimit = limit ?? Infinity;
   // Incremental render cap for the full view (rail/compact use `limit` instead).
@@ -171,8 +176,9 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
       const covenJson = (await covenRes.json()) as CovenMemoryResponse;
       const fileJson = (await fileRes.json()) as FileMemoryResponse;
 
-      if (covenJson.ok) setCovenEntries(covenJson.entries ?? []);
-      if (fileJson.ok) setFileEntries(fileJson.entries ?? []);
+      const pendingDelete = pendingDeletePathRef.current;
+      if (covenJson.ok) setCovenEntries((covenJson.entries ?? []).filter((e) => e.path !== pendingDelete));
+      if (fileJson.ok) setFileEntries((fileJson.entries ?? []).filter((e) => e.fullPath !== pendingDelete));
 
       const errors = [
         covenJson.ok ? null : covenJson.error ?? "Coven memory unavailable",
@@ -189,7 +195,8 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
 
   const handleDelete = useCallback(
     (path: string, key: string, source: "coven" | "file") => {
-      // optimistic removal from the rendered lists
+      // optimistic removal from the rendered lists + suppress a poll re-adding it
+      pendingDeletePathRef.current = path;
       if (source === "coven") setCovenEntries((prev) => prev.filter((e) => e.path !== path));
       else setFileEntries((prev) => prev.filter((e) => e.fullPath !== path));
       scheduleDelete({ key }, path.split("/").pop() ?? "entry", async () => {
@@ -198,12 +205,17 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ path }),
         });
+        // Delete committed server-side; stop filtering (unless a newer delete
+        // has already claimed the slot).
+        if (pendingDeletePathRef.current === path) pendingDeletePathRef.current = null;
       });
     },
     [scheduleDelete],
   );
 
   const handleUndoDelete = useCallback(() => {
+    // Undo cancels the DELETE, so stop suppressing the path before re-pulling.
+    pendingDeletePathRef.current = null;
     undoDelete();
     void load(); // re-pull so the optimistically-removed row reappears
   }, [undoDelete, load]);


### PR DESCRIPTION
Correctness pass on **Familiar Studio** (workspace mode `agents`) — the 16th surface in the audit campaign. Two verified poll/race bugs:

## 1. Daily notes: stale load clobbers the editor + silently drops the dirty flag — P1
`familiar-daily-notes.tsx` `loadDay()` unconditionally wrote `notes`/`reflection`/`savedAt` and set `dirtyRef.current = false` with **no request-ordering guard**. Rapidly switching dates (prev/next arrows or the past-entries list) — or switching the selected familiar — while a fetch is in flight let the slower response land last, overwriting the editor with a **different day's / familiar's body**, and worse, clearing the unsaved-edit dirty flag so the user's just-typed edit wouldn't autosave and could be overwritten. Fixed with a monotonic `loadSeq` token: a superseded response bails before touching any state.

## 2. Memory browser: the poll resurrects an optimistically-deleted row — P1
`familiars-memory-view.tsx` removes a deleted row optimistically, but the real DELETE is deferred 4s for undo (`useUndoDelete`). The 30s `usePausablePoll` refresh (and the on-focus refresh) re-fetches during that window and re-added the still-present entry — so the "deleted" row **popped back into the list while the undo toast was still showing**. Fixed by tracking the one pending path (`useUndoDelete` is single-pending) and filtering it out of anything `load()` applies until the delete commits (clears the ref) or is undone (clears the ref, then re-pulls).

## Scope / deferred
- The a11y batch (two hand-rolled memory dialogs lack focus-trap/restore; `home-feed` tabs; announce create/actions) ships as a **follow-up a11y PR** (collides with these files).
- Perf: the surface is well-optimized (`usePausablePoll` is visibility-gated; stats are Map-bucketed). The real perf note — a **duplicate 30s poll** of `/api/coven-memory`+`/api/memory` when a familiar detail is open (`FamiliarsView` and its embedded `FamiliarsMemoryView` both fetch) — is deferred (a data-ownership refactor, low impact on localhost). Dead code (the fully-dead `/api/youtube` chain, `RailMemoryList` export) deferred to a cleanup.

## Test
- `pnpm test:app` — all 521 app test files pass; `tsc --noEmit` clean. No test pins the changed lines (broad-grepped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)