### PR TITLE
fix(mobile): stop mobile:tailscale dead-ending when the port is squatted by an untracked server

### DIFF
--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -2,8 +2,13 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
+SELF="$PWD/scripts/mobile-tailscale.sh"
 
 COMMAND="${1:-start}"
+# Captured before defaulting: an explicit PORT= (or state-dir) override opts out
+# of the automatic port sidestep/adoption below.
+PORT_WAS_SET="${PORT+1}"
+STATE_DIR_WAS_SET="${COVEN_CAVE_MOBILE_STATE_DIR+1}"
 PORT="${PORT:-3000}"
 HOST="${HOST:-127.0.0.1}"
 TAILSCALE_TIMEOUT_MS="${TAILSCALE_TIMEOUT_MS:-8000}"
@@ -48,8 +53,12 @@ ensure_state_dir() {
   chmod 700 "$STATE_DIR"
 }
 
+port_is_listening_at() {
+  node -e "const net=require('net');const s=net.connect({host:process.argv[1],port:Number(process.argv[2])});s.setTimeout(300);s.on('connect',()=>process.exit(0));s.on('timeout',()=>process.exit(1));s.on('error',()=>process.exit(1));" "$HOST" "$1"
+}
+
 port_is_listening() {
-  node -e "const net=require('net');const s=net.connect({host:process.argv[1],port:Number(process.argv[2])});s.setTimeout(300);s.on('connect',()=>process.exit(0));s.on('timeout',()=>process.exit(1));s.on('error',()=>process.exit(1));" "$HOST" "$PORT"
+  port_is_listening_at "$PORT"
 }
 
 backend_url() {
@@ -73,13 +82,116 @@ recorded_server_is_running() {
   kill -0 "$pid" >/dev/null 2>&1
 }
 
+describe_port_occupant() {
+  command -v lsof >/dev/null 2>&1 || return 0
+  lsof -nP -iTCP:"$1" -sTCP:LISTEN 2>/dev/null | awk 'NR>1 {print "  in use by: pid " $2 " (" $1 ")"}' | sort -u || true
+}
+
+# Next.js allows only one dev server per project directory (dev singleton), so
+# when the occupant runs from THIS checkout a fallback port cannot help — the
+# second `next dev` refuses to boot no matter which port it gets.
+occupant_is_this_checkout() {
+  command -v lsof >/dev/null 2>&1 || return 1
+  local pid cwd
+  for pid in $(lsof -nP -tiTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true); do
+    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+    if [ "$cwd" = "$PWD" ]; then
+      OCCUPANT_PID="$pid"
+      return 0
+    fi
+  done
+  return 1
+}
+
 require_recorded_server() {
   if recorded_server_is_running; then
     return 0
   fi
 
-  echo "Refusing to contact an untracked server on ${HOST}:${PORT}. Run: pnpm mobile:tailscale:stop && pnpm mobile:tailscale" >&2
+  echo "Refusing to contact an untracked server on ${HOST}:${PORT} — this script did not start it, so 'stop' cannot free it." >&2
+  describe_port_occupant "$PORT" >&2
+  echo "Stop that process yourself, or run on a free port: PORT=$((PORT + 1)) pnpm mobile:tailscale" >&2
   exit 1
+}
+
+find_free_port() {
+  local candidate
+  for candidate in $(seq $((PORT + 1)) $((PORT + 20))); do
+    if ! port_is_listening_at "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Servers this script starts are tracked in per-port state dirs. When the
+# default port is squatted by a server it did not start (another session's dev
+# server, a stale corpse), never touch that server — sidestep to a free port
+# instead. Explicit PORT= / state-dir overrides opt out and hit the
+# require_recorded_server refusal with the occupant named.
+maybe_fallback_port() {
+  if [ -n "${PORT_WAS_SET}${STATE_DIR_WAS_SET}" ]; then
+    return 0
+  fi
+  if ! port_is_listening >/dev/null 2>&1; then
+    return 0
+  fi
+  if recorded_server_is_running; then
+    return 0
+  fi
+
+  if occupant_is_this_checkout; then
+    echo "Port ${PORT} is held by a server running from this same checkout (pid ${OCCUPANT_PID}) that this script did not start." >&2
+    echo "Next.js allows one dev server per checkout, so starting the mobile server on another port will not work either." >&2
+    echo "If that server is expendable: kill ${OCCUPANT_PID}   then rerun: pnpm mobile:tailscale" >&2
+    exit 1
+  fi
+
+  local free
+  if ! free="$(find_free_port)"; then
+    echo "Port ${PORT} is in use by an untracked server and no free port was found in $((PORT + 1))-$((PORT + 20))." >&2
+    describe_port_occupant "$PORT" >&2
+    exit 1
+  fi
+
+  echo "Port ${PORT} is in use by a server this script did not start; leaving it alone."
+  describe_port_occupant "$PORT"
+  echo "Starting on ${HOST}:${free} instead — invite/status/stop find it automatically."
+  exec env PORT="$free" bash "$SELF" "$COMMAND"
+}
+
+# Default-port invite/status/start adopt the single live instance this script
+# already runs on a fallback port, so companion commands keep working without
+# an explicit PORT=.
+resolve_active_port() {
+  if [ -n "${PORT_WAS_SET}${STATE_DIR_WAS_SET}" ]; then
+    return 0
+  fi
+  if recorded_server_is_running; then
+    return 0
+  fi
+
+  local live="" dir port pid
+  for dir in "$STATE_ROOT"/mobile-tailscale-*; do
+    [ -d "$dir" ] || continue
+    port="${dir##*mobile-tailscale-}"
+    case "$port" in ''|*[!0-9]*) continue ;; esac
+    [ -s "$dir/next.pid" ] || continue
+    pid="$(cat "$dir/next.pid")"
+    case "$pid" in ''|*[!0-9]*) continue ;; esac
+    kill -0 "$pid" >/dev/null 2>&1 || continue
+    if [ -n "$live" ] && [ "$live" != "$port" ]; then
+      # More than one live instance: ambiguous, keep the requested port.
+      return 0
+    fi
+    live="$port"
+  done
+
+  if [ -z "$live" ] || [ "$live" = "$PORT" ]; then
+    return 0
+  fi
+  exec env PORT="$live" bash "$SELF" "$COMMAND"
 }
 
 write_server_mode() {
@@ -674,7 +786,12 @@ invite_command() {
 status_command() {
   ensure_state_dir
   if port_is_listening >/dev/null 2>&1; then
-    echo "CovenCave mobile server: running on ${HOST}:${PORT}"
+    if recorded_server_is_running; then
+      echo "CovenCave mobile server: running on ${HOST}:${PORT} (pid $(cat "$PID_FILE"))"
+    else
+      echo "CovenCave mobile server: not running. ${HOST}:${PORT} is in use by a server this script does not track."
+      describe_port_occupant "$PORT"
+    fi
   else
     echo "CovenCave mobile server: not listening on ${HOST}:${PORT}"
   fi
@@ -690,33 +807,56 @@ status_command() {
   warn_if_serve_targets_other_backend
 }
 
-stop_command() {
-  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$TMUX_SESSION" 2>/dev/null; then
-    tmux kill-session -t "$TMUX_SESSION"
-    echo "Stopped tmux session: ${TMUX_SESSION}"
+stop_instance() {
+  local dir="$1" session="$2" pid_file pid
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session" 2>/dev/null; then
+    tmux kill-session -t "$session"
+    echo "Stopped tmux session: ${session}"
   fi
 
-  if [ -s "$PID_FILE" ]; then
-    pid="$(cat "$PID_FILE")"
-    if kill -0 "$pid" >/dev/null 2>&1; then
-      kill "$pid" >/dev/null 2>&1 || true
-      echo "Stopped pid: ${pid}"
-    fi
+  pid_file="$dir/next.pid"
+  if [ -s "$pid_file" ]; then
+    pid="$(cat "$pid_file")"
+    case "$pid" in
+      ''|*[!0-9]*) ;;
+      *)
+        if kill -0 "$pid" >/dev/null 2>&1; then
+          kill "$pid" >/dev/null 2>&1 || true
+          echo "Stopped pid: ${pid}"
+        fi
+        ;;
+    esac
   fi
+
+  rm -f "$dir/next.pid" "$dir/invite.url" "$dir/invite.expires" "$dir/server.mode"
+}
+
+stop_command() {
+  stop_instance "$STATE_DIR" "$TMUX_SESSION"
+
+  # Sweep sibling per-port instances so a server started on a fallback port
+  # (see maybe_fallback_port) is not stranded by a default-port stop.
+  local dir port
+  for dir in "$STATE_ROOT"/mobile-tailscale-*; do
+    [ -d "$dir" ] || continue
+    [ "$dir" = "$STATE_DIR" ] && continue
+    port="${dir##*mobile-tailscale-}"
+    case "$port" in ''|*[!0-9]*) continue ;; esac
+    stop_instance "$dir" "coven-cave-mobile-${port}"
+  done
 
   if command -v "$TAILSCALE_BIN" >/dev/null 2>&1; then
     tailscale_cmd serve reset >/dev/null 2>&1 || true
   fi
-  rm -f "$PID_FILE" "$INVITE_FILE" "$EXPIRES_FILE"
   echo "CovenCave mobile Tailscale state stopped."
 }
 
 case "$COMMAND" in
-  start) start_command ;;
-  invite) invite_command ;;
-  native) native_command ;;
-  app) app_command ;;
-  status) status_command ;;
+  start) resolve_active_port; maybe_fallback_port; start_command ;;
+  invite) resolve_active_port; invite_command ;;
+  native) resolve_active_port; maybe_fallback_port; native_command ;;
+  app) resolve_active_port; maybe_fallback_port; app_command ;;
+  status) resolve_active_port; status_command ;;
   stop) stop_command ;;
   *)
     echo "Usage: pnpm mobile:tailscale[:invite|:native|:app|:status|:stop]" >&2

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -27,7 +27,7 @@ test("mobile tailscale app mode serves the native client with no token", () => {
   // The tokenless native-app path must mint/load NO access or sidecar token and
   // unset both (plus COVEN_CAVE_BUNDLE) when starting the server.
   assert.match(script, /CAVE_MOBILE_APP/);
-  assert.match(script, /app\) app_command ;;/);
+  assert.match(script, /app\) resolve_active_port; maybe_fallback_port; app_command ;;/);
   assert.match(
     script,
     /unset COVEN_CAVE_ACCESS_TOKEN COVEN_CAVE_AUTH_TOKEN COVEN_CAVE_BUNDLE/,


### PR DESCRIPTION
## Problem

`pnpm mobile:tailscale:stop && pnpm mobile:tailscale` could fail forever:

```
Refusing to contact an untracked server on 127.0.0.1:3000. Run: pnpm mobile:tailscale:stop && pnpm mobile:tailscale
```

`stop` only kills the pid recorded in the per-port state dir, so a listener the script never started (another session's dev server, a stale corpse) can never be cleared by `stop` — and the error's suggested remedy is the exact sequence that just failed.

## Fix (`scripts/mobile-tailscale.sh`)

- **Foreign squatter** → `start`/`native`/`app` sidestep to a free port (re-exec with the fallback `PORT`); the untracked server is never touched.
- **Squatter from this same checkout** → honest refusal naming the pid and the real remedy (`kill <pid>`), because the Next.js one-dev-server-per-checkout singleton makes a fallback port useless there (verified live: the fallback server boots, then Next refuses with "Another next dev server is already running").
- **`invite`/`status`/`start` adopt** the script's own live instance on whatever port it landed on, so companion commands keep working without `PORT=`.
- **`stop` sweeps every per-port state dir** (and clears the stale `server.mode`) so fallback instances are never stranded.
- **`status` tells the truth**: distinguishes a tracked mobile server from an untracked listener instead of reporting "running".

Explicit `PORT=` / `COVEN_CAVE_MOBILE_STATE_DIR` overrides opt out of the automatic sidestep/adoption and get the named refusal instead.

## Verification

- `bash -n` clean; `pnpm test:mobile` 12/12 (one dispatch pin updated to the new `app)` case line — intent unchanged).
- Live E2E against a real squatted port 3000: fallback path (3000→3001 sidestep, boot, re-exec), same-checkout refusal path, stop sweep, status wording, and a full successful `start` (server + invite + Tailscale Serve) after the squatter was cleared.

Beads: cave-gbo

🤖 Generated with [Claude Code](https://claude.com/claude-code)