### PR TITLE
feat(prompts): enhance drafts without API roundtrip

### DIFF
--- a/src/components/chat-prompt-enhance.test.ts
+++ b/src/components/chat-prompt-enhance.test.ts
@@ -5,10 +5,11 @@ import { readFileSync } from "node:fs";
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 
 assert.match(chatView, /enhancePrompt/, "ChatView defines a composer prompt enhancement action");
-assert.match(chatView, /fetch\("\/api\/prompt\/enhance"/, "enhance action calls the prompt enhance route");
+assert.match(chatView, /import \{ buildPromptEnhancement \} from "@\/lib\/prompt-enhancer"/, "enhance action uses the shared pure prompt enhancer");
+assert.doesNotMatch(chatView, /fetch\("\/api\/prompt\/enhance"/, "enhance action should not round-trip through the API route");
 assert.match(chatView, /mode: activeProjectRoot \? "code" : "chat"/, "enhance request is mode-aware for code/project chats");
-assert.match(chatView, /selectedFiles: mentionedFiles/, "enhance request forwards mentioned file context");
-assert.match(chatView, /setInput\(json\.enhanced\)/, "enhanced prompt replaces the draft in the editor");
+assert.match(chatView, /selectedFiles: \[\.\.\.mentionedFiles, \.\.\.attachments\.map\(\(attachment\) => attachment\.name\)\]/, "enhance request forwards mentioned and attached file context");
+assert.match(chatView, /setInput\(result\.enhanced\)/, "enhanced prompt replaces the draft in the editor");
 assert.doesNotMatch(chatView, /enhancePrompt[\s\S]{0,600}send\(/, "enhancing must not send automatically");
 assert.match(chatView, /setEnhanceOriginal\(input\)/, "original draft is kept for revert");
 assert.match(chatView, /Enhancing prompt\.\.\./, "composer exposes a loading status");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -127,6 +127,7 @@ import {
   type ThreadSelfReport,
 } from "@/lib/thread-self-report";
 import { streamFamiliarText } from "@/lib/familiar-stream";
+import { buildPromptEnhancement } from "@/lib/prompt-enhancer";
 
 type ToolEvent = {
   id: string;
@@ -3742,38 +3743,29 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   }
 
-  async function enhancePrompt() {
+  function enhancePrompt() {
     const draft = input.trim();
     if (!draft || busy || enhanceStatus === "loading") return;
     setEnhanceOriginal(input);
     setEnhanceStatus("loading");
-    try {
-      const res = await fetch("/api/prompt/enhance", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          draft: input,
-          mode: activeProjectRoot ? "code" : "chat",
-          context: {
-            activeProject: activeProjectRoot
-              ? { name: selectedProject?.name ?? null, root: activeProjectRoot }
-              : null,
-            selectedFiles: mentionedFiles,
-            recentThreadTitle: session?.title ?? null,
-          },
-        }),
-      });
-      const json = (await res.json().catch(() => null)) as { ok?: boolean; enhanced?: string } | null;
-      if (!res.ok || !json?.ok || typeof json.enhanced !== "string") {
-        setEnhanceStatus("error");
-        return;
-      }
-      setInput(json.enhanced);
-      setEnhanceStatus("success");
-      window.setTimeout(() => inputRef.current?.focus(), 0);
-    } catch {
+    const result = buildPromptEnhancement({
+      draft: input,
+      mode: activeProjectRoot ? "code" : "chat",
+      context: {
+        activeProject: activeProjectRoot
+          ? { name: selectedProject?.name ?? null, root: activeProjectRoot }
+          : null,
+        selectedFiles: [...mentionedFiles, ...attachments.map((attachment) => attachment.name)],
+        recentThreadTitle: session?.title ?? null,
+      },
+    });
+    if (!result.ok || !result.enhanced.trim()) {
       setEnhanceStatus("error");
+      return;
     }
+    setInput(result.enhanced);
+    setEnhanceStatus("success");
+    window.setTimeout(() => inputRef.current?.focus(), 0);
   }
 
   // CHAT-D6-01: edit-and-resend. Loads a user turn's text into the composer so

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -480,8 +480,23 @@ assert.match(
 );
 assert.match(
   source,
+  /import \{ buildPromptEnhancement \} from "@\/lib\/prompt-enhancer"/,
+  "Enhance uses the shared pure prompt enhancer",
+);
+assert.doesNotMatch(
+  source,
   /fetch\("\/api\/prompt\/enhance"/,
-  "Enhance calls the prompt-enhance endpoint",
+  "Enhance should not round-trip through the prompt-enhance API route",
+);
+assert.match(
+  source,
+  /mode: destination === "board" \? "task" : "chat"/,
+  "Enhance should optimize the prompt for the active Chat or Task destination",
+);
+assert.match(
+  source,
+  /selectedFiles: attachments\.map\(\(attachment\) => attachment\.name\)/,
+  "Enhance should include staged attachment names as file context",
 );
 assert.match(
   source,
@@ -575,7 +590,7 @@ assert.match(
 );
 assert.match(
   source,
-  /setText\(json\.enhanced\);\s*announce\("Prompt enhanced", "polite"\)/,
+  /setText\(result\.enhanced\);\s*announce\("Prompt enhanced", "polite"\)/,
   "a successful enhance is announced (the textarea swap is otherwise silent to AT)",
 );
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -56,6 +56,7 @@ import {
   type CommandResponseSpeed,
   type CommandThinkingEffort,
 } from "@/lib/command-controls";
+import { buildPromptEnhancement } from "@/lib/prompt-enhancer";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -480,34 +481,33 @@ export function HomeComposer({
   }, []);
 
   // ── Enhance ──────────────────────────────────────────────────────────────
-  // Rewrite the draft via /api/prompt/enhance (mirrors the chat composer),
-  // stashing the original for a one-tap revert.
-  const enhancePrompt = useCallback(async () => {
+  // Rewrite the draft through the shared pure enhancer (mirrors the chat
+  // composer), stashing the original for a one-tap revert.
+  const enhancePrompt = useCallback(() => {
     const draft = text.trim();
     if (!draft || sending || enhanceStatus === "loading") return;
     setEnhanceStatus("loading");
-    try {
-      const res = await fetch("/api/prompt/enhance", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ draft, mode: "chat" }),
-      });
-      const json = (await res.json().catch(() => null)) as { ok?: boolean; enhanced?: string } | null;
-      if (!res.ok || !json?.ok || typeof json.enhanced !== "string" || !json.enhanced.trim()) {
-        setEnhanceStatus("error");
-        onToast("Couldn't enhance the prompt.");
-        return;
-      }
-      setEnhanceOriginal(text);
-      setText(json.enhanced);
-      announce("Prompt enhanced", "polite");
-      setEnhanceStatus("idle");
-      setTimeout(() => { textareaRef.current?.focus(); autoGrow(); }, 0);
-    } catch {
+    const result = buildPromptEnhancement({
+      draft,
+      mode: destination === "board" ? "task" : "chat",
+      context: {
+        activeProject: selectedProject
+          ? { name: selectedProject.name, root: selectedProject.root }
+          : null,
+        selectedFiles: attachments.map((attachment) => attachment.name),
+      },
+    });
+    if (!result.ok || !result.enhanced.trim()) {
       setEnhanceStatus("error");
       onToast("Couldn't enhance the prompt.");
+      return;
     }
-  }, [text, sending, enhanceStatus, onToast, autoGrow, announce]);
+    setEnhanceOriginal(text);
+    setText(result.enhanced);
+    announce("Prompt enhanced", "polite");
+    setEnhanceStatus("idle");
+    setTimeout(() => { textareaRef.current?.focus(); autoGrow(); }, 0);
+  }, [text, destination, selectedProject, attachments, sending, enhanceStatus, onToast, autoGrow, announce]);
   const revertEnhance = useCallback(() => {
     setEnhanceOriginal((original) => {
       if (original == null) return null;

--- a/src/lib/prompt-enhancer.test.ts
+++ b/src/lib/prompt-enhancer.test.ts
@@ -47,8 +47,26 @@ const chat = buildPromptEnhancement({
 assert.match(chat.enhanced, /Explain docker networking/i, "chat mode keeps conversational phrasing");
 assert.match(chat.enhanced, /Output format:/, "chat mode asks for a clearer response format");
 
+const task = buildPromptEnhancement({
+  draft: "audit stale onboarding copy",
+  mode: "task",
+  context: {
+    activeProject: { name: "Cave", root: "/repo/cave" },
+    selectedFiles: ["src/components/onboarding.tsx", "docs/onboarding.md"],
+  },
+});
+
+assert.equal(task.ok, true, "task enhancement should succeed for a non-empty draft");
+assert.equal(task.mode, "task", "task mode should be preserved");
+assert.match(task.enhanced, /Task title:/, "task mode adds a title shape");
+assert.match(task.enhanced, /Acceptance criteria:/, "task mode adds acceptance criteria");
+assert.match(task.enhanced, /Subtasks:/, "task mode asks for concrete subtasks");
+assert.match(task.enhanced, /Current project: Cave/, "task mode includes project context when provided");
+assert.match(task.enhanced, /Selected files: src\/components\/onboarding\.tsx, docs\/onboarding\.md/, "task mode includes selected files when provided");
+
 const empty = buildPromptEnhancement({ draft: "   ", mode: "chat" });
 assert.equal(empty.ok, false, "empty drafts are rejected");
+assert.equal(normalizeEnhanceMode("task"), "task", "task mode should normalize explicitly");
 assert.equal(normalizeEnhanceMode("made-up"), "chat", "unknown modes fall back to chat");
 
 console.log("prompt-enhancer.test.ts: ok");

--- a/src/lib/prompt-enhancer.ts
+++ b/src/lib/prompt-enhancer.ts
@@ -1,4 +1,4 @@
-export type PromptEnhanceMode = "chat" | "code" | "image" | "research";
+export type PromptEnhanceMode = "chat" | "code" | "image" | "research" | "task";
 
 type PromptEnhanceContext = {
   activeProject?: {
@@ -29,7 +29,7 @@ export type PromptEnhanceResult =
     };
 
 export function normalizeEnhanceMode(mode: unknown): PromptEnhanceMode {
-  return mode === "code" || mode === "image" || mode === "research" || mode === "chat"
+  return mode === "code" || mode === "image" || mode === "research" || mode === "task" || mode === "chat"
     ? mode
     : "chat";
 }
@@ -129,6 +129,26 @@ export function buildPromptEnhancement(input: PromptEnhanceRequest): PromptEnhan
         "Output format: start with an executive summary, then detailed findings, comparison criteria, and recommended next steps.",
         preserved,
       ].join("\n"),
+    };
+  }
+
+  if (mode === "task") {
+    return {
+      ok: true,
+      mode,
+      label: "Implement",
+      enhanced: [
+        `Turn this into a concrete task: ${draft}.`,
+        contextText,
+        "\nTask brief:",
+        "- Task title: a short imperative title.",
+        "- Outcome: the concrete result that should exist when this is done.",
+        "- Acceptance criteria: 3-5 observable checks that prove completion.",
+        "- Subtasks: ordered implementation steps sized for one maintainer or agent.",
+        "- Context: include relevant project, file, dependency, or user constraints.",
+        "- Verification: name the focused checks or manual proof expected before closing.",
+        `- ${preserved}`,
+      ].filter(Boolean).join("\n"),
     };
   }
 


### PR DESCRIPTION
## What
- Use the shared pure prompt enhancer directly in Chat and Home composers instead of round-tripping through /api/prompt/enhance.
- Include mentioned/staged file names as enhancement context.
- Add task-mode enhancement for board-destination drafts.

## Verification
- node --experimental-strip-types src/lib/prompt-enhancer.test.ts
- node --experimental-strip-types src/components/chat-prompt-enhance.test.ts
- node --experimental-strip-types src/components/home-composer.test.ts
- node --experimental-strip-types src/app/api/prompt/enhance/route.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check