### PR TITLE
test(chat): guard removed home composer selectedResolved local

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -73,6 +73,12 @@ assert.match(
   "HomeComposer should attach the selected project to task creation, crediting the selector's resolved familiar (not the raw active id)",
 );
 
+assert.doesNotMatch(
+  source,
+  /\bselectedResolved\b/,
+  "HomeComposer should not reference the removed selectedResolved render local",
+);
+
 assert.match(
   source,
   /<HomeSelect[\s\S]*?value=\{selectedRuntimeModelValue\}[\s\S]*?ariaLabel="Choose runtime and model"/,


### PR DESCRIPTION
## Summary
- add a source guard that fails if HomeComposer references the removed `selectedResolved` render local again
- routes the protected-main rejection through a PR instead of direct push

## Verification
- `git diff --check origin/main...HEAD`
- `node --experimental-strip-types src/components/home-composer.test.ts`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm test:app` (535 app test files passed)

Bead: cave-sz2