### PR TITLE
style(home-composer): consolidate toolbar into single row

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -324,12 +324,14 @@ assert.match(
   /\(controlsOverride\?\.runtimeHost \?\? runtimeHost\)/,
   "an explicit host pick (or the home composer's initial pick) rides the send body; auto stays absent",
 );
-// Home composer parity: the same chip, threading the pick into the opened chat.
+// Home composer: host pick is threaded into the opened chat via initialControls.
+// The ComposerHostChip was removed from the home toolbar (run-rail removed); runtimeHost
+// state persists so future sessions pick up the correct host via initialControls.
 const homeComposer = readFileSync(new URL("./home-composer.tsx", import.meta.url), "utf8");
 assert.match(
   homeComposer,
-  /<ComposerHostChip[\s\S]{0,200}onPick=\{\(id\) => setRuntimeHost\(id === LOCAL_HOST_ID \? null : id\)\}/,
-  "the home composer renders the shared host chip (local pick = auto)",
+  /const \[runtimeHost, setRuntimeHost\] = useState<string \| null>\(null\)/,
+  "the home composer still tracks runtimeHost for threading into initialControls",
 );
 assert.match(
   homeComposer,

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -47,20 +47,22 @@ assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule remove
 assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*var\(--radius-control\)/, ".hc-send-btn uses the shared control radius");
 
 // ───────── Command-bar hierarchy ─────────
