### PR TITLE
fix(browser): localhost tab dot uses the semantic success token (cave-6pe.5)

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -786,7 +786,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
               {/* Favicon / indicator */}
               <span className="relative flex shrink-0 items-center justify-center">
                 {isLocalhost
-                  ? <span className="h-2 w-2 rounded-full bg-green-400" />
+                  ? <span className="h-2 w-2 rounded-full bg-[var(--color-success)]" />
                   : <TabFavicon url={tab.url} title={tabTitles[tab.id] ?? tab.title ?? title} size={20} />
                 }
               </span>


### PR DESCRIPTION
Phase 3b of the minimalism initiative (epic **cave-6pe**, task **cave-6pe.5**).

## Audit outcome
The Browser pane turned out to already be a model §8 citizen — the Phase 0 audit's static count missed the runtime disclosure:
- Tab rail is a **14px strip** expanding to 48px on hover/focus-within; pin-tabs, address-bar toggle, and pin-current-page all live *inside* the expanded state (disclosure rung 2).
- The full toolbar (back/forward/reload/address/home/open-external) is a **closed-by-default overlay** (⌘L), with per-tab close on hover + `touch-always-visible`.

So: no relocation needed. The one violation found and fixed:
- localhost tab live-dot hardcoded `bg-green-400` → `var(--color-success)` (semantic state colors must be tokens; light mode retunes them — design language §2).

## Verification
- `pnpm typecheck` ✓ · `pnpm test:app` 525 files ✓