### PR TITLE
fix(layout): server-render boot scripts (React 19 warning) + guard growth analytics link

### DIFF
--- a/src/components/dev-cache-reset-script.test.ts
+++ b/src/components/dev-cache-reset-script.test.ts
@@ -5,8 +5,8 @@ import { readFileSync } from "node:fs";
 const src = readFileSync(new URL("./dev-cache-reset-script.tsx", import.meta.url), "utf8");
 const layout = readFileSync(new URL("../app/layout.tsx", import.meta.url), "utf8");
 
-assert.match(src, /import Script from "next\/script"/, "dev cache reset uses Next Script, not a raw script tag");
-assert.match(src, /strategy="beforeInteractive"/, "dev cache reset should run before hydration");
+assert.doesNotMatch(src, /import Script from "next\/script"/, "dev cache reset must render a plain server <script>, not next/script (a client component → React 19 'script never executes on client' warning)");
+assert.match(src, /<script\b/, "dev cache reset renders a plain, server-rendered inline <script> that runs before hydration");
 assert.match(src, /process\.env\.NODE_ENV !== "development"/, "script should render only in development");
 assert.match(src, /navigator\.serviceWorker\.getRegistrations\(\)/, "script should inspect existing service workers before hydration");
 assert.match(src, /registration\.unregister\(\)/, "script should unregister stale service workers");

