### PR TITLE
feat(daily-report): day-in-review content — merged PRs, session groups, cards done + SVG v2 (cave-05p)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -138,6 +138,7 @@ export const SUITES = {
     "src/app/dashboard-runtime-smoke.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/lib/daily-summary-refresh.test.ts",
+    "src/lib/daily-report-facts.test.ts",
     "src/components/dev-cache-reset-script.test.ts",
     "src/components/pwa-register.test.ts",
     "src/lib/readable-text-color.test.ts",

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -11,6 +11,15 @@ import {
   dailySummaryAutoKey,
   dateSlug,
 } from "@/lib/daily-summary-notifications";
+import {
+  buildSessionGroups,
+  completedCardsForDay,
+  dailyFactsHash,
+  unionMergedPrs,
+  type DailyReportPayload,
+} from "@/lib/daily-report-facts";
+import { fetchMergedPrsForDay } from "@/lib/server/github-merged";
+import { loadBoard } from "@/lib/cave-board";
 import type { SessionRow } from "@/lib/types";
 import { isLocalOrigin } from "@/lib/server/local-origin";
 
@@ -37,12 +46,32 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: true, created: false, updated: false, dateMismatch: true });
   }
 
+  // Day-in-review facts, gathered outside the lock (network + board I/O).
+  // Every source degrades to null/absent — a missing PAT or unreadable board
+  // must never block the report itself.
+  const sessions = Array.isArray(body.sessions) ? body.sessions : [];
+  const [githubPrs, board] = await Promise.all([
+    fetchMergedPrsForDay(now).catch(() => null),
+    loadBoard().catch(() => null),
+  ]);
+  const prsMerged = unionMergedPrs(githubPrs, sessions, now);
+  const cardsCompleted = board ? completedCardsForDay(board.cards, now) : null;
+  const sessionGroups = buildSessionGroups(sessions, now);
+  const report: DailyReportPayload = {
+    ...(prsMerged ? { prsMerged } : {}),
+    ...(cardsCompleted ? { cardsCompleted } : {}),
+    ...(sessionGroups.length > 0 ? { sessionGroups } : {}),
+    factsHash: dailyFactsHash({ prsMerged, cardsCompleted, sessionGroups }),
+    refreshedAt: now.toISOString(),
+  };
+
   const result = await withInboxLock(async () => {
     const file = await loadInbox();
     const draft = buildDailySummaryContent({
       items: file.items,
-      sessions: Array.isArray(body.sessions) ? body.sessions : [],
+      sessions,
       now,
+      extras: { report },
     });
     if (!draft) return null;
 
@@ -55,7 +84,9 @@ export async function POST(req: Request) {
         title: draft.title,
         body: draft.body,
         link: draft.link,
-        media: { ...draft.media },
+        // A fact-only refresh must not discard the familiar-written narrative;
+        // its staleness is judged separately via factsHash (Phase C).
+        media: { ...draft.media, narrative: existing.media?.narrative ?? null },
         updatedAt: now.toISOString(),
       };
       file.items = file.items.map((item) => (item.id === existing.id ? refreshed : item));

--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -23,4 +23,17 @@ assert.match(page, /ItemRow/, "report should render deep-linkable item rows");
 assert.match(page, /href="\/dashboard"/, "report should link back to the dashboard");
 assert.match(page, /dr-page/, "report should use the shared daily-report surface styling");
 
+// Day-in-review sections (Phase B): every access to the frozen payload is
+// guarded — historical reports without media.report must render unchanged.
+assert.match(page, /media\?\.report/, "report payload access must be optional-chained");
+assert.match(page, /Merged pull requests/, "report should render the merged-PRs section when frozen");
+assert.match(page, /Sessions by project/, "report should render grouped sessions when frozen");
+assert.match(page, /Cards completed/, "report should render completed board cards when frozen");
+assert.match(page, /\/#card-\$\{card\.id\}/, "completed cards should deep-link into the board");
+assert.match(
+  page,
+  /report\?\.sessionGroups\?\.length[\s\S]*?recentSessions\.length > 0/,
+  "grouped sessions must fall back to the body-recovered flat list for old reports",
+);
+
 console.log("daily-report-page.test.ts: ok");

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -77,12 +77,15 @@ export default async function DailyReportPage({ params }: Props) {
       const s = statBySlug.get(slugFor(d));
       out.push({
         label: d.toLocaleDateString(undefined, { weekday: "short", month: "short", day: "numeric" }),
-        value: s ? s[metric] : null,
+        value: s ? s[metric] ?? null : null,
       });
     }
     return out;
   };
   const recentSessions = parseRecentSessions(item.body);
+  // Frozen day-in-review payload (Phase B+). Reports generated before it exist
+  // render the recovered body lines instead — every access stays guarded.
+  const report = item.media?.report ?? null;
   // media.generatedAt moves on every in-place refresh; firedAt stays at the
   // day's first generation, so prefer the former for a truthful timestamp.
   const generatedAt = item.media?.generatedAt ?? item.firedAt ?? item.updatedAt ?? null;
@@ -184,6 +187,26 @@ export default async function DailyReportPage({ params }: Props) {
               accent="green"
               trend={trendFor("sessions")}
             />
+            {typeof stats.prsMerged === "number" ? (
+              <MetricCard
+                icon="ph:git-merge"
+                value={stats.prsMerged}
+                label="PRs merged"
+                caption="Landed on GitHub"
+                accent="blue"
+                trend={trendFor("prsMerged")}
+              />
+            ) : null}
+            {typeof stats.cardsCompleted === "number" ? (
+              <MetricCard
+                icon="ph:check-square"
+                value={stats.cardsCompleted}
+                label="Cards completed"
+                caption="Across the board"
+                accent="green"
+                trend={trendFor("cardsCompleted")}
+              />
+            ) : null}
           </section>
         ) : null}
 
@@ -224,8 +247,115 @@ export default async function DailyReportPage({ params }: Props) {
           </section>
         ) : null}
 
