### PR TITLE
feat(shell): minimalist pass on top bar, sidebar, and code rail (cave-6pe.2)

### DIFF
--- a/src/app/globals-reveal-on-hover.test.ts
+++ b/src/app/globals-reveal-on-hover.test.ts
@@ -35,6 +35,11 @@ assert.match(
 );
 assert.match(
   globals,
+  /\.reveal-on-hover\[aria-pressed="true"\]/,
+  "a control carrying live pressed state stays visible (state never hides)",
+);
+assert.match(
+  globals,
   /\.reveal-scope:hover \.reveal-on-hover/,
   "hovering the scope reveals its controls",
 );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -452,7 +452,10 @@ select {
 }
 .reveal-scope:hover .reveal-on-hover,
 .reveal-scope:focus-within .reveal-on-hover,
-.reveal-on-hover:focus-visible {
+.reveal-on-hover:focus-visible,
+/* A control carrying live state (pinned, fullscreen…) is a status indicator,
+   not just an action — badges/state never hide (§8). */
+.reveal-on-hover[aria-pressed="true"] {
   opacity: 1;
 }
 @media (hover: none) and (pointer: coarse) {
@@ -6224,10 +6227,12 @@ button:active > .edge-rail-chip {
   color: var(--text-primary);
 }
 
-/* Tasks quick action (folded in from the desktop menu bar) — an icon button
-   with a small open-task count badge. */
+/* Task quick actions live in the overflow menu now (§8 chrome budget); the
+   wrapper keeps the open-task count badge floating over the "⋯" trigger so
+   the live signal survives the relocation. */
 .top-bar__tasks {
   position: relative;
+  display: inline-flex;
 }
 
 .top-bar__tasks-badge {
@@ -7190,9 +7195,6 @@ a.mobile-handoff__link:hover {
       width: 100%;
       height: 100%;
       border-radius: calc(var(--radius-control) - 1px);
-    }
-    .top-bar__actions .top-bar__tasks-enrich {
-      display: none;
     }
   }
   .notification-bell__popover {

--- a/src/components/board-enrich-steps.test.ts
+++ b/src/components/board-enrich-steps.test.ts
@@ -57,8 +57,8 @@ assert.match(
 
 assert.match(
   topBar,
-  /onEnrichTasks \? \([\s\S]*className="top-bar__icon-btn top-bar__tasks-enrich"[\s\S]*onClick=\{onEnrichTasks\}[\s\S]*disabled=\{enrichingTasks \|\| !activeFamiliar\}[\s\S]*onViewTasks \?/,
-  "Mobile top bar should render Enrich immediately before the Tasks button",
+  /onEnrichTasks \? \(\s*<PopoverItem\s*icon="ph:sparkle"\s*disabled=\{enrichingTasks \|\| !activeFamiliar\}\s*onSelect=\{onEnrichTasks\}/,
+  "Mobile top bar should surface Enrich as the first overflow-menu action, disabled while running or unscoped",
 );
 
 assert.match(

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -52,7 +52,7 @@ assert.doesNotMatch(
 // ── Sidebar: one Tools entry for the merged hub ──────────────────────────────
 assert.match(
   sidebar,
-  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities" \},/,
+  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities", quiet: true \},/,
   "Sidebar navigation should expose the merged Marketplace hub with a description covering both halves",
 );
 assert.doesNotMatch(

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -76,7 +76,7 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /FOLDER_MODES\.map\(\(fm\) =>/,
+  /FOLDER_MODES\.map\(\(fm, i\) =>/,
   "Sidebar should render every folder mode directly",
 );
 
@@ -382,6 +382,30 @@ assert.match(
   styles,
   /\.shell-nav--rail \.sidebar-version \{[^}]*display: none/,
   "The 56px rail has no room for text — the version line hides there",
+);
+
+// Quiet cluster (§8): occasional destinations (Browser, Marketplace, GitHub)
+// stay in the same flat list but render muted-until-hover, with the first
+// quiet row opening a spacing gap instead of a divider.
+assert.match(
+  source,
+  /\{ id: "browser",[^}]*quiet: true \}/,
+  "Browser is visually demoted to the quiet cluster",
+);
+assert.match(
+  source,
+  /quietLead=\{Boolean\(fm\.quiet\) && !FOLDER_MODES\[i - 1\]\?\.quiet\}/,
+  "the first quiet row opens the spacing gap",
+);
+assert.match(
+  styles,
+  /\.sidebar-folder-row--quiet \{[^}]*color: var\(--text-muted\);/,
+  "quiet rows read muted at rest",
+);
+assert.match(
+  styles,
+  /\.sidebar-folder-row--quiet-lead \{[^}]*margin-top: var\(--space-3\);/,
+  "the quiet cluster opens with spacing, not a hairline divider",
 );
 
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -82,6 +82,10 @@ const FOLDER_MODES: Array<{
   // One-line hover/long-press help. Differentiates surfaces that read alike at
   // a glance.
   description: string;
+  /** Visual demotion (§8 quiet hierarchy): still one flat list — same roving
+   *  tabindex, same click targets — but quiet rows render muted-until-hover
+   *  and the first one opens a spacing gap, so daily destinations read first. */
+  quiet?: boolean;
 }> = [
   { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
   { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven" },
@@ -90,11 +94,11 @@ const FOLDER_MODES: Array<{
   { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your daily journal and generated sketches" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and crons in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
-  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser" },
-  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities" },
+  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", quiet: true },
+  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities", quiet: true },
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.
-  { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount) },
+  { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
 ];
 
 export { FOLDER_MODES };
@@ -108,6 +112,8 @@ function FolderRow({
   badge,
   kbd,
   description,
+  quiet,
+  quietLead,
   onClick,
 }: {
   id: string;
@@ -117,6 +123,10 @@ function FolderRow({
   badge?: string;
   kbd?: string;
   description?: string;
+  quiet?: boolean;
+  /** First quiet row opens the spacing gap between the daily destinations
+   *  and the demoted cluster (surface step, no divider — §8). */
+  quietLead?: boolean;
   onClick: () => void;
 }) {
   // Splittable pages can be dragged into the main area to open beside the
@@ -134,7 +144,7 @@ function FolderRow({
   return (
     <button
       type="button"
-      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}`}
+      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}${quiet ? " sidebar-folder-row--quiet" : ""}${quietLead ? " sidebar-folder-row--quiet-lead" : ""}`}
       aria-current={active ? "page" : undefined}
       title={title}
       draggable={draggable || undefined}
@@ -210,7 +220,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-nav-scroll" ref={navScrollRef}>
-        {FOLDER_MODES.map((fm) => (
+        {FOLDER_MODES.map((fm, i) => (
           <FolderRow
             key={fm.id}
             id={fm.id}
@@ -222,6 +232,8 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             badge={fm.badge?.(props)}
             kbd={fm.kbd}
             description={fm.description}
+            quiet={fm.quiet}
+            quietLead={Boolean(fm.quiet) && !FOLDER_MODES[i - 1]?.quiet}
             onClick={() => handleModeSelect(fm.id)}
           />
         ))}

--- a/src/components/top-bar.test.ts
+++ b/src/components/top-bar.test.ts
@@ -160,7 +160,10 @@ assert.match(
 
 // Mobile quick actions: Tasks. New chat now lives at the top of the left
 // sidebar (SidebarMinimal) for both desktop and mobile, so the top bar no
-// longer renders a New chat button.
+// longer renders a New chat button. The task quick actions themselves moved
+// into the shared overflow menu (§8 chrome budget — occasional verbs don't
+// earn always-visible chrome), with the live open-task badge kept on the
+// trigger.
 assert.match(
   source,
   /onViewTasks\?: \(\) => void/,
@@ -173,13 +176,18 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /onViewTasks \?[\s\S]*className="top-bar__icon-btn top-bar__tasks"[\s\S]*onClick=\{onViewTasks\}/,
-  "Top bar renders a Tasks button when wired",
+  /<OverflowMenu ariaLabel="More actions"/,
+  "Top bar renders the shared overflow menu for relocated quick actions",
 );
 assert.match(
   source,
-  /taskCount && taskCount > 0 \? \(\s*<span className="top-bar__tasks-badge">/,
-  "Tasks button shows an open-task count badge, hidden at zero",
+  /onViewTasks \? \(\s*<PopoverItem icon="ph:kanban" onSelect=\{onViewTasks\}>/,
+  "View tasks lives in the overflow menu when wired",
+);
+assert.match(
+  source,
+  /<span className="top-bar__tasks-badge" aria-hidden="true">/,
+  "The open-task count badge stays visible on the overflow trigger (live state never hides)",
 );
 
 // Quick-chat reveal: a single top-bar icon button opens the in-app popover.

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -3,6 +3,8 @@
 import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
 import { NotificationBell } from "@/components/notification-bell";
 import { FamiliarQuickSwitch } from "@/components/familiar-quick-switch";
+import { OverflowMenu } from "@/components/ui/overflow-menu";
+import { PopoverItem } from "@/components/ui/popover";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -188,31 +190,37 @@ export function TopBar(props: Props) {
             <Icon name="ph:chat-circle-dots" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
           </button>
         ) : null}
-        {onEnrichTasks ? (
-          <button
-            type="button"
-            className="top-bar__icon-btn top-bar__tasks-enrich"
-            onClick={onEnrichTasks}
-            disabled={enrichingTasks || !activeFamiliar}
-            aria-label={activeFamiliar ? enrichLabel : "Select a familiar to enhance tasks"}
-            title={activeFamiliar ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
-          >
-            <Icon name="ph:sparkle" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
-          </button>
-        ) : null}
-        {onViewTasks ? (
-          <button
-            type="button"
-            className="top-bar__icon-btn top-bar__tasks"
-            onClick={onViewTasks}
-            aria-label={taskCount && taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
-            title="View tasks"
-          >
-            <Icon name="ph:kanban" width={CAVE_ICON_SIZE.headerAction} height={CAVE_ICON_SIZE.headerAction} />
+        {/* Chrome budget (design language §8): the task quick actions moved to
+            the overflow menu — occasional verbs don't earn always-visible
+            chrome. The open-task badge stays on the trigger so the live count
+            survives the relocation. */}
+        {onEnrichTasks || onViewTasks ? (
+          <span className="top-bar__tasks">
+            <OverflowMenu ariaLabel="More actions" size="md" placement="bottom-end">
+              {onEnrichTasks ? (
+                <PopoverItem
+                  icon="ph:sparkle"
+                  disabled={enrichingTasks || !activeFamiliar}
+                  onSelect={onEnrichTasks}
+                  title={activeFamiliar ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
+                >
+                  {activeFamiliar ? enrichLabel : "Select a familiar to enhance tasks"}
+                </PopoverItem>
+              ) : null}
+              {onViewTasks ? (
+                <PopoverItem icon="ph:kanban" onSelect={onViewTasks}>
+                  {taskCount && taskCount > 0
+                    ? `View tasks — ${taskCount > 99 ? "99+" : taskCount} open`
+                    : "View tasks"}
+                </PopoverItem>
+              ) : null}
+            </OverflowMenu>
             {taskCount && taskCount > 0 ? (
-              <span className="top-bar__tasks-badge">{taskCount > 99 ? "99+" : taskCount}</span>
+              <span className="top-bar__tasks-badge" aria-hidden="true">
+                {taskCount > 99 ? "99+" : taskCount}
+              </span>
             ) : null}
-          </button>
+          </span>
         ) : null}
         <button
           type="button"

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -222,6 +222,7 @@ export function PopoverItem({
   danger,
   disabled,
   checked,
+  title,
 }: {
   icon?: IconName;
   /** Rich leading visual (e.g. a ProjectAvatar); wins over `icon`. */
@@ -231,6 +232,9 @@ export function PopoverItem({
   active?: boolean;
   danger?: boolean;
   disabled?: boolean;
+  /** Native tooltip / AT description for items whose label abbreviates a
+   *  longer explanation. */
+  title?: string;
   /** When set (true/false) the item is a menuitemradio with aria-checked and a
    *  trailing check glyph — for mutually exclusive option groups. */
   checked?: boolean;
@@ -249,6 +253,7 @@ export function PopoverItem({
       onClick={onSelect}
       data-active={active || undefined}
       disabled={disabled}
+      title={title}
       role={radio ? "menuitemradio" : "menuitem"}
       aria-checked={radio ? checked : undefined}
     >

--- a/src/components/workspace-rail.test.ts
+++ b/src/components/workspace-rail.test.ts
@@ -29,4 +29,22 @@ assert.doesNotMatch(src, /workspace-rail__soon/, "Terminal placeholder is gone")
 assert.match(src, /onTogglePin/, "pin control wired");
 assert.match(src, /onCollapse/, "collapse control wired");
 assert.match(src, /changeCount > 0/, "shows a change-count badge");
+// Progressive disclosure (§8): pin + fullscreen reveal on header hover /
+// focus-within via the shared utility; collapse stays always visible.
+assert.match(src, /workspace-rail__head reveal-scope/, "rail header is the reveal scope");
+assert.match(
+  src,
+  /focus-ring reveal-on-hover\$\{pinned \? " is-on" : ""\}/,
+  "pin reveals on hover/focus (and stays visible while pinned via aria-pressed)",
+);
+assert.match(
+  src,
+  /focus-ring reveal-on-hover\$\{isFullscreen \? " is-on" : ""\}/,
+  "fullscreen toggle reveals on hover/focus",
+);
+assert.doesNotMatch(
+  src,
+  /aria-label="Collapse code rail"[\s\S]{0,120}reveal-on-hover|reveal-on-hover[^\n]*aria-label="Collapse code rail"/,
+  "collapse stays always visible (primary verb)",
+);
 console.log("workspace-rail.test.ts OK");

--- a/src/components/workspace-rail.tsx
+++ b/src/components/workspace-rail.tsx
@@ -94,13 +94,16 @@ export function WorkspaceRail({
         )}
       </nav>
       <div className="workspace-rail__body">
-        <header className="workspace-rail__head">
+        {/* Progressive disclosure (§8): pin + fullscreen are occasional-use —
+            they reveal on header hover / focus-within (and stay visible on
+            touch); collapse remains the always-visible primary verb. */}
+        <header className="workspace-rail__head reveal-scope">
           <span className="workspace-rail__title">{title}</span>
           <span className="workspace-rail__actions">
             {!hidePin && (
               <button
                 type="button"
-                className={`workspace-rail__btn focus-ring${pinned ? " is-on" : ""}`}
+                className={`workspace-rail__btn focus-ring reveal-on-hover${pinned ? " is-on" : ""}`}
                 aria-label={pinned ? "Unpin code rail" : "Pin code rail open"}
                 aria-pressed={pinned}
                 onClick={onTogglePin}
@@ -110,7 +113,7 @@ export function WorkspaceRail({
             )}
             <button
               type="button"
-              className={`workspace-rail__btn focus-ring${isFullscreen ? " is-on" : ""}`}
+              className={`workspace-rail__btn focus-ring reveal-on-hover${isFullscreen ? " is-on" : ""}`}
               aria-label={isFullscreen ? "Exit code rail fullscreen" : "Expand code rail fullscreen"}
               aria-pressed={isFullscreen}
               onClick={() => setIsFullscreen((value) => !value)}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -507,9 +507,31 @@
   color: var(--text-primary);
 }
 
+/* Quiet cluster (§8 quiet hierarchy): occasional destinations stay in the same
+   flat list (one roving tab stop, same targets) but read muted until hover,
+   focus, or active — and the first quiet row opens a spacing gap instead of a
+   divider (surface step, no extra hairline). */
+.sidebar-folder-row--quiet {
+  color: var(--text-muted);
+}
+
+.sidebar-folder-row--quiet:hover,
+.sidebar-folder-row--quiet:focus-visible,
+.sidebar-folder-row--quiet.sidebar-folder-row--active {
+  color: var(--text-primary);
+}
+
+.sidebar-folder-row--quiet-lead {
+  margin-top: var(--space-3);
+}
+
 .sidebar-folder-icon {
   flex-shrink: 0;
   opacity: 0.6;
+}
+
+.sidebar-folder-row--quiet .sidebar-folder-icon {
+  opacity: 0.45;
 }
 
 .sidebar-folder-row--active .sidebar-folder-icon,


### PR DESCRIPTION
Phase 1 of the app-wide minimalism initiative (epic **cave-6pe**, task **cave-6pe.2**), applying the §8 chrome-discipline rules from #2481. **Relocation, never removal** — every action stays reachable in ≤2 interactions.

## Changes

**Top bar** (`top-bar.tsx`) — audit found 6–10 always-visible actions:
- Enhance-tasks + View-tasks quick actions move into the shared `OverflowMenu` ('⋯', menu semantics, auto-close, focus-return).
- The live open-task badge stays floating on the overflow trigger — live state never hides.
- Visible cell is now: familiar switcher (identity) + overflow + notifications (live) + account. Quick chat stays (primary verb + popover anchor).
- Dead `.top-bar__tasks-enrich` mobile-hiding CSS removed.

**Sidebar** (`sidebar-minimal.tsx` + css) — audit found 11 equal-weight items:
- Browser / Marketplace / GitHub demote to a **quiet cluster**: same flat list (one roving tab stop, badges intact, pinned nav contract untouched), muted until hover/focus/active, spacing gap instead of a divider.

**Code rail** (`workspace-rail.tsx`):
- Pin + fullscreen become `.reveal-on-hover` (reveal on header hover / focus-within / touch); collapse stays always visible.
- New utility leg: `[aria-pressed="true"]` controls stay visible — a pressed pin is state, not chrome.

**Primitives**: `PopoverItem` gains optional `title` (native tooltip / AT description).

## Verification
- `pnpm typecheck` ✓
- `pnpm test:app` — 525 files ✓ (pins updated: top-bar, board-enrich-steps, sidebar-minimal, roles-tools-navigation; extended: workspace-rail, quiet cluster, reveal state leg)
- `pnpm test:mobile` — 70 files ✓

Next under cave-6pe: Phase 2 Board (Chat composer/header already covered by parallel PRs #2479/#2480).