### PR TITLE
feat(board): move Select-multiple and Clear-done into the overflow menu (cave-6pe.3)

### DIFF
--- a/src/components/board-bulk-select.test.ts
+++ b/src/components/board-bulk-select.test.ts
@@ -44,4 +44,17 @@ assert.match(view, /<StandardSelect<CardPriority \| "">[\s\S]*?onChange=\{\(next
 assert.match(view, /list="board-bulk-label-options"/, "label input is backed by a datalist of existing labels");
 assert.match(view, /void bulkAddLabel\(labelDraft\)/, "label form submits bulkAddLabel");
 
+// §8 chrome budget: entering select mode is an occasional verb — it lives in
+// the shared overflow menu rather than as an always-visible toolbar button.
+assert.match(
+  view,
+  /<OverflowMenu ariaLabel="More task actions">/,
+  "board header renders the shared overflow menu",
+);
+assert.match(
+  view,
+  /<PopoverItem\s*icon="ph:check-square"\s*onSelect=\{\(\) => cardSelect\.setSelectMode\(true\)\}/,
+  "Select multiple is an overflow-menu item",
+);
+
 console.log("board-bulk-select.test.ts: ok");

--- a/src/components/board-clear-done.test.ts
+++ b/src/components/board-clear-done.test.ts
@@ -11,8 +11,15 @@ assert.match(
   "doneCards memo filters the current-scope `filtered` list by status done",
 );
 
-// Toolbar control + gating + inline confirm.
+// Toolbar control + gating + inline confirm. Clear-done is an occasional
+// destructive verb, so it lives in the shared overflow menu (§8 chrome
+// budget); the confirm group replaces the menu inline while deciding.
 assert.match(source, /Clear done/, "Clear done control label present");
+assert.match(
+  source,
+  /<PopoverItem\s*icon="ph:trash"\s*danger\s*disabled=\{doneCards\.length === 0\}\s*onSelect=\{\(\) => setClearConfirm\(true\)\}/,
+  "Clear done is a danger overflow-menu item, gated on done-card count",
+);
 assert.match(source, /disabled=\{doneCards\.length === 0\}/, "Clear done gated on done-card count");
 assert.match(source, /setClearConfirm\(true\)/, "clicking the control opens an inline confirm");
 assert.match(source, /Clear \{doneCards\.length\} done/, "confirm names the count");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -15,6 +15,8 @@ import { applyCardOps, hasCardOps, type CardPatch } from "@/lib/board-card-ops";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
+import { OverflowMenu } from "@/components/ui/overflow-menu";
+import { PopoverItem } from "@/components/ui/popover";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { familiarInScope } from "@/lib/familiar-multiselect";
@@ -748,18 +750,10 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             </button>
           </div>
 
-          {!isMobile && (viewMode === "kanban" || viewMode === "table") && filtered.length > 0 && !cardSelect.selectMode && (
-            <button
-              type="button"
-              className="board-toolbar-btn"
-              onClick={() => cardSelect.setSelectMode(true)}
-              title="Select multiple tasks"
-            >
-              <Icon name="ph:check-square" width={13} />
-              Select
-            </button>
-          )}
-
+          {/* Chrome budget (§8): Select-multiple and Clear-done are occasional
+              verbs — they live in the overflow menu. The destructive clear
+              still routes through the inline confirm group, which temporarily
+              replaces the menu while deciding. */}
           {clearConfirm ? (
             <div className="board-clear-confirm" role="group" aria-label="Confirm clear done tasks">
               <button
@@ -779,16 +773,26 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
               </button>
             </div>
           ) : (
-            <button
-              type="button"
-              className="board-toolbar-btn"
-              onClick={() => setClearConfirm(true)}
-              disabled={doneCards.length === 0}
-              title="Remove all done tasks in view"
-            >
-              <Icon name="ph:trash" width={13} />
-              Clear done
-            </button>
+            <OverflowMenu ariaLabel="More task actions">
+              {!isMobile && (viewMode === "kanban" || viewMode === "table") && filtered.length > 0 && !cardSelect.selectMode ? (
+                <PopoverItem
+                  icon="ph:check-square"
+                  onSelect={() => cardSelect.setSelectMode(true)}
+                  title="Select multiple tasks"
+                >
+                  Select multiple
+                </PopoverItem>
+              ) : null}
+              <PopoverItem
+                icon="ph:trash"
+                danger
+                disabled={doneCards.length === 0}
+                onSelect={() => setClearConfirm(true)}
+                title="Remove all done tasks in view"
+              >
+                Clear done
+              </PopoverItem>
+            </OverflowMenu>
           )}
 
           <button

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -112,6 +112,13 @@
     font-size: 13px;
   }
 
+  /* The overflow '⋯' trigger is a tap-only control on phones — grow it to
+     the minimum touch target (WCAG 2.5.5). */
+  .board-header-controls .ui-icon-btn {
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
+  }
+
   .board-toolbar-btn {
     flex: 1 1 auto;
     justify-content: center;


### PR DESCRIPTION
Phase 2 (Board) of the minimalism initiative (epic **cave-6pe**, task **cave-6pe.3**), applying the §8 chrome budget from #2481. Follows #2482 (shell pass). **Relocation, never removal.**

## Changes
- Tasks header now: search + grouping control + view control + **+ New task** + one '⋯' `OverflowMenu`.
- **Select multiple** → overflow item (same gating: desktop, kanban/table, non-empty, not already selecting). Bulk actions stay selection-summoned.
- **Clear done** → danger overflow item, still disabled at zero done cards, still routing through the inline confirm group ("Clear N done / Cancel") which replaces the menu while deciding.
- Mobile: '⋯' trigger grows to `--touch-target` in the board container query; phone toolbar row loses two buttons.

Chat scope of Phase 2 is deliberately deferred — a parallel session already landed composer/header minimalism there (#2479, #2480).

## Verification
- `pnpm typecheck` ✓
- `pnpm test:app` — 525 files ✓ (pins extended: board-clear-done, board-bulk-select)
- No e2e specs reference the relocated buttons.