### PR TITLE
Compact OpenCoven tools settings buttons

### DIFF
--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -6,6 +6,7 @@ const src = await readFile(new URL("./open-coven-tools-update.tsx", import.meta.
 const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 const status = await readFile(new URL("../lib/opencoven-tools-status.ts", import.meta.url), "utf8");
+const dashboardCss = await readFile(new URL("../styles/dashboard.css", import.meta.url), "utf8");
 const runner = await readFile(new URL("../../scripts/run-tests.mjs", import.meta.url), "utf8");
 
 assert.match(src, /import \{ Button \}/, "OpenCoven tools actions use the shared Button primitive");
@@ -50,8 +51,18 @@ assert.match(src, /sidecarTokenPresent/, "diagnostics include whether the sideca
 assert.match(src, /Check tools/, "component offers a manual re-check");
 assert.match(
   src,
-  /const ghostBtn =[\s\S]*settings-touch-action/,
-  "About tools footer buttons should use the shared Settings action touch target",
+  /const toolActionBtn =[\s\S]*settings-tool-action/,
+  "About tools actions should use the compact Settings tool action class",
+);
+assert.doesNotMatch(
+  src,
+  /const (accentBtn|ghostBtn) =[\s\S]*settings-touch-action/,
+  "About tools actions should not inherit the tall Settings touch-action target",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-tool-action\s*\{[\s\S]*?height:\s*28px[\s\S]*?min-height:\s*28px/,
+  "Settings tool actions should match the compact desktop header button height",
 );
 assert.match(status, /minimumVersion: "0\.0\.49"/, "coven CLI compatibility floor is explicit in the status source");
 assert.match(status, /minimumVersion: "0\.0\.22"/, "coven-code compatibility floor is explicit in the status source");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -380,10 +380,12 @@ export function OpenCovenToolsUpdate() {
     }
   };
 
+  const toolActionBtn =
+    "settings-tool-action gap-1.5 rounded-[var(--radius-control)] text-[11px]";
   const accentBtn =
-    "settings-touch-action gap-1.5 rounded-[var(--radius-control)] bg-[var(--accent-presence)] px-3 text-[11px] font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50";
+    `${toolActionBtn} bg-[var(--accent-presence)] px-3 font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50`;
   const ghostBtn =
-    "settings-touch-action gap-1.5 rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
+    `${toolActionBtn} border border-[var(--border-hairline)] px-2.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]`;
   const footerStatusText =
     diagnosticsStatus === "copied"
       ? "Diagnostics copied"

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -306,6 +306,12 @@
   white-space: nowrap;
 }
 
+.settings-tool-action {
+  height: 28px;
+  min-height: 28px;
+  line-height: 1;
+}
+
 .settings-mobile-switch {
   min-width: 64px;
   min-height: var(--touch-target);


### PR DESCRIPTION
## Summary
- replace the tall Settings touch-target utility on OpenCoven Tools actions with a compact settings-tool-action class
- keep Copy command, Copy diagnostics, Check tools, and update actions at the 28px header-button height
- add source coverage for the compact button contract

## Test Plan
- node --experimental-strip-types src/components/open-coven-tools-update.test.ts
- node --experimental-strip-types src/components/settings-shell-polish.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- git diff --check
- Playwright measurement on http://127.0.0.1:3010/settings#about: Copy command, Copy diagnostics, and Check tools all 28px high; screenshot /tmp/coven-cave-settings-tools-buttons-tall.png