### PR TITLE
feat(daily-report): day-in-review facts — merged PRs, session groups, cards done (cave-05p)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -138,6 +138,7 @@ export const SUITES = {
     "src/app/dashboard-runtime-smoke.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/lib/daily-summary-refresh.test.ts",
+    "src/lib/daily-report-facts.test.ts",
     "src/components/dev-cache-reset-script.test.ts",
     "src/components/pwa-register.test.ts",
     "src/lib/readable-text-color.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -262,6 +262,21 @@ for (const contract of contracts) {
     /dateMismatch/,
     "/inbox/daily-summary must reject payloads computed for a different day (midnight-rollover race)",
   );
+  assert.match(
+    dailySummarySource,
+    /fetchMergedPrsForDay\(now\)\.catch\(/,
+    "/inbox/daily-summary should gather merged PRs server-side, degrading to absent on failure",
+  );
+  assert.match(
+    dailySummarySource,
+    /loadBoard\(\)\.catch\(/,
+    "/inbox/daily-summary should gather completed cards server-side, degrading to absent on failure",
+  );
+  assert.match(
+    dailySummarySource,
+    /narrative:\s*existing\.media\?\.narrative/,
+    "/inbox/daily-summary fact refreshes must preserve the narrative layered on top",
+  );
 }
 
 // CHAT-D5-02: cancelling a streaming response (Esc/Stop) must persist an

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -10,7 +10,11 @@ import {
   buildDailySummaryContent,
   dailySummaryAutoKey,
   dateSlug,
+  type DailySummaryExtras,
 } from "@/lib/daily-summary-notifications";
+import { completedCardsForDay, unionMergedPrs } from "@/lib/daily-report-facts";
+import { fetchMergedPrsForDay } from "@/lib/server/github-merged";
+import { loadBoard } from "@/lib/cave-board";
 import type { SessionRow } from "@/lib/types";
 import { isLocalOrigin } from "@/lib/server/local-origin";
 
@@ -37,11 +41,26 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: true, created: false, updated: false, dateMismatch: true });
   }
 
+  const sessions = Array.isArray(body.sessions) ? body.sessions : [];
+
+  // Day-in-review facts the client can't see, gathered outside the inbox
+  // lock (GitHub can take seconds; the lock serializes every inbox write).
+  // Each source degrades to "absent" — never an error, never a blocked write.
+  const [githubPrs, board] = await Promise.all([
+    fetchMergedPrsForDay(now).catch(() => null),
+    loadBoard().catch(() => null),
+  ]);
+  const extras: DailySummaryExtras = {
+    prsMerged: unionMergedPrs(githubPrs, sessions, now),
+    cardsCompleted: board ? completedCardsForDay(board.cards, now) : undefined,
+  };
+
   const result = await withInboxLock(async () => {
     const file = await loadInbox();
     const draft = buildDailySummaryContent({
       items: file.items,
-      sessions: Array.isArray(body.sessions) ? body.sessions : [],
+      sessions,
+      extras,
       now,
     });
     if (!draft) return null;
@@ -55,7 +74,8 @@ export async function POST(req: Request) {
         title: draft.title,
         body: draft.body,
         link: draft.link,
-        media: { ...draft.media },
+        // A fact-only refresh must not discard the narrative layered on top.
+        media: { ...draft.media, narrative: existing.media?.narrative ?? null },
         updatedAt: now.toISOString(),
       };
       file.items = file.items.map((item) => (item.id === existing.id ? refreshed : item));

--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -23,4 +23,12 @@ assert.match(page, /ItemRow/, "report should render deep-linkable item rows");
 assert.match(page, /href="\/dashboard"/, "report should link back to the dashboard");
 assert.match(page, /dr-page/, "report should use the shared daily-report surface styling");
 
+// Day-in-review sections (Phase B) render from the frozen media.report facts,
+// with the flat body-recovered list kept as the pre-Phase-B fallback.
+assert.match(page, /item\.media\?\.report/, "report should read the structured day-in-review facts");
+assert.match(page, /Merged pull requests/, "report should list PRs merged during the day");
+assert.match(page, /Sessions by project/, "report should group sessions by project");
+assert.match(page, /Cards completed/, "report should list board cards finished during the day");
+assert.match(page, /Recent sessions/, "pre-Phase-B reports should keep the flat recovered session list");
+
 console.log("daily-report-page.test.ts: ok");

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -77,18 +77,26 @@ export default async function DailyReportPage({ params }: Props) {
       const s = statBySlug.get(slugFor(d));
       out.push({
         label: d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }),
-        value: s ? s[metric] : null,
+        // Optional metrics are absent on pre-Phase-B reports — chart as gaps.
+        value: s ? (s[metric] ?? null) : null,
       });
     }
     return out;
   };
   const recentSessions = parseRecentSessions(item.body);
+  // Structured day-in-review facts — frozen per refresh, absent on old items.
+  const report = item.media?.report ?? null;
   // media.generatedAt moves on every in-place refresh; firedAt stays at the
   // day's first generation, so prefer the former for a truthful timestamp.
   const generatedAt = item.media?.generatedAt ?? item.firedAt ?? item.updatedAt ?? null;
   const isToday = parsedDate ? slugFor(parsedDate) === slugFor(new Date()) : false;
   const totalEvents = stats
-    ? stats.reminders + stats.responses + stats.familiars + stats.sessions
+    ? stats.reminders +
+      stats.responses +
+      stats.familiars +
+      stats.sessions +
+      (stats.prsMerged ?? 0) +
+      (stats.cardsCompleted ?? 0)
     : 0;
 
   return (
@@ -184,6 +192,26 @@ export default async function DailyReportPage({ params }: Props) {
               accent="green"
               trend={trendFor("sessions")}
             />
+            {typeof stats.prsMerged === "number" ? (
+              <MetricCard
+                icon="ph:git-pull-request"
+                value={stats.prsMerged}
+                label="PRs merged"
+                caption="Shipped to main"
+                accent="blue"
+                trend={trendFor("prsMerged")}
+              />
+            ) : null}
+            {typeof stats.cardsCompleted === "number" ? (
+              <MetricCard
+                icon="ph:kanban-bold"
+                value={stats.cardsCompleted}
+                label="Cards completed"
+                caption="Board work finished"
+                accent="amber"
+                trend={trendFor("cardsCompleted")}
+              />
+            ) : null}
           </section>
         ) : null}
 
@@ -224,8 +252,103 @@ export default async function DailyReportPage({ params }: Props) {
           </section>
         ) : null}
 
