### PR TITLE
fix(tauri): restrict loopback event listeners

### DIFF
--- a/src-tauri/capabilities/loopback-browser.json
+++ b/src-tauri/capabilities/loopback-browser.json
@@ -13,8 +13,6 @@
     ]
   },
   "permissions": [
-    "core:event:allow-listen",
-    "core:event:allow-unlisten",
     "allow-pty-start",
     "allow-pty-write",
     "allow-pty-resize",

--- a/src-tauri/capabilities/loopback-main-events.json
+++ b/src-tauri/capabilities/loopback-main-events.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "loopback-main-events",
+  "description": "allows only the trusted main loopback webview to subscribe to app events",
+  "webviews": [
+    "main"
+  ],
+  "remote": {
+    "urls": [
+      "http://localhost:*/*",
+      "http://127.0.0.1:*/*",
+      "http://[\\:\\:1]:*/*"
+    ]
+  },
+  "permissions": [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten"
+  ]
+}

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -6,6 +6,9 @@ const defaultCapability = JSON.parse(readFileSync(new URL("../capabilities/defau
 const loopbackBrowserCapability = JSON.parse(
   readFileSync(new URL("../capabilities/loopback-browser.json", import.meta.url), "utf8"),
 );
+const loopbackMainEventsCapability = JSON.parse(
+  readFileSync(new URL("../capabilities/loopback-main-events.json", import.meta.url), "utf8"),
+);
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
@@ -129,10 +132,20 @@ test("packaged sidecar loopback origins can use browser commands and main-webvie
     capabilityAllowsOrigin(loopbackBrowserCapability, "http://[::1]:64203/"),
     "packaged random IPv6 loopback sidecar port should be allowed restricted browser IPC",
   );
+  assertCapabilityDoesNotGrant(loopbackBrowserCapability, [
+    "core:event:allow-listen",
+    "core:event:allow-unlisten",
+  ]);
+
+  assert.deepEqual(
+    loopbackMainEventsCapability.webviews,
+    ["main"],
+    "loopback event permissions must be restricted to the trusted main webview",
+  );
   for (const permission of ["core:event:allow-listen", "core:event:allow-unlisten"]) {
     assert.ok(
-      loopbackBrowserCapability.permissions.includes(permission),
-      `loopback terminal/browser pages must be allowed to use Tauri event ${permission}`,
+      loopbackMainEventsCapability.permissions.includes(permission),
+      `trusted main loopback webview must be allowed to use Tauri event ${permission}`,
     );
   }
   for (const permission of [


### PR DESCRIPTION
### Motivation
- Loopback-origin pages were granted `core:event:allow-listen`/`core:event:allow-unlisten` broadly, which allowed untrusted localhost webviews to subscribe to globally broadcast events (e.g. `pty:data`) and leak sensitive terminal output. 
- The intent is to preserve restricted browser/PTTY command access for loopback sidecars while preventing arbitrary loopback pages from eavesdropping on app events.

### Description
- Removed `core:event:allow-listen` and `core:event:allow-unlisten` from `src-tauri/capabilities/loopback-browser.json` so broad loopback origins no longer receive event-listen permissions. 
- Added `src-tauri/capabilities/loopback-main-events.json` that scopes `core:event:allow-listen` and `core:event:allow-unlisten` to the trusted `main` webview via a `webviews: ["main"]` capability. 
- Updated `src-tauri/permissions/desktop-permissions.test.mjs` to load the new capability, assert the broad loopback capability does not grant event permissions, and verify the new `loopback-main-events` capability grants event permissions only to the `main` webview while preserving other loopback permissions.

### Testing
- Ran `node src-tauri/permissions/desktop-permissions.test.mjs` and all tests passed (9 passed, 0 failed). 
- Ran `git diff --check` to validate formatting/whitespace and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4763b9294883278762bbfcd6e54d2a)