### PR TITLE
feat(chat): project identity tiles on Recent sidebar rows

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1181,6 +1181,13 @@ tr[role="checkbox"]:focus-visible {
   flex-shrink: 0;
   background: var(--text-muted);
 }
+/* Project identity tile on Recent rows — the time buckets interleave chats
+   from every project, so each row carries its project's avatar/monogram. */
+.cnav__thread-proj {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
 .cnav__dot--running {
   background: var(--color-success);
   animation: cnav-pulse 1.6s ease-in-out infinite;

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -89,4 +89,29 @@ assert.ok(
   "both view branches should render the shared ThreadRow",
 );
 
+// Recent rows carry their project's identity tile: the time buckets
+// interleave chats from every project, and the mapping comes from the SAME
+// override-aware grouping the folder view uses (a dragged chat shows its
+// override folder's tile, not its recorded cwd's).
+assert.match(
+  chatSidebar,
+  /const sessionProjectById = useMemo\(\(\) => \{[\s\S]*?for \(const group of groups\)/,
+  "Recent-row project lookup derives from the override-aware groups",
+);
+assert.match(
+  chatSidebar,
+  /indent="flat"\s*\n\s*project=\{sessionProjectById\.get\(session\.id\) \?\? null\}/,
+  "Recent rows pass the project identity into ThreadRow",
+);
+assert.match(
+  chatSidebar,
+  /cnav__thread-proj[\s\S]*?<ProjectAvatar name=\{project\.name\} root=\{project\.root\} size="sm"/,
+  "ThreadRow renders the shared ProjectAvatar tile with an accessible project name",
+);
+assert.match(
+  chatSidebar,
+  /<span className="sr-only">\{project\.name\}<\/span>/,
+  "the project name is announced, not just painted",
+);
+
 console.log("chat-sidebar-wiring.test.ts passed");

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -85,6 +85,9 @@ type ThreadRowProps = {
   deleting: boolean;
   /** "folder" indents under a project folder; "flat" aligns with section headers. */
   indent: "folder" | "flat";
+  /** Shown in the time-bucketed Recent view, where rows from every project
+   *  interleave — the folder view already says this via the group header. */
+  project?: { root: string; name: string } | null;
   onOpen: () => void;
   onTogglePin: () => void;
   onRequestDelete: () => void;
@@ -99,6 +102,7 @@ function ThreadRow({
   confirming,
   deleting,
   indent,
+  project = null,
   onOpen,
   onTogglePin,
   onRequestDelete,
@@ -115,6 +119,12 @@ function ThreadRow({
         className="cnav__thread-main focus-ring"
       >
         <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
+        {project ? (
+          <span className="cnav__thread-proj" title={project.name}>
+            <ProjectAvatar name={project.name} root={project.root} size="sm" />
+            <span className="sr-only">{project.name}</span>
+          </span>
+        ) : null}
         <span className="cnav__thread-title" title={title}>{title}</span>
         {confirming ? null : (
           <span className="cnav__time">{bareTime(session.updated_at || session.created_at)}</span>
@@ -210,6 +220,21 @@ export function ChatSidebar({
     () => deriveChatProjectGroups(applyProjectOverrides(visibleSessions, overrides), projects),
     [visibleSessions, overrides, projects],
   );
+
+  // Session → project identity for the Recent view, derived from the SAME
+  // override-aware grouping the folder view renders — a chat dragged into
+  // another folder shows that folder's tile, not its recorded cwd's.
+  const sessionProjectById = useMemo(() => {
+    const byId = new Map<string, { root: string; name: string }>();
+    for (const group of groups) {
+      if (!group.projectRoot) continue;
+      const name = folderLabel(group);
+      for (const session of group.sessions) {
+        byId.set(session.id, { root: group.projectRoot, name });
+      }
+    }
+    return byId;
+  }, [groups]);
 
   const pinnedSessions = useMemo(
     () =>
@@ -456,6 +481,7 @@ export function ChatSidebar({
                             confirming={confirmingSessionId === session.id}
                             deleting={deletingSessionId === session.id}
                             indent="flat"
+                            project={sessionProjectById.get(session.id) ?? null}
                             onOpen={() => onOpenSession(session)}
                             onTogglePin={() => togglePin(session.id)}
                             onRequestDelete={() => setConfirmingSessionId(session.id)}


### PR DESCRIPTION
## Why

The chat sidebar's default Recent view time-buckets conversations from every project into one list with no cue about which project each chat belongs to — you had to open a chat (or switch to the By-project view) to find out.

## What

- Each Recent row now renders its project's **`ProjectAvatar`** tile (uploaded image or deterministic monogram, from #2354) between the status dot and the title, with the project name as tooltip and an `sr-only` announcement for assistive tech.
- The session→project mapping derives from the **same override-aware grouping** the folder view renders — a chat dragged into another project folder shows that folder's tile, not its recorded cwd's. No-project chats stay tile-less.
- Folder view unchanged (the group header already communicates the project).

## Verification

- `chat-sidebar-wiring.test.ts` gained pins for the lookup derivation, the row wiring, the shared tile render, and the announced name; full app suite green (528 files); typecheck clean.
- Screenshot-verified against real data: 25 Recent rows across Today/Yesterday/Previous-7-days buckets, each with its distinct project tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)