### PR TITLE
fix(automations): keep create dialog actions stable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7978,7 +7978,7 @@ a.mobile-handoff__link:hover {
 .workflow-dialog-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 180;
+  z-index: 260;
   display: flex;
   justify-content: flex-end;
   background: color-mix(in oklch, black 18%, transparent);
@@ -7986,8 +7986,9 @@ a.mobile-handoff__link:hover {
 
 .workflow-dialog {
   width: min(760px, calc(100vw - 72px));
+  height: 100dvh;
   max-height: 100dvh;
-  overflow-y: auto;
+  overflow: hidden;
   border-left: 1px solid color-mix(in oklch, var(--border-hairline) 92%, transparent);
   background:
     linear-gradient(180deg, color-mix(in oklch, var(--bg-raised) 62%, transparent), transparent 220px),
@@ -7998,15 +7999,14 @@ a.mobile-handoff__link:hover {
 .automation-create-dialog {
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  height: 100%;
+  max-height: 100%;
   padding: 18px 20px 0;
   color: var(--text-primary);
 }
 
 .automation-create-dialog__hero {
-  position: sticky;
-  top: 0;
-  z-index: 3;
+  flex: 0 0 auto;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -8017,6 +8017,16 @@ a.mobile-handoff__link:hover {
   background: color-mix(in oklch, var(--bg-panel) 94%, transparent);
   backdrop-filter: blur(16px) saturate(140%);
   -webkit-backdrop-filter: blur(16px) saturate(140%);
+}
+
+.automation-create-dialog__body {
+  display: grid;
+  flex: 1 1 auto;
+  min-height: 0;
+  gap: 14px;
+  overflow-y: auto;
+  padding-bottom: 14px;
+  scrollbar-gutter: stable;
 }
 
 .workflow-eyebrow {
@@ -8165,9 +8175,7 @@ a.mobile-handoff__link:hover {
 }
 
 .automation-create-dialog__footer {
-  position: sticky;
-  bottom: 0;
-  z-index: 2;
+  flex: 0 0 auto;
   display: flex;
   justify-content: flex-end;
   gap: 8px;

--- a/src/components/automation-create-dialog.test.ts
+++ b/src/components/automation-create-dialog.test.ts
@@ -9,12 +9,15 @@ assert.match(source, /import \{ Button \}/, "dialog actions should use the share
 assert.match(source, /StandardSelect/, "dialog dropdowns should use the shared StandardSelect primitive");
 assert.doesNotMatch(source, /<button\b/, "dialog should not hand-roll button controls");
 assert.doesNotMatch(source, /rounded-md|rounded-lg/, "dialog controls should use radius tokens instead of hard-coded radii");
-assert.match(source, /className="workflow-dialog automation-create-dialog"/, "dialog should opt into the automation drawer layout");
-for (const section of ["Essentials", "Prompt", "Runtime", "Scope"]) {
-  assert.match(source, new RegExp(`<section className="automation-create-dialog__section" aria-label="${section}"`), `${section} section is grouped and labelled`);
-}
-assert.match(source, /automation-create-dialog__footer/, "dialog actions should use the sticky automation footer");
-assert.match(styles, /\.automation-create-dialog__primary-grid[\s\S]*grid-template-columns: minmax\(220px, 0\.8fr\) minmax\(300px, 1\.2fr\)/, "primary fields use a responsive two-column layout");
-assert.match(styles, /@media \(max-width: 920px\)[\s\S]*\.automation-create-dialog__primary-grid,[\s\S]*grid-template-columns: 1fr/, "dialog grids collapse on narrow screens");
+assert.match(source, /automation-create-dialog__hero/, "new automation editor should have a structured hero/header");
+assert.match(source, /automation-create-dialog__section/, "new automation editor should group fields into scan-friendly sections");
+assert.match(source, /automation-create-dialog__body/, "new automation editor should scroll fields separately from the action footer");
+assert.match(source, /automation-create-dialog__primary-grid/, "name and cadence controls should sit in a compact primary grid");
+assert.match(source, /automation-create-dialog__prompt-grid/, "goals and deliverables should be grouped together");
+assert.match(source, /automation-create-dialog__runtime-grid/, "runtime settings should be grouped in a responsive grid");
+assert.match(source, /automation-create-dialog__scope-grid/, "working directories, tags, and skill should be grouped in the scope section");
+assert.match(source, /automation-create-dialog__footer/, "new automation editor should have a stable action footer");
+assert.match(styles, /\.workflow-dialog[\s\S]*height: 100dvh;[\s\S]*overflow: hidden;/, "drawer should own the viewport height without scrolling");
+assert.match(styles, /\.automation-create-dialog__body[\s\S]*min-height: 0;[\s\S]*overflow-y: auto;/, "dialog body should be the scroll container");
 
 console.log("automation-create-dialog.test.ts: ok");

--- a/src/components/automation-create-dialog.tsx
+++ b/src/components/automation-create-dialog.tsx
@@ -133,231 +133,233 @@ export function AutomationCreateDialog({ resolvedFamiliars, onClose, onCreate, i
           />
         </div>
 
-        <section className="automation-create-dialog__section" aria-label="Essentials">
-          <div className="automation-create-dialog__section-header">
-            <h3>Essentials</h3>
-          </div>
-          <div className="automation-create-dialog__primary-grid">
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Name</span>
-              <input
-                type="text"
-                value={name}
-                autoFocus
-                placeholder="Nightly code review"
-                onChange={(event) => setName(event.target.value)}
-                className={inputClass}
-                style={fieldStyle}
-              />
-            </label>
+        <div className="automation-create-dialog__body">
+          <section className="automation-create-dialog__section" aria-label="Essentials">
+            <div className="automation-create-dialog__section-header">
+              <h3>Essentials</h3>
+            </div>
+            <div className="automation-create-dialog__primary-grid">
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Name</span>
+                <input
+                  type="text"
+                  value={name}
+                  autoFocus
+                  placeholder="Nightly code review"
+                  onChange={(event) => setName(event.target.value)}
+                  className={inputClass}
+                  style={fieldStyle}
+                />
+              </label>
 
-            <div className="workflow-field automation-create-dialog__field automation-create-dialog__schedule">
-              <span>Schedule</span>
-              <div className="automation-create-dialog__schedule-card">
-                <div
-                  className="automation-create-dialog__segment-control"
-                  style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)" }}
-                >
-                  {(["weekly", "daily", "raw"] as const).map((mode) => (
-                    <Button
-                      key={mode}
-                      variant="ghost"
-                      size="xs"
-                      onClick={() => setScheduleMode(mode)}
-                      className="rounded-[var(--radius-control)] px-2 py-1 text-[11px] capitalize transition-colors"
-                      style={{
-                        background: scheduleMode === mode ? "rgba(255,255,255,0.08)" : "transparent",
-                        color: scheduleMode === mode ? "var(--text-primary)" : "var(--text-muted)",
-                      }}
-                    >
-                      {mode}
-                    </Button>
-                  ))}
-                </div>
+              <div className="workflow-field automation-create-dialog__field automation-create-dialog__schedule">
+                <span>Schedule</span>
+                <div className="automation-create-dialog__schedule-card">
+                  <div
+                    className="automation-create-dialog__segment-control"
+                    style={{ borderColor: "var(--border-hairline)", background: "var(--bg-base)" }}
+                  >
+                    {(["weekly", "daily", "raw"] as const).map((mode) => (
+                      <Button
+                        key={mode}
+                        variant="ghost"
+                        size="xs"
+                        onClick={() => setScheduleMode(mode)}
+                        className="rounded-[var(--radius-control)] px-2 py-1 text-[11px] capitalize transition-colors"
+                        style={{
+                          background: scheduleMode === mode ? "rgba(255,255,255,0.08)" : "transparent",
+                          color: scheduleMode === mode ? "var(--text-primary)" : "var(--text-muted)",
+                        }}
+                      >
+                        {mode}
+                      </Button>
+                    ))}
+                  </div>
 
-                {scheduleMode === "raw" ? (
-                  <textarea
-                    value={rawRrule}
-                    onChange={(event) => setRawRrule(event.target.value)}
-                    rows={3}
-                    placeholder="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
-                    className={monoTextareaClass}
-                    style={fieldStyle}
-                  />
-                ) : (
-                  <div className="automation-create-dialog__schedule-body">
-                    {scheduleMode === "weekly" && (
-                      <div className="automation-create-dialog__day-row">
-                        {RRULE_DAY_ORDER.map((day) => {
-                          const active = days.includes(day);
-                          return (
-                            <Button
-                              key={day}
-                              variant="ghost"
-                              size="xs"
-                              onClick={() => toggleDay(day)}
-                              className="rounded-[var(--radius-control)] border px-2 py-1 text-[11px] transition-colors"
-                              style={{
-                                background: active ? "color-mix(in oklch, var(--accent-presence) 18%, transparent)" : "var(--bg-base)",
-                                borderColor: active ? "color-mix(in oklch, var(--accent-presence) 50%, transparent)" : "var(--border-hairline)",
-                                color: active ? "var(--text-primary)" : "var(--text-muted)",
-                              }}
-                            >
-                              {RRULE_DAY_LABEL[day]}
-                            </Button>
-                          );
-                        })}
-                      </div>
-                    )}
-                    <input
-                      type="time"
-                      value={time}
-                      onChange={(event) => setTime(event.target.value)}
-                      className={inputClass}
+                  {scheduleMode === "raw" ? (
+                    <textarea
+                      value={rawRrule}
+                      onChange={(event) => setRawRrule(event.target.value)}
+                      rows={3}
+                      placeholder="RRULE:FREQ=DAILY;BYHOUR=9;BYMINUTE=0"
+                      className={monoTextareaClass}
                       style={fieldStyle}
                     />
-                  </div>
-                )}
+                  ) : (
+                    <div className="automation-create-dialog__schedule-body">
+                      {scheduleMode === "weekly" && (
+                        <div className="automation-create-dialog__day-row">
+                          {RRULE_DAY_ORDER.map((day) => {
+                            const active = days.includes(day);
+                            return (
+                              <Button
+                                key={day}
+                                variant="ghost"
+                                size="xs"
+                                onClick={() => toggleDay(day)}
+                                className="rounded-[var(--radius-control)] border px-2 py-1 text-[11px] transition-colors"
+                                style={{
+                                  background: active ? "color-mix(in oklch, var(--accent-presence) 18%, transparent)" : "var(--bg-base)",
+                                  borderColor: active ? "color-mix(in oklch, var(--accent-presence) 50%, transparent)" : "var(--border-hairline)",
+                                  color: active ? "var(--text-primary)" : "var(--text-muted)",
+                                }}
+                              >
+                                {RRULE_DAY_LABEL[day]}
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      )}
+                      <input
+                        type="time"
+                        value={time}
+                        onChange={(event) => setTime(event.target.value)}
+                        className={inputClass}
+                        style={fieldStyle}
+                      />
+                    </div>
+                  )}
 
-                <p
-                  className="automation-create-dialog__rrule"
-                  style={{ color: validSchedule ? "var(--text-muted)" : "oklch(0.7 0.16 35)" }}
-                >
-                  {rrule || "RRULE required"}
-                </p>
+                  <p
+                    className="automation-create-dialog__rrule"
+                    style={{ color: validSchedule ? "var(--text-muted)" : "oklch(0.7 0.16 35)" }}
+                  >
+                    {rrule || "RRULE required"}
+                  </p>
+                </div>
               </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section className="automation-create-dialog__section" aria-label="Prompt">
-          <div className="automation-create-dialog__section-header">
-            <h3>Prompt</h3>
-          </div>
-          <div className="automation-create-dialog__prompt-grid">
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Goals</span>
-              <textarea
-                value={goals}
-                onChange={(event) => setGoals(event.target.value)}
-                rows={4}
-                placeholder="What should this automation accomplish?"
-                className={`workflow-run-input-field ${textareaClass}`}
-                style={fieldStyle}
-              />
-            </label>
-
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Deliverables</span>
-              <textarea
-                value={deliverables}
-                onChange={(event) => setDeliverables(event.target.value)}
-                rows={4}
-                placeholder="Expected outputs (optional)"
-                className={`workflow-run-input-field ${textareaClass}`}
-                style={fieldStyle}
-              />
-            </label>
-          </div>
-        </section>
-
-        <section className="automation-create-dialog__section" aria-label="Runtime">
-          <div className="automation-create-dialog__section-header">
-            <h3>Runtime</h3>
-          </div>
-          <div className="automation-create-dialog__runtime-grid">
-            <div className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
-              <span>Familiars</span>
-              <FamiliarMultiSelect
-                familiars={resolvedFamiliars}
-                selected={selected}
-                onChange={setSelected}
-              />
+          <section className="automation-create-dialog__section" aria-label="Prompt">
+            <div className="automation-create-dialog__section-header">
+              <h3>Prompt</h3>
             </div>
+            <div className="automation-create-dialog__prompt-grid">
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Goals</span>
+                <textarea
+                  value={goals}
+                  onChange={(event) => setGoals(event.target.value)}
+                  rows={4}
+                  placeholder="What should this automation accomplish?"
+                  className={`workflow-run-input-field ${textareaClass}`}
+                  style={fieldStyle}
+                />
+              </label>
 
-            <label className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
-              <span>Model</span>
-              <input
-                type="text"
-                value={model}
-                onChange={(event) => setModel(event.target.value)}
-                placeholder="e.g. claude-sonnet-4-5 (leave blank for default)"
-                className={inputClass}
-                style={fieldStyle}
-              />
-            </label>
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Deliverables</span>
+                <textarea
+                  value={deliverables}
+                  onChange={(event) => setDeliverables(event.target.value)}
+                  rows={4}
+                  placeholder="Expected outputs (optional)"
+                  className={`workflow-run-input-field ${textareaClass}`}
+                  style={fieldStyle}
+                />
+              </label>
+            </div>
+          </section>
 
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Reasoning</span>
-              <StandardSelect
-                label="Reasoning"
-                value={reasoningEffort}
-                onChange={setReasoningEffort}
-                options={[
-                  { value: "low", label: "low" },
-                  { value: "medium", label: "medium" },
-                  { value: "high", label: "high" },
-                ]}
-                className={selectClass}
-                style={fieldStyle}
-              />
-            </label>
+          <section className="automation-create-dialog__section" aria-label="Runtime">
+            <div className="automation-create-dialog__section-header">
+              <h3>Runtime</h3>
+            </div>
+            <div className="automation-create-dialog__runtime-grid">
+              <div className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
+                <span>Familiars</span>
+                <FamiliarMultiSelect
+                  familiars={resolvedFamiliars}
+                  selected={selected}
+                  onChange={setSelected}
+                />
+              </div>
 
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Environment</span>
-              <StandardSelect
-                label="Environment"
-                value={executionEnvironment}
-                onChange={setExecutionEnvironment}
-                options={[
-                  { value: "worktree", label: "worktree" },
-                  { value: "repo", label: "repo" },
-                ]}
-                className={selectClass}
-                style={fieldStyle}
-              />
-            </label>
-          </div>
-        </section>
+              <label className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
+                <span>Model</span>
+                <input
+                  type="text"
+                  value={model}
+                  onChange={(event) => setModel(event.target.value)}
+                  placeholder="e.g. claude-sonnet-4-5 (leave blank for default)"
+                  className={inputClass}
+                  style={fieldStyle}
+                />
+              </label>
 
-        <section className="automation-create-dialog__section" aria-label="Scope">
-          <div className="automation-create-dialog__section-header">
-            <h3>Scope</h3>
-          </div>
-          <div className="automation-create-dialog__scope-grid">
-            <label className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
-              <span>Working directories</span>
-              <CwdPickerField
-                value={cwds}
-                onChange={setCwds}
-                familiarId={[...selected][0] ?? ""}
-                textareaClass={monoTextareaClass}
-                fieldStyle={fieldStyle}
-              />
-            </label>
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Reasoning</span>
+                <StandardSelect
+                  label="Reasoning"
+                  value={reasoningEffort}
+                  onChange={setReasoningEffort}
+                  options={[
+                    { value: "low", label: "low" },
+                    { value: "medium", label: "medium" },
+                    { value: "high", label: "high" },
+                  ]}
+                  className={selectClass}
+                  style={fieldStyle}
+                />
+              </label>
 
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Tags</span>
-              <input
-                type="text"
-                value={tagsText}
-                onChange={(event) => setTagsText(event.target.value)}
-                placeholder="coven, nightly (comma-separated)"
-                className={inputClass}
-                style={fieldStyle}
-              />
-            </label>
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Environment</span>
+                <StandardSelect
+                  label="Environment"
+                  value={executionEnvironment}
+                  onChange={setExecutionEnvironment}
+                  options={[
+                    { value: "worktree", label: "worktree" },
+                    { value: "repo", label: "repo" },
+                  ]}
+                  className={selectClass}
+                  style={fieldStyle}
+                />
+              </label>
+            </div>
+          </section>
 
-            <label className="workflow-field automation-create-dialog__field">
-              <span>Skill</span>
-              <SkillSelect
-                value={skillPath}
-                onChange={setSkillPath}
-                className={selectClass}
-              />
-            </label>
-          </div>
-        </section>
+          <section className="automation-create-dialog__section" aria-label="Scope">
+            <div className="automation-create-dialog__section-header">
+              <h3>Scope</h3>
+            </div>
+            <div className="automation-create-dialog__scope-grid">
+              <label className="workflow-field automation-create-dialog__field automation-create-dialog__field--wide">
+                <span>Working directories</span>
+                <CwdPickerField
+                  value={cwds}
+                  onChange={setCwds}
+                  familiarId={[...selected][0] ?? ""}
+                  textareaClass={monoTextareaClass}
+                  fieldStyle={fieldStyle}
+                />
+              </label>
+
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Tags</span>
+                <input
+                  type="text"
+                  value={tagsText}
+                  onChange={(event) => setTagsText(event.target.value)}
+                  placeholder="coven, nightly (comma-separated)"
+                  className={inputClass}
+                  style={fieldStyle}
+                />
+              </label>
+
+              <label className="workflow-field automation-create-dialog__field">
+                <span>Skill</span>
+                <SkillSelect
+                  value={skillPath}
+                  onChange={setSkillPath}
+                  className={selectClass}
+                />
+              </label>
+            </div>
+          </section>
+        </div>
 
         <div className="workflow-dialog-actions automation-create-dialog__footer">
           <Button variant="secondary" onClick={onClose}>


### PR DESCRIPTION
## Summary
- make the automation create drawer own viewport height instead of scrolling the whole dialog
- move field scrolling into `automation-create-dialog__body` so the hero and actions stay stable
- add source/CSS guards for the body-scroll contract

## Test plan
- node --experimental-strip-types src/components/automation-create-dialog.test.ts
- node --experimental-strip-types src/components/cwd-picker-field.test.ts
- git diff --check
- tsc --noEmit
- pnpm check:tests-wired
- pnpm test:app (520 files passed)

Refs cave-yo1