### PR TITLE
feat(evals): export familiar runs to Hermes Flight Recorder JSONL

### DIFF
--- a/docs/workflows/hfr-trace-export.md
+++ b/docs/workflows/hfr-trace-export.md
@@ -1,0 +1,70 @@
+# Exporting Coven familiar runs to Hermes Flight Recorder (HFR)
+
+[Hermes Flight Recorder](https://github.com/zwright8/hermes-flight-recorder) turns
+autonomous-agent execution traces into verifiable evidence: it normalizes a trace
+to its internal `hfr.trace.v1` schema, scores it against scenario contracts
+(forbidden commands/URLs, secret patterns, budget caps, assertions), and emits
+scorecards, task-completion verdicts, and regression scenarios.
+
+HFR ingests **observer-hook JSONL** — one JSON event per line, from the vocabulary
+`session · pre_tool_call · post_tool_call · post_llm_call · subagent_start ·
+subagent_stop · final_answer`. This exporter produces exactly that stream from a
+Coven familiar's run history, so a familiar's work can be evaluated in HFR.
+
+## Why the conversation file is the source
+
+A Coven Cave conversation file (`$COVEN_HOME/cave-conversations/<sessionId>.json`)
+is the richest self-contained record of what a familiar actually did: every tool
+call with `input`/`output`/`status`/`durationMs`, per-turn token `usage` and
+`costUsd`, and the assistant's answers. That maps cleanly onto HFR's observer-hook
+events without needing the live daemon.
+
+## Usage
+
+```bash
+pnpm hfr:export                          # every conversation → stdout (JSONL)
+pnpm hfr:export --familiar cody          # only cody's runs
+pnpm hfr:export --session <id> --out trace.jsonl
+pnpm hfr:export --subagents links.json   # splice in delegation edges
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--dir <path>` | conversations dir (default `$COVEN_HOME/cave-conversations`) |
+| `--session <id>` | export a single conversation |
+| `--familiar <id>` | filter to one familiar (the eval scope) |
+| `--subagents <path>` | JSON array of `{parentSessionId, childSessionId, familiarId?, status?, startedAt?, endedAt?}` |
+| `--out <path>` | write JSONL to a file (default stdout) |
+| `--source-format <str>` | override the session event's `source_format` (default `coven.cave.v1`) |
+| `--max-field-chars <n>` | cap free-text fields; tool results keep their tail, `0` disables |
+
+Then hand the JSONL to HFR's normalizer / scenario runner.
+
+## Event mapping
+
+| HFR event | Coven source | Notes |
+|-----------|--------------|-------|
+| `session` | conversation header | `session_id`, `source_format`, `familiar_id` (eval scope), `harness`, `model` |
+| `user_message` | `role:"user"` turn | |
+| `pre_tool_call` / `post_tool_call` | `turn.tools[]` | shared `call_id = tool.id`; `is_error` true for `error` **and** unresolved `running` tools; `post.ts = pre.ts + durationMs` |
+| `post_llm_call` | `turn.usage` / `turn.costUsd` | tokens snake-cased for HFR; omitted when the harness reported neither |
+| `subagent_start` / `subagent_stop` | `--subagents` links | only edges whose `parentSessionId` is this session |
+| `final_answer` | last assistant turn | skips `cancelled`/`isError` turns |
+
+## Scope & follow-ups
+
+- **Pure transform, tested offline.** All mapping logic lives in
+  `src/lib/hfr-trace-export.ts` with `src/lib/hfr-trace-export.test.ts`; the CLI
+  (`scripts/coven-hfr-export.ts`) is a thin I/O shell.
+- **Delegation graph is fed, not derived.** The daemon's `cave-coven-calls`
+  ledger records `callerFamiliarId → calleeFamiliarId` + the callee `sessionId`,
+  but not the *parent* session id, so subagent edges are supplied explicitly via
+  `--subagents`. Deriving them automatically is a follow-up once the ledger
+  exposes the parent session.
+- **Eval metrics.** `results.tsv` (`metric_before/after/delta/outcome` per track)
+  is HFR's natural baseline-vs-candidate compare input; wiring it into an HFR
+  compare export is a separate slice.
+- **Redaction.** Sensitive daemon events are already redacted upstream; HFR's own
+  secret-scan policy runs on the exported text downstream. Field names track
+  HFR's observer-hook contract and are centralized in `hfr-trace-export.ts` for a
+  single-file reconcile once HFR's schema is pinned.

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "beads:prs": "node --experimental-strip-types scripts/beads-pr-bridge.ts --repo OpenCoven/coven-cave",
     "beads:prs:json": "node --experimental-strip-types scripts/beads-pr-bridge.ts --repo OpenCoven/coven-cave --json",
     "beads:prs:apply": "node --experimental-strip-types scripts/beads-pr-bridge.ts --repo OpenCoven/coven-cave --apply",
+    "hfr:export": "node --experimental-strip-types scripts/coven-hfr-export.ts",
     "beads:sync": "bd dolt pull && bd dolt push",
     "beads:doctor": "bd doctor && bd lint",
     "test:sidecar-runtime": "node scripts/sidecar-runtime-smoke.mjs",

--- a/scripts/coven-hfr-export.ts
+++ b/scripts/coven-hfr-export.ts
@@ -1,0 +1,198 @@
+#!/usr/bin/env node --experimental-strip-types
+// Coven → Hermes Flight Recorder (HFR) trace exporter CLI.
+//
+// Reads Coven Cave conversation files (the per-familiar record of tool calls,
+// LLM usage, and answers) and emits HFR observer-hook JSONL to stdout or a
+// file. HFR then normalizes and scores the trace against scenario contracts.
+//
+// The transform lives in src/lib/hfr-trace-export.ts (pure, unit-tested); this
+// file is just the I/O shell — locate files, parse JSON defensively, write out.
+//
+// Usage:
+//   pnpm hfr:export                         # all conversations → stdout
+//   pnpm hfr:export --familiar cody         # only cody's runs
+//   pnpm hfr:export --session <id> --out trace.jsonl
+//   pnpm hfr:export --subagents links.json  # splice in delegation edges
+//
+// Options:
+//   --dir <path>            conversations dir (default $COVEN_HOME/cave-conversations)
+//   --session <id>          export a single conversation by id
+//   --familiar <id>         only conversations for this familiar
+//   --subagents <path>      JSON array of {parentSessionId, childSessionId, ...}
+//   --out <path>            write JSONL here (default stdout)
+//   --source-format <str>   override the session event's source_format
+//   --max-field-chars <n>   cap free-text fields (0 disables)
+
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import {
+  conversationToHfrEvents,
+  serializeHfrJsonl,
+  type HfrConversationInput,
+  type HfrObserverEvent,
+  type HfrSubagentLink,
+} from "../src/lib/hfr-trace-export.ts";
+
+type Options = {
+  dir: string;
+  session: string | null;
+  familiar: string | null;
+  subagents: string | null;
+  out: string | null;
+  sourceFormat: string | null;
+  maxFieldChars: number | null;
+};
+
+function defaultConversationsDir(): string {
+  const home = process.env.COVEN_HOME ?? path.join(homedir(), ".coven");
+  return path.join(home, "cave-conversations");
+}
+
+function parseArgs(argv: string[]): Options {
+  const opts: Options = {
+    dir: defaultConversationsDir(),
+    session: null,
+    familiar: null,
+    subagents: null,
+    out: null,
+    sourceFormat: null,
+    maxFieldChars: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--dir":
+        opts.dir = argv[++i] ?? opts.dir;
+        break;
+      case "--session":
+        opts.session = argv[++i] ?? null;
+        break;
+      case "--familiar":
+        opts.familiar = argv[++i] ?? null;
+        break;
+      case "--subagents":
+        opts.subagents = argv[++i] ?? null;
+        break;
+      case "--out":
+        opts.out = argv[++i] ?? null;
+        break;
+      case "--source-format":
+        opts.sourceFormat = argv[++i] ?? null;
+        break;
+      case "--max-field-chars": {
+        const n = Number(argv[++i] ?? "");
+        if (!Number.isFinite(n) || n < 0) {
+          throw new Error("--max-field-chars requires a non-negative number");
+        }
+        opts.maxFieldChars = n;
+        break;
+      }
+      case "--help":
+      case "-h":
+        process.stdout.write(HELP);
+        process.exit(0);
+        break;
+      default:
+        throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+const HELP = `coven-hfr-export — export Coven familiar runs as HFR observer-hook JSONL
+
+  --dir <path>            conversations dir (default $COVEN_HOME/cave-conversations)
+  --session <id>          export a single conversation by id
+  --familiar <id>         only conversations for this familiar
+  --subagents <path>      JSON array of {parentSessionId, childSessionId, ...}
+  --out <path>            write JSONL here (default stdout)
+  --source-format <str>   override the session event's source_format
+  --max-field-chars <n>   cap free-text fields (0 disables)
+  -h, --help              show this help
+`;
+
+/** Parse a conversation file, returning null (with a stderr warning) on any
+ *  read/parse error so one bad file never aborts the whole export. */
+function readConversation(file: string): HfrConversationInput | null {
+  let raw: string;
+  try {
+    raw = readFileSync(file, "utf8");
+  } catch (err) {
+    process.stderr.write(`warn: cannot read ${file}: ${(err as Error).message}\n`);
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    process.stderr.write(`warn: skipping non-JSON ${file}\n`);
+    return null;
+  }
+  const conv = parsed as Partial<HfrConversationInput>;
+  if (!conv || typeof conv.sessionId !== "string" || !Array.isArray(conv.turns)) {
+    process.stderr.write(`warn: skipping ${file}: not a conversation file\n`);
+    return null;
+  }
+  return conv as HfrConversationInput;
+}
+
+function readSubagentLinks(file: string): HfrSubagentLink[] {
+  const parsed = JSON.parse(readFileSync(file, "utf8")) as unknown;
+  const list = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { calls?: unknown }).calls)
+      ? (parsed as { calls: unknown[] }).calls
+      : [];
+  return (list as Array<Record<string, unknown>>)
+    .filter((l) => typeof l.parentSessionId === "string" && typeof l.childSessionId === "string")
+    .map((l) => l as unknown as HfrSubagentLink);
+}
+
+function main(): void {
+  const opts = parseArgs(process.argv.slice(2));
+
+  let files: string[];
+  try {
+    files = readdirSync(opts.dir)
+      .filter((f) => f.endsWith(".json"))
+      .map((f) => path.join(opts.dir, f))
+      .sort();
+  } catch (err) {
+    process.stderr.write(`error: cannot list ${opts.dir}: ${(err as Error).message}\n`);
+    process.exit(1);
+    return;
+  }
+
+  const subagentLinks = opts.subagents ? readSubagentLinks(opts.subagents) : [];
+
+  const events: HfrObserverEvent[] = [];
+  let exported = 0;
+  for (const file of files) {
+    const conv = readConversation(file);
+    if (!conv) continue;
+    if (opts.session && conv.sessionId !== opts.session) continue;
+    if (opts.familiar && conv.familiarId !== opts.familiar) continue;
+    events.push(
+      ...conversationToHfrEvents(conv, {
+        subagentLinks,
+        sourceFormat: opts.sourceFormat ?? undefined,
+        maxFieldChars: opts.maxFieldChars ?? undefined,
+      }),
+    );
+    exported += 1;
+  }
+
+  const jsonl = serializeHfrJsonl(events);
+  if (opts.out) {
+    writeFileSync(opts.out, jsonl);
+    process.stderr.write(
+      `wrote ${events.length} events from ${exported} conversation(s) → ${opts.out}\n`,
+    );
+  } else {
+    process.stdout.write(jsonl);
+    process.stderr.write(`# ${events.length} events from ${exported} conversation(s)\n`);
+  }
+}
+
+main();

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -41,6 +41,7 @@ export const SUITES = {
     "src/components/open-coven-tools-update.test.ts",
     "src/lib/workflow-run-prompt.test.ts",
     "src/lib/workflow-step-progress.test.ts",
+    "src/lib/hfr-trace-export.test.ts",
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/cave-projects.test.ts",

--- a/src/lib/hfr-trace-export.test.ts
+++ b/src/lib/hfr-trace-export.test.ts
@@ -1,0 +1,338 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  conversationToHfrEvents,
+  conversationToHfrJsonl,
+  serializeHfrJsonl,
+  type HfrConversationInput,
+  type HfrObserverEvent,
+  type HfrSubagentLink,
+} from "./hfr-trace-export.ts";
+
+function baseConversation(
+  overrides: Partial<HfrConversationInput> = {},
+): HfrConversationInput {
+  return {
+    sessionId: "sess-1",
+    familiarId: "cody",
+    harness: "claude",
+    model: "sonnet",
+    title: "Fix the thing",
+    createdAt: "2026-07-04T10:00:00.000Z",
+    turns: [],
+    ...overrides,
+  };
+}
+
+function byType(events: HfrObserverEvent[], type: string): HfrObserverEvent[] {
+  return events.filter((e) => e.type === type);
+}
+
+test("emits a session header with source_format and familiar scope", () => {
+  const events = conversationToHfrEvents(baseConversation());
+  const [head] = events;
+  assert.equal(head.type, "session");
+  assert.equal(head.session_id, "sess-1");
+  assert.equal(head.familiar_id, "cody");
+  assert.equal(head.harness, "claude");
+  assert.equal(head.source_format, "coven.cave.v1");
+  assert.equal(head.ts, "2026-07-04T10:00:00.000Z");
+});
+
+test("source_format is overridable", () => {
+  const events = conversationToHfrEvents(baseConversation(), {
+    sourceFormat: "coven.cave.v2",
+  });
+  assert.equal(events[0].source_format, "coven.cave.v2");
+});
+
+test("a tool call becomes a pre/post pair with a shared call_id", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "done",
+          createdAt: "2026-07-04T10:00:01.000Z",
+          durationMs: 500,
+          tools: [
+            {
+              id: "call-abc",
+              name: "Bash",
+              input: "ls",
+              output: "file.txt",
+              status: "ok",
+              durationMs: 200,
+            },
+          ],
+        },
+      ],
+    }),
+  );
+  const pre = byType(events, "pre_tool_call");
+  const post = byType(events, "post_tool_call");
+  assert.equal(pre.length, 1);
+  assert.equal(post.length, 1);
+  assert.equal(pre[0].call_id, "call-abc");
+  assert.equal(post[0].call_id, "call-abc");
+  assert.equal(pre[0].tool, "Bash");
+  assert.equal(pre[0].args, "ls");
+  assert.equal(post[0].result, "file.txt");
+  assert.equal(post[0].is_error, false);
+  assert.equal(post[0].duration_ms, 200);
+  // post ts = pre ts + durationMs
+  assert.equal(pre[0].ts, "2026-07-04T10:00:01.000Z");
+  assert.equal(post[0].ts, "2026-07-04T10:00:01.200Z");
+});
+
+test("error and still-running tools are marked is_error for the completion check", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "x",
+          createdAt: "2026-07-04T10:00:01.000Z",
+          tools: [
+            { id: "c1", name: "A", status: "error" },
+            { id: "c2", name: "B", status: "running" },
+            { id: "c3", name: "C", status: "ok" },
+          ],
+        },
+      ],
+    }),
+  );
+  const post = byType(events, "post_tool_call");
+  assert.deepEqual(
+    post.map((p) => p.is_error),
+    [true, true, false],
+  );
+});
+
+test("post_llm_call carries snake_cased usage and cost", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "hi",
+          createdAt: "2026-07-04T10:00:01.000Z",
+          durationMs: 1000,
+          usage: {
+            inputTokens: 10,
+            outputTokens: 20,
+            cacheReadTokens: 5,
+          },
+          costUsd: 0.0012,
+        },
+      ],
+    }),
+  );
+  const [llm] = byType(events, "post_llm_call");
+  assert.ok(llm);
+  // Raw events keep undefined-valued keys; the shipped JSONL prunes them, so
+  // assert against the serialized form that HFR actually ingests.
+  const shipped = JSON.parse(serializeHfrJsonl([llm]).trimEnd());
+  assert.deepEqual(shipped.usage, {
+    input_tokens: 10,
+    output_tokens: 20,
+    cache_read_tokens: 5,
+  });
+  assert.equal(shipped.cost_usd, 0.0012);
+  assert.equal(shipped.ts, "2026-07-04T10:00:02.000Z");
+});
+
+test("no usage and no cost means no post_llm_call event", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "hi",
+          createdAt: "2026-07-04T10:00:01.000Z",
+        },
+      ],
+    }),
+  );
+  assert.equal(byType(events, "post_llm_call").length, 0);
+});
+
+test("final_answer is the last non-cancelled, non-error assistant turn", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "first",
+          createdAt: "2026-07-04T10:00:01.000Z",
+        },
+        {
+          id: "t2",
+          role: "assistant",
+          text: "cancelled draft",
+          createdAt: "2026-07-04T10:00:02.000Z",
+          cancelled: true,
+        },
+        {
+          id: "t3",
+          role: "assistant",
+          text: "final",
+          createdAt: "2026-07-04T10:00:03.000Z",
+        },
+      ],
+    }),
+  );
+  const finals = byType(events, "final_answer");
+  assert.equal(finals.length, 1);
+  assert.equal(finals[0].text, "final");
+  // final_answer is always last.
+  assert.equal(events[events.length - 1].type, "final_answer");
+});
+
+test("a cancelled-only conversation has no final_answer", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "stopped",
+          createdAt: "2026-07-04T10:00:01.000Z",
+          cancelled: true,
+        },
+      ],
+    }),
+  );
+  assert.equal(byType(events, "final_answer").length, 0);
+});
+
+test("user turns become user_message events", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "u1",
+          role: "user",
+          text: "please fix",
+          createdAt: "2026-07-04T10:00:00.500Z",
+        },
+      ],
+    }),
+  );
+  const [msg] = byType(events, "user_message");
+  assert.equal(msg.text, "please fix");
+  assert.equal(msg.ts, "2026-07-04T10:00:00.500Z");
+});
+
+test("only subagent links parented by this session are emitted", () => {
+  const links: HfrSubagentLink[] = [
+    {
+      parentSessionId: "sess-1",
+      childSessionId: "child-a",
+      familiarId: "nova",
+      status: "completed",
+      startedAt: "2026-07-04T10:00:04.000Z",
+      endedAt: "2026-07-04T10:00:09.000Z",
+    },
+    {
+      parentSessionId: "other-session",
+      childSessionId: "child-b",
+      status: "completed",
+    },
+  ];
+  const events = conversationToHfrEvents(baseConversation(), {
+    subagentLinks: links,
+  });
+  const starts = byType(events, "subagent_start");
+  const stops = byType(events, "subagent_stop");
+  assert.equal(starts.length, 1);
+  assert.equal(stops.length, 1);
+  assert.equal(starts[0].child_session_id, "child-a");
+  assert.equal(starts[0].familiar_id, "nova");
+  assert.equal(stops[0].status, "completed");
+});
+
+test("field truncation keeps head for args, tail for tool results", () => {
+  const longIn = "a".repeat(50);
+  const longOut = "b".repeat(50);
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "ok",
+          createdAt: "2026-07-04T10:00:01.000Z",
+          tools: [
+            {
+              id: "c1",
+              name: "Bash",
+              input: longIn,
+              output: longOut,
+              status: "ok",
+            },
+          ],
+        },
+      ],
+    }),
+    { maxFieldChars: 10 },
+  );
+  const [pre] = byType(events, "pre_tool_call");
+  const [post] = byType(events, "post_tool_call");
+  assert.equal(pre.args, "aaaaaaaaaa…[+40 chars]");
+  assert.equal(post.result, "…[+40 chars]bbbbbbbbbb");
+});
+
+test("serializeHfrJsonl emits one compact JSON object per line, trailing newline", () => {
+  const jsonl = conversationToHfrJsonl(
+    baseConversation({
+      turns: [
+        {
+          id: "u1",
+          role: "user",
+          text: "hi",
+          createdAt: "2026-07-04T10:00:00.500Z",
+        },
+      ],
+    }),
+  );
+  assert.ok(jsonl.endsWith("\n"));
+  const lines = jsonl.trimEnd().split("\n");
+  // session + user_message
+  assert.equal(lines.length, 2);
+  for (const line of lines) {
+    const parsed = JSON.parse(line);
+    assert.equal(typeof parsed.type, "string");
+    assert.equal(parsed.session_id, "sess-1");
+    // undefined-valued keys are pruned, not serialized as null.
+    assert.ok(!Object.values(parsed).includes(null));
+  }
+});
+
+test("malformed timestamps never throw and fall back to the start ts", () => {
+  const events = conversationToHfrEvents(
+    baseConversation({
+      turns: [
+        {
+          id: "t1",
+          role: "assistant",
+          text: "ok",
+          createdAt: "not-a-date",
+          durationMs: 500,
+          tools: [{ id: "c1", name: "A", status: "ok", durationMs: 200 }],
+        },
+      ],
+    }),
+  );
+  const [post] = byType(events, "post_tool_call");
+  assert.equal(post.ts, "not-a-date");
+});
+
+test("empty serialize is a single newline", () => {
+  assert.equal(serializeHfrJsonl([]), "\n");
+});

