### PR TITLE
docs: add contributor-attribution rule to AGENTS.md + point CLAUDE.md at it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,18 @@ bd prime                # Refresh Beads context
 - Record branch/worktree, session, familiar owner, and verification evidence in the bead before handoff.
 - Close with `bd close <id>` only after merge or explicit completion criteria are satisfied.
 - Never put secrets in bead text, and never treat `.beads/issues.jsonl` as the sync source of truth.
+
+## Crediting Contributors
+
+When you re-land or build on someone else's work — a fork PR, an issue author's proposal, a co-author — **credit the human contributor with a working GitHub-linked trailer** so they show up in the contributors graph and on their profile:
+
+```
+Co-authored-by: Full Name <ID+username@users.noreply.github.com>
+```
+
+- Use the **numeric-id no-reply form**. Get the id with `gh api users/<login> --jq .id`.
+- **Never** use a machine or `.local` email (e.g. `name@Someones-Mac.local`) in a co-author trailer — it links to no account and gives **zero** credit.
+- When a squash-merge folds a contributor's PR into an internal branch, **preserve their `Co-authored-by:` line in the squash commit message** (pass an explicit commit message to the merge). A trailer that only lands as free text in the PR body does not count.
+- For substantial external contributions, also add the person to [`CONTRIBUTORS.md`](CONTRIBUTORS.md).
+
+This is about crediting **people**. Don't add trailers or footers that credit an AI model, assistant, vendor, or coding harness.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Coven Cave — Claude Code project notes
 
+> **Primary agent guide: [`AGENTS.md`](AGENTS.md).** Start there for the branch/PR
+> workflow, worktree conventions, Beads protocol, and contributor attribution.
+> This file adds Claude-specific depth on branch protection and CI gotchas.
+
 ## Branch protection on `main` — all changes go through a PR
 
 **Rule:** `main` is a protected branch. There are **no direct pushes** — not for collaborators, not for admins, not for Claude sessions (which push as the `BunsDev` admin). Every change lands via a pull request whose required checks are green. `git push origin main` (or `HEAD:main`) will be **rejected** with `GH006: Protected branch update failed`.


### PR DESCRIPTION
## What

Adds a **Crediting Contributors** section to `AGENTS.md` and a pointer at the top of `CLAUDE.md` naming `AGENTS.md` as the primary agent guide.

## Why

Directly motivated by the recent lost-credit gap ([CONTRIBUTORS.md](CONTRIBUTORS.md), #2436): an external contributor's re-landed work carried only a `.local` machine-email co-author trailer, which links to no GitHub account and gives zero credit. The new section codifies the fix so agents don't repeat it.

## The rule

- Credit human contributors with `Co-authored-by: Name <ID+username@users.noreply.github.com>` (numeric-id no-reply form; get the id via `gh api users/<login> --jq .id`).
- Never a machine/`.local` email.
- **Preserve the trailer through squash-merges** by passing an explicit commit message — a trailer that only lives in the PR body doesn't count toward the contributors graph.
- Add substantial external contributions to `CONTRIBUTORS.md`.
- Crediting people only; no AI-tool credit lines.

Part of a fleet-wide rollout adding consistent `AGENTS.md`/`CLAUDE.md` guidance across the public Coven repos. Docs-only.