### PR TITLE
Fix dashboard cockpit analytics accuracy

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -67,6 +67,9 @@ assert.match(cockpit, /Sessions · 7d/, "a weekly-sessions usage vital is surfac
 assert.match(cockpit, /Retro accept rate/, "a retro accept-rate performance vital is surfaced");
 assert.match(cockpit, /Contract health/, "a contract-health performance vital is surfaced");
 assert.match(cockpit, /Needs you/, "the attention vital is kept");
+assert.match(cockpit, /contractFetchPartial/, "capped contract/confidence KPI coverage is explicitly tracked");
+assert.match(cockpit, /first \$\{fetched\}\/\$\{total\} \$\{verb\}/, "partial KPI subtitles show first-N familiar coverage");
+assert.match(cockpit, /familiarsLoaded: ready\.has\("familiars"\)/, "empty-coven insight is gated until familiars load");
 
 // ── Truthful freshness + drill-throughs everywhere ──
 

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -228,6 +228,8 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
   } | null>(null);
   const contractFams = data.familiars.slice(0, CONTRACT_FETCH_CAP);
   const contractKey = contractFams.map((f) => f.id).join(",");
+  const contractFetchedCount = contractFams.length;
+  const contractFetchPartial = data.familiars.length > contractFetchedCount;
   useEffect(() => {
     if (!contractKey) { setConfidenceRaw(null); return; }
     let alive = true;
@@ -309,7 +311,10 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     }),
     [insightRows, data.sessions, confidenceRaw, nowMs],
   );
-  const covenInsight = useMemo(() => deriveCovenInsight({ vitals, rows: insightRows }), [vitals, insightRows]);
+  const covenInsight = useMemo(
+    () => deriveCovenInsight({ vitals, rows: insightRows, familiarsLoaded: ready.has("familiars") }),
+    [vitals, insightRows, ready],
+  );
   const covenSeries = useMemo(() => covenSessionsSeries(data.sessions, nowMs, 14), [data.sessions, nowMs]);
 
   // ── Vitals KPI specs. Every tile is a live analytics figure with a 7-day
@@ -317,12 +322,14 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
   //    colored by meaning, and drills into the surface that owns the number. ──
   const contractPct = vitals.contractTotal ? Math.round((vitals.contractPass / vitals.contractTotal) * 100) : null;
   const acceptPct = vitals.retroAcceptRate != null ? Math.round(vitals.retroAcceptRate * 100) : null;
