### PR TITLE
feat(chat): fold Group Chat into a Chat tab + world-class UX pass

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -80,6 +80,19 @@ assert.match(
   /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/,
   "ChatSurface should label the secondary primary tab Projects instead of Traces",
 );
+
+// Group Chat ("coven") is folded in as a first-class scope tab (retiring the
+// standalone groupchat page); it renders GroupChatView for the coven scope.
+assert.match(
+  chatSurface,
+  /\{\s*id:\s*"coven",\s*label:\s*"Group"/,
+  "ChatSurface should expose the Group Chat tab",
+);
+assert.match(
+  chatSurface,
+  /scope === "coven" \?[\s\S]*<GroupChatView[\s\S]*familiars=\{resolvedFamiliars\}/,
+  "ChatSurface should render GroupChatView for the coven scope",
+);
 // Familiar selection now lives in the global top menu bar (and the sidebar /
 // mobile top-bar switcher), so the chat header carries only its scope tabs —
 // no duplicate switcher here.

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -5,8 +5,9 @@ import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panel
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
 import { ProjectsView } from "@/components/projects-view";
+import { GroupChatView } from "@/components/group-chat-view";
 import { InspectorPane } from "@/components/inspector-pane";
-import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, consumeCovenTabPending } from "@/lib/chat-tab-events";
 import { DebugPane } from "@/components/debug-pane";
 import { SessionChangesPanel } from "@/components/session-changes-panel";
 import { WorkspaceRail } from "@/components/workspace-rail";
