### PR TITLE
Standardize Marketplace grouped browse

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11185,6 +11185,83 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   line-height: 1.2;
   color: var(--text-muted);
 }
+.marketplace-browse-summary {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.marketplace-browse-summary__metrics {
+  display: flex;
+  max-width: 52%;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1;
+}
+.marketplace-browse-summary__metrics span {
+  min-height: 22px;
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--bg-panel) 76%, transparent);
+  padding: 5px 7px;
+  white-space: nowrap;
+}
+.marketplace-category-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.marketplace-category-group {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 9px;
+}
+.marketplace-category-group__head {
+  display: flex;
+  min-height: 34px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+  padding-bottom: 7px;
+}
+.marketplace-category-group__head h4 {
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.marketplace-category-group__head p {
+  margin: 2px 0 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.marketplace-category-grid {
+  display: grid;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+  gap: 9px;
+}
+.marketplace-card {
+  min-height: 178px;
+  min-width: 0;
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 86%, transparent);
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--bg-panel) 88%, transparent);
+  padding: 12px;
+}
 .marketplace-card__decision {
   display: flex;
   flex-wrap: wrap;
@@ -11208,6 +11285,39 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   font-weight: 650;
   line-height: 1;
   padding: 4px 7px;
+}
+.marketplace-card__meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+.marketplace-card__meta span,
+.marketplace-card__meta button {
+  display: inline-flex;
+  min-height: 20px;
+  max-width: 100%;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@container marketplace (min-width: 560px) {
+  .marketplace-category-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+@container marketplace (min-width: 1200px) {
+  .marketplace-category-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 .marketplace-detail__decision-grid {
   display: grid;
@@ -11248,6 +11358,14 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   text-transform: uppercase;
 }
 @media (max-width: 520px) {
+  .marketplace-browse-summary {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .marketplace-browse-summary__metrics {
+    max-width: 100%;
+    justify-content: flex-start;
+  }
   .marketplace-detail__decision-grid {
     grid-template-columns: 1fr;
   }

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -31,6 +31,7 @@ import {
   filterPlugins,
   sortPlugins,
   countByKind,
+  groupPluginsByCategory,
   resolveCollection,
   COLLECTIONS,
   type KindFilter,
@@ -363,6 +364,8 @@ export function MarketplaceViewSurface({
     });
     return sortPlugins(matched, sort);
   }, [plugins, query, category, kind, sort, collectionIds, activeCollection]);
+  const groupedFiltered = useMemo(() => groupPluginsByCategory(filtered), [filtered]);
+  const groupedKindCounts = useMemo(() => countByKind(filtered), [filtered]);
 
   const selectedPlugin = useMemo(() => plugins.find((p) => p.id === selected) ?? null, [plugins, selected]);
   const configuringPlugin = useMemo(() => plugins.find((p) => p.id === configuringId) ?? null, [plugins, configuringId]);
@@ -635,11 +638,11 @@ export function MarketplaceViewSurface({
               group, so the store stays aware of what your familiars already
               have. */}
           <aside
-            className="hidden w-56 shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] px-3 py-4 @min-[840px]/marketplace:block"
+            className="hidden w-60 shrink-0 overflow-y-auto border-r border-[var(--border-hairline)] px-3 py-4 @min-[840px]/marketplace:block"
             aria-label="Browse by category"
           >
             <p className="px-2 pb-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
-              Browse
+              Categories
             </p>
             <nav className="flex flex-col gap-0.5">
               {categories.map((cat) => {
@@ -708,6 +711,9 @@ export function MarketplaceViewSurface({
                   }`}
                 >
                   {cat}
+                  <span className="ml-2 text-[11px] opacity-70">
+                    {cat === "All" ? plugins.length : categoryCounts.get(cat) ?? 0}
+                  </span>
                 </button>
               ))}
             </div>
@@ -744,20 +750,31 @@ export function MarketplaceViewSurface({
                 </button>
               </div>
             ) : (
-              <div className="mb-3 flex items-baseline justify-between gap-3">
-                <h3 className="text-[13px] font-semibold text-[var(--text-primary)]">
-                  {query
-                    ? "Search results"
-                    : category === "All" && kind === "all"
-                      ? "All plugins"
-                      : category !== "All"
-                        ? category
-                        : KIND_TABS.find((k) => k.id === kind)?.label ?? "Plugins"}
-                </h3>
+              <div className="marketplace-browse-summary mb-4">
+                <div className="min-w-0">
+                  <h3 className="text-[13px] font-semibold text-[var(--text-primary)]">
+                    {query
+                      ? "Search results"
+                      : category === "All" && kind === "all"
+                        ? "All categories"
+                        : category !== "All"
+                          ? category
+                          : KIND_TABS.find((k) => k.id === kind)?.label ?? "Plugins"}
+                  </h3>
+                  <p className="mt-0.5 text-[12px] text-[var(--text-muted)]">
+                    {category === "All" && !query && kind === "all"
+                      ? "Grouped by category so every tool type uses the same scan pattern."
+                      : "Same card layout, filtered to the current result set."}
+                  </p>
+                </div>
                 {loaded ? (
-                  <span className="text-[12px] text-[var(--text-muted)] tabular-nums">
-                    {filtered.length} {filtered.length === 1 ? "result" : "results"}
-                  </span>
+                  <div className="marketplace-browse-summary__metrics" aria-label="Visible marketplace results">
+                    <span>{filtered.length} total</span>
+                    <span>{groupedFiltered.length} groups</span>
+                    <span>{groupedKindCounts.mcp} MCP</span>
+                    <span>{groupedKindCounts.api} API</span>
+                    <span>{groupedKindCounts.skill} skills</span>
+                  </div>
                 ) : null}
               </div>
             )}
@@ -771,17 +788,33 @@ export function MarketplaceViewSurface({
                 subtitle={query || category !== "All" || kind !== "all" || activeCollection ? "Try a different search, type, or category." : "The catalog is empty."}
               />
             ) : (
-              <div className="grid grid-cols-1 gap-3 @min-[560px]/marketplace:grid-cols-2 @min-[1200px]/marketplace:grid-cols-3">
-                {filtered.map((plugin) => (
-                  <MarketplaceCard
-                    key={plugin.id}
-                    plugin={plugin}
-                    busy={busyId === plugin.id}
-                    onOpen={setSelected}
-                    onAdd={add}
-                    onRemove={remove}
-                    onConfigure={setConfiguringId}
-                  />
+              <div className="marketplace-category-stack">
+                {groupedFiltered.map((group) => (
+                  <section key={group.category} className="marketplace-category-group" aria-labelledby={`marketplace-category-${group.category.replace(/\W+/g, "-").toLowerCase()}`}>
+                    <div className="marketplace-category-group__head">
+                      <div className="min-w-0">
+                        <h4 id={`marketplace-category-${group.category.replace(/\W+/g, "-").toLowerCase()}`}>
+                          {group.category}
+                        </h4>
+                        <p>
+                          {group.plugins.length} {group.plugins.length === 1 ? "tool" : "tools"} · {group.counts.mcp} MCP · {group.counts.api} API · {group.counts.skill} skills
+                        </p>
+                      </div>
+                    </div>
+                    <div className="marketplace-category-grid">
+                      {group.plugins.map((plugin) => (
+                        <MarketplaceCard
+                          key={plugin.id}
+                          plugin={plugin}
+                          busy={busyId === plugin.id}
+                          onOpen={setSelected}
+                          onAdd={add}
+                          onRemove={remove}
+                          onConfigure={setConfiguringId}
+                        />
+                      ))}
+                    </div>
+                  </section>
                 ))}
               </div>
             )}

--- a/src/components/marketplace/collection-strip.tsx
+++ b/src/components/marketplace/collection-strip.tsx
@@ -28,7 +28,7 @@ export function CollectionStrip({ collections, plugins, onOpen }: Props) {
   return (
     <div className="mb-5">
       <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--text-muted)]">
-        Featured collections
+        Recommended groups
       </p>
       {/* Container-query columns — track the marketplace pane, not the viewport. */}
       <div className="grid grid-cols-1 gap-3 @min-[560px]/marketplace:grid-cols-2 @min-[1100px]/marketplace:grid-cols-3">

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -82,7 +82,7 @@ export const MarketplaceCard = memo(function MarketplaceCard({
   const capability = capabilityPreview(plugin);
   const roleFit = roleFitLabel(plugin);
   return (
-    <div className="flex flex-col gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-4">
+    <div className="marketplace-card flex flex-col gap-3">
       <div className="flex items-start justify-between gap-3">
         <button
           type="button"
@@ -96,7 +96,9 @@ export const MarketplaceCard = memo(function MarketplaceCard({
             <span className="block truncate text-[14px] font-semibold text-[var(--text-primary)]">
               {plugin.displayName}
             </span>
-            <span className="block truncate text-[12px] text-[var(--text-muted)]">By {plugin.author}</span>
+            <span className="block truncate text-[12px] text-[var(--text-muted)]">
+              {kindLabel(plugin.kind)} · {plugin.author}
+            </span>
           </span>
         </button>
         {state === "needs-setup" ? (
@@ -132,26 +134,25 @@ export const MarketplaceCard = memo(function MarketplaceCard({
           <Icon name="ph:mask-happy" width={11} aria-hidden /> {roleFit}
         </span>
       </div>
-      <div className="flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-muted)]">
-        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5">
+      <div className="marketplace-card__meta">
+        <span>
           <Icon name={kindIcon(plugin.kind)} width={11} aria-hidden />{" "}
           {kindLabel(plugin.kind)}
         </span>
-        <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5">
+        <span>
           <Icon name="ph:seal-check" width={11} aria-hidden /> {TRUST_LABEL[plugin.trust] ?? plugin.trust}
         </span>
-        <span className="rounded-full border border-[var(--border-hairline)] px-2 py-0.5">{plugin.category}</span>
         {plugin.requiresSetup && plugin.configured ? (
           <button
             type="button"
             onClick={() => onConfigure(plugin.id)}
-            className="focus-ring inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+            className="focus-ring hover:text-[var(--text-primary)]"
           >
             <Icon name="ph:check-circle" width={11} aria-hidden /> Configured
           </button>
         ) : null}
         {state === "needs-setup" ? (
-          <span className="inline-flex items-center gap-1 rounded-full border border-[var(--border-hairline)] px-2 py-0.5 text-[var(--text-primary)]">
+          <span className="text-[var(--text-primary)]">
             <Icon name="ph:warning" width={11} aria-hidden /> Needs setup
           </span>
         ) : null}

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -119,6 +119,15 @@ assert.match(marketplaceView, /Your setup/, "the Browse rail carries a Your-setu
 assert.match(marketplaceView, /onClick=\{\(\) => selectSection\("roles"\)\}/, "the rail jumps to Roles");
 assert.match(marketplaceView, /onClick=\{\(\) => selectSection\("skills"\)\}/, "the rail jumps to Skills");
 assert.match(marketplaceView, /onClick=\{\(\) => selectSection\("capabilities"\)\}/, "the rail jumps to Capabilities");
+assert.match(marketplaceView, /groupPluginsByCategory/, "Browse derives standardized category groups from the visible plugin set");
+assert.match(marketplaceView, /className="marketplace-category-stack"/, "Browse renders a grouped category stack instead of one flat card grid");
+assert.match(marketplaceView, /className="marketplace-category-group"/, "each Marketplace category has a stable grouped section hook");
+assert.match(marketplaceView, /className="marketplace-category-grid"/, "each category group uses the same responsive card grid");
+assert.match(css, /\.marketplace-category-stack \{[\s\S]*?flex-direction: column/, "Marketplace category stack has stable vertical rhythm");
+assert.match(css, /\.marketplace-category-group__head \{[\s\S]*?border-bottom/, "Marketplace category groups use quiet structural dividers");
+assert.match(css, /\.marketplace-category-grid \{[\s\S]*?grid-template-columns/, "Marketplace category groups use a stable responsive grid");
+assert.match(css, /\.marketplace-browse-summary__metrics \{[\s\S]*?flex-wrap: wrap/, "Browse summary metrics wrap instead of overflowing");
+assert.match(css, /\.marketplace-card \{[\s\S]*?min-height:/, "Marketplace cards reserve stable height across categories");
 
 // Browse cards are decision cards: they expose setup effort, capability fit,
 // and role fit before someone opens the detail drawer.

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -9,6 +9,7 @@ import {
   filterPlugins,
   sortPlugins,
   countByKind,
+  groupPluginsByCategory,
   categoriesFrom,
   requiredConfigFromManifest,
   remoteUrlFromManifest,
@@ -187,6 +188,13 @@ assert.deepEqual(filterPlugins(merged, { ids: ["github"], kind: "skill" }).map((
 
 // --- countByKind ---
 assert.deepEqual(countByKind(merged), { api: 1, mcp: 2, skill: 1 });
+
+// --- groupPluginsByCategory ---
+const groups = groupPluginsByCategory(merged);
+assert.deepEqual(groups.map((g) => g.category), ["Developer Tools", "Other", "Web"]);
+assert.deepEqual(groups[0].plugins.map((p) => p.id), ["fetch", "github"]);
+assert.deepEqual(groups[0].counts, { api: 0, mcp: 2, skill: 0 });
+assert.deepEqual(groups.find((g) => g.category === "Web")?.counts, { api: 1, mcp: 0, skill: 0 });
 
 // --- sortPlugins (returns a new array, never mutates) ---
 const before = merged.map((p) => p.id);

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -278,6 +278,29 @@ export function countByKind(plugins: MarketplacePlugin[]): { api: number; mcp: n
   return { api, mcp, skill };
 }
 
+export type MarketplaceCategoryGroup = {
+  category: string;
+  plugins: MarketplacePlugin[];
+  counts: { api: number; mcp: number; skill: number };
+};
+
+export function groupPluginsByCategory(plugins: MarketplacePlugin[]): MarketplaceCategoryGroup[] {
+  const byCategory = new Map<string, MarketplacePlugin[]>();
+  for (const plugin of plugins) {
+    const list = byCategory.get(plugin.category) ?? [];
+    list.push(plugin);
+    byCategory.set(plugin.category, list);
+  }
+
+  return [...byCategory.entries()]
+    .map(([category, groupPlugins]) => ({
+      category,
+      plugins: groupPlugins,
+      counts: countByKind(groupPlugins),
+    }))
+    .sort((a, b) => b.plugins.length - a.plugins.length || a.category.localeCompare(b.category));
+}
+
 export type Collection = {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
- group Marketplace Browse results by category with count-backed category sections
- standardize card metadata so every category uses the same compact scan pattern
- rename featured collections to recommended groups and add responsive grouped layout CSS

## Verification
- node --experimental-strip-types src/lib/marketplace-catalog.test.ts
- node --experimental-strip-types src/components/roles-tools-navigation.test.ts
- git diff --check
- pnpm check:tests-wired (695 wired)
- pnpm typecheck
- pnpm test:app (516 files passed)
- Playwright rendered QA at http://127.0.0.1:3047: desktop 1440x960 and mobile 390x844; 111 cards / 18 groups; MCP filter 53 cards / 13 groups; no console errors/warnings; no horizontal overflow

Bead: cave-dgf