### PR TITLE
style(familiar-strip): round avatars to pill + butter spring-scale on hover

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5887,10 +5887,12 @@ button:active > .edge-rail-chip {
   align-items: center;
   gap: 4px;
   margin: 0;
-  padding: 0;
+  /* vertical room so scaled avatars aren't clipped by the scrollport */
+  padding: 4px 0;
   list-style: none;
   min-width: 0;
   overflow-x: auto;
+  overflow-y: visible;
   scrollbar-width: none;
 }
 
@@ -5900,6 +5902,7 @@ button:active > .edge-rail-chip {
 
 .familiar-quickswitch__item {
   flex: 0 0 auto;
+  overflow: visible;
 }
 
 .familiar-quickswitch__btn {
@@ -5910,16 +5913,22 @@ button:active > .edge-rail-chip {
   width: 28px;
   height: 28px;
   padding: 0;
-  border-radius: var(--radius-control);
+  border-radius: 999px;
   border: 1px solid var(--border-hairline);
   background: var(--bg-raised);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-standard),
-              border-color var(--duration-fast) var(--ease-standard);
+  transform-origin: bottom center;
+  will-change: transform;
+  /* spring overshoot on scale; standard curve on colour props */
+  transition: transform 220ms cubic-bezier(0.34, 1.56, 0.64, 1),
+              background 140ms var(--ease-standard),
+              border-color 140ms var(--ease-standard),
+              box-shadow 140ms var(--ease-standard);
 }
 
 .familiar-quickswitch__btn:hover {
+  transform: scale(1.18);
   background: var(--bg-hover);
   border-color: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 45%, var(--border-hairline));
 }
@@ -5931,13 +5940,15 @@ button:active > .edge-rail-chip {
 
 .familiar-quickswitch__avatar {
   display: inline-flex;
+  border-radius: 999px;
+  overflow: hidden;
 }
 
 .familiar-quickswitch__btn img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: calc(var(--radius-control) - 1px);
+  border-radius: 999px;
 }
 
 .familiar-quickswitch__presence {
@@ -5971,6 +5982,17 @@ button:active > .edge-rail-chip {
   border-radius: 999px;
   background: var(--color-warning);
   box-shadow: 0 0 0 2px var(--bg-base);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .familiar-quickswitch__btn {
+    transition: background 140ms var(--ease-standard),
+                border-color 140ms var(--ease-standard),
+                box-shadow 140ms var(--ease-standard);
+  }
+  .familiar-quickswitch__btn:hover {
+    transform: none;
+  }
 }
 
 /* ── Settings: pinned-familiar order ───────────────────────────────────────── */


### PR DESCRIPTION
## Summary

- **Fully rounded**: `border-radius: 999px` on the button, the avatar wrapper, and the img (was `var(--radius-control)` ≈ 6px square-ish)
- **Spring-scale on hover**: `transform: scale(1.18)` with `cubic-bezier(0.34, 1.56, 0.64, 1)` at 220ms — that curve has a natural overshoot that feels alive without being jittery
- **Transform origin `bottom center`**: avatars pop upward from the strip baseline, anchoring naturally in their row
- **GPU-composited**: `will-change: transform` keeps the animation on the compositor thread
- **Clipping fixed**: `overflow: visible` on the strip and item, plus `padding: 4px 0` on the strip, ensure the scaled avatar isn't cut by the scroll container
- **Colour transitions stay snappy**: border/background at 140ms `var(--ease-standard)` — independent from the slower spring scale so they feel responsive while the scale blooms
- **Respects `prefers-reduced-motion`**: scale is disabled; colour hover still works

## Test plan

- [ ] Hover over familiars in the top-bar strip → smooth pill avatars that pop up with a spring bounce
- [ ] Active avatar (`.is-active`) scales same as others on hover
- [ ] Scaled avatars are not clipped by the strip container
- [ ] `prefers-reduced-motion: reduce` → no scale animation, hover colour still applies
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)