### PR TITLE
feat(daily-report): familiar-written narrative on the day's facts (cave-2mn)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -139,6 +139,7 @@ export const SUITES = {
     "src/lib/daily-summary-notifications.test.ts",
     "src/lib/daily-summary-refresh.test.ts",
     "src/lib/daily-report-facts.test.ts",
+    "src/lib/daily-narrative.test.ts",
     "src/components/dev-cache-reset-script.test.ts",
     "src/components/pwa-register.test.ts",
     "src/lib/readable-text-color.test.ts",
@@ -761,6 +762,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/daily-narrative.test.ts",
   "src/lib/use-code-rail.test.ts",
   "src/lib/cave-familiar-images.test.ts",
   "src/lib/cave-project-images.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -274,8 +274,18 @@ for (const contract of contracts) {
   );
   assert.match(
     dailySummarySource,
-    /narrative:\s*existing\.media\?\.narrative/,
+    /narrative:\s*narrativeInput \?\? existing\.media\?\.narrative/,
     "/inbox/daily-summary fact refreshes must preserve the narrative layered on top",
+  );
+  assert.match(
+    dailySummarySource,
+    /function sanitizeNarrative/,
+    "/inbox/daily-summary must validate client-submitted narratives before storing",
+  );
+  assert.match(
+    dailySummarySource,
+    /NARRATIVE_MAX_STORED_CHARS/,
+    "/inbox/daily-summary must bound stored narrative length",
   );
 }
 

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -22,12 +22,43 @@ export const dynamic = "force-dynamic";
 
 startScheduler();
 
