### PR TITLE
fix(board): validate assigned task chat project root

### DIFF
--- a/src/app/api/board/[id]/chat/route.ts
+++ b/src/app/api/board/[id]/chat/route.ts
@@ -88,12 +88,14 @@ export async function POST(
       return NextResponse.json({ ok: false, error: "assigned project root is invalid" }, { status: 409 });
     }
 
-    const requestedProjectRoot = body.projectRoot ? normalizeProjectRoot(body.projectRoot) : null;
-    if (requestedProjectRoot && requestedProjectRoot !== projectRoot) {
-      return NextResponse.json(
-        { ok: false, error: "project root does not match assigned task project" },
-        { status: 403 },
-      );
+    if (body.projectRoot !== undefined && body.projectRoot !== null) {
+      const requestedProjectRoot = normalizeProjectRoot(body.projectRoot);
+      if (!requestedProjectRoot || requestedProjectRoot !== projectRoot) {
+        return NextResponse.json(
+          { ok: false, error: "project root does not match assigned task project" },
+          { status: 403 },
+        );
+      }
     }
 
     try {

--- a/src/app/api/board/[id]/chat/route.ts
+++ b/src/app/api/board/[id]/chat/route.ts
@@ -8,6 +8,7 @@ import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isAllowedHarness, MAX_SESSION_JSON_BYTES, normalizeProjectRoot } from "@/lib/server/session-security";
 import { issueContentionKey, shouldIsolateInWorktree, type IssueWorktreeKind } from "@/lib/issue-worktree";
 import { provisionIssueWorktree, resolveRepoRoot } from "@/lib/server/issue-worktree-provision";
+import { assertProjectAccess, ProjectAccessDeniedError } from "@/lib/project-permissions";
 
 // Match the daemon's "harness X is not a supported harness" rejection
 // from `/api/v1/sessions`. The daemon emits this when the requested
@@ -60,28 +61,64 @@ export async function POST(
     });
   }
 
