### PR TITLE
Unified workspace — PR 3: nav coupling + rail motion + mobile sheet

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -70,6 +70,7 @@ export const SUITES = {
     "src/components/chat-sidebar-wiring.test.ts",
     "src/components/workspace-rail.test.ts",
     "src/components/workspace-rail-wiring.test.ts",
+    "src/components/nav-rail-coupling.test.ts",
     "src/components/rail-files-panel.test.ts",
     "src/components/rail-terminal-panel.test.ts",
     "src/lib/workflows.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -71,6 +71,7 @@ export const SUITES = {
     "src/components/workspace-rail.test.ts",
     "src/components/workspace-rail-motion.test.ts",
     "src/components/workspace-rail-wiring.test.ts",
+    "src/components/mobile-code-rail.test.ts",
     "src/components/nav-rail-coupling.test.ts",
     "src/components/rail-files-panel.test.ts",
     "src/components/rail-terminal-panel.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -69,6 +69,7 @@ export const SUITES = {
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/components/chat-sidebar-wiring.test.ts",
     "src/components/workspace-rail.test.ts",
+    "src/components/workspace-rail-motion.test.ts",
     "src/components/workspace-rail-wiring.test.ts",
     "src/components/nav-rail-coupling.test.ts",
     "src/components/rail-files-panel.test.ts",

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -367,6 +367,12 @@ export function ChatSurface({
     if (!rail.available || (!isMobile && !paneNarrow) || scope !== "conversation")
       setMobileRailOpen(false);
   }, [rail.available, isMobile, paneNarrow, scope]);
+  // Reverse of the toggle's forward guard: if the right-panel sheet opens while
+  // the code-rail sheet is up, close the rail sheet so two z-[200] aria-modal
+  // overlays never coexist on the same edge (mutual exclusivity, both ways).
+  useEffect(() => {
+    if (rightPanel !== null) setMobileRailOpen(false);
+  }, [rightPanel]);
 
   // Announce code-rail visibility to the shell so it can soft-collapse the left
   // nav to its icon rail while the rail is open (keeps chat centered). Directional

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -359,11 +359,14 @@ export function ChatSurface({
     onEscape: () => setMobileRailOpen(false),
   });
   // Can't get stuck open: close if there's nothing to show (rail no longer
-  // available) or when the layout leaves mobile/narrow (the desktop Panel path
-  // owns the rail there, so the overlay must not linger behind it).
+  // available), when the layout leaves mobile/narrow (the desktop Panel path
+  // owns the rail there, so the overlay must not linger behind it), or when the
+  // side area switches away from the conversation scope (the toggle is
+  // conversation-scoped, so the sheet must not linger over the Projects list).
   useEffect(() => {
-    if (!rail.available || (!isMobile && !paneNarrow)) setMobileRailOpen(false);
-  }, [rail.available, isMobile, paneNarrow]);
+    if (!rail.available || (!isMobile && !paneNarrow) || scope !== "conversation")
+      setMobileRailOpen(false);
+  }, [rail.available, isMobile, paneNarrow, scope]);
 
   // Announce code-rail visibility to the shell so it can soft-collapse the left
   // nav to its icon rail while the rail is open (keeps chat centered). Directional
