### PR TITLE
feat(github): resizable + collapsible detail sidepanel, adaptive to pane width

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -151,13 +151,13 @@ assert.doesNotMatch(
 );
 assert.match(
   boardCss,
-  /@media \(min-width: 1041px\) \{[\s\S]*?\.gh-glass-panel:not\(\.gh-glass-panel--empty\) \{[\s\S]*?height:100%;/,
-  "GitHub detail sidepanel keeps a stable container height while async detail content loads",
+  /\.gh-workspace--split \.gh-detail-holder \{ height:100%; \}[\s\S]*?\.gh-workspace--split \.gh-glass-panel \{[\s\S]*?flex:1 1 auto;/,
+  "GitHub detail sidepanel keeps a stable container height while async detail content loads (fills its split pane)",
 );
 assert.match(
   boardCss,
-  /@media \(max-width: 1040px\) \{[\s\S]*?\.gh-glass-panel:not\(\.gh-glass-panel--empty\) \{[\s\S]*?height:min\(460px,52dvh\);/,
-  "GitHub detail sidepanel stays height-constrained in the single-column layout so hover cannot scroll-jump it",
+  /\.gh-workspace--stacked \.gh-glass-panel:not\(\.gh-glass-panel--empty\) \{[\s\S]*?height:min\(460px,52dvh\);/,
+  "GitHub detail sidepanel stays height-constrained in the stacked layout so hover cannot scroll-jump it",
 );
 assert.doesNotMatch(
   source,
@@ -426,6 +426,80 @@ assert.doesNotMatch(
   source,
   /w-full rounded-lg border border-\[var\(--border-hairline\)\] bg-\[var\(--bg-base\)\]/,
   "PAT modal inputs use .gh-input class, not inline Tailwind",
+);
+
+// ── Workspace split: resizable + collapsible + measured-width responsive ──────
+// The detail sidepanel is a react-resizable-panels Panel behind a drag
+// separator; its width persists per-group and its collapse is its own pref.
+assert.match(
+  source,
+  /const GH_WORKSPACE_GROUP_ID = "cave\.github\.workspace\.v1";/,
+  "workspace split widths persist under a versioned group id",
+);
+assert.match(
+  source,
+  /useDefaultLayout\(\{\s*id: GH_WORKSPACE_GROUP_ID,\s*panelIds: \["gh-list", "gh-detail"\],\s*storage: ghWorkspaceStorage,/,
+  "split layout restores through the guarded storage wrapper (shell.tsx pattern)",
+);
+assert.match(
+  source,
+  /const anyCollapsed = values\.some\(\(v\) => v >= 0 && v <= 6\);/,
+  "storage guard drops rail-width saves so a stale collapse can't restore as a crushed panel",
+);
+assert.match(
+  source,
+  /collapsible\s+collapsedSize=\{GH_DETAIL_RAIL_PX\}/,
+  "detail panel collapses to the expand rail, not to nothing",
+);
+assert.match(
+  source,
+  /<Separator className="shell-separator gh-workspace-separator">\s*<SeparatorHandle orientation="col" \/>/,
+  "list ⇄ detail separator uses the shared drag handle (role=separator a11y)",
+);
+assert.match(
+  source,
+  /const GH_DETAIL_COLLAPSED_KEY = "cave:github:details-collapsed:v1";/,
+  "collapse state persists in its own pref, independent of saved widths",
+);
+assert.match(
+  source,
+  /aria-label="Collapse details panel"[\s\S]{0,200}aria-expanded/,
+  "collapse control is a labelled disclosure button",
+);
+assert.match(
+  source,
+  /aria-label="Expand details panel"/,
+  "collapsed rail keeps a labelled expand control on-screen",
+);
+assert.match(
+  source,
+  /new ResizeObserver\(\(entries\) => \{\s*const next = entries\[0\]\?\.contentRect\.width/,
+  "split-vs-stacked tracks the workspace's own measured width (drag-to-split panes), not the viewport",
+);
+assert.match(
+  source,
+  /width === null \? !isMobile : width >= GH_SPLIT_MIN_PX/,
+  "first paint falls back to the viewport heuristic until the ResizeObserver lands",
+);
+assert.match(
+  source,
+  /if \(!collapsedRef\.current\) onLayoutChanged\(/,
+  "collapsed rail widths are never persisted as the saved layout",
+);
+assert.match(
+  boardCss,
+  /\.gh-detail-toggle-bar \{[\s\S]*?border:1px dashed /,
+  "stacked collapsed state renders the dashed show-details invitation",
+);
+assert.match(
+  boardCss,
+  /\.gh-detail-rail \{[\s\S]*?height:100%;/,
+  "collapsed split state renders the full-height expand rail",
+);
+assert.doesNotMatch(
+  boardCss,
+  /grid-template-columns:minmax\(0,1fr\) minmax\(340px,420px\)/,
+  "fixed-width detail column is gone — the split is user-resizable",
 );
 
 console.log("github-view-polish.test.ts OK");

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -7,13 +7,25 @@
 import "@/styles/board.css";
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
+import {
+  Group,
+  Panel,
+  Separator,
+  useDefaultLayout,
+  type PanelImperativeHandle,
+} from "react-resizable-panels";
+import { SeparatorHandle } from "@/components/ui/separator-handle";
+import { useIsMobile } from "@/lib/use-viewport";
 import { Icon, type IconName } from "@/lib/icon";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -1774,6 +1786,235 @@ function GitHubChecks({ item }: { item: GitHubItem }) {
   );
 }
 
+// ── Workspace split (list ⇄ detail) ──────────────────────────────────────────
+
+const GH_WORKSPACE_GROUP_ID = "cave.github.workspace.v1";
+const GH_DETAIL_COLLAPSED_KEY = "cave:github:details-collapsed:v1";
+// Icons-only rail the detail panel collapses to — keeps the expand control
+// visible instead of vanishing the panel entirely (shell nav-rail pattern).
+const GH_DETAIL_RAIL_PX = 40;
+// Below this measured workspace width the side-by-side split would crush the
+// table, so the detail stacks above the list instead. Measured on the pane,
+// not the viewport — a drag-to-split pane can be narrow in a wide window.
+const GH_SPLIT_MIN_PX = 760;
+
+// Width persistence for the resizable split. Guards mirror shell.tsx's
+// shellStorage: drop corrupt layouts, and drop rail-width saves — collapse
+// state lives in its own pref, so a stale collapsed layout must never restore
+// as a crushed "expanded" panel.
+const ghWorkspaceStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === "undefined") return null;
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (raw) {
+        try {
+          const parsed = JSON.parse(raw) as unknown;
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            const values = Object.values(parsed as Record<string, unknown>).filter(
+              (v): v is number => typeof v === "number" && Number.isFinite(v),
+            );
+            if (values.length >= 2) {
+              const sum = values.reduce((a, b) => a + b, 0);
+              const anyCollapsed = values.some((v) => v >= 0 && v <= 6);
+              if (anyCollapsed || sum < 98 || sum > 102) {
+                window.localStorage.removeItem(key);
+                return null;
+              }
+            }
+          }
+        } catch { /* not a layout object, pass through */ }
+      }
+      return raw;
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(key, value);
+    } catch { /* ignore — strict privacy mode or storage quota */ }
+  },
+};
+
+function readDetailCollapsedPref(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(GH_DETAIL_COLLAPSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function GhWorkspace({ detail, children }: { detail: ReactNode; children: ReactNode }) {
+  const isMobile = useIsMobile();
+  // Until the first measurement lands, fall back to the viewport heuristic so
+  // SSR and first paint agree with the CSS (chat-surface pattern).
+  const [width, setWidth] = useState<number | null>(null);
+  const roRef = useRef<ResizeObserver | null>(null);
+  const measureRef = useCallback((el: HTMLDivElement | null) => {
+    roRef.current?.disconnect();
+    roRef.current = null;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const next = entries[0]?.contentRect.width ?? el.clientWidth;
+      setWidth((prev) => (prev === next ? prev : next));
+    });
+    ro.observe(el);
+    roRef.current = ro;
+  }, []);
+  useEffect(() => () => roRef.current?.disconnect(), []);
+  const split = width === null ? !isMobile : width >= GH_SPLIT_MIN_PX;
+
+  const [collapsed, setCollapsed] = useState(readDetailCollapsedPref);
+  const collapsedRef = useRef(collapsed);
+  const detailPanelRef = useRef<PanelImperativeHandle | null>(null);
+  // Last width the user actually saw expanded. expand() restores the panel's
+  // "most recent size", but a panel that MOUNTS collapsed (persisted pref) has
+  // no such size and would pop open at minSize — onResize seeds this ref from
+  // the restored layout before the mount-time collapse lands.
+  const lastExpandedPxRef = useRef<number | null>(null);
+  const persistCollapsed = useCallback((next: boolean) => {
+    collapsedRef.current = next;
+    setCollapsed(next);
+    try {
+      window.localStorage.setItem(GH_DETAIL_COLLAPSED_KEY, next ? "1" : "0");
+    } catch { /* ignore */ }
+  }, []);
+  const toggleCollapsed = useCallback(() => {
+    const next = !collapsedRef.current;
+    // Flip the ref BEFORE the imperative call — collapse()/expand() fire
+    // onLayoutChanged synchronously, and the save gate must already see the
+    // new state or collapsing overwrites the saved width with the rail's.
+    collapsedRef.current = next;
+    const panel = detailPanelRef.current;
+    if (next) {
+      panel?.collapse();
+    } else {
+      panel?.expand();
+      const px = lastExpandedPxRef.current;
+      if (panel && px != null && px >= 100) panel.resize(`${Math.round(px)}px`);
+    }
+    persistCollapsed(next);
+  }, [persistCollapsed]);
+
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: GH_WORKSPACE_GROUP_ID,
+    panelIds: ["gh-list", "gh-detail"],
+    storage: ghWorkspaceStorage,
+  });
+
+  // The detail Panel remounts whenever the layout flips stacked → split;
+  // re-apply the persisted collapse before paint so it never flashes open.
+  // Capture the restored width first — collapsing this early means the panel
+  // never reports an expanded onResize, so this is the only seed for the
+  // width toggle-expand should return to.
+  useLayoutEffect(() => {
+    if (!split) return;
+    const panel = detailPanelRef.current;
+    if (panel && collapsedRef.current && !panel.isCollapsed()) {
+      const px = panel.getSize().inPixels;
+      if (px > GH_DETAIL_RAIL_PX + 8) lastExpandedPxRef.current = px;
+      panel.collapse();
+    }
+  }, [split]);
+
+  if (!split) {
+    return (
+      <div ref={measureRef} className="gh-workspace gh-workspace--stacked">
+        {children}
+        {collapsed ? (
+          <button
+            type="button"
+            className="gh-detail-toggle-bar"
+            aria-expanded={false}
+            onClick={toggleCollapsed}
+          >
+            <Icon name="ph:caret-down-bold" width={11} aria-hidden />
+            Show details
+          </button>
+        ) : (
+          <div className="gh-detail-holder reveal-scope">
+            {detail}
+            <IconButton
+              icon="ph:sidebar-simple"
+              aria-label="Collapse details panel"
+              aria-expanded
+              size="sm"
+              className="gh-detail-collapse reveal-on-hover"
+              onClick={toggleCollapsed}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={measureRef} className="gh-workspace gh-workspace--split">
+      <Group
+        orientation="horizontal"
+        className="gh-workspace-group"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={(...args) => {
+          // Never persist the collapsed rail as the saved width.
+          if (!collapsedRef.current) onLayoutChanged(...args);
+        }}
+      >
+        <Panel id="gh-list" className="gh-list-pane" minSize="320px">
+          {children}
+        </Panel>
+        <Separator className="shell-separator gh-workspace-separator">
+          <SeparatorHandle orientation="col" />
+        </Separator>
+        <Panel
+          id="gh-detail"
+          className="gh-detail-pane"
+          defaultSize="380px"
+          minSize="300px"
+          maxSize="560px"
+          collapsible
+          collapsedSize={GH_DETAIL_RAIL_PX}
+          panelRef={detailPanelRef}
+          onResize={(size) => {
+            // Dragging past minSize collapses without the toggle button —
+            // keep the pref in sync with what the user can see.
+            const px = size.inPixels ?? 0;
+            const next = px <= GH_DETAIL_RAIL_PX + 8;
+            if (!next) lastExpandedPxRef.current = px;
+            if (next !== collapsedRef.current) persistCollapsed(next);
+          }}
+        >
+          {collapsed ? (
+            <div className="gh-detail-rail">
+              <IconButton
+                icon="ph:sidebar-simple"
+                aria-label="Expand details panel"
+                aria-expanded={false}
+                size="sm"
+                onClick={toggleCollapsed}
+              />
+            </div>
+          ) : (
+            <div className="gh-detail-holder reveal-scope">
+              {detail}
+              <IconButton
+                icon="ph:sidebar-simple"
+                aria-label="Collapse details panel"
+                aria-expanded
+                size="sm"
+                className="gh-detail-collapse reveal-on-hover"
+                onClick={toggleCollapsed}
+              />
+            </div>
+          )}
+        </Panel>
+      </Group>
+    </div>
+  );
+}
+
 // ── Selected item detail ─────────────────────────────────────────────────────
 
 function GitHubItemGlassPanel({
@@ -2519,7 +2760,21 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
           </div>
 
         ) : (
-          <div className="gh-workspace">
+          <GhWorkspace
+            detail={
+              <GitHubItemGlassPanel
+                item={selectedItem}
+                linkedCards={selectedLinkedCards}
+                familiars={familiars}
+                resolvedById={resolvedById}
+                cards={cards}
+                counts={counts}
+                onJumpToSession={onJumpToSession}
+                onFocusCard={onFocusCard}
+                onAfterLink={reloadCards}
+              />
+            }
+          >
             <div className="board-table-wrap gh-list-panel">
               <table className="board-table gh-table" role="grid" aria-label="GitHub activity — use arrow keys to navigate rows">
                 <thead>
@@ -2763,18 +3018,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
                 </tbody>
               </table>
             </div>
-            <GitHubItemGlassPanel
-              item={selectedItem}
-              linkedCards={selectedLinkedCards}
-              familiars={familiars}
-              resolvedById={resolvedById}
-              cards={cards}
-              counts={counts}
-              onJumpToSession={onJumpToSession}
-              onFocusCard={onFocusCard}
-              onAfterLink={reloadCards}
-            />
-          </div>
+          </GhWorkspace>
         )}
       </div>
 

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -690,17 +690,84 @@
 .gh-workspace {
   position:relative;
   z-index:1;
-  display:grid;
-  grid-template-columns:minmax(0,1fr) minmax(340px,420px);
-  gap:14px;
   height:100%;
   min-height:0;
   overflow:hidden;
   padding:14px;
 }
+
+/* Wide panes: resizable list ⇄ detail split (react-resizable-panels). The old
+   1040px viewport media query became a measured-width mode class — a
+   drag-to-split pane can be narrow while the window is wide. */
+.gh-workspace--split .gh-workspace-group { height:100%; }
+.gh-list-pane { min-width:0; height:100%; }
+.gh-detail-pane { min-width:0; height:100%; }
+.gh-workspace-separator { margin:0 6px; }
+.gh-detail-holder {
+  position:relative;
+  min-height:0;
+  display:flex;
+  flex-direction:column;
+}
+.gh-workspace--split .gh-detail-holder { height:100%; }
+.gh-workspace--split .gh-glass-panel {
+  flex:1 1 auto;
+  min-height:0;
+}
+/* Collapse control floats over the panel corner; earns visibility (§8). */
+.gh-detail-collapse {
+  position:absolute;
+  top:20px;
+  right:20px;
+  z-index:2;
+}
+/* Collapsed detail = a slim rail that keeps the expand affordance on-screen. */
+.gh-detail-rail {
+  height:100%;
+  display:flex;
+  align-items:flex-start;
+  justify-content:center;
+  padding-top:10px;
+  border:1px solid color-mix(in oklab,var(--border-hairline) 70%,transparent);
+  border-radius:8px;
+  background:color-mix(in oklab,var(--bg-raised) 46%,transparent);
+}
+
+/* Narrow panes: detail stacks above the list (same DOM, mode class). */
+.gh-workspace--stacked {
+  display:grid;
+  grid-template-columns:1fr;
+  grid-template-rows:auto minmax(0,1fr);
+  gap:14px;
+}
+.gh-workspace--stacked .gh-detail-holder { order:-1; }
+.gh-workspace--stacked .gh-glass-panel:not(.gh-glass-panel--empty) {
+  height:min(460px,52dvh);
+}
+.gh-workspace--stacked .gh-detail-toggle-bar { order:-1; }
+/* Dashed border = invitation: the collapsed details are one tap away. */
+.gh-detail-toggle-bar {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:6px;
+  padding:7px 10px;
+  border:1px dashed color-mix(in oklab,var(--border-hairline) 76%,transparent);
+  border-radius:8px;
+  background:transparent;
+  color:var(--text-muted);
+  font-size:11.5px;
+  cursor:pointer;
+}
+.gh-detail-toggle-bar:hover {
+  color:var(--text-secondary);
+  border-color:var(--border-strong);
+}
+
 .gh-list-panel {
   min-width:0;
   height:100%;
+  overflow-x:auto;
   border:1px solid color-mix(in oklab,var(--border-hairline) 76%,transparent);
   border-radius:8px;
   background:color-mix(in oklab,var(--bg-raised) 62%,transparent);
@@ -777,9 +844,7 @@
 .gh-action-popover-item-familiar { color:var(--text-muted); font-size:10.5px; }
 
 .gh-glass-panel {
-  position:sticky;
-  top:14px;
-  align-self:start;
+  position:relative;
   min-width:0;
   display:flex;
   flex-direction:column;
@@ -959,12 +1024,6 @@
   -ms-overflow-style:none;
 }
 .gh-glass-panel-scroll::-webkit-scrollbar { width:0; height:0; }
-
-@media (min-width: 1041px) {
-  .gh-glass-panel:not(.gh-glass-panel--empty) {
-    height:100%;
-  }
-}
 
 .gh-issue-subline {
   display:flex;
@@ -1623,19 +1682,6 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 }
 .gh-check-logs:hover { color:var(--text-secondary); }
 
-@media (max-width: 1040px) {
-  .gh-workspace { grid-template-columns:1fr; }
-  .gh-glass-panel {
-    position:relative;
-    top:auto;
-    order:-1;
-    align-self:stretch;
-  }
-  .gh-glass-panel:not(.gh-glass-panel--empty) {
-    height:min(460px,52dvh);
-  }
-}
-
 @media (max-width: 760px) {
   .gh-compact-header {
     align-items:flex-start;
@@ -1656,7 +1702,6 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   .gh-workspace { padding:10px; gap:10px; }
   .gh-glass-panel { padding:12px; }
   .gh-glass-hero h3 { font-size:17px; }
-  .gh-list-panel { overflow-x:auto; }
 }
 
 /* ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes bead **cave-den** — the GitHub surface's detail sidepanel was a fixed `minmax(340px,420px)` grid column: no resize, no collapse, and only a viewport-based 1040px stacking breakpoint.

## Changes

**Resizable** — the list ⇄ detail split is now a `react-resizable-panels` Group with a `Separator` + shared `SeparatorHandle` (same idiom as `shell.tsx` / `chat-surface.tsx`). Detail clamps 300–560px (default 380), width persists via `useDefaultLayout` under `cave.github.workspace.v1` behind a shell-style guarded storage wrapper (drops corrupt and rail-width saves).

**Collapsible** — the detail panel collapses to a 40px rail that keeps a labelled expand control on-screen (shell nav-rail pattern). Collapse state persists in its own pref (`cave:github:details-collapsed:v1`), deliberately separate from the saved width; the save gate flips *before* `collapse()`/`expand()` because RRP fires `onLayoutChanged` synchronously — otherwise collapsing overwrites the saved width with the rail's. Expanding restores the last user-set width, including for panels that mount collapsed (seeded from the restored layout right before the mount-time collapse). The collapse control is a hover-revealed (design-language §8 `reveal-on-hover`) disclosure button over the panel corner — no new permanent chrome.

**All screens** — split-vs-stacked now tracks the workspace's **own measured width** (ResizeObserver, 760px threshold; viewport heuristic until first measure) instead of the viewport, so the surface also adapts inside drag-to-split panes. Stacked mode keeps the detail-on-top `min(460px,52dvh)` clamp and collapses to a dashed "Show details" invitation bar. The old `@media (min-width:1041px)` / `(max-width:1040px)` workspace rules became mode classes; dead `position:sticky` base removed.

## Verification
- Playwright against the running app: separator drag 380→500px ✓ · collapse → 40px rail + pref written ✓ · reload keeps collapse ✓ · expand restores 501px ✓ · 700px pane stacks detail above list ✓ · stacked collapse/expand roundtrip ✓ (screenshots taken at each state)
- `pnpm typecheck` ✓ · `pnpm test:app` 525 ✓ — media-query pins in `github-view-polish.test.ts` updated to the mode classes, +14 new pins (storage guard, separator a11y handle, disclosure labels, measured-width switch, dashed invitation)

## Notes
- Open PR #2490 also edits `github-view.tsx`/`board.css` (header/rows/footer §8 pass) — different regions, but expect a small textual merge conflict for whichever lands second.
- `server.mjs` regeneration from the build was intentionally excluded (stale artifact vs #2476's `server.ts`; another session has in-flight work there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)