### PR TITLE
fix(onboarding): airtight focus trap, no wizard relaunch for set-up machines, audible errors & progress

### DIFF
--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -545,9 +545,15 @@ export function HomeComposer({
     writeComposerHistory(HOME_HISTORY_KEY, history);
   }, [history]);
 
-  // Focus on mount
+  // Focus on mount — unless a modal dialog (e.g. the onboarding wizard) is
+  // open. The 80ms delay means this fires AFTER a dialog's focus trap has
+  // placed focus, so an unconditional focus() would steal it out of the
+  // modal and strand keyboard users in a composer they can't even see.
   useEffect(() => {
-    setTimeout(() => textareaRef.current?.focus(), 80);
+    setTimeout(() => {
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      textareaRef.current?.focus();
+    }, 80);
   }, []);
 
   // Maps a familiar id to its display name for the daily-summary carousel.

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/onboarding-install-queue";
 import type { IconName } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { useFamiliarStudio } from "@/lib/familiar-studio-context";
 import { SalemPathfinderEntry } from "@/components/salem/salem-pathfinder-entry";
 import type { SalemPathfinderRequest } from "@/lib/salem/pathfinder-types";
@@ -140,6 +141,10 @@ const NPM_INSTALL_TARGETS = ALL_INSTALL_TARGETS.filter(
 /** Persists the user's choice to skip the (required) Coven Code install so a
  *  failing install can't permanently strand onboarding. */
 const COVEN_CODE_SKIP_KEY = "cave:onboarding:skip-coven-code";
+// ~30s of 2s ticks: long enough to ride out a slow sidecar start, short
+// enough that a genuinely broken /api/harnesses surfaces as a retryable
+// error instead of an empty runtime grid polling silently forever.
+const HARNESS_RETRY_BUDGET = 15;
 
 type SshCheckState =
   | { state: "idle" }
@@ -354,6 +359,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   const [familiarGlyph, setFamiliarGlyph] = useState("ph:sparkle-fill");
   const [openclawAgents, setOpenclawAgents] = useState<OpenClawAgent[]>([]);
   const [harnesses, setHarnesses] = useState<HarnessReport[]>([]);
+  // Consecutive /api/harnesses failures — the empty-list retry loop gives up
+  // once this hits HARNESS_RETRY_BUDGET and StepRuntimes offers a Retry.
+  const [harnessFailures, setHarnessFailures] = useState(0);
   const [selectedHarnessId, setSelectedHarnessId] = useState<string | null>(
     null,
   );
@@ -410,6 +418,22 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
 
   useFocusTrap(open, dialogRef, { onEscape: onDismiss });
 
+  // Finishing setup ("Open Cave") records the dismissal just like "Skip for
+  // now" does. Without this, the workspace auto-open effect re-launches the
+  // ENTIRE wizard on the next visit as soon as status.complete flips false
+  // again — which happens every time the daemon isn't running. A user who
+  // completed setup once should get the lightweight daemon banner after
+  // that, not the first-run flow. (Escape stays session-only on purpose: an
+  // accidental Esc mid-setup shouldn't permanently hide the guide.)
+  const finishOnboarding = useCallback(() => {
+    try {
+      localStorage.setItem("cave:onboarding:dismissed", "1");
+    } catch {
+      /* private mode */
+    }
+    onDismiss();
+  }, [onDismiss]);
+
   const refresh = useCallback(async () => {
     try {
       const res = await fetch("/api/onboarding/status", { cache: "no-store" });
@@ -421,7 +445,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
       setStatus(json);
       setStatusFailures(0);
     } catch {
-      // Track consecutive failures so the UI can move past "checking..." once
+      // Track consecutive failures so the UI can move past "checking…" once
       // we're sure the poll isn't just slow. One blip stays silent.
       setStatusFailures((n) => n + 1);
     }
@@ -478,9 +502,13 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         ok?: boolean;
         harnesses?: HarnessReport[];
       };
-      if (!res.ok || json.ok === false) return;
+      if (!res.ok || json.ok === false) {
+        setHarnessFailures((n) => n + 1);
+        return;
+      }
       const next = json.harnesses ?? [];
       setHarnesses(next);
+      setHarnessFailures(0);
       setSelectedHarnessId((current) => {
         if (
           current &&
@@ -493,7 +521,9 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         return null;
       });
     } catch {
-      /* harness availability is advisory; step cards carry setup hints */
+      // Advisory, but count the failure — the empty-list retry loop below
+      // gives up on a persistent error instead of spinning silently forever.
+      setHarnessFailures((n) => n + 1);
     }
   }, []);
 
