### PR TITLE
fix(ios): dilate diary ink before Vision recognition + trace logging

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/DiaryView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/DiaryView.swift
@@ -1,8 +1,15 @@
 import SwiftUI
 import PencilKit
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import os
 // Vision's request types predate Sendable; @preconcurrency quiets the strict-
 // concurrency warning for the recognize() closure capture.
 @preconcurrency import Vision
+
+/// Diary flow tracing — `log stream --predicate 'subsystem == "ai.opencoven.cave"'`
+/// on the simulator shows pen-lift arming/firing, recognition, and stream state.
+private let diaryLog = Logger(subsystem: "ai.opencoven.cave", category: "diary")
 
 /// The Diary — an experimental iPad surface styled after Tom Riddle's diary.
 ///
@@ -250,6 +257,7 @@ struct DiaryView: View {
     /// Pen activity: fade out a finished reply (the page clears itself for the
     /// next exchange) and (re)arm the pen-lift timer that triggers recognition.
     private func strokesChanged() {
+        diaryLog.info("strokesChanged: phase=\(String(describing: phase)) strokes=\(drawing.strokes.count)")
         guard phase == .idle else { return }
         hint = nil
         if !revealedReply.isEmpty && replyOpacity == 1 {
@@ -262,6 +270,7 @@ struct DiaryView: View {
             // words and strokes must not submit a half-written message.
             try? await Task.sleep(for: .milliseconds(3500))
             guard !Task.isCancelled, phase == .idle, !drawing.strokes.isEmpty else { return }
+            diaryLog.info("pen-lift: firing submit")
             await submit()
         }
     }
@@ -271,26 +280,39 @@ struct DiaryView: View {
     @MainActor
     private func submit() async {
         guard let client = app.client, let familiar = currentFamiliar else {
-            showHint("The diary is not connected.")
+            // A transient connection flap empties the familiar roster (and can
+            // drop the client). The written message is still on the page —
+            // retry shortly instead of dropping it and going silent forever.
+            diaryLog.warning("submit: no client/familiar (client=\(app.client != nil) familiars=\(app.familiars.count)) — retrying in 2.5s")
+            showHint("The diary is reaching for your desktop…")
+            penLiftTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(2500))
+                guard !Task.isCancelled, phase == .idle, !drawing.strokes.isEmpty else { return }
+                await submit()
+            }
             return
         }
         // A stray dot or hairline (an accidental tap) isn't a message — clear
         // it quietly instead of running recognition and nagging with a hint.
         let bounds = drawing.bounds
         if bounds.width < 14 && bounds.height < 14 {
+            diaryLog.info("submit: stray mark cleared (bounds \(bounds.width)x\(bounds.height))")
             drawing = PKDrawing()
             return
         }
         phase = .recognizing
+        diaryLog.info("submit: recognizing \(drawing.strokes.count) strokes")
 
         let text: String
         do {
             text = try await DiaryHandwriting.recognize(drawing)
         } catch {
+            diaryLog.error("submit: recognition failed: \(error.localizedDescription)")
             phase = .idle
             showHint("The diary squints… it can't quite read that.")
             return
         }
+        diaryLog.info("submit: recognized \"\(text)\"")
         guard !text.isEmpty else {
             phase = .idle
             showHint("The diary can't read that — try writing a little larger.")
@@ -533,6 +555,22 @@ enum DiaryHandwriting {
         }
         guard let cgImage = composited.cgImage else { return "" }
 
+        // Thicken the ink before recognition: pen strokes are ~3pt hairlines
+        // at this render scale, right at the edge of what Vision's handwriting
+        // model resolves — thin, widely-spaced strokes read as nothing at all.
+        // Morphology-minimum dilates dark-on-white strokes.
+        let dilated: CGImage = {
+            let input = CIImage(cgImage: cgImage)
+            let filter = CIFilter.morphologyMinimum()
+            filter.inputImage = input
+            filter.radius = 3
+            guard let output = filter.outputImage,
+                  let rendered = CIContext().createCGImage(output, from: input.extent) else {
+                return cgImage
+            }
+            return rendered
+        }()
+
         return try await withCheckedThrowingContinuation { continuation in
             let request = VNRecognizeTextRequest { request, error in
                 if let error {
@@ -551,7 +589,7 @@ enum DiaryHandwriting {
 
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    try VNImageRequestHandler(cgImage: cgImage).perform([request])
+                    try VNImageRequestHandler(cgImage: dilated).perform([request])
                 } catch {
                     continuation.resume(throwing: error)
                 }

--- a/apps/ios/CovenCave/CovenCaveUITests/DiaryUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/DiaryUITests.swift
@@ -47,32 +47,28 @@ final class DiaryUITests: XCTestCase {
         let canvas = app.otherElements["Diary page. Write your message here with Apple Pencil."]
         let surface: XCUIElement = canvas.waitForExistence(timeout: 10) ? canvas : app.windows.firstMatch
 
-        func stroke(_ a: CGVector, _ b: CGVector) {
-            surface.coordinate(withNormalizedOffset: a)
-                .press(forDuration: 0.06, thenDragTo: surface.coordinate(withNormalizedOffset: b))
+        // A polyline draws as chained 2-point strokes sharing endpoints — the
+        // pixels read as one continuous pen line. Vision's handwriting model
+        // returned "" for giant, sparse block capitals; compact connected
+        // lowercase reads reliably (with the app-side ink dilation).
+        func polyline(_ points: [CGVector]) {
+            for i in 0..<(points.count - 1) {
+                surface.coordinate(withNormalizedOffset: points[i])
+                    .press(forDuration: 0.05, thenDragTo: surface.coordinate(withNormalizedOffset: points[i + 1]))
+            }
         }
+        func v(_ x: Double, _ y: Double) -> CGVector { CGVector(dx: x, dy: y) }
 
-        // H E L L O in straight block strokes across the middle of the page.
-        // H
-        stroke(CGVector(dx: 0.15, dy: 0.42), CGVector(dx: 0.15, dy: 0.55))
-        stroke(CGVector(dx: 0.22, dy: 0.42), CGVector(dx: 0.22, dy: 0.55))
-        stroke(CGVector(dx: 0.15, dy: 0.485), CGVector(dx: 0.22, dy: 0.485))
-        // E
-        stroke(CGVector(dx: 0.28, dy: 0.42), CGVector(dx: 0.28, dy: 0.55))
-        stroke(CGVector(dx: 0.28, dy: 0.42), CGVector(dx: 0.35, dy: 0.42))
-        stroke(CGVector(dx: 0.28, dy: 0.485), CGVector(dx: 0.34, dy: 0.485))
-        stroke(CGVector(dx: 0.28, dy: 0.55), CGVector(dx: 0.35, dy: 0.55))
-        // L
-        stroke(CGVector(dx: 0.41, dy: 0.42), CGVector(dx: 0.41, dy: 0.55))
-        stroke(CGVector(dx: 0.41, dy: 0.55), CGVector(dx: 0.46, dy: 0.55))
-        // L
-        stroke(CGVector(dx: 0.52, dy: 0.42), CGVector(dx: 0.52, dy: 0.55))
-        stroke(CGVector(dx: 0.52, dy: 0.55), CGVector(dx: 0.57, dy: 0.55))
-        // O (diamond — Vision's language correction rounds it off)
-        stroke(CGVector(dx: 0.655, dy: 0.42), CGVector(dx: 0.62, dy: 0.485))
-        stroke(CGVector(dx: 0.62, dy: 0.485), CGVector(dx: 0.655, dy: 0.55))
-        stroke(CGVector(dx: 0.655, dy: 0.55), CGVector(dx: 0.69, dy: 0.485))
-        stroke(CGVector(dx: 0.69, dy: 0.485), CGVector(dx: 0.655, dy: 0.42))
+        // "hello" in compact lowercase print across the middle of the page.
+        polyline([v(0.200, 0.440), v(0.200, 0.485)])                                 // h stem
+        polyline([v(0.200, 0.468), v(0.218, 0.458), v(0.218, 0.485)])                // h hump
+        polyline([v(0.242, 0.470), v(0.272, 0.470), v(0.268, 0.458), v(0.250, 0.456),
+                  v(0.242, 0.470), v(0.247, 0.483), v(0.271, 0.482)])                // e
+        polyline([v(0.292, 0.438), v(0.292, 0.485)])                                 // l
+        polyline([v(0.312, 0.438), v(0.312, 0.485)])                                 // l
+        polyline([v(0.345, 0.457), v(0.356, 0.461), v(0.360, 0.4715), v(0.356, 0.482),
+                  v(0.345, 0.486), v(0.334, 0.482), v(0.330, 0.4715), v(0.334, 0.461),
+                  v(0.345, 0.457)])                                                  // o
 
         // Pen-lift (3.5s) → Vision → ink soak → streamed reply. Leave the app
         // UNDISTURBED for the pen-lift + recognition window: waitForExistence


### PR DESCRIPTION
## What

The diary's handwriting sometimes read as nothing at all — the ink sat on the page forever with no reply. Traced end-to-end with os_log: the pen-lift timer fired correctly every time; **Vision was the silent failure**, returning `""` for the diary's thin pen strokes (3.4pt ink renders as hairlines at recognition scale).

```
07:19:40  submit: recognized ""        ← before
07:38:54  submit: recognized "hello"   ← after
```

## Fixes

- **Ink dilation** — a CoreImage morphology-minimum pass (radius 3) thickens dark-on-white strokes before `VNRecognizeTextRequest`. Words that previously recognized as empty now read exactly.
- **Flap retry** — `submit()` retries every 2.5s when a transient connection flap empties the familiar roster mid-write, instead of dropping the written message silently (companion to #2471's presentation fix).
- **Trace logging** — `Logger(subsystem: "ai.opencoven.cave", category: "diary")` on stroke commits, pen-lift arming/firing, recognition results, and retries. The diary's flow is invisible by design (no UI between write and reply), so failures need the log stream.
- **UI test handwriting** — draws compact connected lowercase "hello" via chained polyline strokes; the previous giant, sparse block capitals are precisely the input Vision's handwriting model rejects.

## Verification

- `testWriteHelloAndReceiveInkReply` **PASSES** (135s) on the iPad simulator, trace showing `submit: recognized "hello"`, reply streamed and revealed in cursive on the page
- Built + tested from an isolated worktree (`.worktrees/diary-vision-legibility`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)