### PR TITLE
test(dashboard): add runtime smoke guard

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -134,6 +134,7 @@ export const SUITES = {
     "src/lib/dashboard-model.test.ts",
     "src/lib/dashboard-analytics.test.ts",
     "src/app/dashboard-page.test.ts",
+    "src/app/dashboard-runtime-smoke.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/dev-cache-reset-script.test.ts",
     "src/components/pwa-register.test.ts",

--- a/src/app/dashboard-runtime-smoke.test.ts
+++ b/src/app/dashboard-runtime-smoke.test.ts
@@ -1,0 +1,14 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const page = readFileSync(new URL("./dashboard/page.tsx", import.meta.url), "utf8");
+const inbox = readFileSync(new URL("../lib/cave-inbox.ts", import.meta.url), "utf8");
+
+assert.match(page, /export const dynamic = "force-dynamic"/, "dashboard is explicitly dynamic");
+assert.match(page, /await loadInbox\(\)/, "dashboard server render reads the inbox once");
+assert.match(inbox, /export async function loadInbox/, "loadInbox is the direct server read for dashboard data");
+assert.doesNotMatch(page, /startScheduler\(/, "dashboard render must not start long-lived schedulers");
+assert.doesNotMatch(page, /fetch\(/, "dashboard server render must not block on client data endpoints");
+
+console.log("dashboard-runtime-smoke.test.ts: ok");


### PR DESCRIPTION
## Summary
- add a source-level smoke guard for the /dashboard server render seam
- wire the guard into the app test manifest so check:tests-wired enforces it

## Test Plan
- node --experimental-strip-types src/app/dashboard-runtime-smoke.test.ts
- node --experimental-strip-types src/app/dashboard-page.test.ts
- node --experimental-strip-types src/lib/dashboard-analytics.test.ts
- pnpm check:tests-wired
- git diff --check

Bead: cave-89b