### PR TITLE
fix(chat): scope host runtime selection

### DIFF
--- a/src/app/api/chat/send/harness-routing.test.ts
+++ b/src/app/api/chat/send/harness-routing.test.ts
@@ -104,10 +104,10 @@ assert.match(
 );
 
 // ── Host picker (composer Host chip) ─────────────────────────────────────────
-// An explicit registered host (or "local") wins; with no request, a
-// conversation recorded on an ssh host stays pinned there; only then does the
-// familiar's own runtime binding decide. Unregistered hosts are rejected
-// fail-closed and the remote command comes from the registry, never the body.
+// An explicit allowed host wins; with no request, a conversation recorded on
+// an allowed ssh host stays pinned there; only then does the familiar's own
+// runtime binding decide. Unregistered hosts are rejected fail-closed and the
+// remote command comes from the registry, never the body.
 assert.match(
   chatRoute,
   /const runtimeSelection = resolveRequestedRuntime\(\{\s*requestedHost: body\.runtimeHost,\s*conversationRuntime: existingConversation\?\.runtime,/,
@@ -127,6 +127,21 @@ assert.match(
   chatRoute,
   /remoteHosts: config\.remoteHosts,/,
   "registered remote hosts feed the registry",
+);
+assert.match(
+  chatRoute,
+  /familiarRuntimes: \[config\.defaults\?\.runtime, binding\.runtime\]/,
+  "inherited familiar SSH runtimes are scoped to the current familiar instead of every familiar",
+);
+assert.match(
+  chatRoute,
+  /currentRuntime: binding\.runtime,/,
+  "requested local execution is authorized against the current familiar runtime",
+);
+assert.doesNotMatch(
+  chatRoute,
+  /Object\.values\(config\.familiars \?\? \{\}\)\.map\(\(entry\) => entry\?\.runtime\)/,
+  "send must not expose every familiar's SSH runtime as a selectable chat host",
 );
 
 assert.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -968,20 +968,19 @@ export async function POST(req: Request) {
       { status: 404, headers: { "content-type": "application/json" } },
     );
   }
-  // Host picker: an explicit registered host (or "local") wins; with no
-  // request, a conversation recorded on an ssh host stays pinned there; only
-  // then does the familiar's own runtime binding decide. Unregistered hosts
-  // are rejected fail-closed — the client names registry entries, nothing more.
+  // Host picker: an explicit allowed host wins; with no request, a conversation
+  // recorded on an allowed ssh host stays pinned there; only then does the
+  // familiar's own runtime binding decide. Unregistered hosts are rejected
+  // fail-closed — inherited familiar runtimes are scoped to the current
+  // familiar so one familiar cannot borrow another familiar's SSH binding.
   const runtimeSelection = resolveRequestedRuntime({
     requestedHost: body.runtimeHost,
     conversationRuntime: existingConversation?.runtime,
     registry: sshHostRegistry({
       remoteHosts: config.remoteHosts,
-      familiarRuntimes: [
-        config.defaults?.runtime,
-        ...Object.values(config.familiars ?? {}).map((entry) => entry?.runtime),
-      ],
+      familiarRuntimes: [config.defaults?.runtime, binding.runtime],
     }),
+    currentRuntime: binding.runtime,
   });
   if (!runtimeSelection.ok) {
     return new Response(

--- a/src/lib/chat-hosts.test.ts
+++ b/src/lib/chat-hosts.test.ts
@@ -51,10 +51,16 @@ assert.equal(parseConversationRuntime("garbage"), null);
 assert.equal(parseConversationRuntime(null), null);
 
 // ── Requested-runtime resolution (fail closed) ──────────────────────────────
-const resolve = (requestedHost, conversationRuntime = null) =>
-  resolveRequestedRuntime({ requestedHost, conversationRuntime, registry });
+const resolve = (requestedHost, conversationRuntime = null, currentRuntime = { kind: "local" }) =>
+  resolveRequestedRuntime({ requestedHost, conversationRuntime, registry, currentRuntime });
 
-assert.deepEqual(resolve("local"), { ok: true, runtime: { kind: "local" } }, "'local' forces the local machine");
+assert.deepEqual(resolve("local"), { ok: true, runtime: { kind: "local" } }, "'local' keeps a local-bound familiar on the local machine");
+{
+  const rejected = resolve("local", null, { kind: "ssh", host: "vm-1", cwd: "/srv/work", command: "coven" });
+  assert.equal(rejected.ok, false, "'local' cannot downgrade an ssh-bound familiar to local execution");
+  assert.match(rejected.error, /local runtime is not allowed/);
+}
+
 assert.deepEqual(
   resolve("vm-1"),
   { ok: true, runtime: { kind: "ssh", host: "vm-1", cwd: "/srv/work", command: "coven" } },

--- a/src/lib/chat-hosts.ts
+++ b/src/lib/chat-hosts.ts
@@ -120,10 +120,10 @@ export function resolveRequestedRuntime(args: {
   requestedHost: string | null | undefined;
   conversationRuntime: string | null | undefined;
   registry: SshFamiliarRuntime[];
-  currentRuntime?: FamiliarRuntime | Partial<FamiliarRuntime> | null | undefined;
+  currentRuntime: FamiliarRuntime | Partial<FamiliarRuntime> | null | undefined;
 }): RequestedRuntimeResolution {
   const requested = typeof args.requestedHost === "string" ? args.requestedHost.trim() : "";
-  const currentRuntime = normalizeFamiliarRuntime(args.currentRuntime as FamiliarRuntime);
+  const currentRuntime = normalizeFamiliarRuntime(args.currentRuntime);
   if (requested) {
     if (requested === LOCAL_HOST_ID) {
       if (isSshRuntime(currentRuntime)) {

--- a/src/lib/chat-hosts.ts
+++ b/src/lib/chat-hosts.ts
@@ -4,10 +4,10 @@
 // send route all share one model.
 //
 // Security model (fail-closed, like project permissions): the client only ever
-// names a host id — "local" or a REGISTERED ssh host. The server resolves the
-// id against the registry (config.remoteHosts ∪ familiars' ssh runtime
-// bindings); an unregistered host is rejected, and the remote `command` always
-// comes from the registry, never from the request.
+// names a host id — "local" or an allowed ssh host. The send route resolves the
+// id against a registry scoped to the current familiar plus explicitly
+// registered remote hosts; an unregistered host is rejected, and the remote
+// `command` always comes from the registry, never from the request.
 
 import {
   isSshRuntime,
@@ -16,8 +16,8 @@ import {
   type SshFamiliarRuntime,
 } from "./familiar-runtime.ts";
 
-/** Sentinel host id for "this machine" — a real id so it can force-local a
- *  chat whose familiar is bound to a remote runtime. */
+/** Sentinel host id for "this machine" — a real id so local-bound chats can
+ *  select local execution explicitly. */
 export const LOCAL_HOST_ID = "local";
 
 export type ChatHostOption = {
@@ -38,8 +38,8 @@ export type SshHostRegistryEntry = {
 
 /**
  * The merged, deduped ssh-host registry: explicitly registered remote hosts
- * first (their cwd/command win), then hosts inherited from familiars' runtime
- * bindings. Invalid entries are dropped via the same validation the send
+ * first (their cwd/command win), then supplied familiar runtime bindings.
+ * Invalid entries are dropped via the same validation the send
  * route enforces.
  */
 export function sshHostRegistry(args: {
@@ -106,9 +106,11 @@ export type RequestedRuntimeResolution =
  * Resolve what runtime a send should use, before falling back to the
  * familiar's own binding:
  *
- *  - an explicit `requestedHost` wins — "local" forces the local machine, a
- *    registered ssh host resolves to its registry runtime, anything else is
- *    REJECTED (fail closed; the picker only offers registered hosts);
+ *  - an explicit `requestedHost` wins only within the caller's authorization
+ *    context — "local" is accepted for local-bound familiars but cannot
+ *    downgrade an ssh-bound familiar, an allowed ssh host resolves to its
+ *    registry runtime, anything else is REJECTED (fail closed; the picker only
+ *    offers registered hosts);
  *  - with no request, a conversation previously recorded on an ssh host stays
  *    pinned there while that host remains registered (remote chats must not
  *    silently fall back to local because the picker default is local);
@@ -118,10 +120,17 @@ export function resolveRequestedRuntime(args: {
   requestedHost: string | null | undefined;
   conversationRuntime: string | null | undefined;
   registry: SshFamiliarRuntime[];
+  currentRuntime?: FamiliarRuntime | Partial<FamiliarRuntime> | null | undefined;
 }): RequestedRuntimeResolution {
   const requested = typeof args.requestedHost === "string" ? args.requestedHost.trim() : "";
+  const currentRuntime = normalizeFamiliarRuntime(args.currentRuntime as FamiliarRuntime);
   if (requested) {
-    if (requested === LOCAL_HOST_ID) return { ok: true, runtime: { kind: "local" } };
+    if (requested === LOCAL_HOST_ID) {
+      if (isSshRuntime(currentRuntime)) {
+        return { ok: false, error: "local runtime is not allowed for this familiar" };
+      }
+      return { ok: true, runtime: { kind: "local" } };
+    }
     const match = args.registry.find((runtime) => runtime.host === requested);
     if (!match) return { ok: false, error: `host '${requested}' is not registered` };
     return { ok: true, runtime: match };


### PR DESCRIPTION
### Motivation
- Fix an authorization/isolation bug where a client could select any SSH runtime registered for any familiar (or force `local`) and cause a chat to run on an unrelated host or local machine, bypassing familiar project/runtime checks. 
- Ensure runtime selection is evaluated in the requesting familiar's authorization context so a familiar cannot borrow another familiar's SSH binding or be downgraded to `local` when it is SSH-bound.

### Description
- Change `resolveRequestedRuntime` in `src/lib/chat-hosts.ts` to accept an optional `currentRuntime` and reject `requestedHost === LOCAL_HOST_ID` when the caller's `currentRuntime` is an SSH runtime. 
- Limit the registry passed to `sshHostRegistry` in `/api/chat/send` to `config.defaults?.runtime` and the current `binding.runtime` instead of every familiar's runtime, and pass `currentRuntime: binding.runtime` into `resolveRequestedRuntime`. 
- Update picker/registry comments to reflect the scoped security model and adjust the sentinel `LOCAL_HOST_ID` description. 
- Add and update regression tests in `src/lib/chat-hosts.test.ts` and `src/app/api/chat/send/harness-routing.test.ts` to cover: `local` override rejection for SSH-bound familiars, the scoped registry composition, and that the send route no longer exposes every familiar runtime.

### Testing
- Ran unit/regression tests: `node src/lib/chat-hosts.test.ts` and `node src/app/api/chat/send/harness-routing.test.ts`, both passed. 
- Ran type checks and CI wiring checks: `pnpm typecheck` and `pnpm check:tests-wired`, both succeeded. 
- Ran API test suite: `pnpm test:api`, all 114 `api` test files passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4863352bc48327b79b77184892149f)