### PR TITLE
fix(updater): avoid direct installer after native update failure

### DIFF
--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -69,34 +69,27 @@ assert.match(src, /Open installer in Browser/, "fallback keeps installer recover
 assert.match(src, /Native updater unavailable/, "settings row distinguishes native updater failure from a normal installer fallback");
 assert.match(src, /Retry native update/, "settings row makes retrying native update the primary recovery action");
 
-// A failed native install must not dead-end: it captures the reason and offers
-// in-app recovery plus a retry, so the update is always reachable even when
-// downloadAndInstall/relaunch throws. The recovery path should resolve the
-// platform installer through the same fallback route instead of hardcoding the
-// releases page or sending the user outside Cave.
+// A failed native install must not bypass the signed updater by resolving a
+// direct installer asset from release metadata. It captures the reason, keeps
+// recovery inside Cave, and sends users to the canonical release page instead.
 assert.match(src, /phase: "failed"/, "tracks a dedicated failed state for a thrown install");
 assert.match(src, /message: err instanceof Error \? err\.message/, "captures the real failure reason instead of swallowing it");
-assert.match(src, /async function openFallbackUpdateInBrowser/, "centralizes in-app fallback recovery resolution");
-assert.match(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl/, "in-app recovery resolves a direct platform installer when release metadata is reachable");
+assert.match(src, /function openReleasePageInBrowser/, "centralizes failed-updater recovery");
+assert.match(src, /openInAppBrowserUrl\(RELEASES_PAGE\)/, "failed updater recovery opens the canonical release page");
+assert.doesNotMatch(src, /openFallbackUpdateInBrowser/, "updater recovery must not resolve direct installer assets");
+assert.doesNotMatch(src, /fetchFallbackStatus\(\)[\s\S]*resolveDownloadUrl[\s\S]*openInAppBrowserUrl\(url\)/, "updater recovery must not open metadata-derived direct installer URLs");
+assert.match(src, /Open release page in Browser/, "updater recovery labels the destination as the release page");
 assert.match(
   src,
-  /if \(r\.kind === "native-unavailable"\) \{\s*void openFallbackUpdateInBrowser\(\);\s*\}/,
-  "native-unavailable banner CTA re-resolves the installer at click time",
-);
-assert.match(
-  src,
-  /state\.phase === "native-unavailable"[\s\S]{0,900}?onClick=\{\(\) => void openFallbackUpdateInBrowser\(\)\}/,
-  "native-unavailable settings row opens the freshly resolved installer fallback",
+  /state\.phase === "native-unavailable"[\s\S]{0,900}?onClick=\{openReleasePageInBrowser\}/,
+  "native-unavailable settings row opens the canonical release page",
 );
 assert.doesNotMatch(
   src,
   /state\.phase === "native-unavailable"[\s\S]{0,900}?openInAppBrowserUrl\(r\.url\)/,
   "native-unavailable settings row must not reuse a stale installer URL from the initial check",
 );
-assert.match(src, /onClick=\{\(\) => void openFallbackUpdateInBrowser\(\)\}/, "failed state offers the same in-app installer path as fallback updates");
-assert.match(src, /openInAppBrowserUrl\(url\)/, "fallback recovery opens in Cave's Browser surface");
 assert.doesNotMatch(src, /download manually/i, "failed updater copy should not imply leaving the app for manual recovery");
-assert.doesNotMatch(src, /onClick=\{\(\) => void openInAppBrowserUrl\(RELEASES_PAGE\)\}/, "failed state must not dead-end on the generic release page when a direct installer can be resolved");
 assert.match(src, />\s*Retry\s*</, "failed state offers a retry");
 
 console.log("update-available.test.ts: ok");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -332,12 +332,18 @@ export function UpdateSettingsRow() {
         >
           Update failed
         </span>
-        <button type="button" onClick={openReleasePageInBrowser} className={accentBtn}>
-          <Icon name="ph:arrow-square-out" width={12} />
+        <Button
+          variant="primary"
+          size="xs"
+          onClick={openReleasePageInBrowser}
+          className={accentBtn}
+          leadingIcon="ph:arrow-square-out"
+        >
           Open release page in Browser
-        </button>
-        <button
-          type="button"
+        </Button>
+        <Button
+          variant="secondary"
+          size="xs"
           onClick={check}
           className={secondaryBtn}
         >

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -116,15 +116,13 @@ async function resolveDownloadUrl(status: UpdateStatus): Promise<string> {
 }
 
 /**
- * Open the easiest reachable installer for the running desktop platform in
- * Cave's Browser surface. This is used when the native updater cannot finish,
- * so a broken install attempt still leaves the user one click from the
- * DMG/MSI/AppImage when release metadata is available.
+ * After the signed native updater fails, do not route users to a direct
+ * installer asset resolved from release metadata. Keep the recovery path on the
+ * canonical GitHub release page so a verification/download failure cannot be
+ * turned into a trusted-looking bypass of the signed updater path.
  */
-async function openFallbackUpdateInBrowser(): Promise<void> {
-  const fb = await fetchFallbackStatus();
-  const url = fb ? await resolveDownloadUrl(fb) : RELEASES_PAGE;
-  openInAppBrowserUrl(url);
+function openReleasePageInBrowser(): void {
+  openInAppBrowserUrl(RELEASES_PAGE);
 }
 
 type Resolved =
@@ -191,12 +189,12 @@ export function UpdateBannerTrigger() {
                   title: reason
                     ? `Update failed (${reason})`
                     : "Update failed",
-                  cta: { label: "Open installer in Browser", onClick: () => void openFallbackUpdateInBrowser() },
+                  cta: { label: "Open release page in Browser", onClick: openReleasePageInBrowser },
                   onDismiss: () => markDismissed(r.version),
                 });
               });
             } else if (r.kind === "native-unavailable") {
-              void openFallbackUpdateInBrowser();
+              openReleasePageInBrowser();
             } else {
               openInAppBrowserUrl(r.url);
             }