--- a/src/components/dev-cache-reset-script.tsx
+++ b/src/components/dev-cache-reset-script.tsx
@@ -1,5 +1,3 @@
-import Script from "next/script";
-
 const DEV_CACHE_RESET_SCRIPT = `
 (function () {
   try {
@@ -51,10 +49,14 @@ const DEV_CACHE_RESET_SCRIPT = `
 
 export function DevCacheResetScript() {
   if (process.env.NODE_ENV !== "development") return null;
+  // Plain server-rendered <script>, NOT next/script: that is a client component
+  // and routing a boot <script> through it makes React 19 / Next 16 log
+  // "scripts inside React components are never executed when rendering on the
+  // client." A server-rendered inline <script> executes at HTML parse (before
+  // hydration) and has no client-render path, so no warning.
   return (
-    <Script
+    <script
       id="dev-cache-reset"
-      strategy="beforeInteractive"
       // biome-ignore lint/security/noDangerouslySetInnerHtml: development-only stale SW cleanup before hydration
       dangerouslySetInnerHTML={{ __html: DEV_CACHE_RESET_SCRIPT }}
     />

--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -205,10 +205,12 @@ export function FamiliarGrowthView({
           >
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
           </button>
-          <a className="retro-btn" href={`/dashboard/familiars/${encodeURIComponent(selected.familiar.id)}/analytics`}>
-            <Icon name="ph:chart-bar-bold" aria-hidden />
-            Analytics
-          </a>
+          {selected ? (
+            <a className="retro-btn" href={`/dashboard/familiars/${encodeURIComponent(selected.familiar.id)}/analytics`}>
+              <Icon name="ph:chart-bar-bold" aria-hidden />
+              Analytics
+            </a>
+          ) : null}
         </div>
       </header>
 

--- a/src/components/security/sidecar-auth-bridge.test.ts
+++ b/src/components/security/sidecar-auth-bridge.test.ts
@@ -11,8 +11,8 @@ const match = source.match(/SIDECAR_AUTH_BRIDGE = `([\s\S]*?)`;/);
 assert.ok(match, "should find the SIDECAR_AUTH_BRIDGE script literal");
 const SCRIPT = match[1];
 
-assert.match(source, /import Script from "next\/script"/, "sidecar auth bridge uses Next Script, not a raw script tag");
-assert.match(source, /strategy="beforeInteractive"/, "sidecar auth bridge should run before hydration");
+assert.doesNotMatch(source, /import Script from "next\/script"/, "sidecar auth bridge must render a plain server <script>, not next/script (a client component → React 19 'script never executes on client' warning)");
+assert.match(source, /<script\b/, "sidecar auth bridge renders a plain, server-rendered inline <script> that runs before hydration");
 
 const TOKEN_HEADER = "x-coven-cave-token";
 

--- a/src/components/security/sidecar-auth-bridge.tsx
+++ b/src/components/security/sidecar-auth-bridge.tsx
@@ -1,6 +1,4 @@
 // Exported for the behavioral test; injected verbatim as an inline <script>.
-import Script from "next/script";
-
 export const SIDECAR_AUTH_BRIDGE = `
 (() => {
   const tokenParam = "covenCaveToken";
@@ -82,10 +80,15 @@ export function SidecarAuthBridge() {
   const authRequirementScript = `window.__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__ = ${JSON.stringify(
     sidecarAuthRequired(),
   )};`;
+  // Plain server-rendered <script>, NOT next/script: that is a client component
+  // and routing a boot <script> through it makes React 19 / Next 16 log "scripts
+  // inside React components are never executed when rendering on the client." A
+  // server-rendered inline <script> executes at HTML parse — before hydration,
+  // so window.fetch is patched before any app code runs — and has no
+  // client-render path, so no warning.
   return (
-    <Script
+    <script
       id="sidecar-auth-bridge"
-      strategy="beforeInteractive"
       dangerouslySetInnerHTML={{
         __html: `${authRequirementScript}\n${SIDECAR_AUTH_BRIDGE}`,
       }}

--- a/src/components/theme-script.test.ts
+++ b/src/components/theme-script.test.ts
@@ -5,9 +5,16 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./theme-script.tsx", import.meta.url), "utf8");
 const bootScript = readFileSync(new URL("../../public/scripts/theme-init.js", import.meta.url), "utf8");
 
-assert.match(source, /import Script from "next\/script"/, "ThemeScript uses Next Script, not a raw script tag");
-assert.match(source, /strategy="beforeInteractive"/, "ThemeScript should run before hydration");
-assert.match(source, /src="\/scripts\/theme-init.js"/, "ThemeScript should load external theme init script");
+assert.doesNotMatch(
+  source,
+  /import Script from "next\/script"/,
+  "ThemeScript must render a plain server <script>, not next/script (a client component → React 19 'script never executes on client' warning)",
+);
+assert.match(
+  source,
+  /<script id="theme-init" src="\/scripts\/theme-init.js" \/>/,
+  "ThemeScript renders a plain, render-blocking server <script> that loads the external theme init file before first paint",
+);
 
 // 1. Script defaults theme to "coven" and mode to "dark".
 assert.match(bootScript, /\|\|\s*"coven"/, "theme defaults to coven");

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -27,18 +27,18 @@
  * adding new fonts, changing fallback chains, or editing pair choices.
  */
 
-import Script from "next/script";
-
 /**
  * External boot script that runs synchronously before hydration.
  * Must be placed in <head>.
+ *
+ * Rendered as a plain <script src> from the server-component RootLayout: it
+ * lands in the initial SSR <head> and executes render-blocking, before first
+ * paint (flash-free). It deliberately does NOT use `next/script` — that is a
+ * client component, and routing a boot <script> through it makes React 19 /
+ * Next 16 log "Encountered a script tag while rendering React component —
+ * scripts inside React components are never executed when rendering on the
+ * client." A server-rendered <script> has no client-render path, so no warning.
  */
 export function ThemeScript() {
-  return (
-    <Script
-      id="theme-init"
-      src="/scripts/theme-init.js"
-      strategy="beforeInteractive"
-    />
-  );
+  return <script id="theme-init" src="/scripts/theme-init.js" />;
 }


### PR DESCRIPTION
Fixes two console/runtime errors seen in dev (Next 16.2.9 / React 19).

## 1. Console Error — "script tag while rendering React component"
`ThemeScript`, `DevCacheResetScript`, and `SidecarAuthBridge` rendered their boot
scripts through `next/script`, which is a **client component**. Under React 19 /
Next 16 that logs:

> Encountered a script tag while rendering React component. Scripts inside React
> components are never executed when rendering on the client. Consider using
> template tag instead.

All three now render as **plain server-rendered `<script>` tags** from the
server-component `RootLayout`. They execute at HTML parse — before hydration —
with **no client-render path**, so no warning. Behaviour is preserved:

- `theme-script` stays a render-blocking `<script src>` in `<head>` → flash-free theming.
- `sidecar-auth-bridge` / `dev-cache-reset` stay inline `<script>` at `<body>` top → `window.fetch` is patched before any app code runs.

This effectively restores the original pre-#2366 placement (the `next/script`
switch is what introduced the warning under Next 16).

## 2. Runtime TypeError — `Cannot read properties of null (reading 'familiar')`
`FamiliarGrowthView`'s header Analytics link dereferenced `selected.familiar.id`,
but `selected` is `null` when the familiar roster is empty (`… ?? reports[0] ?? null`).
Wrapped it in a `{selected ? … : null}` guard; the empty-roster state already
communicates "No familiars available."

## Tests
Updated the three co-located tests that pinned `import Script from "next/script"`
/ `strategy="beforeInteractive"` to assert the plain-`<script>` form instead.

- `theme-script`, `dev-cache-reset-script`, `sidecar-auth-bridge` (6/6), `familiar-analytics-navigation` (3/3) — all green.
- Full `node scripts/run-tests.mjs app` suite was green on the same changeset (519 files) before this was moved into an isolated worktree.

## Note for reviewers
The 6 boot-script conversions were also independently staged (identical approach,
uncommitted, no PR) in a concurrent `codex/boot-scripts-server-rendered` worktree.
This PR is the complete version and additionally carries the growth-view null
guard. If a duplicate boot-script PR shows up, close whichever is redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)