### PR TITLE
feat(projects): polish the Projects table UI/UX

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -209,6 +209,14 @@ assert.match(
   /<table className="board-table board-table--grid projects-table"/,
   "Projects should render through the board table grid shell used by Tasks",
 );
+// The board-table/projects-table styling lives in board.css; ProjectsView must
+// import it directly so the surface is styled straight from Chat → Projects,
+// before Board/GitHub (the other board.css importers) have ever mounted.
+assert.match(
+  projectsViewSource,
+  /import "@\/styles\/board\.css"/,
+  "ProjectsView imports its own board.css so the table is always styled",
+);
 assert.match(
   projectsViewSource,
   /<thead>[\s\S]{0,900}?Project[\s\S]{0,900}?Status[\s\S]{0,900}?Sessions[\s\S]{0,900}?Updated[\s\S]{0,900}?Actions/,
@@ -280,6 +288,46 @@ assert.match(
 assert.match(projectsView, /visibleProjects\.map\(\(project\)/, "the filtered list drives the render");
 assert.match(projectsView, /aria-label="Filter projects"/, "there is a labeled filter input");
 assert.match(projectsView, /No projects match/, "a no-match message shows when the filter excludes everything");
+
+// An opt-in Active filter narrows to projects with a live signal WITHOUT
+// reordering — the alphabetical stability is preserved (only the visible set
+// shrinks). Active-ness derives from the shared deriveProjectStatus helper.
+assert.match(
+  projectsView,
+  /const \[statusFilter, setStatusFilter\] = useState<"all" \| "active">\("all"\)/,
+  "there is an opt-in active/all view filter, defaulting to all",
+);
+assert.match(
+  projectsView,
+  /const activeRoots = useMemo[\s\S]{0,240}?deriveProjectStatus\(list\) !== null/,
+  "active projects are derived from deriveProjectStatus over each project's chats",
+);
+assert.match(
+  projectsView,
+  /statusFilter === "active"[\s\S]{0,160}?activeRoots\.has\(normalizeProjectRoot\(p\.root\)\)/,
+  "the Active filter narrows visibleProjects to active roots",
+);
+assert.match(
+  projectsViewToolbar,
+  /aria-label="Filter by activity"/,
+  "the header exposes a labeled activity filter control",
+);
+assert.match(
+  projectsViewToolbar,
+  /aria-pressed=\{statusFilter === opt\.value\}/,
+  "the activity filter reflects the active option",
+);
+// The header summary surfaces how many projects are currently active.
+assert.match(projectsViewToolbar, /\{activeCount\} active/, "the header summarizes the active-project count");
+
+// The Sessions cell leads with a glanceable count (no repeated "sessions"
+// noun — the column header carries it) while staying labeled for assistive tech.
+assert.match(projectsView, /className="board-table-cell-sessions"/, "the sessions cell uses the glanceable stat treatment");
+assert.match(
+  projectsView,
+  /aria-label=\{`\$\{chatCount\} \$\{chatCount === 1 \? "session" : "sessions"\}`\}/,
+  "the sessions count keeps a full accessible label",
+);
 
 // Each project row carries a glanceable status dot: accent when a session is
 // running, danger when the most-recent session failed.

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -2,10 +2,16 @@
 
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 
+// The Projects table's styling (every `board-table`/`projects-table` class)
+// lives in board.css. Import it directly so the surface is always styled — it's
+// reachable straight from the Chat → Projects tab, before Board/GitHub (the
+// other board.css importers) have ever mounted.
+import "@/styles/board.css";
 import { Icon } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { normalizeProjectRoot, sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
+import { deriveProjectStatus } from "@/lib/project-status";
 import { addChatProject } from "@/lib/chat-add-project";
 import type { SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
@@ -59,7 +65,7 @@ type ProjectsViewProps = {
 
 export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, activeFamiliarId = null }: ProjectsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
-  useMinuteTick(); // keep the per-project "last active" relative times current
+  const minuteTick = useMinuteTick(); // keep "last active" relative times + the active filter current
   const {
     projects,
     loading,
@@ -73,6 +79,10 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   } = useProjects({ familiarId: activeFamiliarId });
   const [showForm, setShowForm] = useState(false);
   const [query, setQuery] = useState("");
+  // Opt-in "Active" view filter (ephemeral — resets each visit so a project is
+  // never surprisingly hidden). It only narrows the list; it never reorders it,
+  // so the alphabetical order stays stable.
+  const [statusFilter, setStatusFilter] = useState<"all" | "active">("all");
   const searchRef = useRef<HTMLInputElement>(null);
   const rootInputRef = useRef<HTMLInputElement>(null);
   const [nameDraft, setNameDraft] = useState("");
@@ -185,15 +195,36 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     return sortProjectsAlphabetically(projects);
   }, [projects]);
 
+  // Roots with a live signal (running / recently-failed / active ≤24h) — powers
+  // the header's active count and the opt-in Active filter. Recomputed each
+  // minute (minuteTick) so "recent" ages out. Never reorders the list.
+  const activeRoots = useMemo(() => {
+    void minuteTick;
+    const set = new Set<string>();
+    for (const [root, list] of chatsByRoot) {
+      if (deriveProjectStatus(list) !== null) set.add(root);
+    }
+    return set;
+  }, [chatsByRoot, minuteTick]);
+  const activeCount = useMemo(
+    () => sortedProjects.reduce((n, p) => n + (activeRoots.has(normalizeProjectRoot(p.root)) ? 1 : 0), 0),
+    [sortedProjects, activeRoots],
+  );
+
   // Filter by name or path so the alphabetical list stays scannable when there
-  // are many projects.
+  // are many projects, then (opt-in) narrow to active projects only.
   const visibleProjects = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return sortedProjects;
-    return sortedProjects.filter(
-      (p) => p.name.toLowerCase().includes(q) || p.root.toLowerCase().includes(q),
-    );
-  }, [sortedProjects, query]);
+    let list = q
+      ? sortedProjects.filter(
+          (p) => p.name.toLowerCase().includes(q) || p.root.toLowerCase().includes(q),
+        )
+      : sortedProjects;
+    if (statusFilter === "active") {
+      list = list.filter((p) => activeRoots.has(normalizeProjectRoot(p.root)));
+    }
+    return list;
+  }, [sortedProjects, query, statusFilter, activeRoots]);
 
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
@@ -355,11 +386,51 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
     <div className="flex h-full min-w-0 flex-col bg-[var(--bg-base)]">
       <header className="shrink-0 border-b border-[var(--border-hairline)] px-4 py-2.5 sm:px-6">
         <div className="flex items-center justify-between gap-3">
