### PR TITLE
fix(connection): seamless, stable iOS ↔ desktop connection

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -34,11 +34,16 @@ struct CovenCaveApp: App {
                 // Returning to the foreground after the desktop was unreachable
                 // (locked the phone, desktop blipped/restarted) should recover on
                 // its own — retry unless we're already connected or mid-check.
+                // A state that *says* connected can be stale after a suspension,
+                // so it gets one cheap validation probe instead of blind trust.
                 .onChange(of: scenePhase) { _, phase in
-                    guard phase == .active, app.connection != nil,
-                          app.connectionState != .connected,
-                          app.connectionState != .checking else { return }
-                    Task { await app.connectWithRetry() }
+                    guard phase == .active, app.connection != nil else { return }
+                    if app.connectionState != .connected,
+                       app.connectionState != .checking {
+                        Task { await app.connectWithRetry() }
+                    } else if app.connectionState == .connected {
+                        Task { await app.validateConnectionOnForeground() }
+                    }
                 }
                 // Deep links from the home-screen widget (covencave://…) route to
                 // the matching tab/sheet. Handled even before connect — the tab is

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
@@ -5,13 +5,17 @@ import Foundation
 /// from `connection.baseURL` (with proper query-item encoding) rather than the
 /// core client's path-only helper.
 extension CaveClient {
-    private var devSession: URLSession {
+    /// Shared across all dev-tab calls — one pooled session instead of a
+    /// leaked `URLSession` per request (see `restSession` in the core client).
+    private static let devSharedSession: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 25
-        config.timeoutIntervalForResource = 60
+        config.timeoutIntervalForResource = 300
         config.waitsForConnectivity = true
         return URLSession(configuration: config)
-    }
+    }()
+
+    private var devSession: URLSession { Self.devSharedSession }
 
     /// Build a request against `<base>/<path>` with optional query items.
     private func devRequest(
@@ -30,6 +34,11 @@ extension CaveClient {
         var req = URLRequest(url: url)
         req.httpMethod = method
         req.setValue("application/json", forHTTPHeaderField: "Accept")
+        // Same credential as the core client — without it every dev-tab call
+        // (projects, code browse, GitHub) 401s on a token-gated desktop.
+        if let token = CaveConnection.accessToken {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
         if let body {
             req.httpBody = body
             req.setValue("application/json", forHTTPHeaderField: "Content-Type")

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -15,13 +15,33 @@ struct CaveClient {
         }
     }
 
-    private var session: URLSession {
+    /// One shared session for REST calls. A `URLSession` is never deallocated
+    /// once created, so building one per request (the old computed property)
+    /// leaked sessions and re-negotiated TLS on every call; a single shared
+    /// instance keeps connections pooled and warm.
+    private static let restSession: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 20
-        config.timeoutIntervalForResource = 60
+        config.timeoutIntervalForResource = 300
         config.waitsForConnectivity = true
         return URLSession(configuration: config)
-    }
+    }()
+
+    /// Dedicated session for chat SSE streams. `timeoutIntervalForResource`
+    /// bounds the WHOLE transfer (the per-request `timeoutInterval` only
+    /// resets the idle clock), so sharing the REST session's cap silently
+    /// killed any reply that streamed longer than it — long agentic turns
+    /// died mid-stream at the old 60s cap. Streams get a day-long resource
+    /// window; the idle timeout still catches a genuinely dead connection.
+    private static let streamSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 600
+        config.timeoutIntervalForResource = 24 * 3600
+        config.waitsForConnectivity = true
+        return URLSession(configuration: config)
+    }()
+
+    private var session: URLSession { Self.restSession }
 
     func data(for req: URLRequest) async throws -> (Data, URLResponse) {
         let method = (req.httpMethod ?? "GET").uppercased()
@@ -323,7 +343,7 @@ struct CaveClient {
                     req.setValue("text/event-stream", forHTTPHeaderField: "Accept")
                     req.timeoutInterval = 600
 
-                    let (bytes, resp) = try await session.bytes(for: req)
+                    let (bytes, resp) = try await Self.streamSession.bytes(for: req)
                     try Self.check(resp)
 
                     var dataLines: [String] = []

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -22,8 +22,11 @@ struct CaveConnection: Codable, Equatable {
             return URL(string: trimmed)
         }
 
-        // MagicDNS .ts.net → HTTPS, default port (Tailscale Serve terminates TLS).
-        if trimmed.lowercased().hasSuffix(".ts.net") || trimmed.lowercased().contains(".ts.net/") {
+        // MagicDNS .ts.net → HTTPS, with or without an explicit port
+        // (`tailscale serve` often terminates TLS on :8443, so a relocated
+        // "host.ts.net:8443" must still derive https, not http).
+        let hostPart = trimmed.split(separator: ":").first.map(String.init) ?? trimmed
+        if hostPart.lowercased().hasSuffix(".ts.net") || trimmed.lowercased().contains(".ts.net/") {
             return URL(string: "https://\(trimmed)")
         }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
@@ -27,7 +27,34 @@ final class PtyTerminal {
     private var task: URLSessionWebSocketTask?
     private var receiveLoop: Task<Void, Never>?
 
+    /// One shared session for WebSocket tasks — a `URLSession` is never
+    /// deallocated once created, so building one per (re)connect leaked them.
+    private static let wsSession = URLSession(configuration: .default)
+
+    /// Last connect parameters, kept for transparent auto-reconnect (the
+    /// server holds the shell through a detach grace window and replays
+    /// scrollback on reattach, so a transient drop is recoverable in place).
+    private var lastWsBase: URL?
+    private var lastThreadId = ""
+    private var lastProjectRoot: String?
+    private var lastCols = 80
+    private var lastRows = 24
+    private var reconnectAttempt = 0
+    private var reconnectTask: Task<Void, Never>?
+    private static let maxAutoReconnects = 3
+
     func connect(wsBase: URL, threadId: String, projectRoot: String?, cols: Int, rows: Int) {
+        lastWsBase = wsBase
+        lastThreadId = threadId
+        lastProjectRoot = projectRoot
+        lastCols = cols
+        lastRows = rows
+        reconnectAttempt = 0
+        open()
+    }
+
+    private func open() {
+        guard let wsBase = lastWsBase else { return }
         disconnect()
         exited = false
         exitCode = nil
@@ -39,29 +66,30 @@ final class PtyTerminal {
             error = "Bad terminal URL."
             return
         }
-        var items = [URLQueryItem(name: "threadId", value: threadId)]
-        if let projectRoot, !projectRoot.isEmpty {
+        var items = [URLQueryItem(name: "threadId", value: lastThreadId)]
+        if let projectRoot = lastProjectRoot, !projectRoot.isEmpty {
             items.append(URLQueryItem(name: "projectRoot", value: projectRoot))
         }
         comps.queryItems = items
         guard let url = comps.url else { error = "Bad terminal URL."; return }
 
-        let session = URLSession(configuration: .default)
         // Same credential as the REST client — the pty-ws upgrade passes
         // through the token gate too on a paired desktop.
         var wsRequest = URLRequest(url: url)
         if let token = CaveConnection.accessToken {
             wsRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        let ws = session.webSocketTask(with: wsRequest)
+        let ws = Self.wsSession.webSocketTask(with: wsRequest)
         task = ws
         ws.resume()
         connected = true
-        sendResize(cols: cols, rows: rows)
+        sendResize(cols: lastCols, rows: lastRows)
         startReceiving()
     }
 
     func disconnect() {
+        reconnectTask?.cancel()
+        reconnectTask = nil
         receiveLoop?.cancel()
         receiveLoop = nil
         task?.cancel(with: .goingAway, reason: nil)
@@ -80,6 +108,8 @@ final class PtyTerminal {
 
     func sendResize(cols: Int, rows: Int) {
         guard let task, cols > 0, rows > 0 else { return }
+        lastCols = cols
+        lastRows = rows
         var frame = Data([0x04])
         var c = UInt16(min(cols, 0xFFFF)).littleEndian
         var r = UInt16(min(rows, 0xFFFF)).littleEndian
@@ -92,15 +122,19 @@ final class PtyTerminal {
 
     private func startReceiving() {
         // The closure inherits this class's @MainActor isolation, so member
-        // access is synchronous; only `task.receive()` actually suspends.
+        // access is synchronous; only `ws.receive()` actually suspends. The
+        // socket is pinned per loop: a replaced/cancelled socket's dangling
+        // receive resumes with a stale error after reconnect, and reporting
+        // it through fail() would clobber the live connection's state.
         receiveLoop = Task { [weak self] in
+            guard let ws = self?.task else { return }
             while !Task.isCancelled {
-                guard let self, let task = self.task else { break }
+                guard let self, self.task === ws else { break }
                 do {
-                    let message = try await task.receive()
+                    let message = try await ws.receive()
                     self.handle(message)
                 } catch {
-                    self.fail(error)
+                    if !Task.isCancelled, self.task === ws { self.fail(error) }
                     break
                 }
             }
@@ -108,6 +142,8 @@ final class PtyTerminal {
     }
 
     private func handle(_ message: URLSessionWebSocketTask.Message) {
+        // Any server frame proves the link is live — refill the retry budget.
+        reconnectAttempt = 0
         switch message {
         case .data(let data):
             handleFrame(data)
@@ -138,7 +174,22 @@ final class PtyTerminal {
     private func fail(_ error: Error) {
         // A clean close after exit is not an error worth surfacing.
         if exited { return }
-        self.error = error.localizedDescription
         connected = false
+        // Transient drop (network handoff, backgrounding, desktop blip):
+        // retry with backoff before asking the user — the server's detach
+        // grace keeps the shell alive and replays scrollback on reattach.
+        if reconnectAttempt < Self.maxAutoReconnects, lastWsBase != nil {
+            reconnectAttempt += 1
+            self.error = "Connection lost — reconnecting…"
+            let delay = 1 << (reconnectAttempt - 1)   // 1s, 2s, 4s
+            reconnectTask?.cancel()
+            reconnectTask = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(delay))
+                guard let self, !Task.isCancelled, !self.connected, !self.exited else { return }
+                self.open()
+            }
+            return
+        }
+        self.error = error.localizedDescription
     }
 }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -656,8 +656,43 @@ final class AppModel {
     private func handleSurfaceError(_ error: Error) -> String {
         if CaveError.isAuthFailure(error) {
             connectionState = .needsAuth(pairingMessage())
+        } else if connectionState == .connected {
+            scheduleAutoRecover()
         }
         return error.localizedDescription
+    }
+
+    /// Last time a failed surface load triggered an automatic reconnect —
+    /// bounds the recovery loop so cascading failures fold into one probe.
+    private var lastAutoRecoverAt: Date = .distantPast
+
+    /// A surface load failed while the state says connected — the desktop may
+    /// have restarted or moved ports without a network-path change, which
+    /// NWPathMonitor can't see. Re-run discovery in the background, at most
+    /// once per cooldown, so the app heals itself instead of sitting on a
+    /// stale "connected" with every surface erroring.
+    private func scheduleAutoRecover() {
+        let cooldown: TimeInterval = 10
+        guard Date().timeIntervalSince(lastAutoRecoverAt) > cooldown else { return }
+        lastAutoRecoverAt = Date()
+        Task { [weak self] in await self?.recoverConnectionInBackground() }
+    }
+
+    /// The connected state can be stale after a long suspension: the desktop
+    /// may have restarted or relocated while iOS had the app frozen, with no
+    /// path change for the supervisor to see. Revalidate with one cheap probe
+    /// on foreground — the common case (still reachable) costs a single
+    /// request and repaints nothing; a dead endpoint falls into the usual
+    /// retry/discovery path. A successful probe also gives the rolling token
+    /// renewal a chance to run for long-foregrounded devices.
+    func validateConnectionOnForeground() async {
+        guard connection != nil, connectionState == .connected else { return }
+        if let client, await client.ping() {
+            await refreshAccessTokenIfNeeded()
+            return
+        }
+        guard connectionState == .connected else { return }
+        await connectWithRetry()
     }
 
     private func refreshLoadedSurfaces() async {
@@ -670,9 +705,13 @@ final class AppModel {
         await loadTheme()
     }
 
-    func refreshConnection(reloadLoadedSurfaces: Bool = false) async {
+    /// `quiet` probes without first flipping the state to `.checking`, so a
+    /// background retry (e.g. the unreachable screen's auto-retry ticker)
+    /// doesn't bounce the UI through intermediate states — the state only
+    /// changes when the probe has an outcome.
+    func refreshConnection(reloadLoadedSurfaces: Bool = false, quiet: Bool = false) async {
         guard let connection else { connectionState = .unconfigured; return }
-        connectionState = .checking
+        if !quiet { connectionState = .checking }
 
         // Try the configured endpoint first, then auto-relocate to a working
         // port (e.g. the user typed a `.ts.net` host without `:8443`).
@@ -680,8 +719,13 @@ final class AppModel {
         switch await Self.discoverBaseURL(connection.candidateBaseURLs) {
         case .found(let working):
             if working != configured {
-                // Relocate: persist the working URL so future launches connect directly.
-                let relocated = CaveConnection(host: working.absoluteString)
+                // Relocate: persist the working endpoint so future launches
+                // connect directly. Stored as bare `host:port` when the
+                // default scheme derivation reproduces the URL — a bare host
+                // keeps future discovery able to probe alternate ports if the
+                // desktop moves again, while a full URL is treated as
+                // user-explicit and would pin the connection forever.
+                let relocated = CaveConnection(host: Self.canonicalHost(for: working))
                 self.connection = relocated
                 relocated.save()
                 if let port = working.port {
@@ -750,24 +794,56 @@ final class AppModel {
         case none
     }
 
-    /// Probe candidate base URLs in order; adopt the first that answers as a
-    /// real Cave server. A 401/403 is TERMINAL, not a cue to keep walking:
-    /// it's a live Cave token gate talking, and the fix is pairing. Probing
-    /// past it can silently adopt a different instance on a sibling port
-    /// (e.g. a dev server on :3000) — the user thinks they're talking to the
-    /// desktop they paired with, but they aren't.
+    /// Probe every candidate base URL concurrently, then adjudicate strictly
+    /// in candidate order so the semantics match a sequential walk: the first
+    /// `.ok` in order wins, and a 401/403 earlier in the order is TERMINAL —
+    /// it's a live Cave token gate talking, and the fix is pairing. Adopting
+    /// a later candidate past it could silently connect to a different
+    /// instance on a sibling port (e.g. a dev server on :3000) — the user
+    /// thinks they're talking to the desktop they paired with, but they
+    /// aren't. Concurrency only changes the wall clock: one probe's timeout
+    /// (~6s) instead of the sum across candidates (30s+ on a cold launch).
     static func discoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
-        for base in candidates {
-            switch await probe(base) {
-            case .ok: return .found(base)
+        guard !candidates.isEmpty else { return .none }
+        let results = await withTaskGroup(of: (Int, ProbeResult).self) { group in
+            for (index, base) in candidates.enumerated() {
+                group.addTask { (index, await Self.probe(base)) }
+            }
+            var collected = [ProbeResult?](repeating: nil, count: candidates.count)
+            for await (index, result) in group { collected[index] = result }
+            return collected
+        }
+        for (index, result) in results.enumerated() {
+            switch result {
+            case .ok: return .found(candidates[index])
             case .unauthorized: return .unauthorized
-            case .failed: continue
+            default: continue
             }
         }
         return .none
     }
 
+    /// Persist a relocated endpoint as `host:port` when the default scheme
+    /// derivation reproduces it (see the relocation comment in
+    /// `refreshConnection`); otherwise fall back to the explicit URL.
+    static func canonicalHost(for url: URL) -> String {
+        guard let host = url.host else { return url.absoluteString }
+        let compact = url.port.map { "\(host):\($0)" } ?? host
+        return CaveConnection(host: compact).baseURL == url ? compact : url.absoluteString
+    }
+
     private enum ProbeResult { case ok, unauthorized, failed }
+
+    /// Shared session for discovery probes — ephemeral (no cache/cookie
+    /// carry-over) and never recreated, so repeated discovery rounds don't
+    /// leak URLSessions the way per-probe construction did.
+    private static let probeSession: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 6
+        config.timeoutIntervalForResource = 10
+        config.waitsForConnectivity = false
+        return URLSession(configuration: config)
+    }()
 
     /// Reachability check that requires a *real* Cave API response — a 2xx whose
     /// body decodes as the familiars payload. A bare status check would accept
@@ -777,16 +853,13 @@ final class AppModel {
     /// adopt an actual Cave server. Sends the paired credential when one exists
     /// and reports a 401/403 distinctly — that's a Cave token gate talking.
     private static func probe(_ base: URL) async -> ProbeResult {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 6
-        config.waitsForConnectivity = false
         var req = URLRequest(url: base.appendingPathComponent("api/familiars"))
         req.timeoutInterval = 6
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         if let token = CaveConnection.accessToken {
             req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        guard let (data, resp) = try? await URLSession(configuration: config).data(for: req),
+        guard let (data, resp) = try? await probeSession.data(for: req),
               let http = resp as? HTTPURLResponse
         else { return .failed }
         if http.statusCode == 401 || http.statusCode == 403 { return .unauthorized }

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -214,13 +214,48 @@ final class ChatThread: Identifiable, Hashable {
             }
             mutate(messageId) { $0.streaming = false }
         } catch {
-            mutate(messageId) {
-                if $0.text.isEmpty { $0.text = error.localizedDescription }
-                $0.isError = true; $0.streaming = false
+            // Transport interruption (network handoff, backgrounding, desktop
+            // blip). The server persists the turn — including a partial reply
+            // — even when the stream dies, so recover its copy before
+            // surfacing a raw connection error.
+            let recovered = await resyncInterruptedTurn(familiarId: familiarId, prompt: prompt,
+                                                        into: messageId, client: client)
+            if !recovered {
+                mutate(messageId) {
+                    if $0.text.isEmpty { $0.text = error.localizedDescription }
+                    $0.isError = true; $0.streaming = false
+                }
             }
         }
         updatedAt = Date()
         onChange()
+    }
+
+    /// After a transport failure mid-stream, pull the persisted conversation
+    /// and adopt the server's copy of the interrupted reply. Anchors on the
+    /// prompt: the reply must be an assistant turn AFTER a final user turn
+    /// carrying exactly what we sent, and must extend what already streamed
+    /// into the bubble. Anything else means the reply never persisted (or
+    /// belongs to an older exchange) and the caller falls back to the error
+    /// path. Returns true when the bubble recovered.
+    private func resyncInterruptedTurn(familiarId: String, prompt: String, into messageId: String,
+                                       client: CaveClient) async -> Bool {
+        guard let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { return false }
+        // Give the server a beat to flush the transcript after the drop.
+        try? await Task.sleep(for: .milliseconds(600))
+        guard let convo = try? await client.conversation(sessionId: sessionId),
+              let lastUser = convo.turns.lastIndex(where: { $0.role == "user" }),
+              convo.turns[lastUser].text == prompt,
+              let reply = convo.turns[(lastUser + 1)...].last(where: { $0.role == "assistant" })
+        else { return false }
+        let streamed = messages.first(where: { $0.id == messageId })?.text ?? ""
+        guard !reply.text.isEmpty, reply.text.hasPrefix(streamed) else { return false }
+        mutate(messageId) {
+            $0.text = reply.text
+            $0.isError = reply.isError ?? false
+            $0.streaming = false
+        }
+        return true
     }
 
     private func mutate(_ messageId: String, _ body: (inout DisplayMessage) -> Void) {

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -57,6 +57,20 @@ struct ConnectionView: View {
                 }
                 .ignoresSafeArea()
             }
+            // While this screen shows "unreachable", quietly re-probe so a
+            // desktop that comes back (rebooted, woke from sleep) reconnects
+            // on its own — no tapping Connect again. Quiet mode keeps the
+            // state at .unreachable during each probe, so the screen doesn't
+            // bounce; pairing (.needsAuth) stays manual — only the user can
+            // fix that. Keyed on scenePhase so backgrounding stops the timer.
+            .task(id: scenePhase) {
+                guard scenePhase == .active else { return }
+                while !Task.isCancelled {
+                    try? await Task.sleep(for: .seconds(10))
+                    guard !busy, case .unreachable = app.connectionState else { continue }
+                    await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)
+                }
+            }
         }
     }
 

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Connection seamlessness + stability (cave-30b). The app should hold one
+// warm connection, survive long streams and transient drops, discover the
+// desktop fast, and heal itself when the desktop restarts or moves — without
+// the user touching anything.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const client = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
+const devClient = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift");
+const connection = await read("apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift");
+const terminal = await read("apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const thread = await read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");
+const app = await read("apps/ios/CovenCave/CovenCave/CovenCaveApp.swift");
+const connectView = await read("apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift");
+
+// --- Shared URLSessions: sessions are never deallocated, so per-request
+// construction leaked them and re-negotiated TLS on every call ---------------
+assert.match(
+  client,
+  /private static let restSession: URLSession = \{/,
+  "CaveClient should hold ONE shared REST session",
+);
+assert.match(
+  client,
+  /private var session: URLSession \{ Self\.restSession \}/,
+  "requests should route through the shared REST session",
+);
+assert.match(
+  devClient,
+  /private static let devSharedSession: URLSession = \{/,
+  "dev-tab calls should share one session too",
+);
+assert.match(
+  terminal,
+  /private static let wsSession = URLSession\(configuration: \.default\)/,
+  "PTY websockets should come from one shared session",
+);
+assert.match(
+  model,
+  /private static let probeSession: URLSession = \{/,
+  "discovery probes should share one ephemeral session",
+);
+
+// --- Streaming must NOT ride a session whose resource timeout caps the whole
+// transfer — the old 60s cap killed any reply that streamed longer ----------
+assert.match(
+  client,
+  /private static let streamSession: URLSession = \{[\s\S]*?timeoutIntervalForResource = 24 \* 3600/,
+  "SSE streams need a day-long resource window (resource timeout caps the WHOLE transfer)",
+);
+assert.match(
+  client,
+  /Self\.streamSession\.bytes\(for: req\)/,
+  "sendStream should use the dedicated streaming session",
+);
+assert.doesNotMatch(
+  client,
+  /timeoutIntervalForResource = 60\b/,
+  "no 60s resource cap may return — it killed replies that streamed past a minute",
+);
+
+// --- Dev-tab requests carry the paired credential ---------------------------
+assert.match(
+  devClient,
+  /devRequest[\s\S]*?if let token = CaveConnection\.accessToken \{\s*\n\s*req\.setValue\("Bearer \\\(token\)", forHTTPHeaderField: "Authorization"\)/,
+  "dev-tab requests must send the Bearer token — without it the Developer tab 401s on a paired desktop",
+);
+
+// --- Discovery: concurrent probes, ordered adjudication, 401 stays terminal -
+assert.match(
+  model,
+  /static func discoverBaseURL[\s\S]*?withTaskGroup/,
+  "candidates should be probed concurrently (wall-clock = one probe, not the sum)",
+);
+assert.match(
+  model,
+  /for \(index, result\) in results\.enumerated\(\)[\s\S]*?case \.ok: return \.found\(candidates\[index\]\)[\s\S]*?case \.unauthorized: return \.unauthorized/,
+  "results must be adjudicated in candidate order with 401/403 still terminal (sibling-port safety)",
+);
+
+// --- Relocation keeps discovery alive --------------------------------------
+assert.match(
+  model,
+  /static func canonicalHost\(for url: URL\) -> String/,
+  "relocation should persist a canonical host",
+);
+assert.match(
+  model,
+  /CaveConnection\(host: Self\.canonicalHost\(for: working\)\)/,
+  "relocation must store host:port (not a pinned explicit URL) when the scheme is derivable",
+);
+assert.match(
+  connection,
+  /let hostPart = trimmed\.split\(separator: ":"\)\.first[\s\S]*?hostPart\.lowercased\(\)\.hasSuffix\("\.ts\.net"\)/,
+  "a .ts.net host WITH a port must still derive https (tailscale serve terminates TLS on :8443)",
+);
+
+// --- Self-healing: transport failures while "connected" trigger recovery ----
+assert.match(
+  model,
+  /func handleSurfaceError[\s\S]*?else if connectionState == \.connected \{\s*\n\s*scheduleAutoRecover\(\)/,
+  "a surface failure while connected should schedule background recovery",
+);
+assert.match(
+  model,
+  /func scheduleAutoRecover\(\)[\s\S]*?cooldown[\s\S]*?recoverConnectionInBackground\(\)/,
+  "auto-recovery must be cooldown-bounded so cascading failures fold into one probe",
+);
+assert.match(
+  model,
+  /func validateConnectionOnForeground\(\) async[\s\S]*?client\.ping\(\)[\s\S]*?connectWithRetry\(\)/,
+  "foregrounding while nominally connected should revalidate with one cheap probe",
+);
+assert.match(
+  app,
+  /else if app\.connectionState == \.connected \{\s*\n\s*Task \{ await app\.validateConnectionOnForeground\(\) \}/,
+  "the app should validate a stale connected state on foreground",
+);
+
+// --- Quiet retry: the unreachable screen re-probes without UI bouncing ------
+assert.match(
+  model,
+  /func refreshConnection\(reloadLoadedSurfaces: Bool = false, quiet: Bool = false\) async \{[\s\S]*?if !quiet \{ connectionState = \.checking \}/,
+  "quiet refresh must not flip the state to .checking before it has an outcome",
+);
+assert.match(
+  connectView,
+  /case \.unreachable = app\.connectionState else \{ continue \}\s*\n\s*await app\.refreshConnection\(reloadLoadedSurfaces: true, quiet: true\)/,
+  "the unreachable screen should quietly auto-retry so a returning desktop reconnects on its own",
+);
+
+// --- Chat stream interruption: recover the persisted turn, not a raw error --
+assert.match(
+  thread,
+  /catch \{[\s\S]*?resyncInterruptedTurn\(familiarId: familiarId, prompt: prompt/,
+  "a transport failure mid-stream should try to resync the persisted turn first",
+);
+assert.match(
+  thread,
+  /func resyncInterruptedTurn[\s\S]*?convo\.turns\[lastUser\]\.text == prompt[\s\S]*?reply\.text\.hasPrefix\(streamed\)/,
+  "resync must anchor on our own prompt and only extend what already streamed (never adopt an older reply)",
+);
+
+// --- Terminal: transient drops auto-reconnect within the server's grace -----
+assert.match(
+  terminal,
+  /private static let maxAutoReconnects = 3/,
+  "terminal auto-reconnect must be bounded",
+);
+assert.match(
+  terminal,
+  /func fail[\s\S]*?reconnectAttempt < Self\.maxAutoReconnects[\s\S]*?Task\.sleep[\s\S]*?self\.open\(\)/,
+  "a transport failure should retry with backoff before surfacing the error",
+);
+assert.match(
+  terminal,
+  /func handle\(_ message[\s\S]*?reconnectAttempt = 0/,
+  "any received frame should refill the reconnect budget",
+);
+assert.match(
+  terminal,
+  /guard let ws = self\?\.task else \{ return \}[\s\S]*?self\.task === ws/,
+  "the receive loop must pin its socket — a replaced socket's stale error must not clobber the live connection",
+);
+
+console.log("ios-connection-stability: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -700,6 +700,7 @@ export const SUITES = {
     "scripts/ios-theme.test.mjs",
     "scripts/ios-auto-reconnect.test.mjs",
     "scripts/ios-self-healing-sync.test.mjs",
+    "scripts/ios-connection-stability.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-connect-screen-ux.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",

--- a/server.mjs
+++ b/server.mjs
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
@@ -23,7 +24,10 @@ const LEGACY_ACCESS_COOKIE = "coven_access_token";
 const ACCESS_QUERY_PARAM = "coven_access_token";
 const sessions = /* @__PURE__ */ new Map();
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
-const DETACH_GRACE_MS = 6e4;
+const DETACH_GRACE_MS = (() => {
+  const env = Number.parseInt(process.env.COVEN_CAVE_PTY_DETACH_GRACE_MS ?? "", 10);
+  return Number.isFinite(env) && env > 0 ? env : 3e5;
+})();
 function appendScrollback(session, data) {
   session.scrollback.push(data);
   session.scrollbackBytes += data.length;
@@ -54,7 +58,18 @@ function timingSafeEqualString(a, b) {
   return diff === 0;
 }
 function isExpectedToken(value) {
-  return Boolean(ACCESS_TOKEN && value && timingSafeEqualString(value, ACCESS_TOKEN));
+  if (!ACCESS_TOKEN || !value) return false;
+  if (timingSafeEqualString(value, ACCESS_TOKEN)) return true;
+  return isValidSignedAccessToken(value, ACCESS_TOKEN);
+}
+function isValidSignedAccessToken(value, secret) {
+  const parts = value.split(".");
+  if (parts.length !== 4 || parts[0] !== "v1") return false;
+  const expiresAt = Number(parts[1]);
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) return false;
+  if (!parts[2] || !parts[3]) return false;
+  const expected = createHmac("sha256", secret).update(`v1.${parts[1]}.${parts[2]}`).digest("base64url");
+  return timingSafeEqualString(parts[3], expected);
 }
 function bearerToken(req) {
   const auth = req.headers.authorization ?? "";
@@ -325,6 +340,8 @@ server.on("upgrade", (req, socket, head) => {
     handlePtyConnection(ws, threadId, cols, rows, cwd);
   });
 });
+server.keepAliveTimeout = 75e3;
+server.headersTimeout = 8e4;
 server.listen(port, hostname, () => {
   console.log(`> Ready on http://${hostname}:${port}`);
 });

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import { createRequire } from "node:module";
@@ -55,8 +56,14 @@ const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
 // drag-reorganize, tab switch) or the page reloads; killing the shell the
 // instant the old socket closes turned every one of those into a dead/blank
 // pane with a brand-new shell. Detach instead of kill, and let the timer reap
-// only genuinely-abandoned shells.
-const DETACH_GRACE_MS = 60_000;
+// only genuinely-abandoned shells. The default is sized for the iOS app too:
+// backgrounding the phone kills its socket, and a 60s window meant stepping
+// away for two minutes came back to a dead shell — 5 minutes keeps a quick
+// app-switch/lock survivable while still bounding abandoned shells.
+const DETACH_GRACE_MS = (() => {
+  const env = Number.parseInt(process.env.COVEN_CAVE_PTY_DETACH_GRACE_MS ?? "", 10);
+  return Number.isFinite(env) && env > 0 ? env : 300_000;
+})();
 
 function appendScrollback(session: PtySession, data: Buffer): void {
   session.scrollback.push(data);
@@ -95,7 +102,26 @@ function timingSafeEqualString(a: string, b: string): boolean {
 }
 
 function isExpectedToken(value: string | undefined | null): boolean {
-  return Boolean(ACCESS_TOKEN && value && timingSafeEqualString(value, ACCESS_TOKEN));
+  if (!ACCESS_TOKEN || !value) return false;
+  if (timingSafeEqualString(value, ACCESS_TOKEN)) return true;
+  return isValidSignedAccessToken(value, ACCESS_TOKEN);
+}
+
+// Mirrors src/lib/mobile-access-token.ts (server.mjs is transpiled standalone,
+// so it can't import from src/): `v1.<expiresAtMs>.<nonce>.<sig>` where
+// sig = base64url(HMAC-SHA256(secret, "v1.<expiresAtMs>.<nonce>")). Paired
+// phones and QR-paired browsers hold these SIGNED tokens — not the raw secret
+// — so the PTY upgrade must honour them or every paired terminal 401s.
+function isValidSignedAccessToken(value: string, secret: string): boolean {
+  const parts = value.split(".");
+  if (parts.length !== 4 || parts[0] !== "v1") return false;
+  const expiresAt = Number(parts[1]);
+  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) return false;
+  if (!parts[2] || !parts[3]) return false;
+  const expected = createHmac("sha256", secret)
+    .update(`v1.${parts[1]}.${parts[2]}`)
+    .digest("base64url");
+  return timingSafeEqualString(parts[3], expected);
 }
 
 function bearerToken(req: IncomingMessage): string | null {
@@ -466,6 +492,15 @@ server.on("upgrade", (req, socket, head) => {
     handlePtyConnection(ws, threadId, cols, rows, cwd);
   });
 });
+
+// Keep idle HTTP/1.1 connections open longer than clients hold them for
+// reuse. Node's 5s default races connection pooling in URLSession (the iOS
+// app) and `tailscale serve`'s upstream proxying — the server closes an idle
+// socket just as the client reuses it, surfacing as sporadic "network
+// connection lost" errors. headersTimeout must exceed keepAliveTimeout so a
+// reused socket isn't reaped while request headers are mid-flight.
+server.keepAliveTimeout = 75_000;
+server.headersTimeout = 80_000;
 
 server.listen(port, hostname, () => {
   console.log(`> Ready on http://${hostname}:${port}`);

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -305,6 +305,31 @@ for (const contract of contracts) {
     /if \(cancelledByUser\) \{\s*\n\s*if \(!assistantText\.trim\(\)\) assistantText = "\(cancelled\)";\s*\n\s*isError = false;/,
     "/chat/send: a user cancel must never be recorded as a harness error (openclaw path)",
   );
+
+  // SSE heartbeats: a long tool run can stream nothing for minutes, and a
+  // silent connection gets dropped by NATs/proxies and client idle timeouts
+  // (the iOS app most of all). Both adapter paths must emit comment frames
+  // — which every consumer skips (frames not starting with "data:") — and
+  // clear the interval when the stream closes.
+  assert.match(
+    sendSource,
+    /const SSE_HEARTBEAT = new TextEncoder\(\)\.encode\(": hb\\n\\n"\)/,
+    "/chat/send: heartbeat is an SSE comment frame, invisible to data: parsers",
+  );
+  const heartbeatStarts = [...sendSource.matchAll(/const heartbeat = startSseHeartbeat\(controller,/g)];
+  assert.equal(
+    heartbeatStarts.length,
+    2,
+    "/chat/send: both adapter paths must start the SSE heartbeat",
+  );
+  const heartbeatClears = [
+    ...sendSource.matchAll(/closed = true;\s*\n\s*clearInterval\(heartbeat\);/g),
+  ];
+  assert.equal(
+    heartbeatClears.length,
+    2,
+    "/chat/send: both adapter paths must clear the heartbeat when the stream closes",
+  );
 }
 
 {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -364,6 +364,33 @@ function sse(event: StreamEvent): Uint8Array {
   return new TextEncoder().encode(`data: ${JSON.stringify(event)}\n\n`);
 }
 
+// SSE comment frame + cadence keeping quiet streams alive: NATs, proxies, and
+// client idle timeouts can drop a connection that goes silent for the length
+// of a long tool run. Comments are invisible to every consumer — the web
+// readers and the iOS app all skip frames that don't start with `data:`.
+const SSE_HEARTBEAT = new TextEncoder().encode(": hb\n\n");
+const SSE_HEARTBEAT_INTERVAL_MS = 20_000;
+
+// Emit `: hb` comments until the stream closes/aborts; self-cleaning, but
+// callers also clear it from close() so a finished turn stops immediately.
+function startSseHeartbeat(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  isDone: () => boolean,
+): NodeJS.Timeout {
+  const heartbeat = setInterval(() => {
+    if (isDone()) {
+      clearInterval(heartbeat);
+      return;
+    }
+    try {
+      controller.enqueue(SSE_HEARTBEAT);
+    } catch {
+      clearInterval(heartbeat);
+    }
+  }, SSE_HEARTBEAT_INTERVAL_MS);
+  return heartbeat;
+}
+
 async function maybeQueueOfflineChat(args: {
   body: SendBody;
   config: CaveConfig;
@@ -646,9 +673,11 @@ function openClawChatResponse(args: {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
+      const heartbeat = startSseHeartbeat(controller, () => closed || args.req.signal.aborted);
       const close = () => {
         if (closed) return;
         closed = true;
+        clearInterval(heartbeat);
         try {
           controller.close();
         } catch {
@@ -1252,9 +1281,11 @@ export async function POST(req: Request) {
           ...(detail ? { detail } : {}),
           ...(durationMs != null ? { durationMs } : {}),
         });
+      const heartbeat = startSseHeartbeat(controller, () => closed || req.signal.aborted);
       const close = () => {
         if (closed) return;
         closed = true;
+        clearInterval(heartbeat);
         try {
           controller.close();
         } catch {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -18,6 +18,40 @@ assert.match(src, /if \(!ACCESS_TOKEN\) return false/, "PTY WebSocket auth fails
 // connections working. #714 dropped this guard and 401'd every local terminal.
 assert.match(src, /if \(ACCESS_TOKEN && !isAuthorized\(req, query\)\)/, "PTY upgrade only 401s on missing credentials when a token is configured (credential-less loopback is the local app)");
 assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients");
+// Paired devices hold SIGNED tokens (v1.<expiresAt>.<nonce>.<sig> — see
+// src/lib/mobile-access-token.ts), not the raw secret: the QR/deep-link
+// pairing flow mints them and the phone renews them monthly. The WS gate must
+// verify those or every paired terminal 401s while REST works fine.
+assert.match(
+  src,
+  /function isValidSignedAccessToken\(value: string, secret: string\): boolean/,
+  "PTY WebSocket auth verifies signed mobile access tokens, not only the raw secret",
+);
+assert.match(
+  src,
+  /if \(timingSafeEqualString\(value, ACCESS_TOKEN\)\) return true;\s*\n\s*return isValidSignedAccessToken\(value, ACCESS_TOKEN\);/,
+  "isExpectedToken accepts the raw secret OR a valid signed token",
+);
+assert.match(
+  src,
+  /parts\.length !== 4 \|\| parts\[0\] !== "v1"/,
+  "signed-token verification pins the v1 wire format",
+);
+assert.match(
+  src,
+  /expiresAt <= Date\.now\(\)/,
+  "signed-token verification rejects expired tokens",
+);
+assert.match(
+  src,
+  /createHmac\("sha256", secret\)[\s\S]{0,120}digest\("base64url"\)/,
+  "signed-token verification recomputes the HMAC-SHA256 base64url signature",
+);
+assert.match(
+  src,
+  /timingSafeEqualString\(parts\[3\], expected\)/,
+  "signed-token signatures compare in constant time",
+);
 assert.match(src, /isAllowedUpgradeSource/, "server validates WebSocket upgrade host and origin");
 assert.match(src, /isLoopbackHost\(host\)/, "server only accepts loopback WebSocket hosts by default");
 assert.match(src, /isLoopbackAddress\(req\.socket\.remoteAddress\)/, "server verifies the WebSocket peer address, not only the Host header");
@@ -161,5 +195,25 @@ assert.match(
   /if \(session\.detachTimer\) \{\s*clearTimeout\(session\.detachTimer\)/,
   "adoptSession cancels the pending reap when a client reattaches in time",
 );
+// The grace window is sized for mobile too: backgrounding the iOS app kills
+// its socket, and a 60s window meant a two-minute app-switch came back to a
+// dead shell. 5 minutes by default, tunable per install.
+assert.match(
+  src,
+  /COVEN_CAVE_PTY_DETACH_GRACE_MS/,
+  "detach grace is tunable via COVEN_CAVE_PTY_DETACH_GRACE_MS",
+);
+assert.match(
+  src,
+  /const DETACH_GRACE_MS = [\s\S]{0,200}?300_000/,
+  "detach grace defaults to 5 minutes so a backgrounded phone reattaches to a live shell",
+);
+
+// Idle keep-alive: Node's 5s default closes idle sockets just as pooled
+// clients (URLSession on iOS, tailscale serve upstreams) reuse them, which
+// surfaces as sporadic "network connection lost". headersTimeout must stay
+// above keepAliveTimeout so a reused socket isn't reaped mid-headers.
+assert.match(src, /server\.keepAliveTimeout = 75_000/, "server extends the idle keep-alive window past client reuse");
+assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds keepAliveTimeout");
 
 console.log("server-pty-ws.test.ts OK");


### PR DESCRIPTION
## Summary

Comprehensive audit + fix pass over the iOS app ↔ desktop connection stack (bead `cave-30b`). Twelve defects across client and server, each hurting either seamlessness (things the user had to do manually) or stability (things that failed spuriously).

### iOS app

| Defect | Fix |
|---|---|
| **Chat replies died at 60s** — `timeoutIntervalForResource = 60` capped the whole SSE transfer; the per-request 600s override doesn't apply to resource timeouts | Dedicated shared streaming session with a day-long resource window |
| A fresh `URLSession` per request (never deallocated) → no connection pooling, TLS re-handshake per call, session/FD leak | One shared session per role: REST, stream, dev, discovery probe, WebSocket |
| **Developer tab 401'd on paired desktops** — dev requests never sent the Bearer token | Token attached in `devRequest` |
| Mid-stream network blip showed a raw error and lost the reply | Resync the persisted turn from `/api/chat/conversation` — anchored on our own prompt, adopting only text that extends what already streamed |
| Discovery probed 5 candidate ports serially (6s timeout each → 30s+ cold connect) | Concurrent probes + ordered adjudication: identical semantics (401 stays terminal — sibling-port safety), one probe's wall-clock |
| Port relocation stored an explicit URL → discovery alternates disabled forever; `host.ts.net:8443` derived `http://` | Relocation persists bare `host:port` when the scheme is derivable; `.ts.net`-with-port derives https |
| Stale "connected" after suspension/desktop restart — nothing revalidated until a user action failed | Foreground ping-validate; surface failures while "connected" schedule a cooldown-bounded background rediscovery; the unreachable screen quietly auto-retries every 10s (`quiet` refresh — no UI bouncing) |
| Terminal drops required a manual Reconnect tap | Bounded-backoff auto-reconnect (1/2/4s) inside the server's detach grace; receive loop now pins its socket so a replaced socket's stale error can't clobber the live connection |

### Server

| Defect | Fix |
|---|---|
| **`/api/pty-ws` rejected signed `v1.*` tokens** — the very tokens QR/deep-link pairing mints; only the raw secret passed, so every paired terminal 401'd while REST worked | Inline HMAC verification mirroring `src/lib/mobile-access-token.ts` (server.mjs is transpiled standalone and can't import `src/`) |
| No SSE heartbeats on `/api/chat/send` → quiet long tool-runs idle-dropped by NATs/proxies/client timeouts | `: hb` comment frames every 20s on both adapter paths, cleared on close; every consumer (web readers + iOS) skips non-`data:` frames |
| Node's default 5s `keepAliveTimeout` raced URLSession/tailscale-serve connection reuse → sporadic "network connection lost" | `keepAliveTimeout` 75s, `headersTimeout` 80s |
| 60s PTY detach grace killed the shell during a two-minute phone app-switch | 5min default, tunable via `COVEN_CAVE_PTY_DETACH_GRACE_MS` |

## Test plan

- New `scripts/ios-connection-stability.test.mjs` (wired into the mobile group) pins every client behavior above
- `src/server-pty-ws.test.ts`: pins for signed-token WS auth (format, expiry, constant-time compare), keepalive values, detach-grace default+env
- `src/app/api/api-contracts.test.ts`: pins both heartbeat starts + both clears
- Verified locally: `pnpm typecheck` ✓ · `test:app` 520 ✓ · `test:api` 118 ✓ · `test:mobile` 70 ✓ · `check:tests-wired` ✓ · iOS Simulator build **BUILD SUCCEEDED** ✓ · `server.mjs` rebuilt via `pnpm build:server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)