@@ -529,11 +559,16 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
   // Refresh. Retry on the status cadence while the list is empty — a
   // successful response always carries the bundled adapters, so the loop
   // stops after the first real load and never spins on a healthy state.
+  // A failure budget stops it on a persistently broken endpoint too:
+  // without one the loop spun every 2s forever while the runtime step showed
+  // an empty grid with no explanation. Once spent, StepRuntimes shows a
+  // retryable error (its Retry resets the budget, which restarts this loop).
   useEffect(() => {
     if (!open || harnesses.length > 0) return;
+    if (harnessFailures >= HARNESS_RETRY_BUDGET) return;
     const retry = setInterval(() => void loadHarnesses(), 2000);
     return () => clearInterval(retry);
-  }, [open, harnesses.length, loadHarnesses]);
+  }, [open, harnesses.length, harnessFailures, loadHarnesses]);
 
   // Refresh the familiar list when the familiars step flips healthy so the
   // final step can list them for editing.
@@ -1192,7 +1227,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         // skippable) before this step counts as done.
         ok: !!s?.covenCli.ok && covenCodeSatisfied,
         detail: !s?.covenCli.ok
-          ? (s?.covenCli.detail ?? s?.covenCli.hint ?? "checking...")
+          ? (s?.covenCli.detail ?? s?.covenCli.hint ?? "checking…")
           : covenCodeSatisfied
             ? (s?.covenCli.detail ?? "Installed")
             : "coven CLI ready — Coven Code still needs installing.",
@@ -1202,35 +1237,35 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         key: "covenHome",
         title: "Create your Coven home",
         ok: !!s?.covenHome.ok,
-        detail: s?.covenHome.detail ?? s?.covenHome.hint ?? "checking...",
+        detail: s?.covenHome.detail ?? s?.covenHome.hint ?? "checking…",
         icon: "ph:folder",
       },
       {
         key: "adapters",
         title: "Install a runtime",
         ok: !!s?.adapters.ok,
-        detail: s?.adapters.detail ?? s?.adapters.hint ?? "checking...",
+        detail: s?.adapters.detail ?? s?.adapters.hint ?? "checking…",
         icon: "ph:terminal-window",
       },
       {
         key: "daemon",
         title: "Start the daemon",
         ok: !!s?.daemon.ok,
-        detail: s?.daemon.detail ?? s?.daemon.hint ?? "checking...",
+        detail: s?.daemon.detail ?? s?.daemon.hint ?? "checking…",
         icon: "ph:plug",
       },
       {
         key: "binding",
         title: "Create your familiar",
         ok: !!s?.binding.ok,
-        detail: s?.binding.detail ?? s?.binding.hint ?? "checking...",
+        detail: s?.binding.detail ?? s?.binding.hint ?? "checking…",
         icon: "ph:sparkle",
       },
       {
         key: "familiars",
         title: "Meet your familiars",
         ok: !!s?.familiars.ok,
-        detail: s?.familiars.detail ?? s?.familiars.hint ?? "checking...",
+        detail: s?.familiars.detail ?? s?.familiars.hint ?? "checking…",
         icon: "ph:user",
       },
       {
@@ -1253,6 +1288,36 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     const firstIncomplete = steps.find((s) => !s.optional && !s.ok);
     return firstIncomplete?.key ?? null;
   }, [steps]);