-          <span className="text-[12px] text-[var(--text-muted)]">
-            {query.trim() && visibleProjects.length !== projects.length
-              ? `${visibleProjects.length} of ${projects.length} projects`
-              : `${projects.length} ${projects.length === 1 ? "project" : "projects"}`}
-          </span>
+          <div className="flex min-w-0 items-center gap-2.5">
+            <span className="shrink-0 text-[12px] text-[var(--text-muted)]">
+              {query.trim() && visibleProjects.length !== projects.length ? (
+                `${visibleProjects.length} of ${projects.length} projects`
+              ) : statusFilter === "active" ? (
+                `${activeCount} active project${activeCount === 1 ? "" : "s"}`
+              ) : (
+                <>
+                  {projects.length} {projects.length === 1 ? "project" : "projects"}
+                  {activeCount > 0 ? (
+                    <span className="text-[var(--accent-presence)]"> · {activeCount} active</span>
+                  ) : null}
+                </>
+              )}
+            </span>
+            {/* Opt-in Active filter — only useful (and shown) when there's a mix
+                of active and idle projects. Narrows without reordering. */}
+            {statusFilter === "active" || (projects.length > 1 && activeCount > 0 && activeCount < projects.length) ? (
+              <div
+                role="group"
+                aria-label="Filter by activity"
+                className="flex shrink-0 items-center rounded-[var(--radius-control)] border border-[var(--border-hairline)] p-0.5"
+              >
+                {([
+                  { value: "all", label: "All" },
+                  { value: "active", label: "Active" },
+                ] as const).map((opt) => (
+                  <Button
+                    key={opt.value}
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => setStatusFilter(opt.value)}
+                    aria-pressed={statusFilter === opt.value}
+                    className={`h-7 rounded-[var(--radius-control)] px-2 text-[11px] font-medium ${
+                      statusFilter === opt.value
+                        ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                        : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                    }`}
+                  >
+                    {opt.value === "active" ? `Active ${activeCount}` : opt.label}
+                  </Button>
+                ))}
+              </div>
+            ) : null}
+          </div>
           <div className="flex items-center gap-2">
             <div
               role="group"
