### PR TITLE
fix(browser): close native webviews on surface leave and avoid 1x1 offscreen parking

### DIFF
--- a/src-tauri/capabilities/loopback-browser.json
+++ b/src-tauri/capabilities/loopback-browser.json
@@ -24,6 +24,7 @@
     "allow-browser-hide",
     "allow-browser-hide-all-except",
     "allow-browser-close",
+    "allow-browser-close-all",
     "allow-browser-reload",
     "allow-browser-report-title",
     "allow-browser-report-scroll"

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
   "allow-browser-hide",
   "allow-browser-hide-all-except",
   "allow-browser-close",
+  "allow-browser-close-all",
   "allow-browser-reload",
   "allow-browser-report-title",
   "allow-browser-report-scroll",

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -29,6 +29,7 @@ const requiredPermissionIds = [
   "allow-browser-hide",
   "allow-browser-hide-all-except",
   "allow-browser-close",
+  "allow-browser-close-all",
   "allow-browser-reload",
   "allow-shell-open",
 ];
@@ -45,6 +46,7 @@ const requiredCommands = [
   "browser_hide",
   "browser_hide_all_except",
   "browser_close",
+  "browser_close_all",
   "browser_reload",
   "shell_open",
 ];
@@ -160,6 +162,7 @@ test("packaged sidecar loopback origins can use browser commands and main-webvie
     "allow-browser-hide",
     "allow-browser-hide-all-except",
     "allow-browser-close",
+    "allow-browser-close-all",
     "allow-browser-reload",
     "allow-browser-report-title",
   ]) {

--- a/src-tauri/permissions/pty.toml
+++ b/src-tauri/permissions/pty.toml
@@ -54,6 +54,11 @@ description = "Allows closing an embedded browser webview."
 commands.allow = ["browser_close"]
 
 [[permission]]
+identifier = "allow-browser-close-all"
+description = "Allows closing every embedded browser webview for a pane during surface teardown."
+commands.allow = ["browser_close_all"]
+
+[[permission]]
 identifier = "allow-browser-reload"
 description = "Allows reloading an embedded browser webview."
 commands.allow = ["browser_reload"]

--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -14,6 +14,7 @@
 //   browser_hide(label)
 //   browser_hide_all_except(label)
 //   browser_close(label)
+//   browser_close_all(pane_label)
 //
 // Events:
 //   browser:page-load { label, url, phase: "started" | "finished" }
@@ -221,12 +222,14 @@ fn ensure_browser(
     Ok(true)
 }
 
+// Park the webview offscreen at its CURRENT size. Do not shrink it to 1×1:
+// collapsing the layer lets WKWebView drop its backing surface, and a later
+// browser_set_bounds re-seat can land as an unpainted (black) layer. Keeping
+// the real size while offscreen keeps the layer realized so it repaints
+// immediately when shown again.
 fn hide_webview(webview: &tauri::Webview) -> Result<(), String> {
     webview
         .set_position(LogicalPosition::new(OFFSCREEN_X, OFFSCREEN_Y))
-        .map_err(|e| e.to_string())?;
-    webview
-        .set_size(LogicalSize::new(1.0, 1.0))
         .map_err(|e| e.to_string())?;
     Ok(())
 }
@@ -316,6 +319,25 @@ pub fn browser_close(app: AppHandle, label: Option<String>) -> Result<(), String
     let label = safe_browser_label(label);
     if let Some(webview) = app.get_webview(&label) {
         webview.close().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// Destroy every native browser webview belonging to a pane (labels look
+/// like `cave-browser-<pane>-tab-<id>`), or every cave-browser webview when
+/// no pane label is given. Hiding only parks a webview offscreen — its page
+/// stays alive (and in the OS accessibility tree), so surface teardown must
+/// close instead. The navigate path recreates webviews on the next mount.
+#[tauri::command]
+pub fn browser_close_all(app: AppHandle, label: Option<String>) -> Result<(), String> {
+    let prefix = match label {
+        Some(raw) => format!("{}-tab-", safe_browser_label(Some(raw))),
+        None => BROWSER_LABEL_PREFIX.to_string(),
+    };
+    for (existing_label, webview) in app.webviews() {
+        if existing_label.starts_with(&prefix) {
+            webview.close().map_err(|e| e.to_string())?;
+        }
     }
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -941,6 +941,7 @@ pub fn run() {
             browser::browser_hide,
             browser::browser_hide_all_except,
             browser::browser_close,
+            browser::browser_close_all,
             browser::browser_reload,
             browser::browser_report_title,
             browser::browser_report_scroll,

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -316,6 +316,23 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
     return () => { cancelled = true; };
   }, [nativeBrowserAvailable, platform]);
 
+  // ── Close native webviews on unmount ──────────────────────────────
+  // Hiding only parks a webview offscreen — its page (and process) stays
+  // alive, so navigating away from the Browser surface left page content in
+  // the OS accessibility tree. Surface routing unmounts BrowserPane on
+  // surface leave, so destroy every native webview for this pane here; the
+  // navigate effect recreates them on the next mount. bridge arrives async,
+  // hence the ref — the cleanup must see the final bridge, not the mount-time
+  // null.
+  const bridgeRef = useRef<TauriBridge | null>(null);
+  bridgeRef.current = bridge;
+  useEffect(() => {
+    return () => {
+      void bridgeRef.current?.invoke("browser_close_all", { label });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // ── Page-load + title events ──────────────────────────────────────
   useEffect(() => {
     if (!bridge || !nativeBrowserAvailable) return;

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const pane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const rustBrowser = await readFile(new URL("../../src-tauri/src/browser.rs", import.meta.url), "utf8");
 
 // ───────── Task 1: Keyboard hint footer + [ shortcut ─────────
 assert.match(
@@ -148,6 +149,32 @@ assert.match(
   /const covered = toolbarOpenRef\.current \|\| surfaceIsCovered\(surface, rect\);[\s\S]{0,320}x: covered \? WEBVIEW_OFFSCREEN : rect\.left,\s*\n\s*y: covered \? WEBVIEW_OFFSCREEN : rect\.top,/,
   "navigate loads covered webviews offscreen; the bounds loop re-seats them when the cover lifts",
 );
+
+// ───────── Native webview lifecycle: close on surface leave ─────────
+// Hiding only parks a webview offscreen — the page stays alive and its
+// content lingers in the OS accessibility tree after leaving the Browser
+// surface. Unmount must CLOSE the pane's webviews, not hide them.
+assert.match(
+  pane,
+  /useEffect\(\(\) => \{\s*\n\s*return \(\) => \{\s*\n\s*void bridgeRef\.current\?\.invoke\("browser_close_all", \{ label \}\);/,
+  "unmount cleanup closes the pane's native webviews (browser_close_all), not just hides them",
+);
+assert.match(
+  rustBrowser,
+  /pub fn browser_close_all\(app: AppHandle, label: Option<String>\)[\s\S]{0,600}webview\.close\(\)/,
+  "browser_close_all destroys matching cave-browser webviews",
+);
+
+// ───────── Native webview lifecycle: no 1×1 offscreen parking ─────────
+// Shrinking the parked webview to 1×1 lets WKWebView drop its backing layer;
+// re-seating it with set_bounds could then render black. hide_webview must
+// move it offscreen only, keeping its real size so the layer stays realized.
+const hideWebviewFn = rustBrowser.match(
+  /fn hide_webview\(webview: &tauri::Webview\) -> Result<\(\), String> \{[\s\S]*?\n\}/,
+)?.[0];
+assert.ok(hideWebviewFn, "hide_webview() exists in src-tauri/src/browser.rs");
+assert.match(hideWebviewFn, /set_position\(LogicalPosition::new\(OFFSCREEN_X, OFFSCREEN_Y\)\)/, "hide_webview parks the webview offscreen");
+assert.doesNotMatch(hideWebviewFn, /set_size/, "hide_webview must not resize the parked webview (1×1 parking caused black re-paints)");
 
 // ───────── Task 4: Quick-open backdrop ─────────
 const qo = await readFile(new URL("./browser-quick-open.tsx", import.meta.url), "utf8");


### PR DESCRIPTION
## Problem

Two related native-browser defects on macOS (found via an accessibility/computer-use audit of v0.0.140):

1. **Browser pane renders black.** `hide_webview` parked webviews offscreen *and* shrank them to 1×1. Collapsing the layer lets WKWebView drop its backing surface, so a later `browser_set_bounds` re-seat can land as an unpainted (black) layer.
2. **Pages linger after leaving the Browser surface.** Hiding only parks a webview offscreen — its page and process stay alive, and the page content remains in the OS accessibility tree. Reproduction: with VoiceOver/a11y inspection, AXWebArea count goes 1 → 3 after opening the browser, and stays at 3 after leaving the surface.

## Fix

- `hide_webview` keeps the webview at its current size while offscreen, so the layer stays realized and repaints immediately when shown again.
- New `browser_close_all(pane_label)` Tauri command destroys every native webview belonging to a pane (prefix-scoped by label, so the `main` and `companion` panes can't affect each other).
- `BrowserPane` closes its native webviews on unmount instead of leaving them parked; the existing navigate path recreates them on the next mount. The cleanup reads the Tauri bridge through a ref since the bridge arrives async after mount.
- ACL entries added for the new command (`permissions/pty.toml`, `permissions/default.toml`, `capabilities/loopback-browser.json`, `desktop-permissions.test.mjs`) — without them the frontend invoke is denied silently.

## Tradeoff (deliberate, please weigh)

Tab ids are stable across mounts, so the old parking behavior effectively kept pages warm across surface leave/return (scroll position, sessions) via label reuse. This change reloads tabs on return. The same mechanism was the leak: webviews whose tabs went away were orphaned invisibly with live page processes. We chose deterministic teardown over warm pages; if maintainers prefer persistence, the a11y issue would need a different mechanism (e.g. detaching hidden webviews from the a11y tree).

Minor: in dev, React StrictMode's double-mount closes and recreates the webviews once when the surface opens (one reload flicker, dev only).

## Verification

- AXWebArea count now 1 → 3 (browser open) → 1 (surface leave); previously stuck at 3.
- Browser paints opencoven.ai (previously black).
- 518 app test files pass, `tsc` clean, `cargo check` clean; new `browser-polish.test.ts` covers the lifecycle.