### PR TITLE
Deduplicate listed projects

### DIFF
--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -26,6 +26,25 @@ export function compareProjectsAlphabetically(a: CaveProject, b: CaveProject): n
   return a.root.localeCompare(b.root, undefined, { sensitivity: "base", numeric: true });
 }
 
+function projectTimestamp(project: CaveProject): number {
+  const updatedAt = Date.parse(project.updatedAt);
+  if (Number.isFinite(updatedAt)) return updatedAt;
+  const createdAt = Date.parse(project.createdAt);
+  return Number.isFinite(createdAt) ? createdAt : Number.NEGATIVE_INFINITY;
+}
+
+export function dedupeProjectsByRoot(projects: CaveProject[]): CaveProject[] {
+  const byRoot = new Map<string, CaveProject>();
+  for (const project of projects) {
+    const root = normalizeProjectRoot(project.root);
+    const existing = byRoot.get(root);
+    if (!existing || projectTimestamp(project) > projectTimestamp(existing)) {
+      byRoot.set(root, project);
+    }
+  }
+  return [...byRoot.values()];
+}
+
 export function sortProjectsAlphabetically(projects: CaveProject[]): CaveProject[] {
-  return [...projects].sort(compareProjectsAlphabetically);
+  return dedupeProjectsByRoot(projects).sort(compareProjectsAlphabetically);
 }

--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -11,6 +11,7 @@ try {
   const {
     createProject,
     deleteProject,
+    dedupeProjectsByRoot,
     loadProjects,
     patchProject,
     projectById,
@@ -92,6 +93,37 @@ try {
     ]).map((project) => project.id),
     ["a1", "a2", "z"],
     "shared project sorting is alphabetical by name, then root",
+  );
+
+  const duplicateRootProjects = [
+    {
+      id: "old",
+      name: "Old alpha",
+      root: `C:\\work\\alpha${"/".repeat(4)}`,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    },
+    {
+      id: "new",
+      name: "Alpha",
+      root: "C:/work/alpha",
+      createdAt: "2026-01-02T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    },
+    { id: "solo", name: "Solo", root: "/work/solo", createdAt: "", updatedAt: "" },
+  ];
+  assert.deepEqual(
+    dedupeProjectsByRoot(duplicateRootProjects).map((project) => project.id),
+    ["new", "solo"],
+    "project dedupe keeps one row per normalized root and prefers the newest record",
+  );
+  assert.deepEqual(
+    sortProjectsAlphabetically([
+      { id: "z", name: "Zed", root: "/work/zed", createdAt: "", updatedAt: "" },
+      ...duplicateRootProjects,
+    ]).map((project) => project.id),
+    ["new", "solo", "z"],
+    "shared project sorting deduplicates by normalized root before alphabetical order",
   );
 
   console.log("cave-projects.test.ts: ok");

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -4,7 +4,11 @@ import { homedir } from "node:os";
 import path from "node:path";
 
 export type { CaveProject } from "./cave-projects-types.ts";
-export { normalizeProjectRoot, sortProjectsAlphabetically } from "./cave-projects-types.ts";
+export {
+  dedupeProjectsByRoot,
+  normalizeProjectRoot,
+  sortProjectsAlphabetically,
+} from "./cave-projects-types.ts";
 import type { CaveProject } from "./cave-projects-types.ts";
 
 type ProjectsFile = {


### PR DESCRIPTION
## Summary
- Deduplicate project lists by normalized root in the shared project ordering helper
- Prefer the newest duplicate project record so updated names/colors survive
- Cover normalized-root dedupe and sorted display behavior in cave project tests

## Verification
- node --experimental-strip-types src/lib/cave-projects.test.ts
- node --experimental-strip-types src/components/projects-view.test.ts
- node --experimental-strip-types src/components/project-picker.test.ts
- git diff --check
- pnpm typecheck
- pnpm check:tests-wired
- pnpm test:app