### PR TITLE
docs: credit Chris Thomas (@Aimplemented) for community contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Docs
+- **Add `CONTRIBUTORS.md`** to credit community contributions. Records the fixes and improvements from Chris Thomas ([@Aimplemented](https://github.com/Aimplemented)) whose original PRs were re-landed through internal branches during merge — group-chat parallel first-pass replies (#2206), tokenless native iOS Serve route (#2404), installer links via the system handler (#2381, #2414), and the current-session-id flag (#1989).
+
 ## [0.0.140] - 2026-07-05
 
 Docs release on top of v0.0.139. Adds the approved design spec for the

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,36 @@
+# Contributors
+
+CovenCave is built by the OpenCoven team with help from the wider community.
+Thank you to everyone who has reported issues, proposed fixes, and shipped
+improvements.
+
+## Community Contributors
+
+### Chris Thomas ([@Aimplemented](https://github.com/Aimplemented))
+
+Chris contributed several fixes and improvements that shipped in CovenCave.
+His original pull requests were re-landed through internal branches during
+merge, so this file records the credit his work is due:
+
+- **Parallel group-chat first-pass replies** — reworked full-coven group chat
+  from sequential relay to independent parallel first-pass replies, with
+  roundtable prompt framing so each familiar answers from its own role.
+  (proposed in [#2187](https://github.com/OpenCoven/coven-cave/pull/2187) /
+  [#2188](https://github.com/OpenCoven/coven-cave/issues/2188), shipped in
+  [#2206](https://github.com/OpenCoven/coven-cave/pull/2206))
+- **Native iOS Serve route stays tokenless** — kept the native iOS Serve
+  route reachable without a bearer token so on-device handoff works.
+  (proposed in [#2391](https://github.com/OpenCoven/coven-cave/pull/2391) /
+  [#2396](https://github.com/OpenCoven/coven-cave/pull/2396), shipped in
+  [#2404](https://github.com/OpenCoven/coven-cave/pull/2404))
+- **Installer links open through the system handler** — routed fallback
+  installer/update CTAs through Tauri `shell_open` so DMG/MSI/AppImage assets
+  use the OS browser/download handler, with `window.open` and the Cave Browser
+  as recovery fallbacks.
+  (proposed in [#2379](https://github.com/OpenCoven/coven-cave/pull/2379),
+  shipped in [#2381](https://github.com/OpenCoven/coven-cave/pull/2381) and
+  [#2414](https://github.com/OpenCoven/coven-cave/pull/2414))
+- **Current session id flag for OpenClaw** — used the current session id flag
+  so session targeting resolves correctly.
+  (proposed in [#1974](https://github.com/OpenCoven/coven-cave/pull/1974),
+  shipped in [#1989](https://github.com/OpenCoven/coven-cave/pull/1989))


### PR DESCRIPTION
## What

Adds `CONTRIBUTORS.md` and a changelog note crediting **Chris Thomas ([@Aimplemented](https://github.com/Aimplemented))** for several fixes that shipped in CovenCave but lost attribution when his original PRs were re-landed through internal branches during merge.

## Why

@Aimplemented opened 5 fork PRs whose work shipped without crediting him — his only co-author trailer (on #2206) used a `.local` machine email that links to no GitHub profile, so he currently has zero visible credit. This corrects that.

## Contributions credited
| Proposed | Shipped as |
|---|---|
| #2187 / #2188 (group chat parallel first-pass) | #2206 |
| #2391 / #2396 (tokenless native iOS Serve route) | #2404 |
| #2379 (installer links via system handler) | #2381, #2414 |
| #1974 (current session id flag) | #1989 |

The merge commit here also carries a proper `Co-authored-by:` trailer with his GitHub no-reply email so the attribution links to his profile.

Follow-up: thank-you comments will be posted on each of his closed PRs pointing to where the work shipped.