### PR TITLE
feat(marketplace): group the Skills filter panels into the category rail (cave-dx5)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11920,13 +11920,33 @@ details[open] > .cave-edit-card__summary::before {
   background: var(--bg-base);
 }
 .skill-browser__rail {
-  flex: 0 0 190px;
+  flex: 0 0 224px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 12px;
   padding: 12px 10px;
   overflow-y: auto;
   border-right: 1px solid var(--border-hairline);
+}
+/* Each filter panel (categories, browse, topics, rank, agents) is one labeled
+   group in the rail; hairlines keep the groups reading as separate panels. */
+.skill-browser__rail-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.skill-browser__rail-group + .skill-browser__rail-group {
+  border-top: 1px solid var(--border-hairline);
+  padding-top: 12px;
+}
+.skill-browser__rail-label {
+  margin: 0;
+  padding: 0 2px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 .skill-browser__cat {
   display: flex;
@@ -12480,8 +12500,8 @@ details[open] > .cave-edit-card__summary::before {
 @media (max-width: 900px) {
   /* Narrow panes: the rail becomes a horizontal strip spanning the top and
      the browser re-lays as a grid (strip / list · detail). The rail is the
-     ONLY category control — hiding it stranded 681-900px panes with whatever
-     category was last picked and no way to change it. */
+     ONLY filter control — hiding it stranded 681-900px panes with whatever
+     filters were last picked and no way to change them. */
   .skill-browser {
     display: grid;
     grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
@@ -12490,13 +12510,25 @@ details[open] > .cave-edit-card__summary::before {
   .skill-browser__rail {
     grid-column: 1 / -1;
     flex-direction: row;
-    gap: 4px;
-    overflow-x: auto;
-    overflow-y: hidden;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    overflow: visible;
     padding: 8px 10px;
     border-right: 0;
     border-bottom: 1px solid var(--border-hairline);
   }
+  /* Groups flow inline (label then chips) and wrap as the pane narrows. */
+  .skill-browser__rail-group {
+    flex: 0 1 auto;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+  .skill-browser__rail-group + .skill-browser__rail-group {
+    border-top: 0;
+    padding-top: 0;
+  }
+  .skill-browser__rail-label { flex: 0 0 auto; }
   .skill-browser__cat {
     flex: 0 0 auto;
     padding: 5px 9px;
@@ -12511,6 +12543,15 @@ details[open] > .cave-edit-card__summary::before {
     grid-template-rows: auto minmax(0, 1.2fr) minmax(0, 1fr);
   }
   .skill-browser__rail { grid-column: 1; }
+  /* Phone widths: one full-width row per group; the group owns the sideways
+     scroll (the categories group has no inner chip container). */
+  .skill-browser__rail-group {
+    flex: 1 1 100%;
+    flex-wrap: nowrap;
+    min-width: 0;
+    overflow-x: auto;
+    padding-bottom: 2px;
+  }
   .skill-browser__list {
     border-right: 0;
     border-bottom: 1px solid var(--border-hairline);
@@ -12523,8 +12564,6 @@ details[open] > .cave-edit-card__summary::before {
   .skill-browser__modes,
   .skill-browser__agents {
     flex-wrap: nowrap;
-    overflow-x: auto;
-    padding-bottom: 2px;
   }
   .skill-browser__browse-btn,
   .skill-browser__topic,

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -615,25 +615,113 @@ export function SkillBrowser({
 
   return (
     <div className="skill-browser" role="group" aria-label="Skill browser">
-      {/* ── Category rail ────────────────────────────────────────────── */}
-      <nav className="skill-browser__rail" aria-label="Skill categories">
-        {RAIL.map((cat) => {
-          const count = counts[cat.id === "all" ? "all" : cat.id];
-          const active = category === cat.id;
-          return (
+      {/* ── Filter rail — every filter panel lives here, grouped under a
+             labeled section, so the list column is just the leaderboard. ── */}
+      <nav className="skill-browser__rail" aria-label="Skill filters">
+        <div className="skill-browser__rail-group" role="group" aria-label="Skill categories">
+          <p className="skill-browser__rail-label">Categories</p>
+          {RAIL.map((cat) => {
+            const count = counts[cat.id === "all" ? "all" : cat.id];
+            const active = category === cat.id;
+            return (
+              <Button
+                key={cat.id}
+                variant="ghost"
+                className={`skill-browser__cat${active ? " is-active" : ""}`}
+                aria-pressed={active}
+                onClick={() => setCategory(cat.id)}
+              >
+                <Icon name={cat.icon} width={15} className="skill-browser__cat-icon" aria-hidden />
+                <span className="skill-browser__cat-label">{cat.label}</span>
+                <span className="skill-browser__cat-count">{count}</span>
+              </Button>
+            );
+          })}
+        </div>
+        <div className="skill-browser__rail-group" role="group" aria-label="Browse skills">
+          <p className="skill-browser__rail-label">Browse</p>
+          <div className="skill-browser__browse">
+            {BROWSE_FILTERS.map((item) => (
+              <Button
+                key={item.id}
+                variant="ghost"
+                size="xs"
+                className={`skill-browser__browse-btn${browse === item.id ? " is-active" : ""}`}
+                aria-pressed={browse === item.id}
+                onClick={() => {
+                  setBrowse(item.id);
+                  if (item.id === "all") setTopic("all");
+                }}
+              >
+                <Icon name={item.icon} width={13} aria-hidden />
+                <span>{item.label}</span>
+              </Button>
+            ))}
+          </div>
+        </div>
+        <div className="skill-browser__rail-group" role="group" aria-label="Browse by topic">
+          <p className="skill-browser__rail-label">Topics</p>
+          <div className="skill-browser__topics">
             <Button
-              key={cat.id}
               variant="ghost"
-              className={`skill-browser__cat${active ? " is-active" : ""}`}
-              aria-pressed={active}
-              onClick={() => setCategory(cat.id)}
+              size="xs"
+              className={`skill-browser__topic${topic === "all" ? " is-active" : ""}`}
+              aria-pressed={topic === "all"}
+              onClick={() => setTopic("all")}
             >
-              <Icon name={cat.icon} width={15} className="skill-browser__cat-icon" aria-hidden />
-              <span className="skill-browser__cat-label">{cat.label}</span>
-              <span className="skill-browser__cat-count">{count}</span>
+              All topics
             </Button>
-          );
-        })}
+            {TOPIC_FILTERS.filter((item) => (topics[item.id] ?? 0) > 0).map((item) => (
+              <Button
+                key={item.id}
+                variant="ghost"
+                size="xs"
+                className={`skill-browser__topic${topic === item.id ? " is-active" : ""}`}
+                aria-pressed={topic === item.id}
+                onClick={() => setTopic(item.id)}
+              >
+                <span>{item.label}</span>
+                <span className="skill-browser__topic-count">{topics[item.id]}</span>
+              </Button>
+            ))}
+          </div>
+        </div>
+        <div className="skill-browser__rail-group" role="group" aria-label="Rank skills">
+          <p className="skill-browser__rail-label">Rank</p>
+          <div className="skill-browser__modes">
+            {LEADERBOARD_MODES.map((item) => (
+              <Button
+                key={item.id}
+                variant="ghost"
+                size="xs"
+                className={`skill-browser__mode${mode === item.id ? " is-active" : ""}`}
+                aria-pressed={mode === item.id}
+                onClick={() => setMode(item.id)}
+              >
+                {item.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+        {agents.length > 1 ? (
+          <div className="skill-browser__rail-group" role="group" aria-label="Filter by agent">
+            <p className="skill-browser__rail-label">Agents</p>
+            <div className="skill-browser__agents">
+              {agents.slice(0, 8).map((name) => (
+                <Button
+                  key={name}
+                  variant="ghost"
+                  size="xs"
+                  className={`skill-browser__agent${agent === name ? " is-active" : ""}`}
+                  aria-pressed={agent === name}
+                  onClick={() => setAgent(name)}
+                >
+                  {name === "all" ? "All agents" : name}
+                </Button>
+              ))}
+            </div>
+          </div>
+        ) : null}
       </nav>
 
       {/* ── Card list ────────────────────────────────────────────────── */}
@@ -663,78 +751,6 @@ export function SkillBrowser({
               ))}
             </nav>
           </div>
-          <div className="skill-browser__browse" aria-label="Browse skills">
-            {BROWSE_FILTERS.map((item) => (
-              <Button
-                key={item.id}
-                variant="ghost"
-                size="xs"
-                className={`skill-browser__browse-btn${browse === item.id ? " is-active" : ""}`}
-                aria-pressed={browse === item.id}
-                onClick={() => {
-                  setBrowse(item.id);
-                  if (item.id === "all") setTopic("all");
-                }}
-              >
-                <Icon name={item.icon} width={13} aria-hidden />
-                <span>{item.label}</span>
-              </Button>
-            ))}
-          </div>
-          <div className="skill-browser__topics" aria-label="Browse by topic">
-            <Button
-              variant="ghost"
-              size="xs"
-              className={`skill-browser__topic${topic === "all" ? " is-active" : ""}`}
-              aria-pressed={topic === "all"}
-              onClick={() => setTopic("all")}
-            >
-              Topics
-            </Button>
-            {TOPIC_FILTERS.filter((item) => (topics[item.id] ?? 0) > 0).map((item) => (
-              <Button
-                key={item.id}
-                variant="ghost"
-                size="xs"
-                className={`skill-browser__topic${topic === item.id ? " is-active" : ""}`}
-                aria-pressed={topic === item.id}
-                onClick={() => setTopic(item.id)}
-              >
-                <span>{item.label}</span>
-                <span className="skill-browser__topic-count">{topics[item.id]}</span>
-              </Button>
-            ))}
-          </div>
-          <div className="skill-browser__modes" aria-label="Rank skills">
-            {LEADERBOARD_MODES.map((item) => (
-              <Button
-                key={item.id}
-                variant="ghost"
-                size="xs"
-                className={`skill-browser__mode${mode === item.id ? " is-active" : ""}`}
-                aria-pressed={mode === item.id}
-                onClick={() => setMode(item.id)}
-              >
-                {item.label}
-              </Button>
-            ))}
-          </div>
-          {agents.length > 1 ? (
-            <div className="skill-browser__agents" aria-label="Filter by agent">
-              {agents.slice(0, 8).map((name) => (
-                <Button
-                  key={name}
-                  variant="ghost"
-                  size="xs"
-                  className={`skill-browser__agent${agent === name ? " is-active" : ""}`}
-                  aria-pressed={agent === name}
-                  onClick={() => setAgent(name)}
-                >
-                  {name === "all" ? "All agents" : name}
-                </Button>
-              ))}
-            </div>
-          ) : null}
         </div>
         {!loaded ? (
           <div className="skill-browser__note" role="status">


### PR DESCRIPTION
## What

The Skills tab of the marketplace hub stacked its filter chip clusters (Browse, Topics, rank modes, agent compatibility) above the leaderboard card list, while the left rail held only four category items and a column of empty space. This PR groups every filter panel into the rail as labeled sections — **Categories / Browse / Topics / Rank / Agents** — so the sidebar reads as one grouped filter panel and the list column goes straight from the leaderboard header to the ranked cards.

## Details

- `skill-browser.tsx`: rail is now `nav > .skill-browser__rail-group` sections, each with a kicker label and `role="group"`; the chip clusters moved out of the list header unchanged (same class hooks, same state wiring). The all-topics chip is renamed "All topics" now that its group is labeled Topics.
- `globals.css`: rail widened to 224px, kicker-style `__rail-label`, hairline separators between groups. At ≤900px the rail keeps the pinned horizontal-strip behavior with groups flowing inline and wrapping; at ≤680px each group becomes a full-width row whose chips scroll sideways.

## Verification

- `pnpm test:app` — 525 test files green (source-scan pins in `skill-browser.test.ts` kept: class hooks, ≤900px `flex-direction: row` rail rule).
- `tsc --noEmit` clean.
- Playwright screenshots of a production build at 1440 / 840 / 600 px confirm the grouped rail, the wrapped strip, and the phone rows all render correctly.

Bead: cave-dx5

🤖 Generated with [Claude Code](https://claude.com/claude-code)