### PR TITLE
feat(quick-chat): remake the menubar dropdown as a multi-turn conversation

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -10629,7 +10629,7 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   top: 52px;
   right: 12px;
   z-index: 1200;
-  width: 372px;
+  width: 400px;
   max-width: calc(100vw - 24px);
   max-height: calc(100vh - 72px);
   display: flex;
@@ -10684,19 +10684,35 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   }
 }
 
-/* Header — subtle raised tint separates it from the body. */
-.quick-chat-overlay > header {
+/* Header — identity (avatar + name) on the left, New chat / Close on the right.
+   Shared with the Tauri standalone window (TrayQuickChat). */
+.quick-chat-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--bg-raised) 55%, transparent);
 }
 
-/* Control pickers (familiar / thinking / speed) — hover + focus affordance. */
+/* Context bar — familiar picker (grows) + compact thinking/speed selects. */
+.quick-chat-overlay__controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+/* Control pickers — hover + focus affordance. */
 .quick-chat-overlay [aria-haspopup="menu"] {
   cursor: pointer;
   transition:
     border-color var(--duration-fast, 120ms) var(--ease-standard, ease),
     background var(--duration-fast, 120ms) var(--ease-standard, ease);
 }
-.quick-chat-overlay .grid [aria-haspopup="menu"]:hover {
+.quick-chat-overlay [aria-haspopup="menu"]:hover {
   border-color: var(--border-strong);
   background: color-mix(in oklch, var(--bg-raised) 40%, var(--bg-base));
 }
@@ -10705,39 +10721,220 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   outline: none;
 }
 
