### PR TITLE
fix(daily-report): paginate merged-PR search; reject angle-tag leaks; drop (+0 -0) noise (cave-05p follow-up)

### DIFF
--- a/src/lib/daily-report-facts.test.ts
+++ b/src/lib/daily-report-facts.test.ts
@@ -138,4 +138,12 @@ assert.equal(
 );
 assert.equal(reportSessionTitle({ title: "**Fix** the `parser`" }), "Fix the parser");
 
+
+// Angle-tag prompt-preamble leaks ("<covenroster> You are in a group chat…")
+// are not names — seen live 2026-07-06.
+assert.equal(
+  reportSessionTitle({ title: '<covenroster> You are in a group chat ("coven") with these…' }),
+  "Untitled session",
+);
+
 console.log("daily-report-facts.test.ts: ok");

--- a/src/lib/daily-report-facts.ts
+++ b/src/lib/daily-report-facts.ts
@@ -63,6 +63,9 @@ const REPORT_TITLE_MAX = 64;
 const MD_HEADING_RE = /^#{1,6}\s+/;
 const MD_EMPHASIS_RE = /(\*\*|__|[*_`])/g;
 const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
+// Titles opening with an XML-ish tag ("<covenroster> You are in a group
+// chat…") are prompt-preamble leaks, not names. Seen live on 2026-07-06.
+const ANGLE_TAG_LEAK_RE = /^<[a-z][\w-]*>/i;
 
 /** Session title as it should appear in the daily report: sanitized of
  *  harness-preamble leaks (via sanitizeSessionTitle), stripped of markdown
@@ -70,7 +73,7 @@ const PRIOR_CONVERSATION_LEAK_RE = /^prior conversation\b/i;
  *  session" when nothing survives. */
 export function reportSessionTitle(session: Pick<SessionRow, "title">): string {
   const sanitized = sanitizeSessionTitle(session.title);
-  if (!sanitized) return "Untitled session";
+  if (!sanitized || ANGLE_TAG_LEAK_RE.test(sanitized)) return "Untitled session";
   const stripped = sanitized
     .replace(MD_HEADING_RE, "")
     .replace(MD_EMPHASIS_RE, "")

--- a/src/lib/daily-summary-notifications.test.ts
+++ b/src/lib/daily-summary-notifications.test.ts
@@ -254,4 +254,15 @@ assert.doesNotMatch(decodeURIComponent(unenriched.media.imageUrl), /prs merged/)
 const prOnly = buildDailySummaryContent({ now, items: [], sessions: [], extras });
 assert.ok(prOnly, "a PR-only day should still produce a report");
 
+
+// Zero/zero diffs are daemon boilerplate — the Recent line must not read "(+0 -0)".
+{
+  const zeroDiff = buildDailySummaryContent({
+    now,
+    items: [],
+    sessions: [{ ...sessionAt("z1", "Quiet session", 1), diff: { additions: 0, deletions: 0 } }],
+  });
+  assert.doesNotMatch(zeroDiff.body, /\(\+0 -0\)/, "zero/zero diffs are noise, not signal");
+}
+
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/lib/daily-summary-notifications.ts
+++ b/src/lib/daily-summary-notifications.ts
@@ -54,7 +54,9 @@ function dayLabel(date: Date): string {
 }
 
 function sessionSummaryLine(session: SessionRow): string {
-  const diff = session.diff ? ` (+${session.diff.additions} -${session.diff.deletions})` : "";
+  // A zero/zero diff is daemon boilerplate, not signal — suppress the suffix.
+  const hasDiff = Boolean(session.diff && (session.diff.additions || session.diff.deletions));
+  const diff = hasDiff ? ` (+${session.diff!.additions} -${session.diff!.deletions})` : "";
   return `${reportSessionTitle(session)}${diff}`;
 }
 

--- a/src/lib/server/github-merged.ts
+++ b/src/lib/server/github-merged.ts
@@ -76,13 +76,23 @@ export async function fetchMergedPrsForDay(now: Date): Promise<MergedPr[] | null
   const q = encodeURIComponent(`is:pr is:merged author:${login} merged:>=${fromSlug}`);
 
   try {
-    const data = (await ghJson(`/search/issues?q=${q}&per_page=50&sort=updated&order=desc`, token)) as {
-      items?: SearchItem[];
-    } | null;
+    // Up to two 100-item pages: a heavy multi-agent day really does exceed a
+    // single page (101 merges observed live on 2026-07-06), and a truncated
+    // list would report a dishonest "N PRs merged" count.
+    const results: SearchItem[] = [];
+    for (let page = 1; page <= 2; page++) {
+      const data = (await ghJson(
+        `/search/issues?q=${q}&per_page=100&page=${page}&sort=updated&order=desc`,
+        token,
+      )) as { items?: SearchItem[] } | null;
+      const batch = data?.items ?? [];
+      results.push(...batch);
+      if (batch.length < 100) break;
+    }
     const dayStart = startOfLocalDay(now).getTime();
     const dayEnd = dayStart + 24 * 60 * 60 * 1000;
     const items: MergedPr[] = [];
-    for (const item of data?.items ?? []) {
+    for (const item of results) {
       const mergedAt = item.pull_request?.merged_at;
       if (!mergedAt || typeof item.number !== "number" || !item.html_url) continue;
       const mergedMs = new Date(mergedAt).getTime();


### PR DESCRIPTION
## Summary

Salvaged deltas from #2505, which was closed as superseded by #2504 (two sessions implemented Phase B of the daily-report plan concurrently; #2504 merged first). Three small fixes #2504 doesn't have, all found during live verification against real data:

- **Two-page merged-PR search** — `per_page=50` single-fetch truncates: today's real merged count was **101**, so the report's "N PRs merged" line under-reported by half. Now reads up to two 100-item pages (breaks early when a page comes back short).
- **Angle-tag title-leak reject** — `<covenroster> You are in a group chat…` prompt preambles appeared verbatim in today's real Recent line; `reportSessionTitle` now rejects XML-ish-tag openers to "Untitled session".
- **`(+0 -0)` suppression** — zero/zero diffs are daemon boilerplate; the suffix now only renders when a diff is non-zero.

## Test plan

- New pins: angle-tag case in `daily-report-facts.test.ts`, zero-diff case in `daily-summary-notifications.test.ts` — both green
- `tsc --noEmit` ✓
- Live-verified behaviors originally on #2505's branch against the real inbox (101 PRs via pagination; leak scrubbed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)