### PR TITLE
fix(desktop): make the titlebar actually drag — grant start_dragging to the loopback webview

### DIFF
--- a/src-tauri/capabilities/loopback-window-drag.json
+++ b/src-tauri/capabilities/loopback-window-drag.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "loopback-window-drag",
+  "description": "lets the trusted loopback app webviews drive native window drag (seamless titlebar) and drag-region double-click zoom/maximize",
+  "platforms": [
+    "linux",
+    "macOS",
+    "windows"
+  ],
+  "windows": [
+    "main",
+    "quick-chat"
+  ],
+  "remote": {
+    "urls": [
+      "http://localhost:*/*",
+      "http://127.0.0.1:*/*",
+      "http://[\\:\\:1]:*/*"
+    ]
+  },
+  "permissions": [
+    "core:window:allow-start-dragging",
+    "core:window:allow-internal-toggle-maximize"
+  ]
+}

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -9,6 +9,9 @@ const loopbackBrowserCapability = JSON.parse(
 const loopbackMainEventsCapability = JSON.parse(
   readFileSync(new URL("../capabilities/loopback-main-events.json", import.meta.url), "utf8"),
 );
+const loopbackWindowDragCapability = JSON.parse(
+  readFileSync(new URL("../capabilities/loopback-window-drag.json", import.meta.url), "utf8"),
+);
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
@@ -16,6 +19,8 @@ const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
 const libRust = readFileSync(new URL("../src/lib.rs", import.meta.url), "utf8");
 const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx", import.meta.url), "utf8");
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
+const shellTsx = readFileSync(new URL("../../src/components/shell.tsx", import.meta.url), "utf8");
+const trayQuickChat = readFileSync(new URL("../../src/components/tray-quick-chat.tsx", import.meta.url), "utf8");
 
 const requiredPermissionIds = [
   "allow-pty-start",
@@ -231,6 +236,63 @@ test("privileged PTY commands require the trusted main webview at runtime", () =
       `${command} must reject untrusted child webviews and localhost origins before handling PTY state`,
     );
   }
+});
+
+// The main webview loads from an external http://127.0.0.1 URL, which the
+// capability ACL treats as a REMOTE execution context — capabilities without a
+// matching remote.urls block (like default.json) do not apply there at all.
+// Titlebar drag / drag-region double-click therefore need this explicit
+// remote-scoped grant; without it Tauri's drag.js and any startDragging()
+// call are silently denied and the window can never be dragged (the CSS
+// app-region hint is equally inert on external URLs).
+test("loopback app webviews can drive native window drag for the seamless titlebar", () => {
+  assert.deepEqual(
+    loopbackWindowDragCapability.windows,
+    ["main", "quick-chat"],
+    "drag permissions cover the main shell and the decoration-less quick-chat tray window (which is otherwise unmovable)",
+  );
+  assert.deepEqual(
+    loopbackWindowDragCapability.platforms,
+    ["linux", "macOS", "windows"],
+    "window-drag permissions are desktop-only and must not leak into mobile Tauri builds",
+  );
+  for (const origin of [
+    "http://127.0.0.1:3000/",
+    "http://localhost:3000/",
+    "http://[::1]:3000/",
+    "http://127.0.0.1:64203/",
+    "http://localhost:64203/",
+    "http://[::1]:64203/",
+  ]) {
+    assert.ok(
+      capabilityAllowsOrigin(loopbackWindowDragCapability, origin),
+      `loopback origin ${origin} must be allowed to start a native window drag`,
+    );
+  }
+  assert.equal(
+    capabilityAllowsOrigin(loopbackWindowDragCapability, "http://example.com:64203/"),
+    false,
+    "remote non-loopback origins should stay denied",
+  );
+  assert.deepEqual(
+    loopbackWindowDragCapability.permissions,
+    ["core:window:allow-start-dragging", "core:window:allow-internal-toggle-maximize"],
+    "the drag capability grants exactly the drag + drag-region double-click commands and nothing else",
+  );
+
+  // The web side must actually mark the drag handles: `deep` covers empty
+  // chrome anywhere inside the titlebar subtree while drag.js's clickable
+  // check keeps controls working. Bare (valueless) regions only drag on
+  // direct presses on the attributed element, which is why the shell uses
+  // `deep` everywhere.
+  assert.ok(
+    shellTsx.includes('<div className="shell-top" data-tauri-drag-region="deep">'),
+    "the shell titlebar must be a deep Tauri drag region",
+  );
+  assert.ok(
+    trayQuickChat.includes('<header className="quick-chat-overlay__header" data-tauri-drag-region="deep">'),
+    "the quick-chat tray header must be a deep Tauri drag region so the decoration-less window can be moved",
+  );
 });
 
 test("browser event labels use the same native prefix in Rust and React", () => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1188,8 +1188,10 @@ pub fn run() {
             // very top (the traffic-light buttons float over it) and
             // `hidden_title` drops the centered "CovenCave" label, so the
             // toolbar reads as one continuous strip. The web side reserves room
-            // for the traffic lights and makes the bar draggable (see
-            // `[data-tauri-titlebar]` in globals.css). No-op on Windows/Linux.
+            // for the traffic lights (`[data-tauri-titlebar]` in globals.css)
+            // and marks the bar `data-tauri-drag-region="deep"`; the drag is
+            // an ACL-gated IPC call, granted to this loopback origin by
+            // capabilities/loopback-window-drag.json. No-op on Windows/Linux.
             #[cfg(target_os = "macos")]
             {
                 main_window = main_window

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4819,9 +4819,13 @@ button:active > .edge-rail-chip {
    webview fills to the very top and the traffic-light buttons float over this
    bar — there's no separate native title strip and no seam. We:
      1. reserve room on the left so the toggle doesn't sit under the lights,
-     2. give the bar a touch more height to comfortably frame the lights,
-     3. make the empty bar background a window-drag handle, while keeping every
-        interactive control clickable (no-drag).
+     2. give the bar a touch more height to comfortably frame the lights.
+   The actual window drag is NOT these `app-region` hints: WebKit ignores them
+   on external-URL webviews (the app loads from http://127.0.0.1), so dragging
+   is driven by the `data-tauri-drag-region="deep"` attributes in shell.tsx +
+   the ACL grant in src-tauri/capabilities/loopback-window-drag.json. The
+   app-region rules stay only as a progressive-enhancement fallback for any
+   bundled-scheme build.
    `[data-tauri-titlebar]` is set on <html> only in the macOS desktop shell
    (see shell.tsx), so browser/Windows/Linux are untouched. Scoped to the
    desktop layout (≥1024px) to match where `.menu-bar` renders.

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -32,27 +32,35 @@ assert.match(
 );
 assert.match(
   shell,
-  /<div className="shell-top" data-tauri-drag-region=""(?: onPointerDown=\{onTitlebarPointerDown\})?>[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="">\{renderedTopBar\}<\/div>/,
+  /<div className="shell-top" data-tauri-drag-region="deep">[\s\S]*?\{navToggle\}[\s\S]*?<div className="shell-top__bar" data-tauri-drag-region="deep">\{renderedTopBar\}<\/div>/,
   "the top bar row leads with the nav toggle before the rendered top bar",
 );
+// `deep` (not the bare attribute) is load-bearing: Tauri drag.js only drags a
+// bare region on DIRECT presses on the attributed element, so empty chrome
+// inside .menu-bar/.top-bar children would short-circuit the composedPath walk
+// and never drag. `deep` covers the whole subtree while drag.js's clickable
+// check keeps buttons/inputs/focusable widgets working. The drag itself is an
+// ACL-gated IPC call — see capabilities/loopback-window-drag.json (the webview
+// is an external http://127.0.0.1 origin, a REMOTE ACL context, so it needs an
+// explicit remote-scoped grant; without it start_dragging is silently denied).
 assert.equal(
-  shell.match(/<div className="shell-top" data-tauri-drag-region=""(?: onPointerDown=\{onTitlebarPointerDown\})?>/g)?.length,
+  shell.match(/<div className="shell-top" data-tauri-drag-region="deep">/g)?.length,
   2,
-  "both shell top bars (placeholder + desktop) should expose the Tauri drag region on the titlebar container",
+  "both shell top bars (placeholder + desktop) should expose the deep Tauri drag region on the titlebar container",
+);
+assert.doesNotMatch(
+  shell,
+  /startDragging|onTitlebarPointerDown/,
+  "shell should not hand-roll a startDragging pointer handler — Tauri drag.js owns the drag (and double-click zoom) via the deep drag-region attributes",
 );
 assert.equal(
-  shell.match(/onPointerDown=\{onTitlebarPointerDown\}/g)?.length,
-  2,
-  "every shell-top wires the native startDragging handler so the window drags on external-URL webviews",
-);
-assert.equal(
-  shell.match(/<div className="shell-top__bar" data-tauri-drag-region="">/g)?.length,
+  shell.match(/<div className="shell-top__bar" data-tauri-drag-region="deep">/g)?.length,
   2,
   "both rendered top-bar wrappers should remain draggable when their empty chrome is clicked",
 );
 assert.match(
   shell,
-  /<div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" \/>\s*\{navToggle\}/,
+  /<div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" \/>\s*\{navToggle\}/,
   "the desktop top bar should expose a dedicated non-interactive drag lane before its controls",
 );
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -180,21 +180,26 @@ function ShellInner({
 
   // Seamless macOS title bar: only the macOS desktop Tauri shell overlays the
   // native title bar (lib.rs sets TitleBarStyle::Overlay), so only there do we
-  // mark <html> to reserve room for the traffic lights and make the top bar a
-  // drag handle (see [data-tauri-titlebar] in globals.css). Browser, Windows,
-  // Linux, and Tauri-mobile keep their normal chrome.
+  // mark <html> to reserve room for the traffic lights (see
+  // [data-tauri-titlebar] in globals.css). Browser, Windows, Linux, and
+  // Tauri-mobile keep their normal chrome.
   //
-  // We track this in state (not just the <html> dataset) because the CSS
-  // `-webkit-app-region: drag` hint is INERT here: the webview loads from an
-  // external `http://127.0.0.1` URL (see lib.rs WebviewUrl::External), and
-  // WebKit only bridges `app-region: drag` into a real NSWindow drag on the
-  // native `tauri://` scheme. On external URLs the hint is silently ignored,
-  // which is why the CSS-only approach never actually dragged the window.
-  // So when `tauriTitlebar` is on we also attach a mousedown handler that calls
-  // the Tauri window API's startDragging(), which drives AppKit directly and
-  // works regardless of URL scheme. The CSS stays as a progressive-
-  // enhancement fallback for any bundled-scheme build.
-  const [tauriTitlebar, setTauriTitlebar] = useState(false);
+  // The drag itself is handled by Tauri's injected drag.js via the
+  // `data-tauri-drag-region="deep"` attributes on the titlebar below: a press
+  // on empty chrome anywhere in the subtree invokes
+  // `plugin:window|start_dragging`, while clickable elements (buttons, inputs,
+  // links, focusable widgets) block the drag so controls keep working.
+  // Double-click gets platform-correct zoom/maximize the same way
+  // (`internal_toggle_maximize`; on macOS it fires on mouseup and cancels if
+  // the cursor moved). Both commands are IPC calls gated by the capability
+  // ACL — the webview loads from an external `http://127.0.0.1` URL (a REMOTE
+  // execution context to the ACL), so they only work because
+  // capabilities/loopback-window-drag.json grants them to the loopback
+  // origin. Without that grant every drag path dies silently, and the CSS
+  // `-webkit-app-region: drag` hint is equally INERT on external URLs (WebKit
+  // only bridges it into a real NSWindow drag on the native `tauri://`
+  // scheme) — which is why the titlebar historically never dragged. The CSS
+  // stays as a progressive-enhancement fallback for any bundled-scheme build.
   useEffect(() => {
     if (typeof window === "undefined") return;
     const isTauri = "__TAURI_INTERNALS__" in window;
@@ -211,38 +216,10 @@ function ShellInner({
     if (!isTauri || !isMac) return;
     const root = document.documentElement;
     root.dataset.tauriTitlebar = "";
-    setTauriTitlebar(true);
     return () => {
       delete root.dataset.tauriTitlebar;
-      setTauriTitlebar(false);
     };
   }, []);
-
-  // Native window drag for the macOS overlay titlebar. Fires only in the Tauri
-  // macOS shell (tauriTitlebar). Ignores anything but a primary-button press
-  // that lands on empty chrome — clicks on interactive controls fall through
-  // so buttons/inputs keep working. Double-click still zooms the window via
-  // the OS, so we only handle single-press drags.
-  const onTitlebarPointerDown = useMemo(() => {
-    if (!tauriTitlebar) return undefined;
-    return (event: import("react").PointerEvent<HTMLElement>) => {
-      if (event.button !== 0) return;
-      const target = event.target as HTMLElement | null;
-      if (
-        target?.closest(
-          "button, a, input, select, textarea, kbd, label, [role='button'], [role='textbox'], [contenteditable], .menu-bar__search, .top-bar__search, .top-bar__account",
-        )
-      ) {
-        return;
-      }
-      void import("@tauri-apps/api/window")
-        .then(({ getCurrentWindow }) => getCurrentWindow().startDragging())
-        .catch(() => {
-          // Best-effort: if the API isn't available we simply fall back to the
-          // CSS app-region hint (a no-op on external URLs, but harmless).
-        });
-    };
-  }, [tauriTitlebar]);
   const mobileChromeState: ShellMobileChromeState = {
     navDrawerOpen: isMobile && mobileDrawer === "nav",
     listDrawerOpen: isMobile && mobileDrawer === "list",
@@ -488,9 +465,9 @@ function ShellInner({
   if (!mounted) {
     return (
       <div className="shell-frame flex h-full w-full flex-col">
-        <div className="shell-top" data-tauri-drag-region="" onPointerDown={onTitlebarPointerDown}>
-          <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
-          <div className="shell-top__bar" data-tauri-drag-region="">{renderedTopBar}</div>
+        <div className="shell-top" data-tauri-drag-region="deep">
+          <div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" />
+          <div className="shell-top__bar" data-tauri-drag-region="deep">{renderedTopBar}</div>
         </div>
         <div className="shell-body flex flex-1 min-h-0">
           <div className="shell-root flex-1 min-h-0" />
@@ -619,10 +596,15 @@ function ShellInner({
       {/* Keyboard/SR users can jump straight past the chrome to the active
           surface. Visually hidden until focused (see .skip-link in globals). */}
       <a className="skip-link" href="#shell-main-content">Skip to main content</a>
-      <div className="shell-top" data-tauri-drag-region="" onPointerDown={onTitlebarPointerDown}>
-        <div className="shell-titlebar-drag-lane" data-tauri-drag-region="" aria-hidden="true" />
+      {/* `deep` (not the bare attribute) matters: drag.js's bare value only
+          drags on DIRECT presses on the attributed element, so empty chrome
+          inside .menu-bar / .top-bar wrappers would short-circuit the walk and
+          never drag. `deep` makes the whole subtree a drag region while
+          clickable descendants still opt out. */}
+      <div className="shell-top" data-tauri-drag-region="deep">
+        <div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" />
         {navToggle}
-        <div className="shell-top__bar" data-tauri-drag-region="">{renderedTopBar}</div>
+        <div className="shell-top__bar" data-tauri-drag-region="deep">{renderedTopBar}</div>
       </div>
       <div className="shell-body flex flex-1 min-h-0">
         {hasBottom ? (

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -74,7 +74,13 @@ export function TrayQuickChat() {
   return (
     <main className="min-h-screen bg-[var(--bg-base)] text-[var(--fg-primary)]">
       <section className="flex min-h-screen flex-col border border-[var(--border-hairline)] bg-[var(--bg-panel)]">
-        <header className="quick-chat-overlay__header">
+        {/* The tray window is created with decorations(false) (see lib.rs), so
+            without a drag region it cannot be moved at all. Tauri's injected
+            drag.js turns any empty-chrome press in this subtree into a native
+            window drag (`deep` semantics; the icon buttons still block it),
+            gated by capabilities/loopback-window-drag.json. Inert in plain
+            browsers. */}
+        <header className="quick-chat-overlay__header" data-tauri-drag-region="deep">
           <div className="flex min-w-0 items-center gap-2">
             {selectedFamiliar ? (
               <FamiliarMark familiar={selectedFamiliar} size="md" />


### PR DESCRIPTION
## Problem

Titlebar drag has silently never worked in shipped desktop builds, on any platform:

- The desktop webview loads from an external `http://127.0.0.1` URL, which the Tauri capability ACL treats as a **remote execution context** — capabilities without a matching `remote.urls` block (like `default.json`) don't apply there at all. That's the same reason `loopback-main-events.json` / `loopback-browser.json` had to exist.
- No capability granted `core:window:allow-start-dragging` (it is **not** part of `core:window:default` — verified against the resolved ACL manifest). So Tauri's injected drag.js got denied, and shell.tsx's `startDragging()` handler got denied and swallowed the rejection in an empty `.catch`.
- The CSS `-webkit-app-region: drag` hint is inert on external URLs in WKWebView (and unsupported in WebView2), per the existing code comment.

Net effect: macOS overlay titlebar undraggable, double-click zoom dead (`internal_toggle_maximize` also denied), and the `decorations(false)` quick-chat tray window completely unmovable on every platform. The earlier drag fixes (#1972, #2063, #2139) only pinned DOM structure, so tests stayed green throughout.

## Fix

- **`src-tauri/capabilities/loopback-window-drag.json`** — remote-scoped grant of `core:window:allow-start-dragging` + `core:window:allow-internal-toggle-maximize` to the `main` and `quick-chat` windows on loopback origins (same URL-pattern family already proven in production by `loopback-browser.json`). Desktop platforms only.
- **`shell.tsx`** — titlebar drag regions switch to `data-tauri-drag-region="deep"` so upstream drag.js handles the drag and platform-correct double-click zoom/maximize from any empty chrome. Bare (valueless) regions only fire on *direct* presses on the attributed element, so presses on empty chrome inside `.menu-bar`/`.top-bar` wrappers never dragged; `deep` covers the subtree while drag.js's clickable-element check keeps buttons/inputs/focusable widgets working. The hand-rolled `startDragging` pointer handler is removed — it was redundant once drag.js works, and it would have broken drag.js's macOS mouseup-based double-click zoom (it started a drag on the second press).
- **`tray-quick-chat.tsx`** — the tray window header becomes a deep drag region so the frameless always-on-top window can be repositioned.
- **Windows/Linux bonus** — the in-app top bar's empty chrome now drags/double-click-maximizes there too (native decorations continue to work as before).

## Verification

- Root cause verified against vendored tauri 2.11.2 source: drag.js invokes `plugin:window|start_dragging` over ACL-gated IPC and is injected unconditionally for every webview; ACL fixture tests confirm remote URLs don't match local-only capabilities; resolved ACL manifest confirms `core:window:default` lacks `allow-start-dragging`.
- `cargo check` green — tauri-build validates capability files and referenced permissions at compile time; `tauri.conf.json` has no explicit capability list, so the new file is auto-ingested.
- `pnpm typecheck` green; `pnpm test:app` — 520 files green.
- New pins: `desktop-permissions.test.mjs` locks the capability (windows, platforms, loopback-only origins, exact permission list) and both deep drag-region attributes; `shell-edge-rails.test.ts` updated to the new contract (and now rejects reintroducing a hand-rolled `startDragging`).

Closes bead `cave-3df`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)