--- a/src/lib/hfr-trace-export.ts
+++ b/src/lib/hfr-trace-export.ts
@@ -1,0 +1,290 @@
+// Coven → Hermes Flight Recorder (HFR) trace exporter.
+//
+// HFR (github.com/zwright8/hermes-flight-recorder) ingests agent execution
+// traces as newline-delimited JSON ("observer-hook JSONL") and normalizes them
+// to its internal `hfr.trace.v1` schema before scoring runs against scenario
+// contracts. Its documented observer-hook event vocabulary is:
+//   session · pre_tool_call · post_tool_call · post_llm_call ·
+//   subagent_start · subagent_stop · final_answer
+//
+// This module is the pure transform that turns a Coven Cave conversation file
+// (the richest self-contained record of what a familiar actually did — every
+// tool call with input/output/status/duration, plus per-turn token usage and
+// cost) into that JSONL. The CLI in scripts/coven-hfr-export.ts wires the I/O
+// (read conversation files, optionally splice in the daemon delegation graph,
+// write JSONL); this file has no I/O so it is fully unit-testable offline.
+//
+// Field names track HFR's observer-hook contract. They are centralized here so
+// that reconciling against HFR's normalizer (once its exact schema is pinned)
+// is a single-file change.
+
+/** A tool call recorded on an assistant turn. Structural subset of the
+ *  `tools[]` entries in {@link ./cave-conversations.ts ChatTurn}. */
+export type HfrToolInput = {
+  id: string;
+  name: string;
+  input?: string;
+  output?: string;
+  status: "running" | "ok" | "error";
+  durationMs?: number;
+};
+
+/** Structural subset of ChatTurn consumed by the exporter. Declared locally
+ *  (rather than importing ChatTurn) so the transform stays decoupled from the
+ *  full conversation type and trivially testable. */
+export type HfrTurnInput = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  text: string;
+  createdAt: string;
+  durationMs?: number;
+  isError?: boolean;
+  cancelled?: boolean;
+  tools?: HfrToolInput[];
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens?: number;
+    cacheCreationTokens?: number;
+  };
+  costUsd?: number;
+};
+
+/** Structural subset of ConversationFile consumed by the exporter. */
+export type HfrConversationInput = {
+  sessionId: string;
+  familiarId: string;
+  harness: string;
+  model?: string;
+  title?: string;
+  origin?: string;
+  createdAt: string;
+  turns: HfrTurnInput[];
+};
+
+/** A parent→child delegation edge (from the daemon's cave-coven-calls ledger),
+ *  spliced in by the CLI so subagent runs appear in the parent's trace. */
+export type HfrSubagentLink = {
+  parentSessionId: string;
+  childSessionId: string;
+  familiarId?: string;
+  status?: string;
+  startedAt?: string;
+  endedAt?: string;
+};
+
+export type HfrExportOptions = {
+  /** Version tag stamped into the session event's `source_format`. */
+  sourceFormat?: string;
+  /** Delegation edges; only those whose parent is this session are emitted. */
+  subagentLinks?: HfrSubagentLink[];
+  /** Cap on any single free-text field (tool args/result, answer). Tool
+   *  results keep their tail (error context); everything else keeps its head.
+   *  0/undefined disables truncation. */
+  maxFieldChars?: number;
+};
+
+/** One observer-hook event line. `type` is the discriminator; remaining fields
+ *  vary by type. Kept as an open record because HFR tolerates extra fields and
+ *  only normalizes the ones it recognizes. */
+export type HfrObserverEvent = {
+  type:
+    | "session"
+    | "user_message"
+    | "pre_tool_call"
+    | "post_tool_call"
+    | "post_llm_call"
+    | "subagent_start"
+    | "subagent_stop"
+    | "final_answer";
+  session_id: string;
+  ts?: string;
+  [key: string]: unknown;
+};
+
+const DEFAULT_SOURCE_FORMAT = "coven.cave.v1";
+const DEFAULT_MAX_FIELD_CHARS = 8000;
+
+/** Truncate keeping the head (default) or the tail, with an elision marker that
+ *  records how many characters were dropped. */
+function clip(
+  value: string | undefined,
+  max: number,
+  keep: "head" | "tail" = "head",
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (max <= 0 || value.length <= max) return value;
+  const dropped = value.length - max;
+  const marker = `…[+${dropped} chars]`;
+  return keep === "tail"
+    ? `${marker}${value.slice(value.length - max)}`
+    : `${value.slice(0, max)}${marker}`;
+}
+
+/** Add `durationMs` to an ISO timestamp, returning a new ISO string. Falls back
+ *  to the start timestamp when either input is unusable (never throws — the
+ *  exporter must not fail a whole run over one malformed row). Deterministic:
+ *  no reliance on the current clock. */
+function addMillis(iso: string, durationMs?: number): string {
+  if (!durationMs || durationMs <= 0) return iso;
+  const base = Date.parse(iso);
+  if (Number.isNaN(base)) return iso;
+  return new Date(base + durationMs).toISOString();
+}
+
+/**
+ * Transform one Coven conversation into an ordered array of HFR observer-hook
+ * events. Order is chronological within the conversation: a session header,
+ * then per turn — user messages, each tool's pre/post pair, the LLM-call
+ * summary, and any subagent spans — closing with the final answer.
+ */
+export function conversationToHfrEvents(
+  conv: HfrConversationInput,
+  options: HfrExportOptions = {},
+): HfrObserverEvent[] {
+  const sourceFormat = options.sourceFormat ?? DEFAULT_SOURCE_FORMAT;
+  const max = options.maxFieldChars ?? DEFAULT_MAX_FIELD_CHARS;
+  const sessionId = conv.sessionId;
+  const events: HfrObserverEvent[] = [];
+
+  events.push({
+    type: "session",
+    session_id: sessionId,
+    source_format: sourceFormat,
+    familiar_id: conv.familiarId,
+    harness: conv.harness,
+    model: conv.model,
+    title: conv.title,
+    origin: conv.origin ?? "chat",
+    ts: conv.createdAt,
+  });
+
+  const links = (options.subagentLinks ?? []).filter(
+    (link) => link.parentSessionId === sessionId,
+  );
+
+  let lastAssistantText: { text: string; ts: string } | null = null;
+
+  for (const turn of conv.turns) {
+    if (turn.role === "user") {
+      events.push({
+        type: "user_message",
+        session_id: sessionId,
+        text: clip(turn.text, max),
+        ts: turn.createdAt,
+      });
+      continue;
+    }
+
+    if (turn.role !== "assistant") continue;
+
+    for (const tool of turn.tools ?? []) {
+      const startTs = turn.createdAt;
+      const endTs = addMillis(startTs, tool.durationMs);
+      events.push({
+        type: "pre_tool_call",
+        session_id: sessionId,
+        call_id: tool.id,
+        tool: tool.name,
+        args: clip(tool.input, max),
+        ts: startTs,
+      });
+      // A tool still "running" at persist time never settled — record it as an
+      // error so HFR's completion check treats it as unresolved, not success.
+      const isError = tool.status === "error" || tool.status === "running";
+      events.push({
+        type: "post_tool_call",
+        session_id: sessionId,
+        call_id: tool.id,
+        tool: tool.name,
+        result: clip(tool.output, max, "tail"),
+        is_error: isError,
+        status: tool.status,
+        duration_ms: tool.durationMs,
+        ts: endTs,
+      });
+    }
+
+    if (turn.usage || turn.costUsd !== undefined) {
+      events.push({
+        type: "post_llm_call",
+        session_id: sessionId,
+        model: conv.model,
+        usage: turn.usage
+          ? {
+              input_tokens: turn.usage.inputTokens,
+              output_tokens: turn.usage.outputTokens,
+              cache_read_tokens: turn.usage.cacheReadTokens,
+              cache_creation_tokens: turn.usage.cacheCreationTokens,
+            }
+          : undefined,
+        cost_usd: turn.costUsd,
+        duration_ms: turn.durationMs,
+        ts: addMillis(turn.createdAt, turn.durationMs),
+      });
+    }
+
+    // A cancelled/errored turn is not a valid final answer.
+    if (turn.text && !turn.cancelled && !turn.isError) {
+      lastAssistantText = { text: turn.text, ts: turn.createdAt };
+    }
+  }
+
+  for (const link of links) {
+    events.push({
+      type: "subagent_start",
+      session_id: sessionId,
+      child_session_id: link.childSessionId,
+      familiar_id: link.familiarId,
+      ts: link.startedAt,
+    });
+    events.push({
+      type: "subagent_stop",
+      session_id: sessionId,
+      child_session_id: link.childSessionId,
+      status: link.status,
+      ts: link.endedAt,
+    });
+  }
+
+  if (lastAssistantText) {
+    events.push({
+      type: "final_answer",
+      session_id: sessionId,
+      text: clip(lastAssistantText.text, max),
+      ts: lastAssistantText.ts,
+    });
+  }
+
+  return events;
+}
+
+/** Drop `undefined`-valued keys so emitted JSONL stays compact and stable
+ *  (JSON.stringify already omits them, but nested objects are normalized here
+ *  too for deterministic output). */
+function pruneUndefined(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(pruneUndefined);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v === undefined) continue;
+      out[k] = pruneUndefined(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Serialize observer events to newline-delimited JSON (one event per line,
+ *  trailing newline). This is the exact byte stream HFR ingests. */
+export function serializeHfrJsonl(events: HfrObserverEvent[]): string {
+  return events.map((ev) => JSON.stringify(pruneUndefined(ev))).join("\n") + "\n";
+}
+
+/** Convenience: conversation → JSONL string in one call. */
+export function conversationToHfrJsonl(
+  conv: HfrConversationInput,
+  options?: HfrExportOptions,
+): string {
+  return serializeHfrJsonl(conversationToHfrEvents(conv, options));
+}


### PR DESCRIPTION
## What

Adds a **Coven → Hermes Flight Recorder (HFR)** trace exporter so a familiar's run history can be evaluated in [hermes-flight-recorder](https://github.com/zwright8/hermes-flight-recorder). HFR ingests **observer-hook JSONL** and normalizes it to `hfr.trace.v1` before scoring against scenario contracts; this emits exactly that stream from a Cave conversation file.

## Why

The conversation file (`$COVEN_HOME/cave-conversations/<sessionId>.json`) is the richest self-contained record of what a familiar did — every tool call with input/output/status/duration, per-turn token usage + cost, and answers — so it maps onto HFR's event vocabulary without a live daemon.

## Event mapping

| HFR event | Coven source |
|-----------|--------------|
| `session` | conversation header (`familiar_id` = eval scope, `source_format`, harness, model) |
| `user_message` | user turn |
| `pre_tool_call` / `post_tool_call` | `turn.tools[]` (shared `call_id`; `is_error` for `error` **and** unresolved `running`) |
| `post_llm_call` | `turn.usage` / `turn.costUsd` (snake-cased) |
| `subagent_start` / `subagent_stop` | `--subagents` delegation edges |
| `final_answer` | last non-cancelled/non-error assistant turn |

## Shape

- `src/lib/hfr-trace-export.ts` — pure transform (no I/O), field names centralized for a single-file reconcile against HFR's schema
- `src/lib/hfr-trace-export.test.ts` — 14 unit tests, wired into the `app` suite
- `scripts/coven-hfr-export.ts` — thin CLI: `pnpm hfr:export [--familiar <id>] [--session <id>] [--subagents <path>] [--out <path>]`
- `docs/workflows/hfr-trace-export.md` — mapping + scope/follow-ups

## Verification

- `node --test src/lib/hfr-trace-export.test.ts` → 14/14 pass
- `pnpm typecheck` clean
- `pnpm check:tests-wired` → 717 wired
- `pnpm test:app` → 536 files pass
- End-to-end CLI smoke against a fixture conversation → valid observer-hook JSONL

## Scope / follow-ups (documented)

- Subagent edges are **fed** via `--subagents`, not derived — the `cave-coven-calls` ledger lacks a parent session id (follow-up).
- `results.tsv` (eval metrics) → HFR baseline-vs-candidate compare is a separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)