### PR TITLE
Tighten sidebar option spacing

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -43,6 +43,18 @@ assert.match(
 );
 
 assert.match(
+  styles,
+  /\.sidebar-nav-scroll\s*\{[^}]*gap:\s*4px/,
+  "Sidebar nav options should stay visually close together on desktop",
+);
+
+assert.match(
+  styles,
+  /\.sidebar-folder-row,\n\.sidebar-actions--footer \.sidebar-action-row\s*\{[^}]*min-height:\s*30px/,
+  "Desktop sidebar option rows should use compact height before mobile touch-target overrides",
+);
+
+assert.match(
   source,
   /<div className="sidebar-nav-scroll"/,
   "Sidebar should keep the main navigation in one continuous scrollable rail",

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -268,7 +268,7 @@
   scrollbar-color: var(--border-hairline) transparent;
   /* Sections are separated by whitespace alone (no rules) for a calmer,
      Codex-style nav. */
-  gap: 16px;
+  gap: 4px;
   padding: 2px 0 2px;
 }
 
@@ -887,8 +887,8 @@
 
 .sidebar-folder-row,
 .sidebar-actions--footer .sidebar-action-row {
-  gap: 7px;
-  min-height: 34px;
+  gap: 6px;
+  min-height: 30px;
   border-radius: var(--radius-control);
   padding: 0 8px;
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- tighten desktop sidebar navigation section spacing
- reduce desktop sidebar option row height while preserving mobile touch-target overrides
- add source assertions for the compact sidebar spacing

## Verification
- node src/components/sidebar-minimal.test.ts
- pnpm check:tests-wired
- pnpm test:app
- pnpm typecheck

Bead: cave-mir