### PR TITLE
feat(themes): WCAG-compliant contrast across all appearances + three a11y-first presets

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
@@ -64,7 +64,7 @@ enum ThemeRoster {
         .init("dusk", "Dusk", "Witching-hour magenta. The veil thins.",
               accentDark: "#E175FF", accentLight: "#9930C2", bgDark: "#09000c", bgLight: "#fdf0fd"),
         .init("mist", "Mist", "Scrying-pool teal. Cold as a question.",
-              accentDark: "#6BD8D3", accentLight: "#1A857F", bgDark: "#000405", bgLight: "#eaf9f8"),
+              accentDark: "#6BD8D3", accentLight: "#177b76", bgDark: "#000405", bgLight: "#eaf9f8"),
         .init("hex", "Hex", "Bloodletter's brand. The mark that won't wash off.",
               accentDark: "#E04848", accentLight: "#A41C24", bgDark: "#0f0000", bgLight: "#fff0ee"),
         .init("bane", "Bane", "Wolfsbane bloom. Bright; deeply unwise.",
@@ -74,15 +74,15 @@ enum ThemeRoster {
         .init("ghosty", "Ghosty", "Spectral grayscale. Quiet as a haunt.",
               accentDark: "#a6a6a6", accentLight: "#808080", bgDark: "#1a1a1a", bgLight: "#fafafa"),
         .init("claymorphism", "Claymorphism", "Soft-molded stone with indigo glaze.",
-              accentDark: "#818cf8", accentLight: "#6366f1", bgDark: "#1e1b18", bgLight: "#e7e5e4"),
+              accentDark: "#818cf8", accentLight: "#5457e9", bgDark: "#1e1b18", bgLight: "#e7e5e4"),
         .init("claude", "Claude", "Warm parchment, muted ink, burnt-clay primary.",
               accentDark: "#d97757", accentLight: "#c96442", bgDark: "#262624", bgLight: "#faf9f5"),
         .init("pastel-dreams", "Pastel Dreams", "Soft violet pastels, lifted surfaces.",
-              accentDark: "#c0aafd", accentLight: "#a78bfa", bgDark: "#1c1917", bgLight: "#f7f3f9"),
+              accentDark: "#c0aafd", accentLight: "#9377e6", bgDark: "#1c1917", bgLight: "#f7f3f9"),
         .init("meatseeks", "Meatseeks", "Supabase green over crisp utility surfaces.",
-              accentDark: "#006239", accentLight: "#72e3ad", bgDark: "#121212", bgLight: "#fcfcfc"),
+              accentDark: "#1d7449", accentLight: "#279c6b", bgDark: "#121212", bgLight: "#fcfcfc"),
         .init("trucker", "Trucker", "Roadside evergreen, blacktop panels, cab lights.",
-              accentDark: "#005735", accentLight: "#005735", bgDark: "#020504", bgLight: "#f5fcf9"),
+              accentDark: "#21704a", accentLight: "#005735", bgDark: "#020504", bgLight: "#f5fcf9"),
     ]
 
     /// Look up a theme by id, for resolving the published `themeId` to a name.

--- a/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ThemeRoster.swift
@@ -83,6 +83,12 @@ enum ThemeRoster {
               accentDark: "#1d7449", accentLight: "#279c6b", bgDark: "#121212", bgLight: "#fcfcfc"),
         .init("trucker", "Trucker", "Roadside evergreen, blacktop panels, cab lights.",
               accentDark: "#21704a", accentLight: "#005735", bgDark: "#020504", bgLight: "#f5fcf9"),
+        .init("contrast", "High Contrast", "Maximum-legibility ward. Nothing whispered.",
+              accentDark: "#ffd60a", accentLight: "#0f62fe", bgDark: "#000000", bgLight: "#ffffff"),
+        .init("beacon", "Beacon", "Signal-fire blue-orange; colorblind-considerate.",
+              accentDark: "#f5a623", accentLight: "#a34d00", bgDark: "#030a13", bgLight: "#f2f7fd"),
+        .init("solstice", "Solstice", "Midsummer gold leaf on long shadow.",
+              accentDark: "#e3b341", accentLight: "#7a5c00", bgDark: "#0e0903", bgLight: "#fbf7eb"),
     ]
 
     /// Look up a theme by id, for resolving the published `themeId` to a name.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -422,6 +422,7 @@ export const SUITES = {
     "src/lib/chat-archive-nudge.test.ts",
     "src/components/chat-archive-nudge.test.ts",
     "src/lib/theme-palettes.test.ts",
+    "src/lib/theme-contrast-audit.test.ts",
     "src/lib/title-enricher.test.ts",
     "src/lib/url-safety.test.ts",
     "src/lib/use-focus-trap.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4628,6 +4628,135 @@ textarea.required-inputs-control {
   --ring-focus: color-mix(in oklch, #525258 55%, var(--foreground) 45%);
 }
 
