### PR TITLE
Reduce home composer control crowding

### DIFF
--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -46,8 +46,8 @@ assert.match(
 // ───── Phone composer controls are thumb-sized ─────
 assert.match(
   css,
-  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?align-items:\s*stretch;[\s\S]*?\.hc-control-group--who,\s*\.hc-control-group--run\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-home-select-value\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "phone composer action bar uses thumb-sized custom selectors, send, and two-destination controls",
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?align-items:\s*stretch;[\s\S]*?\.hc-control-group--who\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*var\(--touch-target\);[\s\S]*?\.hc-run-rail__controls\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-home-select-value\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone composer uses thumb-sized main controls plus a readable run-settings rail",
 );
 
 

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -49,8 +49,18 @@ assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*var\(--radius-cont
 // ───────── Command-bar hierarchy ─────────
 assert.match(
   source,
-  /hc-control-group--who[\s\S]*?<HomeSelect[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?<ProjectPicker[\s\S]*?hc-control-group--run[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?aria-label="Send"/,
-  "home composer separates who and run control groups with custom selectors and the send control",
+  /hc-control-group--who[\s\S]*?<HomeSelect[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?<ProjectPicker[\s\S]*?hc-control-group--run[\s\S]*?aria-label="Enhance prompt"[\s\S]*?aria-label="Send"/,
+  "home composer keeps context controls separate from enhance and send in the main input shell",
+);
+assert.match(
+  source,
+  /className="hc-run-rail"[\s\S]*?aria-label="Run settings"[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<ComposerHostChip/,
+  "runtime/model, thinking, speed, and host live in the secondary run-settings rail",
+);
+assert.doesNotMatch(
+  source,
+  /hc-control-group--run[\s\S]*?Choose runtime and model[\s\S]*?aria-label="Send"/,
+  "runtime/model controls should not compete with enhance and send in the main action bar",
 );
 assert.match(source, /import \{ StandardSelect/, "home composer selectors should delegate to StandardSelect");
 assert.match(source, /<StandardSelect[\s\S]*?popoverClassName="hc-home-select-popover"/, "home composer custom selectors should use the shared select popover");
@@ -63,7 +73,12 @@ assert.match(
 assert.match(
   css,
   /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*8px 14px;[\s\S]*?padding:\s*10px 14px 14px;/,
-  "home composer action bar wraps with distinct spacing between who and run clusters",
+  "home composer action bar keeps compact spacing between context and submit clusters",
+);
+assert.match(
+  css,
+  /\.hc-run-rail\s*\{[\s\S]*?display:\s*flex;[\s\S]*?background:[\s\S]*?color-mix/,
+  "run settings rail is a distinct secondary surface",
 );
 assert.match(
   css,
@@ -109,8 +124,8 @@ assert.match(
 );
 assert.match(
   css,
-  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-control-group--who,\s*\.hc-control-group--run\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?grid-template-columns:\s*repeat\(3,\s*minmax\(0,\s*1fr\)\)\s*var\(--touch-target\);/,
-  "mobile who and run clusters wrap as readable custom selector grids",
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-control-group--who\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*var\(--touch-target\);[\s\S]*?\.hc-run-rail\s*\{[\s\S]*?\.hc-run-rail__controls\s*\{[\s\S]*?display:\s*grid;/,
+  "mobile context, send, and run rail controls wrap as readable custom selector grids",
 );
 
 // ── "Jump back in" recent-chats strip REMOVED ──

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -383,8 +383,8 @@ assert.match(
 // creating a board task, so they render only while the Chat mode is selected.
 assert.match(
   source,
-  /destination === "chat" \? \(\s*<>[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/>\s*\) : null/,
-  "Runtime/model, Think, and Speed controls collapse out of the action bar when Task is selected",
+  /destination === "chat" \? \(\s*<div className="hc-run-rail" aria-label="Run settings">[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/div>\s*\) : null/,
+  "Runtime/model, Think, and Speed controls collapse out of the composer when Task is selected",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -1150,6 +1150,67 @@ export function HomeComposer({
           </div>
         )}
 
+        {destination === "chat" ? (
+          <div className="hc-run-rail" aria-label="Run settings">
+            <span className="hc-run-rail__accent" aria-hidden>
+              <Icon name="ph:sliders-horizontal" width={13} />
+            </span>
+            <div className="hc-run-rail__controls">
+              <HomeSelect
+                icon="ph:terminal-window"
+                value={selectedRuntimeModelValue}
+                onChange={handleSelectRuntimeModel}
+                groups={runtimeModelSelectGroups}
+                ariaLabel="Choose runtime and model"
+                disabled={!selectedFamiliarId || sending}
+                className="hc-runtime-model-selector"
+              />
+
+              <HomeSelect
+                label="Think"
+                icon="ph:sparkle-bold"
+                value={thinkingEffort}
+                onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
+                groups={[
+                  {
+                    options: COMMAND_THINKING_OPTIONS.map((option) => ({
+                      ...option,
+                      icon: "ph:sparkle-bold",
+                    })),
+                  },
+                ]}
+                ariaLabel="Choose thinking effort"
+                disabled={sending}
+                className="hc-command-select"
+              />
+
+              <HomeSelect
+                label="Speed"
+                icon="ph:lightning-bold"
+                value={responseSpeed}
+                onChange={(value) => setResponseSpeed(value as CommandResponseSpeed)}
+                groups={[
+                  {
+                    options: COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => ({
+                      ...option,
+                      icon: "ph:lightning-bold",
+                    })),
+                  },
+                ]}
+                ariaLabel="Choose response speed"
+                disabled={sending}
+                className="hc-command-select"
+              />
+
+              <ComposerHostChip
+                value={runtimeHost ?? LOCAL_HOST_ID}
+                disabled={sending}
+                onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
+              />
+            </div>
+          </div>
+        ) : null}
+
         {/* Action bar */}
         <div className="hc-action-bar">
           <div className="hc-control-group hc-control-group--who">
@@ -1198,65 +1259,6 @@ export function HomeComposer({
           </div>
 
           <div className="hc-control-group hc-control-group--run">
-            {/* Runtime/model, Think, and Speed configure a chat send — they're
-                meaningless for creating a board task, so they collapse out when
-                the Task mode is selected, leaving just the submit affordance. */}
-            {destination === "chat" ? (
-              <>
-                <HomeSelect
-                  icon="ph:terminal-window"
-                  value={selectedRuntimeModelValue}
-                  onChange={handleSelectRuntimeModel}
-                  groups={runtimeModelSelectGroups}
-                  ariaLabel="Choose runtime and model"
-                  disabled={!selectedFamiliarId || sending}
-                  className="hc-runtime-model-selector"
-                />
-
-                <HomeSelect
-                  label="Think"
-                  icon="ph:sparkle-bold"
-                  value={thinkingEffort}
-                  onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
-                  groups={[
-                    {
-                      options: COMMAND_THINKING_OPTIONS.map((option) => ({
-                        ...option,
-                        icon: "ph:sparkle-bold",
-                      })),
-                    },
-                  ]}
-                  ariaLabel="Choose thinking effort"
-                  disabled={sending}
-                  className="hc-command-select"
-                />
-
-                <HomeSelect
-                  label="Speed"
-                  icon="ph:lightning-bold"
-                  value={responseSpeed}
-                  onChange={(value) => setResponseSpeed(value as CommandResponseSpeed)}
-                  groups={[
-                    {
-                      options: COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => ({
-                        ...option,
-                        icon: "ph:lightning-bold",
-                      })),
-                    },
-                  ]}
-                  ariaLabel="Choose response speed"
-                  disabled={sending}
-                  className="hc-command-select"
-                />
-
-                <ComposerHostChip
-                  value={runtimeHost ?? LOCAL_HOST_ID}
-                  disabled={sending}
-                  onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
-                />
-              </>
-            ) : null}
-
             {enhanceOriginal != null && (
               <button
                 type="button"

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -164,11 +164,9 @@
 }
 
 /* ── Action bar ──────────────────────────────────────────────────────────────
- *   One balanced row: a compact "who" cluster anchored left and the "run"
- *   config cluster anchored right (pushed there with margin-left:auto). The
- *   intent switch (Chat/Task) no longer lives here — it leads the card as a
- *   mode strip above the textarea — so the bar reads as pure send config. The
- *   larger column gap (vs the intra-group gap) keeps the clusters distinct. */
+ *   The main shell carries immediate composition controls: attach,
+ *   familiar/project, prompt enhancement, and send. Runtime config lives in the
+ *   tucked rail below so it stays available without crowding the textarea. */
 .hc-action-bar {
   display: flex;
   align-items: center;
@@ -192,11 +190,49 @@
   flex: 0 1 auto;
 }
 
-/* The run cluster is content-sized and pinned to the right edge. */
+/* The submit cluster is content-sized and pinned to the right edge. */
 .hc-control-group--run {
   flex: 0 1 auto;
   justify-content: flex-end;
   margin-left: auto;
+}
+
+/* ── Run settings rail ───────────────────────────────────────────────────── */
+.hc-run-rail {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 14px 2px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
+  border-radius: calc(var(--radius-control) + 4px);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--bg-base) 86%, var(--accent-presence) 6%),
+      color-mix(in oklch, var(--bg-base) 92%, var(--bg-raised) 8%)
+    );
+}
+
+.hc-run-rail__accent {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  color: color-mix(in oklch, var(--accent-presence) 82%, var(--text-muted));
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
+
+.hc-run-rail__controls {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
 }
 
 /* ── Attach button (paperclip) ───────────────────────────────────────────── */
@@ -477,6 +513,20 @@
   max-width: 142px;
 }
 
+.hc-run-rail .hc-runtime-model-selector {
+  flex: 1 1 240px;
+  max-width: 320px;
+}
+
+.hc-run-rail .hc-command-select {
+  flex: 0 1 148px;
+}
+
+.hc-run-rail .cave-composer-host-chip {
+  flex: 0 1 230px;
+  min-width: 0;
+}
+
 .hc-home-select-popover {
   min-width: 220px;
 }
@@ -612,6 +662,30 @@
     padding: 10px;
   }
 
+  .hc-run-rail {
+    margin: 0 10px 0;
+    padding: 8px;
+  }
+
+  .hc-run-rail__accent {
+    display: none;
+  }
+
+  .hc-run-rail__controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.74fr) minmax(0, 0.74fr);
+    gap: 8px;
+  }
+
+  .hc-run-rail .hc-runtime-model-selector {
+    max-width: none;
+  }
+
+  .hc-run-rail .cave-composer-host-chip {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
   .hc-familiar-selector {
     flex: 1 1 0;
     min-width: 0;
@@ -691,16 +765,40 @@
     justify-content: stretch;
   }
 
-  .hc-control-group--who,
-  .hc-control-group--run {
+  .hc-control-group--who {
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
   }
 
   .hc-control-group--run {
+    display: grid;
     order: 4;
-    grid-template-columns: repeat(3, minmax(0, 1fr)) var(--touch-target);
+    grid-template-columns: minmax(0, 1fr) var(--touch-target);
     margin-left: 0;
+  }
+
+  .hc-run-rail {
+    margin: 0 10px 0;
+    padding: 8px;
+  }
+
+  .hc-run-rail__accent {
+    display: none;
+  }
+
+  .hc-run-rail__controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.74fr) minmax(0, 0.74fr);
+    gap: 8px;
+  }
+
+  .hc-run-rail .hc-runtime-model-selector {
+    max-width: none;
+  }
+
+  .hc-run-rail .cave-composer-host-chip {
+    grid-column: 1 / -1;
+    width: 100%;
   }
 
   .hc-familiar-selector {
@@ -1008,6 +1106,7 @@
 .hc-enhance-btn,
 .hc-enhance-undo,
 .hc-model-chip,
+.hc-run-rail,
 .hc-home-select-trigger,
 .home-composer-card .cave-project-picker__trigger.hc-project-selector {
   outline: none;
@@ -1022,6 +1121,7 @@
 .hc-enhance-btn:focus-visible,
 .hc-enhance-undo:focus-visible,
 .hc-model-chip:focus-visible,
+.hc-run-rail:focus-within,
 .hc-home-select-trigger:focus-visible,
 .home-composer-card .cave-project-picker__trigger.hc-project-selector:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);


### PR DESCRIPTION
## Summary
- move chat runtime/model, Think, Speed, and Host controls into a secondary run-settings rail
- keep the main composer action bar focused on context, enhance, and send controls
- update responsive source tests for the new control hierarchy

## Test Plan
- node --experimental-strip-types src/components/home-composer-polish.test.ts
- node --experimental-strip-types src/components/home-composer-mobile-gaps.test.ts
- node --experimental-strip-types src/components/home-composer.test.ts
- pnpm check:tests-wired
- pnpm typecheck
- git diff --check && git diff --cached --check