### PR TITLE
a11y(light-mode): shape-code flow status indicators + fix danger-text contrast

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1885,6 +1885,18 @@ textarea.required-inputs-control {
   letter-spacing: var(--tracking-eyebrow);
 }
 
+/* Light-mode: --color-danger-soft (L≈0.70) fails AA contrast on near-white.
+   Swap to --color-danger (L≈0.52) for foreground text only; backgrounds and
+   borders may keep the soft variant since they don't carry text. */
+:root[data-mode="light"] .ui-lifecycle-badge[data-lifecycle="failed"],
+:root[data-mode="light"] .ui-lifecycle-badge[data-needs-human="true"],
+:root[data-mode="light"] .ui-lifecycle-needs-human,
+:root[data-mode="light"] .ui-btn--danger-ghost,
+:root[data-mode="light"] .ui-popover-item--danger,
+:root[data-mode="light"] .cave-project-picker__error {
+  color: var(--color-danger);
+}
+
 /* ---- Chooser list buttons (three-option chooser) ----------- */
 .ui-chooser-list {
   display: flex;

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -230,7 +230,9 @@
 .flow-node-phase-dot-running { background: var(--color-warning); }
 .flow-node-phase-dot-succeeded { background: var(--color-success); }
 .flow-node-phase-dot-failed { background: var(--color-danger); }
-.flow-node-phase-dot-skipped { background: var(--border); }
+/* Skipped: hollow dashed square — shape + fill differ from every other
+   phase so it's never ambiguous in either light or dark mode. */
+.flow-node-phase-dot-skipped { background: transparent; outline: 1.5px dashed var(--text-muted); border-radius: 2px; opacity: 0.55; }
 .flow-node-spinner { display: block; width: 10px; height: 10px; border-radius: 50%; border: 2px solid color-mix(in oklch, var(--color-warning) 30%, transparent); border-top-color: var(--color-warning); animation: flow-spin 0.7s linear infinite; }
 .flow-node-phase-running { box-shadow: 0 0 0 2px color-mix(in oklch, var(--color-warning) 40%, transparent), 0 10px 30px rgb(0 0 0 / 30%); }
 .flow-node-phase-failed { border-color: var(--color-danger); }
@@ -533,7 +535,13 @@
 .flow-exec-step-running { background: var(--color-warning); }
 .flow-exec-step-succeeded { background: var(--color-success); }
 .flow-exec-step-failed { background: var(--color-danger); }
-.flow-exec-step-skipped { background: var(--bg-hover); }
+/* Skipped bars: square corners (vs 2px radius on others) add shape coding
+   so status is never color-alone, even for small 5px-tall bars. */
+.flow-exec-step-skipped { background: var(--bg-hover); border-radius: 0; }
+/* Light-mode contrast: default pending bars (--border = 12% foreground) are
+   near-invisible on near-white surfaces; lift to 20% for legibility. */
+:root[data-mode="light"] .flow-exec-step { background: color-mix(in oklch, var(--foreground) 20%, transparent); }
+:root[data-mode="light"] .flow-exec-step-skipped { background: color-mix(in oklch, var(--foreground) 10%, transparent); }
 .flow-exec-open { flex: none; padding: 5px 11px; font-size: var(--text-sm); font-weight: 500; border: 1px solid var(--border); border-radius: var(--radius-control); background: var(--bg-elevated); color: var(--text-primary); cursor: pointer; }
 .flow-exec-open:hover { border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border)); }
 


### PR DESCRIPTION
## Summary

- **Flow phase dots**: `skipped` is now a hollow dashed square vs solid circle for every other phase — distinguishable by both shape and fill in both themes
- **Flow exec step strip**: `skipped` bars get `border-radius:0` (sharp vs rounded) for shape coding; light-mode override raises pending bar background from 12%→20% foreground opacity so bars are legible on near-white surfaces
- **Badge/button/popover danger text**: `--color-danger-soft` (oklch L≈0.70) fails WCAG AA on near-white backgrounds; a `data-mode=light` override swaps to `--color-danger` (L≈0.52) across lifecycle badges, ghost buttons, popover items, and error text

Closes cave-x32.

## Files changed

- `src/styles/flow.css` — phase-dot shape, step-strip shape + light-mode contrast overrides
- `src/app/globals.css` — light-mode danger-text contrast rule

## Test plan
- [ ] All 717 test files pass (`pnpm test`)
- [ ] TypeScript clean (`pnpm typecheck`)
- [ ] Toggle to light mode and verify flow node dots: `skipped` is a hollow dashed square; `pending` is a solid gray circle
- [ ] In execution history step strip, skipped bars have sharp corners vs rounded; pending bars are visible on white
- [ ] Failed lifecycle badges, ghost danger buttons, danger popover items read in darker red in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)