### PR TITLE
fix(home): close news carousel on hover

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -33,6 +33,7 @@ assert.match(view, /const \[mediaDismissed, setMediaDismissed\] = useState\(fals
 assert.match(view, /mediaCards\.length > 0 && !mediaDismissed/, "dismissing media leaves the chat digest row intact");
 assert.match(view, /aria-label="Close news carousel"/, "news carousel exposes an accessible close button");
 assert.match(view, /onClick=\{\(\) => setMediaDismissed\(true\)\}/, "close button hides the news carousel");
+assert.match(view, /onMouseEnter=\{\(\) => setMediaDismissed\(true\)\}/, "hovering the close affordance hides the news carousel");
 assert.match(view, /home-digest__media-close/, "close button has a stable styling hook");
 
 // ── Media cards support an image thumbnail (with icon fallback on error) ───────

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -91,6 +91,7 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
             className="home-digest__media-close"
             aria-label="Close news carousel"
             title="Close news carousel"
+            onMouseEnter={() => setMediaDismissed(true)}
             onClick={() => setMediaDismissed(true)}
           >
             <Icon name="ph:x-bold" width={11} aria-hidden />


### PR DESCRIPTION
## Summary
- dismiss the home page news carousel when the hover-close affordance is hovered
- keep the existing click close behavior for keyboard/touch activation

## Verification
- node --experimental-strip-types src/components/home-digest-carousel.test.ts
- git diff --check
- pnpm check:tests-wired
- tsc --noEmit
- rendered QA on http://127.0.0.1:3141/ with mocked RSS: parent hover exposed close affordance, hovering close removed .home-digest__media, console warnings/errors empty, horizontal overflow 0

Bead: cave-6hz