-        {/* Sessions — recovered from the frozen summary body (daemon-backed). */}
-        {recentSessions.length > 0 ? (
+        {/* Merged pull requests — frozen from GitHub + session PR links. */}
+        {report?.prsMerged?.length ? (
+          <section className="dr-section" aria-label="Merged pull requests">
+            <SectionHead
+              icon="ph:git-merge"
+              title="Merged pull requests"
+              count={report.prsMerged.length}
+            />
+            <div className="dr-list">
+              {report.prsMerged.map((pr) => (
+                <a
+                  key={`${pr.repo}#${pr.number}`}
+                  className="dr-row"
+                  href={pr.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ ["--row-accent" as string]: "var(--color-info)" }}
+                >
+                  <span className="dr-row__icon">
+                    <Icon name="ph:git-merge" aria-hidden />
+                  </span>
+                  <span className="dr-row__body">
+                    <span className="dr-row__title">{pr.title}</span>
+                    <span className="dr-row__metaline">
+                      <span className="dr-tag">
+                        {pr.repo}#{pr.number}
+                      </span>
+                      <span className="dr-row__time">{relativeTime(pr.mergedAt)}</span>
+                    </span>
+                  </span>
+                  <span className="dr-row__open">
+                    <span>Open</span>
+                    <Icon name="ph:arrow-right-bold" aria-hidden />
+                  </span>
+                </a>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Sessions grouped by project — frozen with the report (Phase B+);
+            older reports fall back to the flat list recovered from the body. */}
+        {report?.sessionGroups?.length ? (
+          <section className="dr-section" aria-label="Sessions by project">
+            <SectionHead
+              icon="ph:graph-bold"
+              title="Sessions by project"
+              count={report.sessionGroups.length}
+            />
+            {report.sessionGroups.map((group) => (
+              <div key={group.key} className="dr-group">
+                <div className="dr-group__head">
+                  <span className="dr-group__label">
+                    <Icon name="ph:folder" aria-hidden />
+                    {group.label}
+                  </span>
+                  {group.additions || group.deletions ? (
+                    <span className="dr-diffstat">
+                      <span className="dr-diffstat__add">+{group.additions}</span>
+                      <span className="dr-diffstat__del">−{group.deletions}</span>
+                    </span>
+                  ) : null}
+                </div>
+                <div className="dr-list">
+                  {group.sessions.map((session) => (
+                    <div
+                      key={session.id}
+                      className="dr-row"
+                      style={{ ["--row-accent" as string]: "var(--color-success)" }}
+                    >
+                      <span className="dr-row__icon">
+                        <Icon name="ph:code-bold" aria-hidden />
+                      </span>
+                      <span className="dr-row__body">
+                        <span className="dr-row__title">{session.title}</span>
+                        <span className="dr-row__metaline">
+                          {session.familiarId ? (
+                            <span className="dr-tag">{session.familiarId}</span>
+                          ) : null}
+                          {session.pr ? (
+                            <a
+                              className="dr-pr-chip"
+                              href={
+                                session.pr.url ??
+                                `https://github.com/${session.pr.repo}${session.pr.number ? `/pull/${session.pr.number}` : ""}`
+                              }
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              <Icon name="ph:git-pull-request" aria-hidden />
+                              {session.pr.repo.split("/").pop()}
+                              {session.pr.number ? `#${session.pr.number}` : ""}
+                            </a>
+                          ) : null}
+                          {session.additions || session.deletions ? (
+                            <span className="dr-diffstat">
+                              <span className="dr-diffstat__add">+{session.additions}</span>
+                              <span className="dr-diffstat__del">−{session.deletions}</span>
+                            </span>
+                          ) : null}
+                        </span>
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </section>
+        ) : recentSessions.length > 0 ? (
           <section className="dr-section" aria-label="Recent sessions">
             <SectionHead
               icon="ph:graph-bold"
@@ -242,6 +372,43 @@ export default async function DailyReportPage({ params }: Props) {
                     <span className="dr-row__title">{line}</span>
                   </span>
                 </div>
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Board cards completed today — deep-links back into the board. */}
+        {report?.cardsCompleted?.length ? (
+          <section className="dr-section" aria-label="Cards completed">
+            <SectionHead
+              icon="ph:check-square"
+              title="Cards completed"
+              count={report.cardsCompleted.length}
+            />
+            <div className="dr-list">
+              {report.cardsCompleted.map((card) => (
+                <a
+                  key={card.id}
+                  className="dr-row"
+                  href={`/#card-${card.id}`}
+                  style={{ ["--row-accent" as string]: "var(--color-success)" }}
+                >
+                  <span className="dr-row__icon">
+                    <Icon name="ph:check-square" aria-hidden />
+                  </span>
+                  <span className="dr-row__body">
+                    <span className="dr-row__title">{card.title}</span>
+                    {card.completedAt ? (
+                      <span className="dr-row__metaline">
+                        <span className="dr-row__time">{relativeTime(card.completedAt)}</span>
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="dr-row__open">
+                    <span>Open</span>
+                    <Icon name="ph:arrow-right-bold" aria-hidden />
+                  </span>
+                </a>
               ))}
             </div>
           </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9049,6 +9049,54 @@ a.dr-row:active { transform: translateY(1px); }
   background: color-mix(in oklch, var(--row-accent, var(--accent-presence)) 12%, transparent);
 }
 .dr-row__time { font-size: 11.5px; color: var(--text-muted); }
+
+/* Day-in-review (Phase B): project groups, PR chips, diffstats. */
+.dr-group { display: grid; gap: 8px; margin-top: 14px; }
+.dr-group:first-of-type { margin-top: 0; }
+.dr-group__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+.dr-group__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12.5px;
+  font-weight: 620;
+  color: var(--text-secondary);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.dr-pr-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 560;
+  color: var(--color-info);
+  background: color-mix(in oklch, var(--color-info) 12%, transparent);
+  text-decoration: none;
+}
+.dr-pr-chip:hover {
+  background: color-mix(in oklch, var(--color-info) 18%, transparent);
+}
+.dr-diffstat {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+}
+.dr-diffstat__add { color: var(--color-success); }
+.dr-diffstat__del { color: var(--color-danger); }
+
 .dr-row__open {
   align-self: center;
   flex-shrink: 0;

--- a/src/components/dashboard/today-summary.tsx
+++ b/src/components/dashboard/today-summary.tsx
@@ -46,7 +46,48 @@ export function TodaySummary({
               Today&apos;s summary is still taking shape — it fills in as activity lands.
             </p>
           )}
-          {summary.recentSessions.length > 0 ? (
+          {summary.report?.prsMerged?.length ? (
+            <div className="dash-today__sessions" aria-label="Merged pull requests">
+              <span className="dash-today__sessions-label">
+                <Icon name="ph:git-merge" aria-hidden />
+                Merged today
+              </span>
+              <div className="dash-today__chips">
+                {summary.report.prsMerged.map((pr) => (
+                  <a
+                    key={`${pr.repo}#${pr.number}`}
+                    className="dash-today__chip dr-pr-chip"
+                    href={pr.url}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {pr.repo.split("/").pop()}#{pr.number}
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {summary.report?.sessionGroups?.length ? (
+            <div className="dash-today__sessions" aria-label="Sessions by project">
+              <span className="dash-today__sessions-label">
+                <Icon name="ph:code-bold" aria-hidden />
+                By project
+              </span>
+              <div className="dash-today__chips">
+                {summary.report.sessionGroups.map((group) => (
+                  <span key={group.key} className="dash-today__chip">
+                    {group.label}
+                    {group.additions || group.deletions ? (
+                      <span className="dr-diffstat">
+                        <span className="dr-diffstat__add">+{group.additions}</span>
+                        <span className="dr-diffstat__del">−{group.deletions}</span>
+                      </span>
+                    ) : null}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : summary.recentSessions.length > 0 ? (
             <div className="dash-today__sessions" aria-label="Recent sessions">
               <span className="dash-today__sessions-label">
                 <Icon name="ph:code-bold" aria-hidden />

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 import { computeNextOccurrence, type Recurrence } from "@/lib/inbox-recurrence";
+import type { DailyReportPayload } from "./daily-report-facts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 const INBOX_PATH = path.join(homedir(), ".coven", "cave-inbox.json");
@@ -31,8 +32,21 @@ export type InboxMedia = {
     responses: number;
     familiars: number;
     sessions: number;
+    /** Present only on reports generated with day-in-review data (Phase B+). */
+    prsMerged?: number;
+    cardsCompleted?: number;
   };
   generatedAt: string;
+  /** Frozen day-in-review facts (merged PRs, session groups, completed cards).
+   *  Absent on reports generated before Phase B — every consumer must guard. */
+  report?: DailyReportPayload | null;
+  /** Familiar-written narrative (Phase C). Preserved across fact refreshes. */
+  narrative?: {
+    text: string;
+    familiarId: string | null;
+    generatedAt: string;
+    factsHash: string;
+  } | null;
 };
 
 export type InboxItem = {

--- a/src/lib/daily-report-facts.test.ts
+++ b/src/lib/daily-report-facts.test.ts
@@ -1,0 +1,164 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildSessionGroups,
+  completedCardsForDay,
+  dailyFactsHash,
+  unionMergedPrs,
+} from "./daily-report-facts.ts";
+
+const now = new Date("2026-06-18T21:15:00.000Z");
+const todayIso = (h) => new Date(now.getTime() - h * 60 * 60 * 1000).toISOString();
+
+const session = (over = {}) => ({
+  id: "s1",
+  title: "Fix board chat route",
+  status: "completed",
+  updated_at: todayIso(1),
+  created_at: todayIso(2),
+  project_root: "/repo/coven-cave",
+  harness: "codex",
+  model: "gpt-5",
+  exit_code: 0,
+  archived_at: null,
+  familiarId: "sage",
+  ...over,
+});
+
+// --- buildSessionGroups ------------------------------------------------------
+
+{
+  const groups = buildSessionGroups(
+    [
+      session({ id: "a1", diff: { additions: 10, deletions: 2 } }),
+      session({ id: "a2", title: "Ship calendar fixes", diff: { additions: 5, deletions: 1 } }),
+      session({ id: "b1", project_root: "/repo/open-meow/", title: "Meow work" }),
+      session({ id: "old", updated_at: "2026-06-10T09:00:00.000Z" }),
+      session({ id: "arch", archived_at: todayIso(1) }),
+    ],
+    now,
+  );
+  assert.equal(groups.length, 2, "groups by project_root, today's non-archived sessions only");
+  const cave = groups.find((g) => g.key === "/repo/coven-cave");
+  assert.equal(cave.label, "coven-cave", "label is the root's basename");
+  assert.equal(cave.additions, 15);
+  assert.equal(cave.deletions, 3);
+  assert.equal(cave.sessions.length, 2);
+  const meow = groups.find((g) => g.key === "/repo/open-meow/");
+  assert.equal(meow.label, "open-meow", "trailing slash does not break the basename");
+}
+
+{
+  const many = [];
+  for (let g = 0; g < 8; g++) {
+    for (let s = 0; s < 7; s++) {
+      many.push(session({ id: `g${g}s${s}`, project_root: `/repo/p${g}`, updated_at: todayIso(g + s / 10) }));
+    }
+  }
+  const groups = buildSessionGroups(many, now);
+  assert.equal(groups.length, 6, "caps at 6 groups");
+  assert.ok(
+    groups.every((g) => g.sessions.length <= 5),
+    "caps at 5 sessions per group",
+  );
+}
+
+// --- unionMergedPrs ----------------------------------------------------------
+
+{
+  assert.equal(unionMergedPrs(null, [session()], now), null, "null when no source has PRs");
+
+  const sessionPr = session({
+    id: "pr1",
+    title: "Land the picker",
+    pullRequest: { repo: "OpenCoven/coven-cave", number: 42, state: "merged" },
+  });
+  const openPr = session({
+    id: "pr2",
+    pullRequest: { repo: "OpenCoven/coven-cave", number: 43, state: "open" },
+  });
+  const fromSessions = unionMergedPrs(null, [sessionPr, openPr], now);
+  assert.equal(fromSessions.length, 1, "only merged session PRs count (PAT-less partial data)");
+  assert.equal(fromSessions[0].number, 42);
+  assert.match(fromSessions[0].url, /\/pull\/42$/, "synthesizes a URL when the session lacks one");
+
+  const github = [
+    {
+      repo: "OpenCoven/coven-cave",
+      number: 42,
+      title: "feat: land the picker properly",
+      url: "https://github.com/OpenCoven/coven-cave/pull/42",
+      mergedAt: todayIso(2),
+    },
+    {
+      repo: "OpenCoven/open-meow",
+      number: 7,
+      title: "fix: purr",
+      url: "https://github.com/OpenCoven/open-meow/pull/7",
+      mergedAt: todayIso(3),
+    },
+  ];
+  const union = unionMergedPrs(github, [sessionPr], now);
+  assert.equal(union.length, 2, "dedupes on repo#number across sources");
+  assert.equal(
+    union.find((pr) => pr.number === 42).title,
+    "feat: land the picker properly",
+    "richer GitHub search entry wins over the session-derived one",
+  );
+
+  const emptyGithub = unionMergedPrs([], [], now);
+  assert.deepEqual(emptyGithub, [], "a working PAT with zero merges is [] (absence ≠ zero)");
+}
+
+// --- completedCardsForDay ----------------------------------------------------
+
+{
+  const cards = [
+    { id: "c1", title: "Done today", lifecycle: "completed", lifecycleAt: todayIso(2) },
+    { id: "c2", title: "Done yesterday", lifecycle: "completed", lifecycleAt: "2026-06-17T10:00:00.000Z" },
+    { id: "c3", title: "Still running", lifecycle: "running", lifecycleAt: todayIso(1) },
+    { id: "c4", title: "Legacy done", status: "done", updatedAt: todayIso(3) },
+    { id: "c5", title: "Legacy stale", status: "done", updatedAt: "2026-06-01T10:00:00.000Z" },
+  ];
+  const done = completedCardsForDay(cards, now);
+  assert.deepEqual(
+    done.map((card) => card.id),
+    ["c1", "c4"],
+    "completed-today lifecycle plus legacy done-updated-today fallback, newest first",
+  );
+}
+
+// --- dailyFactsHash ----------------------------------------------------------
+
+{
+  const facts = {
+    prsMerged: [
+      { repo: "r", number: 1, title: "a", url: "u", mergedAt: todayIso(1) },
+      { repo: "r", number: 2, title: "b", url: "u", mergedAt: todayIso(2) },
+    ],
+    cardsCompleted: [{ id: "c1", title: "t", completedAt: todayIso(1) }],
+    sessionGroups: buildSessionGroups([session()], now),
+  };
+  const h1 = dailyFactsHash(facts);
+  assert.equal(h1, dailyFactsHash(facts), "stable for identical facts");
+  assert.equal(
+    h1,
+    dailyFactsHash({ ...facts, prsMerged: [...facts.prsMerged].reverse() }),
+    "order-insensitive",
+  );
+  assert.equal(
+    h1,
+    dailyFactsHash({
+      ...facts,
+      prsMerged: facts.prsMerged.map((pr) => ({ ...pr, mergedAt: todayIso(5) })),
+    }),
+    "timestamps do not churn the hash",
+  );
+  assert.notEqual(
+    h1,
+    dailyFactsHash({ ...facts, cardsCompleted: [] }),
+    "content changes do change the hash",
+  );
+}
+
+console.log("daily-report-facts.test.ts: ok");

--- a/src/lib/daily-report-facts.ts
+++ b/src/lib/daily-report-facts.ts
@@ -1,0 +1,203 @@
+// Pure day-in-review facts for the daily report: merged PRs, completed board
+// cards, and today's sessions grouped by project. Shared by the daily-summary
+// route (which freezes a payload into `media.report`) and the report/dashboard
+// surfaces that render it. Kept free of `node:`/server imports so tests and
+// client bundles can use it directly.
+
+import type { SessionRow } from "./types";
+import { reportSessionTitle } from "./daily-summary-notifications.ts";
+
+export type MergedPr = {
+  repo: string;
+  number: number;
+  title: string;
+  url: string;
+  /** ISO timestamp; session-derived entries fall back to the session's updated_at. */
+  mergedAt: string;
+};
+
+export type CompletedCard = {
+  id: string;
+  title: string;
+  completedAt: string;
+};
+
+export type ReportSession = {
+  id: string;
+  title: string;
+  familiarId: string | null;
+  additions: number;
+  deletions: number;
+  pr: { repo: string; number?: number; url?: string } | null;
+};
+
+export type SessionGroup = {
+  /** Raw project_root (dedupe key). */
+  key: string;
+  /** Display label — the root's basename. */
+  label: string;
+  additions: number;
+  deletions: number;
+  sessions: ReportSession[];
+};
+
+export type DailyReportPayload = {
+  prsMerged?: MergedPr[];
+  cardsCompleted?: CompletedCard[];
+  sessionGroups?: SessionGroup[];
+  /** Stable content hash (no timestamps) — feeds narrative staleness in Phase C. */
+  factsHash: string;
+  refreshedAt: string;
+};
+
+const MAX_GROUPS = 6;
+const MAX_SESSIONS_PER_GROUP = 5;
+
+function sameLocalDay(iso: string | null | undefined, day: Date): boolean {
+  if (!iso) return false;
+  const value = new Date(iso);
+  if (Number.isNaN(value.getTime())) return false;
+  const start = new Date(day.getFullYear(), day.getMonth(), day.getDate()).getTime();
+  return value.getTime() >= start && value.getTime() < start + 24 * 60 * 60 * 1000;
+}
+
+function basename(root: string): string {
+  const trimmed = root.replace(/\/+$/, "");
+  const last = trimmed.split("/").pop();
+  return last || trimmed || "unknown";
+}
+
+/** Today's non-archived sessions grouped by project_root, newest activity
+ *  first, with per-group diff totals. Caps at 6 groups × 5 sessions so a busy
+ *  day freezes to a bounded payload. */
+export function buildSessionGroups(sessions: SessionRow[], now = new Date()): SessionGroup[] {
+  const today = sessions
+    .filter((session) => !session.archived_at && sameLocalDay(session.updated_at, now))
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+
+  const groups = new Map<string, SessionGroup & { dropped: number }>();
+  for (const session of today) {
+    const key = session.project_root || "unknown";
+    let group = groups.get(key);
+    if (!group) {
+      if (groups.size >= MAX_GROUPS) continue;
+      group = { key, label: basename(key), additions: 0, deletions: 0, sessions: [], dropped: 0 };
+      groups.set(key, group);
+    }
+    group.additions += session.diff?.additions ?? 0;
+    group.deletions += session.diff?.deletions ?? 0;
+    if (group.sessions.length >= MAX_SESSIONS_PER_GROUP) {
+      group.dropped += 1;
+      continue;
+    }
+    group.sessions.push({
+      id: session.id,
+      title: reportSessionTitle(session),
+      familiarId: session.familiarId ?? null,
+      additions: session.diff?.additions ?? 0,
+      deletions: session.diff?.deletions ?? 0,
+      pr: session.pullRequest?.repo
+        ? {
+            repo: session.pullRequest.repo,
+            ...(typeof session.pullRequest.number === "number"
+              ? { number: session.pullRequest.number }
+              : {}),
+            ...(session.pullRequest.url ? { url: session.pullRequest.url } : {}),
+          }
+        : null,
+    });
+  }
+  return [...groups.values()].map(({ dropped: _dropped, ...group }) => group);
+}
+
+/** Union the PAT search results with PRs linked from today's sessions whose
+ *  state is already "merged" — so a PAT-less setup still reports partial data.
+ *  Returns null when neither source produced anything (section stays absent,
+ *  distinct from a zero-merge day with a working PAT). */
+export function unionMergedPrs(
+  github: MergedPr[] | null,
+  sessions: SessionRow[],
+  now = new Date(),
+): MergedPr[] | null {
+  const fromSessions: MergedPr[] = sessions
+    .filter(
+      (session) =>
+        !session.archived_at &&
+        sameLocalDay(session.updated_at, now) &&
+        session.pullRequest?.state === "merged" &&
+        typeof session.pullRequest.number === "number",
+    )
+    .map((session) => ({
+      repo: session.pullRequest!.repo,
+      number: session.pullRequest!.number!,
+      title: reportSessionTitle(session),
+      url:
+        session.pullRequest!.url ??
+        `https://github.com/${session.pullRequest!.repo}/pull/${session.pullRequest!.number}`,
+      mergedAt: session.updated_at,
+    }));
+
+  if (!github && fromSessions.length === 0) return null;
+
+  const byKey = new Map<string, MergedPr>();
+  // Session entries first so richer GitHub search results overwrite them.
+  for (const pr of fromSessions) byKey.set(`${pr.repo}#${pr.number}`, pr);
+  for (const pr of github ?? []) byKey.set(`${pr.repo}#${pr.number}`, pr);
+  return [...byKey.values()].sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+}
+
+/** Minimal structural slice of a board card — keeps this module decoupled
+ *  from the board types (and their import graph). */
+export type CompletableCard = {
+  id: string;
+  title: string;
+  lifecycle?: string;
+  lifecycleAt?: string;
+  status?: string;
+  updatedAt?: string;
+};
+
+/** Cards finished today: lifecycle "completed" stamped today, plus legacy
+ *  cards (pre-lifecycle) sitting in "done" that were touched today. */
+export function completedCardsForDay(cards: CompletableCard[], now = new Date()): CompletedCard[] {
+  return cards
+    .filter((card) =>
+      card.lifecycle === "completed"
+        ? sameLocalDay(card.lifecycleAt, now)
+        : card.status === "done" && !card.lifecycle && sameLocalDay(card.updatedAt, now),
+    )
+    .map((card) => ({
+      id: card.id,
+      title: card.title,
+      completedAt: (card.lifecycle === "completed" ? card.lifecycleAt : card.updatedAt) ?? "",
+    }))
+    .sort((a, b) => b.completedAt.localeCompare(a.completedAt));
+}
+
+function fnv1a(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/** Stable hash over the day's facts, excluding timestamps and diff churn, so
+ *  Phase C's narrative can tell "the story changed" from "the clock moved". */
+export function dailyFactsHash({
+  prsMerged,
+  cardsCompleted,
+  sessionGroups,
+}: {
+  prsMerged?: MergedPr[] | null;
+  cardsCompleted?: CompletedCard[] | null;
+  sessionGroups?: SessionGroup[] | null;
+}): string {
+  const parts = [
+    ...(prsMerged ?? []).map((pr) => `pr:${pr.repo}#${pr.number}`),
+    ...(cardsCompleted ?? []).map((card) => `card:${card.id}`),
+    ...(sessionGroups ?? []).flatMap((group) => group.sessions.map((s) => `s:${group.key}:${s.id}`)),
+  ].sort();
+  return fnv1a(parts.join("|"));
+}

--- a/src/lib/daily-report-facts.ts
+++ b/src/lib/daily-report-facts.ts
@@ -62,8 +62,12 @@ function sameLocalDay(iso: string | null | undefined, day: Date): boolean {
 }
 
 function basename(root: string): string {
-  const trimmed = root.replace(/\/+$/, "");
-  const last = trimmed.split("/").pop();
+  // Trim trailing slashes without a regex — /\/+$/ backtracks polynomially on
+  // long slash runs (CodeQL js/polynomial-redos).
+  let end = root.length;
+  while (end > 0 && root.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  const trimmed = root.slice(0, end);
+  const last = trimmed.slice(trimmed.lastIndexOf("/") + 1);
   return last || trimmed || "unknown";
 }
 

--- a/src/lib/daily-report.test.ts
+++ b/src/lib/daily-report.test.ts
@@ -171,6 +171,17 @@ function item(overrides) {
     }),
   ]);
   assert.equal(reports[0].stats.sessions, 5, "stats recovered from body when media.stats absent");
+
+  // Day-in-review lines (Phase B) parse into optional keys — and stay absent
+  // (not zero) for bodies that predate them.
+  const enriched = parseStatsFromBody(
+    "1 reminder fired\n0 responses waiting\n0 familiar updates\n2 sessions updated\n3 PRs merged\n1 card completed",
+  );
+  assert.equal(enriched.prsMerged, 3);
+  assert.equal(enriched.cardsCompleted, 1);
+  const legacy = parseStatsFromBody("1 reminder fired\n2 sessions updated");
+  assert.ok(!("prsMerged" in legacy), "old bodies keep their shape — no fabricated zero");
+  assert.ok(!("cardsCompleted" in legacy));
 }
 
 console.log("daily-report.test.ts: ok");

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -15,6 +15,9 @@ export type DailyReportStats = {
   responses: number;
   familiars: number;
   sessions: number;
+  /** Only on reports whose day-in-review sources resolved (absence ≠ zero). */
+  prsMerged?: number;
+  cardsCompleted?: number;
 };
 
 /** Parse a `YYYY-MM-DD` slug into a local Date at midnight. */
@@ -270,10 +273,16 @@ export function parseStatsFromBody(body: string | undefined): DailyReportStats |
   if (reminders === null && responses === null && familiars === null && sessions === null) {
     return null;
   }
+  // The day-in-review lines are additive (Phase B); omit the keys entirely when
+  // the body predates them so old reports keep their shape (absence ≠ zero).
+  const prsMerged = count(/(\d+)\s+PRs?\s+merged/i);
+  const cardsCompleted = count(/(\d+)\s+cards?\s+completed/i);
   return {
     reminders: reminders ?? 0,
     responses: responses ?? 0,
     familiars: familiars ?? 0,
     sessions: sessions ?? 0,
+    ...(prsMerged !== null ? { prsMerged } : {}),
+    ...(cardsCompleted !== null ? { cardsCompleted } : {}),
   };
 }

--- a/src/lib/daily-summary-notifications.test.ts
+++ b/src/lib/daily-summary-notifications.test.ts
@@ -141,6 +141,11 @@ assert.equal(
   "markdown syntax should be stripped, not rendered as literal characters",
 );
 assert.equal(reportSessionTitle({ title: "   " }), "Untitled session");
+assert.equal(
+  reportSessionTitle({ title: '<covenroster> You are in a group chat ("coven") with these…' }),
+  "Untitled session",
+  "angle-tag prompt-preamble leaks should fall back to a neutral title",
+);
 const longTitle = "Refactor the entire inbox scheduler pipeline to support recurrence windows and quiet hours";
 assert.ok(
   reportSessionTitle({ title: longTitle }).length <= 64,
@@ -194,5 +199,49 @@ assert.equal(
   "the Recent line should cap at 6 deduped sessions",
 );
 assert.doesNotMatch(recentLine, /Harden avatar storage/, "sessions past the cap are dropped");
+
+{
+  const zeroDiff = buildDailySummaryContent({
+    now,
+    items: [],
+    sessions: [{ ...sessionAt("z1", "Quiet session", 1), diff: { additions: 0, deletions: 0 } }],
+  });
+  assert.doesNotMatch(zeroDiff.body, /\(\+0 -0\)/, "zero/zero diffs are noise, not signal");
+}
+
+// Day-in-review extras (Phase B): additive body lines, stats, and media.report.
+const report = {
+  prsMerged: [
+    { repo: "OpenCoven/coven-cave", number: 42, title: "feat: picker", url: "https://x/42", mergedAt: "2026-06-18T18:00:00.000Z" },
+    { repo: "OpenCoven/coven-cave", number: 43, title: "fix: leak", url: "https://x/43", mergedAt: "2026-06-18T19:00:00.000Z" },
+  ],
+  cardsCompleted: [{ id: "c1", title: "Ship it", completedAt: "2026-06-18T17:00:00.000Z" }],
+  sessionGroups: [],
+  factsHash: "abc123",
+  refreshedAt: "2026-06-18T21:15:00.000Z",
+};
+const enriched = buildDailySummaryContent({
+  now,
+  items: [baseItem],
+  sessions: [],
+  extras: { report },
+});
+assert.ok(enriched);
+assert.match(enriched.body, /2 PRs merged/, "PR line appears when the source resolved");
+assert.match(enriched.body, /1 card completed/, "card line appears when the source resolved");
+assert.match(enriched.body, /1 reminder fired/, "base four lines keep their exact wording");
+assert.equal(enriched.media.stats.prsMerged, 2);
+assert.equal(enriched.media.stats.cardsCompleted, 1);
+assert.equal(enriched.media.report?.factsHash, "abc123", "the payload freezes into media.report");
+
+// Without extras the new lines and keys are absent entirely (absence ≠ zero).
+const plain = buildDailySummaryContent({ now, items: [baseItem], sessions: [] });
+assert.doesNotMatch(plain.body, /PRs? merged|cards? completed/);
+assert.ok(!("prsMerged" in plain.media.stats), "no PR key without a resolved source");
+assert.ok(!("report" in plain.media), "no report payload without extras");
+
+// A PR-only day (no inbox items, no sessions) still produces a report.
+const prOnly = buildDailySummaryContent({ now, items: [], sessions: [], extras: { report } });
+assert.ok(prOnly, "a day with only merged PRs is not an empty day");
 
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/lib/daily-summary-notifications.ts
+++ b/src/lib/daily-summary-notifications.ts
@@ -1,5 +1,6 @@
 import type { InboxItem, InboxMedia, ItemKind, ItemStatus, LinkRef, Recurrence } from "./cave-inbox";
 import { sanitizeSessionTitle } from "./cave-chat-titles.ts";
+import type { DailyReportPayload } from "./daily-report-facts";
 import type { SessionRow } from "./types";
 
 export type DailySummaryDraft = {
@@ -51,6 +52,9 @@ const REPORT_TITLE_MAX = 64;
 const MD_HEADING_RE = /^#{1,6}\s+/;
 const MD_EMPHASIS_RE = /(\*\*|__|[*_`])/g;
 const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
+// Titles opening with an XML-ish tag ("<covenroster> You are in a group
+// chat…") are prompt-preamble leaks, not names.
+const ANGLE_TAG_LEAK_RE = /^<[a-z][\w-]*>/i;
 
 /** Session title as it should appear in the daily report: sanitized of
  *  harness-preamble leaks (via sanitizeSessionTitle), stripped of markdown
@@ -58,7 +62,7 @@ const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
  *  session" when nothing survives. */
 export function reportSessionTitle(session: Pick<SessionRow, "title">): string {
   const sanitized = sanitizeSessionTitle(session.title);
-  if (!sanitized) return "Untitled session";
+  if (!sanitized || ANGLE_TAG_LEAK_RE.test(sanitized)) return "Untitled session";
   const stripped = sanitized
     .replace(MD_HEADING_RE, "")
     .replace(MD_EMPHASIS_RE, "")
@@ -70,7 +74,9 @@ export function reportSessionTitle(session: Pick<SessionRow, "title">): string {
 }
 
 function sessionSummaryLine(session: SessionRow): string {
-  const diff = session.diff ? ` (+${session.diff.additions} -${session.diff.deletions})` : "";
+  // A zero/zero diff is daemon boilerplate, not signal — suppress the suffix.
+  const hasDiff = Boolean(session.diff && (session.diff.additions || session.diff.deletions));
+  const diff = hasDiff ? ` (+${session.diff!.additions} -${session.diff!.deletions})` : "";
   return `${reportSessionTitle(session)}${diff}`;
 }
 
@@ -102,9 +108,13 @@ export function shouldCreateDailySummary(items: InboxItem[], now = new Date()): 
   return !items.some((item) => item.auto === key);
 }
 
-/** Server-side enrichments threaded into the builder. Phase B fills this in
- *  (merged PRs, completed board cards); Phase A only reserves the seam. */
-export type DailySummaryExtras = Record<string, never>;
+/** Server-side enrichments threaded into the builder: the day-in-review
+ *  payload assembled by the daily-summary route (merged PRs, session groups,
+ *  completed board cards). Type-only dependency — the runtime import direction
+ *  is daily-report-facts → this module (reportSessionTitle), never back. */
+export type DailySummaryExtras = {
+  report?: DailyReportPayload | null;
+};
 
 type BuildContentInput = BuildInput & { extras?: DailySummaryExtras };
 
@@ -115,6 +125,7 @@ export function buildDailySummaryContent({
   items,
   sessions,
   now = new Date(),
+  extras,
 }: BuildContentInput): DailySummaryDraft | null {
   const todayReminders = items.filter(
     (item) =>
@@ -138,21 +149,32 @@ export function buildDailySummaryContent({
     .filter((session) => !session.archived_at && isSameLocalDay(session.updated_at, now))
     .sort((a, b) => b.updated_at.localeCompare(a.updated_at));
 
+  const report = extras?.report ?? null;
+  const prsMerged = report?.prsMerged;
+  const cardsCompleted = report?.cardsCompleted;
+
   if (
     todayReminders.length === 0 &&
     waitingResponses.length === 0 &&
     agentNotifications.length === 0 &&
-    todaySessions.length === 0
+    todaySessions.length === 0 &&
+    !prsMerged?.length &&
+    !cardsCompleted?.length
   ) {
     return null;
   }
 
+  // The base four lines keep their exact wording — parseStatsFromBody and the
+  // toast surfaces regex them. The day-in-review lines are additive and appear
+  // only when the section's data source resolved (absence ≠ zero).
   const lines = [
     plural(todayReminders.length, "reminder", "reminders") + " fired",
     plural(waitingResponses.length, "response", "responses") + " waiting",
     plural(agentNotifications.length, "familiar update", "familiar updates"),
     plural(todaySessions.length, "session", "sessions") + " updated",
   ];
+  if (prsMerged) lines.push(plural(prsMerged.length, "PR") + " merged");
+  if (cardsCompleted) lines.push(plural(cardsCompleted.length, "card") + " completed");
   // Dedupe repeated titles (retried/refreshed runs share one) case-insensitively,
   // keeping the most recent occurrence — the list is already sorted newest-first.
   const seenTitles = new Set<string>();
@@ -167,13 +189,31 @@ export function buildDailySummaryContent({
   if (topSessions.length > 0) lines.push(`Recent: ${topSessions.join(" · ")}`);
 
   const sentAt = now.toISOString();
-  const stats = {
+  const stats: InboxMedia["stats"] = {
     reminders: todayReminders.length,
     responses: waitingResponses.length,
     familiars: agentNotifications.length,
     sessions: todaySessions.length,
+    ...(prsMerged ? { prsMerged: prsMerged.length } : {}),
+    ...(cardsCompleted ? { cardsCompleted: cardsCompleted.length } : {}),
   };
   const day = dayLabel(now);
+  // SVG v2 leads with the day's real output (sessions / PRs / cards) when the
+  // day-in-review payload resolved; without it the legacy four-count row keeps
+  // historical parity.
+  const svgColumns = report
+    ? [
+        { value: stats.sessions, label: stats.sessions === 1 ? "session" : "sessions" },
+        { value: prsMerged?.length ?? 0, label: "PRs merged" },
+        { value: cardsCompleted?.length ?? 0, label: "cards done" },
+        { value: stats.reminders + stats.responses + stats.familiars, label: "inbox events" },
+      ]
+    : [
+        { value: stats.reminders, label: "reminders" },
+        { value: stats.responses, label: "responses" },
+        { value: stats.familiars, label: "familiars" },
+        { value: stats.sessions, label: "sessions" },
+      ];
   const svg = `
 <svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
   <defs>
@@ -193,16 +233,17 @@ export function buildDailySummaryContent({
   <text x="64" y="176" fill="#ffffff" font-family="Inter, system-ui, sans-serif" font-size="72" font-weight="800">${xmlEscape(day)}</text>
   <text x="64" y="232" fill="#b9b0c8" font-family="Inter, system-ui, sans-serif" font-size="28">A generated snapshot of today's cave activity.</text>
   <g font-family="Inter, system-ui, sans-serif" font-weight="800">
-    <text x="92" y="362" fill="#ffffff" font-size="58">${stats.reminders}</text>
-    <text x="300" y="362" fill="#ffffff" font-size="58">${stats.responses}</text>
-    <text x="508" y="362" fill="#ffffff" font-size="58">${stats.familiars}</text>
-    <text x="716" y="362" fill="#ffffff" font-size="58">${stats.sessions}</text>
+${svgColumns
+  .map(
+    (col, i) =>
+      `    <text x="${92 + i * 208}" y="362" fill="#ffffff" font-size="58">${col.value}</text>`,
+  )
+  .join("\n")}
   </g>
   <g fill="#b9b0c8" font-family="Inter, system-ui, sans-serif" font-size="22" font-weight="700">
-    <text x="92" y="410">reminders</text>
-    <text x="300" y="410">responses</text>
-    <text x="508" y="410">familiars</text>
-    <text x="716" y="410">sessions</text>
+${svgColumns
+  .map((col, i) => `    <text x="${92 + i * 208}" y="410">${xmlEscape(col.label)}</text>`)
+  .join("\n")}
   </g>
 </svg>`.trim();
 
@@ -220,6 +261,7 @@ export function buildDailySummaryContent({
       alt: `Daily summary generated image for ${day}`,
       stats,
       generatedAt: sentAt,
+      ...(report ? { report } : {}),
     },
     fireAt: sentAt,
     firedAt: sentAt,

--- a/src/lib/dashboard-model.test.ts
+++ b/src/lib/dashboard-model.test.ts
@@ -82,8 +82,36 @@ function summary(slug) {
   assert.ok(model.todaySummary, "today summary present when today's report exists");
   assert.equal(model.todaySummary.imageUrl, "img.png");
   assert.deepEqual(model.todaySummary.recentSessions, ["alpha", "beta"], "recovers session names from body");
+  assert.equal(model.todaySummary.report, null, "no day-in-review payload on pre-Phase-B reports");
   assert.equal(model.metricsLive, false, "metrics are frozen when today's report exists");
   assert.deepEqual(model.metrics, { reminders: 1, responses: 2, familiars: 4, sessions: 3 });
+}
+
+// the frozen day-in-review payload (media.report) rides along when present
+{
+  const payload = {
+    prsMerged: [{ repo: "o/r", number: 1, title: "t", url: "u", mergedAt: ISO }],
+    factsHash: "h",
+    refreshedAt: ISO,
+  };
+  const today = item({
+    id: "s-2026-06-20b",
+    kind: "daily-summary",
+    title: "Report 2026-06-20",
+    body: "1 reminder fired",
+    auto: "daily-summary:2026-06-20",
+    media: {
+      kind: "summary-card",
+      imageUrl: "img.png",
+      alt: "card",
+      stats: { reminders: 1, responses: 0, familiars: 0, sessions: 0, prsMerged: 1 },
+      generatedAt: ISO,
+      report: payload,
+    },
+  });
+  const model = buildDashboardModel([today], now);
+  assert.deepEqual(model.todaySummary.report, payload, "media.report surfaces on TodaySummary");
+  assert.equal(model.metrics.prsMerged, 1, "extended frozen stats ride along");
 }
 
 // before today's report exists, metrics fall back to the live snapshot

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -9,6 +9,7 @@
 // client action-inbox island and the strip-types tests can import it safely.
 
 import type { InboxItem } from "./cave-inbox";
+import type { DailyReportPayload } from "./daily-report-facts";
 import {
   breakdownForDay,
   dateSlug,
@@ -38,6 +39,8 @@ export type TodaySummary = {
   generatedAt: string | null;
   /** Read-only session names recovered from the frozen summary body. */
   recentSessions: string[];
+  /** Frozen day-in-review payload (Phase B+); null on older reports. */
+  report: DailyReportPayload | null;
 };
 
 export type DashboardModel = {
@@ -79,6 +82,7 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
         alt: todayItem.media?.alt ?? "",
         generatedAt: todayItem.media?.generatedAt ?? todayItem.firedAt ?? todayItem.updatedAt ?? null,
         recentSessions: parseRecentSessions(todayItem.body),
+        report: todayItem.media?.report ?? null,
       }
     : null;
 

--- a/src/lib/server/github-merged.ts
+++ b/src/lib/server/github-merged.ts
@@ -1,0 +1,111 @@
+// "PRs merged today" for the daily report. Server-only: reads the local PAT
+// (same tiers as /api/github/activity — never logged, never forwarded beyond
+// api.github.com) and degrades to null whenever token or login can't be
+// resolved, so the report section simply stays absent.
+
+import { resolveSecret } from "@/lib/vault";
+import type { MergedPr } from "@/lib/daily-report-facts";
+
+const GH = "https://api.github.com";
+const TTL_MS = 10 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 8000;
+
+let cache: { at: number; day: string; items: MergedPr[] } | null = null;
+
+function dateSlug(date: Date): string {
+  const y = date.getFullYear();
+  const m = `${date.getMonth() + 1}`.padStart(2, "0");
+  const d = `${date.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+type SearchItem = {
+  number?: number;
+  title?: string;
+  html_url?: string;
+  repository_url?: string;
+  pull_request?: { merged_at?: string | null };
+};
+
+async function ghJson(path: string, token: string | null): Promise<unknown> {
+  const res = await fetch(`${GH}${path}`, {
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`github ${res.status}`);
+  return res.json();
+}
+
+/** PRs authored by the local user merged during the local calendar day of
+ *  `now`. Search qualifiers are UTC, so the query reaches one day back and the
+ *  results are re-filtered against local time. Returns null (never throws)
+ *  when the PAT or login is unresolvable or the fetch fails with no usable
+ *  cache — the caller renders nothing rather than an error. */
+export async function fetchMergedPrsForDay(now = new Date()): Promise<MergedPr[] | null> {
+  const day = dateSlug(now);
+  if (cache && cache.day === day && Date.now() - cache.at < TTL_MS) return cache.items;
+
+  // Same auth tiers as /api/github/activity: PAT when present, else the
+  // public unauthenticated API with GITHUB_USERNAME (search allows anonymous
+  // queries at a low rate — one request per 10-min cache window is fine).
+  const token = resolveSecret("GITHUB_PAT") ?? process.env.GITHUB_TOKEN?.trim() ?? null;
+
+  try {
+    let login = resolveSecret("GITHUB_USERNAME") ?? null;
+    if (!login && token) {
+      const user = (await ghJson("/user", token)) as { login?: string } | null;
+      login = user?.login ?? null;
+    }
+    if (!login) return null;
+
+    // One-day buffer: `merged:>=` compares in UTC, local midnight may precede it.
+    const prev = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const q = encodeURIComponent(`is:pr is:merged author:${login} merged:>=${dateSlug(prev)}`);
+    // Up to two pages (200 PRs) so a heavy multi-agent day isn't silently
+    // truncated at the API's 100-per-page cap.
+    const results: SearchItem[] = [];
+    for (let page = 1; page <= 2; page++) {
+      const data = (await ghJson(`/search/issues?q=${q}&per_page=100&page=${page}`, token)) as {
+        items?: SearchItem[];
+      } | null;
+      const batch = data?.items ?? [];
+      results.push(...batch);
+      if (batch.length < 100) break;
+    }
+
+    const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const items: MergedPr[] = results
+      .flatMap((item) => {
+        const mergedAt = item.pull_request?.merged_at;
+        if (!mergedAt || typeof item.number !== "number" || !item.html_url) return [];
+        const mergedMs = new Date(mergedAt).getTime();
+        if (Number.isNaN(mergedMs) || mergedMs < dayStart || mergedMs >= dayStart + 24 * 60 * 60 * 1000) {
+          return [];
+        }
+        const repo = item.repository_url?.replace(/^.*\/repos\//, "") ?? "";
+        if (!repo) return [];
+        return [
+          {
+            repo,
+            number: item.number,
+            title: item.title ?? `${repo}#${item.number}`,
+            url: item.html_url,
+            mergedAt,
+          },
+        ];
+      })
+      .sort((a, b) => b.mergedAt.localeCompare(a.mergedAt));
+
+    cache = { at: Date.now(), day, items };
+    return items;
+  } catch {
+    // Serve a stale same-day cache over nothing; otherwise degrade to absent.
+    if (cache && cache.day === day) return cache.items;
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Phase B of the daily-report overhaul (bead `cave-05p`; Phase A was #2497). The report now carries the day's real story — merged PRs, sessions grouped by project, and completed board cards — frozen additively into `media.report`.

- **New pure `src/lib/daily-report-facts.ts`** — `buildSessionGroups` (by `project_root`, basename label, diff totals, PR chips; caps 6 groups × 5 sessions), `unionMergedPrs` (PAT search ∪ session-linked merged PRs, so PAT-less setups still get partial data; `null` ≠ `[]` keeps absence distinct from a zero-merge day), `completedCardsForDay` (lifecycle `completed` today + legacy `done` fallback), `dailyFactsHash` (stable, order-insensitive, timestamp-free — feeds Phase C narrative staleness).
- **New `src/lib/server/github-merged.ts`** — merged-today search with the same auth tiers as `/api/github/activity` (PAT, else public unauthenticated + `GITHUB_USERNAME`), two-page pagination (real data exceeded the 100/page cap today), local-day filtering over a one-day UTC buffer, 10-min TTL cache, degrades to `null` on any failure. Lib, not a route — no api-contracts table entry needed.
- **Route** gathers facts outside the inbox lock (`Promise.all`, each source `.catch(() => null)`), threads them as `extras`; refreshes preserve `media.narrative`.
- **Builder** — additive `"N PRs merged"` / `"N cards completed"` body lines only when the source resolved (absence ≠ zero); base four lines keep their regex-pinned wording; empty-day guard extended so a PR-only day still reports; SVG v2 leads with sessions/PRs/cards when the payload resolved.
- **Report page** — Merged pull requests (linked), Sessions by project (group headers with `+A −D`, familiar + PR chips), Cards completed (deep-links `/#card-<id>`); all guarded so historical reports render unchanged; conditional MetricCards for the two new stats. `parseStatsFromBody` gains the two optional regexes (keys omitted when absent).
- **Dashboard** — `TodaySummary.report` + merged-PR / project chips on the today panel.
- **Hygiene follow-ups found during live verify** — reject `<covenroster>`-style angle-tag prompt leaks; suppress `(+0 -0)` diff suffixes.

## Test plan

- `node scripts/run-tests.mjs app` — 528 files pass, including new `daily-report-facts.test.ts` (grouping/caps/union/dedupe/hash matrix) and extended builder / parse / page-pin / dashboard-model tests
- `tsc --noEmit` ✓ · `check:tests-wired` ✓
- **Verified live** against the real inbox on a worktree dev server: report refreshed in place to "101 PRs merged" (pagination exercised on real data), 6 session groups frozen, all three sections render on today's page, historical pages unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)