### PR TITLE
fix(update): open installer links with system handler

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -18,7 +18,7 @@ assert.match(src, /\/api\/app\/latest-release/, "falls back to the server releas
 assert.match(
   src,
   /import \{ openInAppBrowserUrl \} from "@\/lib\/open-external"/,
-  "update fallback should use the explicit Cave Browser URL handoff",
+  "update fallback retains the explicit Cave Browser URL handoff as last-resort recovery",
 );
 assert.doesNotMatch(
   src,
@@ -54,25 +54,27 @@ assert.match(
   "banner native install should surface download progress instead of a static loading state",
 );
 
-// Settings row exposes install / in-app fallback / progress / manual recheck.
+// Settings row exposes install / installer fallback / progress / manual recheck.
 assert.match(src, /Install &amp; restart/, "native path offers install + restart");
 assert.match(src, /Downloading…/, "shows download progress");
 assert.match(src, /Check for updates/, "settings row offers a manual re-check");
-assert.match(src, /Open installer in Browser/, "fallback keeps installer recovery inside Cave's Browser surface");
+assert.match(src, /Open installer/, "fallback exposes a clear installer recovery action");
+assert.match(src, /shell_open/, "fallback installer URLs open through the OS browser/download handler");
 assert.match(src, /Native updater unavailable/, "settings row distinguishes native updater failure from a normal installer fallback");
 assert.match(src, /Retry native update/, "settings row makes retrying native update the primary recovery action");
 
 // A failed native install must not dead-end: it captures the reason and offers
-// in-app recovery plus a retry, so the update is always reachable even when
+// installer recovery plus a retry, so the update is always reachable even when
 // downloadAndInstall/relaunch throws. The recovery path should resolve the
 // platform installer through the same fallback route instead of hardcoding the
-// releases page or sending the user outside Cave.
+// releases page.
 assert.match(src, /phase: "failed"/, "tracks a dedicated failed state for a thrown install");
 assert.match(src, /message: err instanceof Error \? err\.message/, "captures the real failure reason instead of swallowing it");
-assert.match(src, /async function openFallbackUpdateInBrowser/, "centralizes in-app fallback recovery resolution");
-assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "in-app recovery resolves a direct platform installer when release metadata is reachable");
-assert.match(src, /onClick=\{\(\) => void openFallbackUpdateInBrowser\(\)\}/, "failed state offers the same in-app installer path as fallback updates");
-assert.match(src, /openInAppBrowserUrl\(url\)/, "fallback recovery opens in Cave's Browser surface");
+assert.match(src, /async function openFallbackInstaller/, "centralizes fallback installer recovery resolution");
+assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "fallback recovery resolves a direct platform installer when release metadata is reachable");
+assert.match(src, /onClick=\{\(\) => void openFallbackInstaller\(\)\}/, "failed state offers the same installer recovery path as fallback updates");
+assert.match(src, /window\.open\(url, "_blank", "noopener"\)/, "non-Tauri fallback opens the installer in a normal browser tab");
+assert.match(src, /openInAppBrowserUrl\(url\)/, "Cave Browser remains a final fallback when shell/browser opening fails");
 assert.doesNotMatch(src, /download manually/i, "failed updater copy should not imply leaving the app for manual recovery");
 assert.doesNotMatch(src, /onClick=\{\(\) => void openInAppBrowserUrl\(RELEASES_PAGE\)\}/, "failed state must not dead-end on the generic release page when a direct installer can be resolved");
 assert.match(src, />\s*Retry\s*</, "failed state offers a retry");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -116,15 +116,34 @@ async function resolveDownloadUrl(status: UpdateStatus): Promise<string> {
 }
 
 /**
- * Open the easiest reachable installer for the running desktop platform in
- * Cave's Browser surface. This is used when the native updater cannot finish,
- * so a broken install attempt still leaves the user one click from the
- * DMG/MSI/AppImage when release metadata is available.
+ * Open the easiest reachable installer for the running desktop platform in the
+ * OS browser/download handler. Cave's embedded Browser is a viewing surface, not
+ * a download manager; release asset links should go through the shell so DMGs,
+ * MSIs, and AppImages download normally.
  */