+  const scoredCoverageSub = coverageSub(vitals.confidenceTier ?? "no scores yet", contractFetchedCount, data.familiars.length, "scored");
+  const contractCoverageSub = coverageSub(contractSub(vitals), contractFetchedCount, data.familiars.length, "checked");
   const kpis: KpiSpec[] = [
-    { icon: "ph:seal-check", value: vitals.avgConfidence, label: "Coven confidence", sub: vitals.confidenceTier ?? "no scores yet", accent: "teal", metric: "confidence", good: "up", href: "/dashboard/familiars/growth" },
+    { icon: "ph:seal-check", value: vitals.avgConfidence, label: "Coven confidence", sub: contractFetchPartial ? scoredCoverageSub : vitals.confidenceTier ?? "no scores yet", accent: "teal", metric: "confidence", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:sparkle", value: vitals.activeFamiliars, label: "Active familiars", sub: `${vitals.familiarCount} in coven`, accent: "green", metric: "active", good: "up", src: "familiars", href: "/?mode=agents" },
     { icon: "ph:heartbeat", value: vitals.sessions7d, label: "Sessions · 7d", sub: wowSub(vitals.sessionsWowDelta), accent: "lavender", metric: "sessions", good: "up", src: "sessions", href: "/?mode=agents" },
     { icon: "ph:flag-checkered", value: acceptPct, suffix: "%", label: "Retro accept rate", sub: retroSub(vitals), accent: "blue", metric: "accept", good: "up", href: "/dashboard/familiars/growth" },
-    { icon: "ph:list-checks-bold", value: contractPct, suffix: "%", label: "Contract health", sub: contractSub(vitals), accent: "amber", metric: "contract", good: "up", href: "/dashboard/familiars/growth" },
+    { icon: "ph:list-checks-bold", value: contractPct, suffix: "%", label: "Contract health", sub: contractFetchPartial ? contractCoverageSub : contractSub(vitals), accent: "amber", metric: "contract", good: "up", href: "/dashboard/familiars/growth" },
     { icon: "ph:warning-circle", value: model.needsAttention.length, label: "Needs you", sub: model.caughtUp ? "all clear" : "open items", accent: "rose", metric: "needs", good: "down" },
   ];
 
@@ -647,6 +654,10 @@ function retroSub(v: CovenVitals): string {
 function contractSub(v: CovenVitals): string {
   if (v.contractTotal === 0) return "no contracts";
   return `${v.contractPass}/${v.contractTotal} passing`;
+}
+function coverageSub(base: string, fetched: number, total: number, verb: "scored" | "checked"): string {
+  if (total <= fetched) return base;
+  return `${base} · first ${fetched}/${total} ${verb}`;
 }
 
 // ─── Familiar insights table (centerpiece) ────────────────────────────────────────

--- a/src/components/familiars-view-stats.test.ts
+++ b/src/components/familiars-view-stats.test.ts
@@ -16,6 +16,8 @@ const sessions = [
   { id: "s1", familiarId: "f1", updated_at: minutesAgo(2), project_root: "/r", harness: "claude", title: "t", status: "running", exit_code: null, archived_at: null, created_at: minutesAgo(10) },
   { id: "s2", familiarId: "f1", updated_at: daysAgo(1), project_root: "/r", harness: "claude", title: "t", status: "stopped", exit_code: 0, archived_at: null, created_at: daysAgo(1) },
   { id: "s3", familiarId: "f1", updated_at: daysAgo(8), project_root: "/r", harness: "claude", title: "t", status: "stopped", exit_code: 0, archived_at: null, created_at: daysAgo(8) },
+  { id: "s5", familiarId: "f1", updated_at: minutesAgo(1), project_root: "/r", harness: "claude", title: "t", status: "stopped", exit_code: 0, archived_at: null, created_at: daysAgo(9) },
+  { id: "s6", familiarId: "f1", updated_at: minutesAgo(1), project_root: "/r", harness: "claude", title: "t", status: "stopped", exit_code: 0, archived_at: minutesAgo(1), created_at: minutesAgo(1) },
   { id: "s4", familiarId: "f2", updated_at: daysAgo(3), project_root: "/r", harness: "claude", title: "t", status: "stopped", exit_code: 0, archived_at: null, created_at: daysAgo(3) },
 ];
 
@@ -31,9 +33,9 @@ const stats = buildFamiliarCardStats({ familiars, sessions, covenEntries, now: N
 const f1 = stats.get("f1");
 assert.equal(f1?.memoryCount, 2, "f1 has 2 memories");
 assert.equal(f1?.latestMemory?.title, "Latest f1 memory", "f1 latest memory is the most-recent one");
-assert.equal(f1?.lastSessionAt, sessions[0].updated_at, "f1 last session is the most-recent");
+assert.equal(f1?.lastSessionAt, sessions[0].created_at, "f1 last session uses the newest non-archived session start");
 assert.equal(f1?.sessionsLast7d, 2, "f1 has 2 sessions in the last 7d (s1 and s2; s3 is excluded at 8d)");
-assert.equal(f1?.hasActiveSession, true, "f1 has an active session (2min < 5min)");
+assert.equal(f1?.hasActiveSession, false, "f1 has no session start in the active window");
 
 // f2
 const f2 = stats.get("f2");
@@ -67,6 +69,14 @@ const edge5m = buildFamiliarCardStats({
   now: NOW,
 });
 assert.equal(edge5m.get("y")?.hasActiveSession, false, "session at exactly 5min ago is not active");
+
+const activeCreated = buildFamiliarCardStats({
+  familiars: [{ id: "a", display_name: "A", role: "" }],
+  sessions: [{ id: "recent", familiarId: "a", updated_at: minutesAgo(1), project_root: "/r", harness: "c", title: "t", status: "s", exit_code: 0, archived_at: null, created_at: minutesAgo(1) }],
+  covenEntries: [],
+  now: NOW,
+});
+assert.equal(activeCreated.get("a")?.hasActiveSession, true, "recent non-archived session start is active");
 
 // Empty inputs
 const empty = buildFamiliarCardStats({ familiars: [], sessions: [], covenEntries: [], now: NOW });

--- a/src/components/familiars-view-stats.ts
+++ b/src/components/familiars-view-stats.ts
@@ -23,6 +23,10 @@ export type FamiliarCardStats = {
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60_000;
 const FIVE_MINUTES_MS = 5 * 60_000;
 
+function sessionStartAt(session: SessionRow): string | null {
+  return session.created_at ?? session.updated_at ?? null;
+}
+
 export function buildFamiliarCardStats(args: {
   familiars: Familiar[];
   sessions: SessionRow[];
@@ -35,6 +39,7 @@ export function buildFamiliarCardStats(args: {
 
   const sessionsByFamiliar = new Map<string, SessionRow[]>();
   for (const session of args.sessions) {
+    if (session.archived_at) continue;
     const fid = session.familiarId;
     if (!fid) continue;
     const bucket = sessionsByFamiliar.get(fid) ?? [];
@@ -59,11 +64,13 @@ export function buildFamiliarCardStats(args: {
     let sessionsLast7d = 0;
     let hasActiveSession = false;
     for (const session of sessions) {
-      const ms = Date.parse(session.updated_at);
+      const startedAt = sessionStartAt(session);
+      if (!startedAt) continue;
+      const ms = Date.parse(startedAt);
       if (!Number.isFinite(ms)) continue;
       if (ms > lastSessionMs) {
         lastSessionMs = ms;
-        lastSessionAt = session.updated_at;
+        lastSessionAt = startedAt;
       }
       if (ms > sevenCutoff) sessionsLast7d += 1;
       if (ms > activeCutoff) hasActiveSession = true;

--- a/src/lib/coven-analytics.test.ts
+++ b/src/lib/coven-analytics.test.ts
@@ -97,6 +97,14 @@ assert.equal(confidenceTier(0), "Low");
   assert.equal(insight.tone, "warn");
 }
 
+// ── deriveCovenInsight: loading roster should not read as empty coven ───────
+{
+  const vitals = deriveCovenVitals({ rows: [], sessions: [], retro: null, nowMs: NOW });
+  const insight = deriveCovenInsight({ vitals, rows: [], familiarsLoaded: false });
+  assert.match(insight.headline, /Loading familiars/i);
+  assert.doesNotMatch(insight.headline, /No familiars/i);
+}
+
 // ── deriveCovenInsight: healthy coven reads "good" and names the leader ──────
 {
   const sessions = [sess("a", "f1", 0), sess("b", "f1", 1), sess("c", "f2", 0)];

--- a/src/lib/coven-analytics.ts
+++ b/src/lib/coven-analytics.ts
@@ -162,8 +162,16 @@ function capitalize(text: string): string {
  * most pressing concern (stalled → quiet) or, when all is well, a positive.
  * Tone reflects the worst live signal.
  */
-export function deriveCovenInsight(input: { vitals: CovenVitals; rows: FamiliarInsightRow[] }): CovenInsight {
+export function deriveCovenInsight(input: { vitals: CovenVitals; rows: FamiliarInsightRow[]; familiarsLoaded?: boolean }): CovenInsight {
   const { vitals, rows } = input;
+
+  if (input.familiarsLoaded === false) {
+    return {
+      headline: "Loading familiars",
+      detail: "Fetching the coven roster before reading activity, confidence, and contract health.",
+      tone: "warn",
+    };
+  }
 
   if (vitals.familiarCount === 0) {
     return {


### PR DESCRIPTION
## Summary
- Align familiar activity stats with dashboard chart semantics by ignoring archived sessions and counting session starts instead of update recency.
- Gate the coven empty-state insight until the familiar roster has loaded.
- Mark capped confidence and contract KPI coverage as partial for large covens.

## Tracking
- Beads: cave-edz

## Verification
- [x] git diff --check -- src/app/dashboard-page.test.ts src/components/dashboard/dashboard-cockpit.tsx src/components/familiars-view-stats.test.ts src/components/familiars-view-stats.ts src/lib/coven-analytics.test.ts src/lib/coven-analytics.ts
- [x] pnpm check:tests-wired
- [x] pnpm typecheck
- [x] pnpm test:app
