### PR TITLE
fix(chat): Review on edit cards falls back to an in-chat diff modal (cave-1z2)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11094,6 +11094,23 @@ details[open] > .cave-edit-card__summary::before {
   font-size: 11px;
   color: var(--color-danger);
 }
+/* Review modal for edits the Changes panel can't show (file outside the
+   project root, or no repo-linked session): this edit's diff, full-size. */
+.cave-review-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+.cave-review-modal__path {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
+  color: var(--text-muted);
+}
 
 /* Quick-chat reveal: an in-app popover anchored top-right under the top bar,
    opened by the top-bar chat-circle icon. The Tauri standalone window

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -1060,6 +1060,29 @@ assert.match(source, /cave-edit-card/, "mutation tools render as an inline Codex
 assert.match(source, /diffStat/, "edit card derives a +/- stat");
 assert.match(source, /Review/, "edit card has a Review action");
 assert.match(globalsSrc, /\.cave-edit-card/, "edit card styling exists");
+
+// Review adapts to where the edit can actually be reviewed: a file under the
+// session's project root jumps to the code rail's Changes diff; anything else
+// (familiar-workspace docs, repo-less sessions, relative paths) opens an
+// in-chat modal with this edit's diff instead of dispatching an event nothing
+// can service. The actions row renders on every edit card — not only when an
+// absolute target path exists — so Review is always available.
+assert.match(
+  source,
+  /if \(relPath && targetFile\) \{[\s\S]{0,200}cave:open-file-diff[\s\S]{0,200}setReviewOpen\(true\)/,
+  "Review falls back to the in-chat diff modal when the Changes panel can't show the file",
+);
+assert.match(
+  source,
+  /<Modal[\s\S]{0,200}open=\{reviewOpen\}[\s\S]{0,600}<SyntaxBlock text=\{diff\} lang="diff" \/>/,
+  "the review modal renders this edit's structured diff",
+);
+assert.match(
+  source,
+  /<EditCardActions targetFile=\{targetFile\} diff=\{inputDiff \?\? ""\} displayPath=\{displayPath\} \/>/,
+  "edit-card actions render unconditionally (Review works without an absolute target path)",
+);
+assert.match(globalsSrc, /\.cave-review-modal/, "review modal styling exists");
 assert.match(
   source,
   /if \(isEditTool\) \{[\s\S]*<details className="cave-tool-block cave-edit-card"[\s\S]*Edited \{base\}[\s\S]*<DurationText durationMs=\{tool\.durationMs\} \/>[\s\S]*Code changes[\s\S]*<SyntaxBlock text=\{inputDiff\} lang="diff" \/>[\s\S]*<\/details>/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5800,24 +5800,43 @@ function ToolGroup({ tools }: { tools: ToolEvent[] }) {
 // five ToolBlock/ToolGroup render sites.
 const ToolProjectRootContext = createContext<string | null>(null);
 
-// Review + Undo actions for the Codex-style inline edit card. Review opens the
-// comux diff (unchanged behavior); Undo reverts the edited file to its last
-// committed state via `/api/changes` (which auto-snapshots the tree to a
-// checkpoint first, so the revert is itself recoverable). Undo requires a
-// two-step arm→confirm to avoid an accidental one-click revert, and is only
-// offered when the target resolves to a repo-relative path under the project
-// root.
-function EditCardActions({ targetFile }: { targetFile: string }) {
+// Review + Undo actions for the Codex-style inline edit card. Review adapts to
+// where the edit can actually be reviewed: a file under the session's project
+// root jumps to its diff in the code rail's Changes panel (cumulative diff +
+// checkpoint/undo tools); anything else — familiar-workspace docs, repo-less
+// sessions, relative paths — opens an in-chat modal with this edit's diff, so
+// the button never lands on an empty Changes list or silently does nothing.
+// Undo reverts the edited file to its last committed state via `/api/changes`
+// (which auto-snapshots the tree to a checkpoint first, so the revert is
+// itself recoverable). Undo requires a two-step arm→confirm to avoid an
+// accidental one-click revert, and is only offered when the target resolves to
+// a repo-relative path under the project root.
+function EditCardActions({
+  targetFile,
+  diff,
+  displayPath,
+}: {
+  targetFile: string | null;
+  diff: string;
+  displayPath: string;
+}) {
   const projectRoot = useContext(ToolProjectRootContext);
   const relPath =
-    projectRoot && targetFile.startsWith(projectRoot)
+    projectRoot && targetFile && targetFile.startsWith(projectRoot)
       ? targetFile.slice(projectRoot.length).replace(/^\/+/, "")
       : null;
   const [state, setState] = useState<"idle" | "armed" | "reverting" | "reverted" | "error">("idle");
   const [err, setErr] = useState<string | null>(null);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const base = displayPath.split("/").pop() || displayPath;
 
-  const review = () =>
-    window.dispatchEvent(new CustomEvent("cave:open-file-diff", { detail: { path: targetFile } }));
+  const review = () => {
+    if (relPath && targetFile) {
+      window.dispatchEvent(new CustomEvent("cave:open-file-diff", { detail: { path: targetFile } }));
+    } else {
+      setReviewOpen(true);
+    }
+  };
 
   const doUndo = async () => {
     if (!projectRoot || !relPath) return;
@@ -5842,9 +5861,31 @@ function EditCardActions({ targetFile }: { targetFile: string }) {
   return (
     <span className="cave-edit-card__actions" onClick={(e) => e.stopPropagation()}>
       {err ? <span className="cave-edit-card__error" title={err}>{err}</span> : null}
-      <button type="button" className="cave-edit-card__review focus-ring" onClick={review}>
+      <button
+        type="button"
+        className="cave-edit-card__review focus-ring"
+        onClick={review}
+        title={
+          relPath
+            ? "Review this file's pending diff in the Changes panel"
+            : "Review this edit's diff"
+        }
+      >
         Review
       </button>
+      <Modal
+        open={reviewOpen}
+        onClose={() => setReviewOpen(false)}
+        breadcrumb={["Review", base]}
+        wide
+      >
+        <div className="cave-review-modal">
+          <p className="cave-review-modal__path" title={displayPath}>
+            {displayPath}
+          </p>
+          <SyntaxBlock text={diff} lang="diff" />
+        </div>
+      </Modal>
       {relPath ? (
         state === "reverted" ? (
           <span className="cave-edit-card__reverted">Reverted</span>
@@ -5932,7 +5973,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
             {tool.status}
           </span>
           <DurationText durationMs={tool.durationMs} />
-          {targetFile ? <EditCardActions targetFile={targetFile} /> : null}
+          <EditCardActions targetFile={targetFile} diff={inputDiff ?? ""} displayPath={displayPath} />
         </summary>
         <div className="cave-tool-io mt-2">
           <div className="cave-tool-io-label">Code changes</div>


### PR DESCRIPTION
## What

The edit card's **Review** button dispatched `cave:open-file-diff` unconditionally. That only produces a meaningful result when the active session has a `project_root` **and** the edited file lives under it — the code rail's Changes panel matches the path against the repo's uncommitted files. For anything else (familiar-workspace docs like `~/.coven/workspaces/…`, repo-less sessions, relative paths) the click was a silent no-op: the rail either never opens (`rail.available` is false without a repo) or opens a Changes list that doesn't contain the file.

## Fix

- **In-root file** → unchanged: Review jumps to the file's diff in the rail's Changes panel (cumulative diff, checkpoints, undo, commit).
- **Everything else** → Review opens an in-chat `Modal` with this edit's structured diff (breadcrumb `Review › <file>`, full path, `SyntaxBlock lang="diff"`), Escape/backdrop closes with focus return via the shared focus trap.
- The actions row renders on **every** edit card — previously it was hidden entirely when the tool input had no absolute target path, leaving no Review affordance at all. Undo still requires a repo-relative path (unchanged).
- Button `title` states which behavior the click will get.

## Verification

- `pnpm test:app` — 527 test files green; new source-scan pins in `chat-view-polish.test.ts` cover the fallback branch, the modal diff, and the unconditional actions row.
- `tsc --noEmit` clean.
- Production build driven with mocked transcripts (Playwright): out-of-root edit → modal with diff, Escape closes; in-root edit → rail opens on Changes with the file's diff focused and Undo present.

Bead: cave-1z2

🤖 Generated with [Claude Code](https://claude.com/claude-code)