### PR TITLE
chore(release): stamp v0.0.140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.140] - 2026-07-05
+
+Docs release on top of v0.0.139. Adds the approved design spec for the
+upcoming **contextual-only browser surface** — the plan to retire the in-app
+browser as a standalone navigation destination and make it a companion split
+pane on wide viewports / bottom-sheet overlay on mobile, while keeping every
+existing URL-open entry point working unchanged.
+
+### Docs
+- **Browser contextual-only surface design spec** (`docs/superpowers/specs/2026-07-04-browser-contextual-design.md`). Documents the navigation removal, the `openBrowserAdaptive` behaviour for wide vs narrow viewports, and the deep-link paths that stay functional via `?mode=browser` / `#browser`.
+
 ## [0.0.139] - 2026-07-05
 
 Security-hardening release on top of v0.0.138. A coordinated batch of fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.139",
+  "version": "0.0.140",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.139"
+version = "0.0.140"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.139"
+version = "0.0.140"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.139</string>
+	<string>0.0.140</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.139</string>
+	<string>0.0.140</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.139</string>
+	<string>0.0.140</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.139</string>
+	<string>0.0.140</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.139",
+  "version": "0.0.140",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version bump to **v0.0.140** across all six version locations + CHANGELOG.

## Contents
Docs release on top of v0.0.139 — ships the approved **browser contextual-only surface** design spec that landed in #2424.

## Stamped
- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (app package entry)
- `src-tauri/tauri.conf.json`
- `src-tauri/Info.ios.plist` (both version keys)
- `src-tauri/gen/apple/app_iOS/Info.plist` (both version keys)
- `CHANGELOG.md` — new `## [0.0.140]` section

Once merged + green, tag `v0.0.140` → `release.yml` builds signed/notarized DMG + AppImage + MSI.