### PR TITLE
fix(ios): reset stale state when changing hosts

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -588,10 +588,34 @@ final class AppModel {
             // credential to a newly configured host from a tokenless invite.
             CaveConnection.saveAccessToken(nil)
         }
+        if !isSameEndpoint {
+            resetHostScopedStateForNewConnection()
+        }
 
         connection = conn
         conn.save()
         await refreshConnection()
+    }
+
+    private func resetHostScopedStateForNewConnection() {
+        familiars = []
+        familiarsError = nil
+        sessionsLoaded = false
+        tasks = []
+        tasksError = nil
+        tasksLoaded = false
+        reminders = []
+        remindersError = nil
+        remindersLoaded = false
+        projects = []
+        projectsError = nil
+        projectsLoaded = false
+        journalDays = []
+        journalError = nil
+        journalLoaded = false
+        chrome = .fallback
+        publishedThemeId = nil
+        publishedMode = nil
     }
 
     func disconnect() {

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -46,6 +46,18 @@ assert.match(
   "foreground retry should also converge loaded surfaces after a successful reconnect",
 );
 
+// --- New host handoff: do not show stale old-host data while probing the new one
+assert.match(
+  model,
+  /func configure\(host: String, token: String\? = nil\) async \{[\s\S]*?let isSameEndpoint[\s\S]*?if !isSameEndpoint \{[\s\S]*?resetHostScopedStateForNewConnection\(\)/,
+  "configuring a different host should clear host-scoped data before probing it",
+);
+assert.match(
+  model,
+  /private func resetHostScopedStateForNewConnection\(\) \{[\s\S]*?familiars = \[\][\s\S]*?sessionsLoaded = false[\s\S]*?tasksLoaded = false[\s\S]*?remindersLoaded = false[\s\S]*?projectsLoaded = false[\s\S]*?journalLoaded = false/,
+  "new-host reset should drop loaded-surface flags so .checking shows the connection flow instead of stale data",
+);
+
 // --- Auth failures: expired pairing goes to pairing guidance, not generic offline
 assert.match(model, /private func handleSurfaceError\(_ error: Error\) -> String/, "surface loads should share error handling");
 assert.match(


### PR DESCRIPTION
## Summary
- clear host-scoped iOS loaded state before probing a different Cave host
- keep same-endpoint reconnect/re-pair behavior intact
- extend the iOS self-healing source contract so new-host handoff cannot show stale old-host data

## Verification
- node scripts/ios-self-healing-sync.test.mjs
- node scripts/ios-auto-reconnect.test.mjs
- node scripts/ios-connect-screen-ux.test.mjs
- node scripts/ios-connect-paste.test.mjs
- pnpm check:tests-wired
- pnpm typecheck
- pnpm test:mobile
- XcodeBuildMCP build_sim, CovenCave on iPhone 16 Pro
- git diff --check