### PR TITLE
polish(github): profile cache, live checks refresh, thread-comment reactions

### DIFF
--- a/src/app/api/github/comments/route.ts
+++ b/src/app/api/github/comments/route.ts
@@ -91,6 +91,30 @@ function reactions(raw: unknown): Reaction[] {
   return out;
 }
 
+// GraphQL ReactionContent enum → the REST reaction slug the client renders.
+const GQL_REACTION: Record<string, string> = {
+  THUMBS_UP: "+1",
+  THUMBS_DOWN: "-1",
+  LAUGH: "laugh",
+  HOORAY: "hooray",
+  CONFUSED: "confused",
+  HEART: "heart",
+  ROCKET: "rocket",
+  EYES: "eyes",
+};
+
+/** Map GraphQL reactionGroups (inline thread comments) to the REST-slug shape. */
+function gqlReactions(raw: unknown): Reaction[] {
+  if (!Array.isArray(raw)) return [];
+  const out: Reaction[] = [];
+  for (const g of raw as Array<Record<string, unknown>>) {
+    const slug = GQL_REACTION[String(g.content ?? "")];
+    const count = (g.reactors as { totalCount?: unknown } | undefined)?.totalCount;
+    if (slug && typeof count === "number" && count > 0) out.push({ content: slug, count });
+  }
+  return out;
+}
+
 async function ghFetch(path: string, token: string | null) {
   const headers: Record<string, string> = {
     Accept: "application/vnd.github+json",
@@ -138,6 +162,7 @@ async function fetchReviewThreads(owner: string, name: string, number: number, t
                   databaseId author{login avatarUrl url}
                   body createdAt path diffHunk url
                   authorAssociation
+                  reactionGroups{content reactors{totalCount}}
                 }
               }
             }
@@ -168,6 +193,7 @@ async function fetchReviewThreads(owner: string, name: string, number: number, t
             createdAt: typeof co.createdAt === "string" ? co.createdAt : null,
             url: typeof co.url === "string" ? co.url : null,
             authorAssociation: typeof co.authorAssociation === "string" ? co.authorAssociation : null,
+            reactions: gqlReactions(co.reactionGroups),
           };
         })
       : [];

