### PR TITLE
fix(chat): hydration mismatch on #chat- deep links (Opening-chat takeover)

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -134,10 +134,20 @@ assert.match(
 // ── Deep-link loading hint (2026-07-04) ─────────────────────────────────────
 // The restore holds until the sessions fetch settles (~2s warm, longer under a
 // cold compile) — the shell must show intent for that beat, not flash Home.
+// REGRESSION (2026-07-04): seeding this state from the mount-time hash made
+// every #chat- URL a hydration mismatch (SSR renders false — the hash is
+// client-only), which regenerated the whole tree and spewed theme-script
+// console errors. It must start false and flip in a LAYOUT effect: that runs
+// before first paint, so the takeover still appears without a Home flash.
 assert.match(
   workspaceSource,
-  /const \[chatDeepLinkPending, setChatDeepLinkPending\] = useState<boolean>\(\s*\(\) => pendingChatDeepLinkRef\.current !== null,\s*\)/,
-  "the pending deep link mirrors into render state seeded from the mount-time hash",
+  /const \[chatDeepLinkPending, setChatDeepLinkPending\] = useState\(false\);\s*useLayoutEffect\(\(\) => \{\s*if \(pendingChatDeepLinkRef\.current !== null\) setChatDeepLinkPending\(true\);\s*\}, \[\]\);/,
+  "the pending flag starts hydration-safe (false) and reveals pre-paint via useLayoutEffect",
+);
+assert.doesNotMatch(
+  workspaceSource,
+  /useState<boolean>\(\s*\(\) => pendingChatDeepLinkRef\.current !== null,?\s*\)/,
+  "the hash-seeded initializer (hydration mismatch on #chat- URLs) must not return",
 );
 assert.match(
   restoreEffect,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { SidebarMinimal } from "@/components/sidebar-minimal";
 import { groupInboxFeed } from "@/lib/inbox-feed";
@@ -344,9 +344,15 @@ export function Workspace() {
   // Render mirror of the ref: while the deep link awaits the sessions fetch
   // the shell shows an "Opening chat…" takeover instead of flashing Home —
   // that wait is ~2s warm but stretches under a cold dev-server compile.
-  const [chatDeepLinkPending, setChatDeepLinkPending] = useState<boolean>(
-    () => pendingChatDeepLinkRef.current !== null,
-  );
+  // The hash is only readable client-side, so the flag must start false to
+  // match SSR's first render (seeding it from the ref made every #chat- URL
+  // a hydration mismatch that regenerated the whole tree); the layout effect
+  // flips it before first paint, so the takeover still shows without a
+  // Home flash.
+  const [chatDeepLinkPending, setChatDeepLinkPending] = useState(false);
+  useLayoutEffect(() => {
+    if (pendingChatDeepLinkRef.current !== null) setChatDeepLinkPending(true);
+  }, []);
   // Refs for the popstate listener — sessions repoll every 4s and mode flips
   // often; the listener should not resubscribe on either.
   const sessionsRef = useRef(sessions);


### PR DESCRIPTION
## Why

Opening any `#chat-<id>` URL threw a hydration failure at `workspace.tsx` (`chatDeepLinkPending` div rendered on the client's first paint but not the server's) plus a collateral "Encountered a script tag while rendering React component" console error from ThemeScript as React regenerated the tree. Cause: #2351 seeds `chatDeepLinkPending` from `readChatHash()` in the `useState` initializer, and the hash is client-only (SSR-guarded to null) — so SSR and the client's first render disagree.

## What

The flag now starts `false` (matching SSR) and flips in a **`useLayoutEffect`**, which runs before the first paint — preserving exactly what #2351 was built for: the "Opening chat…" takeover still appears with no flash of Home. The pinned initializer in `chat-router-switching.test.ts` is repinned to the hydration-safe pattern with a regression `doesNotMatch` on the old hash-seeded initializer.

## Verification

- Live check on the built app at `/#chat-…`: takeover visible immediately ("Opening chat…"), **0 console errors** (previously: hydration failure + script-tag error).
- Full app suite green (528 files), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)