### PR TITLE
feat(chat): collapse composer controls into one minimal Options menu

### DIFF
--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -106,25 +106,25 @@ assert.match(
 
 assert.match(
   source,
-  /className="cave-composer-utility-row"[\s\S]*<ComposerHostChip value=\{composerHostValue\} disabled=\{busy\} onPick=\{setRuntimeHost\} \/>[\s\S]*className="cave-composer-settings-row" aria-label="Chat response controls"/,
-  "Composer should place Host with utility controls before the response-control row",
+  /className="cave-composer-utility-row"[\s\S]*<ComposerOptionsMenu[\s\S]*hostValue=\{composerHostValue\}/,
+  "Composer places the collapsed Options menu in the utility row (host lives inside it now)",
 );
 
 assert.match(
   source,
-  /className="cave-composer-settings-row" aria-label="Chat response controls">[\s\S]*label="Access"[\s\S]*label="Model"[\s\S]*label="Thinking"[\s\S]*label="Speed"/,
-  "Composer dropdown row should expose Access, Model, Thinking, and Speed in order",
+  /sections=\{\[[\s\S]*label: "Access"[\s\S]*label: "Model"[\s\S]*label: "Thinking"[\s\S]*label: "Speed"/,
+  "The Options menu exposes Access, Model, Thinking, and Speed sections in order",
 );
 
 // Model selection moved out of the composer UI into the /model slash command.
 assert.doesNotMatch(source, /ChatModelControl/, "the model picker is gone from the chat composer");
 assert.match(source, /command === "\/model"/, "the chat composer handles the /model command");
 
-assert.match(
-  source,
-  /className="cave-composer-select__value" aria-hidden[\s\S]*\{selected\}/,
-  "Composer select pills should render a separate visual value so the native select can own the whole hit target",
-);
+// Options render as inline radio pills — no nested StandardSelect popover in the panel.
+const optionsSource = readFileSync(new URL("./composer-options-menu.tsx", import.meta.url), "utf8");
+assert.match(optionsSource, /role="radio"/, "Options choices are radio pills");
+assert.match(optionsSource, /composer-options__choice/, "Options choices use the choice-pill class");
+assert.doesNotMatch(source, /StandardSelect/, "the composer no longer wraps controls in StandardSelect pills");
 
 assert.match(
   source,
@@ -146,14 +146,8 @@ assert.match(
 
 assert.match(
   styles,
-  /\.cave-composer-settings-row\s*\{[\s\S]*flex-wrap:\s*wrap[\s\S]*overflow-x:\s*visible/,
-  "Composer settings row should wrap controls instead of clipping or hiding available row width",
-);
-
-assert.match(
-  source,
-  /<StandardSelect<T>[\s\S]*className="cave-composer-select"[\s\S]*showCaret=\{false\}[\s\S]*renderValue=\{\(\) =>/,
-  "Composer control selects should delegate the full-pill hit target to StandardSelect",
+  /\.composer-options__choices\s*\{[\s\S]*flex-wrap:\s*wrap/,
+  "Options menu choices wrap instead of clipping when a control has many options",
 );
 
 console.log("chat-view-first-class.test.ts: ok");

--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -85,8 +85,8 @@ assert.match(
 
 assert.match(
   styles,
-  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-panel\s*\{[\s\S]*display\s*:\s*flex[\s\S]*flex-direction\s*:\s*column[\s\S]*\.cave-composer-controls\s*\{[\s\S]*position\s*:\s*static[\s\S]*min-height\s*:\s*100px[\s\S]*\.cave-composer-settings-row\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/,
-  "Mobile composer controls should sit in a two-row footer so they never cover multiline text",
+  /@media \(max-width: 767px\) \{[\s\S]*\.cave-composer-panel\s*\{[\s\S]*display\s*:\s*flex[\s\S]*flex-direction\s*:\s*column[\s\S]*\.cave-composer-controls\s*\{[\s\S]*position\s*:\s*static[\s\S]*\.cave-composer-control-row\s*\{[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\) auto/,
+  "Mobile composer footer stays a single utility|submit row (controls collapsed into the Options menu)",
 );
 
 assert.match(

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -275,27 +275,29 @@ assert.doesNotMatch(
 assert.match(
   source,
   /PERMISSION_MODES|permissionMode/,
-  "composer has a permission-mode chip",
+  "composer exposes the permission-mode (Access) control",
+);
+// The five response controls (Host · Access · Model · Thinking · Speed) collapse
+// into ONE icon-only Options menu instead of a row of inline pills.
+assert.match(
+  source,
+  /<ComposerOptionsMenu[\s\S]*hostValue=\{composerHostValue\}[\s\S]*onHostPick=\{setRuntimeHost\}/,
+  "composer collapses host + response controls into the ComposerOptionsMenu",
 );
 assert.match(
   source,
-  /label="Model"/,
-  "composer has a model chip",
+  /<div className="cave-composer-utility-row">[\s\S]*aria-label="Attach images, videos, or files"[\s\S]*<Icon name="ph:paperclip"[\s\S]*aria-label="Voice"[\s\S]*<ComposerOptionsMenu/,
+  "composer utility row keeps attach + voice, then the collapsed Options menu",
 );
 assert.match(
   source,
-  /<ComposerHostChip value=\{composerHostValue\} disabled=\{busy\} onPick=\{setRuntimeHost\} \/>/,
-  "composer has a host chip (remote execution picker, shared with the home composer)",
+  /sections=\{\[[\s\S]*label: "Access"[\s\S]*label: "Model"[\s\S]*label: "Thinking"[\s\S]*label: "Speed"/,
+  "the Options menu carries Access, Model, Thinking, Speed sections in order",
 );
-assert.match(
+assert.doesNotMatch(
   source,
-  /<div className="cave-composer-utility-row">[\s\S]*aria-label="Attach images, videos, or files"[\s\S]*<Icon name="ph:paperclip"[\s\S]*aria-label="Voice"[\s\S]*<ComposerHostChip value=\{composerHostValue\} disabled=\{busy\} onPick=\{setRuntimeHost\} \/>/,
-  "composer utility row should keep attach, voice, and Host together before response controls",
-);
-assert.match(
-  source,
-  /<div className="cave-composer-settings-row" aria-label="Chat response controls">[\s\S]*label="Access"[\s\S]*label="Model"[\s\S]*label="Thinking"[\s\S]*label="Speed"/,
-  "composer response controls should render below the input in Access, Model, Thinking, Speed order",
+  /cave-composer-settings-row/,
+  "the inline settings-row of control pills is gone (collapsed into the Options menu)",
 );
 assert.match(
   source,
@@ -309,9 +311,15 @@ assert.doesNotMatch(
 );
 assert.match(
   styles,
-  /\.cave-composer-control-row\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*auto minmax\(0, 1fr\) auto;/,
-  "composer footer should lay out utility, ordered response controls, and submit actions in one row below the input",
+  /\.cave-composer-control-row\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*minmax\(0, 1fr\) auto;/,
+  "composer footer lays out the utility cluster and submit actions in one minimal row",
 );
+// The Options menu renders each control inline (no nested popover) and keeps the
+// connect-host dialog as a popover sibling so it survives the panel closing.
+const optionsMenu = readFileSync(new URL("./composer-options-menu.tsx", import.meta.url), "utf8");
+assert.match(optionsMenu, /role="radiogroup"/, "each control is an inline radiogroup");
+assert.match(optionsMenu, /ComposerHostChoices/, "host renders inline via the shared choices (no nested popover)");
+assert.match(optionsMenu, /ConnectHostDialog/, "connect-host dialog is rendered as a popover sibling");
 // The chip internals moved to the shared module — pin them there.
 const hostChip = readFileSync(new URL("./composer-host-chip.tsx", import.meta.url), "utf8");
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -51,9 +51,8 @@ import {
 } from "@/lib/file-mention";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
-import { StandardSelect } from "@/components/ui/select";
 import { LOCAL_HOST_ID, parseConversationRuntime } from "@/lib/chat-hosts";
-import { ComposerHostChip } from "@/components/composer-host-chip";
+import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/composer-options-menu";
 import { ThinkingIndicator } from "@/components/ui/thinking-indicator";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
@@ -665,46 +664,6 @@ function UsageText({ usage, costUsd }: { usage?: TurnUsage; costUsd?: number }) 
     >
       {summary}
     </span>
-  );
-}
-
-function ComposerControlSelect<T extends string>({
-  label,
-  icon,
-  value,
-  options,
-  disabled,
-  onChange,
-}: {
-  label: string;
-  icon: IconName;
-  value: T;
-  options: Array<{ value: T; label: string }>;
-  disabled?: boolean;
-  onChange: (value: T) => void;
-}) {
-  const selected = options.find((option) => option.value === value)?.label ?? value;
-  return (
-    <StandardSelect<T>
-      label={label}
-      title={`${label}: ${selected}`}
-      value={value}
-      disabled={disabled}
-      onChange={onChange}
-      className="cave-composer-select"
-      options={options}
-      showCaret={false}
-      renderValue={() => (
-        <>
-          <Icon name={icon} width={13} aria-hidden />
-          <span className="cave-composer-select__label">{label}</span>
-          <span className="cave-composer-select__value" aria-hidden>
-            {selected}
-          </span>
-          <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
-        </>
-      )}
-    />
   );
 }
 
@@ -5131,42 +5090,47 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   >
                     <Icon name="ph:microphone" width={15} aria-hidden />
                   </button>
-                  <ComposerHostChip value={composerHostValue} disabled={busy} onPick={setRuntimeHost} />
-                </div>
-                <div className="cave-composer-settings-row" aria-label="Chat response controls">
-                  <ComposerControlSelect
-                    label="Access"
-                    icon="ph:shield-warning"
-                    value={permissionMode}
-                    options={PERMISSION_MODES.map((m) => ({ value: m.value, label: m.label }))}
+                  <ComposerOptionsMenu
+                    hostValue={composerHostValue}
+                    onHostPick={setRuntimeHost}
                     disabled={busy}
-                    onChange={setPermissionMode}
-                  />
-                  {composerModelOptions.length > 0 ? (
-                    <ComposerControlSelect
-                      label="Model"
-                      icon="ph:lightning-bold"
-                      value={composerModelValue}
-                      options={composerModelOptions.map((m) => ({ value: m.id, label: m.label }))}
-                      disabled={busy}
-                      onChange={(id) => handleSelectModel(id)}
-                    />
-                  ) : null}
-                  <ComposerControlSelect
-                    label="Thinking"
-                    icon="ph:sparkle-bold"
-                    value={thinkingEffort}
-                    options={THINKING_OPTIONS}
-                    disabled={busy}
-                    onChange={setThinkingEffort}
-                  />
-                  <ComposerControlSelect
-                    label="Speed"
-                    icon="ph:lightning-bold"
-                    value={responseSpeed}
-                    options={SPEED_OPTIONS}
-                    disabled={busy}
-                    onChange={setResponseSpeed}
+                    indicator={
+                      permissionMode !== DEFAULT_PERMISSION_MODE ||
+                      thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
+                      responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed
+                    }
+                    sections={[
+                      {
+                        id: "access",
+                        label: "Access",
+                        value: permissionMode,
+                        options: PERMISSION_MODES.map((m) => ({ value: m.value, label: m.label })),
+                        onChange: (v: string) => setPermissionMode(v as CommandPermissionMode),
+                      } satisfies ComposerOptionSection,
+                      ...(composerModelOptions.length > 0
+                        ? [{
+                            id: "model",
+                            label: "Model",
+                            value: composerModelValue,
+                            options: composerModelOptions.map((m) => ({ value: m.id, label: m.label })),
+                            onChange: (id: string) => handleSelectModel(id),
+                          } satisfies ComposerOptionSection]
+                        : []),
+                      {
+                        id: "thinking",
+                        label: "Thinking",
+                        value: thinkingEffort,
+                        options: THINKING_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+                        onChange: (v: string) => setThinkingEffort(v as ComposerThinkingEffort),
+                      } satisfies ComposerOptionSection,
+                      {
+                        id: "speed",
+                        label: "Speed",
+                        value: responseSpeed,
+                        options: SPEED_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+                        onChange: (v: string) => setResponseSpeed(v as ComposerResponseSpeed),
+                      } satisfies ComposerOptionSection,
+                    ]}
                   />
                 </div>
                 <div className="cave-composer-submit-row">

--- a/src/components/composer-density.test.ts
+++ b/src/components/composer-density.test.ts
@@ -1,65 +1,39 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-// Composer density: in the narrow Code-mode chat column the model + Thinking +
-// Speed pills wrapped to 2–3 lines. A container query on the composer collapses
-// the control labels and shrinks the model pill so they stay on one row, while
-// the wide standalone-chat composer keeps the full labels.
+// Composer density (retired hack): the inline row of model + Thinking + Speed
+// pills used to wrap to 2–3 lines in the narrow Code-mode chat column, patched
+// by a `@container composer` query that hid the pill labels. Those controls now
+// collapse into a single icon-only Options menu, so the density problem — and
+// its container query — are gone. When a control has many options, the panel's
+// choices wrap INSIDE the popover instead of the composer footer.
 const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 
-function cssBlock(selector: string): string {
-  const start = css.indexOf(selector);
-  assert.notEqual(start, -1, `${selector} block should exist`);
-  const open = css.indexOf("{", start);
-  assert.notEqual(open, -1, `${selector} block should open`);
-  let depth = 0;
-  for (let index = open; index < css.length; index += 1) {
-    const char = css[index];
-    if (char === "{") depth += 1;
-    if (char === "}") {
-      depth -= 1;
-      if (depth === 0) return css.slice(start, index + 1);
-    }
-  }
-  assert.fail(`${selector} block should close`);
-}
-
-const narrowComposerCss = cssBlock("@container composer (max-width: 480px)");
-
-assert.match(
+assert.doesNotMatch(
   css,
-  /\.cave-composer-controls \{[\s\S]*?container-type: inline-size;[\s\S]*?container-name: composer;/,
-  "the composer controls is a named inline-size query container",
-);
-assert.match(
-  css,
-  /\.cave-composer-settings-row\s*\{/,
-  "the composer exposes a settings row for shared command controls",
-);
-assert.match(
-  css,
-  /@container composer \(max-width: 480px\) \{[\s\S]*?\.cave-composer-select__label \{\s*display: none;/,
-  "a narrow composer collapses the Thinking/Speed labels (value still shows)",
-);
-assert.match(
-  css,
-  /@container composer \(max-width: 480px\) \{[\s\S]*?\.cave-composer-select__label \{\s*display: none;[\s\S]*?\.cave-composer-settings-row \.cave-chat-model-wrap/,
-  "narrow composer containers collapse labels without hiding selected values",
-);
-assert.match(
-  css,
-  /\.cave-composer-select__value \{[\s\S]*?color: var\(--text-primary\);[\s\S]*?white-space: nowrap;/,
-  "composer select values should keep visible text styling",
+  /@container composer \(max-width: 480px\)/,
+  "the settings-row density container query is retired (controls collapsed into the Options menu)",
 );
 assert.doesNotMatch(
-  narrowComposerCss,
-  /\.cave-composer-select__value\s*\{[\s\S]*?(display:\s*none|visibility:\s*hidden|opacity:\s*0)/,
-  "narrow composer containers should not hide selected values",
+  css,
+  /\.cave-composer-settings-row/,
+  "the inline settings row of control pills is gone",
+);
+assert.doesNotMatch(
+  source,
+  /cave-composer-settings-row/,
+  "the composer no longer renders an inline settings row",
+);
+assert.match(
+  source,
+  /<ComposerOptionsMenu/,
+  "the composer collapses response controls into the Options menu",
 );
 assert.match(
   css,
-  /@container composer \(max-width: 480px\) \{[\s\S]*?cave-chat-model-wrap \{\s*flex: 1 1 120px/,
-  "the model pill shrinks when the composer is narrow",
+  /\.composer-options__choices\s*\{[\s\S]*?flex-wrap:\s*wrap/,
+  "the Options panel wraps choices inside the popover, not the composer footer",
 );
 
 console.log("composer-density.test.ts: ok");

--- a/src/components/composer-host-chip.tsx
+++ b/src/components/composer-host-chip.tsx
@@ -14,21 +14,19 @@ import { Modal } from "@/components/ui/modal";
 import {
   Popover,
   PopoverBody,
-  PopoverItem,
   PopoverLabel,
-  PopoverSeparator,
 } from "@/components/ui/popover";
 import { LOCAL_HOST_ID, type ChatHostOption } from "@/lib/chat-hosts";
 import "@/styles/composer-host-chip.css";
 
-function hostStatusKind(option: ChatHostOption): "online" | "offline" | "unknown" {
+export function hostStatusKind(option: ChatHostOption): "online" | "offline" | "unknown" {
   if (option.kind === "local" || option.online === true) return "online";
   return option.online === false ? "offline" : "unknown";
 }
 
 /** Register a new SSH host for chat execution: probe (BatchMode, key auth)
  *  then persist to config.remoteHosts via POST /api/hosts. */
-function ConnectHostDialog({ onClose, onConnected }: { onClose: () => void; onConnected: (host: string) => void }) {
+export function ConnectHostDialog({ onClose, onConnected }: { onClose: () => void; onConnected: (host: string) => void }) {
   const [host, setHost] = useState("");
   const [cwd, setCwd] = useState("");
   const [pending, setPending] = useState(false);
@@ -114,24 +112,20 @@ function ConnectHostDialog({ onClose, onConnected }: { onClose: () => void; onCo
   );
 }
 
-export function ComposerHostChip({
-  value,
-  onPick,
-  disabled,
-}: {
-  /** LOCAL_HOST_ID or an ssh host id — see chat-hosts. */
-  value: string;
-  onPick: (id: string) => void;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [connectOpen, setConnectOpen] = useState(false);
+/**
+ * Shared host registry loader used by both the standalone chip and the inline
+ * choices in the composer Options panel. Lazily fetches the registered hosts
+ * (instant unprobed list, then a probed refresh so online/offline fills in) and
+ * always guarantees the current value is present as an option — covering a stale
+ * pick or a host recorded on the conversation that is no longer registered.
+ */
+export function useComposerHosts(value: string): {
+  options: ChatHostOption[];
+  load: (force?: boolean) => Promise<void>;
+} {
   const [hosts, setHosts] = useState<ChatHostOption[] | null>(null);
   const loading = useRef(false);
-  const anchorRef = useRef<HTMLButtonElement | null>(null);
 
-  // Lazy registry: an instant unprobed list on open, then a probed refresh so
-  // online/offline states fill in without blocking the menu.
   const load = useCallback(async (force = false) => {
     if (loading.current && !force) return;
     loading.current = true;
@@ -149,12 +143,81 @@ export function ComposerHostChip({
     const base: ChatHostOption[] = hosts ?? [
       { id: LOCAL_HOST_ID, kind: "local", label: "This machine", online: true },
     ];
-    // The current value must always be present — cover a stale pick or a host
-    // recorded on the conversation that isn't (or is no longer) registered.
     return base.some((option) => option.id === value)
       ? base
       : [...base, { id: value, kind: "ssh", label: value, online: null }];
   }, [hosts, value]);
+
+  return { options, load };
+}
+
+/**
+ * Inline host picker body — a radiogroup of hosts (with live status dots) plus a
+ * "Connect new host" action. Presentational: the parent owns the registry
+ * (useComposerHosts) and the connect dialog, so the dialog can be rendered
+ * outside any popover and survive it closing. Reused by the standalone
+ * ComposerHostChip (inside its popover) and the composer Options panel (inline).
+ */
+export function ComposerHostChoices({
+  options,
+  value,
+  onPick,
+  onConnectNew,
+}: {
+  options: ChatHostOption[];
+  value: string;
+  onPick: (id: string) => void;
+  onConnectNew: () => void;
+}) {
+  return (
+    <div className="cave-host-choices" role="radiogroup" aria-label="Run this chat on">
+      {options.map((option) => {
+        const optionStatus = hostStatusKind(option);
+        const checked = option.id === value;
+        return (
+          <button
+            key={option.id}
+            type="button"
+            role="radio"
+            aria-checked={checked}
+            className={`cave-host-choice focus-ring${checked ? " is-selected" : ""}`}
+            onClick={() => onPick(option.id)}
+          >
+            <Icon name="ph:desktop" width={13} aria-hidden />
+            <span className="cave-host-row__name">{option.label}</span>
+            <span className={`cave-host-status cave-host-status--${optionStatus}`}>
+              <span className="cave-host-dot cave-host-dot--inline" aria-hidden />
+              {optionStatus === "online" ? "online" : optionStatus === "offline" ? "offline" : "checking"}
+            </span>
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        className="cave-host-choice cave-host-choice--connect focus-ring"
+        onClick={onConnectNew}
+      >
+        <Icon name="ph:plus" width={13} aria-hidden />
+        Connect new host
+      </button>
+    </div>
+  );
+}
+
+export function ComposerHostChip({
+  value,
+  onPick,
+  disabled,
+}: {
+  /** LOCAL_HOST_ID or an ssh host id — see chat-hosts. */
+  value: string;
+  onPick: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [connectOpen, setConnectOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const { options, load } = useComposerHosts(value);
 
   const current = options.find((option) => option.id === value);
   const label = current?.label ?? value;
@@ -189,40 +252,20 @@ export function ComposerHostChip({
         minWidth={240}
         ariaLabel="Chat host"
       >
-        <PopoverBody role="menu" ariaLabel="Chat host">
+        <PopoverBody ariaLabel="Chat host">
           <PopoverLabel>Run this chat on</PopoverLabel>
-          {options.map((option) => {
-            const optionStatus = hostStatusKind(option);
-            return (
-              <PopoverItem
-                key={option.id}
-                checked={option.id === value}
-                onSelect={() => {
-                  onPick(option.id);
-                  setOpen(false);
-                }}
-              >
-                <span className="cave-host-row">
-                  <Icon name="ph:desktop" width={13} aria-hidden />
-                  <span className="cave-host-row__name">{option.label}</span>
-                  <span className={`cave-host-status cave-host-status--${optionStatus}`}>
-                    <span className="cave-host-dot cave-host-dot--inline" aria-hidden />
-                    {optionStatus === "online" ? "online" : optionStatus === "offline" ? "offline" : "checking"}
-                  </span>
-                </span>
-              </PopoverItem>
-            );
-          })}
-          <PopoverSeparator />
-          <PopoverItem
-            icon="ph:plus"
-            onSelect={() => {
+          <ComposerHostChoices
+            options={options}
+            value={value}
+            onPick={(id) => {
+              onPick(id);
+              setOpen(false);
+            }}
+            onConnectNew={() => {
               setOpen(false);
               setConnectOpen(true);
             }}
-          >
-            Connect new host
-          </PopoverItem>
+          />
         </PopoverBody>
       </Popover>
       {connectOpen && (

--- a/src/components/composer-options-menu.tsx
+++ b/src/components/composer-options-menu.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+// Composer Options menu — a single icon-only trigger that collapses the chat
+// composer's response controls (Host · Access · Model · Thinking · Speed) into
+// one popover panel. Each control is an inline radiogroup, so there are no
+// nested popovers (the shared Popover treats a portaled child popover's clicks
+// as "outside" and would close — see ui/popover.tsx). The Host picker reuses the
+// inline choices extracted from ComposerHostChip; its Connect-new-host dialog is
+// rendered as a sibling of the Popover so it survives the panel closing.
+
+import { useRef, useState, type KeyboardEvent } from "react";
+import { Icon } from "@/lib/icon";
+import { Popover, PopoverBody } from "@/components/ui/popover";
+import {
+  ComposerHostChoices,
+  ConnectHostDialog,
+  useComposerHosts,
+} from "@/components/composer-host-chip";
+import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
+
+type Choice = { value: string; label: string };
+
+export type ComposerOptionSection = {
+  /** Stable id (React key) — accessible name comes from `label`. */
+  id: string;
+  label: string;
+  value: string;
+  options: Choice[];
+  onChange: (value: string) => void;
+};
+
+/** One labeled single-select rendered as a proper radiogroup: roving tabindex
+ *  plus arrow-key navigation, so keyboard users move between options with one
+ *  Tab stop per group rather than tabbing through every pill. */
+function OptionRadioGroup({ label, value, options, onChange }: ComposerOptionSection) {
+  const groupRef = useRef<HTMLDivElement | null>(null);
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!["ArrowRight", "ArrowDown", "ArrowLeft", "ArrowUp"].includes(e.key)) return;
+    e.preventDefault();
+    const idx = Math.max(0, options.findIndex((o) => o.value === value));
+    const dir = e.key === "ArrowRight" || e.key === "ArrowDown" ? 1 : -1;
+    const nextIdx = (idx + dir + options.length) % options.length;
+    const next = options[nextIdx];
+    if (!next) return;
+    onChange(next.value);
+    groupRef.current
+      ?.querySelectorAll<HTMLButtonElement>('[role="radio"]')
+      ?.[nextIdx]?.focus();
+  };
+
+  return (
+    <div className="composer-options__section">
+      <span className="composer-options__label">{label}</span>
+      <div
+        ref={groupRef}
+        className="composer-options__choices"
+        role="radiogroup"
+        aria-label={label}
+        onKeyDown={onKeyDown}
+      >
+        {options.map((opt) => {
+          const checked = opt.value === value;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={checked}
+              tabIndex={checked ? 0 : -1}
+              className={`composer-options__choice focus-ring${checked ? " is-selected" : ""}`}
+              onClick={() => onChange(opt.value)}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function ComposerOptionsMenu({
+  hostValue,
+  onHostPick,
+  sections,
+  indicator,
+  disabled,
+}: {
+  hostValue: string;
+  onHostPick: (id: string) => void;
+  /** Access, Model, Thinking, Speed (Model omitted when there are no models). */
+  sections: ComposerOptionSection[];
+  /** Show the "non-default" dot on the trigger (host-remote is added here). */
+  indicator?: boolean;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [connectOpen, setConnectOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+  const { options: hostOptions, load } = useComposerHosts(hostValue);
+
+  const showDot = Boolean(indicator) || hostValue !== LOCAL_HOST_ID;
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="cave-composer-icon-button composer-options__trigger focus-ring relative grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label="Response settings"
+        title="Response settings"
+        onClick={() => {
+          void load();
+          setOpen((v) => !v);
+        }}
+      >
+        <Icon name="ph:sliders-horizontal" width={15} aria-hidden />
+        {showDot ? <span className="composer-options__dot" aria-hidden /> : null}
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        placement="top-start"
+        minWidth={288}
+        ariaLabel="Response settings"
+        className="composer-options__panel"
+      >
+        <PopoverBody ariaLabel="Response settings">
+          <div className="composer-options__section">
+            <span className="composer-options__label">Host</span>
+            <ComposerHostChoices
+              options={hostOptions}
+              value={hostValue}
+              onPick={onHostPick}
+              onConnectNew={() => {
+                setOpen(false);
+                setConnectOpen(true);
+              }}
+            />
+          </div>
+          {sections.map((section) => (
+            <OptionRadioGroup key={section.id} {...section} />
+          ))}
+        </PopoverBody>
+      </Popover>
+      {connectOpen && (
+        <ConnectHostDialog
+          onClose={() => setConnectOpen(false)}
+          onConnected={(host) => {
+            onHostPick(host);
+            void load(true);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1911,15 +1911,14 @@ details[open] > .cave-tool-summary::before {
   flex-direction: column;
   gap: 0;
   padding: 0 12px 12px;
-  /* Container for the settings-row density query below: in the narrow Code-mode
-     column the model + Thinking + Speed pills used to wrap to 2–3 lines. */
-  container-type: inline-size;
-  container-name: composer;
 }
 
 .cave-composer-control-row {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  /* Utility cluster (attach · voice · Options) flexes on the left; submit
+     actions (enhance · send) hug the right. Response controls now live inside
+     the Options popover, so the footer stays a single minimal row. */
+  grid-template-columns: minmax(0, 1fr) auto;
   min-height: 34px;
   align-items: center;
   gap: 8px;
@@ -1944,30 +1943,7 @@ details[open] > .cave-tool-summary::before {
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
-.cave-composer-settings-row {
-  display: flex;
-  min-width: 0;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  overflow-x: visible;
-  overflow-y: visible;
-  padding-bottom: 1px;
-  scrollbar-width: none;
-}
-
-.cave-composer-settings-row::-webkit-scrollbar {
-  display: none;
-}
-
-.cave-composer-settings-row .cave-chat-model-wrap {
-  flex: 2 1 220px;
-  min-width: 150px;
-  max-width: none;
-}
-
-.cave-composer-settings-row .cave-chat-model-control,
+/* Base control pill — still used by the standalone ComposerHostChip. */
 .cave-composer-select {
   height: 30px;
   border-radius: var(--radius-control);
@@ -1975,23 +1951,6 @@ details[open] > .cave-tool-summary::before {
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
   box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
-}
-
-.cave-composer-settings-row .cave-chat-model-control {
-  width: 100%;
-  max-width: none;
-  padding: 0 10px;
-}
-
-.cave-composer-settings-row .cave-chat-model-control__state {
-  display: none;
-}
-
-.cave-composer-settings-row .cave-chat-model-popover {
-  top: auto;
-  bottom: calc(100% + 8px);
-  right: auto;
-  left: 0;
 }
 
 .cave-composer-select {
@@ -2032,23 +1991,6 @@ details[open] > .cave-tool-summary::before {
   white-space: nowrap;
 }
 
-/* Density: when the composer column is narrow (notably the Code-mode chat pane),
-   drop the "Thinking"/"Speed" control labels — the icon + value still show — and
-   let the model pill shrink, so model + Thinking + Speed stay on one row instead
-   of wrapping to two or three. The wide standalone-chat composer is unaffected. */
-@container composer (max-width: 480px) {
-  .cave-composer-settings-row {
-    gap: 6px;
-  }
-  .cave-composer-select__label {
-    display: none;
-  }
-  .cave-composer-settings-row .cave-chat-model-wrap {
-    flex: 1 1 120px;
-    min-width: 92px;
-  }
-}
-
 .cave-composer-select:disabled {
   cursor: default;
   opacity: 0.55;
@@ -2069,6 +2011,88 @@ details[open] > .cave-tool-summary::before {
   margin-left: -1px;
   color: var(--text-muted) !important;
   pointer-events: none;
+}
+
+/* ── Composer Options menu ──────────────────────────────────────────────────
+   One icon-only trigger collapses the response controls (Host · Access · Model
+   · Thinking · Speed) into a single popover of inline radiogroups. */
+.composer-options__trigger {
+  color: var(--text-secondary);
+}
+
+.composer-options__trigger[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-strong));
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+/* Non-default indicator: a small accent dot on the trigger's top-right corner. */
+.composer-options__dot {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  box-shadow: 0 0 0 2px var(--bg-surface);
+}
+
+.composer-options__panel {
+  padding: 4px;
+}
+
+.composer-options__section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 6px;
+}
+
+.composer-options__section + .composer-options__section {
+  border-top: 1px solid var(--border-hairline);
+}
+
+.composer-options__label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+}
+
+.composer-options__choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.composer-options__choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: color 120ms ease, background-color 120ms ease, border-color 120ms ease;
+}
+
+.composer-options__choice:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
+.composer-options__choice.is-selected {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--text-primary);
+  font-weight: 600;
 }
 
 .cave-composer-input::-webkit-scrollbar { width: 4px; }
@@ -3541,54 +3565,18 @@ details[open] > .cave-tool-summary::before {
 
   .cave-composer-controls {
     position: static;
-    min-height: 100px;
     padding: 0 10px 10px !important;
   }
 
   .cave-composer-control-row {
     grid-template-columns: minmax(0, 1fr) auto;
     min-height: 48px;
-    align-items: start;
+    align-items: center;
     gap: 8px;
   }
 
   .cave-composer-utility-row {
     flex-wrap: wrap;
-  }
-
-  .cave-composer-submit-row {
-    align-self: start;
-  }
-
-  .cave-composer-settings-row {
-    display: grid;
-    grid-column: 1 / -1;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 6px;
-    overflow: visible;
-    justify-content: stretch;
-    width: 100%;
-  }
-
-  .cave-composer-settings-row .cave-chat-model-control,
-  .cave-composer-select {
-    height: var(--touch-target);
-    width: 100%;
-    min-width: 0;
-    padding-inline: 8px;
-  }
-
-  .cave-composer-settings-row .cave-chat-model-wrap {
-    min-width: 0;
-    max-width: none;
-  }
-
-  .cave-composer-select {
-    gap: 5px;
-  }
-
-  .cave-composer-select__label {
-    display: none;
   }
 
   .cave-composer-icon-button {

--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -49,6 +49,34 @@
 .cave-host-status--unknown { color: var(--text-muted); }
 .cave-host-status--unknown .cave-host-dot--inline { background: var(--text-muted); }
 
+/* Inline host picker — the radiogroup rendered inside the composer Options panel
+   (and the standalone chip's popover). Full-width rows so the status reads on the
+   trailing edge. */
+.cave-host-choices { display: flex; flex-direction: column; gap: 3px; }
+.cave-host-choice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+.cave-host-choice:hover { background: var(--bg-raised); color: var(--text-primary); }
+.cave-host-choice.is-selected {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--text-primary);
+}
+.cave-host-choice--connect { color: var(--text-muted); }
+.cave-host-choice--connect:hover { color: var(--text-primary); }
+
 /* Connect-new-host dialog */
 .cave-connect-host { display: flex; flex-direction: column; gap: 12px; }
 .cave-connect-host__hint { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text-muted); }


### PR DESCRIPTION
## What

The chat composer footer showed **five inline control pills** — Host · Access · Model · Thinking · Speed — alongside attach/mic/enhance/send, which read as visually busy:

Before: `📎 🎙 [Host ▾] [Access ▾] [Model ▾] [Thinking ▾] [Speed ▾]  … ✦ ↑`
After:  `📎 🎙 ⚙  ……………………………  ✦ ↑`

All five collapse into a single **icon-only Options trigger** (sliders) that opens one popover of inline radiogroups.

## How

- **New `ComposerOptionsMenu`** — icon-only trigger (with a non-default accent dot) → one panel with Host · Access · Model · Thinking · Speed as inline radio-pill groups (roving tabindex + arrow-key nav). **No nested popovers**: the shared `Popover` treats a portaled child popover's clicks as "outside" and would close, so every control renders inline instead.
- **Host inline** via `ComposerHostChoices`, extracted from `ComposerHostChip` (shared `useComposerHosts` hook + exported `ConnectHostDialog`). The connect-host dialog is a **popover sibling** so it survives the panel closing. The standalone `ComposerHostChip` still works, re-expressed on the shared pieces.
- **Footer grid** simplified to `utility | submit`; the `cave-composer-settings-row`, its `@container composer` density query, and the mobile two-row rules are removed (the density problem is gone with the pill row).

## Verification

- `tsc --noEmit` clean (0 errors)
- All 4 composer test files green: `chat-view-polish`, `chat-view-first-class`, `chat-view-mobile-command-center`, `composer-density`
- Rendered in the app (demo build): minimal footer + Options panel showing all five controls with accent-tinted selected states, host status dot, and Connect-new-host — no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)