+/* ---- High Contrast — maximum-legibility ward; AAA text everywhere ----
+   Built for low vision: true black/white surfaces, 7:1+ body text, a
+   goldenrod accent that clears 3:1 as a non-text mark on both modes. */
+[data-theme="contrast"] {
+  --background: #000000;
+  --foreground: #ffffff;
+  --card: #0d0d0d;
+  --popover: #0d0d0d;
+  --muted: #1a1a1a;
+  --accent: #1a1a1a;
+  --secondary: #1a1a1a;
+  --muted-foreground: #d9d9d9;
+  --accent-presence: #ffd60a;
+  --accent-presence-foreground: #000000;
+  --ring: #ffd60a;
+  --border: #666666;
+  --border-strong: #9a9a9a;
+  --text-muted: #cccccc;
+  --bg-base: var(--background);
+  --bg-panel: #050505;
+  --bg-raised: var(--card);
+  --bg-elevated: #161616;
+  --bg-hover: #222222;
+  --ring-focus: #ffd60a;
+}
+[data-theme="contrast"][data-mode="light"] {
+  --background: #ffffff;
+  --foreground: #000000;
+  --card: #f2f2f2;
+  --popover: #fafafa;
+  --muted: #e6e6e6;
+  --accent: #e6e6e6;
+  --secondary: #e6e6e6;
+  --muted-foreground: #262626;
+  --accent-presence: #0f62fe;
+  --accent-presence-foreground: #ffffff;
+  --ring: #0f62fe;
+  --border: #8c8c8c;
+  --border-strong: #595959;
+  --text-muted: #333333;
+  --bg-base: var(--background);
+  --bg-panel: #fcfcfc;
+  --bg-raised: var(--card);
+  --bg-elevated: #e9e9e9;
+  --bg-hover: #dedede;
+  --ring-focus: #0f62fe;
+}
+
+/* ---- Beacon (harbor 250/60) — signal-fire on a night sea ----
+   Colorblind-considerate: the palette leans on the blue↔orange axis,
+   which stays distinct under deutan/protan vision; nothing important
+   rides a red↔green difference. */
+[data-theme="beacon"] {
+  --background: oklch(0.14 0.025 250);
+  --card: oklch(0.175 0.028 250);
+  --popover: oklch(0.175 0.028 250);
+  --muted: oklch(0.22 0.030 250);
+  --accent: oklch(0.22 0.030 250);
+  --secondary: oklch(0.22 0.030 250);
+  --muted-foreground: oklch(0.72 0.030 250);
+  --accent-presence: #f5a623;
+  --accent-presence-foreground: #000000;
+  --ring: oklch(0.68 0.14 65);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.11 0.022 250);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.22 0.030 250);
+  --bg-hover: oklch(0.26 0.032 250);
+  --ring-focus: color-mix(in oklch, #f5a623 55%, var(--foreground) 45%);
+}
+[data-theme="beacon"][data-mode="light"] {
+  --background: oklch(0.975 0.010 250);
+  --foreground: oklch(0.17 0.030 250);
+  --card: oklch(0.94 0.012 250);
+  --popover: oklch(0.965 0.012 250);
+  --muted: oklch(0.90 0.016 250);
+  --accent: oklch(0.90 0.016 250);
+  --secondary: oklch(0.90 0.016 250);
+  --muted-foreground: oklch(0.40 0.030 250);
+  --accent-presence: #a34d00;
+  --accent-presence-foreground: #ffffff;
+  --ring: oklch(0.50 0.13 65);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.99 0.008 250);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.91 0.014 250);
+  --bg-hover: oklch(0.87 0.018 250);
+  --ring-focus: color-mix(in oklch, #a34d00 55%, var(--foreground) 45%);
+}
+
+/* ---- Solstice (midsummer 85) — long light, gold leaf on shadow ---- */
+[data-theme="solstice"] {
+  --background: oklch(0.145 0.020 85);
+  --card: oklch(0.185 0.022 85);
+  --popover: oklch(0.185 0.022 85);
+  --muted: oklch(0.23 0.024 85);
+  --accent: oklch(0.23 0.024 85);
+  --secondary: oklch(0.23 0.024 85);
+  --muted-foreground: oklch(0.72 0.040 85);
+  --accent-presence: #e3b341;
+  --accent-presence-foreground: #000000;
+  --ring: oklch(0.70 0.13 85);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.115 0.018 85);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.23 0.024 85);
+  --bg-hover: oklch(0.27 0.026 85);
+  --ring-focus: color-mix(in oklch, #e3b341 55%, var(--foreground) 45%);
+}
+[data-theme="solstice"][data-mode="light"] {
+  --background: oklch(0.975 0.016 90);
+  --foreground: oklch(0.19 0.030 85);
+  --card: oklch(0.94 0.020 90);
+  --popover: oklch(0.965 0.018 90);
+  --muted: oklch(0.90 0.026 90);
+  --accent: oklch(0.90 0.026 90);
+  --secondary: oklch(0.90 0.026 90);
+  --muted-foreground: oklch(0.40 0.036 85);
+  --accent-presence: #7a5c00;
+  --accent-presence-foreground: #ffffff;
+  --ring: oklch(0.48 0.11 85);
+  --bg-base: var(--background);
+  --bg-panel: oklch(0.99 0.012 90);
+  --bg-raised: var(--card);
+  --bg-elevated: oklch(0.91 0.022 90);
+  --bg-hover: oklch(0.87 0.026 90);
+  --ring-focus: color-mix(in oklch, #7a5c00 55%, var(--foreground) 45%);
+}
+
 /* ────────────────────────────────────────────────
    Edge-rail chip — the pressable chip the collapsed chat-projects
    strip uses for its reopen tab. (The familiar trigger rails that

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -50,7 +50,10 @@
   --accent: oklch(0.20 0.028 293);
   --accent-foreground: oklch(0.985 0 0);
   --border: color-mix(in oklch, var(--foreground) 12%, transparent);
-  --border-strong: color-mix(in oklch, var(--foreground) 22%, transparent);
+  /* WCAG 1.4.11: --border-strong marks interactive boundaries (inputs,
+     emphasized dividers) and must read at ≥3:1 against the base surface —
+     22% composited under 2:1 on every theme. Hairline stays decorative. */
+  --border-strong: color-mix(in oklch, var(--foreground) 48%, transparent);
   --input: color-mix(in oklch, var(--foreground) 18%, transparent);
   --ring: oklch(0.55 0.08 293);
 
@@ -61,7 +64,9 @@
   --accent-presence-foreground: var(--primary-foreground);
   --accent-presence-soft: oklch(0.72 0.08 295);
   --brand: var(--accent-presence);
-  --brand-foreground: oklch(0.985 0 0);
+  /* Follows the per-theme ink choice — hardcoded white failed AA on every
+     palette whose accent is light (22 of 32 theme×mode combos). */
+  --brand-foreground: var(--accent-presence-foreground);
 
   /* ---- Issue #14 named aliases ----
      Semantic names called out in the spec. Resolve to the same
@@ -79,11 +84,11 @@
   --fg-muted: var(--text-secondary);
   --text-primary: var(--foreground);
   --text-secondary: var(--muted-foreground);
-  /* CHAT-D13-02: 40% alpha composited ~3:1 on the dark panel ladder — under
-     AA for the 9-11px labels that consume this token. 55% lands ~6:1 over
-     --card/--bg-elevated while still reading as muted next to
-     --text-secondary. Light mode needs its own ratio (override below). */
-  --text-muted: color-mix(in oklch, var(--foreground) 55%, transparent);
+  /* CHAT-D13-02 → a11y audit 2026-07: the 9-11px labels consuming this token
+     need full AA (4.5:1) on every premade palette, not just Coven's. 72%
+     keeps it visibly quieter than --text-secondary while clearing 4.5:1 on
+     the whole panel ladder across themes (theme-contrast-audit.test.ts). */
+  --text-muted: color-mix(in oklch, var(--foreground) 72%, transparent);
 
   /* ---- Radii ---- */
   --radius: 0.625rem;
@@ -181,7 +186,11 @@
      Single source of truth for keyboard focus. Pair with
      `outline: none` on the element and apply via box-shadow or
      outline-width. */
-  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  /* Solid, not translucent: a keyboard focus indicator must hit 3:1 against
+     the surface (WCAG 1.4.11 / 2.4.13). Mixing toward --foreground keeps the
+     accent hue while guaranteeing visibility on every theme; the -soft glow
+     below stays translucent for decoration. */
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, var(--foreground) 45%);
   --ring-focus-soft: color-mix(in oklch, var(--accent-presence) 30%, transparent);
   --ring-width: 2px;
   --ring-offset: 2px;
@@ -266,14 +275,17 @@
 
   --text-primary: var(--foreground);
   --text-secondary: var(--muted-foreground);
-  /* --border, --border-strong, --input are derived from --foreground;
-     they auto-invert. No override needed. */
-  /* CHAT-D13-02: dark ink over near-white needs a higher mix than light ink
-     over near-black for the same contrast — 55% composites ~4.1:1 here; 62%
-     lands ~5:1 against --background/--card. */
-  --text-muted: color-mix(in oklch, var(--foreground) 62%, transparent);
+  /* --border and --input derive from --foreground and auto-invert; the
+     strong border needs a higher ink mix over near-white to hold 3:1
+     (WCAG 1.4.11), same asymmetry as --text-muted below. */
+  --border-strong: color-mix(in oklch, var(--foreground) 60%, transparent);
+  /* CHAT-D13-02 → a11y audit 2026-07: dark ink over near-white needs a
+     higher mix than light ink over near-black for the same contrast — 76%
+     clears 4.5:1 across every premade light palette. */
+  --text-muted: color-mix(in oklch, var(--foreground) 76%, transparent);
 
-  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  /* Solid for 3:1 focus visibility — see the dark-mode note. */
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, var(--foreground) 45%);
   --ring-focus-soft: color-mix(in oklch, var(--accent-presence) 30%, transparent);
   --backdrop-scrim: oklch(0 0 0 / 40%);
 
@@ -3788,7 +3800,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.18 0.040 245);
   --bg-hover: oklch(0.22 0.042 245);
