### PR TITLE
fix(layout): use Next Script for inline boot scripts

### DIFF
--- a/src/components/dev-cache-reset-script.test.ts
+++ b/src/components/dev-cache-reset-script.test.ts
@@ -5,6 +5,8 @@ import { readFileSync } from "node:fs";
 const src = readFileSync(new URL("./dev-cache-reset-script.tsx", import.meta.url), "utf8");
 const layout = readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8");
 
+assert.match(src, /import Script from "next\/script"/, "dev cache reset uses Next Script, not a raw script tag");
+assert.match(src, /strategy="beforeInteractive"/, "dev cache reset should run before hydration");
 assert.match(src, /process\.env\.NODE_ENV !== "development"/, "script should render only in development");
 assert.match(src, /navigator\.serviceWorker\.getRegistrations\(\)/, "script should inspect existing service workers before hydration");
 assert.match(src, /registration\.unregister\(\)/, "script should unregister stale service workers");

--- a/src/components/dev-cache-reset-script.tsx
+++ b/src/components/dev-cache-reset-script.tsx
@@ -1,3 +1,5 @@
+import Script from "next/script";
+
 const DEV_CACHE_RESET_SCRIPT = `
 (function () {
   try {
@@ -50,8 +52,9 @@ const DEV_CACHE_RESET_SCRIPT = `
 export function DevCacheResetScript() {
   if (process.env.NODE_ENV !== "development") return null;
   return (
-    <script
+    <Script
       id="dev-cache-reset"
+      strategy="beforeInteractive"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: development-only stale SW cleanup before hydration
       dangerouslySetInnerHTML={{ __html: DEV_CACHE_RESET_SCRIPT }}
     />

--- a/src/components/security/sidecar-auth-bridge.test.ts
+++ b/src/components/security/sidecar-auth-bridge.test.ts
@@ -11,6 +11,9 @@ const match = source.match(/SIDECAR_AUTH_BRIDGE = `([\s\S]*?)`;/);
 assert.ok(match, "should find the SIDECAR_AUTH_BRIDGE script literal");
 const SCRIPT = match[1];
 
+assert.match(source, /import Script from "next\/script"/, "sidecar auth bridge uses Next Script, not a raw script tag");
+assert.match(source, /strategy="beforeInteractive"/, "sidecar auth bridge should run before hydration");
+
 const TOKEN_HEADER = "x-coven-cave-token";
 
 function makeWindow({ search = "", hash = "", origin = "http://localhost:3210" }) {

--- a/src/components/security/sidecar-auth-bridge.tsx
+++ b/src/components/security/sidecar-auth-bridge.tsx
@@ -1,4 +1,6 @@
 // Exported for the behavioral test; injected verbatim as an inline <script>.
+import Script from "next/script";
+
 export const SIDECAR_AUTH_BRIDGE = `
 (() => {
   const tokenParam = "covenCaveToken";
@@ -81,7 +83,9 @@ export function SidecarAuthBridge() {
     sidecarAuthRequired(),
   )};`;
   return (
-    <script
+    <Script
+      id="sidecar-auth-bridge"
+      strategy="beforeInteractive"
       dangerouslySetInnerHTML={{
         __html: `${authRequirementScript}\n${SIDECAR_AUTH_BRIDGE}`,
       }}

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -4,6 +4,9 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./theme-script.tsx", import.meta.url), "utf8");
 
+assert.match(source, /import Script from "next\/script"/, "ThemeScript uses Next Script, not a raw script tag");
+assert.match(source, /strategy="beforeInteractive"/, "ThemeScript should run before hydration");
+
 // 1. Script defaults theme to "coven" and mode to "dark".
 assert.match(source, /\|\|\s*"coven"/, "theme defaults to coven");
 assert.match(source, /\|\|\s*"dark"/, "mode defaults to dark");

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -29,6 +29,8 @@
  * fallback chains, or editing pair choices.
  */
 
+import Script from "next/script";
+
 const THEME_SCRIPT = `
 (function () {
   try {
@@ -138,8 +140,9 @@ const THEME_SCRIPT = `
  */
 export function ThemeScript() {
   return (
-    <script
+    <Script
       id="theme-init"
+      strategy="beforeInteractive"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: intentional flash-prevention inline script
       dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }}
     />


### PR DESCRIPTION
## Summary
- replace raw component-rendered inline script tags with Next Script beforeInteractive wrappers
- keep theme, dev cache reset, and sidecar auth boot script payloads unchanged
- add source-level assertions so boot scripts stay on the supported Next script path

## Verification
- node --experimental-strip-types src/components/theme-script.test.ts
- node --experimental-strip-types src/components/dev-cache-reset-script.test.ts
- node --experimental-strip-types src/components/security/sidecar-auth-bridge.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- Playwright loaded http://127.0.0.1:3001 and reloaded: console reported 0 errors, 0 warnings