### PR TITLE
fix(ios): clear bearer token on host-only reconfigure

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -574,8 +574,17 @@ final class AppModel {
     // MARK: - Connection lifecycle
 
     func configure(host: String, token: String? = nil) async {
-        if let token { CaveConnection.saveAccessToken(token) }
         let conn = CaveConnection(host: host)
+        let isSameEndpoint = connection?.baseURL == conn.baseURL
+
+        if let token {
+            CaveConnection.saveAccessToken(token)
+        } else if !isSameEndpoint {
+            // Tokens are stored globally, so never carry an old desktop's
+            // credential to a newly configured host from a tokenless invite.
+            CaveConnection.saveAccessToken(nil)
+        }
+
         connection = conn
         conn.save()
         await refreshConnection()

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -575,8 +575,12 @@ final class AppModel {
 
     func configure(host: String, token: String? = nil) async {
         let conn = CaveConnection(host: host)
-        let isSameEndpoint = connection?.baseURL == conn.baseURL
-
+        let trimmedHost = host.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hostIsExplicitURL = trimmedHost.lowercased().hasPrefix("http://") || trimmedHost.lowercased().hasPrefix("https://")
+        let hostHasExplicitPort = !hostIsExplicitURL && trimmedHost.contains(":")
+        let isSameEndpoint = (hostIsExplicitURL || hostHasExplicitPort)
+            ? (connection?.baseURL == conn.baseURL)
+            : (connection?.baseURL?.host?.lowercased() == conn.baseURL?.host?.lowercased())
         if let token {
             CaveConnection.saveAccessToken(token)
         } else if !isSameEndpoint {


### PR DESCRIPTION
### Motivation
- Deep links like `covencave://connect?host=…` without a `token` could reconfigure the app to a different host while leaving a previously stored global bearer token in the Keychain, causing that token to be sent to the newly configured (potentially attacker-controlled) host. 
- The intent is to avoid leaking a desktop-scoped credential when a host change is driven by a tokenless invite while preserving normal reconnect and token-supplied flows.

### Description
- Change `AppModel.configure(host:token:)` to construct the target `CaveConnection` first and compare `connection?.baseURL` to the new connection's `baseURL` to detect an endpoint change. 
- When a non-nil `token` is provided, the token is still saved via `CaveConnection.saveAccessToken(token)` as before. 
- When `token` is `nil` and the endpoint changes, the global stored token is cleared via `CaveConnection.saveAccessToken(nil)` to ensure old credentials are not carried to a new host (file modified: `apps/ios/CovenCave/CovenCave/State/AppModel.swift`).

### Testing
- Ran `git diff --check` which passed with no whitespace or index errors. 
- Verified the change was committed locally and the modified lines appear at `AppModel.swift` around the `configure` method. 
- Could not run Xcode/unit tests in this environment because `xcodebuild` is not available (`xcodebuild: command not found`), so full iOS test execution was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4824d296588327aa4c5dd3412ae99b)