### PR TITLE
feat(auth): serve an HTML access gate for unauthenticated page navigations

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -82,6 +82,25 @@ assert.match(
 assert.match(source, /if \(queryVerification\.ok\)/, "invalid query tokens should not overwrite the access cookie");
 assert.match(source, /maxAge/, "signed mobile cookie lifetime should track token expiry");
 assert.match(source, /req\.method === "GET" \|\| req\.method === "HEAD"/, "mobile token bootstrap should avoid redirects for mutating requests");
+
+// ── HTML access gate for unauthenticated browser navigations ──────────────
+// Same 401 fail-closed posture; only the body differs by client. The page's
+// form re-enters the query-token exchange above — no new auth logic.
+assert.match(
+  source,
+  /isHtmlNavigationRequest\(req\.method, req\.nextUrl\.pathname, req\.headers\.get\("accept"\)\)/,
+  "unauthenticated browser page navigations should get the HTML access gate",
+);
+assert.match(
+  source,
+  /if \(!verification\) \{[\s\S]*?accessGatePage\(\{ invalidToken: suppliedTokens\.length > 0 \}\)[\s\S]*?status: 401[\s\S]*?return jsonError\(401, "unauthorized"\);[\s\S]*?\}/,
+  "the HTML gate must live inside the failed-verification branch, still 401, with the JSON envelope retained for non-navigations",
+);
+assert.match(
+  source,
+  /"cache-control": "no-store"/,
+  "the access gate page must never be cached",
+);
 assert.match(
   sidecarBridgeSource,
   /__COVEN_CAVE_SIDECAR_AUTH_REQUIRED__/,

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -22,6 +22,9 @@ import {
   bearerFromReferer,
   shouldRequireMobileAccessCredential,
   timingSafeEqualString,
+  isHtmlNavigationRequest,
+  accessGatePage,
+  ACCESS_TOKEN_QUERY_PARAM,
 } from "./proxy-helpers.ts";
 
 // ─── isLoopbackHost ────────────────────────────────────────────────────────
@@ -282,6 +285,45 @@ assert.equal(timingSafeEqualString("12345", "12346"), false);
   const right = "a".repeat(1023) + "b";
   assert.equal(timingSafeEqualString(left, right), false);
   assert.equal(timingSafeEqualString(left, left), true);
+}
+
+// ─── isHtmlNavigationRequest ───────────────────────────────────────────────
+// Only browser PAGE navigations (HTML-accepting GET outside /api/) qualify
+// for the HTML access gate; everything else must keep the JSON 401 envelope.
+const BROWSER_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+assert.equal(isHtmlNavigationRequest("GET", "/", BROWSER_ACCEPT), true);
+assert.equal(isHtmlNavigationRequest("GET", "/dashboard/familiars/growth", BROWSER_ACCEPT), true);
+assert.equal(
+  isHtmlNavigationRequest("GET", "/api/familiars", BROWSER_ACCEPT),
+  false,
+  "API routes keep JSON even for HTML-accepting clients",
+);
+assert.equal(isHtmlNavigationRequest("GET", "/api", BROWSER_ACCEPT), false, "bare /api is an API path");
+assert.equal(
+  isHtmlNavigationRequest("GET", "/apidocs", BROWSER_ACCEPT),
+  true,
+  "prefix match must not swallow non-API paths that merely start with 'api'",
+);
+assert.equal(isHtmlNavigationRequest("POST", "/", BROWSER_ACCEPT), false, "mutations keep JSON");
+assert.equal(isHtmlNavigationRequest("HEAD", "/", BROWSER_ACCEPT), false, "HEAD keeps JSON");
+assert.equal(isHtmlNavigationRequest("GET", "/", "application/json"), false, "fetch/curl keep JSON");
+assert.equal(isHtmlNavigationRequest("GET", "/", null), false, "no Accept header keeps JSON");
+
+// ─── accessGatePage ────────────────────────────────────────────────────────
+{
+  const page = accessGatePage();
+  assert.match(page, /Access token required/);
+  // The form re-enters the audited query-token exchange — the input MUST be
+  // named exactly ACCESS_TOKEN_QUERY_PARAM and submit via GET.
+  assert.match(page, new RegExp(`name="${ACCESS_TOKEN_QUERY_PARAM}"`));
+  assert.match(page, /method="get"/);
+  assert.match(page, /type="password"/, "token input must not echo on screen");
+  assert.doesNotMatch(page, /<script/i, "gate page must be script-free (CSP-immune, no new surface)");
+  assert.doesNotMatch(page, /didn&rsquo;t verify/, "neutral prompt shows no failure note");
+
+  const invalid = accessGatePage({ invalidToken: true });
+  assert.match(invalid, /didn&rsquo;t verify/, "supplied-but-invalid tokens get the expiry hint");
+  assert.match(invalid, /role="alert"/);
 }
 
 console.log("proxy-behavior.test.ts: ok");

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -100,6 +100,114 @@ export function bearerFromReferer(value: string | null, expectedOrigin: string) 
   }
 }
 
