### PR TITLE
feat(projects): identity follow-ups — comux header + board lane avatars, tile color setter

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -13,7 +13,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     return NextResponse.json({ ok: false, error: "invalid JSON" }, { status: 400 });
   }
 
-  const patch: { name?: string; root?: string; color?: string } = {};
+  const patch: { name?: string; root?: string; color?: string | null } = {};
   if (typeof body.name === "string") {
     const trimmed = body.name.trim();
     if (trimmed.length === 0) {
@@ -28,7 +28,15 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
     }
     patch.root = trimmed;
   }
-  if (typeof body.color === "string") patch.color = body.color;
+  if (typeof body.color === "string") {
+    const trimmed = body.color.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ ok: false, error: "color cannot be empty" }, { status: 400 });
+    }
+    patch.color = trimmed;
+  } else if (body.color === null) {
+    patch.color = null; // clear — the tile falls back to the auto root-hash tint
+  }
   if (Object.keys(patch).length === 0) {
     return NextResponse.json({ ok: false, error: "nothing to update" }, { status: 400 });
   }

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -8,6 +8,7 @@ import { scheduleLabel, scheduleUrgency } from "@/lib/board-schedule";
 import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { CaveProject } from "@/lib/cave-projects";
+import { ProjectAvatar } from "@/components/project-avatar";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { Icon } from "@/lib/icon";
 import type { GroupBy } from "@/components/board-table";
