### PR TITLE
Unified workspace — PR 2: code rail Terminal tab (lazy pty)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -71,6 +71,7 @@ export const SUITES = {
     "src/components/workspace-rail.test.ts",
     "src/components/workspace-rail-wiring.test.ts",
     "src/components/rail-files-panel.test.ts",
+    "src/components/rail-terminal-panel.test.ts",
     "src/lib/workflows.test.ts",
     "src/lib/familiar-multiselect.test.ts",
     "src/lib/codex-automation-form.test.ts",

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -320,6 +320,29 @@ export function ChatSurface({
   useEffect(() => {
     if (rail.activeTab === "terminal" && rail.open) setTerminalOpened(true);
   }, [rail.activeTab, rail.open]);
+  // When the active session changes, stop the rail shell that was started for
+  // the previous session and drop the terminal-held-open latch. The rail's pty
+  // uses a per-session thread id (`cave.rail.<id>`), and BottomTerminal never
+  // stops the shell on unmount (keepalive) — so without this, a session switch
+  // strands the old shell (desktop PTYs have no idle reaper; the WS bridge
+  // self-reaps) and keeps the rail forced-open on an unrelated session. Mirrors
+  // ComuxView.removeSession's desktop teardown.
+  const railTermSessionRef = useRef<string | null>(snapshot.sessionId ?? null);
+  useEffect(() => {
+    const id = snapshot.sessionId ?? null;
+    const prev = railTermSessionRef.current;
+    railTermSessionRef.current = id;
+    if (prev === id) return;
+    if (prev && terminalOpened) {
+      const internals = (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+      if (internals) {
+        void import("@tauri-apps/api/core")
+          .then(({ invoke }) => invoke("pty_stop", { threadId: `cave.rail.${prev}` }))
+          .catch(() => {});
+      }
+    }
+    setTerminalOpened(false);
+  }, [snapshot.sessionId, terminalOpened]);
   const showCodeRail = !isCodeSurface && rail.available && rail.open && !isMobile && !paneNarrow;
 
   // Persist the chat / right-area split. panelIds tracks which panels are

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -312,7 +312,14 @@ export function ChatSurface({
     };
   }, [isCodeSurface, railProjectRoot, sessionRunning]);
 
-  const rail = useCodeRail({ projectRoot: railProjectRoot, changeCount, terminalActive: false });
+  // Once the Terminal tab has been opened, keep the rail available (terminalActive)
+  // even if the session has no repo and no edits — otherwise switching away would
+  // yank the running pty. Flips false→true once; never resets → no render loop.
+  const [terminalOpened, setTerminalOpened] = useState(false);
+  const rail = useCodeRail({ projectRoot: railProjectRoot, changeCount, terminalActive: terminalOpened });
+  useEffect(() => {
+    if (rail.activeTab === "terminal" && rail.open) setTerminalOpened(true);
+  }, [rail.activeTab, rail.open]);
   const showCodeRail = !isCodeSurface && rail.available && rail.open && !isMobile && !paneNarrow;
 
   // Persist the chat / right-area split. panelIds tracks which panels are
@@ -590,6 +597,7 @@ export function ChatSurface({
                     pinned={rail.pinned}
                     projectRoot={railProjectRoot}
                     familiarId={snapshot.familiar?.id ?? null}
+                    sessionId={snapshot.sessionId ?? null}
                     onSelectTab={rail.setActiveTab}
                     onTogglePin={rail.togglePin}
                     onCollapse={rail.collapse}

--- a/src/components/rail-terminal-panel.test.ts
+++ b/src/components/rail-terminal-panel.test.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+// PR 2 / Task 2: the Terminal tab of the code rail hosts the reusable
+// BottomTerminal on a per-session pty thread id. Source-text guard.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./rail-terminal-panel.tsx", import.meta.url), "utf8");
+
+assert.match(src, /export function RailTerminalPanel\(/, "exports RailTerminalPanel");
+assert.match(
+  src,
+  /import \{ BottomTerminal \} from "@\/components\/bottom-terminal"/,
+  "hosts the reusable BottomTerminal",
+);
+// A stable, per-session pty identity so the shell re-adopts across tab switches.
+assert.match(src, /threadId=\{`cave\.rail\.\$\{sessionId\}`\}/, "builds cave.rail.<sessionId> threadId");
+assert.match(src, /projectRoot=\{projectRoot \?\? undefined\}/, "threads projectRoot as the cwd");
+assert.match(src, /active=\{active\}/, "forwards the active flag (fit/focus only when visible)");
+// Null-session empty state — no pty without a session.
+assert.match(src, /if \(!sessionId\)/, "guards the null-sessionId case");
+assert.match(src, /Open a session to use the terminal/, "renders a muted empty state");
+// Minimal host — no broadcast/split wiring.
+assert.doesNotMatch(src, /registerWriter|onUserInput|paneId/, "no broadcast/split wiring");
+
+console.log("rail-terminal-panel.test.ts OK");

--- a/src/components/rail-terminal-panel.tsx
+++ b/src/components/rail-terminal-panel.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { BottomTerminal } from "@/components/bottom-terminal";
+
+// Terminal tab for the code rail. A thin host over the reusable BottomTerminal:
+// it derives a stable per-session pty thread id (`cave.rail.<sessionId>`) so the
+// shell persists across tab switches (keepalive lives in BottomTerminal, which
+// re-adopts a running pty for the same threadId on remount). No broadcast/split
+// wiring — the rail hosts a single shell.
+export function RailTerminalPanel({
+  sessionId,
+  projectRoot,
+  active,
+}: {
+  sessionId: string | null;
+  projectRoot: string | null;
+  active: boolean;
+}) {
+  if (!sessionId) {
+    return (
+      <p className="workspace-rail__terminal-empty">Open a session to use the terminal</p>
+    );
+  }
+  return (
+    <BottomTerminal
+      threadId={`cave.rail.${sessionId}`}
+      projectRoot={projectRoot ?? undefined}
+      active={active}
+    />
+  );
+}

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -22,8 +22,24 @@ assert.match(
 
 assert.match(
   source,
-  /useCodeRail\(\s*\{[\s\S]*?projectRoot:[\s\S]*?changeCount[\s\S]*?terminalActive:\s*false[\s\S]*?\}\s*\)/,
-  "chat-surface calls useCodeRail with projectRoot/changeCount and terminalActive:false",
+  /useCodeRail\(\s*\{[\s\S]*?projectRoot:[\s\S]*?changeCount[\s\S]*?terminalActive:\s*terminalOpened[\s\S]*?\}\s*\)/,
+  "chat-surface calls useCodeRail with projectRoot/changeCount and terminalActive:terminalOpened",
+);
+
+// Once the Terminal tab is opened the rail stays available (keepalive) — the
+// terminalOpened flag flips false→true and feeds back into terminalActive.
+assert.match(
+  source,
+  /rail\.activeTab === "terminal" && rail\.open[\s\S]*?setTerminalOpened\(true\)/,
+  "chat-surface flips terminalOpened once the Terminal tab is opened",
+);
+
+// The active session id is threaded into the rail so the terminal gets a stable
+// per-session pty identity.
+assert.match(
+  source,
+  /<WorkspaceRail[\s\S]*?sessionId=\{snapshot\.sessionId \?\? null\}/,
+  "WorkspaceRail receives the active session id",
 );
 
 assert.match(

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -42,6 +42,20 @@ assert.match(
   "WorkspaceRail receives the active session id",
 );
 
+// On session change the previous session's rail shell is stopped (desktop PTYs
+// have no idle reaper) and the terminal-held-open latch is reset so the rail is
+// not forced open on an unrelated session.
+assert.match(
+  source,
+  /pty_stop"?,\s*\{\s*threadId:\s*`cave\.rail\.\$\{prev\}`/,
+  "chat-surface stops the previous session's rail pty on session change",
+);
+assert.match(
+  source,
+  /railTermSessionRef[\s\S]*?setTerminalOpened\(false\)/,
+  "chat-surface resets the terminal-held-open latch when the session changes",
+);
+
 assert.match(
   source,
   /"cave:changes-refresh"/,

--- a/src/components/workspace-rail.test.ts
+++ b/src/components/workspace-rail.test.ts
@@ -14,8 +14,14 @@ assert.match(src, /SessionChangesPanel/, "Changes tab reuses SessionChangesPanel
 assert.match(src, /RailFilesPanel/, "Files tab renders RailFilesPanel");
 assert.match(src, /activeTab === "files"/, "Files tab is branched on explicitly");
 assert.match(src, /projectRoot=\{projectRoot\}/, "threads projectRoot into the files panel");
-// Terminal is still the placeholder.
-assert.match(src, /workspace-rail__soon/, "Terminal keeps the placeholder");
+// Terminal tab hosts RailTerminalPanel, mounted lazily (pty must not start early)
+// and kept mounted thereafter (keepalive) — gated behind terminalEverOpened.
+assert.match(src, /RailTerminalPanel/, "Terminal tab renders RailTerminalPanel");
+assert.match(src, /terminalEverOpened/, "lazy gate: terminal not mounted until first opened");
+assert.match(src, /setTerminalEverOpened\(true\)/, "flips the lazy gate once the Terminal tab opens");
+assert.match(src, /workspace-rail__terminal/, "terminal wrapper class for keepalive hide/show");
+assert.match(src, /sessionId=\{sessionId\}/, "threads the session id into the terminal host");
+assert.doesNotMatch(src, /workspace-rail__soon/, "Terminal placeholder is gone");
 assert.match(src, /onTogglePin/, "pin control wired");
 assert.match(src, /onCollapse/, "collapse control wired");
 assert.match(src, /changeCount > 0/, "shows a change-count badge");

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -1,7 +1,9 @@
 "use client";
+import { useEffect, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { RailFilesPanel } from "@/components/rail-files-panel";
+import { RailTerminalPanel } from "@/components/rail-terminal-panel";
 import type { CodeRailTab } from "@/lib/code-rail";
 
 const TAB_TITLE: Record<CodeRailTab, string> = {
@@ -16,6 +18,7 @@ export function WorkspaceRail({
   pinned,
   projectRoot,
   familiarId,
+  sessionId,
   onSelectTab,
   onTogglePin,
   onCollapse,
@@ -25,10 +28,20 @@ export function WorkspaceRail({
   pinned: boolean;
   projectRoot: string | null;
   familiarId?: string | null;
+  sessionId: string | null;
   onSelectTab: (tab: CodeRailTab) => void;
   onTogglePin: () => void;
   onCollapse: () => void;
 }) {
+  // Lazy pty: the terminal (and its shell) is not mounted until the Terminal tab
+  // is first selected. Once opened it stays mounted (keepalive) but is hidden
+  // when another tab is active, so the pty survives tab switches.
+  const [terminalEverOpened, setTerminalEverOpened] = useState(false);
+  useEffect(() => {
+    if (activeTab === "terminal") setTerminalEverOpened(true);
+  }, [activeTab]);
+  const terminalVisible = activeTab === "terminal";
+
   return (
     <section className="workspace-rail" aria-label="Code rail">
       <nav className="workspace-rail__strip" aria-label="Code rail tabs">
@@ -89,11 +102,21 @@ export function WorkspaceRail({
             <SessionChangesPanel />
           ) : activeTab === "files" ? (
             <RailFilesPanel projectRoot={projectRoot} familiarId={familiarId} />
-          ) : (
-            <p className="workspace-rail__soon">
-              {TAB_TITLE[activeTab]} arrives in the next step.
-            </p>
-          )}
+          ) : null}
+          {/* Terminal: mounted lazily on first selection, then kept mounted but
+              visually hidden when another tab is active so the pty persists. */}
+          {terminalEverOpened ? (
+            <div
+              className={`workspace-rail__terminal${terminalVisible ? "" : " is-hidden"}`}
+              hidden={!terminalVisible}
+            >
+              <RailTerminalPanel
+                sessionId={sessionId}
+                projectRoot={projectRoot}
+                active={terminalVisible}
+              />
+            </div>
+          ) : null}
         </div>
       </div>
     </section>

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4323,6 +4323,29 @@ details[open] > .cave-tool-summary::before {
   color: var(--text-muted);
 }
 
+/* Terminal tab — fills the pane so xterm's fit addon can size the shell. Kept
+   mounted but display:none'd when another tab is active (pty keepalive). */
+.workspace-rail__terminal {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.workspace-rail__terminal.is-hidden {
+  display: none;
+}
+
+.workspace-rail__terminal-empty {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  padding: 24px;
+  text-align: center;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
 /* Files tab — a scrollable project tree stacked over a read-only preview. */
 .workspace-rail__files {
   display: flex;

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -145,4 +145,30 @@ test.describe("code rail beside chat", () => {
     await expect(rail.locator(".workspace-rail__preview")).toBeVisible({ timeout: 15_000 });
     await expect(rail.locator(".workspace-rail__preview-name")).toContainText("README.md");
   });
+
+  test("(f) Terminal tab → lazy pty host (not mounted until first opened)", async ({ page }) => {
+    const filesRef = { count: 0 };
+    await routeChanges(page, filesRef);
+
+    await base(page, [REPO_SESSION]);
+    await openSession(page, "Refactor auth flow");
+
+    const rail = page.locator(".workspace-rail");
+    await expect(rail).toBeVisible({ timeout: 30_000 });
+
+    // The Terminal tab button exists…
+    const terminalTab = rail.getByRole("button", { name: "Terminal" });
+    await expect(terminalTab).toBeVisible();
+
+    // …but its host container is ABSENT before the first click (genuine
+    // laziness — the pty must not start early).
+    await expect(rail.locator(".workspace-rail__terminal")).toHaveCount(0);
+
+    // Clicking Terminal mounts the host wrapper. In daemon-less e2e there is no
+    // live pty websocket bridge, so we assert the host wrapper mounts (not a
+    // working shell) and that the "next step" placeholder is gone.
+    await terminalTab.click();
+    await expect(rail.locator(".workspace-rail__terminal")).toBeVisible({ timeout: 15_000 });
+    await expect(rail.locator(".workspace-rail__soon")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
Part of the unified chat/code workspace arc (spec `docs/specs/2026-07-03-unified-chat-code-workspace-design.md`, plan `…-plan.md`). PR 1 landed the code-rail foundation (Changes tab) and the Files tab (`f8cb9414`) is already on `main`. **This PR adds the third rail tab: Terminal.**

## What
- **`RailTerminalPanel`** (`src/components/rail-terminal-panel.tsx`) — a thin host over the existing `BottomTerminal`, giving the rail a single shell with a stable per-session pty thread id `cave.rail.<sessionId>` so it survives tab switches (keepalive lives in `BottomTerminal`). Renders an empty state when there is no active session (no bogus `cave.rail.null` pty).
- **`WorkspaceRail`** gains the Terminal tab + a lazy gate (`terminalEverOpened`) so the pty isn't spawned until the tab is first opened, then stays mounted.
- **`chat-surface.tsx`** threads the active `sessionId` (from `useChatDebugSnapshot()`) into the rail, and holds the rail available once the terminal has been opened (`terminalOpened`).
- **Session-switch teardown** — when the active session changes, the previous session's rail shell is stopped (`pty_stop`, desktop only; the WS bridge self-reaps) and the held-open latch resets so the rail isn't forced open on an unrelated session. Mirrors `ComuxView.removeSession`.

## Tests
- `rail-terminal-panel.test.ts`, `workspace-rail.test.ts`, `workspace-rail-wiring.test.ts` — wiring/behaviour guards (incl. the pty teardown + latch reset).
- `tests/code-rail.spec.ts` — daemon-less E2E asserting the terminal mounts lazily (0 `.workspace-rail__terminal` before the tab is clicked, mounts after).

## Verification
`tsc --noEmit`, `check:tests-wired` (710 wired), rail unit tests, and `pnpm build` (bundle within budget) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)