+
+  // Steps tick themselves via the 2s status poll — visually obvious, silent
+  // to screen readers. Announce spotlight moves (forward on completion,
+  // backward on regression like the daemon dying mid-setup) through the
+  // shared polite live region. The ref-seeded first observation keeps the
+  // wizard from narrating its own opening.
+  const { announce } = useAnnouncer();
+  const prevActiveStepRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (!open || !status) {
+      prevActiveStepRef.current = undefined;
+      return;
+    }
+    const prev = prevActiveStepRef.current;
+    prevActiveStepRef.current = activeStepKey;
+    if (prev === undefined || prev === activeStepKey) return;
+    if (activeStepKey === null) {
+      announce("Setup complete — every required step is done.");
+      return;
+    }
+    const stepIndex = steps.findIndex((s) => s.key === activeStepKey);
+    const step = steps[stepIndex];
+    if (!step) return;
+    const prevStep = steps.find((s) => s.key === prev);
+    announce(
+      prevStep?.ok
+        ? `${prevStep.title} — done. Next: step ${stepIndex + 1}, ${step.title}.`
+        : `Now on step ${stepIndex + 1}: ${step.title}.`,
+    );
+  }, [open, status, activeStepKey, steps, announce]);
 
   // Safe machine-state context for Setup Salem — platform + detected runtime
   // health only; never secrets, tokens, or logs (design §"Privacy").
@@ -1377,8 +1442,23 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
         ) : null}
 
         {setupError ? (
-          <section className="mt-5 rounded-lg border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_10%,transparent)] p-4 text-[13px] text-[var(--color-danger)]">
-            {setupError}
+          // Every setup action (scaffold, daemon start, familiar create,
+          // connection save) reports through this banner — it must be a live
+          // alert or screen-reader users never hear why their click did
+          // nothing, and it must be dismissible so a stale error doesn't
+          // outlive the retry.
+          <section
+            role="alert"
+            className="mt-5 flex items-start justify-between gap-3 rounded-lg border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-danger)_10%,transparent)] p-4 text-[13px] text-[var(--color-danger)]"
+          >
+            <div>{setupError}</div>
+            <button
+              type="button"
+              onClick={() => setSetupError(null)}
+              className="focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_40%,transparent)] px-2 py-1 font-mono text-[11px] text-[var(--color-danger)] hover:bg-[color-mix(in_oklch,var(--color-danger)_15%,transparent)]"
+            >
+              Dismiss
+            </button>
           </section>
         ) : null}
 
