### PR TITLE
feat(ios): add The Diary — experimental Apple Pencil handwriting page (iPad)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -13,7 +13,10 @@ enum ChatRoute: Hashable {
 /// tapping a thread pushes `ChatView`.
 struct ChatsHomeView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showNewChat = false
+    /// The Diary — the experimental Pencil-handwriting page (iPad only).
+    @State private var showDiary = false
     @State private var query = ""
     /// Drives the accent glow on the search field while it's being edited.
     @FocusState private var searchFocused: Bool
@@ -56,6 +59,9 @@ struct ChatsHomeView: View {
                     showNewChat = false
                     open(.thread(thread))
                 }
+            }
+            .fullScreenCover(isPresented: $showDiary) {
+                DiaryView()
             }
             .refreshable {
                 await app.loadFamiliars()
@@ -404,6 +410,21 @@ struct ChatsHomeView: View {
             .padding(.vertical, 11)
             .glass(.control, in: Capsule())
             .accentGlow(active: searchFocused)
+
+            // The Diary — Pencil-handwriting experiment. iPad only: the page is
+            // sized for Pencil writing, so the entry point hides on iPhone.
+            if sizeClass == .regular {
+                Button {
+                    showDiary = true
+                } label: {
+                    Image(systemName: "book.closed")
+                        .font(.system(.title3, weight: .medium))
+                        .scaledControlFrame(50)
+                        .glass(.control, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open the Diary — write with Apple Pencil")
+            }
 
             Button {
                 showNewChat = true

--- a/apps/ios/CovenCave/CovenCave/Views/DiaryView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/DiaryView.swift
@@ -1,0 +1,522 @@
+import SwiftUI
+import PencilKit
+// Vision's request types predate Sendable; @preconcurrency quiets the strict-
+// concurrency warning for the recognize() closure capture.
+@preconcurrency import Vision
+
+/// The Diary — an experimental iPad surface styled after Tom Riddle's diary.
+///
+/// Write a message on the page with Apple Pencil (finger works too, which keeps
+/// the page usable in the Simulator). After a pause the handwriting is
+/// recognized, the ink "soaks" into the page, and the familiar's reply writes
+/// itself out stroke by stroke in a cursive hand — then fades away when you
+/// start writing again.
+///
+/// The reply streams through the same `POST /api/chat/send` SSE bridge as chat,
+/// resuming one session per page so follow-up questions keep their context.
+/// "New page" (or switching familiar) starts a fresh session.
+struct DiaryView: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// What the page is doing. The canvas accepts ink in `.idle`; everything
+    /// downstream of a pen-lift flows through the remaining phases in order.
+    private enum Phase: Equatable {
+        case idle            // blank page or finished exchange; ready for ink
+        case recognizing     // pen lifted, Vision reading the handwriting
+        case replying        // reply streaming + writing itself out
+    }
+
+    @State private var phase: Phase = .idle
+    @State private var drawing = PKDrawing()
+    /// Fades + blurs the written ink as it "soaks" into the page.
+    @State private var inkOpacity: Double = 1
+    @State private var inkBlur: Double = 0
+
+    /// The reply as revealed so far (grows char by char) and the not-yet-revealed
+    /// buffer the stream fills. `streamFinished` lets the reveal loop know the
+    /// buffer won't grow anymore.
+    @State private var revealedReply = ""
+    @State private var pendingReply: [Character] = []
+    @State private var streamFinished = false
+    @State private var replyIsError = false
+    /// Fades the finished reply out when the user starts the next message.
+    @State private var replyOpacity: Double = 1
+
+    /// One diary session per familiar+page; nil until the first send answers.
+    @State private var sessionId: String?
+    @AppStorage("cave.diary.familiar") private var familiarIdRaw = ""
+    @State private var hint: String?
+
+    @State private var penLiftTask: Task<Void, Never>?
+    @State private var streamTask: Task<Void, Never>?
+    @State private var revealTask: Task<Void, Never>?
+
+    /// Dark sepia writing ink — legible on the parchment and high-contrast
+    /// enough for Vision's handwriting recognition.
+    private static let ink = UIColor(red: 0.16, green: 0.10, blue: 0.05, alpha: 1)
+
+    var body: some View {
+        ZStack {
+            paper.ignoresSafeArea()
+
+            // The reply writes itself across the upper page; ink lands anywhere.
+            VStack(spacing: 0) {
+                header
+                ZStack(alignment: .topLeading) {
+                    DiaryCanvas(drawing: $drawing,
+                                ink: Self.ink,
+                                onStrokesChanged: strokesChanged)
+                        .opacity(inkOpacity)
+                        .blur(radius: inkBlur)
+                        .accessibilityLabel("Diary page. Write your message here with Apple Pencil.")
+
+                    if !revealedReply.isEmpty {
+                        replyText
+                            .padding(.horizontal, 36)
+                            .padding(.top, 28)
+                            .allowsHitTesting(false)
+                    }
+
+                    if drawing.strokes.isEmpty && revealedReply.isEmpty && phase == .idle {
+                        blankPageHint
+                    }
+
+                    if phase == .recognizing {
+                        readingIndicator
+                    }
+                }
+            }
+
+            if let hint {
+                hintToast(hint)
+            }
+        }
+        .preferredColorScheme(.light) // a diary page is parchment in any theme
+        .onDisappear {
+            penLiftTask?.cancel()
+            streamTask?.cancel()
+            revealTask?.cancel()
+        }
+    }
+
+    // MARK: - Chrome
+
+    private var header: some View {
+        HStack(spacing: 14) {
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color(uiColor: Self.ink).opacity(0.55))
+                    .frame(width: 34, height: 34)
+                    .contentShape(Circle())
+            }
+            .accessibilityLabel("Close the diary")
+
+            Spacer()
+
+            VStack(spacing: 1) {
+                Text("The Diary")
+                    .font(.system(size: 17, weight: .semibold, design: .serif))
+                    .foregroundStyle(Color(uiColor: Self.ink).opacity(0.8))
+                Text(currentFamiliar.map { "kept by \($0.displayName)" } ?? "experimental")
+                    .font(.system(size: 11, design: .serif).italic())
+                    .foregroundStyle(Color(uiColor: Self.ink).opacity(0.45))
+            }
+
+            Spacer()
+
+            familiarMenu
+
+            Button {
+                newPage()
+            } label: {
+                Image(systemName: "book.pages")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color(uiColor: Self.ink).opacity(0.55))
+                    .frame(width: 34, height: 34)
+                    .contentShape(Circle())
+            }
+            .accessibilityLabel("Turn to a new page")
+            .disabled(phase != .idle)
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 10)
+        .padding(.bottom, 4)
+    }
+
+    private var familiarMenu: some View {
+        Menu {
+            ForEach(app.familiars) { familiar in
+                Button {
+                    guard familiar.id != currentFamiliar?.id else { return }
+                    familiarIdRaw = familiar.id
+                    newPage() // a different spirit answers on a fresh page
+                } label: {
+                    if familiar.id == currentFamiliar?.id {
+                        Label(familiar.displayName, systemImage: "checkmark")
+                    } else {
+                        Text(familiar.displayName)
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "person.crop.circle")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(Color(uiColor: Self.ink).opacity(0.55))
+                .frame(width: 34, height: 34)
+                .contentShape(Circle())
+        }
+        .accessibilityLabel("Choose who answers the diary")
+        .disabled(phase != .idle)
+    }
+
+    // MARK: - Page dressing
+
+    /// Aged-parchment page: warm cream with a soft edge vignette.
+    private var paper: some View {
+        ZStack {
+            Color(red: 0.949, green: 0.910, blue: 0.831)
+            RadialGradient(
+                colors: [.clear, Color(red: 0.72, green: 0.62, blue: 0.46).opacity(0.35)],
+                center: .center, startRadius: 240, endRadius: 900
+            )
+        }
+    }
+
+    private var blankPageHint: some View {
+        VStack {
+            Spacer()
+            Text("Write with your pencil… the diary is listening.")
+                .font(.system(size: 20, design: .serif).italic())
+                .foregroundStyle(Color(uiColor: Self.ink).opacity(0.28))
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .allowsHitTesting(false)
+    }
+
+    private var readingIndicator: some View {
+        VStack {
+            Spacer()
+            Text("the ink stirs…")
+                .font(.system(size: 15, design: .serif).italic())
+                .foregroundStyle(Color(uiColor: Self.ink).opacity(0.4))
+                .padding(.bottom, 42)
+        }
+        .frame(maxWidth: .infinity)
+        .allowsHitTesting(false)
+        .accessibilityLabel("Reading your handwriting")
+    }
+
+    private var replyText: some View {
+        Text(revealedReply)
+            .font(.custom("SnellRoundhand-Bold", size: 30))
+            .foregroundStyle(Color(uiColor: Self.ink).opacity(replyIsError ? 0.55 : 0.88))
+            .lineSpacing(9)
+            .opacity(replyOpacity)
+            .animation(reduceMotion ? nil : .easeIn(duration: 0.12), value: revealedReply)
+            .accessibilityLabel("The diary replies: \(revealedReply)")
+    }
+
+    private func hintToast(_ text: String) -> some View {
+        VStack {
+            Spacer()
+            Text(text)
+                .font(.system(size: 14, design: .serif).italic())
+                .foregroundStyle(Color(uiColor: Self.ink).opacity(0.65))
+                .padding(.horizontal, 18)
+                .padding(.vertical, 10)
+                .background(Color.white.opacity(0.55), in: Capsule())
+                .padding(.bottom, 60)
+        }
+        .transition(.opacity)
+        .allowsHitTesting(false)
+    }
+
+    // MARK: - Flow
+
+    private var currentFamiliar: Familiar? {
+        app.familiars.first { $0.id == familiarIdRaw } ?? app.familiars.first
+    }
+
+    /// Pen activity: fade out a finished reply (the page clears itself for the
+    /// next exchange) and (re)arm the pen-lift timer that triggers recognition.
+    private func strokesChanged() {
+        guard phase == .idle else { return }
+        hint = nil
+        if !revealedReply.isEmpty && replyOpacity == 1 {
+            withAnimation(reduceMotion ? nil : .easeOut(duration: 1.1)) { replyOpacity = 0 }
+        }
+        penLiftTask?.cancel()
+        guard !drawing.strokes.isEmpty else { return }
+        penLiftTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(1500))
+            guard !Task.isCancelled, phase == .idle, !drawing.strokes.isEmpty else { return }
+            await submit()
+        }
+    }
+
+    /// Pen-lift pause elapsed: recognize the ink, soak it into the page, and
+    /// stream the reply.
+    @MainActor
+    private func submit() async {
+        guard let client = app.client, let familiar = currentFamiliar else {
+            showHint("The diary is not connected.")
+            return
+        }
+        phase = .recognizing
+
+        let text: String
+        do {
+            text = try await DiaryHandwriting.recognize(drawing)
+        } catch {
+            phase = .idle
+            showHint("The diary squints… it can't quite read that.")
+            return
+        }
+        guard !text.isEmpty else {
+            phase = .idle
+            showHint("The diary can't read that — try writing a little larger.")
+            return
+        }
+
+        // The ink soaks into the page, Riddle-style.
+        clearReply()
+        Haptics.tap(.soft)
+        if reduceMotion {
+            drawing = PKDrawing()
+        } else {
+            withAnimation(.easeIn(duration: 0.9)) {
+                inkOpacity = 0
+                inkBlur = 6
+            }
+            try? await Task.sleep(for: .milliseconds(950))
+            drawing = PKDrawing()
+            inkOpacity = 1
+            inkBlur = 0
+        }
+
+        phase = .replying
+        stream(prompt: text, familiar: familiar, client: client)
+    }
+
+    /// First turn on a page carries a light framing so replies stay short and
+    /// diary-like; follow-ups send the recognized text alone (the session keeps
+    /// the framing).
+    private func prompt(for text: String) -> String {
+        guard sessionId == nil else { return text }
+        return """
+        You are the spirit answering inside an enchanted diary. Reply in 1–3 short \
+        sentences of plain prose — no markdown, no code, no lists. Someone has just \
+        written on your page: \(text)
+        """
+    }
+
+    private func stream(prompt text: String, familiar: Familiar, client: CaveClient) {
+        streamFinished = false
+        replyIsError = false
+        let body = CaveClient.SendBody(familiarId: familiar.id,
+                                       prompt: prompt(for: text),
+                                       sessionId: sessionId,
+                                       attachments: nil)
+        streamTask = Task { @MainActor in
+            do {
+                for try await event in client.sendStream(body) {
+                    if Task.isCancelled { return }
+                    switch event {
+                    case .session(let sid):
+                        if !sid.isEmpty { sessionId = sid }
+                    case .assistantChunk(let chunk):
+                        pendingReply.append(contentsOf: chunk)
+                        startRevealLoop()
+                    case .done(let isError, let sid):
+                        if let sid, !sid.isEmpty { sessionId = sid }
+                        if isError { replyIsError = true }
+                    case .error(let message):
+                        replyIsError = true
+                        if pendingReply.isEmpty && revealedReply.isEmpty {
+                            pendingReply.append(contentsOf: "The ink swirls, but nothing answers. (\(message))")
+                            startRevealLoop()
+                        }
+                    default:
+                        break
+                    }
+                }
+            } catch {
+                replyIsError = true
+                if pendingReply.isEmpty && revealedReply.isEmpty {
+                    pendingReply.append(contentsOf: "The ink swirls, but nothing answers.")
+                    startRevealLoop()
+                }
+            }
+            streamFinished = true
+            if revealTask == nil { phase = .idle } // nothing left to write out
+        }
+    }
+
+    /// Writes the buffered reply out one character at a time — the quill. An
+    /// uneven cadence (with a breath after sentences) reads as handwriting
+    /// rather than a teleprinter. Under Reduce Motion the reveal runs near-
+    /// instant so the text simply appears.
+    private func startRevealLoop() {
+        guard revealTask == nil else { return }
+        if revealedReply.isEmpty { Haptics.tap(.soft) }
+        replyOpacity = 1
+        revealTask = Task { @MainActor in
+            while !Task.isCancelled {
+                if pendingReply.isEmpty {
+                    if streamFinished { break }
+                    try? await Task.sleep(for: .milliseconds(70))
+                    continue
+                }
+                let ch = pendingReply.removeFirst()
+                revealedReply.append(ch)
+                if reduceMotion { continue }
+                let pause: Int
+                switch ch {
+                case ".", "!", "?": pause = Int.random(in: 260...400)
+                case ",", ";", "—": pause = Int.random(in: 140...220)
+                case " ":           pause = Int.random(in: 40...90)
+                default:            pause = Int.random(in: 28...58)
+                }
+                try? await Task.sleep(for: .milliseconds(pause))
+            }
+            revealTask = nil
+            if streamFinished { phase = .idle }
+        }
+    }
+
+    private func clearReply() {
+        revealTask?.cancel()
+        revealTask = nil
+        revealedReply = ""
+        pendingReply = []
+        replyOpacity = 1
+        replyIsError = false
+    }
+
+    /// Fresh page: clears the ink, the reply, and the session.
+    private func newPage() {
+        penLiftTask?.cancel()
+        streamTask?.cancel()
+        clearReply()
+        drawing = PKDrawing()
+        inkOpacity = 1
+        inkBlur = 0
+        sessionId = nil
+        phase = .idle
+        hint = nil
+    }
+
+    private func showHint(_ text: String) {
+        withAnimation { hint = text }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(4))
+            withAnimation { if hint == text { hint = nil } }
+        }
+    }
+}
+
+// MARK: - Pencil canvas
+
+/// PencilKit canvas bridged into SwiftUI. `.anyInput` keeps the page usable
+/// with a finger (and in the Simulator); on iPad the Pencil is the natural
+/// instrument. The canvas is forced light so PencilKit doesn't invert the
+/// sepia ink in dark mode.
+private struct DiaryCanvas: UIViewRepresentable {
+    @Binding var drawing: PKDrawing
+    let ink: UIColor
+    let onStrokesChanged: () -> Void
+
+    func makeUIView(context: Context) -> PKCanvasView {
+        let canvas = PKCanvasView()
+        canvas.backgroundColor = .clear
+        canvas.isOpaque = false
+        canvas.overrideUserInterfaceStyle = .light
+        canvas.drawingPolicy = .anyInput
+        canvas.tool = PKInkingTool(.pen, color: ink, width: 3.4)
+        canvas.delegate = context.coordinator
+        return canvas
+    }
+
+    func updateUIView(_ canvas: PKCanvasView, context: Context) {
+        // Push model → view only on real divergence (clearing the page); the
+        // delegate handles view → model, and an unconditional write here would
+        // re-enter the delegate for every stroke.
+        if canvas.drawing != drawing {
+            context.coordinator.squelch = true
+            canvas.drawing = drawing
+            context.coordinator.squelch = false
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, PKCanvasViewDelegate {
+        var parent: DiaryCanvas
+        /// True while updateUIView writes the drawing (programmatic changes
+        /// must not re-arm the pen-lift timer).
+        var squelch = false
+
+        init(_ parent: DiaryCanvas) { self.parent = parent }
+
+        func canvasViewDrawingDidChange(_ canvas: PKCanvasView) {
+            guard !squelch else { return }
+            parent.drawing = canvas.drawing
+            parent.onStrokesChanged()
+        }
+    }
+}
+
+// MARK: - Handwriting recognition
+
+enum DiaryHandwriting {
+    /// Read handwriting from a PencilKit drawing via Vision. The strokes are
+    /// composited onto white first — Vision needs the contrast, and a
+    /// transparent-background render can rasterize unpredictably.
+    static func recognize(_ drawing: PKDrawing) async throws -> String {
+        guard !drawing.strokes.isEmpty else { return "" }
+        let bounds = drawing.bounds.insetBy(dx: -24, dy: -24)
+        let scale: CGFloat = 2
+        let strokes = drawing.image(from: bounds, scale: scale)
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1 // the stroke image is already scaled; render 1:1
+        let size = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        let composited = UIGraphicsImageRenderer(size: size, format: format).image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+            strokes.draw(in: CGRect(origin: .zero, size: size))
+        }
+        guard let cgImage = composited.cgImage else { return "" }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let request = VNRecognizeTextRequest { request, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let observations = request.results as? [VNRecognizedTextObservation] ?? []
+                let text = observations
+                    .compactMap { $0.topCandidates(1).first?.string }
+                    .joined(separator: " ")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                continuation.resume(returning: text)
+            }
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = true
+
+            DispatchQueue.global(qos: .userInitiated).async {
+                do {
+                    try VNImageRequestHandler(cgImage: cgImage).perform([request])
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/scripts/ios-diary-page.test.mjs
+++ b/scripts/ios-diary-page.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// The Diary — the experimental iPad page where you write to a familiar with
+// Apple Pencil and the reply writes itself out live, Tom Riddle style. This
+// locks the load-bearing pieces: PencilKit input that stays Simulator-testable,
+// Vision handwriting recognition composited on white, pen-lift (not per-stroke)
+// submission, the SSE stream feeding a paced reveal loop, session resume for
+// follow-ups, and the iPad-only entry point.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const diary = await read("apps/ios/CovenCave/CovenCave/Views/DiaryView.swift");
+const home = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
+
+// ── Pencil input ─────────────────────────────────────────────────────────────
+assert.match(diary, /import PencilKit/, "the diary draws with PencilKit");
+assert.match(
+  diary,
+  /drawingPolicy = \.anyInput/,
+  "finger input stays enabled — the Simulator has no Pencil, and the page must stay testable there",
+);
+assert.match(
+  diary,
+  /overrideUserInterfaceStyle = \.light/,
+  "the canvas is forced light so PencilKit doesn't invert the sepia ink in dark mode",
+);
+assert.match(
+  diary,
+  /squelch/,
+  "programmatic drawing writes (clearing the page) must not re-enter the stroke delegate",
+);
+
+// ── Pen-lift submission (not per-stroke) ─────────────────────────────────────
+assert.match(
+  diary,
+  /penLiftTask\?\.cancel\(\)/,
+  "each new stroke re-arms the pen-lift timer — recognition fires on a writing pause, not mid-word",
+);
+
+// ── Handwriting recognition ──────────────────────────────────────────────────
+assert.match(diary, /import Vision/, "handwriting is read via Vision");
+assert.match(
+  diary,
+  /VNRecognizeTextRequest/,
+  "recognition uses VNRecognizeTextRequest",
+);
+assert.match(
+  diary,
+  /UIColor\.white\.setFill\(\)/,
+  "strokes are composited onto white before recognition — Vision needs the contrast",
+);
+assert.match(
+  diary,
+  /recognitionLevel = \.accurate/,
+  "handwriting needs the accurate recognition level",
+);
+
+// ── The reply writes itself out ──────────────────────────────────────────────
+assert.match(
+  diary,
+  /client\.sendStream\(body\)/,
+  "the reply streams through the sanctioned chat SSE bridge",
+);
+assert.match(
+  diary,
+  /sessionId: sessionId/,
+  "follow-up writes resume the same session so the diary keeps context",
+);
+assert.match(
+  diary,
+  /case \.assistantChunk\(let chunk\):[\s\S]*?pendingReply\.append/,
+  "streamed chunks land in the reveal buffer, not directly on screen",
+);
+assert.match(
+  diary,
+  /SnellRoundhand/,
+  "the reply renders in a cursive hand",
+);
+assert.match(
+  diary,
+  /case "\.", "!", "\?":/,
+  "the reveal cadence breathes at sentence ends — handwriting, not a teleprinter",
+);
+assert.match(
+  diary,
+  /reduceMotion/,
+  "Reduce Motion collapses the reveal/soak animations",
+);
+
+// ── iPad-only entry point ────────────────────────────────────────────────────
+assert.match(
+  home,
+  /if sizeClass == \.regular \{[\s\S]*?showDiary = true/,
+  "the Diary entry point only shows in regular width (iPad) — the page is sized for Pencil writing",
+);
+assert.match(
+  home,
+  /fullScreenCover\(isPresented: \$showDiary\) \{\s*\n\s*DiaryView\(\)/,
+  "the Diary opens full screen",
+);
+
+console.log("ios-diary-page.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -717,6 +717,7 @@ export const SUITES = {
     "scripts/ios-development-code-title.test.mjs",
     "scripts/ios-development-github-title.test.mjs",
     "scripts/ios-development-terminal-chrome.test.mjs",
+    "scripts/ios-diary-page.test.mjs",
     "scripts/ios-surface-failures.test.mjs",
     "scripts/mobile-tailscale.test.mjs",
     "scripts/mobile-tailscale-native.test.mjs",


### PR DESCRIPTION
## What

An experimental iPad page styled after Tom Riddle's diary: write to a familiar in your own hand with Apple Pencil, and the reply writes itself back out live in cursive.

## How it works

- **Pencil input** — a PencilKit canvas covers a parchment page. `.anyInput` drawing policy keeps the page usable with a finger (and in the Simulator, which has no Pencil); the canvas is forced light so PencilKit doesn't invert the sepia ink in dark mode.
- **Pen-lift recognition** — 1.5s after the last stroke, Vision (`VNRecognizeTextRequest`, accurate level, language correction) reads the handwriting. Strokes are composited onto white first — Vision needs the contrast.
- **The ink soaks in** — the written ink fades and blurs into the page, then the canvas clears.
- **The reply writes itself out** — streamed through the existing `POST /api/chat/send` SSE bridge into a buffer, then revealed character-by-character in SnellRoundhand cursive with an uneven cadence (a breath after sentence punctuation, shorter at commas) so it reads as a quill, not a teleprinter. Soft haptic when the writing starts.
- **Context carries** — one session per page; follow-up writes resume it. "New page" or switching the answering familiar (header menu) starts fresh. The first turn carries a light framing so replies stay short and diary-like; later turns send the recognized text alone.
- **Fades on the next message** — a finished reply dissolves when you start writing again, keeping the page clean.
- **a11y** — Reduce Motion collapses the soak/reveal animations to instant; canvas, controls, and the reply all carry labels.

## Entry point

A `book.closed` button in the Chats bottom bar, shown only in regular width (iPad — the page is sized for Pencil writing), opening the diary as a `fullScreenCover`.

## Verification

- `xcodebuild build` (iOS Simulator destination) — clean, no warnings in changed files (`@preconcurrency import Vision` quiets the module's pre-Sendable types)
- New source-contract test `scripts/ios-diary-page.test.mjs` pins the load-bearing pieces: anyInput policy, dark-mode ink guard, delegate re-entry squelch, pen-lift debounce, white compositing, SSE → reveal buffer, session resume, reveal cadence, iPad-only gate
- `node scripts/run-tests.mjs mobile` — **69/69 pass** (new test registered in the suite)
- `xcodegen generate` ran; `project.pbxproj` is gitignored so the project regenerates on checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)