### PR TITLE
fix(onboarding): require manual sudo for npm installs

### DIFF
--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -166,21 +166,6 @@ async function npmGlobalDirsWritable(npm: string): Promise<boolean> {
   return true;
 }
 
-/** `sudo -n true` succeeds only when sudo needs no password (cached creds or
- *  a NOPASSWD rule). We never spawn a password-prompting sudo from this
- *  non-interactive server context — with no TTY it would hang forever. */
-async function passwordlessSudoAvailable(): Promise<boolean> {
-  try {
-    await execFileAsync("sudo", ["-n", "true"], {
-      env: covenSpawnEnv(),
-      timeout: 3000,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 type SpawnPlan = {
   command: string;
   args: string[];
@@ -215,22 +200,12 @@ async function spawnPlanFor(
     if (!npm) return { npmMissing: true };
 
     // On POSIX a root-owned global prefix (system Node, /usr/local) fails
-    // `npm install -g` with EACCES. Elevate ONLY when the prefix really isn't
-    // writable; nvm/fnm/Homebrew prefixes are user-owned and must not be
-    // sudo'd (root-owned files there break later user installs).
+    // `npm install -g` with EACCES. Do not elevate from this API route: even
+    // with an allowlisted package and fixed argv, global npm installs may run
+    // package lifecycle scripts and write system locations. Require the
+    // operator to run the sudo command manually instead. nvm/fnm/Homebrew
+    // prefixes are user-owned and return true here, so they stay one-click.
     if (process.platform !== "win32" && !(await npmGlobalDirsWritable(npm))) {
-      // No TTY here: a password-prompting `sudo` would block forever. Only
-      // auto-elevate when passwordless sudo works; otherwise bail with a
-      // marker so the UI can tell the user to run it themselves.
-      if (await passwordlessSudoAvailable()) {
-        return {
-          command: "sudo",
-          // `-n` keeps sudo non-interactive — argv stays fully fixed
-          // (allowlisted package, no user input).
-          args: ["-n", npm, "install", "-g", target.packageName],
-          shell: false,
-        };
-      }
       return { sudoRequired: true, packageName: target.packageName };
     }
 
@@ -520,7 +495,7 @@ export async function POST(req: Request) {
         ok: false,
         sudoRequired: true,
         error: "the global npm directory needs elevated permissions to write",
-        hint: `Cave can't write to the global npm directory and passwordless sudo isn't available here. Run \`sudo npm install -g ${plan.packageName}\` in a terminal, then click Install again.`,
+        hint: `Cave can't write to the global npm directory from this API route. Run \`sudo npm install -g ${plan.packageName}\` in a terminal, then click Install again.`,
       },
       { status: 422 },
     );

--- a/src/app/onboarding-install-route.test.ts
+++ b/src/app/onboarding-install-route.test.ts
@@ -27,7 +27,7 @@ assert.match(
 
 assert.doesNotMatch(
   route,
-  /command:\s*["']sudo["']|passwordlessSudoAvailable|sudo\s*,\s*\["-n"/,
+  /command:\s*["']sudo["']|passwordlessSudoAvailable|(?:spawn|execFileAsync)\(\s*["']sudo["']|\[\s*["']-n["']/,
   "install route must not auto-elevate npm installs with sudo",
 );
 

--- a/src/app/onboarding-install-route.test.ts
+++ b/src/app/onboarding-install-route.test.ts
@@ -25,4 +25,16 @@ assert.match(
   "fire-and-forget installer task should catch synchronous spawn failures",
 );
 
+assert.doesNotMatch(
+  route,
+  /command:\s*["']sudo["']|passwordlessSudoAvailable|sudo\s*,\s*\["-n"/,
+  "install route must not auto-elevate npm installs with sudo",
+);
+
+assert.match(
+  route,
+  /Do not elevate from this API route:[\s\S]*?Require the[\s\S]*?operator to run the sudo command manually instead/,
+  "install route should require manual sudo when global npm dirs are not writable",
+);
+
 console.log("onboarding-install-route.test.ts OK");


### PR DESCRIPTION
### Motivation
- Prevent a privilege-escalation vector where the onboarding API could spawn `sudo -n npm install -g ...` from the server process when passwordless sudo or cached creds were present.
- Ensure network-accessible routes never perform non-interactive, root-level package installs without explicit operator action.

### Description
- Remove automatic elevation logic by deleting `passwordlessSudoAvailable()` and by avoiding a `sudo` spawn plan in `spawnPlanFor` when global npm dirs are not writable; the function now returns `{ sudoRequired: true }` in that case instead of a `sudo` command plan in `src/app/api/onboarding/install/route.ts`.
- Update the `sudoRequired` response hint to make it explicit that the operator must run the `sudo npm install -g <pkg>` command manually from a terminal.
- Add a source-level regression assertion to `src/app/onboarding-install-route.test.ts` that prevents reintroduction of auto-elevation by checking the route does not reference `sudo`, `passwordlessSudoAvailable`, or `-n`.

### Testing
- Ran the route source test with `node src/app/onboarding-install-route.test.ts`, which passed.
- Ran type checking with `pnpm typecheck` (`tsc --noEmit`), which succeeded.