@@ -485,6 +486,12 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
       {groups.map(({ key, label, cards: gc }) => {
         const isCollapsed = collapsedGroups.has(key);
         const grpGrouped = grouped(gc);
+        // Project lanes lead with the project's identity tile (image/monogram);
+        // the "No project" lane and familiar/status grouping stay text-only.
+        const laneProject =
+          groupBy === "project" && key !== NO_PROJECT_KEY
+            ? projects.find((p) => p.id === key)
+            : undefined;
         const isStatusGroup = groupBy === "status"; // single-group, full-height
         const isMultiSwimlane = showSwimlanes && !isStatusGroup;
         return (
@@ -498,6 +505,14 @@ export function BoardKanban({ cards, familiars, projects, sessions, groupBy, sel
                   aria-expanded={!isCollapsed}
                 >
                   <Icon name={isCollapsed ? "ph:caret-right" : "ph:caret-down"} width={10} />
+                  {laneProject ? (
+                    <ProjectAvatar
+                      name={laneProject.name}
+                      root={laneProject.root}
+                      color={laneProject.color}
+                      size="sm"
+                    />
+                  ) : null}
                   {label}
                   <span className="board-swimlane-badge">{gc.length}</span>
                 </button>

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1730,7 +1730,11 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       <div className="flex items-start justify-between gap-2">
                         <div className="min-w-0">
                           <div className="flex items-center gap-2">
-                            <Icon name="ph:folder-open" width={15} className="shrink-0 text-[var(--text-muted)]" />
+                            <ProjectAvatar
+                              name={selectedProject.name}
+                              root={selectedProject.root}
+                              size="md"
+                            />
                             <h2 className="truncate text-sm font-semibold text-[var(--text-primary)]">
                               {selectedProject.name}
                             </h2>

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -66,6 +66,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     createProject,
     renameProject,
     updateRoot,
+    updateColor,
     deleteProject,
     reload,
   } = useProjects({ familiarId: activeFamiliarId });
@@ -635,6 +636,7 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
                     chats={chatsByRoot.get(normalizeProjectRoot(project.root)) ?? []}
                     onRename={renameProject}
                     onUpdateRoot={updateRoot}
+                    onUpdateColor={updateColor}
                     onDelete={deleteProject}
                     onNewChat={onNewChat}
                     onOpenSession={openSessionById}

--- a/src/components/projects/project-row.tsx
+++ b/src/components/projects/project-row.tsx
@@ -26,14 +26,31 @@ import { PopoverItem, PopoverSeparator } from "@/components/ui/popover";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 
+import { projectTint } from "@/lib/comux-projects";
+
 import { ProjectChatRow } from "./session-row";
 import { CHAT_CAP, chatDotClass, shortRoot, type MoveTarget } from "./projects-shared";
+
+/** Preset tile tints — the same oklch recipe projectTint() hashes into, at
+ *  fixed hues, so a hand-picked color sits naturally next to auto-tinted
+ *  tiles. Stored verbatim in CaveProject.color. */
+const PROJECT_COLOR_SWATCHES: { name: string; value: string }[] = [
+  { name: "Clay", value: "oklch(0.74 0.12 25)" },
+  { name: "Amber", value: "oklch(0.74 0.12 70)" },
+  { name: "Fern", value: "oklch(0.74 0.12 145)" },
+  { name: "Teal", value: "oklch(0.74 0.12 200)" },
+  { name: "Sky", value: "oklch(0.74 0.12 250)" },
+  { name: "Violet", value: "oklch(0.74 0.12 300)" },
+  { name: "Rose", value: "oklch(0.74 0.12 340)" },
+];
 
 type ProjectRowProps = {
   project: CaveProject;
   chats: SessionRow[];
   onRename: (id: string, name: string) => Promise<boolean>;
   onUpdateRoot: (id: string, root: string) => Promise<boolean>;
+  /** Set an explicit tile tint, or null to restore the auto root-hash tint. */
+  onUpdateColor: (id: string, color: string | null) => Promise<boolean>;
   onDelete: (id: string) => Promise<boolean>;
   onNewChat?: (projectRoot: string) => void;
   onOpenSession?: (sessionId: string) => void;
@@ -51,6 +68,7 @@ export function ProjectRow({
   chats,
   onRename,
   onUpdateRoot,
+  onUpdateColor,
   onDelete,
   onNewChat,
   onOpenSession,
@@ -163,7 +181,7 @@ export function ProjectRow({
   const [nameDraft, setNameDraft] = useState(project.name);
   const [rootDraft, setRootDraft] = useState(project.root);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [busy, setBusy] = useState<"name" | "root" | "delete" | null>(null);
+  const [busy, setBusy] = useState<"name" | "root" | "color" | "delete" | null>(null);
   const [copiedRoot, setCopiedRoot] = useState(false);
   const [menu, setMenu] = useState<ContextMenuState>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
@@ -226,6 +244,12 @@ export function ProjectRow({
     setBusy("delete");
     const ok = await onDelete(project.id);
     if (ok) void clearProjectImage(project.root);
+    setBusy(null);
+  };
+
+  const setColor = async (color: string | null) => {
+    setBusy("color");
+    await onUpdateColor(project.id, color);
     setBusy(null);
   };
 
@@ -494,6 +518,43 @@ export function ProjectRow({
             <Icon name={copiedRoot ? "ph:check" : "ph:copy"} width={12} aria-hidden />
           </button>
         )}
+      </div>
+
+      <div className="mt-2 flex min-w-0 items-center gap-2 pl-6">
+        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+          Color
+        </span>
+        <div className="flex items-center gap-1.5" role="group" aria-label={`Tile color for ${project.name}`}>
+          <button
+            type="button"
+            onClick={() => void setColor(null)}
+            disabled={busy === "color"}
+            aria-pressed={!project.color}
+            title="Auto — tinted from the project path"
+            aria-label="Auto color"
+            className={`focus-ring h-4 w-4 shrink-0 rounded-full border border-dashed border-[var(--border-strong)] ${
+              !project.color ? "ring-2 ring-[var(--accent-presence)] ring-offset-1 ring-offset-[var(--bg-base)]" : ""
+            }`}
+            style={{ background: `color-mix(in oklch, ${projectTint(project.root)} 45%, transparent)` }}
+          />
+          {PROJECT_COLOR_SWATCHES.map((swatch) => (
+            <button
+              key={swatch.value}
+              type="button"
+              onClick={() => void setColor(swatch.value)}
+              disabled={busy === "color"}
+              aria-pressed={project.color === swatch.value}
+              title={swatch.name}
+              aria-label={`${swatch.name} color`}
+              className={`focus-ring h-4 w-4 shrink-0 rounded-full ${
+                project.color === swatch.value
+                  ? "ring-2 ring-[var(--accent-presence)] ring-offset-1 ring-offset-[var(--bg-base)]"
+                  : ""
+              }`}
+              style={{ background: swatch.value }}
+            />
+          ))}
+        </div>
       </div>
 
       {chats.length > 0 ? (

--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -37,6 +37,20 @@ try {
   assert.equal(patched?.name, "New");
   assert.equal(patched?.root, "/tmp/test");
 
+  // color: string sets, undefined leaves untouched, null clears (back to the
+  // auto root-hash tint — the field disappears rather than persisting null).
+  const colored = await patchProject(created.id, { color: "oklch(0.74 0.12 250)" });
+  assert.equal(colored?.color, "oklch(0.74 0.12 250)");
+  const rootPatchKeepsColor = await patchProject(created.id, { root: "/tmp/test" });
+  assert.equal(rootPatchKeepsColor?.color, "oklch(0.74 0.12 250)", "untouched patch keeps the color");
+  const cleared = await patchProject(created.id, { color: null });
+  assert.equal(cleared?.color, undefined, "null clears the explicit color");
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(cleared ?? {}, "color"),
+    false,
+    "cleared color is removed from the record, not persisted as null",
+  );
+
   const slashHeavy = await createProject({
     name: "Slash heavy",
     root: `  C:\\tmp\\slash-heavy${"/".repeat(5000)}  `,

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -95,7 +95,9 @@ export function createProject(input: {
 
 export function patchProject(
   id: string,
-  patch: Partial<Pick<CaveProject, "name" | "root" | "color">>,
+  // color: string sets an explicit tint; null clears it (back to the auto
+  // root-hash tint); undefined leaves it untouched.
+  patch: { name?: string; root?: string; color?: string | null },
 ): Promise<CaveProject | null> {
   return withWriteMutex(async () => {
     const projects = await loadProjects();
@@ -104,11 +106,14 @@ export function patchProject(
     const current = projects[idx];
     const updated: CaveProject = {
       ...current,
-      ...patch,
       name: patch.name !== undefined ? patch.name.trim() : current.name,
       root: patch.root !== undefined ? normalizeRoot(patch.root) : current.root,
       updatedAt: new Date().toISOString(),
     };
+    if (patch.color !== undefined) {
+      if (patch.color === null) delete updated.color;
+      else updated.color = patch.color;
+    }
     const next = [...projects];
     next[idx] = updated;
     await saveProjects(next);

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -12,6 +12,8 @@ export type ProjectsState = {
   createProject: (name: string, root: string) => Promise<CaveProject | null>;
   renameProject: (id: string, name: string) => Promise<boolean>;
   updateRoot: (id: string, root: string) => Promise<boolean>;
+  /** Set an explicit tile tint, or pass null to restore the auto root-hash tint. */
+  updateColor: (id: string, color: string | null) => Promise<boolean>;
   deleteProject: (id: string) => Promise<boolean>;
 };
 
@@ -115,6 +117,20 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     return false;
   }, []);
 
+  const updateColor = useCallback(async (id: string, color: string | null): Promise<boolean> => {
+    const res = await fetch(`/api/projects/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ color }),
+    });
+    const data = await res.json();
+    if (data.ok && data.project) {
+      setProjects((prev) => prev.map((project) => (project.id === id ? data.project : project)));
+      return true;
+    }
+    return false;
+  }, []);
+
   const deleteProject = useCallback(async (id: string): Promise<boolean> => {
     const res = await fetch(`/api/projects/${id}`, { method: "DELETE" });
     const data = await res.json();
@@ -133,6 +149,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     createProject,
     renameProject,
     updateRoot,
+    updateColor,
     deleteProject,
   };
 }


### PR DESCRIPTION
## Summary

Closes out the follow-ups deferred from #2354:

- **Comux in-project header** leads with the `ProjectAvatar` tile instead of a generic folder icon (`ComuxProject` has no `color` field, so this site uses the root tint / uploaded image only).
- **Board project swimlanes** lead with the project's tile; the "No project" lane and familiar/status grouping stay text-only.
- **Tile color setter**: the expanded project row gains a Color row — seven preset oklch swatches on `projectTint`'s recipe (`oklch(0.74 0.12 H)`) plus an Auto swatch that restores the root-hash tint. Wired through a new `useProjects.updateColor`; `PUT /api/projects/[id]` + `patchProject` now accept `color: null` to clear (the field is removed, never persisted as null), and empty-string colors are rejected 400.

## Test plan

- [x] `node scripts/run-tests.mjs app` — 528 files green (cave-projects.test.ts extended: set / keep-on-unrelated-patch / clear semantics)
- [x] `pnpm build` green, bundle within budget
- [x] Live Playwright verify: picked Sky on a real project → store shows the oklch value, Projects tile and the board lane tile both re-tint; Auto restores the root tint and removes `color` from the record; board lanes show avatars on project lanes and none on "No project"
- [ ] Comux in-project header state not reachable headless — markup-equivalent swap, covered by suite/CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)