### PR TITLE
style(automations): polish create dialog layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7975,6 +7975,245 @@ a.mobile-handoff__link:hover {
   }
 }
 
+.workflow-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 180;
+  display: flex;
+  justify-content: flex-end;
+  background: color-mix(in oklch, black 18%, transparent);
+}
+
+.workflow-dialog {
+  width: min(760px, calc(100vw - 72px));
+  max-height: 100dvh;
+  overflow-y: auto;
+  border-left: 1px solid color-mix(in oklch, var(--border-hairline) 92%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--bg-raised) 62%, transparent), transparent 220px),
+    var(--bg-panel);
+  box-shadow: -22px 0 54px color-mix(in oklch, black 34%, transparent);
+}
+
+.automation-create-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px 20px 0;
+  color: var(--text-primary);
+}
+
+.automation-create-dialog__hero {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin: -18px -20px 2px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
+  background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+}
+
+.workflow-eyebrow {
+  margin: 0 0 4px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.automation-create-dialog__hero h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 18px;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.workflow-icon-button {
+  display: grid;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  place-items: center;
+  border-radius: var(--radius-control);
+}
+
+.automation-create-dialog__section {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 86%, transparent);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-raised) 34%, transparent);
+}
+
+.automation-create-dialog__section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  padding-bottom: 2px;
+}
+
+.automation-create-dialog__section-header h3 {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.1;
+  text-transform: uppercase;
+}
+
+.workflow-field,
+.automation-create-dialog__field {
+  display: grid;
+  min-width: 0;
+  gap: 6px;
+}
+
+.workflow-field > span,
+.automation-create-dialog__field > span {
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 650;
+  line-height: 1.2;
+}
+
+.automation-create-dialog__primary-grid,
+.automation-create-dialog__prompt-grid,
+.automation-create-dialog__runtime-grid,
+.automation-create-dialog__scope-grid {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.automation-create-dialog__primary-grid {
+  grid-template-columns: minmax(220px, 0.8fr) minmax(300px, 1.2fr);
+  align-items: start;
+}
+
+.automation-create-dialog__prompt-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.automation-create-dialog__runtime-grid,
+.automation-create-dialog__scope-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.automation-create-dialog__field--wide {
+  grid-column: 1 / -1;
+}
+
+.automation-create-dialog__schedule-card,
+.automation-create-dialog__schedule-body {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.automation-create-dialog__segment-control {
+  display: inline-flex;
+  width: max-content;
+  max-width: 100%;
+  overflow: hidden;
+  border: 1px solid;
+  border-radius: var(--radius-control);
+  padding: 2px;
+}
+
+.automation-create-dialog__day-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.automation-create-dialog__rrule {
+  margin: 0;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.automation-create-dialog :is(input, textarea, select) {
+  min-width: 0;
+}
+
+.automation-create-dialog textarea {
+  min-height: 92px;
+}
+
+.automation-create-dialog .workflow-run-input-field {
+  min-height: 116px;
+}
+
+.automation-create-dialog .workflow-field > div[role="group"] {
+  margin-bottom: 0;
+}
+
+.automation-create-dialog__footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 0 -20px;
+  padding: 12px 20px calc(12px + max(0px, var(--sai-bottom)));
+  border-top: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
+  background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
+  backdrop-filter: blur(16px) saturate(140%);
+  -webkit-backdrop-filter: blur(16px) saturate(140%);
+}
+
+@media (max-width: 920px) {
+  .workflow-dialog {
+    width: min(100vw, 680px);
+  }
+
+  .automation-create-dialog__primary-grid,
+  .automation-create-dialog__prompt-grid,
+  .automation-create-dialog__runtime-grid,
+  .automation-create-dialog__scope-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 560px) {
+  .workflow-dialog-backdrop {
+    background: var(--bg-panel);
+  }
+
+  .workflow-dialog {
+    width: 100vw;
+    border-left: 0;
+    box-shadow: none;
+  }
+
+  .automation-create-dialog {
+    padding-inline: 14px;
+  }
+
+  .automation-create-dialog__hero,
+  .automation-create-dialog__footer {
+    margin-inline: -14px;
+    padding-inline: 14px;
+  }
+}
+
 .chat-scope-tabs--minimal {
   min-height: 38px;
   background: color-mix(in oklch, var(--bg-raised) 72%, transparent);

--- a/src/components/automation-create-dialog.test.ts
+++ b/src/components/automation-create-dialog.test.ts
@@ -3,10 +3,18 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./automation-create-dialog.tsx", import.meta.url), "utf8");
+const styles = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 
 assert.match(source, /import \{ Button \}/, "dialog actions should use the shared Button primitive");
 assert.match(source, /StandardSelect/, "dialog dropdowns should use the shared StandardSelect primitive");
 assert.doesNotMatch(source, /<button\b/, "dialog should not hand-roll button controls");
 assert.doesNotMatch(source, /rounded-md|rounded-lg/, "dialog controls should use radius tokens instead of hard-coded radii");
+assert.match(source, /className="workflow-dialog automation-create-dialog"/, "dialog should opt into the automation drawer layout");
+for (const section of ["Essentials", "Prompt", "Runtime", "Scope"]) {
+  assert.match(source, new RegExp(`<section className="automation-create-dialog__section" aria-label="${section}"`), `${section} section is grouped and labelled`);
+}
+assert.match(source, /automation-create-dialog__footer/, "dialog actions should use the sticky automation footer");
+assert.match(styles, /\.automation-create-dialog__primary-grid[\s\S]*grid-template-columns: minmax\(220px, 0\.8fr\) minmax\(300px, 1\.2fr\)/, "primary fields use a responsive two-column layout");
+assert.match(styles, /@media \(max-width: 920px\)[\s\S]*\.automation-create-dialog__primary-grid,[\s\S]*grid-template-columns: 1fr/, "dialog grids collapse on narrow screens");
 
 console.log("automation-create-dialog.test.ts: ok");

--- a/src/components/automation-create-dialog.tsx
+++ b/src/components/automation-create-dialog.tsx
@@ -47,7 +47,6 @@ type Props = {
   initialValues?: AutomationCreateInitialValues;
 };
 
-
 const fieldBaseClass =
   "w-full rounded-[var(--radius-control)] border bg-[var(--bg-base)] text-[var(--text-primary)] outline-none transition-colors focus:border-[var(--border-strong)]";
 const inputClass = `${fieldBaseClass} h-8 px-2 text-[12px]`;
@@ -114,14 +113,13 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate, i
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="workflow-dialog"
+        className="workflow-dialog automation-create-dialog"
         role="dialog"
         aria-modal="true"
         aria-label="New automation"
         onClick={(event) => event.stopPropagation()}
       >
-        {/* Header */}
-        <div className="workflow-panel-heading">
+        <div className="workflow-panel-heading automation-create-dialog__hero">
           <div>
             <p className="workflow-eyebrow">New automation</p>
             <h2>Schedule a Codex run</h2>
@@ -135,210 +133,233 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate, i
           />
         </div>
 
-        {/* Name */}
-        <label className="workflow-field">
-          <span>Name</span>
-          <input
-            type="text"
-            value={name}
-            autoFocus
-            placeholder="Nightly code review"
-            onChange={(event) => setName(event.target.value)}
-          />
-        </label>
-
-        {/* Schedule */}
-        <div className="workflow-field">
-          <span>Schedule</span>
-          <div className="mb-2 inline-flex rounded-[var(--radius-control)] border p-0.5"
-            style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)" }}>
-            {(["weekly", "daily", "raw"] as const).map((mode) => (
-              <Button
-                key={mode}
-                variant="ghost"
-                size="xs"
-                onClick={() => setScheduleMode(mode)}
-                className="rounded-[var(--radius-control)] px-2 py-1 text-[11px] capitalize transition-colors"
-                style={{
-                  background: scheduleMode === mode ? "rgba(255,255,255,0.08)" : "transparent",
-                  color: scheduleMode === mode ? "var(--text-primary)" : "var(--text-muted)",
-                }}
-              >
-                {mode}
-              </Button>
-            ))}
+        <section className="automation-create-dialog__section" aria-label="Essentials">
+          <div className="automation-create-dialog__section-header">
+            <h3>Essentials</h3>
           </div>
-
-          {scheduleMode === "raw" ? (
-            <textarea
-              value={rawRrule}
-              onChange={(event) => setRawRrule(event.target.value)}
-              rows={3}
-              placeholder="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
-              className={monoTextareaClass}
-              style={fieldStyle}
-            />
-          ) : (
-            <div className="space-y-3">
-              {scheduleMode === "weekly" && (
-                <div className="flex flex-wrap gap-1.5">
-                  {RRULE_DAY_ORDER.map((day) => {
-                    const active = days.includes(day);
-                    return (
-                      <Button
-                        key={day}
-                        variant="ghost"
-                        size="xs"
-                        onClick={() => toggleDay(day)}
-                        className="rounded-[var(--radius-control)] border px-2 py-1 text-[11px] transition-colors"
-                        style={{
-                          background: active ? "color-mix(in oklch, var(--accent-presence) 18%, transparent)" : "var(--bg-base)",
-                          borderColor: active ? "color-mix(in oklch, var(--accent-presence) 50%, transparent)" : "var(--border-hairline)",
-                          color: active ? "var(--text-primary)" : "var(--text-muted)",
-                        }}
-                      >
-                        {RRULE_DAY_LABEL[day]}
-                      </Button>
-                    );
-                  })}
-                </div>
-              )}
+          <div className="automation-create-dialog__primary-grid">
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Name</span>
               <input
-                type="time"
-                value={time}
-                onChange={(event) => setTime(event.target.value)}
+                type="text"
+                value={name}
+                autoFocus
+                placeholder="Nightly code review"
+                onChange={(event) => setName(event.target.value)}
                 className={inputClass}
                 style={fieldStyle}
               />
+            </label>
+
+            <div className="workflow-field automation-create-dialog__field automation-create-dialog__schedule">
+              <span>Schedule</span>
+              <div className="automation-create-dialog__schedule-card">
+                <div
+                  className="automation-create-dialog__segment-control"
+                  style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)" }}
+                >
+                  {(["weekly", "daily", "raw"] as const).map((mode) => (
+                    <Button
+                      key={mode}
+                      variant="ghost"
+                      size="xs"
+                      onClick={() => setScheduleMode(mode)}
+                      className="rounded-[var(--radius-control)] px-2 py-1 text-[11px] capitalize transition-colors"
+                      style={{
+                        background: scheduleMode === mode ? "rgba(255,255,255,0.08)" : "transparent",
+                        color: scheduleMode === mode ? "var(--text-primary)" : "var(--text-muted)",
+                      }}
+                    >
+                      {mode}
+                    </Button>
+                  ))}
+                </div>
+
+                {scheduleMode === "raw" ? (
+                  <textarea
+                    value={rawRrule}
+                    onChange={(event) => setRawRrule(event.target.value)}
+                    rows={3}
+                    placeholder="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+                    className={monoTextareaClass}
+                    style={fieldStyle}
+                  />
+                ) : (
+                  <div className="automation-create-dialog__schedule-body">
+                    {scheduleMode === "weekly" && (
+                      <div className="automation-create-dialog__day-row">
+                        {RRULE_DAY_ORDER.map((day) => {
+                          const active = days.includes(day);
+                          return (
+                            <Button
+                              key={day}
+                              variant="ghost"
+                              size="xs"
+                              onClick={() => toggleDay(day)}
+                              className="rounded-[var(--radius-control)] border px-2 py-1 text-[11px] transition-colors"
+                              style={{
+                                background: active ? "color-mix(in oklch, var(--accent-presence) 18%, transparent)" : "var(--bg-base)",
+                                borderColor: active ? "color-mix(in oklch, var(--accent-presence) 50%, transparent)" : "var(--border-hairline)",
+                                color: active ? "var(--text-primary)" : "var(--text-muted)",
+                              }}
+                            >
+                              {RRULE_DAY_LABEL[day]}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                    )}
+                    <input
+                      type="time"
+                      value={time}
+                      onChange={(event) => setTime(event.target.value)}
+                      className={inputClass}
+                      style={fieldStyle}
+                    />
+                  </div>
+                )}
+
+                <p
+                  className="automation-create-dialog__rrule"
+                  style={{ color: validSchedule ? "var(--text-muted)" : "oklch(0.7 0.16 35)" }}
+                >
+                  {rrule || "RRULE required"}
+                </p>
+              </div>
             </div>
-          )}
+          </div>
+        </section>
 
-          <p className="mt-1 break-all font-mono text-[10px]"
-            style={{ color: validSchedule ? "var(--text-muted)" : "oklch(0.7 0.16 35)" }}>
-            {rrule || "RRULE required"}
-          </p>
-        </div>
+        <section className="automation-create-dialog__section" aria-label="Prompt">
+          <div className="automation-create-dialog__section-header">
+            <h3>Prompt</h3>
+          </div>
+          <div className="automation-create-dialog__prompt-grid">
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Goals</span>
+              <textarea
+                value={goals}
+                onChange={(event) => setGoals(event.target.value)}
+                rows={4}
+                placeholder="What should this automation accomplish?"
+                className={`workflow-run-input-field ${textareaClass}`}
+                style={fieldStyle}
+              />
+            </label>
 
-        {/* Goals */}
-        <label className="workflow-field">
-          <span>Goals</span>
-          <textarea
-            value={goals}
-            onChange={(event) => setGoals(event.target.value)}
-            rows={4}
-            placeholder="What should this automation accomplish?"
-            className={`workflow-run-input-field ${textareaClass}`}
-            style={fieldStyle}
-          />
-        </label>
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Deliverables</span>
+              <textarea
+                value={deliverables}
+                onChange={(event) => setDeliverables(event.target.value)}
+                rows={4}
+                placeholder="Expected outputs (optional)"
+                className={`workflow-run-input-field ${textareaClass}`}
+                style={fieldStyle}
+              />
+            </label>
+          </div>
+        </section>
 
-        {/* Deliverables */}
-        <label className="workflow-field">
-          <span>Deliverables</span>
-          <textarea
-            value={deliverables}
-            onChange={(event) => setDeliverables(event.target.value)}
-            rows={3}
-            placeholder="Expected outputs (optional)"
-            className={`workflow-run-input-field ${textareaClass}`}
-            style={fieldStyle}
-          />
-        </label>
+        <section className="automation-create-dialog__section" aria-label="Runtime">
+          <div className="automation-create-dialog__section-header">
+            <h3>Runtime</h3>
+          </div>
+          <div className="automation-create-dialog__runtime-grid">
+            <div className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
+              <span>Familiars</span>
+              <FamiliarMultiSelect
+                familiars={resolvedFamiliars}
+                selected={selected}
+                onChange={setSelected}
+              />
+            </div>
 
-        {/* Familiars */}
-        <div className="workflow-field">
-          <span>Familiars</span>
-          <FamiliarMultiSelect
-            familiars={resolvedFamiliars}
-            selected={selected}
-            onChange={setSelected}
-          />
-        </div>
+            <label className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
+              <span>Model</span>
+              <input
+                type="text"
+                value={model}
+                onChange={(event) => setModel(event.target.value)}
+                placeholder="e.g. claude-sonnet-4-5 (leave blank for default)"
+                className={inputClass}
+                style={fieldStyle}
+              />
+            </label>
 
-        {/* Model */}
-        <label className="workflow-field">
-          <span>Model</span>
-          <input
-            type="text"
-            value={model}
-            onChange={(event) => setModel(event.target.value)}
-            placeholder="e.g. claude-sonnet-4-5 (leave blank for default)"
-            className={inputClass}
-            style={fieldStyle}
-          />
-        </label>
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Reasoning</span>
+              <StandardSelect
+                label="Reasoning"
+                value={reasoningEffort}
+                onChange={setReasoningEffort}
+                options={[
+                  { value: "low", label: "low" },
+                  { value: "medium", label: "medium" },
+                  { value: "high", label: "high" },
+                ]}
+                className={selectClass}
+                style={fieldStyle}
+              />
+            </label>
 
-        {/* Reasoning effort */}
-        <label className="workflow-field">
-          <span>Reasoning</span>
-          <StandardSelect
-            label="Reasoning"
-            value={reasoningEffort}
-            onChange={setReasoningEffort}
-            options={[
-              { value: "low", label: "low" },
-              { value: "medium", label: "medium" },
-              { value: "high", label: "high" },
-            ]}
-            className={selectClass}
-            style={fieldStyle}
-          />
-        </label>
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Environment</span>
+              <StandardSelect
+                label="Environment"
+                value={executionEnvironment}
+                onChange={setExecutionEnvironment}
+                options={[
+                  { value: "worktree", label: "worktree" },
+                  { value: "repo", label: "repo" },
+                ]}
+                className={selectClass}
+                style={fieldStyle}
+              />
+            </label>
+          </div>
+        </section>
 
-        {/* Execution environment */}
-        <label className="workflow-field">
-          <span>Environment</span>
-          <StandardSelect
-            label="Environment"
-            value={executionEnvironment}
-            onChange={setExecutionEnvironment}
-            options={[
-              { value: "worktree", label: "worktree" },
-              { value: "repo", label: "repo" },
-            ]}
-            className={selectClass}
-            style={fieldStyle}
-          />
-        </label>
+        <section className="automation-create-dialog__section" aria-label="Scope">
+          <div className="automation-create-dialog__section-header">
+            <h3>Scope</h3>
+          </div>
+          <div className="automation-create-dialog__scope-grid">
+            <label className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
+              <span>Working directories</span>
+              <CwdPickerField
+                value={cwds}
+                onChange={setCwds}
+                familiarId={[...selected][0] ?? ""}
+                textareaClass={monoTextareaClass}
+                fieldStyle={fieldStyle}
+              />
+            </label>
 
-        {/* Working directories — type paths or browse projects (parity with the
-            cron detail editor). */}
-        <label className="workflow-field">
-          <span>Working directories</span>
-          <CwdPickerField
-            value={cwds}
-            onChange={setCwds}
-            familiarId={[...selected][0] ?? ""}
-            textareaClass={monoTextareaClass}
-            fieldStyle={fieldStyle}
-          />
-        </label>
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Tags</span>
+              <input
+                type="text"
+                value={tagsText}
+                onChange={(event) => setTagsText(event.target.value)}
+                placeholder="coven, nightly (comma-separated)"
+                className={inputClass}
+                style={fieldStyle}
+              />
+            </label>
 
-        {/* Tags */}
-        <label className="workflow-field">
-          <span>Tags</span>
-          <input
-            type="text"
-            value={tagsText}
-            onChange={(event) => setTagsText(event.target.value)}
-            placeholder="coven, nightly (comma-separated)"
-            className={inputClass}
-            style={fieldStyle}
-          />
-        </label>
+            <label className="workflow-field automation-create-dialog__field">
+              <span>Skill</span>
+              <SkillSelect
+                value={skillPath}
+                onChange={setSkillPath}
+                className={selectClass}
+              />
+            </label>
+          </div>
+        </section>
 
-        {/* Skill */}
-        <label className="workflow-field">
-          <span>Skill</span>
-          <SkillSelect
-            value={skillPath}
-            onChange={setSkillPath}
-            className={selectClass}
-          />
-        </label>
-
-        {/* Footer */}
-        <div className="workflow-dialog-actions">
+        <div className="workflow-dialog-actions automation-create-dialog__footer">
           <Button variant="secondary" onClick={onClose}>
             Cancel
           </Button>


### PR DESCRIPTION
## Summary
- group the automation create form into Essentials, Prompt, Runtime, and Scope sections
- add responsive drawer, sticky header, and sticky footer styles for scanability
- add source guards for the grouped drawer structure and responsive CSS

## Test plan
- node --experimental-strip-types src/components/automation-create-dialog.test.ts
- node --experimental-strip-types src/components/cwd-picker-field.test.ts
- git diff --check
- tsc --noEmit
- pnpm check:tests-wired
- pnpm test:app (520 files passed)

Refs cave-gbj