### PR TITLE
fix(mobile): keep native iOS Serve route tokenless

### DIFF
--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -10,6 +10,7 @@ TAILSCALE_TIMEOUT_MS="${TAILSCALE_TIMEOUT_MS:-8000}"
 PRINT_URL="${PRINT_URL:-0}"
 COPY_INVITE="${COPY_INVITE:-1}"
 USE_TMUX="${USE_TMUX:-1}"
+TAILSCALE_BIN="${TAILSCALE_BIN:-tailscale}"
 
 if [ -d "$HOME/.cargo/bin" ]; then
   PATH="$HOME/.cargo/bin:$PATH"
@@ -96,18 +97,18 @@ clear_mobile_tokens() {
 }
 
 tailscale_cmd() {
-  node - "$TAILSCALE_TIMEOUT_MS" "$@" <<'NODE'
+  node - "$TAILSCALE_TIMEOUT_MS" "$TAILSCALE_BIN" "$@" <<'NODE'
 const { spawnSync } = require("node:child_process");
 
-const [timeoutMsRaw, ...args] = process.argv.slice(2);
+const [timeoutMsRaw, bin, ...args] = process.argv.slice(2);
 const timeout = Number(timeoutMsRaw);
-const res = spawnSync("tailscale", args, {
+const res = spawnSync(bin, args, {
   stdio: "inherit",
   timeout: Number.isFinite(timeout) ? timeout : 8000,
 });
 
 if (res.error?.code === "ETIMEDOUT") {
-  console.error(`tailscale ${args.join(" ")} timed out`);
+  console.error(`${bin} ${args.join(" ")} timed out`);
   process.exit(124);
 }
 if (res.error) {
@@ -119,18 +120,18 @@ NODE
 }
 
 tailscale_capture() {
-  node - "$TAILSCALE_TIMEOUT_MS" "$@" <<'NODE'
+  node - "$TAILSCALE_TIMEOUT_MS" "$TAILSCALE_BIN" "$@" <<'NODE'
 const { spawnSync } = require("node:child_process");
 
-const [timeoutMsRaw, ...args] = process.argv.slice(2);
+const [timeoutMsRaw, bin, ...args] = process.argv.slice(2);
 const timeout = Number(timeoutMsRaw);
-const res = spawnSync("tailscale", args, {
+const res = spawnSync(bin, args, {
   encoding: "utf8",
   timeout: Number.isFinite(timeout) ? timeout : 8000,
 });
 
 if (res.error?.code === "ETIMEDOUT") {
-  console.error(`tailscale ${args.join(" ")} timed out`);
+  console.error(`${bin} ${args.join(" ")} timed out`);
   process.exit(124);
 }
 if (res.error) {
@@ -150,7 +151,7 @@ masked_serve_status() {
 }
 
 warn_if_serve_targets_other_backend() {
-  if ! command -v tailscale >/dev/null 2>&1; then
+  if ! command -v "$TAILSCALE_BIN" >/dev/null 2>&1; then
     return 0
   fi
 
@@ -208,7 +209,7 @@ load_or_create_sidecar_token() {
 
 ensure_tailscale() {
   need node
-  need tailscale
+  need "$TAILSCALE_BIN"
   if ! tailscale_cmd status --self >/dev/null 2>&1; then
     echo "tailscale is not connected or did not respond. Run: tailscale up" >&2
     exit 1
@@ -703,7 +704,7 @@ stop_command() {
     fi
   fi
 
-  if command -v tailscale >/dev/null 2>&1; then
+  if command -v "$TAILSCALE_BIN" >/dev/null 2>&1; then
     tailscale_cmd serve reset >/dev/null 2>&1 || true
   fi
   rm -f "$PID_FILE" "$INVITE_FILE" "$EXPIRES_FILE"

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -43,6 +43,15 @@ test("mobile tailscale app mode serves the native client with no token", () => {
   assert.match(script, /PORT="\$PORT"/);
 });
 
+test("mobile tailscale runner can use an explicit Tailscale binary", () => {
+  assert.match(script, /TAILSCALE_BIN="\$\{TAILSCALE_BIN:-tailscale\}"/);
+  assert.match(script, /node - "\$TAILSCALE_TIMEOUT_MS" "\$TAILSCALE_BIN" "\$@"/);
+  assert.match(script, /const \[timeoutMsRaw, bin, \.\.\.args\]/);
+  assert.match(script, /spawnSync\(bin, args/);
+  assert.match(script, /need "\$TAILSCALE_BIN"/);
+  assert.match(script, /command -v "\$TAILSCALE_BIN"/);
+});
+
 test("mobile tailscale app mode falls back to Tailscale IP HTTP when MagicDNS is missing", () => {
   assert.match(script, /tailscale_ip_host\(\)/);
   assert.match(script, /Array\.isArray\(rawIps\)/);

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -98,6 +98,34 @@ function backendUrl(req: Request) {
   return `http://127.0.0.1:${port}`;
 }
 
+function normalizeLoopbackBackend(value: string | null | undefined) {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:") return null;
+    if (!["127.0.0.1", "localhost", "::1"].includes(url.hostname)) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+function nativeAppBackendUrl(req: Request) {
+  const configured = normalizeLoopbackBackend(process.env.COVEN_CAVE_NATIVE_APP_BACKEND_URL);
+  if (configured) return configured;
+
+  // The packaged desktop app runs an authenticated sidecar on a random loopback
+  // port. The native SwiftUI iOS app is tokenless and trusts Tailscale instead,
+  // so publishing the packaged port makes the iPhone hit 401. In bundled mode,
+  // reconcile the native route against the tokenless app server started by
+  // `pnpm mobile:tailscale:app` instead of the packaged sidecar itself.
+  if (process.env.COVEN_CAVE_BUNDLE === "1" && process.env.COVEN_CAVE_TAILNET_TRUST !== "1") {
+    return "http://127.0.0.1:3000";
+  }
+
+  return backendUrl(req);
+}
+
 function backendPort(backend: string) {
   try {
     return new URL(backend).port || process.env.PORT || "3000";
@@ -106,7 +134,46 @@ function backendPort(backend: string) {
   }
 }
 
+async function verifyNativeAppBackend(req: Request, backend: string) {
+  if (backend === backendUrl(req)) return { ok: true as const };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1500);
+  try {
+    const res = await fetch(new URL("/api/familiars", backend), {
+      headers: { accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (res.ok) return { ok: true as const };
+    const authHint =
+      res.status === 401 || res.status === 403
+        ? " The backend is still token-gated; start the tokenless native app server with `pnpm mobile:tailscale:app`."
+        : "";
+    return {
+      ok: false as const,
+      error: `native app backend ${backend} returned HTTP ${res.status}.${authHint}`,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false as const,
+      error: `native app backend ${backend} is not ready. Run \`pnpm mobile:tailscale:app\` first. (${message})`,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function ensureNativeAppServe(req: Request) {
+  const backend = nativeAppBackendUrl(req);
+  const backendReady = await verifyNativeAppBackend(req, backend);
+  if (!backendReady.ok) {
+    return NextResponse.json(
+      { ok: false, error: backendReady.error, backendUrl: backend },
+      { status: 503 },
+    );
+  }
+
   const self = await runTailscale(["status", "--self", "--json"]);
   if (!self.ok) {
     return NextResponse.json(
@@ -117,7 +184,6 @@ async function ensureNativeAppServe(req: Request) {
 
   const parsedSelf = parseServeStatus(self.stdout);
   const selfStatus: unknown = "error" in parsedSelf ? null : parsedSelf.value;
-  const backend = backendUrl(req);
   const serve = await runTailscale(["serve", "--bg", backend]);
   const serveWarning = serve.ok
     ? null

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -48,6 +48,12 @@ assert.match(handoffRoute, /action === "app-stop"/, "API should expose a native 
 assert.match(handoffRoute, /nativeHost/, "API should return the exact host the native iOS app should connect to");
 assert.match(handoffRoute, /nativeUrl/, "API should return the full Tailscale Serve URL for smoke checks and copying");
 assert.match(handoffRoute, /ensureNativeAppServe/, "API should share one reconcile path for stale Tailscale Serve targets");
+assert.match(handoffRoute, /nativeAppBackendUrl/, "native mobile mode should choose a backend separately from invite handoff");
+assert.match(handoffRoute, /COVEN_CAVE_NATIVE_APP_BACKEND_URL/, "native mobile mode should allow an explicit loopback backend override");
+assert.match(handoffRoute, /COVEN_CAVE_BUNDLE === "1"[\s\S]*http:\/\/127\.0\.0\.1:3000/, "bundled desktop app must publish the tokenless native backend, not its authenticated sidecar port");
+assert.match(handoffRoute, /verifyNativeAppBackend/, "native mobile mode should verify the tokenless backend before publishing Serve");
+assert.match(handoffRoute, /\/api\/familiars/, "native backend readiness should use the same lightweight endpoint as the iOS connection probe");
+assert.match(handoffRoute, /pnpm mobile:tailscale:app/, "native backend readiness errors should point to the documented app-mode command");
 assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscale/, "API should give an actionable dev hint when the access token is missing");
 assert.match(settings, /MobileModeToggle/, "Settings should render a mobile mode toggle component");
 assert.match(settings, /mobileModeEnabled/, "Settings should receive the live mobile mode enabled state");


### PR DESCRIPTION
Supersedes #2396 for landing. The original external-author PR was reviewed, approved, and green, but branch protection still blocked merge because the required CodeQL status was expected/missing. This OpenCoven-owned branch carries the same reviewed four-file patch so the full required check set can run.

## Root cause
The desktop mobile-mode reconciler calls `/api/mobile-handoff` with `action: "app-start"`. In the packaged desktop app, that route derived the Tailscale Serve backend from the packaged app request port, so relaunching the desktop app republished an authenticated random sidecar port instead of the tokenless native iOS server on `127.0.0.1:3000`. The native SwiftUI iOS app sends no browser cookie/token by design, so it hit `401`.

The shell runner also always spawned `tailscale` from PATH, which can hit the broken macOS app shim instead of the working lowercase binary.

## Fix
- Make native app mobile-mode choose its backend separately from browser invite handoff.
- In bundled desktop mode, publish `http://127.0.0.1:3000` or `COVEN_CAVE_NATIVE_APP_BACKEND_URL` for native iOS instead of the packaged authenticated sidecar port.
- Verify the native backend with `/api/familiars` before changing Tailscale Serve, returning an actionable error if the tokenless app server is not running.
- Let `scripts/mobile-tailscale.sh` honor `TAILSCALE_BIN` for Tailscale commands.

## Verification
- `node --experimental-strip-types src/components/mobile-handoff.test.ts`
- `node scripts/mobile-tailscale.test.mjs`
- `node --experimental-strip-types src/lib/mobile-handoff.test.ts`
- `node scripts/mobile-tailscale-native.test.mjs`
- `bash -n scripts/mobile-tailscale.sh`
- `git diff --check origin/main...HEAD`
- `pnpm install --frozen-lockfile --offline`
- `pnpm typecheck`