--- a/src/components/github-advanced.test.ts
+++ b/src/components/github-advanced.test.ts
@@ -104,4 +104,26 @@ assert.match(source, /gh-check-logs[\s\S]{0,200}openExternalUrl\(r\.detailsUrl!\
 assert.match(boardCss, /\.gh-checks-list \{/, "the checks list is styled");
 assert.match(boardCss, /\.gh-checks-rollup--failing \{ color:var\(--color-danger\)/, "the failing rollup pill is danger-tinted");
 
+// ── Wave 2 polish ─────────────────────────────────────────────────────────────
+
+// Profile cache: reopening a person's card is instant and doesn't respend the
+// rate limit — cache-first, populated on the first successful fetch.
+assert.match(source, /const profileCache = new Map<string, UserProfile>\(\)/, "a session-lifetime profile cache exists");
+assert.match(source, /const cached = profileCache\.get\(login\);[\s\S]{0,120}status: "ready", profile: cached/, "the card serves a cached profile without refetching");
+assert.match(source, /profileCache\.set\(login, profile\)/, "a fetched profile populates the cache");
+
+// Checks live-refresh: while the rollup is pending, poll every 30s; the same-PR
+// refresh is silent (no skeleton flash) and a hidden tab spends no rate limit.
+assert.match(source, /if \(rollup !== "pending"\) return;[\s\S]{0,240}setInterval[\s\S]{0,160}30_000/, "a pending rollup schedules a 30s live-refresh");
+assert.match(source, /document\.hidden\) return;[\s\S]{0,60}setTick/, "the live-refresh skips fetching while the tab is hidden");
+assert.match(source, /const silent = keyRef\.current === key;[\s\S]{0,120}if \(!silent\) setState\(\{ status: "loading" \}\)/, "a same-PR refresh keeps the list mounted (no loading flash)");
+assert.match(source, /else if \(!silent\) setState\(\{ status: "error" \}\)/, "a failed silent refresh keeps the last good list");
+
+// Reaction parity: inline review-thread comments (GraphQL) carry reactionGroups
+// mapped to the same REST slugs the timeline chips render.
+assert.match(commentsRoute, /reactionGroups\{content reactors\{totalCount\}\}/, "the GraphQL thread query requests reactionGroups");
+assert.match(commentsRoute, /const GQL_REACTION: Record<string, string> = \{[\s\S]{0,200}THUMBS_UP: "\+1"/, "GraphQL reaction enums map to REST slugs");
+assert.match(commentsRoute, /reactions: gqlReactions\(co\.reactionGroups\)/, "thread comments carry their reaction counts");
+assert.match(source, /thread\.comments\.map\(\(c\) => \([\s\S]{0,300}<CommentReactions reactions=\{c\.reactions\}/, "reactions render under inline thread comments");
+
 console.log("github-advanced.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -782,10 +782,16 @@ function compactCount(n: number): string {
   return `${k >= 100 ? Math.round(k) : k.toFixed(1).replace(/\.0$/, "")}k`;
 }
 
+// Session-lifetime profile cache: reopening a person's card is instant and
+// doesn't respend the GitHub rate limit. Profiles change rarely enough that a
+// page-load-scoped cache never going stale in practice is the right trade.
+const profileCache = new Map<string, UserProfile>();
+
 /**
  * Floating GitHub profile card. Anchored under the clicked chip, clamped to the
  * viewport, focus-trapped, and dismissed on Escape / outside click. Fetches the
- * public profile on open; a since-closed selection's response is dropped.
+ * public profile on open (cache-first); a since-closed selection's response is
+ * dropped.
  */
 function UserProfileCard({
   login,
@@ -801,14 +807,22 @@ function UserProfileCard({
   useFocusTrap(true, cardRef, { onEscape: onClose, focusFirst: false });
 
   useEffect(() => {
+    const cached = profileCache.get(login);
+    if (cached) {
+      setState({ status: "ready", profile: cached });
+      return;
+    }
     let cancelled = false;
     setState({ status: "loading" });
     fetch(`/api/github/user?login=${encodeURIComponent(login)}`)
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
-        if (data?.ok) setState({ status: "ready", profile: data as UserProfile });
-        else setState({ status: "error" });
+        if (data?.ok) {
+          const profile = data as UserProfile;
+          profileCache.set(login, profile);
+          setState({ status: "ready", profile });
+        } else setState({ status: "error" });
       })
       .catch(() => { if (!cancelled) setState({ status: "error" }); });
     return () => { cancelled = true; };
@@ -1395,6 +1409,7 @@ function GitHubComments({
                     <div key={c.id} className="gh-comment gh-comment--inline">
                       <CommentHeader comment={c} />
                       <CommentBody comment={c} repo={repo} />
+                      <CommentReactions reactions={c.reactions} />
                     </div>
                   ))}
                 </div>
@@ -1568,26 +1583,48 @@ function checkDuration(startedAt: string | null, completedAt: string | null): st
 
 function useGitHubChecks(item: GitHubItem | null, enabled: boolean): ChecksState {
   const [state, setState] = useState<ChecksState>({ status: "idle" });
+  const [tick, setTick] = useState(0);
   const repo = item?.repo ?? null;
   const number = item?.number ?? null;
+  // Tracks the last-fetched PR so a live-refresh of the SAME PR is silent (no
+  // skeleton flash, list stays mounted) while switching PRs shows loading.
+  const keyRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!enabled || !repo || number == null) {
+      keyRef.current = null;
       setState({ status: "idle" });
       return;
     }
+    const key = `${repo}#${number}`;
+    const silent = keyRef.current === key;
+    keyRef.current = key;
     let cancelled = false;
-    setState({ status: "loading" });
+    if (!silent) setState({ status: "loading" });
     fetch(`/api/github/checks?repo=${encodeURIComponent(repo)}&number=${encodeURIComponent(String(number))}`)
       .then((r) => r.json())
       .then((data) => {
         if (cancelled) return;
         if (data?.ok) setState({ status: "ready", data: data as ChecksResult });
-        else setState({ status: "error" });
+        else if (!silent) setState({ status: "error" }); // a failed refresh keeps the last good list
       })
-      .catch(() => { if (!cancelled) setState({ status: "error" }); });
+      .catch(() => { if (!cancelled && !silent) setState({ status: "error" }); });
     return () => { cancelled = true; };
-  }, [enabled, repo, number]);
+  }, [enabled, repo, number, tick]);
+
+  // Live-refresh while CI is still running: poll every 30s until the rollup
+  // leaves "pending". Fetches are skipped while the tab is hidden (the interval
+  // itself is a no-op then) so a backgrounded tab doesn't spend rate limit —
+  // mirroring the surface's own activity-poll discipline.
+  const rollup = state.status === "ready" ? state.data.rollup : null;
+  useEffect(() => {
+    if (rollup !== "pending") return;
+    const id = window.setInterval(() => {
+      if (typeof document !== "undefined" && document.hidden) return;
+      setTick((t) => t + 1);
+    }, 30_000);
+    return () => window.clearInterval(id);
+  }, [rollup]);
 
   return state;
 }


### PR DESCRIPTION
## What

Wave-2 polish on the GitHub surface enhancements shipped in #2450:

- **Profile cache** — fetched user profiles are cached for the session (module-level `Map`), so reopening a person's card is instant and doesn't respend the GitHub rate limit. Cache-first; populated on first successful fetch.
- **Live checks refresh** — while a PR's CI rollup is `pending`, the Checks section polls every 30s until it settles. Same-PR refreshes are **silent** (no skeleton flash; open list stays mounted; a failed refresh keeps the last good list), fetches are **skipped while the tab is hidden** (matches the surface's activity-poll discipline), and a pending→failing transition **auto-expands** the run list.
- **Reaction parity** — inline PR review-thread comments (GraphQL) now request `reactionGroups{content reactors{totalCount}}`, mapped to the same REST slugs, and render the same emoji reaction chips as timeline comments.

## Verification
- `tsc` clean · `next build` green (bundle within budget)
- `github-advanced.test.ts` extended with pins for all three behaviors; sibling github + API-contract tests pass
- **Live (prod build, mocked GitHub APIs):**
  - thread reaction chip renders under the inline comment
  - rollup went `Checks running` → `Some checks failed` in one 30s cycle (exactly 2 route calls) and the run list auto-expanded
  - second profile-card open served **from cache** with the `/api/github/user` route deliberately returning 500 (1 network call total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)