### PR TITLE
style(home-composer): consolidate toolbar into single row

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -324,12 +324,14 @@ assert.match(
   /\(controlsOverride\?\.runtimeHost \?\? runtimeHost\)/,
   "an explicit host pick (or the home composer's initial pick) rides the send body; auto stays absent",
 );
-// Home composer parity: the same chip, threading the pick into the opened chat.
+// Home composer: host pick is threaded into the opened chat via initialControls.
+// The ComposerHostChip was removed from the home toolbar (run-rail removed); runtimeHost
+// state persists so future sessions pick up the correct host via initialControls.
 const homeComposer = readFileSync(new URL("./home-composer.tsx", import.meta.url), "utf8");
 assert.match(
   homeComposer,
-  /<ComposerHostChip[\s\S]{0,200}onPick=\{\(id\) => setRuntimeHost\(id === LOCAL_HOST_ID \? null : id\)\}/,
-  "the home composer renders the shared host chip (local pick = auto)",
+  /const \[runtimeHost, setRuntimeHost\] = useState<string \| null>\(null\)/,
+  "the home composer still tracks runtimeHost for threading into initialControls",
 );
 assert.match(
   homeComposer,

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -38,13 +38,18 @@ assert.doesNotMatch(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ 
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 assert.doesNotMatch(css, /\.hc-keyboard-hint\b/, "unused .hc-keyboard-hint CSS is removed");
 
+const sendButtonRule = Array.from(css.matchAll(/\.hc-send-btn\s*\{[\s\S]*?\n\}/g), (match) => match[0]).find((rule) =>
+  /background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/.test(rule),
+);
+assert.ok(sendButtonRule, "base .hc-send-btn rule exists");
+
 // ───────── Task 3: Tokenized icon-only Send button ─────────
 // The visible "Send" text label is gone, but the button keeps an aria-label so
-// screen readers announce it, and its chrome uses the shared control radius.
+// screen readers announce it, and its chrome is a compact pill.
 assert.match(source, /aria-label="Send"/, "Send button keeps aria-label='Send'");
 assert.doesNotMatch(source, /className="hc-send-label"/, "visible Send text label removed (button is icon-only)");
 assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule removed");
-assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*var\(--radius-control\)/, ".hc-send-btn uses the shared control radius");
+assert.doesNotMatch(sendButtonRule, /border-radius:\s*var\(--radius-control\)/, ".hc-send-btn no longer uses the shared control radius (now pill-shaped)");
 
 // ───────── Command-bar hierarchy ─────────
 // New: single-row toolbar — context left, run controls right.
@@ -79,8 +84,8 @@ assert.match(
 );
 // Run rail removed; its CSS survives as dead code for now (radius etc. still tested below).
 assert.match(
-  css,
-  /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/,
+  sendButtonRule,
+  /border-radius:\s*999px/,
   "send button is pill-shaped (border-radius 999px)",
 );
 assert.match(
@@ -89,8 +94,8 @@ assert.match(
   "custom selector triggers keep button styling while reading as compact selects",
 );
 assert.match(
-  css,
-  /\.hc-send-btn\s*\{[\s\S]*?background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
+  sendButtonRule,
+  /background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
   "active send button uses dark text-primary fill (Codex-style dark pill)",
 );
 for (const selector of [

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -47,20 +47,22 @@ assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule remove
 assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*var\(--radius-control\)/, ".hc-send-btn uses the shared control radius");
 
 // ───────── Command-bar hierarchy ─────────
+// New: single-row toolbar — context left, run controls right.
+// Access chip (familiar) is in the left group; model/thinking/mic/send in the right.
 assert.match(
   source,
-  /hc-control-group--who[\s\S]*?<HomeSelect[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?<ProjectPicker[\s\S]*?hc-control-group--run[\s\S]*?aria-label="Enhance prompt"[\s\S]*?aria-label="Send"/,
-  "home composer keeps context controls separate from enhance and send in the main input shell",
+  /hc-control-group--who[\s\S]*?ph:plus-bold[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
+  "home composer left cluster has plus-attach + warning-circle access chip for the familiar",
 );
 assert.match(
   source,
-  /className="hc-run-rail"[\s\S]*?aria-label="Run settings"[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<ComposerHostChip/,
-  "runtime/model, thinking, speed, and host live in the secondary run-settings rail",
+  /hc-control-group--run[\s\S]*?hc-status-dot[\s\S]*?ariaLabel="Choose runtime and model"[\s\S]*?ariaLabel="Choose thinking effort"[\s\S]*?hc-mic-btn[\s\S]*?aria-label="Send"/,
+  "home composer right cluster has status dot, model, thinking, mic, and send",
 );
 assert.doesNotMatch(
   source,
-  /hc-control-group--run[\s\S]*?Choose runtime and model[\s\S]*?aria-label="Send"/,
-  "runtime/model controls should not compete with enhance and send in the main action bar",
+  /className="hc-run-rail"/,
+  "the secondary run-settings rail is removed from the home composer",
 );
 assert.match(source, /import \{ StandardSelect/, "home composer selectors should delegate to StandardSelect");
 assert.match(source, /<StandardSelect[\s\S]*?popoverClassName="hc-home-select-popover"/, "home composer custom selectors should use the shared select popover");
@@ -72,13 +74,14 @@ assert.match(
 );
 assert.match(
   css,
-  /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*8px 14px;[\s\S]*?padding:\s*10px 14px 14px;/,
-  "home composer action bar keeps compact spacing between context and submit clusters",
+  /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*6px 10px;[\s\S]*?padding:\s*8px 12px 12px;/,
+  "home composer action bar uses compact single-toolbar spacing",
 );
+// Run rail removed; its CSS survives as dead code for now (radius etc. still tested below).
 assert.match(
   css,
-  /\.hc-run-rail\s*\{[\s\S]*?display:\s*flex;[\s\S]*?background:[\s\S]*?color-mix/,
-  "run settings rail is a distinct secondary surface",
+  /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/,
+  "send button is pill-shaped (border-radius 999px)",
 );
 assert.match(
   css,
@@ -87,19 +90,14 @@ assert.match(
 );
 assert.match(
   css,
-  /\.hc-send-btn\s*\{[\s\S]*?background:\s*var\(--accent-presence\);/,
-  "active send button keeps the presence accent fill",
+  /\.hc-send-btn\s*\{[\s\S]*?background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
+  "active send button uses dark text-primary fill (Codex-style dark pill)",
 );
 for (const selector of [
   ".hc-add-btn",
-  ".hc-enhance-btn",
-  ".hc-enhance-undo",
-  ".hc-model-chip",
   ".hc-familiar-selector",
   ".hc-home-select-trigger",
-  ".home-composer-card .cave-project-picker__trigger.hc-project-selector",
-  ".hc-dest-pills",
-  ".hc-dest-pill",
+  ".hc-mic-btn",
 ]) {
   assert.match(
     css,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -179,12 +179,6 @@ assert.match(
 
 assert.match(
   source,
-  /COMMAND_RESPONSE_SPEED_OPTIONS/,
-  "HomeComposer should use shared response speed options",
-);
-
-assert.match(
-  source,
   /const \[thinkingEffort, setThinkingEffort\] = useState<CommandThinkingEffort>\(\s*COMMAND_CONTROL_DEFAULTS\.thinkingEffort,\s*\)/,
   "HomeComposer should initialise thinking effort from shared command control defaults",
 );

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -37,22 +37,12 @@ assert.match(
   "HomeComposer headline should reflect the selected project name",
 );
 
-assert.match(
+// Project picker was moved out of the toolbar (no longer rendered inline in
+// the composer card). Project context is preserved in the headline and enhancer.
+assert.doesNotMatch(
   source,
-  /<ProjectPicker[\s\S]*?value=\{selectedProjectId \|\| null\}[\s\S]*?ariaLabel="Choose project"/,
-  "HomeComposer should render the shared custom project selector",
-);
-
-assert.match(
-  source,
-  /<ProjectPicker[\s\S]*?allowNoProject/,
-  "HomeComposer should offer an explicit No-project choice, matching chat semantics",
-);
-
-assert.match(
-  source,
-  /<ProjectPicker[\s\S]*?createProject=\{createProject\}/,
-  "The Add-project row should come from the shared register+grant picker flow",
+  /className="hc-project-selector"/,
+  "ProjectPicker selector is removed from the home composer toolbar",
 );
 
 assert.match(
@@ -217,11 +207,7 @@ assert.match(
   "HomeComposer should render a thinking effort select with an accessible label",
 );
 
-assert.match(
-  source,
-  /"Choose response speed"/,
-  "HomeComposer should render a response speed select with an accessible label",
-);
+// Speed control removed from toolbar (response speed passed via initialControls default).
 
 assert.match(
   css,
@@ -349,42 +335,32 @@ assert.match(source, /command === "\/skill" \|\| command === "\/skills"/, "HomeC
 assert.match(source, /role="listbox" aria-label="Skills"/, "HomeComposer renders a Skills picker listbox");
 assert.match(source, /buildSkillPrompt\(skill\)/, "HomeComposer invokes a skill by starting a chat with the skill prompt");
 
-// ── Destination pills are an accessible single-select radiogroup ─────────────
-assert.match(
-  source,
-  /className="hc-dest-pills"\s+role="radiogroup"\s+aria-label="Send to"\s+ref=\{destGroupRef\}\s+onKeyDown=\{handleDestKeyDown\}/,
-  "Destination pills form a labelled radiogroup with keyboard navigation",
-);
-assert.match(
-  source,
-  /role="radio"\s+aria-checked=\{destination === d\.id\}\s+tabIndex=\{destination === d\.id \? 0 : -1\}/,
-  "Each destination pill is a radio that announces its checked state and roves the tab stop",
-);
+// ── Destination state is preserved for task-vs-chat routing (even without visible pills) ──────
+// The mode strip was removed from the composer; destination defaults to "chat".
+// The keyboard handler and nav array remain for potential future re-exposure.
 assert.match(
   source,
   /const nav = \["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp", "Home", "End"\];/,
-  "The radiogroup supports arrow/Home/End keyboard selection per the ARIA radio pattern",
+  "The destination nav array is retained for the handleDestKeyDown callback",
 );
 
-// ── Chat/Task lead the card as a mode strip above the textarea ───────────────
-assert.match(
+// ── Single-row toolbar replaces mode strip + run rail ───────────────────────
+// The mode strip (Chat/Task pills) and the separate run rail were removed.
+// Controls are now in one action bar: [+] [access chip] · [●] [model] [think] [🎤] [↑]
+assert.doesNotMatch(
   source,
-  /hc-mode-strip[\s\S]*?className="hc-dest-pills"[\s\S]*?className="hc-textarea"/,
-  "The Chat/Task switch renders in a mode strip above the textarea, not in the action bar",
+  /className="hc-mode-strip"/,
+  "The mode strip is removed from the composer card",
+);
+assert.doesNotMatch(
+  source,
+  /className="hc-run-rail"/,
+  "The secondary run-settings rail is removed from the composer card",
 );
 assert.match(
-  css,
-  /\.hc-mode-strip\s*\{/,
-  "HomeComposer CSS should define the mode strip that seats the Chat/Task switch atop the card",
-);
-
-// ── Chat-only send config collapses when Task is the destination ─────────────
-// Runtime/model, Think, and Speed configure a chat send and are meaningless for
-// creating a board task, so they render only while the Chat mode is selected.
-assert.match(
   source,
-  /destination === "chat" \? \(\s*<div className="hc-run-rail" aria-label="Run settings">[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/div>\s*\) : null/,
-  "Runtime/model, Think, and Speed controls collapse out of the composer when Task is selected",
+  /hc-control-group--who[\s\S]*?ph:plus-bold[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?hc-control-group--run[\s\S]*?hc-status-dot[\s\S]*?ariaLabel="Choose runtime and model"[\s\S]*?ariaLabel="Choose thinking effort"[\s\S]*?hc-mic-btn[\s\S]*?aria-label="Send"/,
+  "The action bar toolbar has: attach/access-chip left, status/model/thinking/mic/send right",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────
@@ -463,11 +439,11 @@ assert.match(
   "home prompt history is persisted when it changes",
 );
 
-// ── Attachments + Enhance (added to the home composer) ──────────────────────
+// ── Attachments ─────────────────────────────────────────────────────────────
 assert.match(
   source,
-  /className="hc-add-btn"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:paperclip/,
-  "the + launcher is now a paperclip that opens the file picker",
+  /className="hc-add-btn"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:plus-bold/,
+  "the + launcher uses a plus-bold icon that opens the file picker",
 );
 assert.match(
   source,
@@ -485,11 +461,7 @@ assert.match(
   /initialAttachments: outgoing/,
   "staged attachments are threaded into the started chat",
 );
-assert.match(
-  source,
-  /className=\{`hc-enhance-btn[\s\S]*?onClick=\{\(\) => void enhancePrompt\(\)\}/,
-  "an Enhance button invokes prompt enhancement",
-);
+// Enhance button removed from toolbar; logic stays for potential future use.
 assert.match(
   source,
   /import \{ buildPromptEnhancement \} from "@\/lib\/prompt-enhancer"/,
@@ -510,11 +482,7 @@ assert.match(
   /selectedFiles: attachments\.map\(\(attachment\) => attachment\.name\)/,
   "Enhance should include staged attachment names as file context",
 );
-assert.match(
-  source,
-  /enhanceOriginal != null &&[\s\S]*?onClick=\{revertEnhance\}/,
-  "a one-tap Undo reverts an enhancement",
-);
+// Enhance undo UI removed from toolbar; revertEnhance callback remains in code.
 
 // ── Drag-and-drop attachments ───────────────────────────────────────────────
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -1043,35 +1043,6 @@ export function HomeComposer({
             </div>
           ) : null}
 
-        {/* Mode strip — the composer's primary intent switch (Chat vs Task)
-            leads the card, above the textarea, so it reads as the top-level
-            mode rather than one control buried among the per-send config. */}
-        <div className="hc-mode-strip">
-          <div
-            className="hc-dest-pills"
-            role="radiogroup"
-            aria-label="Send to"
-            ref={destGroupRef}
-            onKeyDown={handleDestKeyDown}
-          >
-            {DESTINATIONS.map((d) => (
-              <button
-                key={d.id}
-                type="button"
-                role="radio"
-                aria-checked={destination === d.id}
-                tabIndex={destination === d.id ? 0 : -1}
-                className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-                onClick={() => setDestination(d.id)}
-                title={d.label}
-              >
-                <Icon name={d.icon} width={12} aria-hidden />
-                <span className="hc-dest-label">{d.label}</span>
-              </button>
-            ))}
-          </div>
-        </div>
-
         {/* Textarea */}
         <textarea
           ref={textareaRef}
@@ -1150,69 +1121,9 @@ export function HomeComposer({
           </div>
         )}
 
-        {destination === "chat" ? (
-          <div className="hc-run-rail" aria-label="Run settings">
-            <span className="hc-run-rail__accent" aria-hidden>
-              <Icon name="ph:sliders-horizontal" width={13} />
-            </span>
-            <div className="hc-run-rail__controls">
-              <HomeSelect
-                icon="ph:terminal-window"
-                value={selectedRuntimeModelValue}
-                onChange={handleSelectRuntimeModel}
-                groups={runtimeModelSelectGroups}
-                ariaLabel="Choose runtime and model"
-                disabled={!selectedFamiliarId || sending}
-                className="hc-runtime-model-selector"
-              />
-
-              <HomeSelect
-                label="Think"
-                icon="ph:sparkle-bold"
-                value={thinkingEffort}
-                onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
-                groups={[
-                  {
-                    options: COMMAND_THINKING_OPTIONS.map((option) => ({
-                      ...option,
-                      icon: "ph:sparkle-bold",
-                    })),
-                  },
-                ]}
-                ariaLabel="Choose thinking effort"
-                disabled={sending}
-                className="hc-command-select"
-              />
-
-              <HomeSelect
-                label="Speed"
-                icon="ph:lightning-bold"
-                value={responseSpeed}
-                onChange={(value) => setResponseSpeed(value as CommandResponseSpeed)}
-                groups={[
-                  {
-                    options: COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => ({
-                      ...option,
-                      icon: "ph:lightning-bold",
-                    })),
-                  },
-                ]}
-                ariaLabel="Choose response speed"
-                disabled={sending}
-                className="hc-command-select"
-              />
-
-              <ComposerHostChip
-                value={runtimeHost ?? LOCAL_HOST_ID}
-                disabled={sending}
-                onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
-              />
-            </div>
-          </div>
-        ) : null}
-
-        {/* Action bar */}
+        {/* Action bar — single-row toolbar: [+] [access chip]  ···  [●] [model] [think] [🎤] [↑] */}
         <div className="hc-action-bar">
+          {/* Left cluster: attach + familiar (access chip) */}
           <div className="hc-control-group hc-control-group--who">
             <input
               ref={fileInputRef}
@@ -1231,11 +1142,11 @@ export function HomeComposer({
               aria-label="Attach files"
               title="Attach files"
             >
-              <Icon name="ph:paperclip" width={15} aria-hidden />
+              <Icon name="ph:plus-bold" width={15} aria-hidden />
             </button>
 
             <HomeSelect
-              icon="ph:sparkle"
+              icon="ph:warning-circle"
               value={selectedFamiliarId}
               onChange={(value) => {
                 if (value) onSetActiveFamiliar(value);
@@ -1243,47 +1154,50 @@ export function HomeComposer({
               groups={familiarSelectGroups}
               ariaLabel="Choose chat agent"
               disabled={visibleFamiliars.length === 0 || sending}
-            />
-
-            <ProjectPicker
-              projects={projects}
-              value={selectedProjectId || null}
-              onChange={setSelectedProjectId}
-              allowNoProject
-              familiarId={selectedFamiliarId || null}
-              createProject={createProject}
-              disabled={sending}
-              ariaLabel="Choose project"
-              className="hc-project-selector"
+              className="hc-access-chip"
             />
           </div>
 
+          {/* Right cluster: status · model · thinking · mic · send */}
           <div className="hc-control-group hc-control-group--run">
-            {enhanceOriginal != null && (
-              <button
-                type="button"
-                className="hc-enhance-undo"
-                onClick={revertEnhance}
-                disabled={sending}
-                title="Undo enhance"
-              >
-                Undo
-              </button>
-            )}
+            <span className="hc-status-dot" aria-hidden="true" />
+
+            <HomeSelect
+              icon="ph:lightning-bold"
+              value={selectedRuntimeModelValue}
+              onChange={handleSelectRuntimeModel}
+              groups={runtimeModelSelectGroups}
+              ariaLabel="Choose runtime and model"
+              disabled={!selectedFamiliarId || sending}
+              className="hc-runtime-model-selector"
+            />
+
+            <HomeSelect
+              label="Think"
+              icon="ph:sparkle-bold"
+              value={thinkingEffort}
+              onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
+              groups={[
+                {
+                  options: COMMAND_THINKING_OPTIONS.map((option) => ({
+                    ...option,
+                    icon: "ph:sparkle-bold",
+                  })),
+                },
+              ]}
+              ariaLabel="Choose thinking effort"
+              disabled={sending}
+              className="hc-command-select"
+            />
+
             <button
               type="button"
-              className={`hc-enhance-btn${enhanceStatus === "loading" ? " loading" : ""}`}
-              onClick={() => void enhancePrompt()}
-              disabled={!text.trim() || sending || enhanceStatus === "loading"}
-              aria-label="Enhance prompt"
-              title="Enhance prompt"
+              className="hc-mic-btn"
+              aria-label="Voice input"
+              title="Voice input"
+              disabled={sending}
             >
-              {enhanceStatus === "loading" ? (
-                <span className="hc-spinner" />
-              ) : (
-                <Icon name="ph:sparkle" width={13} aria-hidden />
-              )}
-              <span className="hc-enhance-label">Enhance</span>
+              <Icon name="ph:microphone" width={15} aria-hidden />
             </button>
 
             <button

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -17,8 +17,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { ComposerHostChip } from "@/components/composer-host-chip";
-import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
@@ -37,7 +35,6 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
-import { ProjectPicker } from "@/components/project-picker";
 import { StandardSelect, type StandardSelectGroup, type StandardSelectOption } from "@/components/ui/select";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
@@ -52,7 +49,6 @@ import {
 } from "@/lib/chat-attachments";
 import {
   COMMAND_CONTROL_DEFAULTS,
-  COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
   type CommandResponseSpeed,
   type CommandThinkingEffort,
@@ -1194,8 +1190,8 @@ export function HomeComposer({
               type="button"
               className="hc-mic-btn"
               aria-label="Voice input"
-              title="Voice input"
-              disabled={sending}
+              title="Voice input (coming soon)"
+              disabled
             >
               <Icon name="ph:microphone" width={15} aria-hidden />
             </button>

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -35,9 +35,10 @@ assert.doesNotMatch(
   "picker should use shared CSS/tokenized radii instead of hard-coded rounded classes",
 );
 
-// ── Home composer uses the shared custom picker, not an OS-native select ────
-assert.match(homeComposer, /<ProjectPicker[\s\S]*?ariaLabel="Choose project"/, "home composer uses ProjectPicker");
-assert.doesNotMatch(homeComposer, /<select[\s\S]*?aria-label="Choose project"/, "home composer project picker is custom");
+// ── Home composer: project picker removed from toolbar (project context in headline) ────
+// Project selection logic remains via selectedProject; the picker UI was removed
+// when the toolbar was consolidated into a single row.
+assert.doesNotMatch(homeComposer, /className="hc-project-selector"/, "home composer project selector CSS class is removed");
 
 // ── Styled ──────────────────────────────────────────────────────────────────
 assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -164,15 +164,14 @@
 }
 
 /* ── Action bar ──────────────────────────────────────────────────────────────
- *   The main shell carries immediate composition controls: attach,
- *   familiar/project, prompt enhancement, and send. Runtime config lives in the
- *   tucked rail below so it stays available without crowding the textarea. */
+ *   Single-row toolbar: [+] [access chip] · · · [●] [model] [think] [🎤] [↑]
+ *   Left cluster = context; right cluster = run controls + send. */
 .hc-action-bar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px 14px;
-  padding: 10px 14px 14px;
+  gap: 6px 10px;
+  padding: 8px 12px 12px;
 }
 
 /* Groups never split internally — a cluster wraps as a whole unit (so Speed and
@@ -866,19 +865,67 @@
   }
 }
 
-/* ── Send button (circular, icon-only — matches the Codex-style composer) ──── */
+/* ── Access chip — familiar selector in warning/amber ───────────────────── */
+.hc-access-chip.hc-familiar-selector,
+.hc-access-chip.hc-home-select-trigger {
+  background: color-mix(in oklch, var(--color-warning) 10%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--color-warning) 28%, transparent);
+}
+.hc-access-chip.hc-familiar-selector:hover:not(:disabled),
+.hc-access-chip.hc-home-select-trigger:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--color-warning) 16%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--color-warning) 38%, transparent);
+}
+.hc-access-chip .hc-familiar-glyph,
+.hc-access-chip .hc-home-select-value {
+  color: var(--color-warning);
+}
+
+/* ── Status dot — presence indicator before the model selector ──────────── */
+.hc-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in oklch, var(--text-muted) 55%, transparent);
+  background: transparent;
+  flex-shrink: 0;
+}
+
+/* ── Mic button ──────────────────────────────────────────────────────────── */
+.hc-mic-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border-radius: var(--radius-control);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.hc-mic-btn:hover:not(:disabled) {
+  background: var(--bg-base);
+  border-color: var(--border-hairline);
+  color: var(--text-secondary);
+}
+.hc-mic-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ── Send button — dark pill, icon-only ─────────────────────────────────── */
 .hc-send-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 5px;
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   padding: 0;
-  border-radius: var(--radius-control);
+  border-radius: 999px;
   border: none;
-  background: var(--accent-presence);
-  color: #fff;
+  background: color-mix(in oklch, var(--text-primary) 80%, var(--bg-raised));
+  color: var(--bg-base);
   cursor: pointer;
   margin-left: auto;
   flex-shrink: 0;
@@ -886,20 +933,19 @@
 }
 
 .hc-control-group--run .hc-send-btn {
-  margin-left: 0;
+  margin-left: 2px;
 }
 
 .hc-send-btn:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--accent-presence) 85%, #000);
+  background: var(--text-primary);
   transform: scale(1.05);
 }
 
-/* Empty/disabled reads as a neutral grey disc (no green) until there's a prompt
- * to send — mirrors the screenshot's idle send affordance. */
+/* Empty/disabled reads as a neutral grey pill until there's a prompt to send */
 .hc-send-btn.empty,
 .hc-send-btn:disabled {
-  background: color-mix(in oklch, var(--text-muted) 24%, var(--bg-base));
-  color: var(--text-muted);
+  background: color-mix(in oklch, var(--text-muted) 30%, var(--bg-raised));
+  color: color-mix(in oklch, var(--bg-base) 70%, var(--text-muted));
   cursor: default;
   transform: none;
 }

--- a/tests/board-attachments.spec.ts
+++ b/tests/board-attachments.spec.ts
@@ -1,55 +1,26 @@
 import { test, expect } from "@playwright/test";
 
-// Board-destination attachments, end to end in the UI (arc #2219→#2234):
-// stage a file on the home composer → Task destination → the POST /api/board
-// body carries it → the board renders the paperclip chip → the inspector lists
-// the files. Daemon-less: every asserted route is mocked.
+// Home-composer attachment staging, end to end (originally arc #2219→#2234,
+// updated for consolidated toolbar where Task destination moved to board view).
+// Daemon-less: only familiars/sessions/escalations routes are mocked.
 
-const cardWithAttachments = {
-  id: "att-1",
-  title: "Task with files",
-  notes: "",
-  status: "backlog",
-  priority: "medium",
-  familiarId: null,
-  sessionId: null,
-  cwd: null,
-  projectId: null,
-  links: [],
-  github: [],
-  labels: [],
-  createdAt: "2026-07-02T12:00:00Z",
-  updatedAt: "2026-07-02T12:00:00Z",
-  lifecycle: "queued",
-  lifecycleAt: "2026-07-02T12:00:00Z",
-  retryCount: 0,
-  maxRetries: 3,
-  steps: [],
-  attachments: [
-    { name: "spec.md", type: "text/markdown", size: 30, text: "# Spec" },
-    { name: "shot.png", type: "image/png", size: 900 },
-  ],
-};
-
-test("home composer files ride onto a Task card and render on the board", async ({ page }) => {
-  const boardPosts: any[] = [];
-  await page.route("**/api/familiars**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, familiars: [] }) }));
-  await page.route("**/api/sessions/list**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, sessions: [] }) }));
-  await page.route("**/api/escalations**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }));
-  await page.route("**/api/board", (r) => {
-    if (r.request().method() === "POST") {
-      boardPosts.push(JSON.parse(r.request().postData() || "{}"));
-      return r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, card: cardWithAttachments }) });
-    }
-    return r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, cards: [cardWithAttachments] }) });
-  });
+test("home composer files stage and display as chips with remove controls", async ({ page }) => {
+  await page.route("**/api/familiars**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, familiars: [] }) }),
+  );
+  await page.route("**/api/sessions/list**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, sessions: [] }) }),
+  );
+  await page.route("**/api/escalations**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }),
+  );
   await page.addInitScript(() => window.localStorage.setItem("cave:onboarding:dismissed", "1"));
 
   await page.goto("/");
   await page.waitForSelector(".shell-frame", { timeout: 60000 });
-
-  // ── Stage files on the home composer ───────────────────────────────────────
   await page.waitForSelector(".hc-textarea", { timeout: 60000 });
+
+  // ── Stage two files ──────────────────────────────────────────────────────────
   await page.locator(".hc-file-input").setInputFiles([
     {
       name: "spec.md",
@@ -62,28 +33,19 @@ test("home composer files ride onto a Task card and render on the board", async 
       buffer: Buffer.from("fake image bytes"),
     },
   ]);
+
+  // Both chips appear
   await expect(page.locator(".hc-attachment-name")).toHaveText(["spec.md", "shot.png"]);
 
-  // ── Send to the Task destination ───────────────────────────────────────────
-  await page.getByRole("radio", { name: "Task" }).click();
-  await page.locator(".hc-textarea").fill("Ship the spec");
-  await page.locator(".hc-send-btn").click();
+  // Count header reads "2/10 attached"
+  await expect(page.locator(".hc-attachments-count")).toHaveText("2/10 attached");
 
-  // The POST body carries the staged attachment, content included.
-  await expect.poll(() => boardPosts.length, { timeout: 15000 }).toBeGreaterThan(0);
-  expect(boardPosts[0].title).toBe("Ship the spec");
-  expect(boardPosts[0].attachments?.map((a: { name?: string }) => a.name)).toEqual(["spec.md", "shot.png"]);
-  expect(boardPosts[0].attachments?.[0]?.name).toBe("spec.md");
-  expect(boardPosts[0].attachments?.[0]?.text).toContain("do the thing");
+  // ── Per-chip remove ──────────────────────────────────────────────────────────
+  await page.getByRole("button", { name: "Remove spec.md" }).click();
+  await expect(page.locator(".hc-attachment-name")).toHaveText(["shot.png"]);
+  await expect(page.locator(".hc-attachments-count")).toHaveText("1/10 attached");
 
-  // ── Board renders the paperclip chip (auto-navigated after create) ─────────
-  await page.waitForSelector(".board-kanban-card", { timeout: 60000 });
-  await expect(page.locator('[title="2 attachments"]')).toBeVisible();
-
-  // ── Inspector lists the files with per-file remove affordances ─────────────
-  await page.locator('[data-card-id="att-1"]').click();
-  await expect(page.getByText("Attachments")).toBeVisible();
-  await expect(page.getByText("spec.md", { exact: true })).toBeVisible();
-  await expect(page.getByText("shot.png", { exact: true })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Remove spec.md" })).toBeVisible();
+  // ── Clear all ────────────────────────────────────────────────────────────────
+  await page.locator(".hc-attachments-clear").click();
+  await expect(page.locator(".hc-attachments")).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Removes the mode strip (Chat/Task destination pills) and the secondary run-rail from the home composer card
- Replaces both with a single bottom toolbar: `[+]` attach · amber access chip (familiar) on the left; status dot · model · thinking · mic · dark pill send on the right
- Send button updated to dark `color-mix(--text-primary)` pill (`border-radius: 999px`), matching Codex-style input chrome
- Adds `.hc-access-chip` (warning/amber tint), `.hc-status-dot`, and `.hc-mic-btn` CSS utility classes
- Project picker and Enhance button removed from the toolbar; their underlying logic (project selection, enhancePrompt, runtimeHost) is preserved

## Test plan

- [ ] All 704 existing tests pass (`node scripts/run-tests.mjs`)
- [ ] TypeScript clean (`npx tsc --noEmit`)
- [ ] `home-composer.test.ts`, `home-composer-polish.test.ts`, `chat-view-polish.test.ts`, `project-picker.test.ts` updated to pin new toolbar layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)