### PR TITLE
fix(projects): stabilize project scoping and ordering

### DIFF
--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -25,6 +25,8 @@ assert.match(src, /Add project…/, "proactive add affordance (not 403-recovery-
 assert.match(src, /aria-label="Filter projects"/, "filter input for long lists");
 assert.match(src, /aria-haspopup="dialog"/, "trigger announces the popover");
 assert.match(src, /role="alert"/, "add-flow failures surface inline, not silently");
+assert.match(src, /sortProjectsAlphabetically\(projects\)/, "picker renders projects alphabetically");
+assert.doesNotMatch(src, /if \(!q\) return projects;/, "unfiltered picker must not expose raw API order");
 
 // ── Home composer uses the shared custom picker, not an OS-native select ────
 assert.match(homeComposer, /<ProjectPicker[\s\S]*?ariaLabel="Choose project"/, "home composer uses ProjectPicker");

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -13,7 +13,7 @@ import { DirectoryPickerModal } from "@/components/directory-picker-modal";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { addChatProject } from "@/lib/chat-add-project";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
-import type { CaveProject } from "@/lib/cave-projects";
+import { sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
 import { isTauri } from "@/lib/tauri-platform";
 
 export type AddProjectFlow = {
@@ -123,21 +123,22 @@ export function ProjectPicker({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const sortedProjects = useMemo(() => sortProjectsAlphabetically(projects), [projects]);
 
   const selected =
     value === NO_PROJECT_ID
       ? null
-      : (value ? projects.find((project) => project.id === value) ?? projects[0] : projects[0]) ??
+      : (value ? sortedProjects.find((project) => project.id === value) ?? sortedProjects[0] : sortedProjects[0]) ??
         null;
 
   const visible = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return projects;
-    return projects.filter(
+    if (!q) return sortedProjects;
+    return sortedProjects.filter(
       (project) =>
         project.name.toLowerCase().includes(q) || project.root.toLowerCase().includes(q),
     );
-  }, [projects, query]);
+  }, [sortedProjects, query]);
 
   const close = () => {
     setOpen(false);

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -243,9 +243,12 @@ assert.doesNotMatch(projectsView, /defaultExpanded/, "expansion is controlled by
 assert.match(projectsView, /aria-label="List density"/, "there is a labeled density toggle");
 assert.match(projectsView, /aria-pressed=\{density === opt\.value\}/, "the density toggle reflects the active option");
 
-// Projects are ordered by most-recent session activity, not API order.
+// Projects are ordered alphabetically by project name/root, not API order or
+// most-recent session activity. Sessions inside each project still keep their
+// own recency/manual ordering.
 assert.match(projectsView, /const sortedProjects = useMemo/, "projects are sorted before rendering");
-assert.match(projectsView, /function lastActiveMs/, "recency is derived from each project's latest session");
+assert.match(projectsView, /sortProjectsAlphabetically\(projects\)/, "Projects tab uses the shared alphabetical project order");
+assert.doesNotMatch(projectsView, /b\.score - a\.score/, "Projects tab must not sort project rows by session recency");
 
 // A filter box narrows the (sorted) list by name or path; the filtered list
 // drives the render and an empty result shows a no-match message.

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { Icon } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { useMinuteTick } from "@/lib/use-minute-tick";
-import { normalizeProjectRoot, type CaveProject } from "@/lib/cave-projects-types";
+import { normalizeProjectRoot, sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
 import { addChatProject } from "@/lib/chat-add-project";
 import type { SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
@@ -39,7 +39,7 @@ import {
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 
 import { ProjectRow } from "./projects/project-row";
-import { lastActiveMs, shortRoot, openSessionById } from "./projects/projects-shared";
+import { shortRoot, openSessionById } from "./projects/projects-shared";
 import { DirectoryPickerModal } from "@/components/directory-picker-modal";
 import { isTauri } from "@/lib/tauri-platform";
 
@@ -178,24 +178,14 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     return map;
   }, [chatsByRoot]);
 
-  // Surface the projects you're actually working in: order by most-recent
-  // session activity, falling back to the project's own updatedAt.
+  // Keep projects stable and scannable: alphabetical by project name/root.
+  // Session rows inside each project keep their own manual/recency ordering.
   const sortedProjects = useMemo(() => {
-    // Decorate-sort-undecorate: compute each score ONCE (each call runs
-    // lastActiveMs over the root's chats) instead of ~2x per comparison.
-    const scored = projects.map((p) => ({
-      p,
-      score:
-        lastActiveMs(chatsByRoot.get(normalizeProjectRoot(p.root)) ?? []) ||
-        new Date(p.updatedAt).getTime() ||
-        0,
-    }));
-    scored.sort((a, b) => b.score - a.score);
-    return scored.map((s) => s.p);
-  }, [projects, chatsByRoot]);
+    return sortProjectsAlphabetically(projects);
+  }, [projects]);
 
-  // Filter by name or path so the (recency-sorted) list stays scannable when
-  // there are many projects.
+  // Filter by name or path so the alphabetical list stays scannable when there
+  // are many projects.
   const visibleProjects = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return sortedProjects;

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -70,6 +70,18 @@ assert.match(
 
 assert.match(
   source,
+  /const activeSession = snapshot\.session;[\s\S]{0,100}?const railProjectRoot = activeSession\?\.project_root \?\? null;/,
+  "standalone files/changes rail is scoped to the active session's project root",
+);
+
+assert.doesNotMatch(
+  source,
+  /const railProjectRoot = (?!activeSession\?\.project_root)/,
+  "standalone files/changes rail must not drift to a selected or fallback project root",
+);
+
+assert.match(
+  source,
   /json\.files\?\.length\s*\?\?\s*0/,
   "changeCount is derived from the /api/changes files length",
 );
@@ -92,6 +104,12 @@ assert.match(
   source,
   /<WorkspaceRail[\s\S]*?changeCount=\{changeCount\}[\s\S]*?activeTab=\{rail\.activeTab\}[\s\S]*?pinned=\{rail\.pinned\}[\s\S]*?onSelectTab=\{rail\.setActiveTab\}[\s\S]*?onTogglePin=\{rail\.togglePin\}[\s\S]*?onCollapse=\{rail\.collapse\}/,
   "WorkspaceRail receives changeCount + rail state/handlers",
+);
+
+assert.match(
+  source,
+  /<WorkspaceRail[\s\S]*?projectRoot=\{railProjectRoot\}/,
+  "WorkspaceRail Files tab receives the same active-session project root",
 );
 
 // Collapsed state renders a reopen strip.

--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -19,3 +19,13 @@ export type CaveProject = {
 export function normalizeProjectRoot(root: string | null | undefined): string {
   return root?.trim().replace(/\\/g, "/").replace(/\/+$/, "") || "/";
 }
+
+export function compareProjectsAlphabetically(a: CaveProject, b: CaveProject): number {
+  const byName = a.name.localeCompare(b.name, undefined, { sensitivity: "base", numeric: true });
+  if (byName !== 0) return byName;
+  return a.root.localeCompare(b.root, undefined, { sensitivity: "base", numeric: true });
+}
+
+export function sortProjectsAlphabetically(projects: CaveProject[]): CaveProject[] {
+  return [...projects].sort(compareProjectsAlphabetically);
+}

--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -16,6 +16,7 @@ try {
     projectById,
     projectForRoot,
     seedDefaultProjectsIfEmpty,
+    sortProjectsAlphabetically,
   } = await import("./cave-projects.ts");
   const source = await readFile(new URL("./cave-projects.ts", import.meta.url), "utf8");
 
@@ -82,6 +83,16 @@ try {
   );
   await seedDefaultProjectsIfEmpty();
   assert.equal((await loadProjects()).length, 0, "calling seed twice remains a no-op");
+
+  assert.deepEqual(
+    sortProjectsAlphabetically([
+      { id: "z", name: "Zed", root: "/work/zed", createdAt: "", updatedAt: "" },
+      { id: "a2", name: "alpha", root: "/work/alpha-2", createdAt: "", updatedAt: "" },
+      { id: "a1", name: "Alpha", root: "/work/alpha-1", createdAt: "", updatedAt: "" },
+    ]).map((project) => project.id),
+    ["a1", "a2", "z"],
+    "shared project sorting is alphabetical by name, then root",
+  );
 
   console.log("cave-projects.test.ts: ok");
 } finally {

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -4,7 +4,7 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 export type { CaveProject } from "./cave-projects-types.ts";
-export { normalizeProjectRoot } from "./cave-projects-types.ts";
+export { normalizeProjectRoot, sortProjectsAlphabetically } from "./cave-projects-types.ts";
 import type { CaveProject } from "./cave-projects-types.ts";
 
 type ProjectsFile = {

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -63,11 +63,11 @@ assert.deepEqual(
     sessionIds: group.sessions.map((s) => s.id),
   })),
   [
-    { root: null, defaultFamiliarId: "charm", sessionIds: ["scratch"] },
     { root: "/work/alpha", defaultFamiliarId: "cody", sessionIds: ["new-alpha", "old-alpha"] },
     { root: "/work/beta", defaultFamiliarId: "nova", sessionIds: ["beta"] },
+    { root: null, defaultFamiliarId: "charm", sessionIds: ["scratch"] },
   ],
-  "project groups should be ordered by recency and expose the latest familiar for project-scoped launch",
+  "project groups should be alphabetical by project label, with No project last, and expose the latest familiar for launch",
 );
 
 assert.equal(chatProjectName("/work/alpha", projects), "Alpha");
@@ -93,8 +93,8 @@ const worktreeGroups = deriveChatProjectGroups(
 );
 assert.deepEqual(
   worktreeGroups.map((group) => group.projectName),
-  ["feature-b/coven-cave", "feature-a/coven-cave"],
-  "duplicate worktree repo names should include the parent directory so branches are distinguishable",
+  ["feature-a/coven-cave", "feature-b/coven-cave"],
+  "duplicate worktree repo names should include the parent directory and sort alphabetically",
 );
 
 // Eval-discuss threads are migrated to the Evals page and hidden from the chat list.

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -1,5 +1,6 @@
 import type { SessionRow } from "./types.ts";
 import type { CaveProject } from "./cave-projects.ts";
+import { compareProjectsAlphabetically } from "./cave-projects-types.ts";
 
 export type ChatProject = CaveProject;
 export type { CaveProject };
@@ -175,14 +176,16 @@ export function deriveChatProjectGroups(
       };
     })
     .sort((a, b) => {
-      if (a.updatedAt && b.updatedAt) return b.updatedAt.localeCompare(a.updatedAt);
-      if (a.updatedAt) return -1;
-      if (b.updatedAt) return 1;
-      const aKnown = a.projectId ? projects.findIndex((project) => project.id === a.projectId) : -1;
-      const bKnown = b.projectId ? projects.findIndex((project) => project.id === b.projectId) : -1;
-      if (aKnown >= 0 && bKnown >= 0) return aKnown - bKnown;
-      if (aKnown >= 0) return -1;
-      if (bKnown >= 0) return 1;
+      if (a.projectRoot === null && b.projectRoot === null) return 0;
+      if (a.projectRoot === null) return 1;
+      if (b.projectRoot === null) return -1;
+      const aProject = a.projectId ? projects.find((project) => project.id === a.projectId) : null;
+      const bProject = b.projectId ? projects.find((project) => project.id === b.projectId) : null;
+      if (aProject && bProject) return compareProjectsAlphabetically(aProject, bProject);
+      const aLabel = a.projectName ?? chatProjectName(a.projectRoot, projects);
+      const bLabel = b.projectName ?? chatProjectName(b.projectRoot, projects);
+      const byLabel = aLabel.localeCompare(bLabel, undefined, { sensitivity: "base", numeric: true });
+      if (byLabel !== 0) return byLabel;
       return (a.projectRoot ?? "").localeCompare(b.projectRoot ?? "");
     });
 }

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { CaveProject } from "@/lib/cave-projects";
+import { sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
 
 export type ProjectsState = {
   projects: CaveProject[];
@@ -51,7 +51,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
         if (data.ok === false) {
           setError(data.error ?? "Failed to load projects");
         } else {
-          setProjects(Array.isArray(data.projects) ? data.projects : []);
+          setProjects(sortProjectsAlphabetically(Array.isArray(data.projects) ? data.projects : []));
         }
       }
     } catch (err) {
@@ -83,7 +83,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
-      setProjects((prev) => [...prev, data.project as CaveProject]);
+      setProjects((prev) => sortProjectsAlphabetically([...prev, data.project as CaveProject]));
       return data.project as CaveProject;
     }
     return null;
