### PR TITLE
fix(github): address PR 2450 review conversations

### DIFF
--- a/src/app/api/github/checks/route.ts
+++ b/src/app/api/github/checks/route.ts
@@ -95,6 +95,14 @@ export async function GET(req: Request) {
       ghFetch(`/repos/${repo}/commits/${sha}/status`, token),
     ]);
 
+    if (!runsResp.res.ok && !statusResp.res.ok) {
+      const status = runsResp.res.status === 403 || statusResp.res.status === 403 ? 403 : 502;
+      return NextResponse.json(
+        { ok: false, error: `github error (${runsResp.res.status}, ${statusResp.res.status})` },
+        { status },
+      );
+    }
+
     const rawRuns = ((runsResp.data as { check_runs?: unknown[] } | null)?.check_runs ?? []) as Array<
       Record<string, unknown>
     >;

--- a/src/components/github-advanced.test.ts
+++ b/src/components/github-advanced.test.ts
@@ -77,6 +77,9 @@ assert.match(source, /entry\.kind === "review"[\s\S]{0,120}<ReviewEntry/, "revie
 assert.match(source, /function CommentReactions/, "a reaction summary component exists");
 assert.match(source, /<CommentReactions reactions=\{entry\.comment\.reactions\}/, "reactions render under each comment");
 assert.match(source, /const REACTION_EMOJI:/, "reaction slugs map to emoji glyphs");
+assert.doesNotMatch(source, /import \{[\s\S]{0,120}\bFragment\b/, "github-view does not import unused Fragment");
+assert.match(source, /const REACTION_LABEL:/, "reaction slugs map to accessible labels");
+assert.match(source, /aria-label=\{`\$\{r\.count\} \$\{REACTION_LABEL\[r\.content\]/, "reaction chips expose their reaction type to assistive tech");
 assert.match(boardCss, /\.gh-reaction \{/, "reaction chips are styled");
 assert.match(boardCss, /\.gh-review-entry \{/, "review timeline entries are styled");
 assert.match(boardCss, /\.gh-review-entry\.is-approved \{ border-left-color:var\(--color-success\)/, "approved reviews get a success accent");
@@ -91,6 +94,8 @@ assert.match(checksRoute, /\/commits\/\$\{sha\}\/check-runs/, "checks route read
 assert.match(checksRoute, /\/commits\/\$\{sha\}\/status/, "checks route reads the legacy combined status");
 assert.match(checksRoute, /summarizeChecks\(runs as CheckRun\[\], combinedState\)/, "checks route rolls up a single summary");
 assert.match(checksRoute, /detailsUrl:[\s\S]{0,60}details_url/, "each run carries its logs URL");
+assert.match(checksRoute, /if \(!runsResp\.res\.ok && !statusResp\.res\.ok\)/, "checks route errors when both upstream CI requests fail");
+assert.match(checksRoute, /github error \(\$\{runsResp\.res\.status\}, \$\{statusResp\.res\.status\}\)/, "checks route reports the failed upstream status pair");
 
 // The detail panel renders an expandable checks section for PRs only.
 assert.match(source, /function GitHubChecks/, "the checks section component exists");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -7,7 +7,6 @@
 import "@/styles/board.css";
 import {
   createContext,
-  Fragment,
   useContext,
   useEffect,
   useMemo,
@@ -1114,13 +1113,29 @@ const REACTION_EMOJI: Record<string, string> = {
   eyes: "👀",
 };
 
+const REACTION_LABEL: Record<string, string> = {
+  "+1": "thumbs up",
+  "-1": "thumbs down",
+  laugh: "laugh",
+  hooray: "hooray",
+  confused: "confused",
+  heart: "heart",
+  rocket: "rocket",
+  eyes: "eyes",
+};
+
 /** Read-only reaction summary (emoji + count) under a comment. */
 function CommentReactions({ reactions }: { reactions?: GhReaction[] }) {
   if (!reactions || reactions.length === 0) return null;
   return (
     <div className="gh-reactions" aria-label="Reactions">
       {reactions.map((r) => (
-        <span key={r.content} className="gh-reaction" title={`${r.count} ${r.content}`}>
+        <span
+          key={r.content}
+          className="gh-reaction"
+          title={`${r.count} ${r.content}`}
+          aria-label={`${r.count} ${REACTION_LABEL[r.content] ?? r.content} ${r.count === 1 ? "reaction" : "reactions"}`}
+        >
           <span aria-hidden>{REACTION_EMOJI[r.content] ?? "•"}</span>
           {r.count}
         </span>


### PR DESCRIPTION
## Summary

Follow-up for unresolved review conversations left on merged PR #2450.

- remove the unused `Fragment` import from `github-view.tsx`
- add accessible labels for GitHub reaction chips so screen readers announce the reaction type
- return `ok:false` from `/api/github/checks` when both upstream CI/status fetches fail, instead of showing an empty checks payload
- add regression assertions in `github-advanced.test.ts`

Addresses the three unresolved threads on #2450.

## Verification

- `node --experimental-strip-types src/components/github-advanced.test.ts`
- `pnpm typecheck`
- `git diff --check`

Earlier, before rebasing this same patch onto current `origin/main`, I also ran `pnpm test:app` successfully: 520/520.
