### PR TITLE
fix(chat): keep in-flight generation progress when navigating away (cave-0er)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -188,6 +188,7 @@ export const SUITES = {
     "src/components/run-activity-strip.test.ts",
     "src/components/chat-view-lifecycle.test.ts",
     "src/lib/live-chat-snapshot.test.ts",
+    "src/lib/live-chat-generations.test.ts",
     "src/components/chat-view-render-optimization.test.ts",
     "src/components/chat-view-canvas-artifact.test.ts",
     "src/components/chat-response-metadata.test.ts",

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -140,13 +140,13 @@ assert.match(
 
 assert.match(
   source,
-  /const liveChatGenerations = new Map<string, LiveChatGenerationSnapshot>\(\)/,
+  /const liveChatRegistry = createLiveGenerationRegistry<Turn>\(cloneLiveTurn\)/,
   "In-flight chat generations should be persisted outside the ChatView component so navigation away does not lose them",
 );
 
 assert.match(
   source,
-  /function subscribeLiveChatGeneration\(sessionId: string, listener: LiveChatGenerationListener\)/,
+  /function subscribeLiveChatGeneration\(\s*sessionId: string,\s*listener: \(snapshot: LiveChatGenerationSnapshot \| null\) => void,\s*\)/,
   "ChatView should subscribe to live generation snapshots when returning to a session",
 );
 
@@ -499,12 +499,21 @@ assert.match(
 );
 
 // ── Mid-stream thread switch must not cross wires (2026-07-03 audit P0) ───────
-// A background stream updates its OWN registry snapshot, never the displayed
-// transcript — otherwise switching threads renders/persists the wrong session.
+// A live stream accumulates in its session's registry snapshot — module scope,
+// so it survives thread switches AND full surface unmounts (cave-0er). Only a
+// view currently showing that session mirrors the update into setTurns.
 assert.match(
   source,
-  /if \(targetSessionId && targetSessionId !== currentSessionRef\.current\) \{[\s\S]*?const snap = readLiveChatGeneration\(targetSessionId\);[\s\S]*?recordLiveChatGeneration\(\{[\s\S]*?turns: updater\(snap\.turns\)/,
-  "updateLiveTurns routes background-stream updates to the streaming session's snapshot, not setTurns",
+  /if \(targetSessionId\) \{[\s\S]*?const stored = liveChatRegistry\.advance\(targetSessionId, updater, nextActiveLeafId\);[\s\S]*?if \(targetSessionId === currentSessionRef\.current\) \{[\s\S]*?setTurns\(stored\.turns\);/,
+  "updateLiveTurns accumulates in the module-scope registry first so unmounted views can't drop chunks, mirroring into setTurns only for the on-screen session",
+);
+// A view that adopted (not started) a stream reconciles from disk on settle —
+// it never sees the stream's "done" event, and the server only persists the
+// exchange when the harness exits (cave-0er).
+assert.match(
+  source,
+  /if \(!live && refetchOnSettleRef\.current === sessionId && !streamOwnerRef\.current\) \{[\s\S]*?setHistoryRetryKey\(\(k\) => k \+ 1\);/,
+  "a non-owner view refetches the conversation from disk when an adopted/orphaned stream settles",
 );
 // Switching threads releases the previous thread's streaming lock so its busy
 // state / Esc-cancel don't bleed onto the newly displayed thread.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -9,6 +9,7 @@ import { ChatArtifactViewer } from "@/components/chat-artifact-viewer";
 import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib/canvas-artifacts";
 import { segmentTurn } from "@/lib/turn-segments";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
+import { createLiveGenerationRegistry, type LiveGenerationSnapshot } from "@/lib/live-chat-generations";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
 import { Icon, type IconName } from "@/lib/icon";
@@ -191,17 +192,7 @@ type Turn = {
 // value is a pure function of the turn, so sharing across instances is safe.
 const replyableTurnCache = new WeakMap<Turn, boolean>();
 
-type LiveChatGenerationSnapshot = {
-  sessionId: string;
-  turns: Turn[];
-  activeLeafId: string;
-  controller: AbortController;
-  updatedAt: number;
-};
-type LiveChatGenerationListener = (snapshot: LiveChatGenerationSnapshot | null) => void;
-
-const liveChatGenerations = new Map<string, LiveChatGenerationSnapshot>();
-const liveChatGenerationListeners = new Map<string, Set<LiveChatGenerationListener>>();
+type LiveChatGenerationSnapshot = LiveGenerationSnapshot<Turn>;
 
 function cloneLiveTurn(turn: Turn): Turn {
   return {
@@ -212,38 +203,31 @@ function cloneLiveTurn(turn: Turn): Turn {
   };
 }
 
-function notifyLiveChatGeneration(sessionId: string, snapshot: LiveChatGenerationSnapshot | null) {
-  const listeners = liveChatGenerationListeners.get(sessionId);
-  if (!listeners?.size) return;
-  for (const listener of listeners) listener(snapshot);
-}
+// Module-scope so a generation outlives the ChatView instance that started
+// it (thread switches AND full surface unmounts — cave-0er). All streaming
+// mutations must go through the registry (see updateLiveTurns), never only
+// through component setState: React silently drops setState on an unmounted
+// instance, which used to freeze the snapshot mid-generation and lose the
+// response. See src/lib/live-chat-generations.ts.
+const liveChatRegistry = createLiveGenerationRegistry<Turn>(cloneLiveTurn);
 
 function readLiveChatGeneration(sessionId: string): LiveChatGenerationSnapshot | null {
-  return liveChatGenerations.get(sessionId) ?? null;
+  return liveChatRegistry.read(sessionId);
 }
 
-function recordLiveChatGeneration(snapshot: LiveChatGenerationSnapshot) {
-  const next = {
-    ...snapshot,
-    turns: snapshot.turns.map(cloneLiveTurn),
-  };
-  liveChatGenerations.set(snapshot.sessionId, next);
-  queueMicrotask(() => notifyLiveChatGeneration(snapshot.sessionId, next));
+function recordLiveChatGeneration(snapshot: LiveChatGenerationSnapshot): LiveChatGenerationSnapshot {
+  return liveChatRegistry.record(snapshot);
 }
 
 function clearLiveChatGeneration(sessionId: string | null | undefined) {
-  if (!sessionId || !liveChatGenerations.delete(sessionId)) return;
-  queueMicrotask(() => notifyLiveChatGeneration(sessionId, null));
+  liveChatRegistry.clear(sessionId);
 }
 
-function subscribeLiveChatGeneration(sessionId: string, listener: LiveChatGenerationListener) {
-  const listeners = liveChatGenerationListeners.get(sessionId) ?? new Set<LiveChatGenerationListener>();
-  listeners.add(listener);
-  liveChatGenerationListeners.set(sessionId, listeners);
-  return () => {
-    listeners.delete(listener);
-    if (listeners.size === 0) liveChatGenerationListeners.delete(sessionId);
-  };
+function subscribeLiveChatGeneration(
+  sessionId: string,
+  listener: (snapshot: LiveChatGenerationSnapshot | null) => void,
+) {
+  return liveChatRegistry.subscribe(sessionId, listener);
 }
 
 // `isLiveSnapshotActive` lives in @/lib/live-chat-snapshot so the staleness rule
@@ -2479,6 +2463,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const activeSlashOptionRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const initialPromptSentRef = useRef(false);
+  /** True while THIS instance's sendRaw reader loop is running. The owner
+   *  applies stream events itself (handleEvent), so it never needs the
+   *  settle-refetch below; an instance that merely ADOPTED a live snapshot
+   *  (remounted mid-generation) does. */
+  const streamOwnerRef = useRef(false);
+  /** Session whose settle (registry clear) should trigger a disk refetch:
+   *  set when this non-owner view adopts a live snapshot, or when it evicts
+   *  a stale one while the orphaned stream may still be running (cave-0er). */
+  const refetchOnSettleRef = useRef<string | null>(null);
+  /** Count of registry null-notifications to swallow: evicting a stale
+   *  snapshot emits one, and that self-inflicted settle must not refetch a
+   *  conversation the history effect is already loading. */
+  const skipSettleNotifyRef = useRef(0);
   const keys = useKeySymbols();
 
   function persistLiveTurns(
@@ -2504,23 +2501,34 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     controller: AbortController | null = abortRef.current,
     targetSessionId: string | null = currentSessionRef.current,
   ) {
-    // Background stream: the user navigated to a DIFFERENT thread while this
-    // session is still generating. Update that session's OWN registry snapshot
-    // (its turns, its controller) — calling setTurns here would splice the
-    // streaming session's messages into the thread now on screen AND persist
-    // the on-screen thread's turns back into the streaming session's snapshot
-    // (returning to it then shows the wrong conversation, stuck "Streaming…").
-    if (targetSessionId && targetSessionId !== currentSessionRef.current) {
-      const snap = readLiveChatGeneration(targetSessionId);
-      if (!snap) return; // stream already settled / snapshot evicted
-      recordLiveChatGeneration({
-        ...snap,
-        turns: updater(snap.turns),
-        activeLeafId: nextActiveLeafId,
-        updatedAt: Date.now(),
-      });
-      return;
+    // Registry-first (cave-0er): while a generation has a registry snapshot,
+    // the registry is the accumulating source of truth — it lives at module
+    // scope, so chunks keep landing even after this component instance
+    // unmounts (navigating to another surface). Routing accumulation through
+    // setTurns instead silently dropped every post-unmount update (React
+    // ignores setState on unmounted instances), freezing the snapshot and
+    // losing the response.
+    if (targetSessionId) {
+      const stored = liveChatRegistry.advance(targetSessionId, updater, nextActiveLeafId);
+      if (stored) {
+        // Mirror synchronously into THIS view's state when it is showing the
+        // streaming session. Reusing the stored array means the microtask
+        // notification delivers the same reference — setTurns bails, no
+        // double render. A view on a different thread ignores the update; an
+        // unmounted view's setTurns is a harmless no-op (the registry
+        // already has the data and a remount adopts it).
+        if (targetSessionId === currentSessionRef.current) {
+          turnsRef.current = stored.turns;
+          setTurns(stored.turns);
+        }
+        return;
+      }
+      // Stream already settled / snapshot evicted: drop background updates
+      // aimed at a thread that is not on screen.
+      if (targetSessionId !== currentSessionRef.current) return;
     }
+    // No registry snapshot (e.g. a brand-new chat before its "session" event
+    // assigns an id): plain component state, exactly as before.
     setTurns((prev) => {
       const next = updater(prev);
       turnsRef.current = next;
@@ -2539,10 +2547,28 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         abortRef.current = live.controller;
         setHistoryState("loaded");
         setBusy(true);
+        // Adopted someone else's stream (this instance mounted mid-
+        // generation): reconcile from disk when it settles, because this
+        // view never sees the stream's "done" event and the optimistic
+        // snapshot lacks the persisted turn ids/usage.
+        if (!streamOwnerRef.current) refetchOnSettleRef.current = sessionId;
         return;
       }
       abortRef.current = null;
       setBusy(false);
+      if (!live && skipSettleNotifyRef.current > 0) {
+        skipSettleNotifyRef.current -= 1;
+        return;
+      }
+      // Settle (registry cleared) for a generation this view adopted but
+      // does not own: the server has now persisted the full exchange (or a
+      // cancel marker) — reload the conversation from disk so the completed
+      // response actually appears (cave-0er). The owner skips this: its own
+      // handleEvent already applied the final state.
+      if (!live && refetchOnSettleRef.current === sessionId && !streamOwnerRef.current) {
+        refetchOnSettleRef.current = null;
+        setHistoryRetryKey((k) => k + 1);
+      }
     });
   }, [sessionId]);
 
@@ -3000,6 +3026,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
     currentSessionRef.current = sessionId;
     liveSessionIdRef.current = null;
+    // Reset the settle-refetch marker on every (re)load; the live-snapshot
+    // branches below re-arm it when there is actually an adopted or possibly-
+    // orphaned stream to reconcile. A marker left armed after a normal disk
+    // load would fire a spurious reload after the NEXT send settles.
+    refetchOnSettleRef.current = null;
     // Thread switch: release streaming state owned by the PREVIOUS thread so its
     // busy lock / Esc-cancel don't bleed onto this one. A background stream
     // keeps running via its registry snapshot + controller; the live-snapshot
@@ -3023,13 +3054,23 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       abortRef.current = live.controller;
       setHistoryState("loaded");
       setBusy(true);
+      // Adopting a stream this instance did not start (remount mid-
+      // generation): reconcile from disk when it settles — this view never
+      // sees the stream's "done" event (cave-0er).
+      if (!streamOwnerRef.current) refetchOnSettleRef.current = sessionId;
       return;
     }
     if (live) {
       // Stale/aborted snapshot whose cleanup never ran — evict it so neither
       // this view nor the subscription re-adopts a dead "Streaming…" state,
-      // then fall through to loading the conversation from disk.
+      // then fall through to loading the conversation from disk. The evict
+      // emits a null notification; swallow it (we are about to load from
+      // disk anyway). If the orphaned stream is in fact still running, its
+      // own clear on settle fires a SECOND notification — arm the settle
+      // refetch so the finished response gets picked up then (cave-0er).
+      skipSettleNotifyRef.current += 1;
       clearLiveChatGeneration(sessionId);
+      if (!live.controller.signal.aborted) refetchOnSettleRef.current = sessionId;
     }
     let cancelled = false;
     void (async () => {
@@ -3470,6 +3511,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const controller = new AbortController();
     const liveGeneration = { sessionId: initialLiveSessionId, controller };
     abortRef.current = controller;
+    streamOwnerRef.current = true;
+    refetchOnSettleRef.current = null;
     const nextTurns = [...turnsRef.current, userTurn, assistantTurn];
     appendTurn([userTurn, assistantTurn]);
     turnsRef.current = nextTurns;
@@ -3627,6 +3670,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         raiseDebugError({ turnId: assistantId });
       }
     } finally {
+      streamOwnerRef.current = false;
       clearLiveChatGeneration(liveGeneration.sessionId);
       abortRef.current = null;
       setBusy(false);

--- a/src/lib/live-chat-generations.test.ts
+++ b/src/lib/live-chat-generations.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createLiveGenerationRegistry } from "./live-chat-generations.ts";
+
+type FakeTurn = { id: string; text: string };
+
+function makeRegistry() {
+  return createLiveGenerationRegistry<FakeTurn>((turn) => ({ ...turn }));
+}
+
+function controller() {
+  return new AbortController();
+}
+
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("record + read round-trips a snapshot with cloned turns", () => {
+  const registry = makeRegistry();
+  const turns = [{ id: "u1", text: "hi" }];
+  registry.record({ sessionId: "s1", turns, activeLeafId: "u1", controller: controller(), updatedAt: 1 });
+  const stored = registry.read("s1");
+  assert.ok(stored);
+  assert.deepEqual(stored.turns, turns);
+  // Defensive clone: mutating the caller's array must not reach the registry.
+  turns[0].text = "mutated";
+  assert.equal(stored.turns[0].text, "hi");
+});
+
+test("advance accumulates chunks with no component involved (cave-0er)", () => {
+  // The bug: routing accumulation through an unmounted component's setState
+  // silently dropped every chunk after navigating away from the chat
+  // surface. The registry must accumulate at module scope instead.
+  const registry = makeRegistry();
+  registry.record({
+    sessionId: "s1",
+    turns: [{ id: "a1", text: "" }],
+    activeLeafId: "a1",
+    controller: controller(),
+    updatedAt: 1,
+  });
+  for (const chunk of ["Hel", "lo ", "world"]) {
+    registry.advance("s1", (prev) => prev.map((t) => ({ ...t, text: t.text + chunk })), "a1");
+  }
+  assert.equal(registry.read("s1")?.turns[0].text, "Hello world");
+});
+
+test("advance refreshes updatedAt so a live stream never looks stale", () => {
+  const registry = makeRegistry();
+  registry.record({
+    sessionId: "s1",
+    turns: [{ id: "a1", text: "" }],
+    activeLeafId: "a1",
+    controller: controller(),
+    updatedAt: 0,
+  });
+  const before = Date.now();
+  registry.advance("s1", (prev) => prev, "a1");
+  assert.ok((registry.read("s1")?.updatedAt ?? 0) >= before);
+});
+
+test("advance after settle/evict is a null no-op", () => {
+  const registry = makeRegistry();
+  assert.equal(registry.advance("gone", (prev) => prev, "a1"), null);
+  registry.record({ sessionId: "s1", turns: [], activeLeafId: "", controller: controller(), updatedAt: 1 });
+  registry.clear("s1");
+  assert.equal(registry.advance("s1", (prev) => prev, "a1"), null);
+});
+
+test("record/advance return the stored snapshot listeners will receive", async () => {
+  // The mounted view mirrors the returned snapshot synchronously; the
+  // microtask notification must carry the SAME reference so the mirror's
+  // setState bails instead of double-rendering.
+  const registry = makeRegistry();
+  const seen: unknown[] = [];
+  registry.subscribe("s1", (snapshot) => seen.push(snapshot));
+  const stored = registry.record({
+    sessionId: "s1",
+    turns: [{ id: "a1", text: "x" }],
+    activeLeafId: "a1",
+    controller: controller(),
+    updatedAt: 1,
+  });
+  const advanced = registry.advance("s1", (prev) => prev, "a1");
+  await flushMicrotasks();
+  assert.equal(seen.length, 2);
+  assert.equal(seen[0], stored);
+  assert.equal(seen[1], advanced);
+});
+
+test("clear notifies null exactly once per call, even when already evicted", async () => {
+  // Eviction path: a remounted view expires a quiet snapshot while the
+  // orphaned stream keeps running. The stream's own clear-on-settle must
+  // still notify so adopters reconcile from disk.
+  const registry = makeRegistry();
+  const seen: unknown[] = [];
+  registry.subscribe("s1", (snapshot) => seen.push(snapshot));
+  registry.record({ sessionId: "s1", turns: [], activeLeafId: "", controller: controller(), updatedAt: 1 });
+  registry.clear("s1"); // eviction
+  registry.clear("s1"); // orphaned stream settles later
+  await flushMicrotasks();
+  assert.deepEqual(seen.slice(1), [null, null]);
+});
+
+test("clear with a null/undefined session id does not notify", async () => {
+  const registry = makeRegistry();
+  const seen: unknown[] = [];
+  registry.subscribe("", (snapshot) => seen.push(snapshot));
+  registry.clear(null);
+  registry.clear(undefined);
+  await flushMicrotasks();
+  assert.equal(seen.length, 0);
+});
+
+test("subscribe scopes notifications to the session and unsubscribes cleanly", async () => {
+  const registry = makeRegistry();
+  const forS1: unknown[] = [];
+  const forS2: unknown[] = [];
+  const unsubscribe = registry.subscribe("s1", (snapshot) => forS1.push(snapshot));
+  registry.subscribe("s2", (snapshot) => forS2.push(snapshot));
+  registry.record({ sessionId: "s1", turns: [], activeLeafId: "", controller: controller(), updatedAt: 1 });
+  await flushMicrotasks();
+  assert.equal(forS1.length, 1);
+  assert.equal(forS2.length, 0);
+  unsubscribe();
+  registry.record({ sessionId: "s1", turns: [], activeLeafId: "", controller: controller(), updatedAt: 2 });
+  await flushMicrotasks();
+  assert.equal(forS1.length, 1);
+});

--- a/src/lib/live-chat-generations.ts
+++ b/src/lib/live-chat-generations.ts
@@ -1,0 +1,105 @@
+/**
+ * Module-scope registry for in-flight chat generations.
+ *
+ * A chat generation is CLIENT-OWNED: the ChatView instance that sent the
+ * prompt holds the SSE reader loop for /api/chat/send in a closure. This
+ * registry is what lets that stream outlive the component: switching threads
+ * or navigating to another surface unmounts (or re-targets) the view, while
+ * the orphaned closure keeps consuming chunks and accumulating them HERE —
+ * never through the unmounted instance's setState, which React silently
+ * drops (cave-0er). The view that next mounts on the session adopts the
+ * snapshot and mirrors subsequent updates via `subscribe`.
+ *
+ * Generic over the turn shape so the accumulation/notification rules can be
+ * unit-tested without React or ChatView's Turn type; the caller supplies the
+ * turn-clone function used to isolate snapshots from component-state mutation.
+ * The staleness rule for adopting a snapshot lives in
+ * @/lib/live-chat-snapshot (isLiveSnapshotActive).
+ */
+
+export type LiveGenerationSnapshot<T> = {
+  sessionId: string;
+  turns: T[];
+  activeLeafId: string;
+  controller: AbortController;
+  updatedAt: number;
+};
+
+export type LiveGenerationListener<T> = (snapshot: LiveGenerationSnapshot<T> | null) => void;
+
+export type LiveGenerationRegistry<T> = {
+  read(sessionId: string): LiveGenerationSnapshot<T> | null;
+  /** Store a snapshot (turns are defensively cloned). Returns the stored
+   *  snapshot — the same object listeners receive — so a caller can mirror
+   *  it into component state without triggering a second render when its
+   *  own notification arrives. */
+  record(snapshot: LiveGenerationSnapshot<T>): LiveGenerationSnapshot<T>;
+  /** Apply `updater` to the session's snapshot turns and stamp `updatedAt`.
+   *  Returns the stored snapshot, or null when the stream already settled /
+   *  the snapshot was evicted. */
+  advance(
+    sessionId: string,
+    updater: (prev: T[]) => T[],
+    nextActiveLeafId: string,
+  ): LiveGenerationSnapshot<T> | null;
+  clear(sessionId: string | null | undefined): void;
+  /** Listen for snapshot updates (record/advance) and settle (clear → null).
+   *  Notifications are delivered on a microtask. Returns an unsubscriber. */
+  subscribe(sessionId: string, listener: LiveGenerationListener<T>): () => void;
+};
+
+export function createLiveGenerationRegistry<T>(cloneTurn: (turn: T) => T): LiveGenerationRegistry<T> {
+  const snapshots = new Map<string, LiveGenerationSnapshot<T>>();
+  const listeners = new Map<string, Set<LiveGenerationListener<T>>>();
+
+  function notify(sessionId: string, snapshot: LiveGenerationSnapshot<T> | null) {
+    const set = listeners.get(sessionId);
+    if (!set?.size) return;
+    for (const listener of set) listener(snapshot);
+  }
+
+  function record(snapshot: LiveGenerationSnapshot<T>): LiveGenerationSnapshot<T> {
+    const next = {
+      ...snapshot,
+      turns: snapshot.turns.map(cloneTurn),
+    };
+    snapshots.set(snapshot.sessionId, next);
+    queueMicrotask(() => notify(snapshot.sessionId, next));
+    return next;
+  }
+
+  return {
+    read(sessionId) {
+      return snapshots.get(sessionId) ?? null;
+    },
+    record,
+    advance(sessionId, updater, nextActiveLeafId) {
+      const snap = snapshots.get(sessionId);
+      if (!snap) return null; // stream already settled / snapshot evicted
+      return record({
+        ...snap,
+        turns: updater(snap.turns),
+        activeLeafId: nextActiveLeafId,
+        updatedAt: Date.now(),
+      });
+    },
+    clear(sessionId) {
+      if (!sessionId) return;
+      // Notify even when the entry was already evicted (e.g. a remounted
+      // view expired a quiet snapshot while the orphaned stream kept
+      // running): the settle signal is what tells adopters to reconcile
+      // from disk, and it must fire exactly once per clear call.
+      snapshots.delete(sessionId);
+      queueMicrotask(() => notify(sessionId, null));
+    },
+    subscribe(sessionId, listener) {
+      const set = listeners.get(sessionId) ?? new Set<LiveGenerationListener<T>>();
+      set.add(listener);
+      listeners.set(sessionId, set);
+      return () => {
+        set.delete(listener);
+        if (set.size === 0) listeners.delete(sessionId);
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Problem

Navigating away from a chat mid-generation loses the progress on that chat.

**Root cause** (bead `cave-0er`): chat generation is client-owned — the ChatView instance holds the `/api/chat/send` SSE reader loop. Cross-navigation continuity relies on a module-level snapshot registry, but registry writes for the on-screen session were routed **through `setTurns`** (`persistLiveTurns` ran inside the state updater). React silently drops setState on an unmounted instance, so navigating to another surface (which unmounts ChatView, `workspace.tsx` renderSurface) froze the snapshot mid-generation:

- **Return < 90s:** frozen snapshot adopted → stuck "Streaming…", no further chunks; on settle the subscription only cleared `busy`, never refetched — the finished answer never appeared.
- **Return > 90s:** snapshot evicted as stale; disk load shows *nothing* — the server persists turns only after the harness child exits (`api/chat/send/route.ts`).
- The thread-switch branch (`targetSessionId !== currentSessionRef.current`) only covered switches within a *mounted* ChatView — hence thread switches worked while surface switches lost progress.

## Fix

- **Registry-first accumulation:** extracted the snapshot registry to `src/lib/live-chat-generations.ts`; `updateLiveTurns` now advances the module-scope snapshot first (unmount-safe) and mirrors the stored array into component state only for the on-screen session. Same-reference mirroring keeps the microtask notification from double-rendering.
- **Settle notification always fires:** `clear()` notifies even when the entry was already evicted, so an orphaned stream's completion still reaches adopters.
- **Disk reconcile on settle:** a view that adopted a live snapshot (remount mid-generation) or evicted a stale-but-possibly-running one refetches the conversation when the stream settles, so the persisted response appears. The stream's owner skips this — the common send path stays flicker-free.

## Verification

- New unit suite `src/lib/live-chat-generations.test.ts` (8 tests: component-free accumulation, TTL refresh, settle semantics, same-ref notification, subscription scoping) — wired into `scripts/run-tests.mjs`.
- Updated `chat-view-lifecycle.test.ts` source-shape assertions for the registry-first flow + settle refetch.
- `pnpm test:app`: **528 test files pass** · `pnpm typecheck`: clean · `pnpm build`: clean, bundle within budget.

Closes bead `cave-0er`.