### PR TITLE
feat(chat): ultra-minimal chat header — collapse actions, condense meta

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -428,6 +428,35 @@ assert.match(
   /\.cave-chat-icon-button\s*\{[\s\S]*border:\s*1px solid transparent;[\s\S]*background:\s*transparent;/,
   "Open chat header icon buttons should be chromeless until hover/focus",
 );
+
+// Ultra-minimal header: at rest only the ⋮ kebab shows; the quick actions
+// collapse and reveal on hover / keyboard focus (touch devices show them).
+assert.match(
+  source,
+  /className="focus-ring cave-chat-actions-kebab"/,
+  "The overflow kebab is tagged so it stays visible while sibling actions collapse",
+);
+assert.match(
+  styles,
+  /@media \(hover: hover\) and \(pointer: fine\)\s*\{[\s\S]*\.cave-chat-session-actions > \.focus-ring:not\(\.cave-chat-actions-kebab\):not\(\.cave-chat-find\)[\s\S]*opacity:\s*0;/,
+  "Quick header actions are hidden at rest on pointer devices",
+);
+assert.match(
+  styles,
+  /\.cave-chat-linear-header:hover \.cave-chat-session-actions > \.focus-ring[\s\S]*opacity:\s*1;/,
+  "Quick header actions reveal on header hover",
+);
+// "No plan limits" is suppressed — the plan chip only shows a real limit.
+assert.match(
+  source,
+  /availability === "unconfigured"\) return null;/,
+  "UsagePlanChip suppresses the uninformative 'No plan limits' chip",
+);
+assert.match(
+  source,
+  /function shortModelLabel\(/,
+  "Model id is shortened for the header (vendor/claude- prefix dropped)",
+);
 assert.match(
   source,
   /<MetaLine\b/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -971,7 +971,7 @@ function SessionOverflowMenu({
       <button
         ref={triggerRef}
         type="button"
-        className="focus-ring"
+        className="focus-ring cave-chat-actions-kebab"
         aria-label="Session options"
         aria-haspopup="menu"
         aria-expanded={open}
@@ -1419,6 +1419,16 @@ function visibleModelId(model: string | null | undefined, harness: string | null
   return trimmed;
 }
 
+/** Header display label for a model id: drop a leading vendor segment
+ *  ("anthropic/…") and a "claude-" prefix so the meta line reads "opus-4-8"
+ *  instead of "anthropic/claude-opus-4-8". The full id still rides in the meta
+ *  line's title tooltip for provenance. Non-Claude / bare ids pass through
+ *  unchanged ("openai/gpt-5.5" → "gpt-5.5", "gpt-5.5" → "gpt-5.5"). */
+function shortModelLabel(model: string): string {
+  const afterVendor = model.includes("/") ? model.slice(model.lastIndexOf("/") + 1) : model;
+  return afterVendor.replace(/^claude-/i, "") || afterVendor;
+}
+
 function responseMetadataModel(metadata?: ChatResponseMetadata): string | null {
   const confirmed = metadata?.confirmedModel?.trim();
   const requested = metadata?.model?.trim();
@@ -1466,11 +1476,11 @@ function metaLineSegments(args: {
   if (args.state === "offline") {
     segs.push("daemon offline · check Coven");
   } else if (args.state === "failed") {
-    if (args.model) segs.push(args.model);
+    if (args.model) segs.push(shortModelLabel(args.model));
     if (runtime) segs.push({ dir: runtime });
     segs.push("failed");
   } else if (args.state === "streaming") {
-    if (args.model) segs.push(args.model);
+    if (args.model) segs.push(shortModelLabel(args.model));
     if (runtime) segs.push({ dir: runtime });
     segs.push(args.lifecycle === "tooling" ? "using tools…" : args.lifecycle === "connecting" || args.lifecycle === "queued" ? "connecting…" : "writing…");
     // CHAT-D3-06: the "· 14s" ticker + esc hint tail is rendered by MetaLine
@@ -1479,7 +1489,7 @@ function metaLineSegments(args: {
   } else {
     // Lead with the model (ChatGPT idiom) — the harness name is redundant with
     // it, so it only appears as a fallback when no model id is resolved.
-    if (args.model) segs.push(args.model);
+    if (args.model) segs.push(shortModelLabel(args.model));
     else if (args.harness) segs.push(args.harness);
     if (runtime) segs.push({ dir: runtime });
     const dur = fmtDuration(args.durationMs);
@@ -1678,6 +1688,10 @@ function ContextMeterChip({ usage, model }: { usage?: TurnUsage; model?: string 
 }
 
 function UsagePlanChip({ usagePlan }: { usagePlan: ChatUsagePlanSnapshot | null }) {
+  // Ultra-minimal header: an "unconfigured" plan is the common, uninformative
+  // case — suppress the "No plan limits" chip entirely and only surface the
+  // plan when there's an actual limit/usage (or a degraded "unavailable").
+  if (!usagePlan || usagePlan.availability === "unconfigured") return null;
   const summary = formatChatUsagePlanSummary(usagePlan);
   if (!summary) return null;
   return (
@@ -1769,7 +1783,7 @@ function MetaLine({
           onSessionsChanged={onSessionsChanged}
         />
       ) : null}
-      <span className="cave-chat-meta-line__meta">
+      <span className="cave-chat-meta-line__meta" title={metaModel ?? undefined}>
         {segments.map((seg, i) => (
           <Fragment key={i}>
             {i > 0 ? " · " : null}

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2526,6 +2526,42 @@ details[open] > .cave-tool-summary::before {
   opacity: 0.45;
 }
 
+/* Ultra-minimal header (pointer devices): at rest only the ⋮ kebab and the
+ * find affordance show; the quick actions (thinking, debug, delete, reflect)
+ * and the lone "link a task" + reveal on header hover or keyboard focus. They
+ * keep their layout slot (no reflow on reveal). Touch devices — which have no
+ * hover — skip this and show everything. The kebab still holds every action,
+ * so nothing becomes hover-only. */
+@media (hover: hover) and (pointer: fine) {
+  .cave-chat-session-actions > .focus-ring:not(.cave-chat-actions-kebab):not(.cave-chat-find),
+  .cave-chat-linked-context .cave-chat-linked-chip--link-task {
+    opacity: 0;
+    transform: translateX(4px);
+    pointer-events: none;
+    transition:
+      opacity var(--duration-fast) var(--ease-standard),
+      transform var(--duration-fast) var(--ease-standard);
+  }
+
+  .cave-chat-linear-header:hover .cave-chat-session-actions > .focus-ring,
+  .cave-chat-session-actions:focus-within > .focus-ring,
+  .cave-chat-session-actions:has([aria-expanded="true"]) > .focus-ring,
+  .cave-chat-linear-header:hover .cave-chat-linked-context .cave-chat-linked-chip--link-task,
+  .cave-chat-linked-context:focus-within .cave-chat-linked-chip--link-task {
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cave-chat-session-actions > .focus-ring:not(.cave-chat-actions-kebab):not(.cave-chat-find),
+  .cave-chat-linked-context .cave-chat-linked-chip--link-task {
+    transition: none;
+    transform: none;
+  }
+}
+
 .voice-call-overlay {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
Restyles the open-chat header for an ultra-minimal-yet-powerful feel. Every capability is retained — the change is about what's visible **at rest** vs. one hover/keystroke away.

## At rest → one quiet line
`board --help` … `opus-4-8 · 📁 ~/.coven` … `⋮`

- **Actions collapse:** Debug / Delete / Reflect (and the lone "link a task" `+`) are hidden at rest; only the `⋮` overflow kebab shows. They reveal on **header hover** or **keyboard focus-within**. On **touch** devices (`hover: none`) they stay visible, and the kebab still holds every action — so nothing becomes hover-only. `prefers-reduced-motion` drops the transition; icons keep their layout slot (no reflow on reveal).
- **Model shortened:** `anthropic/claude-opus-4-8` → `opus-4-8` (`openai/gpt-5.5` → `gpt-5.5`); the full id rides in the meta line's `title` tooltip.
- **`No plan limits` removed:** the plan chip only appears when there's an actual limit/usage.

## Files (+84 / −5)
- `chat-view.tsx` — `shortModelLabel()` helper; `UsagePlanChip` suppresses the `unconfigured` case; meta `title` = full model id; kebab tagged `cave-chat-actions-kebab`.
- `cave-chat.css` — hover/focus reveal (guarded by `@media (hover: hover)` + `prefers-reduced-motion`).
- `chat-view-polish.test.ts` — 5 new pins for the collapse behavior + suppressed plan chip + short model label.

## Verified in the running app (dev mode, real `board --help` session)
| Check | Result |
|---|---|
| Idle meta | `gpt-5.5 · ~/.coven` — `No plan limits` gone |
| Model tooltip | `title="openai/gpt-5.5"` (full id) |
| Quick actions at rest | opacity `[0,0,0]` |
| …on hover | opacity `[1,1,1]` |
| Kebab | opacity `1` (always visible) |
| Page errors | none |

All 10 chat co-located test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)