### PR TITLE
Fix HFR observer hook JSONL export

### DIFF
--- a/scripts/coven-hfr-export.test.mjs
+++ b/scripts/coven-hfr-export.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const dir = mkdtempSync(path.join(tmpdir(), "coven-hfr-export-"));
+
+function writeConversation(sessionId, familiarId, text) {
+  writeFileSync(
+    path.join(dir, `${sessionId}.json`),
+    JSON.stringify({
+      sessionId,
+      familiarId,
+      harness: "codex",
+      model: "gpt",
+      createdAt: "2026-07-04T10:00:00.000Z",
+      turns: [
+        {
+          id: `${sessionId}-assistant`,
+          role: "assistant",
+          text,
+          createdAt: "2026-07-04T10:00:01.000Z",
+        },
+      ],
+    }),
+  );
+}
+
+function run(args) {
+  return spawnSync(process.execPath, ["--experimental-strip-types", "scripts/coven-hfr-export.ts", ...args], {
+    cwd: new URL("..", import.meta.url),
+    encoding: "utf8",
+  });
+}
+
+try {
+  writeConversation("sess-a", "cody", "answer a");
+  writeConversation("sess-b", "cody", "answer b");
+
+  const ambiguous = run(["--dir", dir, "--familiar", "cody"]);
+  assert.notEqual(ambiguous.status, 0, "multi-conversation exports must fail");
+  assert.match(
+    ambiguous.stderr,
+    /matched 2 conversation\(s\).*Re-run with --session <id>/,
+    "error explains that HFR requires one trace per JSONL file",
+  );
+
+  const selected = run(["--dir", dir, "--session", "sess-a"]);
+  assert.equal(selected.status, 0, selected.stderr);
+  const lines = selected.stdout.trimEnd().split("\n").map((line) => JSON.parse(line));
+  assert.ok(lines.length >= 2);
+  assert.ok(lines.every((line) => line.session_id === "sess-a"));
+  assert.ok(lines.every((line) => typeof line.hook === "string"));
+  assert.ok(lines.every((line) => line.type === undefined));
+  assert.equal(lines.at(-1).hook, "post_llm_call");
+  assert.equal(lines.at(-1).assistant_response, "answer a");
+  assert.equal(lines.at(-1).output, "answer a");
+  assert.match(selected.stderr, /events from session sess-a/);
+} finally {
+  rmSync(dir, { force: true, recursive: true });
+}
+
+console.log("coven-hfr-export.test.mjs: ok");

--- a/scripts/coven-hfr-export.ts
+++ b/scripts/coven-hfr-export.ts
@@ -9,8 +9,8 @@
 // file is just the I/O shell — locate files, parse JSON defensively, write out.
 //
 // Usage:
-//   pnpm hfr:export                         # all conversations → stdout
-//   pnpm hfr:export --familiar cody         # only cody's runs
+//   pnpm hfr:export --session <id>          # selected conversation → stdout
+//   pnpm hfr:export --familiar cody         # cody's run, if it selects one
 //   pnpm hfr:export --session <id> --out trace.jsonl
 //   pnpm hfr:export --subagents links.json  # splice in delegation edges
 //
