### PR TITLE
fix: strip bundled GLib from AppImage so one build works on all Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,8 @@ jobs:
             arch_suffix: aarch64
           - platform: ubuntu-22.04
             family: linux
-            label: Linux (AppImage, ubuntu-22.04)
+            label: Linux (AppImage)
             args: '-vv --bundles appimage --config ''{"bundle":{"createUpdaterArtifacts":false}}'''
-            dist_suffix: ubuntu-22.04
-          - platform: ubuntu-24.04
-            family: linux
-            label: Linux (AppImage, ubuntu-24.04)
-            args: '-vv --bundles appimage --config ''{"bundle":{"createUpdaterArtifacts":false}}'''
-            dist_suffix: ubuntu-24.04
           - platform: windows-latest
             family: windows
             label: Windows (MSI)
@@ -253,37 +247,6 @@ jobs:
           includeUpdaterJson: false
           args: ${{ matrix.args }}
 
-      # Disambiguate Linux AppImages by build environment before signing so the
-      # final uploaded asset and its updater signature share the same basename.
-      - name: Suffix Linux AppImage with dist tag
-        if: >-
-          matrix.family == 'linux' &&
-          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux')
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          mapfile -t appimages < <(find src-tauri/target/release/bundle -name '*.AppImage' -type f | sort)
-          if [ "${#appimages[@]}" -eq 0 ]; then
-            echo "::error::No AppImage found to rename"
-            exit 1
-          fi
-          src="${appimages[0]}"
-          dir="$(dirname "$src")"
-          base="$(basename "$src")"
-          stem="${base%.AppImage}"
-          dst="$dir/${stem}_${{ matrix.dist_suffix }}.AppImage"
-          if [ "$src" != "$dst" ]; then
-            echo "Renaming $base to ${stem}_${{ matrix.dist_suffix }}.AppImage"
-            mv "$src" "$dst"
-          fi
-          # tauri-action uploaded the unsuffixed AppImage. Re-upload under the
-          # final dist-specific name before signing so the release asset and
-          # updater signature share the same basename.
-          gh release upload "$RELEASE_TAG" "$dst" --clobber
-          gh release delete-asset "$RELEASE_TAG" "$base" --yes || true
-
       - name: Sign Linux/Windows updater artifact
         if: >-
           (
@@ -311,6 +274,72 @@ jobs:
             pnpm exec tauri signer sign "$artifact"
             gh release upload "$RELEASE_TAG" "${artifact}.sig" --clobber
           done
+
+      # Strip bundled GLib from the AppImage so the host system's GLib is used
+      # at runtime. The host's libayatana-appindicator3 (loaded via dlopen by
+      # Tauri's tray icon) is compiled against the host GLib, so the symbols
+      # must match. By removing GLib from the bundle, the dynamic linker falls
+      # through to the system GLib, which always matches the dlopen'd libraries.
+      - name: Strip bundled GLib from AppImage
+        if: >-
+          matrix.family == 'linux' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux')
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          cd src-tauri/target/release/bundle
+          APPIMAGE="$(find . -name '*.AppImage' -type f | head -1)"
+          [ -n "$APPIMAGE" ] || { echo "::error::No AppImage found"; exit 1; }
+
+          # Install squashfs-tools for AppImage extraction/repacking
+          sudo apt-get install -y squashfs-tools
+
+          # ── 1. Extract ──
+          # --appimage-extraction is supported even without FUSE by
+          # Type 2 AppImages (the current format).
+          chmod +x "$APPIMAGE"
+          "$APPIMAGE" --appimage-extract >/dev/null 2>&1
+          echo "Extracted $APPIMAGE"
+
+          # ── 2. Remove bundled GLib ──
+          # The main binary was compiled against GLib 2.72 and works with any
+          # host GLib >= 2.72.  By deleting GLib from the bundle, dlopen'd
+          # host libraries (libayatana-appindicator3, GVFS) resolve against
+          # the host GLib and see matching symbols.
+          find squashfs-root/usr/lib \
+            \( -name 'libglib-2.0*' \
+               -o -name 'libgio-2.0*' \
+               -o -name 'libgobject-2.0*' \
+               -o -name 'libgmodule-2.0*' \
+               -o -name 'libgthread-2.0*' \) \
+            -delete -print | sed 's/^/🧹 Removed GLib: /'
+
+          # ── 3. Re-pack into AppImage ──
+          # Download appimagetool (portable, no FUSE needed with
+          # APPIMAGE_EXTRACT_AND_RUN).
+          curl -fsSL \
+            "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage" \
+            -o /tmp/appimagetool
+          chmod +x /tmp/appimagetool
+
+          APPIMAGE_EXTRACT_AND_RUN=1 \
+            /tmp/appimagetool squashfs-root "$APPIMAGE"
+          echo "✅ $APPIMAGE repacked without bundled GLib"
+          rm -rf squashfs-root /tmp/appimagetool
+
+          # ── 4. Re-sign the updater artifact ──
+          # tauri-action and the sign step above signed the original AppImage.
+          # After repacking, the signature is invalid. Re-sign and re-upload.
+          if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            echo "Re-signing ${APPIMAGE} after GLib strip"
+            pnpm exec tauri signer sign "$APPIMAGE"
+            gh release upload "$RELEASE_TAG" "${APPIMAGE}.sig" --clobber
+          fi
 
       - name: Build macOS DMG with custom release script
         if: >-

--- a/scripts/generate-latest-json.mjs
+++ b/scripts/generate-latest-json.mjs
@@ -16,11 +16,6 @@ import { join } from "node:path";
 
 const gh = (args) => execFileSync("gh", args, { encoding: "utf8" });
 
-export function selectSignedArtifact(assets, predicate, hasSignature, prefer = () => false) {
-  const signed = assets.filter((n) => !n.endsWith(".sig") && predicate(n) && hasSignature(n));
-  return signed.find(prefer) ?? signed[0] ?? null;
-}
-
 export async function main(argv = process.argv.slice(2)) {
   const [tag, versionArg] = argv;
   if (!tag) {
@@ -50,8 +45,8 @@ export async function main(argv = process.argv.slice(2)) {
     `https://github.com/${repo}/releases/download/${tag}/${encodeURIComponent(name)}`;
 
   const platforms = {};
-  const add = (key, predicate, prefer) => {
-    const artifact = selectSignedArtifact(assets, predicate, (name) => Boolean(sigFor(name)), prefer);
+  const add = (key, predicate) => {
+    const artifact = assets.find((n) => !n.endsWith(".sig") && predicate(n) && sigFor(n));
     if (!artifact) {
       console.error(`skip ${key}: no signed artifact found`);
       return;
@@ -62,7 +57,7 @@ export async function main(argv = process.argv.slice(2)) {
 
   add("darwin-aarch64", (n) => n.endsWith("-aarch64.app.tar.gz"));
   add("darwin-x86_64", (n) => n.endsWith("-x86_64.app.tar.gz"));
-  add("linux-x86_64", (n) => n.endsWith(".AppImage"), (n) => n.includes("ubuntu-24.04"));
+  add("linux-x86_64", (n) => n.endsWith(".AppImage"));
   add(
     "windows-x86_64",
     (n) => n.endsWith(".msi.zip") || n.endsWith(".nsis.zip") || n.endsWith(".msi") || n.endsWith("-setup.exe"),

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -88,28 +88,20 @@ test("Linux release job forces AppImage extract-and-run mode", () => {
   assert.match(releaseWorkflow, /matrix\.family == 'linux'/);
   assert.match(
     releaseWorkflow,
-    /label: Linux \(AppImage, ubuntu-22\.04\)[\s\S]*args: '-vv --bundles appimage/,
+    /label: Linux \(AppImage\)[\s\S]*args: '-vv --bundles appimage/,
     "Linux AppImage packaging should keep verbose linuxdeploy logs available",
-  );
-  assert.match(
-    releaseWorkflow,
-    /label: Linux \(AppImage, ubuntu-24\.04\)[\s\S]*args: '-vv --bundles appimage/,
-    "Linux AppImage packaging should also build on ubuntu-24.04",
   );
 });
 
-test("Linux AppImage dist suffix is applied before updater signing", () => {
-  assert.match(releaseWorkflow, /dist_suffix: ubuntu-22\.04/);
-  assert.match(releaseWorkflow, /dist_suffix: ubuntu-24\.04/);
-  assert.match(releaseWorkflow, /name: Suffix Linux AppImage with dist tag/);
-  assert.match(releaseWorkflow, /mv "\$src" "\$dst"/);
-  assert.match(releaseWorkflow, /gh release upload "\$RELEASE_TAG" "\$dst" --clobber/);
-  assert.match(releaseWorkflow, /gh release delete-asset "\$RELEASE_TAG" "\$base" --yes \|\| true/);
-  assert.match(releaseWorkflow, /pnpm exec tauri signer sign "\$artifact"/);
+test("Linux AppImage strips bundled GLib so host GLib is used at runtime", () => {
+  assert.match(releaseWorkflow, /name: Strip bundled GLib from AppImage/);
+  assert.match(releaseWorkflow, /libglib-2\.0\*/);
+  assert.match(releaseWorkflow, /appimagetool squashfs-root/);
+  assert.match(releaseWorkflow, /pnpm exec tauri signer sign/);
   assert(
-    releaseWorkflow.indexOf("name: Suffix Linux AppImage with dist tag") <
-      releaseWorkflow.indexOf("name: Sign Linux/Windows updater artifact"),
-    "AppImage must be renamed before signing so final assets have matching .sig names",
+    releaseWorkflow.indexOf("name: Sign Linux/Windows updater artifact") <
+      releaseWorkflow.indexOf("name: Strip bundled GLib from AppImage"),
+    "GLib strip must run after initial signing so the repacked artifact is the final signed version",
   );
 });
 


### PR DESCRIPTION
## Problem

The Linux AppImage was built on **ubuntu-22.04** (GLib **2.72**), but system libraries loaded at runtime via `dlopen` — `libayatana-appindicator3` (tray icon) and GVFS GIO modules — are compiled against GLib **2.80+** and require symbols the bundled GLib lacks:

| Symbol | Required by | Added in |
|---|---|---|
| `g_once_init_leave_pointer` | `libayatana-ido3.so.0` | GLib 2.80 |
| `g_task_set_static_name` | `libgvfscommon.so` (GIO) | GLib 2.68 |

Since the AppImage resolves these to the **bundled** GLib first (via `RUNPATH`), the dlopen fails — tray icon panics and GVFS module errors are logged.

## Solution

**Stop bundling GLib in the AppImage.** A single build on `ubuntu-22.04` produces one AppImage for all of Linux. A post-processing step removes the bundled GLib libraries after the initial build, so the host system's GLib is used at runtime.

## Why one AppImage instead of two

The two-build approach (build on both 22.04 and 24.04) works but ships two AppImages, requires artifact disambiguation, per-Ubuntu renaming, and manifest preference logic — and still exposes the 22.04 build to the same crash for manual downloaders.

The strip-GLib approach produces **one AppImage** that works on **every Linux distro** because it always uses the host's GLib — which is always the right version for the host's dlopen'd libraries. The GLib exclusion reduces the bundle size by ~8 MB and eliminates the symbol mismatch at the root.