### PR TITLE
refactor(settings): flatten sidebar options

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -438,69 +438,6 @@ select {
   .settings-group--found > div:last-child { transition: none; }
 }
 
-/* Per-section overview header (SettingsOverview): accent mark + kicker + title +
-   description, with a short "what's in here" highlight strip. */
-.settings-overview {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-}
-.settings-overview__heading {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-.settings-overview__mark {
-  display: grid;
-  place-items: center;
-  height: 2.25rem;
-  width: 2.25rem;
-  flex-shrink: 0;
-  border-radius: 0.625rem;
-}
-.settings-overview__kicker {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-.settings-overview__title {
-  font-size: 18px;
-  font-weight: 600;
-  line-height: 1.2;
-  color: var(--text-primary);
-}
-.settings-overview__description {
-  margin-top: 0.125rem;
-  font-size: 12px;
-  color: var(--text-muted);
-}
-.settings-overview__strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.375rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.settings-overview__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  border: 1px solid var(--border-hairline);
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--bg-raised) 50%, transparent);
-  padding: 0.125rem 0.5rem;
-  font-size: 11px;
-  color: var(--text-secondary);
-}
-.settings-overview__chip-dot {
-  flex-shrink: 0;
-  color: var(--accent-presence);
-  opacity: 0.7;
-}
-
 /* Skip-to-content link: off-screen until it receives keyboard focus, then it
    slides into the top-left so the first Tab on any surface reaches it. */
 .skip-link {

--- a/src/components/chat-all-familiars-project-list.test.ts
+++ b/src/components/chat-all-familiars-project-list.test.ts
@@ -110,8 +110,8 @@ assert.match(
 );
 assert.match(
   workspace,
-  /addons\.github\s*\?[\s\S]{0,120}fetch\("\/api\/github\/tasks"/,
-  "Workspace should only poll GitHub task context when the GitHub addon is enabled",
+  /const githubTasksPromise = fetch\("\/api\/github\/tasks"/,
+  "Workspace polls GitHub task context because GitHub is visible by default",
 );
 
 console.log("chat-all-familiars-project-list.test.ts: ok");

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -136,10 +136,10 @@ assert.match(
   /name:\s*`Go to \$\{fm\.label\}`/,
   "each navigable surface renders a 'Go to <label>' row",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /fm\.id === "github"[\s\S]{0,80}?addons\?\.github === true/,
-  "surface rows respect the same add-on gating as the sidebar (GitHub)",
+  /addons\?\.github|addons\?\.browser|addons\?\.flow|addons\?\.groupchat|addons\?\.journal|addons\?: AddonsConfig/,
+  "surface rows are no longer hidden behind add-on config",
 );
 assert.match(
   source,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -11,7 +11,7 @@ import { fuzzyMatch, bestFuzzyScore } from "@/lib/fuzzy-match";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
-import { FOLDER_MODES, type FolderMode, type AddonsConfig } from "@/components/sidebar-minimal";
+import { FOLDER_MODES, type FolderMode } from "@/components/sidebar-minimal";
 import { useProjects } from "@/lib/use-projects";
 
 function shortProjectRoot(root: string): string {
@@ -113,8 +113,6 @@ type Props = {
   initialQuery?: string;
   onQueryChange?: (query: string) => void;
   onIntent: (intent: PaletteIntent) => void;
-  /** Add-on gating so palette navigation matches the sidebar's visible surfaces. */
-  addons?: AddonsConfig;
 };
 
 // One hit from the conversation content search (/api/chat/search).
@@ -240,7 +238,6 @@ export function CommandPalette({
   initialQuery = "",
   onQueryChange,
   onIntent,
-  addons,
 }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const { projects } = useProjects();
@@ -517,19 +514,12 @@ export function CommandPalette({
       ? [{ id: "create-task", kind: "create-task", title: trimmedTitle }]
       : [];
 
-    // "Go to <surface>" rows make ⌘K a launcher for the sidebar surfaces. Gated
-    // the same way the sidebar gates them, and hidden while typing a slash
-    // command or a familiar scope (where surface nav would be noise).
+    // "Go to <surface>" rows make ⌘K a launcher for the visible sidebar
+    // surfaces. Hidden while typing a slash command or a familiar scope (where
+    // surface nav would be noise).
     const surfaceRows: Row[] = (scoped || slashToken)
       ? []
-      : rank(FOLDER_MODES.filter((fm) => {
-          if (fm.id === "github") return addons?.github === true;
-          if (fm.id === "browser") return addons?.browser === true;
-          if (fm.id === "flow") return addons?.flow === true;
-          if (fm.id === "groupchat") return addons?.groupchat === true;
-          if (fm.id === "journal") return addons?.journal === true;
-          return true;
-        })
+      : rank(FOLDER_MODES
           // Fuzzy on the short label/id; substring-only on the long description
           // (subsequence-matching prose surfaces irrelevant items).
           .filter((fm) => !q || fz(fm.label) || fz(fm.id) || fm.description.toLowerCase().includes(q)),
@@ -626,7 +616,7 @@ export function CommandPalette({
       : [];
 
     return [...salemRows, ...localRows];
-  }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, contentHits, query, activeFamiliarId, projects, addons]);
+  }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, contentHits, query, activeFamiliarId, projects]);
 
   useEffect(() => {
     if (activeIdx >= rows.length) setActiveIdx(Math.max(0, rows.length - 1));

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -52,7 +52,7 @@ assert.doesNotMatch(
 // ── Sidebar: one Tools entry for the merged hub ──────────────────────────────
 assert.match(
   sidebar,
-  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", group: "tools", description: "Browse the store and manage your familiars' roles, skills, and capabilities" \},/,
+  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities" \},/,
   "Sidebar navigation should expose the merged Marketplace hub with a description covering both halves",
 );
 assert.doesNotMatch(

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -12,7 +12,7 @@ import {
 // ── settings-sections catalog (pure) ─────────────────────────────────────────
 
 test("every section has full overview metadata + a highlight strip", () => {
-  const ids = ["general", "daemon", "familiars", "addons", "mobile", "appearance", "about"];
+  const ids = ["general", "daemon", "familiars", "mobile", "appearance", "about"];
   assert.deepEqual(SECTIONS.map((s) => s.id), ids, "the section set matches the shell nav");
   for (const s of SECTIONS) {
     assert.ok(s.label && s.icon.startsWith("ph:") && s.description.length > 0, `${s.id} has label/icon/description`);
@@ -56,9 +56,10 @@ test("the shell sources sections from settings-sections and renders the overview
   // The shared search index is sourced from settings-sections.
   assert.doesNotMatch(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/);
   // Each SettingsPage-based section opts into its overview header.
-  for (const id of ["general", "daemon", "addons", "mobile", "appearance", "about"]) {
+  for (const id of ["general", "daemon", "mobile", "appearance", "about"]) {
     assert.match(shell, new RegExp(`section="${id}"`), `${id} page passes its section`);
   }
+  assert.doesNotMatch(shell, /section="addons"|AddonsSection|Add-ons/, "Add-ons is not a settings section");
 });
 
 console.log("settings-overview.test.ts: ok");

--- a/src/components/settings-section-tabs.test.ts
+++ b/src/components/settings-section-tabs.test.ts
@@ -37,22 +37,19 @@ test("uses idOf to compare (so it works on derived DOM ids, not raw labels)", ()
   assert.equal(tabForScrollTarget(GROUPS, "Corners", slug), null); // raw label no longer matches
 });
 
-// Source guard: the long sections route through the shared tabbed wrapper so the
-// "minimize scrolling" behaviour can't silently regress to a flat scroll. Every
-// gated group label must also appear in its tab map (search/deep-link relies on
-// the labels matching the SettingsGroup labels).
+// Source guard: Settings now keeps all section options visible by default.
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 
-test("Appearance and Add-ons render through SettingsTabbed", () => {
-  assert.match(shell, /import \{ SettingsTabbed \} from "\.\/settings-section-tabs"/);
-  assert.match(shell, /tabs=\{APPEARANCE_TABS\}/, "Appearance uses the appearance tab set");
-  assert.match(shell, /tabs=\{ADDONS_TABS\}/, "Add-ons uses the add-ons tab set");
+test("Settings no longer hides Appearance or Add-ons groups behind tabs", () => {
+  assert.doesNotMatch(shell, /import \{ SettingsTabbed \} from "\.\/settings-section-tabs"/);
+  assert.doesNotMatch(shell, /tabs=\{APPEARANCE_TABS\}/, "Appearance groups are all visible by default");
+  assert.doesNotMatch(shell, /ADDONS_TABS|AddonsSection/, "Add-ons section is removed");
 });
 
 test("every tab-map group label still has a matching SettingsGroup in the shell", () => {
   const labels = [
     "Mode", "Theme", "Theme tokens", "Import from tweakcn",
-    "Familiar switcher", "Corners", "Sidebar surfaces", "Integrations",
+    "Familiar switcher", "Corners",
   ];
   for (const label of labels) {
     assert.match(shell, new RegExp(`<SettingsGroup label="${label}"`), `${label} group still rendered`);

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -7,7 +7,6 @@ export type Section =
   | "general"
   | "daemon"
   | "familiars"
-  | "addons"
   | "mobile"
   | "appearance"
   | "about";
@@ -20,7 +19,6 @@ export const SECTIONS: SectionMeta[] = [
   { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9a8ecd" },
   { id: "daemon", label: "Daemon", icon: "ph:terminal-window", description: "Local runtime status and process controls.", accent: "#69d6a6" },
   { id: "familiars", label: "Familiars", icon: "ph:users-three", description: "Roster, identity, permissions, and pin order.", accent: "#d8a9ff" },
-  { id: "addons", label: "Add-ons", icon: "ph:puzzle-piece", description: "Optional integrations and sidebar surfaces.", accent: "#7bb7ff" },
   { id: "mobile", label: "Phone", icon: "ph:device-mobile", description: "Native iOS handoff over your Tailscale network.", accent: "#73d9d0" },
   { id: "appearance", label: "Appearance", icon: "ph:paint-brush", description: "Theme, typography, and reading controls.", accent: "#ff9fb5" },
   { id: "about", label: "About", icon: "ph:info", description: "Version, updates, and project links.", accent: "#b8d8ff" },
@@ -30,7 +28,6 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
   general: ["Workspace path", "Launch behavior", "Default start view"],
   daemon: ["Runtime health", "Local/hub routing", "Socket & version"],
   familiars: ["Roster & identity", "Per-familiar permissions", "Pinned strip order"],
-  addons: ["Sidebar surfaces", "Integrations", "Hidden when disabled"],
   mobile: ["Mobile mode", "Tailscale handoff", "Native iOS guide"],
   appearance: ["Theme & colors", "Typography", "Reading comfort"],
   about: ["App version", "Tool updates", "Project links"],
@@ -43,7 +40,6 @@ export const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "daemon", group: "Connection", keywords: "daemon hub server executor private network tailscale remote multihost multi host" },
   { section: "daemon", group: "Info", keywords: "daemon info version socket pid api" },
   { section: "familiars", keywords: "familiars agents personas avatar name look permissions projects access grants allow deny tool policy guard security audit requests vault memory" },
-  { section: "addons", group: "Integrations", keywords: "add-ons addons integrations plugins github youtube sidebar surfaces code terminal browser flow roles journal coven group chat" },
   { section: "mobile", group: "Steps", keywords: "phone mobile connect qr pair tailscale" },
   { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
   { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -116,42 +116,15 @@ assert.match(
   "comingSoon rows get opacity-50",
 );
 
-// Add-on toggle must treat a non-ok response as a failure (fetch only throws on
-// network errors), revert, and surface the error — not silently stick.
-assert.match(
+assert.doesNotMatch(
   source,
-  /if \(!res\.ok\) throw new Error\(`save failed \(\$\{res\.status\}\)`\)/,
-  "add-on toggle checks res.ok so a 4xx/5xx is treated as a failed save",
+  /AddonsSection|ADDONS_TABS|settings-addon-switch|aria-label=\{`\$\{row\.label\} add-on`\}|Add-ons/,
+  "Settings should not render an Add-ons section or add-on switches",
 );
-assert.match(
-  source,
-  /setToggleError\("Couldn't save that change/,
-  "a failed add-on toggle surfaces an inline error",
-);
-assert.match(
-  source,
-  /aria-label=\{`\$\{row\.label\} add-on`\}/,
-  "each add-on switch should expose the add-on name to assistive tech",
-);
-assert.match(
-  source,
-  /className="settings-addon-switch/,
-  "add-on switches should use the dedicated touch-target class",
-);
-assert.match(
-  source,
-  /className="settings-addon-switch__track"/,
-  "add-on switches should keep a compact visual track inside the larger hit target",
-);
-assert.match(
+assert.doesNotMatch(
   dashboardCss,
-  /\.settings-addon-switch\s*\{[\s\S]*?min-width:\s*var\(--touch-target\)[\s\S]*?min-height:\s*var\(--touch-target\)/,
-  "add-on switch hit targets should meet the shared touch target without enlarging the track",
-);
-assert.match(
-  dashboardCss,
-  /\.settings-addon-switch__track\s*\{[\s\S]*?width:\s*36px[\s\S]*?height:\s*20px/,
-  "add-on switch visual track should remain compact inside the touch target",
+  /settings-addon-switch/,
+  "Settings stylesheet should not keep Add-ons switch chrome after the section is removed",
 );
 assert.match(
   dashboardCss,
@@ -223,10 +196,22 @@ assert.match(
   "Settings shell styles should live in an imported tracked stylesheet so the dev CSS bundle includes them reliably",
 );
 
+assert.doesNotMatch(
+  globals,
+  /\.settings-overview\s*\{/,
+  "globals.css should not override the Settings overview styles owned by dashboard.css",
+);
+
 assert.match(
   dashboardCss,
-  /\.settings-overview-strip\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/,
-  "Settings overview strip grid should live in the imported Settings stylesheet owner",
+  /\.settings-overview\s*\{[\s\S]*?display:\s*flex[\s\S]*?align-items:\s*center/,
+  "Settings overview headers should compact into a single row on desktop",
+);
+
+assert.match(
+  dashboardCss,
+  /\.settings-overview-strip\s*\{[\s\S]*?display:\s*flex/,
+  "Settings overview highlight chips should sit inline with the title row where space allows",
 );
 
 assert.match(
@@ -303,14 +288,14 @@ assert.match(
 
 assert.match(
   dashboardCss,
-  /\.settings-overview-strip[\s\S]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\)/,
-  "Settings overview should use a stable three-column summary strip on desktop",
+  /\.settings-overview\s*\{[\s\S]*?display:\s*flex[\s\S]*?align-items:\s*center/,
+  "Settings overview should use a single-row desktop header",
 );
 
 assert.match(
   dashboardCss,
-  /@media \(max-width: 767px\) \{[\s\S]*\.settings-overview-strip[\s\S]*grid-template-columns:\s*1fr/,
-  "Settings overview should collapse to one column on mobile",
+  /@media \(max-width: 767px\) \{[\s\S]*\.settings-overview\s*\{[\s\S]*display:\s*block[\s\S]*\.settings-overview-strip[\s\S]*flex-direction:\s*column/,
+  "Settings overview should stack on mobile",
 );
 
 // ── 2026-07-03 settings a11y batch ────────────────────────────────────────────

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -26,8 +26,6 @@ import { useIsMobile } from "@/lib/use-viewport";
 import { ThemeColorEditor } from "@/components/theme-color-editor";
 import { rgbaBytesToHex } from "@/lib/theme-token-hex";
 import { FontSettings } from "./settings-fonts";
-import { SettingsTabbed } from "./settings-section-tabs";
-import type { TabItem } from "@/components/ui/tabs";
 import { SettingsOverview } from "./settings-overview";
 import {
   SECTIONS,
@@ -329,9 +327,8 @@ export function SettingsShell() {
           {section === "general" && <GeneralSection />}
           {section === "daemon"   && <DaemonSection />}
           {section === "familiars" && <FamiliarsSection />}
-          {section === "addons"   && <AddonsSection scrollTarget={scrollTarget} />}
           {section === "mobile"   && <MobileSection />}
-          {section === "appearance" && <AppearanceSection scrollTarget={scrollTarget} />}
+          {section === "appearance" && <AppearanceSection />}
           {section === "about"    && <AboutSection />}
         </main>
       </div>
@@ -688,190 +685,6 @@ function DaemonSection() {
           <SettingsKV label="Workspace"     value={status.workspacePath ?? "—"} mono />
         </SettingsGroup>
       )}
-    </SettingsPage>
-  );
-}
-
-// ─── Section: Add-ons ─────────────────────────────────────────────────────────────
-
-type AddonKey =
-  | "github"
-  | "browser"
-  | "flow"
-  | "groupchat"
-  | "journal";
-
-const ADDON_ROWS: Array<{
-  key: AddonKey;
-  label: string;
-  icon: string;
-  group: "integrations" | "surfaces";
-  description: string;
-}> = [
-  // Integrations
-  {
-    key: "github",
-    label: "GitHub",
-    icon: "ph:github-logo",
-    group: "integrations",
-    description: "Browse open issues and pull requests, attach them to tasks, and hand off to a familiar.",
-  },
-  // Sidebar surfaces — off by default to keep Cave simple; turn on what you need.
-  {
-    key: "browser",
-    label: "Browser",
-    icon: "ph:globe",
-    group: "surfaces",
-    description: "A built-in web browser.",
-  },
-  {
-    key: "flow",
-    label: "Flow",
-    icon: "ph:flow-arrow",
-    group: "surfaces",
-    description: "Freeform automation editor — wire nodes on a canvas.",
-  },
-  {
-    key: "groupchat",
-    label: "Group chat",
-    icon: "ph:users-three",
-    group: "surfaces",
-    description: "Broadcast one prompt to a coven of familiars at once.",
-  },
-  {
-    key: "journal",
-    label: "Journal",
-    icon: "ph:book-open",
-    group: "surfaces",
-    description: "Your daily journal and generated sketches.",
-  },
-];
-
-const DEFAULT_ADDONS = Object.fromEntries(
-  ADDON_ROWS.map((r) => [r.key, false]),
-) as Record<AddonKey, boolean>;
-
-type AddonsTab = "surfaces" | "integrations";
-const ADDONS_TABS: ReadonlyArray<TabItem<AddonsTab>> = [
-  { id: "surfaces", label: "Surfaces" },
-  { id: "integrations", label: "Integrations" },
-];
-const ADDONS_TAB_GROUPS: Record<AddonsTab, readonly string[]> = {
-  surfaces: ["Sidebar surfaces"],
-  integrations: ["Integrations"],
-};
-
-function AddonsSection({ scrollTarget }: { scrollTarget?: string | null }) {
-  const [addons, setAddons] = useState<Record<AddonKey, boolean>>(DEFAULT_ADDONS);
-  const [loading, setLoading] = useState(true);
-  const [toggleError, setToggleError] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch("/api/config", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j: { ok?: boolean; config?: { addons?: Partial<Record<AddonKey, boolean>> } }) => {
-        if (j.ok && j.config?.addons) {
-          const cfg = j.config.addons;
-          setAddons(
-            Object.fromEntries(
-              ADDON_ROWS.map((r) => [r.key, cfg[r.key] ?? false]),
-            ) as Record<AddonKey, boolean>,
-          );
-        }
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, []);
-
-  const toggle = async (key: AddonKey) => {
-    const newValue = !addons[key];
-    // Optimistic update
-    setAddons((prev) => ({ ...prev, [key]: newValue }));
-    setToggleError(null);
-    try {
-      const res = await fetch("/api/config", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ addons: { [key]: newValue } }),
-      });
-      // fetch only throws on network errors — a 4xx/5xx still "succeeds", so a
-      // failed save would otherwise leave the toggle stuck in the wrong state.
-      if (!res.ok) throw new Error(`save failed (${res.status})`);
-    } catch {
-      // Revert + surface the failure instead of silently flipping back.
-      setAddons((prev) => ({ ...prev, [key]: !newValue }));
-      setToggleError("Couldn't save that change — check the daemon and try again.");
-    }
-  };
-
-  const renderRow = (row: (typeof ADDON_ROWS)[number]) => (
-    <div key={row.key} className="flex items-center justify-between gap-4 px-4 py-3">
-      <div className="flex min-w-0 items-center gap-3">
-        <Icon
-          name={row.icon as Parameters<typeof Icon>[0]["name"]}
-          width={18}
-          className="shrink-0 text-[var(--text-muted)]"
-        />
-        <div className="min-w-0">
-          <p className="text-[13px] text-[var(--text-primary)]">{row.label}</p>
-          <p className="text-[11px] text-[var(--text-muted)]">{row.description}</p>
-        </div>
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={addons[row.key]}
-        aria-label={`${row.label} add-on`}
-        onClick={() => void toggle(row.key)}
-        className="settings-addon-switch focus-ring relative inline-flex shrink-0 cursor-pointer items-center justify-center"
-      >
-        <span
-          className="settings-addon-switch__track"
-          aria-hidden="true"
-        >
-          <span className="settings-addon-switch__thumb" />
-        </span>
-      </button>
-    </div>
-  );
-
-  const skeleton = (rows: number) => (
-    <div aria-hidden className="animate-pulse space-y-3 px-4 py-3">
-      {Array.from({ length: rows }).map((_, i) => (
-        <div key={i} className="flex items-center justify-between gap-4">
-          <span className="h-3 w-1/3 rounded bg-[var(--bg-hover)]" />
-          <span className="h-5 w-9 rounded-full bg-[var(--bg-hover)] opacity-70" />
-        </div>
-      ))}
-    </div>
-  );
-
-  return (
-    <SettingsPage section="addons" title="Add-ons" description="Optional surfaces and integrations. Anything disabled here is hidden from the sidebar — turn on what you need.">
-      {toggleError && (
-        <p role="alert" className="mb-2 px-1 text-[12px] text-[var(--color-danger)]">{toggleError}</p>
-      )}
-      <SettingsTabbed
-        ariaLabel="Add-on settings"
-        tabs={ADDONS_TABS}
-        groupsByTab={ADDONS_TAB_GROUPS}
-        scrollTarget={scrollTarget}
-      >
-        {(tab) => (
-          <>
-      {tab === "surfaces" && (
-      <SettingsGroup label="Sidebar surfaces">
-        {loading ? skeleton(4) : ADDON_ROWS.filter((r) => r.group === "surfaces").map(renderRow)}
-      </SettingsGroup>
-      )}
-      {tab === "integrations" && (
-      <SettingsGroup label="Integrations">
-        {loading ? skeleton(2) : ADDON_ROWS.filter((r) => r.group === "integrations").map(renderRow)}
-      </SettingsGroup>
-      )}
-          </>
-        )}
-      </SettingsTabbed>
     </SettingsPage>
   );
 }
@@ -1329,25 +1142,7 @@ function ThemeTokenOverrides({
 
 // ─── Section: Appearance ───────────────────────────────────────────────────────────────────────
 
-// Appearance stacks 7 groups — tab them so the common controls don't require a
-// long scroll. Labels in APPEARANCE_TAB_GROUPS must match each SettingsGroup
-// label so search/deep-link can switch to the right tab. Module-level (stable
-// ref) so the tab effect doesn't re-run every render.
-type AppearanceTab = "theme" | "colors" | "text" | "interface";
-const APPEARANCE_TABS: ReadonlyArray<TabItem<AppearanceTab>> = [
-  { id: "theme", label: "Theme" },
-  { id: "colors", label: "Colors" },
-  { id: "text", label: "Text" },
-  { id: "interface", label: "Interface" },
-];
-const APPEARANCE_TAB_GROUPS: Record<AppearanceTab, readonly string[]> = {
-  theme: ["Mode", "Theme", "Import from tweakcn"],
-  colors: ["Theme tokens"],
-  text: ["Reading text"],
-  interface: ["Familiar switcher", "Corners"],
-};
-
-function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
+function AppearanceSection() {
   const [activeTheme, setActiveTheme] = useState<ActiveTheme>("coven");
   const [mode, setMode] = useState<ModePref>("dark");
   const [customData, setCustomData] = useState<CustomThemeData | null>(null);
@@ -1527,25 +1322,14 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
 
   return (
     <SettingsPage section="appearance" title="Appearance" description="Colors and visual style.">
-      <SettingsTabbed
-        ariaLabel="Appearance settings"
-        tabs={APPEARANCE_TABS}
-        groupsByTab={APPEARANCE_TAB_GROUPS}
-        scrollTarget={scrollTarget}
-      >
-        {(tab) => (
-          <>
       {/* ── Mode toggle ── */}
-      {tab === "theme" && (
       <SettingsGroup label="Mode">
         <div className="px-4 py-3">
           <ModeToggle value={mode} onChange={handleSetMode} />
         </div>
       </SettingsGroup>
-      )}
 
       {/* ── Preset themes ── */}
-      {tab === "theme" && (
       <SettingsGroup label="Theme">
         {/* Custom theme chip */}
         {activeTheme === "custom" && customData && (
@@ -1617,10 +1401,8 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
           </div>
         )}
       </SettingsGroup>
-      )}
 
       {/* ── Per-token overrides + manual resync ── */}
-      {tab === "colors" && (
       <SettingsGroup label="Theme tokens">
         <ThemeTokenOverrides
           mode={resolveMode(mode)}
@@ -1646,10 +1428,8 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
           </span>
         </div>
       </SettingsGroup>
-      )}
 
       {/* ── tweakcn import ── */}
-      {tab === "theme" && (
       <SettingsGroup label="Import from tweakcn">
         <div className="flex flex-col gap-2 px-4 py-3">
           <p className="text-[12px] text-[var(--text-muted)]">
@@ -1708,13 +1488,11 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
           )}
         </div>
       </SettingsGroup>
-      )}
 
-      {tab === "text" && <FontSettings />}
+      <FontSettings />
 
       {/* ── Familiar switcher ── choose the top-bar familiar control: a row of
           quick-switch avatars, or just the switcher dropdown. */}
-      {tab === "interface" && (
       <SettingsGroup label="Familiar switcher">
         <SettingControlRow
           label="Top-bar style"
@@ -1761,11 +1539,9 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
           </>
         ) : null}
       </SettingsGroup>
-      )}
 
       {/* ── Corner radius ── a minor shape tweak (drives the shared --radius
           tokens), kept last so the primary color/theme and text controls lead. */}
-      {tab === "interface" && (
       <SettingsGroup label="Corners">
         <SettingControlRow
           label="Corner radius"
@@ -1780,10 +1556,6 @@ function AppearanceSection({ scrollTarget }: { scrollTarget?: string | null }) {
           />
         </SettingControlRow>
       </SettingsGroup>
-      )}
-          </>
-        )}
-      </SettingsTabbed>
     </SettingsPage>
   );
 }

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -48,14 +48,14 @@ assert.match(
   "Sidebar should keep the main navigation in one continuous scrollable rail",
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
-  /fm\.group === "work"/,
-  'Sidebar Work section must filter on group === "work"',
+  /function SidebarSection|<SidebarSection|sidebar-section-label|fm\.group === "work"|fm\.group === "tools"/,
+  "Left sidepanel should render one flat list without collapsible Work/Tools sections",
 );
 
 // The standalone Knowledge section is gone; Library is now isolated on its
-// feature branch, so the integrated sidebar renders just Work and Tools.
+// feature branch, so the integrated sidebar renders one flat app list.
 assert.doesNotMatch(
   source,
   /"knowledge"/,
@@ -64,8 +64,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /fm\.group === "tools"/,
-  'Sidebar Tools section must filter on group === "tools"',
+  /FOLDER_MODES\.map\(\(fm\) =>/,
+  "Sidebar should render every folder mode directly",
 );
 
 assert.match(
@@ -103,14 +103,14 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description:/,
-  "The Chat surface should live at the ⌘2 Work shortcut",
+  /\{ id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description:/,
+  "The Chat surface should keep the ⌘2 shortcut",
 );
 
 assert.match(
   source,
-  /\{ id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description:/,
-  "the Tasks surface (mode id 'board') sits on the ⌘3 Work shortcut",
+  /\{ id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description:/,
+  "the Tasks surface (mode id 'board') sits on the ⌘3 shortcut",
 );
 
 assert.doesNotMatch(
@@ -121,7 +121,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "inbox", label: "Schedules", iconName: "ph:calendar-check", group: "work", kbd: "⌘4", description:/,
+  /\{ id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description:/,
   "Schedules should own the old Calendar shortcut as the active schedule surface",
 );
 
@@ -147,7 +147,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘5", description:/,
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description:/,
   "Browser is the first Tools surface after Schedules, on ⌘5",
 );
 
@@ -155,7 +155,7 @@ assert.doesNotMatch(source, /id:\s*"terminal"/, "Terminal is not a standalone si
 
 assert.match(
   source,
-  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", group: "tools", description:/,
+  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description:/,
   "The merged Marketplace hub should appear as a Tools surface",
 );
 
@@ -173,7 +173,7 @@ assert.doesNotMatch(
 
 assert.doesNotMatch(
   source,
-  /\{ id: "flow", label: "Flow", iconName: "ph:flow-arrow", group: "tools", description:/,
+  /\{ id: "flow", label: "Flow", iconName: "ph:flow-arrow", description:/,
   "Flow should not appear as a top-level Tools surface on the active branch",
 );
 
@@ -237,23 +237,35 @@ assert.doesNotMatch(
   "footer should not render an unread reminders badge",
 );
 
-// Tools-group entries include browser and marketplace.
+// Default visible entries include browser and marketplace.
 // (Capabilities moved to a tab on the Roles page — no standalone entry.)
 assert.match(
   source,
-  /id:\s*"browser"[^}]*group:\s*"tools"/,
-  "browser stays in Tools",
+  /id:\s*"browser"[^}]*label:\s*"Browser"/,
+  "browser stays visible",
 );
-assert.doesNotMatch(source, /id:\s*"terminal"[^}]*group:\s*"tools"/, "terminal does not stay in Tools");
+assert.doesNotMatch(source, /id:\s*"terminal"/, "terminal does not stay visible");
 assert.match(
   source,
-  /id:\s*"marketplace"[^}]*group:\s*"tools"/,
-  "marketplace stays in Tools",
+  /id:\s*"marketplace"[^}]*label:\s*"Marketplace"/,
+  "marketplace stays visible",
 );
 assert.doesNotMatch(
   source,
-  /id:\s*"flow"[^}]*group:\s*"tools"/,
+  /id:\s*"flow"[^}]*label:\s*"Flow"/,
   "flow does not stay in Tools",
+);
+
+assert.doesNotMatch(
+  source,
+  /addons\?\.github|addons\?\.browser|addons\?\.groupchat|addons\?\.journal|AddonsConfig|addons\?:/,
+  "Sidebar should not hide surfaces behind add-on config",
+);
+
+assert.match(
+  source,
+  /\{ id: "github", label: "GitHub", iconName: "ph:github-logo"/,
+  "GitHub is visible by default",
 );
 
 // Recent Activity items must navigate: RecentActivityRollup's onClick calls

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -5,9 +5,7 @@
  *
  * Layout (top to bottom):
  *   1. Familiar scope selector + New chat CTA
- *   2. App destinations grouped by purpose:
- *      Work  (Home / Chat / Tasks / Schedules)
- *      Tools (Browser / Marketplace / GitHub)
+ *   2. App destinations as one flat visible list
  *   3. Footer: Dashboard, Settings
  */
 
@@ -44,14 +42,6 @@ export type FolderMode =
   | "capabilities"
   | "journal";
 
-export type AddonsConfig = {
-  github?: boolean;
-  browser?: boolean;
-  flow?: boolean;
-  groupchat?: boolean;
-  journal?: boolean;
-};
-
 export type SidebarMinimalProps = {
   mode: string;
   sessions: SessionRow[];
@@ -60,7 +50,6 @@ export type SidebarMinimalProps = {
   onOpenSettings: () => void;
   onModeChange: (mode: string) => void;
   onOpenSession: (id: string) => void;
-  addons?: AddonsConfig;
   /* Notifications — when omitted, the bell is hidden. */
   inboxItems?: InboxItem[];
   inboxPrefs?: InboxPrefs;
@@ -89,79 +78,25 @@ const FOLDER_MODES: Array<{
   label: string;
   iconName: Parameters<typeof Icon>[0]["name"];
   badge?: (props: SidebarMinimalProps) => string | undefined;
-  group: "work" | "tools" | "addons";
   kbd?: string;
   // One-line hover/long-press help. Differentiates surfaces that read alike at
   // a glance.
   description: string;
 }> = [
-  // Work
-  { id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description: "Overview and quick actions" },
-  { id: "chat", label: "Chat", iconName: "ph:chats", group: "work", kbd: "⌘2", description: "Talk with your familiars" },
-  { id: "groupchat", label: "Group", iconName: "ph:users-three", group: "work", description: "Group chat — broadcast to a coven of familiars at once" },
-  { id: "board", label: "Tasks", iconName: "ph:kanban", group: "work", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
-  { id: "journal", label: "Journal", iconName: "ph:book-open", group: "work", description: "Your daily journal and generated sketches" },
-  { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", group: "work", kbd: "⌘4", description: "Calendar and crons in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
-  // Tools
-  { id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘5", description: "Built-in web browser" },
-  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", group: "tools", description: "Browse the store and manage your familiars' roles, skills, and capabilities" },
+  { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
+  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars" },
+  { id: "groupchat", label: "Group", iconName: "ph:users-three", description: "Group chat — broadcast to a coven of familiars at once" },
+  { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
+  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your daily journal and generated sketches" },
+  { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and crons in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
+  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser" },
+  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities" },
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.
-  // Add-ons (gated)
-  { id: "github", label: "GitHub", iconName: "ph:github-logo", group: "addons", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount) },
+  { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount) },
 ];
 
 export { FOLDER_MODES };
-
-function SidebarSection({
-  label,
-  className = "",
-  children,
-}: {
-  label?: string;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  const storageKey = label
-    ? `cave:sidebar:section:${label.toLowerCase().replace(/\s+/g, "-")}`
-    : null;
-  const [collapsed, setCollapsed] = React.useState(false);
-  // Hydrate the persisted collapse state after mount so the SSR markup (always
-  // expanded) matches the first client render, then reconcile from storage.
-  React.useEffect(() => {
-    if (!storageKey) return;
-    setCollapsed(localStorage.getItem(storageKey) === "1");
-  }, [storageKey]);
-  const toggle = React.useCallback(() => {
-    setCollapsed((v) => {
-      const next = !v;
-      if (storageKey) localStorage.setItem(storageKey, next ? "1" : "0");
-      return next;
-    });
-  }, [storageKey]);
-  return (
-    <div className={`sidebar-folders ${className}`.trim()}>
-      {label ? (
-        // The whole header is the hit target — clicking anywhere across its full
-        // height/width collapses or expands the section.
-        <button
-          type="button"
-          className="sidebar-section-label"
-          aria-expanded={!collapsed}
-          onClick={toggle}
-        >
-          <span className="sidebar-section-label__text">{label}</span>
-          <Icon
-            name="ph:caret-down-bold"
-            width={CAVE_ICON_SIZE.sidePanelChevron} height={CAVE_ICON_SIZE.sidePanelChevron}
-            className={`sidebar-section-label__chevron${collapsed ? " sidebar-section-label__chevron--collapsed" : ""}`}
-          />
-        </button>
-      ) : null}
-      {collapsed ? null : children}
-    </div>
-  );
-}
 
 
 function FolderRow({
@@ -235,11 +170,10 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     onModeChange,
     onOpenSession,
     activeSessionId,
-    addons,
   } = props;
 
-  // Arrow-key navigation across the nav rows (Work + Tools): one tab stop,
-  // Up/Down moves focus, Home/End jumps. Uses the shared roving-tabindex hook.
+  // Arrow-key navigation across the flat nav rows: one tab stop, Up/Down moves
+  // focus, Home/End jumps. Uses the shared roving-tabindex hook.
   const navScrollRef = React.useRef<HTMLDivElement | null>(null);
   useRovingTabIndex({ containerRef: navScrollRef, itemSelector: ".sidebar-folder-row", orientation: "vertical" });
 
@@ -248,20 +182,6 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
   const handleModeSelect = (id: FolderMode) => {
     onModeChange(id);
   };
-
-  // Gated surfaces are hidden from the nav until enabled in Settings → Add-ons
-  // (all default off). This keeps the default Cave to a simple core — Home, Chat,
-  // Board, Schedules — with everything else opt-in.
-  const visibleFolderModes = FOLDER_MODES.filter((fm) => {
-    if (fm.id === "github") return addons?.github === true;
-    if (fm.id === "browser") return addons?.browser === true;
-    if (fm.id === "groupchat") return addons?.groupchat === true;
-    if (fm.id === "journal") return addons?.journal === true;
-    return true;
-  });
-
-  const workModes = visibleFolderModes.filter((fm) => fm.group === "work");
-  const toolsModes = visibleFolderModes.filter((fm) => fm.group === "tools" || fm.group === "addons");
 
   return (
     <nav className="sidebar-minimal">
@@ -289,43 +209,21 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-nav-scroll" ref={navScrollRef}>
-        <SidebarSection label="Work">
-          {workModes.map((fm) => (
-            <FolderRow
-              key={fm.id}
-              id={fm.id}
-              label={fm.label}
-              iconName={fm.iconName}
-              active={mode === fm.id}
-              badge={fm.badge?.(props)}
-              kbd={fm.kbd}
-              description={fm.description}
-              onClick={() => handleModeSelect(fm.id)}
-            />
-          ))}
-        </SidebarSection>
-
-        {/* Hide the whole Tools section when every tool is gated off — an empty
-            labelled section reads as broken. */}
-        {toolsModes.length > 0 && (
-          <SidebarSection label="Tools">
-            {toolsModes.map((fm) => (
-              <FolderRow
-                key={fm.id}
-                id={fm.id}
-                label={fm.label}
-                iconName={fm.iconName}
-                // Roles and Capabilities are sections of the Marketplace hub,
-                // so keep the Marketplace entry lit when those modes are active.
-                active={mode === fm.id || (fm.id === "marketplace" && (mode === "roles" || mode === "capabilities"))}
-                badge={fm.badge?.(props)}
-                kbd={fm.kbd}
-                description={fm.description}
-                onClick={() => handleModeSelect(fm.id)}
-              />
-            ))}
-          </SidebarSection>
-        )}
+        {FOLDER_MODES.map((fm) => (
+          <FolderRow
+            key={fm.id}
+            id={fm.id}
+            label={fm.label}
+            iconName={fm.iconName}
+            // Roles and Capabilities are sections of the Marketplace hub, so keep
+            // the Marketplace entry lit when those modes are active.
+            active={mode === fm.id || (fm.id === "marketplace" && (mode === "roles" || mode === "capabilities"))}
+            badge={fm.badge?.(props)}
+            kbd={fm.kbd}
+            description={fm.description}
+            onClick={() => handleModeSelect(fm.id)}
+          />
+        ))}
 
         <RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
       </div>

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -76,15 +76,10 @@ assert.doesNotMatch(
   />Loading…</,
   "Settings integrations no longer shows a bare Loading… line",
 );
-assert.match(
+assert.doesNotMatch(
   settings,
-  /loading \? skeleton\(/,
-  "Settings add-ons shows skeleton rows while the config loads",
-);
-assert.match(
-  settings,
-  /const skeleton = [\s\S]{0,160}animate-pulse/,
-  "the add-ons skeleton helper renders animate-pulse placeholder rows",
+  /loading \? skeleton\(|const skeleton = [\s\S]{0,160}animate-pulse/,
+  "Settings no longer keeps Add-ons skeleton rows after removing the section",
 );
 
 const vault = read("./vault-panel.tsx");

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -157,14 +157,14 @@ assert.doesNotMatch(
 
 assert.match(
   sidebar,
-  /\{ id: "home", label: "Home", iconName: "ph:house-bold", group: "work", kbd: "⌘1", description:/,
+  /\{ id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description:/,
   "Sidebar Home keeps its shortcut hint",
 );
 
 assert.match(
   sidebar,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", group: "tools", kbd: "⌘5", description:/,
-  "Sidebar Browser is the first Tools shortcut, on ⌘5",
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description:/,
+  "Sidebar Browser keeps its shortcut hint",
 );
 
 assert.doesNotMatch(sidebar, /id:\s*"terminal"/, "Sidebar does not expose Terminal as a standalone destination");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -309,13 +309,6 @@ export function Workspace() {
   const [mobileModeEnabled, setMobileModeEnabledState] = useState(readMobileModeEnabled);
   const [mobileModeHost, setMobileModeHost] = useState<string | null>(null);
   const [mobileModeError, setMobileModeError] = useState<string | null>(null);
-  const [addons, setAddons] = useState<{
-    github?: boolean;
-    browser?: boolean;
-    flow?: boolean;
-    groupchat?: boolean;
-    journal?: boolean;
-  }>({});
   const responseNeededRef = useRef(responseNeeded);
   responseNeededRef.current = responseNeeded;
   // Deep-link target captured at mount, held until the async sessions fetch
@@ -522,15 +515,6 @@ export function Workspace() {
     return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
   }, []);
 
-  useEffect(() => {
-    fetch("/api/config", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j: { ok?: boolean; config?: { addons?: typeof addons } }) => {
-        if (j.ok && j.config?.addons) setAddons(j.config.addons);
-      })
-      .catch(() => {/* keep defaults */});
-  }, []);
-
   // Daemon status poll (previously lived on DaemonBar before chrome consolidation)
   // — pauses while the tab is hidden and refreshes on return (usePausablePoll).
   useEffect(() => {
@@ -609,11 +593,9 @@ export function Workspace() {
 
     const request = (async () => {
       let baseSessionsApplied = false;
-      const githubTasksPromise = addons.github
-        ? fetch("/api/github/tasks", { cache: "no-store" })
-            .then((res) => (res.ok ? res.json() : null))
-            .catch(() => null)
-        : Promise.resolve(null);
+      const githubTasksPromise = fetch("/api/github/tasks", { cache: "no-store" })
+        .then((res) => (res.ok ? res.json() : null))
+        .catch(() => null);
       try {
         // Scope the session list to the active familiar's granted projects so
         // every surface fed by `sessions` enforces the familiar→projects map.
@@ -652,7 +634,7 @@ export function Workspace() {
 
     loadSessionsInFlightRef.current = request;
     return request;
-  }, [addons.github, activeId]);
+  }, [activeId]);
 
   useEffect(() => {
     loadFamiliars();
@@ -1737,7 +1719,6 @@ export function Workspace() {
       mode={mode}
       sessions={sessions}
       activeSessionId={routerRef.current?.currentSessionId() ?? null}
-      addons={addons}
       onNewChat={() => {
         startFamiliarChat(activeId);
         shellRef.current?.dismissNavMobile();
@@ -2104,7 +2085,6 @@ export function Workspace() {
         initialQuery={topSearchQuery}
         onQueryChange={setTopSearchQuery}
         onIntent={onPaletteIntent}
-        addons={addons}
       />
 
       <ShortcutsSheet open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -204,6 +204,10 @@
 }
 
 .settings-overview {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
   margin-bottom: 24px;
   padding: 18px;
   border: 1px solid var(--border-hairline);
@@ -257,10 +261,12 @@
 }
 
 .settings-overview-strip {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  flex: 1 1 360px;
+  justify-content: flex-end;
   gap: 8px;
-  margin-top: 16px;
+  min-width: 0;
+  margin-top: 0;
 }
 
 .settings-overview-strip__item {
@@ -268,6 +274,7 @@
   align-items: center;
   gap: 7px;
   min-width: 0;
+  max-width: 190px;
   padding: 8px 10px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
@@ -304,42 +311,6 @@
   min-height: var(--touch-target);
 }
 
-.settings-addon-switch {
-  min-width: var(--touch-target);
-  min-height: var(--touch-target);
-}
-
-.settings-addon-switch__track {
-  position: relative;
-  display: inline-flex;
-  width: 36px;
-  height: 20px;
-  border-radius: 999px;
-  background: var(--bg-elevated);
-  transition: background var(--duration-fast) var(--ease-standard);
-}
-
-.settings-addon-switch[aria-checked="true"] .settings-addon-switch__track {
-  background: var(--accent-presence);
-}
-
-.settings-addon-switch__thumb {
-  position: absolute;
-  top: 2px;
-  left: 0;
-  width: 16px;
-  height: 16px;
-  border-radius: 999px;
-  background: #fff;
-  box-shadow: 0 1px 4px rgb(0 0 0 / 0.28);
-  transform: translateX(2px);
-  transition: transform var(--duration-fast) var(--ease-standard);
-}
-
-.settings-addon-switch[aria-checked="true"] .settings-addon-switch__thumb {
-  transform: translateX(18px);
-}
-
 @media (max-width: 767px) {
   .settings-shell__sidebar {
     width: 100%;
@@ -351,6 +322,7 @@
   }
 
   .settings-overview {
+    display: block;
     padding: 14px;
     border-radius: 14px;
   }
@@ -370,7 +342,8 @@
   }
 
   .settings-overview-strip {
-    grid-template-columns: 1fr;
+    flex-direction: column;
+    margin-top: 16px;
   }
 
   .settings-overview-strip__item span {


### PR DESCRIPTION
## Summary

Flatten the sidebar/settings navigation so all surfaces are visible by default and Add-ons gating is removed.

## Why

Val requested the left sidepanel sections removed, Add-ons removed, all options visible by default, and settings headers compacted into a single row where possible. Bead: cave-3dg.

## Changes

- Removed sidebar section grouping and add-on visibility gating.
- Removed the Settings Add-ons section from the nav/index and shell.
- Flattened Appearance settings so all groups are visible without tabs.
- Refactored the settings overview header to use a single desktop row and mobile stack.
- Updated source guards for sidebar, command palette, settings, and affected navigation behavior.

## Verification

- pnpm typecheck
- git diff --check
- node --experimental-strip-types src/components/sidebar-minimal.test.ts
- node --experimental-strip-types src/components/command-palette.test.ts
- node --experimental-strip-types src/components/settings-shell-polish.test.ts
- node --experimental-strip-types src/components/settings-section-tabs.test.ts
- node --experimental-strip-types src/components/settings-overview.test.ts
- node --experimental-strip-types src/components/surface-loading-states.test.ts
- node --experimental-strip-types src/components/chat-all-familiars-project-list.test.ts
- node --experimental-strip-types src/components/roles-tools-navigation.test.ts

Note: pnpm check:tests-wired is blocked locally by unrelated untracked src/app/dashboard-runtime-smoke.test.ts, which is not included in this PR.

## Risk + rollout notes

Narrow UI/navigation refactor. Main risk is stale code expecting Add-ons config to hide sidebar entries; tests now assert those entries are visible by default.