@@ -315,17 +313,17 @@ export function UpdateSettingsRow() {
         <Button
           variant="secondary"
           size="xs"
-          onClick={() => void openFallbackUpdateInBrowser()}
+          onClick={openReleasePageInBrowser}
           className={secondaryBtn}
         >
-          Open installer in Browser
+          Open release page in Browser
         </Button>
       </>
     );
   } else if (state.phase === "failed") {
     // The native install threw (e.g. unsigned/dev build, app translocation, or
-    // a network/verification error). Don't dead-end: surface the reason and
-    // keep recovery inside Cave.
+    // a network/verification error). Surface the reason and keep recovery on
+    // the canonical release page rather than a direct installer asset.
     control = (
       <>
         <span
@@ -334,12 +332,12 @@ export function UpdateSettingsRow() {
         >
           Update failed
         </span>
-        <Button variant="primary" size="xs" onClick={() => void openFallbackUpdateInBrowser()} className={accentBtn} leadingIcon="ph:arrow-square-out">
-          Open installer in Browser
-        </Button>
-        <Button
-          variant="secondary"
-          size="xs"
+        <button type="button" onClick={openReleasePageInBrowser} className={accentBtn}>
+          <Icon name="ph:arrow-square-out" width={12} />
+          Open release page in Browser
+        </button>
+        <button
+          type="button"
           onClick={check}
           className={secondaryBtn}
         >


### PR DESCRIPTION
### Motivation
- The native updater fallback previously resolved and opened direct installer URLs from GitHub release metadata when `downloadAndInstall`/`relaunch` failed, which bypasses the signed-updater trust boundary. 
- The goal is to keep recovery on the canonical GitHub release page so a verification/download failure cannot be turned into a trusted-looking bypass to an unverified installer.

### Description
- Replace the metadata-derived manual-download path with a simple release-page opener by adding `openReleasePageInBrowser()` and routing failed-updater CTAs to it in `src/components/update-available.tsx`.
- Update the settings-row and banner UI copy/CTA to explicitly say `Open release page in Browser` instead of offering an in-app direct installer.
- Remove the helper that resolved and opened platform-specific direct installer URLs from the failed-updater path, while leaving the direct-installer resolution logic intact for non-failure fallback usage.
- Tighten the unit test expectations in `src/components/update-available.test.ts` to assert the failed-updater recovery no longer resolves or opens metadata-derived direct installer URLs.

### Testing
- Ran component test: `node src/components/update-available.test.ts`, which passed.
- Ran update helpers test: `node --experimental-strip-types src/lib/app-update.test.ts`, which passed (all assertions OK).
- Ran typecheck: `pnpm typecheck` (`tsc --noEmit`), which completed without errors.