### PR TITLE
feat(settings): search deep-links into the Familiars studio tabs (cave-kdw)

### DIFF
--- a/src/components/settings-search.test.ts
+++ b/src/components/settings-search.test.ts
@@ -34,4 +34,26 @@ assert.match(shell, /No settings match/, "search shows a no-match message");
 // Highlight style ships.
 assert.match(css, /\.settings-group--found/, "globals styles the search highlight");
 
+// ── Search reaches inside the Familiars studio panel (2026-07-06) ────────────
+// Each studio tab is indexed with a familiarTab target, so "voice" or
+// "archive" lands on the right tab instead of just the section.
+assert.match(
+  sections,
+  /familiarTab\?: FamiliarStudioTab/,
+  "index entries can target a Familiars studio tab",
+);
+for (const tab of ["identity", "look", "brain", "lifecycle", "memory", "projects", "vault"]) {
+  assert.match(
+    sections,
+    new RegExp(`familiarTab: "${tab}"`),
+    `the ${tab} studio tab is indexed for search`,
+  );
+}
+// Picking a familiars entry activates the studio tab below the provider
+// instead of scrolling to a SettingsGroup (the panel has none).
+assert.match(shell, /if \(entry\.familiarTab\) \{[\s\S]*?setFamiliarsTabTarget\(entry\.familiarTab\)/, "goToSetting branches familiars entries to the tab target");
+assert.match(shell, /setActiveTab\(tabTarget\)/, "FamiliarsSection activates the targeted studio tab");
+assert.match(shell, /familiar-studio-inline-tab-\$\{tabTarget\}/, "the targeted tab button receives focus");
+assert.match(shell, /onTabTargetConsumed\?\.\(\)/, "the one-shot tab target is handed back to the shell");
+
 console.log("settings-search.test.ts OK");

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -3,6 +3,8 @@
 // "what's in here" highlight strip). Kept in its own module so the shell nav and
 // the SettingsOverview header share one source of truth.
 //
+import type { FamiliarStudioTab } from "@/lib/familiar-studio-context";
+
 export type Section =
   | "general"
   | "daemon"
@@ -13,7 +15,14 @@ export type Section =
 
 export type SectionMeta = { id: Section; label: string; icon: string; description: string; accent: string };
 
-export type SettingsIndexEntry = { section: Section; group?: string; keywords: string };
+// `familiarTab` marks an entry that lives inside the Familiars studio panel —
+// picking it activates that studio tab instead of scrolling to a SettingsGroup.
+export type SettingsIndexEntry = {
+  section: Section;
+  group?: string;
+  keywords: string;
+  familiarTab?: FamiliarStudioTab;
+};
 
 export const SECTIONS: SectionMeta[] = [
   { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9a8ecd" },
@@ -39,7 +48,14 @@ export const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "daemon", group: "Status", keywords: "daemon status running start stop restart hub server executor private network tailscale" },
   { section: "daemon", group: "Connection", keywords: "daemon hub server executor private network tailscale remote multihost multi host" },
   { section: "daemon", group: "Info", keywords: "daemon info version socket pid api" },
-  { section: "familiars", keywords: "familiars agents personas avatar name look permissions projects access grants allow deny tool policy guard security audit requests vault memory" },
+  { section: "familiars", keywords: "familiars agents personas roster" },
+  { section: "familiars", group: "Identity", familiarTab: "identity", keywords: "identity name role pronouns description rename" },
+  { section: "familiars", group: "Look", familiarTab: "look", keywords: "look avatar image photo upload icon glyph color accent swatch palette" },
+  { section: "familiars", group: "Brain", familiarTab: "brain", keywords: "brain runtime harness model voice system prompt note capabilities" },
+  { section: "familiars", group: "Lifecycle", familiarTab: "lifecycle", keywords: "lifecycle archive unarchive reorder roster order reset overrides" },
+  { section: "familiars", group: "Memory", familiarTab: "memory", keywords: "memory memories daily notes recall" },
+  { section: "familiars", group: "Projects", familiarTab: "projects", keywords: "projects access grants allow deny tool policy guard security audit requests permissions" },
+  { section: "familiars", group: "Vault", familiarTab: "vault", keywords: "vault secrets env environment keys tokens credentials 1password" },
   { section: "mobile", group: "Steps", keywords: "phone mobile connect qr pair tailscale" },
   { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
   { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -19,7 +19,7 @@ import { OpenCovenToolsUpdate } from "@/components/open-coven-tools-update";
 import { THEME_IDS, THEME_META, getSwatches, type ThemeId } from "@/lib/theme-palettes";
 import { COVEN_THEME_KEY, COVEN_MODE_KEY, COVEN_CUSTOM_THEME_KEY, LEGACY_THEME_RENAME, type Mode, type ModePref } from "@/lib/theme-storage";
 import { ModeToggle } from "@/components/mode-toggle";
-import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
+import { FamiliarStudioProvider, useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
 import { APP_VERSION } from "@/lib/app-version";
 import { UpdateSettingsRow } from "@/components/update-available";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -125,6 +125,9 @@ export function SettingsShell() {
   // ── Search across settings ────────────────────────────────────────────────
   const [query, setQuery] = useState("");
   const [scrollTarget, setScrollTarget] = useState<string | null>(null);
+  // One-shot studio-tab target for search results that point inside the
+  // Familiars panel (see SettingsIndexEntry.familiarTab).
+  const [familiarsTabTarget, setFamiliarsTabTarget] = useState<FamiliarStudioTab | null>(null);
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
@@ -135,6 +138,14 @@ export function SettingsShell() {
   function goToSetting(entry: SettingsIndexEntry) {
     openSection(entry.section);
     setQuery("");
+    if (entry.familiarTab) {
+      // The Familiars panel isn't a SettingsGroup — the entry targets one of
+      // its studio tabs instead, activated below the provider by
+      // FamiliarsSection once the roster has loaded.
+      setFamiliarsTabTarget(entry.familiarTab);
+      setScrollTarget(null);
+      return;
+    }
     setScrollTarget(entry.group ? settingsGroupId(entry.group) : null);
   }
 
@@ -326,7 +337,12 @@ export function SettingsShell() {
         >
           {section === "general" && <GeneralSection />}
           {section === "daemon"   && <DaemonSection />}
-          {section === "familiars" && <FamiliarsSection />}
+          {section === "familiars" && (
+            <FamiliarsSection
+              tabTarget={familiarsTabTarget}
+              onTabTargetConsumed={() => setFamiliarsTabTarget(null)}
+            />
+          )}
           {section === "mobile"   && <MobileSection />}
           {section === "appearance" && <AppearanceSection />}
           {section === "about"    && <AboutSection />}
@@ -691,12 +707,40 @@ function DaemonSection() {
 
 // ─── Section: Familiars ───────────────────────────────────────────────────────
 
-function FamiliarsSection() {
+function FamiliarsSection({
+  tabTarget,
+  onTabTargetConsumed,
+}: {
+  /** Studio tab a search result asked to open; consumed once activated. */
+  tabTarget?: FamiliarStudioTab | null;
+  onTabTargetConsumed?: () => void;
+}) {
   // Settings is a standalone route with no workspace context, so this panel
   // sources its own familiar roster and resolves cave overrides locally.
   const [rawFamiliars, setRawFamiliars] = useState<Familiar[]>([]);
   const [loaded, setLoaded] = useState(false);
   const familiars = useResolvedFamiliars(rawFamiliars);
+  // This renders below FamiliarStudioProvider (the shell mounts it), so the
+  // studio tab state is reachable here even though the shell body can't.
+  const { setActiveTab } = useFamiliarStudio();
+
+  // A search result can target a specific studio tab (e.g. "voice" → Brain).
+  // Activate it once the roster has settled so the tab strip exists, move
+  // focus to the tab button (the panel has no SettingsGroup to flash), and
+  // hand the one-shot target back to the shell.
+  useEffect(() => {
+    if (!tabTarget || !loaded) return;
+    setActiveTab(tabTarget);
+    const raf = requestAnimationFrame(() => {
+      const el = document.getElementById(`familiar-studio-inline-tab-${tabTarget}`);
+      if (el) {
+        el.scrollIntoView({ block: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
+        el.focus({ preventScroll: true });
+      }
+      onTabTargetConsumed?.();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [tabTarget, loaded, setActiveTab, onTabTargetConsumed]);
 
   useEffect(() => {
     let cancelled = false;


### PR DESCRIPTION
## What

Settings search indexed the whole Familiars section as one flat entry, while the panel holds seven tabs of real settings (identity, avatar/icon/color, runtime/model/voice/system prompt, archive/reorder, memory, project grants, vault). Searching "voice" or "archive" found nothing.

## How

- `SettingsIndexEntry` gains an optional `familiarTab?: FamiliarStudioTab`; the flat familiars entry becomes a slim section entry plus seven tab entries (`Identity / Look / Brain / Lifecycle / Memory / Projects / Vault`) with per-tab keywords. Result rows already render `Group › Section`.
- `goToSetting` branches: familiars entries store a one-shot tab target instead of a group scroll target. `FamiliarsSection` — which renders **below** `FamiliarStudioProvider` (the shell mounts the provider, so its own body can't reach the context) — consumes the target once the roster has loaded: `setActiveTab(tab)`, focus the tab button with reduced-motion-aware scroll, then hand the target back to the shell.

## Verification

- 531 test files green (`pnpm test:app`) incl. new pins in `settings-search.test.ts` (all seven `familiarTab` entries, the `goToSetting` branch, the activation + focus wiring); every pre-existing pin untouched. `tsc --noEmit` clean.
- Production build driven with Playwright: search "voice" → pick "Brain" → Familiars section opens with the Brain tab selected and focused; search "archive" → Lifecycle tab.

Bead: cave-kdw (PR 1 of the approved settings/familiars plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)