### PR TITLE
fix(chat): use custom home composer dropdowns

### DIFF
--- a/src/components/home-composer-hide-archived.test.ts
+++ b/src/components/home-composer-hide-archived.test.ts
@@ -65,7 +65,7 @@ assert.match(
 );
 
 // 4a. If the active familiar is archived, fall through to the first visible
-//     one so the <select>'s value matches an option in the DOM.
+//     one so the custom select's value matches an option in the DOM.
 assert.match(
   source,
   /activeIsArchived/,
@@ -75,8 +75,8 @@ assert.match(
 // 5. Dropdown renders visibleFamiliars, not raw familiars.
 assert.match(
   source,
-  /visibleFamiliars\.map\(\(familiar\)\s*=>\s*\(\s*<option/,
-  "HomeComposer dropdown should render <option>s from visibleFamiliars (non-archived only)",
+  /visibleFamiliars\.map\(\(familiar\)\s*=>\s*\{[\s\S]{0,500}value:\s*familiar\.id[\s\S]{0,500}label:\s*familiar\.display_name/,
+  "HomeComposer dropdown should build custom select options from visibleFamiliars (non-archived only)",
 );
 
 // 6. The empty-state check should also reflect that there might be zero visible

--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -46,8 +46,8 @@ assert.match(
 // ───── Phone composer controls are thumb-sized ─────
 assert.match(
   css,
-  /@media \(max-width: 520px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-familiar-select\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "phone composer action bar wraps into thumb-sized familiar/send/two-destination controls",
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?align-items:\s*stretch;[\s\S]*?\.hc-control-group--who,\s*\.hc-control-group--run\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-home-select-value\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone composer action bar uses thumb-sized custom selectors, send, and two-destination controls",
 );
 
 

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -50,33 +50,33 @@ assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/, ".hc-send-
 // ───────── Command-bar hierarchy ─────────
 assert.match(
   source,
-  /hc-control-group--tools[\s\S]*?hc-control-group--identity[\s\S]*?hc-control-group--settings[\s\S]*?hc-control-group--submit/,
-  "home composer separates tools, identity, settings, and submit control groups",
+  /hc-control-group--who[\s\S]*?<HomeSelect[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?<ProjectPicker[\s\S]*?hc-control-group--run[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?aria-label="Send"/,
+  "home composer separates who and run control groups with custom selectors and the send control",
 );
 assert.match(
   css,
-  /\.home-composer-card\s*\{[\s\S]*?border-radius:\s*18px;[\s\S]*?box-shadow:\s*0 8px 28px/,
-  "home composer card uses quieter radius and shadow than the oversized command-shell chrome",
+  /\.home-composer-card\s*\{[\s\S]*?border-radius:\s*22px;[\s\S]*?box-shadow:\s*0 12px 40px/,
+  "home composer card keeps the rounded elevated composer chrome",
 );
 assert.match(
   css,
-  /\.hc-action-bar\s*\{[\s\S]*?border-top:\s*1px solid[\s\S]*?background:\s*color-mix/,
-  "home composer action bar has a subtle separated control rail",
+  /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*8px 14px;[\s\S]*?padding:\s*10px 14px 14px;/,
+  "home composer action bar wraps with distinct spacing between who and run clusters",
 );
 assert.match(
   css,
-  /\.hc-control-group--settings\s+\.hc-familiar-selector\s*\{[\s\S]*?background:\s*transparent/,
-  "runtime and tuning settings are visually demoted inside the command bar",
+  /\.hc-home-select-trigger\s*\{[\s\S]*?border:\s*1px solid[\s\S]*?text-align:\s*left;/,
+  "custom selector triggers keep button styling while reading as compact selects",
 );
 assert.match(
   css,
-  /\.hc-send-btn:not\(\.empty\):not\(:disabled\)\s*\{/,
-  "active send button has an explicit non-empty state",
+  /\.hc-send-btn\s*\{[\s\S]*?background:\s*var\(--accent-presence\);/,
+  "active send button keeps the presence accent fill",
 );
 assert.match(
   css,
-  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-control-group--identity\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-control-group--settings\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-control-group--settings\s+\.hc-command-select\s+\.hc-command-select-label\s*\{[\s\S]*?display:\s*inline;/,
-  "mobile identity and advanced settings wrap as readable two-column controls",
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-control-group--who,\s*\.hc-control-group--run\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)\s*var\(--touch-target\);/,
+  "mobile who and run clusters wrap as readable custom selector grids",
 );
 
 // ── "Jump back in" recent-chats strip REMOVED ──

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -39,20 +39,20 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label="Choose project"[\s\S]*value=\{selectedProjectId\}/,
-  "HomeComposer should render a project selector",
+  /<ProjectPicker[\s\S]*?value=\{selectedProjectId \|\| null\}[\s\S]*?ariaLabel="Choose project"/,
+  "HomeComposer should render the shared custom project selector",
 );
 
 assert.match(
   source,
-  /<option value=\{NO_PROJECT_ID\}>No project<\/option>/,
+  /<ProjectPicker[\s\S]*?allowNoProject/,
   "HomeComposer should offer an explicit No-project choice, matching chat semantics",
 );
 
 assert.match(
   source,
-  /value === ADD_PROJECT_ID[\s\S]{0,120}?beginAddProject\(\);/,
-  "The Add-project option should open the shared register+grant flow instead of changing the selection",
+  /<ProjectPicker[\s\S]*?createProject=\{createProject\}/,
+  "The Add-project row should come from the shared register+grant picker flow",
 );
 
 assert.match(
@@ -75,13 +75,13 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label="Choose runtime and model"[\s\S]*value=\{selectedRuntimeModelValue\}/,
-  "HomeComposer should expose one combined runtime/model selector for the selected familiar",
+  /<HomeSelect[\s\S]*?value=\{selectedRuntimeModelValue\}[\s\S]*?ariaLabel="Choose runtime and model"/,
+  "HomeComposer should expose one combined custom runtime/model selector for the selected familiar",
 );
 
 assert.match(
   source,
-  /<optgroup key=\{adapter\.id\} label=\{adapter\.label\}>[\s\S]*?runtimeModelOptionsFor\(adapter\.id\)\.map/,
+  /runtimeModelSelectGroups[\s\S]*?label: adapter\.label,[\s\S]*?models\.map/,
   "HomeComposer should group model choices under their runtime",
 );
 
@@ -165,8 +165,14 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label="Choose chat agent"[\s\S]*value=\{selectedFamiliarId\}/,
-  "HomeComposer should include an agent selector when starting chat from home",
+  /<HomeSelect[\s\S]*?value=\{selectedFamiliarId\}[\s\S]*?ariaLabel="Choose chat agent"/,
+  "HomeComposer should include a custom agent selector when starting chat from home",
+);
+
+assert.doesNotMatch(
+  source,
+  /<select\b/,
+  "HomeComposer toolbar dropdowns should be custom popovers, not native selects",
 );
 
 assert.match(
@@ -195,8 +201,8 @@ assert.match(
 
 assert.match(
   source,
-  /aria-label=\{ariaLabel\}[\s\S]*?value=\{value\}/,
-  "HomeComposer compact command select should render the supplied aria label and selected value",
+  /function HomeSelect\([\s\S]*?aria-label=\{ariaLabel\}[\s\S]*?aria-haspopup="dialog"[\s\S]*?PopoverItem[\s\S]*?checked=\{option\.value === value\}/,
+  "HomeComposer compact command select should render custom popover options with the supplied aria label and selected value",
 );
 
 assert.match(
@@ -225,8 +231,8 @@ assert.match(
 
 assert.match(
   css,
-  /\.hc-control-group--tools\s*\{[\s\S]*?flex: 0 0 auto;[\s\S]*?\.hc-control-group--identity\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--settings\s*\{[\s\S]*?margin-left: auto;[\s\S]*?\.hc-control-group--submit\s*\{[\s\S]*?flex: 0 0 auto;/,
-  "HomeComposer action bar should separate tools, identity, settings, and submit clusters",
+  /\.hc-control-group--who\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?margin-left: auto;/,
+  "HomeComposer action bar should keep the who cluster content-sized and pin the run cluster to the right edge",
 );
 
 assert.match(
@@ -371,7 +377,7 @@ assert.match(
 // creating a board task, so they render only while the Chat mode is selected.
 assert.match(
   source,
-  /destination === "chat" \? \(\s*<div className="hc-control-group hc-control-group--settings">[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/div>\s*\) : null/,
+  /destination === "chat" \? \(\s*<>[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/>\s*\) : null/,
   "Runtime/model, Think, and Speed controls collapse out of the action bar when Task is selected",
 );
 

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -9,6 +9,7 @@
 
 import {
   type KeyboardEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useId,
@@ -17,7 +18,6 @@ import {
   useState,
 } from "react";
 import { ComposerHostChip } from "@/components/composer-host-chip";
-import { ProjectAvatar } from "@/components/project-avatar";
 import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
@@ -37,7 +37,13 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
-import { ADD_PROJECT_ID, useAddProjectFlow } from "@/components/project-picker";
+import { ProjectPicker } from "@/components/project-picker";
+import {
+  Popover,
+  PopoverBody,
+  PopoverItem,
+  PopoverLabel,
+} from "@/components/ui/popover";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
@@ -71,6 +77,113 @@ const PLACEHOLDERS: Record<Destination, string> = {
   chat: "Summon something magical",
   board: "Describe a new task…",
 };
+
+type HomeSelectOption = {
+  value: string;
+  label: string;
+  icon?: IconName;
+  leading?: ReactNode;
+  detail?: string;
+  disabled?: boolean;
+};
+
+type HomeSelectGroup = {
+  label?: string;
+  options: HomeSelectOption[];
+};
+
+function HomeSelect({
+  label,
+  icon,
+  value,
+  onChange,
+  groups,
+  ariaLabel,
+  disabled = false,
+  className,
+}: {
+  label?: string;
+  icon: IconName;
+  value: string;
+  onChange: (value: string) => void;
+  groups: HomeSelectGroup[];
+  ariaLabel: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const selected = groups.flatMap((group) => group.options).find((option) => option.value === value);
+
+  const close = () => setOpen(false);
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={["hc-familiar-selector", "hc-home-select-trigger", className ?? ""]
+          .filter(Boolean)
+          .join(" ")}
+        aria-label={ariaLabel}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        disabled={disabled}
+        title={selected?.detail ?? selected?.label ?? ariaLabel}
+        onClick={() => (open ? close() : setOpen(true))}
+      >
+        {selected?.leading ?? (
+          <Icon name={selected?.icon ?? icon} width={13} className="hc-familiar-glyph" aria-hidden />
+        )}
+        {label ? <span className="hc-command-select-label">{label}</span> : null}
+        <span className="hc-home-select-value">{selected?.label ?? "None"}</span>
+        <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={(next) => (next ? setOpen(true) : close())}
+        anchorRef={triggerRef}
+        placement="bottom-start"
+        minWidth={220}
+        className="hc-home-select-popover"
+        ariaLabel={ariaLabel}
+      >
+        <PopoverBody role="menu" ariaLabel={ariaLabel}>
+          {groups.map((group, groupIndex) => (
+            <div key={group.label ?? groupIndex} className="hc-home-select-group">
+              {group.label ? <PopoverLabel>{group.label}</PopoverLabel> : null}
+              {group.options.map((option) => (
+                <PopoverItem
+                  key={option.value}
+                  leading={
+                    option.leading ?? (
+                      <Icon name={option.icon ?? icon} width={13} aria-hidden />
+                    )
+                  }
+                  checked={option.value === value}
+                  active={option.value === value}
+                  disabled={option.disabled}
+                  onSelect={() => {
+                    if (option.disabled) return;
+                    onChange(option.value);
+                    close();
+                  }}
+                >
+                  <span className="hc-home-select-option">
+                    <span className="hc-home-select-option__label">{option.label}</span>
+                    {option.detail ? (
+                      <span className="hc-home-select-option__detail">{option.detail}</span>
+                    ) : null}
+                  </span>
+                </PopoverItem>
+              ))}
+            </div>
+          ))}
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}
 
 type Props = {
   familiars: Familiar[];
@@ -186,7 +299,7 @@ export function HomeComposer({
     [familiars, archivedFamiliars],
   );
   // If the user's previously-active familiar is now archived, fall through to
-  // the first visible one so the <select>'s value matches an actual option and
+  // the first visible one so the picker value matches an actual option and
   // the new-session flow stays usable.
   const activeIsArchived =
     activeFamiliarId != null && activeFamiliarId in archivedFamiliars;
@@ -201,21 +314,13 @@ export function HomeComposer({
   // Resolve avatars so the selector chip shows the selected familiar's actual
   // avatar image (falling back to its glyph) instead of a static sparkle icon.
   const resolvedFamiliars = useResolvedFamiliars(familiars);
-  const selectedResolved = useMemo(
-    () => resolvedFamiliars.find((familiar) => familiar.id === selectedFamiliarId) ?? null,
-    [resolvedFamiliars, selectedFamiliarId],
+  const resolvedFamiliarById = useMemo(
+    () => new Map(resolvedFamiliars.map((familiar) => [familiar.id, familiar])),
+    [resolvedFamiliars],
   );
   const [modelState, setModelState] = useState<ChatModelState | null>(null);
   const { projects, createProject } = useProjects({ familiarId: selectedFamiliarId || null });
   const [selectedProjectId, setSelectedProjectId] = useState("");
-  // Shared register+grant flow behind the select's "Add project…" option —
-  // the composer no longer dead-ends when the wanted root isn't registered.
-  const addProjectFlow = useAddProjectFlow({
-    familiarId: selectedFamiliarId || null,
-    createProject,
-    projects,
-    onAdded: setSelectedProjectId,
-  });
   const [thinkingEffort, setThinkingEffort] = useState<CommandThinkingEffort>(
     COMMAND_CONTROL_DEFAULTS.thinkingEffort,
   );
@@ -246,6 +351,58 @@ export function HomeComposer({
         ? modelState!.effectiveModel
         : runtimeModelOptions[0]?.id ?? "";
   const selectedRuntimeModelValue = runtimeModelValue(selectedRuntime, selectedModelId);
+  const familiarSelectGroups = useMemo<HomeSelectGroup[]>(
+    () => [
+      {
+        options:
+          visibleFamiliars.length === 0
+            ? [{ value: "", label: "No agents", icon: "ph:sparkle", disabled: true }]
+            : visibleFamiliars.map((familiar) => {
+                const resolved = resolvedFamiliarById.get(familiar.id);
+                return {
+                  value: familiar.id,
+                  label: familiar.display_name,
+                  leading: resolved ? (
+                    <FamiliarAvatar
+                      familiar={resolved}
+                      size="sm"
+                      className="hc-familiar-glyph hc-familiar-avatar"
+                    />
+                  ) : (
+                    <Icon name="ph:sparkle" width={13} aria-hidden />
+                  ),
+                };
+              }),
+      },
+    ],
+    [resolvedFamiliarById, visibleFamiliars],
+  );
+  const runtimeModelSelectGroups = useMemo<HomeSelectGroup[]>(
+    () =>
+      COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => {
+        const models = runtimeModelOptionsFor(adapter.id);
+        return {
+          label: adapter.label,
+          options:
+            models.length === 0
+              ? [
+                  {
+                    value: runtimeModelValue(adapter.id, ""),
+                    label: "Runtime managed",
+                    detail: adapter.label,
+                    icon: "ph:terminal-window",
+                  },
+                ]
+              : models.map((model) => ({
+                  value: runtimeModelValue(adapter.id, model.id),
+                  label: model.label,
+                  detail: adapter.label,
+                  icon: "ph:terminal-window" as IconName,
+                })),
+        };
+      }),
+    [runtimeModelOptionsFor],
+  );
 
   useEffect(() => {
     if (selectedProjectId === NO_PROJECT_ID) return; // an explicit No-project choice is valid
@@ -791,34 +948,6 @@ export function HomeComposer({
     ],
   );
 
-  const renderCompactSelect = (
-    label: string,
-    icon: IconName,
-    value: string,
-    onChange: (value: string) => void,
-    options: Array<{ value: string; label: string }>,
-    ariaLabel: string,
-  ) => (
-    <label className="hc-familiar-selector hc-command-select">
-      <Icon name={icon} width={13} className="hc-familiar-glyph" aria-hidden />
-      <span className="hc-command-select-label">{label}</span>
-      <select
-        aria-label={ariaLabel}
-        className="hc-familiar-select"
-        value={value}
-        onChange={(e) => onChange(e.currentTarget.value)}
-        disabled={sending}
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-      <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-    </label>
-  );
-
   return (
     <div className="home-composer-root">
 
@@ -1070,7 +1199,7 @@ export function HomeComposer({
 
         {/* Action bar */}
         <div className="hc-action-bar">
-          <div className="hc-control-group hc-control-group--tools">
+          <div className="hc-control-group hc-control-group--who">
             <input
               ref={fileInputRef}
               type="file"
@@ -1090,6 +1219,90 @@ export function HomeComposer({
             >
               <Icon name="ph:paperclip" width={15} aria-hidden />
             </button>
+
+            <HomeSelect
+              icon="ph:sparkle"
+              value={selectedFamiliarId}
+              onChange={(value) => {
+                if (value) onSetActiveFamiliar(value);
+              }}
+              groups={familiarSelectGroups}
+              ariaLabel="Choose chat agent"
+              disabled={visibleFamiliars.length === 0 || sending}
+            />
+
+            <ProjectPicker
+              projects={projects}
+              value={selectedProjectId || null}
+              onChange={setSelectedProjectId}
+              allowNoProject
+              familiarId={selectedFamiliarId || null}
+              createProject={createProject}
+              disabled={sending}
+              ariaLabel="Choose project"
+              className="hc-project-selector"
+            />
+          </div>
+
+          <div className="hc-control-group hc-control-group--run">
+            {/* Runtime/model, Think, and Speed configure a chat send — they're
+                meaningless for creating a board task, so they collapse out when
+                the Task mode is selected, leaving just the submit affordance. */}
+            {destination === "chat" ? (
+              <>
+                <HomeSelect
+                  icon="ph:terminal-window"
+                  value={selectedRuntimeModelValue}
+                  onChange={handleSelectRuntimeModel}
+                  groups={runtimeModelSelectGroups}
+                  ariaLabel="Choose runtime and model"
+                  disabled={!selectedFamiliarId || sending}
+                  className="hc-runtime-model-selector"
+                />
+
+                <HomeSelect
+                  label="Think"
+                  icon="ph:sparkle-bold"
+                  value={thinkingEffort}
+                  onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
+                  groups={[
+                    {
+                      options: COMMAND_THINKING_OPTIONS.map((option) => ({
+                        ...option,
+                        icon: "ph:sparkle-bold",
+                      })),
+                    },
+                  ]}
+                  ariaLabel="Choose thinking effort"
+                  disabled={sending}
+                  className="hc-command-select"
+                />
+
+                <HomeSelect
+                  label="Speed"
+                  icon="ph:lightning-bold"
+                  value={responseSpeed}
+                  onChange={(value) => setResponseSpeed(value as CommandResponseSpeed)}
+                  groups={[
+                    {
+                      options: COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => ({
+                        ...option,
+                        icon: "ph:lightning-bold",
+                      })),
+                    },
+                  ]}
+                  ariaLabel="Choose response speed"
+                  disabled={sending}
+                  className="hc-command-select"
+                />
+
+                <ComposerHostChip
+                  value={runtimeHost ?? LOCAL_HOST_ID}
+                  disabled={sending}
+                  onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
+                />
+              </>
+            ) : null}
 
             {enhanceOriginal != null && (
               <button
@@ -1117,143 +1330,7 @@ export function HomeComposer({
               )}
               <span className="hc-enhance-label">Enhance</span>
             </button>
-          </div>
 
-          <div className="hc-control-group hc-control-group--identity">
-            <label className="hc-familiar-selector">
-              {selectedResolved ? (
-                <FamiliarAvatar familiar={selectedResolved} size="sm" className="hc-familiar-glyph hc-familiar-avatar" />
-              ) : (
-                <Icon name="ph:sparkle" width={13} className="hc-familiar-glyph" aria-hidden />
-              )}
-              <select
-                aria-label="Choose chat agent"
-                className="hc-familiar-select"
-                value={selectedFamiliarId}
-                onChange={(e) => {
-                  if (e.currentTarget.value) onSetActiveFamiliar(e.currentTarget.value);
-                }}
-                disabled={visibleFamiliars.length === 0 || sending}
-              >
-                {visibleFamiliars.length === 0 ? (
-                  <option value="">No agents</option>
-                ) : (
-                  visibleFamiliars.map((familiar) => (
-                    <option key={familiar.id} value={familiar.id}>
-                      {familiar.display_name}
-                    </option>
-                  ))
-                )}
-              </select>
-              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-            </label>
-
-            <label className="hc-familiar-selector hc-project-selector">
-              {selectedProject && selectedProjectId !== NO_PROJECT_ID ? (
-                <ProjectAvatar
-                  name={selectedProject.name}
-                  root={selectedProject.root}
-                  color={selectedProject.color}
-                  size="sm"
-                />
-              ) : (
-                <Icon name="ph:folder" width={13} className="hc-familiar-glyph" aria-hidden />
-              )}
-              <select
-                aria-label="Choose project"
-                className="hc-familiar-select"
-                value={selectedProjectId}
-                onChange={(e) => {
-                  const value = e.currentTarget.value;
-                  // The add row is an action, not a selection — keep the
-                  // current value and open the shared register+grant flow.
-                  if (value === ADD_PROJECT_ID) {
-                    addProjectFlow.beginAddProject();
-                    return;
-                  }
-                  setSelectedProjectId(value);
-                }}
-                disabled={sending}
-              >
-                {projects.length === 0 ? (
-                  <option value="">No projects yet</option>
-                ) : (
-                  <>
-                    <option value={NO_PROJECT_ID}>No project</option>
-                    {projects.map((project) => (
-                      <option key={project.id} value={project.id}>
-                        {project.name}
-                      </option>
-                    ))}
-                  </>
-                )}
-                <option value={ADD_PROJECT_ID}>＋ Add project…</option>
-              </select>
-              <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-            </label>
-            {addProjectFlow.addProjectModal}
-          </div>
-
-          {/* Runtime/model, Think, and Speed configure a chat send — they're
-              meaningless for creating a board task, so they collapse out when
-              the Task mode is selected, leaving just the submit affordance. */}
-          {destination === "chat" ? (
-            <div className="hc-control-group hc-control-group--settings">
-              <label className="hc-familiar-selector hc-runtime-model-selector">
-                <Icon name="ph:terminal-window" width={13} className="hc-familiar-glyph" aria-hidden />
-                <select
-                  aria-label="Choose runtime and model"
-                  className="hc-familiar-select"
-                  value={selectedRuntimeModelValue}
-                  onChange={(e) => handleSelectRuntimeModel(e.currentTarget.value)}
-                  disabled={!selectedFamiliarId || sending}
-                >
-                  {COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => (
-                    <optgroup key={adapter.id} label={adapter.label}>
-                      {runtimeModelOptionsFor(adapter.id).length === 0 ? (
-                        <option value={runtimeModelValue(adapter.id, "")}>
-                          Runtime managed
-                        </option>
-                      ) : (
-                        runtimeModelOptionsFor(adapter.id).map((model) => (
-                          <option key={model.id} value={runtimeModelValue(adapter.id, model.id)}>
-                            {model.label}
-                          </option>
-                        ))
-                      )}
-                    </optgroup>
-                  ))}
-                </select>
-                <Icon name="ph:caret-up-down-bold" width={10} className="hc-select-caret" aria-hidden />
-              </label>
-
-              {renderCompactSelect(
-                "Think",
-                "ph:sparkle-bold",
-                thinkingEffort,
-                (value) => setThinkingEffort(value as CommandThinkingEffort),
-                COMMAND_THINKING_OPTIONS,
-                "Choose thinking effort",
-              )}
-
-              {renderCompactSelect(
-                "Speed",
-                "ph:lightning-bold",
-                responseSpeed,
-                (value) => setResponseSpeed(value as CommandResponseSpeed),
-                COMMAND_RESPONSE_SPEED_OPTIONS,
-                "Choose response speed",
-              )}
-
-              <ComposerHostChip
-                value={runtimeHost ?? LOCAL_HOST_ID}
-                disabled={sending}
-                onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
-              />
-            </div>
-          ) : null}
-
-          <div className="hc-control-group hc-control-group--submit">
             <button
               type="button"
               className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() && attachments.length === 0 ? " empty" : ""}`}

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // Project selection used to be four unrelated widgets (chat overflow popover,
-// chat empty-state <select>, home-composer <select>, comux rail), and the only
+// chat empty-state picker, home-composer picker, comux rail), and the only
 // way to register a new root was to fail a send and click the 403 recovery.
 // ProjectPicker is the one shared picker, and useAddProjectFlow the one shared
 // add flow — folder dialog → addChatProject, which registers AND grants, so a
@@ -10,6 +10,7 @@ import { readFileSync } from "node:fs";
 
 const src = readFileSync(new URL("./project-picker.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const homeComposer = readFileSync(new URL("./home-composer.tsx", import.meta.url), "utf8");
 
 // ── One shared add flow: register + grant in a single human-initiated step ──
 assert.match(src, /export function useAddProjectFlow\(/, "shared flow exported");
@@ -25,8 +26,9 @@ assert.match(src, /aria-label="Filter projects"/, "filter input for long lists")
 assert.match(src, /aria-haspopup="dialog"/, "trigger announces the popover");
 assert.match(src, /role="alert"/, "add-flow failures surface inline, not silently");
 
-// ── Sentinel for native selects that embed the same flow (home composer) ────
-assert.match(src, /export const ADD_PROJECT_ID = "__add-project__";/, "select sentinel exported");
+// ── Home composer uses the shared custom picker, not an OS-native select ────
+assert.match(homeComposer, /<ProjectPicker[\s\S]*?ariaLabel="Choose project"/, "home composer uses ProjectPicker");
+assert.doesNotMatch(homeComposer, /<select[\s\S]*?aria-label="Choose project"/, "home composer project picker is custom");
 
 // ── Styled ──────────────────────────────────────────────────────────────────
 assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -16,9 +16,6 @@ import { NO_PROJECT_ID } from "@/lib/chat-projects";
 import type { CaveProject } from "@/lib/cave-projects";
 import { isTauri } from "@/lib/tauri-platform";
 
-/** Sentinel `<option>` value for native selects that embed the add flow. */
-export const ADD_PROJECT_ID = "__add-project__";
-
 export type AddProjectFlow = {
   /** Open the folder chooser — native dialog on desktop, in-app browser on web. */
   beginAddProject: () => void;

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -92,11 +92,11 @@
   position: relative;
   width: 100%;
   max-width: 100%;
-  background: color-mix(in oklch, var(--bg-raised) 58%, var(--bg-base));
-  border: 1px solid color-mix(in oklch, var(--border-hairline) 78%, transparent);
-  border-radius: 18px;
+  background: color-mix(in oklch, var(--bg-raised) 70%, var(--bg-base));
+  border: 1px solid var(--border-hairline);
+  border-radius: 22px;
   overflow: hidden;
-  box-shadow: 0 8px 28px color-mix(in oklch, var(--text-primary) 10%, transparent),
+  box-shadow: 0 12px 40px color-mix(in oklch, var(--text-primary) 14%, transparent),
               0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
@@ -111,7 +111,7 @@
   z-index: 5;
   display: grid;
   place-items: center;
-  border-radius: 18px;
+  border-radius: 22px;
   background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base) 88%);
   border: 2px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
   pointer-events: none;
@@ -126,9 +126,9 @@
 }
 
 .home-composer-card:focus-within {
-  border-color: color-mix(in oklch, var(--accent-presence) 38%, var(--border-strong));
-  box-shadow: 0 10px 32px color-mix(in oklch, var(--text-primary) 12%, transparent),
-              0 0 0 1px color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
+  box-shadow: 0 8px 40px color-mix(in oklch, var(--text-primary) 15%, transparent),
+              0 0 0 1px color-mix(in oklch, var(--accent-presence) 20%, transparent);
 }
 
 /* ── Textarea ────────────────────────────────────────────────────────────── */
@@ -144,9 +144,9 @@
      worth a (pointer: coarse) gate. */
   font-size: 16px;
   line-height: 1.6;
-  padding: 24px 26px 12px;
+  padding: 22px 22px 8px;
   font-family: inherit;
-  min-height: 104px;
+  min-height: 92px;
   max-height: 240px;
   overflow-y: auto;
   scrollbar-width: thin;
@@ -155,8 +155,8 @@
 }
 
 .hc-textarea::placeholder {
-  color: color-mix(in oklch, var(--text-muted) 82%, var(--text-primary));
-  opacity: 0.86;
+  color: var(--text-muted);
+  opacity: 0.7;
 }
 
 .hc-textarea:disabled {
@@ -164,16 +164,17 @@
 }
 
 /* ── Action bar ──────────────────────────────────────────────────────────────
- *   One balanced rail: tools and identity sit near the prompt, advanced runtime
- *   settings are muted and pushed right, and submit gets its own stable slot. */
+ *   One balanced row: a compact "who" cluster anchored left and the "run"
+ *   config cluster anchored right (pushed there with margin-left:auto). The
+ *   intent switch (Chat/Task) no longer lives here — it leads the card as a
+ *   mode strip above the textarea — so the bar reads as pure send config. The
+ *   larger column gap (vs the intra-group gap) keeps the clusters distinct. */
 .hc-action-bar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px 12px;
-  padding: 11px 16px 15px;
-  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 58%, transparent);
-  background: color-mix(in oklch, var(--bg-base) 30%, transparent);
+  gap: 8px 14px;
+  padding: 10px 14px 14px;
 }
 
 /* Groups never split internally — a cluster wraps as a whole unit (so Speed and
@@ -187,24 +188,15 @@
 }
 
 /* Side clusters are content-sized (no grow → no trailing/leading gap). */
-.hc-control-group--tools {
-  flex: 0 0 auto;
-  gap: 5px;
-}
-
-.hc-control-group--identity {
+.hc-control-group--who {
   flex: 0 1 auto;
 }
 
-.hc-control-group--settings {
+/* The run cluster is content-sized and pinned to the right edge. */
+.hc-control-group--run {
   flex: 0 1 auto;
   justify-content: flex-end;
   margin-left: auto;
-  gap: 5px;
-}
-
-.hc-control-group--submit {
-  flex: 0 0 auto;
 }
 
 /* ── Attach button (paperclip) ───────────────────────────────────────────── */
@@ -334,7 +326,7 @@
   height: 30px;
   padding: 0 10px;
   border-radius: 9px;
-  border: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+  border: 1px solid var(--border-hairline);
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
@@ -347,12 +339,7 @@
   border-color: var(--border-strong);
   color: var(--text-primary);
 }
-.hc-enhance-btn:disabled {
-  opacity: 0.44;
-  cursor: default;
-  border-color: transparent;
-  background: color-mix(in oklch, var(--bg-base) 34%, transparent);
-}
+.hc-enhance-btn:disabled { opacity: 0.5; cursor: default; }
 .hc-enhance-btn.loading { color: var(--accent-presence); }
 .hc-enhance-label { line-height: 1; }
 .hc-enhance-undo {
@@ -423,35 +410,36 @@
   min-width: 0;
 }
 
+.hc-home-select-trigger {
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 25%, transparent);
+  color: var(--text-primary);
+  cursor: pointer;
+  text-align: left;
+}
+
+.hc-home-select-trigger:hover:not(:disabled),
+.home-composer-card .cave-project-picker__trigger.hc-project-selector:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--accent-presence) 36%, transparent);
+}
+
+.hc-home-select-trigger:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
 .hc-command-select {
   gap: 6px;
 }
 
-.hc-runtime-model-selector .hc-familiar-select {
-  max-width: 152px;
+.hc-runtime-model-selector {
+  max-width: 172px;
 }
 
 .hc-command-select .hc-command-select-label {
   flex-shrink: 0;
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 550;
-  color: var(--text-muted);
-}
-
-.hc-control-group--settings .hc-familiar-selector {
-  min-height: 28px;
-  background: transparent;
-  border-color: color-mix(in oklch, var(--border-hairline) 72%, transparent);
-  color: var(--text-muted);
-}
-
-.hc-control-group--settings .hc-familiar-select {
-  font-size: 11.5px;
-  color: var(--text-secondary);
-}
-
-.hc-control-group--settings .hc-familiar-glyph,
-.hc-control-group--settings .hc-select-caret {
   color: var(--text-muted);
 }
 
@@ -472,32 +460,66 @@
   object-fit: cover;
 }
 
-.hc-familiar-select {
+.hc-home-select-value {
+  min-width: 0;
+  max-width: 132px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-size: 12px;
   font-weight: 500;
   color: var(--text-primary);
-  background: transparent;
-  border: none;
-  outline: none;
-  appearance: none;
-  -webkit-appearance: none;
-  cursor: pointer;
   padding-right: 14px;
-  max-width: 132px;
 }
 
-/* The dropdown popup of a native <select> is drawn on the OS's own surface
-   (white on macOS), but its <option>/<optgroup> text inherits the control's
-   light dark-theme color — leaving every item invisible until the OS hover
-   highlight lands on it. Pin an explicit, theme-aware background + color so the
-   model / familiar / project menus stay readable in every theme. */
-.hc-familiar-select option,
-.hc-familiar-select optgroup {
-  background-color: var(--bg-elevated);
-  color: var(--text-primary);
+.hc-runtime-model-selector .hc-home-select-value {
+  max-width: 142px;
 }
-.hc-familiar-select optgroup {
-  font-weight: 600;
+
+.hc-home-select-popover {
+  min-width: 220px;
+}
+
+.hc-home-select-group + .hc-home-select-group {
+  border-top: 1px solid var(--border-hairline);
+  margin-top: 4px;
+  padding-top: 4px;
+}
+
+.hc-home-select-popover .ui-popover-item > span {
+  min-width: 0;
+}
+
+.hc-home-select-option {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  text-align: left;
+}
+
+.hc-home-select-option__label,
+.hc-home-select-option__detail {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hc-home-select-option__detail {
+  font-size: 10.5px;
+  color: var(--text-secondary);
+}
+
+.home-composer-card .cave-project-picker__trigger.hc-project-selector {
+  min-height: 30px;
+  max-width: 178px;
+  padding: 3px 22px 3px 6px;
+  border-color: color-mix(in oklch, var(--accent-presence) 25%, transparent);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
+}
+
+.home-composer-card .cave-project-picker__trigger.hc-project-selector .cave-project-picker__trigger-label {
+  max-width: 132px;
 }
 
 .hc-select-caret {
@@ -601,11 +623,23 @@
     height: 20px;
   }
 
-  .hc-familiar-select {
+  .hc-home-select-value {
     width: 100%;
     max-width: none;
     min-height: var(--touch-target);
     font-size: 15px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .home-composer-card .cave-project-picker__trigger.hc-project-selector {
+    max-width: none;
+    min-height: var(--touch-target);
+    padding: 0 34px 0 12px;
+  }
+
+  .home-composer-card .cave-project-picker__trigger.hc-project-selector .cave-project-picker__trigger-label {
+    max-width: none;
   }
 
   .hc-select-caret {
@@ -656,25 +690,16 @@
     justify-content: stretch;
   }
 
-  .hc-control-group--identity,
-  .hc-control-group--settings {
+  .hc-control-group--who,
+  .hc-control-group--run {
     display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
   }
 
-  .hc-control-group--identity {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .hc-control-group--settings {
+  .hc-control-group--run {
     order: 4;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr)) var(--touch-target);
     margin-left: 0;
-  }
-
-  .hc-control-group--submit {
-    order: 5;
-    align-items: center;
-    justify-content: flex-end;
   }
 
   .hc-familiar-selector {
@@ -686,16 +711,25 @@
     display: none;
   }
 
-  .hc-control-group--settings .hc-command-select .hc-command-select-label {
-    display: inline;
-  }
-
-  .hc-familiar-select {
+  .hc-home-select-value {
     width: 100%;
     max-width: none;
     min-width: 0;
     min-height: var(--touch-target);
     font-size: 13px;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .home-composer-card .cave-project-picker__trigger.hc-project-selector {
+    width: 100%;
+    max-width: none;
+    min-height: var(--touch-target);
+    padding: 0 30px 0 10px;
+  }
+
+  .home-composer-card .cave-project-picker__trigger.hc-project-selector .cave-project-picker__trigger-label {
+    max-width: none;
   }
 
   .hc-dest-pills {
@@ -738,12 +772,8 @@
   transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
 }
 
-.hc-control-group--submit .hc-send-btn {
+.hc-control-group--run .hc-send-btn {
   margin-left: 0;
-}
-
-.hc-send-btn:not(.empty):not(:disabled) {
-  box-shadow: 0 3px 12px color-mix(in oklch, var(--accent-presence) 28%, transparent);
 }
 
 .hc-send-btn:hover:not(:disabled) {
@@ -975,9 +1005,8 @@
 .home-feed__retry,
 .hc-add-btn,
 .hc-model-chip,
-.hc-enhance-btn,
-.hc-enhance-undo,
-.hc-familiar-select {
+.hc-home-select-trigger,
+.home-composer-card .cave-project-picker__trigger.hc-project-selector {
   outline: none;
 }
 .hc-dest-pill:focus-visible,
@@ -987,14 +1016,13 @@
 .home-feed__refresh:focus-visible,
 .home-feed__retry:focus-visible,
 .hc-add-btn:focus-visible,
-.hc-enhance-btn:focus-visible,
 .hc-model-chip:focus-visible,
-.hc-enhance-undo:focus-visible {
+.hc-home-select-trigger:focus-visible,
+.home-composer-card .cave-project-picker__trigger.hc-project-selector:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: var(--ring-offset);
 }
-/* The familiar selector is a pill (glyph + borderless native <select>). Ring the
-   whole pill when the select is focused, not just the inner rectangular control. */
+/* Ring the whole selector pill when a custom trigger is focused. */
 .hc-familiar-selector:focus-within {
   outline: var(--ring-width) solid var(--ring-focus);
   outline-offset: var(--ring-offset);


### PR DESCRIPTION
## Summary\n- Replace HomeComposer native selects with custom popover controls for agent, runtime/model, thinking, and speed.\n- Reuse the shared ProjectPicker for the HomeComposer project selector and keep the add-project flow centralized.\n- Update HomeComposer and ProjectPicker source tests for the custom picker contract.\n\n## Verification\n- node --experimental-strip-types src/components/home-composer.test.ts\n- node --experimental-strip-types src/components/home-composer-hide-archived.test.ts\n- node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts\n- node --experimental-strip-types src/components/home-composer-polish.test.ts\n- node --experimental-strip-types src/components/project-picker.test.ts\n- git diff --check origin/main...HEAD\n- pnpm typecheck\n- pnpm check:tests-wired\n- pnpm test:app\n- Playwright smoke on http://127.0.0.1:3000/ for desktop and mobile HomeComposer controls; no overlaps or fresh console/page errors.