### PR TITLE
Fix native updater installer fallback

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -71,6 +71,21 @@ assert.match(src, /phase: "failed"/, "tracks a dedicated failed state for a thro
 assert.match(src, /message: err instanceof Error \? err\.message/, "captures the real failure reason instead of swallowing it");
 assert.match(src, /async function openFallbackUpdateInBrowser/, "centralizes in-app fallback recovery resolution");
 assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "in-app recovery resolves a direct platform installer when release metadata is reachable");
+assert.match(
+  src,
+  /if \(r\.kind === "native-unavailable"\) \{\s*void openFallbackUpdateInBrowser\(\);\s*\}/,
+  "native-unavailable banner CTA re-resolves the installer at click time",
+);
+assert.match(
+  src,
+  /state\.phase === "native-unavailable"[\s\S]{0,900}?onClick=\{\(\) => void openFallbackUpdateInBrowser\(\)\}/,
+  "native-unavailable settings row opens the freshly resolved installer fallback",
+);
+assert.doesNotMatch(
+  src,
+  /state\.phase === "native-unavailable"[\s\S]{0,900}?openInAppBrowserUrl\(r\.url\)/,
+  "native-unavailable settings row must not reuse a stale installer URL from the initial check",
+);
 assert.match(src, /onClick=\{\(\) => void openFallbackUpdateInBrowser\(\)\}/, "failed state offers the same in-app installer path as fallback updates");
 assert.match(src, /openInAppBrowserUrl\(url\)/, "fallback recovery opens in Cave's Browser surface");
 assert.doesNotMatch(src, /download manually/i, "failed updater copy should not imply leaving the app for manual recovery");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -195,6 +195,8 @@ export function UpdateBannerTrigger() {
                   onDismiss: () => markDismissed(r.version),
                 });
               });
+            } else if (r.kind === "native-unavailable") {
+              void openFallbackUpdateInBrowser();
             } else {
               openInAppBrowserUrl(r.url);
             }
@@ -313,7 +315,7 @@ export function UpdateSettingsRow() {
         </button>
         <button
           type="button"
-          onClick={() => openInAppBrowserUrl(r.url)}
+          onClick={() => void openFallbackUpdateInBrowser()}
           className="rounded-md border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
         >
           Open installer in Browser


### PR DESCRIPTION
## Summary
- route the native-updater-unavailable banner CTA through the shared installer fallback resolver
- route the Settings row `Open installer in Browser` button through the same fresh fallback resolver
- add regression coverage so the native-unavailable state does not reuse a stale URL from the initial check

## Verification
- `node --experimental-strip-types src/components/update-available.test.ts`
- `node --experimental-strip-types src/lib/app-update.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `git diff --check`

Bead: cave-6vo