+const NARRATIVE_MAX_STORED_CHARS = 4_000;
+
+type NarrativePatch = NonNullable<NonNullable<InboxItem["media"]>["narrative"]>;
+
+/** Validate a client-submitted narrative: required fields present, control
+ *  characters stripped, length bounded. Returns null (ignored) when invalid. */
+function sanitizeNarrative(
+  input: { text?: string; familiarId?: string; familiarName?: string; factsHash?: string } | undefined,
+  generatedAt: string,
+): NarrativePatch | null {
+  if (!input) return null;
+  if (typeof input.text !== "string" || typeof input.familiarId !== "string") return null;
+  if (typeof input.factsHash !== "string" || !input.factsHash) return null;
+  // eslint-disable-next-line no-control-regex
+  const text = input.text.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").trim();
+  if (!text) return null;
+  return {
+    text: text.slice(0, NARRATIVE_MAX_STORED_CHARS),
+    familiarId: input.familiarId.slice(0, 128),
+    ...(typeof input.familiarName === "string" && input.familiarName.trim()
+      ? { familiarName: input.familiarName.trim().slice(0, 128) }
+      : {}),
+    generatedAt,
+    factsHash: input.factsHash.slice(0, 64),
+  };
+}
+
 export async function POST(req: Request) {
   if (!isLocalOrigin(req)) {
     return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
   }
 
-  let body: { sessions?: SessionRow[]; date?: string } = {};
+  let body: {
+    sessions?: SessionRow[];
+    date?: string;
+    narrative?: { text?: string; familiarId?: string; familiarName?: string; factsHash?: string };
+  } = {};
   try {
     body = await req.json();
   } catch {
@@ -42,6 +73,11 @@ export async function POST(req: Request) {
   }
 
   const sessions = Array.isArray(body.sessions) ? body.sessions : [];
+
+  // Familiar-written narrative submitted by the client. Validated hard — it
+  // is generated text headed for persistent storage: non-empty, bounded, and
+  // stripped of control characters. Invalid → ignored, never an error.
+  const narrativeInput = sanitizeNarrative(body.narrative, now.toISOString());
 
   // Day-in-review facts the client can't see, gathered outside the inbox
   // lock (GitHub can take seconds; the lock serializes every inbox write).
@@ -74,8 +110,12 @@ export async function POST(req: Request) {
         title: draft.title,
         body: draft.body,
         link: draft.link,
-        // A fact-only refresh must not discard the narrative layered on top.
-        media: { ...draft.media, narrative: existing.media?.narrative ?? null },
+        // A validated narrative submission replaces the stored one; a
+        // fact-only refresh must not discard the narrative layered on top.
+        media: {
+          ...draft.media,
+          narrative: narrativeInput ?? existing.media?.narrative ?? null,
+        },
         updatedAt: now.toISOString(),
       };
       file.items = file.items.map((item) => (item.id === existing.id ? refreshed : item));

--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -30,5 +30,7 @@ assert.match(page, /Merged pull requests/, "report should list PRs merged during
 assert.match(page, /Sessions by project/, "report should group sessions by project");
 assert.match(page, /Cards completed/, "report should list board cards finished during the day");
 assert.match(page, /Recent sessions/, "pre-Phase-B reports should keep the flat recovered session list");
+assert.match(page, /media\?\.narrative\?\.text/, "report should lead with the familiar-written narrative when present");
+assert.match(page, /Written by/, "narrative should carry a familiar attribution byline");
 
 console.log("daily-report-page.test.ts: ok");

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -412,7 +412,25 @@ export default async function DailyReportPage({ params }: Props) {
         >
           <div className="dr-panel">
             <h2 className="dr-panel__title">Summary</h2>
-            <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>{item.body}</p>
+            {item.media?.narrative?.text ? (
+              <>
+                <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>
+                  {item.media.narrative.text}
+                </p>
+                <p className="dr-narrative-byline">
+                  <Icon name="ph:sparkle" aria-hidden />
+                  Written by {item.media.narrative.familiarName || "a familiar"}
+                  {" · "}
+                  {relativeTime(item.media.narrative.generatedAt)}
+                </p>
+                <h3 className="dr-panel__subtitle">By the numbers</h3>
+                <p className="dr-summary-body dr-summary-body--muted" style={{ whiteSpace: "pre-line" }}>
+                  {item.body}
+                </p>
+              </>
+            ) : (
+              <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>{item.body}</p>
+            )}
           </div>
           {item.media?.imageUrl ? (
             <img

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9084,6 +9084,17 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
 }
 .dr-panel__title { margin: 0 0 12px; font-size: 14px; font-weight: 620; }
 .dr-summary-body { margin: 0; white-space: pre-line; line-height: 1.75; font-size: 14px; color: var(--text-secondary); }
+.dr-summary-body--muted { font-size: 13px; color: var(--text-muted); }
+.dr-narrative-byline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.dr-narrative-byline svg { color: var(--accent-presence); }
+.dr-panel__subtitle { margin: 16px 0 8px; font-size: 12px; font-weight: 620; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
 .dr-cardimg {
   display: block;
   width: 100%;

--- a/src/components/dashboard/today-summary.tsx
+++ b/src/components/dashboard/today-summary.tsx
@@ -37,7 +37,19 @@ export function TodaySummary({
       />
       <div className="dash-today__grid">
         <div className="dr-panel dash-today__panel">
-          {hasBody ? (
+          {summary.narrative?.text ? (
+            <>
+              <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>
+                {summary.narrative.text}
+              </p>
+              <p className="dr-narrative-byline">
+                <Icon name="ph:sparkle" aria-hidden />
+                Written by {summary.narrative.familiarName || "a familiar"}
+                {" · "}
+                {relativeTime(summary.narrative.generatedAt, now)}
+              </p>
+            </>
+          ) : hasBody ? (
             <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>
               {summary.body}
             </p>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -62,6 +62,7 @@ import type { InboxItem, LinkRef } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
 import {
   dailySummaryAutoKey,
+  dateSlug,
   ensureDailySummaryNotification,
 } from "@/lib/daily-summary-notifications";
 import {
@@ -69,6 +70,11 @@ import {
   dailySummarySignature,
   shouldRefreshDailySummary,
 } from "@/lib/daily-summary-refresh";
+import {
+  NARRATIVE_RETRY_MS,
+  generateDailyNarrative,
+  shouldRegenerateNarrative,
+} from "@/lib/daily-narrative";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { InitialCommandControls } from "@/lib/command-controls";
 import { normalizeGitHubTasks, type GitHubTask } from "@/lib/github-tasks";
@@ -362,6 +368,8 @@ export function Workspace() {
   const dailySummarySignatureRef = useRef<string | null>(null);
   const dailySummaryAttemptAtRef = useRef(0);
   const dailySummaryInFlightRef = useRef(false);
+  const narrativeInFlightRef = useRef(false);
+  const narrativeAttemptAtRef = useRef(0);
   const sessionsLoadedRef = useRef(sessionsLoaded);
   sessionsLoadedRef.current = sessionsLoaded;
   const modeRef = useRef(mode);
@@ -877,6 +885,62 @@ export function Workspace() {
   usePausablePoll(() => refreshDailySummary(true), DAILY_REFRESH_POLL_MS, {
     enabled: sessionsLoaded,
   });
+
+  // Layer a familiar-written narrative on today's report once its facts
+  // exist. One-shot generation through the chat bridge; every failure path is
+  // silent — the deterministic count-line body simply remains the summary.
+  useEffect(() => {
+    if (!sessionsLoaded || daemonOffline || narrativeInFlightRef.current) return;
+    const now = new Date();
+    const item = inboxItems.find((it) => it.auto === dailySummaryAutoKey(now));
+    const report = item?.media?.report;
+    const stats = item?.media?.stats;
+    if (!report?.factsHash || !stats) return;
+    if (
+      !shouldRegenerateNarrative({
+        narrative: item.media?.narrative,
+        factsHash: report.factsHash,
+        now,
+      })
+    ) {
+      return;
+    }
+    if (now.getTime() - narrativeAttemptAtRef.current < NARRATIVE_RETRY_MS) return;
+    const familiar = familiars.find((f) => f.id === activeId) ?? familiars[0];
+    if (!familiar) return;
+    narrativeAttemptAtRef.current = now.getTime();
+    narrativeInFlightRef.current = true;
+    void (async () => {
+      try {
+        const dayLabel = new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(
+          now,
+        );
+        const { text, error } = await generateDailyNarrative({
+          familiarId: familiar.id,
+          report,
+          stats,
+          dayLabel,
+        });
+        if (error || !text) return;
+        await fetch("/api/inbox/daily-summary", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            sessions: sessionsRef.current,
+            date: dateSlug(now),
+            narrative: {
+              text,
+              familiarId: familiar.id,
+              familiarName: familiar.display_name || familiar.name,
+              factsHash: report.factsHash,
+            },
+          }),
+        }).catch(() => undefined);
+      } finally {
+        narrativeInFlightRef.current = false;
+      }
+    })();
+  }, [inboxItems, sessionsLoaded, daemonOffline, familiars, activeId]);
 
   const openOnboarding = useCallback(() => setOnboardingOpen(true), []);
   const closeOnboarding = useCallback(() => {

--- a/src/lib/cave-inbox.ts
+++ b/src/lib/cave-inbox.ts
@@ -43,6 +43,8 @@ export type InboxMedia = {
   narrative?: {
     text: string;
     familiarId: string;
+    /** Display name at generation time — survives familiar renames/deletes. */
+    familiarName?: string;
     generatedAt: string;
     factsHash: string;
   } | null;

--- a/src/lib/daily-narrative.test.ts
+++ b/src/lib/daily-narrative.test.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  NARRATIVE_MAX_CHARS,
+  NARRATIVE_MIN_REGEN_MS,
+  buildDailyNarrativePrompt,
+  normalizeNarrativeText,
+  shouldRegenerateNarrative,
+} from "./daily-narrative.ts";
+
+const now = new Date("2026-06-18T21:15:00.000Z");
+
+// ── Prompt ──────────────────────────────────────────────────────────────────
+{
+  const report = {
+    prsMerged: [
+      { repo: "OpenCoven/coven-cave", number: 2504, title: "day-in-review facts", url: "u", mergedAt: "2026-06-18T17:00:00.000Z" },
+    ],
+    cardsCompleted: [
+      { id: "c1", title: "Ship it", completedAt: "2026-06-18T15:00:00.000Z" },
+    ],
+    sessionGroups: [
+      { key: "/repo/coven-cave", label: "coven-cave", additions: 9, deletions: 4, sessions: [{ id: "s1", title: "Ship the parser" }] },
+    ],
+    factsHash: "abc123",
+    refreshedAt: "2026-06-18T21:00:00.000Z",
+  };
+  const stats = { reminders: 0, responses: 1, familiars: 0, sessions: 3, prsMerged: 1, cardsCompleted: 1 };
+  const prompt = buildDailyNarrativePrompt(report, stats, "Jun 18");
+  assert.match(prompt, /Jun 18/, "prompt should carry the day label");
+  assert.match(prompt, /Two to four sentences/, "prompt should constrain length");
+  assert.match(prompt, /no preamble, no sign-off/i, "prompt should forbid wrapper text");
+  assert.match(prompt, /OpenCoven\/coven-cave#2504 — day-in-review facts/, "prompt should list merged PRs");
+  assert.match(prompt, /done: Ship it/, "prompt should list completed cards");
+  assert.match(prompt, /coven-cave \(\+9 -4\): Ship the parser/, "prompt should carry project groups with diff totals");
+
+  const bare = buildDailyNarrativePrompt({ factsHash: "x", refreshedAt: "t" }, { reminders: 0, responses: 0, familiars: 0, sessions: 2 }, "Jun 18");
+  assert.doesNotMatch(bare, /Pull requests merged/, "unavailable sources should not be claimed to the model");
+}
+
+// ── Regeneration policy ─────────────────────────────────────────────────────
+{
+  const fresh = { text: "narr", familiarId: "sage", generatedAt: now.toISOString(), factsHash: "h1" };
+  assert.equal(
+    shouldRegenerateNarrative({ narrative: null, factsHash: "h1", now }),
+    true,
+    "missing narrative should generate",
+  );
+  assert.equal(
+    shouldRegenerateNarrative({ narrative: fresh, factsHash: "h1", now }),
+    false,
+    "unchanged facts should never regenerate",
+  );
+  assert.equal(
+    shouldRegenerateNarrative({ narrative: fresh, factsHash: "h2", now }),
+    false,
+    "changed facts inside the regen interval should wait",
+  );
+  const stale = { ...fresh, generatedAt: new Date(now.getTime() - NARRATIVE_MIN_REGEN_MS - 1000).toISOString() };
+  assert.equal(
+    shouldRegenerateNarrative({ narrative: stale, factsHash: "h2", now }),
+    true,
+    "changed facts past the regen interval should regenerate",
+  );
+  assert.equal(
+    shouldRegenerateNarrative({ narrative: stale, factsHash: null, now }),
+    false,
+    "no facts hash (pre-Phase-B item) should never trigger generation",
+  );
+}
+
+// ── Normalization ───────────────────────────────────────────────────────────
+{
+  assert.equal(normalizeNarrativeText("  a day well spent \n\n\n\nmore  "), "a day well spent \n\nmore");
+  const long = normalizeNarrativeText("x".repeat(NARRATIVE_MAX_CHARS + 500));
+  assert.ok(long.length <= NARRATIVE_MAX_CHARS, "narrative should cap at the max length");
+  assert.match(long, /…$/, "capped narrative should end with an ellipsis");
+}
+
+console.log("daily-narrative.test.ts: ok");

--- a/src/lib/daily-narrative.ts
+++ b/src/lib/daily-narrative.ts
@@ -1,0 +1,125 @@
+// Familiar-written narrative for the daily report: a short prose paragraph
+// generated from the day's frozen facts (media.report) and layered on top of
+// the deterministic count lines. The prompt builder and regeneration policy
+// are pure and unit-tested; the transport rides streamFamiliarText — the
+// sanctioned client-side LLM path (Cave has no server-side LLM route). When
+// the daemon is down or generation fails, the report simply keeps its
+// deterministic body: the narrative is an enhancement, never a dependency.
+
+import type { InboxMedia } from "./cave-inbox";
+import type { DailyReportPayload } from "./daily-report-facts.ts";
+import type { DailyReportStats } from "./daily-report.ts";
+import { streamFamiliarText } from "./familiar-stream";
+
+/** Don't regenerate for a facts change more often than this. */
+export const NARRATIVE_MIN_REGEN_MS = 60 * 60_000;
+
+/** Wait at least this long before retrying a failed generation. */
+export const NARRATIVE_RETRY_MS = 15 * 60_000;
+
+/** Hard cap on stored narrative length (defense against runaway generations). */
+export const NARRATIVE_MAX_CHARS = 1_200;
+
+/**
+ * Wrap the day's facts into a request for a short day-in-review paragraph.
+ * Mirrors the journal reflection prompt's constraints: a few sentences of
+ * plain prose, no heading/preamble/sign-off, grounded in the facts given.
+ */
+export function buildDailyNarrativePrompt(
+  report: DailyReportPayload,
+  stats: DailyReportStats,
+  dayLabel: string,
+): string {
+  const facts: string[] = [
+    `Sessions updated: ${stats.sessions}`,
+    `Reminders fired: ${stats.reminders} · responses waiting: ${stats.responses} · familiar updates: ${stats.familiars}`,
+  ];
+  if (typeof stats.prsMerged === "number") {
+    facts.push(`Pull requests merged: ${stats.prsMerged}`);
+    for (const pr of (report.prsMerged ?? []).slice(0, 12)) {
+      facts.push(`- merged ${pr.repo}#${pr.number} — ${pr.title}`);
+    }
+  }
+  if (typeof stats.cardsCompleted === "number" && stats.cardsCompleted > 0) {
+    facts.push(`Board cards completed: ${stats.cardsCompleted}`);
+    for (const card of (report.cardsCompleted ?? []).slice(0, 8)) {
+      facts.push(`- done: ${card.title}`);
+    }
+  }
+  for (const group of (report.sessionGroups ?? []).slice(0, 6)) {
+    const diff =
+      group.additions + group.deletions > 0 ? ` (+${group.additions} -${group.deletions})` : "";
+    facts.push(
+      `Project ${group.label}${diff}: ${group.sessions.map((s) => s.title).join(" · ")}`,
+    );
+  }
+  return [
+    `Write a short narrative of my day (${dayLabel}) in the cave, as my familiar reporting back to me.`,
+    "Two to four sentences of plain prose. Concrete and specific — lead with what shipped and what the work centered on, not the raw numbers.",
+    "No heading, no preamble, no sign-off, no bullet points — return only the narrative text.",
+    "",
+    "The day's facts:",
+    ...facts,
+  ].join("\n");
+}
+
+type NarrativeState = NonNullable<InboxMedia["narrative"]> | null | undefined;
+
+/**
+ * Whether the narrative should be (re)generated for the current facts.
+ * - No narrative yet → generate.
+ * - Facts changed → regenerate, but at most once per NARRATIVE_MIN_REGEN_MS —
+ *   the narrative summarizes the day, it doesn't tick like a counter.
+ * - Facts unchanged → never regenerate (the hash excludes timestamps, so a
+ *   fact-free refresh cannot invalidate it).
+ */
+export function shouldRegenerateNarrative({
+  narrative,
+  factsHash,
+  now = new Date(),
+  minRegenMs = NARRATIVE_MIN_REGEN_MS,
+}: {
+  narrative: NarrativeState;
+  factsHash: string | null | undefined;
+  now?: Date;
+  minRegenMs?: number;
+}): boolean {
+  if (!factsHash) return false;
+  if (!narrative?.text) return true;
+  if (narrative.factsHash === factsHash) return false;
+  const generatedMs = new Date(narrative.generatedAt).getTime();
+  if (Number.isNaN(generatedMs)) return true;
+  return now.getTime() - generatedMs >= minRegenMs;
+}
+
+/** Trim, collapse stray blank runs, and cap the generated narrative. */
+export function normalizeNarrativeText(raw: string): string {
+  const text = raw.replace(/\r/g, "").replace(/\n{3,}/g, "\n\n").trim();
+  if (text.length <= NARRATIVE_MAX_CHARS) return text;
+  return `${text.slice(0, NARRATIVE_MAX_CHARS - 1).trimEnd()}…`;
+}
+
+export type DailyNarrativeResult = { text: string; error: string | null };
+
+/**
+ * One-shot generation — no sessionId, so the run is ephemeral and never
+ * touches saved conversations. Returns empty text + error on any failure;
+ * callers skip silently (the deterministic body remains the narrative).
+ */
+export async function generateDailyNarrative(opts: {
+  familiarId: string;
+  report: DailyReportPayload;
+  stats: DailyReportStats;
+  dayLabel: string;
+  signal?: AbortSignal;
+}): Promise<DailyNarrativeResult> {
+  const { text, error } = await streamFamiliarText({
+    familiarId: opts.familiarId,
+    prompt: buildDailyNarrativePrompt(opts.report, opts.stats, opts.dayLabel),
+    signal: opts.signal,
+  });
+  if (error) return { text: "", error };
+  const normalized = normalizeNarrativeText(text);
+  if (!normalized) return { text: "", error: "empty narrative" };
+  return { text: normalized, error: null };
+}

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -41,6 +41,8 @@ export type TodaySummary = {
   recentSessions: string[];
   /** Structured day-in-review facts — null on items generated before Phase B. */
   report: DailyReportPayload | null;
+  /** Familiar-written narrative for today, or null before one generates. */
+  narrative: { text: string; familiarName?: string; generatedAt: string } | null;
 };
 
 export type DashboardModel = {
@@ -83,6 +85,7 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
         generatedAt: todayItem.media?.generatedAt ?? todayItem.firedAt ?? todayItem.updatedAt ?? null,
         recentSessions: parseRecentSessions(todayItem.body),
         report: todayItem.media?.report ?? null,
+        narrative: todayItem.media?.narrative ?? null,
       }
     : null;
 


### PR DESCRIPTION
Phase C — final phase of the daily-report overhaul (builds on #2497 live refresh and #2504 day-in-review facts).

## Problem

The report's summary is a counter dump ("0 reminders fired / 6 sessions updated"). The facts are now rich (merged PRs, project groups, cards), but nothing tells the day's story.

## What changed

- **New `src/lib/daily-narrative.ts`** — pure prompt builder (2–4 sentences, plain prose, no heading/preamble/sign-off, grounded in a compact facts block: merged PRs, completed cards, per-project session groups with diff totals) + regeneration policy (**generate when missing; regenerate only when `factsHash` changed AND ≥60 min elapsed** — the hash excludes timestamps, so fact-free refreshes never invalidate it) + one-shot transport via `streamFamiliarText` (**no `sessionId`** — ephemeral, never touches saved conversations), output normalized and capped at 1200 chars.
- **`workspace.tsx`** — a narrative effect watches today's item: when `media.report` exists, the daemon is up, and the policy says regenerate, it generates with the active familiar (else the first) and re-POSTs `{sessions, date, narrative}`. Every failure path is silent with a ≥15-min retry backoff — the deterministic body simply remains the summary. `familiarName` is captured at generation time so attribution survives renames/deletes.
- **`POST /api/inbox/daily-summary`** — `sanitizeNarrative` validates hard (required fields, control characters stripped, 4000-char bound); invalid input is ignored, never an error. A validated submission replaces the stored narrative; fact-only refreshes continue to preserve it.
- **Rendering** — the report page's Summary panel leads with the narrative and a "Written by {familiar} · Xh ago" byline, with the count-line body beneath as a muted "By the numbers" block; the dashboard today-panel prefers the narrative too. **No narrative → exactly the previous rendering** (daemon-down degradation; all historical reports unchanged).

## Verification

- `pnpm typecheck` ✓ · `test:app` 531 ✓ · `test:api` 118 ✓ · `test:mobile` 70 ✓ · `check:tests-wired` 715 ✓ · production build within bundle budget ✓
- New `daily-narrative.test.ts` (wired into the suite + ALIAS_LOADER) covers the prompt's facts/constraints, the full regeneration-policy matrix (missing / unchanged / changed-within-interval / changed-past-interval / no-facts-hash), and normalization capping. api-contracts pins the server-side validation and narrative preservation; page test pins the narrative rendering path.

Closes cave-2mn (bead). Completes the three-phase plan: #2497 (live refresh + hygiene) → #2504 (day-in-review facts) → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)