### PR TITLE
feat(chat): show inline edit details

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10508,18 +10508,48 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   .cave-fill-btn::before { transition: none; }
 }
 
-/* Codex inline file-edit card: a mutation tool call rendered in the chat
-   transcript as `[icon] Edited <file>  +N −M  [Review]` instead of the
-   collapsed tool block. Horizontal flex row, hairline border. */
+/* Codex inline file-edit card: a mutation tool call rendered visibly in the
+   chat transcript. The summary stays compact; expanding shows the diff body
+   using the same details pattern as other tool calls. */
 .cave-edit-card {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  display: block;
   padding: 0.4rem 0.6rem;
-  border: 1px solid var(--border-hairline);
   border-radius: 0.625rem;
   background: var(--bg-raised);
   font-size: 12px;
+}
+.cave-edit-card__summary {
+  display: grid !important;
+  grid-template-columns: auto auto minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+  cursor: pointer;
+  list-style: none;
+}
+.cave-edit-card__summary::-webkit-details-marker {
+  display: none;
+}
+.cave-edit-card__summary::before {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  flex: none;
+  background-color: var(--text-muted);
+  opacity: 0.65;
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6 4l4 4-4 4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  mask-size: contain;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M6 4l4 4-4 4' stroke='currentColor' stroke-width='2' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  -webkit-mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  transition: transform 0.15s ease;
+}
+details[open] > .cave-edit-card__summary::before {
+  transform: rotate(90deg);
 }
 .cave-edit-card__icon {
   flex: none;
@@ -10531,6 +10561,11 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   flex: 1 1 auto;
   align-items: center;
   gap: 0.5rem;
+}
+.cave-edit-card > .cave-tool-io {
+  margin-top: 0.55rem;
+  border-top: 1px solid var(--border-hairline);
+  padding-top: 0.55rem;
 }
 .cave-edit-card__title {
   min-width: 0;

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -175,6 +175,11 @@ assert.match(
 );
 assert.match(
   turnRow,
+  /const isEditCard = \(t: ToolEvent\) =>\s*toolInputAsDiff\(t\.name, t\.input\) != null;/,
+  "any structured file mutation diff stays visible inline, even when the tool input only has a relative path",
+);
+assert.match(
+  turnRow,
   /otherTools\.length \? <ToolGroup tools=\{otherTools\}/,
   "non-edit tool activity still collapses into the designated ToolGroup",
 );
@@ -1011,11 +1016,18 @@ assert.ok(
 );
 
 // Codex inline file-edit card: Edit/Write/MultiEdit/NotebookEdit tool calls
-// render as a compact `Edited <file>  +N −M  Review` card in the transcript.
+// render as a visible details card in the transcript. The collapsed summary
+// shows when/status + what file changed; expanding the same card shows the
+// actual diff, matching the Bash/tool-use disclosure pattern.
 assert.match(source, /cave-edit-card/, "mutation tools render as an inline Codex edit card");
 assert.match(source, /diffStat/, "edit card derives a +/- stat");
 assert.match(source, /Review/, "edit card has a Review action");
 assert.match(globalsSrc, /\.cave-edit-card/, "edit card styling exists");
+assert.match(
+  source,
+  /if \(isEditTool\) \{[\s\S]*<details className="cave-tool-block cave-edit-card"[\s\S]*Edited \{base\}[\s\S]*<DurationText durationMs=\{tool\.durationMs\} \/>[\s\S]*Code changes[\s\S]*<SyntaxBlock text=\{inputDiff\} lang="diff" \/>[\s\S]*<\/details>/,
+  "edit cards should use the same expandable tool details pattern and include the code diff in chat",
+);
 
 // Inline "Undo" reverts the edited file to its last committed state via the
 // changes revert API, resolving the repo-relative path through a context, and

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -111,7 +111,7 @@ import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
 import { toolVisual } from "@/lib/tool-visual";
 import { toolReadableFields, prettyToolOutput, type ReadableField } from "@/lib/tool-readable";
 import { useShowThinking } from "@/lib/reasoning-visibility";
-import { toolInputAsDiff, toolTargetFile } from "@/lib/tool-input-diff";
+import { toolInputAsDiff, toolTargetFile, toolTargetPath } from "@/lib/tool-input-diff";
 import { diffStat } from "@/lib/tool-edit-stat";
 import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
@@ -5607,7 +5607,7 @@ function TurnRowImpl({
             {!turn.pending && turn.tools?.length
               ? (() => {
                   const isEditCard = (t: ToolEvent) =>
-                    toolInputAsDiff(t.name, t.input) != null && toolTargetFile(t.name, t.input) != null;
+                    toolInputAsDiff(t.name, t.input) != null;
                   const editCards = turn.tools.filter(isEditCard);
                   const otherTools = turn.tools.filter((t) => !isEditCard(t));
                   return (
@@ -5862,7 +5862,7 @@ function EditCardActions({ targetFile }: { targetFile: string }) {
   };
 
   return (
-    <span className="cave-edit-card__actions">
+    <span className="cave-edit-card__actions" onClick={(e) => e.stopPropagation()}>
       {err ? <span className="cave-edit-card__error" title={err}>{err}</span> : null}
       <button type="button" className="cave-edit-card__review focus-ring" onClick={review}>
         Review
@@ -5904,6 +5904,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
   // structured before/after diff instead of the raw JSON payload; null for
   // every other tool (or unparseable input) falls back to the plain block.
   const inputDiff = toolInputAsDiff(tool.name, tool.input);
+  const targetPath = toolTargetPath(tool.name, tool.input);
   // Click-to-open: a file tool's target opens in the Code workspace preview.
   // Dispatched as an event; the comux pane (Code/Terminal) handles it, and the
   // workspace switches to Code mode first when neither is showing.
@@ -5924,25 +5925,48 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
   };
   const visual = toolVisual(tool.name);
   // Codex-style inline edit card: a mutation tool (Edit/Write/MultiEdit/
-  // NotebookEdit, i.e. `isEditTool`) with a known target file renders as a
-  // compact `[icon] Edited <basename>  +N −M  [Review]` row instead of the
-  // collapsed tool block. Review opens the comux diff via the same
-  // `cave:open-file-diff` event the default block dispatches.
-  if (isEditTool && targetFile) {
+  // NotebookEdit, i.e. `isEditTool`) stays visible in the transcript as a
+  // compact details summary, and expands to the structured code diff. Review
+  // opens the comux diff when the input carries an absolute target path.
+  if (isEditTool) {
     const stat = diffStat(inputDiff ?? "");
-    const base = targetFile.split("/").pop() || targetFile;
+    const displayPath = targetPath ?? (argSummary || tool.name);
+    const base = displayPath.split("/").pop() || displayPath;
     return (
-      <div className="cave-edit-card">
-        <Icon name="ph:pencil-simple" width={16} className="cave-edit-card__icon" aria-hidden />
-        <span className="cave-edit-card__body">
-          <span className="cave-edit-card__title">Edited {base}</span>
-          <span className="cave-edit-card__stat">
-            <span className="cave-edit-card__ins">+{stat.insertions}</span>{" "}
-            <span className="cave-edit-card__del">−{stat.deletions}</span>
+      <details className="cave-tool-block cave-edit-card" data-default-collapsed="true" data-tool-category={visual.category}>
+        <summary className="cave-edit-card__summary">
+          <Icon name="ph:pencil-simple" width={16} className="cave-edit-card__icon" aria-hidden />
+          <span className="cave-edit-card__body">
+            <span className="cave-edit-card__title">Edited {base}</span>
+            <span className="cave-edit-card__stat">
+              <span className="cave-edit-card__ins">+{stat.insertions}</span>{" "}
+              <span className="cave-edit-card__del">−{stat.deletions}</span>
+            </span>
           </span>
-        </span>
-        <EditCardActions targetFile={targetFile} />
-      </div>
+          <span className={[
+            "rounded px-1.5 py-0.5 font-mono text-[10px]",
+            tool.status === "error"
+              ? "bg-[color-mix(in_oklch,var(--color-danger)_20%,transparent)] text-[var(--color-danger)]"
+              : tool.status === "running"
+                ? "bg-[color-mix(in_oklch,var(--color-warning)_20%,transparent)] text-[var(--color-warning)]"
+                : "bg-[color-mix(in_oklch,var(--color-success)_18%,transparent)] text-[var(--color-success)]",
+          ].join(" ")}>
+            {tool.status}
+          </span>
+          <DurationText durationMs={tool.durationMs} />
+          {targetFile ? <EditCardActions targetFile={targetFile} /> : null}
+        </summary>
+        <div className="cave-tool-io mt-2">
+          <div className="cave-tool-io-label">Code changes</div>
+          <SyntaxBlock text={inputDiff} lang="diff" />
+        </div>
+        {tool.output ? (
+          <div className="cave-tool-io mt-2">
+            <div className="cave-tool-io-label">Output</div>
+            <SyntaxBlock text={prettyToolOutput(tool.output)} />
+          </div>
+        ) : null}
+      </details>
     );
   }
   return (

--- a/src/lib/tool-input-diff.ts
+++ b/src/lib/tool-input-diff.ts
@@ -114,12 +114,11 @@ export function toolInputAsDiff(name: string, input?: string | null): string | n
 const FILE_TOOLS = new Set([...MUTATION_TOOLS, "read"]);
 
 /**
- * Best-effort absolute file path a tool call targets, for click-to-open in the
- * Code workspace. Returns null for non-file tools, unparseable input, or when
- * no concrete path is present (so the caller renders a plain, non-clickable
- * label rather than a dead link).
+ * Best-effort file path a tool call targets, for transcript display. Relative
+ * paths are still useful here because mutation diffs should remain visible in
+ * chat even when the Code workspace cannot open the file directly.
  */
-export function toolTargetFile(name: string, input?: string | null): string | null {
+export function toolTargetPath(name: string, input?: string | null): string | null {
   if (!FILE_TOOLS.has(name.toLowerCase())) return null;
   const raw = (input ?? "").trim();
   if (!raw) return null;
@@ -131,7 +130,16 @@ export function toolTargetFile(name: string, input?: string | null): string | nu
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
   const path = filePathOf(parsed as Rec);
-  // filePathOf falls back to the literal "file" when no key matched; treat that
-  // sentinel (and any non-absolute path) as "no openable target".
-  return path !== "file" && path.startsWith("/") ? path : null;
+  return path !== "file" ? path : null;
+}
+
+/**
+ * Best-effort absolute file path a tool call targets, for click-to-open in the
+ * Code workspace. Returns null for non-file tools, unparseable input, or when
+ * no concrete absolute path is present (so callers render a plain, non-clickable
+ * label rather than a dead link).
+ */
+export function toolTargetFile(name: string, input?: string | null): string | null {
+  const path = toolTargetPath(name, input);
+  return path && path.startsWith("/") ? path : null;
 }

--- a/src/lib/tool-target-file.test.ts
+++ b/src/lib/tool-target-file.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const { toolTargetFile } = await import("./tool-input-diff.ts");
+const { toolTargetFile, toolTargetPath } = await import("./tool-input-diff.ts");
 
 // ── toolTargetFile: openable absolute path for file tools, else null ─────────
 {
@@ -19,6 +19,11 @@ const { toolTargetFile } = await import("./tool-input-diff.ts");
   );
   // Case-insensitive tool name.
   assert.equal(toolTargetFile("edit", JSON.stringify({ path: "/repo/d.ts" })), "/repo/d.ts");
+  assert.equal(
+    toolTargetPath("Edit", JSON.stringify({ file_path: "src/rel.ts", old_string: "x", new_string: "y" })),
+    "src/rel.ts",
+    "relative mutation paths remain displayable in chat even though they are not openable",
+  );
 
   // Non-file tools → null.
   assert.equal(toolTargetFile("Bash", JSON.stringify({ command: "ls" })), null);


### PR DESCRIPTION
## Summary
- keep mutation tool calls visible inline whenever a structured code diff can render, including relative file paths
- render edit tool blocks as expandable details cards with status, timing, changed-file summary, and code diff body
- keep Review available for absolute workspace targets while preserving display paths for relative targets

## Test Plan
- `node --experimental-strip-types src/components/chat-view-polish.test.ts`
- `node --experimental-strip-types src/lib/tool-target-file.test.ts`
- `node --experimental-strip-types src/components/code-view.test.ts`
- `tsc --noEmit`
- `pnpm check:tests-wired`
- `git diff --check`
- `pnpm test:app`

Refs cave-5p7