### PR TITLE
feat(home): match home composer to the chat composer

### DIFF
--- a/src/components/home-composer-mobile-gaps.test.ts
+++ b/src/components/home-composer-mobile-gaps.test.ts
@@ -44,10 +44,13 @@ assert.match(
 );
 
 // ───── Phone composer controls are thumb-sized ─────
+// The composer footer reuses the chat composer's structure (cave-chat.css owns
+// its mobile rules); the home-only controls — destination pills and the agent
+// picker — still get thumb-sized touch targets from the container query.
 assert.match(
   css,
-  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-action-bar\s*\{[\s\S]*?align-items:\s*stretch;[\s\S]*?\.hc-control-group--who\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*var\(--touch-target\);[\s\S]*?\.hc-run-rail__controls\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-home-select-value\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pills\s*\{[\s\S]*?grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-send-btn\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
-  "phone composer uses thumb-sized main controls plus a readable run-settings rail",
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-home-select-value\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone composer keeps thumb-sized home-only controls (agent picker, destination pills)",
 );
 
 

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -38,31 +38,31 @@ assert.doesNotMatch(source, /⏎ send · ⇧⏎ newline · ↑↓ history · \/ 
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
 assert.doesNotMatch(css, /\.hc-keyboard-hint\b/, "unused .hc-keyboard-hint CSS is removed");
 
-const sendButtonRule = Array.from(css.matchAll(/\.hc-send-btn\s*\{[\s\S]*?\n\}/g), (match) => match[0]).find((rule) =>
-  /background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/.test(rule),
-);
-assert.ok(sendButtonRule, "base .hc-send-btn rule exists");
-
-// ───────── Task 3: Tokenized icon-only Send button ─────────
-// The visible "Send" text label is gone, but the button keeps an aria-label so
-// screen readers announce it, and its chrome is a compact pill.
+// ───────── Task 3: chat-parity Send button ─────────
+// The bespoke home send pill is gone — the button reuses the chat composer's
+// accent-filled icon button, keeping an aria-label for screen readers.
 assert.match(source, /aria-label="Send"/, "Send button keeps aria-label='Send'");
 assert.doesNotMatch(source, /className="hc-send-label"/, "visible Send text label removed (button is icon-only)");
 assert.doesNotMatch(css, /\.hc-send-label\s*\{/, "old .hc-send-label rule removed");
-assert.doesNotMatch(sendButtonRule, /border-radius:\s*var\(--radius-control\)/, ".hc-send-btn no longer uses the shared control radius (now pill-shaped)");
-
-// ───────── Command-bar hierarchy ─────────
-// New: single-row toolbar — context left, run controls right.
-// Attach, destination, and access chip are in the left group; model/thinking/mic/send in the right.
+assert.doesNotMatch(css, /\.hc-send-btn\s*\{/, "bespoke .hc-send-btn CSS removed (chat composer button styles apply)");
 assert.match(
   source,
-  /hc-control-group--who[\s\S]*?ph:plus-bold[\s\S]*?className="hc-dest-pills"[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
-  "home composer left cluster has plus-attach + Chat/Task destination + warning-circle access chip for the familiar",
+  /bg-\[var\(--accent-presence\)\][\s\S]{0,400}?aria-label="Send"/,
+  "send button uses the chat composer's accent-filled icon-button chrome",
+);
+
+// ───────── Command-bar hierarchy ─────────
+// Chat-composer footer: utility cluster (attach · voice · Options) plus the
+// home-only destination pills and agent picker left; enhance · send right.
+assert.match(
+  source,
+  /cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?className="hc-dest-pills"[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
+  "home composer utility cluster has attach + voice + Options + Chat/Task destination + warning-circle access chip",
 );
 assert.match(
   source,
-  /hc-control-group--run[\s\S]*?hc-status-dot[\s\S]*?ariaLabel="Choose runtime and model"[\s\S]*?ariaLabel="Choose thinking effort"[\s\S]*?hc-mic-btn[\s\S]*?aria-label="Send"/,
-  "home composer right cluster has status dot, model, thinking, mic, and send",
+  /cave-composer-submit-row[\s\S]*?aria-label="Enhance prompt"[\s\S]*?aria-label="Send"/,
+  "home composer submit cluster has enhance and send",
 );
 assert.doesNotMatch(
   source,
@@ -73,36 +73,24 @@ assert.match(source, /import \{ StandardSelect/, "home composer selectors should
 assert.match(source, /<StandardSelect[\s\S]*?popoverClassName="hc-home-select-popover"/, "home composer custom selectors should use the shared select popover");
 assert.doesNotMatch(source, /PopoverBody|PopoverItem|PopoverLabel/, "home composer should not maintain a local dropdown implementation");
 assert.match(
-  css,
-  /\.home-composer-card\s*\{[\s\S]*?border-radius:\s*var\(--radius-card\);[\s\S]*?box-shadow:\s*0 12px 40px/,
-  "home composer card keeps the rounded elevated composer chrome",
+  source,
+  /className=\{`home-composer-card cave-composer-panel\$\{dropActive \? " is-drop-active" : ""\}`\}/,
+  "home composer card reuses the chat composer's panel chrome (cave-composer-panel)",
 );
 assert.match(
   css,
-  /\.hc-action-bar\s*\{[\s\S]*?flex-wrap:\s*wrap;[\s\S]*?gap:\s*6px 10px;[\s\S]*?padding:\s*8px 12px 12px;/,
-  "home composer action bar uses compact single-toolbar spacing",
+  /\.home-composer-card\s*\{[\s\S]*?position: relative;[\s\S]*?max-width: 100%;/,
+  "home composer card keeps only layout rules — visual chrome comes from cave-composer-panel",
 );
-// Run rail removed; its CSS survives as dead code for now (radius etc. still tested below).
-assert.match(
-  sendButtonRule,
-  /border-radius:\s*999px/,
-  "send button is pill-shaped (border-radius 999px)",
-);
+assert.doesNotMatch(css, /\.hc-action-bar\b/, "the bespoke action-bar CSS is gone (chat composer footer styles apply)");
 assert.match(
   css,
   /\.hc-home-select-trigger\s*\{[\s\S]*?border:\s*1px solid[\s\S]*?text-align:\s*left;/,
   "custom selector triggers keep button styling while reading as compact selects",
 );
-assert.match(
-  sendButtonRule,
-  /background:\s*color-mix\(in oklch,\s*var\(--text-primary\)/,
-  "active send button uses dark text-primary fill (Codex-style dark pill)",
-);
 for (const selector of [
-  ".hc-add-btn",
   ".hc-familiar-selector",
   ".hc-home-select-trigger",
-  ".hc-mic-btn",
 ]) {
   assert.match(
     css,
@@ -112,23 +100,24 @@ for (const selector of [
 }
 assert.match(
   css,
-  /\.hc-drop-overlay\s*\{[\s\S]*?border-radius:\s*var\(--radius-card\)/,
-  "drop overlay should follow the card radius token",
+  /\.hc-drop-overlay\s*\{[\s\S]*?border-radius:\s*inherit/,
+  "drop overlay inherits the panel radius",
+);
+// Enhance is a chat-parity icon button (shared .focus-ring focus treatment).
+assert.match(
+  source,
+  /className="cave-composer-icon-button focus-ring[\s\S]{0,300}?aria-label="Enhance prompt"/,
+  "enhance is a chat-style icon button with the shared focus ring",
+);
+assert.match(
+  source,
+  /role="status"[\s\S]*?Prompt improved[\s\S]*?aria-label="Revert prompt enhancement"/,
+  "a post-enhance status strip offers a one-tap revert (chat parity)",
 );
 assert.match(
   css,
-  /\.hc-enhance-btn,\s*[\s\S]*?\.hc-enhance-undo,[\s\S]*?\{[\s\S]*?outline:\s*none;/,
-  "enhance controls should be included in the keyboard focus reset",
-);
-assert.match(
-  css,
-  /\.hc-enhance-btn:focus-visible,\s*[\s\S]*?\.hc-enhance-undo:focus-visible,[\s\S]*?\{[\s\S]*?outline:\s*var\(--ring-width\) solid var\(--ring-focus\);/,
-  "enhance controls should get the standard keyboard focus ring",
-);
-assert.match(
-  css,
-  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-control-group--who\s*\{[\s\S]*?display:\s*grid;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*var\(--touch-target\);[\s\S]*?\.hc-run-rail\s*\{[\s\S]*?\.hc-run-rail__controls\s*\{[\s\S]*?display:\s*grid;/,
-  "mobile context, send, and run rail controls wrap as readable custom selector grids",
+  /@container \(max-width: 620px\)\s*\{[\s\S]*?\.hc-familiar-selector\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);[\s\S]*?\.hc-dest-pill\s*\{[\s\S]*?min-height:\s*var\(--touch-target\);/,
+  "phone composer keeps thumb-sized home-only controls (agent picker, destination pills)",
 );
 
 // ── "Jump back in" recent-chats strip REMOVED ──

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -71,14 +71,20 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /<HomeSelect[\s\S]*?value=\{selectedRuntimeModelValue\}[\s\S]*?ariaLabel="Choose runtime and model"/,
-  "HomeComposer should expose one combined custom runtime/model selector for the selected familiar",
+  /<ComposerOptionsMenu[\s\S]*?hostValue=\{runtimeHost \?\? LOCAL_HOST_ID\}[\s\S]*?onHostPick=\{setRuntimeHost\}/,
+  "HomeComposer collapses response controls into the chat composer's Options menu, with the Host picker wired to runtimeHost",
 );
 
 assert.match(
   source,
-  /runtimeModelSelectGroups[\s\S]*?label: adapter\.label,[\s\S]*?models\.map/,
-  "HomeComposer should group model choices under their runtime",
+  /id: "runtime",[\s\S]*?value: selectedRuntime,[\s\S]*?options: runtimeSectionOptions,[\s\S]*?handleSelectRuntime\(id\)/,
+  "the Options menu exposes a Runtime section that persists runtime picks",
+);
+
+assert.match(
+  source,
+  /\.\.\.\(runtimeModelOptions\.length > 0[\s\S]*?id: "model",[\s\S]*?options: runtimeModelOptions\.map\(\(m\) => \(\{ value: m\.id, label: m\.label \}\)\),[\s\S]*?handleSelectModel\(id\)/,
+  "the Options menu Model section lists the selected runtime's catalog and is omitted for runtime-managed runtimes",
 );
 
 assert.match(
@@ -197,28 +203,22 @@ assert.match(
 
 assert.match(
   source,
-  /"Choose thinking effort"/,
-  "HomeComposer should render a thinking effort select with an accessible label",
+  /id: "thinking",[\s\S]*?label: "Thinking",[\s\S]*?COMMAND_THINKING_OPTIONS/,
+  "the Options menu exposes the shared thinking-effort options",
+);
+
+assert.match(
+  source,
+  /id: "speed",[\s\S]*?label: "Speed",[\s\S]*?COMMAND_RESPONSE_SPEED_OPTIONS/,
+  "the Options menu exposes the shared response-speed options",
 );
 
 // Speed control removed from toolbar (response speed passed via initialControls default).
 
 assert.match(
-  css,
-  /\.hc-control-group\b/,
-  "HomeComposer CSS should define grouped command controls",
-);
-
-assert.match(
-  css,
-  /\.hc-control-group\s*\{[\s\S]*?flex-wrap: nowrap;[\s\S]*?gap: 6px;/,
-  "HomeComposer command clusters should stay together with compact internal spacing",
-);
-
-assert.match(
-  css,
-  /\.hc-control-group--who\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?\.hc-control-group--run\s*\{[\s\S]*?flex: 0 1 auto;[\s\S]*?margin-left: auto;/,
-  "HomeComposer action bar should keep the who cluster content-sized and pin the run cluster to the right edge",
+  source,
+  /className="cave-composer-controls"[\s\S]*?className="cave-composer-control-row"[\s\S]*?className="cave-composer-utility-row"[\s\S]*?className="cave-composer-submit-row"/,
+  "HomeComposer reuses the chat composer's footer row structure",
 );
 
 assert.match(
@@ -347,8 +347,9 @@ assert.match(
 );
 
 // ── Single-row toolbar replaces mode strip + run rail ───────────────────────
-// The top mode strip and the separate run rail were removed.
-// Controls are now in one action bar: [+] [Chat/Task] [access chip] · [●] [model] [think] [mic] [send]
+// The top mode strip and the separate run rail were removed. The footer is the
+// chat composer's: attach/voice/Options + Chat-Task pills + agent chip on the
+// left, enhance + send on the right.
 assert.doesNotMatch(
   source,
   /className="hc-mode-strip"/,
@@ -361,8 +362,8 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /hc-control-group--who[\s\S]*?ph:plus-bold[\s\S]*?hc-dest-pills[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?hc-control-group--run[\s\S]*?hc-status-dot[\s\S]*?ariaLabel="Choose runtime and model"[\s\S]*?ariaLabel="Choose thinking effort"[\s\S]*?hc-mic-btn[\s\S]*?aria-label="Send"/,
-  "The action bar toolbar has: attach/destination/access-chip left, status/model/thinking/mic/send right",
+  /cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?hc-dest-pills[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?cave-composer-submit-row[\s\S]*?ph:sparkle[\s\S]*?aria-label="Send"/,
+  "The footer has attach/voice/Options + Chat/Task destination + access chip left; enhance + send right",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────
@@ -444,8 +445,8 @@ assert.match(
 // ── Attachments ─────────────────────────────────────────────────────────────
 assert.match(
   source,
-  /className="hc-add-btn"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:plus-bold/,
-  "the + launcher uses a plus-bold icon that opens the file picker",
+  /aria-label="Attach images, videos, or files"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:paperclip/,
+  "the paperclip button opens the file picker (chat-composer parity)",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -36,6 +36,9 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
 import { StandardSelect, type StandardSelectGroup, type StandardSelectOption } from "@/components/ui/select";
+import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/composer-options-menu";
+import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
+import { useKeySymbols } from "@/lib/platform-keys";
 import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
@@ -49,6 +52,7 @@ import {
 } from "@/lib/chat-attachments";
 import {
   COMMAND_CONTROL_DEFAULTS,
+  COMMAND_RESPONSE_SPEED_OPTIONS,
   COMMAND_THINKING_OPTIONS,
   type CommandResponseSpeed,
   type CommandThinkingEffort,
@@ -167,7 +171,8 @@ const HOME_DRAFT_KEY = "cave:home-composer-draft:v1";
 const HOME_DRAFT_WRITE_DELAY_MS = 250;
 // Persisted ↑/↓ prompt-history recall stack for the home composer.
 const HOME_HISTORY_KEY = "cave:home-composer-history:v1";
-const RUNTIME_MODEL_SEPARATOR = "::";
+// Composer textarea growth cap — mirrors the chat composer (13 lines + padding).
+const HOME_COMPOSER_MAX_HEIGHT = 332;
 
 function readHomeDraft(): string {
   if (typeof window === "undefined") return "";
@@ -186,15 +191,6 @@ function writeHomeDraft(text: string) {
   } catch {
     /* best effort */
   }
-}
-
-function runtimeModelValue(runtime: string, model: string): string {
-  return `${runtime}${RUNTIME_MODEL_SEPARATOR}${model}`;
-}
-
-function parseRuntimeModelValue(value: string): { runtime: string; model: string } {
-  const [runtime = "", model = ""] = value.split(RUNTIME_MODEL_SEPARATOR);
-  return { runtime, model };
 }
 
 // ─── HomeComposer ─────────────────────────────────────────────────────────────
@@ -299,7 +295,7 @@ export function HomeComposer({
       : runtimeModelOptions.some((model) => model.id === modelState?.effectiveModel)
         ? modelState!.effectiveModel
         : runtimeModelOptions[0]?.id ?? "";
-  const selectedRuntimeModelValue = runtimeModelValue(selectedRuntime, selectedModelId);
+  const keys = useKeySymbols();
   const familiarSelectGroups = useMemo<HomeSelectGroup[]>(
     () => [
       {
@@ -326,31 +322,13 @@ export function HomeComposer({
     ],
     [resolvedFamiliarById, visibleFamiliars],
   );
-  const runtimeModelSelectGroups = useMemo<HomeSelectGroup[]>(
+  const runtimeSectionOptions = useMemo(
     () =>
-      COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => {
-        const models = runtimeModelOptionsFor(adapter.id);
-        return {
-          label: adapter.label,
-          options:
-            models.length === 0
-              ? [
-                  {
-                    value: runtimeModelValue(adapter.id, ""),
-                    label: "Runtime managed",
-                    detail: adapter.label,
-                    icon: "ph:terminal-window",
-                  },
-                ]
-              : models.map((model) => ({
-                  value: runtimeModelValue(adapter.id, model.id),
-                  label: model.label,
-                  detail: adapter.label,
-                  icon: "ph:terminal-window" as IconName,
-                })),
-        };
-      }),
-    [runtimeModelOptionsFor],
+      COMPATIBILITY_ADAPTERS.filter((adapter) => adapter.chatSupported).map((adapter) => ({
+        value: adapter.id,
+        label: adapter.label,
+      })),
+    [],
   );
 
   useEffect(() => {
@@ -462,19 +440,6 @@ export function HomeComposer({
     [refetchModelState, selectedFamiliarId],
   );
 
-  const handleSelectRuntimeModel = useCallback(
-    (value: string) => {
-      const { runtime, model } = parseRuntimeModelValue(value);
-      if (!runtime) return;
-      if (runtime === selectedRuntime) {
-        handleSelectModel(model || defaultModelForRuntime(runtime));
-        return;
-      }
-      handleSelectRuntime(runtime, model);
-    },
-    [handleSelectModel, handleSelectRuntime, selectedRuntime],
-  );
-
   // Mirror the chat composer's matching rule: surface only while the user is
   // still typing the command token (no whitespace yet).
   const slashSuggestions: SlashCommand[] = useMemo(() => {
@@ -563,13 +528,21 @@ export function HomeComposer({
     return m;
   }, [familiars]);
 
-  // Auto-grow textarea
+  // Auto-grow textarea — chat-composer sizing: start at one line, grow with
+  // content, and hand overflow to a scrollbar past the max-height cap.
   const autoGrow = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
+    const computedMaxHeight = Number.parseFloat(window.getComputedStyle(el).maxHeight);
+    const maxHeight = Number.isFinite(computedMaxHeight) ? computedMaxHeight : HOME_COMPOSER_MAX_HEIGHT;
     el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    el.style.overflowY = el.scrollHeight > maxHeight ? "auto" : "hidden";
   }, []);
+
+  useEffect(() => {
+    autoGrow();
+  }, [text, autoGrow]);
 
   // ── Attachments ──────────────────────────────────────────────────────────
   // Paperclip stages picked files (cap 10, mirroring the chat composer); they
@@ -1012,7 +985,7 @@ export function HomeComposer({
         ) : null}
 
         <div
-          className={`home-composer-card${dropActive ? " is-drop-active" : ""}`}
+          className={`home-composer-card cave-composer-panel${dropActive ? " is-drop-active" : ""}`}
           onDragEnter={(e) => {
             if (!hasDraggedFiles(e.dataTransfer.types)) return;
             e.preventDefault();
@@ -1045,43 +1018,8 @@ export function HomeComposer({
             </div>
           ) : null}
 
-        {/* Textarea */}
-        <textarea
-          ref={textareaRef}
-          className="hc-textarea"
-          placeholder={PLACEHOLDERS[destination]}
-          rows={3}
-          value={text}
-          onChange={(e) => { setText(e.target.value); autoGrow(); if (enhanceOriginal != null) setEnhanceOriginal(null); }}
-          onPaste={(e) => {
-            // Paste-to-attach: clipboard files (screenshots, copied files) stage
-            // as attachments. Only preventDefault when files were consumed so a
-            // plain-text paste is untouched.
-            const pastedFiles = Array.from(e.clipboardData.items)
-              .filter((item) => item.kind === "file")
-              .map((item) => item.getAsFile())
-              .filter((file): file is File => file !== null);
-            if (pastedFiles.length > 0) {
-              e.preventDefault();
-              void addFiles(pastedFiles);
-            }
-          }}
-          onKeyDown={handleKeyDown}
-          disabled={sending}
-          aria-label="Ask anything"
-          aria-autocomplete="list"
-          aria-haspopup="listbox"
-          aria-expanded={menuOpen}
-          aria-controls={menuOpen ? slashListboxId : undefined}
-          aria-activedescendant={
-            menuOpen ? `${slashListboxId}-opt-${slashIdx}` : undefined
-          }
-          inputMode="text"
-          enterKeyHint="send"
-        />
-
-        {/* Staged attachments — a count + clear-all header over the chips
-            (each chip has its own remove control; mirrors chat). */}
+        {/* Staged attachments — chat-style strip above the textarea, plus a
+            count + clear-all header (each chip has its own remove control). */}
         {attachments.length > 0 && (
           <div className="hc-attachments-wrap">
             <div className="hc-attachments-head">
@@ -1123,122 +1061,197 @@ export function HomeComposer({
           </div>
         )}
 
-        {/* Action bar — single-row toolbar: [+] [Chat/Task] [access chip]  ···  [●] [model] [think] [🎤] [↑] */}
-        <div className="hc-action-bar">
-          {/* Left cluster: attach + destination + familiar (access chip) */}
-          <div className="hc-control-group hc-control-group--who">
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              className="hc-file-input"
-              onChange={(e) => { void addFiles(e.target.files); e.target.value = ""; }}
-              tabIndex={-1}
-              aria-hidden
-            />
+        {/* Textarea */}
+        <textarea
+          ref={textareaRef}
+          className="hc-textarea cave-composer-input w-full resize-none bg-transparent px-4 pt-3 pb-2 leading-6 text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)] md:text-sm"
+          placeholder={PLACEHOLDERS[destination]}
+          rows={1}
+          value={text}
+          onChange={(e) => { setText(e.target.value); if (enhanceOriginal != null) setEnhanceOriginal(null); }}
+          onPaste={(e) => {
+            // Paste-to-attach: clipboard files (screenshots, copied files) stage
+            // as attachments. Only preventDefault when files were consumed so a
+            // plain-text paste is untouched.
+            const pastedFiles = Array.from(e.clipboardData.items)
+              .filter((item) => item.kind === "file")
+              .map((item) => item.getAsFile())
+              .filter((file): file is File => file !== null);
+            if (pastedFiles.length > 0) {
+              e.preventDefault();
+              void addFiles(pastedFiles);
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          disabled={sending}
+          aria-label="Ask anything"
+          aria-autocomplete="list"
+          aria-haspopup="listbox"
+          aria-expanded={menuOpen}
+          aria-controls={menuOpen ? slashListboxId : undefined}
+          aria-activedescendant={
+            menuOpen ? `${slashListboxId}-opt-${slashIdx}` : undefined
+          }
+          inputMode="text"
+          enterKeyHint="send"
+        />
+
+        {/* Enhance revert strip — mirrors the chat composer's post-enhance
+            status row: confirms the swap and offers a one-tap revert. */}
+        {enhanceOriginal !== null ? (
+          <div className="flex items-center gap-2 border-t border-[var(--border-hairline)]/60 px-3 py-1.5 text-[11px] text-[var(--text-muted)]" role="status">
+            <Icon name="ph:check" width={12} aria-hidden />
+            <span className="min-w-0 flex-1 truncate">Prompt improved</span>
             <button
               type="button"
-              className="hc-add-btn"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={sending}
-              aria-label="Attach files"
-              title="Attach files"
+              onClick={revertEnhance}
+              className="focus-ring rounded px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+              aria-label="Revert prompt enhancement"
+              title="Revert prompt enhancement"
             >
-              <Icon name="ph:plus-bold" width={15} aria-hidden />
+              Revert
             </button>
-
-            <div
-              className="hc-dest-pills"
-              role="radiogroup"
-              aria-label="Send to"
-              ref={destGroupRef}
-              onKeyDown={handleDestKeyDown}
-            >
-              {DESTINATIONS.map((d) => (
-                <button
-                  key={d.id}
-                  type="button"
-                  className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-                  role="radio"
-                  aria-checked={destination === d.id}
-                  tabIndex={destination === d.id ? 0 : -1}
-                  onClick={() => setDestination(d.id)}
-                  disabled={sending}
-                >
-                  <Icon name={d.icon} width={14} aria-hidden />
-                  <span className="hc-dest-label">{d.label}</span>
-                </button>
-              ))}
-            </div>
-
-            <HomeSelect
-              icon="ph:warning-circle"
-              value={selectedFamiliarId}
-              onChange={(value) => {
-                if (value) onSetActiveFamiliar(value);
-              }}
-              groups={familiarSelectGroups}
-              ariaLabel="Choose chat agent"
-              disabled={visibleFamiliars.length === 0 || sending}
-              className="hc-access-chip"
-            />
           </div>
+        ) : null}
 
-          {/* Right cluster: status · model · thinking · mic · send */}
-          <div className="hc-control-group hc-control-group--run">
-            <span className="hc-status-dot" aria-hidden="true" />
+        {/* Controls — chat-composer footer: utility cluster (attach · voice ·
+            Options) plus the home-only destination pills and agent picker on
+            the left; enhance · send hug the right. */}
+        <div className="cave-composer-controls">
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hc-file-input"
+            onChange={(e) => { void addFiles(e.target.files); e.target.value = ""; }}
+            tabIndex={-1}
+            aria-hidden
+          />
+          <div className="cave-composer-control-row">
+            <div className="cave-composer-utility-row">
+              <button
+                type="button"
+                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                title="Attach images, videos, or files"
+                aria-label="Attach images, videos, or files"
+                disabled={sending || attachments.length >= 10}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Icon name="ph:paperclip" width={14} aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                title="Voice input (coming soon)"
+                aria-label="Voice input"
+                disabled
+              >
+                <Icon name="ph:microphone" width={15} aria-hidden />
+              </button>
+              <ComposerOptionsMenu
+                hostValue={runtimeHost ?? LOCAL_HOST_ID}
+                onHostPick={setRuntimeHost}
+                disabled={sending}
+                indicator={
+                  thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
+                  responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed
+                }
+                sections={[
+                  {
+                    id: "runtime",
+                    label: "Runtime",
+                    value: selectedRuntime,
+                    options: runtimeSectionOptions,
+                    onChange: (id: string) => handleSelectRuntime(id),
+                  } satisfies ComposerOptionSection,
+                  ...(runtimeModelOptions.length > 0
+                    ? [{
+                        id: "model",
+                        label: "Model",
+                        value: selectedModelId,
+                        options: runtimeModelOptions.map((m) => ({ value: m.id, label: m.label })),
+                        onChange: (id: string) => handleSelectModel(id),
+                      } satisfies ComposerOptionSection]
+                    : []),
+                  {
+                    id: "thinking",
+                    label: "Thinking",
+                    value: thinkingEffort,
+                    options: COMMAND_THINKING_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+                    onChange: (v: string) => setThinkingEffort(v as CommandThinkingEffort),
+                  } satisfies ComposerOptionSection,
+                  {
+                    id: "speed",
+                    label: "Speed",
+                    value: responseSpeed,
+                    options: COMMAND_RESPONSE_SPEED_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+                    onChange: (v: string) => setResponseSpeed(v as CommandResponseSpeed),
+                  } satisfies ComposerOptionSection,
+                ]}
+              />
 
-            <HomeSelect
-              icon="ph:lightning-bold"
-              value={selectedRuntimeModelValue}
-              onChange={handleSelectRuntimeModel}
-              groups={runtimeModelSelectGroups}
-              ariaLabel="Choose runtime and model"
-              disabled={!selectedFamiliarId || sending}
-              className="hc-runtime-model-selector"
-            />
+              <div
+                className="hc-dest-pills"
+                role="radiogroup"
+                aria-label="Send to"
+                ref={destGroupRef}
+                onKeyDown={handleDestKeyDown}
+              >
+                {DESTINATIONS.map((d) => (
+                  <button
+                    key={d.id}
+                    type="button"
+                    className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
+                    role="radio"
+                    aria-checked={destination === d.id}
+                    tabIndex={destination === d.id ? 0 : -1}
+                    onClick={() => setDestination(d.id)}
+                    disabled={sending}
+                  >
+                    <Icon name={d.icon} width={14} aria-hidden />
+                    <span className="hc-dest-label">{d.label}</span>
+                  </button>
+                ))}
+              </div>
 
-            <HomeSelect
-              label="Think"
-              icon="ph:sparkle-bold"
-              value={thinkingEffort}
-              onChange={(value) => setThinkingEffort(value as CommandThinkingEffort)}
-              groups={[
-                {
-                  options: COMMAND_THINKING_OPTIONS.map((option) => ({
-                    ...option,
-                    icon: "ph:sparkle-bold",
-                  })),
-                },
-              ]}
-              ariaLabel="Choose thinking effort"
-              disabled={sending}
-              className="hc-command-select"
-            />
-
-            <button
-              type="button"
-              className="hc-mic-btn"
-              aria-label="Voice input"
-              title="Voice input (coming soon)"
-              disabled
-            >
-              <Icon name="ph:microphone" width={15} aria-hidden />
-            </button>
-
-            <button
-              type="button"
-              className={`hc-send-btn${sending ? " sending" : ""}${!text.trim() && attachments.length === 0 ? " empty" : ""}`}
-              onClick={() => void handleSubmit()}
-              disabled={(!text.trim() && attachments.length === 0) || sending}
-              aria-label="Send"
-            >
-              {sending ? (
-                <span className="hc-spinner" />
-              ) : (
-                <Icon name="ph:arrow-up-bold" width={14} aria-hidden />
-              )}
-            </button>
+              <HomeSelect
+                icon="ph:warning-circle"
+                value={selectedFamiliarId}
+                onChange={(value) => {
+                  if (value) onSetActiveFamiliar(value);
+                }}
+                groups={familiarSelectGroups}
+                ariaLabel="Choose chat agent"
+                disabled={visibleFamiliars.length === 0 || sending}
+                className="hc-access-chip"
+              />
+            </div>
+            <div className="cave-composer-submit-row">
+              <button
+                type="button"
+                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                title="Enhance prompt"
+                aria-label="Enhance prompt"
+                disabled={sending || enhanceStatus === "loading" || !text.trim()}
+                onClick={() => enhancePrompt()}
+              >
+                <Icon name="ph:sparkle" width={13} aria-hidden />
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSubmit()}
+                disabled={(!text.trim() && attachments.length === 0) || sending}
+                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-white transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
+                title={`Send message (${keys.enter})`}
+                aria-label="Send"
+              >
+                {sending ? (
+                  <span className="hc-spinner" />
+                ) : (
+                  <Icon name="ph:arrow-up-bold" width={13} aria-hidden />
+                )}
+              </button>
+            </div>
           </div>
         </div>
         </div>

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -87,19 +87,18 @@
   container-type: inline-size;
 }
 
-/* ── Composer card ───────────────────────────────────────────────────────── */
+/* ── Composer card ─────────────────────────────────────────────────────────
+ *   Chrome comes from the shared .cave-composer-panel class (cave-chat.css) so
+ *   the home input stays visually identical to the chat composer. This rule
+ *   only keeps the home layout constraints. */
 .home-composer-card {
   position: relative;
   width: 100%;
   max-width: 100%;
-  background: color-mix(in oklch, var(--bg-raised) 70%, var(--bg-base));
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-card);
-  overflow: hidden;
-  box-shadow: 0 12px 40px color-mix(in oklch, var(--text-primary) 14%, transparent),
-              0 1px 0 color-mix(in oklch, var(--foreground) 4%, transparent) inset;
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
+
+/* While a file drag hovers the card, tint the panel border toward the accent
+   so the drop target reads before the overlay fades in. */
 .home-composer-card.is-drop-active {
   border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-strong));
 }
@@ -111,7 +110,7 @@
   z-index: 5;
   display: grid;
   place-items: center;
-  border-radius: var(--radius-card);
+  border-radius: inherit;
   background: color-mix(in oklch, var(--accent-presence) 12%, var(--bg-base) 88%);
   border: 2px dashed color-mix(in oklch, var(--accent-presence) 55%, transparent);
   pointer-events: none;
@@ -127,134 +126,15 @@
 
 .home-composer-card:focus-within {
   border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
-  box-shadow: 0 8px 40px color-mix(in oklch, var(--text-primary) 15%, transparent),
-              0 0 0 1px color-mix(in oklch, var(--accent-presence) 20%, transparent);
 }
 
-/* ── Textarea ────────────────────────────────────────────────────────────── */
-.hc-textarea {
-  width: 100%;
-  resize: none;
-  background: transparent;
-  border: none;
-  outline: none;
-  color: var(--text-primary);
-  /* 16px floor so iOS Safari doesn't auto-zoom on focus. The desktop
-     baseline was 15px — the 1px bump is barely perceptible and not
-     worth a (pointer: coarse) gate. */
-  font-size: 16px;
-  line-height: 1.6;
-  padding: 22px 22px 8px;
-  font-family: inherit;
-  min-height: 92px;
-  max-height: 240px;
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border-hairline) transparent;
-  display: block;
-}
-
-.hc-textarea::placeholder {
-  color: var(--text-muted);
-  opacity: 0.7;
-}
-
+/* ── Textarea ──────────────────────────────────────────────────────────────
+ *   Sizing and chrome come from the shared .cave-composer-input class plus the
+ *   same utility classes the chat composer uses; .hc-textarea stays as a
+ *   stable hook (tests, e2e) with home-only bits. */
 .hc-textarea:disabled {
   opacity: 0.5;
 }
-
-/* ── Action bar ──────────────────────────────────────────────────────────────
- *   Single-row toolbar: [+] [access chip] · · · [●] [model] [think] [🎤] [↑]
- *   Left cluster = context; right cluster = run controls + send. */
-.hc-action-bar {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 6px 10px;
-  padding: 8px 12px 12px;
-}
-
-/* Groups never split internally — a cluster wraps as a whole unit (so Speed and
- * the send button can't orphan onto their own line, as they did before). */
-.hc-control-group {
-  display: flex;
-  align-items: center;
-  flex-wrap: nowrap;
-  gap: 6px;
-  min-width: 0;
-}
-
-/* Side clusters are content-sized (no grow → no trailing/leading gap). */
-.hc-control-group--who {
-  flex: 0 1 auto;
-}
-
-/* The submit cluster is content-sized and pinned to the right edge. */
-.hc-control-group--run {
-  flex: 0 1 auto;
-  justify-content: flex-end;
-  margin-left: auto;
-}
-
-/* ── Run settings rail ───────────────────────────────────────────────────── */
-.hc-run-rail {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin: 0 14px 2px;
-  padding: 8px 10px;
-  border: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
-  border-radius: calc(var(--radius-control) + 4px);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in oklch, var(--bg-base) 86%, var(--accent-presence) 6%),
-      color-mix(in oklch, var(--bg-base) 92%, var(--bg-raised) 8%)
-    );
-}
-
-.hc-run-rail__accent {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 22px;
-  height: 22px;
-  border-radius: 999px;
-  color: color-mix(in oklch, var(--accent-presence) 82%, var(--text-muted));
-  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
-}
-
-.hc-run-rail__controls {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-  min-width: 0;
-  width: 100%;
-}
-
-/* ── Attach button (paperclip) ───────────────────────────────────────────── */
-.hc-add-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  flex-shrink: 0;
-  border-radius: var(--radius-control);
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-.hc-add-btn:hover:not(:disabled) {
-  background: var(--bg-base);
-  border-color: var(--border-hairline);
-  color: var(--text-secondary);
-}
-.hc-add-btn:disabled { opacity: 0.5; cursor: default; }
 
 /* Hidden native file input driven by the paperclip button. */
 .hc-file-input {
@@ -269,17 +149,18 @@
   border: 0;
 }
 
-/* ── Attachment chips ────────────────────────────────────────────────────── */
+/* ── Attachment chips — chat-style strip above the textarea ──────────────── */
 .hc-attachments-wrap {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  padding: 8px 12px;
+  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
 }
 .hc-attachments-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 14px 0;
 }
 .hc-attachments-count {
   font-size: 10.5px;
@@ -306,7 +187,7 @@
   gap: 6px;
   list-style: none;
   margin: 0;
-  padding: 0 14px 0;
+  padding: 0;
 }
 .hc-attachment {
   display: inline-flex;
@@ -352,83 +233,6 @@
 }
 .hc-attachment-remove:hover { background: var(--bg-hover); color: var(--text-primary); }
 
-/* ── Enhance button ──────────────────────────────────────────────────────── */
-.hc-enhance-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  flex-shrink: 0;
-  height: 30px;
-  padding: 0 10px;
-  border-radius: var(--radius-control);
-  border: 1px solid var(--border-hairline);
-  background: transparent;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-.hc-enhance-btn:hover:not(:disabled) {
-  background: var(--bg-base);
-  border-color: var(--border-strong);
-  color: var(--text-primary);
-}
-.hc-enhance-btn:disabled { opacity: 0.5; cursor: default; }
-.hc-enhance-btn.loading { color: var(--accent-presence); }
-.hc-enhance-label { line-height: 1; }
-.hc-enhance-undo {
-  flex-shrink: 0;
-  height: 30px;
-  padding: 0 8px;
-  border-radius: var(--radius-control);
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--text-muted);
-  font-size: 12px;
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease;
-}
-.hc-enhance-undo:hover:not(:disabled) { background: var(--bg-base); color: var(--text-secondary); }
-.hc-enhance-undo:disabled { opacity: 0.5; cursor: default; }
-
-@media (max-width: 640px) {
-  .hc-enhance-label { display: none; }
-}
-
-/* ── Model chip ──────────────────────────────────────────────────────────── */
-.hc-model-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  flex-shrink: 0;
-  padding: 4px 8px;
-  border-radius: var(--radius-control);
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-.hc-model-chip:hover {
-  background: var(--bg-base);
-  border-color: var(--border-hairline);
-  color: var(--text-secondary);
-}
-.hc-model-bolt {
-  color: var(--accent-presence);
-  flex-shrink: 0;
-}
-.hc-model-name {
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  max-width: 120px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 /* ── Familiar selector ───────────────────────────────────────────────────── */
 .hc-familiar-selector {
   position: relative;
@@ -464,35 +268,6 @@
   cursor: default;
 }
 
-.hc-command-select {
-  gap: 6px;
-}
-
-.hc-runtime-model-selector {
-  max-width: 172px;
-}
-
-.hc-run-rail .hc-runtime-model-selector {
-  flex: 1 1 240px;
-  max-width: 320px;
-}
-
-.hc-run-rail .hc-command-select {
-  flex: 0 1 148px;
-}
-
-.hc-run-rail .cave-composer-host-chip {
-  flex: 0 1 230px;
-  min-width: 0;
-}
-
-.hc-command-select .hc-command-select-label {
-  flex-shrink: 0;
-  font-size: 11px;
-  font-weight: 550;
-  color: var(--text-muted);
-}
-
 .hc-familiar-glyph {
   display: flex;
   align-items: center;
@@ -520,24 +295,6 @@
   font-weight: 500;
   color: var(--text-primary);
   padding-right: 14px;
-}
-
-.hc-runtime-model-selector .hc-home-select-value {
-  max-width: 142px;
-}
-
-.hc-run-rail .hc-runtime-model-selector {
-  flex: 1 1 240px;
-  max-width: 320px;
-}
-
-.hc-run-rail .hc-command-select {
-  flex: 0 1 148px;
-}
-
-.hc-run-rail .cave-composer-host-chip {
-  flex: 0 1 230px;
-  min-width: 0;
 }
 
 .hc-home-select-popover {
@@ -594,19 +351,7 @@
   flex-shrink: 0;
 }
 
-/* ── Mode strip (Chat / Task) ──────────────────────────────────────────────────
- *   The composer's primary intent switch, seated at the top of the card above
- *   the textarea. A compact segmented control so the Chat-vs-Task choice reads
- *   as the top-level mode, distinct from the per-send config in the action bar. */
-.hc-mode-strip {
-  display: flex;
-  align-items: center;
-  padding: 12px 14px 10px;
-  /* A whisper-faint hairline separates the mode switch from the prompt area. */
-  border-bottom: 1px solid color-mix(in oklch, var(--border-hairline) 40%, transparent);
-}
-
-/* Destination pills — a segmented toggle inside the mode strip. */
+/* Destination pills — a segmented toggle in the composer footer. */
 .hc-dest-pills {
   display: inline-flex;
   gap: 2px;
@@ -667,164 +412,19 @@
   opacity: 1;
 }
 
-@media (max-width: 520px) {
-  .hc-action-bar {
-    align-items: stretch;
-    flex-wrap: wrap;
-    gap: 8px;
-    padding: 10px;
-  }
-
-  .hc-run-rail {
-    margin: 0 10px 0;
-    padding: 8px;
-  }
-
-  .hc-run-rail__accent {
-    display: none;
-  }
-
-  .hc-run-rail__controls {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.74fr) minmax(0, 0.74fr);
-    gap: 8px;
-  }
-
-  .hc-run-rail .hc-runtime-model-selector {
-    max-width: none;
-  }
-
-  .hc-run-rail .cave-composer-host-chip {
-    grid-column: 1 / -1;
-    width: 100%;
-  }
-
-  .hc-familiar-selector {
-    flex: 1 1 0;
-    min-width: 0;
-    min-height: var(--touch-target);
-    padding: 0 34px 0 12px;
-  }
-
-  .hc-familiar-glyph {
-    width: 20px;
-    height: 20px;
-  }
-
-  .hc-home-select-value {
-    width: 100%;
-    max-width: none;
-    min-height: var(--touch-target);
-    font-size: 15px;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .home-composer-card .cave-project-picker__trigger.hc-project-selector {
-    max-width: none;
-    min-height: var(--touch-target);
-    padding: 0 34px 0 12px;
-  }
-
-  .home-composer-card .cave-project-picker__trigger.hc-project-selector .cave-project-picker__trigger-label {
-    max-width: none;
-  }
-
-  .hc-select-caret {
-    right: 12px;
-  }
-
-  .hc-send-btn {
-    min-height: var(--touch-target);
-    width: var(--touch-target);
-    border-radius: var(--radius-control);
-    padding-inline: 0;
-  }
-
-  .hc-dest-pills {
-    order: 3;
-    flex: 1 0 100%;
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
-  }
-
-  .hc-dest-pill {
-    min-height: var(--touch-target);
-    justify-content: center;
-    gap: 6px;
-    padding: 0 8px;
-    border-color: var(--border-hairline);
-    background: color-mix(in oklch, var(--bg-base) 72%, transparent);
-    font-size: 12px;
-  }
-
-  .hc-dest-label {
-    display: inline;
-  }
-}
-
+/* ── Phone-width composer (container query on the card wrap) ─────────────────
+ * The shared cave-composer footer rules (cave-chat.css) already adapt the icon
+ * buttons on small screens; the home-only controls (destination pills and the
+ * agent picker) also need thumb-sized touch targets. */
 @container (max-width: 620px) {
-  .hc-action-bar {
-    align-items: stretch;
-    gap: 8px;
-    padding: 10px;
-  }
-
-  .hc-control-group {
-    flex: 1 0 100%;
-    width: 100%;
-    align-items: stretch;
-    justify-content: stretch;
-  }
-
-  .hc-control-group--who {
-    display: grid;
-    grid-template-columns: auto minmax(0, 1fr) minmax(0, 1fr);
-  }
-
-  .hc-control-group--run {
-    display: grid;
-    order: 4;
-    grid-template-columns: minmax(0, 1fr) var(--touch-target);
-    margin-left: 0;
-  }
-
-  .hc-run-rail {
-    margin: 0 10px 0;
-    padding: 8px;
-  }
-
-  .hc-run-rail__accent {
-    display: none;
-  }
-
-  .hc-run-rail__controls {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.74fr) minmax(0, 0.74fr);
-    gap: 8px;
-  }
-
-  .hc-run-rail .hc-runtime-model-selector {
-    max-width: none;
-  }
-
-  .hc-run-rail .cave-composer-host-chip {
-    grid-column: 1 / -1;
-    width: 100%;
-  }
-
   .hc-familiar-selector {
+    flex: 1 1 auto;
+    min-width: 0;
     min-height: var(--touch-target);
     padding: 0 30px 0 10px;
   }
 
-  .hc-command-select .hc-command-select-label {
-    display: none;
-  }
-
   .hc-home-select-value {
-    width: 100%;
     max-width: none;
     min-width: 0;
     min-height: var(--touch-target);
@@ -833,22 +433,8 @@
     align-items: center;
   }
 
-  .home-composer-card .cave-project-picker__trigger.hc-project-selector {
-    width: 100%;
-    max-width: none;
-    min-height: var(--touch-target);
-    padding: 0 30px 0 10px;
-  }
-
-  .home-composer-card .cave-project-picker__trigger.hc-project-selector .cave-project-picker__trigger-label {
-    max-width: none;
-  }
-
-  .hc-dest-pills {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    width: 100%;
-    gap: 8px;
+  .hc-select-caret {
+    right: 10px;
   }
 
   .hc-dest-pill {
@@ -856,12 +442,6 @@
     justify-content: center;
     border-color: var(--border-hairline);
     background: color-mix(in oklch, var(--bg-base) 72%, transparent);
-  }
-
-  .hc-send-btn {
-    min-height: var(--touch-target);
-    width: var(--touch-target);
-    height: var(--touch-target);
   }
 }
 
@@ -881,82 +461,7 @@
   color: var(--color-warning);
 }
 
-/* ── Status dot — presence indicator before the model selector ──────────── */
-.hc-status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  border: 1.5px solid color-mix(in oklch, var(--text-muted) 55%, transparent);
-  background: transparent;
-  flex-shrink: 0;
-}
-
-/* ── Mic button ──────────────────────────────────────────────────────────── */
-.hc-mic-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
-  flex-shrink: 0;
-  border-radius: var(--radius-control);
-  border: 1px solid transparent;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease;
-}
-.hc-mic-btn:hover:not(:disabled) {
-  background: var(--bg-base);
-  border-color: var(--border-hairline);
-  color: var(--text-secondary);
-}
-.hc-mic-btn:disabled { opacity: 0.5; cursor: default; }
-
-/* ── Send button — dark pill, icon-only ─────────────────────────────────── */
-.hc-send-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  width: 34px;
-  height: 34px;
-  padding: 0;
-  border-radius: 999px;
-  border: none;
-  background: color-mix(in oklch, var(--text-primary) 80%, var(--bg-raised));
-  color: var(--bg-base);
-  cursor: pointer;
-  margin-left: auto;
-  flex-shrink: 0;
-  transition: background 0.15s ease, opacity 0.15s ease, transform 0.1s ease;
-}
-
-.hc-control-group--run .hc-send-btn {
-  margin-left: 2px;
-}
-
-.hc-send-btn:hover:not(:disabled) {
-  background: var(--text-primary);
-  transform: scale(1.05);
-}
-
-/* Empty/disabled reads as a neutral grey pill until there's a prompt to send */
-.hc-send-btn.empty,
-.hc-send-btn:disabled {
-  background: color-mix(in oklch, var(--text-muted) 30%, var(--bg-raised));
-  color: color-mix(in oklch, var(--bg-base) 70%, var(--text-muted));
-  cursor: default;
-  transform: none;
-}
-
-.hc-send-btn.sending {
-  opacity: 0.75;
-  cursor: wait;
-  transform: none;
-}
-
-/* Spinner */
+/* Spinner — shown inside the send button while a submit is in flight. */
 .hc-spinner {
   display: inline-block;
   width: 13px;
@@ -1157,31 +662,19 @@
 
 /* ── Focus rings (keyboard-only) ─────────────────────────────────────────── */
 .hc-dest-pill,
-.hc-send-btn,
 .home-feed__tab,
 .home-feed__row,
 .home-feed__refresh,
 .home-feed__retry,
-.hc-add-btn,
-.hc-enhance-btn,
-.hc-enhance-undo,
-.hc-model-chip,
-.hc-run-rail,
 .hc-home-select-trigger,
 .home-composer-card .cave-project-picker__trigger.hc-project-selector {
   outline: none;
 }
 .hc-dest-pill:focus-visible,
-.hc-send-btn:focus-visible,
 .home-feed__tab:focus-visible,
 .home-feed__row:focus-visible,
 .home-feed__refresh:focus-visible,
 .home-feed__retry:focus-visible,
-.hc-add-btn:focus-visible,
-.hc-enhance-btn:focus-visible,
-.hc-enhance-undo:focus-visible,
-.hc-model-chip:focus-visible,
-.hc-run-rail:focus-within,
 .hc-home-select-trigger:focus-visible,
 .home-composer-card .cave-project-picker__trigger.hc-project-selector:focus-visible {
   outline: var(--ring-width) solid var(--ring-focus);


### PR DESCRIPTION
## What

Rebuilds the home page input to be structurally identical to the chat composer, keeping only the home-specific controls (Chat/Task destination pills + agent picker).

- **Panel chrome**: the card now reuses `.cave-composer-panel` (glassy blurred panel + focus treatment) — one source of visual truth with chat.
- **Textarea**: `.cave-composer-input` sizing — starts at one line, grows to the 332px cap, scrolls past it (chat's resize logic, `rows={1}`).
- **Footer**: chat's control row — paperclip + voice icon buttons and the **ComposerOptionsMenu** popover (Host / Runtime / Model / Thinking / Speed) left; enhance + accent send right.
- **Host picker wired**: the menu's Host section now drives the existing `runtimeHost` state (previously unreachable from the UI); Speed joins Thinking (both already rode `initialControls`).
- **Enhance**: chat-style sparkle icon button + "Prompt improved / Revert" status strip.
- **Attachments**: strip moves above the textarea (chat position); `hc-attachment*` e2e hooks unchanged.
- Dead home-only CSS removed (~500 lines); guard tests updated to describe the new structure.

## Screenshots

Home composer and its Options popover now render with the chat composer's look (verified in the running app at 1440×900).

## Verification

- `pnpm typecheck` ✓
- `pnpm test:app` — 525 test files ✓
- `pnpm build` — bundle within budget ✓
- `playwright test tests/board-attachments.spec.ts` ✓
- Visual check of home surface + options popover ✓