### PR TITLE
fix+a11y(dashboard): reading signal counts only the active queue; honor reduced-motion on drag

### DIFF
--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -23,6 +23,7 @@ import type { ContractReport } from "@/lib/familiar-contract";
 import type { RetroRunsSnapshot } from "@/lib/retro-runs";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { useMinuteTick } from "@/lib/use-minute-tick";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { ActionInbox } from "@/components/dashboard/action-inbox";
 import { TodaySummary } from "@/components/dashboard/today-summary";
 import { RecentReports } from "@/components/dashboard/recent-reports";
@@ -195,7 +196,17 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
 
   // Predictive signals — pure + cheap over already-fetched data.
   const signals = useMemo(
-    () => dashboardSignals({ github: data.github, reading: data.reading, sessions: data.sessions, familiars: data.familiars, nowMs: now.getTime() }),
+    () =>
+      dashboardSignals({
+        github: data.github,
+        // Only the *active* queue (want-to-read / reading) — counting done and
+        // abandoned items made "Reading queue is large (N)" contradict the
+        // "To read" KPI, which uses this same filter.
+        reading: data.reading.filter((r) => r.status === "want-to-read" || r.status === "reading"),
+        sessions: data.sessions,
+        familiars: data.familiars,
+        nowMs: now.getTime(),
+      }),
     [data.github, data.reading, data.sessions, data.familiars, now],
   );
 
@@ -456,9 +467,13 @@ function Panel({ title, icon, count, hint, href, children }: {
 
 function SortableWidget({ id, children }: { id: string; children: ReactNode }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const reduceMotion = usePrefersReducedMotion();
   const style: CSSProperties = {
     transform: CSS.Translate.toString(transform),
-    transition,
+    // dnd-kit drives the settle animation via an inline JS transition that the
+    // global reduced-motion CSS reset can't reach — drop it so panels snap into
+    // place instead of sliding when the user asks for less motion.
+    transition: reduceMotion ? undefined : transition,
     zIndex: isDragging ? 20 : undefined,
     opacity: isDragging ? 0.92 : undefined,
   };


### PR DESCRIPTION
Audit pass on the **Dashboard cockpit** (17th surface). Most of the audit's headline findings turned out to be **stale false positives** — the agents read a pre-#2347 snapshot, so the "freshness pill stuck on just now" and "dead `Panel.href`" flags no longer match source (#2347 already fixed the freshness pill via `lastUpdated`+`useMinuteTick`, and wired `href` drill-throughs into 7 panels). Verified in source; only two genuinely-real fixes remain:

## 1. "Reading queue is large" counted finished items — P1
`dashboardSignals` received the raw `data.reading` (all statuses: want-to-read / reading / **done** / **abandoned**), so the signal `Reading queue is large (N items)` counted archived items and **contradicted the "To read" KPI** right beside it (which filters to the active want-to-read/reading queue). Now the signal gets the same active filter.

## 2. Drag reorder ignored `prefers-reduced-motion` — a11y
`SortableWidget` applies dnd-kit's inline JS `transition` for the panel-settle animation, which the global reduced-motion CSS reset can't reach (it only zeroes CSS `transition-duration`). Gated on the existing `usePrefersReducedMotion` hook so panels snap into place instead of sliding when reduced motion is requested. (The grid is already keyboard-draggable — `KeyboardSensor` is wired — so no P0 there.)

## Verified-clean / dropped (agents read stale code)
- Freshness pill: **correct** — `relativeTime(lastUpdated.toISOString())` against real wall-clock, refreshed by `useMinuteTick`. Not the #2347 self-comparison.
- `Panel.href`: **used** by 7 panels for drill-throughs (with `aria-label`). Not dead.
- Layout reorder math, persistence/migration (`reconcileLayout`), action-inbox optimistic rollback, analytics math: all verified clean.

## Deferred (noted)
KPI-trend fire-once snapshot (has a deliberate `eslint-disable` — intended), frozen `now = model.date` for greeting/agenda, drag SR announcements naming panels by title, action-inbox success announce + semantic `<ul>`, and dead-code re-verification (`dashboardLayout`/`DashboardZone`, unused `DashboardModel` fields) — left for a follow-up after re-verifying against current source.

## Test
- `pnpm test:app` — all 521 app test files pass; `tsc --noEmit` clean; no test pins the changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)