### PR TITLE
feat(settings): create familiars from Settings + honest daemon-offline state (cave-i7y)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -146,6 +146,7 @@ export const SUITES = {
     "src/components/settings-appearance.test.ts",
     "src/components/settings-search.test.ts",
     "src/components/settings-daemon-multihost.test.ts",
+    "src/components/settings-familiars-section.test.ts",
     "src/components/familiar-studio-projects-tab.test.ts",
     "src/components/theme-color-editor.test.ts",
     "src/lib/theme-token-hex.test.ts",

--- a/src/components/settings-familiars-section.test.ts
+++ b/src/components/settings-familiars-section.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Settings → Familiars section (cave-i7y): the daemon-offline 503 must never
+// masquerade as "no familiars", and familiars are creatable from Settings.
+const shell = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const section = shell.slice(shell.indexOf("function FamiliarsSection"));
+
+assert.match(
+  section,
+  /res\.status === 503[\s\S]{0,80}setDaemonDown\(true\)/,
+  "a 503 roster response must flip the daemon-down state, not render an empty roster",
+);
+assert.match(
+  section,
+  /if \(daemonDown\)[\s\S]{0,1500}Start daemon/,
+  "the daemon-down state must offer a Start-daemon action",
+);
+assert.match(
+  section,
+  /familiars\.length === 0[\s\S]{0,1500}Create familiar/,
+  "the genuinely-empty state must offer a Create-familiar action",
+);
+assert.match(
+  section,
+  /CreateFamiliarDialog/,
+  "Settings should reuse the shared CreateFamiliarDialog",
+);
+assert.match(
+  section,
+  /onCreated=\{[\s\S]{0,300}openFamiliarStudio\(id\)/,
+  "a created familiar must be selected in the studio, not left on the first roster entry",
+);
+assert.match(
+  section,
+  /onCreated=\{[\s\S]{0,300}void load\(\)/,
+  "creation must refresh the roster via the extracted load()",
+);
+
+console.log("settings-familiars-section.test.ts: ok");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -20,6 +20,7 @@ import { THEME_IDS, THEME_META, getSwatches, type ThemeId } from "@/lib/theme-pa
 import { COVEN_THEME_KEY, COVEN_MODE_KEY, COVEN_CUSTOM_THEME_KEY, LEGACY_THEME_RENAME, type Mode, type ModePref } from "@/lib/theme-storage";
 import { ModeToggle } from "@/components/mode-toggle";
 import { FamiliarStudioProvider, useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
+import { CreateFamiliarDialog } from "@/components/create-familiar-dialog";
 import { APP_VERSION } from "@/lib/app-version";
 import { UpdateSettingsRow } from "@/components/update-available";
 import { useIsMobile } from "@/lib/use-viewport";
@@ -719,10 +720,16 @@ function FamiliarsSection({
   // sources its own familiar roster and resolves cave overrides locally.
   const [rawFamiliars, setRawFamiliars] = useState<Familiar[]>([]);
   const [loaded, setLoaded] = useState(false);
+  // The roster endpoint 503s when the daemon is down — that means "unknown",
+  // not "no familiars"; the two must never share an empty state.
+  const [daemonDown, setDaemonDown] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
   const familiars = useResolvedFamiliars(rawFamiliars);
   // This renders below FamiliarStudioProvider (the shell mounts it), so the
   // studio tab state is reachable here even though the shell body can't.
-  const { setActiveTab } = useFamiliarStudio();
+  const { setActiveTab, openFamiliarStudio } = useFamiliarStudio();
 
   // A search result can target a specific studio tab (e.g. "voice" → Brain).
   // Activate it once the roster has settled so the tab strip exists, move
@@ -742,27 +749,46 @@ function FamiliarsSection({
     return () => cancelAnimationFrame(raf);
   }, [tabTarget, loaded, setActiveTab, onTabTargetConsumed]);
 
-  useEffect(() => {
-    let cancelled = false;
-    const loadFamiliars = async () => {
-      try {
-        const res = await fetch("/api/familiars", { cache: "no-store" });
-        const json = await res.json();
-        if (cancelled) return;
-        if (json.ok) {
-          setRawFamiliars((json.familiars ?? []) as Familiar[]);
-        }
-      } catch {
-        /* transient — keep last good list */
-      } finally {
-        if (!cancelled) setLoaded(true);
+  const load = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const res = await fetch("/api/familiars", { cache: "no-store", signal });
+      const json = await res.json().catch(() => null);
+      if (signal?.aborted) return;
+      if (json?.ok) {
+        setRawFamiliars((json.familiars ?? []) as Familiar[]);
+        setDaemonDown(false);
+      } else if (res.status === 503) {
+        setDaemonDown(true);
       }
-    };
-    void loadFamiliars();
-    return () => {
-      cancelled = true;
-    };
+    } catch {
+      /* transient (or aborted) — keep last good list */
+    } finally {
+      if (!signal?.aborted) setLoaded(true);
+    }
   }, []);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    void load(ctrl.signal);
+    return () => ctrl.abort();
+  }, [load]);
+
+  const startDaemon = useCallback(async () => {
+    setStarting(true);
+    setStartError(null);
+    try {
+      const res = await fetch("/api/daemon/start", { method: "POST" });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json?.ok === false) {
+        throw new Error(json?.error || json?.stderr || "daemon did not start");
+      }
+      await load();
+    } catch (err) {
+      setStartError(err instanceof Error ? err.message : "daemon did not start");
+    } finally {
+      setStarting(false);
+    }
+  }, [load]);
 
   // Hold the panel until the first fetch settles so the "No familiars
   // configured" empty state never flashes before the roster loads.
@@ -774,11 +800,91 @@ function FamiliarsSection({
     );
   }
 
-  return (
-    <FamiliarStudioInlinePanel
-      familiars={rawFamiliars}
-      resolved={familiars}
+  const createDialog = (
+    <CreateFamiliarDialog
+      open={createOpen}
+      onClose={() => setCreateOpen(false)}
+      existingIds={rawFamiliars.map((f) => f.id)}
+      defaultHarness={rawFamiliars.find((f) => f.defaultHarness)?.defaultHarness}
+      onCreated={(id) => {
+        // Select the freshly created familiar (not the first in the roster);
+        // the shared studio context drives the inline panel's detail pane.
+        openFamiliarStudio(id);
+        void load();
+      }}
     />
+  );
+
+  if (daemonDown) {
+    return (
+      <div className="settings-familiars-panel">
+        <div className="flex flex-col items-start gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-4">
+          <p className="text-[13px] text-[var(--text-secondary)]">
+            <Icon name="ph:warning-circle" width={13} aria-hidden className="mr-1.5 inline-block align-[-2px]" />
+            The daemon is offline, so the familiar roster can&apos;t be read. Start it to manage
+            familiars.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void startDaemon()}
+              disabled={starting}
+              className="focus-ring inline-flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] font-medium text-[var(--accent-presence-foreground)] hover:opacity-90 disabled:opacity-60"
+              title="coven daemon start"
+            >
+              <Icon name="ph:rocket-launch-bold" width={12} />
+              {starting ? "Starting..." : "Start daemon"}
+            </button>
+            {startError ? (
+              <span role="alert" className="text-[11px] text-[var(--color-danger)]">
+                {startError}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (familiars.length === 0) {
+    return (
+      <div className="settings-familiars-panel">
+        <div className="flex flex-col items-start gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-4">
+          <p className="text-[13px] text-[var(--text-secondary)]">
+            No familiars configured yet. Create one to get started.
+          </p>
+          <button
+            type="button"
+            onClick={() => setCreateOpen(true)}
+            className="focus-ring inline-flex items-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] font-medium text-[var(--accent-presence-foreground)] hover:opacity-90"
+          >
+            <Icon name="ph:plus-bold" width={12} />
+            Create familiar
+          </button>
+        </div>
+        {createDialog}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-3 flex justify-end">
+        <button
+          type="button"
+          onClick={() => setCreateOpen(true)}
+          className="settings-touch-action focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name="ph:plus-bold" width={12} />
+          New familiar
+        </button>
+      </div>
+      <FamiliarStudioInlinePanel
+        familiars={rawFamiliars}
+        resolved={familiars}
+      />
+      {createDialog}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

Settings → Familiars had two gaps (bead `cave-i7y`):

- **A daemon-offline 503 rendered as "No familiars configured"** — an empty roster and an unreadable roster shared one state, actively misleading. The section now tracks the 503 separately and renders a daemon-offline state with a **Start daemon** action (same `POST /api/daemon/start` recipe the Daemon section uses).
- **No way to create a familiar from Settings.** The shared `CreateFamiliarDialog` is now mounted in the section: a "New familiar" header action next to the studio panel, plus a "Create familiar" action on the genuinely-empty state. Creation selects the new familiar via the shared studio context (`openFamiliarStudio(id)` — not the localStorage handoff, which only fires when nothing is selected) and refreshes the roster through the extracted `load()` (AbortController-per-load).

## Test plan

- New `settings-familiars-section.test.ts` (wired into the suite) pins: 503 → daemon-down branch, Start-daemon action, Create-familiar empty-state action, dialog reuse, select-after-create, refresh-after-create
- Full app suite: 532 files ✓ · `tsc --noEmit` ✓ · `check:tests-wired` ✓ (716 wired)
- **Verified live** (worktree server + Playwright, screenshots checked): mocked 503 → offline state with Start daemon; mocked empty roster → Create familiar opens the dialog; real daemon → header action opens the dialog, panel unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)