### PR TITLE
a11y(familiars): focus-trap the memory dialogs; announce familiar creation

### DIFF
--- a/src/components/create-familiar-dialog.tsx
+++ b/src/components/create-familiar-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/lib/icon";
@@ -54,6 +55,7 @@ export function CreateFamiliarDialog({
   defaultHarness,
   onCreated,
 }: Props) {
+  const { announce } = useAnnouncer();
   const [name, setName] = useState("");
   const [idOverride, setIdOverride] = useState<string | null>(null);
   const [glyph, setGlyph] = useState<string>(DEFAULT_GLYPH);
@@ -129,7 +131,9 @@ export function CreateFamiliarDialog({
       });
       const json = (await res.json().catch(() => ({}))) as { ok?: boolean; id?: string; error?: string };
       if (!res.ok || !json.ok) {
-        setError(json.error ?? `Could not create familiar (HTTP ${res.status}).`);
+        const msg = json.error ?? `Could not create familiar (HTTP ${res.status}).`;
+        setError(msg);
+        announce(msg, "assertive");
         setSubmitting(false);
         return;
       }
@@ -149,9 +153,12 @@ export function CreateFamiliarDialog({
       }
       reset();
       onCreated(newId);
+      announce(`${name.trim() || "Familiar"} created`, "polite");
       onClose();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Could not create familiar.");
+      const msg = err instanceof Error ? err.message : "Could not create familiar.";
+      setError(msg);
+      announce(msg, "assertive");
       setSubmitting(false);
     }
   }

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
@@ -786,12 +787,9 @@ type MemoryReaderModalProps = {
 
 export function MemoryReaderModal({ path, title, onClose }: MemoryReaderModalProps) {
   const { text, error } = useMemoryFile(path);
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Trap focus inside the reader + Escape-to-close + restore focus to the opener.
+  useFocusTrap(true, panelRef, { onEscape: onClose });
 
   const heading = title ?? path.split("/").pop() ?? "Memory";
 
@@ -804,7 +802,9 @@ export function MemoryReaderModal({ path, title, onClose }: MemoryReaderModalPro
       aria-label={`Memory reader: ${heading}`}
     >
       <div
-        className="relative flex h-[92vh] w-[94vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl"
+        ref={panelRef}
+        tabIndex={-1}
+        className="relative flex h-[92vh] w-[94vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl focus:outline-none"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Tabs } from "@/components/ui/tabs";
 // Shared relative-time formatter, imported as `age` so the call sites read the
 // same — standardizes this surface on the app-wide "2m ago / 3h ago / Jun 12" style.
@@ -515,16 +516,9 @@ type AgentMemoryOverlayProps = {
 };
 
 function FamiliarMemoryOverlay({ familiars, familiar, onClose, onOpenMemoryFile }: AgentMemoryOverlayProps) {
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Trap focus inside the panel + Escape-to-close + restore focus to the opener.
+  useFocusTrap(true, panelRef, { onEscape: onClose });
 
   return (
     <div
@@ -535,7 +529,9 @@ function FamiliarMemoryOverlay({ familiars, familiar, onClose, onOpenMemoryFile 
       onClick={onClose}
     >
       <div
-        className="familiars-view__overlay-panel relative flex h-[100dvh] w-full flex-col overflow-hidden border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl md:h-[85vh] md:w-[90vw] md:max-w-[1280px] md:rounded-xl"
+        ref={panelRef}
+        tabIndex={-1}
+        className="familiars-view__overlay-panel relative flex h-[100dvh] w-full flex-col overflow-hidden border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-2xl focus:outline-none md:h-[85vh] md:w-[90vw] md:max-w-[1280px] md:rounded-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <button


### PR DESCRIPTION
Accessibility follow-up to #2352 on **Familiar Studio** (mode `agents`).

## 1. Two hand-rolled full-screen dialogs never trapped focus
`FamiliarMemoryOverlay` (`familiars-view.tsx`, the full-screen memory browser) and `MemoryReaderModal` (`familiars-memory-view.tsx`, opened from every memory row's Expand) both set `role="dialog"`/`aria-modal` and wired Escape, but **never moved focus into the panel, never trapped it, and never restored focus on close** — Tab walked out into the roster behind the backdrop. Both now use the shared **`useFocusTrap`** (trap + Escape + focus-restore), replacing the redundant local Escape effects; the panels get `tabIndex={-1}` + `focus:outline-none` as a focus fallback.

## 2. Familiar creation was silent to assistive tech
Create-success just closed the modal; create-failure rendered a visual-only banner. Now announces `"<name> created"` (polite) on success and the error message (assertive) on failure via the shared **`useAnnouncer`**.

## Already-correct (verified, not touched)
The create dialog itself already uses the shared `Modal` (real focus trap + labelled inputs); the avatar-preview overlay uses `Modal`; `FamiliarDetailPanel`'s internal tabs use the shared `Tabs` with proper `tabpanel` wiring; daily-notes textareas are labelled; memory search/filter controls are labelled and the load error is `role="alert"`; delete goes through the `role="status"` undo toast.

## Deferred (noted)
`home-feed.tsx` hand-rolled feed tabs → shared `Tabs` (a refactor, deferred consistently across the home/marketplace audits); roving arrow-keys on the roster grid / detail rail / glyph picker; `aria-current` on memory file-rows; moving focus to the new familiar card after create.

## Why separate from #2352
Both touch `familiars-view.tsx` + `familiars-memory-view.tsx`, so per the campaign convention the correctness fix (#2352) and this a11y pass ship as two PRs; this branch was rebased onto main after #2352 merged.

## Test
- `pnpm test:app` — all 521 app test files pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)