### PR TITLE
fix(sidebars): remove fake user plan footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1318,50 +1318,6 @@ tr[role="checkbox"]:focus-visible {
   white-space: nowrap;
 }
 
-/* Footer — user identity chip */
-.cnav__footer {
-  margin-top: auto;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  padding: 9px var(--cnav-pad);
-  border-top: 1px solid var(--border-hairline);
-}
-.cnav__avatar {
-  display: grid;
-  place-items: center;
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-  border-radius: 999px;
-  background: linear-gradient(
-    135deg,
-    color-mix(in oklch, var(--accent) 42%, var(--bg-raised)),
-    var(--bg-raised)
-  );
-  font-size: 11px;
-  font-weight: 650;
-  color: var(--text-primary);
-}
-.cnav__user {
-  min-width: 0;
-  flex: 1;
-}
-.cnav__user-name {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-  font-weight: 550;
-  color: var(--text-primary);
-}
-.cnav__user-plan {
-  display: block;
-  font-size: 10px;
-  color: var(--text-muted);
-}
-
 .shell-nav-header {
   display: flex;
   align-items: center;

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -113,5 +113,6 @@ assert.match(
   /<span className="sr-only">\{project\.name\}<\/span>/,
   "the project name is announced, not just painted",
 );
+assert.doesNotMatch(chatSidebar, /cnav__footer|cnav__user-plan/, "ChatSidebar should not render the user plan footer");
 
 console.log("chat-sidebar-wiring.test.ts passed");

--- a/src/components/chat-sidebar.tsx
+++ b/src/components/chat-sidebar.tsx
@@ -39,8 +39,6 @@ type Props = {
   onOpenSession: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
   onDeleteSession: (session: SessionRow) => Promise<void>;
-  userName?: string;
-  userPlan?: string;
 };
 
 const THREADS_PREVIEW = 6;
@@ -174,8 +172,6 @@ export function ChatSidebar({
   onOpenSession,
   onNewChat,
   onDeleteSession,
-  userName,
-  userPlan = "Pro",
 }: Props) {
   const { projects, createProject, reload } = useProjects({ familiarId: activeFamiliarId });
   const overrides = useProjectOverrides();
@@ -322,8 +318,6 @@ export function ChatSidebar({
       setRegisteringRoot(null);
     }
   }
-
-  const initials = (userName ?? "You").split(/\s+/).map((p) => p[0]).join("").slice(0, 2).toUpperCase();
 
   return (
     <div className="chat-sidebar flex h-full min-h-0 flex-col">
@@ -608,13 +602,6 @@ export function ChatSidebar({
           )}
         </nav>
 
-        <footer className="cnav__footer">
-          <span className="cnav__avatar" aria-hidden>{initials}</span>
-          <span className="cnav__user">
-            <span className="cnav__user-name">{userName ?? "You"}</span>
-            <span className="cnav__user-plan">{userPlan}</span>
-          </span>
-        </footer>
       </div>
     </div>
   );

--- a/src/components/code-sidebar.tsx
+++ b/src/components/code-sidebar.tsx
@@ -21,8 +21,6 @@ type Props = {
   onOpenSession: (session: SessionRow) => void;
   onNewChat: (projectRoot: string | null) => void;
   onDeleteSession: (session: SessionRow) => Promise<void>;
-  userName?: string;
-  userPlan?: string;
   scheduledCount?: number;
 };
 
@@ -65,8 +63,6 @@ export function CodeSidebar({
   onOpenSession,
   onNewChat,
   onDeleteSession,
-  userName,
-  userPlan = "Pro",
   scheduledCount,
 }: Props) {
   const [query, setQuery] = useState("");
@@ -118,8 +114,6 @@ export function CodeSidebar({
   const selectProject = (project: ComuxProject) => {
     window.dispatchEvent(new CustomEvent("cave:code-select-project", { detail: { root: project.root } }));
   };
-
-  const initials = (userName ?? "You").split(/\s+/).map((p) => p[0]).join("").slice(0, 2).toUpperCase();
 
   return (
     <div className="code-sidebar flex h-full min-h-0 flex-col">
@@ -366,13 +360,6 @@ export function CodeSidebar({
           )}
         </nav>
 
-        <footer className="code-sidebar__footer code-sidebar__user cnav__footer">
-          <span className="cnav__avatar" aria-hidden>{initials}</span>
-          <span className="cnav__user">
-            <span className="cnav__user-name">{userName ?? "You"}</span>
-            <span className="cnav__user-plan">{userPlan}</span>
-          </span>
-        </footer>
       </div>
     </div>
   );

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -106,7 +106,7 @@ assert.match(codeSidebar, /New session|New chat/, "sidebar nav has a New session
 assert.match(codeSidebar, /cave:navigate-mode/, "sidebar deep-links to other surfaces via the nav bus");
 assert.match(codeSidebar, /mode:\s*"inbox"/, "Scheduled deep-links to Automations (inbox mode)");
 assert.match(codeSidebar, /mode:\s*"marketplace"/, "Plugins deep-links to the Marketplace surface (its own mode after #2154)");
-assert.match(codeSidebar, /code-sidebar__footer|code-sidebar__user/, "sidebar has a user footer");
+assert.doesNotMatch(codeSidebar, /code-sidebar__footer|code-sidebar__user|cnav__user-plan/, "CodeSidebar should not render the user plan footer");
 assert.match(
   workspace,
   /onDeleteSession=\{async \(session\) => \{[\s\S]*?fetch\(`\/api\/chat\/conversation\/\$\{encodeURIComponent\(session\.id\)\}`,[\s\S]*?method: "DELETE"[\s\S]*?loadSessions\(\)/,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1950,7 +1950,6 @@ export function Workspace() {
         await loadSessions();
       }}
       scheduledCount={codeScheduledCount}
-      userPlan="Pro"
     />
   );
 
@@ -1972,7 +1971,6 @@ export function Workspace() {
         await fetch(`/api/chat/conversation/${encodeURIComponent(session.id)}`, { method: "DELETE" });
         await loadSessions();
       }}
-      userPlan="Pro"
     />
   );
 


### PR DESCRIPTION
## What
- Remove the hard-coded user plan footer from Chat and Code sidebars.
- Drop the unused userName/userPlan props and related CSS.
- Update source-text coverage so the footer does not come back.

## Verification
- node --experimental-strip-types src/components/chat-sidebar-wiring.test.ts
- node --experimental-strip-types src/components/code-view.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check origin/main..HEAD