### PR TITLE
fix(chat): drop late stream enqueues on cancelled OpenClaw sends

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -272,6 +272,11 @@ assert.match(
   /catch \(error\) \{[\s\S]*?closed = true;[\s\S]*?if \(!req\.signal\.aborted\) console\.warn/,
   "Native stream enqueue failures should mark the stream closed and avoid noisy abort-path errors",
 );
+assert.match(
+  chatRoute,
+  /const push = \(event: StreamEvent\) => \{[\s\S]*?if \(closed \|\| args\.req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(event\)\);[\s\S]*?catch/,
+  "OpenClaw stream pushes should be ignored after close/abort so late child close/error output cannot enqueue into a cancelled stream",
+);
 assert.doesNotMatch(
   chatRoute,
   /saveConfig\([\s\S]*modelOverride/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -648,7 +648,21 @@ function openClawChatResponse(args: {
 }): Response {
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
-      const push = (event: StreamEvent) => controller.enqueue(sse(event));
+      let closed = false;
+      // A user "stop" aborts the request while the OpenClaw child is still
+      // running; its late `close`/`error` handlers keep calling push after the
+      // client stream has been cancelled. Guard every enqueue so those tail
+      // events are dropped instead of throwing ERR_INVALID_STATE on a closed
+      // controller (mirrors the native coven-run stream below).
+      const push = (event: StreamEvent) => {
+        if (closed || args.req.signal.aborted) return;
+        try {
+          controller.enqueue(sse(event));
+        } catch (error) {
+          closed = true;
+          if (!args.req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);
+        }
+      };
       const pushProgress = (
         id: string,
         label: string,
@@ -664,7 +678,6 @@ function openClawChatResponse(args: {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
-      let closed = false;
       const close = () => {
         if (closed) return;
         closed = true;


### PR DESCRIPTION
## What

Guards the **OpenClaw** chat-send stream's `push` so late child output after a user cancel is dropped instead of throwing on a cancelled stream.

## Why

When a user presses **Stop** mid-stream, the request aborts while the OpenClaw child is still running. Its tail `close`/`error` handlers kept calling `push` → `controller.enqueue(...)` on an already-cancelled stream, throwing `ERR_INVALID_STATE` and logging noisy `Failed to enqueue chat stream event` warnings on what was an intentional cancel.

The **native coven-run** stream already had this guard (landed in `5c1914ff`); the OpenClaw adapter was the residual gap.

## Change

- `openClawChatResponse` `push` now short-circuits on `closed || req.signal.aborted` and wraps `enqueue` in try/catch, marking the stream closed and suppressing warnings on the abort path — mirroring the native stream exactly.
- Hoisted `let closed = false;` above `push` so the guard can reference it.
- Locking source assertion added in `harness-routing.test.ts` so the OpenClaw guard can't silently regress.

The offline travel-local stream in the same route is intentionally left unguarded: its `start` runs synchronously to `controller.close()` with no child process or async tail, so a cancel can't interleave a late enqueue there.

## Verification (local, on this branch off fresh `origin/main`)

- `node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts` — passed (incl. new assertion)
- `pnpm typecheck` — clean
- `pnpm check:tests-wired` — 707 wired (1 allowlisted)
- `pnpm test:app` — 528 files passed
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)