-async function openFallbackUpdateInBrowser(): Promise<void> {
+async function openInstallerUrl(url: string): Promise<void> {
+  if (isTauri()) {
+    try {
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("shell_open", { url });
+      return;
+    } catch {
+      // Fall through to browser-based recovery paths below.
+    }
+  }
+
+  if (typeof window !== "undefined") {
+    const opened = window.open(url, "_blank", "noopener");
+    if (opened) return;
+  }
+
+  openInAppBrowserUrl(url);
+}
+
+async function openFallbackInstaller(): Promise<void> {
   const fb = await fetchFallbackStatus();
   const url = fb ? await resolveDownloadUrl(fb) : RELEASES_PAGE;
-  openInAppBrowserUrl(url);
+  await openInstallerUrl(url);
 }
 
 type Resolved =
@@ -173,7 +192,7 @@ export function UpdateBannerTrigger() {
             ? `Native updater unavailable — v${r.version}`
             : `Update available — v${r.version}`,
         cta: {
-          label: r.kind === "native" ? "Install & restart" : "Open installer in Browser",
+          label: r.kind === "native" ? "Install & restart" : "Open installer",
           onClick: () => {
             if (r.kind === "native") {
               pushBanner({ id: BANNER_ID, severity: "info", title: `Preparing update v${r.version}…` });
@@ -191,12 +210,12 @@ export function UpdateBannerTrigger() {
                   title: reason
                     ? `Update failed (${reason})`
                     : "Update failed",
-                  cta: { label: "Open installer in Browser", onClick: () => void openFallbackUpdateInBrowser() },
+                  cta: { label: "Open installer", onClick: () => void openFallbackInstaller() },
                   onDismiss: () => markDismissed(r.version),
                 });
               });
             } else {
-              openInAppBrowserUrl(r.url);
+              void openInstallerUrl(r.url);
             }
           },
         },
@@ -223,8 +242,8 @@ type RowState =
 
 /**
  * Desktop-only row for Settings ▸ About. Native updater when available
- * (Install & restart with progress), else opens the release installer in Cave's
- * Browser surface.
+ * (Install & restart with progress), else opens the release installer through
+ * the OS browser/download handler.
  */
 export function UpdateSettingsRow() {
   const isDesktop = useIsTauriDesktop();
@@ -290,9 +309,9 @@ export function UpdateSettingsRow() {
             Install &amp; restart
           </button>
         ) : (
-          <button type="button" onClick={() => openInAppBrowserUrl(r.url)} className={accentBtn}>
+          <button type="button" onClick={() => void openInstallerUrl(r.url)} className={accentBtn}>
             <Icon name="ph:arrow-square-out" width={12} />
-            Open installer in Browser
+            Open installer
           </button>
         )}
       </>
@@ -313,17 +332,17 @@ export function UpdateSettingsRow() {
         </button>
         <button
           type="button"
-          onClick={() => openInAppBrowserUrl(r.url)}
+          onClick={() => void openInstallerUrl(r.url)}
           className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
         >
-          Open installer in Browser
+          Open installer
         </button>
       </>
     );
   } else if (state.phase === "failed") {
     // The native install threw (e.g. unsigned/dev build, app translocation, or
     // a network/verification error). Don't dead-end: surface the reason and
-    // keep recovery inside Cave.
+    // hand the installer URL to the OS browser/download handler.
     control = (
       <>
         <span
@@ -332,9 +351,9 @@ export function UpdateSettingsRow() {
         >
           Update failed
         </span>
-        <button type="button" onClick={() => void openFallbackUpdateInBrowser()} className={accentBtn}>
+        <button type="button" onClick={() => void openFallbackInstaller()} className={accentBtn}>
           <Icon name="ph:arrow-square-out" width={12} />
-          Open installer in Browser
+          Open installer
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

- route fallback installer/update CTAs through Tauri `shell_open` so DMG/MSI/AppImage assets use the OS browser/download handler
- keep `window.open` and Cave Browser as recovery fallbacks when native shell opening is unavailable
- update source assertions for the new installer handoff behavior

## Tests

- `node --experimental-strip-types src/components/update-available.test.ts`
- `node --experimental-strip-types src/lib/app-update.test.ts`
- `node --experimental-strip-types src/lib/open-external.test.ts`
- `/Users/christhomas/.openclaw/workspace/repos/coven-cave/node_modules/.bin/tsc --noEmit`
- `node scripts/run-tests.mjs app` (533 test files passed)
