### PR TITLE
feat(home): show the project selector in the composer toolbar

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -37,12 +37,13 @@ assert.match(
   "HomeComposer headline should reflect the selected project name",
 );
 
-// Project picker was moved out of the toolbar (no longer rendered inline in
-// the composer card). Project context is preserved in the headline and enhancer.
-assert.doesNotMatch(
+// Project selector lives in the composer toolbar so the user can choose which
+// project a new chat runs in (mirrors the chat composer). It's a standalone
+// ProjectPicker — its own search popover, so it can't nest in the ⚙ menu.
+assert.match(
   source,
-  /className="hc-project-selector"/,
-  "ProjectPicker selector is removed from the home composer toolbar",
+  /<ProjectPicker[\s\S]*value=\{selectedProjectId \|\| null\}[\s\S]*onChange=\{setSelectedProjectId\}[\s\S]*className="hc-project-selector"/,
+  "ProjectPicker is rendered in the home composer toolbar, wired to selectedProjectId",
 );
 
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -35,6 +35,7 @@ import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
+import { ProjectPicker } from "@/components/project-picker";
 import { StandardSelect, type StandardSelectGroup, type StandardSelectOption } from "@/components/ui/select";
 import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/composer-options-menu";
 import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
@@ -1224,6 +1225,20 @@ export function HomeComposer({
                 ariaLabel="Choose chat agent"
                 disabled={visibleFamiliars.length === 0 || sending}
                 className="hc-access-chip"
+              />
+              {/* Project selector — picks which project the new chat runs in
+                  (mirrors the chat composer). Its own search popover, so it sits
+                  alongside the familiar select rather than inside the ⚙ menu. */}
+              <ProjectPicker
+                projects={projects}
+                value={selectedProjectId || null}
+                onChange={setSelectedProjectId}
+                allowNoProject
+                familiarId={selectedFamiliarId || null}
+                createProject={createProject}
+                disabled={sending}
+                ariaLabel="Choose project"
+                className="hc-project-selector"
               />
             </div>
             <div className="cave-composer-submit-row">

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -35,10 +35,11 @@ assert.doesNotMatch(
   "picker should use shared CSS/tokenized radii instead of hard-coded rounded classes",
 );
 
-// ── Home composer: project picker removed from toolbar (project context in headline) ────
-// Project selection logic remains via selectedProject; the picker UI was removed
-// when the toolbar was consolidated into a single row.
-assert.doesNotMatch(homeComposer, /className="hc-project-selector"/, "home composer project selector CSS class is removed");
+// ── Home composer: project picker rendered in the toolbar ───────────────────
+// The selector lets the user choose which project a new chat runs in (mirrors
+// the chat composer). It's a standalone ProjectPicker with the hc-project-selector
+// styling — its own search popover, so it can't nest in the ⚙ Options menu.
+assert.match(homeComposer, /className="hc-project-selector"/, "home composer renders the project selector in its toolbar");
 
 // ── Styled ──────────────────────────────────────────────────────────────────
 assert.match(css, /\.cave-project-picker__trigger/, "trigger styled");


### PR DESCRIPTION
## What

The home composer auto-selected `projects[0]` but gave the user **no way to change it** — the project picker had been dropped in an earlier toolbar consolidation (`bf3a5d2c`), leaving its `hc-project-selector` styling behind as dead CSS. This restores it so a new chat's project is a visible, selectable control, mirroring the chat composer.

**Toolbar now:** 📎 · 🎙 · ⚙ · Chat/Task · **Nova** (familiar) · **📁 No project** (new) · … · ✦ · ↑

## How

- Render the shared `ProjectPicker` in the composer utility row, right after the familiar select — wired to `selectedProjectId` / `setSelectedProjectId` with `createProject` + `allowNoProject` (the exact wiring it had before removal).
- It keeps its **own search popover**, so it sits *alongside* the ⚙ Options menu rather than nesting inside it — nested popovers close on outside-click (the same constraint that shaped the Options menu).
- Reuses the existing `.hc-project-selector` CSS (30px, accent-tinted, 178px label cap) — no new styles.
- Flip the home-composer test pin from "removed" → "rendered".

## Verification

- `tsc --noEmit` clean.
- All 5 home-composer test files green (`home-composer`, `-polish`, `-centering`, `-hide-archived`, `-mobile-gaps`).
- Built + ran the app: picker renders in the toolbar, opens its popover (**No project** ✓ / **Add project…**), positioned and styled correctly, no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)