### PR TITLE
chore(release): stamp v0.0.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.142] - 2026-07-06
+
+> 📊 **Analytics you can actually steer by** — familiar analytics and growth pages get pulse trends, drill-through KPIs, and a triage roster, while the marketplace gets an ultraminimal header and a full functionality pass. On iPad, **The Diary** arrives: an experimental Apple Pencil handwriting surface.
+
+Feature release on top of v0.0.141. Ships a revamped analytics/growth surface, a marketplace overhaul, the new experimental iOS Diary, Projects-table polish, and a batch of connection/desktop/onboarding/GitHub fixes.
+
+### Features
+- **Familiar analytics + growth revamp** (#2469). Pulse trend lines, drill-through KPIs, and a triage roster across the familiar analytics and growth pages, with dashboard cockpit analytics accuracy fixed so the numbers match reality.
+- **Marketplace ultraminimal header + UX pass** (#2463). A comprehensive functionality and UX pass on the marketplace with a stripped-down header.
+- **The Diary — experimental Apple Pencil handwriting page (iPad)** (#2457, #2458, #2471). A new experimental handwriting surface for iPad: longer replies, no option menus, sentence-length pen-lift detection, and presented from RootView so connection flaps can't dismiss it mid-session.
+- **Projects table polish** (#2459). UI/UX cleanup on the Projects table, including de-duped project listings.
+
+### Fixes
+- **Seamless, stable iOS ↔ desktop connection** (#2465, cave-30b). Hardens the mobile/desktop connection path so it stays stable instead of flapping.
+- **Titlebar drag** (#2464). Grants `start_dragging` to the loopback webview so the desktop titlebar actually drags.
+- **Onboarding focus trap** (#2466). Keeps the wizard's focus trap airtight and stops it relaunching on already-set-up machines.
+- **mobile:tailscale port squatting** (#2468, cave-gbo). Stops `mobile:tailscale` dead-ending when the port is squatted by an untracked server.
+- **GitHub review-conversation regressions** (#2467). Addresses regressions surfaced in PR #2450 review conversations.
+
+### Polish
+- **GitHub surface** (#2456). Profile cache, live checks refresh, and thread-comment reactions.
+
+### Tests
+- **Inline file editing + Diary UI tests** (#2470). Adds coverage for inline file editing and the new Diary UI.
+
 ## [0.0.141] - 2026-07-06
 
 > ⚡ **Quick chat is now a real conversation** — the menubar / ⌘J dropdown holds a full multi-turn thread: streaming replies, context that carries across turns, copy & regenerate, all without leaving what you were doing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.141",
+  "version": "0.0.142",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.141"
+version = "0.0.142"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.141"
+version = "0.0.142"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.141</string>
+	<string>0.0.142</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.141</string>
+	<string>0.0.142</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.141</string>
+	<string>0.0.142</string>
 	<key>CFBundleVersion</key>
-	<string>0.0.141</string>
+	<string>0.0.142</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.141",
+  "version": "0.0.142",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
## Release v0.0.142

Feature release on top of v0.0.141. Stamps the version across all six locations + CHANGELOG.

### What ships (16 commits since `v0.0.141`)

**Features**
- `feat(analytics)` familiar analytics + growth revamp — pulse trends, drill-through KPIs, triage roster (#2469)
- `feat(marketplace)` ultraminimal header + comprehensive UX/functionality pass (#2463)
- `feat(ios)` The Diary — experimental Apple Pencil handwriting page for iPad (#2457, #2458, #2471)
- `feat(projects)` Projects table UI/UX polish + dedupe (#2459)

**Fixes**
- `fix(connection)` seamless, stable iOS ↔ desktop connection (#2465, cave-30b)
- `fix(desktop)` titlebar drag via loopback `start_dragging` (#2464)
- `fix(onboarding)` airtight focus trap, no relaunch on set-up machines (#2466)
- `fix(mobile)` mobile:tailscale port-squatting dead-end (#2468, cave-gbo)
- `fix(github)` PR #2450 review-conversation regressions (#2467)

**Polish / Tests**
- `polish(github)` profile cache, live checks refresh, thread-comment reactions (#2456)
- inline file editing + Diary UI tests (#2470)

### Version stamp (6 locations)
`package.json` · `src-tauri/Cargo.toml` · `src-tauri/Cargo.lock` (app entry) · `src-tauri/tauri.conf.json` · `src-tauri/Info.ios.plist` · `src-tauri/gen/apple/app_iOS/Info.plist` — all `0.0.141` → `0.0.142`.

### Pre-release QC — all green ✅
Run locally against this branch's tree before stamping:

| Gate | Result |
|---|---|
| `tsc --noEmit` | ✅ clean |
| tests-wired guard | ✅ 706 wired |
| app suite | ✅ 522 files |
| api suite | ✅ 118 files |
| mobile suite | ✅ 70 files |
| conformance | ✅ (1 Windows-only skip) |
| api-contracts | ✅ 144 route contracts |
| supply-chain policy | ✅ sharp pinned coherently @ 0.34.5 |
| production build + bundle budget | ✅ within budget (shell 447/650KB, largest 1700/2400KB) |

Tag `v0.0.142` will be pushed after this merges to trigger the release workflow (DMG/AppImage/MSI).