### PR TITLE
feat(daily-report): keep today's report live + clean session titles (cave-938)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -137,6 +137,7 @@ export const SUITES = {
     "src/app/dashboard-page.test.ts",
     "src/app/dashboard-runtime-smoke.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
+    "src/lib/daily-summary-refresh.test.ts",
     "src/components/dev-cache-reset-script.test.ts",
     "src/components/pwa-register.test.ts",
     "src/lib/readable-text-color.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -252,6 +252,16 @@ for (const contract of contracts) {
     /media:\s*draft\.media/,
     "/inbox/daily-summary should persist the generated media card",
   );
+  assert.match(
+    dailySummarySource,
+    /broadcastUpdated\(/,
+    "/inbox/daily-summary refreshes must broadcast an updated event (created would re-toast)",
+  );
+  assert.match(
+    dailySummarySource,
+    /dateMismatch/,
+    "/inbox/daily-summary must reject payloads computed for a different day (midnight-rollover race)",
+  );
 }
 
 // CHAT-D5-02: cancelling a streaming response (Esc/Stop) must persist an

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -5,8 +5,12 @@ import {
   withInboxLock,
   type InboxItem,
 } from "@/lib/cave-inbox";
-import { broadcastCreated, startScheduler } from "@/lib/inbox-scheduler";
-import { buildDailySummaryNotification } from "@/lib/daily-summary-notifications";
+import { broadcastCreated, broadcastUpdated, startScheduler } from "@/lib/inbox-scheduler";
+import {
+  buildDailySummaryContent,
+  dailySummaryAutoKey,
+  dateSlug,
+} from "@/lib/daily-summary-notifications";
 import type { SessionRow } from "@/lib/types";
 import { isLocalOrigin } from "@/lib/server/local-origin";
 
@@ -19,7 +23,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
   }
 
