### PR TITLE
feat(code-rail): add Files tab preview

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -70,6 +70,7 @@ export const SUITES = {
     "src/components/chat-sidebar-wiring.test.ts",
     "src/components/workspace-rail.test.ts",
     "src/components/workspace-rail-wiring.test.ts",
+    "src/components/rail-files-panel.test.ts",
     "src/lib/workflows.test.ts",
     "src/lib/familiar-multiselect.test.ts",
     "src/lib/codex-automation-form.test.ts",

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -588,6 +588,8 @@ export function ChatSurface({
                     changeCount={changeCount}
                     activeTab={rail.activeTab}
                     pinned={rail.pinned}
+                    projectRoot={railProjectRoot}
+                    familiarId={snapshot.familiar?.id ?? null}
                     onSelectTab={rail.setActiveTab}
                     onTogglePin={rail.togglePin}
                     onCollapse={rail.collapse}

--- a/src/components/rail-file-preview.tsx
+++ b/src/components/rail-file-preview.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MarkdownBlock, SyntaxBlock } from "@/components/message-bubble";
+
+// ─── API response shape (mirrors src/app/api/project-file/route.ts) ───────────
+
+type ProjectFileBody =
+  | { ok: true; kind: "text"; content: string; size: number }
+  | { ok: true; kind: "image"; dataUrl: string; mimeType: string; size: number }
+  | { ok: false; error: string };
+
+type Loaded =
+  | { kind: "text"; content: string; size: number }
+  | { kind: "image"; dataUrl: string; mimeType: string; size: number };
+
+const MARKDOWN_EXTS = new Set(["md", "mdx", "markdown"]);
+
+function isMarkdownPath(path: string): boolean {
+  const ext = path.split(".").pop()?.toLowerCase();
+  return Boolean(ext && MARKDOWN_EXTS.has(ext));
+}
+
+function fileName(path: string): string {
+  return path.split("/").pop() ?? path;
+}
+
+/**
+ * Read-only preview for a single file selected in the code rail's Files tab.
+ *
+ * Fetches `/api/project-file` whenever `path` changes and renders:
+ *  - a muted "Select a file" empty state when no file is selected,
+ *  - a skeleton while loading,
+ *  - highlighted text (SyntaxBlock), rendered markdown (MarkdownBlock), or an
+ *    `<img>` for images, and
+ *  - a graceful error state on failure.
+ *
+ * There is deliberately NO editing/save affordance — the comux view owns the
+ * editable preview; this is a lightweight reader for the rail.
+ */
+export function RailFilePreview({
+  path,
+  projectRoot,
+  familiarId,
+}: {
+  path: string | null;
+  projectRoot: string | null;
+  familiarId?: string | null;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [file, setFile] = useState<Loaded | null>(null);
+
+  useEffect(() => {
+    if (!path) {
+      setFile(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setFile(null);
+    const params = new URLSearchParams({ path });
+    if (familiarId) params.set("familiarId", familiarId);
+    void fetch(`/api/project-file?${params.toString()}`, { cache: "no-store" })
+      .then(async (res) => {
+        const json = (await res.json()) as ProjectFileBody;
+        if (cancelled) return;
+        if (!json.ok) {
+          setError(json.error || "Couldn't open this file.");
+          setLoading(false);
+          return;
+        }
+        setFile(json.kind === "image"
+          ? { kind: "image", dataUrl: json.dataUrl, mimeType: json.mimeType, size: json.size }
+          : { kind: "text", content: json.content, size: json.size });
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError("Couldn't open this file.");
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [path, familiarId, projectRoot]);
+
+  if (!path) {
+    return (
+      <div className="workspace-rail__files-empty">
+        <Icon name="ph:file" width={22} aria-hidden />
+        <p>Select a file to preview it here.</p>
+      </div>
+    );
+  }
+
+  const name = fileName(path);
+
+  return (
+    <div className="workspace-rail__preview">
+      <header className="workspace-rail__preview-head">
+        <Icon
+          name={file?.kind === "image" ? "ph:file-image" : isMarkdownPath(path) ? "ph:file-text" : "ph:file-code"}
+          width={12}
+          aria-hidden
+        />
+        <span className="workspace-rail__preview-name" title={path}>{name}</span>
+      </header>
+      <div className="workspace-rail__preview-body">
+        {loading ? (
+          <div className="workspace-rail__preview-skeleton" aria-busy="true" aria-label="Loading file">
+            {["94%", "82%", "97%", "70%", "88%", "60%"].map((w, i) => (
+              <Skeleton key={i} variant="text" width={w} />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="workspace-rail__preview-error" role="alert">
+            <Icon name="ph:warning-circle" width={24} aria-hidden />
+            <p>{error}</p>
+          </div>
+        ) : file?.kind === "image" ? (
+          <div className="workspace-rail__preview-image">
+            <img src={file.dataUrl} alt={`Preview of ${name}`} />
+            <span className="workspace-rail__preview-meta">
+              {file.mimeType}
+              {typeof file.size === "number" ? ` · ${file.size.toLocaleString()} bytes` : ""}
+            </span>
+          </div>
+        ) : file?.kind === "text" && isMarkdownPath(path) ? (
+          <MarkdownBlock text={file.content} className="comux-md max-w-[72ch]" />
+        ) : file?.kind === "text" ? (
+          <SyntaxBlock text={file.content} lang={path.split(".").pop()} className="leading-relaxed" />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/rail-files-panel.test.ts
+++ b/src/components/rail-files-panel.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const panel = readFileSync(new URL("./rail-files-panel.tsx", import.meta.url), "utf8");
+const preview = readFileSync(new URL("./rail-file-preview.tsx", import.meta.url), "utf8");
+
+// ─── rail-files-panel.tsx ─────────────────────────────────────────────────────
+assert.match(panel, /export function RailFilesPanel\(/, "exports RailFilesPanel");
+assert.match(panel, /import \{ ProjectTree \} from "@\/components\/project-tree"/, "imports ProjectTree");
+assert.match(panel, /import \{ RailFilePreview \} from "@\/components\/rail-file-preview"/, "imports RailFilePreview");
+assert.match(panel, /useState<string \| null>\(null\)/, "owns selectedPath state");
+assert.match(panel, /onFileClick=\{setSelectedPath\}/, "passes onFileClick to the tree");
+assert.match(panel, /selectedPath=\{selectedPath\}/, "threads selectedPath into the tree");
+assert.match(panel, /path=\{selectedPath\}/, "feeds the selected path into the preview");
+assert.match(panel, /if \(!projectRoot\)/, "handles the null-projectRoot state");
+assert.match(panel, /No project linked/, "renders a muted no-project state");
+
+// ─── rail-file-preview.tsx (read-only) ───────────────────────────────────────
+assert.match(preview, /export function RailFilePreview\(/, "exports RailFilePreview");
+assert.match(preview, /\/api\/project-file/, "fetches the project-file route");
+assert.match(preview, /Select a file/, "muted empty state when no file selected");
+assert.match(preview, /SyntaxBlock/, "renders text via SyntaxBlock");
+assert.match(preview, /MarkdownBlock/, "renders markdown via MarkdownBlock");
+assert.match(preview, /kind === "image"/, "handles image files");
+assert.doesNotMatch(preview, /CodeEditor/, "read-only: no editor");
+assert.doesNotMatch(preview, /onSave|saveEdit/, "read-only: no save path");
+
+console.log("rail-files-panel.test.ts OK");

--- a/src/components/rail-files-panel.tsx
+++ b/src/components/rail-files-panel.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { ProjectTree } from "@/components/project-tree";
+import { RailFilePreview } from "@/components/rail-file-preview";
+
+/**
+ * Files tab of the code rail: a scrollable project tree stacked over a
+ * read-only preview of the selected file. Owns the `selectedPath` selection
+ * and threads it into ProjectTree (controlled) and RailFilePreview.
+ *
+ * When the surface has no repo-linked project, renders a muted empty state.
+ */
+export function RailFilesPanel({
+  projectRoot,
+  familiarId,
+}: {
+  projectRoot: string | null;
+  familiarId?: string | null;
+}) {
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  // A new project resets the selection so a stale file from the previous repo
+  // doesn't linger in the preview.
+  useEffect(() => {
+    setSelectedPath(null);
+  }, [projectRoot]);
+
+  if (!projectRoot) {
+    return (
+      <div className="workspace-rail__files-empty">
+        <Icon name="ph:folder-open" width={22} aria-hidden />
+        <p>No project linked to this session.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="workspace-rail__files">
+      <div className="workspace-rail__files-tree">
+        <ProjectTree
+          root={projectRoot ?? undefined}
+          familiarId={familiarId ?? undefined}
+          selectedPath={selectedPath}
+          onFileClick={setSelectedPath}
+        />
+      </div>
+      <div className="workspace-rail__files-preview">
+        <RailFilePreview path={selectedPath} projectRoot={projectRoot} familiarId={familiarId} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/workspace-rail.test.ts
+++ b/src/components/workspace-rail.test.ts
@@ -10,6 +10,12 @@ for (const t of ["Changes", "Files", "Terminal"]) {
   assert.match(src, new RegExp(`aria-label="${t}"`), `has a ${t} tab`);
 }
 assert.match(src, /SessionChangesPanel/, "Changes tab reuses SessionChangesPanel");
+// Files tab now renders the composed tree + read-only preview panel.
+assert.match(src, /RailFilesPanel/, "Files tab renders RailFilesPanel");
+assert.match(src, /activeTab === "files"/, "Files tab is branched on explicitly");
+assert.match(src, /projectRoot=\{projectRoot\}/, "threads projectRoot into the files panel");
+// Terminal is still the placeholder.
+assert.match(src, /workspace-rail__soon/, "Terminal keeps the placeholder");
 assert.match(src, /onTogglePin/, "pin control wired");
 assert.match(src, /onCollapse/, "collapse control wired");
 assert.match(src, /changeCount > 0/, "shows a change-count badge");

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Icon } from "@/lib/icon";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
+import { RailFilesPanel } from "@/components/rail-files-panel";
 import type { CodeRailTab } from "@/lib/code-rail";
 
 const TAB_TITLE: Record<CodeRailTab, string> = {
@@ -13,6 +14,8 @@ export function WorkspaceRail({
   changeCount,
   activeTab,
   pinned,
+  projectRoot,
+  familiarId,
   onSelectTab,
   onTogglePin,
   onCollapse,
@@ -20,6 +23,8 @@ export function WorkspaceRail({
   changeCount: number;
   activeTab: CodeRailTab;
   pinned: boolean;
+  projectRoot: string | null;
+  familiarId?: string | null;
   onSelectTab: (tab: CodeRailTab) => void;
   onTogglePin: () => void;
   onCollapse: () => void;
@@ -82,6 +87,8 @@ export function WorkspaceRail({
         <div className="workspace-rail__pane">
           {activeTab === "changes" ? (
             <SessionChangesPanel />
+          ) : activeTab === "files" ? (
+            <RailFilesPanel projectRoot={projectRoot} familiarId={familiarId} />
           ) : (
             <p className="workspace-rail__soon">
               {TAB_TITLE[activeTab]} arrives in the next step.

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4323,6 +4323,120 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-muted);
 }
 
+/* Files tab — a scrollable project tree stacked over a read-only preview. */
+.workspace-rail__files {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.workspace-rail__files-tree {
+  flex: 0 0 45%;
+  min-height: 0;
+  overflow: auto;
+  padding: 6px 4px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.workspace-rail__files-preview {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+}
+
+.workspace-rail__files-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.workspace-rail__preview {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.workspace-rail__preview-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border-hairline);
+  color: var(--text-muted);
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+}
+
+.workspace-rail__preview-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+
+.workspace-rail__preview-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: 10px;
+}
+
+.workspace-rail__preview-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.workspace-rail__preview-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 160px;
+  padding: 16px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.workspace-rail__preview-error svg {
+  color: var(--color-danger, #f87171);
+  opacity: 0.8;
+}
+
+.workspace-rail__preview-image {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.workspace-rail__preview-image img {
+  max-width: 100%;
+  object-fit: contain;
+  border: 1px solid var(--border-hairline);
+  border-radius: 6px;
+}
+
+.workspace-rail__preview-meta {
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
 /* Collapsed code rail — a slim clickable strip on the surface's right edge
    that reopens the rail. Absolutely positioned so it overlays the chat gutter
    without reserving layout width. */

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -107,4 +107,42 @@ test.describe("code rail beside chat", () => {
     await reopen.click();
     await expect(page.locator(".workspace-rail")).toBeVisible();
   });
+
+  test("(e) Files tab → project tree + read-only preview", async ({ page }) => {
+    const filesRef = { count: 0 };
+    await routeChanges(page, filesRef);
+    // Mock the file tree: a single readme file at the project root.
+    await page.route("**/api/project-tree**", (route) =>
+      route.fulfill({
+        json: {
+          ok: true,
+          entries: [{ name: "README.md", path: "/repo/alpha/README.md", isDir: false }],
+        },
+      }),
+    );
+    // Mock the read-only preview payload for that file.
+    await page.route("**/api/project-file**", (route) =>
+      route.fulfill({
+        json: { ok: true, kind: "text", content: "# Alpha\n\nHello world.", size: 22 },
+      }),
+    );
+
+    await base(page, [REPO_SESSION]);
+    await openSession(page, "Refactor auth flow");
+
+    const rail = page.locator(".workspace-rail");
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+
+    // Switch to the Files tab — the placeholder is gone and the tree appears.
+    await rail.getByRole("button", { name: "Files" }).click();
+    await expect(rail.locator(".workspace-rail__files")).toBeVisible();
+    await expect(rail.locator(".workspace-rail__soon")).toHaveCount(0);
+    await expect(rail.locator('[role="tree"]')).toBeVisible({ timeout: 15_000 });
+
+    // Empty preview until a file is picked, then read-only content renders.
+    await expect(rail.locator(".workspace-rail__files-empty")).toBeVisible();
+    await rail.getByText("README.md", { exact: false }).first().click();
+    await expect(rail.locator(".workspace-rail__preview")).toBeVisible({ timeout: 15_000 });
+    await expect(rail.locator(".workspace-rail__preview-name")).toContainText("README.md");
+  });
 });


### PR DESCRIPTION
## What
- Wires the code rail Files tab to the existing ProjectTree.
- Adds a read-only file preview that uses /api/project-file for text, markdown, and image responses.
- Adds source-level coverage plus a focused Playwright Files-tab flow.

## Verification
- node --experimental-strip-types src/components/rail-files-panel.test.ts
- node --experimental-strip-types src/components/workspace-rail.test.ts
- git diff --check origin/main..HEAD
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:app
- pnpm exec playwright test tests/code-rail.spec.ts -g "Files tab"