### PR TITLE
Make tools update button more visible

### DIFF
--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -64,6 +64,16 @@ assert.match(
   /\.settings-tool-action\s*\{[\s\S]*?height:\s*28px[\s\S]*?min-height:\s*28px/,
   "Settings tool actions should match the compact desktop header button height",
 );
+assert.match(
+  src,
+  /settings-tool-action--primary/,
+  "Update tools action should opt into the more visible primary styling",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-tool-action--primary\s*\{[\s\S]*?border:[\s\S]*?box-shadow:/,
+  "Primary Settings tool action should have a visible border and elevation",
+);
 assert.match(status, /minimumVersion: "0\.0\.49"/, "coven CLI compatibility floor is explicit in the status source");
 assert.match(status, /minimumVersion: "0\.0\.22"/, "coven-code compatibility floor is explicit in the status source");
 assert.match(status, /installCommand: "npm i -g @opencoven\/cli@latest"/, "coven CLI exposes the exact update command");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -383,7 +383,7 @@ export function OpenCovenToolsUpdate() {
   const toolActionBtn =
     "settings-tool-action gap-1.5 rounded-[var(--radius-control)] text-[11px]";
   const accentBtn =
-    `${toolActionBtn} bg-[var(--accent-presence)] px-3 font-semibold text-white transition-opacity hover:opacity-90 disabled:opacity-50`;
+    `${toolActionBtn} settings-tool-action--primary bg-[var(--accent-presence)] px-3 font-semibold text-white disabled:opacity-50`;
   const ghostBtn =
     `${toolActionBtn} border border-[var(--border-hairline)] px-2.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]`;
   const footerStatusText =

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -312,6 +312,22 @@
   line-height: 1;
 }
 
+.settings-tool-action--primary {
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 72%, white 18%);
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--accent-presence) 24%, transparent) inset,
+    0 8px 18px color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  transition: background 0.14s, border-color 0.14s, box-shadow 0.14s, transform 0.14s;
+}
+
+.settings-tool-action--primary:hover {
+  background: color-mix(in oklch, var(--accent-presence) 88%, white 12%);
+  border-color: color-mix(in oklch, var(--accent-presence) 82%, white 18%);
+  box-shadow:
+    0 0 0 1px color-mix(in oklch, var(--accent-presence) 32%, transparent) inset,
+    0 10px 22px color-mix(in oklch, var(--accent-presence) 24%, transparent);
+}
+
 .settings-mobile-switch {
   min-width: 64px;
   min-height: var(--touch-target);


### PR DESCRIPTION
## Summary
- make the compact OpenCoven tools update action opt into stronger primary styling
- add visible border/elevation styling for the primary update action while keeping the 28px desktop height
- add source assertions for the visible primary treatment

## Verification
- node src/components/open-coven-tools-update.test.ts
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app

Bead: cave-i22