### PR TITLE
test(design): minimalism invariants — accent-white scan + reveal-scope pairing (cave-6pe.9)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -483,6 +483,7 @@ export const SUITES = {
 	    "src/components/ui/button.test.ts",
 	    "src/components/ui/popover.test.ts",
     "src/components/ui/overflow-menu.test.ts",
+    "src/components/minimalism-invariants.test.ts",
     "src/components/ui/select.test.ts",
     "src/components/ui/context-menu.test.ts",
     "src/components/ui/undo-toast.test.ts",

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -767,7 +767,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               type="button"
               onClick={() => onNewChat(undefined, fallbackFamiliarId)}
               disabled={!fallbackFamiliarId}
-              className="chat-list-new-button mt-0.5 flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-white shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
+              className="chat-list-new-button mt-0.5 flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-[var(--accent-presence-foreground)] shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
               Session
@@ -883,7 +883,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
               type="button"
               onClick={() => onNewChat(undefined, fallbackFamiliarId)}
               disabled={!fallbackFamiliarId}
-              className="chat-list-new-button flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-white shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
+              className="chat-list-new-button flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[12px] font-semibold text-[var(--accent-presence-foreground)] shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
               Session
@@ -1140,7 +1140,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                               aria-hidden
                               className={`mt-[3px] grid h-4 w-4 shrink-0 place-items-center rounded border ${
                                 selectedIds.has(s.id)
-                                  ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-white"
+                                  ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
                                   : "border-[var(--border-strong)] text-transparent"
                               }`}
                             >

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1749,7 +1749,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         <button
                           type="button"
                           onClick={() => onNewChat(selectedProject.root)}
-                          className="flex h-7 items-center gap-1 rounded-md bg-[var(--accent-presence)] px-2.5 text-[11px] font-medium text-white hover:opacity-85"
+                          className="flex h-7 items-center gap-1 rounded-md bg-[var(--accent-presence)] px-2.5 text-[11px] font-medium text-[var(--accent-presence-foreground)] hover:opacity-85"
                         >
                           <Icon name="ph:chat-circle-dots" width={12} />
                           New chat

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -1256,7 +1256,7 @@ export function HomeComposer({
                 type="button"
                 onClick={() => void handleSubmit()}
                 disabled={(!text.trim() && attachments.length === 0) || sending}
-                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-white transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
+                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
                 title={`Send message (${keys.enter})`}
                 aria-label="Send"
               >

--- a/src/components/minimalism-invariants.test.ts
+++ b/src/components/minimalism-invariants.test.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+// Minimalism-initiative invariants (epic cave-6pe, design language §8).
+// Repo-wide source scans that keep the quieting work from regressing:
+//
+//  1. No hardcoded white foreground on an --accent-presence fill. The token
+//     contract (globals.css) is explicit: white fails AA on the 22 of 32
+//     palette×mode combos whose accent is light — use
+//     --accent-presence-foreground (swept app-wide in PR #2499).
+//
+//  2. Every component that applies `.reveal-on-hover` must also establish a
+//     `.reveal-scope` (or rely on a self-revealing guard) in the same file —
+//     an orphaned reveal-on-hover control would simply be invisible.
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Temporary debt: another live session holds the edit claim on chat-view.tsx
+// (multi-session coordination §1), so its two accent/text-white instances are
+// tracked on bead cave-6pe.7 instead of being fixed here. Remove this entry
+// with that bead.
+const ACCENT_WHITE_ALLOWLIST = new Set(["components/chat-view.tsx"]);
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else if (full.endsWith(".tsx") && !full.endsWith(".test.tsx")) yield full;
+  }
+}
+
+const offendersWhite = [];
+const offendersScope = [];
+
+for (const file of walk(SRC)) {
+  const src = readFileSync(file, "utf8");
+  const rel = path.relative(SRC, file);
+
+  // 1. Same class string carrying both an accent-presence background and a
+  //    hardcoded white foreground.
+  for (const m of src.matchAll(/className=\{?[`"']([^`"']*)[`"']/g)) {
+    const cls = m[1];
+    if (cls.includes("bg-[var(--accent-presence)]") && /(?:^|\s)text-white(?:\/\d+)?(?:\s|$)/.test(cls)) {
+      offendersWhite.push(rel);
+    }
+  }
+  // Also catch ternary halves like `? "bg-[var(--accent-presence)] text-white"`.
+  if (/bg-\[var\(--accent-presence\)\][^"'`\n]*text-white/.test(src)) {
+    offendersWhite.push(rel);
+  }
+
+  // 2. reveal-on-hover applied as a class needs a reveal-scope in the file.
+  const applies = /(?:className|class)=[^>\n]*reveal-on-hover/.test(src);
+  if (applies && !src.includes("reveal-scope")) {
+    offendersScope.push(rel);
+  }
+}
+
+assert.deepEqual(
+  [...new Set(offendersWhite)].filter((f) => !ACCENT_WHITE_ALLOWLIST.has(f)),
+  [],
+  "hardcoded white foreground on an accent-presence fill — use --accent-presence-foreground (design language §2/§8)",
+);
+assert.deepEqual(
+  offendersScope,
+  [],
+  "reveal-on-hover applied without a reveal-scope in the same file — the control would never reveal (design language §8)",
+);
+
+console.log("minimalism-invariants.test.ts: ok");


### PR DESCRIPTION
Phase 5 (verification & hardening) — the final phase of the minimalism initiative (epic **cave-6pe**, task **cave-6pe.9**).

## Changes
- **`minimalism-invariants.test.ts`** — repo-wide source scan, wired into the app suite:
  1. No hardcoded white foreground on an `--accent-presence` fill in any `src/**/*.tsx` (the token rule enforced piecemeal by #2485/#2488/#2489/#2499 — now a CI invariant).
  2. Every file applying `.reveal-on-hover` also establishes a `.reveal-scope` — an orphaned reveal control would be permanently invisible.
- The scan **immediately caught 3 stragglers**: comux-view, home-composer, chat-list — fixed here. `chat-view.tsx` is allowlisted with a comment pointing at bead **cave-6pe.7** (a live session holds its edit claim; multi-session coordination §1).

## Epic wrap-up
9 PRs merged: #2481 foundations · #2482 shell · #2483 board · #2485 calendar · #2488 browser · #2489 automations · #2490 github · #2499 accent sweep · this. Before/after chrome census recorded on the bead. Remaining: cave-6pe.7 (Chat, claim-gated).

## Verification
- `check-tests-wired` 712 ✓ · `pnpm typecheck` ✓ · `pnpm test:app` 528 ✓