### PR TITLE
fix(layout): render boot scripts from document

### DIFF
--- a/src/components/dev-cache-reset-script.test.ts
+++ b/src/components/dev-cache-reset-script.test.ts
@@ -5,8 +5,8 @@ import { readFileSync } from "node:fs";
 const src = readFileSync(new URL("./dev-cache-reset-script.tsx", import.meta.url), "utf8");
 const layout = readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8");
 
-assert.match(src, /import Script from "next\/script"/, "dev cache reset uses Next Script, not a raw script tag");
-assert.match(src, /strategy="beforeInteractive"/, "dev cache reset should run before hydration");
+assert.doesNotMatch(src, /import Script from "next\/script"/, "dev cache reset must render a plain server script, not next/script");
+assert.match(src, /<script\b/, "dev cache reset renders an inline server document script");
 assert.match(src, /process\.env\.NODE_ENV !== "development"/, "script should render only in development");
 assert.match(src, /navigator\.serviceWorker\.getRegistrations\(\)/, "script should inspect existing service workers before hydration");
 assert.match(src, /registration\.unregister\(\)/, "script should unregister stale service workers");

--- a/src/components/dev-cache-reset-script.tsx
+++ b/src/components/dev-cache-reset-script.tsx
@@ -1,5 +1,3 @@
-import Script from "next/script";
-
 const DEV_CACHE_RESET_SCRIPT = `
 (function () {
   try {
@@ -51,10 +49,10 @@ const DEV_CACHE_RESET_SCRIPT = `
 
 export function DevCacheResetScript() {
   if (process.env.NODE_ENV !== "development") return null;
+  // This must be in the initial document, before hydration and before app code.
   return (
-    <Script
+    <script
       id="dev-cache-reset"
-      strategy="beforeInteractive"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: development-only stale SW cleanup before hydration
       dangerouslySetInnerHTML={{ __html: DEV_CACHE_RESET_SCRIPT }}
     />

--- a/src/components/security/sidecar-auth-bridge.test.ts
+++ b/src/components/security/sidecar-auth-bridge.test.ts
@@ -11,8 +11,8 @@ const match = source.match(/SIDECAR_AUTH_BRIDGE = `([\s\S]*?)`;/);
 assert.ok(match, "should find the SIDECAR_AUTH_BRIDGE script literal");
 const SCRIPT = match[1];
 
-assert.match(source, /import Script from "next\/script"/, "sidecar auth bridge uses Next Script, not a raw script tag");
-assert.match(source, /strategy="beforeInteractive"/, "sidecar auth bridge should run before hydration");
+assert.doesNotMatch(source, /import Script from "next\/script"/, "sidecar auth bridge must render a plain server script, not next/script");
+assert.match(source, /<script\b/, "sidecar auth bridge renders an inline server document script");
 
 const TOKEN_HEADER = "x-coven-cave-token";
 

--- a/src/components/security/sidecar-auth-bridge.tsx
+++ b/src/components/security/sidecar-auth-bridge.tsx
@@ -1,6 +1,4 @@
 // Exported for the behavioral test; injected verbatim as an inline <script>.
-import Script from "next/script";
-
 export const SIDECAR_AUTH_BRIDGE = `
 (() => {
   const tokenParam = "covenCaveToken";
@@ -82,10 +80,10 @@ export function SidecarAuthBridge() {
   const authRequirementScript = `window.__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__ = ${JSON.stringify(
     sidecarAuthRequired(),
   )};`;
+  // This must patch fetch from the initial document, before hydration and app code.
   return (
-    <Script
+    <script
       id="sidecar-auth-bridge"
-      strategy="beforeInteractive"
       dangerouslySetInnerHTML={{
         __html: `${authRequirementScript}\n${SIDECAR_AUTH_BRIDGE}`,
       }}

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -5,9 +5,16 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./theme-script.tsx", import.meta.url), "utf8");
 const bootScript = readFileSync(new URL("../../public/scripts/theme-init.js", import.meta.url), "utf8");
 
-assert.match(source, /import Script from "next\/script"/, "ThemeScript uses Next Script, not a raw script tag");
-assert.match(source, /strategy="beforeInteractive"/, "ThemeScript should run before hydration");
-assert.match(source, /src="\/scripts\/theme-init.js"/, "ThemeScript should load external theme init script");
+assert.doesNotMatch(
+  source,
+  /import Script from "next\/script"/,
+  "ThemeScript must render a plain server script, not next/script",
+);
+assert.match(
+  source,
+  /<script id="theme-init" src="\/scripts\/theme-init.js" \/>/,
+  "ThemeScript renders a server document script that loads the external theme init file",
+);
 
 // 1. Script defaults theme to "coven" and mode to "dark".
 assert.match(bootScript, /\|\|\s*"coven"/, "theme defaults to coven");

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -27,18 +27,14 @@
  * adding new fonts, changing fallback chains, or editing pair choices.
  */
 
-import Script from "next/script";
-
 /**
  * External boot script that runs synchronously before hydration.
  * Must be placed in <head>.
+ *
+ * Rendered as a plain <script src> from the server-component RootLayout: it
+ * lands in the initial SSR <head> before first paint, without a client-rendered
+ * script wrapper.
  */
 export function ThemeScript() {
-  return (
-    <Script
-      id="theme-init"
-      src="/scripts/theme-init.js"
-      strategy="beforeInteractive"
-    />
-  );
+  return <script id="theme-init" src="/scripts/theme-init.js" />;
 }


### PR DESCRIPTION
## Summary
- render theme init, dev cache reset, and sidecar auth boot scripts as server document `<script>` tags instead of `next/script`
- keep the scripts in the initial document path so theme, dev cache cleanup, and sidecar fetch patching happen before hydration/app code
- update source guards to prevent regressing these boot scripts back to `next/script`

## Test Plan
- `node --experimental-strip-types src/components/theme-script.test.ts`
- `node --experimental-strip-types src/components/dev-cache-reset-script.test.ts`
- `node --experimental-strip-types src/components/security/sidecar-auth-bridge.test.ts`
- `git diff --check`
- `tsc --noEmit`
- `pnpm check:tests-wired`
- `pnpm test:app`

Note: local `pnpm build` in the linked worktree reached app compilation but is not used as proof here: Turbopack cannot resolve a worktree without local node_modules, and the webpack fallback hit existing generated Next route-type checks unrelated to this patch. CI will run the normal checkout build.

Refs cave-33x