### PR TITLE
docs(changelog): add release highlight banner to v0.0.141

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ breaking config changes; patch releases stay additive.
 
 ## [0.0.141] - 2026-07-06
 
+> ⚡ **Quick chat is now a real conversation** — the menubar / ⌘J dropdown holds a full multi-turn thread: streaming replies, context that carries across turns, copy & regenerate, all without leaving what you were doing.
+
 Feature release on top of v0.0.140. Remakes the quick-chat menubar dropdown
 into a genuine multi-turn conversational surface.
 


### PR DESCRIPTION
Mirrors the one-line highlight banner from the [published v0.0.141 release notes](https://github.com/OpenCoven/coven-cave/releases/tag/v0.0.141) into the `CHANGELOG.md` `[0.0.141]` section so both records match.

> ⚡ **Quick chat is now a real conversation** — the menubar / ⌘J dropdown holds a full multi-turn thread: streaming replies, context that carries across turns, copy & regenerate, all without leaving what you were doing.

Docs-only, one line added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)