### PR TITLE
fix(chat): scope agent attachments to granted roots

### DIFF
--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1618,7 +1618,9 @@ export async function POST(req: Request) {
       // is the marker-free text that gets persisted (the client also strips
       // markers from the live-streamed text for parity — see chat-view).
       const { text: cleanedAssistantText, attachments: agentAttachments } =
-        parseAgentAttachments(assistantText.trim());
+        parseAgentAttachments(assistantText.trim(), {
+          allowedRoots: sshRuntime ? [] : [familiarCwd ?? cwd, ...grantedProjectRoots],
+        });
       for (const attachment of agentAttachments) {
         push({ kind: "attachment", attachment });
       }

--- a/src/lib/server/agent-attachments.test.ts
+++ b/src/lib/server/agent-attachments.test.ts
@@ -27,11 +27,12 @@ function restoreEnv() {
 
 const allowed = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-allowed-"));
 const outside = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-outside-"));
+const globalOnly = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-global-"));
 
 try {
-  // Make `allowed` the only project-defined root; clear the rest so the
-  // outside dir is genuinely outside every allowed root.
-  process.env.WORKSPACE_ROOT = allowed;
+  // Make `globalOnly` globally allowed while tests pass only `allowed` as the
+  // runtime-scoped grant set; clear the rest to keep `outside` isolated.
+  process.env.WORKSPACE_ROOT = globalOnly;
   process.env.COVEN_HOME = path.join(allowed, ".coven");
   process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(allowed, "cave-projects.json");
   delete process.env.COVEN_WORKSPACES_ROOT;
@@ -42,9 +43,11 @@ try {
   const imgPath = path.join(allowed, "diagram.png");
   const txtPath = path.join(allowed, "notes.txt");
   const outsidePath = path.join(outside, "secret.png");
+  const globalOnlyPath = path.join(globalOnly, "global-secret.txt");
   await writeFile(imgPath, Buffer.from(PNG_1x1_BASE64, "base64"));
   await writeFile(txtPath, "hello\nworld");
   await writeFile(outsidePath, Buffer.from(PNG_1x1_BASE64, "base64"));
+  await writeFile(globalOnlyPath, "should not be read");
 
   const { extractAgentAttachmentMarkers } = await import("../chat-attachments.ts");
   const { parseAgentAttachments } = await import("./agent-attachments.ts");
@@ -66,7 +69,7 @@ try {
   // --- image attachment → bounded data URL ---
   {
     const text = `Here is the image.\n\n\`\`\`coven:attachment\n${JSON.stringify({ path: imgPath, name: "diagram.png" })}\n\`\`\``;
-    const out = parseAgentAttachments(text);
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
     assert.equal(out.attachments.length, 1, "image attachment parsed");
     assert.equal(out.attachments[0].name, "diagram.png");
     assert.equal(out.attachments[0].mimeType, "image/png");
@@ -78,7 +81,7 @@ try {
   // --- text attachment → inline text, no data URL ---
   {
     const text = `\`\`\`coven:attachment\n${JSON.stringify({ path: txtPath })}\n\`\`\``;
-    const out = parseAgentAttachments(text);
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
     assert.equal(out.attachments.length, 1, "text attachment parsed");
     assert.equal(out.attachments[0].name, "notes.txt");
     assert.equal(out.attachments[0].text, "hello\nworld");
@@ -88,15 +91,32 @@ try {
   // --- path outside allowed roots → dropped, but marker still stripped ---
   {
     const text = `nope\n\n\`\`\`coven:attachment\n${JSON.stringify({ path: outsidePath })}\n\`\`\``;
-    const out = parseAgentAttachments(text);
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
     assert.equal(out.attachments.length, 0, "out-of-root path is dropped");
     assert.ok(!out.text.includes("coven:attachment"), "marker still stripped for dropped path");
     assert.equal(out.text, "nope");
   }
 
+
+  // --- globally allowed but not runtime-granted root → dropped ---
+  {
+    const text = `nope\n\n\`\`\`coven:attachment\n${JSON.stringify({ path: globalOnlyPath })}\n\`\`\``;
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
+    assert.equal(out.attachments.length, 0, "global-only path is dropped without runtime grant");
+    assert.equal(out.text, "nope");
+  }
+
+  // --- no runtime-granted roots → no local file reads ---
+  {
+    const text = `nope\n\n\`\`\`coven:attachment\n${JSON.stringify({ path: txtPath })}\n\`\`\``;
+    const out = parseAgentAttachments(text);
+    assert.equal(out.attachments.length, 0, "default parser does not read local files");
+    assert.equal(out.text, "nope");
+  }
+
   // --- no marker → passthrough ---
   {
-    const out = parseAgentAttachments("plain reply");
+    const out = parseAgentAttachments("plain reply", { allowedRoots: [allowed] });
     assert.equal(out.attachments.length, 0);
     assert.equal(out.text, "plain reply");
   }
@@ -104,6 +124,7 @@ try {
   restoreEnv();
   await rm(allowed, { recursive: true, force: true });
   await rm(outside, { recursive: true, force: true });
+  await rm(globalOnly, { recursive: true, force: true });
 }
 
 console.log("agent-attachments.test.ts: ok");

--- a/src/lib/server/agent-attachments.ts
+++ b/src/lib/server/agent-attachments.ts
@@ -7,7 +7,6 @@ import {
   MAX_ATTACHMENT_TEXT_CHARS,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
-import { resolveAllowedProjectSubpath } from "@/lib/server/project-paths";
 
 /**
  * Server-side parser for agent-produced inline attachments.
@@ -18,9 +17,9 @@ import { resolveAllowedProjectSubpath } from "@/lib/server/project-paths";
  *   { "path": "/abs/path/to/file.png", "name": "file.png" }
  *   ```
  *
- * The server resolves the path against the project-root allowlist (the SAME
- * guard the Code/file-preview surfaces use — anything outside a granted root is
- * silently dropped), reads the file under a size cap, and turns it into a
+ * The server resolves the path against the chat runtime's granted local roots
+ * (anything outside those roots is silently dropped), reads the file under a
+ * size cap, and turns it into a
  * {@link ChatAttachment}. Images ride through as a bounded base64 data URL so
  * the chat surface can preview them; text files carry their (truncated) text;
  * everything else is metadata-only. The marker block is stripped from the
@@ -52,6 +51,15 @@ const TEXT_EXTS = new Set([
 
 type AttachmentMarker = { path: string; name?: string };
 
+export type AgentAttachmentParseOptions = {
+  /**
+   * Runtime-scoped local roots that agent-produced attachment markers may read from.
+   * Omit or pass an empty array for runtimes that must not read local files
+   * (for example SSH).
+   */
+  allowedRoots?: readonly string[];
+};
+
 /** Strip control characters and cap length — mirrors the `cleanName` guard in chat-attachments.ts. */
 function sanitizeAttachmentName(name: string): string {
   const base = name.split(/[\\/]/).filter(Boolean).pop() ?? "attachment";
@@ -76,10 +84,22 @@ function parseMarker(body: string): AttachmentMarker | null {
   };
 }
 
-function buildAttachment(marker: AttachmentMarker): ChatAttachment | null {
-  const allowed = resolveAllowedProjectSubpath(marker.path);
-  if (!allowed) return null; // outside every granted root — drop silently
-  const resolved = path.join(allowed.root, allowed.relativePath);
+function resolveAttachmentPath(markerPath: string, allowedRoots: readonly string[] = []): string | null {
+  const resolvedMarkerPath = path.resolve(markerPath);
+  for (const root of allowedRoots) {
+    const resolvedRoot = path.resolve(root);
+    const relative = path.relative(resolvedRoot, resolvedMarkerPath);
+    if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+      return resolvedMarkerPath;
+    }
+    if (!relative) return resolvedMarkerPath;
+  }
+  return null;
+}
+
+function buildAttachment(marker: AttachmentMarker, options: AgentAttachmentParseOptions = {}): ChatAttachment | null {
+  const resolved = resolveAttachmentPath(marker.path, options.allowedRoots);
+  if (!resolved) return null; // outside the runtime/granted roots — drop silently
 
   let stat: fs.Stats;
   try {
@@ -133,13 +153,16 @@ function buildAttachment(marker: AttachmentMarker): ChatAttachment | null {
  * {@link MAX_AGENT_ATTACHMENTS} files; markers that don't resolve are dropped
  * but still stripped from the text.
  */
-export function parseAgentAttachments(text: string): { text: string; attachments: ChatAttachment[] } {
+export function parseAgentAttachments(
+  text: string,
+  options: AgentAttachmentParseOptions = {},
+): { text: string; attachments: ChatAttachment[] } {
   const { text: cleaned, markers } = extractAgentAttachmentMarkers(text);
   const attachments: ChatAttachment[] = [];
   for (const body of markers) {
     if (attachments.length >= MAX_AGENT_ATTACHMENTS) break;
     const marker = parseMarker(body);
-    const attachment = marker ? buildAttachment(marker) : null;
+    const attachment = marker ? buildAttachment(marker, options) : null;
     if (attachment) attachments.push(attachment);
   }
   return { text: cleaned, attachments };


### PR DESCRIPTION
### Motivation

- Close an authorization gap where assistant-produced `coven:attachment` markers could read files from globally allowed project roots instead of the chat runtime's granted project roots, exposing sensitive files.
- Ensure attachment parsing respects the familiar/session grant boundary and disables local reads for SSH runtimes.

### Description

- Add `AgentAttachmentParseOptions` with an `allowedRoots` array and change `parseAgentAttachments` to accept an `options` parameter and honor `allowedRoots` when resolving marker paths.
- Replace the previous global `resolveAllowedProjectSubpath()`-based resolution with `resolveAttachmentPath(markerPath, allowedRoots)` and update `buildAttachment` to use the resolved runtime-scoped path, keeping existing size/type caps and behavior.
- Pass runtime-scoped roots from the chat send route into the parser (`allowedRoots: sshRuntime ? [] : [familiarCwd ?? cwd, ...grantedProjectRoots]`) so SSH runtimes disallow local reads and local chats only read from the familiar's runtime/root + granted project roots.
- Harden tests in `agent-attachments.test.ts` by adding a globally-allowed-but-ungranted root and new assertions that globally-allowed-but-ungranted paths are dropped and that the default parser (no `allowedRoots`) performs no local reads.

### Testing

- Type checking: ran `pnpm exec tsc --noEmit --pretty false` and it succeeded.
- API test suite: ran `node scripts/run-tests.mjs api` and all API tests passed (including the updated `agent-attachments.test.ts`).