### PR TITLE
fix(theme): sweep hardcoded white foregrounds off accent-presence fills (cave-6pe.8)

### DIFF
--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -777,7 +777,7 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
             background: isSelected ? "var(--accent-presence)" : "transparent",
           }}
         >
-          {isSelected && <Icon name="ph:check-bold" width={12} className="text-white" />}
+          {isSelected && <Icon name="ph:check-bold" width={12} className="text-[var(--accent-presence-foreground)]" />}
         </span>
       )}
       <div className="board-kanban-card-top">

--- a/src/components/board-table.tsx
+++ b/src/components/board-table.tsx
@@ -400,7 +400,7 @@ export function BoardTable({ cards, familiars, projects, groupBy, selectedCardId
                                     background: rowChecked ? "var(--accent-presence)" : "transparent",
                                   }}
                                 >
-                                  {rowChecked && <Icon name="ph:check-bold" width={11} className="text-white" />}
+                                  {rowChecked && <Icon name="ph:check-bold" width={11} className="text-[var(--accent-presence-foreground)]" />}
                                 </span>
                               )}
                               <span className="board-table-title" title={card.title}>{card.title}</span>

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -1008,7 +1008,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
               <button
                 type="button"
                 onClick={() => { setModalDefaultStatus("backlog"); setModalOpen(true); }}
-                className="mt-4 inline-flex h-8 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 text-[12px] font-medium text-white transition-opacity hover:opacity-85"
+                className="mt-4 inline-flex h-8 items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 text-[12px] font-medium text-[var(--accent-presence-foreground)] transition-opacity hover:opacity-85"
               >
                 <Icon name="ph:plus-bold" width={12} />
                 New task

