### PR TITLE
feat(projects): project avatars — uploaded image or monogram tile on every project surface

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -354,6 +354,7 @@ export const SUITES = {
     "src/components/drag-to-split.test.ts",
     "src/components/daemon-start-button.test.ts",
     "src/components/familiar-avatar.test.ts",
+    "src/components/project-avatar.test.ts",
     "src/components/familiar-glyph-picker-panel.test.ts",
     "src/components/familiar-studio-brain-tab.test.ts",
     "src/components/familiar-studio-identity-tab.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -389,6 +389,7 @@ export const SUITES = {
     "src/lib/cave-familiar-archive.test.ts",
     "src/lib/cave-familiar-images.test.ts",
     "src/lib/cave-familiar-overrides.test.ts",
+    "src/lib/cave-project-images.test.ts",
     "src/lib/chat-assistant-filter.test.ts",
     "src/lib/chat-attachments.test.ts",
     "src/lib/codex-automations.test.ts",
@@ -747,6 +748,7 @@ const STRIP_TYPES_MJS = new Set([
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
   "src/lib/cave-familiar-images.test.ts",
+  "src/lib/cave-project-images.test.ts",
   "src/lib/user-avatar-image.test.ts",
   "src/lib/familiar-resolve.test.ts",
   "src/lib/gh-review-html.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3297,6 +3297,33 @@ textarea.required-inputs-control {
   background: color-mix(in oklch, var(--tile, var(--accent-presence)) 22%, transparent);
   border-color: color-mix(in oklch, var(--tile, var(--accent-presence)) 40%, transparent);
 }
+/* Shared project identity tile (ProjectAvatar): uploaded image or a tinted
+   monogram — the generalisation of .comux-project-tile for every surface.
+   Size comes from --pa-size, hue from --tile (projectTint / project.color). */
+.project-avatar {
+  width: var(--pa-size, 20px);
+  height: var(--pa-size, 20px);
+  border-radius: calc(var(--pa-size, 20px) * 0.29);
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  overflow: hidden;
+  color: color-mix(in oklch, var(--tile, var(--accent-presence)) 65%, var(--text-primary));
+  background: color-mix(in oklch, var(--tile, var(--accent-presence)) 14%, transparent);
+  border: 1px solid color-mix(in oklch, var(--tile, var(--accent-presence)) 24%, transparent);
+}
+.project-avatar__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.project-avatar__monogram {
+  font-size: calc(var(--pa-size, 20px) * 0.375);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.01em;
+  font-variant-numeric: tabular-nums;
+}
 /* Frosted PROJECTS header. Sticks flush at the scrollport top (the scroller has
    no top padding) so rows scrolling past frost under it rather than bleeding
    into a gap above. Kept mostly opaque — a header, not a pane — so row text

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3278,28 +3278,14 @@ textarea.required-inputs-control {
     0 10px 28px color-mix(in oklch, var(--accent-presence) 22%, transparent);
   transform: none;
 }
-/* Per-project identity chip — a colour-tinted glass tile holding a 1–2 char
-   monogram. Hue comes from projectTint() via the --tile custom property. */
-.comux-project-tile {
-  width: 28px;
-  height: 28px;
-  border-radius: 8px;
-  display: grid;
-  place-items: center;
-  /* Sized to seat a 1–2 char monogram; text brightened toward the foreground so
-     it stays legible over the translucent tint fill. */
-  font-size: 10.5px;
-  color: color-mix(in oklch, var(--tile, var(--accent-presence)) 65%, var(--text-primary));
-  background: color-mix(in oklch, var(--tile, var(--accent-presence)) 14%, transparent);
-  border: 1px solid color-mix(in oklch, var(--tile, var(--accent-presence)) 24%, transparent);
-}
-.comux-project-row--active .comux-project-tile {
+.comux-project-row--active .project-avatar {
   background: color-mix(in oklch, var(--tile, var(--accent-presence)) 22%, transparent);
   border-color: color-mix(in oklch, var(--tile, var(--accent-presence)) 40%, transparent);
 }
 /* Shared project identity tile (ProjectAvatar): uploaded image or a tinted
-   monogram — the generalisation of .comux-project-tile for every surface.
-   Size comes from --pa-size, hue from --tile (projectTint / project.color). */
+   monogram — grown out of the old .comux-project-tile chip to serve every
+   surface. Size comes from --pa-size, hue from --tile (projectTint /
+   project.color). */
 .project-avatar {
   width: var(--pa-size, 20px);
   height: var(--pa-size, 20px);

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { Icon, type IconName } from "@/lib/icon";
+import { ProjectAvatar } from "@/components/project-avatar";
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
 import type { SessionRow } from "@/lib/types";
@@ -506,7 +507,11 @@ export function ChatSidebar({
                         className="cnav__group-toggle focus-ring"
                       >
                         <Icon name="ph:caret-down" width={10} className="cnav__chev" aria-hidden />
-                        <Icon name={folderIcon(group, expanded)} width={14} className="cnav__folder" aria-hidden />
+                        {group.projectId ? (
+                          <ProjectAvatar name={label} root={group.projectRoot} size="sm" className="cnav__folder" />
+                        ) : (
+                          <Icon name={folderIcon(group, expanded)} width={14} className="cnav__folder" aria-hidden />
+                        )}
                         <span className="cnav__group-name" title={group.projectRoot ?? "Threads with no project"}>
                           {label}
                         </span>

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -33,10 +33,9 @@ import { Button } from "@/components/ui/button";
 import {
   deriveComuxProjects,
   projectName,
-  projectTint,
-  projectMonogram,
   type ComuxProject,
 } from "@/lib/comux-projects";
+import { ProjectAvatar } from "@/components/project-avatar";
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { ContextMenu, openContextMenuAt, type ContextMenuState } from "@/components/ui/context-menu";
 import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
@@ -355,9 +354,7 @@ function SortableProjectRow({
     meta.push(`${project.sessionCount} ${project.sessionCount === 1 ? "chat" : "chats"}`);
   }
   if (project.updatedAt) meta.push(shortProjectTime(project.updatedAt));
-  const monogram = projectMonogram(project.name);
   const style: CSSProperties = {
-    ["--tile" as string]: projectTint(project.root),
     transform: CSS.Translate.toString(transform),
     transition,
   };
@@ -386,9 +383,7 @@ function SortableProjectRow({
           : "text-[var(--text-primary)]"
       }`}
     >
-      <span className="comux-project-tile shrink-0 font-bold leading-none tracking-tight tabular-nums" aria-hidden>
-        {monogram}
-      </span>
+      <ProjectAvatar name={project.name} root={project.root} size="lg" className="shrink-0" />
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate font-medium leading-tight">{project.name}</span>
         {meta.length > 0 && (

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -17,6 +17,7 @@ import {
   useState,
 } from "react";
 import { ComposerHostChip } from "@/components/composer-host-chip";
+import { ProjectAvatar } from "@/components/project-avatar";
 import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
@@ -1100,7 +1101,16 @@ export function HomeComposer({
             </label>
 
             <label className="hc-familiar-selector hc-project-selector">
-              <Icon name="ph:folder" width={13} className="hc-familiar-glyph" aria-hidden />
+              {selectedProject && selectedProjectId !== NO_PROJECT_ID ? (
+                <ProjectAvatar
+                  name={selectedProject.name}
+                  root={selectedProject.root}
+                  color={selectedProject.color}
+                  size="sm"
+                />
+              ) : (
+                <Icon name="ph:folder" width={13} className="hc-familiar-glyph" aria-hidden />
+              )}
               <select
                 aria-label="Choose project"
                 className="hc-familiar-select"

--- a/src/components/project-avatar.test.ts
+++ b/src/components/project-avatar.test.ts
@@ -1,0 +1,16 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./project-avatar.tsx", import.meta.url), "utf8");
+
+assert.match(source, /export function ProjectAvatar/, "Must export ProjectAvatar");
+assert.match(source, /useProjectImages\(\)/, "Must read the project image store");
+assert.match(source, /normalizeProjectRoot/, "Image lookup must normalize the root key");
+assert.match(source, /projectMonogram/, "Monogram fallback must reuse the comux helper");
+assert.match(source, /projectTint/, "Tint fallback must reuse the comux helper");
+assert.match(source, /onError/, "img must fall back to the monogram tile on load error");
+assert.match(source, /aria-hidden/, "decorative — adjacent text carries the project name");
+assert.match(source, /color \?\?/, "explicit project color must win over the root tint");
+
+console.log("project-avatar.test.ts: ok");

--- a/src/components/project-avatar.tsx
+++ b/src/components/project-avatar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useProjectImages } from "@/lib/cave-project-images";
+import { normalizeProjectRoot } from "@/lib/cave-projects-types";
+import { projectMonogram, projectTint } from "@/lib/comux-projects";
+
+const PX = { sm: 16, md: 20, lg: 28 } as const;
+
+/**
+ * A project's visual identity: the user-uploaded image when one is set,
+ * otherwise a colour-tinted monogram tile — the same deterministic tile comux
+ * rows have always rendered, so a project looks identical everywhere. The
+ * span is decorative (aria-hidden): every call site renders the project name
+ * right next to it.
+ */
+export function ProjectAvatar({
+  name,
+  root,
+  color,
+  size = "md",
+  className,
+}: {
+  name: string;
+  root?: string | null;
+  color?: string | null;
+  size?: keyof typeof PX;
+  className?: string;
+}) {
+  const images = useProjectImages();
+  const image = root ? images[normalizeProjectRoot(root)] : undefined;
+  const [broken, setBroken] = useState(false);
+  // A replaced image gets a fresh chance even if the previous one failed.
+  useEffect(() => setBroken(false), [image?.dataUrl]);
+
+  const classes = `project-avatar${className ? ` ${className}` : ""}`;
+  const style = {
+    ["--pa-size" as string]: `${PX[size]}px`,
+    ["--tile" as string]: color ?? (root ? projectTint(root) : "var(--accent-presence)"),
+  };
+
+  return (
+    <span className={classes} style={style} aria-hidden="true">
+      {image && !broken ? (
+        <img
+          src={image.dataUrl}
+          alt=""
+          className="project-avatar__img"
+          onError={() => setBroken(true)}
+        />
+      ) : (
+        <span className="project-avatar__monogram">{projectMonogram(name)}</span>
+      )}
+    </span>
+  );
+}

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -10,6 +10,7 @@ import {
   PopoverSeparator,
 } from "@/components/ui/popover";
 import { DirectoryPickerModal } from "@/components/directory-picker-modal";
+import { ProjectAvatar } from "@/components/project-avatar";
 import { addChatProject } from "@/lib/chat-add-project";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
 import type { CaveProject } from "@/lib/cave-projects";
@@ -166,7 +167,11 @@ export function ProjectPicker({
         disabled={disabled}
         title={selected ? selected.root : "No project"}
       >
-        <Icon name={selected ? "ph:folder-open" : "ph:folder"} width={14} aria-hidden />
+        {selected ? (
+          <ProjectAvatar name={selected.name} root={selected.root} color={selected.color} size="sm" />
+        ) : (
+          <Icon name="ph:folder" width={14} aria-hidden />
+        )}
         <span className="cave-project-picker__trigger-label">
           {selected ? selected.name : "No project"}
         </span>
@@ -195,7 +200,8 @@ export function ProjectPicker({
           <PopoverLabel>Project</PopoverLabel>
           {allowNoProject ? (
             <PopoverItem
-              icon={selected ? "ph:folder" : "ph:check"}
+              icon="ph:folder"
+              checked={!selected}
               active={!selected}
               onSelect={() => {
                 onChange(NO_PROJECT_ID);
@@ -208,7 +214,10 @@ export function ProjectPicker({
           {visible.map((entry) => (
             <PopoverItem
               key={entry.id}
-              icon={entry.id === selected?.id ? "ph:check" : "ph:folder"}
+              leading={
+                <ProjectAvatar name={entry.name} root={entry.root} color={entry.color} size="sm" />
+              }
+              checked={entry.id === selected?.id}
               active={entry.id === selected?.id}
               onSelect={() => {
                 onChange(entry.id);

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -298,8 +298,9 @@ assert.match(projectsView, /const stats = projectStats\(chats\)/, "the header de
 assert.match(projectsView, /stats\.running > 0 \?/, "the stat line shows a running count when any session is running");
 assert.match(projectsView, /stats\.tasks > 0 \?/, "the stat line shows a task count when the project has tasks");
 
-// The project folder icon is tinted by the project's color (when set).
-assert.match(projectsView, /color: project\.color \|\| "var\(--accent-presence\)"/, "the folder icon takes the project color, falling back to the accent");
+// The project identity tile is the shared ProjectAvatar (uploaded image or
+// monogram), tinted by the project's color when set.
+assert.match(projectsView, /<ProjectAvatar name=\{project\.name\} root=\{project\.root\} color=\{project\.color\}/, "the identity tile is the shared ProjectAvatar, fed the project color");
 
 // A project card expands + scrolls into view when the command palette's
 // "Open project" navigation fires CHAT_FOCUS_PROJECT_EVENT for its root.

--- a/src/components/projects/project-row.tsx
+++ b/src/components/projects/project-row.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Icon } from "@/lib/icon";
+import { ProjectAvatar } from "@/components/project-avatar";
+import {
+  clearProjectImage,
+  moveProjectImage,
+  setProjectImage,
+  useProjectImages,
+} from "@/lib/cave-project-images";
+import { FAMILIAR_IMAGE_ACCEPT, prepareFamiliarImage } from "@/lib/familiar-image-upload";
 import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { relativeTime } from "@/lib/relative-time";
 import type { CaveProject } from "@/lib/cave-projects-types";
@@ -158,6 +166,14 @@ export function ProjectRow({
   const [busy, setBusy] = useState<"name" | "root" | "delete" | null>(null);
   const [copiedRoot, setCopiedRoot] = useState(false);
   const [menu, setMenu] = useState<ContextMenuState>(null);
+  const imageInputRef = useRef<HTMLInputElement | null>(null);
+  const [imageStatus, setImageStatus] = useState<string | null>(null);
+  const projectImages = useProjectImages();
+  const hasImage = Boolean(projectImages[cardKey]);
+  const pickImage = () => {
+    setImageStatus(null);
+    imageInputRef.current?.click();
+  };
 
   const openTerminalHere = () => {
     window.dispatchEvent(new CustomEvent("cave:terminal-open", { detail: { projectRoot: project.root } }));
@@ -198,7 +214,9 @@ export function ProjectRow({
     }
     if (normalizeProjectRoot(next) !== normalizeProjectRoot(project.root)) {
       setBusy("root");
-      await onUpdateRoot(project.id, next);
+      const ok = await onUpdateRoot(project.id, next);
+      // The avatar is keyed by root — re-key it so it follows the project.
+      if (ok) void moveProjectImage(project.root, next);
       setBusy(null);
     }
     setEditingRoot(false);
@@ -206,7 +224,8 @@ export function ProjectRow({
 
   const deleteProject = async () => {
     setBusy("delete");
-    await onDelete(project.id);
+    const ok = await onDelete(project.id);
+    if (ok) void clearProjectImage(project.root);
     setBusy(null);
   };
 
@@ -246,15 +265,14 @@ export function ProjectRow({
         >
           <Icon name={expanded ? "ph:caret-down" : "ph:caret-right"} width={12} aria-hidden />
         </button>
-        <span
-          className="relative shrink-0"
-          style={{ color: project.color || "var(--accent-presence)" }}
+        <button
+          type="button"
+          onClick={pickImage}
+          className="focus-ring relative shrink-0 rounded-md"
+          title={imageStatus ?? (hasImage ? "Change project image" : "Set project image")}
+          aria-label={`${hasImage ? "Change" : "Set"} image for ${project.name}`}
         >
-          <Icon
-            name="ph:folder-open-bold"
-            width={15}
-            aria-hidden
-          />
+          <ProjectAvatar name={project.name} root={project.root} color={project.color} size="md" />
           {projectStatus ? (
             <span
               className={`absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full ring-2 ring-[var(--bg-base)] ${chatDotClass(
@@ -270,7 +288,30 @@ export function ProjectRow({
               aria-hidden
             />
           ) : null}
-        </span>
+        </button>
+        <input
+          ref={imageInputRef}
+          type="file"
+          accept={FAMILIAR_IMAGE_ACCEPT}
+          className="sr-only"
+          tabIndex={-1}
+          onChange={(event) => {
+            const file = event.currentTarget.files?.[0];
+            event.currentTarget.value = "";
+            if (!file) return;
+            setImageStatus(null);
+            void prepareFamiliarImage(file)
+              .then(async (prepared) => {
+                const res = await setProjectImage(project.root, prepared);
+                setImageStatus(
+                  res.ok ? (prepared.downsized ? "Image was downsized for Cave." : null) : res.reason,
+                );
+              })
+              .catch((err) => {
+                setImageStatus(err instanceof Error ? err.message : "Could not read image.");
+              });
+          }}
+        />
         {editingName ? (
           <input
             autoFocus
@@ -397,6 +438,12 @@ export function ProjectRow({
           )}
         </div>
       </div>
+
+      {imageStatus ? (
+        <p role="status" className="mt-1 pl-8 text-[11px] text-[var(--text-muted)]">
+          {imageStatus}
+        </p>
+      ) : null}
 
       {expanded ? (
         <div className="projects-expand-enter">
@@ -543,6 +590,14 @@ export function ProjectRow({
         <PopoverItem icon="ph:pencil-simple-bold" onSelect={() => { setMenu(null); setNameDraft(project.name); setEditingName(true); }}>
           Rename
         </PopoverItem>
+        <PopoverItem icon="ph:image-bold" onSelect={() => { setMenu(null); pickImage(); }}>
+          {hasImage ? "Change image…" : "Set image…"}
+        </PopoverItem>
+        {hasImage ? (
+          <PopoverItem icon="ph:minus-circle" onSelect={() => { setMenu(null); void clearProjectImage(project.root); }}>
+            Remove image
+          </PopoverItem>
+        ) : null}
         <PopoverItem icon={copiedRoot ? "ph:check" : "ph:copy"} onSelect={() => { setMenu(null); void copyRoot(); }}>
           Copy path
         </PopoverItem>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -215,6 +215,7 @@ export function PopoverSeparator() {
 
 export function PopoverItem({
   icon,
+  leading,
   children,
   onSelect,
   active,
@@ -223,6 +224,8 @@ export function PopoverItem({
   checked,
 }: {
   icon?: IconName;
+  /** Rich leading visual (e.g. a ProjectAvatar); wins over `icon`. */
+  leading?: ReactNode;
   children: ReactNode;
   onSelect?: () => void;
   active?: boolean;
@@ -249,7 +252,7 @@ export function PopoverItem({
       role={radio ? "menuitemradio" : "menuitem"}
       aria-checked={radio ? checked : undefined}
     >
-      {icon ? <Icon name={icon} width={13} aria-hidden /> : null}
+      {leading ?? (icon ? <Icon name={icon} width={13} aria-hidden /> : null)}
       <span>{children}</span>
       {radio && checked ? (
         <Icon name="ph:check" width={12} aria-hidden className="ml-auto" />

--- a/src/lib/avatar-idb.ts
+++ b/src/lib/avatar-idb.ts
@@ -15,7 +15,7 @@
 
 export type AvatarRecord = { dataUrl: string; mime: string; updatedAt: string };
 
-export type AvatarStore = "familiarImages" | "userAvatar";
+export type AvatarStore = "familiarImages" | "userAvatar" | "projectAvatars";
 
 export type AvatarStorageDriver = {
   getAll(store: AvatarStore): Promise<Record<string, AvatarRecord>>;
@@ -24,8 +24,8 @@ export type AvatarStorageDriver = {
 };
 
 const DB_NAME = "cave-avatars";
-const DB_VERSION = 1;
-const STORES: readonly AvatarStore[] = ["familiarImages", "userAvatar"];
+const DB_VERSION = 2; // v2: + projectAvatars
+const STORES: readonly AvatarStore[] = ["familiarImages", "userAvatar", "projectAvatars"];
 
 let dbPromise: Promise<IDBDatabase> | null = null;
 

--- a/src/lib/cave-project-images.test.ts
+++ b/src/lib/cave-project-images.test.ts
@@ -1,0 +1,93 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+globalThis.window = {
+  localStorage: { getItem: () => null, setItem: () => {}, removeItem: () => {} },
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+
+// Map-backed fake IndexedDB driver with a write-failure toggle (simulates the
+// browser refusing a write — quota, private mode, etc.). All three stores are
+// present because importing the project store transitively hydrates the
+// familiar store (shared size-cap constant).
+const idb = { projectAvatars: new Map(), familiarImages: new Map(), userAvatar: new Map() };
+let denyWrites = false;
+const fakeDriver = {
+  async getAll(store) {
+    return Object.fromEntries(idb[store]);
+  },
+  async put(store, key, value) {
+    if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+    idb[store].set(key, value);
+  },
+  async delete(store, key) {
+    idb[store].delete(key);
+  },
+};
+
+// Inject the fake BEFORE the store module loads — its import-time hydration
+// must already go through the driver seam.
+const { setAvatarStorageForTests } = await import("./avatar-idb.ts");
+setAvatarStorageForTests(fakeDriver);
+
+const mod = await import("./cave-project-images.ts");
+await mod.whenProjectImagesHydrated();
+
+const png = (fill) => "data:image/png;base64," + fill.repeat(1000);
+
+// Set + read, and roots are normalized: a trailing slash buckets to the same
+// key, so every surface (picker, sidebar, comux) reads the same record.
+{
+  const res = await mod.setProjectImage("/Users/x/app/", { dataUrl: png("A"), mime: "image/png" });
+  assert.equal(res.ok, true);
+  const got = mod.readProjectImagesSnapshot();
+  assert.ok(got["/Users/x/app"], "stored under the normalized root");
+  assert.equal(got["/Users/x/app"].mime, "image/png");
+  assert.ok(Number.isFinite(Date.parse(got["/Users/x/app"].updatedAt)));
+  assert.ok(idb.projectAvatars.has("/Users/x/app"), "write reached IndexedDB");
+}
+
+// Refused write (quota/private mode): the store reports the friendly
+// storage-full reason and the snapshot stays unchanged — no phantom avatar.
+{
+  denyWrites = true;
+  const res = await mod.setProjectImage("/Users/x/other", { dataUrl: png("B"), mime: "image/png" });
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /storage full/i);
+  assert.equal(mod.readProjectImagesSnapshot()["/Users/x/other"], undefined);
+  denyWrites = false;
+}
+
+// Per-image size cap and disallowed mime mirror the familiar store.
+{
+  const huge = "data:image/png;base64," + "A".repeat(3 * 1024 * 1024);
+  const res = await mod.setProjectImage("/Users/x/app", { dataUrl: huge, mime: "image/png" });
+  assert.equal(res.ok, false);
+  assert.match(res.reason, /too large/i);
+  const bad = await mod.setProjectImage("/Users/x/app", { dataUrl: "data:image/gif;base64,AAA", mime: "image/gif" });
+  assert.equal(bad.ok, false);
+  assert.match(bad.reason, /unsupported|format/i);
+}
+
+// moveProjectImage follows a root edit: the record lands under the new key,
+// the old key is gone, and a move to the same normalized root is a no-op.
+{
+  await mod.moveProjectImage("/Users/x/app", "/Users/x/renamed");
+  const got = mod.readProjectImagesSnapshot();
+  assert.equal(got["/Users/x/app"], undefined);
+  assert.ok(got["/Users/x/renamed"]);
+  assert.ok(idb.projectAvatars.has("/Users/x/renamed"));
+  assert.equal(idb.projectAvatars.has("/Users/x/app"), false);
+  await mod.moveProjectImage("/Users/x/renamed/", "/Users/x/renamed");
+  assert.ok(mod.readProjectImagesSnapshot()["/Users/x/renamed"], "same-key move is a no-op");
+}
+
+// Clear
+{
+  await mod.clearProjectImage("/Users/x/renamed");
+  assert.equal(mod.readProjectImagesSnapshot()["/Users/x/renamed"], undefined);
+  assert.equal(idb.projectAvatars.has("/Users/x/renamed"), false);
+}
+
+console.log("cave-project-images.test.ts: ok");

--- a/src/lib/cave-project-images.ts
+++ b/src/lib/cave-project-images.ts
@@ -1,0 +1,158 @@
+"use client";
+
+/**
+ * Cave-local per-project avatar image store.
+ *
+ * Keyed by normalized project root — the identity every surface already
+ * buckets by (sessions carry project_root; comux and the chat sidebar group by
+ * root; CaveProject ids are per-machine nanoids). Images are base64 data URLs
+ * persisted in IndexedDB (see avatar-idb.ts) with an in-memory map as the
+ * render source. No legacy localStorage migration — this store is IDB-native.
+ */
+
+import { useSyncExternalStore } from "react";
+import { avatarStorage } from "@/lib/avatar-idb";
+import { MAX_FAMILIAR_IMAGE_DATAURL_BYTES } from "./cave-familiar-images.ts";
+import { normalizeProjectRoot } from "./cave-projects-types.ts";
+
+const CHANNEL_NAME = "cave:project-images";
+const STORAGE_FULL_REASON = "Cave avatar storage full. Remove an image to free space.";
+const ALLOWED_MIMES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/webp",
+  "image/svg+xml",
+]);
+
+export type ProjectImage = {
+  dataUrl: string;
+  mime: string;
+  updatedAt: string;
+};
+
+type ImageMap = Record<string, ProjectImage>;
+type SetResult = { ok: true } | { ok: false; reason: string };
+
+const EMPTY: ImageMap = Object.freeze({});
+
+let cached: ImageMap = EMPTY;
+let hydration: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function notify() { for (const fn of listeners) fn(); }
+
+// Cross-window sync — writes broadcast and other windows re-read IndexedDB.
+let channel: BroadcastChannel | null = null;
+function ensureChannel(): void {
+  if (channel || typeof BroadcastChannel === "undefined") return;
+  channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.onmessage = () => {
+    hydration = null;
+    void ensureHydrated();
+  };
+  // Node's global BroadcastChannel holds the event loop open — unref so test
+  // processes can exit. Browsers have no unref; the optional call is a no-op.
+  (channel as { unref?: () => void }).unref?.();
+}
+function broadcast(): void {
+  ensureChannel();
+  channel?.postMessage("changed");
+}
+
+async function hydrate(): Promise<void> {
+  if (typeof window === "undefined") return;
+  ensureChannel();
+  const map = await avatarStorage().getAll("projectAvatars");
+  cached = Object.keys(map).length > 0 ? map : EMPTY;
+  notify();
+}
+
+function ensureHydrated(): Promise<void> {
+  if (!hydration) hydration = hydrate();
+  return hydration;
+}
+
+if (typeof window !== "undefined") void ensureHydrated();
+
+export async function setProjectImage(root: string, image: { dataUrl: string; mime: string }): Promise<SetResult> {
+  if (!ALLOWED_MIMES.has(image.mime)) {
+    return { ok: false, reason: "Unsupported format. Use PNG, JPEG, WebP, or SVG." };
+  }
+  if (image.dataUrl.length > MAX_FAMILIAR_IMAGE_DATAURL_BYTES) {
+    return { ok: false, reason: "Image too large (max 2MB)." };
+  }
+  await ensureHydrated();
+  const key = normalizeProjectRoot(root);
+  const entry: ProjectImage = { dataUrl: image.dataUrl, mime: image.mime, updatedAt: new Date().toISOString() };
+  // Persist first, then commit to memory — a refused write must not leave the
+  // cache claiming an image that storage never accepted.
+  try {
+    await avatarStorage().put("projectAvatars", key, entry);
+  } catch {
+    return { ok: false, reason: STORAGE_FULL_REASON };
+  }
+  cached = { ...cached, [key]: entry };
+  notify();
+  broadcast();
+  return { ok: true };
+}
+
+export async function clearProjectImage(root: string): Promise<void> {
+  await ensureHydrated();
+  const key = normalizeProjectRoot(root);
+  if (!(key in cached)) return;
+  try {
+    await avatarStorage().delete("projectAvatars", key);
+  } catch {
+    return; // keep memory and storage consistent — the image simply stays
+  }
+  const next = { ...cached };
+  delete next[key];
+  cached = Object.keys(next).length > 0 ? next : EMPTY;
+  notify();
+  broadcast();
+}
+
+/** Follow a root edit: re-key the stored image so the avatar survives. */
+export async function moveProjectImage(fromRoot: string, toRoot: string): Promise<void> {
+  await ensureHydrated();
+  const from = normalizeProjectRoot(fromRoot);
+  const to = normalizeProjectRoot(toRoot);
+  const entry = cached[from];
+  if (!entry || from === to) return;
+  try {
+    await avatarStorage().put("projectAvatars", to, entry);
+  } catch {
+    return; // couldn't write the new key — leave the old record in place
+  }
+  const next = { ...cached, [to]: entry };
+  try {
+    await avatarStorage().delete("projectAvatars", from);
+    delete next[from];
+  } catch { /* both keys persisted — snapshot mirrors storage */ }
+  cached = next;
+  notify();
+  broadcast();
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+const getSnapshot = () => cached;
+const getServerSnapshot = () => EMPTY;
+
+/** Map of normalized project root → image. */
+export function useProjectImages(): ImageMap {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+export function readProjectImagesSnapshot(): ImageMap {
+  return cached;
+}
+
+/** Resolves once the store has loaded persisted images. */
+export function whenProjectImagesHydrated(): Promise<void> {
+  return ensureHydrated();
+}

--- a/src/lib/comux-projects.ts
+++ b/src/lib/comux-projects.ts
@@ -23,7 +23,7 @@ export function projectName(root: string): string {
  * so the Projects list reads like a set of distinct objects rather than a
  * uniform monochrome stack. Moderate chroma + a fixed lightness keep every hue
  * tasteful against both the dark and light themes; callers feed it to the
- * `--tile` custom property the `.comux-project-tile` glass chip reads.
+ * `--tile` custom property the `.project-avatar` glass tile reads.
  */
 export function projectTint(root: string): string {
   let hash = 0;


### PR DESCRIPTION
## Summary

Gives every project a visual identity, rendered consistently across the surfaces that list projects, with a user-settable image per project.

- **Store**: new `projectAvatars` object store in the `cave-avatars` IndexedDB (v2) + `src/lib/cave-project-images.ts`, keyed by **normalized project root** (the identity comux/chat-sidebar/sessions already bucket by), mirroring the familiar-image store: persist-then-commit, 2MB cap, mime allowlist, `cave:project-images` BroadcastChannel. `moveProjectImage` re-keys the record when a project's root is edited; deleting a project clears it.
- **Component**: `ProjectAvatar` — uploaded image when set, otherwise the deterministic tinted monogram tile comux rows already rendered (`projectTint`/`projectMonogram`), with `project.color` winning over the root-hash tint. `.comux-project-tile` CSS retires in favour of the generalized `.project-avatar`.
- **Setter**: Projects surface — the row's identity glyph is now a click-to-upload avatar button (same `prepareFamiliarImage` downsize pipeline as familiar avatars); context menu gains *Set/Change image…* and *Remove image*; friendly status line on rejected files.
- **Renders in**: Projects rows, shared ProjectPicker (trigger + avatar-led `menuitemradio` rows via a new `leading` slot on `PopoverItem`), chat-sidebar project groups (unregistered keep the dashed folder), home composer project chip, comux rail.

Spec: `docs/superpowers/specs/2026-07-03-project-avatars-design.md` (local, gitignored per repo convention).

## Test plan

- [x] `node scripts/run-tests.mjs app` — 523 files green (new: `cave-project-images.test.ts` incl. quota-refusal, cap, mime, move/normalization; `project-avatar.test.ts` source pins)
- [x] `pnpm build` green, bundle within budget
- [x] Live Playwright verify on the prod build: monogram tiles on all Projects rows → upload swaps to image on Projects/home-composer/sidebar/picker → Remove restores monogram → non-image file rejected with status text → image survives reload (IndexedDB)
- [ ] Comux rail exercised via CI e2e only (state not reachable headless); swap is markup-equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)