### PR TITLE
feat(skills): add skills directory-backed marketplace entries

### DIFF
--- a/docs/superpowers/specs/2026-07-04-skills-directory-integration-design.md
+++ b/docs/superpowers/specs/2026-07-04-skills-directory-integration-design.md
@@ -1,0 +1,375 @@
+# Skills Directory Integration Design
+
+**Date:** 2026-07-04
+**Status:** Approved direction; pending written-spec review
+**Surfaces:** `MarketplaceViewSurface`, `SkillBrowser`, role skill chips, workflow skill pickers, `/api/skills/*`
+
+## Goal
+
+Turn the Marketplace `Skills` section into a Cave-native skills directory that
+feels comparable to `skills.sh`: searchable, ranked, install-aware, trust-aware,
+and useful before and after a skill is installed.
+
+The Skills section remains inside the existing Marketplace hub. It should not
+become a standalone marketing page or a separate top-level mode. The hub already
+groups `Browse`, `Roles`, `Skills`, and `Capabilities`; this work upgrades the
+Skills room so it can serve as both the remote directory and the local installed
+skill manager.
+
+## Current State
+
+- `src/components/marketplace-view.tsx` owns the Marketplace hub and loads local
+  skills through `/api/skills/local`.
+- `src/components/skill-browser.tsx` renders the current three-column local
+  browser: category rail, card list, and local `SKILL.md` preview.
+- `src/components/skill-detail-drawer.tsx` is still used by role skill chips,
+  but it is a separate drawer model from the Skills tab detail pane.
+- `src/app/api/skills/local/route.ts` scans shared Coven skills and
+  `~/.claude/skills`; DELETE is local-origin gated and constrained to scanned
+  skill directories.
+- `src/app/api/skills/file/route.ts` previews allow-listed local skill files
+  through `src/lib/server/skill-file-paths.ts`.
+- `src/app/api/skills/route.ts` proxies the local daemon skill endpoint, but it
+  does not provide a registry directory model.
+- `src/lib/server/skill-scan.ts` parses `SKILL.md` frontmatter for local skills.
+
+The current Skills tab is good as a file manager for already-installed skills,
+but it does not answer registry questions: what is popular, which skills are
+official or audited, which agent they target, how to install them, or whether a
+local installed skill matches a remote directory entry.
+
+## Reference Shape
+
+The external reference is `skills.sh`. The useful product patterns to adapt are:
+
+- terminal-like header and command affordance
+- install command in the form `npx skills add <owner/repo>`
+- directory navigation by topics, official entries, audits, and docs
+- ranked skill list with install/activity signals
+- search, time-window tabs, and agent compatibility filters
+- detail surfaces that explain source, tags, agent support, audit state, and
+  install path
+
+Cave should use those patterns without copying the site literally. The result
+needs to be dense, maintainer-oriented, and consistent with the existing
+Marketplace visual system.
+
+## Chosen Approach
+
+Build a registry-backed Skills directory inside the existing Marketplace hub,
+then merge local installed skills into the same normalized list.
+
+Rejected alternatives:
+
+- **Local-only polish:** lowest risk, but it would keep Cave from answering the
+  main discovery and install questions.
+- **Standalone Skills route:** gives the surface more room, but fragments the
+  hub and weakens the existing `Browse | Roles | Skills | Capabilities` model.
+- **Registry-only rebuild:** attractive for discovery, but it would lose the
+  concrete file-management affordances that already work for installed skills.
+
+## Product Design
+
+### Entry and header
+
+`MarketplaceViewSurface` keeps `Skills` as the selected section. When active,
+the header changes from a simple local count to a directory header with:
+
+- a compact terminal-style brand line for skills discovery
+- a command bar showing the selected skill install command
+- copy-to-clipboard for `npx skills add <owner/repo>`
+- status pills for registry state, audited count, official count, and installed
+  count
+- `/` search focus using the existing Marketplace shortcut
+
+The header is a product control surface, not a hero. It should leave the ranked
+list visible in the first viewport.
+
+### Navigation and filtering
+
+The Skills section exposes directory-level controls:
+
+- ranking tabs: `All Time`, `Trending`, `Hot`
+- trust tabs or toggles: `Official`, `Audited`, `Installed`
+- agent filters: `All agents`, `Codex`, `Claude Code`, `Cursor`, `Copilot`,
+  `Windsurf`, and any additional agents returned by the registry
+- topic chips from registry tags plus local skill tags
+- search across name, owner, repo, description, topics, tags, agents, and local
+  path
+
+Filters should combine predictably. Selecting `Installed` narrows the same list
+instead of switching to a different UI.
+
+### Ranked list
+
+Replace the current card list with a table-like ranked list optimized for scan:
+
+- rank
+- skill name and description
+- owner/repo or local source
+- compatible agents
+- activity window signal
+- all-time installs
+- trust badges
+- installed state
+
+Rows must have stable height and predictable keyboard behavior. On narrow panes,
+the list can collapse secondary metrics under the name, but the rank, skill,
+trust state, and installed state must remain visible.
+
+### Detail panel
+
+The right detail panel becomes the single detail model for both remote and local
+skills. It shows:
+
+- name, owner/repo, description, tags, topics, and compatible agents
+- install command and copy action for remote entries
+- official/audited/source trust badges
+- registry URL and source URL when known
+- local path, reveal action, delete action, and `SKILL.md` preview when
+  installed
+- registry summary or README excerpt when remote-only and available
+- a clear unavailable state when registry detail cannot be loaded
+
+The existing `SkillDetailDrawer` should either wrap this detail model or be
+retired after role skill chips can open the same panel.
+
+### Installed skills
+
+Local scan results remain authoritative for installed state. A registry entry
+is marked installed when it matches a local skill by one of these keys, in order:
+
+1. exact registry slug, if stored locally
+2. owner/repo identifier from frontmatter or install metadata
+3. package/name alias from frontmatter
+4. local skill id or directory name
+
+Unmatched local skills appear as installed local-only entries with no registry
+rank. They can still be searched, previewed, revealed, and deleted.
+
+### Role and workflow links
+
+Role skill chips and workflow skill pickers should route into the same Skills
+directory detail surface:
+
+- exact local or registry match opens the detail panel
+- unknown skill text switches to `Skills` and pre-filters the query
+- workflow skill pickers can reuse the normalized directory data for labels,
+  tags, compatible agents, and install state
+
+This keeps skill discovery, role inspection, and workflow assembly aligned.
+
+## Data Model
+
+Introduce a normalized directory entry type near the Skills feature boundary:
+
+```ts
+type SkillDirectoryEntry = {
+  id: string;
+  slug: string;
+  name: string;
+  description?: string;
+  owner?: string;
+  repo?: string;
+  packageName?: string;
+  tags: string[];
+  topics: string[];
+  agents: string[];
+  installCommand?: string;
+  installsAllTime?: number;
+  activity8w?: number;
+  trendScore?: number;
+  hotScore?: number;
+  trust: {
+    official: boolean;
+    audited: boolean;
+    source: "registry" | "local" | "daemon" | "fallback";
+  };
+  registryUrl?: string;
+  sourceUrl?: string;
+  local?: {
+    installed: boolean;
+    path?: string;
+    scope?: "coven" | "claude-user" | "other-local";
+    version?: string;
+  };
+};
+```
+
+The implementation can split this into server and client types, but this is the
+contract the UI should consume.
+
+## Data Sources
+
+### Local scan
+
+`/api/skills/local` remains the source for installed skills. Its scanner can be
+extended to parse optional fields used for registry matching, such as:
+
+- `owner`
+- `repo`
+- `source`
+- `agents`
+- `topics`
+- `install`
+- `registry`
+
+Existing skills without those fields must continue to work.
+
+### Registry adapter
+
+Add a server-side registry adapter for remote skills. The adapter should hide
+registry-provider details behind a small internal API such as
+`listSkillDirectoryEntries()` and `getSkillDirectoryEntry(slug)`.
+
+When a `skills.sh` API token or OIDC path is configured, the adapter can query
+the live registry. When it is not configured, the UI must still work from a
+bundled fallback fixture or recent cache.
+
+### Fallback fixture and cache
+
+Add a checked-in fallback fixture for development and offline mode. It should be
+small, representative, and safe to render without network access. If a live
+registry query succeeds, cache the normalized result server-side with a clear
+timestamp so the UI can show whether data is live or cached.
+
+The UI should distinguish these states:
+
+- live registry
+- cached registry
+- fallback fixture
+- local-only
+- registry unavailable
+
+## API Design
+
+Add or extend server routes so the client does not call external registries
+directly:
+
+- `GET /api/skills/directory` returns normalized entries, filter metadata,
+  source state, and scan timestamp.
+- `GET /api/skills/directory/[slug]` returns richer registry detail when
+  available.
+- `POST /api/skills/install` installs a registry skill through a constrained
+  server-side command wrapper.
+- Existing `GET /api/skills/local`, `DELETE /api/skills/local`, and
+  `GET /api/skills/file` remain the local installed-skill authority.
+
+Install route constraints:
+
+- local-origin gated
+- accepts only known registry slugs or exact owner/repo identifiers
+- derives the command server-side instead of executing arbitrary client input
+- supports explicit agent target options only from an allow-list
+- streams or returns structured progress and final local scan state
+
+## Interaction Design
+
+- `/` focuses Skills search through the existing Marketplace shortcut.
+- `Enter` on a selected row opens or focuses the detail panel.
+- `Cmd/Ctrl+C` on the command bar copies the install command when focused.
+- Install updates the row optimistically only after the server accepts the
+  request; final state is reconciled from `/api/skills/local`.
+- Delete keeps the existing two-step destructive confirmation and local-origin
+  gate.
+- Reveal keeps the current Tauri desktop behavior and browser clipboard
+  fallback.
+- Filter changes announce result counts through the existing live region.
+- Registry or install failures keep the user's selection and show a scoped
+  inline error.
+
+## Visual Design
+
+The page should feel like an operational directory:
+
+- terminal-inspired header treatment, but no oversized landing hero
+- table/list-first layout for comparison and fast scanning
+- single detail panel, not cards nested inside cards
+- compact badges for trust, agents, topics, and installed state
+- stable row, toolbar, and detail dimensions across hover, loading, and empty
+  states
+- mobile and narrow-pane layout that preserves search, ranking tabs, row list,
+  and detail access without overlap
+
+Do not turn the Skills section into a marketing splash. The primary value is
+finding, inspecting, installing, and managing skills quickly.
+
+## Error Handling
+
+- Registry unavailable: show local installed skills plus fallback or cached
+  entries when present.
+- Missing registry auth: show fallback/local data and a scoped status message,
+  not a full-page failure.
+- Remote detail unavailable: keep the row selected and show summary metadata.
+- Install failure: clear pending state, keep the command visible, and surface
+  the server error.
+- Local scan failure: remote directory still renders, but installed markers are
+  disabled and the status pill explains why.
+- File preview denied by the allow-list: use scanned description or registry
+  summary so the detail panel does not go blank.
+
+## Security and Trust
+
+- Do not execute install commands supplied directly by the browser.
+- Keep install/delete local-origin gated.
+- Preserve the existing file-preview allow-list and byte limit.
+- Never expose arbitrary local paths from remote registry data.
+- Treat audit badges as metadata, not as a safety guarantee.
+- Make source and trust state visible enough that an unaudited skill is not
+  confused with an official or audited one.
+
+## Testing
+
+Add source and route tests before relying on rendered verification:
+
+- registry response normalization and fallback fixture loading
+- local scan merge and installed-state matching
+- ranking sort modes for all-time, trending, and hot
+- combined search/filter behavior
+- install command derivation from a known slug
+- install route rejects arbitrary command input and unlisted agents
+- local preview/delete guards still reject unsafe paths
+- `MarketplaceViewSurface` keeps `Browse | Roles | Skills | Capabilities`
+  ownership and routes role skill chips into the Skills detail path
+- workflow skill picker uses normalized labels without losing existing skill ids
+- keyboard navigation and live-region announcements for result changes
+
+Rendered verification should cover:
+
+- desktop Skills tab with live or fallback directory data
+- narrow pane/mobile Skills tab with no text overlap
+- installed local-only skill detail with preview, reveal, and delete controls
+- remote-only skill detail with command copy and registry/source links
+- registry unavailable state
+
+Expected verification bundle for the implementation PR:
+
+- `node --experimental-strip-types src/components/roles-tools-navigation.test.ts`
+- focused new tests for the directory normalizer, API routes, and UI ownership
+- `pnpm check:tests-wired`
+- `pnpm typecheck`
+- `pnpm test:app`
+- Playwright screenshot checks for desktop and mobile Skills layouts
+
+## Rollout Phases
+
+1. Add the normalized directory model, fallback fixture, registry adapter, and
+   merge tests.
+2. Replace `SkillBrowser` with the ranked directory UI inside the existing
+   Marketplace `Skills` section.
+3. Wire detail panel actions: command copy, install, local preview, reveal,
+   delete, and source links.
+4. Route role skill chips and workflow skill pickers into the shared detail
+   model.
+5. Run rendered desktop/mobile QA and open the PR through the protected branch
+   path.
+
+## Resolved Defaults
+
+- The directory is registry-backed with local installed skills merged in.
+- The UI stays inside Marketplace, not a standalone top-level route.
+- A fallback fixture or cache is required so development and offline use still
+  render a useful directory.
+- Local scan remains authoritative for installed state.
+- Registry install work is server-mediated and constrained, not raw shell input
+  from the client.

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -158,6 +158,8 @@ const contracts: RouteContract[] = [
   { route: "/skills/eval-loop/[familiarId]", methods: ["GET"], kind: "json" },
   { route: "/skills/eval-loop/[familiarId]/run", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/skills/eval-loop/[familiarId]/run-lock", methods: ["DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/skills/directory", methods: ["GET"], kind: "json" },
+  { route: "/skills/directory/[slug]", methods: ["GET"], kind: "json" },
   { route: "/skills/local", methods: ["GET", "DELETE"], kind: "json" },
   { route: "/skills", methods: ["GET"], kind: "json" },
   { route: "/theme", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/skills/directory/[slug]/route.ts
+++ b/src/app/api/skills/directory/[slug]/route.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /api/skills/directory/[slug]
+ *
+ * Returns a single merged directory entry by matching slug, id, owner/repo, or
+ * local path key.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  listSkillDirectoryEntriesWithLocal,
+  matchDirectoryEntry,
+  type SkillDirectoryEntry,
+  type SkillDirectoryListResponse,
+} from "@/lib/server/skills-directory";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+function decodeSlug(value: string | undefined): string {
+  if (!value) return "";
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export async function GET(_: Request, ctx: { params: Promise<{ slug: string }> }) {
+  const { slug } = await ctx.params;
+  const key = decodeSlug(slug).trim();
+  if (!key) {
+    return NextResponse.json({ ok: false, error: "missing slug" }, { status: 400 });
+  }
+
+  const response = await listSkillDirectoryEntriesWithLocal();
+  const entry = matchDirectoryEntry(key, response.entries);
+  if (!entry) {
+    return NextResponse.json({ ok: false, error: `skill "${key}" not found` }, { status: 404 });
+  }
+
+  const data = {
+    ok: true,
+    source: response.source,
+    reason: response.reason,
+    fetchedAt: response.fetchedAt,
+    entry,
+  } satisfies Omit<SkillDirectoryListResponse, "entries"> & { entry: SkillDirectoryEntry };
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/skills/directory/fallback.json
+++ b/src/app/api/skills/directory/fallback.json
@@ -1,0 +1,70 @@
+{
+  "entries": [
+    {
+      "id": "skill-scanner",
+      "slug": "coven/skill-scanner",
+      "name": "skill-scanner",
+      "description": "Scan and surface reusable workflow capabilities from installed and remote skill packs.",
+      "owner": "coven",
+      "repo": "skill-scanner",
+      "package": "skill-scanner",
+      "tags": ["skills", "automation", "workflow"],
+      "topics": ["skill-management", "agent-tools"],
+      "agents": ["codex", "claude-code", "cursor"],
+      "trust": {
+        "official": true,
+        "audited": true,
+        "source": "registry"
+      },
+      "installs": 420,
+      "trend": 86,
+      "hot": 63,
+      "registryUrl": "https://registry.example.com/skills/coven/skill-scanner",
+      "sourceUrl": "https://github.com/OpenCoven/skill-scanner"
+    },
+    {
+      "id": "web-research",
+      "slug": "coven/web-research",
+      "name": "web-research",
+      "description": "Search and summarize web research for chat and planning workflows.",
+      "owner": "coven",
+      "repo": "web-research",
+      "package": "web-research",
+      "tags": ["research", "knowledge", "network"],
+      "topics": ["research", "browser", "context"],
+      "agents": ["codex", "copilot", "windsurf"],
+      "trust": {
+        "official": true,
+        "audited": false,
+        "source": "registry"
+      },
+      "installs": 188,
+      "trend": 72,
+      "hot": 79,
+      "registryUrl": "https://registry.example.com/skills/coven/web-research",
+      "sourceUrl": "https://github.com/OpenCoven/web-research"
+    },
+    {
+      "id": "github-reviewer",
+      "slug": "coven/github-reviewer",
+      "name": "github-reviewer",
+      "description": "Review pull requests and summarize risk in a familiar-friendly format.",
+      "owner": "coven",
+      "repo": "github-reviewer",
+      "package": "github-reviewer",
+      "tags": ["github", "pr", "review"],
+      "topics": ["code-review", "automation"],
+      "agents": ["codex", "r1", "sonnet"],
+      "trust": {
+        "official": false,
+        "audited": true,
+        "source": "daemon"
+      },
+      "installs": 79,
+      "trend": 54,
+      "hot": 46,
+      "registryUrl": "https://registry.example.com/skills/coven/github-reviewer",
+      "sourceUrl": "https://github.com/OpenCoven/github-reviewer"
+    }
+  ]
+}

--- a/src/app/api/skills/directory/route.ts
+++ b/src/app/api/skills/directory/route.ts
@@ -1,0 +1,21 @@
+/**
+ * GET /api/skills/directory
+ *
+ * Merges a local directory feed (registry or fallback fixture) with locally
+ * installed skills from /api/skills/local. This is the Skills tab data source for
+ * discovery and installation state.
+ */
+
+import { NextResponse } from "next/server";
+import {
+  listSkillDirectoryEntriesWithLocal,
+  type SkillDirectoryListResponse,
+} from "@/lib/server/skills-directory";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const data: SkillDirectoryListResponse = await listSkillDirectoryEntriesWithLocal();
+  return NextResponse.json(data);
+}

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -88,14 +88,15 @@ const SORT_OPTIONS: ReadonlyArray<{ id: SortKey; label: string }> = [
 // Map a scanned local skill to the detail drawer's shape (shared by the Skills
 // browser and the role-card skill chips).
 function toSkillDetail(skill: SkillBrowserEntry): SkillDetailEntry {
+  const owner = skill.owner && skill.repo ? `${skill.owner}/${skill.repo}` : skill.owner;
   return {
     id: skill.id,
     name: skill.name,
     description: skill.description,
-    version: skill.version,
-    category: skill.kind,
-    owner: skill.familiar,
-    tags: skill.tags,
+    version: skill.local?.version,
+    category: skill.installed ? "Installed" : "Directory",
+    owner,
+    tags: [...new Set([...(skill.tags ?? []), ...(skill.topics ?? [])])],
     source: skill.path,
   };
 }
@@ -203,11 +204,17 @@ export function MarketplaceViewSurface({
     skillsCtl.current = ctl;
     setSkillsLoaded(false);
     try {
-      const res = await fetch("/api/skills/local", { cache: "no-store", signal: ctl.signal });
-      const json = (await res.json()) as { ok?: boolean; skills?: SkillBrowserEntry[]; error?: string };
+      const res = await fetch("/api/skills/directory", { cache: "no-store", signal: ctl.signal });
+      const json = (await res.json()) as {
+        ok?: boolean;
+        entries?: SkillBrowserEntry[];
+        error?: string;
+        source?: string;
+        fetchedAt?: string;
+      };
       if (ctl.signal.aborted) return;
       if (!json.ok) throw new Error(json.error ?? `skills http ${res.status}`);
-      setSkills(json.skills ?? []);
+      setSkills(json.entries ?? []);
       setSkillsError(null);
     } catch (err) {
       if (ctl.signal.aborted) return;
@@ -383,8 +390,17 @@ export function MarketplaceViewSurface({
   // skills fall back to the Skills section, pre-filtered to the name.
   const openSkillByName = useCallback(
     (name: string) => {
+      const q = name.toLowerCase();
       const match = skills.find(
-        (s) => s.id === name || s.name.toLowerCase() === name.toLowerCase(),
+        (s) =>
+          s.id === name ||
+          s.slug?.toLowerCase() === q ||
+          s.packageName?.toLowerCase() === q ||
+          (s.owner && s.repo
+            ? `${s.owner.toLowerCase()}/${s.repo.toLowerCase()}` === q
+            : false) ||
+          s.name.toLowerCase() === q ||
+          s.owner?.toLowerCase() === q,
       );
       if (match) {
         setSelectedSkill(toSkillDetail(match));

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -12,8 +12,9 @@ assert.match(src, /className="skill-browser__rail"/, "renders the category rail"
 assert.match(src, /className="skill-browser__list"/, "renders the card list");
 assert.match(src, /className="skill-browser__detail"/, "renders the detail pane");
 
-// Category rail: All / Claude Code / Generic with derived counts.
+// Category rail: All / Installed / Claude Code / Generic with derived counts.
 assert.match(src, /label: "All Skills"/, "rail has an All Skills entry");
+assert.match(src, /label: "Installed"/, "rail has an Installed entry");
 assert.match(src, /label: "Claude Code"[\s\S]*?icon: "ph:terminal-window"/, "rail has a Claude Code entry");
 assert.match(src, /label: "Generic"[\s\S]*?icon: "ph:puzzle-piece"/, "rail has a Generic entry");
 assert.match(
@@ -38,7 +39,7 @@ assert.match(src, /skill-browser__detail-path/, "detail shows the skill's path")
 assert.match(src, /visible\.find\(\(s\) => skillKey\(s\) === selectedKey\) \?\? visible\[0\]/, "auto-selects the first visible skill");
 
 // ── Detail-pane actions: reveal folder + delete ─────────────────────────────
-assert.match(src, /className="skill-browser__actions"/, "detail head has an actions cluster");
+assert.match(src, /selectedHasLocalPath \? \(/, "detail actions are limited to installed/local entries");
 assert.match(src, /name="ph:folder-open"/, "reveal-folder action uses the folder-open icon");
 assert.match(src, /name="ph:trash"/, "delete action uses the trash icon");
 // Reveal shells out via Tauri and copies the path on the web.

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -16,38 +16,70 @@ export type SkillBrowserEntry = {
   description?: string;
   version?: string;
   kind?: string;
+  slug?: string;
+  owner?: string;
+  repo?: string;
+  packageName?: string;
   tags?: string[];
-  /** Absolute path to the skill's SKILL.md. */
-  path: string;
-  /** Scan scope: "user" (~/.claude/skills) or "global" (Coven shared skills). */
-  familiar: string;
+  topics?: string[];
+  agents?: string[];
+  trust?: {
+    official?: boolean;
+    audited?: boolean;
+    source?: "registry" | "local" | "daemon" | "fallback";
+  };
+  installed?: boolean;
+  installsAllTime?: number;
+  trendScore?: number;
+  hotScore?: number;
+  source?: "registry" | "local" | "daemon" | "fallback";
+  local?: {
+    installed: boolean;
+    path?: string;
+    version?: string;
+    scope?: "coven" | "claude-user" | "other-local";
+    source?: "local-match" | "local-scan";
+  };
+  /** Absolute path to the skill's SKILL.md (local entries only). */
+  path?: string;
+  /** Scan scope: "user" (~/.claude/skills), "global" (Coven shared skills),
+   * or omitted for directory-only entries.
+   */
+  familiar?: string;
 };
 
-type Category = "all" | "claude" | "generic";
+type Category = "all" | "installed" | "claude" | "generic";
 type PreviewState = {
   status: "idle" | "loading" | "loaded" | "error";
   text: string | null;
   error: string | null;
 };
 
-// The scan tags user skills (~/.claude/skills) as "user" and shared Coven skills
-// as "global"; surface those as "Claude Code" vs "Generic".
-function categoryOf(skill: SkillBrowserEntry): "claude" | "generic" {
+// The scan tags user skills (~/.claude/skills) as "user" and shared Coven
+// skills as "global"; directory entries without a local path are grouped with
+// Generic while installed entries get a first-class Installed tab.
+function categoryOf(skill: SkillBrowserEntry): "installed" | "claude" | "generic" {
+  if (skill.installed || skill.local?.installed) return "installed";
   return skill.familiar === "user" ? "claude" : "generic";
 }
-const CATEGORY_LABEL: Record<"claude" | "generic", string> = {
+const CATEGORY_LABEL: Record<"installed" | "claude" | "generic", string> = {
+  installed: "Installed",
   claude: "Claude Code",
   generic: "Generic",
 };
 
 const RAIL: { id: Category; label: string; icon: IconName }[] = [
   { id: "all", label: "All Skills", icon: "ph:squares-four" },
+  { id: "installed", label: "Installed", icon: "ph:check-circle" },
   { id: "claude", label: "Claude Code", icon: "ph:terminal-window" },
   { id: "generic", label: "Generic", icon: "ph:puzzle-piece" },
 ];
 
 function skillKey(skill: SkillBrowserEntry): string {
-  return `${skill.familiar}:${skill.id}:${skill.path}`;
+  const scope = skill.local ? "local" : "remote";
+  const base = skill.slug ?? skill.id;
+  const bucket = skill.path ?? `${skill.owner ?? ""}:${skill.repo ?? ""}`;
+  return `${scope}:${base}:${bucket}`;
 }
 
 // SKILL.md opens with a YAML frontmatter block (name/description/tags) already
@@ -58,7 +90,20 @@ function stripFrontmatter(text: string): string {
 
 function matchesQuery(skill: SkillBrowserEntry, query: string): boolean {
   if (!query) return true;
-  const hay = [skill.id, skill.name, skill.description, skill.kind, skill.familiar, ...(skill.tags ?? [])]
+  const hay = [
+    skill.id,
+    skill.name,
+    skill.description,
+    skill.kind,
+    skill.owner,
+    skill.repo,
+    skill.slug,
+    skill.packageName,
+    skill.familiar,
+    ...(skill.tags ?? []),
+    ...(skill.topics ?? []),
+    ...(skill.agents ?? []),
+  ]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
@@ -115,6 +160,7 @@ export function SkillBrowser({
   const counts = useMemo(
     () => ({
       all: skills.length,
+      installed: skills.filter((s) => categoryOf(s) === "installed").length,
       claude: skills.filter((s) => categoryOf(s) === "claude").length,
       generic: skills.filter((s) => categoryOf(s) === "generic").length,
     }),
@@ -132,7 +178,8 @@ export function SkillBrowser({
     () => visible.find((s) => skillKey(s) === selectedKey) ?? visible[0] ?? null,
     [visible, selectedKey],
   );
-  const selectedPath = selected?.path ?? null;
+  const selectedPath = selected?.local?.path ?? selected?.path ?? null;
+  const selectedHasLocalPath = Boolean(selected?.local?.installed && selectedPath);
 
   // Load the selected skill's SKILL.md for the detail pane. Only paths under the
   // allow-listed roots return content; anything else 403s → fall back to the
@@ -243,7 +290,7 @@ export function SkillBrowser({
         ) : skills.length === 0 ? (
           <div className="skill-browser__empty">
             <Icon name="ph:puzzle-piece" width={22} aria-hidden />
-            <p>No local skills found.</p>
+            <p>No directory skills found.</p>
             {onCreateSkill ? (
               <button type="button" className="skill-browser__empty-action" onClick={onCreateSkill}>
                 Open Capabilities
@@ -290,35 +337,48 @@ export function SkillBrowser({
             <div className="skill-browser__detail-head">
               <div className="skill-browser__detail-titlerow">
                 <h2 className="skill-browser__detail-name">{selected.name}</h2>
-                <div className="skill-browser__actions">
-                  <button
-                    type="button"
-                    className="skill-browser__action"
-                    onClick={handleReveal}
-                    disabled={busy != null}
-                    title="Reveal skill folder"
-                    aria-label="Reveal skill folder"
-                  >
-                    <Icon name="ph:folder-open" width={16} aria-hidden />
-                  </button>
-                  <button
-                    type="button"
-                    className={`skill-browser__action skill-browser__action--danger${confirmingDelete ? " is-confirming" : ""}`}
-                    onClick={handleDelete}
-                    disabled={busy != null}
-                    title={confirmingDelete ? "Confirm delete" : "Delete skill"}
-                    aria-label={confirmingDelete ? "Confirm delete skill" : "Delete skill"}
-                  >
-                    <Icon name="ph:trash" width={16} aria-hidden />
-                    {confirmingDelete ? <span className="skill-browser__action-label">Delete?</span> : null}
-                  </button>
-                </div>
+                {selectedHasLocalPath ? (
+                  <div className="skill-browser__actions">
+                    <button
+                      type="button"
+                      className="skill-browser__action"
+                      onClick={handleReveal}
+                      disabled={busy != null}
+                      title="Reveal skill folder"
+                      aria-label="Reveal skill folder"
+                    >
+                      <Icon name="ph:folder-open" width={16} aria-hidden />
+                    </button>
+                    <button
+                      type="button"
+                      className={`skill-browser__action skill-browser__action--danger${confirmingDelete ? " is-confirming" : ""}`}
+                      onClick={handleDelete}
+                      disabled={busy != null}
+                      title={confirmingDelete ? "Confirm delete" : "Delete skill"}
+                      aria-label={confirmingDelete ? "Confirm delete skill" : "Delete skill"}
+                    >
+                      <Icon name="ph:trash" width={16} aria-hidden />
+                      {confirmingDelete ? <span className="skill-browser__action-label">Delete?</span> : null}
+                    </button>
+                  </div>
+                ) : null}
               </div>
-              <p className="skill-browser__detail-path" title={selected.path}>
-                {displayPath(selected.path)}
+              <p className="skill-browser__detail-path" title={selected.path ?? selected?.source ?? "directory"}>
+                {selected.path
+                  ? displayPath(selected.path)
+                  : selected.owner
+                    ? `${selected.owner}/${selected.repo ?? ""}`
+                    : "Directory listing"}
               </p>
               <div className="skill-browser__detail-meta">
                 <span className="skill-browser__badge">{CATEGORY_LABEL[categoryOf(selected)]}</span>
+                {selected.installsAllTime ? (
+                  <span className="skill-browser__badge">Installs: {selected.installsAllTime}</span>
+                ) : null}
+                {selected.trendScore ? <span className="skill-browser__badge">Trend: {selected.trendScore}</span> : null}
+                {selected.hotScore ? <span className="skill-browser__badge">Hot: {selected.hotScore}</span> : null}
+                {selected.trust?.official ? <span className="skill-browser__badge">Official</span> : null}
+                {selected.trust?.audited ? <span className="skill-browser__badge">Audited</span> : null}
                 {selected.version ? <span className="skill-browser__badge">v{selected.version}</span> : null}
                 {(selected.tags ?? []).slice(0, 6).map((t) => (
                   <span key={t} className="skill-browser__tag">

--- a/src/lib/server/skill-scan.ts
+++ b/src/lib/server/skill-scan.ts
@@ -15,6 +15,11 @@ export type LocalSkillEntry = {
   version?: string;
   kind?: string;
   tags?: string[];
+  owner?: string;
+  repo?: string;
+  packageName?: string;
+  topics?: string[];
+  agents?: string[];
   /**
    * Capabilities the skill needs, declared in its SKILL.md frontmatter as a
    * `permissions:` list (e.g. `web.fetch`, `repo.read`). Surfaced as inherited
@@ -83,12 +88,14 @@ export async function scanSkillsDir(dir: string, familiar: string, out: LocalSki
 
   for (const skillName of entries) {
     const skillMdPath = path.join(dir, skillName, "SKILL.md");
-    try {
+  try {
       await stat(skillMdPath);
       const text = await readFile(skillMdPath, "utf8");
       const fm = parseFrontmatter(text);
       const tags = parseListField(text, "tags");
       const permissions = parseListField(text, "permissions");
+      const topics = parseListField(text, "topics");
+      const agents = parseListField(text, "agents");
       out.push({
         id: skillName,
         name: fm.name ?? skillName,
@@ -97,6 +104,11 @@ export async function scanSkillsDir(dir: string, familiar: string, out: LocalSki
         kind: fm.kind,
         tags: tags.length ? tags : (fm.tags ? [fm.tags] : []),
         permissions: permissions.length ? permissions : undefined,
+        owner: fm.owner,
+        repo: fm.repo,
+        packageName: fm.package,
+        topics: topics.length ? topics : undefined,
+        agents: agents.length ? agents : undefined,
         path: skillMdPath,
         familiar,
       });

--- a/src/lib/server/skills-directory.ts
+++ b/src/lib/server/skills-directory.ts
@@ -1,0 +1,374 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { scanSkillsDir, scanClaudeUserSkills, type LocalSkillEntry } from "@/lib/server/skill-scan";
+
+export type SkillDirectoryTrust = {
+  official: boolean;
+  audited: boolean;
+  source: "registry" | "local" | "daemon" | "fallback";
+};
+
+export type SkillDirectoryInstalled = {
+  installed: boolean;
+  path?: string;
+  version?: string;
+  scope: "coven" | "claude-user" | "other-local";
+  source: "local-scan" | "local-match";
+};
+
+export type SkillDirectoryEntry = {
+  id: string;
+  slug: string;
+  name: string;
+  owner?: string;
+  repo?: string;
+  packageName?: string;
+  description?: string;
+  tags: string[];
+  topics: string[];
+  agents: string[];
+  trust: SkillDirectoryTrust;
+  installed: boolean;
+  local?: SkillDirectoryInstalled;
+  installsAllTime: number;
+  trendScore: number;
+  hotScore: number;
+  registryUrl?: string;
+  sourceUrl?: string;
+  source: "registry" | "daemon" | "fallback";
+};
+
+export type SkillDirectoryListResponse = {
+  ok: boolean;
+  source: "live" | "fallback";
+  reason?: string;
+  fetchedAt: string;
+  entries: SkillDirectoryEntry[];
+};
+
+type RawDirectoryEntry = {
+  id?: unknown;
+  slug?: unknown;
+  name?: unknown;
+  owner?: unknown;
+  repo?: unknown;
+  package?: unknown;
+  packageName?: unknown;
+  description?: unknown;
+  tags?: unknown;
+  topics?: unknown;
+  agents?: unknown;
+  trust?: unknown;
+  installsAllTime?: unknown;
+  installs?: unknown;
+  trend?: unknown;
+  hot?: unknown;
+  registryUrl?: unknown;
+  sourceUrl?: unknown;
+  source?: unknown;
+};
+
+const DIRECTORY_FALLBACK_PATH = path.join(
+  process.cwd(),
+  "src",
+  "app",
+  "api",
+  "skills",
+  "directory",
+  "fallback.json",
+);
+
+const FALLBACK_AGENTS = new Set([
+  "codex",
+  "claude-code",
+  "cursor",
+  "copilot",
+  "windsurf",
+  "gemini",
+  "r1",
+  "sonnet",
+]);
+
+function norm(value: string | undefined | null): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asBool(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function asStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out = value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean)
+    .map((entry) => entry.toLowerCase());
+  return [...new Set(out)];
+}
+
+function toSlug(owner: string | undefined, repo: string | undefined, fallbackId: string): string {
+  if (owner && repo) return `${owner.toLowerCase()}/${repo.toLowerCase()}`;
+  return norm(fallbackId);
+}
+
+function localScope(value: string): "coven" | "claude-user" | "other-local" {
+  return value === "user" ? "claude-user" : "coven";
+}
+
+function trustFromRaw(value: unknown): SkillDirectoryTrust {
+  if (!value || typeof value !== "object") {
+    return { official: false, audited: false, source: "fallback" };
+  }
+  const raw = value as {
+    official?: unknown;
+    audited?: unknown;
+    source?: unknown;
+  };
+  return {
+    official: asBool(raw.official, false),
+    audited: asBool(raw.audited, false),
+    source: raw.source === "local" || raw.source === "daemon" || raw.source === "registry" || raw.source === "fallback"
+      ? raw.source
+      : "fallback",
+  };
+}
+
+function normalizeRawEntry(raw: RawDirectoryEntry): SkillDirectoryEntry | null {
+  const id = asString(raw.id) ?? asString(raw.slug);
+  if (!id) return null;
+  const name = asString(raw.name) ?? id;
+  const owner = asString(raw.owner);
+  const repo = asString(raw.repo);
+  const packageName = asString(raw.packageName) ?? asString(raw.package);
+  const slug = toSlug(owner, repo, id);
+
+  return {
+    id,
+    slug,
+    name,
+    owner,
+    repo,
+    packageName,
+    description: asString(raw.description),
+    tags: asStringList(raw.tags),
+    topics: asStringList(raw.topics),
+    agents: asStringList(raw.agents),
+    trust: trustFromRaw(raw.trust),
+    installed: false,
+    installsAllTime: typeof raw.installsAllTime === "number" && Number.isFinite(raw.installsAllTime)
+      ? raw.installsAllTime
+      : typeof raw.installs === "number" && Number.isFinite(raw.installs)
+        ? raw.installs
+        : 0,
+    trendScore: typeof raw.trend === "number" && Number.isFinite(raw.trend) ? raw.trend : 0,
+    hotScore: typeof raw.hot === "number" && Number.isFinite(raw.hot) ? raw.hot : 0,
+    registryUrl: asString(raw.registryUrl),
+    sourceUrl: asString(raw.sourceUrl),
+    source: raw.source === "daemon" ? "daemon" : "registry",
+  };
+}
+
+function ownerRepoKey(entry: { owner?: string; repo?: string; slug?: string }): string {
+  const owner = norm(entry.owner);
+  const repo = norm(entry.repo);
+  if (owner && repo) return `${owner}/${repo}`;
+  return norm(entry.slug);
+}
+
+function matchesByOrder(entry: SkillDirectoryEntry, local: LocalSkillEntry, order: number): boolean {
+  const localSlug = ownerRepoKey(local);
+  const targetSlug = ownerRepoKey(entry);
+  const localPackage = norm(local.packageName);
+  const entryPackage = norm(entry.packageName);
+
+  if (order === 0 && localSlug && targetSlug && localSlug === targetSlug) return true;
+  if (order === 1 && local.owner && local.repo) {
+    return entry.owner?.toLowerCase() === local.owner.toLowerCase() &&
+      entry.repo?.toLowerCase() === local.repo.toLowerCase();
+  }
+  if (order === 2 && localPackage && entryPackage) return localPackage === entryPackage;
+  if (order === 3 && norm(local.id) === norm(entry.id)) return true;
+  if (order === 4 && norm(local.name) === norm(entry.name)) return true;
+  return false;
+}
+
+function chooseLocalMatch(entry: SkillDirectoryEntry, locals: LocalSkillEntry[], consumed: Set<number>): LocalSkillEntry | null {
+  for (let step = 0; step <= 4; step++) {
+    for (let i = 0; i < locals.length; i++) {
+      if (consumed.has(i)) continue;
+      if (matchesByOrder(entry, locals[i], step)) {
+        consumed.add(i);
+        return locals[i];
+      }
+    }
+  }
+  return null;
+}
+
+function attachLocalState(entry: SkillDirectoryEntry, local: LocalSkillEntry | null): SkillDirectoryEntry {
+  if (!local) return entry;
+  return {
+    ...entry,
+    installed: true,
+    local: {
+      installed: true,
+      path: local.path,
+      version: local.version,
+      scope: localScope(local.familiar),
+      source: "local-match",
+    },
+    // registry trust is not overridden by local metadata; but local-only installs
+    // for remote rows should still inherit the authoritative registry source.
+  };
+}
+
+function addInstalledLocalOnly(entry: LocalSkillEntry): SkillDirectoryEntry {
+  const slug = ownerRepoKey({ owner: entry.owner, repo: entry.repo, slug: entry.id });
+  return {
+    id: entry.id,
+    slug,
+    name: entry.name,
+    owner: entry.owner,
+    repo: entry.repo,
+    packageName: entry.packageName,
+    description: entry.description,
+    tags: entry.tags ?? [],
+    topics: entry.topics ?? [],
+    agents: entry.agents ?? [],
+    trust: {
+      official: false,
+      audited: false,
+      source: "local",
+    },
+    installed: true,
+    local: {
+      installed: true,
+      path: entry.path,
+      version: entry.version,
+      scope: localScope(entry.familiar),
+      source: "local-scan",
+    },
+    installsAllTime: 0,
+    trendScore: 0,
+    hotScore: 0,
+    source: "fallback",
+  };
+}
+
+function uniqueEntries(entries: SkillDirectoryEntry[]): SkillDirectoryEntry[] {
+  const out: SkillDirectoryEntry[] = [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const key = `${entry.slug}:${entry.id}`.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(entry);
+  }
+  return out;
+}
+
+async function readFallbackEntries(): Promise<SkillDirectoryEntry[]> {
+  try {
+    const raw = await readFile(DIRECTORY_FALLBACK_PATH, "utf8");
+    const parsed = JSON.parse(raw) as { entries?: unknown };
+    if (!Array.isArray(parsed?.entries)) return [];
+    const out: SkillDirectoryEntry[] = [];
+    for (const item of parsed.entries) {
+      const normalized = normalizeRawEntry(item as RawDirectoryEntry);
+      if (normalized) out.push(normalized);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+async function readLiveEntries(): Promise<SkillDirectoryEntry[]> {
+  const endpoint = process.env.SKILLS_DIRECTORY_ENDPOINT?.trim();
+  const token = process.env.SKILLS_DIRECTORY_TOKEN?.trim();
+  if (!endpoint) return [];
+  const url = new URL(endpoint);
+  const headers: Record<string, string> = {};
+  if (token) headers.authorization = `Bearer ${token}`;
+  const response = await fetch(url, { headers });
+  if (!response.ok) return [];
+  const parsed = (await response.json()) as { data?: unknown; entries?: unknown };
+  const source = parsed?.entries ?? parsed?.data;
+  if (!Array.isArray(source)) return [];
+  const normalized = source.map((item) => normalizeRawEntry(item as RawDirectoryEntry)).filter((item) => item !== null);
+  return normalized;
+}
+
+export async function listSkillDirectoryEntries(): Promise<SkillDirectoryListResponse> {
+  const live = await readLiveEntries();
+  const source: SkillDirectoryListResponse["source"] = live.length > 0 ? "live" : "fallback";
+  const fallback = source === "fallback" ? await readFallbackEntries() : [];
+  const entries = live.length > 0 ? live : fallback;
+  const reason = source === "fallback"
+    ? (fallback.length > 0 ? "Using bundled fallback directory fixture." : "Directory source unavailable.")
+    : undefined;
+
+  return {
+    ok: true,
+    source,
+    reason,
+    fetchedAt: new Date().toISOString(),
+    entries: uniqueEntries(entries),
+  };
+}
+
+function isDirectoryMatch(entry: SkillDirectoryEntry, key: string): boolean {
+  const target = norm(key);
+  return (
+    norm(entry.slug) === target ||
+    norm(entry.id) === target ||
+    `${norm(entry.owner)}/${norm(entry.repo)}` === target ||
+    `${norm(entry.id)}` === target
+  );
+}
+
+export async function listSkillDirectoryEntriesWithLocal(): Promise<SkillDirectoryListResponse> {
+  const locals: LocalSkillEntry[] = [];
+  const global = await scanSkillsDir(path.join(process.cwd(), ".coven"), "global", locals);
+  await scanClaudeUserSkills().then((items) => locals.push(...items));
+
+  const directory = await listSkillDirectoryEntries();
+  const merged = mergeDirectoryWithLocal(directory.entries, locals);
+  return {
+    ...directory,
+    entries: merged,
+  };
+}
+
+export function mergeDirectoryWithLocal(
+  entries: SkillDirectoryEntry[],
+  locals: LocalSkillEntry[],
+): SkillDirectoryEntry[] {
+  const consumed = new Set<number>();
+  const matched = entries.map((entry) => attachLocalState(entry, chooseLocalMatch(entry, locals, consumed)));
+  const localOnly: SkillDirectoryEntry[] = locals
+    .map((local, index) => (consumed.has(index) ? null : addInstalledLocalOnly(local)))
+    .filter((entry): entry is SkillDirectoryEntry => entry !== null);
+  return uniqueEntries([...matched, ...localOnly]);
+}
+
+export function matchDirectoryEntry(
+  key: string,
+  entries: SkillDirectoryEntry[],
+): SkillDirectoryEntry | null {
+  const match = entries.find((entry) => isDirectoryMatch(entry, key));
+  return match ?? null;
+}
+
+export function fallbackAgentsForDirectory(): string[] {
+  return [...FALLBACK_AGENTS];
+}
+
+export function allowedSkillInstallAgents(): string[] {
+  return [...FALLBACK_AGENTS];
+}


### PR DESCRIPTION
## Summary
- Add skills directory backend feed endpoints and merge-layer service.
- Replace marketplace skills loading from local scan with remote directory-first flow.
- Update skill browser typing/metadata for directory rows and installed state.
- Add route contract coverage for new directory APIs.

## Verification
- pnpm typecheck
- node --experimental-strip-types src/app/api/api-contracts.test.ts
- node --experimental-strip-types src/components/skill-browser.test.ts