### PR TITLE
fix(copy): finish runtime vocabulary cleanup

### DIFF
--- a/src/components/create-familiar-dialog.tsx
+++ b/src/components/create-familiar-dialog.tsx
@@ -367,7 +367,7 @@ export function CreateFamiliarDialog({
                 id="create-familiar-model"
                 value={model}
                 onChange={(e) => setModel(e.target.value)}
-                placeholder="Default for this harness"
+                placeholder="Default for this runtime"
                 className={inputClass}
               />
             </div>

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -514,7 +514,7 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
               compact
               icon="ph:brain"
               headline={`No memories yet for ${selectedFamiliar?.display_name ?? "this familiar"}`}
-              subtitle="Familiar memories are saved during chats. Memory files appear when the familiar's harness writes to disk."
+              subtitle="Familiar memories are saved during chats. Memory files appear when the familiar's runtime writes to disk."
             />
           </div>
         ) : (

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -1302,10 +1302,10 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
       </CapSection>
 
       {/* ── Section 3: Plugins ────────────────────────────────────────────── */}
-      <CapSection title="Plugins" scope={`${nonMcpPlugins.length} from harness`}>
+      <CapSection title="Plugins" scope={`${nonMcpPlugins.length} from runtime`}>
         {nonMcpPlugins.length === 0 ? (
           <p className="rounded border border-dashed border-[var(--border-hairline)] px-2 py-2 text-[var(--text-muted)]">
-            No plugins in harness capability scan. Run /refresh in the Capabilities page.
+            No plugins in runtime capability scan. Run /refresh in the Capabilities page.
           </p>
         ) : (
           <ul className="space-y-1.5">

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -62,7 +62,7 @@ const SECTION_COPY: Record<MarketplaceSection, { title: string; subtitle: string
   },
   capabilities: {
     title: "Capabilities",
-    subtitle: "What each harness supports — compare tools and features side by side.",
+    subtitle: "What each runtime supports — compare tools and features side by side.",
   },
 };
 

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1035,7 +1035,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       ) ?? null;
     if (!selectedHarness) {
       setSetupError(
-        "Pick an installed harness first, or choose an existing OpenClaw agent.",
+        "Pick an installed runtime first, or choose an existing OpenClaw agent.",
       );
       return;
     }


### PR DESCRIPTION
## Summary
- Replaces remaining user-facing harness copy with runtime copy in familiar creation, memory empty states, capability scans, marketplace capabilities, and onboarding setup errors.
- Keeps internal variable names unchanged where they still refer to existing harness data structures.

## Test Plan
- [x] pnpm typecheck
- [x] pnpm check:tests-wired
- [x] git diff --check origin/main...HEAD