### PR TITLE
fix(marketplace): avoid resolving secrets in status checks

### DIFF
--- a/src/app/api/marketplace/config/route.ts
+++ b/src/app/api/marketplace/config/route.ts
@@ -13,7 +13,7 @@
 import { NextResponse } from "next/server";
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
-import { canResolve, getVaultStatuses } from "@/lib/vault";
+import { getVaultMetadataStatuses, hasConfiguredSecretMetadata } from "@/lib/vault";
 import { envLocalPath, readEnvLocalValue, upsertEnvContent } from "@/lib/env-file";
 import { hasValidator } from "@/lib/secret-validators";
 import { resolveCatalogName, requiredConfigFor } from "./catalog-config";
@@ -35,11 +35,11 @@ export async function GET(req: Request) {
     return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
   }
   const fields = await requiredConfigFor(name);
-  const vault = getVaultStatuses();
+  const vault = getVaultMetadataStatuses();
   const out = fields.map((f) => {
     const inEnv = readEnvLocalValue(f.env) !== undefined || !!process.env[f.env]?.trim();
     const vaultEntry = vault.find((v) => v.key === f.env) ?? null;
-    const satisfied = inEnv || canResolve(f.env);
+    const satisfied = inEnv || hasConfiguredSecretMetadata(f.env);
     const source = inEnv ? "env" : vaultEntry?.status === "encrypted" ? "encrypted" : satisfied ? "vault" : "none";
     return {
       key: f.key,

--- a/src/app/api/marketplace/route.ts
+++ b/src/app/api/marketplace/route.ts
@@ -12,7 +12,7 @@ import { NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadConfig } from "@/lib/cave-config";
-import { canResolve } from "@/lib/vault";
+import { hasConfiguredSecretMetadata } from "@/lib/vault";
 import { readEnvLocalValue } from "@/lib/env-file";
 import {
   mergeCatalog,
@@ -55,10 +55,10 @@ export async function GET() {
   const merged = mergeCatalog(marketplaceSafePlugins, manifests, cfg.marketplace.installed);
   const plugins = sanitizeMarketplaceCatalogCards(merged.map((p) => ({
     ...p,
-    // configured = every required field's env var resolves (vault op:// or
-    // process.env) or is present in .env.local (written but not yet loaded).
+    // configured = every required field has a value already in env/.env.local
+    // or has vault metadata. This must not resolve or cache secret values.
     configured: p.requiredConfig.every(
-      (f) => readEnvLocalValue(f.env) !== undefined || canResolve(f.env),
+      (f) => readEnvLocalValue(f.env) !== undefined || hasConfiguredSecretMetadata(f.env),
     ),
   })));
   return NextResponse.json({ ok: true, plugins });

--- a/src/app/api/marketplace/route.ts
+++ b/src/app/api/marketplace/route.ts
@@ -13,7 +13,6 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { loadConfig } from "@/lib/cave-config";
 import { hasConfiguredSecretMetadata } from "@/lib/vault";
-import { readEnvLocalValue } from "@/lib/env-file";
 import {
   mergeCatalog,
   sanitizeMarketplaceCatalogCards,
@@ -57,9 +56,7 @@ export async function GET() {
     ...p,
     // configured = every required field has a value already in env/.env.local
     // or has vault metadata. This must not resolve or cache secret values.
-    configured: p.requiredConfig.every(
-      (f) => readEnvLocalValue(f.env) !== undefined || hasConfiguredSecretMetadata(f.env),
-    ),
+    configured: p.requiredConfig.every((f) => hasConfiguredSecretMetadata(f.env)),
   })));
   return NextResponse.json({ ok: true, plugins });
 }

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -37,6 +37,12 @@ assert.match(
 
 assert.match(
   source,
+  /FORBIDDEN_SPAWN_ENV_KEYS = \["GITHUB_PAT", "GITHUB_PERSONAL_ACCESS_TOKEN"\]/,
+  "coven child processes strip both legacy and marketplace GitHub token env vars",
+);
+
+assert.match(
+  source,
   /export function refreshCovenSpawnEnv\(\)[\s\S]*cachedPath = null[\s\S]*return covenSpawnEnv\(\)/,
   "desktop install retries can refresh Cave's cached PATH after Node/npm is installed",
 );

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -36,7 +36,7 @@ export type CovenLaunchCommand = {
   fixedArgs: string[];
 };
 
-const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT"] as const;
+const FORBIDDEN_SPAWN_ENV_KEYS = ["GITHUB_PAT", "GITHUB_PERSONAL_ACCESS_TOKEN"] as const;
 
 const HOME = os.homedir();
 

--- a/src/lib/env-file.ts
+++ b/src/lib/env-file.ts
@@ -23,6 +23,39 @@ export function envLocalPath(): string {
 }
 
 /**
+ * Parse `.env.local` into a key→value record in one file read.
+ *
+ * Uses the same minimal `.env` parsing as {@link readEnvLocalValue}. Useful
+ * when multiple keys need to be looked up in a single call (e.g. iterating
+ * over all vault entries) to avoid O(N) file reads.
+ */
+export function readEnvLocalAll(): Record<string, string> {
+  let raw: string;
+  try {
+    raw = readFileSync(envLocalPath(), "utf8");
+  } catch {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq < 0) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) result[key] = value;
+  }
+  return result;
+}
+
+/**
  * Read a single key's value from the writable `.env.local`, or undefined.
  *
  * In dev, Next auto-loads `<cwd>/.env.local` into `process.env` at boot, so

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -27,6 +27,17 @@ assert.doesNotMatch(githubPatRouteSource, /updates\[PAT_KEY\] = pat/, "GitHub PA
 assert.match(panelSource, /Local encrypted/, "Vault panel exposes local encrypted storage as a first-class option");
 assert.match(panelSource, /type="password"/, "Vault panel uses a password input for raw local secrets");
 assert.match(marketplaceConfigureSource, /storage: "encrypted", value: draft/, "Marketplace sensitive config can save raw values through the encrypted vault");
+
+assert.match(
+  vaultSource,
+  /export function getVaultMetadataStatuses[\s\S]*status: "configured"[\s\S]*export function getVaultStatuses/,
+  "marketplace status can inspect vault metadata without op read or secret caching",
+);
+assert.match(
+  vaultSource,
+  /export function hasConfiguredSecretMetadata[\s\S]*loadVaultMap\(\)[\s\S]*return !!entry\?\.ref/,
+  "configured checks use vault metadata instead of resolving secret values",
+);
 assert.doesNotMatch(marketplaceConfigureSource, /enter a 1Password reference/, "Marketplace sensitive config no longer requires 1Password");
 
 console.log("vault.test.ts: ok");

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -20,7 +20,7 @@ import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from
 import { dirname, join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
 import { covenHome } from "./coven-paths.ts";
-import { readEnvLocalValue } from "./env-file.ts";
+import { readEnvLocalAll, readEnvLocalValue } from "./env-file.ts";
 import { getLocalEncryptedSecret, hasLocalEncryptedSecret } from "./local-encrypted-vault.ts";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -258,8 +258,9 @@ export function hasConfiguredSecretMetadata(key: string): boolean {
 
 export function getVaultMetadataStatuses(): VaultMappingStatus[] {
   const map = loadVaultMap(true); // always fresh for status checks
+  const envLocal = readEnvLocalAll(); // read once for all entries
   return Object.entries(map).map(([key, entry]) => {
-    const inEnv = !!(process.env[key]?.trim()) || readEnvLocalValue(key) !== undefined;
+    const inEnv = !!(process.env[key]?.trim()) || key in envLocal;
     const hasEncrypted = entry.storage === "encrypted" || hasLocalEncryptedSecret(key);
 
     if (inEnv) {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -34,7 +34,7 @@ export type VaultEntry = {
 
 export type VaultMap = Record<string, VaultEntry>;
 
-export type VaultStatus = "resolved" | "encrypted" | "env-only" | "unresolved" | "error" | "no-ref";
+export type VaultStatus = "resolved" | "configured" | "encrypted" | "env-only" | "unresolved" | "error" | "no-ref";
 
 export type VaultMappingStatus = {
   key: string;
@@ -233,12 +233,70 @@ export function resolveSecret(key: string): string | undefined {
   return undefined;
 }
 
-/** Check if a key is resolvable without returning the value. */
+/** Check if a key is resolvable without returning the value.
+ *
+ * This is a materializing check: it may decrypt local secrets, run `op read`,
+ * and cache the resolved secret in process.env. Do not call it from read-only
+ * status endpoints that only need configuration metadata.
+ */
 export function canResolve(key: string): boolean {
   return !!resolveSecret(key);
 }
 
+/** Check whether a key appears configured without reading or caching its value. */
+export function hasConfiguredSecretMetadata(key: string): boolean {
+  if (process.env[key]?.trim()) return true;
+  if (readEnvLocalValue(key) !== undefined) return true;
+
+  const map = loadVaultMap();
+  const entry = map[key];
+  if (entry?.storage === "encrypted" || hasLocalEncryptedSecret(key)) return true;
+  return !!entry?.ref;
+}
+
 // ── Status reporter (for /api/vault UI) ──────────────────────────────────────
+
+export function getVaultMetadataStatuses(): VaultMappingStatus[] {
+  const map = loadVaultMap(true); // always fresh for status checks
+  return Object.entries(map).map(([key, entry]) => {
+    const inEnv = !!(process.env[key]?.trim()) || readEnvLocalValue(key) !== undefined;
+    const hasEncrypted = entry.storage === "encrypted" || hasLocalEncryptedSecret(key);
+
+    if (inEnv) {
+      return {
+        key, ref: entry.ref ?? null, description: entry.description ?? null,
+        storage: entry.storage ?? (entry.ref ? "1password" : null),
+        required: entry.required ?? false,
+        status: "env-only" as VaultStatus, hasValue: true,
+      };
+    }
+
+    if (hasEncrypted) {
+      return {
+        key, ref: entry.ref ?? null, description: entry.description ?? null,
+        storage: "encrypted",
+        required: entry.required ?? false,
+        status: "encrypted" as VaultStatus, hasValue: true,
+      };
+    }
+
+    if (entry.ref) {
+      return {
+        key, ref: entry.ref, description: entry.description ?? null,
+        storage: "1password",
+        required: entry.required ?? false,
+        status: "configured" as VaultStatus, hasValue: true,
+      };
+    }
+
+    return {
+      key, ref: null, description: entry.description ?? null,
+      storage: entry.storage ?? null,
+      required: entry.required ?? false,
+      status: "no-ref" as VaultStatus, hasValue: false,
+    };
+  });
+}
 
 export function getVaultStatuses(): VaultMappingStatus[] {
   const map = loadVaultMap(true); // always fresh for status checks

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -285,7 +285,7 @@ export function getVaultMetadataStatuses(): VaultMappingStatus[] {
         key, ref: entry.ref, description: entry.description ?? null,
         storage: "1password",
         required: entry.required ?? false,
-        status: "configured" as VaultStatus, hasValue: true,
+        status: "configured" as VaultStatus, hasValue: false,
       };
     }
 


### PR DESCRIPTION
### Motivation

- Read-only marketplace endpoints were calling `canResolve()` which materializes secrets by calling `resolveSecret()` and caching values in `process.env`, enabling secret leakage to child processes.
- The marketplace catalog now declares a sensitive GitHub token env var, so listing/config modal could unexpectedly trigger secret resolution and inheritance by spawned agents.
- The intent is to compute configuration presence metadata without decrypting or loading secret values into the server process environment.

### Description

- Added `hasConfiguredSecretMetadata()` and `getVaultMetadataStatuses()` to `src/lib/vault.ts` to provide metadata-only checks that do not call `op read`, decrypt, or write secrets into `process.env`.
- Updated marketplace endpoints to use metadata-only checks: replaced `canResolve()` with `hasConfiguredSecretMetadata()` in `src/app/api/marketplace/route.ts` and `src/app/api/marketplace/config/route.ts` so status/listing requests no longer materialize secrets.
- Preserved the existing materializing `getVaultStatuses()` API for the vault UI (which requires actual resolution) while introducing the non-materializing status helper for metadata inspection.
- Prevented child-process env inheritance of the newly-declared marketplace GitHub token by adding `GITHUB_PERSONAL_ACCESS_TOKEN` to the `FORBIDDEN_SPAWN_ENV_KEYS` list in `src/lib/coven-bin.ts` and added regression assertions in `src/lib/vault.test.ts` and `src/lib/coven-bin.test.ts`.

### Testing

- Typecheck: ran `pnpm exec tsc --noEmit` and it succeeded.
- Targeted unit checks: ran `node --experimental-strip-types src/lib/vault.test.ts` and `node --experimental-strip-types src/lib/coven-bin.test.ts` and they passed.
- Full test suite: ran `pnpm test` and all app tests passed (533 test file(s) passed).
- Additional lint/consistency checks: ran `git diff --check` (no issues) and ran the repository test harness commands used above; automated tests succeeded.