### PR TITLE
fix(growth): guard analytics link against null selected familiar

### DIFF
--- a/src/components/familiar-growth-view.tsx
+++ b/src/components/familiar-growth-view.tsx
@@ -205,10 +205,12 @@ export function FamiliarGrowthView({
           >
             <Icon name="ph:arrows-clockwise-bold" aria-hidden />
           </button>
-          <a className="retro-btn" href={`/dashboard/familiars/${encodeURIComponent(selected.familiar.id)}/analytics`}>
-            <Icon name="ph:chart-bar-bold" aria-hidden />
-            Analytics
-          </a>
+          {selected ? (
+            <a className="retro-btn" href={`/dashboard/familiars/${encodeURIComponent(selected.familiar.id)}/analytics`}>
+              <Icon name="ph:chart-bar-bold" aria-hidden />
+              Analytics
+            </a>
+          ) : null}
         </div>
       </header>
 


### PR DESCRIPTION
## What

`FamiliarGrowthView` derives its `selected` familiar as:

```ts
const selected = reports.find((item) => item.familiar.id === selectedFamiliarId) ?? reports[0] ?? null;
```

…so `selected` is legitimately `null` when there are no familiar reports (empty state). But the **Analytics** link in the hero dereferenced `selected.familiar.id` **unconditionally**, which crashes on the empty state. Every other consumer in the component already guards with `selected?.familiar` / `selected && selectedReport`, so this was the lone unguarded site.

## Fix

Wrap the Analytics link in a `{selected ? ... : null}` guard so the empty state renders cleanly.

~6 lines, one file. No behavior change when a familiar is selected.

## Context

This is the one surviving fix extracted from #2448. The boot-script portion of #2448 was fully superseded by #2447 (`021073e` — all three boot-script components already converted to plain server `<script>` on `main`), so #2448 is being closed in favor of this focused PR.

## Verification

- `./node_modules/.bin/tsc --noEmit` — clean
- `node scripts/check-tests-wired.mjs` — 702 test files wired
- `git diff --check` — clean