### PR TITLE
fix(ios): present the Diary from RootView so connection flaps can't dismiss it

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -57,6 +57,12 @@ final class AppModel {
     /// pushes the card, and clears it (mirrors `threadToOpen`).
     var cardToOpen: BoardCard?
 
+    /// The Diary (Pencil-handwriting experiment) is presented from `RootView`,
+    /// ABOVE the connectionState switch — a transient flap to `.checking`
+    /// swaps `MainTabView` out and would destroy any cover presented from
+    /// within it, dismissing the diary mid-reply and aborting its stream.
+    var diaryPresented = false
+
     /// The active confirmation toast, auto-dismissed by the overlay.
     var toast: ToastMessage?
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -15,8 +15,6 @@ struct ChatsHomeView: View {
     @Environment(AppModel.self) private var app
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showNewChat = false
-    /// The Diary — the experimental Pencil-handwriting page (iPad only).
-    @State private var showDiary = false
     @State private var query = ""
     /// Drives the accent glow on the search field while it's being edited.
     @FocusState private var searchFocused: Bool
@@ -59,9 +57,6 @@ struct ChatsHomeView: View {
                     showNewChat = false
                     open(.thread(thread))
                 }
-            }
-            .fullScreenCover(isPresented: $showDiary) {
-                DiaryView()
             }
             .refreshable {
                 await app.loadFamiliars()
@@ -413,9 +408,11 @@ struct ChatsHomeView: View {
 
             // The Diary — Pencil-handwriting experiment. iPad only: the page is
             // sized for Pencil writing, so the entry point hides on iPhone.
+            // Presented from RootView (app.diaryPresented) so a connection
+            // flap swapping the tab tree can't dismiss it mid-reply.
             if sizeClass == .regular {
                 Button {
-                    showDiary = true
+                    app.diaryPresented = true
                 } label: {
                     Image(systemName: "book.closed")
                         .font(.system(.title3, weight: .medium))

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -5,6 +5,7 @@ struct RootView: View {
     @Environment(\.chrome) private var chrome
 
     var body: some View {
+        @Bindable var app = app
         Group {
             switch app.connectionState {
             case .unconfigured:
@@ -22,6 +23,13 @@ struct RootView: View {
         // Frosted, accent-infused tab + navigation bars that track the desktop
         // palette and degrade to solid themed surfaces under Reduce Transparency.
         .glassBars()
+        // The Diary presents HERE, not inside MainTabView: the switch above
+        // swaps the tab tree out on a transient connection flap, and a cover
+        // presented from within it would dismiss mid-reply, aborting the
+        // diary's stream.
+        .fullScreenCover(isPresented: $app.diaryPresented) {
+            DiaryView()
+        }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCaveUITests/DiaryUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/DiaryUITests.swift
@@ -74,12 +74,20 @@ final class DiaryUITests: XCTestCase {
         stroke(CGVector(dx: 0.655, dy: 0.55), CGVector(dx: 0.69, dy: 0.485))
         stroke(CGVector(dx: 0.69, dy: 0.485), CGVector(dx: 0.655, dy: 0.42))
 
-        // Pen-lift (3.5s) → Vision → ink soak → streamed reply. The reply Text
-        // carries "The diary replies: …" as its accessibility label.
+        // Pen-lift (3.5s) → Vision → ink soak → streamed reply. Leave the app
+        // UNDISTURBED for the pen-lift + recognition window: waitForExistence
+        // polls accessibility snapshots continuously, which can starve the
+        // in-app timers. Sparse one-shot probes instead.
+        Thread.sleep(forTimeInterval: 12)
         let reply = app.staticTexts.matching(
             NSPredicate(format: "label BEGINSWITH 'The diary replies:'")
         ).firstMatch
-        XCTAssertTrue(reply.waitForExistence(timeout: 120), "the diary should write a reply out on the page")
+        var replyAppeared = false
+        for _ in 0..<24 {
+            if reply.exists { replyAppeared = true; break }
+            Thread.sleep(forTimeInterval: 5)
+        }
+        XCTAssertTrue(replyAppeared, "the diary should write a reply out on the page")
 
         // Let the quill finish for anyone watching the simulator.
         Thread.sleep(forTimeInterval: 25)

--- a/scripts/ios-diary-page.test.mjs
+++ b/scripts/ios-diary-page.test.mjs
@@ -102,16 +102,22 @@ assert.match(
   "Reduce Motion collapses the reveal/soak animations",
 );
 
-// ── iPad-only entry point ────────────────────────────────────────────────────
+// ── iPad-only entry point, presented above the connection switch ────────────
+const root = await read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
 assert.match(
   home,
-  /if sizeClass == \.regular \{[\s\S]*?showDiary = true/,
+  /if sizeClass == \.regular \{[\s\S]*?app\.diaryPresented = true/,
   "the Diary entry point only shows in regular width (iPad) — the page is sized for Pencil writing",
 );
 assert.match(
+  root,
+  /fullScreenCover\(isPresented: \$app\.diaryPresented\) \{\s*\n\s*DiaryView\(\)/,
+  "the Diary presents from RootView, above the connectionState switch — a transient flap must not dismiss it mid-reply",
+);
+assert.doesNotMatch(
   home,
-  /fullScreenCover\(isPresented: \$showDiary\) \{\s*\n\s*DiaryView\(\)/,
-  "the Diary opens full screen",
+  /fullScreenCover[\s\S]*?DiaryView/,
+  "the Diary cover must NOT live inside the tab tree (a connection flap destroys it)",
 );
 
 console.log("ios-diary-page.test.mjs: ok");


### PR DESCRIPTION
## What

The Diary dismissed itself mid-reply — twice in live use, then reproduced deterministically under XCUITest. Root cause: the `fullScreenCover` was presented from `ChatsHomeView`, inside `RootView`'s `connectionState` switch. A transient flap to `.checking` swaps `MainTabView` out, destroying the tab tree and the cover with it; the diary's `onDisappear` then aborts the SSE stream, so the familiar's reply lands as "(cancelled)".

## Fix

- `AppModel.diaryPresented` + the cover moves to `RootView`, **above** the switch — a flap now only swaps the background content; the diary stays up and the stream survives.
- `ChatsHomeView`'s book button just sets the flag.

## Test hardening (from the debugging journey)

- `DiaryUITests` pairing invite is **typed** into the Connect screen's host field (via `TEST_RUNNER_CAVE_TEST_INVITE`) — the paste-permission sheet is hosted by a system process XCUITest can't reach, so the clipboard path can't be automated.
- The reply wait uses sparse one-shot probes after a quiet window — `waitForExistence`'s continuous accessibility-snapshot polling starved the in-app pen-lift timer.
- `ios-diary-page.test.mjs` pins the new presentation wiring and that the cover must NOT live inside the tab tree.

## Verification

- `testWriteHelloAndReceiveInkReply` **PASSES** on the iPad simulator: pair → open diary → hand-draw HELLO in strokes → Vision reads it → ink soaks into the page → streamed reply reveals in cursive (129s).
- `node scripts/ios-diary-page.test.mjs` green; mobile suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)