### PR TITLE
fix(server): clear stale 'listening' listeners on port-retry (cave-w5v)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -342,6 +342,25 @@ server.on("upgrade", (req, socket, head) => {
 });
 server.keepAliveTimeout = 75e3;
 server.headersTimeout = 8e4;
-server.listen(port, hostname, () => {
-  console.log(`> Ready on http://${hostname}:${port}`);
-});
+function startListening(attempt = 0) {
+  const currentPort = port + attempt;
+  const maxAttempts = 10;
+  server.listen(currentPort, hostname, () => {
+    console.log(`> Ready on http://${hostname}:${currentPort}`);
+    if (process.env.PORT !== String(currentPort)) {
+      process.env.PORT = String(currentPort);
+    }
+  });
+  server.once("error", (err) => {
+    if (err.code === "EADDRINUSE" && attempt < maxAttempts) {
+      console.warn(`Port ${currentPort} in use, trying ${currentPort + 1}...`);
+      server.removeAllListeners("error");
+      server.removeAllListeners("listening");
+      startListening(attempt + 1);
+    } else {
+      console.error(err);
+      process.exit(1);
+    }
+  });
+}
+startListening();

--- a/server.ts
+++ b/server.ts
@@ -518,6 +518,9 @@ function startListening(attempt: number = 0): void {
     if (err.code === "EADDRINUSE" && attempt < maxAttempts) {
       console.warn(`Port ${currentPort} in use, trying ${currentPort + 1}...`);
       server.removeAllListeners("error");
+      // listen() attached its callback via once('listening') before the failed
+      // bind — clear it too, or every stale callback fires on the winning port.
+      server.removeAllListeners("listening");
       startListening(attempt + 1);
     } else {
       console.error(err);


### PR DESCRIPTION
## Summary

`startListening` registers a `once('listening')` callback via `server.listen()` on every attempt, but the EADDRINUSE retry branch only cleared `'error'` listeners. When a bind finally succeeded, every stale callback fired in order, printing one wrong-port `> Ready on http://…` line per failed attempt — misleading anything that scrapes the first Ready line (dev automation, healthchecks), and tripping `MaxListenersExceededWarning` when all 10 attempts are used.

Fix: `server.removeAllListeners("listening")` alongside the existing `removeAllListeners("error")` in the retry branch of `server.ts`, then rebuild `server.mjs` via `pnpm build:server`.

**Also included:** the rebuilt `server.mjs` closes a drift — the #2476 port-fallback loop landed in `server.ts` but its build output was never committed, so `server.mjs` on main still had the bare `server.listen(port, …)` call.

Found by ultrareview. Tracked as bead `cave-w5v`.

## Test plan

- `pnpm build:server` regenerates `server.mjs` byte-identical to what's committed here
- Verified the retry path is exercised only on EADDRINUSE; success path unchanged
- CI required checks (Frontend build, Rust check, CodeQL, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)