@@ -629,7 +700,9 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
             ) : null}
             {visibleProjects.length === 0 ? (
               <p className="px-2 py-6 text-center text-[12px] text-[var(--text-muted)]">
-                No projects match “{query.trim()}”.
+                {query.trim()
+                  ? `No projects match “${query.trim()}”.`
+                  : "No active projects right now."}
               </p>
             ) : (
               <DndContext id="projects-grid" sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
@@ -637,8 +710,8 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
                   <table className="board-table board-table--grid projects-table">
                     <colgroup>
                       <col />
-                      <col style={{ width: "130px" }} />
-                      <col style={{ width: "110px" }} />
+                      <col style={{ width: "120px" }} />
+                      <col style={{ width: "138px" }} />
                       <col style={{ width: "112px" }} />
                       <col style={{ width: "180px" }} />
                     </colgroup>

--- a/src/components/projects/project-row.tsx
+++ b/src/components/projects/project-row.tsx
@@ -373,7 +373,7 @@ export function ProjectRow({
         </td>
 
         <td>
-          <span className="board-table-cell-status">
+          <span className={`board-table-cell-status${projectStatus ? "" : " board-table-cell-status--idle"}`}>
             {projectStatus ? (
               <span className={`board-table-status-dot ${chatDotClass(projectStatus)}`} aria-hidden />
             ) : null}
@@ -382,10 +382,24 @@ export function ProjectRow({
         </td>
 
         <td>
-          <span className="flex shrink-0 items-center gap-1.5 text-[10px] text-[var(--text-muted)]">
+          {/* Glanceable sessions metric: the count leads (the column header
+              already says "Sessions", so the noun is dropped), with running /
+              task chips trailing. Full text stays available to assistive tech. */}
+          <span
+            className="board-table-cell-sessions"
+            aria-label={`${chatCount} ${chatCount === 1 ? "session" : "sessions"}`}
+          >
+          {chatCount > 0 ? (
+            <span className="projects-session-count">
+              <Icon name="ph:chats-circle" width={12} aria-hidden />
+              {chatCount}
+            </span>
+          ) : (
+            <span className="board-table-muted" aria-hidden>—</span>
+          )}
           {stats.running > 0 ? (
             <span
-              className="inline-flex items-center gap-1 font-medium text-[var(--accent-presence)]"
+              className="projects-session-chip projects-session-chip--running"
               title={`${stats.running} running`}
             >
               <Icon name="ph:circle-notch-bold" width={9} className="animate-spin" aria-hidden />
@@ -394,16 +408,13 @@ export function ProjectRow({
           ) : null}
           {stats.tasks > 0 ? (
             <span
-              className="inline-flex items-center gap-1"
+              className="projects-session-chip"
               title={`${stats.tasks} ${stats.tasks === 1 ? "task" : "tasks"}`}
             >
               <Icon name="ph:check-square" width={10} aria-hidden />
               {stats.tasks}
             </span>
           ) : null}
-          <span className="rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-0.5">
-            {chatCount} {chatCount === 1 ? "session" : "sessions"}
-          </span>
           </span>
         </td>
 

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -236,6 +236,21 @@
 .projects-table-wrap { flex:1; min-height:0; }
 .projects-table-row--compact td { padding-top:6px; padding-bottom:6px; }
 .projects-table-row--comfortable td { padding-top:10px; padding-bottom:10px; }
+/* The projects list is intentionally alphabetical + stable (not sortable), so
+   the headers must NOT inherit board-table's clickable/brighten-on-hover look —
+   that would imply a sort affordance that doesn't exist. */
+.projects-table thead th { cursor:default; }
+.projects-table thead th:hover { color:var(--text-muted); }
+/* Idle projects recede; active ones keep their dot + primary-weight label. */
+.board-table-cell-status--idle { color:var(--text-muted); }
+/* Sessions cell: count leads, running/task chips trail. Single line always —
+   the fixed column is narrow, so nowrap keeps the metric on one row (overflow
+   is clipped rather than stacked). */
+.board-table-cell-sessions { display:inline-flex; align-items:center; gap:6px; min-width:0; max-width:100%; flex-wrap:nowrap; white-space:nowrap; overflow:hidden; }
+.projects-session-count { display:inline-flex; align-items:center; gap:5px; flex:none; white-space:nowrap; color:var(--text-secondary); font-size:12px; font-variant-numeric:tabular-nums; font-weight:500; }
+.projects-session-count > svg { color:var(--text-muted); }
+.projects-session-chip { display:inline-flex; align-items:center; gap:3px; flex:none; padding:1px 6px; border-radius:999px; white-space:nowrap; background:color-mix(in oklch,var(--foreground) 6%,transparent); color:var(--text-muted); font-size:10px; font-variant-numeric:tabular-nums; }
+.projects-session-chip--running { color:var(--accent-presence); background:color-mix(in oklch,var(--accent-presence) 12%,transparent); font-weight:600; }
 .projects-table-detail-row { cursor:default; }
 .projects-table-detail-row:hover { background:transparent; }
 .projects-table-detail-row td {


### PR DESCRIPTION
A UI/UX pass over the **Projects** tab (Chat → Projects) to make the table cleaner and more glanceable — plus a latent styling-bug fix surfaced along the way.

### Changes
- **Sessions cell → single-line glanceable metric.** The count leads (icon + number; the column header already carries the "sessions" noun, so it's dropped), with running / task chips trailing. Adds a `nowrap` rule + a slightly wider column so realistic counts never wrap into the cramped multi-line stack they did before. Full text stays available to assistive tech via `aria-label`.
- **Fix a latent styling bug.** `board.css` (every `board-table`/`projects-table` class) was only imported by `board-view`/`github-view` — so opening **Chat → Projects before ever visiting Board/GitHub** rendered the table unstyled. `ProjectsView` now imports `board.css` directly, exactly as `github-view.tsx` already does.
- **Drop the misleading sortable-looking headers.** The list is intentionally alphabetical + stable (#2 "stabilize project scoping and ordering" deliberately reverted recency-sorting), so the inherited `board-table` `cursor:pointer` / brighten-on-hover implied a sort affordance that doesn't exist. Now `cursor:auto`.
- **Header summary + Active filter.** The count line surfaces the active-project count ("N active"), with an opt-in **All / Active** activity filter. It only *narrows* the visible set — never reorders — so alphabetical stability is preserved and nothing is surprisingly hidden (the filter is ephemeral, defaulting to All).
- **De-emphasize Idle status** so active projects stand out.

### Respecting existing decisions
No recency/session-count reordering (keeps `sortProjectsAlphabetically`, no `b.score - a.score`) — the Active filter is a stable, opt-in *narrowing*, not a re-sort.

### Verification
- `pnpm typecheck` clean
- Full app suite → **520 test files pass** (added assertions for the Active filter, the glanceable sessions cell, and the board.css import)
- **Live app** (real project data): 22 projects; the Active filter narrows to 8 (matching the "Active 8" count); sessions cells render single-line (18px, zero wrapping); headers no longer imply sortability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)