--- a/src/components/github-action-popover.tsx
+++ b/src/components/github-action-popover.tsx
@@ -286,7 +286,7 @@ function FamiliarPicker({
         type="button"
         onClick={() => void handleSubmit()}
         disabled={!selected || busy}
-        className="mt-1 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[12px] font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-40"
+        className="mt-1 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[12px] font-medium text-[var(--accent-presence-foreground)] transition-opacity hover:opacity-90 disabled:opacity-40"
       >
         {busy
           ? "Working…"

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1565,7 +1565,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                             <button
                               onClick={scaffoldOnly}
                               disabled={picking !== null}
-                              className="focus-ring inline-flex w-fit items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+                              className="focus-ring inline-flex w-fit items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-[var(--accent-presence-foreground)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
                             >
                               <Icon name="ph:folder-open-bold" />
                               {picking === "scaffold"
@@ -1672,7 +1672,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                   onClick={() => setOnboardingMultiHostMode("local")}
                                   className={`focus-ring rounded-md border px-2 py-1 text-[11px] ${
                                     onboardingMultiHostMode === "local"
-                                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-white"
+                                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
                                       : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                                   }`}
                                 >
@@ -1683,7 +1683,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                   onClick={() => setOnboardingMultiHostMode("hub")}
                                   className={`focus-ring rounded-md border px-2 py-1 text-[11px] ${
                                     onboardingMultiHostMode === "hub"
-                                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-white"
+                                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
                                       : "border-[var(--border-hairline)] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
                                   }`}
                                 >
@@ -1734,7 +1734,7 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
                                 disabled={
                                   startingDaemon || !status?.steps.covenCli.ok
                                 }
-                                className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+                                className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-[var(--accent-presence-foreground)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
                                 title={
                                   !status?.steps.covenCli.ok
                                     ? "Install coven CLI first (step 1)"
@@ -2014,7 +2014,7 @@ function StepCovenCli({
           }}
           disabled={busy || covenCodeJobRunning}
           aria-busy={busy || covenCodeJobRunning}
-          className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+          className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-[var(--accent-presence-foreground)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
         >
           {busy || covenCodeJobRunning ? (
             <Icon name="ph:circle-notch-bold" className="animate-spin" />
@@ -2291,7 +2291,7 @@ function StepRuntimes({
                         onClick={() => onInstall(oneClick.target)}
                         disabled={busy || (NPM_INSTALL_TARGETS.includes(oneClick.target) && npmJobRunning)}
                         aria-busy={busy}
-                        className="focus-ring inline-flex w-fit items-center gap-2 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[12px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+                        className="focus-ring inline-flex w-fit items-center gap-2 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[12px] font-medium text-[var(--accent-presence-foreground)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
                       >
                         {busy ? (
                           <Icon name="ph:circle-notch-bold" className="animate-spin" />
@@ -2920,7 +2920,7 @@ function StepFamiliar(props: {
                   !confirmCreateNewFamiliar ||
                   (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
                 }
-                className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+                className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-[var(--accent-presence-foreground)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
               >
                 <Icon name="ph:terminal-window" />
                 {picking === "local" ? "Creating…" : "Create new Coven familiar"}
@@ -2953,7 +2953,7 @@ function StepFamiliar(props: {
                   familiarName.trim().length === 0 ||
                   (familiarGlyph.trim() !== "" && !familiarGlyph.trim().startsWith("ph:"))
                 }
-                className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-white hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
+                className="focus-ring inline-flex items-center gap-2 rounded-md bg-[var(--accent-presence)] px-4 py-2 text-[13px] font-medium text-[var(--accent-presence-foreground)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-50"
               >
                 <Icon name="ph:git-fork" />
                 {picking === "familiar"

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -383,7 +383,7 @@ export function OpenCovenToolsUpdate() {
   const toolActionBtn =
     "settings-tool-action gap-1.5 rounded-[var(--radius-control)] text-[11px]";
   const accentBtn =
-    `${toolActionBtn} settings-tool-action--primary bg-[var(--accent-presence)] px-3 font-semibold text-white disabled:opacity-50`;
+    `${toolActionBtn} settings-tool-action--primary bg-[var(--accent-presence)] px-3 font-semibold text-[var(--accent-presence-foreground)] disabled:opacity-50`;
   const ghostBtn =
     `${toolActionBtn} border border-[var(--border-hairline)] px-2.5 text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]`;
   const footerStatusText =

--- a/src/components/project-tree.tsx
+++ b/src/components/project-tree.tsx
@@ -528,7 +528,7 @@ function TreeRow({
         } : undefined}
         className={`focus-ring-inset group flex w-full items-center gap-0 rounded-[var(--radius-control)] py-[3px] text-left transition-colors ${
           isSelected
-            ? "bg-[var(--accent-presence)] text-white"
+            ? "bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
             : "text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
         } ${dropTarget ? "outline-dashed outline-1 outline-[var(--accent-presence)] bg-[var(--accent-presence)]/10" : ""} ${dragging ? "opacity-40" : ""} ${isHidden ? "opacity-40" : ""}`}
         style={{ paddingLeft: indentPx, paddingRight: 8, marginLeft: 4, marginRight: 4, width: "calc(100% - 8px)" }}
@@ -563,7 +563,7 @@ function TreeRow({
         {/* Icon */}
         <span
           className={`flex h-[18px] w-[16px] shrink-0 items-center justify-center ${
-            isSelected ? "text-white/80" : "text-[var(--text-muted)]"
+            isSelected ? "text-[var(--accent-presence-foreground)] opacity-80" : "text-[var(--text-muted)]"
           }`}
           aria-hidden="true"
         >
@@ -579,7 +579,7 @@ function TreeRow({
         </span>
 
         {/* Name */}
-        <span className={`min-w-0 flex-1 truncate pl-1 ${isSelected ? "text-white" : ""}`}>
+        <span className={`min-w-0 flex-1 truncate pl-1 ${isSelected ? "text-[var(--accent-presence-foreground)]" : ""}`}>
           {entry.name}
         </span>
 

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -270,7 +270,7 @@ export function UpdateSettingsRow() {
   };
 
   const accentBtn =
-    "rounded-[var(--radius-control)] bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-white transition-opacity hover:opacity-90";
+    "rounded-[var(--radius-control)] bg-[var(--accent-presence)] px-3 py-1 text-[11px] font-semibold text-[var(--accent-presence-foreground)] transition-opacity hover:opacity-90";
   const secondaryBtn =
     "rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2.5 py-1 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
 


### PR DESCRIPTION
Phase 4 (global visual quieting) of the minimalism initiative (epic **cave-6pe**, task **cave-6pe.8**) — the accent-discipline sweep.

## Why
The token contract (`globals.css:66-68`, design language §2) is explicit: **hardcoded white on `--accent-presence` fails AA on every palette whose accent is light** (22 of 32 theme×mode combos). Repo memory + prior PRs (#2485, #2488, #2489) fixed these per-surface; this PR finishes the app-wide sweep.

## Changes (8 files, 17 lines)
`text-white` → `text-[var(--accent-presence-foreground)]` on accent-presence fills in: board-view (retry CTA), board-table + board-kanban (select checkmarks), github-action-popover (confirm), update-available + open-coven-tools-update (CTAs), project-tree (selected row text/icon/name), onboarding-overlay (8 accent CTAs + radio dots).

**Left alone deliberately**: white on success/danger `color-mix` fills (semantic tokens retune per mode, contrast holds), browser favicon monogram + theme-editor swatch glyph (non-themed arbitrary backgrounds).

## Verification
- `pnpm typecheck` ✓ · `pnpm test:app` 526 ✓ · `pnpm test:api` 118 ✓