-        {/* Sessions — recovered from the frozen summary body (daemon-backed). */}
-        {recentSessions.length > 0 ? (
+        {/* Shipped — PRs merged during this day (day-in-review facts). */}
+        {report?.prsMerged && report.prsMerged.length > 0 ? (
+          <section className="dr-section" aria-label="Merged pull requests">
+            <SectionHead
+              icon="ph:git-pull-request"
+              title="Merged pull requests"
+              count={report.prsMerged.length}
+            />
+            <div className="dr-list">
+              {report.prsMerged.map((pr) => (
+                <a
+                  key={`${pr.repo}#${pr.number}`}
+                  className="dr-row"
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ ["--row-accent" as string]: "var(--color-info)" }}
+                >
+                  <span className="dr-row__icon">
+                    <Icon name="ph:git-pull-request" aria-hidden />
+                  </span>
+                  <span className="dr-row__body">
+                    <span className="dr-row__title">{pr.title}</span>
+                    <span className="dr-row__metaline">
+                      <span className="dr-tag">
+                        {pr.repo}#{pr.number}
+                      </span>
+                      <span className="dr-row__time">merged {relativeTime(pr.mergedAt)}</span>
+                    </span>
+                  </span>
+                  <span className="dr-row__open">
+                    <span>Open</span>
+                    <Icon name="ph:arrow-right-bold" aria-hidden />
+                  </span>
+                </a>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Sessions grouped by project (structured facts), falling back to the
+            flat list recovered from the frozen body on pre-Phase-B reports. */}
+        {report?.sessionGroups && report.sessionGroups.length > 0 ? (
+          <section className="dr-section" aria-label="Sessions by project">
+            <SectionHead
+              icon="ph:graph-bold"
+              title="Sessions by project"
+              count={report.sessionGroups.length}
+            />
+            <div className="dr-groups">
+              {report.sessionGroups.map((group) => (
+                <div key={group.key} className="dr-group">
+                  <div className="dr-group__head">
+                    <span className="dr-group__label">
+                      <Icon name="ph:code-bold" aria-hidden />
+                      {group.label}
+                    </span>
+                    {group.additions + group.deletions > 0 ? (
+                      <span className="dr-diffstat">
+                        <span className="dr-diffstat__add">+{group.additions}</span>
+                        <span className="dr-diffstat__del">-{group.deletions}</span>
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="dr-list">
+                    {group.sessions.map((session) => (
+                      <div
+                        key={session.id}
+                        className="dr-row"
+                        style={{ ["--row-accent" as string]: "var(--color-success)" }}
+                      >
+                        <span className="dr-row__icon">
+                          <Icon name="ph:code-bold" aria-hidden />
+                        </span>
+                        <span className="dr-row__body">
+                          <span className="dr-row__title">{session.title}</span>
+                        </span>
+                        {session.pr?.url ? (
+                          <a
+                            className="dr-pr-chip"
+                            href={session.pr.url}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <Icon name="ph:git-pull-request" aria-hidden />
+                            {session.pr.repo?.split("/").pop() ?? session.pr.repo}
+                            {typeof session.pr.number === "number" ? `#${session.pr.number}` : ""}
+                          </a>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        ) : recentSessions.length > 0 ? (
           <section className="dr-section" aria-label="Recent sessions">
             <SectionHead
               icon="ph:graph-bold"
@@ -242,6 +365,41 @@ export default async function DailyReportPage({ params }: Props) {
                     <span className="dr-row__title">{line}</span>
                   </span>
                 </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Board cards finished today. */}
+        {report?.cardsCompleted && report.cardsCompleted.length > 0 ? (
+          <section className="dr-section" aria-label="Cards completed">
+            <SectionHead
+              icon="ph:kanban-bold"
+              title="Cards completed"
+              count={report.cardsCompleted.length}
+            />
+            <div className="dr-list">
+              {report.cardsCompleted.map((card) => (
+                <a
+                  key={card.id}
+                  className="dr-row"
+                  href={`/#card-${card.id}`}
+                  style={{ ["--row-accent" as string]: "var(--color-warning)" }}
+                >
+                  <span className="dr-row__icon">
+                    <Icon name="ph:kanban-bold" aria-hidden />
+                  </span>
+                  <span className="dr-row__body">
+                    <span className="dr-row__title">{card.title}</span>
+                    <span className="dr-row__metaline">
+                      <span className="dr-row__time">completed {relativeTime(card.completedAt)}</span>
+                    </span>
+                  </span>
+                  <span className="dr-row__open">
+                    <span>Open</span>
+                    <Icon name="ph:arrow-right-bold" aria-hidden />
+                  </span>
+                </a>
               ))}
             </div>
           </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9092,6 +9092,62 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   box-shadow: 0 24px 60px -36px color-mix(in oklch, var(--accent-presence) 70%, #000);
 }
 
+/* Day-in-review: sessions grouped by project ------------------------------- */
+.dr-groups { display: grid; gap: 14px; }
+.dr-group {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-raised);
+  padding: 12px 14px;
+  display: grid;
+  gap: 10px;
+}
+.dr-group__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.dr-group__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 620;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dr-group__label svg { color: var(--color-success); flex: none; }
+.dr-diffstat {
+  display: inline-flex;
+  gap: 8px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  flex: none;
+}
+.dr-diffstat__add { color: var(--color-success); }
+.dr-diffstat__del { color: var(--color-danger); }
+.dr-pr-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  align-self: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-decoration: none;
+  color: var(--color-info);
+  border: 1px solid color-mix(in oklch, var(--color-info) 38%, transparent);
+  background: color-mix(in oklch, var(--color-info) 9%, transparent);
+}
+.dr-pr-chip:hover {
+  border-color: color-mix(in oklch, var(--color-info) 55%, transparent);
+  background: color-mix(in oklch, var(--color-info) 15%, transparent);
+}
+
 /* Dashboard quick links ----------------------------------------------------- */
 /* Six links: 2 cols (mobile) → 3 cols, so rows always fill evenly (no orphan). */
 .dr-quicklinks {

--- a/src/components/dashboard/today-summary.tsx
+++ b/src/components/dashboard/today-summary.tsx
@@ -46,6 +46,28 @@ export function TodaySummary({
               Today&apos;s summary is still taking shape — it fills in as activity lands.
             </p>
           )}
+          {summary.report?.prsMerged && summary.report.prsMerged.length > 0 ? (
+            <div className="dash-today__sessions" aria-label="Merged pull requests">
+              <span className="dash-today__sessions-label">
+                <Icon name="ph:git-pull-request" aria-hidden />
+                Shipped
+              </span>
+              <div className="dash-today__chips">
+                {summary.report.prsMerged.map((pr) => (
+                  <a
+                    key={`${pr.repo}#${pr.number}`}
+                    className="dash-today__chip dash-today__chip--link"
+                    href={pr.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    title={pr.title}
+                  >
+                    {pr.repo.split("/").pop()}#{pr.number}
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
           {summary.recentSessions.length > 0 ? (
             <div className="dash-today__sessions" aria-label="Recent sessions">
               <span className="dash-today__sessions-label">

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
+import type { DailyReportPayload } from "./daily-report-facts.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 const INBOX_PATH = path.join(homedir(), ".coven", "cave-inbox.json");
@@ -31,8 +32,20 @@ export type InboxMedia = {
     responses: number;
     familiars: number;
     sessions: number;
+    /** Optional day-in-review counts — absent on items generated before Phase B. */
+    prsMerged?: number;
+    cardsCompleted?: number;
   };
   generatedAt: string;
+  /** Structured day-in-review facts, frozen per refresh. Absent on old items. */
+  report?: DailyReportPayload | null;
+  /** Familiar-written narrative layered on the facts (Phase C). */
+  narrative?: {
+    text: string;
+    familiarId: string;
+    generatedAt: string;
+    factsHash: string;
+  } | null;
 };
 
 export type InboxItem = {

--- a/src/lib/daily-report-facts.test.ts
+++ b/src/lib/daily-report-facts.test.ts
@@ -1,0 +1,141 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildSessionGroups,
+  completedCardsForDay,
+  dailyFactsHash,
+  reportSessionTitle,
+  unionMergedPrs,
+} from "./daily-report-facts.ts";
+
+const now = new Date("2026-06-18T21:15:00.000Z");
+
+const session = (over) => ({
+  id: "s1",
+  title: "Fix board chat route",
+  status: "completed",
+  updated_at: "2026-06-18T20:00:00.000Z",
+  created_at: "2026-06-18T19:00:00.000Z",
+  project_root: "/repo/coven-cave",
+  harness: "codex",
+  exit_code: 0,
+  archived_at: null,
+  ...over,
+});
+
+// ── Session groups ──────────────────────────────────────────────────────────
+{
+  const groups = buildSessionGroups(
+    [
+      session({ id: "a1", project_root: "/repo/coven-cave", diff: { additions: 10, deletions: 2 } }),
+      session({
+        id: "a2",
+        project_root: "/repo/coven-cave",
+        title: "fix board chat route",
+        updated_at: "2026-06-18T19:30:00.000Z",
+        diff: { additions: 5, deletions: 1 },
+      }),
+      session({
+        id: "b1",
+        project_root: "/repo/open-meow",
+        title: "Ship the parser",
+        updated_at: "2026-06-18T18:00:00.000Z",
+        pullRequest: { repo: "OpenCoven/open-meow", number: 26, url: "https://github.com/OpenCoven/open-meow/pull/26", state: "merged" },
+      }),
+      session({ id: "old", updated_at: "2026-06-17T18:00:00.000Z" }),
+      session({ id: "arch", archived_at: "2026-06-18T12:00:00.000Z" }),
+    ],
+    now,
+  );
+  assert.equal(groups.length, 2, "sessions should group by project, today only");
+  const cave = groups.find((g) => g.label === "coven-cave");
+  assert.ok(cave, "group label should be the project basename");
+  assert.equal(cave.sessions.length, 1, "duplicate titles should dedupe within a group");
+  assert.equal(cave.additions, 15, "group totals should sum every session, not just listed ones");
+  assert.equal(cave.deletions, 3);
+  const meow = groups.find((g) => g.label === "open-meow");
+  assert.equal(meow.sessions[0].pr?.number, 26, "session PR context should ride into the group");
+}
+
+// ── Completed cards ─────────────────────────────────────────────────────────
+{
+  const cards = completedCardsForDay(
+    [
+      { id: "c1", title: "Ship it", lifecycle: "completed", lifecycleAt: "2026-06-18T15:00:00.000Z", updatedAt: "2026-06-18T15:00:00.000Z" },
+      { id: "c2", title: "Dragged to done", status: "done", lifecycle: "review", lifecycleAt: null, updatedAt: "2026-06-18T16:00:00.000Z" },
+      { id: "c3", title: "Old completion", lifecycle: "completed", lifecycleAt: "2026-06-17T15:00:00.000Z", updatedAt: "2026-06-17T15:00:00.000Z" },
+      { id: "c4", title: "Still running", lifecycle: "running", lifecycleAt: "2026-06-18T15:00:00.000Z", updatedAt: "2026-06-18T15:00:00.000Z" },
+    ],
+    now,
+  );
+  assert.deepEqual(
+    cards.map((c) => c.id),
+    ["c2", "c1"],
+    "completed = lifecycle completed today or dragged to done today, newest first",
+  );
+}
+
+// ── Merged PR union ─────────────────────────────────────────────────────────
+{
+  const gh = [
+    { repo: "OpenCoven/coven-cave", number: 2497, title: "keep today's report live", url: "https://github.com/OpenCoven/coven-cave/pull/2497", mergedAt: "2026-06-18T17:00:00.000Z" },
+  ];
+  const withPrSession = [
+    session({
+      id: "pr1",
+      pullRequest: { repo: "OpenCoven/open-meow", number: 26, url: "https://github.com/OpenCoven/open-meow/pull/26", state: "merged" },
+    }),
+    session({
+      id: "pr2",
+      pullRequest: { repo: "OpenCoven/coven-cave", number: 2497, url: "https://github.com/OpenCoven/coven-cave/pull/2497", state: "merged" },
+    }),
+    session({ id: "pr3", pullRequest: { repo: "OpenCoven/coven-cave", number: 9, url: "", state: "open" } }),
+  ];
+  const union = unionMergedPrs(gh, withPrSession, now);
+  assert.equal(union.length, 2, "GitHub and session PRs should union, deduped by repo#number");
+  assert.equal(
+    union.find((pr) => pr.number === 2497).title,
+    "keep today's report live",
+    "GitHub data should win the dedupe (real title)",
+  );
+  assert.equal(
+    unionMergedPrs(null, [session({ id: "plain" })], now),
+    undefined,
+    "no PAT and no session PRs should yield an absent section, not an empty one",
+  );
+  assert.equal(
+    unionMergedPrs(null, withPrSession, now).length,
+    2,
+    "session-attached merged PRs should surface even without a PAT",
+  );
+}
+
+// ── Facts hash ──────────────────────────────────────────────────────────────
+{
+  const stats = { reminders: 1, responses: 0, familiars: 0, sessions: 2 };
+  const groups = buildSessionGroups([session({ id: "h1" })], now);
+  const a = dailyFactsHash({ stats, sessionGroups: groups });
+  assert.equal(a, dailyFactsHash({ stats, sessionGroups: groups }), "hash should be stable");
+  assert.notEqual(
+    a,
+    dailyFactsHash({ stats: { ...stats, sessions: 3 }, sessionGroups: groups }),
+    "changed facts should change the hash",
+  );
+  assert.equal(
+    a,
+    dailyFactsHash({
+      stats,
+      sessionGroups: groups.map((g) => ({ ...g, sessions: [...g.sessions] })),
+    }),
+    "hash should not depend on object identity",
+  );
+}
+
+// ── Title hygiene (canonical home of reportSessionTitle) ────────────────────
+assert.equal(
+  reportSessionTitle({ title: "## Prior conversation **User:** Merge PR #26 **" }),
+  "Untitled session",
+);
+assert.equal(reportSessionTitle({ title: "**Fix** the `parser`" }), "Fix the parser");
+
+console.log("daily-report-facts.test.ts: ok");

--- a/src/lib/daily-report-facts.ts
+++ b/src/lib/daily-report-facts.ts
@@ -1,0 +1,260 @@
+// Day-in-review facts for the daily report: what actually happened today —
+// merged PRs, sessions grouped by project, board cards completed — frozen
+// into the daily-summary item's `media.report` on each refresh. Pure (no
+// node: imports, no fetches) so the builder, the report page, and loaderless
+// tests can all share it. The GitHub search itself is server-only and lives
+// in server/github-merged.ts.
+
+import { sanitizeSessionTitle } from "./cave-chat-titles.ts";
+import type { SessionRow } from "./types";
+
+export type MergedPr = {
+  /** "owner/name" */
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  mergedAt: string;
+};
+
+export type CompletedCard = {
+  id: string;
+  title: string;
+  projectId?: string | null;
+  familiarId?: string | null;
+  completedAt: string;
+};
+
+export type ReportSession = {
+  id: string;
+  title: string;
+  familiarId?: string | null;
+  additions?: number;
+  deletions?: number;
+  pr?: { repo?: string; number?: number; url?: string; state?: string } | null;
+};
+
+export type SessionGroup = {
+  /** Grouping key — the session's project_root. */
+  key: string;
+  /** Human label — the project directory's basename. */
+  label: string;
+  sessions: ReportSession[];
+  additions: number;
+  deletions: number;
+};
+
+export type DailyReportPayload = {
+  /** Absent (not empty) when neither GitHub nor session PR data is available. */
+  prsMerged?: MergedPr[];
+  /** Absent when the board could not be read. */
+  cardsCompleted?: CompletedCard[];
+  sessionGroups?: SessionGroup[];
+  /** Stable hash of the facts — the narrative layer regenerates on change. */
+  factsHash: string;
+  refreshedAt: string;
+};
+
+const REPORT_TITLE_MAX = 64;
+
+// Session titles come from harness transcripts and can leak raw markdown
+// ("## Prior conversation **User:** Merge PR #26 **"). Report surfaces render
+// plain text, so markdown syntax must be stripped, not rendered.
+const MD_HEADING_RE = /^#{1,6}\s+/;
+const MD_EMPHASIS_RE = /(\*\*|__|[*_`])/g;
+const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
+
+/** Session title as it should appear in the daily report: sanitized of
+ *  harness-preamble leaks (via sanitizeSessionTitle), stripped of markdown
+ *  syntax, truncated to a report-sized string. Falls back to "Untitled
+ *  session" when nothing survives. */
+export function reportSessionTitle(session: Pick<SessionRow, "title">): string {
+  const sanitized = sanitizeSessionTitle(session.title);
+  if (!sanitized) return "Untitled session";
+  const stripped = sanitized
+    .replace(MD_HEADING_RE, "")
+    .replace(MD_EMPHASIS_RE, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!stripped || PRIOR_CONVERSATION_LEAK_RE.test(stripped)) return "Untitled session";
+  if (stripped.length <= REPORT_TITLE_MAX) return stripped;
+  return `${stripped.slice(0, REPORT_TITLE_MAX - 1).trimEnd()}…`;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+}
+
+function isSameLocalDay(iso: string | null | undefined, day: Date): boolean {
+  if (!iso) return false;
+  const value = new Date(iso);
+  if (Number.isNaN(value.getTime())) return false;
+  const start = startOfLocalDay(day).getTime();
+  return value.getTime() >= start && value.getTime() < start + 24 * 60 * 60 * 1000;
+}
+
+function projectLabel(root: string): string {
+  const segments = root.split(/[\\/]/).filter(Boolean);
+  return segments[segments.length - 1] ?? root;
+}
+
+const MAX_GROUPS = 6;
+const MAX_SESSIONS_PER_GROUP = 5;
+
+/**
+ * Today's non-archived sessions grouped by project, newest activity first.
+ * Titles are report-sanitized and deduped within a group; per-group diff
+ * totals sum every session in the group (not just the listed ones).
+ */
+export function buildSessionGroups(sessions: SessionRow[], now: Date): SessionGroup[] {
+  const today = sessions
+    .filter((session) => !session.archived_at && isSameLocalDay(session.updated_at, now))
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+
+  const groups = new Map<string, SessionGroup & { seen: Set<string> }>();
+  for (const session of today) {
+    const key = session.project_root || "(no project)";
+    let group = groups.get(key);
+    if (!group) {
+      group = { key, label: projectLabel(key), sessions: [], additions: 0, deletions: 0, seen: new Set() };
+      groups.set(key, group);
+    }
+    group.additions += session.diff?.additions ?? 0;
+    group.deletions += session.diff?.deletions ?? 0;
+    const title = reportSessionTitle(session);
+    const titleKey = title.toLowerCase();
+    if (group.seen.has(titleKey) || group.sessions.length >= MAX_SESSIONS_PER_GROUP) continue;
+    group.seen.add(titleKey);
+    group.sessions.push({
+      id: session.id,
+      title,
+      familiarId: session.familiarId ?? null,
+      additions: session.diff?.additions,
+      deletions: session.diff?.deletions,
+      pr: session.pullRequest
+        ? {
+            repo: session.pullRequest.repo,
+            number: session.pullRequest.number,
+            url: session.pullRequest.url,
+            state: session.pullRequest.state,
+          }
+        : null,
+    });
+  }
+
+  // Busiest groups first (by session count, then diff volume), capped.
+  return [...groups.values()]
+    .sort(
+      (a, b) =>
+        b.sessions.length - a.sessions.length ||
+        b.additions + b.deletions - (a.additions + a.deletions),
+    )
+    .slice(0, MAX_GROUPS)
+    .map(({ seen: _seen, ...group }) => group);
+}
+
+/**
+ * Merge the GitHub search results with PRs already attached to today's
+ * sessions (SessionRow.pullRequest, state "merged"), deduped by repo#number —
+ * GitHub data wins (it has the real title and merge time). Returns undefined
+ * when neither source has anything to say (PAT unconfigured and no session
+ * PRs), so the section is absent rather than an empty claim.
+ */
+export function unionMergedPrs(
+  fromGitHub: MergedPr[] | null,
+  sessions: SessionRow[],
+  now: Date,
+): MergedPr[] | undefined {
+  const byKey = new Map<string, MergedPr>();
+  for (const session of sessions) {
+    const pr = session.pullRequest;
+    if (!pr || pr.state !== "merged" || typeof pr.number !== "number") continue;
+    if (!isSameLocalDay(session.updated_at, now)) continue;
+    byKey.set(`${pr.repo}#${pr.number}`, {
+      repo: pr.repo,
+      number: pr.number,
+      title: reportSessionTitle(session),
+      url: pr.url ?? `https://github.com/${pr.repo}/pull/${pr.number}`,
+      mergedAt: session.updated_at,
+    });
+  }
+  for (const pr of fromGitHub ?? []) {
+    byKey.set(`${pr.repo}#${pr.number}`, pr);
+  }
+  if (fromGitHub === null && byKey.size === 0) return undefined;
+  return [...byKey.values()].sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+}
+
+/** Structural card shape — keeps this module decoupled from the board store. */
+type CardLike = {
+  id: string;
+  title: string;
+  status?: string;
+  lifecycle?: string;
+  lifecycleAt?: string | null;
+  updatedAt?: string;
+  projectId?: string | null;
+  familiarId?: string | null;
+};
+
+const MAX_COMPLETED_CARDS = 10;
+
+/**
+ * Board cards finished today: primarily lifecycle "completed" stamped today,
+ * plus cards manually dragged to "done" today (their only timestamp is
+ * updatedAt). Newest first, capped.
+ */
+export function completedCardsForDay(cards: CardLike[], now: Date): CompletedCard[] {
+  const out: CompletedCard[] = [];
+  for (const card of cards) {
+    const completedAt =
+      card.lifecycle === "completed" && isSameLocalDay(card.lifecycleAt, now)
+        ? (card.lifecycleAt as string)
+        : card.status === "done" && isSameLocalDay(card.updatedAt, now)
+          ? (card.updatedAt as string)
+          : null;
+    if (!completedAt) continue;
+    out.push({
+      id: card.id,
+      title: card.title,
+      projectId: card.projectId ?? null,
+      familiarId: card.familiarId ?? null,
+      completedAt,
+    });
+  }
+  return out.sort((a, b) => b.completedAt.localeCompare(a.completedAt)).slice(0, MAX_COMPLETED_CARDS);
+}
+
+function djb2Hex(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) >>> 0;
+  }
+  return hash.toString(16);
+}
+
+/**
+ * Stable hash of the day's facts. Deliberately excludes timestamps
+ * (refreshedAt, mergedAt) so a mere refresh with unchanged facts never
+ * invalidates the narrative built on top of them.
+ */
+export function dailyFactsHash(input: {
+  stats: { reminders: number; responses: number; familiars: number; sessions: number };
+  prsMerged?: MergedPr[];
+  cardsCompleted?: CompletedCard[];
+  sessionGroups?: SessionGroup[];
+}): string {
+  const parts: string[] = [
+    `r:${input.stats.reminders}`,
+    `q:${input.stats.responses}`,
+    `f:${input.stats.familiars}`,
+    `s:${input.stats.sessions}`,
+  ];
+  for (const pr of input.prsMerged ?? []) parts.push(`pr:${pr.repo}#${pr.number}`);
+  for (const card of input.cardsCompleted ?? []) parts.push(`card:${card.id}`);
+  for (const group of input.sessionGroups ?? []) {
+    parts.push(`g:${group.key}:${group.sessions.map((s) => s.id).join(",")}`);
+  }
+  parts.sort();
+  return djb2Hex(parts.join("|"));
+}

--- a/src/lib/daily-report.test.ts
+++ b/src/lib/daily-report.test.ts
@@ -160,6 +160,16 @@ function item(overrides) {
   assert.equal(parseStatsFromBody("just some prose, nothing countable"), null);
   assert.equal(parseStatsFromBody(undefined), null);
 
+  // day-in-review lines (Phase B) are optional: parsed when present, absent —
+  // not zero — when the body predates them or the source wasn't consulted.
+  const enriched = parseStatsFromBody(
+    "0 reminders fired\n0 responses waiting\n0 familiar updates\n3 sessions updated\n12 PRs merged\n1 card completed",
+  );
+  assert.equal(enriched.prsMerged, 12);
+  assert.equal(enriched.cardsCompleted, 1);
+  const legacy = parseStatsFromBody("1 reminder fired\n1 session updated");
+  assert.equal("prsMerged" in legacy, false, "old bodies must not grow fabricated zero counts");
+
   // recentReports recovers stats from the body when media.stats is absent
   const reports = recentReports([
     item({

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -15,6 +15,10 @@ export type DailyReportStats = {
   responses: number;
   familiars: number;
   sessions: number;
+  /** Day-in-review counts — absent (not zero) on reports generated before
+   *  Phase B or when the source (GitHub PAT, board file) was unavailable. */
+  prsMerged?: number;
+  cardsCompleted?: number;
 };
 
 /** Parse a `YYYY-MM-DD` slug into a local Date at midnight. */
@@ -270,10 +274,16 @@ export function parseStatsFromBody(body: string | undefined): DailyReportStats |
   if (reminders === null && responses === null && familiars === null && sessions === null) {
     return null;
   }
+  // Day-in-review lines are optional — absent stays absent (never zero), so
+  // pre-Phase-B bodies keep their original shape.
+  const prsMerged = count(/(\d+)\s+PRs?\s+merged/i);
+  const cardsCompleted = count(/(\d+)\s+cards?\s+completed/i);
   return {
     reminders: reminders ?? 0,
     responses: responses ?? 0,
     familiars: familiars ?? 0,
     sessions: sessions ?? 0,
+    ...(prsMerged !== null ? { prsMerged } : {}),
+    ...(cardsCompleted !== null ? { cardsCompleted } : {}),
   };
 }

--- a/src/lib/daily-summary-notifications.test.ts
+++ b/src/lib/daily-summary-notifications.test.ts
@@ -195,4 +195,63 @@ assert.equal(
 );
 assert.doesNotMatch(recentLine, /Harden avatar storage/, "sessions past the cap are dropped");
 
+// ── Day-in-review extras (Phase B) ──────────────────────────────────────────
+const extras = {
+  prsMerged: [
+    {
+      repo: "OpenCoven/coven-cave",
+      number: 2497,
+      title: "keep today's report live",
+      url: "https://github.com/OpenCoven/coven-cave/pull/2497",
+      mergedAt: "2026-06-18T17:00:00.000Z",
+    },
+  ],
+  cardsCompleted: [
+    { id: "c1", title: "Ship it", projectId: null, familiarId: null, completedAt: "2026-06-18T15:00:00.000Z" },
+    { id: "c2", title: "Close it", projectId: null, familiarId: null, completedAt: "2026-06-18T16:00:00.000Z" },
+  ],
+};
+const enriched = buildDailySummaryContent({
+  now,
+  items: [],
+  sessions: [sessionAt("e1", "Ship the parser", 1)],
+  extras,
+});
+assert.ok(enriched);
+assert.match(enriched.body, /1 PR merged/, "body should carry the merged-PR count line");
+assert.match(enriched.body, /2 cards completed/, "body should carry the completed-cards count line");
+assert.equal(enriched.media.stats.prsMerged, 1, "stats should freeze the merged-PR count");
+assert.equal(enriched.media.stats.cardsCompleted, 2, "stats should freeze the completed-card count");
+assert.equal(
+  enriched.media.report?.prsMerged?.[0]?.number,
+  2497,
+  "media.report should carry the structured merged PRs",
+);
+assert.equal(
+  enriched.media.report?.sessionGroups?.[0]?.sessions?.[0]?.title,
+  "Ship the parser",
+  "media.report should carry sessions grouped by project",
+);
+assert.ok(enriched.media.report?.factsHash, "media.report should carry a facts hash");
+assert.match(
+  decodeURIComponent(enriched.media.imageUrl),
+  /prs merged/,
+  "the generated card should show the day-in-review row when sources were consulted",
+);
+
+// Sources not consulted → no count lines, no claims (absent, not zero).
+const unenriched = buildDailySummaryContent({
+  now,
+  items: [],
+  sessions: [sessionAt("e2", "Ship the parser", 1)],
+});
+assert.ok(unenriched);
+assert.doesNotMatch(unenriched.body, /PRs? merged|cards? completed/);
+assert.equal(unenriched.media.stats.prsMerged, undefined);
+assert.doesNotMatch(decodeURIComponent(unenriched.media.imageUrl), /prs merged/);
+
+// A day with nothing client-visible but merged PRs still deserves a report.
+const prOnly = buildDailySummaryContent({ now, items: [], sessions: [], extras });
+assert.ok(prOnly, "a PR-only day should still produce a report");
+
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/lib/daily-summary-notifications.ts
+++ b/src/lib/daily-summary-notifications.ts
@@ -1,6 +1,16 @@
 import type { InboxItem, InboxMedia, ItemKind, ItemStatus, LinkRef, Recurrence } from "./cave-inbox";
-import { sanitizeSessionTitle } from "./cave-chat-titles.ts";
+import {
+  buildSessionGroups,
+  dailyFactsHash,
+  reportSessionTitle,
+  type CompletedCard,
+  type MergedPr,
+} from "./daily-report-facts.ts";
 import type { SessionRow } from "./types";
+
+// Title hygiene lives in daily-report-facts.ts (shared with the day-in-review
+// payload); re-exported here for existing consumers.
+export { reportSessionTitle };
 
 export type DailySummaryDraft = {
   kind: Extract<ItemKind, "daily-summary">;
@@ -43,32 +53,6 @@ function dayLabel(date: Date): string {
   return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(date);
 }
 
-const REPORT_TITLE_MAX = 64;
-
-// Session titles come from harness transcripts and can leak raw markdown
-// ("## Prior conversation **User:** Merge PR #26 **"). The report body is
-// rendered as plain text, so markdown syntax must be stripped, not rendered.
-const MD_HEADING_RE = /^#{1,6}\s+/;
-const MD_EMPHASIS_RE = /(\*\*|__|[*_`])/g;
-const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
-
-/** Session title as it should appear in the daily report: sanitized of
- *  harness-preamble leaks (via sanitizeSessionTitle), stripped of markdown
- *  syntax, truncated to a report-sized string. Falls back to "Untitled
- *  session" when nothing survives. */
-export function reportSessionTitle(session: Pick<SessionRow, "title">): string {
-  const sanitized = sanitizeSessionTitle(session.title);
-  if (!sanitized) return "Untitled session";
-  const stripped = sanitized
-    .replace(MD_HEADING_RE, "")
-    .replace(MD_EMPHASIS_RE, "")
-    .replace(/\s+/g, " ")
-    .trim();
-  if (!stripped || PRIOR_CONVERSATION_LEAK_RE.test(stripped)) return "Untitled session";
-  if (stripped.length <= REPORT_TITLE_MAX) return stripped;
-  return `${stripped.slice(0, REPORT_TITLE_MAX - 1).trimEnd()}…`;
-}
-
 function sessionSummaryLine(session: SessionRow): string {
   const diff = session.diff ? ` (+${session.diff.additions} -${session.diff.deletions})` : "";
   return `${reportSessionTitle(session)}${diff}`;
@@ -102,9 +86,13 @@ export function shouldCreateDailySummary(items: InboxItem[], now = new Date()): 
   return !items.some((item) => item.auto === key);
 }
 
-/** Server-side enrichments threaded into the builder. Phase B fills this in
- *  (merged PRs, completed board cards); Phase A only reserves the seam. */
-export type DailySummaryExtras = Record<string, never>;
+/** Server-side enrichments threaded into the builder — facts the client
+ *  can't see. `undefined` fields mean "source unavailable" (section absent),
+ *  not "nothing happened". */
+export type DailySummaryExtras = {
+  prsMerged?: MergedPr[];
+  cardsCompleted?: CompletedCard[];
+};
 
 type BuildContentInput = BuildInput & { extras?: DailySummaryExtras };
 
@@ -114,6 +102,7 @@ type BuildContentInput = BuildInput & { extras?: DailySummaryExtras };
 export function buildDailySummaryContent({
   items,
   sessions,
+  extras,
   now = new Date(),
 }: BuildContentInput): DailySummaryDraft | null {
   const todayReminders = items.filter(
@@ -138,11 +127,16 @@ export function buildDailySummaryContent({
     .filter((session) => !session.archived_at && isSameLocalDay(session.updated_at, now))
     .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
 
+  const prsMerged = extras?.prsMerged;
+  const cardsCompleted = extras?.cardsCompleted;
+
   if (
     todayReminders.length === 0 &&
     waitingResponses.length === 0 &&
     agentNotifications.length === 0 &&
-    todaySessions.length === 0
+    todaySessions.length === 0 &&
+    (prsMerged?.length ?? 0) === 0 &&
+    (cardsCompleted?.length ?? 0) === 0
   ) {
     return null;
   }
@@ -153,6 +147,12 @@ export function buildDailySummaryContent({
     plural(agentNotifications.length, "familiar update", "familiar updates"),
     plural(todaySessions.length, "session", "sessions") + " updated",
   ];
+  // Only claim day-in-review counts when the source was actually consulted —
+  // an unconfigured PAT or unreadable board omits the line entirely.
+  if (prsMerged !== undefined) lines.push(plural(prsMerged.length, "PR") + " merged");
+  if (cardsCompleted !== undefined) {
+    lines.push(plural(cardsCompleted.length, "card") + " completed");
+  }
   // Dedupe repeated titles (retried/refreshed runs share one) case-insensitively,
   // keeping the most recent occurrence — the list is already sorted newest-first.
   const seenTitles = new Set<string>();
@@ -172,7 +172,33 @@ export function buildDailySummaryContent({
     responses: waitingResponses.length,
     familiars: agentNotifications.length,
     sessions: todaySessions.length,
+    ...(prsMerged !== undefined ? { prsMerged: prsMerged.length } : {}),
+    ...(cardsCompleted !== undefined ? { cardsCompleted: cardsCompleted.length } : {}),
   };
+  const sessionGroups = buildSessionGroups(sessions, now);
+  const report = {
+    ...(prsMerged !== undefined ? { prsMerged } : {}),
+    ...(cardsCompleted !== undefined ? { cardsCompleted } : {}),
+    sessionGroups,
+    factsHash: dailyFactsHash({ stats, prsMerged, cardsCompleted, sessionGroups }),
+    refreshedAt: sentAt,
+  };
+  // Second SVG row for the day-in-review counts; omitted when neither source
+  // was consulted so pre-Phase-B cards keep their exact layout.
+  const shipCells: { value: number; label: string }[] = [];
+  if (prsMerged !== undefined) shipCells.push({ value: prsMerged.length, label: "prs merged" });
+  if (cardsCompleted !== undefined) {
+    shipCells.push({ value: cardsCompleted.length, label: "cards completed" });
+  }
+  const shipRow = shipCells.length
+    ? `
+  <g font-family="Inter, system-ui, sans-serif" font-weight="800">
+    ${shipCells.map((cell, i) => `<text x="${92 + i * 288}" y="480" fill="#ffffff" font-size="44">${cell.value}</text>`).join("\n    ")}
+  </g>
+  <g fill="#b9b0c8" font-family="Inter, system-ui, sans-serif" font-size="20" font-weight="700">
+    ${shipCells.map((cell, i) => `<text x="${92 + i * 288}" y="516">${xmlEscape(cell.label)}</text>`).join("\n    ")}
+  </g>`
+    : "";
   const day = dayLabel(now);
   const svg = `
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
@@ -203,7 +229,7 @@ export function buildDailySummaryContent({
     <text x="300" y="410">responses</text>
     <text x="508" y="410">familiars</text>
     <text x="716" y="410">sessions</text>
-  </g>
+  </g>${shipRow}
 </svg>`.trim();
 
   return {
@@ -220,6 +246,7 @@ export function buildDailySummaryContent({
       alt: `Daily summary generated image for ${day}`,
       stats,
       generatedAt: sentAt,
+      report,
     },
     fireAt: sentAt,
     firedAt: sentAt,
@@ -232,10 +259,11 @@ export function buildDailySummaryContent({
 export function buildDailySummaryNotification({
   items,
   sessions,
+  extras,
   now = new Date(),
-}: BuildInput): DailySummaryDraft | null {
+}: BuildContentInput): DailySummaryDraft | null {
   if (!shouldCreateDailySummary(items, now)) return null;
-  return buildDailySummaryContent({ items, sessions, now });
+  return buildDailySummaryContent({ items, sessions, extras, now });
 }
 
 export async function ensureDailySummaryNotification({
@@ -243,7 +271,12 @@ export async function ensureDailySummaryNotification({
   sessions,
   now = new Date(),
 }: EnsureInput): Promise<"created" | "updated" | "skipped" | "failed"> {
-  if (!buildDailySummaryContent({ items, sessions, now })) return "skipped";
+  // Once today's item exists, always POST: the server folds in facts the
+  // client can't see (merged PRs, board cards), so an unchanged client view
+  // does not mean an unchanged report. Creation stays gated on client-visible
+  // activity to keep empty days quiet.
+  const exists = !shouldCreateDailySummary(items, now);
+  if (!exists && !buildDailySummaryContent({ items, sessions, now })) return "skipped";
   try {
     const res = await fetch("/api/inbox/daily-summary", {
       method: "POST",

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -9,6 +9,7 @@
 // client action-inbox island and the strip-types tests can import it safely.
 
 import type { InboxItem } from "./cave-inbox";
+import type { DailyReportPayload } from "./daily-report-facts";
 import {
   breakdownForDay,
   dateSlug,
@@ -38,6 +39,8 @@ export type TodaySummary = {
   generatedAt: string | null;
   /** Read-only session names recovered from the frozen summary body. */
   recentSessions: string[];
+  /** Structured day-in-review facts — null on items generated before Phase B. */
+  report: DailyReportPayload | null;
 };
 
 export type DashboardModel = {
@@ -79,6 +82,7 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
         alt: todayItem.media?.alt ?? "",
         generatedAt: todayItem.media?.generatedAt ?? todayItem.firedAt ?? todayItem.updatedAt ?? null,
         recentSessions: parseRecentSessions(todayItem.body),
+        report: todayItem.media?.report ?? null,
       }
     : null;
 

--- a/src/lib/server/github-merged.ts
+++ b/src/lib/server/github-merged.ts
@@ -1,0 +1,108 @@
+// Server-only: PRs the user merged today, for the daily report's
+// day-in-review section. Same auth posture as /api/github/activity — the PAT
+// is read from env/vault, never echoed, never logged, and only ever sent to
+// api.github.com. Returns null (section absent, never an error) when neither
+// a PAT nor GITHUB_USERNAME is configured.
+
+import { resolveSecret } from "@/lib/vault";
+import type { MergedPr } from "@/lib/daily-report-facts";
+
+const GH = "https://api.github.com";
+const FETCH_TIMEOUT_MS = 8_000;
+const CACHE_TTL_MS = 10 * 60_000;
+
+type Cache = { atMs: number; daySlug: string; items: MergedPr[] } | null;
+let cache: Cache = null;
+
+function slug(date: Date): string {
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+async function ghJson(path: string, token: string | null): Promise<unknown> {
+  const res = await fetch(`${GH}${path}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`github ${res.status}`);
+  return res.json();
+}
+
+type SearchItem = {
+  number?: number;
+  title?: string;
+  html_url?: string;
+  repository_url?: string;
+  pull_request?: { merged_at?: string | null };
+};
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+}
+
+/**
+ * PRs authored by the configured user and merged during the local `now` day.
+ * The search qualifier is UTC, so it queries from the previous day and
+ * filters `merged_at` against the local day boundary. Failures fall back to
+ * the same-day cache, then to null — the report simply omits the section.
+ */
+export async function fetchMergedPrsForDay(now: Date): Promise<MergedPr[] | null> {
+  const daySlug = slug(now);
+  if (cache && cache.daySlug === daySlug && Date.now() - cache.atMs < CACHE_TTL_MS) {
+    return cache.items;
+  }
+
+  const token = resolveSecret("GITHUB_PAT") ?? null;
+  let login = resolveSecret("GITHUB_USERNAME") ?? null;
+  if (token) {
+    try {
+      const user = (await ghJson("/user", token)) as { login?: string } | null;
+      login = user?.login ?? login;
+    } catch {
+      // Invalid PAT — the public path below still works when a username is set.
+    }
+  }
+  if (!login) return null;
+
+  // One-day UTC buffer: local "today" can start up to a day earlier in UTC.
+  const from = new Date(startOfLocalDay(now).getTime() - 24 * 60 * 60 * 1000);
+  const fromSlug = `${from.getUTCFullYear()}-${`${from.getUTCMonth() + 1}`.padStart(2, "0")}-${`${from.getUTCDate()}`.padStart(2, "0")}`;
+  const q = encodeURIComponent(`is:pr is:merged author:${login} merged:>=${fromSlug}`);
+
+  try {
+    const data = (await ghJson(`/search/issues?q=${q}&per_page=50&sort=updated&order=desc`, token)) as {
+      items?: SearchItem[];
+    } | null;
+    const dayStart = startOfLocalDay(now).getTime();
+    const dayEnd = dayStart + 24 * 60 * 60 * 1000;
+    const items: MergedPr[] = [];
+    for (const item of data?.items ?? []) {
+      const mergedAt = item.pull_request?.merged_at;
+      if (!mergedAt || typeof item.number !== "number" || !item.html_url) continue;
+      const mergedMs = new Date(mergedAt).getTime();
+      if (Number.isNaN(mergedMs) || mergedMs < dayStart || mergedMs >= dayEnd) continue;
+      const repo = (item.repository_url ?? "").replace(/^.*\/repos\//, "");
+      if (!repo) continue;
+      items.push({
+        repo,
+        number: item.number,
+        title: item.title ?? `#${item.number}`,
+        url: item.html_url,
+        mergedAt,
+      });
+    }
+    items.sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+    cache = { atMs: Date.now(), daySlug, items };
+    return items;
+  } catch {
+    // Rate-limited or offline: reuse anything we fetched for this day.
+    if (cache && cache.daySlug === daySlug) return cache.items;
+    return null;
+  }
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -426,6 +426,16 @@
   background: var(--bg-base);
   border: 1px solid var(--border-hairline);
 }
+.dash-today__chip--link {
+  text-decoration: none;
+  color: var(--color-info);
+  border-color: color-mix(in oklch, var(--color-info) 38%, transparent);
+  background: color-mix(in oklch, var(--color-info) 9%, transparent);
+}
+.dash-today__chip--link:hover {
+  border-color: color-mix(in oklch, var(--color-info) 55%, transparent);
+  background: color-mix(in oklch, var(--color-info) 15%, transparent);
+}
 
 /* Greeting eyebrow icon — replaces the old presence dot with a sun/moon. */
 .dr-eyebrow__icon { font-size: 0.85rem; color: var(--accent-presence); }


### PR DESCRIPTION
Phase B of the daily-report overhaul (builds on #2497's live-refresh upsert).

## Problem

Today's report counted activity but never said what happened: a day with a dozen merged PRs read "0 reminders fired / 0 responses waiting / 0 familiar updates / 6 sessions updated". The day's real story — PRs shipped, which projects the sessions touched, board cards finished — appeared nowhere.

## What changed

- **New `src/lib/daily-report-facts.ts`** (pure, loaderless-testable): sessions grouped by project (report-sanitized titles, per-group `+A −D` diff totals, PR chips from `SessionRow.pullRequest`, capped 6 groups × 5 sessions), board cards completed today (`lifecycle: completed` stamped today, or dragged to `done` today), merged-PR union, and a stable `factsHash` (timestamps excluded) that Phase C's narrative will key regeneration on. `reportSessionTitle` moves here and is re-exported from the notifications lib.
- **New server-only `src/lib/server/github-merged.ts`**: `is:pr is:merged author:<login>` search using the activity route's PAT/username resolution, one-day UTC buffer + local-day `merged_at` filter, 10-min TTL cache, 8s timeout. Unconfigured PAT → `null` → section absent, never an error; session-attached merged PRs still surface PAT-less.
- **`POST /api/inbox/daily-summary`** gathers the extras outside the inbox lock (each source `.catch(() => null)` → absent) and preserves `media.narrative` across fact-only refreshes (Phase C seam).
- **Builder**: optional "N PRs merged" / "N cards completed" body lines and stats — absent when a source wasn't consulted, never fabricated zeros; `media.report` payload; the SVG card gains a day-in-review row only when sources were consulted, so pre-Phase-B cards keep their exact layout.
- **Report page**: new "Merged pull requests", "Sessions by project", and "Cards completed" sections rendered from the frozen `media.report` (the flat body-recovered list remains the pre-Phase-B fallback), plus conditional PRs-merged / cards-completed MetricCards with 7-day trends.
- **Dashboard**: `TodaySummary` gains `report`; today's panel shows "Shipped" `repo#number` chips linking the merged PRs.
- **Back-compat**: all 19 historical reports render unchanged — every consumer guards `media.report`/new stats with `?.`, and `parseStatsFromBody` adds the new counts only when the lines exist (old bodies keep their exact shape).

## Verification

- `pnpm typecheck` ✓ · `test:app` 528 ✓ · `test:api` 118 ✓ · `test:mobile` 70 ✓ · `check:tests-wired` 712 ✓ · production build within bundle budget ✓
- New `daily-report-facts.test.ts` covers grouping/dedupe/caps, completed-card selection, PAT-less union semantics, facts-hash stability; builder test covers enriched body/stats/SVG and the absent-vs-zero contract; api-contracts pins the route's degrade-to-absent gathering and narrative preservation.

Closes cave-05p (bead). Phase C (familiar-written narrative, cave-2mn) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)