### PR TITLE
fix(onboarding): align workspace auto-open gate with the wizard's Coven Code check (cave-219)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -414,6 +414,7 @@ export const SUITES = {
     "src/lib/memory-inspector.test.ts",
     "src/lib/memory-source-context.test.ts",
     "src/lib/onboarding-familiars.test.ts",
+    "src/lib/onboarding-gate.test.ts",
     "src/lib/onboarding-install-queue.test.ts",
     "src/app/onboarding-install-route.test.ts",
     "src/lib/openclaw-agents.test.ts",

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -17,6 +17,7 @@ import { SalemPathfinderEntry } from "@/components/salem/salem-pathfinder-entry"
 import type { SalemPathfinderRequest } from "@/lib/salem/pathfinder-types";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
 import { openExternalUrl } from "@/lib/open-external";
+import { COVEN_CODE_SKIP_KEY } from "@/lib/onboarding-gate";
 
 // Guided onboarding: one numbered path from "nothing installed" to "chatting
 // with a familiar". Every step carries its own instructions, a one-click
@@ -138,9 +139,9 @@ const NPM_INSTALL_TARGETS = ALL_INSTALL_TARGETS.filter(
   (target) => INSTALL_TARGET_KIND[target] === "npm",
 );
 
-/** Persists the user's choice to skip the (required) Coven Code install so a
- *  failing install can't permanently strand onboarding. */
-const COVEN_CODE_SKIP_KEY = "cave:onboarding:skip-coven-code";
+// The "skip Coven Code" choice persists under COVEN_CODE_SKIP_KEY (shared
+// with the workspace auto-open gate via @/lib/onboarding-gate — cave-219) so
+// a failing install can't permanently strand onboarding.
 // ~30s of 2s ticks: long enough to ride out a slow sidecar start, short
 // enough that a genuinely broken /api/harnesses surfaces as a retryable
 // error instead of an empty runtime grid polling silently forever.

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -12,6 +12,11 @@ import { CommandPalette, type PaletteIntent } from "@/components/command-palette
 import { JournalView } from "@/components/journal/journal-view";
 import type { CalendarDeadline } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
+import {
+  COVEN_CODE_SKIP_KEY,
+  shouldAutoOpenOnboarding,
+  type OnboardingStatusPayload,
+} from "@/lib/onboarding-gate";
 import { InboxEscalationsView } from "@/components/inbox-escalations-view";
 import { NewReminderModal, draftFromSlashArgs } from "@/components/new-reminder-modal";
 import { InboxToastStack, toastFromItem, type Toast } from "@/components/inbox-toast";
@@ -828,14 +833,12 @@ export function Workspace() {
   }, [loadFamiliars]);
 
   // First-run: auto-open onboarding if setup is missing and the user hasn't
