### PR TITLE
chore(config): remove vestigial addons.groupchat flag

### DIFF
--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -138,7 +138,7 @@ assert.match(
 );
 assert.doesNotMatch(
   source,
-  /addons\?\.github|addons\?\.browser|addons\?\.flow|addons\?\.groupchat|addons\?\.journal|addons\?: AddonsConfig/,
+  /addons\?\.github|addons\?\.browser|addons\?\.flow|addons\?\.journal|addons\?: AddonsConfig/,
   "surface rows are no longer hidden behind add-on config",
 );
 assert.match(

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -270,7 +270,7 @@ assert.doesNotMatch(
 
 assert.doesNotMatch(
   source,
-  /addons\?\.github|addons\?\.browser|addons\?\.groupchat|addons\?\.journal|AddonsConfig|addons\?:/,
+  /addons\?\.github|addons\?\.browser|addons\?\.journal|AddonsConfig|addons\?:/,
   "Sidebar should not hide surfaces behind add-on config",
 );
 

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -22,7 +22,6 @@ const DEFAULT_CONFIG: CaveConfig = {
     browser: false,
     flow: false,
     roles: false,
-    groupchat: false,
     journal: false,
     docs: false,
   },
@@ -160,7 +159,6 @@ export type CaveConfig = {
     browser?: boolean;
     flow?: boolean;
     roles?: boolean;
-    groupchat?: boolean;
     journal?: boolean;
     docs?: boolean;
   };
@@ -202,7 +200,6 @@ export async function loadConfig(): Promise<CaveConfig> {
         browser: parsed.addons?.browser ?? false,
         flow: parsed.addons?.flow ?? false,
         roles: parsed.addons?.roles ?? false,
-        groupchat: parsed.addons?.groupchat ?? false,
         journal: parsed.addons?.journal ?? false,
         docs: parsed.addons?.docs ?? false,
       },


### PR DESCRIPTION
Follow-up to #2446. Group Chat is now the **Group tab** inside the Chat page, reached via `ChatSurface`'s scope tabs — nothing gates it behind `addons.groupchat` (the old sidebar nav row rendered unconditionally too), so the boolean is dead.

Removes it from:
- the `AddonsConfig` type
- `DEFAULT_CONFIG.addons`
- the `loadConfig` parse

…plus the two `doesNotMatch` test regexes that listed it. On-disk configs that still carry the old key are simply ignored on load — no migration needed, no behavior change.

**Verification:** `pnpm typecheck` clean; full app suite **519 files pass** (`cave-config-write-race: ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)