-  --ring-focus: color-mix(in oklch, #5FB0FF 55%, transparent);
+  --ring-focus: color-mix(in oklch, #5FB0FF 55%, var(--foreground) 45%);
 }
 [data-theme="tide"][data-mode="light"] {
   --background: oklch(0.97 0.020 240);
@@ -3806,7 +3818,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.91 0.024 240);
   --bg-hover: oklch(0.87 0.028 240);
-  --ring-focus: color-mix(in oklch, #2E6FC9 55%, transparent);
+  --ring-focus: color-mix(in oklch, #2E6FC9 55%, var(--foreground) 45%);
 }
 
 /* ---- Grove (hexenwald 150) — damp, patient, full of teeth ---- */
@@ -3825,7 +3837,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.18 0.044 150);
   --bg-hover: oklch(0.22 0.046 150);
-  --ring-focus: color-mix(in oklch, #7FD89F 55%, transparent);
+  --ring-focus: color-mix(in oklch, #7FD89F 55%, var(--foreground) 45%);
 }
 [data-theme="grove"][data-mode="light"] {
   --background: oklch(0.97 0.018 145);
@@ -3843,7 +3855,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.91 0.022 145);
   --bg-hover: oklch(0.87 0.026 145);
-  --ring-focus: color-mix(in oklch, #2A8050 55%, transparent);
+  --ring-focus: color-mix(in oklch, #2A8050 55%, var(--foreground) 45%);
 }
 
 /* ---- Vintage Paper (id: ember) — warm tan ink steeped into aged folio.
@@ -3870,7 +3882,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.3795 0.0181 57.1280);
   --bg-hover: oklch(0.4186 0.0281 56.3404);
-  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, var(--foreground) 45%);
 }
 [data-theme="ember"][data-mode="light"] {
   --background: oklch(0.9582 0.0152 90.2357);
@@ -3882,8 +3894,9 @@ textarea.required-inputs-control {
   --muted: oklch(0.9239 0.0190 83.0636);
   --accent: oklch(0.8348 0.0426 88.8064);
   --secondary: oklch(0.8846 0.0302 85.5655);
-  --muted-foreground: oklch(0.5391 0.0387 71.1655);
+  --muted-foreground: oklch(0.495 0.0387 71.1655);
   --accent-presence: oklch(0.6180 0.0778 65.5444);
+  --accent-presence-foreground: #111111;
   --accent-presence-soft: oklch(0.6180 0.060 65);
   --ring: oklch(0.6180 0.0778 65.5444);
   --border: oklch(0.8606 0.0321 84.5881);
@@ -3893,7 +3906,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.9239 0.0190 83.0636);
   --bg-hover: oklch(0.8846 0.0302 85.5655);
-  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  --ring-focus: color-mix(in oklch, var(--accent-presence) 55%, var(--foreground) 45%);
 }
 
 /* ---- Bloom (bewitching-blood 20) — saccharine looks; thorned hands ---- */
@@ -3912,7 +3925,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.19 0.046 20);
   --bg-hover: oklch(0.23 0.048 20);
-  --ring-focus: color-mix(in oklch, #F09BB1 55%, transparent);
+  --ring-focus: color-mix(in oklch, #F09BB1 55%, var(--foreground) 45%);
 }
 [data-theme="bloom"][data-mode="light"] {
   --background: oklch(0.975 0.018 20);
@@ -3924,13 +3937,14 @@ textarea.required-inputs-control {
   --secondary: oklch(0.91 0.026 20);
   --muted-foreground: oklch(0.44 0.036 20);
   --accent-presence: #BE506E;
+  --accent-presence-foreground: #ffffff;
   --ring: oklch(0.60 0.16 20);
   --bg-base: var(--background);
   --bg-panel: oklch(0.99 0.014 20);
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.92 0.024 20);
   --bg-hover: oklch(0.88 0.028 20);
-  --ring-focus: color-mix(in oklch, #BE506E 55%, transparent);
+  --ring-focus: color-mix(in oklch, #BE506E 55%, var(--foreground) 45%);
 }
 
 /* ---- Dusk (witching-hour 322) — the veil thins; so does your patience ---- */
@@ -3949,7 +3963,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.18 0.054 322);
   --bg-hover: oklch(0.22 0.056 322);
-  --ring-focus: color-mix(in oklch, #E175FF 55%, transparent);
+  --ring-focus: color-mix(in oklch, #E175FF 55%, var(--foreground) 45%);
 }
 [data-theme="dusk"][data-mode="light"] {
   --background: oklch(0.97 0.022 325);
@@ -3967,7 +3981,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.91 0.026 325);
   --bg-hover: oklch(0.87 0.030 325);
-  --ring-focus: color-mix(in oklch, #9930C2 55%, transparent);
+  --ring-focus: color-mix(in oklch, #9930C2 55%, var(--foreground) 45%);
 }
 
 /* ---- Mist (scrying-pool 198) — cold as a question without an answer ---- */
@@ -3986,7 +4000,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.17 0.034 198);
   --bg-hover: oklch(0.21 0.036 198);
-  --ring-focus: color-mix(in oklch, #6BD8D3 55%, transparent);
+  --ring-focus: color-mix(in oklch, #6BD8D3 55%, var(--foreground) 45%);
 }
 [data-theme="mist"][data-mode="light"] {
   --background: oklch(0.97 0.015 195);
@@ -3997,14 +4011,15 @@ textarea.required-inputs-control {
   --accent: oklch(0.90 0.022 195);
   --secondary: oklch(0.90 0.022 195);
   --muted-foreground: oklch(0.42 0.028 198);
-  --accent-presence: #1A857F;
+  --accent-presence: #177b76;
+  --accent-presence-foreground: #ffffff;
   --ring: oklch(0.55 0.14 198);
   --bg-base: var(--background);
   --bg-panel: oklch(0.99 0.010 195);
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.91 0.020 195);
   --bg-hover: oklch(0.87 0.024 195);
-  --ring-focus: color-mix(in oklch, #1A857F 55%, transparent);
+  --ring-focus: color-mix(in oklch, #1A857F 55%, var(--foreground) 45%);
 }
 
 /* ---- Hex (bloodletter 25) — the mark that doesn't wash off ---- */
@@ -4023,7 +4038,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.17 0.066 25);
   --bg-hover: oklch(0.21 0.068 25);
-  --ring-focus: color-mix(in oklch, #E04848 55%, transparent);
+  --ring-focus: color-mix(in oklch, #E04848 55%, var(--foreground) 45%);
 }
 [data-theme="hex"][data-mode="light"] {
   --background: oklch(0.97 0.022 25);
@@ -4041,7 +4056,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.91 0.026 25);
   --bg-hover: oklch(0.87 0.030 25);
-  --ring-focus: color-mix(in oklch, #A41C24 55%, transparent);
+  --ring-focus: color-mix(in oklch, #A41C24 55%, var(--foreground) 45%);
 }
 
 /* ---- Bane (wolfsbane 125) — bright; deeply unwise ---- */
@@ -4060,7 +4075,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.17 0.054 125);
   --bg-hover: oklch(0.21 0.056 125);
-  --ring-focus: color-mix(in oklch, #A5F050 55%, transparent);
+  --ring-focus: color-mix(in oklch, #A5F050 55%, var(--foreground) 45%);
 }
 [data-theme="bane"][data-mode="light"] {
   --background: oklch(0.97 0.022 125);
@@ -4078,7 +4093,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.91 0.026 125);
   --bg-hover: oklch(0.87 0.030 125);
-  --ring-focus: color-mix(in oklch, #4A7C18 55%, transparent);
+  --ring-focus: color-mix(in oklch, #4A7C18 55%, var(--foreground) 45%);
 }
 
 /* ---- Ghosty (tweakcn Ghostlyy) — spectral grayscale with soft graphite chrome ---- */
@@ -4096,7 +4111,7 @@ textarea.required-inputs-control {
   --muted: #1a1a1a;
   --muted-foreground: #a6a6a6;
   --accent: #a6a6a6;
-  --accent-foreground: #cccccc;
+  --accent-foreground: #1a1a1a;
   --destructive: #4d4d4d;
   --destructive-foreground: #fafafa;
   --border: #242424;
@@ -4111,8 +4126,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: #1e1e1e;
   --bg-hover: #242424;
-  --border-strong: color-mix(in oklch, #242424 62%, #a6a6a6 38%);
-  --ring-focus: color-mix(in oklch, #a6a6a6 55%, transparent);
+  --border-strong: #6a6a6a;
+  --ring-focus: color-mix(in oklch, #a6a6a6 55%, var(--foreground) 45%);
   --chart-1: #a6a6a6;
   --chart-2: #999999;
   --chart-3: #b3b3b3;
@@ -4127,7 +4142,7 @@ textarea.required-inputs-control {
   --popover: #fafafa;
   --popover-foreground: #1a1a1a;
   --primary: #808080;
-  --primary-foreground: #fafafa;
+  --primary-foreground: #111111;
   --secondary: #272727;
   --secondary-foreground: #fafafa;
   --muted: #ebebeb;
@@ -4135,12 +4150,12 @@ textarea.required-inputs-control {
   --accent: #f2f2f2;
   --accent-foreground: #666666;
   --destructive: #999999;
-  --destructive-foreground: #fafafa;
+  --destructive-foreground: #111111;
   --border: #e5e5e5;
   --input: #e5e5e5;
   --ring: #808080;
   --accent-presence: #808080;
-  --accent-presence-foreground: #fafafa;
+  --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #808080 78%, transparent);
   --accent-faint: color-mix(in oklch, #808080 14%, transparent);
   --bg-base: var(--background);
@@ -4148,8 +4163,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: #f2f2f2;
   --bg-hover: #ebebeb;
-  --border-strong: color-mix(in oklch, #e5e5e5 62%, #808080 38%);
-  --ring-focus: color-mix(in oklch, #808080 55%, transparent);
+  --border-strong: #8c8c8c;
+  --ring-focus: color-mix(in oklch, #808080 55%, var(--foreground) 45%);
   --chart-1: #808080;
   --chart-2: #272727;
   --chart-3: #999999;
@@ -4198,8 +4213,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #3a3633 62%, #818cf8 38%);
-  --ring-focus: color-mix(in oklch, #818cf8 55%, transparent);
+  --border-strong: #8e5e69;
+  --ring-focus: color-mix(in oklch, #818cf8 55%, var(--foreground) 45%);
   --chart-1: #818cf8;
   --chart-2: #6366f1;
   --chart-3: #4f46e5;
@@ -4213,20 +4228,20 @@ textarea.required-inputs-control {
   --card-foreground: #1e293b;
   --popover: #f5f5f4;
   --popover-foreground: #1e293b;
-  --primary: #6366f1;
+  --primary: #5457e9;
   --primary-foreground: #ffffff;
   --secondary: #d6d3d1;
   --secondary-foreground: #4b5563;
   --muted: #e7e5e4;
-  --muted-foreground: #6b7280;
+  --muted-foreground: #555c6a;
   --accent: #f3e5f5;
   --accent-foreground: #374151;
-  --destructive: #ef4444;
+  --destructive: #dc2626;
   --destructive-foreground: #ffffff;
   --border: #d6d3d1;
   --input: #d6d3d1;
-  --ring: #6366f1;
-  --accent-presence: #6366f1;
+  --ring: #5457e9;
+  --accent-presence: #5457e9;
   --accent-presence-foreground: #ffffff;
   --accent-presence-soft: color-mix(in oklch, #6366f1 78%, transparent);
   --accent-faint: color-mix(in oklch, #6366f1 14%, transparent);
@@ -4235,8 +4250,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #d6d3d1 62%, #6366f1 38%);
-  --ring-focus: color-mix(in oklch, #6366f1 55%, transparent);
+  --border-strong: #b07281;
+  --ring-focus: color-mix(in oklch, #6366f1 55%, var(--foreground) 45%);
   --chart-1: #6366f1;
   --chart-2: #4f46e5;
   --chart-3: #4338ca;
@@ -4260,20 +4275,20 @@ textarea.required-inputs-control {
   --popover: #30302e;
   --popover-foreground: #e5e5e2;
   --primary: #d97757;
-  --primary-foreground: #ffffff;
+  --primary-foreground: #111111;
   --secondary: #faf9f5;
   --secondary-foreground: #30302e;
   --muted: #1b1b19;
   --muted-foreground: #b7b5a9;
   --accent: #1a1915;
   --accent-foreground: #f5f4ee;
-  --destructive: #ef4444;
+  --destructive: #dc2626;
   --destructive-foreground: #ffffff;
   --border: #3e3e38;
   --input: #52514a;
   --ring: #d97757;
   --accent-presence: #d97757;
-  --accent-presence-foreground: #ffffff;
+  --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #d97757 78%, transparent);
   --accent-faint: color-mix(in oklch, #d97757 14%, transparent);
   --bg-base: var(--background);
@@ -4281,8 +4296,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: #30302e;
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #3e3e38 62%, #d97757 38%);
-  --ring-focus: color-mix(in oklch, #d97757 55%, transparent);
+  --border-strong: #806c49;
+  --ring-focus: color-mix(in oklch, #d97757 55%, var(--foreground) 45%);
   --chart-1: #b05730;
   --chart-2: #9c87f5;
   --chart-3: #1a1915;
@@ -4297,11 +4312,11 @@ textarea.required-inputs-control {
   --popover: #ffffff;
   --popover-foreground: #28261b;
   --primary: #c96442;
-  --primary-foreground: #ffffff;
+  --primary-foreground: #111111;
   --secondary: #e9e6dc;
   --secondary-foreground: #535146;
   --muted: #ede9de;
-  --muted-foreground: #83827d;
+  --muted-foreground: #676661;
   --accent: #e9e6dc;
   --accent-foreground: #28261b;
   --destructive: #141413;
@@ -4310,7 +4325,7 @@ textarea.required-inputs-control {
   --input: #b4b2a7;
   --ring: #c96442;
   --accent-presence: #c96442;
-  --accent-presence-foreground: #ffffff;
+  --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #c96442 78%, transparent);
   --accent-faint: color-mix(in oklch, #c96442 14%, transparent);
   --bg-base: var(--background);
@@ -4318,8 +4333,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #dad9d4 62%, #c96442 38%);
-  --ring-focus: color-mix(in oklch, #c96442 55%, transparent);
+  --border-strong: #a68d6b;
+  --ring-focus: color-mix(in oklch, #c96442 55%, var(--foreground) 45%);
   --chart-1: #b05730;
   --chart-2: #9c87f5;
   --chart-3: #ded8c4;
@@ -4368,8 +4383,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #3f324a 62%, #c0aafd 38%);
-  --ring-focus: color-mix(in oklch, #c0aafd 55%, transparent);
+  --border-strong: #705d89;
+  --ring-focus: color-mix(in oklch, #c0aafd 55%, var(--foreground) 45%);
   --chart-1: #c0aafd;
   --chart-2: #a78bfa;
   --chart-3: #8b5cf6;
@@ -4384,20 +4399,21 @@ textarea.required-inputs-control {
   --popover: #ffffff;
   --popover-foreground: #374151;
   --primary: #a78bfa;
-  --primary-foreground: #ffffff;
+  --primary-foreground: #111111;
   --secondary: #e9d8fd;
   --secondary-foreground: #4b5563;
   --muted: #f3e8ff;
-  --muted-foreground: #6b7280;
+  --muted-foreground: #555c6a;
+  --text-muted: color-mix(in oklch, var(--foreground) 84%, transparent);
   --accent: #f3e5f5;
   --accent-foreground: #374151;
   --destructive: #fca5a5;
-  --destructive-foreground: #ffffff;
+  --destructive-foreground: #111111;
   --border: #e9d8fd;
   --input: #e9d8fd;
-  --ring: #a78bfa;
-  --accent-presence: #a78bfa;
-  --accent-presence-foreground: #ffffff;
+  --ring: #9377e6;
+  --accent-presence: #9377e6;
+  --accent-presence-foreground: #111111;
   --accent-presence-soft: color-mix(in oklch, #a78bfa 78%, transparent);
   --accent-faint: color-mix(in oklch, #a78bfa 14%, transparent);
   --bg-base: var(--background);
@@ -4405,8 +4421,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #e9d8fd 62%, #a78bfa 38%);
-  --ring-focus: color-mix(in oklch, #a78bfa 55%, transparent);
+  --border-strong: #9077b8;
+  --ring-focus: color-mix(in oklch, #a78bfa 55%, var(--foreground) 45%);
   --chart-1: #a78bfa;
   --chart-2: #8b5cf6;
   --chart-3: #7c3aed;
@@ -4444,8 +4460,8 @@ textarea.required-inputs-control {
   --border: #292929;
   --input: #242424;
   --ring: #4ade80;
-  --accent-presence: #006239;
-  --accent-presence-foreground: #dde8e3;
+  --accent-presence: #1d7449;
+  --accent-presence-foreground: #ffffff;
   --accent-presence-soft: color-mix(in oklch, #006239 78%, transparent);
   --accent-faint: color-mix(in oklch, #006239 14%, transparent);
   --bg-base: var(--background);
@@ -4453,8 +4469,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #292929 62%, #4ade80 38%);
-  --ring-focus: color-mix(in oklch, #4ade80 55%, transparent);
+  --border-strong: #427050;
+  --ring-focus: color-mix(in oklch, #4ade80 55%, var(--foreground) 45%);
   --chart-1: #4ade80;
   --chart-2: #60a5fa;
   --chart-3: #a78bfa;
@@ -4480,9 +4496,9 @@ textarea.required-inputs-control {
   --destructive-foreground: #fffcfc;
   --border: #dfdfdf;
   --input: #f6f6f6;
-  --ring: #72e3ad;
-  --accent-presence: #72e3ad;
-  --accent-presence-foreground: #1e2723;
+  --ring: #279c6b;
+  --accent-presence: #279c6b;
+  --accent-presence-foreground: #0d120f;
   --accent-presence-soft: color-mix(in oklch, #72e3ad 78%, transparent);
   --accent-faint: color-mix(in oklch, #72e3ad 14%, transparent);
   --bg-base: var(--background);
@@ -4490,8 +4506,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #dfdfdf 62%, #72e3ad 38%);
-  --ring-focus: color-mix(in oklch, #72e3ad 55%, transparent);
+  --border-strong: #6f927e;
+  --ring-focus: color-mix(in oklch, #72e3ad 55%, var(--foreground) 45%);
   --chart-1: #72e3ad;
   --chart-2: #3b82f6;
   --chart-3: #8b5cf6;
@@ -4515,12 +4531,12 @@ textarea.required-inputs-control {
   --muted-foreground: #a8c7b8;
   --accent: #005735;
   --accent-foreground: #ffffff;
-  --destructive: #ef4444;
+  --destructive: #dc2626;
   --destructive-foreground: #ffffff;
   --border: #14241e;
   --input: #14241e;
-  --ring: #005735;
-  --accent-presence: #005735;
+  --ring: #21704a;
+  --accent-presence: #21704a;
   --accent-presence-foreground: #ffffff;
   --accent-presence-soft: color-mix(in oklch, #005735 78%, transparent);
   --accent-faint: color-mix(in oklch, #005735 14%, transparent);
@@ -4529,8 +4545,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #14241e 62%, #005735 38%);
-  --ring-focus: color-mix(in oklch, #005735 55%, transparent);
+  --border-strong: #426a58;
+  --ring-focus: color-mix(in oklch, #005735 55%, var(--foreground) 45%);
   --chart-1: #005735;
   --chart-2: #007a4a;
   --chart-3: #009c60;
@@ -4566,8 +4582,8 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: var(--secondary);
   --bg-hover: var(--accent);
-  --border-strong: color-mix(in oklch, #d1e0d9 62%, #005735 38%);
-  --ring-focus: color-mix(in oklch, #005735 55%, transparent);
+  --border-strong: #6f9280;
+  --ring-focus: color-mix(in oklch, #005735 55%, var(--foreground) 45%);
   --chart-1: #005735;
   --chart-2: #208b5e;
   --chart-3: #40bd8a;
@@ -4591,7 +4607,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.14 0.000 0);
   --bg-hover: oklch(0.18 0.000 0);
-  --ring-focus: color-mix(in oklch, #B8B8C2 55%, transparent);
+  --ring-focus: color-mix(in oklch, #B8B8C2 55%, var(--foreground) 45%);
 }
 [data-theme="slate"][data-mode="light"] {
   --background: oklch(0.985 0.000 0);
@@ -4609,7 +4625,7 @@ textarea.required-inputs-control {
   --bg-raised: var(--card);
   --bg-elevated: oklch(0.93 0.000 0);
   --bg-hover: oklch(0.89 0.000 0);
-  --ring-focus: color-mix(in oklch, #525258 55%, transparent);
+  --ring-focus: color-mix(in oklch, #525258 55%, var(--foreground) 45%);
 }
 
 /* ────────────────────────────────────────────────

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -45,8 +45,14 @@ assert.match(
 
 console.log("globals.css.test.ts (task 3) OK");
 
-// Task 4 assertions: the 9 non-default themes each have dark + light blocks.
-const otherThemes = ["tide", "grove", "ember", "bloom", "dusk", "mist", "hex", "bane", "slate"];
+// Task 4 assertions: every non-default theme has dark + light blocks —
+// including the tweakcn ports and the a11y additions (contrast/beacon/
+// solstice), which the original loop of 9 never covered.
+const otherThemes = [
+  "tide", "grove", "ember", "bloom", "dusk", "mist", "hex", "bane", "slate",
+  "ghosty", "claymorphism", "claude", "pastel-dreams", "meatseeks", "trucker",
+  "contrast", "beacon", "solstice",
+];
 for (const id of otherThemes) {
   const darkRe = new RegExp(`\\[data-theme="${id}"\\]\\s*\\{`);
   const lightRe = new RegExp(`\\[data-theme="${id}"\\]\\[data-mode="light"\\]\\s*\\{`);

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -255,13 +255,13 @@ assert.match(
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 assert.match(
   globals,
-  /--text-muted: color-mix\(in oklch, var\(--foreground\) 55%, transparent\);/,
-  "Dark-mode --text-muted mixes at 55% (≥4.5:1 over the panel ladder, CHAT-D13-02)",
+  /--text-muted: color-mix\(in oklch, var\(--foreground\) 72%, transparent\);/,
+  "Dark-mode --text-muted mixes at 72% — 55% passed AA only on Coven; 72% clears 4.5:1 on every premade palette (theme-contrast-audit.test.ts)",
 );
 assert.match(
   globals,
-  /--text-muted: color-mix\(in oklch, var\(--foreground\) 62%, transparent\);/,
-  "Light-mode --text-muted overrides to 62% (dark ink needs a higher mix for the same contrast)",
+  /--text-muted: color-mix\(in oklch, var\(--foreground\) 76%, transparent\);/,
+  "Light-mode --text-muted overrides to 76% (dark ink needs a higher mix for the same contrast)",
 );
 assert.doesNotMatch(
   globals,

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -33,7 +33,7 @@ const THEME_SCRIPT = `
 (function () {
   try {
     var rename = { "mood-c": "coven", "sky": "tide", "orchid": "dusk", "midnight": "slate" };
-    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","pastel-dreams","meatseeks","trucker","custom"];
+    var valid = ["coven","tide","grove","ember","bloom","dusk","mist","hex","bane","slate","ghosty","claymorphism","claude","pastel-dreams","meatseeks","trucker","contrast","beacon","solstice","custom"];
     var theme = localStorage.getItem("coven-theme") || "coven";
     if (rename[theme]) {
       theme = rename[theme];

--- a/src/lib/theme-contrast-audit.test.ts
+++ b/src/lib/theme-contrast-audit.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import {
+  themeTokens,
+  resolveThemeColor,
+  parseThemeColor,
+  flattenOnto,
+  contrastRatio,
+  type TokenMap,
+  type Rgba,
+} from "./theme-contrast.ts";
+import { THEME_IDS } from "./theme-palettes.ts";
+
+// ── unit sanity for the color math ──────────────────────────────────────────
+
+{
+  // Known WCAG anchors.
+  const white = parseThemeColor("#ffffff")!;
+  const black = parseThemeColor("#000000")!;
+  assert.equal(contrastRatio(white, black).toFixed(0), "21");
+  assert.equal(contrastRatio(white, white).toFixed(0), "1");
+
+  // oklch pure white/black round-trip.
+  assert.ok(contrastRatio(parseThemeColor("oklch(1 0 0)")!, black) > 20.9);
+  assert.ok(contrastRatio(parseThemeColor("oklch(0 0 0)")!, white) > 20.9);
+
+  // color-mix with transparent scales alpha; flattening composites it.
+  const mixed = parseThemeColor("color-mix(in oklch, #ffffff 50%, transparent)")!;
+  assert.ok(Math.abs(mixed.alpha - 0.5) < 1e-6);
+  const flattened = flattenOnto(mixed, black);
+  assert.ok(Math.abs(flattened.r - 0.5) < 0.02);
+
+  // var() resolution incl. fallback.
+  const tokens: TokenMap = new Map([
+    ["--a", "#336699"],
+    ["--b", "var(--a)"],
+    ["--c", "var(--missing, var(--b))"],
+  ]);
+  assert.equal(resolveThemeColor(tokens, "--c")!.b > 0.5, true);
+}
+
+// ── the shipping gate: every premade palette meets WCAG 2.1 ────────────────
+// Text pairs need AA 4.5:1; non-text UI (focus rings, presence accents,
+// strong borders) needs 3:1 per §1.4.11. If this fails after a palette edit,
+// the palette is what has to change — not the thresholds.
+
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+const OPAQUE_BLACK: Rgba = { r: 0, g: 0, b: 0, alpha: 1 };
+
+function surface(tokens: TokenMap, bgToken: string): Rgba | null {
+  const base = resolveThemeColor(tokens, "--bg-base");
+  const bg = resolveThemeColor(tokens, bgToken);
+  if (!bg) return null;
+  const flatBase = base ? flattenOnto(base, OPAQUE_BLACK) : OPAQUE_BLACK;
+  return flattenOnto(bg, flatBase);
+}
+
+type Pair = { fg: string; bg: string; min: number };
+const PAIRS: Pair[] = [
+  { fg: "--text-primary", bg: "--bg-base", min: 4.5 },
+  { fg: "--text-primary", bg: "--bg-elevated", min: 4.5 },
+  { fg: "--text-secondary", bg: "--bg-base", min: 4.5 },
+  { fg: "--text-secondary", bg: "--bg-raised", min: 4.5 },
+  { fg: "--text-secondary", bg: "--bg-elevated", min: 4.5 },
+  { fg: "--text-muted", bg: "--bg-base", min: 4.5 },
+  { fg: "--text-muted", bg: "--bg-panel", min: 4.5 },
+  { fg: "--muted-foreground", bg: "--background", min: 4.5 },
+  { fg: "--muted-foreground", bg: "--card", min: 4.5 },
+  { fg: "--card-foreground", bg: "--card", min: 4.5 },
+  { fg: "--popover-foreground", bg: "--popover", min: 4.5 },
+  { fg: "--secondary-foreground", bg: "--secondary", min: 4.5 },
+  { fg: "--accent-foreground", bg: "--accent", min: 4.5 },
+  { fg: "--primary-foreground", bg: "--primary", min: 4.5 },
+  { fg: "--accent-presence-foreground", bg: "--accent-presence", min: 4.5 },
+  { fg: "--destructive-foreground", bg: "--destructive", min: 4.5 },
+  { fg: "--brand-foreground", bg: "--brand", min: 4.5 },
+  { fg: "--accent-presence", bg: "--bg-base", min: 3 },
+  { fg: "--ring", bg: "--background", min: 3 },
+  { fg: "--ring-focus", bg: "--bg-base", min: 3 },
+  { fg: "--border-strong", bg: "--bg-base", min: 3 },
+];
+
+const failures: string[] = [];
+let checked = 0;
+for (const id of THEME_IDS) {
+  for (const mode of ["dark", "light"] as const) {
+    const tokens = themeTokens(css, id, mode);
+    // Guard the extraction itself: a regression that empties a theme's block
+    // would otherwise "pass" by having nothing to check.
+    assert.ok(
+      resolveThemeColor(tokens, "--bg-base"),
+      `${id}/${mode}: --bg-base must resolve to a color (theme block extraction broke?)`,
+    );
+    for (const pair of PAIRS) {
+      const fg = resolveThemeColor(tokens, pair.fg);
+      const bg = surface(tokens, pair.bg);
+      if (!fg || !bg) continue; // token not used by this theme
+      checked++;
+      const ratio = contrastRatio(flattenOnto(fg, bg), bg);
+      if (ratio < pair.min) {
+        failures.push(
+          `${id} ${mode}: ${pair.fg} on ${pair.bg} = ${ratio.toFixed(2)} (needs ${pair.min})`,
+        );
+      }
+    }
+  }
+}
+
+assert.ok(checked > 600, `expected to audit >600 pairs, only checked ${checked}`);
+assert.deepEqual(
+  failures,
+  [],
+  `WCAG contrast regressions:\n${failures.join("\n")}`,
+);
+
+// The High Contrast theme holds itself to AAA body text (7:1), both modes.
+for (const mode of ["dark", "light"] as const) {
+  const tokens = themeTokens(css, "contrast", mode);
+  for (const [fg, bg] of [
+    ["--text-primary", "--bg-base"],
+    ["--text-secondary", "--bg-base"],
+    ["--text-muted", "--bg-panel"],
+  ] as const) {
+    const f = resolveThemeColor(tokens, fg)!;
+    const b = surface(tokens, bg)!;
+    const ratio = contrastRatio(flattenOnto(f, b), b);
+    assert.ok(ratio >= 7, `contrast/${mode}: ${fg} on ${bg} = ${ratio.toFixed(2)} — AAA (7:1) required`);
+  }
+}
+
+console.log(`theme-contrast-audit: ${checked} pairs across ${THEME_IDS.length} themes × 2 modes, 0 failures`);

--- a/src/lib/theme-contrast.ts
+++ b/src/lib/theme-contrast.ts
@@ -1,0 +1,383 @@
+/**
+ * Pure color math for auditing the premade theme palettes against WCAG 2.1.
+ *
+ * globals.css authors tokens in oklch()/color-mix()/hex/hsl with var()
+ * references; nothing in Node could read those (readable-text-color.ts parses
+ * hex/rgb only, and the runtime path rasterizes through a browser canvas).
+ * This module evaluates the shipped CSS directly so a test can compute real
+ * contrast ratios for every theme × mode without a DOM.
+ *
+ * Conversion math is Björn Ottosson's reference OKLab implementation
+ * (https://bottosson.github.io/posts/oklab/); WCAG relative luminance and
+ * contrast ratio follow WCAG 2.1 §1.4.3 definitions.
+ */
+
+export type Rgba = { r: number; g: number; b: number; alpha: number };
+
+// ── sRGB <-> linear <-> OKLab ───────────────────────────────────────────────
+
+function srgbToLinear(channel: number): number {
+  return channel <= 0.04045 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+}
+
+function linearToSrgb(channel: number): number {
+  const c = channel <= 0.0031308 ? channel * 12.92 : 1.055 * Math.pow(channel, 1 / 2.4) - 0.055;
+  return Math.min(1, Math.max(0, c));
+}
+
+type Oklab = { L: number; a: number; b: number; alpha: number };
+
+export function oklabToRgb({ L, a, b, alpha }: Oklab): Rgba {
+  const l_ = L + 0.3963377774 * a + 0.2158037573 * b;
+  const m_ = L - 0.1055613458 * a - 0.0638541728 * b;
+  const s_ = L - 0.0894841775 * a - 1.291485548 * b;
+  const l = l_ * l_ * l_;
+  const m = m_ * m_ * m_;
+  const s = s_ * s_ * s_;
+  return {
+    r: linearToSrgb(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s),
+    g: linearToSrgb(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s),
+    b: linearToSrgb(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s),
+    alpha,
+  };
+}
+
+export function rgbToOklab({ r, g, b, alpha }: Rgba): Oklab {
+  const lr = srgbToLinear(r);
+  const lg = srgbToLinear(g);
+  const lb = srgbToLinear(b);
+  const l = Math.cbrt(0.4122214708 * lr + 0.5363325363 * lg + 0.0514459929 * lb);
+  const m = Math.cbrt(0.2119034982 * lr + 0.6806995451 * lg + 0.1073969566 * lb);
+  const s = Math.cbrt(0.0883024619 * lr + 0.2817188376 * lg + 0.6299787005 * lb);
+  return {
+    L: 0.2104542553 * l + 0.793617785 * m - 0.0040720468 * s,
+    a: 1.9779984951 * l - 2.428592205 * m + 0.4505937099 * s,
+    b: 0.0259040371 * l + 0.7827717662 * m - 0.808675766 * s,
+    alpha,
+  };
+}
+
+// ── CSS color parsing ───────────────────────────────────────────────────────
+
+function parseHex(value: string): Rgba | null {
+  const m = value.match(/^#([0-9a-f]{3,8})$/i);
+  if (!m) return null;
+  let hex = m[1];
+  if (hex.length === 3 || hex.length === 4) {
+    hex = [...hex].map((c) => c + c).join("");
+  }
+  if (hex.length !== 6 && hex.length !== 8) return null;
+  const int = (offset: number) => parseInt(hex.slice(offset, offset + 2), 16) / 255;
+  return { r: int(0), g: int(2), b: int(4), alpha: hex.length === 8 ? int(6) : 1 };
+}
+
+function parseNumberOrPercent(token: string, percentScale: number): number {
+  const trimmed = token.trim();
+  if (trimmed.endsWith("%")) return (parseFloat(trimmed) / 100) * percentScale;
+  return parseFloat(trimmed);
+}
+
+function parseOklch(value: string): Rgba | null {
+  const m = value.match(/^oklch\(\s*([^)]+)\)$/i);
+  if (!m) return null;
+  const [core, alphaPart] = m[1].split("/");
+  const parts = core.trim().split(/\s+/);
+  if (parts.length < 3) return null;
+  const L = parseNumberOrPercent(parts[0], 1);
+  const C = parseNumberOrPercent(parts[1], 0.4);
+  const hRaw = parts[2] === "none" ? 0 : parseFloat(parts[2]);
+  const alpha = alphaPart ? parseNumberOrPercent(alphaPart, 1) : 1;
+  if (![L, C, hRaw, alpha].every(Number.isFinite)) return null;
+  const hRad = (hRaw * Math.PI) / 180;
+  return oklabToRgb({ L, a: C * Math.cos(hRad), b: C * Math.sin(hRad), alpha });
+}
+
+function parseRgbFunc(value: string): Rgba | null {
+  const m = value.match(/^rgba?\(\s*([^)]+)\)$/i);
+  if (!m) return null;
+  const parts = m[1].split(/[\s,/]+/).filter(Boolean);
+  if (parts.length < 3) return null;
+  const channel = (token: string) =>
+    token.endsWith("%") ? parseFloat(token) / 100 : parseFloat(token) / 255;
+  const alpha = parts[3] !== undefined ? parseNumberOrPercent(parts[3], 1) : 1;
+  return { r: channel(parts[0]), g: channel(parts[1]), b: channel(parts[2]), alpha };
+}
+
+function parseHsl(value: string): Rgba | null {
+  const m = value.match(/^hsla?\(\s*([^)]+)\)$/i);
+  if (!m) return null;
+  const parts = m[1].split(/[\s,/]+/).filter(Boolean);
+  if (parts.length < 3) return null;
+  const h = ((parseFloat(parts[0]) % 360) + 360) % 360;
+  const s = parseNumberOrPercent(parts[1], 1);
+  const l = parseNumberOrPercent(parts[2], 1);
+  const alpha = parts[3] !== undefined ? parseNumberOrPercent(parts[3], 1) : 1;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m0 = l - c / 2;
+  const [r1, g1, b1] =
+    h < 60 ? [c, x, 0] :
+    h < 120 ? [x, c, 0] :
+    h < 180 ? [0, c, x] :
+    h < 240 ? [0, x, c] :
+    h < 300 ? [x, 0, c] : [c, 0, x];
+  return { r: r1 + m0, g: g1 + m0, b: b1 + m0, alpha };
+}
+
+/** Split a comma-separated argument list, respecting nested parentheses. */
+function splitTopLevel(input: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let current = "";
+  for (const ch of input) {
+    if (ch === "(") depth += 1;
+    if (ch === ")") depth -= 1;
+    if (ch === "," && depth === 0) {
+      out.push(current.trim());
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) out.push(current.trim());
+  return out;
+}
+
+/**
+ * color-mix(in oklch|srgb, A p%?, B p%?). Mixing with `transparent` keeps the
+ * other color's channels and scales alpha (CSS treats transparent's channels
+ * as missing). Opaque pairs interpolate in the requested space — oklch uses
+ * LCh with shorter-arc hue interpolation, matching browser behavior.
+ */
+function parseColorMix(value: string, resolve: (v: string) => Rgba | null): Rgba | null {
+  const m = value.match(/^color-mix\(\s*in\s+(oklch|oklab|srgb)\s*,(.+)\)$/i);
+  if (!m) return null;
+  const space = m[1].toLowerCase();
+  const args = splitTopLevel(m[2]);
+  if (args.length !== 2) return null;
+
+  const parseArg = (arg: string): { color: string; weight: number | null } => {
+    const wm = arg.match(/^(.*?)\s+([\d.]+)%$/);
+    if (wm) return { color: wm[1].trim(), weight: parseFloat(wm[2]) / 100 };
+    return { color: arg.trim(), weight: null };
+  };
+  const a = parseArg(args[0]);
+  const b = parseArg(args[1]);
+  let wa = a.weight ?? (b.weight !== null ? 1 - b.weight : 0.5);
+  let wb = b.weight ?? 1 - wa;
+  const total = wa + wb;
+  if (total <= 0) return null;
+  wa /= total;
+  wb /= total;
+
+  const aTransparent = a.color === "transparent";
+  const bTransparent = b.color === "transparent";
+  if (aTransparent && bTransparent) return { r: 0, g: 0, b: 0, alpha: 0 };
+  if (aTransparent || bTransparent) {
+    const solid = resolve(aTransparent ? b.color : a.color);
+    if (!solid) return null;
+    return { ...solid, alpha: solid.alpha * (aTransparent ? wb : wa) };
+  }
+
+  const ca = resolve(a.color);
+  const cb = resolve(b.color);
+  if (!ca || !cb) return null;
+
+  if (space === "srgb") {
+    return {
+      r: ca.r * wa + cb.r * wb,
+      g: ca.g * wa + cb.g * wb,
+      b: ca.b * wa + cb.b * wb,
+      alpha: ca.alpha * wa + cb.alpha * wb,
+    };
+  }
+
+  const la = rgbToOklab(ca);
+  const lb = rgbToOklab(cb);
+  if (space === "oklab") {
+    return oklabToRgb({
+      L: la.L * wa + lb.L * wb,
+      a: la.a * wa + lb.a * wb,
+      b: la.b * wa + lb.b * wb,
+      alpha: ca.alpha * wa + cb.alpha * wb,
+    });
+  }
+
+  // oklch: interpolate L/C plus hue along the shorter arc; an achromatic
+  // endpoint (C≈0) adopts the other endpoint's hue.
+  const toLch = (lab: Oklab) => ({
+    L: lab.L,
+    C: Math.hypot(lab.a, lab.b),
+    h: (Math.atan2(lab.b, lab.a) * 180) / Math.PI,
+  });
+  const A = toLch(la);
+  const B = toLch(lb);
+  const EPS = 1e-6;
+  let ha = A.C < EPS ? B.h : A.h;
+  let hb = B.C < EPS ? A.h : B.h;
+  let diff = hb - ha;
+  if (diff > 180) hb -= 360;
+  else if (diff < -180) hb += 360;
+  const L = A.L * wa + B.L * wb;
+  const C = A.C * wa + B.C * wb;
+  const h = ((ha * wa + hb * wb) * Math.PI) / 180;
+  return oklabToRgb({
+    L,
+    a: C * Math.cos(h),
+    b: C * Math.sin(h),
+    alpha: ca.alpha * wa + cb.alpha * wb,
+  });
+}
+
+const NAMED: Record<string, Rgba> = {
+  transparent: { r: 0, g: 0, b: 0, alpha: 0 },
+  white: { r: 1, g: 1, b: 1, alpha: 1 },
+  black: { r: 0, g: 0, b: 0, alpha: 1 },
+};
+
+/** Parse any color syntax the theme blocks use. Returns null on failure. */
+export function parseThemeColor(raw: string): Rgba | null {
+  const value = raw.trim();
+  const named = NAMED[value.toLowerCase()];
+  if (named) return { ...named };
+  return (
+    parseHex(value) ??
+    parseOklch(value) ??
+    parseRgbFunc(value) ??
+    parseHsl(value) ??
+    parseColorMix(value, parseThemeColor)
+  );
+}
+
+// ── CSS custom-property extraction + cascade ────────────────────────────────
+
+export type TokenMap = Map<string, string>;
+
+/** Pull `--token: value;` declarations out of one selector's block. */
+function tokensFromBlock(css: string, selectorPattern: RegExp): TokenMap {
+  const tokens: TokenMap = new Map();
+  for (const match of css.matchAll(selectorPattern)) {
+    const body = match[1];
+    for (const decl of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+      tokens.set(decl[1], decl[2].trim());
+    }
+  }
+  return tokens;
+}
+
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Resolved token map for a (theme, mode), following the real cascade:
+ * dark  = :root ∪ [data-theme]
+ * light = :root ∪ [data-theme] ∪ :root[light] ∪ [data-theme][light]
+ * (`:root[data-mode="light"]` out-specifies the bare theme block, and the
+ * theme's own light block comes later in the file, so it wins overall.)
+ */
+export function themeTokens(css: string, themeId: string, mode: "dark" | "light"): TokenMap {
+  const root = tokensFromBlock(css, /(?:^|\n):root\s*\{([^}]+)\}/g);
+  const rootLight = tokensFromBlock(css, /:root\[data-mode="light"\]\s*\{([^}]+)\}/g);
+  const id = escapeRe(themeId);
+  const themeDark =
+    themeId === "coven"
+      ? new Map<string, string>()
+      : tokensFromBlock(css, new RegExp(`\\[data-theme="${id}"\\]\\s*\\{([^}]+)\\}`, "g"));
+  const themeLight =
+    themeId === "coven"
+      ? new Map<string, string>()
+      : tokensFromBlock(
+          css,
+          new RegExp(`\\[data-theme="${id}"\\]\\[data-mode="light"\\]\\s*\\{([^}]+)\\}`, "g"),
+        );
+
+  const merged: TokenMap = new Map(root);
+  for (const [k, v] of themeDark) merged.set(k, v);
+  if (mode === "light") {
+    for (const [k, v] of rootLight) merged.set(k, v);
+    for (const [k, v] of themeLight) merged.set(k, v);
+  }
+  return merged;
+}
+
+/** Substitute var() references (with optional fallbacks), recursively. */
+export function resolveTokenValue(tokens: TokenMap, name: string, depth = 0): string | null {
+  if (depth > 16) return null;
+  const raw = tokens.get(name);
+  if (raw === undefined) return null;
+  return substituteVars(tokens, raw, depth);
+}
+
+function substituteVars(tokens: TokenMap, value: string, depth: number): string | null {
+  let out = "";
+  let i = 0;
+  while (i < value.length) {
+    const start = value.indexOf("var(", i);
+    if (start === -1) {
+      out += value.slice(i);
+      break;
+    }
+    out += value.slice(i, start);
+    // find the matching close paren
+    let depthCount = 0;
+    let end = start;
+    for (; end < value.length; end++) {
+      if (value[end] === "(") depthCount++;
+      if (value[end] === ")") {
+        depthCount--;
+        if (depthCount === 0) break;
+      }
+    }
+    if (end >= value.length) return null;
+    const inner = value.slice(start + 4, end);
+    const args = splitTopLevel(inner);
+    const varName = args[0];
+    let replacement = resolveTokenValue(tokens, varName, depth + 1);
+    if (replacement === null && args.length > 1) {
+      replacement = substituteVars(tokens, args.slice(1).join(","), depth + 1);
+    }
+    if (replacement === null) return null;
+    out += replacement;
+    i = end + 1;
+  }
+  return out;
+}
+
+/** Fully resolve a token to a color, or null when it isn't a color. */
+export function resolveThemeColor(tokens: TokenMap, name: string): Rgba | null {
+  const value = resolveTokenValue(tokens, name);
+  return value === null ? null : parseThemeColor(value);
+}
+
+// ── WCAG 2.1 ────────────────────────────────────────────────────────────────
+
+export function relativeLuminance({ r, g, b }: Rgba): number {
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+export function contrastRatio(a: Rgba, b: Rgba): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Composite a (possibly translucent) foreground over an opaque backdrop. */
+export function flattenOnto(fg: Rgba, backdrop: Rgba): Rgba {
+  const a = fg.alpha;
+  return {
+    r: fg.r * a + backdrop.r * (1 - a),
+    g: fg.g * a + backdrop.g * (1 - a),
+    b: fg.b * a + backdrop.b * (1 - a),
+    alpha: 1,
+  };
+}
+
+/** Effective WCAG contrast of a foreground token over a background token,
+ *  flattening translucency onto the background first (how it renders). */
+export function effectiveContrast(tokens: TokenMap, fgToken: string, bgToken: string): number | null {
+  const fg = resolveThemeColor(tokens, fgToken);
+  const bgRaw = resolveThemeColor(tokens, bgToken);
+  if (!fg || !bgRaw) return null;
+  const bg = bgRaw.alpha < 1 ? flattenOnto(bgRaw, { r: 0, g: 0, b: 0, alpha: 1 }) : bgRaw;
+  return contrastRatio(flattenOnto(fg, bg), bg);
+}

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -3,16 +3,18 @@ import assert from "node:assert/strict";
 import { THEME_IDS, THEME_META, getSwatches } from "./theme-palettes.ts";
 import { LEGACY_THEME_RENAME, COVEN_THEME_KEY, COVEN_MODE_KEY } from "./theme-storage.ts";
 
-// 16 themes, coven is the default (first).
-assert.equal(THEME_IDS.length, 16);
+// 19 themes, coven is the default (first).
+assert.equal(THEME_IDS.length, 19);
 assert.equal(THEME_IDS[0], "coven");
 assert.deepEqual(
   [...THEME_IDS].sort(),
   [
     "bane",
+    "beacon",
     "bloom",
     "claude",
     "claymorphism",
+    "contrast",
     "coven",
     "dusk",
     "ember",
@@ -23,6 +25,7 @@ assert.deepEqual(
     "mist",
     "pastel-dreams",
     "slate",
+    "solstice",
     "tide",
     "trucker",
   ],
@@ -74,6 +77,11 @@ assert.equal(THEME_META.meatseeks.name, "Meatseeks");
 assert.equal(THEME_META.trucker.name, "Trucker");
 assert.equal(THEME_META.trucker.accentDark, "#21704a");
 assert.equal(THEME_META.trucker.accentLight, "#005735");
+assert.equal(THEME_META.contrast.name, "High Contrast");
+assert.equal(THEME_META.contrast.accentDark, "#ffd60a");
+assert.equal(THEME_META.contrast.accentLight, "#0f62fe");
+assert.equal(THEME_META.beacon.name, "Beacon");
+assert.equal(THEME_META.solstice.name, "Solstice");
 
 // Storage keys are stable strings.
 assert.equal(COVEN_THEME_KEY, "coven-theme");

--- a/src/lib/theme-palettes.test.ts
+++ b/src/lib/theme-palettes.test.ts
@@ -69,10 +69,10 @@ assert.equal(THEME_META.claymorphism.name, "Claymorphism");
 assert.equal(THEME_META.claude.name, "Claude");
 assert.equal(THEME_META["pastel-dreams"].name, "Pastel Dreams");
 assert.equal(THEME_META["pastel-dreams"].accentDark, "#c0aafd");
-assert.equal(THEME_META["pastel-dreams"].accentLight, "#a78bfa");
+assert.equal(THEME_META["pastel-dreams"].accentLight, "#9377e6");
 assert.equal(THEME_META.meatseeks.name, "Meatseeks");
 assert.equal(THEME_META.trucker.name, "Trucker");
-assert.equal(THEME_META.trucker.accentDark, "#005735");
+assert.equal(THEME_META.trucker.accentDark, "#21704a");
 assert.equal(THEME_META.trucker.accentLight, "#005735");
 
 // Storage keys are stable strings.

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -79,7 +79,7 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
   mist: {
     name: "Mist",
     description: "Scrying-pool teal. Cold as a question without an answer.",
-    hue: 198, accentDark: "#6BD8D3", accentLight: "#1A857F",
+    hue: 198, accentDark: "#6BD8D3", accentLight: "#177b76",
     bgDark: "oklch(0.09 0.030 198)", bgLight: "oklch(0.97 0.015 195)",
   },
   hex: {
@@ -109,7 +109,7 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
   claymorphism: {
     name: "Claymorphism",
     description: "Soft-molded stone with indigo glaze and lifted clay shadows.",
-    hue: 239, accentDark: "#818cf8", accentLight: "#6366f1",
+    hue: 239, accentDark: "#818cf8", accentLight: "#5457e9",
     bgDark: "#1e1b18", bgLight: "#e7e5e4",
   },
   claude: {
@@ -121,19 +121,19 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
   "pastel-dreams": {
     name: "Pastel Dreams",
     description: "Soft violet pastels with lifted white surfaces.",
-    hue: 263, accentDark: "#c0aafd", accentLight: "#a78bfa",
+    hue: 263, accentDark: "#c0aafd", accentLight: "#9377e6",
     bgDark: "#1c1917", bgLight: "#f7f3f9",
   },
   meatseeks: {
     name: "Meatseeks",
     description: "Supabase green over crisp utility surfaces.",
-    hue: 153, accentDark: "#006239", accentLight: "#72e3ad",
+    hue: 153, accentDark: "#1d7449", accentLight: "#279c6b",
     bgDark: "#121212", bgLight: "#fcfcfc",
   },
   trucker: {
     name: "Trucker",
     description: "Roadside evergreen, blacktop panels, and clean cab lights.",
-    hue: 156, accentDark: "#005735", accentLight: "#005735",
+    hue: 156, accentDark: "#21704a", accentLight: "#005735",
     bgDark: "#020504", bgLight: "#f5fcf9",
   },
 };

--- a/src/lib/theme-palettes.ts
+++ b/src/lib/theme-palettes.ts
@@ -1,8 +1,12 @@
 /**
- * 16-theme roster metadata + swatch lookup for the appearance settings UI.
+ * 19-theme roster metadata + swatch lookup for the appearance settings UI.
  * The actual palette CSS lives in `src/app/globals.css`; this module
  * mirrors the accent values and a representative background swatch
  * per (theme, mode) so the settings grid can preview each card.
+ *
+ * Every premade palette is held to WCAG 2.1 AA by
+ * `src/lib/theme-contrast-audit.test.ts` — run it before shipping a new
+ * theme or touching accent/surface values here or in globals.css.
  */
 
 import type { Mode } from "./theme-storage.ts";
@@ -24,6 +28,9 @@ export const THEME_IDS = [
   "pastel-dreams",
   "meatseeks",
   "trucker",
+  "contrast",
+  "beacon",
+  "solstice",
 ] as const;
 
 export type ThemeId = (typeof THEME_IDS)[number];
@@ -135,6 +142,24 @@ export const THEME_META: Record<ThemeId, ThemeMeta> = {
     description: "Roadside evergreen, blacktop panels, and clean cab lights.",
     hue: 156, accentDark: "#21704a", accentLight: "#005735",
     bgDark: "#020504", bgLight: "#f5fcf9",
+  },
+  contrast: {
+    name: "High Contrast",
+    description: "Maximum-legibility ward. True black and white, nothing whispered.",
+    hue: 0, accentDark: "#ffd60a", accentLight: "#0f62fe",
+    bgDark: "#000000", bgLight: "#ffffff",
+  },
+  beacon: {
+    name: "Beacon",
+    description: "Signal-fire on a night sea. Blue-orange keel; colorblind-considerate.",
+    hue: 250, accentDark: "#f5a623", accentLight: "#a34d00",
+    bgDark: "oklch(0.14 0.025 250)", bgLight: "oklch(0.975 0.010 250)",
+  },
+  solstice: {
+    name: "Solstice",
+    description: "Midsummer gold leaf on long shadow. The light that lingers.",
+    hue: 85, accentDark: "#e3b341", accentLight: "#7a5c00",
+    bgDark: "oklch(0.145 0.020 85)", bgLight: "oklch(0.975 0.016 90)",
   },
 };
 


### PR DESCRIPTION
## Why

No test ever computed a contrast ratio for the premade appearance palettes. An audit over the shipped CSS found **126 WCAG failures across the 16 themes × 2 modes** (651 token pairs): translucent focus rings averaging ~2:1, strong borders under 2:1 on every theme, `--text-muted` self-documented as sub-AA, hardcoded white `--brand-foreground` failing on 22 light-accent combos, and multiple tweakcn-ported themes with illegible secondary text in light mode.

## What

**Contrast fixes (126 → 0 failing pairs)**
- `--ring-focus` is now solid (accent mixed 55/45 toward foreground) — a keyboard focus indicator must hit 3:1 (WCAG 1.4.11/2.4.13); the translucent `-soft` variant stays for decoration.
- `--border-strong` raised to a real 3:1 interactive boundary (48% dark / 56% light ink mix; per-theme overrides fixed individually).
- `--text-muted` raised to 72% dark / 76% light — 4.5:1 on the whole panel ladder across every theme, not just Coven.
- `--brand-foreground` now follows the per-theme `--accent-presence-foreground` ink instead of hardcoded white.
- Per-theme surgery on claude, claymorphism, ghosty, pastel-dreams, meatseeks, trucker, ember, mist, bloom: foreground ink flips, darkened light-mode accents, destructive reds moved to `#dc2626` where white text failed, secondary text darkened to AA. Five accents moved; swatch metadata synced (`theme-palettes.ts` + iOS `ThemeRoster.swift`).

**Three new accessibility-first presets (16 → 19)**
- **High Contrast** — true black/white, AAA (7:1) body text in both modes, goldenrod/IBM-blue accents. Explicitly for low vision.
- **Beacon** — blue↔orange palette axis, distinct under deuteranopia/protanopia.
- **Solstice** — midsummer gold, filling the warm-hue gap in the roster.

**Permanent regression gate**
- `src/lib/theme-contrast.ts`: pure Node evaluator for the shipped CSS — oklch (Ottosson), color-mix (incl. oklch-space hue interpolation and transparent-mix alpha semantics), hsl/hex/rgb, `var()` cascade resolution matching the real `:root` → theme → light-override specificity order. No DOM, no new dependencies.
- `src/lib/theme-contrast-audit.test.ts`: gates **771 pairs across 19 themes × 2 modes** at AA text 4.5:1 / non-text UI 3:1, plus an AAA (7:1) gate for High Contrast. A palette edit that regresses contrast now fails `Frontend build`.
- `globals.css.test.ts` structural loop extended from the original 9 themes to all 18 non-default ones.

## Verification

- Full suites green: app 522 / api 114 / mobile 68 files; typecheck; tests-wired; `pnpm build` (bundle within budget); iOS app builds with the extended roster.
- Visual pass in the running app: High Contrast dark/light, Beacon, Solstice, and the repaired Claude/Pastel light modes all screenshot-verified (boot allowlist applies the new ids flash-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)