### PR TITLE
fix(proxy): guard tokenless GET webhooks

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -20,9 +20,13 @@ assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject un
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
 assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated \|\| tailnetTrusted\)/, "valid mobile access or tailnet-trust should satisfy the API host gate");
 assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless app mode (COVEN_CAVE_TAILNET_TRUST) should relax the host gate for tailnet-forwarded requests");
-assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("origin"\), expectedOrigin\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
-assert.match(source, /isAllowedRequestSource\(req\.headers\.get\("referer"\), expectedOrigin\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
+assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
+assert.match(source, /const referer = req\.headers\.get\("referer"\)/, "API referer gate should read the source referer header once");
+assert.match(source, /isAllowedRequestSource\(origin, expectedOrigin\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
+assert.match(source, /isAllowedRequestSource\(referer, expectedOrigin\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
+assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless-tailnet CSRF guard");
+assert.match(source, /missing request source/, "tokenless tailnet GET webhooks should reject absent Origin and Referer headers");
 
 // Tailscale Serve fix (re-applies #618; #716 reverted it): a request bearing the
 // sidecar token in the CSRF-immune CUSTOM HEADER bypasses the origin/referer gate
@@ -37,7 +41,7 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(!headerCsrfTrusted\) \{[\s\S]*?isAllowedRequestSource\(req\.headers\.get\("origin"\)/,
+  /if \(!headerCsrfTrusted\) \{[\s\S]*?isAllowedRequestSource\(origin, expectedOrigin\)/,
   "origin gate must run unless the request is header-CSRF-trusted",
 );
 assert.doesNotMatch(
@@ -52,8 +56,8 @@ assert.doesNotMatch(
 // `pnpm dev` if anything ever bound the dev server outside 127.0.0.1.
 {
   const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)");
-  const originIdx = source.indexOf('isAllowedRequestSource(req.headers.get("origin")');
-  const refererIdx = source.indexOf('isAllowedRequestSource(req.headers.get("referer")');
+  const originIdx = source.indexOf("isAllowedRequestSource(origin, expectedOrigin)");
+  const refererIdx = source.indexOf("isAllowedRequestSource(referer, expectedOrigin)");
   const contentTypeIdx = source.indexOf("unsupported content-type");
   const bypassIdx = source.indexOf("missing sidecar auth token");
   assert.ok(hostIdx > 0, "host check should be present");

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -118,6 +118,13 @@ function hasSafeContentType(req: NextRequest) {
   return SAFE_CONTENT_TYPES.includes(mediaType);
 }
 
+function isProductionWebhookGet(pathname: string, method: string) {
+  return (
+    method === "GET" &&
+    (pathname === "/api/flows/webhook" || pathname.startsWith("/api/flows/webhook/"))
+  );
+}
+
 function nextWithMobileAccessMarker(req: NextRequest, mobileAccessAuthenticated: boolean) {
   const requestHeaders = new Headers(req.headers);
   requestHeaders.delete(MOBILE_ACCESS_HEADER);
@@ -175,11 +182,29 @@ export async function proxy(req: NextRequest) {
     Boolean(sidecarToken) && req.headers.get(TOKEN_HEADER) === sidecarToken;
 
   if (!headerCsrfTrusted) {
-    if (!isAllowedRequestSource(req.headers.get("origin"), expectedOrigin)) {
+    const origin = req.headers.get("origin");
+    const referer = req.headers.get("referer");
+    if (!isAllowedRequestSource(origin, expectedOrigin)) {
       return jsonError(403, "forbidden origin");
     }
-    if (!isAllowedRequestSource(req.headers.get("referer"), expectedOrigin)) {
+    if (!isAllowedRequestSource(referer, expectedOrigin)) {
       return jsonError(403, "forbidden referer");
+    }
+    // Production GET webhooks are intentionally state-changing: a matching
+    // request starts an agent-backed flow. In tokenless Tailscale mode there is
+    // no sidecar secret to prove the caller is first-party, and browsers can
+    // issue cross-site GET navigations/subresources with both Origin and
+    // Referer omitted (for example via Referrer-Policy: no-referrer). Require a
+    // same-origin source header for that narrow state-changing GET surface so
+    // absent headers cannot bypass the CSRF gate.
+    if (
+      tailnetTrusted &&
+      !sidecarToken &&
+      isProductionWebhookGet(req.nextUrl.pathname, req.method) &&
+      !origin &&
+      !referer
+    ) {
+      return jsonError(403, "missing request source");
     }
   }
   if (!hasSafeContentType(req)) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -121,7 +121,10 @@ function hasSafeContentType(req: NextRequest) {
 function isProductionWebhookGet(pathname: string, method: string) {
   return (
     method === "GET" &&
-    (pathname === "/api/flows/webhook" || pathname.startsWith("/api/flows/webhook/"))
+    (pathname === "/api/flows/webhook" ||
+      pathname.startsWith("/api/flows/webhook/") ||
+      pathname === "/api/flows/webhook-test" ||
+      pathname.startsWith("/api/flows/webhook-test/"))
   );
 }
 


### PR DESCRIPTION
### Motivation
- Prevent cross-site GET requests from triggering state-changing production webhook flows when the server is running in tokenless Tailscale/native mode and both `Origin` and `Referer` headers are omitted.
- Close a high-severity CSRF hole introduced by allowing the same mutating handler to be exported for `GET` without a stricter source check in tokenless mode.

### Description
- Add a narrow helper `isProductionWebhookGet` to detect production webhook GET requests at `/api/flows/webhook` and `/api/flows/webhook/*`.
- In the proxy CSRF/source gate, read `Origin` and `Referer` into local variables and reject requests that fail the same-origin checks as before.
- For tokenless tailnet mode (`COVEN_CAVE_TAILNET_TRUST=1`) when no sidecar token is configured, additionally reject production webhook `GET` requests that have both `Origin` and `Referer` absent by returning a `403` with message `missing request source`.
- Update the middleware source-contract test in `src/middleware.test.ts` to pin the new header caching and the dedicated tokenless-tailnet GET-webhook guard.

### Testing
- Ran typecheck with `pnpm exec tsc --noEmit`, which succeeded.
- Executed `node src/middleware.test.ts` and `node src/proxy-behavior.test.ts`, both of which completed successfully (tests passed with only Node module-type warnings).
- Existing behavior for header-token-authenticated requests and other API requests was preserved and asserted by the updated tests.