### PR TITLE
fix(chat): guard OpenClaw stream enqueue after abort

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -272,6 +272,11 @@ assert.match(
   /catch \(error\) \{[\s\S]*?closed = true;[\s\S]*?if \(!req\.signal\.aborted\) console\.warn/,
   "Native stream enqueue failures should mark the stream closed and avoid noisy abort-path errors",
 );
+assert.match(
+  chatRoute,
+  /const push = \(event: StreamEvent\) => \{[\s\S]*?if \(closed \|\| args\.req\.signal\.aborted\) return;[\s\S]*?controller\.enqueue\(sse\(event\)\);[\s\S]*?catch/,
+  "OpenClaw stream pushes should be ignored after close/abort so late child close/error output cannot enqueue into a cancelled stream",
+);
 assert.doesNotMatch(
   chatRoute,
   /saveConfig\([\s\S]*modelOverride/,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -648,7 +648,21 @@ function openClawChatResponse(args: {
 }): Response {
   const stream = new ReadableStream<Uint8Array>({
     start: async (controller) => {
-      const push = (event: StreamEvent) => controller.enqueue(sse(event));
+      let closed = false;
+      // A user "stop" aborts the request while the OpenClaw child is still
+      // running; its late `close`/`error` handlers keep calling push after the
+      // client stream has been cancelled. Guard every enqueue so those tail
+      // events are dropped instead of throwing ERR_INVALID_STATE on a closed
+      // controller (mirrors the native coven-run stream below).
+      const push = (event: StreamEvent) => {
+        if (closed || args.req.signal.aborted) return;
+        try {
+          controller.enqueue(sse(event));
+        } catch (error) {
+          closed = true;
+          if (!args.req.signal.aborted) console.warn("Failed to enqueue chat stream event", error);
+        }
+      };
       const pushProgress = (
         id: string,
         label: string,
@@ -664,7 +678,6 @@ function openClawChatResponse(args: {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
-      let closed = false;
       const close = () => {
         if (closed) return;
         closed = true;


### PR DESCRIPTION
## Summary
- guard OpenClaw chat stream enqueues after the client stream closes or aborts
- drop late child close/error events instead of enqueueing into a closed controller
- add a source-level regression assertion for the OpenClaw stream push guard

## Verification
- node --experimental-strip-types src/app/api/chat/send/harness-routing.test.ts
- pnpm check:tests-wired
- pnpm typecheck