### PR TITLE
fix(mobile): trust sidecar port for handoff serve

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -99,8 +99,8 @@ function trustedBackendPort() {
 function rejectMismatchedHostPort(req: Request) {
   const url = new URL(req.url);
   const hostPort = url.port;
-  const backendPort = trustedBackendPort();
-  if (hostPort && hostPort !== backendPort) {
+  const expectedPort = trustedBackendPort();
+  if (hostPort && hostPort !== expectedPort) {
     return NextResponse.json(
       { ok: false, error: "request Host port does not match the Cave sidecar port" },
       { status: 400 },

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -93,7 +93,7 @@ function parseServeStatus(raw: string): { value: unknown } | { error: string } {
 }
 
 function trustedBackendPort() {
-  return process.env.PORT || "3000";
+  return (process.env.PORT || "3000").trim();
 }
 
 function rejectMismatchedHostPort(req: Request) {

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -92,10 +92,25 @@ function parseServeStatus(raw: string): { value: unknown } | { error: string } {
   }
 }
 
-function backendUrl(req: Request) {
+function trustedBackendPort() {
+  return process.env.PORT || "3000";
+}
+
+function rejectMismatchedHostPort(req: Request) {
   const url = new URL(req.url);
-  const port = url.port || process.env.PORT || "3000";
-  return `http://127.0.0.1:${port}`;
+  const hostPort = url.port;
+  const backendPort = trustedBackendPort();
+  if (hostPort && hostPort !== backendPort) {
+    return NextResponse.json(
+      { ok: false, error: "request Host port does not match the Cave sidecar port" },
+      { status: 400 },
+    );
+  }
+  return null;
+}
+
+function backendUrl() {
+  return `http://127.0.0.1:${trustedBackendPort()}`;
 }
 
 function normalizeLoopbackBackend(value: string | null | undefined) {
@@ -123,19 +138,19 @@ function nativeAppBackendUrl(req: Request) {
     return "http://127.0.0.1:3000";
   }
 
-  return backendUrl(req);
+  return backendUrl();
 }
 
 function backendPort(backend: string) {
   try {
-    return new URL(backend).port || process.env.PORT || "3000";
+    return new URL(backend).port || trustedBackendPort();
   } catch {
-    return process.env.PORT || "3000";
+    return trustedBackendPort();
   }
 }
 
 async function verifyNativeAppBackend(req: Request, backend: string) {
-  if (backend === backendUrl(req)) return { ok: true as const };
+  if (backend === backendUrl()) return { ok: true as const };
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 1500);
@@ -182,6 +197,9 @@ function mobileAccessUnavailableResponse() {
 }
 
 async function ensureNativeAppServe(req: Request) {
+  const hostPortRejection = rejectMismatchedHostPort(req);
+  if (hostPortRejection) return hostPortRejection;
+
   if (!mobileAccessSecret()) {
     return mobileAccessUnavailableResponse();
   }
@@ -272,6 +290,9 @@ async function ensureNativeAppServe(req: Request) {
 }
 
 async function mobileHandoff(req: Request) {
+  const hostPortRejection = rejectMismatchedHostPort(req);
+  if (hostPortRejection) return hostPortRejection;
+
   const accessSecret = mobileAccessSecret();
   if (!accessSecret) {
     return mobileAccessUnavailableResponse();
@@ -292,7 +313,7 @@ async function mobileHandoff(req: Request) {
   const parsedSelf = parseServeStatus(self.stdout);
   const selfStatus: unknown = "error" in parsedSelf ? null : parsedSelf.value;
 
-  const backend = backendUrl(req);
+  const backend = backendUrl();
 
   // Best-effort (re)start of Tailscale Serve. Don't hard-fail when this errors
   // — on macOS the CLI can return "GUI failed to start (CLIError 3)" even

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -54,6 +54,26 @@ assert.match(handoffRoute, /COVEN_CAVE_BUNDLE === "1"[\s\S]*http:\/\/127\.0\.0\.
 assert.match(handoffRoute, /verifyNativeAppBackend/, "native mobile mode should verify the tokenless backend before publishing Serve");
 assert.match(handoffRoute, /\/api\/familiars/, "native backend readiness should use the same lightweight endpoint as the iOS connection probe");
 assert.match(handoffRoute, /pnpm mobile:tailscale:app/, "native backend readiness errors should point to the documented app-mode command");
+assert.match(
+  handoffRoute,
+  /function trustedBackendPort\(\)[\s\S]*process\.env\.PORT \|\| "3000"/,
+  "API should derive the backend port from the trusted sidecar PORT instead of the request Host",
+);
+assert.match(
+  handoffRoute,
+  /function rejectMismatchedHostPort[\s\S]*hostPort && hostPort !== backendPort[\s\S]*status: 400/,
+  "API should reject request Host ports that do not match the trusted sidecar port",
+);
+assert.match(
+  handoffRoute,
+  /const backend = backendUrl\(\)/,
+  "API should build the backend URL without passing the request-derived URL into the backend target",
+);
+assert.doesNotMatch(
+  handoffRoute,
+  /const port = url\.port \|\| process\.env\.PORT/,
+  "API must not use the request URL Host port as the backend Serve target",
+);
 assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscale/, "API should give an actionable dev hint when the access token is missing");
 assert.match(
   handoffRoute,

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -61,7 +61,7 @@ assert.match(
 );
 assert.match(
   handoffRoute,
-  /function rejectMismatchedHostPort[\s\S]*hostPort && hostPort !== backendPort[\s\S]*status: 400/,
+  /function rejectMismatchedHostPort[\s\S]*hostPort && hostPort !== expectedPort[\s\S]*status: 400/,
   "API should reject request Host ports that do not match the trusted sidecar port",
 );
 assert.match(


### PR DESCRIPTION
### Motivation

- Prevent a request-controlled Host port from being used as the Tailscale Serve backend target, which could cause an authenticated mobile caller to make Tailscale Serve publish arbitrary localhost ports to the tailnet.

### Description

- Derive the backend listen port from the trusted sidecar/source `PORT` (`process.env.PORT` with a `"3000"` fallback) instead of using the request `Host`/URL port by introducing `trustedBackendPort()` and switching `backendUrl()`/`backendPort()` to use it (`src/app/api/mobile-handoff/route.ts`).
- Reject requests that include a Host port that does not match the trusted sidecar port early with `rejectMismatchedHostPort(req)` to avoid executing any `tailscale serve` calls with attacker-controlled ports (`src/app/api/mobile-handoff/route.ts`).
- Preserve the existing Tailscale Serve HTTP fallback behavior while ensuring `--http=` and advertised native URLs use the trusted backend port.
- Add source-level regression assertions to `src/components/mobile-handoff.test.ts` to prevent reintroducing Host-derived backend ports and to assert the presence of the new validation and trusted-port code paths.

### Testing

- Ran `pnpm test:mobile`, all mobile tests passed (68 test files) ✅.
- Ran `pnpm typecheck` (`tsc --noEmit`) with no type errors ✅.