### PR TITLE
feat(chat): show each thread's project icon in the Recent sidebar view

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1039,6 +1039,16 @@ tr[role="checkbox"]:focus-visible {
   flex-shrink: 0;
   color: var(--text-muted);
 }
+/* Per-row project tile in the flat Recent view (avatar for a registered project,
+   dashed folder for an unregistered cwd / no-project thread). */
+.cnav__thread-project {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+.cnav__thread-project--dir {
+  color: var(--text-muted);
+}
 .cnav__group-name {
   flex: 1;
   min-width: 0;

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -108,5 +108,10 @@ assert.match(
   /project\.projectId \? \([\s\S]{0,160}<ProjectAvatar/,
   "a registered project renders a ProjectAvatar tile in the row",
 );
+assert.match(
+  chatSidebar,
+  /<span className="sr-only">, \{folderLabel\(project\)\}<\/span>/,
+  "the decorative tile is paired with a screen-reader-only project name",
+);
 
 console.log("chat-sidebar-wiring.test.ts passed");

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -89,4 +89,24 @@ assert.ok(
   "both view branches should render the shared ThreadRow",
 );
 
+// ── Recent (flat) view shows a per-row project tile ──────────────────────────
+// The grouped view conveys the project via its folder header; the flat Recent
+// list mixes projects, so each row leads with the project's avatar (or a dashed
+// folder for an unregistered cwd / no-project thread).
+assert.match(
+  chatSidebar,
+  /const groupBySession = useMemo\(/,
+  "sidebar builds a session→project-group lookup for the Recent view",
+);
+assert.match(
+  chatSidebar,
+  /project=\{groupBySession\.get\(session\.id\) \?\? null\}/,
+  "the Recent-view ThreadRow receives its thread's project group",
+);
+assert.match(
+  chatSidebar,
+  /project\.projectId \? \([\s\S]{0,160}<ProjectAvatar/,
+  "a registered project renders a ProjectAvatar tile in the row",
+);
+
 console.log("chat-sidebar-wiring.test.ts passed");

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -131,6 +131,11 @@ function ThreadRow({
           )
         ) : null}
         <span className="cnav__thread-title" title={title}>{title}</span>
+        {project && (project.projectId || project.projectRoot) ? (
+          // The tile is decorative; name the project so a screen reader reading
+          // this flat, cross-project list still gets each thread's project.
+          <span className="sr-only">, {folderLabel(project)}</span>
+        ) : null}
         {confirming ? null : (
           <span className="cnav__time">{bareTime(session.updated_at || session.created_at)}</span>
         )}

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -85,6 +85,9 @@ type ThreadRowProps = {
   deleting: boolean;
   /** "folder" indents under a project folder; "flat" aligns with section headers. */
   indent: "folder" | "flat";
+  /** The thread's project group (Recent view only). Renders a leading project
+   *  tile so a flat, cross-project list still shows each thread's project. */
+  project?: ChatProjectGroup | null;
   onOpen: () => void;
   onTogglePin: () => void;
   onRequestDelete: () => void;
@@ -99,6 +102,7 @@ function ThreadRow({
   confirming,
   deleting,
   indent,
+  project,
   onOpen,
   onTogglePin,
   onRequestDelete,
@@ -115,6 +119,17 @@ function ThreadRow({
         className="cnav__thread-main focus-ring"
       >
         <span className={`cnav__dot ${statusDotClass(session.status)}`} aria-hidden />
+        {project ? (
+          project.projectId ? (
+            <span className="cnav__thread-project" title={folderLabel(project)}>
+              <ProjectAvatar name={folderLabel(project)} root={project.projectRoot} size="sm" />
+            </span>
+          ) : (
+            <span className="cnav__thread-project cnav__thread-project--dir" title={folderLabel(project)} aria-hidden>
+              <Icon name={folderIcon(project, false)} width={13} />
+            </span>
+          )
+        ) : null}
         <span className="cnav__thread-title" title={title}>{title}</span>
         {confirming ? null : (
           <span className="cnav__time">{bareTime(session.updated_at || session.created_at)}</span>
@@ -210,6 +225,15 @@ export function ChatSidebar({
     () => deriveChatProjectGroups(applyProjectOverrides(visibleSessions, overrides), projects),
     [visibleSessions, overrides, projects],
   );
+
+  // Map each session to its (override-resolved) project group so the flat Recent
+  // view can render a per-row project tile — the grouped view conveys the project
+  // through its header, but Recent mixes threads from every project together.
+  const groupBySession = useMemo(() => {
+    const map = new Map<string, ChatProjectGroup>();
+    for (const group of groups) for (const s of group.sessions) map.set(s.id, group);
+    return map;
+  }, [groups]);
 
   const pinnedSessions = useMemo(
     () =>
@@ -451,6 +475,7 @@ export function ChatSidebar({
                         <li key={session.id}>
                           <ThreadRow
                             session={session}
+                            project={groupBySession.get(session.id) ?? null}
                             active={activeSessionId === session.id}
                             pinned={isSessionPinned(pinnedIds, session.id)}
                             confirming={confirmingSessionId === session.id}


### PR DESCRIPTION
## What
The chat sidebar's **Recent** view (the time-bucketed thread list) now shows each thread's **project icon** on its row — the same `ProjectAvatar` tile the *Projects* view already renders in its folder header.

The grouped **By project** view conveys a thread's project through its folder header, but **Recent** is a flat list that mixes threads from every project with no project cue. Now each Recent row leads with:
- the project's **`ProjectAvatar`** (the user-uploaded image, or the deterministic tinted monogram tile — identical to everywhere else the project appears) for a **registered** project, or
- the **dashed folder** glyph (`ph:folder-simple-dashed`) for an unregistered cwd / no-project thread, matching the app's existing "outside a project" visual language.

## How
- A `groupBySession` memo maps each session → its project group off the existing `deriveChatProjectGroups(...)` result (which is **override-applied**, so a thread's per-user project override is honored).
- `ThreadRow` gains an optional `project?: ChatProjectGroup | null` prop; only the Recent view passes it (the Projects view keeps its header-only treatment). Existing status dot, title, time, and hover actions are unchanged.
- New `.cnav__thread-project` CSS (a `flex-shrink:0` inline-flex slot in the existing `gap:8px` row).

## Verified visually
Built + drove the chat sidebar with mocked sessions/projects (Playwright). Recent view rendered: `Refactor auth flow`/`Write API docs` → **AL** tile (registered Alpha), `Fix eslint config` → **BE** tile (registered Beta), `Tune the ranker` (unregistered cwd) + `Scratch experiment` (no project) → dashed folder. Tiles align cleanly, status dots preserved.

## Test
- `pnpm test:app` — all app test files pass; new source-text pins in `chat-sidebar-wiring.test.ts` (the group lookup, the Recent-row `project` wiring, the `ProjectAvatar` render). `tsc --noEmit` clean.

## Notes / possible follow-up
The tile is decorative (`aria-hidden`, as everywhere `ProjectAvatar` is used) with a `title` tooltip; the thread title remains the row's accessible name. A visually-hidden project name per row could be added if we want AT to announce the project in the flat list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)