-  let body: { sessions?: SessionRow[] } = {};
+  let body: { sessions?: SessionRow[]; date?: string } = {};
   try {
     body = await req.json();
   } catch {
@@ -27,14 +31,37 @@ export async function POST(req: Request) {
   }
 
   const now = new Date();
-  const item = await withInboxLock(async () => {
+  // Midnight-rollover race: a client that computed its payload just before the
+  // day flipped must not create or overwrite the new day's report.
+  if (typeof body.date === "string" && body.date !== dateSlug(now)) {
+    return NextResponse.json({ ok: true, created: false, updated: false, dateMismatch: true });
+  }
+
+  const result = await withInboxLock(async () => {
     const file = await loadInbox();
-    const draft = buildDailySummaryNotification({
+    const draft = buildDailySummaryContent({
       items: file.items,
       sessions: Array.isArray(body.sessions) ? body.sessions : [],
       now,
     });
     if (!draft) return null;
+
+    // Ensure-or-refresh: today's report is rebuilt in place so it tracks the
+    // day instead of freezing at the first app-open after midnight.
+    const existing = file.items.find((item) => item.auto === dailySummaryAutoKey(now));
+    if (existing) {
+      const refreshed: InboxItem = {
+        ...existing,
+        title: draft.title,
+        body: draft.body,
+        link: draft.link,
+        media: { ...draft.media },
+        updatedAt: now.toISOString(),
+      };
+      file.items = file.items.map((item) => (item.id === existing.id ? refreshed : item));
+      await saveInbox(file);
+      return { item: refreshed, created: false };
+    }
 
     const next: InboxItem = {
       id: crypto.randomUUID(),
@@ -57,10 +84,16 @@ export async function POST(req: Request) {
     };
     file.items.push(next);
     await saveInbox(file);
-    return next;
+    return { item: next, created: true };
   });
 
-  if (!item) return NextResponse.json({ ok: true, created: false });
-  broadcastCreated(item);
-  return NextResponse.json({ ok: true, created: true, item });
+  if (!result) return NextResponse.json({ ok: true, created: false, updated: false });
+  if (result.created) broadcastCreated(result.item);
+  else broadcastUpdated(result.item);
+  return NextResponse.json({
+    ok: true,
+    created: result.created,
+    updated: !result.created,
+    item: result.item,
+  });
 }

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -83,7 +83,10 @@ export default async function DailyReportPage({ params }: Props) {
     return out;
   };
   const recentSessions = parseRecentSessions(item.body);
-  const generatedAt = item.firedAt ?? item.updatedAt ?? null;
+  // media.generatedAt moves on every in-place refresh; firedAt stays at the
+  // day's first generation, so prefer the former for a truthful timestamp.
+  const generatedAt = item.media?.generatedAt ?? item.firedAt ?? item.updatedAt ?? null;
+  const isToday = parsedDate ? slugFor(parsedDate) === slugFor(new Date()) : false;
   const totalEvents = stats
     ? stats.reminders + stats.responses + stats.familiars + stats.sessions
     : 0;
@@ -124,8 +127,14 @@ export default async function DailyReportPage({ params }: Props) {
           <div className="dr-meta-row">
             <span className="dr-meta-row__item">
               <Icon name="ph:clock" aria-hidden />
-              Generated {generatedAt ? relativeTime(generatedAt) : "today"}
+              Updated {generatedAt ? relativeTime(generatedAt) : "today"}
             </span>
+            {isToday ? (
+              <span className="dr-meta-row__item">
+                <Icon name="ph:arrows-clockwise" aria-hidden />
+                Live — refreshes today
+              </span>
+            ) : null}
             {breakdown.openItems.length > 0 ? (
               <span className="dr-meta-row__item">
                 <Icon name="ph:warning-circle" aria-hidden />

--- a/src/components/dashboard/today-summary.tsx
+++ b/src/components/dashboard/today-summary.tsx
@@ -29,7 +29,11 @@ export function TodaySummary({
       <SectionHead
         icon="ph:newspaper"
         title="Today's report"
-        hint={summary.generatedAt ? `Generated ${relativeTime(summary.generatedAt, now)}` : undefined}
+        hint={
+          summary.generatedAt
+            ? `Updated ${relativeTime(summary.generatedAt, now)} · live`
+            : "Live — refreshes today"
+        }
       />
       <div className="dash-today__grid">
         <div className="dr-panel dash-today__panel">

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -61,10 +61,14 @@ import { nativeNotify } from "@/lib/native-notify";
 import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import {
-  buildDailySummaryNotification,
   dailySummaryAutoKey,
   ensureDailySummaryNotification,
 } from "@/lib/daily-summary-notifications";
+import {
+  DAILY_REFRESH_POLL_MS,
+  dailySummarySignature,
+  shouldRefreshDailySummary,
+} from "@/lib/daily-summary-refresh";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { InitialCommandControls } from "@/lib/command-controls";
 import { normalizeGitHubTasks, type GitHubTask } from "@/lib/github-tasks";
@@ -351,7 +355,13 @@ export function Workspace() {
   // often; the listener should not resubscribe on either.
   const sessionsRef = useRef(sessions);
   sessionsRef.current = sessions;
+  // Daily-summary refresh state: the day key whose cycle we're in, the input
+  // signature and time of the last POST attempt, and an in-flight latch. All
+  // reset when the day key rolls over (midnight).
   const dailySummaryRequestedRef = useRef<string | null>(null);
+  const dailySummarySignatureRef = useRef<string | null>(null);
+  const dailySummaryAttemptAtRef = useRef(0);
+  const dailySummaryInFlightRef = useRef(false);
   const sessionsLoadedRef = useRef(sessionsLoaded);
   sessionsLoadedRef.current = sessionsLoaded;
   const modeRef = useRef(mode);
@@ -813,18 +823,60 @@ export function Workspace() {
     return () => es.close();
   }, []);
 
+  // Keep today's report live: create it on first activity, then refresh it in
+  // place whenever its inputs change (throttled server-writes; the report
+  // freezes for good once the day key rolls over).
+  const refreshDailySummary = useCallback(
+    (force: boolean) => {
+      if (!sessionsLoaded || dailySummaryInFlightRef.current) return;
+      const now = new Date();
+      const key = dailySummaryAutoKey(now);
+      if (dailySummaryRequestedRef.current !== key) {
+        // New day (or first run) — start a fresh refresh cycle.
+        dailySummaryRequestedRef.current = key;
+        dailySummarySignatureRef.current = null;
+        dailySummaryAttemptAtRef.current = 0;
+      }
+      const signature = dailySummarySignature({ items: inboxItems, sessions, now });
+      const hasItem = inboxItems.some((item) => item.auto === key);
+      const refresh = shouldRefreshDailySummary({
+        hasItem,
+        signature,
+        lastSignature: dailySummarySignatureRef.current,
+        lastAttemptAt: dailySummaryAttemptAtRef.current,
+        now,
+        force,
+      });
+      if (!refresh) return;
+      dailySummarySignatureRef.current = signature;
+      dailySummaryAttemptAtRef.current = now.getTime();
+      dailySummaryInFlightRef.current = true;
+      void ensureDailySummaryNotification({ items: inboxItems, sessions, now })
+        .then((result) => {
+          if (result === "failed") {
+            // Retry on the next input change once the min interval passes.
+            dailySummarySignatureRef.current = null;
+          } else if (result === "skipped" && !hasItem) {
+            // Empty day — nothing was posted; keep the create path immediate
+            // for when the first activity lands.
+            dailySummarySignatureRef.current = null;
+            dailySummaryAttemptAtRef.current = 0;
+          }
+        })
+        .finally(() => {
+          dailySummaryInFlightRef.current = false;
+        });
+    },
+    [inboxItems, sessions, sessionsLoaded],
+  );
   useEffect(() => {
-    if (!sessionsLoaded) return;
-    const now = new Date();
-    const key = dailySummaryAutoKey(now);
-    if (dailySummaryRequestedRef.current === key) return;
-    const draft = buildDailySummaryNotification({ items: inboxItems, sessions, now });
-    if (!draft) return;
-    dailySummaryRequestedRef.current = key;
-    void ensureDailySummaryNotification({ items: inboxItems, sessions, now }).then((result) => {
-      if (result === "failed") dailySummaryRequestedRef.current = null;
-    });
-  }, [inboxItems, sessions, sessionsLoaded]);
+    refreshDailySummary(false);
+  }, [refreshDailySummary]);
+  // Fallback tick: forces an attempt even with an unchanged signature, and
+  // rolls the refresh cycle past midnight for an app that stays open.
+  usePausablePoll(() => refreshDailySummary(true), DAILY_REFRESH_POLL_MS, {
+    enabled: sessionsLoaded,
+  });
 
   const openOnboarding = useCallback(() => setOnboardingOpen(true), []);
   const closeOnboarding = useCallback(() => {

--- a/src/lib/daily-summary-notifications.test.ts
+++ b/src/lib/daily-summary-notifications.test.ts
@@ -1,8 +1,10 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import {
+  buildDailySummaryContent,
   buildDailySummaryNotification,
   dailySummaryAutoKey,
+  reportSessionTitle,
   shouldCreateDailySummary,
 } from "./daily-summary-notifications.ts";
 
@@ -112,5 +114,85 @@ assert.equal(
   null,
   "empty days should not produce a noisy daily summary notification",
 );
+
+// The content builder skips the auto-key dedup so the refresh path can rebuild
+// today's report in place.
+const refreshed = buildDailySummaryContent({
+  now,
+  items: [{ ...baseItem, auto: dailySummaryAutoKey(now) }],
+  sessions: [],
+});
+assert.ok(refreshed, "content builder should rebuild even when today's report already exists");
+assert.equal(
+  buildDailySummaryContent({ now, items: [], sessions: [] }),
+  null,
+  "content builder should still return null on an empty day",
+);
+
+// Session-title hygiene: harness transcripts leak markdown into titles.
+assert.equal(
+  reportSessionTitle({ title: "## Prior conversation **User:** Merge PR #26 **" }),
+  "Untitled session",
+  "prior-conversation preamble leaks should fall back to a neutral title",
+);
+assert.equal(
+  reportSessionTitle({ title: "## Fix the **flaky** `packEventColumns` test" }),
+  "Fix the flaky packEventColumns test",
+  "markdown syntax should be stripped, not rendered as literal characters",
+);
+assert.equal(reportSessionTitle({ title: "   " }), "Untitled session");
+const longTitle = "Refactor the entire inbox scheduler pipeline to support recurrence windows and quiet hours";
+assert.ok(
+  reportSessionTitle({ title: longTitle }).length <= 64,
+  "report titles should truncate to a report-sized string",
+);
+assert.match(reportSessionTitle({ title: longTitle }), /…$/);
+
+const sessionAt = (id, title, hoursAgo) => ({
+  id,
+  title,
+  status: "completed",
+  updated_at: new Date(now.getTime() - hoursAgo * 60 * 60 * 1000).toISOString(),
+  created_at: "2026-06-18T08:00:00.000Z",
+  project_root: "/repo/coven-cave",
+  harness: "codex",
+  model: "gpt-5",
+  exit_code: 0,
+  archived_at: null,
+  familiarId: "sage",
+});
+const hygieneDraft = buildDailySummaryContent({
+  now,
+  items: [],
+  sessions: [
+    sessionAt("h1", "## Prior conversation **User:** Merge PR #26 **", 1),
+    sessionAt("h2", "Refresh task: Wire Cave", 2),
+    sessionAt("h3", "refresh task: wire cave", 3),
+    sessionAt("h4", "Ship calendar fixes", 4),
+    sessionAt("h5", "Audit the flow surface", 5),
+    sessionAt("h6", "Polish marketplace cards", 6),
+    sessionAt("h7", "Tune terminal mirror", 7),
+    sessionAt("h8", "Rework project picker", 8),
+    sessionAt("h9", "Harden avatar storage", 9),
+  ],
+});
+assert.ok(hygieneDraft);
+assert.doesNotMatch(
+  hygieneDraft.body,
+  /Prior conversation|##|\*\*/,
+  "the Recent line must not leak raw markdown from session titles",
+);
+assert.equal(
+  hygieneDraft.body.match(/Refresh task: Wire Cave/gi)?.length ?? 0,
+  1,
+  "repeated session titles should be deduped case-insensitively",
+);
+const recentLine = hygieneDraft.body.split("\n").find((line) => line.startsWith("Recent:")) ?? "";
+assert.equal(
+  recentLine.split(" · ").length,
+  6,
+  "the Recent line should cap at 6 deduped sessions",
+);
+assert.doesNotMatch(recentLine, /Harden avatar storage/, "sessions past the cap are dropped");
 
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/lib/daily-summary-notifications.ts
+++ b/src/lib/daily-summary-notifications.ts
@@ -1,4 +1,5 @@
 import type { InboxItem, InboxMedia, ItemKind, ItemStatus, LinkRef, Recurrence } from "./cave-inbox";
+import { sanitizeSessionTitle } from "./cave-chat-titles.ts";
 import type { SessionRow } from "./types";
 
 export type DailySummaryDraft = {
@@ -42,10 +43,35 @@ function dayLabel(date: Date): string {
   return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(date);
 }
 
+const REPORT_TITLE_MAX = 64;
+
+// Session titles come from harness transcripts and can leak raw markdown
+// ("## Prior conversation **User:** Merge PR #26 **"). The report body is
+// rendered as plain text, so markdown syntax must be stripped, not rendered.
+const MD_HEADING_RE = /^#{1,6}\s+/;
+const MD_EMPHASIS_RE = /(\*\*|__|[*_`])/g;
+const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
+
+/** Session title as it should appear in the daily report: sanitized of
+ *  harness-preamble leaks (via sanitizeSessionTitle), stripped of markdown
+ *  syntax, truncated to a report-sized string. Falls back to "Untitled
+ *  session" when nothing survives. */
+export function reportSessionTitle(session: Pick<SessionRow, "title">): string {
+  const sanitized = sanitizeSessionTitle(session.title);
+  if (!sanitized) return "Untitled session";
+  const stripped = sanitized
+    .replace(MD_HEADING_RE, "")
+    .replace(MD_EMPHASIS_RE, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!stripped || PRIOR_CONVERSATION_LEAK_RE.test(stripped)) return "Untitled session";
+  if (stripped.length <= REPORT_TITLE_MAX) return stripped;
+  return `${stripped.slice(0, REPORT_TITLE_MAX - 1).trimEnd()}…`;
+}
+
 function sessionSummaryLine(session: SessionRow): string {
-  const title = session.title?.trim() || "Untitled session";
   const diff = session.diff ? ` (+${session.diff.additions} -${session.diff.deletions})` : "";
-  return `${title}${diff}`;
+  return `${reportSessionTitle(session)}${diff}`;
 }
 
 function xmlEscape(value: string): string {
@@ -56,7 +82,7 @@ function xmlEscape(value: string): string {
     .replace(/"/g, "&quot;");
 }
 
-function dateSlug(date: Date): string {
+export function dateSlug(date: Date): string {
   const y = date.getFullYear();
   const m = `${date.getMonth() + 1}`.padStart(2, "0");
   const d = `${date.getDate()}`.padStart(2, "0");
@@ -76,13 +102,20 @@ export function shouldCreateDailySummary(items: InboxItem[], now = new Date()): 
   return !items.some((item) => item.auto === key);
 }
 
-export function buildDailySummaryNotification({
+/** Server-side enrichments threaded into the builder. Phase B fills this in
+ *  (merged PRs, completed board cards); Phase A only reserves the seam. */
+export type DailySummaryExtras = Record<string, never>;
+
+type BuildContentInput = BuildInput & { extras?: DailySummaryExtras };
+
+/** Build today's report content unconditionally (no auto-key dedup check) —
+ *  the refresh path rebuilds an existing item in place. Returns null only when
+ *  the day is empty. */
+export function buildDailySummaryContent({
   items,
   sessions,
   now = new Date(),
-}: BuildInput): DailySummaryDraft | null {
-  if (!shouldCreateDailySummary(items, now)) return null;
-
+}: BuildContentInput): DailySummaryDraft | null {
   const todayReminders = items.filter(
     (item) =>
       item.kind === "reminder" &&
@@ -120,7 +153,17 @@ export function buildDailySummaryNotification({
     plural(agentNotifications.length, "familiar update", "familiar updates"),
     plural(todaySessions.length, "session", "sessions") + " updated",
   ];
-  const topSessions = todaySessions.slice(0, 3).map(sessionSummaryLine);
+  // Dedupe repeated titles (retried/refreshed runs share one) case-insensitively,
+  // keeping the most recent occurrence — the list is already sorted newest-first.
+  const seenTitles = new Set<string>();
+  const topSessions: string[] = [];
+  for (const session of todaySessions) {
+    if (topSessions.length >= 6) break;
+    const titleKey = reportSessionTitle(session).toLowerCase();
+    if (seenTitles.has(titleKey)) continue;
+    seenTitles.add(titleKey);
+    topSessions.push(sessionSummaryLine(session));
+  }
   if (topSessions.length > 0) lines.push(`Recent: ${topSessions.join(" · ")}`);
 
   const sentAt = now.toISOString();
@@ -184,21 +227,39 @@ export function buildDailySummaryNotification({
   };
 }
 
+/** First-of-the-day create path: null once today's report already exists.
+ *  Refresh flows should use {@link buildDailySummaryContent} directly. */
+export function buildDailySummaryNotification({
+  items,
+  sessions,
+  now = new Date(),
+}: BuildInput): DailySummaryDraft | null {
+  if (!shouldCreateDailySummary(items, now)) return null;
+  return buildDailySummaryContent({ items, sessions, now });
+}
+
 export async function ensureDailySummaryNotification({
   items,
   sessions,
   now = new Date(),
-}: EnsureInput): Promise<"created" | "skipped" | "failed"> {
-  if (!buildDailySummaryNotification({ items, sessions, now })) return "skipped";
+}: EnsureInput): Promise<"created" | "updated" | "skipped" | "failed"> {
+  if (!buildDailySummaryContent({ items, sessions, now })) return "skipped";
   try {
     const res = await fetch("/api/inbox/daily-summary", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ sessions }),
+      // The date pins the payload to the day it was computed for, so a request
+      // racing midnight can't overwrite the new day's report server-side.
+      body: JSON.stringify({ sessions, date: dateSlug(now) }),
     });
     if (!res.ok) return "failed";
-    const json = (await res.json().catch(() => null)) as { ok?: boolean; created?: boolean } | null;
-    return json?.ok && json.created ? "created" : "skipped";
+    const json = (await res.json().catch(() => null)) as {
+      ok?: boolean;
+      created?: boolean;
+      updated?: boolean;
+    } | null;
+    if (!json?.ok) return "failed";
+    return json.created ? "created" : json.updated ? "updated" : "skipped";
   } catch {
     return "failed";
   }

--- a/src/lib/daily-summary-refresh.test.ts
+++ b/src/lib/daily-summary-refresh.test.ts
@@ -1,0 +1,152 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  DAILY_REFRESH_MIN_INTERVAL_MS,
+  DAILY_REFRESH_POLL_MS,
+  dailySummarySignature,
+  shouldRefreshDailySummary,
+} from "./daily-summary-refresh.ts";
+
+const now = new Date("2026-06-18T21:15:00.000Z");
+
+const item = (over = {}) => ({
+  id: "item-1",
+  kind: "reminder",
+  title: "Review release notes",
+  body: "",
+  status: "fired",
+  createdAt: "2026-06-18T12:00:00.000Z",
+  updatedAt: "2026-06-18T15:00:00.000Z",
+  fireAt: "2026-06-18T15:00:00.000Z",
+  firedAt: "2026-06-18T15:00:00.000Z",
+  snoozeUntil: null,
+  recurrence: { type: "none" },
+  source: "user",
+  familiarId: null,
+  sessionId: null,
+  link: null,
+  auto: null,
+  ...over,
+});
+
+const session = (over = {}) => ({
+  id: "s1",
+  title: "Fix board chat route",
+  status: "completed",
+  updated_at: "2026-06-18T20:00:00.000Z",
+  created_at: "2026-06-18T19:00:00.000Z",
+  project_root: "/repo/coven-cave",
+  harness: "codex",
+  model: "gpt-5",
+  exit_code: 0,
+  archived_at: null,
+  familiarId: "sage",
+  ...over,
+});
+
+// --- signature -------------------------------------------------------------
+
+const base = dailySummarySignature({ items: [item()], sessions: [session()], now });
+assert.equal(
+  base,
+  dailySummarySignature({ items: [item()], sessions: [session()], now }),
+  "signature must be stable for identical inputs",
+);
+assert.notEqual(
+  base,
+  dailySummarySignature({ items: [item({ status: "done" })], sessions: [session()], now }),
+  "an item status change must change the signature",
+);
+assert.notEqual(
+  base,
+  dailySummarySignature({
+    items: [item()],
+    sessions: [session({ updated_at: "2026-06-18T20:30:00.000Z" })],
+    now,
+  }),
+  "a session update must change the signature",
+);
+assert.notEqual(
+  base,
+  dailySummarySignature({
+    items: [item()],
+    sessions: [session()],
+    now: new Date("2026-06-19T21:15:00.000Z"),
+  }),
+  "the date slug is part of the signature",
+);
+assert.equal(
+  base,
+  dailySummarySignature({
+    items: [
+      item(),
+      item({ id: "summary", kind: "daily-summary", auto: "daily-summary:2026-06-18" }),
+    ],
+    sessions: [session()],
+    now,
+  }),
+  "the daily-summary item itself must not feed the signature (its own refresh would loop)",
+);
+assert.equal(
+  base,
+  dailySummarySignature({
+    items: [item()],
+    sessions: [session(), session({ id: "old", updated_at: "2026-06-10T09:00:00.000Z" })],
+    now,
+  }),
+  "sessions from other days must not feed the signature",
+);
+assert.equal(
+  base,
+  dailySummarySignature({
+    items: [item()],
+    sessions: [session(), session({ id: "arch", archived_at: "2026-06-18T20:30:00.000Z" })],
+    now,
+  }),
+  "archived sessions must not feed the signature",
+);
+
+// --- refresh policy ----------------------------------------------------------
+
+const FIVE_MIN = DAILY_REFRESH_MIN_INTERVAL_MS;
+assert.ok(FIVE_MIN < DAILY_REFRESH_POLL_MS, "poll fallback must be slower than the write throttle");
+
+const decide = (over = {}) =>
+  shouldRefreshDailySummary({
+    hasItem: true,
+    signature: "sig-b",
+    lastSignature: "sig-a",
+    lastAttemptAt: now.getTime() - FIVE_MIN,
+    now,
+    ...over,
+  });
+
+assert.equal(decide({ hasItem: false, lastAttemptAt: 0 }), true, "missing report → create immediately");
+assert.equal(
+  decide({ hasItem: false, lastAttemptAt: now.getTime() - 1000 }),
+  false,
+  "a just-attempted create must not re-fire before the min interval",
+);
+assert.equal(decide(), true, "signature change past the min interval → refresh");
+assert.equal(
+  decide({ lastAttemptAt: now.getTime() - 1000 }),
+  false,
+  "signature change inside the min interval → wait",
+);
+assert.equal(
+  decide({ lastSignature: "sig-b" }),
+  false,
+  "unchanged signature → no refresh",
+);
+assert.equal(
+  decide({ lastSignature: "sig-b", force: true }),
+  true,
+  "forced poll tick refreshes despite an unchanged signature",
+);
+assert.equal(
+  decide({ lastSignature: "sig-b", force: true, lastAttemptAt: now.getTime() - 1000 }),
+  false,
+  "even a forced tick respects the write throttle",
+);
+
+console.log("daily-summary-refresh.test.ts: ok");

--- a/src/lib/daily-summary-refresh.ts
+++ b/src/lib/daily-summary-refresh.ts
@@ -1,0 +1,81 @@
+import type { InboxItem } from "./cave-inbox";
+import type { SessionRow } from "./types";
+import { dateSlug } from "./daily-summary-notifications.ts";
+
+/** Minimum gap between daily-summary POSTs — the sessions list polls every 4s,
+ *  so refresh decisions must throttle well above that cadence. */
+export const DAILY_REFRESH_MIN_INTERVAL_MS = 5 * 60_000;
+
+/** Fallback poll that forces a refresh attempt even when the client-visible
+ *  signature is unchanged (picks up server-only changes, rolls the date). */
+export const DAILY_REFRESH_POLL_MS = 15 * 60_000;
+
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function sameLocalDay(iso: string | null | undefined, day: Date): boolean {
+  if (!iso) return false;
+  const value = new Date(iso);
+  if (Number.isNaN(value.getTime())) return false;
+  const start = new Date(day.getFullYear(), day.getMonth(), day.getDate());
+  return value >= start && value.getTime() < start.getTime() + 24 * 60 * 60 * 1000;
+}
+
+/** Stable signature over the inputs that feed today's report: the date slug,
+ *  the count-input inbox items (id/status/timestamps — never the daily-summary
+ *  item itself, so the refresh it triggers can't re-trigger it), and today's
+ *  sessions (id + updated_at). Changes exactly when a rebuild would produce
+ *  different content. */
+export function dailySummarySignature({
+  items,
+  sessions,
+  now = new Date(),
+}: {
+  items: InboxItem[];
+  sessions: SessionRow[];
+  now?: Date;
+}): string {
+  const itemParts = items
+    .filter(
+      (item) =>
+        item.kind === "reminder" || item.kind === "response-needed" || item.kind === "agent",
+    )
+    .map((item) => `${item.id}:${item.status}:${item.firedAt ?? ""}:${item.updatedAt ?? ""}`)
+    .sort();
+  const sessionParts = sessions
+    .filter((session) => !session.archived_at && sameLocalDay(session.updated_at, now))
+    .map((session) => `${session.id}:${session.updated_at}`)
+    .sort();
+  return `${dateSlug(now)}.${fnv1a(itemParts.join("|"))}.${fnv1a(sessionParts.join("|"))}`;
+}
+
+/** Refresh policy: create immediately when today's report is missing, else
+ *  refresh only when the signature changed (or a forced poll tick asks) and
+ *  the minimum interval since the last attempt has passed. `lastAttemptAt` is
+ *  epoch ms of the last POST attempt (0 = never this day). */
+export function shouldRefreshDailySummary({
+  hasItem,
+  signature,
+  lastSignature,
+  lastAttemptAt,
+  now,
+  force = false,
+}: {
+  hasItem: boolean;
+  signature: string;
+  lastSignature: string | null;
+  lastAttemptAt: number;
+  now: Date;
+  force?: boolean;
+}): boolean {
+  const elapsed = now.getTime() - lastAttemptAt;
+  if (!hasItem) return lastAttemptAt === 0 || elapsed >= DAILY_REFRESH_MIN_INTERVAL_MS;
+  if (elapsed < DAILY_REFRESH_MIN_INTERVAL_MS) return false;
+  return force || signature !== lastSignature;
+}

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -77,7 +77,7 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
         body: todayItem.body ?? "",
         imageUrl: todayItem.media?.imageUrl ?? null,
         alt: todayItem.media?.alt ?? "",
-        generatedAt: todayItem.firedAt ?? todayItem.updatedAt ?? null,
+        generatedAt: todayItem.media?.generatedAt ?? todayItem.firedAt ?? todayItem.updatedAt ?? null,
         recentSessions: parseRecentSessions(todayItem.body),
       }
     : null;


### PR DESCRIPTION
## Summary

Phase A of the daily-report overhaul (bead `cave-938`, three-phase plan). Today's report froze minutes after midnight and leaked raw markdown into its Recent line; this makes it live-for-the-day and hygienic.

**Live-refresh upsert** — `POST /api/inbox/daily-summary` becomes ensure-or-refresh under `withInboxLock`: today's item is rebuilt in place (`id`/`createdAt`/`firedAt` preserved, `broadcastUpdated` so it can't re-toast), created only when missing. A `date` guard returns `dateMismatch` for payloads computed before midnight rolled over, so a racing client can't contaminate the new day's report.

**Refresh policy** (new pure `src/lib/daily-summary-refresh.ts`) — signature over the report's inputs (date slug + count-input inbox items + today's sessions; excludes the daily-summary item itself so its own refresh event can't loop). Create immediately when missing; refresh on signature change throttled to ≥5 min; 15-min `usePausablePoll` fallback tick forces an attempt and rolls the cycle past midnight. `workspace.tsx` swaps its once-per-day guard for this (keeps the pinned `dailySummaryRequestedRef` identifier as the day-key ref).

**Session-title hygiene** — new `reportSessionTitle`: composes `sanitizeSessionTitle`, strips markdown syntax, rejects "Prior conversation" transcript leaks, truncates to 64 chars. Recent line dedupes case-insensitively and caps at 6 (was 3).

**Freshness labels** — report page + dashboard prefer `media.generatedAt` ("Updated X ago"), and today's page shows a "Live — refreshes today" hint.

## Test plan

- `node scripts/run-tests.mjs app` — 527 files pass, including new `daily-summary-refresh.test.ts` (signature stability/exclusions + refresh-policy matrix) and extended builder tests (markdown-leak, dedupe, cap-6, content-vs-notification split)
- `check:tests-wired` ✓ (new test appended to SUITES) · `tsc --noEmit` ✓
- New api-contracts pins: `broadcastUpdated` + `dateMismatch` in the route
- **Verified live** against the real inbox on a worktree dev server: refresh preserved item identity and un-froze the report (6 → 21 sessions, markdown leak scrubbed, 6 deduped titles); stale-date POST wrote nothing; today's page shows the live hint; historical report pages render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)