### PR TITLE
fix(chat): restore file handoff routing

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -474,6 +474,7 @@ export const SUITES = {
 	    "src/components/ui/color-picker.test.ts",
 	    "src/components/ui/button.test.ts",
 	    "src/components/ui/popover.test.ts",
+    "src/components/ui/select.test.ts",
     "src/components/ui/context-menu.test.ts",
     "src/components/ui/undo-toast.test.ts",
     "src/components/ui/search-input.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5918,9 +5918,7 @@ button:active > .edge-rail-chip {
 }
 
 .familiar-quickswitch__btn.is-active {
-  border-color: var(--familiar-accent, var(--accent-presence));
-  box-shadow: 0 0 0 2px var(--bg-base),
-              0 0 0 3px var(--familiar-accent, var(--accent-presence));
+  border: 2px solid var(--familiar-accent, var(--accent-presence));
 }
 
 .familiar-quickswitch__avatar {

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
@@ -21,6 +21,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+import type { PendingCodeRailOpen } from "@/lib/pending-code-rail-open";
 import type { InitialCommandControls } from "@/lib/command-controls";
 
 // ── Layout persistence ─────────────────────────────────────────────────────────
@@ -70,11 +71,13 @@ type Props = {
   rightPanel?: RightPanelKind | null;
   pendingProjectRoot: string | null;
   pendingChatAction?: PendingChatAction;
+  pendingCodeRailOpen?: PendingCodeRailOpen | null;
   onSetInspectorOpen: (open: boolean) => void;
   onSetRightPanel?: (panel: RightPanelKind | null) => void;
   onSetActiveFamiliar: (id: string | null) => void;
   onClearPendingProjectRoot: () => void;
   onPendingChatActionHandled: () => void;
+  onPendingCodeRailOpenHandled: () => void;
   onSessionStarted: () => void;
   onSlashFromChat: (command: string, args: string) => boolean;
   onOpenOnboarding: () => void;
@@ -193,11 +196,13 @@ export function ChatSurface({
   rightPanel: rightPanelProp,
   pendingProjectRoot,
   pendingChatAction,
+  pendingCodeRailOpen,
   onSetInspectorOpen,
   onSetRightPanel,
   onSetActiveFamiliar,
   onClearPendingProjectRoot,
   onPendingChatActionHandled,
+  onPendingCodeRailOpenHandled,
   onSessionStarted,
   onSlashFromChat,
   onOpenOnboarding,
@@ -307,6 +312,7 @@ export function ChatSurface({
   // yank the running pty. Flips false→true once; never resets → no render loop.
   const [terminalOpened, setTerminalOpened] = useState(false);
   const rail = useCodeRail({ projectRoot: railProjectRoot, changeCount, terminalActive: terminalOpened });
+  const [codeRailFocus, setCodeRailFocus] = useState<PendingCodeRailOpen | null>(null);
   useEffect(() => {
     if (rail.activeTab === "terminal" && rail.open) setTerminalOpened(true);
   }, [rail.activeTab, rail.open]);
@@ -362,6 +368,36 @@ export function ChatSurface({
   useEffect(() => {
     if (rightPanel !== null) setMobileRailOpen(false);
   }, [rightPanel]);
+
+  const openCodeRailTarget = useCallback((target: PendingCodeRailOpen) => {
+    setScope("conversation");
+    rail.reopen();
+    rail.setActiveTab(target.kind === "changes" ? "changes" : "files");
+    setCodeRailFocus(target);
+    if (isMobile || paneNarrow) {
+      onSetRightPanel?.(null);
+      setMobileRailOpen(true);
+    }
+  }, [isMobile, onSetRightPanel, paneNarrow, rail]);
+
+  useEffect(() => {
+    const onOpenProjectFile = (event: Event) => {
+      const detail = (event as CustomEvent<{ path?: string; line?: number }>).detail;
+      if (!detail?.path) return;
+      openCodeRailTarget({ kind: "files", path: detail.path, line: detail.line, nonce: Date.now() });
+    };
+    const onOpenFileDiff = (event: Event) => {
+      const detail = (event as CustomEvent<{ path?: string }>).detail;
+      if (!detail?.path) return;
+      openCodeRailTarget({ kind: "changes", path: detail.path, nonce: Date.now() });
+    };
+    window.addEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
+    window.addEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+    return () => {
+      window.removeEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
+      window.removeEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+    };
+  }, [openCodeRailTarget]);
 
   // Announce code-rail visibility to the shell so it can soft-collapse the left
   // nav to its icon rail while the rail is open (keeps chat centered). Directional
@@ -487,6 +523,12 @@ export function ChatSurface({
     window.setTimeout(() => routerRef.current?.goToList(), 0);
     onPendingChatActionHandled();
   }, [onPendingChatActionHandled, onSetActiveFamiliar, pendingChatAction, routerRef]);
+
+  useEffect(() => {
+    if (!pendingCodeRailOpen) return;
+    openCodeRailTarget(pendingCodeRailOpen);
+    onPendingCodeRailOpenHandled();
+  }, [onPendingCodeRailOpenHandled, openCodeRailTarget, pendingCodeRailOpen]);
 
   function startProjectChat(projectRoot: string) {
     setScope("conversation");
@@ -640,6 +682,7 @@ export function ChatSurface({
                     projectRoot={railProjectRoot}
                     familiarId={snapshot.familiar?.id ?? null}
                     sessionId={snapshot.sessionId ?? null}
+                    focus={codeRailFocus}
                     onSelectTab={rail.setActiveTab}
                     onTogglePin={rail.togglePin}
                     onCollapse={rail.collapse}
@@ -731,6 +774,7 @@ export function ChatSurface({
               projectRoot={railProjectRoot}
               familiarId={snapshot.familiar?.id ?? null}
               sessionId={snapshot.sessionId ?? null}
+              focus={codeRailFocus}
               hidePin
               onSelectTab={rail.setActiveTab}
               onTogglePin={rail.togglePin}

--- a/src/components/code-view.test.ts
+++ b/src/components/code-view.test.ts
@@ -44,8 +44,8 @@ assert.match(
 );
 assert.match(
   workspace,
-  /Click-to-open a file from chat stays on the unified chat\/code workspace[\s\S]*?setMode\("chat"\)/,
-  "file-open events should stay in the unified Chat workspace after Code mode retirement",
+  /File\/diff links target ChatSurface's code rail[\s\S]*?setPendingCodeRailOpen\([\s\S]*?setMode\("chat"\)/,
+  "file-open events should stay in the unified Chat workspace and preserve their code-rail target after Code mode retirement",
 );
 assert.match(
   workspace,

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -74,6 +74,8 @@ assert.match(
   /\.familiar-quickswitch__strip \{[\s\S]*overflow-x: auto;/,
   "strip scrolls horizontally rather than wrapping/clipping",
 );
-assert.match(globals, /\.familiar-quickswitch__btn\.is-active \{/, "active familiar is ringed in the strip");
+const activeButtonRule = globals.match(/\.familiar-quickswitch__btn\.is-active \{([\s\S]*?)\}/)?.[1] ?? "";
+assert.match(activeButtonRule, /border:\s*2px solid var\(--familiar-accent, var\(--accent-presence\)\);/, "active familiar uses one accent border ring");
+assert.doesNotMatch(activeButtonRule, /box-shadow:/, "active familiar must not stack additional shadow rings around the avatar");
 
 console.log("familiar-quick-switch component: all assertions passed");

--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -35,6 +35,12 @@ assert.match(view, /aria-label="Close news carousel"/, "news carousel exposes an
 assert.match(view, /onClick=\{\(\) => setMediaDismissed\(true\)\}/, "close button hides the news carousel");
 assert.doesNotMatch(view, /onMouseEnter=\{\(\) => setMediaDismissed\(true\)\}/, "hovering the close affordance must not hide the news carousel");
 assert.match(view, /home-digest__media-close/, "close button has a stable styling hook");
+assert.match(
+  view,
+  /className="home-digest__media-chrome"[\s\S]*className="home-digest__media-label"[\s\S]*News[\s\S]*className="home-digest__media-close"[\s\S]*home-digest__track home-digest__track--media/,
+  "news row chrome labels the media lane and keeps the close button outside the moving track",
+);
+assert.doesNotMatch(view, /title="Close news carousel"/, "news close uses aria-label only, avoiding native tooltip overlap");
 
 // ── Media cards support an image thumbnail (with icon fallback on error) ───────
 assert.match(view, /home-digest__thumb/, "media card renders an image thumbnail when available");
@@ -67,7 +73,8 @@ assert.match(css, /\.home-digest__thumb[\s\S]*?object-fit: cover/, "media thumbn
 assert.match(css, /\.home-digest__thumb[\s\S]*?width: 46px/, "media thumbnail is enlarged for the image-forward row");
 assert.match(css, /\.home-digest__card--media[\s\S]*?padding-left/, "media cards are image-forward (thumbnail hugs the leading edge)");
 assert.match(css, /\.home-digest__media[\s\S]*?position: relative/, "media row anchors the close button");
-assert.match(css, /\.home-digest__media-close[\s\S]*?position: absolute[\s\S]*?top: 0[\s\S]*?right: 0/, "news close button sits at the media row's top-right corner");
+assert.match(css, /\.home-digest__media-chrome\s*\{[\s\S]*?display: flex[\s\S]*?justify-content: space-between/, "news row has static chrome outside the marquee track");
+assert.doesNotMatch(css, /\.home-digest__media-close[\s\S]*?position: absolute/, "news close button must not overlay the moving headline cards");
 assert.match(css, /\.home-digest__media-close\s*\{[^}]*pointer-events: auto/, "news close button is always directly clickable");
 assert.doesNotMatch(css, /\.home-digest__media-close\s*\{[^}]*opacity: 0/, "news close button must not be hidden behind hover-only reveal");
 

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -86,15 +86,20 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
       ) : null}
       {mediaCards.length > 0 && !mediaDismissed ? (
         <div className="home-digest__media">
-          <button
-            type="button"
-            className="home-digest__media-close"
-            aria-label="Close news carousel"
-            title="Close news carousel"
-            onClick={() => setMediaDismissed(true)}
-          >
-            <Icon name="ph:x-bold" width={11} aria-hidden />
-          </button>
+          <div className="home-digest__media-chrome">
+            <span className="home-digest__media-label">
+              <Icon name="ph:newspaper" width={12} aria-hidden />
+              <span>News</span>
+            </span>
+            <button
+              type="button"
+              className="home-digest__media-close"
+              aria-label="Close news carousel"
+              onClick={() => setMediaDismissed(true)}
+            >
+              <Icon name="ph:x-bold" width={11} aria-hidden />
+            </button>
+          </div>
           <div className="home-digest__track home-digest__track--media" aria-label="Media headlines">
             <DigestRow cards={mediaCards} onOpenSession={onOpenSession} />
             <DigestRow cards={mediaCards} onOpenSession={onOpenSession} duplicate />

--- a/src/components/rail-files-panel.tsx
+++ b/src/components/rail-files-panel.tsx
@@ -19,10 +19,16 @@ export function RailFilesPanel({
   projectRoot,
   familiarId,
   isFullscreen = false,
+  focusPath,
+  focusLine,
+  focusNonce,
 }: {
   projectRoot: string | null;
   familiarId?: string | null;
   isFullscreen?: boolean;
+  focusPath?: string | null;
+  focusLine?: number;
+  focusNonce?: number;
 }) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
@@ -31,6 +37,16 @@ export function RailFilesPanel({
   useEffect(() => {
     setSelectedPath(null);
   }, [projectRoot]);
+
+  useEffect(() => {
+    if (!focusPath) return;
+    const nextPath = focusPath.startsWith("/")
+      ? focusPath
+      : projectRoot
+        ? `${projectRoot.replace(/\/$/, "")}/${focusPath.replace(/^\.?\//, "")}`
+        : focusPath;
+    setSelectedPath(nextPath);
+  }, [focusLine, focusNonce, focusPath, projectRoot]);
 
   if (!projectRoot) {
     return (

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -1077,7 +1077,13 @@ export function SessionChangesInner({
 
 /** Resolves the active session's project root the same way DebugPane resolves
  *  its session context: via the chat debug store bridge from ChatView. */
-export function SessionChangesPanel() {
+export function SessionChangesPanel({
+  focusPath,
+  focusNonce,
+}: {
+  focusPath?: string | null;
+  focusNonce?: number;
+} = {}) {
   const snapshot = useChatDebugSnapshot();
   const projectRoot = snapshot.session?.project_root ?? null;
   if (!projectRoot) {
@@ -1093,6 +1099,8 @@ export function SessionChangesPanel() {
       key={projectRoot}
       projectRoot={projectRoot}
       running={snapshot.session?.status === "running"}
+      focusPath={focusPath}
+      focusNonce={focusNonce}
     />
   );
 }

--- a/src/components/ui/select.test.ts
+++ b/src/components/ui/select.test.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./select.tsx", import.meta.url), "utf8");
+
+assert.match(source, /export function StandardSelect/, "exports the StandardSelect primitive");
+assert.doesNotMatch(
+  source,
+  /import \{ Button \} from "@\/components\/ui\/button"/,
+  "StandardSelect trigger should not import the shared Button primitive",
+);
+assert.doesNotMatch(
+  source,
+  /<Button[\s\S]*variant="secondary"[\s\S]*size="md"/,
+  "StandardSelect trigger should not force .ui-btn/.ui-btn--secondary chrome over call-site select classes",
+);
+assert.match(
+  source,
+  /<button[\s\S]*className=\{\[[\s\S]*"standard-select-trigger[\s\S]*className \?\? ""/,
+  "StandardSelect trigger should be a plain button with a reset hook and caller className applied",
+);
+assert.match(
+  source,
+  /ref=\{triggerRef\}[\s\S]*aria-haspopup="menu"[\s\S]*aria-expanded=\{open\}/,
+  "plain trigger should preserve popover anchoring and menu accessibility",
+);
+
+console.log("select.test.ts OK");

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -3,7 +3,6 @@
 import { useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { Popover, PopoverBody, PopoverItem } from "@/components/ui/popover";
-import { Button } from "@/components/ui/button";
 
 export type StandardSelectOption<T extends string> = {
   value: T;
@@ -80,14 +79,13 @@ export function StandardSelect<T extends string>({
 
   return (
     <>
-      <Button
+      <button
         id={id}
         type="button"
         ref={triggerRef}
-        variant="secondary"
-        size="md"
         className={[
-            "min-w-0 justify-between gap-1 px-3 py-1.5 text-left text-[12px] leading-none",
+            "standard-select-trigger focus-ring inline-flex min-w-0 items-center justify-between gap-1 text-left leading-none disabled:pointer-events-none disabled:opacity-50",
+            className ? "" : "h-8 rounded-md border border-border bg-background px-3 py-1.5 text-[12px] text-foreground transition-colors hover:bg-muted",
             className ?? "",
           ]
           .filter(Boolean)
@@ -113,7 +111,7 @@ export function StandardSelect<T extends string>({
             aria-hidden
           />
         ) : null}
-      </Button>
+      </button>
 
       <Popover
         open={open}

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -5,6 +5,9 @@ import { readFile } from "node:fs/promises";
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const chatSurface = await readFile(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const pendingChatActionLib = await readFile(new URL("../lib/pending-chat-action.ts", import.meta.url), "utf8");
+const pendingCodeRailOpenLib = await readFile(new URL("../lib/pending-code-rail-open.ts", import.meta.url), "utf8");
+const workspaceRail = await readFile(new URL("./workspace-rail.tsx", import.meta.url), "utf8");
+const railFilesPanel = await readFile(new URL("./rail-files-panel.tsx", import.meta.url), "utf8");
 
 assert.match(
   pendingChatActionLib,
@@ -112,4 +115,83 @@ assert.match(
   chatSurface,
   /routerRef\.current\?\.newChat\([\s\S]*?pendingChatAction\.initialControls \?\? undefined/,
   "ChatSurface should pass pending initial controls into ChatRouter.newChat",
+);
+
+// File/diff links can be dispatched while ChatSurface is not mounted. Workspace
+// must keep the event detail long enough for ChatSurface to route it into the
+// repo-aware code rail after switching to chat.
+assert.match(
+  pendingCodeRailOpenLib,
+  /export type PendingCodeRailOpen =[\s\S]*kind: "files"[\s\S]*kind: "changes"[\s\S]*path: string[\s\S]*nonce: number/,
+  "PendingCodeRailOpen should be defined once in the shared lib so Workspace and ChatSurface cannot drift",
+);
+assert.match(
+  workspace,
+  /import type \{ PendingCodeRailOpen \} from "@\/lib\/pending-code-rail-open"/,
+  "Workspace should import the shared pending code-rail open type",
+);
+assert.match(
+  chatSurface,
+  /import type \{ PendingCodeRailOpen \} from "@\/lib\/pending-code-rail-open"/,
+  "ChatSurface should import the shared pending code-rail open type",
+);
+assert.match(
+  workspace,
+  /const \[pendingCodeRailOpen, setPendingCodeRailOpen\] = useState<PendingCodeRailOpen \| null>\(null\)/,
+  "Workspace should retain file/diff open detail across the mode switch into chat",
+);
+assert.match(
+  workspace,
+  /window\.addEventListener\("cave:open-project-file", onOpenProjectFile as EventListener\);[\s\S]*window\.addEventListener\("cave:open-file-diff", onOpenFileDiff as EventListener\);/,
+  "Workspace should bridge both file preview and diff events from non-chat modes",
+);
+assert.match(
+  workspace,
+  /if \(modeRef\.current === "chat"\) return;[\s\S]*setPendingCodeRailOpen\([\s\S]*kind === "files"[\s\S]*path: detail\.path[\s\S]*line: detail\.line[\s\S]*path: detail\.path[\s\S]*nonce: Date\.now\(\)[\s\S]*\);[\s\S]*setMode\("chat"\)/,
+  "Workspace should skip duplicate handling in chat but preserve path/line detail before switching there",
+);
+assert.match(
+  workspace,
+  /pendingCodeRailOpen=\{pendingCodeRailOpen\}[\s\S]*onPendingCodeRailOpenHandled=\{\(\) => setPendingCodeRailOpen\(null\)\}/,
+  "Workspace should pass pending file/diff opens into ChatSurface and clear them after consumption",
+);
+assert.match(
+  chatSurface,
+  /pendingCodeRailOpen\?: PendingCodeRailOpen/,
+  "ChatSurface should accept pending code-rail open actions",
+);
+assert.match(
+  chatSurface,
+  /openCodeRailTarget[\s\S]*rail\.reopen\(\)[\s\S]*rail\.setActiveTab\(target\.kind === "changes" \? "changes" : "files"\)[\s\S]*setCodeRailFocus/,
+  "ChatSurface should reopen the code rail, select Files/Changes, and store the focused path",
+);
+assert.match(
+  chatSurface,
+  /onOpenProjectFile[\s\S]*openCodeRailTarget\(\{ kind: "files"[\s\S]*onOpenFileDiff[\s\S]*openCodeRailTarget\(\{ kind: "changes"[\s\S]*addEventListener\("cave:open-project-file"[\s\S]*addEventListener\("cave:open-file-diff"/,
+  "ChatSurface should directly consume file and diff events while mounted",
+);
+assert.match(
+  chatSurface,
+  /if \(!pendingCodeRailOpen\) return[\s\S]*openCodeRailTarget\(pendingCodeRailOpen\)[\s\S]*onPendingCodeRailOpenHandled\(\)/,
+  "ChatSurface should consume pending file/diff opens after mounting",
+);
+assert.match(
+  chatSurface,
+  /<WorkspaceRail[\s\S]*focus=\{codeRailFocus\}/,
+  "ChatSurface should thread the focused file/diff target into WorkspaceRail",
+);
+assert.match(
+  workspaceRail,
+  /focus\?: CodeRailFocus \| null[\s\S]*<SessionChangesPanel[\s\S]*focusPath=\{focus\?\.kind === "changes" \? focus\.path : null\}[\s\S]*focusNonce=\{focus\?\.kind === "changes" \? focus\.nonce : undefined\}/,
+  "WorkspaceRail should focus diff targets in the Changes tab",
+);
+assert.match(
+  workspaceRail,
+  /<RailFilesPanel[\s\S]*focusPath=\{focus\?\.kind === "files" \? focus\.path : null\}[\s\S]*focusLine=\{focus\?\.kind === "files" \? focus\.line : undefined\}[\s\S]*focusNonce=\{focus\?\.kind === "files" \? focus\.nonce : undefined\}/,
+  "WorkspaceRail should focus file targets in the Files tab",
+);
+assert.match(
+  railFilesPanel,
+  /focusPath\?: string \| null[\s\S]*focusNonce\?: number[\s\S]*useEffect\(\(\) => \{[\s\S]*setSelectedPath\([\s\S]*focusPath/,
+  "RailFilesPanel should update its selected file from an external focus target",
 );

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -5,6 +5,7 @@ import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { RailFilesPanel } from "@/components/rail-files-panel";
 import { RailTerminalPanel } from "@/components/rail-terminal-panel";
 import type { CodeRailTab } from "@/lib/code-rail";
+import type { PendingCodeRailOpen as CodeRailFocus } from "@/lib/pending-code-rail-open";
 
 const TAB_TITLE: Record<CodeRailTab, string> = {
   changes: "Changes",
@@ -19,6 +20,7 @@ export function WorkspaceRail({
   projectRoot,
   familiarId,
   sessionId,
+  focus,
   hidePin = false,
   onSelectTab,
   onTogglePin,
@@ -30,6 +32,7 @@ export function WorkspaceRail({
   projectRoot: string | null;
   familiarId?: string | null;
   sessionId: string | null;
+  focus?: CodeRailFocus | null;
   /** Hide the pin toggle (e.g. when hosted in a mobile sheet, where pinning a
    *  transient overlay open is meaningless). Defaults to false — desktop keeps
    *  the pin control. */
@@ -132,9 +135,19 @@ export function WorkspaceRail({
           {activeTab !== "terminal" ? (
             <div className="workspace-rail__panel" key={activeTab}>
               {activeTab === "changes" ? (
-                <SessionChangesPanel />
+                <SessionChangesPanel
+                  focusPath={focus?.kind === "changes" ? focus.path : null}
+                  focusNonce={focus?.kind === "changes" ? focus.nonce : undefined}
+                />
               ) : (
-                <RailFilesPanel projectRoot={projectRoot} familiarId={familiarId} isFullscreen={isFullscreen} />
+                <RailFilesPanel
+                  projectRoot={projectRoot}
+                  familiarId={familiarId}
+                  isFullscreen={isFullscreen}
+                  focusPath={focus?.kind === "files" ? focus.path : null}
+                  focusLine={focus?.kind === "files" ? focus.line : undefined}
+                  focusNonce={focus?.kind === "files" ? focus.nonce : undefined}
+                />
               )}
             </div>
           ) : null}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -70,6 +70,7 @@ import { TopBar } from "@/components/top-bar";
 import { QuickChatOverlay } from "@/components/quick-chat-overlay";
 import { FamiliarMenuBar } from "@/components/familiar-menu-bar";
 import type { PendingChatAction } from "@/lib/pending-chat-action";
+import type { PendingCodeRailOpen } from "@/lib/pending-code-rail-open";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import {
   OPEN_IN_APP_BROWSER_EVENT,
@@ -277,6 +278,7 @@ export function Workspace() {
   }, []);
   const [pendingProjectChatRoot, setPendingProjectChatRoot] = useState<string | null>(null);
   const [pendingChatAction, setPendingChatAction] = useState<PendingChatAction>(null);
+  const [pendingCodeRailOpen, setPendingCodeRailOpen] = useState<PendingCodeRailOpen | null>(null);
   const [onboardingOpen, setOnboardingOpen] = useState(false);
   const [inboxItems, setInboxItems] = useState<InboxItem[]>([]);
   const [escalationsUnresolved, setEscalationsUnresolved] = useState(0);
@@ -503,16 +505,28 @@ export function Workspace() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Click-to-open a file from chat stays on the unified chat/code workspace.
-  // The code rail owns Files/Changes; there is no standalone Terminal page to
-  // switch into as a side effect of a file link.
+  // File/diff links target ChatSurface's code rail. ChatSurface only mounts in
+  // chat mode, so preserve event detail from non-chat surfaces until it mounts.
   useEffect(() => {
-    const onOpenFile = (e: Event) => {
-      void (e as CustomEvent).detail;
+    const enqueue = (kind: PendingCodeRailOpen["kind"], e: Event) => {
+      if (modeRef.current === "chat") return;
+      const detail = (e as CustomEvent<{ path?: string; line?: number }>).detail;
+      if (!detail?.path) return;
+      setPendingCodeRailOpen(
+        kind === "files"
+          ? { kind, path: detail.path, line: detail.line, nonce: Date.now() }
+          : { kind, path: detail.path, nonce: Date.now() },
+      );
       setMode("chat");
     };
-    window.addEventListener("cave:open-project-file", onOpenFile as EventListener);
-    return () => window.removeEventListener("cave:open-project-file", onOpenFile as EventListener);
+    const onOpenProjectFile = (e: Event) => enqueue("files", e);
+    const onOpenFileDiff = (e: Event) => enqueue("changes", e);
+    window.addEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
+    window.addEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+    return () => {
+      window.removeEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
+      window.removeEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+    };
   }, []);
 
   // Daemon status poll (previously lived on DaemonBar before chrome consolidation)
@@ -1824,11 +1838,13 @@ export function Workspace() {
         rightPanel={rightPanel}
         pendingProjectRoot={pendingProjectChatRoot}
         pendingChatAction={pendingChatAction}
+        pendingCodeRailOpen={pendingCodeRailOpen}
         onSetInspectorOpen={setInspectorOpen}
         onSetRightPanel={setRightPanel}
         onSetActiveFamiliar={setActiveId}
         onClearPendingProjectRoot={() => setPendingProjectChatRoot(null)}
         onPendingChatActionHandled={() => setPendingChatAction(null)}
+        onPendingCodeRailOpenHandled={() => setPendingCodeRailOpen(null)}
         onSessionStarted={loadSessions}
         onSlashFromChat={handleSlashIntent}
         onOpenOnboarding={openOnboarding}

--- a/src/lib/pending-code-rail-open.ts
+++ b/src/lib/pending-code-rail-open.ts
@@ -1,0 +1,12 @@
+export type PendingCodeRailOpen =
+  | {
+      kind: "files";
+      path: string;
+      line?: number;
+      nonce: number;
+    }
+  | {
+      kind: "changes";
+      path: string;
+      nonce: number;
+    };

--- a/src/lib/tool-target-file.test.ts
+++ b/src/lib/tool-target-file.test.ts
@@ -33,10 +33,11 @@ const { toolTargetFile } = await import("./tool-input-diff.ts");
   assert.equal(toolTargetFile("Edit", null), null);
 }
 
-// ── wiring: chat dispatches, comux handles, workspace falls back ─────────────
+// ── wiring: chat dispatches, code rail handles, workspace bridges ────────────
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 const comux = await readFile(new URL("../components/comux-view.tsx", import.meta.url), "utf8");
 const workspace = await readFile(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+const chatSurface = await readFile(new URL("../components/chat-surface.tsx", import.meta.url), "utf8");
 
 assert.match(
   chatView,
@@ -64,8 +65,13 @@ assert.match(
 
 assert.match(
   workspace,
-  /Click-to-open a file from chat stays on the unified chat\/code workspace[\s\S]*?setMode\("chat"\)/,
-  "workspace keeps file-open events in the unified chat/code workspace",
+  /File\/diff links target ChatSurface's code rail[\s\S]*?setPendingCodeRailOpen\([\s\S]*?setMode\("chat"\)/,
+  "workspace preserves file-open event detail while switching into chat",
+);
+assert.match(
+  chatSurface,
+  /addEventListener\("cave:open-project-file"[\s\S]*addEventListener\("cave:open-file-diff"[\s\S]*openCodeRailTarget/,
+  "chat surface routes file and diff open events into the code rail",
 );
 
 console.log("tool-target-file.test.ts: ok");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -1248,25 +1248,39 @@
    direction, so the two streams read as clearly separate. */
 .home-digest__media {
   position: relative;
+  margin-top: 10px;
+}
+.home-digest__media-chrome {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding-inline: max(24px, 7%);
+  margin-bottom: 6px;
+}
+.home-digest__media-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 .home-digest__track--media {
-  margin-top: 10px;
   animation-direction: reverse;
 }
 .home-digest__media-close {
-  position: absolute;
-  z-index: 2;
-  top: 0;
-  right: 0;
   display: grid;
   place-items: center;
-  width: 28px;
-  height: 28px;
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
   border-radius: var(--radius-control);
   border: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
+  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
   color: var(--text-secondary);
-  box-shadow: var(--shadow-elevated);
   pointer-events: auto;
   transition: background 0.14s, color 0.14s, border-color 0.14s;
 }


### PR DESCRIPTION
## Summary
- Restore `cave:open-project-file` / `cave:open-file-diff` handoff into the ChatSurface code rail after Comux removal.
- Preserve pending file/diff opens until the rail project is ready, including line/diff metadata.
- Keep compact `StandardSelect` call sites from inheriting Button chrome.

## Test Plan
- `node --experimental-strip-types src/components/ui/select.test.ts`
- `node --experimental-strip-types src/components/workspace-chat-handoff.test.ts`
- `node --experimental-strip-types src/lib/tool-target-file.test.ts`
- `node --experimental-strip-types src/components/code-view.test.ts`
- `PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules/.bin:$PATH NODE_PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules tsc --noEmit`
- `PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules/.bin:$PATH NODE_PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules pnpm check:tests-wired`
- `git diff --check`
- `PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules/.bin:$PATH NODE_PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules pnpm test:app`

Bead: `cave-s8h`.
