### PR TITLE
fix(home-composer): remove unused imports, update tests for new toolbar

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -38,13 +38,18 @@ assert.doesNotMatch(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ 
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 assert.doesNotMatch(css, /\.hc-keyboard-hint\b/, "unused .hc-keyboard-hint CSS is removed");
 
+const sendButtonRule = Array.from(css.matchAll(/\.hc-send-btn\s*\{[\s\S]*?\n\}/g), (match) => match[0]).find((rule) =>
+  /background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/.test(rule),
+);
+assert.ok(sendButtonRule, "base .hc-send-btn rule exists");
+
 // ───────── Task 3: Tokenized icon-only Send button ─────────
 // The visible "Send" text label is gone, but the button keeps an aria-label so
-// screen readers announce it, and its chrome uses the shared control radius.
+// screen readers announce it, and its chrome is a compact pill.
 assert.match(source, /aria-label="Send"/, "Send button keeps aria-label='Send'");
 assert.doesNotMatch(source, /className="hc-send-label"/, "visible Send text label removed (button is icon-only)");
 assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule removed");
-assert.match(css, /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*var\(--radius-control\)/, ".hc-send-btn uses the shared control radius");
+assert.doesNotMatch(sendButtonRule, /border-radius:\s*var\(--radius-control\)/, ".hc-send-btn no longer uses the shared control radius (now pill-shaped)");
 
 // ───────── Command-bar hierarchy ─────────
 // New: single-row toolbar — context left, run controls right.
@@ -79,8 +84,8 @@ assert.match(
 );
 // Run rail removed; its CSS survives as dead code for now (radius etc. still tested below).
 assert.match(
-  css,
-  /\.hc-send-btn\s*\{[\s\S]*?border-radius:\s*999px/,
+  sendButtonRule,
+  /border-radius:\s*999px/,
   "send button is pill-shaped (border-radius 999px)",
 );
 assert.match(
@@ -89,8 +94,8 @@ assert.match(
   "custom selector triggers keep button styling while reading as compact selects",
 );
 assert.match(
-  css,
-  /\.hc-send-btn\s*\{[\s\S]*?background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
+  sendButtonRule,
+  /background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
   "active send button uses dark text-primary fill (Codex-style dark pill)",
 );
 for (const selector of [

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -179,12 +179,6 @@ assert.match(
 
 assert.match(
   source,
-  /COMMAND_RESPONSE_SPEED_OPTIONS/,
-  "HomeComposer should use shared response speed options",
-);
-
-assert.match(
-  source,
   /const \[thinkingEffort, setThinkingEffort\] = useState<CommandThinkingEffort>\(\s*COMMAND_CONTROL_DEFAULTS\.thinkingEffort,\s*\)/,
   "HomeComposer should initialise thinking effort from shared command control defaults",
 );

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -17,8 +17,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { ComposerHostChip } from "@/components/composer-host-chip";
-import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
@@ -37,7 +35,6 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
-import { ProjectPicker } from "@/components/project-picker";
 import { StandardSelect, type StandardSelectGroup, type StandardSelectOption } from "@/components/ui/select";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
@@ -52,7 +49,6 @@ import {
 } from "@/lib/chat-attachments";
 import {
   COMMAND_CONTROL_DEFAULTS,
-  COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
   type CommandResponseSpeed,
   type CommandThinkingEffort,
@@ -1218,8 +1214,8 @@ export function HomeComposer({
               type="button"
               className="hc-mic-btn"
               aria-label="Voice input"
-              title="Voice input"
-              disabled={sending}
+              title="Voice input (coming soon)"
+              disabled
             >
               <Icon name="ph:microphone" width={15} aria-hidden />
             </button>

--- a/tests/board-attachments.spec.ts
+++ b/tests/board-attachments.spec.ts
@@ -1,55 +1,26 @@
 import { test, expect } from "@playwright/test";
 
-// Board-destination attachments, end to end in the UI (arc #2219→#2234):
-// stage a file on the home composer → Task destination → the POST /api/board
-// body carries it → the board renders the paperclip chip → the inspector lists
-// the files. Daemon-less: every asserted route is mocked.
+// Home-composer attachment staging, end to end (originally arc #2219→#2234,
+// updated for consolidated toolbar where Task destination moved to board view).
+// Daemon-less: only familiars/sessions/escalations routes are mocked.
 
-const cardWithAttachments = {
-  id: "att-1",
-  title: "Task with files",
-  notes: "",
-  status: "backlog",
-  priority: "medium",
-  familiarId: null,
-  sessionId: null,
-  cwd: null,
-  projectId: null,
-  links: [],
-  github: [],
-  labels: [],
-  createdAt: "2026-07-02T12:00:00Z",
-  updatedAt: "2026-07-02T12:00:00Z",
-  lifecycle: "queued",
-  lifecycleAt: "2026-07-02T12:00:00Z",
-  retryCount: 0,
-  maxRetries: 3,
-  steps: [],
-  attachments: [
-    { name: "spec.md", type: "text/markdown", size: 30, text: "# Spec" },
-    { name: "shot.png", type: "image/png", size: 900 },
-  ],
-};
-
-test("home composer files ride onto a Task card and render on the board", async ({ page }) => {
-  const boardPosts: any[] = [];
-  await page.route("**/api/familiars**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, familiars: [] }) }));
-  await page.route("**/api/sessions/list**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, sessions: [] }) }));
-  await page.route("**/api/escalations**", (r) => r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }));
-  await page.route("**/api/board", (r) => {
-    if (r.request().method() === "POST") {
-      boardPosts.push(JSON.parse(r.request().postData() || "{}"));
-      return r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, card: cardWithAttachments }) });
-    }
-    return r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, cards: [cardWithAttachments] }) });
-  });
+test("home composer files stage and display as chips with remove controls", async ({ page }) => {
+  await page.route("**/api/familiars**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, familiars: [] }) }),
+  );
+  await page.route("**/api/sessions/list**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, sessions: [] }) }),
+  );
+  await page.route("**/api/escalations**", (r) =>
+    r.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, count: 0 }) }),
+  );
   await page.addInitScript(() => window.localStorage.setItem("cave:onboarding:dismissed", "1"));
 
   await page.goto("/");
   await page.waitForSelector(".shell-frame", { timeout: 60000 });
-
-  // ── Stage files on the home composer ───────────────────────────────────────
   await page.waitForSelector(".hc-textarea", { timeout: 60000 });
+
+  // ── Stage two files ──────────────────────────────────────────────────────────
   await page.locator(".hc-file-input").setInputFiles([
     {
       name: "spec.md",
@@ -62,28 +33,19 @@ test("home composer files ride onto a Task card and render on the board", async 
       buffer: Buffer.from("fake image bytes"),
     },
   ]);
+
+  // Both chips appear
   await expect(page.locator(".hc-attachment-name")).toHaveText(["spec.md", "shot.png"]);
 
-  // ── Send to the Task destination ───────────────────────────────────────────
-  await page.getByRole("radio", { name: "Task" }).click();
-  await page.locator(".hc-textarea").fill("Ship the spec");
-  await page.locator(".hc-send-btn").click();
+  // Count header reads "2/10 attached"
+  await expect(page.locator(".hc-attachments-count")).toHaveText("2/10 attached");
 
-  // The POST body carries the staged attachment, content included.
-  await expect.poll(() => boardPosts.length, { timeout: 15000 }).toBeGreaterThan(0);
-  expect(boardPosts[0].title).toBe("Ship the spec");
-  expect(boardPosts[0].attachments?.map((a: { name?: string }) => a.name)).toEqual(["spec.md", "shot.png"]);
-  expect(boardPosts[0].attachments?.[0]?.name).toBe("spec.md");
-  expect(boardPosts[0].attachments?.[0]?.text).toContain("do the thing");
+  // ── Per-chip remove ──────────────────────────────────────────────────────────
+  await page.getByRole("button", { name: "Remove spec.md" }).click();
+  await expect(page.locator(".hc-attachment-name")).toHaveText(["shot.png"]);
+  await expect(page.locator(".hc-attachments-count")).toHaveText("1/10 attached");
 
-  // ── Board renders the paperclip chip (auto-navigated after create) ─────────
-  await page.waitForSelector(".board-kanban-card", { timeout: 60000 });
-  await expect(page.locator('[title="2 attachments"]')).toBeVisible();
-
-  // ── Inspector lists the files with per-file remove affordances ─────────────
-  await page.locator('[data-card-id="att-1"]').click();
-  await expect(page.getByText("Attachments")).toBeVisible();
-  await expect(page.getByText("spec.md", { exact: true })).toBeVisible();
-  await expect(page.getByText("shot.png", { exact: true })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Remove spec.md" })).toBeVisible();
+  // ── Clear all ────────────────────────────────────────────────────────────────
+  await page.locator(".hc-attachments-clear").click();
+  await expect(page.locator(".hc-attachments")).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary
- Remove unused imports left over from toolbar consolidation: `ComposerHostChip`, `LOCAL_HOST_ID`, `ProjectPicker`, `COMMAND_RESPONSE_SPEED_OPTIONS`
- Disable mic button permanently (labeled "Voice input (coming soon)") — it had no implementation
- Update unit test: remove `COMMAND_RESPONSE_SPEED_OPTIONS` assertion (no longer in source)
- Update E2E test: replace the board-via-Task-radio flow with an attachment-staging flow that tests chips, count display, per-chip remove, and clear-all — the Task radio button path no longer exists in the consolidated toolbar

## Test plan
- [ ] `node scripts/run-tests.mjs` — all 705 tests pass
- [ ] E2E (Playwright) — no radio-button lookup; tests attachment chip lifecycle instead
- [ ] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)