-  // explicitly skipped or finished it. Keyed on the STRUCTURAL steps (CLI,
-  // Coven home, runtime adapters) — not on bare `complete` — because a
-  // stopped daemon flips `complete` false (daemon/familiars/binding all
-  // report not-ok while it's down), and that would relaunch the full wizard
-  // for an already-set-up machine on every visit. Daemon-down on a set-up
-  // machine belongs to the offline banner below, not the first-run flow.
-  // When the daemon IS reachable, any remaining incompleteness (no familiar
-  // yet, no binding) is genuine setup work, so the wizard still opens.
+  // explicitly skipped or finished it. The decision lives in the shared
+  // shouldAutoOpenOnboarding gate so it can't diverge from the wizard's
+  // finish-state again (cave-219): server `complete` ignores Coven Code
+  // (client-side tools[] check + skip choice), so bare `complete` must not
+  // short-circuit the gate. See onboarding-gate.ts for the structural-steps
+  // vs daemon-down rationale.
   useEffect(() => {
     let cancelled = false;
     const skipped =
@@ -845,16 +848,9 @@ export function Workspace() {
       try {
         const res = await fetch("/api/onboarding/status", { cache: "no-store" });
         if (!res.ok || cancelled) return;
-        const json = (await res.json()) as {
-          complete?: boolean;
-          steps?: Record<string, { ok?: boolean }>;
-        };
-        if (json.complete) return;
-        const step = (key: string) => json.steps?.[key]?.ok === true;
-        const structuralMissing =
-          !step("covenCli") || !step("covenHome") || !step("adapters");
-        const daemonUpButUnfinished = step("daemon");
-        if (structuralMissing || daemonUpButUnfinished) setOnboardingOpen(true);
+        const json = (await res.json()) as OnboardingStatusPayload;
+        const covenCodeSkipped = window.localStorage.getItem(COVEN_CODE_SKIP_KEY) === "1";
+        if (shouldAutoOpenOnboarding(json, covenCodeSkipped)) setOnboardingOpen(true);
       } catch {
         /* ignore — the daemon-offline banner surfaces transport issues */
       }

--- a/src/lib/onboarding-gate.test.ts
+++ b/src/lib/onboarding-gate.test.ts
@@ -1,0 +1,102 @@
+// cave-219: the workspace auto-open gate must agree with the wizard's
+// finish-state (`effectiveComplete = complete && covenCodeSatisfied`). Before
+// the shared gate, the gatekeeper returned early on bare server `complete`,
+// so a user missing only Coven Code never saw onboarding auto-open even
+// though the wizard (opened manually) showed step 1 unfinished.
+import assert from "node:assert/strict";
+import {
+  COVEN_CODE_SKIP_KEY,
+  isCovenCodeSatisfied,
+  shouldAutoOpenOnboarding,
+  type OnboardingStatusPayload,
+} from "./onboarding-gate.ts";
+
+const allStepsOk = {
+  covenCli: { ok: true },
+  covenHome: { ok: true },
+  adapters: { ok: true },
+  daemon: { ok: true },
+  binding: { ok: true },
+  familiars: { ok: true },
+};
+
+const covenCodeReady = { id: "coven-code", installed: true, outdated: false };
+const covenCodeMissing = { id: "coven-code", installed: false, outdated: false };
+const covenCodeOutdated = { id: "coven-code", installed: true, outdated: true };
+
+function payload(overrides: Partial<OnboardingStatusPayload>): OnboardingStatusPayload {
+  return { complete: true, steps: allStepsOk, tools: [covenCodeReady], ...overrides };
+}
+
+// ── Fully set up: never auto-open ────────────────────────────────────────────
+assert.equal(
+  shouldAutoOpenOnboarding(payload({}), false),
+  false,
+  "complete + Coven Code ready → no auto-open",
+);
+
+// ── The cave-219 divergence: complete=true but Coven Code unhandled ──────────
+assert.equal(
+  shouldAutoOpenOnboarding(payload({ tools: [covenCodeMissing] }), false),
+  true,
+  "server complete but Coven Code missing → auto-open (wizard shows step 1 unfinished)",
+);
+assert.equal(
+  shouldAutoOpenOnboarding(payload({ tools: [covenCodeOutdated] }), false),
+  true,
+  "server complete but Coven Code outdated → auto-open",
+);
+assert.equal(
+  shouldAutoOpenOnboarding(payload({ tools: [] }), false),
+  true,
+  "server complete but Coven Code not reported → auto-open (matches wizard's unsatisfied state)",
+);
+
+// ── An explicit skip satisfies Coven Code, exactly like the wizard ───────────
+assert.equal(
+  shouldAutoOpenOnboarding(payload({ tools: [covenCodeMissing] }), true),
+  false,
+  "complete + Coven Code skipped → no auto-open",
+);
+assert.equal(isCovenCodeSatisfied(payload({ tools: [covenCodeMissing] }), true), true);
+assert.equal(isCovenCodeSatisfied(payload({}), false), true);
+assert.equal(isCovenCodeSatisfied(payload({ tools: [covenCodeOutdated] }), false), false);
+
+// ── Incomplete payloads keep the pre-existing structural/daemon rules ────────
+assert.equal(
+  shouldAutoOpenOnboarding(
+    payload({ complete: false, steps: { ...allStepsOk, covenCli: { ok: false }, daemon: { ok: false } } }),
+    false,
+  ),
+  true,
+  "structural step missing → auto-open even with the daemon down",
+);
+assert.equal(
+  shouldAutoOpenOnboarding(
+    payload({
+      complete: false,
+      steps: { ...allStepsOk, daemon: { ok: false }, binding: { ok: false }, familiars: { ok: false } },
+    }),
+    false,
+  ),
+  false,
+  "set-up machine with the daemon stopped → offline banner territory, no wizard relaunch",
+);
+assert.equal(
+  shouldAutoOpenOnboarding(
+    payload({ complete: false, steps: { ...allStepsOk, binding: { ok: false } } }),
+    false,
+  ),
+  true,
+  "daemon up with genuine setup work left → auto-open",
+);
+assert.equal(
+  shouldAutoOpenOnboarding({ complete: false }, false),
+  true,
+  "missing steps map counts as structural-missing → auto-open",
+);
+
+// ── Skip key stays the wizard's key ──────────────────────────────────────────
+assert.equal(COVEN_CODE_SKIP_KEY, "cave:onboarding:skip-coven-code");
+
+console.log("onboarding-gate.test.ts: ok");

--- a/src/lib/onboarding-gate.ts
+++ b/src/lib/onboarding-gate.ts
@@ -1,0 +1,51 @@
+// Onboarding auto-open gate — the single decision for whether the workspace
+// should launch the first-run wizard from a /api/onboarding/status payload.
+//
+// The server's `complete` covers every step EXCEPT Coven Code: that tool only
+// exists in the payload's `tools[]`, and the user's "skip Coven Code" choice
+// lives client-side (localStorage). The wizard's finish CTA already ANDs the
+// two (`effectiveComplete = complete && covenCodeSatisfied`); this gate must
+// apply the same rule or the two diverge — a user missing only Coven Code had
+// server `complete: true`, so onboarding never auto-opened, yet the wizard
+// showed step 1 unfinished when opened manually (cave-219).
+
+/** localStorage key recording an explicit "skip Coven Code" choice. */
+export const COVEN_CODE_SKIP_KEY = "cave:onboarding:skip-coven-code";
+
+export type OnboardingStatusPayload = {
+  complete?: boolean;
+  steps?: Record<string, { ok?: boolean }>;
+  tools?: Array<{ id?: string; installed?: boolean; outdated?: boolean }>;
+};
+
+/** Mirrors the wizard's rule: an explicit skip, or installed and current. */
+export function isCovenCodeSatisfied(
+  payload: OnboardingStatusPayload,
+  covenCodeSkipped: boolean,
+): boolean {
+  if (covenCodeSkipped) return true;
+  const tool = payload.tools?.find((t) => t.id === "coven-code");
+  return !!tool?.installed && !tool.outdated;
+}
+
+/**
+ * First-run: auto-open onboarding if setup is missing. Keyed on the STRUCTURAL
+ * steps (CLI, Coven home, runtime adapters) — not on bare `complete` — because
+ * a stopped daemon flips `complete` false (daemon/familiars/binding all report
+ * not-ok while it's down), and that would relaunch the full wizard for an
+ * already-set-up machine on every visit. Daemon-down on a set-up machine
+ * belongs to the offline banner, not the first-run flow. When the daemon IS
+ * reachable, any remaining incompleteness (no familiar yet, no binding, Coven
+ * Code missing) is genuine setup work, so the wizard opens.
+ */
+export function shouldAutoOpenOnboarding(
+  payload: OnboardingStatusPayload,
+  covenCodeSkipped: boolean,
+): boolean {
+  if (payload.complete && isCovenCodeSatisfied(payload, covenCodeSkipped)) return false;
+  const step = (key: string) => payload.steps?.[key]?.ok === true;
+  const structuralMissing =
+    !step("covenCli") || !step("covenHome") || !step("adapters");
+  const daemonUpButUnfinished = step("daemon");
+  return structuralMissing || daemonUpButUnfinished;
+}


### PR DESCRIPTION
## Bug (bead `cave-219`)

The workspace's first-run gatekeeper returned early on bare server `complete`, but the wizard's finish CTA requires `effectiveComplete = complete && covenCodeSatisfied` — Coven Code exists only in the payload's `tools[]` plus the client-side skip choice (`cave:onboarding:skip-coven-code`). A user missing only Coven Code had `complete: true`, so onboarding never auto-opened, yet the manually-opened wizard showed step 1 unfinished.

## Fix

Extracted the decision into a shared pure gate, **`src/lib/onboarding-gate.ts`**:

- `shouldAutoOpenOnboarding()` ANDs the wizard's `covenCodeSatisfied` rule into the early return, then keeps the existing structural-steps vs daemon-down behavior verbatim (a stopped daemon on a set-up machine still belongs to the offline banner, not a wizard relaunch).
- `COVEN_CODE_SKIP_KEY` moves into the gate module and the wizard imports it — both surfaces read the same skip choice.
- `workspace.tsx`'s gatekeeper delegates to the gate.

## Tests

New `src/lib/onboarding-gate.test.ts` (wired into the app suite) covers:
- the divergence case: `complete: true` + tool missing / outdated / unreported → auto-open
- explicit skip → no auto-open
- pre-existing rules preserved: structural-missing opens; daemon-down-only does not; daemon-up-unfinished opens

## Verification
- `pnpm typecheck` ✓
- `node scripts/check-tests-wired.mjs` ✓ (710 files wired)
- `pnpm test:app` — 526 files ✓