### PR TITLE
fix: standardize project picker avatar sizing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3302,10 +3302,13 @@ textarea.required-inputs-control {
 .project-avatar {
   width: var(--pa-size, 20px);
   height: var(--pa-size, 20px);
+  min-width: var(--pa-size, 20px);
+  max-width: var(--pa-size, 20px);
+  flex: 0 0 var(--pa-size, 20px);
+  box-sizing: border-box;
   border-radius: calc(var(--pa-size, 20px) * 0.29);
   display: grid;
   place-items: center;
-  flex-shrink: 0;
   overflow: hidden;
   color: color-mix(in oklch, var(--tile, var(--accent-presence)) 65%, var(--text-primary));
   background: color-mix(in oklch, var(--tile, var(--accent-presence)) 14%, transparent);
@@ -11442,8 +11445,13 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   display: flex;
   flex-direction: column;
   gap: 1px;
+  width: 100%;
   min-width: 0;
   text-align: left;
+}
+.ui-popover.cave-project-picker__popover .ui-popover-item > span:not(.project-avatar) {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .cave-project-picker__option-name {
   overflow: hidden;

--- a/src/components/project-avatar.test.ts
+++ b/src/components/project-avatar.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./project-avatar.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
 assert.match(source, /export function ProjectAvatar/, "Must export ProjectAvatar");
 assert.match(source, /useProjectImages\(\)/, "Must read the project image store");
@@ -12,5 +13,8 @@ assert.match(source, /projectTint/, "Tint fallback must reuse the comux helper")
 assert.match(source, /onError/, "img must fall back to the monogram tile on load error");
 assert.match(source, /aria-hidden/, "decorative — adjacent text carries the project name");
 assert.match(source, /color \?\?/, "explicit project color must win over the root tint");
+assert.match(css, /\.project-avatar\s*\{[\s\S]*?flex:\s*0 0 var\(--pa-size/, "avatar keeps a fixed flex basis");
+assert.match(css, /\.project-avatar\s*\{[\s\S]*?min-width:\s*var\(--pa-size/, "avatar width does not collapse below its configured size");
+assert.match(css, /\.project-avatar\s*\{[\s\S]*?max-width:\s*var\(--pa-size/, "avatar width does not expand past its configured size");
 
 console.log("project-avatar.test.ts: ok");

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -31,5 +31,10 @@ assert.match(src, /export const ADD_PROJECT_ID = "__add-project__";/, "select se
 // ── Styled ──────────────────────────────────────────────────────────────────
 assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");
 assert.match(css, /\.cave-project-picker__option-root/, "root subtitle styled");
+assert.match(
+  css,
+  /\.ui-popover\.cave-project-picker__popover \.ui-popover-item > span:not\(\.project-avatar\)/,
+  "project picker grows the text column without stretching avatar badges",
+);
 
 console.log("project-picker.test.ts OK");


### PR DESCRIPTION
## Summary
- keep shared project avatars at a fixed square flex basis so monogram badges cannot stretch in picker rows
- make the project picker text column flex without targeting `.project-avatar`
- add source guards for avatar sizing and picker text-column CSS

## Verification
- `node src/components/project-avatar.test.ts`
- `node src/components/project-picker.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `git diff --check`

Rendered note: clean worktree dev server served `http://127.0.0.1:3017/` with `200 OK`; current `origin/main` did not expose the custom `ProjectPicker` through the probed route, so visual proof is limited to the earlier local picker QA before the PR worktree split.