### PR TITLE
Polish home composer command bar

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -47,6 +47,38 @@ assert.doesNotMatch(source, /className="hc-send-label"/, "visible Send text labe
 assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule removed");
 assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/, ".hc-send-btn is a circular disc");
 
+// ───────── Command-bar hierarchy ─────────
+assert.match(
+  source,
+  /hc-control-group--tools[\s\S]*?hc-control-group--identity[\s\S]*?hc-control-group--settings[\s\S]*?hc-control-group--submit/,
+  "home composer separates tools, identity, settings, and submit control groups",
+);
+assert.match(
+  css,
+  /\.home-composer-card\s*\{[\s\S]*?border-radius:\s*18px;[\s\S]*?box-shadow:\s*0 8px 28px/,
+  "home composer card uses quieter radius and shadow than the oversized command-shell chrome",
+);
+assert.match(
+  css,
+  /\.hc-action-bar\s*\{[\s\S]*?border-top:\s*1px solid[\s\S]*?background:\s*color-mix/,
+  "home composer action bar has a subtle separated control rail",
+);
+assert.match(
+  css,
+  /\.hc-control-group--settings\s+\.hc-familiar-selector\s*\{[\s\S]*?background:\s*transparent/,
+  "runtime and tuning settings are visually demoted inside the command bar",
+);
+assert.match(
+  css,
+  /\.hc-send-btn:not\(\.empty\):not\(:disabled\)\s*\{/,
+  "active send button has an explicit non-empty state",
+);
+assert.match(
+  css,
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-control-group--identity\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-control-group--settings\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-control-group--settings\s+\.hc-command-select\s+\.hc-command-select-label\s*\{[\s\S]*?display:\s*inline;/,
+  "mobile identity and advanced settings wrap as readable two-column controls",
+);
+
 // ── "Jump back in" recent-chats strip REMOVED ──
 // The standalone recents strip was dropped from the home surface; resume now
 // lives only in the Daily-summary carousel's session cards.

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -225,8 +225,8 @@ assert.match(
 
 assert.match(
   css,
-  /\.hc-control-group--who\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?margin-left: auto;/,
-  "HomeComposer action bar should keep the who cluster content-sized and pin the run cluster to the right edge",
+  /\.hc-control-group--tools\s*\{[\s\S]*?flex: 0 0 auto;[\s\S]*?\.hc-control-group--identity\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--settings\s*\{[\s\S]*?margin-left: auto;[\s\S]*?\.hc-control-group--submit\s*\{[\s\S]*?flex: 0 0 auto;/,
+  "HomeComposer action bar should separate tools, identity, settings, and submit clusters",
 );
 
 assert.match(
@@ -371,7 +371,7 @@ assert.match(
 // creating a board task, so they render only while the Chat mode is selected.
 assert.match(
   source,
-  /destination === "chat" \? \(\s*<>[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/>\s*\) : null/,
+  /destination === "chat" \? \(\s*<div className="hc-control-group hc-control-group--settings">[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/div>\s*\) : null/,
   "Runtime/model, Think, and Speed controls collapse out of the action bar when Task is selected",
 );
 

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -1070,7 +1070,7 @@ export function HomeComposer({
 
         {/* Action bar */}
         <div className="hc-action-bar">
-          <div className="hc-control-group hc-control-group--who">
+          <div className="hc-control-group hc-control-group--tools">
             <input
               ref={fileInputRef}
               type="file"
@@ -1091,6 +1091,35 @@ export function HomeComposer({
               <Icon name="ph:paperclip" width={15} aria-hidden />
             </button>
 
+            {enhanceOriginal != null && (
+              <button
+                type="button"
+                className="hc-enhance-undo"
+                onClick={revertEnhance}
+                disabled={sending}
+                title="Undo enhance"
+              >
+                Undo
+              </button>
+            )}
+            <button
+              type="button"
+              className={`hc-enhance-btn${enhanceStatus === "loading" ? " loading" : ""}`}
+              onClick={() => void enhancePrompt()}
+              disabled={!text.trim() || sending || enhanceStatus === "loading"}
+              aria-label="Enhance prompt"
+              title="Enhance prompt"
+            >
+              {enhanceStatus === "loading" ? (
+                <span className="hc-spinner" />
+              ) : (
+                <Icon name="ph:sparkle" width={13} aria-hidden />
+              )}
+              <span className="hc-enhance-label">Enhance</span>
+            </button>
+          </div>
+
+          <div className="hc-control-group hc-control-group--identity">
             <label className="hc-familiar-selector">
               {selectedResolved ? (
                 <FamiliarAvatar familiar={selectedResolved} size="sm" className="hc-familiar-glyph hc-familiar-avatar" />
@@ -1165,93 +1194,66 @@ export function HomeComposer({
             {addProjectFlow.addProjectModal}
           </div>
 
-          <div className="hc-control-group hc-control-group--run">
-            {/* Runtime/model, Think, and Speed configure a chat send — they're
-                meaningless for creating a board task, so they collapse out when
-                the Task mode is selected, leaving just the submit affordance. */}
-            {destination === "chat" ? (
-              <>
-                <label className="hc-familiar-selector hc-runtime-model-selector">
-                  <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
-                  <select
-                    aria-label="Choose runtime and model"
-                    className="hc-familiar-select"
-                    value={selectedRuntimeModelValue}
-                    onChange={(e) => handleSelectRuntimeModel(e.currentTarget.value)}
-                    disabled={!selectedFamiliarId || sending}
-                  >
-                    {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
-                      <optgroup key={adapter.id} label={adapter.label}>
-                        {runtimeModelOptionsFor(adapter.id).length === 0 ? (
-                          <option value={runtimeModelValue(adapter.id, "")}>
-                            Runtime managed
+          {/* Runtime/model, Think, and Speed configure a chat send — they're
+              meaningless for creating a board task, so they collapse out when
+              the Task mode is selected, leaving just the submit affordance. */}
+          {destination === "chat" ? (
+            <div className="hc-control-group hc-control-group--settings">
+              <label className="hc-familiar-selector hc-runtime-model-selector">
+                <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
+                <select
+                  aria-label="Choose runtime and model"
+                  className="hc-familiar-select"
+                  value={selectedRuntimeModelValue}
+                  onChange={(e) => handleSelectRuntimeModel(e.currentTarget.value)}
+                  disabled={!selectedFamiliarId || sending}
+                >
+                  {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
+                    <optgroup key={adapter.id} label={adapter.label}>
+                      {runtimeModelOptionsFor(adapter.id).length === 0 ? (
+                        <option value={runtimeModelValue(adapter.id, "")}>
+                          Runtime managed
+                        </option>
+                      ) : (
+                        runtimeModelOptionsFor(adapter.id).map((model) => (
+                          <option key={model.id} value={runtimeModelValue(adapter.id, model.id)}>
+                            {model.label}
                           </option>
-                        ) : (
-                          runtimeModelOptionsFor(adapter.id).map((model) => (
-                            <option key={model.id} value={runtimeModelValue(adapter.id, model.id)}>
-                              {model.label}
-                            </option>
-                          ))
-                        )}
-                      </optgroup>
-                    ))}
-                  </select>
-                  <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-                </label>
+                        ))
+                      )}
+                    </optgroup>
+                  ))}
+                </select>
+                <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+              </label>
 
-                {renderCompactSelect(
-                  "Think",
-                  "ph:sparkle-bold",
-                  thinkingEffort,
-                  (value) => setThinkingEffort(value as CommandThinkingEffort),
-                  COMMAND_THINKING_OPTIONS,
-                  "Choose thinking effort",
-                )}
-
-                {renderCompactSelect(
-                  "Speed",
-                  "ph:lightning-bold",
-                  responseSpeed,
-                  (value) => setResponseSpeed(value as CommandResponseSpeed),
-                  COMMAND_RESPONSE_SPEED_OPTIONS,
-                  "Choose response speed",
-                )}
-
-                <ComposerHostChip
-                  value={runtimeHost ?? LOCAL_HOST_ID}
-                  disabled={sending}
-                  onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
-                />
-              </>
-            ) : null}
-
-            {enhanceOriginal != null && (
-              <button
-                type="button"
-                className="hc-enhance-undo"
-                onClick={revertEnhance}
-                disabled={sending}
-                title="Undo enhance"
-              >
-                Undo
-              </button>
-            )}
-            <button
-              type="button"
-              className={`hc-enhance-btn${enhanceStatus === "loading" ? " loading" : ""}`}
-              onClick={() => void enhancePrompt()}
-              disabled={!text.trim() || sending || enhanceStatus === "loading"}
-              aria-label="Enhance prompt"
-              title="Enhance prompt"
-            >
-              {enhanceStatus === "loading" ? (
-                <span className="hc-spinner" />
-              ) : (
-                <Icon name="ph:sparkle" width={13} aria-hidden />
+              {renderCompactSelect(
+                "Think",
+                "ph:sparkle-bold",
+                thinkingEffort,
+                (value) => setThinkingEffort(value as CommandThinkingEffort),
+                COMMAND_THINKING_OPTIONS,
+                "Choose thinking effort",
               )}
-              <span className="hc-enhance-label">Enhance</span>
-            </button>
 
+              {renderCompactSelect(
+                "Speed",
+                "ph:lightning-bold",
+                responseSpeed,
+                (value) => setResponseSpeed(value as CommandResponseSpeed),
+                COMMAND_RESPONSE_SPEED_OPTIONS,
+                "Choose response speed",
+              )}
+
+              <ComposerHostChip
+                value={runtimeHost ?? LOCAL_HOST_ID}
+                disabled={sending}
+                onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
+              />
+            </div>
+          ) : null}
+
+          <div className="hc-control-group hc-control-group--submit">
             <button
               type="button"
               className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() && attachments.length === 0 ? " empty" : ""}`}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -92,11 +92,11 @@
   position: relative;
   width: 100%;
   max-width: 100%;
-  background: color-mix(in oklch, var(--bg-raised) 70%, var(--bg-base));
-  border: 1px solid var(--border-hairline);
-  border-radius: 22px;
+  background: color-mix(in oklch, var(--bg-raised) 58%, var(--bg-base));
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 78%, transparent);
+  border-radius: 18px;
   overflow: hidden;
-  box-shadow: 0 12px 40px color-mix(in oklch, var(--text-primary) 14%, transparent),
+  box-shadow: 0 8px 28px color-mix(in oklch, var(--text-primary) 10%, transparent),
               0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
@@ -111,7 +111,7 @@
   z-index: 5;
   display: grid;
   place-items: center;
-  border-radius: 22px;
+  border-radius: 18px;
   background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base) 88%);
   border: 2px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
   pointer-events: none;
@@ -126,9 +126,9 @@
 }
 
 .home-composer-card:focus-within {
-  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
-  box-shadow: 0 8px 40px color-mix(in oklch, var(--text-primary) 15%, transparent),
-              0 0 0 1px color-mix(in oklch, var(--accent-presence) 20%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, var(--border-strong));
+  box-shadow: 0 10px 32px color-mix(in oklch, var(--text-primary) 12%, transparent),
+              0 0 0 1px color-mix(in oklch, var(--accent-presence) 16%, transparent);
 }
 
 /* ── Textarea ────────────────────────────────────────────────────────────── */
@@ -144,9 +144,9 @@
      worth a (pointer: coarse) gate. */
   font-size: 16px;
   line-height: 1.6;
-  padding: 22px 22px 8px;
+  padding: 24px 26px 12px;
   font-family: inherit;
-  min-height: 92px;
+  min-height: 104px;
   max-height: 240px;
   overflow-y: auto;
   scrollbar-width: thin;
@@ -155,8 +155,8 @@
 }
 
 .hc-textarea::placeholder {
-  color: var(--text-muted);
-  opacity: 0.7;
+  color: color-mix(in oklch, var(--text-muted) 82%, var(--text-primary));
+  opacity: 0.86;
 }
 
 .hc-textarea:disabled {
@@ -164,17 +164,16 @@
 }
 
 /* ── Action bar ──────────────────────────────────────────────────────────────
- *   One balanced row: a compact "who" cluster anchored left and the "run"
- *   config cluster anchored right (pushed there with margin-left:auto). The
- *   intent switch (Chat/Task) no longer lives here — it leads the card as a
- *   mode strip above the textarea — so the bar reads as pure send config. The
- *   larger column gap (vs the intra-group gap) keeps the clusters distinct. */
+ *   One balanced rail: tools and identity sit near the prompt, advanced runtime
+ *   settings are muted and pushed right, and submit gets its own stable slot. */
 .hc-action-bar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px 14px;
-  padding: 10px 14px 14px;
+  gap: 8px 12px;
+  padding: 11px 16px 15px;
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 58%, transparent);
+  background: color-mix(in oklch, var(--bg-base) 30%, transparent);
 }
 
 /* Groups never split internally — a cluster wraps as a whole unit (so Speed and
@@ -188,15 +187,24 @@
 }
 
 /* Side clusters are content-sized (no grow → no trailing/leading gap). */
-.hc-control-group--who {
+.hc-control-group--tools {
+  flex: 0 0 auto;
+  gap: 5px;
+}
+
+.hc-control-group--identity {
   flex: 0 1 auto;
 }
 
-/* The run cluster is content-sized and pinned to the right edge. */
-.hc-control-group--run {
+.hc-control-group--settings {
   flex: 0 1 auto;
   justify-content: flex-end;
   margin-left: auto;
+  gap: 5px;
+}
+
+.hc-control-group--submit {
+  flex: 0 0 auto;
 }
 
 /* ── Attach button (paperclip) ───────────────────────────────────────────── */
@@ -326,7 +334,7 @@
   height: 30px;
   padding: 0 10px;
   border-radius: 9px;
-  border: 1px solid var(--border-hairline);
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
@@ -339,7 +347,12 @@
   border-color: var(--border-strong);
   color: var(--text-primary);
 }
-.hc-enhance-btn:disabled { opacity: 0.5; cursor: default; }
+.hc-enhance-btn:disabled {
+  opacity: 0.44;
+  cursor: default;
+  border-color: transparent;
+  background: color-mix(in oklch, var(--bg-base) 34%, transparent);
+}
 .hc-enhance-btn.loading { color: var(--accent-presence); }
 .hc-enhance-label { line-height: 1; }
 .hc-enhance-undo {
@@ -415,13 +428,30 @@
 }
 
 .hc-runtime-model-selector .hc-familiar-select {
-  max-width: 172px;
+  max-width: 152px;
 }
 
 .hc-command-select .hc-command-select-label {
   flex-shrink: 0;
-  font-size: 11px;
+  font-size: 10.5px;
   font-weight: 550;
+  color: var(--text-muted);
+}
+
+.hc-control-group--settings .hc-familiar-selector {
+  min-height: 28px;
+  background: transparent;
+  border-color: color-mix(in oklch, var(--border-hairline) 72%, transparent);
+  color: var(--text-muted);
+}
+
+.hc-control-group--settings .hc-familiar-select {
+  font-size: 11.5px;
+  color: var(--text-secondary);
+}
+
+.hc-control-group--settings .hc-familiar-glyph,
+.hc-control-group--settings .hc-select-caret {
   color: var(--text-muted);
 }
 
@@ -626,16 +656,25 @@
     justify-content: stretch;
   }
 
-  .hc-control-group--who,
-  .hc-control-group--run {
+  .hc-control-group--identity,
+  .hc-control-group--settings {
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
   }
 
-  .hc-control-group--run {
+  .hc-control-group--identity {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hc-control-group--settings {
     order: 4;
-    grid-template-columns: repeat(3, minmax(0, 1fr)) var(--touch-target);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     margin-left: 0;
+  }
+
+  .hc-control-group--submit {
+    order: 5;
+    align-items: center;
+    justify-content: flex-end;
   }
 
   .hc-familiar-selector {
@@ -645,6 +684,10 @@
 
   .hc-command-select .hc-command-select-label {
     display: none;
+  }
+
+  .hc-control-group--settings .hc-command-select .hc-command-select-label {
+    display: inline;
   }
 
   .hc-familiar-select {
@@ -695,8 +738,12 @@
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
 }
 
-.hc-control-group--run .hc-send-btn {
+.hc-control-group--submit .hc-send-btn {
   margin-left: 0;
+}
+
+.hc-send-btn:not(.empty):not(:disabled) {
+  box-shadow: 0 3px 12px color-mix(in oklch, var(--accent-presence) 28%, transparent);
 }
 
 .hc-send-btn:hover:not(:disabled) {
@@ -928,6 +975,8 @@
 .home-feed__retry,
 .hc-add-btn,
 .hc-model-chip,
+.hc-enhance-btn,
+.hc-enhance-undo,
 .hc-familiar-select {
   outline: none;
 }
@@ -938,7 +987,9 @@
 .home-feed__refresh:focus-visible,
 .home-feed__retry:focus-visible,
 .hc-add-btn:focus-visible,
-.hc-model-chip:focus-visible {
+.hc-enhance-btn:focus-visible,
+.hc-model-chip:focus-visible,
+.hc-enhance-undo:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: var(--ring-offset);
 }


### PR DESCRIPTION
## Summary
- Split the home composer command bar into tools, identity, settings, and submit groups.
- Reduced the heavy composer chrome and strengthened the prompt/send hierarchy.
- Fixed mobile wrapping so identity and runtime controls remain readable.

## Test Plan
- node --experimental-strip-types src/components/home-composer-polish.test.ts
- node --experimental-strip-types src/components/home-composer.test.ts
- node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- Playwright desktop/mobile render check at http://127.0.0.1:3021
