### PR TITLE
Require mobile token before native Serve startup

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -164,7 +164,28 @@ async function verifyNativeAppBackend(req: Request, backend: string) {
   }
 }
 
+function mobileAccessSecret() {
+  return process.env.COVEN_CAVE_ACCESS_TOKEN?.trim() ?? "";
+}
+
+function mobileAccessUnavailableResponse() {
+  // Plain `next dev` never sets COVEN_CAVE_ACCESS_TOKEN, so neither signed
+  // invites nor persistent native-app Serve routes are safe to create. Give
+  // devs the exact next step instead of an opaque string; keep the terse
+  // message in packaged builds, where a missing token is a real
+  // misconfiguration rather than the dev default.
+  const error =
+    process.env.NODE_ENV !== "production"
+      ? "Mobile handoff isn't available in plain `pnpm dev` — it needs the signed access token that the packaged app and `pnpm mobile:tailscale` set up. Run `pnpm mobile:tailscale` (or open the packaged app), then use Open on phone from that session."
+      : "mobile access token unavailable";
+  return NextResponse.json({ ok: false, error }, { status: 503 });
+}
+
 async function ensureNativeAppServe(req: Request) {
+  if (!mobileAccessSecret()) {
+    return mobileAccessUnavailableResponse();
+  }
+
   const backend = nativeAppBackendUrl(req);
   const backendReady = await verifyNativeAppBackend(req, backend);
   if (!backendReady.ok) {
@@ -251,17 +272,9 @@ async function ensureNativeAppServe(req: Request) {
 }
 
 async function mobileHandoff(req: Request) {
-  const accessSecret = process.env.COVEN_CAVE_ACCESS_TOKEN?.trim();
+  const accessSecret = mobileAccessSecret();
   if (!accessSecret) {
-    // Plain `next dev` never sets COVEN_CAVE_ACCESS_TOKEN, so the handoff
-    // can't mint a signed invite. Give devs the exact next step instead of
-    // an opaque string; keep the terse message in packaged builds, where a
-    // missing token is a real misconfiguration rather than the dev default.
-    const error =
-      process.env.NODE_ENV !== "production"
-        ? "Mobile handoff isn't available in plain `pnpm dev` — it needs the signed access token that the packaged app and `pnpm mobile:tailscale` set up. Run `pnpm mobile:tailscale` (or open the packaged app), then use Open on phone from that session."
-        : "mobile access token unavailable";
-    return NextResponse.json({ ok: false, error }, { status: 503 });
+    return mobileAccessUnavailableResponse();
   }
 
   // `--json` doubles as the connectivity check (exit 0 == connected) and the

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -55,6 +55,11 @@ assert.match(handoffRoute, /verifyNativeAppBackend/, "native mobile mode should 
 assert.match(handoffRoute, /\/api\/familiars/, "native backend readiness should use the same lightweight endpoint as the iOS connection probe");
 assert.match(handoffRoute, /pnpm mobile:tailscale:app/, "native backend readiness errors should point to the documented app-mode command");
 assert.match(handoffRoute, /NODE_ENV !== "production"[\s\S]*pnpm mobile:tailscale/, "API should give an actionable dev hint when the access token is missing");
+assert.match(
+  handoffRoute,
+  /async function ensureNativeAppServe[\s\S]*if \(!mobileAccessSecret\(\)\)[\s\S]*return mobileAccessUnavailableResponse\(\)/,
+  "native app mobile-mode start must require the mobile access token before starting Tailscale Serve",
+);
 assert.match(settings, /MobileModeToggle/, "Settings should render a mobile mode toggle component");
 assert.match(settings, /mobileModeEnabled/, "Settings should receive the live mobile mode enabled state");
 assert.match(settings, /onMobileModeChange/, "Settings should expose a toggle callback for mobile mode");


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated Tailscale Serve startup in plain dev/no-token runs which could publish an unauthenticated sidecar reachable from the tailnet and expose privileged APIs or a PTY.

### Description
- Added `mobileAccessSecret()` and `mobileAccessUnavailableResponse()` helpers to centralize the mobile access-token check and standard 503 response (updated `src/app/api/mobile-handoff/route.ts`).
- Guarded `ensureNativeAppServe()` so `app-start` returns the same 503 guidance when `COVEN_CAVE_ACCESS_TOKEN` is missing instead of invoking `tailscale serve --bg`.
- Updated the signed-invite flow in `mobileHandoff()` to reuse the shared guard and adjusted `src/components/mobile-handoff.test.ts` to assert that the native startup path requires the token.

### Testing
- Ran `node src/components/mobile-handoff.test.ts`, which completed successfully and printed the expected test output. (success)
- Ran `pnpm exec tsc --noEmit` to verify types, which completed without errors. (success)