@@ -104,7 +104,7 @@ const HELP = `coven-hfr-export — export Coven familiar runs as HFR observer-ho
 
   --dir <path>            conversations dir (default $COVEN_HOME/cave-conversations)
   --session <id>          export a single conversation by id
-  --familiar <id>         only conversations for this familiar
+  --familiar <id>         only conversations for this familiar; must select one
   --subagents <path>      JSON array of {parentSessionId, childSessionId, ...}
   --out <path>            write JSONL here (default stdout)
   --source-format <str>   override the session event's source_format
@@ -166,32 +166,47 @@ function main(): void {
 
   const subagentLinks = opts.subagents ? readSubagentLinks(opts.subagents) : [];
 
-  const events: HfrObserverEvent[] = [];
-  let exported = 0;
+  const matches: Array<{ conv: HfrConversationInput; events: HfrObserverEvent[] }> = [];
   for (const file of files) {
     const conv = readConversation(file);
     if (!conv) continue;
     if (opts.session && conv.sessionId !== opts.session) continue;
     if (opts.familiar && conv.familiarId !== opts.familiar) continue;
-    events.push(
-      ...conversationToHfrEvents(conv, {
+    matches.push({
+      conv,
+      events: conversationToHfrEvents(conv, {
         subagentLinks,
         sourceFormat: opts.sourceFormat ?? undefined,
         maxFieldChars: opts.maxFieldChars ?? undefined,
       }),
-    );
-    exported += 1;
+    });
   }
 
+  if (matches.length !== 1) {
+    const filter = opts.session
+      ? `session ${opts.session}`
+      : opts.familiar
+        ? `familiar ${opts.familiar}`
+        : "all conversations";
+    const ids = matches.map(({ conv }) => conv.sessionId).slice(0, 10).join(", ");
+    const suffix = matches.length > 10 ? ", ..." : "";
+    process.stderr.write(
+      `error: ${filter} matched ${matches.length} conversation(s); HFR ingests one JSONL file as one trace. Re-run with --session <id>.${ids ? ` Matched: ${ids}${suffix}.` : ""}\n`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const [{ conv, events }] = matches;
   const jsonl = serializeHfrJsonl(events);
   if (opts.out) {
     writeFileSync(opts.out, jsonl);
     process.stderr.write(
-      `wrote ${events.length} events from ${exported} conversation(s) → ${opts.out}\n`,
+      `wrote ${events.length} events from session ${conv.sessionId} → ${opts.out}\n`,
     );
   } else {
     process.stdout.write(jsonl);
-    process.stderr.write(`# ${events.length} events from ${exported} conversation(s)\n`);
+    process.stderr.write(`# ${events.length} events from session ${conv.sessionId}\n`);
   }
 }
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -42,6 +42,7 @@ export const SUITES = {
     "src/lib/workflow-run-prompt.test.ts",
     "src/lib/workflow-step-progress.test.ts",
     "src/lib/hfr-trace-export.test.ts",
+    "scripts/coven-hfr-export.test.mjs",
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/cave-projects.test.ts",

--- a/src/lib/hfr-trace-export.test.ts
+++ b/src/lib/hfr-trace-export.test.ts
@@ -24,19 +24,20 @@ function baseConversation(
   };
 }
 
-function byType(events: HfrObserverEvent[], type: string): HfrObserverEvent[] {
-  return events.filter((e) => e.type === type);
+function byHook(events: HfrObserverEvent[], hook: string): HfrObserverEvent[] {
+  return events.filter((e) => e.hook === hook);
 }
 
 test("emits a session header with source_format and familiar scope", () => {
   const events = conversationToHfrEvents(baseConversation());
   const [head] = events;
-  assert.equal(head.type, "session");
+  assert.equal(head.hook, "session");
   assert.equal(head.session_id, "sess-1");
   assert.equal(head.familiar_id, "cody");
   assert.equal(head.harness, "claude");
   assert.equal(head.source_format, "coven.cave.v1");
   assert.equal(head.ts, "2026-07-04T10:00:00.000Z");
+  assert.equal(head.timestamp, "2026-07-04T10:00:00.000Z");
 });
 
 test("source_format is overridable", () => {
@@ -70,15 +71,18 @@ test("a tool call becomes a pre/post pair with a shared call_id", () => {
       ],
     }),
   );
-  const pre = byType(events, "pre_tool_call");
-  const post = byType(events, "post_tool_call");
+  const pre = byHook(events, "pre_tool_call");
+  const post = byHook(events, "post_tool_call");
   assert.equal(pre.length, 1);
   assert.equal(post.length, 1);
-  assert.equal(pre[0].call_id, "call-abc");
-  assert.equal(post[0].call_id, "call-abc");
-  assert.equal(pre[0].tool, "Bash");
+  assert.equal(pre[0].tool_call_id, "call-abc");
+  assert.equal(post[0].tool_call_id, "call-abc");
+  assert.equal(pre[0].tool_name, "Bash");
   assert.equal(pre[0].args, "ls");
+  assert.equal(pre[0].tool_input, "ls");
+  assert.equal(post[0].tool_name, "Bash");
   assert.equal(post[0].result, "file.txt");
+  assert.equal(post[0].tool_output, "file.txt");
   assert.equal(post[0].is_error, false);
   assert.equal(post[0].duration_ms, 200);
   // post ts = pre ts + durationMs
@@ -104,7 +108,7 @@ test("error and still-running tools are marked is_error for the completion check
       ],
     }),
   );