-/* Message textarea — accent focus glow. */
-.quick-chat-overlay textarea {
-  transition:
-    border-color var(--duration-fast, 120ms) var(--ease-standard, ease),
-    box-shadow var(--duration-fast, 120ms) var(--ease-standard, ease);
-}
-.quick-chat-overlay textarea:focus {
-  border-color: var(--accent-presence, var(--accent));
-  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
-}
-
-/* Answer pane — inset surface + slim custom scrollbar. */
-.quick-chat-overlay [aria-live] {
-  background: color-mix(in oklch, var(--bg-base) 90%, var(--foreground) 10%);
+/* ── Conversation thread (shared overlay + tray) ─────────────────────────── */
+.quick-chat-thread {
+  flex: 1 1 auto;
+  min-height: 132px;
+  max-height: 46vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
   scrollbar-width: thin;
   scrollbar-color: var(--border-hairline) transparent;
 }
-.quick-chat-overlay [aria-live]::-webkit-scrollbar {
+.quick-chat-thread::-webkit-scrollbar {
   width: 8px;
 }
-.quick-chat-overlay [aria-live]::-webkit-scrollbar-thumb {
+.quick-chat-thread::-webkit-scrollbar-thumb {
   background: var(--border-hairline);
   border-radius: 999px;
 }
 
-/* Footer buttons — smooth hover; accent Send gets a gentle lift. */
-.quick-chat-overlay > footer button {
-  transition:
-    background var(--duration-fast, 120ms) var(--ease-standard, ease),
-    border-color var(--duration-fast, 120ms) var(--ease-standard, ease),
-    filter var(--duration-fast, 120ms) var(--ease-standard, ease);
+/* Turns — user right-aligned; familiar left with an avatar gutter. */
+.quick-chat-turn {
+  display: flex;
+  gap: 8px;
+  max-width: 100%;
 }
-.quick-chat-overlay > footer button:not(:disabled):hover {
+.quick-chat-turn--user {
+  justify-content: flex-end;
+}
+.quick-chat-turn--familiar {
+  align-items: flex-start;
+}
+.quick-chat-turn--familiar > :first-child {
+  margin-top: 2px;
+  flex: 0 0 auto;
+}
+
+.quick-chat-bubble {
+  min-width: 0;
+  border-radius: var(--radius-panel, 14px);
+  padding: 8px 11px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.quick-chat-bubble--user {
+  max-width: 84%;
+  color: var(--fg-primary);
+  background: color-mix(in oklch, var(--accent) 20%, var(--bg-base));
+  border: 1px solid color-mix(in oklch, var(--accent) 34%, transparent);
+  border-bottom-right-radius: 5px;
+}
+.quick-chat-bubble--familiar {
+  max-width: calc(100% - 28px);
+  background: color-mix(in oklch, var(--bg-raised) 60%, var(--bg-base));
+  border: 1px solid var(--border-hairline);
+  border-bottom-left-radius: 5px;
+}
+
+/* Markdown reply — trim create-markdown's default block margins in the bubble. */
+.quick-chat-md > .cave-md > :first-child {
+  margin-top: 0;
+}
+.quick-chat-md > .cave-md > :last-child {
+  margin-bottom: 0;
+}
+.quick-chat-md pre {
+  white-space: pre-wrap;
+}
+
+/* Per-turn actions (copy / regenerate) — quiet until the reply is hovered. */
+.quick-chat-turn__actions {
+  display: flex;
+  gap: 2px;
+  margin-top: 6px;
+  opacity: 0.55;
+  transition: opacity var(--duration-fast, 120ms) var(--ease-standard, ease);
+}
+.quick-chat-bubble--familiar:hover .quick-chat-turn__actions,
+.quick-chat-turn__actions:focus-within {
+  opacity: 1;
+}
+.quick-chat-turn__error {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--color-danger, #e5484d);
+}
+
+/* Streaming affordances: a blinking caret and a three-dot "thinking" pulse. */
+.quick-chat-caret {
+  display: inline-block;
+  width: 2px;
+  height: 1em;
+  margin-left: 1px;
+  vertical-align: text-bottom;
+  background: var(--accent-presence, var(--accent));
+  animation: quick-chat-caret-blink 1s steps(2, start) infinite;
+}
+@keyframes quick-chat-caret-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+.quick-chat-typing {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px 0;
+}
+.quick-chat-typing i {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--fg-muted);
+  animation: quick-chat-typing-bounce 1.1s ease-in-out infinite;
+}
+.quick-chat-typing i:nth-child(2) {
+  animation-delay: 0.15s;
+}
+.quick-chat-typing i:nth-child(3) {
+  animation-delay: 0.3s;
+}
+@keyframes quick-chat-typing-bounce {
+  0%, 80%, 100% { opacity: 0.35; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-3px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .quick-chat-caret,
+  .quick-chat-typing i {
+    animation: none;
+  }
+  .quick-chat-caret {
+    opacity: 1;
+  }
+}
+
+/* Empty state — a friendly nudge + one-tap starters. */
+.quick-chat-empty {
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 6px;
+  text-align: center;
+}
+.quick-chat-empty__glyph {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  color: var(--accent-presence, var(--accent));
+  background: color-mix(in oklch, var(--accent) 12%, transparent);
+}
+.quick-chat-empty__title {
+  font-size: 13px;
+  font-weight: 600;
+}
+.quick-chat-empty__hint {
+  max-width: 20rem;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+.quick-chat-empty__chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+.quick-chat-chip {
+  border-radius: 999px;
+}
+
+/* Composer — textarea + action row pinned to the bottom (shared overlay + tray). */
+.quick-chat-overlay__composer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 30%, transparent);
+}
+.quick-chat-overlay__error {
+  font-size: 11.5px;
+  color: var(--color-danger, #e5484d);
+}
+.quick-chat-overlay__input {
+  width: 100%;
+  min-height: 40px;
+  max-height: 128px;
+  resize: none;
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.45;
+  outline: none;
+  field-sizing: content;
+  transition:
+    border-color var(--duration-fast, 120ms) var(--ease-standard, ease),
+    box-shadow var(--duration-fast, 120ms) var(--ease-standard, ease);
+}
+.quick-chat-overlay__input:focus {
+  border-color: var(--accent-presence, var(--accent));
+  box-shadow: 0 0 0 3px color-mix(in oklch, var(--accent) 18%, transparent);
+}
+.quick-chat-overlay__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.quick-chat-overlay__actions button:not(:disabled):hover {
   filter: brightness(1.06);
 }
 

--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -8,4 +8,11 @@ assert.match(source, /StandardSelect/, "quick-chat select helper should delegate
 assert.doesNotMatch(source, /PopoverBody|PopoverItem|anchorRef|useState\(false\)/, "quick-chat select helper should not maintain its own popover implementation");
 assert.match(source, /renderValue=/, "quick-chat select helper should keep its compact trigger rendering through StandardSelect");
 
+// Shared conversation thread — used by both the in-app dropdown and the tray.
+assert.match(source, /export function QuickChatThread/, "controls export the shared multi-turn thread renderer");
+assert.match(source, /import \{ MarkdownBlock \} from "@\/components\/message-bubble"/, "familiar replies render markdown via the shared MarkdownBlock");
+assert.match(source, /copyText\(message\.text\)/, "each familiar reply can be copied to the clipboard");
+assert.match(source, /aria-live="polite"/, "the thread is a polite live region so streamed replies are announced");
+assert.match(source, /quick-chat-caret|quick-chat-typing/, "streaming turns show a caret / thinking affordance");
+
 console.log("quick-chat-controls.test.ts OK");

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -1,8 +1,14 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
+import { MarkdownBlock } from "@/components/message-bubble";
+import { copyText } from "@/lib/clipboard";
+import type { QuickChatMessage } from "@/lib/use-quick-chat";
 
 export type QuickChatSelectOption<T extends string> = StandardSelectOption<T>;
 
@@ -63,5 +69,176 @@ export function QuickChatSelect<T extends string>({
         </>
       )}
     />
+  );
+}
+
+// ── Conversation thread ──────────────────────────────────────────────────────
+// Shared between the in-app dropdown and the Tauri standalone window so the two
+// render identical turns. Owns its own scroll container + auto-scroll and marks
+// it as a polite live region so streamed replies are announced.
+
+function QuickChatBubble({
+  message,
+  familiar,
+  isLastAssistant,
+  onRegenerate,
+}: {
+  message: QuickChatMessage;
+  familiar: Familiar | null;
+  isLastAssistant: boolean;
+  onRegenerate?: () => void;
+}) {
+  const [copied, setCopied] = useState<string | null>(null);
+
+  if (message.role === "user") {
+    return (
+      <div className="quick-chat-turn quick-chat-turn--user">
+        <div className="quick-chat-bubble quick-chat-bubble--user">
+          <p className="whitespace-pre-wrap break-words leading-6">{message.text}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const streaming = message.pending;
+  const canAct = !streaming && message.text.length > 0;
+  return (
+    <div className="quick-chat-turn quick-chat-turn--familiar">
+      {familiar ? (
+        <FamiliarMark familiar={familiar} size="sm" />
+      ) : (
+        <span className="grid h-5 w-5 place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)]">
+          <Icon name="ph:sparkle" width={12} aria-hidden />
+        </span>
+      )}
+      <div className="quick-chat-bubble quick-chat-bubble--familiar">
+        {message.text ? (
+          streaming ? (
+            // Render partial text plainly while it streams — re-parsing markdown
+            // per token is wasteful and flashes half-open code fences.
+            <p className="whitespace-pre-wrap break-words leading-6">
+              {message.text}
+              <span className="quick-chat-caret" aria-hidden />
+            </p>
+          ) : (
+            <div className="quick-chat-md">
+              <MarkdownBlock text={message.text} />
+            </div>
+          )
+        ) : streaming ? (
+          <span className="quick-chat-typing" aria-label="Thinking…">
+            <i />
+            <i />
+            <i />
+          </span>
+        ) : (
+          <p className="text-[var(--fg-muted)]">No response.</p>
+        )}
+
+        {message.error ? (
+          <p className="quick-chat-turn__error">{message.error}</p>
+        ) : null}
+
+        {canAct ? (
+          <div className="quick-chat-turn__actions">
+            <IconButton
+              icon={copied === message.id ? "ph:check" : "ph:copy"}
+              size="xs"
+              aria-label={copied === message.id ? "Copied" : "Copy reply"}
+              title="Copy reply"
+              onClick={() => {
+                void copyText(message.text).then((ok) => {
+                  if (ok) setCopied(message.id);
+                });
+              }}
+            />
+            {isLastAssistant && onRegenerate ? (
+              <IconButton
+                icon="ph:arrow-clockwise"
+                size="xs"
+                aria-label="Regenerate reply"
+                title="Regenerate"
+                onClick={onRegenerate}
+              />
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function QuickChatThread({
+  messages,
+  familiar,
+  emptyIcon = "ph:chat-circle-dots",
+  emptyTitle,
+  emptyHint,
+  suggestions,
+  onSuggestion,
+  onRegenerate,
+}: {
+  messages: QuickChatMessage[];
+  familiar: Familiar | null;
+  emptyIcon?: IconName;
+  emptyTitle: string;
+  emptyHint: string;
+  suggestions?: string[];
+  onSuggestion?: (value: string) => void;
+  onRegenerate?: () => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const lastText = messages.length > 0 ? messages[messages.length - 1].text : "";
+
+  // Keep the newest turn in view as it streams.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length, lastText]);
+
+  const lastAssistantId = (() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === "assistant") return messages[i].id;
+    }
+    return null;
+  })();
+
+  return (
+    <div ref={scrollRef} className="quick-chat-thread" aria-live="polite">
+      {messages.length === 0 ? (
+        <div className="quick-chat-empty">
+          <span className="quick-chat-empty__glyph" aria-hidden>
+            <Icon name={emptyIcon} width={22} />
+          </span>
+          <p className="quick-chat-empty__title">{emptyTitle}</p>
+          <p className="quick-chat-empty__hint">{emptyHint}</p>
+          {suggestions && suggestions.length > 0 ? (
+            <div className="quick-chat-empty__chips">
+              {suggestions.map((suggestion) => (
+                <Button
+                  key={suggestion}
+                  size="xs"
+                  variant="secondary"
+                  className="quick-chat-chip"
+                  onClick={() => onSuggestion?.(suggestion)}
+                >
+                  {suggestion}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        messages.map((message) => (
+          <QuickChatBubble
+            key={message.id}
+            message={message}
+            familiar={familiar}
+            isLastAssistant={message.id === lastAssistantId}
+            onRegenerate={onRegenerate}
+          />
+        ))
+      )}
+    </div>
   );
 }

--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -29,23 +29,29 @@ assert.match(
 );
 assert.match(
   source,
-  /event\.key === "Escape"[\s\S]*onClose\(\)/,
-  "Escape closes the overlay via a window keydown listener",
+  /useFocusTrap\(open, dialogRef, \{ onEscape: onClose/,
+  "overlay traps focus while open — Tab cycles within it, Escape closes, focus returns to the trigger",
 );
 assert.match(
   source,
-  /window\.addEventListener\("keydown"/,
-  "overlay listens for keydown while open",
+  /<QuickChatThread[\s\S]*messages=\{messages\}/,
+  "overlay renders the shared multi-turn conversation thread",
 );
 assert.match(
   source,
   /onOpenFullSession\?\.\(sessionId, selectedFamiliarId\)/,
-  "overlay opens the saved session in the full app",
+  "overlay opens the saved session (the whole thread's context) in the full app",
+);
+const controls = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
+assert.match(
+  controls,
+  /aria-live="polite"/,
+  "the shared thread announces streamed replies via a polite live region",
 );
 assert.match(
-  source,
-  /aria-live="polite"/,
-  "overlay answer pane announces streamed text",
+  controls,
+  /MarkdownBlock/,
+  "familiar replies render markdown through the shared MarkdownBlock",
 );
 assert.match(
   source,
@@ -133,6 +139,31 @@ assert.match(
   /<QuickChatOverlay[\s\S]*?activeFamiliarId=\{activeId\}/,
   "workspace passes its active familiar to the quick-chat popover",
 );
+
+// ── Multi-turn conversation: the dropdown holds a real back-and-forth ────────
+assert.match(
+  hook,
+  /messages: QuickChatMessage\[\]/,
+  "the hook exposes the conversation as a list of turns, not a single answer",
+);
+assert.match(
+  hook,
+  /sessionId: resume \? sessionIdRef\.current \?\? undefined : undefined/,
+  "follow-up turns resume the same daemon session so context carries over",
+);
+assert.match(
+  hook,
+  /setDraft\(""\);/,
+  "the composer draft is cleared the moment a turn is sent (no stale resend)",
+);
+assert.match(
+  hook,
+  /if \(selectedIdRef\.current !== id\) newThread\(\);/,
+  "switching to a different familiar starts a fresh thread",
+);
+for (const fn of ["newThread", "regenerate", "cancel"]) {
+  assert.ok(hook.includes(`${fn},`), `the hook exposes ${fn}() to its consumers`);
+}
 
 console.log("quick-chat-overlay.test.ts OK");
 

--- a/src/components/quick-chat-overlay.tsx
+++ b/src/components/quick-chat-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
@@ -12,7 +12,8 @@ import { IconButton } from "@/components/ui/icon-button";
 import { StandardSelect } from "@/components/ui/select";
 import { Icon } from "@/lib/icon";
 import { useQuickChat } from "@/lib/use-quick-chat";
-import type { Familiar } from "@/lib/types";
+import { useFocusTrap } from "@/lib/use-focus-trap";
+import { FamiliarMark, QuickChatSelect, QuickChatThread } from "@/components/quick-chat-controls";
 
 type Props = {
   open: boolean;
@@ -23,14 +24,12 @@ type Props = {
   activeFamiliarId?: string | null;
 };
 
-function initials(familiar: Familiar): string {
-  return (familiar.display_name || familiar.id)
-    .split(/\s+/)
-    .map((part) => part[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
-}
+// One-tap starters for a cold thread — they fill the composer, not send.
+const QUICK_CHAT_SUGGESTIONS = [
+  "Summarize what needs my attention",
+  "Draft a short status update",
+  "What changed recently?",
+];
 
 export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamiliarId }: Props) {
   const {
@@ -40,7 +39,8 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
     selectedFamiliar,
     draft,
     setDraft,
-    answer,
+    messages,
+    hasThread,
     error,
     sessionId,
     sendState,
@@ -51,9 +51,13 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
     setResponseSpeed,
     send,
     cancel,
+    newThread,
+    regenerate,
   } = useQuickChat({ preferredFamiliarId: activeFamiliarId ?? null });
 
   const sending = sendState === "sending";
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const composerRef = useRef<HTMLTextAreaElement>(null);
 
   // Anchor the popover directly beneath its menubar trigger so it reads as a
   // dropdown from the bar (with a caret pointing up at the icon) rather than a
@@ -90,27 +94,32 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
     return () => window.removeEventListener("resize", measure);
   }, [open]);
 
-  // Escape closes the popover while it's open.
+  // Trap focus inside the dropdown while open: Tab cycles within it, Escape
+  // closes it, and focus returns to the menubar trigger on close.
+  useFocusTrap(open, dialogRef, { onEscape: onClose, focusFirst: false });
+
+  // Land the caret in the composer on open. Deferred to an effect (not
+  // `autoFocus`) so it runs *after* useFocusTrap has captured the trigger as
+  // the return-focus target — otherwise autofocus would steal it and closing
+  // wouldn't restore focus to the menubar button.
   useEffect(() => {
     if (!open) return;
-    const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.stopPropagation();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+    const id = requestAnimationFrame(() => composerRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
 
   const onTextareaKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      const cmdEnter = (event.metaKey || event.ctrlKey) && event.key === "Enter";
+      // Enter sends; Shift+Enter inserts a newline; IME composition is left alone.
+      const plainEnter =
+        event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing;
+      if (cmdEnter || plainEnter) {
         event.preventDefault();
-        if (!sending) void send();
+        if (!sending && draft.trim()) void send();
       }
     },
-    [send, sending],
+    [draft, send, sending],
   );
 
   const openFull = useCallback(() => {
@@ -118,6 +127,15 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
     onOpenFullSession?.(sessionId, selectedFamiliarId);
     onClose();
   }, [onClose, onOpenFullSession, selectedFamiliarId, sessionId]);
+
+  const pickSuggestion = useCallback(
+    (value: string) => {
+      setDraft(value);
+      // Move the caret into the composer so the user can tweak-and-send.
+      requestAnimationFrame(() => composerRef.current?.focus());
+    },
+    [setDraft],
+  );
 
   if (!open) return null;
 
@@ -137,17 +155,24 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
         />
       ) : null}
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-label="Quick chat"
         className="quick-chat-overlay"
         style={anchor ? { top: anchor.top, right: anchor.right } : undefined}
       >
-        <header className="flex items-center justify-between border-b border-[var(--border-hairline)] px-4 py-3">
+        <header className="quick-chat-overlay__header">
           <div className="flex min-w-0 items-center gap-2">
-            <Icon name="ph:chat-circle-dots" width={18} aria-hidden />
+            {selectedFamiliar ? (
+              <FamiliarMark familiar={selectedFamiliar} size="md" />
+            ) : (
+              <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
+            )}
             <div className="min-w-0">
-              <h2 className="truncate text-sm font-semibold">Quick chat</h2>
+              <h2 className="truncate text-sm font-semibold">
+                {selectedFamiliar ? selectedFamiliar.display_name : "Quick chat"}
+              </h2>
               <p className="truncate text-xs text-[var(--fg-muted)]">
                 {/* While the roster loads, say so — "No familiar selected" reads
                     as an error/empty state when it's really just cold. */}
@@ -155,32 +180,42 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
               </p>
             </div>
           </div>
-          <IconButton
-            onClick={onClose}
-            icon="ph:x"
-            aria-label="Close quick chat"
-            title="Close"
-            size="sm"
-          />
+          <div className="flex items-center gap-1">
+            <IconButton
+              onClick={newThread}
+              disabled={!hasThread}
+              icon="ph:plus"
+              aria-label="New chat"
+              title="New chat"
+              size="sm"
+            />
+            <IconButton
+              onClick={onClose}
+              icon="ph:x"
+              aria-label="Close quick chat"
+              title="Close"
+              size="sm"
+            />
+          </div>
         </header>
 
-        <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
-          <Icon name="ph:at" width={14} aria-hidden />
-          <StandardSelect
+        <div className="quick-chat-overlay__controls">
+          <QuickChatSelect
             label="Familiar"
             value={selectedFamiliarId ?? ""}
             onChange={(next) => setSelectedFamiliarId(next || null)}
             disabled={loading || familiars.length === 0}
-            className="min-w-0 flex-1 rounded-[var(--radius-control)] bg-transparent text-sm outline-none"
+            className="flex-1"
             options={
               loading && familiars.length === 0
                 ? [{ value: "", label: "Loading…", disabled: true }]
-                : familiars.map((familiar) => ({ value: familiar.id, label: familiar.display_name }))
+                : familiars.map((familiar) => ({
+                    value: familiar.id,
+                    label: familiar.display_name,
+                    leading: <FamiliarMark familiar={familiar} size="sm" />,
+                  }))
             }
           />
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
           <StandardSelect
             label="Choose thinking effort"
             value={thinkingEffort}
@@ -199,90 +234,59 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
           />
         </div>
 
-        <div className="px-4 py-3">
-          {selectedFamiliar ? (
-            <div className="mb-3 flex items-center gap-2 text-xs text-[var(--fg-muted)]">
-              {selectedFamiliar.avatarUrl ? (
-                <img
-                  src={selectedFamiliar.avatarUrl}
-                  alt=""
-                  className="h-6 w-6 rounded-sm object-cover"
-                />
-              ) : (
-                <span className="grid h-6 w-6 place-items-center rounded-sm bg-[var(--bg-elevated)] text-[10px] font-semibold text-[var(--fg-primary)]">
-                  {initials(selectedFamiliar)}
-                </span>
-              )}
-              <span className="min-w-0 truncate">{selectedFamiliar.role}</span>
-            </div>
-          ) : null}
+        <QuickChatThread
+          messages={messages}
+          familiar={selectedFamiliar}
+          emptyIcon="ph:chat-circle-dots"
+          emptyTitle={selectedFamiliar ? `Ask ${selectedFamiliar.display_name} anything` : "Ask a familiar anything"}
+          emptyHint="Replies stream right here · @name to switch familiar · Enter to send"
+          suggestions={QUICK_CHAT_SUGGESTIONS}
+          onSuggestion={pickSuggestion}
+          onRegenerate={sending ? undefined : regenerate}
+        />
 
-          <label className="block text-xs font-medium text-[var(--fg-muted)]" htmlFor="quick-chat-overlay-draft">
-            Message
-          </label>
+        <footer className="quick-chat-overlay__composer">
+          {error ? (
+            <p className="quick-chat-overlay__error" role="alert">
+              {error}
+            </p>
+          ) : null}
           <textarea
+            ref={composerRef}
             id="quick-chat-overlay-draft"
             value={draft}
-            autoFocus
+            aria-label="Message"
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={onTextareaKeyDown}
-            placeholder="@sage summarize what needs attention"
-            className="mt-2 h-24 w-full resize-none rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-sm outline-none focus:border-[var(--accent-presence)]"
+            placeholder={selectedFamiliar ? `Message @${selectedFamiliar.id}…` : "@sage summarize what needs attention"}
+            className="quick-chat-overlay__input"
           />
-
-          {error ? (
-            <div className="mt-2 flex items-center justify-between gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--fg-primary)]">
-              <span className="min-w-0 truncate">{error}</span>
+          <div className="quick-chat-overlay__actions">
+            <Button
+              size="sm"
+              variant="ghost"
+              leadingIcon="ph:arrow-square-out"
+              onClick={openFull}
+              disabled={!sessionId}
+            >
+              Open in full chat
+            </Button>
+            <div className="flex items-center gap-2">
+              {sending ? (
+                <Button variant="secondary" size="sm" onClick={cancel}>
+                  Stop
+                </Button>
+              ) : null}
               <Button
-                size="xs"
+                variant="primary"
+                size="sm"
+                leadingIcon="ph:sparkle"
                 onClick={() => void send()}
-                disabled={sending}
+                disabled={sending || loading || !draft.trim()}
               >
-                Retry
+                Send
               </Button>
             </div>
-          ) : null}
-
-          <div
-            className="mt-3 max-h-48 min-h-24 overflow-auto rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 text-sm"
-            aria-live="polite"
-          >
-            {answer ? (
-              <p className="whitespace-pre-wrap leading-6">{answer}</p>
-            ) : sending ? (
-              <p className="text-[var(--fg-muted)]">Thinking...</p>
-            ) : (
-              <p className="text-[var(--fg-muted)]">The reply will appear here.</p>
-            )}
-          </div>
-        </div>
-
-        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-3">
-          <Button
-            size="sm"
-            leadingIcon="ph:arrow-square-out"
-            onClick={openFull}
-            disabled={!sessionId}
-          >
-            Open in full chat
-          </Button>
-          <div className="flex items-center gap-2">
-            {sending ? (
-              <Button
-                variant="secondary"
-                onClick={cancel}
-              >
-                Cancel
-              </Button>
-            ) : null}
-            <Button
-              variant="primary"
-              leadingIcon="ph:sparkle"
-              onClick={() => void send()}
-              disabled={sending || loading}
-            >
-              Send
-            </Button>
           </div>
         </footer>
       </div>

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -12,16 +12,14 @@ import { IconButton } from "@/components/ui/icon-button";
 import { StandardSelect } from "@/components/ui/select";
 import { Icon } from "@/lib/icon";
 import { useQuickChat } from "@/lib/use-quick-chat";
-import type { Familiar } from "@/lib/types";
+import { FamiliarMark, QuickChatSelect, QuickChatThread } from "@/components/quick-chat-controls";
 
-function initials(familiar: Familiar): string {
-  return (familiar.display_name || familiar.id)
-    .split(/\s+/)
-    .map((part) => part[0])
-    .join("")
-    .slice(0, 2)
-    .toUpperCase();
-}
+// One-tap starters for a cold thread — they fill the composer, not send.
+const TRAY_SUGGESTIONS = [
+  "Summarize what needs my attention",
+  "Draft a short status update",
+  "What changed recently?",
+];
 
 export function TrayQuickChat() {
   const {
@@ -31,7 +29,8 @@ export function TrayQuickChat() {
     selectedFamiliar,
     draft,
     setDraft,
-    answer,
+    messages,
+    hasThread,
     error,
     sessionId,
     sendState,
@@ -42,18 +41,24 @@ export function TrayQuickChat() {
     setResponseSpeed,
     send,
     cancel,
+    newThread,
+    regenerate,
   } = useQuickChat();
 
   const sending = sendState === "sending";
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+      const cmdEnter = (event.metaKey || event.ctrlKey) && event.key === "Enter";
+      // Enter sends; Shift+Enter inserts a newline; IME composition is left alone.
+      const plainEnter =
+        event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing;
+      if (cmdEnter || plainEnter) {
         event.preventDefault();
-        if (!sending) void send();
+        if (!sending && draft.trim()) void send();
       }
     },
-    [send, sending],
+    [draft, send, sending],
   );
 
   const openFullSession = useCallback(async () => {
@@ -69,44 +74,60 @@ export function TrayQuickChat() {
   return (
     <main className="min-h-screen bg-[var(--bg-base)] text-[var(--fg-primary)]">
       <section className="flex min-h-screen flex-col border border-[var(--border-hairline)] bg-[var(--bg-panel)]">
-        <header className="flex items-center justify-between border-b border-[var(--border-hairline)] px-4 py-3">
+        <header className="quick-chat-overlay__header">
           <div className="flex min-w-0 items-center gap-2">
-            <Icon name="ph:chat-circle-dots" width={18} aria-hidden />
+            {selectedFamiliar ? (
+              <FamiliarMark familiar={selectedFamiliar} size="md" />
+            ) : (
+              <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
+            )}
             <div className="min-w-0">
-              <h1 className="truncate text-sm font-semibold">Quick Chat</h1>
+              <h1 className="truncate text-sm font-semibold">
+                {selectedFamiliar ? selectedFamiliar.display_name : "Quick Chat"}
+              </h1>
               <p className="truncate text-xs text-[var(--fg-muted)]">
                 {/* Mirror the in-app overlay: loading is not "no familiar". */}
                 {loading ? "Loading familiars…" : selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
               </p>
             </div>
           </div>
-          <IconButton
-            onClick={openFullSession}
-            disabled={!sessionId}
-            icon="ph:arrow-square-out"
-            aria-label="Open in CovenCave"
-            title="Open in CovenCave"
-            size="sm"
-          />
+          <div className="flex items-center gap-1">
+            <IconButton
+              onClick={newThread}
+              disabled={!hasThread}
+              icon="ph:plus"
+              aria-label="New chat"
+              title="New chat"
+              size="sm"
+            />
+            <IconButton
+              onClick={openFullSession}
+              disabled={!sessionId}
+              icon="ph:arrow-square-out"
+              aria-label="Open in CovenCave"
+              title="Open in CovenCave"
+              size="sm"
+            />
+          </div>
         </header>
 
-        <div className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
-          <Icon name="ph:at" width={14} aria-hidden />
-          <StandardSelect
+        <div className="quick-chat-overlay__controls">
+          <QuickChatSelect
             label="Familiar"
             value={selectedFamiliarId ?? ""}
             onChange={(next) => setSelectedFamiliarId(next || null)}
             disabled={loading || familiars.length === 0}
-            className="min-w-0 flex-1 rounded-[var(--radius-control)] bg-transparent text-sm outline-none"
+            className="flex-1"
             options={
               loading && familiars.length === 0
                 ? [{ value: "", label: "Loading…", disabled: true }]
-                : familiars.map((familiar) => ({ value: familiar.id, label: familiar.display_name }))
+                : familiars.map((familiar) => ({
+                    value: familiar.id,
+                    label: familiar.display_name,
+                    leading: <FamiliarMark familiar={familiar} size="sm" />,
+                  }))
             }
           />
-        </div>
-
-        <div className="grid grid-cols-2 gap-2 border-b border-[var(--border-hairline)] px-4 py-2">
           <StandardSelect
             label="Choose thinking effort"
             value={thinkingEffort}
@@ -125,85 +146,53 @@ export function TrayQuickChat() {
           />
         </div>
 
-        <div className="flex-1 overflow-auto px-4 py-3">
-          {selectedFamiliar ? (
-            <div className="mb-3 flex items-center gap-2 text-xs text-[var(--fg-muted)]">
-              {selectedFamiliar.avatarUrl ? (
-                <img
-                  src={selectedFamiliar.avatarUrl}
-                  alt=""
-                  className="h-6 w-6 rounded-sm object-cover"
-                />
-              ) : (
-                <span className="grid h-6 w-6 place-items-center rounded-sm bg-[var(--bg-elevated)] text-[10px] font-semibold text-[var(--fg-primary)]">
-                  {initials(selectedFamiliar)}
-                </span>
-              )}
-              <span className="min-w-0 truncate">{selectedFamiliar.role}</span>
-            </div>
-          ) : null}
+        <QuickChatThread
+          messages={messages}
+          familiar={selectedFamiliar}
+          emptyIcon="ph:chat-circle-dots"
+          emptyTitle={selectedFamiliar ? `Ask ${selectedFamiliar.display_name} anything` : "Ask a familiar anything"}
+          emptyHint="Replies stream right here · @name to switch familiar · Enter to send"
+          suggestions={TRAY_SUGGESTIONS}
+          onSuggestion={setDraft}
+          onRegenerate={sending ? undefined : regenerate}
+        />
 
-          <label className="block text-xs font-medium text-[var(--fg-muted)]" htmlFor="quick-chat-draft">
-            Message
-          </label>
+        <footer className="quick-chat-overlay__composer">
+          {error ? (
+            <p className="quick-chat-overlay__error" role="alert">
+              {error}
+            </p>
+          ) : null}
           <textarea
             id="quick-chat-draft"
             value={draft}
             autoFocus
+            aria-label="Message"
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={onKeyDown}
-            placeholder="@sage summarize what needs attention"
-            className="mt-2 h-28 w-full resize-none rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-sm outline-none focus:border-[var(--accent-presence)]"
+            placeholder={selectedFamiliar ? `Message @${selectedFamiliar.id}…` : "@sage summarize what needs attention"}
+            className="quick-chat-overlay__input"
           />
-
-          {error ? (
-            <div className="mt-2 flex items-center justify-between gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-elevated)] px-3 py-2 text-xs text-[var(--fg-primary)]">
-              <span className="min-w-0 truncate">{error}</span>
+          <div className="quick-chat-overlay__actions">
+            <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
+              @id switches familiars · ⌘↵ to send
+            </p>
+            <div className="flex items-center gap-2">
+              {sending ? (
+                <Button variant="secondary" size="sm" onClick={cancel}>
+                  Stop
+                </Button>
+              ) : null}
               <Button
-                size="xs"
+                variant="primary"
+                size="sm"
+                leadingIcon="ph:sparkle"
                 onClick={() => void send()}
-                disabled={sending}
+                disabled={sending || loading || !draft.trim()}
               >
-                Retry
+                Send
               </Button>
             </div>
-          ) : null}
-
-          <div
-            className="mt-3 min-h-32 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 text-sm"
-            aria-live="polite"
-          >
-            {answer ? (
-              <p className="whitespace-pre-wrap leading-6">{answer}</p>
-            ) : sending ? (
-              <p className="text-[var(--fg-muted)]">Thinking...</p>
-            ) : (
-              <p className="text-[var(--fg-muted)]">The reply will appear here.</p>
-            )}
-          </div>
-        </div>
-
-        <footer className="flex items-center justify-between gap-3 border-t border-[var(--border-hairline)] px-4 py-3">
-          <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
-            Use @id to switch familiars. ⌘↵ to send.
-          </p>
-          <div className="flex items-center gap-2">
-            {sending ? (
-              <Button
-                variant="secondary"
-                onClick={cancel}
-              >
-                Cancel
-              </Button>
-            ) : null}
-            <Button
-              variant="primary"
-              leadingIcon="ph:sparkle"
-              onClick={() => void send()}
-              disabled={sending || loading}
-            >
-              Send
-            </Button>
           </div>
         </footer>
       </section>

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -1,10 +1,12 @@
 "use client";
 
 // Shared quick-chat state + send logic, used by both the Tauri standalone
-// window (`TrayQuickChat`) and the in-app popover (`QuickChatOverlay`). It
-// loads the familiar roster, resolves @mentions, and streams a one-shot reply
-// through the sanctioned familiar chat bridge — with incremental token
-// streaming, in-flight abort, and unmount cleanup.
+// window (`TrayQuickChat`) and the in-app dropdown (`QuickChatOverlay`). It
+// loads the familiar roster, resolves @mentions, and holds a *multi-turn*
+// conversation with the chosen familiar — streaming each reply through the
+// sanctioned chat bridge and resuming the same session so follow-ups keep
+// their context. Switching familiars (in the picker or via a leading @mention)
+// starts a fresh thread; `newThread()` clears the current one on demand.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -12,13 +14,25 @@ import {
   type CommandResponseSpeed,
   type CommandThinkingEffort,
 } from "@/lib/command-controls";
-import { resolveQuickChatTarget } from "@/lib/quick-chat";
+import { resolveQuickChatTarget, type QuickChatTarget } from "@/lib/quick-chat";
 import { streamFamiliarText } from "@/lib/familiar-stream";
 import type { Familiar } from "@/lib/types";
 
 const LAST_FAMILIAR_KEY = "cave.quick-chat.last-familiar";
 
 export type QuickChatSendState = "idle" | "sending" | "done";
+
+export type QuickChatRole = "user" | "assistant";
+
+export type QuickChatMessage = {
+  id: string;
+  role: QuickChatRole;
+  text: string;
+  /** Assistant turn still streaming in. */
+  pending?: boolean;
+  /** Per-turn error (the familiar failed / reported an error). */
+  error?: string | null;
+};
 
 export type UseQuickChat = {
   familiars: Familiar[];
@@ -27,7 +41,10 @@ export type UseQuickChat = {
   selectedFamiliar: Familiar | null;
   draft: string;
   setDraft: (value: string) => void;
-  answer: string;
+  /** The conversation so far — user + streamed familiar turns. */
+  messages: QuickChatMessage[];
+  /** True once the current thread has at least one turn. */
+  hasThread: boolean;
   error: string | null;
   sessionId: string | null;
   sendState: QuickChatSendState;
@@ -38,6 +55,10 @@ export type UseQuickChat = {
   setResponseSpeed: (value: CommandResponseSpeed) => void;
   send: () => Promise<void>;
   cancel: () => void;
+  /** Clear the conversation (keeps the familiar + control choices). */
+  newThread: () => void;
+  /** Re-send the most recent user turn, replacing the trailing reply. */
+  regenerate: () => void;
 };
 
 export type UseQuickChatOptions = {
@@ -51,15 +72,8 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   const preferredFamiliarId = options?.preferredFamiliarId ?? null;
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
-  // Once the user explicitly picks a familiar in the UI, stop following the
-  // preferred (workspace-active) familiar — their choice is stickier.
-  const userPickedRef = useRef(false);
-  const pickFamiliar = useCallback((id: string | null) => {
-    userPickedRef.current = true;
-    setSelectedFamiliarId(id);
-  }, []);
   const [draft, setDraft] = useState("");
-  const [answer, setAnswer] = useState("");
+  const [messages, setMessages] = useState<QuickChatMessage[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [sendState, setSendState] = useState<QuickChatSendState>("idle");
@@ -72,9 +86,39 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   );
 
   const abortRef = useRef<AbortController | null>(null);
+  // The daemon session backing the visible thread (for context resume + the
+  // Open-in-full-chat hand-off) and the familiar it belongs to.
+  const sessionIdRef = useRef<string | null>(null);
+  const threadFamiliarRef = useRef<string | null>(null);
+  // Raw text of the last user turn, so `regenerate()` re-resolves any @mention.
+  const lastUserPromptRef = useRef<string>("");
+  // Monotonic id source for message keys (stable across renders).
+  const msgSeqRef = useRef(0);
+  // Once the user explicitly picks a familiar in the UI, stop following the
+  // preferred (workspace-active) familiar — their choice is stickier.
+  const userPickedRef = useRef(false);
   // Latest preferred id for the one-shot roster load below (no effect re-run).
   const preferredRef = useRef<string | null>(preferredFamiliarId);
   preferredRef.current = preferredFamiliarId;
+  // Mirror the current selection so pickFamiliar can detect a real change
+  // without threading it through a state updater.
+  const selectedIdRef = useRef<string | null>(selectedFamiliarId);
+  selectedIdRef.current = selectedFamiliarId;
+
+  const nextId = useCallback((prefix: string) => `${prefix}-${msgSeqRef.current++}`, []);
+
+  // Clear the conversation; keeps the familiar + control choices intact.
+  const newThread = useCallback(() => {
+    abortRef.current?.abort();
+    abortRef.current = null;
+    sessionIdRef.current = null;
+    threadFamiliarRef.current = null;
+    lastUserPromptRef.current = "";
+    setSessionId(null);
+    setMessages([]);
+    setError(null);
+    setSendState("idle");
+  }, []);
 
   useEffect(() => {
     let alive = true;
@@ -129,50 +173,143 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     [familiars, selectedFamiliarId],
   );
 
+  // Stream one reply for a resolved target, appending a pending assistant turn
+  // and filling it as tokens arrive. `resume` continues the current daemon
+  // session so follow-ups keep their context.
+  const deliver = useCallback(
+    async (target: QuickChatTarget, resume: boolean) => {
+      if (!target.familiarId) return;
+      const assistantId = nextId("a");
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setMessages((prev) => [
+        ...prev,
+        { id: assistantId, role: "assistant", text: "", pending: true, error: null },
+      ]);
+      setSendState("sending");
+
+      let result: Awaited<ReturnType<typeof streamFamiliarText>>;
+      try {
+        result = await streamFamiliarText({
+          familiarId: target.familiarId,
+          prompt: target.prompt,
+          sessionId: resume ? sessionIdRef.current ?? undefined : undefined,
+          reasoningEffort: thinkingEffort,
+          responseSpeed,
+          signal: controller.signal,
+          onText: (t) =>
+            setMessages((prev) =>
+              prev.map((m) => (m.id === assistantId ? { ...m, text: t } : m)),
+            ),
+        });
+      } catch (err) {
+        // A mid-stream abort (Stop / unmount) rejects the reader; keep whatever
+        // streamed so far and only surface non-abort failures.
+        if (abortRef.current === controller) abortRef.current = null;
+        const aborted = controller.signal.aborted;
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === assistantId
+              ? { ...m, pending: false, error: aborted ? null : (err as Error)?.message ?? "Generation failed." }
+              : m,
+          ),
+        );
+        setSendState("idle");
+        return;
+      }
+
+      if (abortRef.current === controller) abortRef.current = null;
+      if (result.sessionId) {
+        sessionIdRef.current = result.sessionId;
+        setSessionId(result.sessionId);
+      }
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? { ...m, text: result.text, error: result.error, pending: false }
+            : m,
+        ),
+      );
+      setSendState("done");
+    },
+    [nextId, responseSpeed, thinkingEffort],
+  );
+
   const send = useCallback(async () => {
     const target = resolveQuickChatTarget(draft, familiars, selectedFamiliarId);
     setError(target.error);
-    setAnswer("");
-    setSessionId(null);
     if (target.error || !target.familiarId) return;
 
-    setSendState("sending");
+    // A leading @mention (or picker change) that swaps familiar starts a fresh
+    // thread — a resumed session belongs to the previous familiar.
+    const sameFamiliar = threadFamiliarRef.current === target.familiarId;
+    const resume = sameFamiliar && sessionIdRef.current != null;
+    if (!sameFamiliar) {
+      sessionIdRef.current = null;
+      setSessionId(null);
+      if (threadFamiliarRef.current) setMessages([]);
+    }
+    threadFamiliarRef.current = target.familiarId;
+
+    const userText = draft.trim();
+    lastUserPromptRef.current = draft;
+    setDraft("");
     setSelectedFamiliarId(target.familiarId);
     window.localStorage.setItem(LAST_FAMILIAR_KEY, target.familiarId);
+    setMessages((prev) => [...prev, { id: nextId("u"), role: "user", text: userText }]);
 
-    const controller = new AbortController();
-    abortRef.current = controller;
-    const result = await streamFamiliarText({
-      familiarId: target.familiarId,
-      prompt: target.prompt,
-      reasoningEffort: thinkingEffort,
-      responseSpeed,
-      signal: controller.signal,
-      onText: (t) => setAnswer(t),
+    await deliver(target, resume);
+  }, [deliver, draft, familiars, nextId, selectedFamiliarId]);
+
+  const regenerate = useCallback(() => {
+    const prompt = lastUserPromptRef.current;
+    if (!prompt || sendState === "sending") return;
+    const target = resolveQuickChatTarget(prompt, familiars, selectedFamiliarId);
+    if (target.error || !target.familiarId) return;
+    // Drop the trailing assistant turn(s) after the last user turn, then re-run.
+    setMessages((prev) => {
+      let cut = prev.length;
+      for (let i = prev.length - 1; i >= 0; i--) {
+        if (prev[i].role === "user") {
+          cut = i + 1;
+          break;
+        }
+      }
+      return prev.slice(0, cut);
     });
-    if (abortRef.current === controller) abortRef.current = null;
-    setAnswer(result.text);
-    setError(result.error);
-    setSessionId(result.sessionId ?? null);
-    setSendState("done");
-  }, [draft, familiars, responseSpeed, selectedFamiliarId, thinkingEffort]);
+    const resume = threadFamiliarRef.current === target.familiarId && sessionIdRef.current != null;
+    void deliver(target, resume);
+  }, [deliver, familiars, selectedFamiliarId, sendState]);
 
   const cancel = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
+    // Keep whatever streamed so far, but stop the spinner on the open turn.
+    setMessages((prev) => prev.map((m) => (m.pending ? { ...m, pending: false } : m)));
     setSendState("idle");
   }, []);
+
+  // Manual picks flow through here: they override the workspace-active default
+  // from then on, and switching to a different familiar starts a fresh thread.
+  const pickFamiliar = useCallback(
+    (id: string | null) => {
+      userPickedRef.current = true;
+      if (selectedIdRef.current !== id) newThread();
+      selectedIdRef.current = id;
+      setSelectedFamiliarId(id);
+    },
+    [newThread],
+  );
 
   return {
     familiars,
     selectedFamiliarId,
-    // Manual picks flow through pickFamiliar so they override the
-    // workspace-active default from then on.
     setSelectedFamiliarId: pickFamiliar,
     selectedFamiliar,
     draft,
     setDraft,
-    answer,
+    messages,
+    hasThread: messages.length > 0,
     error,
     sessionId,
     sendState,
@@ -183,5 +320,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     setResponseSpeed,
     send,
     cancel,
+    newThread,
+    regenerate,
   };
 }


### PR DESCRIPTION
## What

Comprehensively remakes the **quick-chat dropdown** — the one opened from the desktop menubar / mobile top-bar chat trigger (and `⌘J`). It was a one-shot ask: every send wiped the previous reply, the draft was never cleared, three stacked form rows crowded out the answer, the familiar picker was a plain `<select>` (the avatar-rich `QuickChatSelect`/`FamiliarMark` helpers were dead code), replies rendered as flat text, and the modal had no focus trap.

`streamFamiliarText` already accepts a `sessionId` to resume a thread, so the headline change is turning this into a **genuine mini-conversation**.

## Highlights

- **Multi-turn threaded chat** — user + streamed familiar turns in scrollable, auto-scrolling bubbles; follow-ups resume the same daemon session so context carries over. Switching familiar (picker or a leading `@mention`) starts a fresh thread; **New chat** clears on demand.
- **Streaming affordances** — partial text renders plainly with a blinking caret while it streams (no per-token markdown reparse / half-open code fences), a three-dot *thinking* pulse before the first token, then full markdown via the shared `MarkdownBlock` once the turn completes.
- **Per-reply copy + regenerate**; **Stop** mid-stream keeps whatever streamed.
- **Draft cleared** the instant a turn is sent (fixes the stale-resend bug).
- **Rich familiar picker** (avatar + name) reusing the previously-unused helpers; compact thinking/speed selects on one row.
- **Empty state** with one-tap starter chips that fill the composer.
- **Keyboard**: Enter sends, Shift+Enter newlines, `⌘/Ctrl+Enter` still sends.
- **a11y**: real focus trap (Tab cycles within the dropdown, Escape closes, focus returns to the menubar trigger) replacing the ad-hoc keydown listener; polite live region on the thread.
- **Robustness**: mid-stream aborts are now caught (previously an uncaught reader rejection).

The Tauri standalone window (`TrayQuickChat`) shares the same `useQuickChat` hook + `QuickChatThread` component, so it gets the conversation upgrade for free. Menubar anchoring, the `⌘J` shortcut, and the *workspace-active > last-used > first* familiar default are all preserved.

## Verification

- `pnpm typecheck` clean · `pnpm build` green (bundle-budget within budget: shell 447 KB / 650 KB, largest chunk 1681 KB / 2400 KB).
- Updated source-scan tests pass: `quick-chat-overlay`, `quick-chat-controls`, `tray-quick-chat`, `quick-chat`, plus neighbouring `top-bar` / `familiar-menu-bar`.
- Drove the built app in a real browser (Nova demo familiar): opened via `⌘J`, confirmed the empty state + chips, typed-and-sent, and saw the user bubble + familiar turn (avatar + thinking pulse) with the draft cleared and a Stop button while streaming.

Tracked as `cave-9r6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)