@@ -53,7 +54,7 @@ const chatStorage = {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
-type FamiliarsScope = "conversation" | "memory" | "projects";
+type FamiliarsScope = "conversation" | "memory" | "projects" | "coven";
 
 export type RightPanelKind = "inspector" | "changes" | "debug";
 
@@ -499,6 +500,17 @@ export function ChatSurface({
     return () => window.removeEventListener(CHAT_OPEN_PROJECTS_EVENT, open);
   }, []);
 
+  // The retired standalone `groupchat` mode now lands here as a tab: the
+  // Workspace redirects it to chat and fires this event so the Group tab opens.
+  // On a fresh mount (redirect from another surface) the event can beat this
+  // listener, so we also consume a retained latch the Workspace sets first.
+  useEffect(() => {
+    if (consumeCovenTabPending()) setScope("coven");
+    const open = () => setScope("coven");
+    window.addEventListener(CHAT_OPEN_COVEN_EVENT, open);
+    return () => window.removeEventListener(CHAT_OPEN_COVEN_EVENT, open);
+  }, []);
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
@@ -520,6 +532,7 @@ export function ChatSurface({
             items={[
               { id: "conversation", label: "Sessions" },
               { id: "projects", label: "Projects" },
+              { id: "coven", label: "Group", icon: "ph:users-three", title: "Group chat — broadcast one prompt to a coven of familiars" },
             ]}
           />
           {/* Mobile / narrow-pane code-rail toggle. On desktop the rail is a
@@ -562,6 +575,17 @@ export function ChatSurface({
           />
         ) : scope === "projects" ? (
           <ProjectsView sessions={sessions} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
+        ) : scope === "coven" ? (
+          // Group Chat ("coven") lives here as a first-class chat tab instead of
+          // a standalone surface. It broadcasts one prompt to several familiars,
+          // each answering in its own resumable session (see GroupChatView).
+          <div className="flex min-h-0 min-w-0 flex-1">
+            <GroupChatView
+              familiars={resolvedFamiliars}
+              onSessionStarted={onSessionStarted}
+              onOpenUrl={onOpenUrl}
+            />
+          </div>
         ) : (
           <Group
             className="flex min-h-0 min-w-0 flex-1"

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -6,6 +6,7 @@ import { readFileSync } from "node:fs";
 const view = readFileSync(new URL("./group-chat-view.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const mode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 
 test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () => {
@@ -77,18 +78,74 @@ test("Group chat transcript uses avatar author rows with recency", () => {
   );
 });
 
-test("Group Chat is wired into navigation", () => {
-  assert.match(mode, /\| "groupchat"/, "groupchat is a valid WorkspaceMode");
-  assert.match(sidebar, /id: "groupchat", label: "Group"/, "sidebar exposes the Group surface");
-  assert.match(workspace, /groupchat: "Group Chat"/, "groupchat mode has a title");
-  assert.match(
-    workspace,
-    /mode === "groupchat" \?\s*\(\s*<GroupChatView/,
-    "workspace renders GroupChatView for the groupchat mode",
-  );
-  assert.match(
+test("Group Chat is a tab inside the Chat surface, not a standalone page", () => {
+  // The mode still exists purely as a redirect target for legacy deep links.
+  assert.match(mode, /\| "groupchat"/, "groupchat stays a valid WorkspaceMode for redirects");
+  assert.match(workspace, /groupchat: "Group Chat"/, "groupchat keeps a title entry");
+
+  // The standalone page is retired: the Workspace no longer imports or renders
+  // GroupChatView, and redirects the legacy mode into the Chat surface's tab.
+  assert.doesNotMatch(
     workspace,
     /import \{ GroupChatView \} from "@\/components\/group-chat-view"/,
-    "workspace imports GroupChatView",
+    "workspace no longer imports GroupChatView (it moved into ChatSurface)",
   );
+  assert.doesNotMatch(
+    workspace,
+    /mode === "groupchat" \?\s*\(\s*<GroupChatView/,
+    "workspace no longer renders a standalone GroupChatView surface",
+  );
+  assert.match(
+    workspace,
+    /if \(next === "groupchat"\)[\s\S]*setModeRaw\("chat"\)[\s\S]*CHAT_OPEN_COVEN_EVENT/,
+    "workspace redirects the groupchat mode into chat + opens the coven tab",
+  );
+
+  // The standalone left-nav destination is gone.
+  assert.doesNotMatch(
+    sidebar,
+    /id: "groupchat", label: "Group"/,
+    "sidebar no longer exposes a standalone Group destination",
+  );
+
+  // ChatSurface owns Group Chat now: it imports GroupChatView, offers a Group
+  // scope tab, listens for the open-coven event, and renders it for that scope.
+  assert.match(
+    chatSurface,
+    /import \{ GroupChatView \} from "@\/components\/group-chat-view"/,
+    "ChatSurface imports GroupChatView",
+  );
+  assert.match(
+    chatSurface,
+    /\{\s*id:\s*"coven",\s*label:\s*"Group"/,
+    "ChatSurface exposes a Group tab",
+  );
+  assert.match(
+    chatSurface,
+    /scope === "coven" \?[\s\S]*<GroupChatView/,
+    "ChatSurface renders GroupChatView for the coven scope",
+  );
+  assert.match(
+    chatSurface,
+    /addEventListener\(CHAT_OPEN_COVEN_EVENT/,
+    "ChatSurface opens the Group tab when the workspace redirects the legacy mode",
+  );
+});
+
+test("Group chat is a world-class chat surface (a11y + resilience)", () => {
+  // Smart autoscroll: never yank a reader who scrolled up; offer a jump pill.
+  assert.match(view, /stickToBottomRef/, "tracks whether the transcript is pinned to the bottom");
+  assert.match(view, /onTranscriptScroll/, "recomputes stickiness on scroll");
+  assert.match(view, /jumpToLatest/, "offers a jump-to-latest affordance");
+  // Transcript is an accessible log region.
+  assert.match(view, /role="log"/, "transcript is exposed as a log region");
+  // Destructive delete is confirmed and outcomes are announced to AT.
+  assert.match(view, /const confirm = useConfirm\(\)/, "coven delete is guarded by a confirm dialog");
+  assert.match(view, /requestDeleteGroup/, "delete routes through the confirm wrapper");
+  assert.match(view, /const \{ announce \} = useAnnouncer\(\)/, "broadcast outcomes are announced");
+  // Coven rows are real buttons (keyboard-accessible), with aria-current.
+  assert.match(view, /aria-current=\{isActive \? "true" : undefined\}/, "the active coven row is marked aria-current");
+  // A failed familiar reply can be retried in place.
+  assert.match(view, /const retryReply = useCallback/, "failed replies can be retried");
+  assert.match(view, /onClick=\{\(\) => void retryReply\(r\)\}/, "the Retry control re-runs a single familiar");
 });

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -23,6 +23,8 @@ import { extractNextPaths } from "@/lib/next-paths";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Popover } from "@/components/ui/popover";
+import { useConfirm } from "@/components/ui/confirm-dialog";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { MessageBubble } from "@/components/message-bubble";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -84,7 +86,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // @mention autocomplete in the composer.
   const [mention, setMention] = useState<{ start: number; query: string } | null>(null);
   const [mentionIndex, setMentionIndex] = useState(0);
+  // Whether the transcript is scrolled to the bottom. When the reader has
+  // scrolled up to review history, new streaming content must NOT yank them
+  // back down — instead we surface a "jump to latest" pill.
+  const [showJump, setShowJump] = useState(false);
+  const stickToBottomRef = useRef(true);
   const dtPrefs = useDateTimePrefs();
+  const confirm = useConfirm();
+  const { announce } = useAnnouncer();
 
   const addBtnRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -95,6 +104,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   const pendingCaretRef = useRef<number | null>(null);
   const groupsRef = useRef<CovenGroup[]>(groups);
   groupsRef.current = groups;
+  // Live mirror of the transcript so retry can read the answered user turn
+  // without re-creating its callback on every streaming token.
+  const transcriptRef = useRef<GroupTurn[]>(transcript);
+  transcriptRef.current = transcript;
 
   const byId = useMemo(() => {
     const m = new Map<string, ResolvedFamiliar>();
@@ -130,11 +143,44 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     if (activeId) saveTranscript(activeId, transcript);
   }, [activeId, transcript]);
 
-  // --- autoscroll to newest -----------------------------------------------
+  // --- autoscroll to newest, but only when the reader is already at the bottom
+  // Streaming replies grow the transcript constantly; force-scrolling on every
+  // update would fight a reader who scrolled up to re-read an earlier answer.
   useEffect(() => {
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (!el) return;
+    if (stickToBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+      setShowJump(false);
+    } else {
+      // Something new landed while scrolled up — offer a jump affordance.
+      setShowJump(true);
+    }
   }, [transcript]);
+
+  // When the active group changes, snap to the bottom of its transcript.
+  useEffect(() => {
+    stickToBottomRef.current = true;
+    setShowJump(false);
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [activeId]);
+
+  const onTranscriptScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // 48px slop so a near-bottom position still counts as "stuck to bottom".
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    stickToBottomRef.current = atBottom;
+    if (atBottom) setShowJump(false);
+  }, []);
+
+  const jumpToLatest = useCallback(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+    stickToBottomRef.current = true;
+    setShowJump(false);
+  }, []);
 
   // --- restore caret after a programmatic draft rewrite (mention insert) ---
   useEffect(() => {
@@ -146,6 +192,15 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       el.focus();
       el.setSelectionRange(caret, caret);
     }
+  }, [draft]);
+
+  // --- auto-grow the composer to fit its content (capped at max-height) -----
+  // Covers typing, @mention inserts, and the collapse back to one row on send.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
   }, [draft]);
 
   const persistGroups = useCallback((next: CovenGroup[]) => {
@@ -198,6 +253,20 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       if (activeId === id) setActiveId(next[0]?.id ?? null);
     },
     [persistGroups, activeId],
+  );
+
+  // Deleting a coven drops its transcript irreversibly, so confirm first.
+  const requestDeleteGroup = useCallback(
+    async (id: string, name: string) => {
+      const ok = await confirm({
+        title: `Delete “${name || "this coven"}”?`,
+        body: "This removes the coven and its transcript on this device. The familiars and their individual chats are untouched.",
+        confirmLabel: "Delete coven",
+        danger: true,
+      });
+      if (ok) deleteGroup(id);
+    },
+    [confirm, deleteGroup],
   );
 
   const toggleParticipant = useCallback(
@@ -338,13 +407,16 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         status: "queued",
         createdAt: at,
       }));
+      // The user just sent — snap them to the bottom regardless of prior scroll.
+      stickToBottomRef.current = true;
+      setShowJump(false);
       setTranscript((prev) => [...prev, userTurn, ...replies]);
       setDraft("");
       setMention(null);
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
-      await Promise.all(
+      const settled = await Promise.all(
         replies.map((r) =>
           streamOne(
             group,
@@ -361,8 +433,18 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
       );
       abortRef.current = null;
       setBusy(false);
+      // The streaming bubbles are visual-only — announce the outcome for AT.
+      const failed = settled.filter((r) => r.status === "error").length;
+      const total = settled.length;
+      if (failed === 0) {
+        announce(`All ${total} familiar${total === 1 ? "" : "s"} replied.`);
+      } else if (failed === total) {
+        announce(`All ${total} ${total === 1 ? "reply" : "replies"} failed.`, "assertive");
+      } else {
+        announce(`${total - failed} of ${total} familiars replied; ${failed} failed.`, "assertive");
+      }
     },
-    [busy, streamOne, byId],
+    [busy, streamOne, byId, announce],
   );
 
   // The composer and "click a next-path suggestion to send" chips both go
@@ -372,6 +454,60 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   const stop = useCallback(() => {
     abortRef.current?.abort();
   }, []);
+
+  // Re-run a single familiar's reply after a failure (or a cancel), reusing the
+  // original user turn's text + targeting so the roundtable context is identical.
+  const retryReply = useCallback(
+    async (reply: GroupReply) => {
+      const group = activeGroupRef.current;
+      if (!group || busy || abortRef.current) return;
+      const userTurn = transcriptRef.current.find(
+        (t): t is GroupUserTurn => t.role === "user" && t.id === reply.replyTo,
+      );
+      if (!userTurn) return;
+      const rosterParticipants: RosterParticipant[] = [
+        ...group.familiarIds.map((id) => ({
+          id,
+          name: byId.get(id)?.display_name ?? id,
+          role: byId.get(id)?.role ?? "",
+          kind: "familiar" as const,
+        })),
+        { id: "__human__", name: "You", role: "", kind: "human" as const },
+      ];
+      // Reset the failed bubble in place so it re-enters the streaming state.
+      const fresh: GroupReply = {
+        ...reply,
+        sessionId: group.sessions[reply.familiarId] ?? reply.sessionId ?? null,
+        text: "",
+        status: "queued",
+        error: undefined,
+        activity: undefined,
+      };
+      updateReply(reply.id, () => fresh);
+      setBusy(true);
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const settled = await streamOne(
+        group,
+        fresh,
+        renderCovenRoundtablePrompt({
+          participants: rosterParticipants,
+          receivingFamiliarId: fresh.familiarId,
+          userText: userTurn.text,
+          targeted: Boolean(userTurn.targetFamiliarIds && userTurn.targetFamiliarIds.length > 0),
+        }),
+        controller.signal,
+      );
+      abortRef.current = null;
+      setBusy(false);
+      const name = byId.get(fresh.familiarId)?.display_name ?? "Familiar";
+      announce(
+        settled.status === "error" ? `${name} failed again.` : `${name} replied.`,
+        settled.status === "error" ? "assertive" : "polite",
+      );
+    },
+    [busy, byId, updateReply, streamOne, announce],
+  );
 
   // --- @mention autocomplete ----------------------------------------------
   const mentionable = useMemo<MentionableFamiliar[]>(() => {
@@ -447,9 +583,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                 const members = g.familiarIds.map((id) => byId.get(id)).filter(Boolean) as ResolvedFamiliar[];
                 const isActive = g.id === activeId;
                 return (
-                  <li key={g.id}>
-                    <div
-                      className="group/coven flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5"
+                  // Row = a real button (keyboard + roving focus). The delete
+                  // control is a sibling overlay, not a nested button (which is
+                  // invalid HTML and traps keyboard focus).
+                  <li key={g.id} className="group/coven relative">
+                    <button
+                      type="button"
+                      className="focus-ring flex w-full items-center gap-2 rounded-md px-2 py-1.5 pr-8 text-left transition-colors hover:bg-[var(--bg-raised)]"
+                      aria-current={isActive ? "true" : undefined}
                       style={isActive ? { background: "var(--bg-raised)" } : undefined}
                       onClick={() => setActiveId(g.id)}
                     >
@@ -471,19 +612,16 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                           {members.length} familiar{members.length === 1 ? "" : "s"} · <RelativeTime iso={g.updatedAt} />
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        className="opacity-0 transition-opacity group-hover/coven:opacity-100"
-                        title="Delete coven"
-                        aria-label={`Delete ${g.name}`}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          deleteGroup(g.id);
-                        }}
-                      >
-                        <Icon name="ph:trash" width={14} height={14} />
-                      </button>
-                    </div>
+                    </button>
+                    <button
+                      type="button"
+                      className="focus-ring absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover/coven:opacity-100"
+                      title="Delete coven"
+                      aria-label={`Delete ${g.name}`}
+                      onClick={() => void requestDeleteGroup(g.id, g.name)}
+                    >
+                      <Icon name="ph:trash" width={14} height={14} />
+                    </button>
                   </li>
                 );
               })}
@@ -605,7 +743,15 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             </header>
 
             {/* Transcript */}
-            <div ref={scrollRef} className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
+            <div className="relative min-h-0 flex-1">
+            <div
+              ref={scrollRef}
+              onScroll={onTranscriptScroll}
+              role="log"
+              aria-label="Coven transcript"
+              aria-live="off"
+              className="h-full overflow-y-auto px-4 py-4"
+            >
               {threads.length === 0 ? (
                 <div className="grid h-full place-items-center">
                   <EmptyState
@@ -694,6 +840,19 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                   onOpenUrl={onOpenUrl}
                                   showTimestamp={false}
                                 />
+                                {r.status === "error" ? (
+                                  <div className="mt-1.5">
+                                    <Button
+                                      size="xs"
+                                      variant="secondary"
+                                      leadingIcon="ph:arrow-clockwise"
+                                      onClick={() => void retryReply(r)}
+                                      disabled={busy}
+                                    >
+                                      Retry
+                                    </Button>
+                                  </div>
+                                ) : null}
                                 {r.status === "done" && suggestions.length > 0 ? (
                                   <div className="cave-next-paths mt-1.5">
                                     {suggestions.map((s, i) => {
@@ -725,6 +884,24 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                     );
                   })}
                 </div>
+              )}
+            </div>
+              {/* Jump-to-latest: shown when new replies land while the reader has
+                  scrolled up. Clicking snaps back to the newest message. */}
+              {showJump && (
+                <button
+                  type="button"
+                  onClick={jumpToLatest}
+                  className="focus-ring absolute bottom-3 left-1/2 flex -translate-x-1/2 items-center gap-1.5 rounded-full border px-3 py-1.5 text-[12px] font-medium shadow-md"
+                  style={{
+                    background: "var(--bg-raised)",
+                    borderColor: "var(--border-hairline)",
+                    color: "var(--text-primary)",
+                  }}
+                >
+                  <Icon name="ph:arrow-down" width={13} height={13} />
+                  {busy ? "New replies" : "Jump to latest"}
+                </button>
               )}
             </div>
 
@@ -770,6 +947,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                     }
                   }}
                   rows={1}
+                  aria-label={activeGroup ? `Message the ${activeGroup.name} coven` : "Message the coven"}
                   placeholder={
                     participants.length === 0
                       ? "Add familiars to this coven first…"

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -84,8 +84,9 @@ const FOLDER_MODES: Array<{
   description: string;
 }> = [
   { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
-  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars" },
-  { id: "groupchat", label: "Group", iconName: "ph:users-three", description: "Group chat — broadcast to a coven of familiars at once" },
+  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven" },
+  // Group Chat ("coven") is no longer a standalone destination — it lives as the
+  // Group tab inside Chat. The `groupchat` mode still exists as a redirect target.
   { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your daily journal and generated sketches" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and crons in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -25,7 +25,6 @@ import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
 import { RailInspector } from "@/components/inspector-pane";
 import { SalemChatPanel } from "@/components/salem/salem-widget";
 import { FamiliarsView } from "@/components/familiars-view";
-import { GroupChatView } from "@/components/group-chat-view";
 import {
   getFamiliarScope,
   setFamiliarScope,
@@ -48,7 +47,7 @@ import {
 } from "@/components/lazy-surfaces";
 import { WorkspaceSidebar } from "@/components/workspace-sidebar";
 import { OpenCovenSubmissionPage } from "@/components/opencoven-submission-page";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_COVEN_EVENT, markCovenTabPending } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface, type RightPanelKind } from "@/components/chat-surface";
 import { MobileHandoffModal } from "@/components/mobile-handoff-modal";
@@ -248,7 +247,22 @@ export function Workspace() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [topSearchQuery, setTopSearchQuery] = useState("");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const [mode, setMode] = useState<WorkspaceMode>("home");
+  const [mode, setModeRaw] = useState<WorkspaceMode>("home");
+  // Group Chat retired its standalone page — it's now a tab inside the Chat
+  // surface. Any request for the legacy `groupchat` mode (nav, deep link,
+  // palette, keyboard, drag-to-split) is redirected to chat and opens the Group
+  // tab, so `mode` is never actually "groupchat" and the surface never flashes.
+  const setMode = useCallback((next: WorkspaceMode) => {
+    if (next === "groupchat") {
+      // Set the latch synchronously so a freshly-mounting ChatSurface opens the
+      // Group tab on mount; the event covers an already-mounted ChatSurface.
+      markCovenTabPending();
+      setModeRaw("chat");
+      window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_COVEN_EVENT)), 0);
+      return;
+    }
+    setModeRaw(next);
+  }, []);
   // Chat mode swaps the left nav for the ChatSidebar (project-grouped threads).
   // Its back control returns to the surface the user came from.
   const [lastNonChatMode, setLastNonChatMode] = useState<WorkspaceMode>("home");
@@ -1838,12 +1852,6 @@ export function Workspace() {
         onInboxItemChanged={refreshInbox}
         onSessionsChanged={loadSessions}
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
-        onOpenUrl={openUrlInAppBrowser}
-      />
-    ) : mode === "groupchat" ? (
-      <GroupChatView
-        familiars={resolvedFamiliars}
-        onSessionStarted={loadSessions}
         onOpenUrl={openUrlInAppBrowser}
       />
     ) : mode === "board" ? (

--- a/src/lib/chat-tab-events.ts
+++ b/src/lib/chat-tab-events.ts
@@ -4,3 +4,24 @@ export const CHAT_OPEN_PROJECTS_EVENT = "cave:chat-open-projects";
 /** Window event that asks the Projects tab to expand and scroll a specific
  *  project into view. `detail.root` is the project's (un-normalized) root. */
 export const CHAT_FOCUS_PROJECT_EVENT = "cave:chat-focus-project";
+
+/** Window event that asks the chat surface to select its Group Chat (coven) tab.
+ *  Dispatched by the Workspace when the retired standalone `groupchat` mode is
+ *  requested (nav/deep link) so it lands on the in-chat tab instead of a page. */
+export const CHAT_OPEN_COVEN_EVENT = "cave:chat-open-coven";
+
+// A retained latch backing CHAT_OPEN_COVEN_EVENT. When the legacy `groupchat`
+// mode is requested from a DIFFERENT surface, ChatSurface mounts fresh — and a
+// fire-and-forget event can race its listener subscription. The Workspace sets
+// this flag synchronously (before the mode flips), so a just-mounting
+// ChatSurface can consume it on mount and open the Group tab deterministically.
+// The event still covers the already-mounted case.
+let covenTabPending = false;
+export function markCovenTabPending(): void {
+  covenTabPending = true;
+}
+export function consumeCovenTabPending(): boolean {
+  const pending = covenTabPending;
+  covenTabPending = false;
+  return pending;
+}


### PR DESCRIPTION
## What & why

Group Chat ("coven") shipped as an addon-gated **standalone `groupchat` surface**. This folds it into `ChatSurface` as a third scope tab — **Sessions · Projects · Group** — so it's a first-class option in the chat page instead of a separate destination, and gives the surface a world-class UX/a11y pass.

## Integration

- **`ChatSurface`** gains a `coven` scope tab that renders `GroupChatView` inline.
- **`Workspace`** wraps `setMode` so any request for the legacy `groupchat` mode (nav, deep link, palette, keyboard, drag-to-split) redirects to chat and opens the Group tab. `mode` is never actually `"groupchat"`, so the surface never flashes. A retained latch (`markCovenTabPending` / `consumeCovenTabPending`) makes the cross-surface redirect **race-free** when `ChatSurface` mounts fresh; the window event covers the already-mounted case.
- The **standalone left-nav row is removed**; the mode + title remain only as a redirect target (so old deep links still resolve).

## World-class refactor of `GroupChatView`

- **Smart autoscroll** — sticks to bottom only when already there; snaps on your own send / group switch; a **"Jump to latest"** pill otherwise. Fixes the old bug where every streaming token force-scrolled you down while re-reading history.
- **Keyboard-accessible coven rows** — real `<button>` with `aria-current` and a **sibling** delete overlay (was a `<div onClick>` with an invalid *nested* button that trapped focus).
- **Destructive delete confirmed** via `useConfirm` (dropping a coven discards its transcript).
- **`useAnnouncer`** for broadcast/retry outcomes · `role="log"` transcript · composer `aria-label` · composer **auto-grow**.
- **Per-reply Retry** for a failed familiar, reusing the original turn's text + targeting.

All pinned streaming / @mention / relay / transcript semantics are preserved.

## Verification

- `pnpm typecheck` → clean
- Full app suite → **517 test files pass** (2 new tests; wiring assertions updated across `group-chat-view.test.ts` + `chat-surface.test.ts`)
- **Live prod build** — Group tab renders inside the chat surface; coven create → participants → composer all work; legacy `groupchat` mode redirect lands on the Group tab (`aria-selected=true`).

## Note

`addons.groupchat` is now vestigial for visibility (the old nav row rendered unconditionally too, so this isn't a gating regression) — a candidate for a later tidy-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)