-  const post = byType(events, "post_tool_call");
+  const post = byHook(events, "post_tool_call");
   assert.deepEqual(
     post.map((p) => p.is_error),
     [true, true, false],
@@ -131,7 +135,7 @@ test("post_llm_call carries snake_cased usage and cost", () => {
       ],
     }),
   );
-  const [llm] = byType(events, "post_llm_call");
+  const [llm] = byHook(events, "post_llm_call");
   assert.ok(llm);
   // Raw events keep undefined-valued keys; the shipped JSONL prunes them, so
   // assert against the serialized form that HFR actually ingests.
@@ -141,11 +145,13 @@ test("post_llm_call carries snake_cased usage and cost", () => {
     output_tokens: 20,
     cache_read_tokens: 5,
   });
+  assert.equal(shipped.assistant_response, "hi");
+  assert.equal(shipped.output, "hi");
   assert.equal(shipped.cost_usd, 0.0012);
   assert.equal(shipped.ts, "2026-07-04T10:00:02.000Z");
 });
 
-test("no usage and no cost means no post_llm_call event", () => {
+test("valid assistant text emits post_llm_call even without usage or cost", () => {
   const events = conversationToHfrEvents(
     baseConversation({
       turns: [
@@ -158,10 +164,12 @@ test("no usage and no cost means no post_llm_call event", () => {
       ],
     }),
   );
-  assert.equal(byType(events, "post_llm_call").length, 0);
+  const [llm] = byHook(events, "post_llm_call");
+  assert.equal(llm.assistant_response, "hi");
+  assert.equal(llm.output, "hi");
 });
 
-test("final_answer is the last non-cancelled, non-error assistant turn", () => {
+test("final answer text lives on the last valid post_llm_call hook", () => {
   const events = conversationToHfrEvents(
     baseConversation({
       turns: [
@@ -187,14 +195,14 @@ test("final_answer is the last non-cancelled, non-error assistant turn", () => {
       ],
     }),
   );
-  const finals = byType(events, "final_answer");
-  assert.equal(finals.length, 1);
-  assert.equal(finals[0].text, "final");
-  // final_answer is always last.
-  assert.equal(events[events.length - 1].type, "final_answer");
+  const llms = byHook(events, "post_llm_call");
+  assert.equal(llms.length, 2);
+  assert.equal(llms[0].assistant_response, "first");
+  assert.equal(llms[1].assistant_response, "final");
+  assert.equal(events.some((event) => String(event.hook) === "final_answer"), false);
 });
 
-test("a cancelled-only conversation has no final_answer", () => {
+test("a cancelled-only conversation has no assistant_response output", () => {
   const events = conversationToHfrEvents(
     baseConversation({
       turns: [
@@ -208,7 +216,7 @@ test("a cancelled-only conversation has no final_answer", () => {
       ],
     }),
   );
-  assert.equal(byType(events, "final_answer").length, 0);
+  assert.equal(byHook(events, "post_llm_call").length, 0);
 });
 
 test("user turns become user_message events", () => {
@@ -224,7 +232,7 @@ test("user turns become user_message events", () => {
       ],
     }),
   );
-  const [msg] = byType(events, "user_message");
+  const [msg] = byHook(events, "user_message");
   assert.equal(msg.text, "please fix");
   assert.equal(msg.ts, "2026-07-04T10:00:00.500Z");
 });
@@ -248,8 +256,8 @@ test("only subagent links parented by this session are emitted", () => {
   const events = conversationToHfrEvents(baseConversation(), {
     subagentLinks: links,
   });
-  const starts = byType(events, "subagent_start");
-  const stops = byType(events, "subagent_stop");
+  const starts = byHook(events, "subagent_start");
+  const stops = byHook(events, "subagent_stop");
   assert.equal(starts.length, 1);
   assert.equal(stops.length, 1);
   assert.equal(starts[0].child_session_id, "child-a");
@@ -282,10 +290,12 @@ test("field truncation keeps head for args, tail for tool results", () => {
     }),
     { maxFieldChars: 10 },
   );
-  const [pre] = byType(events, "pre_tool_call");
-  const [post] = byType(events, "post_tool_call");
+  const [pre] = byHook(events, "pre_tool_call");
+  const [post] = byHook(events, "post_tool_call");
   assert.equal(pre.args, "aaaaaaaaaa…[+40 chars]");
+  assert.equal(pre.tool_input, "aaaaaaaaaa…[+40 chars]");
   assert.equal(post.result, "…[+40 chars]bbbbbbbbbb");
+  assert.equal(post.tool_output, "…[+40 chars]bbbbbbbbbb");
 });
 
 test("serializeHfrJsonl emits one compact JSON object per line, trailing newline", () => {
@@ -307,7 +317,8 @@ test("serializeHfrJsonl emits one compact JSON object per line, trailing newline
   assert.equal(lines.length, 2);
   for (const line of lines) {
     const parsed = JSON.parse(line);
-    assert.equal(typeof parsed.type, "string");
+    assert.equal(typeof parsed.hook, "string");
+    assert.equal(parsed.type, undefined);
     assert.equal(parsed.session_id, "sess-1");
     // undefined-valued keys are pruned, not serialized as null.
     assert.ok(!Object.values(parsed).includes(null));
@@ -329,7 +340,7 @@ test("malformed timestamps never throw and fall back to the start ts", () => {
       ],
     }),
   );
-  const [post] = byType(events, "post_tool_call");
+  const [post] = byHook(events, "post_tool_call");
   assert.equal(post.ts, "not-a-date");
 });
 

--- a/src/lib/hfr-trace-export.ts
+++ b/src/lib/hfr-trace-export.ts
@@ -4,8 +4,8 @@
 // traces as newline-delimited JSON ("observer-hook JSONL") and normalizes them
 // to its internal `hfr.trace.v1` schema before scoring runs against scenario
 // contracts. Its documented observer-hook event vocabulary is:
-//   session · pre_tool_call · post_tool_call · post_llm_call ·
-//   subagent_start · subagent_stop · final_answer
+//   session · user_message · pre_tool_call · post_tool_call · post_llm_call ·
+//   subagent_start · subagent_stop
 //
 // This module is the pure transform that turns a Coven Cave conversation file
 // (the richest self-contained record of what a familiar actually did — every
@@ -84,21 +84,22 @@ export type HfrExportOptions = {
   maxFieldChars?: number;
 };
 
-/** One observer-hook event line. `type` is the discriminator; remaining fields
- *  vary by type. Kept as an open record because HFR tolerates extra fields and
- *  only normalizes the ones it recognizes. */
+/** One observer-hook event line. `hook` is the discriminator HFR's observer
+ *  normalizer recognizes; remaining fields vary by hook. Kept as an open
+ *  record because HFR tolerates extra fields and only normalizes the ones it
+ *  recognizes. */
 export type HfrObserverEvent = {
-  type:
+  hook:
     | "session"
     | "user_message"
     | "pre_tool_call"
     | "post_tool_call"
     | "post_llm_call"
     | "subagent_start"
-    | "subagent_stop"
-    | "final_answer";
+    | "subagent_stop";
   session_id: string;
   ts?: string;
+  timestamp?: string;
   [key: string]: unknown;
 };
 
@@ -136,7 +137,7 @@ function addMillis(iso: string, durationMs?: number): string {
  * Transform one Coven conversation into an ordered array of HFR observer-hook
  * events. Order is chronological within the conversation: a session header,
  * then per turn — user messages, each tool's pre/post pair, the LLM-call
- * summary, and any subagent spans — closing with the final answer.
+ * summary, and any subagent spans.
  */
 export function conversationToHfrEvents(
   conv: HfrConversationInput,
@@ -148,7 +149,7 @@ export function conversationToHfrEvents(
   const events: HfrObserverEvent[] = [];
 
   events.push({
-    type: "session",
+    hook: "session",
     session_id: sessionId,
     source_format: sourceFormat,
     familiar_id: conv.familiarId,
@@ -157,21 +158,21 @@ export function conversationToHfrEvents(
     title: conv.title,
     origin: conv.origin ?? "chat",
     ts: conv.createdAt,
+    timestamp: conv.createdAt,
   });
 
   const links = (options.subagentLinks ?? []).filter(
     (link) => link.parentSessionId === sessionId,
   );
 
-  let lastAssistantText: { text: string; ts: string } | null = null;
-
   for (const turn of conv.turns) {
     if (turn.role === "user") {
       events.push({
-        type: "user_message",
+        hook: "user_message",
         session_id: sessionId,
         text: clip(turn.text, max),
         ts: turn.createdAt,
+        timestamp: turn.createdAt,
       });
       continue;
     }
@@ -182,34 +183,47 @@ export function conversationToHfrEvents(
       const startTs = turn.createdAt;
       const endTs = addMillis(startTs, tool.durationMs);
       events.push({
-        type: "pre_tool_call",
+        hook: "pre_tool_call",
         session_id: sessionId,
-        call_id: tool.id,
-        tool: tool.name,
+        tool_call_id: tool.id,
+        tool_name: tool.name,
+        tool_input: clip(tool.input, max),
         args: clip(tool.input, max),
         ts: startTs,
+        timestamp: startTs,
       });
       // A tool still "running" at persist time never settled — record it as an
       // error so HFR's completion check treats it as unresolved, not success.
       const isError = tool.status === "error" || tool.status === "running";
       events.push({
-        type: "post_tool_call",
+        hook: "post_tool_call",
         session_id: sessionId,
-        call_id: tool.id,
-        tool: tool.name,
+        tool_call_id: tool.id,
+        tool_name: tool.name,
+        tool_output: clip(tool.output, max, "tail"),
         result: clip(tool.output, max, "tail"),
         is_error: isError,
         status: tool.status,
         duration_ms: tool.durationMs,
         ts: endTs,
+        timestamp: endTs,
       });
     }
 
-    if (turn.usage || turn.costUsd !== undefined) {
+    // HFR derives `final_answer` from the LLM observer hook's
+    // assistant_response/output. Emit this hook even without usage/cost when
+    // the turn has a valid assistant response.
+    const assistantResponse = turn.text && !turn.cancelled && !turn.isError
+      ? clip(turn.text, max)
+      : undefined;
+    if (assistantResponse !== undefined || turn.usage || turn.costUsd !== undefined) {
+      const ts = addMillis(turn.createdAt, turn.durationMs);
       events.push({
-        type: "post_llm_call",
+        hook: "post_llm_call",
         session_id: sessionId,
         model: conv.model,
+        assistant_response: assistantResponse,
+        output: assistantResponse,
         usage: turn.usage
           ? {
               input_tokens: turn.usage.inputTokens,
@@ -220,39 +234,28 @@ export function conversationToHfrEvents(
           : undefined,
         cost_usd: turn.costUsd,
         duration_ms: turn.durationMs,
-        ts: addMillis(turn.createdAt, turn.durationMs),
+        ts,
+        timestamp: ts,
       });
-    }
-
-    // A cancelled/errored turn is not a valid final answer.
-    if (turn.text && !turn.cancelled && !turn.isError) {
-      lastAssistantText = { text: turn.text, ts: turn.createdAt };
     }
   }
 
   for (const link of links) {
     events.push({
-      type: "subagent_start",
+      hook: "subagent_start",
       session_id: sessionId,
       child_session_id: link.childSessionId,
       familiar_id: link.familiarId,
       ts: link.startedAt,
+      timestamp: link.startedAt,
     });
     events.push({
-      type: "subagent_stop",
+      hook: "subagent_stop",
       session_id: sessionId,
       child_session_id: link.childSessionId,
       status: link.status,
       ts: link.endedAt,
-    });
-  }
-
-  if (lastAssistantText) {
-    events.push({
-      type: "final_answer",
-      session_id: sessionId,
-      text: clip(lastAssistantText.text, max),
-      ts: lastAssistantText.ts,
+      timestamp: link.endedAt,
     });
   }
 


### PR DESCRIPTION
## Summary
- Emit HFR observer-hook rows using `hook` plus HFR-recognized tool/LLM fields.
- Carry assistant final-answer text on `post_llm_call` as `assistant_response` / `output`.
- Make the CLI reject ambiguous multi-conversation exports and add a CLI regression test.

## Test Plan
- `node --experimental-strip-types src/lib/hfr-trace-export.test.ts`
- `node scripts/coven-hfr-export.test.mjs`
- `git diff --check`
- `pnpm check:tests-wired`
- `./node_modules/.bin/tsc --noEmit -p .worktrees/hfr-observer-jsonl-fix/tsconfig.json`
- `pnpm test:app`