@@ -97,7 +97,9 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
-      setProjects((prev) => prev.map((project) => (project.id === id ? data.project : project)));
+      setProjects((prev) =>
+        sortProjectsAlphabetically(prev.map((project) => (project.id === id ? data.project : project))),
+      );
       return true;
     }
     return false;
@@ -111,7 +113,9 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
-      setProjects((prev) => prev.map((project) => (project.id === id ? data.project : project)));
+      setProjects((prev) =>
+        sortProjectsAlphabetically(prev.map((project) => (project.id === id ? data.project : project))),
+      );
       return true;
     }
     return false;
@@ -125,7 +129,9 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     });
     const data = await res.json();
     if (data.ok && data.project) {
-      setProjects((prev) => prev.map((project) => (project.id === id ? data.project : project)));
+      setProjects((prev) =>
+        sortProjectsAlphabetically(prev.map((project) => (project.id === id ? data.project : project))),
+      );
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- Sorts projects alphabetically across project picker state, the Projects view, and chat project groups so project order is stable instead of recency/API-order dependent.
- Keeps No project grouped last while preserving session ordering within each project group.
- Pins the standalone files/changes rail to the active session project root so it does not drift to a selected or fallback project.

## Test Plan
- [x] pnpm typecheck
- [x] pnpm check:tests-wired
- [x] git diff --check origin/main...HEAD
- [x] node --experimental-strip-types src/components/project-picker.test.ts
- [x] node --experimental-strip-types src/components/projects-view.test.ts
- [x] node --experimental-strip-types src/components/workspace-rail-wiring.test.ts
- [x] node --experimental-strip-types src/lib/cave-projects.test.ts
- [x] node --experimental-strip-types src/lib/chat-projects.test.ts