+/**
+ * True when an unauthenticated request is a browser PAGE navigation (an
+ * HTML-accepting GET outside /api/). Only these get the HTML access-gate
+ * page; API routes, mutations, and non-browser clients (curl, fetch) keep
+ * the machine-readable JSON 401 envelope.
+ */
+export function isHtmlNavigationRequest(
+  method: string,
+  pathname: string,
+  accept: string | null,
+) {
+  if (method !== "GET") return false;
+  if (pathname === "/api" || pathname.startsWith("/api/")) return false;
+  return Boolean(accept && accept.toLowerCase().includes("text/html"));
+}
+
+/**
+ * The access-gate page served (with a 401) to unauthenticated browser
+ * navigations when COVEN_CAVE_ACCESS_TOKEN is configured. Deliberately
+ * static — nothing from the request is interpolated — and script-free.
+ * The form submits the token as the existing ACCESS_TOKEN_QUERY_PARAM GET
+ * parameter, so verification and the cookie exchange reuse the audited
+ * query-token path in the proxy; this page adds no new auth logic.
+ */
+export function accessGatePage({ invalidToken = false }: { invalidToken?: boolean } = {}) {
+  const note = invalidToken
+    ? '<p class="note" role="alert">That token didn&rsquo;t verify &mdash; it may have expired. Mint a new pairing link and try again.</p>'
+    : "";
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Access required · Coven Cave</title>
+<style>
+  :root { color-scheme: dark; }
+  body {
+    margin: 0;
+    display: grid;
+    place-items: center;
+    min-height: 100vh;
+    background: oklch(0.13 0.022 293);
+    color: oklch(0.93 0.01 293);
+    font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
+  }
+  main {
+    width: min(360px, calc(100vw - 48px));
+    padding: 28px;
+    border: 1px solid oklch(0.93 0.01 293 / 12%);
+    border-radius: 16px;
+    background: oklch(0.165 0.025 293);
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: #9a8ecd;
+    box-shadow: 0 0 0 4px oklch(0.62 0.08 293 / 16%);
+    margin-bottom: 16px;
+  }
+  h1 { margin: 0 0 6px; font-size: 16px; font-weight: 650; }
+  p { margin: 0 0 16px; color: oklch(0.66 0.018 293); font-size: 13px; }
+  .note { color: oklch(0.72 0.14 78); }
+  form { display: flex; gap: 8px; }
+  input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 12px;
+    border: 1px solid oklch(0.93 0.01 293 / 22%);
+    border-radius: 999px;
+    background: oklch(0.13 0.022 293);
+    color: inherit;
+    font: inherit;
+  }
+  input:focus-visible, button:focus-visible {
+    outline: 2px solid oklch(0.62 0.08 293 / 55%);
+    outline-offset: 1px;
+  }
+  button {
+    padding: 8px 16px;
+    border: 1px solid oklch(0.93 0.01 293 / 22%);
+    border-radius: 999px;
+    background: oklch(0.20 0.028 293);
+    color: inherit;
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  button:hover { background: oklch(0.24 0.030 293); }
+</style>
+</head>
+<body>
+<main>
+  <div class="dot" aria-hidden="true"></div>
+  <h1>Access token required</h1>
+  <p>This Cave is protected. Open your pairing link, or paste an access token below.</p>
+  ${note}
+  <form method="get" action="">
+    <input type="password" name="${ACCESS_TOKEN_QUERY_PARAM}" autocomplete="off" required aria-label="Access token" placeholder="Access token">
+    <button type="submit">Unlock</button>
+  </form>
+</main>
+</body>
+</html>
+`;
+}
+
 export const ACCESS_TOKEN_COOKIE = "coven_cave_access";
 export const ACCESS_TOKEN_QUERY_PARAM = "coven_access_token";
 export const TOKEN_PARAM = "covenCaveToken";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -14,6 +14,8 @@ import {
   isAllowedRequestSource,
   bearerFromReferer,
   shouldRequireMobileAccessCredential,
+  isHtmlNavigationRequest,
+  accessGatePage,
 } from "./proxy-helpers";
 import { isValidMobileAccessCredential } from "./lib/mobile-access-token.ts";
 
@@ -81,6 +83,20 @@ async function mobileAccessGate(req: NextRequest) {
   const queryToken = req.nextUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM);
   const verification = await mobileAccessVerification(req, expected, suppliedTokens);
   if (!verification) {
+    // Browser page navigations get an HTML access page instead of a raw JSON
+    // dead end. Same 401, same fail-closed posture — the page's form submits
+    // the token as ACCESS_TOKEN_QUERY_PARAM, re-entering the audited
+    // query-token exchange below. API routes and non-browser clients keep the
+    // machine-readable envelope.
+    if (isHtmlNavigationRequest(req.method, req.nextUrl.pathname, req.headers.get("accept"))) {
+      return new NextResponse(accessGatePage({ invalidToken: suppliedTokens.length > 0 }), {
+        status: 401,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      });
+    }
     return jsonError(401, "unauthorized");
   }
 


### PR DESCRIPTION
## What

When `COVEN_CAVE_ACCESS_TOKEN` is set, the mobile-access gate (correctly) fails closed for **every** request — but a browser page load ended in raw `{"ok":false,"error":"unauthorized"}` JSON with no path forward.

Unauthenticated **HTML-accepting GET page navigations** (non-`/api/`) now get a small static access page instead — same 401 status, `cache-control: no-store`:

- The form submits the token as the existing `coven_access_token` **GET query param**, re-entering the already-audited exchange path (verify → httpOnly cookie → redirect with the token stripped from the URL). **No new auth logic**; the security posture is unchanged.
- A supplied-but-invalid credential — including an **expired cookie** — gets an explanatory note ("didn't verify — may have expired").
- The page is **fully static** (nothing from the request is interpolated → zero reflection surface) and **script-free** (CSP-immune). Token input is `type="password"`.
- `/api/*`, mutations, `HEAD`, and non-browser clients (curl/fetch, no `Accept: text/html`) keep the JSON envelope **byte-for-byte** — scripts and tests that match on it are unaffected.

## Where

- `src/proxy-helpers.ts` — pure `isHtmlNavigationRequest()` + `accessGatePage()`
- `src/proxy.ts` — the failed-verification branch of `mobileAccessGate` picks the body by client; `jsonError(401)` retained as the fallthrough

## Tests

- `proxy-behavior.test.ts` — routing matrix (GET/POST/HEAD × path × Accept, incl. `/apidocs` prefix non-swallow) + page contract (form param name = `ACCESS_TOKEN_QUERY_PARAM`, GET method, password input, script-free, alert note only when invalid)
- `middleware.test.ts` — pins that the HTML gate lives inside the failed-verification branch, still 401, JSON retained, no-store

## Verified live (server with the token gate enabled)

| Request | Result |
|---|---|
| GET page, browser Accept | 401 `text/html` gate page |
| GET `/api/familiars` (even with HTML Accept) | 401 JSON envelope |
| POST `/api/*`, GET without Accept | 401 JSON envelope |
| Form submit with bad token | 401 gate + "didn't verify" note |
| Signed query token | 307 + `Set-Cookie` (Max-Age tracks token expiry) |
| With cookie | 200 |

Playwright drove the full paste-token → Unlock → app flow; final URL contains no token.

Closes cave-189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)