@@ -1402,7 +1482,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
               const expanded = openStepKey === step.key;
               const isActive = activeStepKey === step.key;
               return (
-                <li key={step.key}>
+                <li key={step.key} aria-current={isActive ? "step" : undefined}>
                   <section
                     aria-label={step.title}
                     className={`rounded-lg border ${
@@ -1488,7 +1568,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             >
                               <Icon name="ph:folder-open-bold" />
                               {picking === "scaffold"
-                                ? "Creating..."
+                                ? "Creating…"
                                 : "Create Coven home"}
                             </button>
                           </div>
@@ -1499,9 +1579,18 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             installJobs={installJobs}
                             installResults={installResults}
                             nodeHint={nodeHint}
+                            harnessesStuck={
+                              harnesses.length === 0 &&
+                              harnessFailures >= HARNESS_RETRY_BUDGET
+                            }
                             onInstall={(target) => void runInstall(target)}
                             onCopy={copyText}
-                            onRefresh={() => void loadHarnesses()}
+                            onRefresh={() => {
+                              // Also resets the failure budget so the
+                              // empty-list retry loop starts over.
+                              setHarnessFailures(0);
+                              void loadHarnesses();
+                            }}
                             codexPortPreflight={codexPortPreflight}
                             codexPortPreflightBusy={codexPortPreflightBusy}
                             onCodexPortPreflight={() =>
@@ -1628,7 +1717,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                 className="focus-ring mt-2 inline-flex items-center gap-2 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-60"
                               >
                                 <Icon name="ph:floppy-disk-bold" width={12} />
-                                {savingOnboardingConnection ? "Saving..." : "Save connection"}
+                                {savingOnboardingConnection ? "Saving…" : "Save connection"}
                               </button>
                             </div>
                             <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
@@ -1652,7 +1741,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                 }
                               >
                                 <Icon name="ph:rocket-launch-bold" />
-                                {startingDaemon ? "Starting..." : "Start local daemon"}
+                                {startingDaemon ? "Starting…" : "Start local daemon"}
                               </button>
                               {!status?.steps.covenCli.ok ? (
                                 <span className="text-[11px] text-[var(--text-muted)]">
@@ -1668,7 +1757,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             statusOk={step.ok}
                             complete={effectiveComplete}
                             onEdit={editFamiliar}
-                            onOpenCave={onDismiss}
+                            onOpenCave={finishOnboarding}
                           />
                         ) : step.key === "git" ? (
                           <div className="flex flex-col gap-2">
@@ -1719,7 +1808,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
           </button>
           {effectiveComplete ? (
             <button
-              onClick={onDismiss}
+              onClick={finishOnboarding}
               className="focus-ring inline-flex items-center gap-2 rounded-md bg-[color-mix(in_oklch,var(--color-success)_92%,#000)] px-5 py-2.5 text-[14px] font-semibold text-white shadow-sm shadow-[color-mix(in_oklch,var(--color-success)_30%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-success)_82%,#000)]"
             >
               <Icon name="ph:rocket-launch-bold" />
@@ -2048,6 +2137,7 @@ function StepRuntimes({
   installJobs,
   installResults,
   nodeHint,
+  harnessesStuck,
   onInstall,
   onCopy,
   onRefresh,
@@ -2060,6 +2150,7 @@ function StepRuntimes({
   installJobs: Partial<Record<InstallTarget, InstallJobView>>;
   installResults: Partial<Record<InstallTarget, InstallResult>>;
   nodeHint: string | null;
+  harnessesStuck: boolean;
   onInstall: (target: InstallTarget) => void;
   onCopy: (text: string) => Promise<boolean>;
   onRefresh: () => void;
@@ -2070,6 +2161,24 @@ function StepRuntimes({
   const npmJobRunning = anyNpmInstallRunning(installJobs);
   return (
     <div className="flex flex-col gap-3">
+      {harnessesStuck ? (
+        <div
+          role="alert"
+          className="flex items-start justify-between gap-3 rounded-md border border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_10%,transparent)] px-3 py-2.5 text-[12px] text-[var(--color-warning)]"
+        >
+          <span className="leading-5">
+            Couldn&rsquo;t load the runtime list — the local server didn&rsquo;t
+            answer after repeated tries.
+          </span>
+          <button
+            type="button"
+            onClick={onRefresh}
+            className="focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-warning)_40%,transparent)] px-2 py-1 font-mono text-[11px] text-[var(--color-warning)] hover:bg-[color-mix(in_oklch,var(--color-warning)_15%,transparent)]"
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
       <div className="flex items-start justify-between gap-3">
         <p className="text-[12px] leading-5 text-[var(--text-secondary)]">
           A runtime is the agent CLI your familiar speaks through.
@@ -2490,7 +2599,7 @@ function StepFamiliar(props: {
                 name="ph:arrows-clockwise-bold"
                 className={agentsLoading ? "animate-spin" : undefined}
               />
-              {agentsLoading ? "Scanning..." : "Refresh"}
+              {agentsLoading ? "Scanning…" : "Refresh"}
             </button>
           </div>
           {agentsError ? (
@@ -2637,7 +2746,7 @@ function StepFamiliar(props: {
               <input
                 value={familiarRole}
                 onChange={(e) => props.setFamiliarRole(e.target.value)}
-                placeholder="Research, Code, Ops..."
+                placeholder="Research, Code, Ops…"
                 className="focus-ring mt-1 w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[13px] text-[var(--text-primary)] focus:border-[var(--border-strong)]"
               />
             </label>
@@ -2813,7 +2922,7 @@ function StepFamiliar(props: {
                 className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
               >
                 <Icon name="ph:terminal-window" />
-                {picking === "local" ? "Creating..." : "Create new Coven familiar"}
+                {picking === "local" ? "Creating…" : "Create new Coven familiar"}
               </button>
             ) : null}
             {!selectedHarnessId && selectedAgentId ? (
@@ -2847,7 +2956,7 @@ function StepFamiliar(props: {
               >
                 <Icon name="ph:git-fork" />
                 {picking === "familiar"
-                  ? "Connecting..."
+                  ? "Connecting…"
                   : selectedOpenClawAgent
                     ? `Connect ${selectedOpenClawAgent.displayName}`
                     : "Connect OpenClaw agent"}
@@ -2973,11 +3082,11 @@ function MaintenancePanel({
           {"idle" in prune ? (
             "Prune stale sessions: completed, failed, or killed sessions older than 24 hours."
           ) : "counting" in prune ? (
-            "Counting stale sessions..."
+            "Counting stale sessions…"
           ) : "count" in prune ? (
             `Found ${prune.count} stale session${prune.count === 1 ? "" : "s"}. Confirm to delete.`
           ) : "pruning" in prune ? (
-            "Pruning..."
+            "Pruning…"
           ) : "pruned" in prune ? (
             `Done. ${prune.pruned} session${prune.pruned === 1 ? "" : "s"} removed.`
           ) : "error" in prune ? (

--- a/src/components/onboarding-polish.test.ts
+++ b/src/components/onboarding-polish.test.ts
@@ -91,4 +91,71 @@ assert.match(
   "both error responses and network throws count toward the give-up budget",
 );
 
+// Finishing setup must record the dismissal exactly like "Skip for now" —
+// otherwise the workspace auto-open relaunches the whole wizard for a
+// finished user whenever the daemon happens to be down (complete flips false).
+assert.match(
+  source,
+  /const finishOnboarding = useCallback\(\(\) => \{[\s\S]*?localStorage\.setItem\("cave:onboarding:dismissed", "1"\);[\s\S]*?onDismiss\(\);[\s\S]*?\}, \[onDismiss\]\)/,
+  "finishing onboarding writes the dismissed flag before closing",
+);
+assert.equal(
+  source.match(/(?:onClick=\{finishOnboarding\}|onOpenCave=\{finishOnboarding\})/g)?.length,
+  2,
+  "both Open Cave CTAs (footer + meet-familiars step) finish via finishOnboarding",
+);
+
+// The shared setup-action error banner must be a live alert with a dismiss —
+// every setup action (scaffold, daemon start, familiar create, connection
+// save) reports through it, and a silent <div> means SR users never hear
+// why their click did nothing.
+assert.match(
+  source,
+  /\{setupError \? \([\s\S]{0,700}?role="alert"/,
+  "the setupError banner announces as an alert",
+);
+assert.match(
+  source,
+  /onClick=\{\(\) => setSetupError\(null\)\}/,
+  "the setupError banner is dismissible so a stale error doesn't outlive a retry",
+);
+
+// The empty-list harness retry loop has a failure budget + retry affordance;
+// without it a broken /api/harnesses left the runtime grid empty and polling
+// silently forever.
+assert.match(
+  source,
+  /const HARNESS_RETRY_BUDGET = 15/,
+  "harness retry loop declares a give-up budget",
+);
+assert.match(
+  source,
+  /if \(harnessFailures >= HARNESS_RETRY_BUDGET\) return;/,
+  "the harness retry interval stops once the budget is spent",
+);
+assert.match(
+  source,
+  /harnessesStuck \? \([\s\S]{0,400}?role="alert"/,
+  "a spent harness budget surfaces as a retryable alert in the runtime step",
+);
+
+// Step progress is announced to screen readers (steps tick via a 2s poll,
+// which is visually obvious and otherwise silent), and the spotlighted step
+// carries aria-current for AT step navigation.
+assert.match(
+  source,
+  /const \{ announce \} = useAnnouncer\(\)/,
+  "the wizard wires the shared polite live region",
+);
+assert.match(
+  source,
+  /announce\([\s\S]{0,200}?— done\. Next: step /,
+  "completing a step announces the completion and what comes next",
+);
+assert.match(
+  source,
+  /aria-current=\{isActive \? "step" : undefined\}/,
+  "the active step is exposed via aria-current",
+);
+
 console.log("onboarding-polish.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -396,7 +396,17 @@ export function Workspace() {
     }
   }, []);
 
+  // Reconcile only when mobile mode is (or just was) enabled. With the pref
+  // off there is nothing to stop — an unconditional boot-time POST meant
+  // every plain-web session hit /api/mobile-handoff, got the expected 503
+  // (the route needs the packaged app's signed token), and logged a console
+  // error + a misleading "Mobile mode unavailable" state for a feature the
+  // user never touched. Turning the toggle OFF still posts app-stop because
+  // the state change re-runs this effect while wasEnabledRef is set.
+  const mobileModeWasEnabledRef = useRef(false);
   useEffect(() => {
+    if (!mobileModeEnabled && !mobileModeWasEnabledRef.current) return;
+    mobileModeWasEnabledRef.current = mobileModeEnabled;
     void reconcileMobileMode(mobileModeEnabled);
   }, [mobileModeEnabled, reconcileMobileMode]);
   // Recurring reconcile only while mobile mode is on; usePausablePoll pauses it
@@ -817,8 +827,15 @@ export function Workspace() {
     void loadFamiliars();
   }, [loadFamiliars]);
 
-  // First-run: auto-open onboarding if anything is missing and the user
-  // hasn't explicitly skipped it.
+  // First-run: auto-open onboarding if setup is missing and the user hasn't
+  // explicitly skipped or finished it. Keyed on the STRUCTURAL steps (CLI,
+  // Coven home, runtime adapters) — not on bare `complete` — because a
+  // stopped daemon flips `complete` false (daemon/familiars/binding all
+  // report not-ok while it's down), and that would relaunch the full wizard
+  // for an already-set-up machine on every visit. Daemon-down on a set-up
+  // machine belongs to the offline banner below, not the first-run flow.
+  // When the daemon IS reachable, any remaining incompleteness (no familiar
+  // yet, no binding) is genuine setup work, so the wizard still opens.
   useEffect(() => {
     let cancelled = false;
     const skipped =
@@ -828,10 +845,18 @@ export function Workspace() {
       try {
         const res = await fetch("/api/onboarding/status", { cache: "no-store" });
         if (!res.ok || cancelled) return;
-        const json = (await res.json()) as { complete?: boolean };
-        if (!json.complete) setOnboardingOpen(true);
+        const json = (await res.json()) as {
+          complete?: boolean;
+          steps?: Record<string, { ok?: boolean }>;
+        };
+        if (json.complete) return;
+        const step = (key: string) => json.steps?.[key]?.ok === true;
+        const structuralMissing =
+          !step("covenCli") || !step("covenHome") || !step("adapters");
+        const daemonUpButUnfinished = step("daemon");
+        if (structuralMissing || daemonUpButUnfinished) setOnboardingOpen(true);
       } catch {
-        /* ignore — DaemonBar surfaces transport issues */
+        /* ignore — the daemon-offline banner surfaces transport issues */
       }
     })();
     return () => {

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -80,6 +80,17 @@ export function useFocusTrap(
         const first = focusables[0];
         const last = focusables[focusables.length - 1];
         const activeEl = document.activeElement as HTMLElement | null;
+        // Recapture: if focus escaped the container (a late autofocus
+        // elsewhere, a click on the backdrop, a removed element), Tab must
+        // pull it back in — otherwise every subsequent Tab silently walks
+        // the page BEHIND the dialog and the "trap" never applies again.
+        // (Live-reproduced: the home composer's mount autofocus stole focus
+        // from the onboarding wizard and Tab toured the covered workspace.)
+        if (!activeEl || !container.contains(activeEl)) {
+          e.preventDefault();
+          (e.shiftKey ? last : first).focus();
+          return;
+        }
         if (e.shiftKey && activeEl === first) {
           e.preventDefault();
           last.focus();

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Behavioral coverage for the first-run onboarding wizard — previously the
+// only e2e mentions of onboarding were specs BYPASSING it. All daemon-shaped
+// endpoints are stubbed (CI runs daemon-less), and /api/onboarding/status is
+// stubbed to a fresh-machine shape so the wizard auto-opens.
+//
+// The focus assertions exist because of a live-reproduced bug: the home
+// composer's mount autofocus stole focus out of the wizard, and the focus
+// trap never recaptured it, so Tab silently walked the workspace BEHIND the
+// full-screen modal.
+
+const FRESH_STATUS = {
+  ok: true,
+  complete: false,
+  steps: {
+    covenCli: { ok: false, detail: "coven not found on PATH" },
+    covenHome: { ok: false, detail: "~/.coven missing" },
+    git: { ok: true, optional: true, detail: "/usr/bin/git" },
+    adapters: { ok: false, detail: "no adapters detected" },
+    daemon: { ok: false, detail: "daemon socket not reachable" },
+    familiars: { ok: false, detail: "no familiars" },
+    binding: { ok: false, detail: "no binding configured" },
+  },
+  tools: [],
+};
+
+// A machine that finished setup once but whose daemon is currently stopped:
+// structural steps are healthy, daemon-dependent ones are not.
+const DAEMON_DOWN_VETERAN_STATUS = {
+  ok: true,
+  complete: false,
+  steps: {
+    covenCli: { ok: true, detail: "0.0.53" },
+    covenHome: { ok: true, detail: "~/.coven" },
+    git: { ok: true, optional: true, detail: "/usr/bin/git" },
+    adapters: { ok: true, detail: "Codex" },
+    daemon: { ok: false, detail: "daemon socket not reachable" },
+    familiars: { ok: false, detail: "daemon offline" },
+    binding: { ok: false, detail: "Waiting for the daemon" },
+  },
+  tools: [],
+};
+
+async function gotoApp(page: Page, status: unknown, opts?: { dismissed?: boolean }) {
+  await page.route("**/api/onboarding/status**", (r) => r.fulfill({ json: status }));
+  await page.route("**/api/familiars**", (r) => r.fulfill({ json: { ok: true, familiars: [] } }));
+  await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions: [] } }));
+  await page.route("**/api/harnesses**", (r) => r.fulfill({ json: { ok: true, harnesses: [] } }));
+  await page.route("**/api/openclaw-agents**", (r) => r.fulfill({ json: { ok: true, agents: [] } }));
+  if (opts?.dismissed) {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    });
+  }
+  await page.goto("/");
+}
+
+const wizard = (page: Page) => page.getByRole("dialog", { name: "Onboarding" });
+
+test.describe("onboarding wizard", () => {
+  test("auto-opens on a fresh machine and keeps keyboard focus trapped inside", async ({ page }) => {
+    await gotoApp(page, FRESH_STATUS);
+    await expect(wizard(page)).toBeVisible({ timeout: 30_000 });
+    await expect(wizard(page).getByText("Set up CovenCave, step by step.")).toBeVisible();
+
+    // Give the home composer's 80ms mount-autofocus a chance to (wrongly)
+    // steal focus, then require that keyboard interaction stays in the modal.
+    await page.waitForTimeout(1_000);
+    for (let i = 0; i < 8; i++) {
+      await page.keyboard.press("Tab");
+      const inDialog = await page.evaluate(() =>
+        Boolean(document.activeElement?.closest('[role="dialog"][aria-label="Onboarding"]')),
+      );
+      expect(inDialog, `Tab press ${i + 1} must stay inside the wizard`).toBe(true);
+    }
+  });
+
+  test("marks the first incomplete step as the current step", async ({ page }) => {
+    await gotoApp(page, FRESH_STATUS);
+    await expect(wizard(page)).toBeVisible({ timeout: 30_000 });
+    const current = wizard(page).locator('li[aria-current="step"]');
+    await expect(current).toHaveCount(1);
+    await expect(current.first()).toContainText("Install the OpenCoven tools");
+  });
+
+  test("Escape closes for the session without permanently skipping", async ({ page }) => {
+    await gotoApp(page, FRESH_STATUS);
+    await expect(wizard(page)).toBeVisible({ timeout: 30_000 });
+    await page.keyboard.press("Escape");
+    await expect(wizard(page)).toHaveCount(0);
+    // Escape must NOT write the permanent opt-out — a fresh visit still guides.
+    const dismissed = await page.evaluate(() => window.localStorage.getItem("cave:onboarding:dismissed"));
+    expect(dismissed).toBeNull();
+  });
+
+  test("stays hidden once dismissed", async ({ page }) => {
+    await gotoApp(page, FRESH_STATUS, { dismissed: true });
+    await page.getByRole("textbox").first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.waitForTimeout(1_000);
+    await expect(wizard(page)).toHaveCount(0);
+  });
+
+  test("does not relaunch for a set-up machine whose daemon is merely stopped", async ({ page }) => {
+    await gotoApp(page, DAEMON_DOWN_VETERAN_STATUS);
+    await page.getByRole("textbox").first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.waitForTimeout(1_000);
+    await expect(wizard(page)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Problem

Walked the first-run flow live against a fresh browser profile (mocked fresh-machine `/api/onboarding/status`) plus a full code audit. Verified issues:

1. **The wizard's focus containment was broken end-to-end.** The home composer's 80 ms mount-autofocus stole focus out of the just-opened wizard, and `use-focus-trap` only redirected Tab when focus sat exactly on the first/last focusable *inside* the container — once focus escaped, every subsequent Tab silently walked the workspace *behind* the full-screen modal (reproduced: 10 straight Tab presses landing in the covered composer/chat list).
2. **Set-up machines got the whole wizard relaunched.** Neither "Open Cave" CTA recorded dismissal, and the workspace auto-open keyed on bare `status.complete` — which flips false whenever the daemon isn't running. A user who finished setup once was re-thrown into the first-run flow on every daemon-down visit.
3. **Silent failure paths.** The shared `setupError` banner (daemon start, scaffold, familiar create, connection save) was a plain `<div>` — no `role="alert"`, no dismiss. The empty-list `/api/harnesses` retry loop had no failure budget: a broken endpoint left the runtime step's grid empty while polling silently forever.
4. **Step progress was invisible to screen readers** — steps tick via a 2 s poll with no live region and no `aria-current`.
5. **Every plain-web boot POSTed `/api/mobile-handoff`** with mobile mode off, guaranteeing a 503 console error + a misleading "Mobile mode unavailable" state for brand-new users.

## Fix

- `use-focus-trap.ts`: Tab now recaptures focus into the container whenever it has escaped (hardens every dialog using the hook). `home-composer.tsx`: mount-focus skips while an `aria-modal` dialog is open.
- `onboarding-overlay.tsx`: new `finishOnboarding` writes `cave:onboarding:dismissed` on both "Open Cave" CTAs (Escape stays session-only on purpose — accidental Esc shouldn't permanently hide the guide). `workspace.tsx`: auto-open keys on structural steps (CLI/home/adapters) or daemon-up-but-unfinished; daemon-down on a set-up machine now belongs solely to the offline banner.
- `setupError` → `role="alert"` + Dismiss. Harness retry loop → 15-attempt (~30 s) budget + retryable inline alert in the runtime step.
- Active step exposes `aria-current="step"`; spotlight transitions announce via the shared polite live region ("Install the OpenCoven tools — done. Next: step 2, …").
- Mobile-handoff reconcile skips the boot POST while the pref is off (toggling off still posts app-stop).
- Wizard strings use typographic ellipses per `docs/coven-design-language.md`.

## Verification

- **New e2e** `tests/onboarding-wizard.spec.ts` — first executable coverage of the wizard (it previously had only source-regex pins; every existing spec merely bypassed it): auto-open on fresh status, focus containment under the composer race, `aria-current`, session-only Escape, dismissed suppression, and no-relaunch for a daemon-down veteran. **Focus spec verified red** against the previous trap/composer code, green after.
- Source pins for the non-e2e-reachable contracts added to `onboarding-polish.test.ts` (finish-writes-dismissal, alert banners, harness budget, announcer wiring).
- `pnpm typecheck` green; `pnpm test:app` 520 files green; new spec 5/5 green.

Closes bead `cave-5tb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)