-  // The UI sends the root for card.projectId when present; prefer that explicit
-  // project scope, then the card's own project association, then its cwd.
-  // NEVER fall back to the app's own working directory: that roots the task
-  // chat in the coven-cave checkout, records the wrong project_root on the
-  // session, and the chat picker then displays the wrong project for the task.
-  const cardProjectRoot = card.projectId
-    ? (projectById(card.projectId, await loadProjects())?.root ?? null)
-    : null;
-  const rawProjectRoot = body.projectRoot ?? cardProjectRoot ?? card.cwd;
-  if (!rawProjectRoot) {
-    return NextResponse.json(
-      { ok: false, error: "assign a project to this task before starting chat" },
-      { status: 409 },
-    );
+  const config = await loadConfig();
+  const binding = bindingFor(config, familiarId);
+
+  // Resolve the project the task chat will run in. Security-critical: when the
+  // card is assigned to a project we resolve the root SERVER-SIDE from
+  // card.projectId (never trust a client-supplied body.projectRoot to point
+  // elsewhere), reject a mismatched requested root, and authorize the familiar
+  // for that project. Only when the card has no assigned project do we fall
+  // back to the supplied/persisted root.
+  //
+  // NEVER silently fall back to the app's own working directory for an assigned
+  // task: that roots the chat in the coven-cave checkout, records the wrong
+  // project_root on the session, and the chat picker then shows the wrong
+  // project for the task.
+  let projectRoot: string | null = null;
+
+  if (card.projectId) {
+    const assignedProject = projectById(card.projectId, await loadProjects());
+    if (!assignedProject) {
+      return NextResponse.json({ ok: false, error: "assigned project not found" }, { status: 409 });
+    }
+
+    projectRoot = normalizeProjectRoot(assignedProject.root);
+    if (!projectRoot) {
+      return NextResponse.json({ ok: false, error: "assigned project root is invalid" }, { status: 409 });
+    }
+
+    const requestedProjectRoot = body.projectRoot ? normalizeProjectRoot(body.projectRoot) : null;
+    if (requestedProjectRoot && requestedProjectRoot !== projectRoot) {
+      return NextResponse.json(
+        { ok: false, error: "project root does not match assigned task project" },
+        { status: 403 },
+      );
+    }
+
+    try {
+      await assertProjectAccess({ familiarId }, assignedProject.id, "session-launch");
+    } catch (error) {
+      if (error instanceof ProjectAccessDeniedError) {
+        return NextResponse.json({ ok: false, error: error.message }, { status: error.status });
+      }
+      throw error;
+    }
+  } else {
+    const rawProjectRoot = body.projectRoot ?? card.cwd;
+    if (!rawProjectRoot) {
+      return NextResponse.json(
+        { ok: false, error: "assign a project to this task before starting chat" },
+        { status: 409 },
+      );
+    }
+    projectRoot = normalizeProjectRoot(rawProjectRoot);
   }
-  const projectRoot = normalizeProjectRoot(rawProjectRoot);
+
   if (!projectRoot) {
     return NextResponse.json({ ok: false, error: "invalid project root" }, { status: 400 });
   }
 
-  const config = await loadConfig();
-  const binding = bindingFor(config, familiarId);
   if (!isAllowedHarness(binding.harness)) {
     return NextResponse.json({ ok: false, error: "unsupported harness" }, { status: 400 });
   }
@@ -169,7 +206,7 @@ export async function POST(
     // one.
     ...(worktree
       ? { cwd: sessionRoot }
-      : (body.projectRoot ? { cwd: projectRoot } : {})),
+      : (card.projectId || body.projectRoot ? { cwd: projectRoot } : {})),
   });
   if (!updated) {
     return NextResponse.json({ ok: false, error: "card disappeared" }, { status: 404 });

--- a/src/components/board-chat-link.test.ts
+++ b/src/components/board-chat-link.test.ts
@@ -49,13 +49,23 @@ assert.match(
 );
 assert.match(
   route,
-  /normalizeProjectRoot\(rawProjectRoot\)/,
+  /normalizeProjectRoot\(rawProjectRoot\)|projectRoot = normalizeProjectRoot\(assignedProject\.root\)/,
   "Board chat endpoint normalizes the resolved project root",
 );
 assert.match(
   route,
-  /body\.projectRoot \?\? cardProjectRoot \?\? card\.cwd/,
-  "Board chat endpoint prefers the explicitly assigned root, then the card's project, then stale card cwd — never the app's own working directory",
+  /projectById\(card\.projectId, await loadProjects\(\)\)[\s\S]{0,900}assertProjectAccess\(\{ familiarId \}, assignedProject\.id, "session-launch"\)/,
+  "Board chat endpoint should resolve assigned project roots server-side and authorize the familiar",
+);
+assert.match(
+  route,
+  /project root does not match assigned task project/,
+  "Board chat endpoint rejects a client-supplied root that disagrees with the assigned project",
+);
+assert.doesNotMatch(
+  route,
+  /process\.cwd\(\)/,
+  "Board chat endpoint must never fall back to the app's own working directory",
 );
 assert.match(
   route,

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -87,7 +87,7 @@ assert.doesNotMatch(
 
 assert.match(
   taskChatRoute,
-  /body\.projectRoot \?\? cardProjectRoot \?\? card\.cwd/,
+  /body\.projectRoot \?\? cardProjectRoot \?\? card\.cwd|body\.projectRoot \?\? card\.cwd/,
   "Task chat sessions start in the assigned project root, then the card's own project, then its cwd",
 );
 // REGRESSION (2026-07-03): the route must never root a task chat in the app's
@@ -105,12 +105,17 @@ assert.match(
 );
 assert.match(
   taskChatRoute,
+  /assertProjectAccess\(\{ familiarId \}, assignedProject\.id, "session-launch"\)/,
+  "Task chat must authorize the familiar for the assigned project before launching",
+);
+assert.match(
+  taskChatRoute,
   /assign a project to this task before starting chat/,
   "A projectless task chat start is refused instead of silently mis-rooted",
 );
 assert.match(
   taskChatRoute,
-  /body\.projectRoot \? \{ cwd: projectRoot \}/,
+  /card\.projectId \|\| body\.projectRoot \? \{ cwd: projectRoot \}/,
   "The assigned project root is persisted onto the card for subsequent task-chat starts",
 );
 assert.match(


### PR DESCRIPTION
### Motivation
- Prevent caller-forged `projectRoot` values from redirecting task-linked daemon sessions into projects the assigned card/familiar shouldn't access by resolving assigned project roots server-side and enforcing project grants.

### Description
- Resolve the runtime `projectRoot` from the registered project when a card has `projectId` by using `projectById` and `loadProjects` instead of trusting `body.projectRoot`.
- Reject requests where a provided `body.projectRoot` does not match the assigned project's normalized root with a `403` response, and enforce the familiar's `session-launch` grant via `assertProjectAccess`.
- Preserve existing daemon-launch and worktree isolation logic while ensuring persisted `cwd` on the card uses the server-resolved root for project-assigned cards.
- Update source-contract tests in `src/components/task-chat-cwd.test.ts` and `src/components/board-chat-link.test.ts` to require server-side project resolution and authorization behavior.

### Testing
- Ran the component source-contract checks with `node --experimental-strip-types src/components/task-chat-cwd.test.ts` and `node --experimental-strip-types src/components/board-chat-link.test.ts`, both succeeded.
- Type-checked with `pnpm typecheck` and verified wired tests with `pnpm check:tests-wired`, both succeeded.
- Executed the full app test suite with `pnpm test:app`, and the app tests passed (all automated checks green).