### PR TITLE
chore(release): stamp v0.0.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.141] - 2026-07-06
+
+Feature release on top of v0.0.140. Remakes the quick-chat menubar dropdown
+into a genuine multi-turn conversational surface.
+
+### Features
+- **Multi-turn quick chat** (#2451). The menubar / ⌘J quick-chat dropdown is now a real conversation instead of a one-shot ask: threaded user + familiar turns that resume the same session so follow-ups keep their context, streaming with a caret and a "thinking" pulse then full markdown once the reply lands, per-reply copy and regenerate, Stop mid-stream, an avatar familiar picker, empty-state starter chips, and Enter-to-send (Shift+Enter for a newline, ⌘/Ctrl+Enter still sends). The draft clears the instant a turn is sent, switching familiar starts a fresh thread, and the dropdown now traps focus (Tab cycles, Escape closes, focus returns to the trigger). The Tauri tray quick-chat window shares the same upgrade.
+
 ### Docs
 - **Add `CONTRIBUTORS.md`** to credit community contributions. Records the fixes and improvements from Chris Thomas ([@Aimplemented](https://github.com/Aimplemented)) whose original PRs were re-landed through internal branches during merge — group-chat parallel first-pass replies (#2206), tokenless native iOS Serve route (#2404), installer links via the system handler (#2381, #2414), and the current-session-id flag (#1989).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.140",
+  "version": "0.0.141",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.140"
+version = "0.0.141"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.140"
+version = "0.0.141"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.140</string>
+	<string>0.0.141</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.140</string>
+	<string>0.0.141</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.140</string>
+	<string>0.0.141</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.140</string>
+	<string>0.0.141</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.140",
+  "version": "0.0.141",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version stamp for **v0.0.141** (patch). Publishes nothing on its own — the signed `v0.0.141` tag pushed after this merges is what triggers `release.yml` to build the 4 platforms + update `latest.json` / `SHA256SUMS`.

Bumps `0.0.140 → 0.0.141` across the standard 7 files (package.json, Cargo.toml, Cargo.lock, tauri.conf.json, both iOS Info.plists) and rolls up the CHANGELOG.

### Release contents
- **Multi-turn quick chat** ([#2451](https://github.com/OpenCoven/coven-cave/pull/2451)) — the menubar / ⌘J quick-chat dropdown remade from a one-shot ask into a real conversation: threaded turns with session-resumed context, streaming caret + thinking pulse → markdown, copy/regenerate/stop, draft-clear-on-send, avatar familiar picker, empty-state chips, focus trap. Tray window shares the upgrade.
- **Docs**: `CONTRIBUTORS.md` (pending [Unreleased] entry, rolled into this release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)