@@ -566,10 +569,16 @@ export function ChatSurface({
               <button
                 type="button"
                 className="mobile-code-rail-toggle focus-ring"
-                aria-label="Show code rail"
+                aria-label={mobileRailOpen ? "Hide code rail" : "Show code rail"}
                 aria-haspopup="dialog"
                 aria-expanded={mobileRailOpen}
-                onClick={() => setMobileRailOpen((v) => !v)}
+                onClick={() => {
+                  // Mutually exclusive with the right-panel sheet: two z-[200]
+                  // aria-modal overlays on the same edge would stack and confuse
+                  // AT. Opening the code rail dismisses the other sheet.
+                  if (!mobileRailOpen) onSetRightPanel?.(null);
+                  setMobileRailOpen((v) => !v);
+                }}
               >
                 <Icon name="ph:code" width={16} aria-hidden />
                 {changeCount > 0 ? (

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -14,6 +14,7 @@ import { useCodeRail } from "@/lib/use-code-rail";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { useIsMobile } from "@/lib/use-viewport";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import { CodeInlineToolbar } from "@/components/code-inline-toolbar";
@@ -345,6 +346,25 @@ export function ChatSurface({
   }, [snapshot.sessionId, terminalOpened]);
   const showCodeRail = !isCodeSurface && rail.available && rail.open && !isMobile && !paneNarrow;
 
+  // ── Mobile code rail (PR 3, Task 3) ─────────────────────────────────────────
+  // Below the mobile/narrow breakpoint there's no room for the third-column
+  // Panel, so the rail is presented as a right-edge slide-over sheet over the
+  // full-screen chat, opened by an explicit toggle button. Default closed —
+  // auto-opening an overlay on mobile is intrusive, so we do NOT mirror
+  // rail.open here.
+  const mobileRail = !isCodeSurface && (isMobile || paneNarrow) && rail.available;
+  const [mobileRailOpen, setMobileRailOpen] = useState(false);
+  const mobileRailSheetRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(mobileRailOpen, mobileRailSheetRef, {
+    onEscape: () => setMobileRailOpen(false),
+  });
+  // Can't get stuck open: close if there's nothing to show (rail no longer
+  // available) or when the layout leaves mobile/narrow (the desktop Panel path
+  // owns the rail there, so the overlay must not linger behind it).
+  useEffect(() => {
+    if (!rail.available || (!isMobile && !paneNarrow)) setMobileRailOpen(false);
+  }, [rail.available, isMobile, paneNarrow]);
+
   // Announce code-rail visibility to the shell so it can soft-collapse the left
   // nav to its icon rail while the rail is open (keeps chat centered). Directional
   // event — the shell owns the nav state and decides how to react. Runs on mount
@@ -537,6 +557,26 @@ export function ChatSurface({
                 { id: "projects", label: "Projects" },
               ]}
             />
+            {/* Mobile / narrow-pane code-rail toggle. On desktop the rail is a
+                third column; below the breakpoint there's no room, so it opens
+                as a right-edge slide-over sheet (below). Mirrors the mobile
+                right-sheet affordance placement. Scoped to the conversation tab
+                so it doesn't hover over the Projects list. */}
+            {mobileRail && scope === "conversation" && (
+              <button
+                type="button"
+                className="mobile-code-rail-toggle focus-ring"
+                aria-label="Show code rail"
+                aria-haspopup="dialog"
+                aria-expanded={mobileRailOpen}
+                onClick={() => setMobileRailOpen((v) => !v)}
+              >
+                <Icon name="ph:code" width={16} aria-hidden />
+                {changeCount > 0 ? (
+                  <span className="mobile-code-rail-toggle__badge">{changeCount}</span>
+                ) : null}
+              </button>
+            )}
           </div>
         ) : null}
 
@@ -686,6 +726,46 @@ export function ChatSurface({
               onCreateReminder={onCreateReminder}
               onOpenInboxItem={onOpenInboxItem}
               onInboxItemChanged={onInboxItemChanged}
+            />
+          </div>
+        </div>
+      )}
+      {/* Mobile / narrow code rail: same WorkspaceRail as desktop, but hosted in
+          a full-height right-edge slide-over sheet over the full-screen chat
+          instead of a third-column Panel. Opened by the toggle button in the
+          scope-tabs header; dismissed by backdrop tap, Escape (via useFocusTrap),
+          or the rail's own collapse control (which here means "close the
+          overlay"). The pin control is hidden — pinning a transient sheet open
+          is meaningless. */}
+      {mobileRail && mobileRailOpen && (
+        <div
+          className="mobile-code-rail-sheet fixed inset-0 z-[200] flex justify-end"
+          role="presentation"
+        >
+          <button
+            type="button"
+            aria-label="Close code rail"
+            className="absolute inset-0 bg-[var(--backdrop-scrim)]"
+            onClick={() => setMobileRailOpen(false)}
+          />
+          <div
+            ref={mobileRailSheetRef}
+            className="mobile-code-rail-sheet__panel relative flex h-full w-[min(92vw,420px)] flex-col bg-[var(--bg-raised)] shadow-[-8px_0_32px_rgba(0,0,0,0.2)] [padding-bottom:var(--sai-bottom)] [padding-top:var(--sai-top)]"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Code rail"
+          >
+            <WorkspaceRail
+              changeCount={changeCount}
+              activeTab={rail.activeTab}
+              pinned={rail.pinned}
+              projectRoot={railProjectRoot}
+              familiarId={snapshot.familiar?.id ?? null}
+              sessionId={snapshot.sessionId ?? null}
+              hidePin
+              onSelectTab={rail.setActiveTab}
+              onTogglePin={rail.togglePin}
+              onCollapse={() => setMobileRailOpen(false)}
             />
           </div>
         </div>

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -345,6 +345,16 @@ export function ChatSurface({
   }, [snapshot.sessionId, terminalOpened]);
   const showCodeRail = !isCodeSurface && rail.available && rail.open && !isMobile && !paneNarrow;
 
+  // Announce code-rail visibility to the shell so it can soft-collapse the left
+  // nav to its icon rail while the rail is open (keeps chat centered). Directional
+  // event — the shell owns the nav state and decides how to react. Runs on mount
+  // too, so a late-mounting shell listener still gets the initial state.
+  useEffect(() => {
+    window.dispatchEvent(
+      new CustomEvent("cave:code-rail-visibility", { detail: { open: showCodeRail } }),
+    );
+  }, [showCodeRail]);
+
   // Persist the chat / right-area split. panelIds tracks which panels are
   // actually mounted so the with-sidebar and bare layouts persist separately.
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({

--- a/src/components/mobile-code-rail.test.ts
+++ b/src/components/mobile-code-rail.test.ts
@@ -1,0 +1,157 @@
+// @ts-nocheck
+// PR 3 / Task 3: below the mobile breakpoint (isMobile || paneNarrow) the code
+// rail is presented as a full-height right-edge slide-over sheet over the
+// full-screen chat, opened by an explicit toggle button and dismissible by
+// backdrop tap / Escape / onCollapse. Source-text guard — pins the wiring so it
+// survives refactors of chat-surface.tsx and workspace-rail.tsx.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const rail = await readFile(new URL("./workspace-rail.tsx", import.meta.url), "utf8");
+const css = await readFile(
+  new URL("../styles/cave-chat.css", import.meta.url),
+  "utf8",
+);
+
+// ── Local state, default false ──────────────────────────────────────────────
+// The overlay must NOT auto-open from rail.open — an unbidden overlay on mobile
+// is intrusive. It starts closed and only the toggle button opens it.
+assert.match(
+  source,
+  /const\s+\[\s*mobileRailOpen\s*,\s*setMobileRailOpen\s*\]\s*=\s*useState\(\s*false\s*\)/,
+  "mobileRailOpen state defaults to false",
+);
+
+// ── Toggle button gated on (isMobile || paneNarrow) && rail.available ────────
+assert.match(
+  source,
+  /\(isMobile \|\| paneNarrow\) && rail\.available/,
+  "toggle button (and sheet) gated on (isMobile || paneNarrow) && rail.available",
+);
+// The toggle flips mobileRailOpen and carries the right a11y attributes.
+assert.match(
+  source,
+  /aria-haspopup="dialog"/,
+  "toggle button advertises aria-haspopup=dialog",
+);
+assert.match(
+  source,
+  /aria-expanded=\{mobileRailOpen\}/,
+  "toggle button reflects sheet open state via aria-expanded",
+);
+assert.match(
+  source,
+  /aria-label="Show code rail"/,
+  "toggle button has an accessible label",
+);
+assert.match(
+  source,
+  /setMobileRailOpen\(\s*(?:\(\s*v\s*\)\s*=>\s*!v|true)\s*\)/,
+  "toggle button opens the sheet",
+);
+// The change-count badge rides the toggle when there are pending edits.
+assert.match(
+  source,
+  /changeCount > 0[\s\S]{0,120}mobile-code-rail-toggle__badge/,
+  "toggle button shows the change-count badge when changeCount > 0",
+);
+
+// ── The sheet: cloned from chat-right-sheet ─────────────────────────────────
+assert.match(
+  source,
+  /className="[^"]*mobile-code-rail-sheet[^"]*fixed inset-0[\s\S]*?justify-end"/,
+  "sheet is a fixed inset-0 justify-end scrim (chat-right-sheet clone)",
+);
+assert.match(
+  source,
+  /bg-\[var\(--backdrop-scrim\)\]/,
+  "sheet backdrop uses --backdrop-scrim",
+);
+assert.match(
+  source,
+  /w-\[min\(92vw,420px\)\]/,
+  "sheet panel is w-[min(92vw,420px)]",
+);
+assert.match(
+  source,
+  /padding-bottom:var\(--sai-bottom\)/,
+  "sheet panel honors the bottom safe-area inset",
+);
+assert.match(
+  source,
+  /role="dialog"/,
+  "sheet is a role=dialog",
+);
+assert.match(
+  source,
+  /aria-modal="true"/,
+  "sheet is aria-modal",
+);
+
+// ── WorkspaceRail hosted in the sheet with onCollapse → close ───────────────
+// The sheet mounts WorkspaceRail with the same feed as desktop, but onCollapse
+// closes the overlay (mobile "collapse" == dismiss) and the pin control is
+// hidden (meaningless in a sheet).
+assert.match(
+  source,
+  /<WorkspaceRail[\s\S]*?hidePin[\s\S]*?onCollapse=\{\(\)\s*=>\s*setMobileRailOpen\(false\)\}[\s\S]*?\/>/,
+  "sheet WorkspaceRail hides the pin and maps onCollapse to closing the sheet",
+);
+
+// ── Dismiss surfaces: backdrop + Escape ─────────────────────────────────────
+assert.match(
+  source,
+  /aria-label="Close code rail"[\s\S]*?onClick=\{\(\)\s*=>\s*setMobileRailOpen\(false\)\}/,
+  "backdrop button closes the sheet",
+);
+assert.match(
+  source,
+  /useFocusTrap\(\s*mobileRailOpen\s*,\s*mobileRailSheetRef\s*,\s*\{\s*onEscape:\s*\(\)\s*=>\s*setMobileRailOpen\(false\)/,
+  "sheet traps focus while open and Escape closes it",
+);
+
+// ── Auto-close guards ───────────────────────────────────────────────────────
+// Close when nothing to show (rail.available false) and when leaving mobile
+// (desktop layout owns the third column) so the sheet can't get stuck open.
+assert.match(
+  source,
+  /useEffect\(\s*\(\)\s*=>\s*\{[\s\S]*?if\s*\(\s*!rail\.available[\s\S]*?setMobileRailOpen\(false\)/,
+  "sheet auto-closes when rail.available goes false or leaving mobile",
+);
+assert.match(
+  source,
+  /!isMobile && !paneNarrow[\s\S]*?setMobileRailOpen\(false\)/,
+  "sheet auto-closes when leaving the mobile / narrow layout",
+);
+
+// ── WorkspaceRail gained an optional hidePin prop (desktop unchanged) ────────
+assert.match(
+  rail,
+  /hidePin\??:\s*boolean/,
+  "WorkspaceRail accepts an optional hidePin prop",
+);
+assert.match(
+  rail,
+  /\{\s*!hidePin\s*(?:&&|\?)[\s\S]*?Pin code rail open/,
+  "WorkspaceRail hides the pin button when hidePin is set",
+);
+
+// ── Motion + reduced-motion CSS ─────────────────────────────────────────────
+assert.match(
+  css,
+  /@keyframes\s+mobile-code-rail-sheet-in\b/,
+  "defines the sheet slide-in keyframes",
+);
+assert.match(
+  css,
+  /\.mobile-code-rail-sheet__panel\s*\{[^}]*animation:\s*mobile-code-rail-sheet-in/s,
+  "sheet panel runs the slide-in animation",
+);
+assert.match(
+  css,
+  /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^@]*\.mobile-code-rail-sheet__panel[^}]*\{[^}]*animation:\s*none/s,
+  "reduced-motion disables the sheet slide-in",
+);
+
+console.log("mobile-code-rail.test.ts OK");

--- a/src/components/mobile-code-rail.test.ts
+++ b/src/components/mobile-code-rail.test.ts
@@ -42,8 +42,8 @@ assert.match(
 );
 assert.match(
   source,
-  /aria-label="Show code rail"/,
-  "toggle button has an accessible label",
+  /aria-label=\{mobileRailOpen \? "Hide code rail" : "Show code rail"\}/,
+  "toggle button has a state-reflecting accessible label",
 );
 assert.match(
   source,

--- a/src/components/nav-rail-coupling.test.ts
+++ b/src/components/nav-rail-coupling.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+// PR 3 / Task 1: the left nav is coupled to the code rail. When the code rail
+// becomes visible, the shell soft-collapses the nav to its icon rail so the
+// chat stays centered; it restores the nav when the rail closes UNLESS the user
+// explicitly re-expanded the nav while the rail was open (their intent wins).
+// The two components talk over a directional cave:code-rail-visibility event.
+// Desktop-only — mobile nav is a drawer, so the coupling is a no-op there.
+// Source-text guard — asserts the wiring survives refactors.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
+
+// (a) chat-surface dispatches cave:code-rail-visibility with detail:{open:showCodeRail}
+//     from an effect keyed on showCodeRail.
+assert.match(
+  chatSurface,
+  /useEffect\(\(\)\s*=>\s*\{[\s\S]*?dispatchEvent\([\s\S]*?new CustomEvent\(\s*"cave:code-rail-visibility"\s*,\s*\{\s*detail:\s*\{\s*open:\s*showCodeRail\s*\}\s*\}\s*,?\s*\)[\s\S]*?\},\s*\[showCodeRail\]\)/,
+  "chat-surface dispatches cave:code-rail-visibility { open: showCodeRail } from an effect keyed on showCodeRail",
+);
+
+// (b) shell.tsx listens for the cave:code-rail-visibility event.
+assert.match(
+  shell,
+  /addEventListener\(\s*"cave:code-rail-visibility"/,
+  "shell listens for cave:code-rail-visibility",
+);
+assert.match(
+  shell,
+  /"cave:code-rail-visibility"/,
+  "shell references the cave:code-rail-visibility event name",
+);
+
+// The state-machine bookkeeping refs exist.
+assert.match(
+  shell,
+  /railAutoCollapsedNavRef\s*=\s*useRef/,
+  "shell keeps a railAutoCollapsedNavRef",
+);
+assert.match(
+  shell,
+  /userOverrodeNavRef\s*=\s*useRef/,
+  "shell keeps a userOverrodeNavRef",
+);
+
+// (c) shell collapses via navRef.current?.collapse() and restores via
+//     navRef.current?.expand() inside the rail-visibility handler.
+assert.match(
+  shell,
+  /navRef\.current\?\.collapse\(\)/,
+  "shell collapses the nav via navRef.current?.collapse()",
+);
+assert.match(
+  shell,
+  /navRef\.current\?\.expand\(\)/,
+  "shell restores the nav via navRef.current?.expand()",
+);
+
+// (d) the restore is guarded by the user-override ref and !isMobile.
+assert.match(
+  shell,
+  /railAutoCollapsedNavRef\.current\s*&&\s*!userOverrodeNavRef\.current\s*&&\s*!isMobile/,
+  "the rail-close restore is guarded by railAutoCollapsed && !userOverrode && !isMobile",
+);
+
+// User-override detection: navOpen flipping true while the rail auto-collapsed
+// it marks the user's intent so the later restore is suppressed.
+assert.match(
+  shell,
+  /railAutoCollapsedNavRef\.current[\s\S]*?userOverrodeNavRef\.current\s*=\s*true/,
+  "shell sets userOverrodeNavRef when the user re-opens the nav while rail-collapsed",
+);
+
+console.log("nav-rail-coupling.test.ts ok");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -151,6 +151,13 @@ function ShellInner({
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
   const bottomRef = useRef<PanelImperativeHandle | null>(null);
+  // Code-rail ↔ nav coupling bookkeeping (desktop only). When the code rail
+  // opens we soft-collapse the nav to its icon rail and remember that WE did it
+  // (railAutoCollapsedNavRef); on rail close we restore it — unless the user
+  // re-expanded the nav in the meantime (userOverrodeNavRef), in which case
+  // their intent wins and we leave the nav alone.
+  const railAutoCollapsedNavRef = useRef(false);
+  const userOverrodeNavRef = useRef(false);
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
 
@@ -420,6 +427,51 @@ function ShellInner({
       window.removeEventListener("cave:toggle-left-panel", onToggleLeft);
     };
   }, [twoPane, hasBottom, isMobile, panelShortcuts]);
+
+  // Couple the left nav to the code rail (desktop only — mobile nav is a
+  // drawer, so this must never touch it). When the rail opens we soft-collapse
+  // the nav to its icon rail so chat stays centered; when it closes we restore
+  // the nav UNLESS the user re-expanded it while the rail was open.
+  useEffect(() => {
+    const onRailVisibility = (e: Event) => {
+      const open = (e as CustomEvent<{ open?: boolean }>).detail?.open ?? false;
+      if (isMobile) return;
+      if (open) {
+        // Rail became visible: collapse the nav only if it's currently open,
+        // and remember we did it so we can restore later.
+        if (navOpen) {
+          navRef.current?.collapse();
+          railAutoCollapsedNavRef.current = true;
+          userOverrodeNavRef.current = false;
+        }
+        return;
+      }
+      // Rail hidden: restore the nav if we auto-collapsed it and the user
+      // didn't override in the meantime. Clear the auto-collapsed flag BEFORE
+      // expanding so the resulting navOpen→true transition isn't misread as a
+      // user override (which would wrongly suppress future restores).
+      const shouldRestore =
+        railAutoCollapsedNavRef.current && !userOverrodeNavRef.current && !isMobile;
+      railAutoCollapsedNavRef.current = false;
+      userOverrodeNavRef.current = false;
+      if (shouldRestore) navRef.current?.expand();
+    };
+    window.addEventListener("cave:code-rail-visibility", onRailVisibility);
+    return () => window.removeEventListener("cave:code-rail-visibility", onRailVisibility);
+  }, [isMobile, navOpen]);
+
+  // User-override detection: if the nav becomes open WHILE the rail had
+  // auto-collapsed it, that's the user deliberately re-expanding (via the
+  // reopen button, ⌘-shortcut, or a drag). Record it so the later rail-close
+  // restore is suppressed and we don't fight the user. Programmatic collapse
+  // sets navOpen→false (not true) so it never trips this; the programmatic
+  // restore-expand clears railAutoCollapsedNavRef first (above) so it doesn't
+  // either.
+  useEffect(() => {
+    if (navOpen && railAutoCollapsedNavRef.current) {
+      userOverrodeNavRef.current = true;
+    }
+  }, [navOpen]);
 
   if (!mounted) {
     return (

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -473,6 +473,18 @@ function ShellInner({
     }
   }, [navOpen]);
 
+  // Clear coupling bookkeeping when the viewport crosses into mobile: the nav
+  // becomes a drawer and the rail-close handler early-returns on mobile, so a
+  // mid-interaction desktop→mobile flip would otherwise strand
+  // railAutoCollapsedNavRef=true and cause a spurious nav expand on a later
+  // desktop session.
+  useEffect(() => {
+    if (isMobile) {
+      railAutoCollapsedNavRef.current = false;
+      userOverrodeNavRef.current = false;
+    }
+  }, [isMobile]);
+
   if (!mounted) {
     return (
       <div className="shell-frame flex h-full w-full flex-col">

--- a/src/components/workspace-rail-motion.test.ts
+++ b/src/components/workspace-rail-motion.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+// Source-text guards for the code-rail entrance + tab-switch motion (PR 3, Task 2).
+// Pins the animation className / keyed remount in the component and the CSS
+// @keyframes + reduced-motion override, without which the polish silently rots.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const tsx = readFileSync(new URL("./workspace-rail.tsx", import.meta.url), "utf8");
+const css = readFileSync(
+  new URL("../styles/cave-chat.css", import.meta.url),
+  "utf8",
+);
+
+// --- component wiring -------------------------------------------------------
+// The non-terminal panel body carries the animation hook class so it eases in.
+assert.match(
+  tsx,
+  /workspace-rail__panel/,
+  "panel-body wrapper has the animation className",
+);
+// Tab-switch replay: the non-terminal body is keyed by activeTab so React
+// remounts it and the CSS entrance animation re-fires. The terminal wrapper is
+// deliberately NOT keyed (keepalive — remounting would respawn the pty).
+assert.match(
+  tsx,
+  /key=\{activeTab\}/,
+  "non-terminal panel body is keyed by activeTab to replay the entrance",
+);
+// Keepalive must survive: the keyed wrapper must not enclose the terminal host.
+// Guard by asserting the terminal wrapper class is still present and gated.
+assert.match(
+  tsx,
+  /workspace-rail__terminal/,
+  "terminal wrapper class still present (keepalive)",
+);
+assert.match(
+  tsx,
+  /terminalEverOpened/,
+  "terminal keepalive gate still present",
+);
+
+// --- CSS: entrance keyframes + rail-scoped rules ----------------------------
+assert.match(
+  css,
+  /@keyframes\s+workspace-rail-content-in\b/,
+  "defines the rail content entrance @keyframes",
+);
+assert.match(
+  css,
+  /\.workspace-rail__panel\s*\{[^}]*animation:\s*workspace-rail-content-in/s,
+  "panel body runs the entrance animation",
+);
+assert.match(
+  css,
+  /\.workspace-rail__body\s*\{[^}]*animation:\s*workspace-rail-content-in/s,
+  "rail body content eases in on mount",
+);
+
+// --- CSS: reduced-motion override zeroes the rail animations -----------------
+// Find a prefers-reduced-motion block that disables the rail animation classes.
+const rmBlocks = [...css.matchAll(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{/g)];
+assert.ok(rmBlocks.length > 0, "has at least one reduced-motion media block");
+// A rail-specific reduced-motion rule must set animation: none for the hooks.
+assert.match(
+  css,
+  /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^@]*\.workspace-rail__panel[^}]*\{[^}]*animation:\s*none/s,
+  "reduced-motion sets animation:none for .workspace-rail__panel",
+);
+assert.match(
+  css,
+  /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[^@]*\.workspace-rail__body[^}]*\{[^}]*animation:\s*none/s,
+  "reduced-motion sets animation:none for .workspace-rail__body",
+);
+
+console.log("workspace-rail-motion.test.ts OK");

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -98,16 +98,24 @@ export function WorkspaceRail({
           </span>
         </header>
         <div className="workspace-rail__pane">
-          {activeTab === "changes" ? (
-            <SessionChangesPanel />
-          ) : activeTab === "files" ? (
-            <RailFilesPanel projectRoot={projectRoot} familiarId={familiarId} />
+          {/* Non-terminal panel body. Keyed by activeTab so React remounts it on
+              a Changes<->Files switch and the CSS entrance animation replays
+              (short crossfade). The terminal host below is deliberately OUTSIDE
+              this keyed wrapper so its pty keepalive is never remounted. */}
+          {activeTab !== "terminal" ? (
+            <div className="workspace-rail__panel" key={activeTab}>
+              {activeTab === "changes" ? (
+                <SessionChangesPanel />
+              ) : (
+                <RailFilesPanel projectRoot={projectRoot} familiarId={familiarId} />
+              )}
+            </div>
           ) : null}
           {/* Terminal: mounted lazily on first selection, then kept mounted but
               visually hidden when another tab is active so the pty persists. */}
           {terminalEverOpened ? (
             <div
-              className={`workspace-rail__terminal${terminalVisible ? "" : " is-hidden"}`}
+              className={`workspace-rail__terminal workspace-rail__panel${terminalVisible ? "" : " is-hidden"}`}
               hidden={!terminalVisible}
             >
               <RailTerminalPanel

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -19,6 +19,7 @@ export function WorkspaceRail({
   projectRoot,
   familiarId,
   sessionId,
+  hidePin = false,
   onSelectTab,
   onTogglePin,
   onCollapse,
@@ -29,6 +30,10 @@ export function WorkspaceRail({
   projectRoot: string | null;
   familiarId?: string | null;
   sessionId: string | null;
+  /** Hide the pin toggle (e.g. when hosted in a mobile sheet, where pinning a
+   *  transient overlay open is meaningless). Defaults to false — desktop keeps
+   *  the pin control. */
+  hidePin?: boolean;
   onSelectTab: (tab: CodeRailTab) => void;
   onTogglePin: () => void;
   onCollapse: () => void;
@@ -78,15 +83,17 @@ export function WorkspaceRail({
         <header className="workspace-rail__head">
           <span className="workspace-rail__title">{TAB_TITLE[activeTab]}</span>
           <span className="workspace-rail__actions">
-            <button
-              type="button"
-              className={`workspace-rail__btn focus-ring${pinned ? " is-on" : ""}`}
-              aria-label={pinned ? "Unpin code rail" : "Pin code rail open"}
-              aria-pressed={pinned}
-              onClick={onTogglePin}
-            >
-              <Icon name={pinned ? "ph:push-pin-fill" : "ph:push-pin"} width={13} aria-hidden />
-            </button>
+            {!hidePin && (
+              <button
+                type="button"
+                className={`workspace-rail__btn focus-ring${pinned ? " is-on" : ""}`}
+                aria-label={pinned ? "Unpin code rail" : "Pin code rail open"}
+                aria-pressed={pinned}
+                onClick={onTogglePin}
+              >
+                <Icon name={pinned ? "ph:push-pin-fill" : "ph:push-pin"} width={13} aria-hidden />
+              </button>
+            )}
             <button
               type="button"
               className="workspace-rail__btn focus-ring"

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4242,6 +4242,75 @@ details[open] > .cave-tool-summary::before {
   }
 }
 
+/* ── Mobile code-rail toggle + slide-over sheet (PR 3, Task 3) ────────────────
+   Below the mobile/narrow breakpoint the rail is a right-edge sheet opened by a
+   compact toggle button in the scope-tabs header (a </> glyph with the pending
+   change-count badge). The sheet slides in from the right edge; reduced-motion
+   zeroes the slide (mirrors the workspace-rail entrance convention above). */
+.mobile-code-rail-toggle {
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+.mobile-code-rail-toggle:hover {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
+}
+.mobile-code-rail-toggle[aria-expanded="true"] {
+  color: var(--composer-pill-gold, oklch(0.81 0.105 83));
+  border-color: color-mix(in oklch, var(--composer-pill-gold, oklch(0.81 0.105 83)) 42%, transparent);
+  background: color-mix(in oklch, var(--composer-pill-gold, oklch(0.81 0.105 83)) 12%, transparent);
+}
+.mobile-code-rail-toggle__badge {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 4px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  background: var(--composer-pill-gold, oklch(0.81 0.105 83));
+  color: oklch(0.22 0.02 83);
+  font-size: 9.5px;
+  font-weight: 600;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes mobile-code-rail-sheet-in {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.mobile-code-rail-sheet__panel {
+  animation: mobile-code-rail-sheet-in var(--duration-base, 180ms)
+    var(--ease-decelerate, ease) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .mobile-code-rail-sheet__panel {
+    animation: none;
+  }
+}
+
 .workspace-rail__strip {
   flex: 0 0 36px;
   display: flex;

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4202,9 +4202,6 @@ details[open] > .cave-tool-summary::before {
   min-height: 0;
   min-width: 0;
   background: var(--bg-surface, var(--background));
-  /* Clip the small entrance slide so translateX never spills a horizontal
-     scrollbar while the content settles to 0. */
-  overflow: hidden;
 }
 
 /* Rail entrance + tab-switch motion.
@@ -4305,6 +4302,10 @@ details[open] > .cave-tool-summary::before {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  /* Clip the small entrance slide so translateX never spills a horizontal
+     scrollbar while content settles to 0. Scoped to the body (not the whole
+     rail) so the sibling tab strip's focus rings are never clipped. */
+  overflow: hidden;
 }
 
 .workspace-rail__head {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4202,6 +4202,47 @@ details[open] > .cave-tool-summary::before {
   min-height: 0;
   min-width: 0;
   background: var(--bg-surface, var(--background));
+  /* Clip the small entrance slide so translateX never spills a horizontal
+     scrollbar while the content settles to 0. */
+  overflow: hidden;
+}
+
+/* Rail entrance + tab-switch motion.
+   - .workspace-rail__body eases in when the rail mounts (opens) — a subtle
+     fade + short slide from the right. We animate the inner content, not the
+     react-resizable-panels frame width, so panel layout is never fought.
+   - .workspace-rail__panel is the per-tab body wrapper; it is keyed by
+     activeTab in the component, so switching Changes<->Files remounts it and
+     this same entrance replays as a short crossfade. */
+@keyframes workspace-rail-content-in {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+.workspace-rail__body {
+  /* mount entrance — slightly longer, emphasized ease */
+  animation: workspace-rail-content-in var(--duration-base, 180ms)
+    var(--ease-emphasized, ease) both;
+}
+.workspace-rail__panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  /* tab-switch crossfade — shorter, standard ease */
+  animation: workspace-rail-content-in var(--duration-fast, 120ms)
+    var(--ease-standard, ease) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .workspace-rail__body,
+  .workspace-rail__panel {
+    animation: none;
+  }
 }
 
 .workspace-rail__strip {

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -146,6 +146,28 @@ test.describe("code rail beside chat", () => {
     await expect(rail.locator(".workspace-rail__preview-name")).toContainText("README.md");
   });
 
+  // PR 3 / Task 3: below the mobile breakpoint there's no room for the
+  // third-column rail Panel, so the rail is presented as a right-edge
+  // slide-over sheet opened by an explicit toggle button. Desktop-project runs
+  // must NOT see the toggle (the Panel path owns the rail there); mobile
+  // projects (pixel-5 / iphone-13) must.
+  test("(g) desktop → no mobile rail toggle (third-column Panel path owns it)", async ({ page, isMobile }) => {
+    test.skip(!!isMobile, "desktop-only");
+    const filesRef = { count: 0 };
+    await routeChanges(page, filesRef);
+    await base(page, [REPO_SESSION]);
+    await openSession(page, "Refactor auth flow");
+    // Rail is the third-column Panel on desktop…
+    await expect(page.locator(".workspace-rail")).toBeVisible({ timeout: 30_000 });
+    // …and the mobile toggle affordance is absent.
+    await expect(page.locator(".mobile-code-rail-toggle")).toHaveCount(0);
+  });
+
+  // The mobile slide-over-sheet path lives in tests/mobile/code-rail-sheet.spec.ts
+  // because Playwright's mobile projects (pixel-5 / iphone-13) only match specs
+  // under tests/mobile/ (see playwright.config.ts testMatch). A mobile-only test
+  // placed here would only ever run under the desktop project and self-skip.
+
   test("(f) Terminal tab → lazy pty host (not mounted until first opened)", async ({ page }) => {
     const filesRef = { count: 0 };
     await routeChanges(page, filesRef);

--- a/tests/mobile/code-rail-sheet.spec.ts
+++ b/tests/mobile/code-rail-sheet.spec.ts
@@ -102,8 +102,9 @@ test.describe("mobile code-rail slide-over sheet", () => {
     await openRepoChat(page);
 
     // On mobile the third-column rail Panel is NOT rendered (no room). Instead
-    // the toggle affordance appears for the repo-linked session.
-    const toggle = page.getByRole("button", { name: "Show code rail" });
+    // the toggle affordance appears for the repo-linked session. The toggle's
+    // accessible name flips Show↔Hide with open state, so match either.
+    const toggle = page.getByRole("button", { name: /^(Show|Hide) code rail$/ });
     await expect(toggle).toBeVisible({ timeout: 30_000 });
     await expect(page.locator(".workspace-rail")).toHaveCount(0);
     await expect(toggle).toHaveAttribute("aria-expanded", "false");

--- a/tests/mobile/code-rail-sheet.spec.ts
+++ b/tests/mobile/code-rail-sheet.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// PR 3 / Task 3: below the mobile breakpoint the code rail (WorkspaceRail) has
+// no room for the third-column Panel, so it is presented as a full-height
+// right-edge slide-over sheet over the full-screen chat, opened by an explicit
+// toggle button in the chat scope-tabs header and dismissed by backdrop tap /
+// Escape / the rail's own collapse control.
+//
+// This spec lives under tests/mobile/ because Playwright's mobile projects
+// (pixel-5 / iphone-13) only match specs there (see playwright.config.ts
+// testMatch). It is guarded mobile-only so the desktop project — which also
+// matches this path — self-skips (the desktop third-column path is covered in
+// tests/code-rail.spec.ts). Daemon-less: onboarding dismissed, APIs mocked.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+
+const REPO_SESSION = {
+  id: "s-repo",
+  title: "Refactor auth flow",
+  project_root: "/repo/alpha",
+  status: "running",
+  origin: "chat",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local",
+  exit_code: null,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+async function base(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:familiar:nova:last-surface", "chat");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:code-rail:pinned:v1", "false");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [{ id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" }] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [REPO_SESSION] } }),
+  );
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: { turns: [{ id: "t1", role: "assistant", text: "On it.", createdAt: ISO }] },
+        context: {},
+      },
+    }),
+  );
+  // /api/changes returns two modified files so the rail is available (repo-linked)
+  // and the change-count badge shows.
+  await page.route("**/api/changes**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        repo: true,
+        repoRoot: "/repo/alpha",
+        files: [
+          { path: "src/a.ts", status: "modified" },
+          { path: "src/b.ts", status: "modified" },
+        ],
+      },
+    }),
+  );
+  await page.goto("/");
+  await page.waitForSelector(".shell-frame", { timeout: 30_000 });
+}
+
+// Navigate to the standalone chat surface and open the repo session. On mobile
+// the surface switch is driven by the cave:navigate-mode custom event (there's
+// no Meta+2). Re-dispatch inside the poll — on a cold mobile load the Workspace
+// listener can attach after .shell-frame appears.
+async function openRepoChat(page: Page) {
+  await page.waitForFunction(
+    () => {
+      window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } }));
+      return document.querySelector(".chat-surface") !== null;
+    },
+    undefined,
+    { timeout: 25_000 },
+  );
+  // The chat surface's main region shows the Sessions list; open the repo
+  // session from there (the left sidebar's copy is off-screen on mobile). The
+  // session card's accessible name embeds the title.
+  const surface = page.locator(".chat-surface");
+  await surface
+    .getByRole("button", { name: /^Reorder chat Refactor auth flow/ })
+    .first()
+    .click();
+  await page.waitForTimeout(700);
+}
+
+test.describe("mobile code-rail slide-over sheet", () => {
+  test("toggle opens the sheet; no inline rail; backdrop closes it", async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === "desktop", "mobile-only");
+    await base(page);
+    await openRepoChat(page);
+
+    // On mobile the third-column rail Panel is NOT rendered (no room). Instead
+    // the toggle affordance appears for the repo-linked session.
+    const toggle = page.getByRole("button", { name: "Show code rail" });
+    await expect(toggle).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(".workspace-rail")).toHaveCount(0);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Opening: the toggle reveals the slide-over sheet (role=dialog) hosting the
+    // WorkspaceRail, and aria-expanded flips true.
+    await toggle.click();
+    const sheet = page.getByRole("dialog", { name: "Code rail" });
+    await expect(sheet).toBeVisible();
+    await expect(sheet.locator(".workspace-rail")).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    // The pin control is meaningless in a transient sheet → hidden.
+    await expect(sheet.getByRole("button", { name: /Pin code rail/ })).toHaveCount(0);
+
+    // Dismiss: tapping the backdrop closes the sheet and restores aria-expanded.
+    // The backdrop button spans the full viewport but the sheet panel overlays
+    // its right portion, so click the exposed top-left strip (center would land
+    // on the panel and be intercepted).
+    await page.getByRole("button", { name: "Close code rail" }).click({ position: { x: 8, y: 8 } });
+    await expect(page.getByRole("dialog", { name: "Code rail" })).toHaveCount(0);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+});


### PR DESCRIPTION
Part of the unified chat/code workspace arc (spec `docs/specs/2026-07-03-unified-chat-code-workspace-design.md`). Builds on PR 1 (rail + Changes) and PR 2 (Terminal tab). **PR 3 = polish: couple the nav to the rail, add motion, and make the rail usable on mobile.**

## What
1. **Nav ↔ rail coupling** (desktop only). When the code rail opens, the shell's left nav soft-collapses to its icon rail so chat stays centered; it restores when the rail closes — **unless the user explicitly expanded the nav** while the rail was open (their intent wins). Wired via a directional `cave:code-rail-visibility` event + a small state machine in `shell.tsx` (`railAutoCollapsedNavRef` / `userOverrodeNavRef`). Mobile nav is a drawer, so coupling is a strict no-op there (plus a desktop→mobile flip clears the bookkeeping).
2. **Rail motion** (reduced-motion aware). Subtle entrance (fade + short slide) on open and a tab-switch crossfade, both disabled under `@media (prefers-reduced-motion: reduce)`. The Terminal tab is **not** remounted (pty keepalive preserved) — only the Changes/Files body is keyed by `activeTab`. The entrance-slide clip is scoped to `.workspace-rail__body` so the tab strip's focus rings aren't clipped.
3. **Mobile slide-over sheet.** Below the mobile/narrow breakpoint (no room for a third column), the rail opens as a right-edge slide-over sheet over full-screen chat via an explicit toggle (with change badge). Clones the existing `chat-right-sheet` pattern (`role=dialog`, `aria-modal`, focus-trapped, backdrop + Escape dismiss, safe-area insets). The pin control is hidden in the sheet; `onCollapse` closes it; it auto-closes when the rail goes unavailable, the layout leaves mobile, or the scope leaves the conversation tab. Mutually exclusive with the right-panel sheet in **both** directions.

## Tests
- Source-text wiring guards: `nav-rail-coupling.test.ts`, `workspace-rail-motion.test.ts`, `mobile-code-rail.test.ts` (all wired into `run-tests.mjs`).
- E2E: `tests/mobile/code-rail-sheet.spec.ts` (pixel-5 / iphone-13 — toggle opens the sheet, no inline rail on mobile, backdrop closes) + a desktop negative assertion in `tests/code-rail.spec.ts` (no mobile toggle on desktop). Daemon-less (`page.route` mocks, onboarding dismissed).

## Verification (local, all green)
`tsc --noEmit`, `check:tests-wired` (713 wired), the new unit suites, `pnpm build` (bundle within budget), and the e2e on pixel-5 + desktop (6 passed / 1 self-skipped).

Each of the 3 tasks went through spec + code-quality review; a final integration review confirmed no cross-task issues. Follow-up (deferred, tracked in the arc): reconcile the duplicate Changes UI between the rail and the RightPanel (PR 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)