+// New: single-row toolbar — context left, run controls right.
+// Attach, destination, and access chip are in the left group; model/thinking/mic/send in the right.
 assert.match(
   source,
-  /hc-control-group--who[\s\S]*?<HomeSelect[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?<ProjectPicker[\s\S]*?hc-control-group--run[\s\S]*?aria-label="Enhance prompt"[\s\S]*?aria-label="Send"/,
-  "home composer keeps context controls separate from enhance and send in the main input shell",
+  /hc-control-group--who[\s\S]*?ph:plus-bold[\s\S]*?className="hc-dest-pills"[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
+  "home composer left cluster has plus-attach + Chat/Task destination + warning-circle access chip for the familiar",
 );
 assert.match(
   source,
-  /className="hc-run-rail"[\s\S]*?aria-label="Run settings"[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<ComposerHostChip/,
-  "runtime/model, thinking, speed, and host live in the secondary run-settings rail",
+  /hc-control-group--run[\s\S]*?hc-status-dot[\s\S]*?ariaLabel="Choose runtime and model"[\s\S]*?ariaLabel="Choose thinking effort"[\s\S]*?hc-mic-btn[\s\S]*?aria-label="Send"/,
+  "home composer right cluster has status dot, model, thinking, mic, and send",
 );
 assert.doesNotMatch(
   source,
-  /hc-control-group--run[\s\S]*?Choose runtime and model[\s\S]*?aria-label="Send"/,
-  "runtime/model controls should not compete with enhance and send in the main action bar",
+  /className="hc-run-rail"/,
+  "the secondary run-settings rail is removed from the home composer",
 );
 assert.match(source, /import \{ StandardSelect/, "home composer selectors should delegate to StandardSelect");
 assert.match(source, /<StandardSelect[\s\S]*?popoverClassName="hc-home-select-popover"/, "home composer custom selectors should use the shared select popover");
@@ -72,13 +74,14 @@ assert.match(
 );
 assert.match(
   css,
-  /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*8px 14px;[\s\S]*?padding:\s*10px 14px 14px;/,
-  "home composer action bar keeps compact spacing between context and submit clusters",
+  /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*6px 10px;[\s\S]*?padding:\s*8px 12px 12px;/,
+  "home composer action bar uses compact single-toolbar spacing",
 );
+// Run rail removed; its CSS survives as dead code for now (radius etc. still tested below).
 assert.match(
   css,
-  /\.hc-run-rail\s*\{[\s\S]*?display:\s*flex;[\s\S]*?background:[\s\S]*?color-mix/,
-  "run settings rail is a distinct secondary surface",
+  /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/,
+  "send button is pill-shaped (border-radius 999px)",
 );
 assert.match(
   css,
@@ -87,19 +90,14 @@ assert.match(
 );
 assert.match(
   css,
-  /\.hc-send-btn\s*\{[\s\S]*?background:\s*var\(--accent-presence\);/,
-  "active send button keeps the presence accent fill",
+  /\.hc-send-btn\s*\{[\s\S]*?background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
+  "active send button uses dark text-primary fill (Codex-style dark pill)",
 );
 for (const selector of [
   ".hc-add-btn",
-  ".hc-enhance-btn",
-  ".hc-enhance-undo",
-  ".hc-model-chip",
   ".hc-familiar-selector",
   ".hc-home-select-trigger",
-  ".home-composer-card .cave-project-picker__trigger.hc-project-selector",
-  ".hc-dest-pills",
-  ".hc-dest-pill",
+  ".hc-mic-btn",
 ]) {
   assert.match(
     css,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -37,22 +37,12 @@ assert.match(
   "HomeComposer headline should reflect the selected project name",
 );
 
-assert.match(
+// Project picker was moved out of the toolbar (no longer rendered inline in
+// the composer card). Project context is preserved in the headline and enhancer.
+assert.doesNotMatch(
   source,
-  /<ProjectPicker[\s\S]*?value=\{selectedProjectId \|\| null\}[\s\S]*?ariaLabel="Choose project"/,
-  "HomeComposer should render the shared custom project selector",
-);
-
-assert.match(
-  source,
-  /<ProjectPicker[\s\S]*?allowNoProject/,
-  "HomeComposer should offer an explicit No-project choice, matching chat semantics",
-);
-
-assert.match(
-  source,
-  /<ProjectPicker[\s\S]*?createProject=\{createProject\}/,
-  "The Add-project row should come from the shared register+grant picker flow",
+  /className="hc-project-selector"/,
+  "ProjectPicker selector is removed from the home composer toolbar",
 );
 
 assert.match(
@@ -217,11 +207,7 @@ assert.match(
   "HomeComposer should render a thinking effort select with an accessible label",
 );
 
-assert.match(
-  source,
-  /"Choose response speed"/,
-  "HomeComposer should render a response speed select with an accessible label",
-);
+// Speed control removed from toolbar (response speed passed via initialControls default).
 
 assert.match(
   css,
@@ -366,25 +352,23 @@ assert.match(
   "The radiogroup supports arrow/Home/End keyboard selection per the ARIA radio pattern",
 );
 
-// ── Chat/Task lead the card as a mode strip above the textarea ───────────────
-assert.match(
+// ── Single-row toolbar replaces mode strip + run rail ───────────────────────
+// The top mode strip and the separate run rail were removed.
+// Controls are now in one action bar: [+] [Chat/Task] [access chip] · [●] [model] [think] [mic] [send]
+assert.doesNotMatch(
   source,
-  /hc-mode-strip[\s\S]*?className="hc-dest-pills"[\s\S]*?className="hc-textarea"/,
-  "The Chat/Task switch renders in a mode strip above the textarea, not in the action bar",
+  /className="hc-mode-strip"/,
+  "The mode strip is removed from the composer card",
+);
+assert.doesNotMatch(
+  source,
+  /className="hc-run-rail"/,
+  "The secondary run-settings rail is removed from the composer card",
 );
 assert.match(
-  css,
-  /\.hc-mode-strip\s*\{/,
-  "HomeComposer CSS should define the mode strip that seats the Chat/Task switch atop the card",
-);
-
-// ── Chat-only send config collapses when Task is the destination ─────────────
-// Runtime/model, Think, and Speed configure a chat send and are meaningless for
-// creating a board task, so they render only while the Chat mode is selected.
-assert.match(
   source,
-  /destination === "chat" \? \(\s*<div className="hc-run-rail" aria-label="Run settings">[\s\S]*?Choose runtime and model[\s\S]*?Choose thinking effort[\s\S]*?Choose response speed[\s\S]*?<\/div>\s*\) : null/,
-  "Runtime/model, Think, and Speed controls collapse out of the composer when Task is selected",
+  /hc-control-group--who[\s\S]*?ph:plus-bold[\s\S]*?hc-dest-pills[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?hc-control-group--run[\s\S]*?hc-status-dot[\s\S]*?ariaLabel="Choose runtime and model"[\s\S]*?ariaLabel="Choose thinking effort"[\s\S]*?hc-mic-btn[\s\S]*?aria-label="Send"/,
+  "The action bar toolbar has: attach/destination/access-chip left, status/model/thinking/mic/send right",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────
@@ -463,11 +447,11 @@ assert.match(
   "home prompt history is persisted when it changes",
 );
 
-// ── Attachments + Enhance (added to the home composer) ──────────────────────
+// ── Attachments ─────────────────────────────────────────────────────────────
 assert.match(
   source,
-  /className="hc-add-btn"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:paperclip/,
-  "the + launcher is now a paperclip that opens the file picker",
+  /className="hc-add-btn"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:plus-bold/,
+  "the + launcher uses a plus-bold icon that opens the file picker",
 );
 assert.match(
   source,
@@ -485,11 +469,7 @@ assert.match(
   /initialAttachments: outgoing/,
   "staged attachments are threaded into the started chat",
 );
-assert.match(
-  source,
-  /className=\{`hc-enhance-btn[\s\S]*?onClick=\{\(\) => void enhancePrompt\(\)\}/,
-  "an Enhance button invokes prompt enhancement",
-);
+// Enhance button removed from toolbar; logic stays for potential future use.
 assert.match(
   source,
   /import \{ buildPromptEnhancement \} from "@\/lib\/prompt-enhancer"/,
@@ -510,11 +490,7 @@ assert.match(
   /selectedFiles: attachments\.map\(\(attachment\) => attachment\.name\)/,
   "Enhance should include staged attachment names as file context",
 );
-assert.match(
-  source,
-  /enhanceOriginal != null &&[\s\S]*?onClick=\{revertEnhance\}/,
-  "a one-tap Undo reverts an enhancement",
-);
+// Enhance undo UI removed from toolbar; revertEnhance callback remains in code.
 
 // ── Drag-and-drop attachments ───────────────────────────────────────────────
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -1043,35 +1043,6 @@ export function HomeComposer({
             </div>
           ) : null}
 
-        {/* Mode strip — the composer's primary intent switch (Chat vs Task)
-            leads the card, above the textarea, so it reads as the top-level
-            mode rather than one control buried among the per-send config. */}
-        <div className="hc-mode-strip">
-          <div
-            className="hc-dest-pills"
-            role="radiogroup"
-            aria-label="Send to"
-            ref={destGroupRef}
-            onKeyDown={handleDestKeyDown}
-          >
-            {DESTINATIONS.map((d) => (
-              <button
-                key={d.id}
-                type="button"
-                role="radio"
-                aria-checked={destination === d.id}
-                tabIndex={destination === d.id ? 0 : -1}
-                className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-                onClick={() => setDestination(d.id)}
-                title={d.label}
-              >
-                <Icon name={d.icon} width={12} aria-hidden />
-                <span className="hc-dest-label">{d.label}</span>
-              </button>
-            ))}
-          </div>
-        </div>
-
         {/* Textarea */}
         <textarea
           ref={textareaRef}
@@ -1150,69 +1121,9 @@ export function HomeComposer({
           </div>
         )}
 
-        {destination === "chat" ? (
-          <div className="hc-run-rail" aria-label="Run settings">
-            <span className="hc-run-rail__accent" aria-hidden>
-              <Icon name="ph:sliders-horizontal" width={13} />
-            </span>
-            <div className="hc-run-rail__controls">
-              <HomeSelect
-                icon="ph:terminal-window"
-                value={selectedRuntimeModelValue}
-                onChange={handleSelectRuntimeModel}
-                groups={runtimeModelSelectGroups}
-                ariaLabel="Choose runtime and model"
-                disabled={!selectedFamiliarId || sending}
-                className="hc-runtime-model-selector"
-              />
-
-              <HomeSelect
-                label="Think"
-                icon="ph:sparkle-bold"
-                value={thinkingEffort}
-                onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
-                groups={[
-                  {
-                    options: COMMAND_THINKING_OPTIONS.map((option) => ({
-                      ...option,
-                      icon: "ph:sparkle-bold",
-                    })),
-                  },
-                ]}
-                ariaLabel="Choose thinking effort"
-                disabled={sending}
-                className="hc-command-select"
-              />
-
-              <HomeSelect
-                label="Speed"
-                icon="ph:lightning-bold"
-                value={responseSpeed}
-                onChange={(value) => setResponseSpeed(value as CommandResponseSpeed)}
-                groups={[
-                  {
-                    options: COMMAND_RESPONSE_SPEED_OPTIONS.map((option) => ({
-                      ...option,
-                      icon: "ph:lightning-bold",
-                    })),
-                  },
-                ]}
-                ariaLabel="Choose response speed"
-                disabled={sending}
-                className="hc-command-select"
-              />
-
-              <ComposerHostChip
-                value={runtimeHost ?? LOCAL_HOST_ID}
-                disabled={sending}
-                onPick={(id) => setRuntimeHost(id === LOCAL_HOST_ID ? null : id)}
-              />
-            </div>
-          </div>
-        ) : null}
-
-        {/* Action bar */}
+        {/* Action bar — single-row toolbar: [+] [Chat/Task] [access chip]  ···  [●] [model] [think] [🎤] [↑] */}
         <div className="hc-action-bar">
+          {/* Left cluster: attach + destination + familiar (access chip) */}
           <div className="hc-control-group hc-control-group--who">
             <input
               ref={fileInputRef}
@@ -1231,11 +1142,35 @@ export function HomeComposer({
               aria-label="Attach files"
               title="Attach files"
             >
-              <Icon name="ph:paperclip" width={15} aria-hidden />
+              <Icon name="ph:plus-bold" width={15} aria-hidden />
             </button>
 
+            <div
+              className="hc-dest-pills"
+              role="radiogroup"
+              aria-label="Send to"
+              ref={destGroupRef}
+              onKeyDown={handleDestKeyDown}
+            >
+              {DESTINATIONS.map((d) => (
+                <button
+                  key={d.id}
+                  type="button"
+                  className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
+                  role="radio"
+                  aria-checked={destination === d.id}
+                  tabIndex={destination === d.id ? 0 : -1}
+                  onClick={() => setDestination(d.id)}
+                  disabled={sending}
+                >
+                  <Icon name={d.icon} width={14} aria-hidden />
+                  <span className="hc-dest-label">{d.label}</span>
+                </button>
+              ))}
+            </div>
+
             <HomeSelect
-              icon="ph:sparkle"
+              icon="ph:warning-circle"
               value={selectedFamiliarId}
               onChange={(value) => {
                 if (value) onSetActiveFamiliar(value);
@@ -1243,47 +1178,50 @@ export function HomeComposer({
               groups={familiarSelectGroups}
               ariaLabel="Choose chat agent"
               disabled={visibleFamiliars.length === 0 || sending}
-            />
-
-            <ProjectPicker
-              projects={projects}
-              value={selectedProjectId || null}
-              onChange={setSelectedProjectId}
-              allowNoProject
-              familiarId={selectedFamiliarId || null}
-              createProject={createProject}
-              disabled={sending}
-              ariaLabel="Choose project"
-              className="hc-project-selector"
+              className="hc-access-chip"
             />
           </div>
 
+          {/* Right cluster: status · model · thinking · mic · send */}
           <div className="hc-control-group hc-control-group--run">
-            {enhanceOriginal != null && (
-              <button
-                type="button"
-                className="hc-enhance-undo"
-                onClick={revertEnhance}
-                disabled={sending}
-                title="Undo enhance"
-              >
-                Undo
-              </button>
-            )}
+            <span className="hc-status-dot" aria-hidden="true" />
+
+            <HomeSelect
+              icon="ph:lightning-bold"
+              value={selectedRuntimeModelValue}
+              onChange={handleSelectRuntimeModel}
+              groups={runtimeModelSelectGroups}
+              ariaLabel="Choose runtime and model"
+              disabled={!selectedFamiliarId || sending}
+              className="hc-runtime-model-selector"
+            />
+
+            <HomeSelect
+              label="Think"
+              icon="ph:sparkle-bold"
+              value={thinkingEffort}
+              onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
+              groups={[
+                {
+                  options: COMMAND_THINKING_OPTIONS.map((option) => ({
+                    ...option,
+                    icon: "ph:sparkle-bold",
+                  })),
+                },
+              ]}
+              ariaLabel="Choose thinking effort"
+              disabled={sending}
+              className="hc-command-select"
+            />
+
             <button
               type="button"
-              className={`hc-enhance-btn${enhanceStatus === "loading" ? " loading" : ""}`}
-              onClick={() => void enhancePrompt()}
-              disabled={!text.trim() || sending || enhanceStatus === "loading"}
-              aria-label="Enhance prompt"
-              title="Enhance prompt"
+              className="hc-mic-btn"
+              aria-label="Voice input"
+              title="Voice input"
+              disabled={sending}
             >
-              {enhanceStatus === "loading" ? (
-                <span className="hc-spinner" />
-              ) : (
-                <Icon name="ph:sparkle" width={13} aria-hidden />
-              )}
-              <span className="hc-enhance-label">Enhance</span>
+              <Icon name="ph:microphone" width={15} aria-hidden />
             </button>
 
             <button

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -35,9 +35,10 @@ assert.doesNotMatch(
   "picker should use shared CSS/tokenized radii instead of hard-coded rounded classes",
 );
 
-// ── Home composer uses the shared custom picker, not an OS-native select ────
-assert.match(homeComposer, /<ProjectPicker[\s\S]*?ariaLabel="Choose project"/, "home composer uses ProjectPicker");
-assert.doesNotMatch(homeComposer, /<select[\s\S]*?aria-label="Choose project"/, "home composer project picker is custom");
+// ── Home composer: project picker removed from toolbar (project context in headline) ────
+// Project selection logic remains via selectedProject; the picker UI was removed
+// when the toolbar was consolidated into a single row.
+assert.doesNotMatch(homeComposer, /className="hc-project-selector"/, "home composer project selector CSS class is removed");
 
 // ── Styled ──────────────────────────────────────────────────────────────────
 assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -164,15 +164,14 @@
 }
 
 /* ── Action bar ──────────────────────────────────────────────────────────────
- *   The main shell carries immediate composition controls: attach,
- *   familiar/project, prompt enhancement, and send. Runtime config lives in the
- *   tucked rail below so it stays available without crowding the textarea. */
+ *   Single-row toolbar: [+] [access chip] · · · [●] [model] [think] [🎤] [↑]
+ *   Left cluster = context; right cluster = run controls + send. */
 .hc-action-bar {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px 14px;
-  padding: 10px 14px 14px;
+  gap: 6px 10px;
+  padding: 8px 12px 12px;
 }
 
 /* Groups never split internally — a cluster wraps as a whole unit (so Speed and
@@ -866,19 +865,67 @@
   }
 }
 
-/* ── Send button (circular, icon-only — matches the Codex-style composer) ──── */
+/* ── Access chip — familiar selector in warning/amber ───────────────────── */
+.hc-access-chip.hc-familiar-selector,
+.hc-access-chip.hc-home-select-trigger {
+  background: color-mix(in oklch, var(--color-warning) 10%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--color-warning) 28%, transparent);
+}
+.hc-access-chip.hc-familiar-selector:hover:not(:disabled),
+.hc-access-chip.hc-home-select-trigger:hover:not(:disabled) {
+  background: color-mix(in oklch, var(--color-warning) 16%, var(--bg-base));
+  border-color: color-mix(in oklch, var(--color-warning) 38%, transparent);
+}
+.hc-access-chip .hc-familiar-glyph,
+.hc-access-chip .hc-home-select-value {
+  color: var(--color-warning);
+}
+
+/* ── Status dot — presence indicator before the model selector ──────────── */
+.hc-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in oklch, var(--text-muted) 55%, transparent);
+  background: transparent;
+  flex-shrink: 0;
+}
+
+/* ── Mic button ──────────────────────────────────────────────────────────── */
+.hc-mic-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  border-radius: var(--radius-control);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+}
+.hc-mic-btn:hover:not(:disabled) {
+  background: var(--bg-base);
+  border-color: var(--border-hairline);
+  color: var(--text-secondary);
+}
+.hc-mic-btn:disabled { opacity: 0.5; cursor: default; }
+
+/* ── Send button — dark pill, icon-only ─────────────────────────────────── */
 .hc-send-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 5px;
-  width: 36px;
-  height: 36px;
+  width: 34px;
+  height: 34px;
   padding: 0;
-  border-radius: var(--radius-control);
+  border-radius: 999px;
   border: none;
-  background: var(--accent-presence);
-  color: #fff;
+  background: color-mix(in oklch, var(--text-primary) 80%, var(--bg-raised));
+  color: var(--bg-base);
   cursor: pointer;
   margin-left: auto;
   flex-shrink: 0;
@@ -886,20 +933,19 @@
 }
 
 .hc-control-group--run .hc-send-btn {
-  margin-left: 0;
+  margin-left: 2px;
 }
 
 .hc-send-btn:hover:not(:disabled) {
-  background: color-mix(in oklch, var(--accent-presence) 85%, #000);
+  background: var(--text-primary);
   transform: scale(1.05);
 }
 
-/* Empty/disabled reads as a neutral grey disc (no green) until there's a prompt
- * to send — mirrors the screenshot's idle send affordance. */
+/* Empty/disabled reads as a neutral grey pill until there's a prompt to send */
 .hc-send-btn.empty,
 .hc-send-btn:disabled {
-  background: color-mix(in oklch, var(--text-muted) 24%, var(--bg-base));
-  color: var(--text-muted);
+  background: color-mix(in oklch, var(--text-muted) 30%, var(--bg-raised));
+  color: color-mix(in oklch, var(--bg-base) 70%, var(--text-muted));
   cursor: default;
   transform: none;
 }


### PR DESCRIPTION
## Summary
- consolidate HomeComposer controls into the single-row toolbar variant
- keep the composer source guards aligned with the streamlined control layout
- move the local-only main commit through the protected PR path

## Test Plan
- node --experimental-strip-types src/components/home-composer-polish.test.ts
- node --experimental-strip-types src/components/home-composer.test.ts
- node --experimental-strip-types src/components/chat-view-polish.test.ts
- node --experimental-strip-types src/components/project-picker.test.ts
- PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules/.bin:$PATH NODE_PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules tsc --noEmit
- PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules/.bin:$PATH NODE_PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules pnpm check:tests-wired
- git diff --check
- PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules/.bin:$PATH NODE_PATH=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/node_modules pnpm test:app