### PR TITLE
feat: add opencode as a compatibility adapter in web UI

### DIFF
--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -68,6 +68,16 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
     source: "bundled",
   },
   {
+    id: "opencode",
+    label: "OpenCode",
+    binary: "opencode",
+    chatSupported: true,
+    versionArgs: ["--version"],
+    installHint:
+      "Install OpenCode with `curl -fsSL https://opencode.ai/install | bash`, then ensure `opencode` is on PATH.",
+    source: "bundled",
+  },
+  {
     id: "hermes",
     label: "Hermes",
     binary: "hermes",
@@ -215,7 +225,7 @@ export function mergeAdapterReports(
 
   return [...merged.values()].sort((a, b) => {
     const rank = (id: string) =>
-      id === "codex" ? 0 : id === "claude" ? 1 : id === "hermes" ? 2 : id === "openclaw" ? 3 : 4;
+      id === "codex" ? 0 : id === "claude" ? 1 : id === "opencode" ? 2 : id === "hermes" ? 3 : id === "openclaw" ? 4 : 5;
     return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
   });
 }

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -49,8 +49,8 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
   },
   opencode: {
     runtime: "opencode",
-    provider: "openai",
-    models: [{ id: "openai/gpt-5.5", label: "GPT-5.5" }],
+    provider: null,
+    models: [],
     allowCustom: true,
   },
   hermes: {

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -47,6 +47,12 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     ],
     allowCustom: true,
   },
+  opencode: {
+    runtime: "opencode",
+    provider: "openai",
+    models: [{ id: "openai/gpt-5.5", label: "GPT-5.5" }],
+    allowCustom: true,
+  },
   hermes: {
     runtime: "hermes",
     provider: null,


### PR DESCRIPTION
Adds opencode as a compatibility adapter in the coven-cave web UI, so users can select and configure it alongside Codex, Claude Code, Hermes, and OpenClaw.

## Changes
- Add opencode entry to COMPATIBILITY_ADAPTERS with install hint
- Add opencode to RUNTIME_MODEL_CATALOG with OpenAI model support
- Update adapter sort ranking to include opencode