### PR TITLE
feat(nav): move Browser out of the sidebar — summon it on demand

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -76,8 +76,13 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /FOLDER_MODES\.map\(\(fm, i\) =>/,
-  "Sidebar should render every folder mode directly",
+  /VISIBLE_MODES\.map\(\(fm, i\) =>/,
+  "Sidebar renders the visible folder modes (navHidden surfaces filtered out)",
+);
+assert.match(
+  source,
+  /const VISIBLE_MODES = FOLDER_MODES\.filter\(\(fm\) => !fm\.navHidden\)/,
+  "VISIBLE_MODES drops navHidden surfaces (Browser) from the rendered nav",
 );
 
 assert.match(
@@ -157,10 +162,12 @@ assert.doesNotMatch(
   "Library should not be a root add-on gate in the integrated sidebar",
 );
 
+// Browser stays in FOLDER_MODES (so ⌘5 + the ⌘K "Go to" launcher still reach
+// it) but is navHidden, so it renders no sidebar row — summoned on demand.
 assert.match(
   source,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description:/,
-  "Browser is the first Tools surface after Schedules, on ⌘5",
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true \}/,
+  "Browser is kept for ⌘5/palette but hidden from the sidebar rows (navHidden)",
 );
 
 assert.doesNotMatch(source, /id:\s*"terminal"/, "Terminal is not a standalone sidebar destination");
@@ -249,12 +256,13 @@ assert.doesNotMatch(
   "footer should not render an unread reminders badge",
 );
 
-// Default visible entries include browser and marketplace.
+// Marketplace stays a visible entry; Browser is now summoned on demand
+// (navHidden), so it must NOT appear among the rendered VISIBLE_MODES rows.
 // (Capabilities moved to a tab on the Roles page — no standalone entry.)
 assert.match(
   source,
-  /id:\s*"browser"[^}]*label:\s*"Browser"/,
-  "browser stays visible",
+  /id:\s*"browser"[^}]*navHidden:\s*true/,
+  "browser is navHidden (kept for ⌘5/palette, not a sidebar row)",
 );
 assert.doesNotMatch(source, /id:\s*"terminal"/, "terminal does not stay visible");
 assert.match(
@@ -384,18 +392,19 @@ assert.match(
   "The 56px rail has no room for text — the version line hides there",
 );
 
-// Quiet cluster (§8): occasional destinations (Browser, Marketplace, GitHub)
-// stay in the same flat list but render muted-until-hover, with the first
-// quiet row opening a spacing gap instead of a divider.
+// Quiet cluster (§8): occasional destinations (Marketplace, GitHub) stay in the
+// same flat list but render muted-until-hover, with the first quiet row opening
+// a spacing gap instead of a divider. (Browser is now navHidden, so Marketplace
+// leads the quiet cluster.)
 assert.match(
   source,
-  /\{ id: "browser",[^}]*quiet: true \}/,
-  "Browser is visually demoted to the quiet cluster",
+  /\{ id: "marketplace",[^}]*quiet: true \}/,
+  "Marketplace is in the quiet cluster",
 );
 assert.match(
   source,
-  /quietLead=\{Boolean\(fm\.quiet\) && !FOLDER_MODES\[i - 1\]\?\.quiet\}/,
-  "the first quiet row opens the spacing gap",
+  /quietLead=\{Boolean\(fm\.quiet\) && !VISIBLE_MODES\[i - 1\]\?\.quiet\}/,
+  "the first quiet row opens the spacing gap (indexed on the VISIBLE list)",
 );
 assert.match(
   styles,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -86,6 +86,11 @@ const FOLDER_MODES: Array<{
    *  tabindex, same click targets — but quiet rows render muted-until-hover
    *  and the first one opens a spacing gap, so daily destinations read first. */
   quiet?: boolean;
+  /** Kept in the list (so the command palette's "Go to" launcher and the
+   *  ⌘-number shortcut still reach it) but NOT rendered as a sidebar row. For
+   *  surfaces you summon on demand rather than navigate to daily — the Browser
+   *  opens itself when a link/URL is clicked, so it needn't sit in the nav. */
+  navHidden?: boolean;
 }> = [
   { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
   { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven" },
@@ -94,12 +99,19 @@ const FOLDER_MODES: Array<{
   { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
   { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your daily journal and generated sketches" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and crons in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
-  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", quiet: true },
+  // Browser is summoned on demand (a clicked link/URL opens it, plus ⌘5 and the
+  // ⌘K palette) rather than navigated to daily, so it's kept in the list for
+  // those launchers but hidden from the sidebar rows.
+  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true },
   { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' roles, skills, and capabilities", quiet: true },
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.
   { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
 ];
+
+// Rows actually rendered in the sidebar — everything except on-demand surfaces
+// (navHidden), which stay in FOLDER_MODES for the ⌘K palette + ⌘-number launcher.
+const VISIBLE_MODES = FOLDER_MODES.filter((fm) => !fm.navHidden);
 
 export { FOLDER_MODES };
 
@@ -220,7 +232,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-nav-scroll" ref={navScrollRef}>
-        {FOLDER_MODES.map((fm, i) => (
+        {VISIBLE_MODES.map((fm, i) => (
           <FolderRow
             key={fm.id}
             id={fm.id}
@@ -233,7 +245,9 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             kbd={fm.kbd}
             description={fm.description}
             quiet={fm.quiet}
-            quietLead={Boolean(fm.quiet) && !FOLDER_MODES[i - 1]?.quiet}
+            // Index the VISIBLE list, not FOLDER_MODES — a navHidden entry between
+            // quiet rows must not throw off the "first quiet row" gap.
+            quietLead={Boolean(fm.quiet) && !VISIBLE_MODES[i - 1]?.quiet}
             onClick={() => handleModeSelect(fm.id)}
           />
         ))}

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -163,8 +163,8 @@ assert.match(
 
 assert.match(
   sidebar,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description:/,
-  "Sidebar Browser keeps its shortcut hint",
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true \}/,
+  "Browser is kept for ⌘5/palette but navHidden from the sidebar rows",
 );
 
 assert.doesNotMatch(sidebar, /id:\s*"terminal"/, "Sidebar does not expose Terminal as a standalone destination");


### PR DESCRIPTION
## What

The **Browser** surface sat as a permanent (quiet) row in the left sidebar nav, but it already opens itself whenever a link/URL is clicked (`openUrlInAppBrowser` → `setMode("browser")`). This drops the sidebar row so the nav carries daily destinations only, while keeping the surface reachable **on demand**.

**Sidebar before:** Home · Chat · Tasks · Journal · Schedules · Browser · Marketplace · GitHub
**Sidebar after:** Home · Chat · Tasks · Journal · Schedules · Marketplace · GitHub

Browser is still reachable via: a clicked link/URL (auto-opens), the **⌘5** shortcut, the **⌘K** command palette ("Go to Browser · ⌘5"), and the `#browser` hash.

## How

- Add a `navHidden` flag to `FOLDER_MODES`. The sidebar renders `VISIBLE_MODES` (`FOLDER_MODES` minus `navHidden`), so Browser no longer shows a row. The command palette's "Go to" launcher and the ⌘-number shortcut both still map the full `FOLDER_MODES`, so Browser stays summonable — no functionality lost, just de-cluttered nav.
- `quietLead` is indexed on `VISIBLE_MODES` so **Marketplace** correctly leads the quiet cluster (opens the spacing gap) now that Browser is filtered out.
- Mobile bottom-tabs (`home/chat/board/inbox`) never listed Browser — unaffected.
- Updated the `sidebar-minimal` and `workspace-familiars-landing` test pins.

## Verification

- `tsc --noEmit` clean.
- `sidebar-minimal`, `workspace-familiars-landing`, and `command-palette` tests green.
- Ran the built app: sidebar nav reads `Home, Chat, Tasks, Journal, Schedules, Marketplace, GitHub` (no Browser); ⌘K → "browser" still surfaces **"Go to Browser · Built-in web browser · ⌘5"**; no page errors; quiet-cluster gap lands correctly on Marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)