### PR TITLE
feat(marketplace): ultraminimal header + comprehensive UX/functionality pass

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11543,103 +11543,13 @@ details[open] > .cave-edit-card__summary::before {
   }
 }
 
-/* ── Marketplace section overview: Browse · Roles · Skills · Capabilities ── */
-.marketplace-section-overview {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-  width: 100%;
-}
-.marketplace-section-card {
-  display: flex;
-  min-height: 82px;
-  min-width: 0;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 5px;
-  border: 1px solid var(--border-hairline);
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--bg-panel, var(--bg-base)) 82%, transparent);
-  color: var(--text-secondary);
-  padding: 9px 10px;
-  text-align: left;
-  transition:
-    border-color 0.12s ease,
-    background 0.12s ease,
-    color 0.12s ease;
-}
-.marketplace-section-card:hover {
-  border-color: var(--border-strong);
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-.marketplace-section-card.is-active {
-  border-color: color-mix(in oklch, var(--accent-presence) 46%, var(--border-hairline));
-  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-panel, var(--bg-base)));
-  color: var(--text-primary);
-}
-.marketplace-section-card[data-status="error"] {
-  border-color: color-mix(in oklch, var(--danger-border) 70%, var(--border-hairline));
-}
-.marketplace-section-card__top {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  font-weight: 700;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-.marketplace-section-card__label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.marketplace-section-card__metric {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 14px;
-  font-weight: 750;
-  line-height: 1.15;
-  color: var(--text-primary);
-}
-.marketplace-section-card__detail {
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 11px;
-  line-height: 1.2;
-  color: var(--text-muted);
-}
+/* ── Marketplace browse toolbar: result context · kind filter · sort ── */
 .marketplace-browse-summary {
   display: flex;
   min-width: 0;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-}
-.marketplace-browse-summary__metrics {
-  display: flex;
-  max-width: 52%;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 5px;
-  color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1;
-}
-.marketplace-browse-summary__metrics span {
-  min-height: 22px;
-  border: 1px solid color-mix(in oklch, var(--border-hairline) 84%, transparent);
-  border-radius: 8px;
-  background: color-mix(in oklch, var(--bg-panel) 76%, transparent);
-  padding: 5px 7px;
-  white-space: nowrap;
 }
 .marketplace-category-stack {
   display: flex;
@@ -11661,7 +11571,7 @@ details[open] > .cave-edit-card__summary::before {
   border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
   padding-bottom: 7px;
 }
-.marketplace-category-group__head h4 {
+.marketplace-category-group__head h2 {
   margin: 0;
   overflow: hidden;
   color: var(--text-primary);
@@ -11792,10 +11702,6 @@ details[open] > .cave-edit-card__summary::before {
   .marketplace-browse-summary {
     flex-direction: column;
     gap: 8px;
-  }
-  .marketplace-browse-summary__metrics {
-    max-width: 100%;
-    justify-content: flex-start;
   }
   .marketplace-detail__decision-grid {
     grid-template-columns: 1fr;
@@ -12374,12 +12280,6 @@ details[open] > .cave-edit-card__summary::before {
   .skill-browser__rail { display: none; }
 }
 @media (max-width: 680px) {
-  .marketplace-section-overview {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-  .marketplace-section-card {
-    min-height: 74px;
-  }
   .skill-browser { flex-direction: column; }
   .skill-browser__list {
     flex: 0 0 min(360px, 58%);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12277,7 +12277,25 @@ details[open] > .cave-edit-card__summary::before {
 @media (prefers-reduced-motion: reduce) { .skill-browser__skeleton span { animation: none; } }
 
 @media (max-width: 900px) {
-  .skill-browser__rail { display: none; }
+  /* Narrow panes: the rail becomes a horizontal strip. It is the ONLY
+     category control — hiding it stranded 681-900px panes with whatever
+     category was last picked and no way to change it. */
+  .skill-browser__rail {
+    flex: 0 0 auto;
+    flex-direction: row;
+    gap: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 8px 10px;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-hairline);
+  }
+  .skill-browser__cat {
+    flex: 0 0 auto;
+    padding: 5px 9px;
+    white-space: nowrap;
+  }
+  .skill-browser__cat-label { flex: 0 0 auto; }
 }
 @media (max-width: 680px) {
   .skill-browser { flex-direction: column; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12277,11 +12277,17 @@ details[open] > .cave-edit-card__summary::before {
 @media (prefers-reduced-motion: reduce) { .skill-browser__skeleton span { animation: none; } }
 
 @media (max-width: 900px) {
-  /* Narrow panes: the rail becomes a horizontal strip. It is the ONLY
-     category control — hiding it stranded 681-900px panes with whatever
+  /* Narrow panes: the rail becomes a horizontal strip spanning the top and
+     the browser re-lays as a grid (strip / list · detail). The rail is the
+     ONLY category control — hiding it stranded 681-900px panes with whatever
      category was last picked and no way to change it. */
+  .skill-browser {
+    display: grid;
+    grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
   .skill-browser__rail {
-    flex: 0 0 auto;
+    grid-column: 1 / -1;
     flex-direction: row;
     gap: 4px;
     overflow-x: auto;
@@ -12298,10 +12304,13 @@ details[open] > .cave-edit-card__summary::before {
   .skill-browser__cat-label { flex: 0 0 auto; }
 }
 @media (max-width: 680px) {
-  .skill-browser { flex-direction: column; }
+  /* Single column: strip / list / detail (the ≤900px grid handles columns). */
+  .skill-browser {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1.2fr) minmax(0, 1fr);
+  }
+  .skill-browser__rail { grid-column: 1; }
   .skill-browser__list {
-    flex: 0 0 min(360px, 58%);
-    max-height: 58%;
     border-right: 0;
     border-bottom: 1px solid var(--border-hairline);
   }

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -231,7 +231,7 @@ export function CapabilitiesViewSurface({
       const res = await fetch(url, { cache: "no-store" });
       const json = (await res.json()) as CapabilitiesResponse;
       if (!json.ok) {
-        setError(json.error ?? `daemon http ${res.status}`);
+        setError(json.error ?? "Couldn't reach the Coven daemon.");
         setItems([]);
         setCovenSkills([]);
         setScannedAt(null);
@@ -400,9 +400,27 @@ export function CapabilitiesViewSurface({
     }
   }, []);
 
-  const openLocalPath = useCallback((path?: string) => {
+  const openLocalPath = useCallback(async (path?: string) => {
     if (!path || !path.startsWith("/")) return;
-    window.open(`file://${path}`, "_blank", "noopener");
+    // Browsers block file:// navigation from an http(s) origin, so the old
+    // window.open silently did nothing on the web. Desktop opens via Tauri;
+    // the web falls back to copying the path and the action label says so.
+    if (typeof window !== "undefined" && "__TAURI_INTERNALS__" in window) {
+      try {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("shell_open", { url: path });
+        return;
+      } catch {
+        // fall through to the clipboard
+      }
+    }
+    try {
+      await copyText(path);
+      setCopiedKey("open");
+      window.setTimeout(() => setCopiedKey(null), 1200);
+    } catch {
+      setCopiedKey(null);
+    }
   }, []);
 
   const applyHarnessFilter = (id: string | null) => {
@@ -887,9 +905,9 @@ function CapabilityDetails({
               onClick={() => void onCopy("path", item.sourcePath)}
             />
             <InspectorAction
-              icon="ph:file-text"
-              label="Open file"
-              onClick={() => onOpenPath(item.sourcePath)}
+              icon={copiedKey === "open" ? "ph:check" : "ph:file-text"}
+              label={copiedKey === "open" ? "Path copied" : "Open file"}
+              onClick={() => void onOpenPath(item.sourcePath)}
             />
           </>
         ) : null}
@@ -1083,7 +1101,7 @@ function CapabilityPreviewModal({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-[var(--backdrop-scrim)] p-4 backdrop-blur-sm"
       onClick={onClose}
       role="dialog"
       aria-modal="true"

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 // Marketplace hub — the store and your familiars' setup merged into one
-// surface. A section tablist (Browse · Roles · Skills · Capabilities) sits in
-// the hero: Browse is the plugin store (collections, categories, cards);
+// surface. A single slim header row holds the section tabs (Browse · Roles ·
+// Skills · Capabilities, with live counts) and the scoped search — no hero.
+// Browse is the plugin store (collections, categories, cards);
 // Roles/Skills/Capabilities are the "what my familiars can do" views that used
 // to live on the separate Roles page. Deep links via WorkspaceMode still work —
 // the "roles" and "capabilities" modes open the matching section here.
@@ -11,7 +12,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { SearchInput } from "@/components/ui/search-input";
 import { EmptyState } from "@/components/ui/empty-state";
-import { Tabs } from "@/components/ui/tabs";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { Tabs, type TabItem } from "@/components/ui/tabs";
 import { StandardSelect } from "@/components/ui/select";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { MarketplaceCard } from "@/components/marketplace/marketplace-card";
@@ -48,36 +50,19 @@ const SECTIONS: ReadonlyArray<{ id: MarketplaceSection; label: string; icon: Ico
   { id: "capabilities", label: "Capabilities", icon: "ph:lightning-bold" },
 ];
 
-// Hero copy per section — one surface, four clearly-named rooms.
-const SECTION_COPY: Record<MarketplaceSection, { title: string; subtitle: string }> = {
-  browse: {
-    title: "Add tools to your familiars",
-    subtitle: "Browse MCP servers and skills, then add them to give your familiars new capabilities.",
-  },
-  roles: {
-    title: "Roles",
-    subtitle: "Personas your familiars wear — each bundles skills, tools, MCP servers, and workflows.",
-  },
-  skills: {
-    title: "Skills",
-    subtitle: "Reusable SKILL.md procedures your familiars can load while they work.",
-  },
-  capabilities: {
-    title: "Capabilities",
-    subtitle: "What each runtime supports — compare tools and features side by side.",
-  },
+// One-line hint per section — surfaces as the tab tooltip (the old hero
+// subtitle, demoted so the header stays a single row).
+const SECTION_HINT: Record<MarketplaceSection, string> = {
+  browse: "Browse MCP servers and skills, then add them to give your familiars new capabilities.",
+  roles: "Personas your familiars wear — each bundles skills, tools, MCP servers, and workflows.",
+  skills: "Reusable SKILL.md procedures your familiars can load while they work.",
+  capabilities: "What each runtime supports — compare tools and features side by side.",
 };
 
 const SEARCH_LABEL: Record<Exclude<MarketplaceSection, "capabilities">, string> = {
   browse: "Search the marketplace",
   roles: "Search roles",
   skills: "Search skills",
-};
-
-type SectionSummary = {
-  metric: string;
-  detail: string;
-  status: "loading" | "ready" | "error";
 };
 
 const KIND_TABS: ReadonlyArray<{ id: KindFilter; label: string }> = [
@@ -129,7 +114,6 @@ export function MarketplaceViewSurface({
   const [section, setSection] = useState<MarketplaceSection>(initialSection);
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement | null>(null);
-  const tablistRef = useRef<HTMLDivElement | null>(null);
 
   // Store state (Browse section).
   const [plugins, setPlugins] = useState<MarketplacePlugin[]>([]);
@@ -140,8 +124,21 @@ export function MarketplaceViewSurface({
   const [sort, setSort] = useState<SortKey>("recommended");
   const [collectionId, setCollectionId] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
-  const [busyId, setBusyId] = useState<string | null>(null);
+  // Ids with an install/uninstall in flight. A Set (not a scalar) so two
+  // concurrent installs each keep their own busy state — with a scalar, the
+  // second click overwrote the first and whichever settled first cleared the
+  // other's spinner. The ref mirror lets load() read the in-flight set without
+  // re-creating the loader.
+  const [busyIds, setBusyIds] = useState<ReadonlySet<string>>(new Set());
+  const busyIdsRef = useRef<ReadonlySet<string>>(busyIds);
   const [configuringId, setConfiguringId] = useState<string | null>(null);
+  const markBusy = useCallback((id: string, busy: boolean) => {
+    const next = new Set(busyIdsRef.current);
+    if (busy) next.add(id);
+    else next.delete(id);
+    busyIdsRef.current = next;
+    setBusyIds(next);
+  }, []);
 
   // Setup state (Roles / Skills sections).
   const [roles, setRoles] = useState<RoleEntry[]>([]);
@@ -174,7 +171,19 @@ export function MarketplaceViewSurface({
       const json = (await res.json()) as { ok?: boolean; plugins?: MarketplacePlugin[]; error?: string };
       if (ctl.signal.aborted) return;
       if (!json.ok) throw new Error(json.error ?? `marketplace http ${res.status}`);
-      setPlugins(json.plugins ?? []);
+      // A reload can land while an install/uninstall is still writing (e.g.
+      // the configure dialog fires onChanged → load()). For those ids, keep
+      // the optimistic `installed` — the response was snapshotted before the
+      // write finished and would silently revert the button.
+      setPlugins((prev) => {
+        const next = json.plugins ?? [];
+        if (busyIdsRef.current.size === 0) return next;
+        const prevById = new Map(prev.map((p) => [p.id, p]));
+        return next.map((p) => {
+          const pending = busyIdsRef.current.has(p.id) ? prevById.get(p.id) : undefined;
+          return pending ? { ...p, installed: pending.installed } : p;
+        });
+      });
       setError(null);
     } catch (err) {
       if (ctl.signal.aborted) return;
@@ -282,69 +291,29 @@ export function MarketplaceViewSurface({
     for (const p of plugins) counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
     return counts;
   }, [plugins]);
-  const kindCounts = useMemo(() => countByKind(plugins), [plugins]);
-  const installedCount = useMemo(() => plugins.filter((p) => p.installed).length, [plugins]);
-  const installedSkillCount = useMemo(() => skills.filter((skill) => skill.installed || skill.local).length, [skills]);
-
   const rolesSummary = useMemo(() => {
-    const mcpServerNames = new Set<string>();
-    let activeRoles = 0;
-    for (const role of roles) {
-      if (role.active) activeRoles += 1;
-      for (const server of role.mcpServers) mcpServerNames.add(server);
-    }
-    return { activeRoles, totalRoles: roles.length, mcpServers: mcpServerNames.size };
+    const activeRoles = roles.reduce((n, role) => n + (role.active ? 1 : 0), 0);
+    return { activeRoles, totalRoles: roles.length };
   }, [roles]);
 
-  const sectionSummaries = useMemo<Record<MarketplaceSection, SectionSummary>>(() => {
-    const browseReadyDetail =
-      installedCount > 0 ? `${installedCount} added` : `${Math.max(categories.length - 1, 0)} categories`;
-    const rolesReadyDetail =
-      rolesSummary.activeRoles > 0
-        ? `${rolesSummary.activeRoles} active`
-        : `${rolesSummary.mcpServers} MCP servers`;
-    const skillsReadyDetail =
-      installedSkillCount > 0 ? `${installedSkillCount} installed` : "Directory ready";
-
-    return {
-      browse: {
-        metric: error ? "Offline" : loaded ? `${plugins.length} tools` : "Loading",
-        detail: loaded ? browseReadyDetail : "Catalog sync",
-        status: error ? "error" : loaded ? "ready" : "loading",
-      },
-      roles: {
-        metric: rolesError ? "Offline" : rolesLoaded ? `${rolesSummary.totalRoles} roles` : "Loading",
-        detail: rolesLoaded ? rolesReadyDetail : "Role manifests",
-        status: rolesError ? "error" : rolesLoaded ? "ready" : "loading",
-      },
-      skills: {
-        metric: skillsError ? "Offline" : skillsLoaded ? `${skills.length} skills` : "Loading",
-        detail: skillsLoaded ? skillsReadyDetail : "Local + registry",
-        status: skillsError ? "error" : skillsLoaded ? "ready" : "loading",
-      },
-      capabilities: {
-        metric: activeHarness ? activeHarness : "Runtime map",
-        detail: "Compare agent support",
-        status: "ready",
-      },
-    };
-  }, [
-    activeHarness,
-    categories.length,
-    error,
-    installedCount,
-    installedSkillCount,
-    loaded,
-    plugins.length,
-    rolesError,
-    rolesLoaded,
-    rolesSummary.activeRoles,
-    rolesSummary.mcpServers,
-    rolesSummary.totalRoles,
-    skills.length,
-    skillsError,
-    skillsLoaded,
-  ]);
+  // The slim header's tab items — label plus a live count per section. Counts
+  // appear once their loader settles so the header never flashes a stale 0;
+  // the old hero subtitle survives as the tab tooltip.
+  const sectionTabs = useMemo<ReadonlyArray<TabItem<MarketplaceSection>>>(
+    () =>
+      SECTIONS.map((s) => ({
+        id: s.id,
+        label: s.label,
+        icon: s.icon,
+        count:
+          s.id === "browse" && loaded ? plugins.length
+          : s.id === "roles" && rolesLoaded ? roles.length
+          : s.id === "skills" && skillsLoaded ? skills.length
+          : undefined,
+        title: SECTION_HINT[s.id],
+      })),
+    [loaded, plugins.length, rolesLoaded, roles.length, skillsLoaded, skills.length],
+  );
 
   const activeCollection = useMemo(
     () => COLLECTIONS.find((c) => c.id === collectionId) ?? null,
@@ -383,7 +352,7 @@ export function MarketplaceViewSurface({
   }, []);
 
   const add = useCallback(async (id: string) => {
-    setBusyId(id);
+    markBusy(id, true);
     setInstalled(id, true);
     try {
       const res = await fetch("/api/marketplace/install", {
@@ -400,12 +369,12 @@ export function MarketplaceViewSurface({
       setError(msg);
       announce(msg, "assertive");
     } finally {
-      setBusyId(null);
+      markBusy(id, false);
     }
-  }, [setInstalled, announce]);
+  }, [markBusy, setInstalled, announce]);
 
   const remove = useCallback(async (id: string) => {
-    setBusyId(id);
+    markBusy(id, true);
     setInstalled(id, false);
     try {
       const res = await fetch("/api/marketplace/uninstall", {
@@ -422,9 +391,9 @@ export function MarketplaceViewSurface({
       setError(msg);
       announce(msg, "assertive");
     } finally {
-      setBusyId(null);
+      markBusy(id, false);
     }
-  }, [setInstalled, announce]);
+  }, [markBusy, setInstalled, announce]);
 
   const toggleRole = useCallback(async (role: RoleEntry) => {
     const key = `${role.familiar}:${role.id}`;
@@ -483,53 +452,43 @@ export function MarketplaceViewSurface({
     [skills],
   );
 
-  const copy = SECTION_COPY[section];
   const activeError =
     section === "browse" ? error
     : section === "roles" ? rolesError
     : section === "skills" ? skillsError
     : null;
 
+  // Browse toolbar context — names the active scope only when it isn't the
+  // default landing (the rail highlight and search box already show it, and
+  // the collection banner names an open collection).
+  const scopeLabel = activeCollection
+    ? null
+    : query.trim()
+      ? "Search results"
+      : category !== "All"
+        ? category
+        : null;
+
   return (
     // @container/marketplace — layout responds to the PANE width, not the
     // viewport, so the surface also adapts inside a narrow drag-to-split pane
     // on a wide screen (same pattern as chat's chatlist/composer containers).
     <section className="marketplace-view @container/marketplace flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
-      {/* Hero header — kicker, per-section title/stats, search, section tabs. */}
-      <header className="border-b border-[var(--border-hairline)] px-4 py-4 @min-[560px]/marketplace:px-6 @min-[560px]/marketplace:py-5">
-        <div className="flex flex-col gap-4 @min-[840px]/marketplace:flex-row @min-[840px]/marketplace:items-start @min-[840px]/marketplace:justify-between">
-          <div className="min-w-0">
-            <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-[var(--text-muted)]">
-              Marketplace
-            </p>
-            <h2 className="mt-0.5 text-[24px] font-semibold leading-tight text-[var(--text-primary)]">
-              {copy.title}
-            </h2>
-            <p className="mt-1 max-w-prose text-[13px] text-[var(--text-muted)]">
-              {copy.subtitle}
-            </p>
-            <div className="mt-3 flex flex-wrap items-center gap-2">
-              {section === "browse" ? (
-                <>
-                  <StatPill icon="ph:plug-bold" label={`${kindCounts.mcp} MCP servers`} />
-                  <StatPill icon="ph:cloud-bold" label={`${kindCounts.api} APIs`} />
-                  <StatPill icon="ph:sparkle-bold" label={`${kindCounts.skill} skills`} />
-                  {installedCount > 0 ? (
-                    <StatPill icon="ph:check-circle" label={`${installedCount} added`} accent />
-                  ) : null}
-                </>
-              ) : section === "roles" ? (
-                <>
-                  <StatPill icon="ph:mask-happy" label={`${rolesSummary.totalRoles} roles`} />
-                  {rolesSummary.activeRoles > 0 ? (
-                    <StatPill icon="ph:check-circle" label={`${rolesSummary.activeRoles} active`} accent />
-                  ) : null}
-                  <StatPill icon="ph:plug-bold" label={`${rolesSummary.mcpServers} MCP servers`} />
-                </>
-              ) : section === "skills" ? (
-                <StatPill icon="ph:sparkle-bold" label={`${skills.length} skills`} />
-              ) : null}
-            </div>
+      {/* Slim header — one row: section tabs (live counts, subtitle as
+          tooltip) plus the scoped search. The shared Tabs primitive supplies
+          role=tablist/tab, roving tabindex, and the marketplace-tab / panel
+          aria wiring via idPrefix. */}
+      <header className="border-b border-[var(--border-hairline)] px-4 @min-[560px]/marketplace:px-6">
+        <div className="flex flex-wrap items-end justify-between gap-x-4">
+          <div className="-mx-3 min-w-0 overflow-x-auto">
+            <Tabs
+              items={sectionTabs}
+              value={section}
+              onChange={selectSection}
+              ariaLabel="Marketplace sections"
+              idPrefix="marketplace"
+              bordered={false}
+            />
           </div>
           {section !== "capabilities" ? (
             <SearchInput
@@ -538,90 +497,13 @@ export function MarketplaceViewSurface({
               onValueChange={setQuery}
               onClear={() => setQuery("")}
               placeholder={SEARCH_LABEL[section]}
-              containerClassName="@min-[840px]/marketplace:w-96"
+              containerClassName="my-1.5 w-full self-center @min-[680px]/marketplace:w-72"
               aria-label={SEARCH_LABEL[section]}
             />
           ) : null}
         </div>
-
-        <div className="mt-4 flex flex-col gap-3">
-          {/* Section tabs — the merged surface's primary navigation. */}
-          <div
-            ref={tablistRef}
-            role="tablist"
-            aria-label="Marketplace sections"
-            className="marketplace-section-overview"
-            onKeyDown={(e) => {
-              if (e.key !== "ArrowRight" && e.key !== "ArrowLeft" && e.key !== "Home" && e.key !== "End") return;
-              e.preventDefault();
-              const i = SECTIONS.findIndex((s) => s.id === section);
-              const ni =
-                e.key === "ArrowRight" ? (i + 1) % SECTIONS.length
-                : e.key === "ArrowLeft" ? (i - 1 + SECTIONS.length) % SECTIONS.length
-                : e.key === "Home" ? 0
-                : SECTIONS.length - 1;
-              const next = SECTIONS[ni];
-              if (next) {
-                selectSection(next.id);
-                tablistRef.current?.querySelector<HTMLButtonElement>(`#marketplace-tab-${next.id}`)?.focus();
-              }
-            }}
-          >
-            {SECTIONS.map((s) => {
-              const summary = sectionSummaries[s.id];
-              return (
-                <button
-                  key={s.id}
-                  type="button"
-                  role="tab"
-                  id={`marketplace-tab-${s.id}`}
-                  aria-selected={section === s.id}
-                  aria-controls={`marketplace-panel-${s.id}`}
-                  aria-label={`${s.label}: ${summary.metric}. ${summary.detail}`}
-                  tabIndex={section === s.id ? 0 : -1}
-                  data-status={summary.status}
-                  onClick={() => selectSection(s.id)}
-                  className={`marketplace-section-card focus-ring ${section === s.id ? "is-active" : ""}`}
-                >
-                  <span className="marketplace-section-card__top">
-                    <Icon name={s.icon} width={15} aria-hidden />
-                    <span className="marketplace-section-card__label">{s.label}</span>
-                  </span>
-                  <span className="marketplace-section-card__metric">{summary.metric}</span>
-                  <span className="marketplace-section-card__detail">{summary.detail}</span>
-                </button>
-              );
-            })}
-          </div>
-
-          {section === "browse" ? (
-            <div className="flex flex-wrap items-center justify-end gap-3">
-              <Tabs
-                items={KIND_TABS}
-                value={kind}
-                onChange={setKind}
-                variant="segment"
-                size="sm"
-                bordered={false}
-                ariaLabel="Filter plugins by type"
-              />
-              <label className="flex items-center gap-2 text-[12px] text-[var(--text-muted)]">
-                <span className="sr-only">Sort plugins</span>
-                <Icon name="ph:sort-ascending" width={14} aria-hidden />
-                <StandardSelect
-                  label="Sort plugins"
-                  value={sort}
-                  onChange={(next) => setSort(next as SortKey)}
-                  className="focus-ring cursor-pointer rounded-md border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-2 py-1 text-[12px] text-[var(--text-primary)]"
-                  options={SORT_OPTIONS.map((option) => ({ value: option.id, label: option.label }))}
-                />
-              </label>
-            </div>
-          ) : null}
-        </div>
-
         {activeError ? (
-          <p className="mt-3 rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
+          <p role="alert" className="mb-3 rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
             {activeError}
           </p>
         ) : null}
@@ -749,38 +631,52 @@ export function MarketplaceViewSurface({
                   <Icon name="ph:arrow-left" width={12} aria-hidden /> All plugins
                 </button>
               </div>
-            ) : (
-              <div className="marketplace-browse-summary mb-4">
-                <div className="min-w-0">
-                  <h3 className="text-[13px] font-semibold text-[var(--text-primary)]">
-                    {query
-                      ? "Search results"
-                      : category === "All" && kind === "all"
-                        ? "All categories"
-                        : category !== "All"
-                          ? category
-                          : KIND_TABS.find((k) => k.id === kind)?.label ?? "Plugins"}
-                  </h3>
-                  <p className="mt-0.5 text-[12px] text-[var(--text-muted)]">
-                    {category === "All" && !query && kind === "all"
-                      ? "Grouped by category so every tool type uses the same scan pattern."
-                      : "Same card layout, filtered to the current result set."}
-                  </p>
-                </div>
-                {loaded ? (
-                  <div className="marketplace-browse-summary__metrics" aria-label="Visible marketplace results">
-                    <span>{filtered.length} total</span>
-                    <span>{groupedFiltered.length} groups</span>
-                    <span>{groupedKindCounts.mcp} MCP</span>
-                    <span>{groupedKindCounts.api} API</span>
-                    <span>{groupedKindCounts.skill} skills</span>
-                  </div>
-                ) : null}
+            ) : null}
+
+            {/* Browse toolbar — result context on the left, kind filter + sort
+                on the right (moved out of the header so it stays one row). */}
+            <div className="marketplace-browse-summary mb-4">
+              <p className="min-w-0 self-center truncate text-[12px] text-[var(--text-muted)]">
+                {!loaded ? (
+                  "Loading the catalog…"
+                ) : (
+                  <>
+                    {scopeLabel ? (
+                      <span className="font-medium text-[var(--text-secondary)]">{scopeLabel} · </span>
+                    ) : null}
+                    {filtered.length} {filtered.length === 1 ? "tool" : "tools"}
+                    {kind === "all" && filtered.length > 0
+                      ? ` · ${groupedKindCounts.mcp} MCP · ${groupedKindCounts.api} API · ${groupedKindCounts.skill} ${groupedKindCounts.skill === 1 ? "skill" : "skills"}`
+                      : null}
+                  </>
+                )}
+              </p>
+              <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                <Tabs
+                  items={KIND_TABS}
+                  value={kind}
+                  onChange={setKind}
+                  variant="segment"
+                  size="sm"
+                  bordered={false}
+                  ariaLabel="Filter plugins by type"
+                />
+                <label className="flex items-center gap-2 text-[12px] text-[var(--text-muted)]">
+                  <span className="sr-only">Sort plugins</span>
+                  <Icon name="ph:sort-ascending" width={14} aria-hidden />
+                  <StandardSelect
+                    label="Sort plugins"
+                    value={sort}
+                    onChange={(next) => setSort(next as SortKey)}
+                    className="focus-ring cursor-pointer rounded-md border border-[var(--border-hairline)] bg-[var(--bg-panel)] px-2 py-1 text-[12px] text-[var(--text-primary)]"
+                    options={SORT_OPTIONS.map((option) => ({ value: option.id, label: option.label }))}
+                  />
+                </label>
               </div>
-            )}
+            </div>
 
             {!loaded ? (
-              <p className="text-[12px] text-[var(--text-muted)]">Loading…</p>
+              <SkeletonRows count={6} />
             ) : filtered.length === 0 ? (
               <EmptyState
                 icon="ph:puzzle-piece-bold"
@@ -793,9 +689,9 @@ export function MarketplaceViewSurface({
                   <section key={group.category} className="marketplace-category-group" aria-labelledby={`marketplace-category-${group.category.replace(/\W+/g, "-").toLowerCase()}`}>
                     <div className="marketplace-category-group__head">
                       <div className="min-w-0">
-                        <h4 id={`marketplace-category-${group.category.replace(/\W+/g, "-").toLowerCase()}`}>
+                        <h2 id={`marketplace-category-${group.category.replace(/\W+/g, "-").toLowerCase()}`}>
                           {group.category}
-                        </h4>
+                        </h2>
                         <p>
                           {group.plugins.length} {group.plugins.length === 1 ? "tool" : "tools"} · {group.counts.mcp} MCP · {group.counts.api} API · {group.counts.skill} skills
                         </p>
@@ -806,7 +702,7 @@ export function MarketplaceViewSurface({
                         <MarketplaceCard
                           key={plugin.id}
                           plugin={plugin}
-                          busy={busyId === plugin.id}
+                          busy={busyIds.has(plugin.id)}
                           onOpen={setSelected}
                           onAdd={add}
                           onRemove={remove}
@@ -871,8 +767,12 @@ export function MarketplaceViewSurface({
 
       {selectedPlugin ? (
         <MarketplaceDetail
+          // Keyed so switching plugins remounts the drawer — otherwise the
+          // previous plugin's connection-test result lingers under the new
+          // plugin's header.
+          key={selectedPlugin.id}
           plugin={selectedPlugin}
-          busy={busyId === selectedPlugin.id}
+          busy={busyIds.has(selectedPlugin.id)}
           onClose={() => setSelected(null)}
           onAdd={() => void add(selectedPlugin.id)}
           onRemove={() => void remove(selectedPlugin.id)}
@@ -923,20 +823,5 @@ function SetupRailLink({
         <span className="shrink-0 text-[11px] tabular-nums text-[var(--text-muted)]">{detail}</span>
       ) : null}
     </button>
-  );
-}
-
-function StatPill({ icon, label, accent }: { icon: IconName; label: string; accent?: boolean }) {
-  return (
-    <span
-      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[12px] ${
-        accent
-          ? "border-[var(--accent-faint)] bg-[var(--accent-faint)] text-[var(--accent)]"
-          : "border-[var(--border-hairline)] bg-[var(--bg-panel)] text-[var(--text-secondary)]"
-      }`}
-    >
-      <Icon name={icon} width={12} aria-hidden />
-      {label}
-    </span>
   );
 }

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -52,21 +52,23 @@ function setupEffortLabel(plugin: MarketplacePlugin) {
   return { icon: "ph:check-circle" as const, label: "No setup" };
 }
 
+// label is the clamped chip text; full is the untruncated list for the
+// tooltip — a "+3" chip whose title repeats the same "+3" hides the rest.
 function capabilityPreview(plugin: MarketplacePlugin) {
   const capabilities = plugin.capabilities.length > 0 ? plugin.capabilities : plugin.keywords;
-  if (capabilities.length === 0) return "Core capability";
+  if (capabilities.length === 0) return { label: "Core capability", full: "Core capability" };
   const first = capabilities.slice(0, 2).join(", ");
   const more = capabilities.length > 2 ? ` +${capabilities.length - 2}` : "";
-  return `${first}${more}`;
+  return { label: `${first}${more}`, full: capabilities.join(", ") };
 }
 
 function roleFitLabel(plugin: MarketplacePlugin) {
   const roles = plugin.roleAffinity.flatMap((entry) => entry.roles).filter(Boolean);
-  if (roles.length === 0) return "General fit";
+  if (roles.length === 0) return { label: "General fit", full: "General fit" };
   const unique = [...new Set(roles)];
   const first = unique.slice(0, 2).join(", ");
   const more = unique.length > 2 ? ` +${unique.length - 2}` : "";
-  return `${first}${more}`;
+  return { label: `${first}${more}`, full: unique.join(", ") };
 }
 
 export const MarketplaceCard = memo(function MarketplaceCard({
@@ -122,16 +124,16 @@ export const MarketplaceCard = memo(function MarketplaceCard({
       <p className="line-clamp-2 text-[12px] text-[var(--text-muted)]">{plugin.description}</p>
       <div
         className="marketplace-card__decision"
-        aria-label={`Decision notes: ${setup.label}; ${capability}; ${roleFit}`}
+        aria-label={`Decision notes: ${setup.label}; ${capability.full}; ${roleFit.full}`}
       >
         <span className="marketplace-card__decision-chip" title={setup.label}>
           <Icon name={setup.icon} width={11} aria-hidden /> {setup.label}
         </span>
-        <span className="marketplace-card__decision-chip" title={capability}>
-          <Icon name="ph:lightning-bold" width={11} aria-hidden /> {capability}
+        <span className="marketplace-card__decision-chip" title={capability.full}>
+          <Icon name="ph:lightning-bold" width={11} aria-hidden /> {capability.label}
         </span>
-        <span className="marketplace-card__decision-chip" title={roleFit}>
-          <Icon name="ph:mask-happy" width={11} aria-hidden /> {roleFit}
+        <span className="marketplace-card__decision-chip" title={roleFit.full}>
+          <Icon name="ph:mask-happy" width={11} aria-hidden /> {roleFit.label}
         </span>
       </div>
       <div className="marketplace-card__meta">

--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 
@@ -66,7 +67,12 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
 
   useEffect(() => {
     if (open) {
+      // Full reset — the dialog stays mounted between opens, and `results` is
+      // keyed by field key, so without this a stale "Valid — @login" from the
+      // last session (or another plugin sharing a key) survives into this one.
       setDrafts({});
+      setResults({});
+      setError(null);
       void load(true);
     }
   }, [open, load]);
@@ -140,23 +146,29 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
       footerActions={<Button variant="secondary" size="sm" onClick={onClose}>Done</Button>}
     >
       <div className="flex flex-col gap-4">
-        <p className="text-[12px] text-[var(--text-muted)]">
-          {displayName} needs the following before its tools can run. Secrets are saved in the
-          encrypted local vault or stored as 1Password references.
-        </p>
+        {!loaded || fields.length > 0 ? (
+          <p className="text-[12px] text-[var(--text-muted)]">
+            {displayName} needs the following before its tools can run. Secrets are saved in the
+            encrypted local vault or stored as 1Password references.
+          </p>
+        ) : null}
         {error ? (
-          <p className="rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
+          <p role="alert" className="rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
             {error}
           </p>
         ) : null}
         {!loaded ? (
-          <p className="text-[12px] text-[var(--text-muted)]">Loading…</p>
+          <SkeletonRows count={3} />
+        ) : fields.length === 0 && !error ? (
+          <p className="text-[12px] text-[var(--text-muted)]">
+            Nothing to set up — {displayName} has no required values. You can close this dialog.
+          </p>
         ) : (
           fields.map((f) => (
             <div key={f.key} className="flex flex-col gap-1.5 rounded-lg border border-[var(--border-hairline)] p-3">
               <div className="flex items-center justify-between gap-2">
                 <span className="text-[13px] font-medium text-[var(--text-primary)]">{f.title}</span>
-                <span className={`inline-flex items-center gap-1 text-[11px] ${f.satisfied ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
+                <span className={`inline-flex items-center gap-1 text-[11px] ${f.satisfied ? "text-[var(--text-primary)]" : "text-[var(--color-warning)]"}`}>
                   <Icon name={f.satisfied ? "ph:check-circle" : "ph:warning"} width={12} aria-hidden />
                   {f.satisfied ? `Set${f.source === "encrypted" ? " · encrypted" : f.source === "vault" ? " · 1Password" : ""}` : "Not set"}
                 </span>
@@ -192,7 +204,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
                 ) : null}
               </div>
               {results[f.key] && results[f.key].state !== "idle" && results[f.key].state !== "testing" ? (
-                <p className={`inline-flex items-center gap-1 text-[11px] ${results[f.key].state === "valid" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
+                <p className={`inline-flex items-center gap-1 text-[11px] ${results[f.key].state === "valid" ? "text-[var(--text-primary)]" : "text-[var(--danger-text)]"}`}>
                   <Icon name={results[f.key].state === "valid" ? "ph:check-circle" : "ph:warning"} width={11} aria-hidden />
                   {results[f.key].message}
                 </p>

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -82,13 +82,13 @@ function detailDecisionItems(plugin: MarketplacePlugin) {
       label: "Capability fit",
       icon: "ph:lightning-bold" as const,
       value: capabilities.length > 0 ? capabilities.slice(0, 3).join(", ") : "Core capability",
-      detail: capabilities.length > 3 ? `${capabilities.length - 3} more capability signals in the catalog.` : "Primary ways this listing extends a familiar.",
+      detail: capabilities.length > 3 ? `And ${capabilities.length - 3} more — full list below.` : "Primary ways this listing extends a familiar.",
     },
     {
       label: "Role fit",
       icon: "ph:mask-happy" as const,
       value: roles.length > 0 ? roles.slice(0, 3).join(", ") : "General fit",
-      detail: roles.length > 3 ? `${roles.length - 3} more mapped roles.` : "Best matching familiar role assignments.",
+      detail: roles.length > 3 ? `And ${roles.length - 3} more — full list below.` : "Best matching familiar role assignments.",
     },
   ];
 }
@@ -119,7 +119,7 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
   const state = pluginBadgeState(plugin);
   const decisionItems = detailDecisionItems(plugin);
   return (
-    <div className="fixed inset-0 z-50 flex justify-end bg-black/40" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex justify-end bg-[var(--backdrop-scrim)]" onClick={onClose}>
       <div
         ref={ref}
         role="dialog"
@@ -219,7 +219,10 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
                 Test connection
               </Button>
               {conn.state === "reachable" || conn.state === "unreachable" ? (
-                <span className={`inline-flex items-center gap-1 text-[11px] ${conn.state === "reachable" ? "text-[var(--text-primary)]" : "text-[var(--text-muted)]"}`}>
+                <span
+                  role="status"
+                  className={`inline-flex items-center gap-1 text-[11px] ${conn.state === "reachable" ? "text-[var(--text-primary)]" : "text-[var(--danger-text)]"}`}
+                >
                   <Icon name={conn.state === "reachable" ? "ph:check-circle" : "ph:warning"} width={12} aria-hidden />
                   {conn.message}
                 </span>

--- a/src/components/marketplace/roles-section.tsx
+++ b/src/components/marketplace/roles-section.tsx
@@ -3,8 +3,8 @@
 // Roles section of the Marketplace hub — role cards with per-capability rows
 // (skills, MCP servers, tools, plugins, workflows). Extracted from the old
 // standalone Roles page (plugins-view) when Roles and Marketplace merged into
-// one surface; the plugins-role-* class hooks are kept so existing styling and
-// tap-target rules keep applying.
+// one surface. Chips style themselves with utilities; the one surviving CSS
+// hook is plugins-role-chip--mcp (accent tint for MCP server chips).
 
 import { useMemo } from "react";
 import { Icon, type IconName } from "@/lib/icon";
@@ -306,7 +306,7 @@ function CapabilityRow({
                   type="button"
                   onClick={() => onOpen(item)}
                   title={openHint ? `${openHint}: ${item}` : item}
-                  className={`plugins-role-chip plugins-role-chip--${tone} plugins-role-chip--action focus-ring inline-flex items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-[11px] text-[var(--text-primary)] hover:border-[var(--border-strong)] hover:text-[var(--accent-text)]`}
+                  className={`${tone === "mcp" ? "plugins-role-chip--mcp " : ""}focus-ring inline-flex items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2 py-1 text-[11px] text-[var(--text-primary)] hover:border-[var(--border-strong)] hover:text-[var(--accent-text)]`}
                 >
                   <Icon name={icon} width={10} aria-hidden />
                   {item}
@@ -314,7 +314,7 @@ function CapabilityRow({
               ) : (
                 <span
                   key={item}
-                  className={`plugins-role-chip plugins-role-chip--${tone} inline-flex items-center gap-1 rounded-md bg-[var(--bg-raised)] px-2 py-1 text-[11px] text-[var(--text-secondary)]`}
+                  className={`${tone === "mcp" ? "plugins-role-chip--mcp " : ""}inline-flex items-center gap-1 rounded-md bg-[var(--bg-raised)] px-2 py-1 text-[11px] text-[var(--text-secondary)]`}
                 >
                   {tone === "mcp" ? <Icon name={icon} width={10} aria-hidden /> : null}
                   {item}

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -85,17 +85,17 @@ assert.match(
   "hub accepts an initial section for workspace deep links",
 );
 
-// Section tablist is an accessible tablist (not just styled buttons).
-assert.match(marketplaceView, /role="tablist"\s+aria-label="Marketplace sections"/, "the section bar is a labelled tablist");
-assert.match(marketplaceView, /role="tab"\s*\n\s*id=\{`marketplace-tab-\$\{s\.id\}`\}/, "each tab carries role=tab + a stable id");
-assert.match(marketplaceView, /aria-selected=\{section === s\.id\}/, "the active tab is aria-selected");
-assert.match(marketplaceView, /aria-controls=\{`marketplace-panel-\$\{s\.id\}`\}/, "tabs point at their panel via aria-controls");
-assert.match(marketplaceView, /tabIndex=\{section === s\.id \? 0 : -1\}/, "the tablist uses a roving tab stop");
-assert.match(marketplaceView, /e\.key === "ArrowRight"[\s\S]{0,80}?\(i \+ 1\) % SECTIONS\.length/, "Left/Right arrows move between tabs");
-assert.match(marketplaceView, /const sectionSummaries = useMemo/, "the shell derives status summaries for every Marketplace section");
-assert.match(marketplaceView, /className="marketplace-section-overview"/, "the section tabs render as an overview rail, not loose pills");
-assert.match(marketplaceView, /className="marketplace-section-card__metric"/, "each section tab exposes a compact status metric");
-assert.match(marketplaceView, /className="marketplace-section-card__detail"/, "each section tab explains the status metric");
+// Section tablist — the header is a single slim row. The shared Tabs
+// primitive (underline variant) supplies role=tablist/tab, aria-selected,
+// the roving tabindex + arrow keys, and the marketplace-tab-* /
+// marketplace-panel-* aria wiring via idPrefix; the hub only feeds it items.
+assert.match(marketplaceView, /<Tabs\s*\n\s*items=\{sectionTabs\}/, "the section bar delegates to the shared Tabs primitive");
+assert.match(marketplaceView, /ariaLabel="Marketplace sections"/, "the section tablist keeps its accessible name");
+assert.match(marketplaceView, /idPrefix="marketplace"/, "idPrefix wires marketplace-tab-* ids + aria-controls to the panels");
+assert.match(marketplaceView, /const sectionTabs = useMemo/, "the header derives live per-section counts for the tab badges");
+assert.match(marketplaceView, /title: SECTION_HINT\[s\.id\]/, "the old hero subtitle survives as the tab tooltip");
+assert.doesNotMatch(marketplaceView, /marketplace-section-card/, "the stat-card hero tablist is retired — the header stays ultraminimal");
+assert.doesNotMatch(marketplaceView, /SECTION_COPY|StatPill/, "the hero title/subtitle block and stat pills are retired with it");
 for (const id of ["browse", "roles", "skills", "capabilities"]) {
   assert.match(
     marketplaceView,
@@ -103,10 +103,6 @@ for (const id of ["browse", "roles", "skills", "capabilities"]) {
     `the ${id} panel is a tabpanel labelled by its tab`,
   );
 }
-assert.match(css, /\.marketplace-section-overview \{[\s\S]*?grid-template-columns/, "Marketplace section overview uses a stable responsive grid");
-assert.match(css, /\.marketplace-section-card \{[\s\S]*?min-height:/, "Marketplace section cards reserve stable height");
-assert.match(css, /\.marketplace-section-card\.is-active \{/, "active Marketplace section card has a distinct state");
-assert.match(css, /@media \(max-width: 680px\)[\s\S]*?\.marketplace-section-overview \{/, "Marketplace section overview has a mobile treatment");
 
 // One search field, scoped per section; the self-contained Capabilities
 // surface owns its own search so the hub hides the shared one there.
@@ -126,7 +122,12 @@ assert.match(marketplaceView, /className="marketplace-category-grid"/, "each cat
 assert.match(css, /\.marketplace-category-stack \{[\s\S]*?flex-direction: column/, "Marketplace category stack has stable vertical rhythm");
 assert.match(css, /\.marketplace-category-group__head \{[\s\S]*?border-bottom/, "Marketplace category groups use quiet structural dividers");
 assert.match(css, /\.marketplace-category-grid \{[\s\S]*?grid-template-columns/, "Marketplace category groups use a stable responsive grid");
-assert.match(css, /\.marketplace-browse-summary__metrics \{[\s\S]*?flex-wrap: wrap/, "Browse summary metrics wrap instead of overflowing");
+// The kind filter + sort moved out of the header into the Browse toolbar so
+// the header stays one row; the toolbar also carries the result context line.
+assert.match(marketplaceView, /className="marketplace-browse-summary mb-4"/, "Browse keeps a toolbar row above the grid");
+assert.match(marketplaceView, /ariaLabel="Filter plugins by type"/, "the kind filter lives in the Browse toolbar");
+assert.match(marketplaceView, /label="Sort plugins"/, "the sort select lives in the Browse toolbar");
+assert.match(css, /\.marketplace-browse-summary \{[\s\S]*?justify-content: space-between/, "the Browse toolbar keeps context and controls apart");
 assert.match(css, /\.marketplace-card \{[\s\S]*?min-height:/, "Marketplace cards reserve stable height across categories");
 
 // Browse cards are decision cards: they expose setup effort, capability fit,

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -190,6 +190,10 @@ assert.match(css, /\.skill-browser__activity \{/, "CSS includes the 8-week activ
 assert.match(css, /\.skill-browser__activity-bar \{/, "CSS includes individual activity bars");
 assert.match(css, /\.skill-browser__card \{[\s\S]*?min-height: 72px;/, "skill cards reserve enough height for activity and install stats");
 assert.match(css, /\.skill-browser__card\.is-active \{/, "the selected card is highlighted");
-assert.match(css, /@media \(max-width: 900px\)[\s\S]*?\.skill-browser__rail \{ display: none;/, "the rail collapses on small screens");
+assert.match(
+  css,
+  /@media \(max-width: 900px\)[\s\S]*?\.skill-browser__rail \{[\s\S]*?flex-direction: row/,
+  "the rail becomes a horizontal strip on small screens — it is the only category control, so it must never be display:none",
+);
 
 console.log("skill-browser.test.ts OK");

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -9,6 +9,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { copyText } from "@/lib/clipboard";
 
@@ -359,6 +361,21 @@ export function SkillBrowser({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [busy, setBusy] = useState<BusyState>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [copiedInstall, setCopiedInstall] = useState(false);
+  const { announce } = useAnnouncer();
+
+  // Notices are transient feedback, not state — without this they lingered
+  // indefinitely ("Install command copied" an hour later reads as broken).
+  useEffect(() => {
+    if (!notice) return;
+    const t = window.setTimeout(() => setNotice(null), 4000);
+    return () => window.clearTimeout(t);
+  }, [notice]);
+  useEffect(() => {
+    if (!copiedInstall) return;
+    const t = window.setTimeout(() => setCopiedInstall(false), 1500);
+    return () => window.clearTimeout(t);
+  }, [copiedInstall]);
 
   const counts = useMemo(
     () => ({
@@ -482,6 +499,7 @@ export function SkillBrowser({
     if (!selected) return;
     try {
       await copyText(installCommand(selected));
+      setCopiedInstall(true);
       setNotice("Install command copied");
     } catch {
       setNotice("Could not copy install command");
@@ -501,7 +519,7 @@ export function SkillBrowser({
       });
       const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; alreadyInstalled?: boolean };
       if (!res.ok || !json.ok) {
-        setNotice(json.error ? `Install failed: ${json.error}` : `Install failed (${res.status})`);
+        setNotice(json.error ? `Install failed: ${json.error}` : "Install failed. Try again.");
         return;
       }
       setNotice(json.alreadyInstalled ? "Skill already installed" : "Skill installed");
@@ -522,7 +540,7 @@ export function SkillBrowser({
     });
     const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; prompt?: string };
     if (!res.ok || !json.ok || !json.prompt) {
-      setNotice(json.error ? `Use failed: ${json.error}` : `Use failed (${res.status})`);
+      setNotice(json.error ? `Use failed: ${json.error}` : "Couldn't fetch the skill prompt. Try again.");
       return null;
     }
     return json.prompt;
@@ -579,11 +597,14 @@ export function SkillBrowser({
       });
       const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
       if (!res.ok || !json.ok) {
-        setNotice(json.error ? `Delete failed: ${json.error}` : `Delete failed (${res.status})`);
+        setNotice(json.error ? `Delete failed: ${json.error}` : "Delete failed. Try again.");
         return;
       }
       setConfirmingDelete(false);
       setSelectedKey(null);
+      // The selection jumps to the next skill and the local notice resets with
+      // it, so the confirmation goes through the shared live region instead.
+      announce("Skill deleted", "polite");
       onChanged?.();
     } catch (err) {
       setNotice(err instanceof Error ? `Delete failed: ${err.message}` : "Delete failed");
@@ -616,7 +637,7 @@ export function SkillBrowser({
       </nav>
 
       {/* ── Card list ────────────────────────────────────────────────── */}
-      <div className="skill-browser__list" role="listbox" aria-label="Skills">
+      <div className="skill-browser__list">
         <div className="skill-browser__leaderboard">
           <div>
             <p className="skill-browser__leaderboard-kicker">Skills Leaderboard</p>
@@ -624,8 +645,10 @@ export function SkillBrowser({
           </div>
           <div className="skill-browser__ecosystem">
             <div className="skill-browser__ecosystem-command">
-              <span>Try it now</span>
-              <code>{ecosystemCommand}</code>
+              {/* The command tracks the selection — say so, or a generic
+                  "Try it now" silently changes meaning three columns over. */}
+              <span>{selected ? `Install ${selected.name}` : "Try it now"}</span>
+              <code title={ecosystemCommand}>{ecosystemCommand}</code>
             </div>
             <div className="skill-browser__agent-strip" aria-label="Available for these agents">
               {FEATURED_AGENT_LABELS.map((name) => (
@@ -714,26 +737,45 @@ export function SkillBrowser({
           ) : null}
         </div>
         {!loaded ? (
-          <div className="skill-browser__note" aria-hidden>
+          <div className="skill-browser__note" role="status">
             Loading skills…
           </div>
         ) : skills.length === 0 ? (
-          <div className="skill-browser__empty">
-            <Icon name="ph:puzzle-piece" width={22} aria-hidden />
-            <p>No directory skills found.</p>
-            {onCreateSkill ? (
-              <Button variant="secondary" size="xs" className="skill-browser__empty-action" onClick={onCreateSkill}>
-                Open Capabilities
-              </Button>
-            ) : null}
-          </div>
+          <EmptyState
+            compact
+            icon="ph:puzzle-piece"
+            headline="No skills yet"
+            subtitle="Nothing turned up in your skill roots or the directory."
+            actions={
+              onCreateSkill ? (
+                <Button variant="secondary" size="xs" onClick={onCreateSkill}>
+                  Open Capabilities
+                </Button>
+              ) : undefined
+            }
+          />
         ) : rankedVisible.length === 0 ? (
-          <div className="skill-browser__empty">
-            <p>No skills match “{query.trim()}”.</p>
-            <Button variant="secondary" size="xs" className="skill-browser__empty-action" onClick={onClearQuery}>
-              Clear search
-            </Button>
-          </div>
+          <EmptyState
+            compact
+            icon="ph:magnifying-glass"
+            headline={query.trim() ? `No skills match “${query.trim()}”` : "No skills match these filters"}
+            subtitle="Try a different search, topic, or category."
+            actions={
+              <Button
+                variant="secondary"
+                size="xs"
+                onClick={() => {
+                  onClearQuery();
+                  setCategory("all");
+                  setBrowse("all");
+                  setTopic("all");
+                  setAgent("all");
+                }}
+              >
+                Clear filters
+              </Button>
+            }
+          />
         ) : (
           rankedVisible.map((skill, index) => {
             const key = skillKey(skill);
@@ -744,8 +786,7 @@ export function SkillBrowser({
               <Button
                 key={key}
                 variant="ghost"
-                role="option"
-                aria-selected={isSel}
+                aria-pressed={isSel}
                 className={`skill-browser__card${isSel ? " is-active" : ""}`}
                 onClick={() => setSelectedKey(key)}
               >
@@ -830,13 +871,13 @@ export function SkillBrowser({
                 ))}
               </div>
               <div className="skill-browser__install">
-                <code>{installCommand(selected)}</code>
+                <code title={installCommand(selected)}>{installCommand(selected)}</code>
                 <IconButton
-                  icon="ph:copy"
+                  icon={copiedInstall ? "ph:check" : "ph:copy"}
                   size="sm"
                   className="skill-browser__action"
                   onClick={handleCopyInstall}
-                  title="Copy install command"
+                  title={copiedInstall ? "Copied" : "Copy install command"}
                   aria-label="Copy install command"
                 />
                 <Button
@@ -951,9 +992,13 @@ export function SkillBrowser({
                 <MarkdownBlock text={body} className="cave-md--expanded" />
               ) : (
                 // 403 (path outside allow-listed roots), empty file, or error —
-                // show the scanned description so the pane is never blank.
+                // show the scanned description so the pane is never blank. For
+                // a local skill whose file SHOULD be readable, say the read
+                // failed instead of passing it off as "no preview".
                 <p className="skill-browser__fallback">
-                  {selected.description || "No preview available for this skill."}
+                  {preview.status === "error" && selectedPath
+                    ? `Couldn’t read this skill’s SKILL.md.${selected.description ? ` ${selected.description}` : ""}`
+                    : selected.description || "No preview available for this skill."}
                 </p>
               )}
             </div>

--- a/src/components/skill-detail-drawer.tsx
+++ b/src/components/skill-detail-drawer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect } from "react";
+import { useRef } from "react";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 export type SkillEntry = {
   id: string;
@@ -44,14 +45,11 @@ export function SkillDetailDrawer({
   familiars: FamiliarForSkill[];
   onClose: () => void;
 }) {
-  useEffect(() => {
-    if (!skill) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [skill, onClose]);
+  const panelRef = useRef<HTMLElement | null>(null);
+  // Focus moves into the drawer on open and returns to the trigger on close;
+  // Escape comes with it (the old hand-rolled listener left focus stranded
+  // behind the backdrop).
+  useFocusTrap(Boolean(skill), panelRef, { onEscape: onClose });
 
   if (!skill) return null;
 
@@ -66,12 +64,18 @@ export function SkillDetailDrawer({
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px]"
+        className="fixed inset-0 z-40 bg-[var(--backdrop-scrim)] backdrop-blur-[2px]"
         onClick={onClose}
         aria-hidden="true"
       />
       {/* Drawer */}
-      <aside className="fixed bottom-0 right-0 top-0 z-50 flex w-full max-w-sm flex-col bg-[var(--bg-panel)] shadow-2xl sm:max-w-[380px]">
+      <aside
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${skill.name} details`}
+        className="fixed bottom-0 right-0 top-0 z-50 flex w-full max-w-sm flex-col bg-[var(--bg-panel)] shadow-2xl sm:max-w-[380px]"
+      >
         {/* Header */}
         <div className="flex items-start gap-3 border-b border-[var(--border-hairline)] px-5 py-4">
           <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-raised)] text-[15px] font-semibold text-[var(--text-primary)]">
@@ -153,23 +157,20 @@ export function SkillDetailDrawer({
               <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-[var(--text-muted)]">
                 Assigned to
               </p>
+              {/* Plain rows — the old decorative toggles looked switchable
+                  but did nothing. */}
               <div className="space-y-1">
                 {familiars.map((f) => (
-                  <div
-                    key={f.id}
-                    className="flex items-center justify-between rounded-lg px-3 py-2 hover:bg-[var(--bg-raised)]"
-                  >
+                  <div key={f.id} className="flex items-center gap-2 rounded-lg px-3 py-2">
+                    <Icon name="ph:paw-print-fill" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
                     <span className="text-[12px] text-[var(--text-secondary)]">
                       {f.display_name}
-                    </span>
-                    <span className="text-[var(--text-muted)] opacity-40">
-                      <Icon name="ph:toggle-left-bold" width={20} />
                     </span>
                   </div>
                 ))}
               </div>
-              <p className="mt-2 text-[10px] text-[var(--text-muted)] opacity-60">
-                Assignment writes to daemon config — coming soon.
+              <p className="mt-2 text-[10px] text-[var(--text-muted)]">
+                Every familiar can load this skill while it works.
               </p>
             </div>
           )}


### PR DESCRIPTION
## What

**1. Ultraminimal header (the headline).** The hero — eyebrow, 24px title, subtitle, stat pills, four 82px stat-card tabs, and a separate filter row (~300px of chrome before content) — is now a **single slim row**: the shared `Tabs` primitive (underline variant, live counts, roving tabindex, `idPrefix` aria wiring to the existing panels) plus the scoped search. The old hero subtitles survive as tab tooltips. Kind filter + sort moved into the Browse toolbar, whose dev-speak summary ("same scan pattern", "current result set") became a plain result-context line. Net: **−377/+163** on the header commit.

**2. Store correctness** (confirmed deferred items from the #2349/#2350 audits):
- `busyId` scalar → `busyIds` Set — concurrent installs no longer clobber each other's spinner, and `load()` preserves optimistic `installed` for in-flight ids so a background reload (e.g. configure's `onChanged`) can't silently revert an Add.
- Configure dialog fully resets on open — stale "Valid — @login" results survived across opens and across plugins sharing a field key.
- Detail drawer keyed by plugin id — switching plugins no longer shows the previous plugin's connection-test result.
- Honest state colors: "Not set" = warning token, failed validation/connection = danger token (were neutral muted grey); scrims use `--backdrop-scrim` instead of hardcoded `bg-black/*`; skeletons instead of bare "Loading…"; zero-field configure gets an explicit empty state; card "+N" chips carry full-list tooltips.

**3. Skills + Capabilities functionality:**
- The category rail was `display:none` under 900px while being the **only** category control — 681–900px panes were stuck on the last-picked category. It's now a horizontal strip on a grid re-layout (strip / list · detail; single-column stack ≤680px).
- Dropped the broken `role=listbox/option` semantics (no keyboard support behind them); notices auto-clear; copy buttons flash a check; delete announces via the live region (previously zero feedback); "Try it now" names the skill it installs; local SKILL.md read failures say so; raw "(500)" errors humanized.
- Capabilities "Open file" ran `window.open("file://…")` — silently blocked in browsers. Desktop opens via Tauri; web copies the path and the label says "Path copied".
- Skill detail drawer is a real dialog now (focus trap, focus-return, `role=dialog`); removed the decorative assignment toggles that looked switchable but did nothing.

## Verification
- `tsc --noEmit` clean; full app suite **520/520** files pass (pins updated to the new header contract).
- Verified in the running app (prod build, Playwright): Browse/Skills/Roles sections dark + light, header at 1440px and 840px, skills layout at 840px and 620px.

Bead: cave-965

🤖 Generated with [Claude Code](https://claude.com/claude-code)