### PR TITLE
feat(home): make the News carousel opt-out in Settings, retire the inline X

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -69,6 +69,7 @@ export const SUITES = {
     "src/lib/marketplace-catalog.test.ts",
     "src/lib/rss.test.ts",
     "src/lib/home-feed.test.ts",
+    "src/lib/home-news-pref.test.ts",
     "src/lib/secret-validators.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/components/chat-sidebar-wiring.test.ts",

--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -28,19 +28,17 @@ assert.match(view, /home-digest__track--media/, "media headlines render on their
 assert.match(view, /c\.kind === "summary" \|\| c\.kind === "session"/, "chats row = summary + session cards");
 assert.match(view, /c\.kind === "rss"/, "media row = the rss headline cards");
 
-// ── News carousel can be dismissed only from its explicit close affordance ────
-assert.match(view, /const \[mediaDismissed, setMediaDismissed\] = useState\(false\)/, "tracks dismissed state for the news/media carousel");
-assert.match(view, /mediaCards\.length > 0 && !mediaDismissed/, "dismissing media leaves the chat digest row intact");
-assert.match(view, /aria-label="Close news carousel"/, "news carousel exposes an accessible close button");
-assert.match(view, /onClick=\{\(\) => setMediaDismissed\(true\)\}/, "close button hides the news carousel");
-assert.doesNotMatch(view, /onMouseEnter=\{\(\) => setMediaDismissed\(true\)\}/, "hovering the close affordance must not hide the news carousel");
-assert.match(view, /home-digest__media-close/, "close button has a stable styling hook");
+// ── News is opt-out in Settings → General — no inline dismiss on the row ──────
+assert.match(view, /const newsEnabled = useHomeNewsEnabled\(\)/, "news visibility comes from the persistent user setting");
+assert.match(view, /mediaCards\.length > 0 && newsEnabled/, "disabling news leaves the chat digest row intact");
+assert.doesNotMatch(view, /mediaDismissed|setMediaDismissed/, "the per-mount dismissed state is retired (setting is the one source of truth)");
+assert.doesNotMatch(view, /aria-label="Close news carousel"/, "the inline X close button is removed");
+assert.doesNotMatch(view, /home-digest__media-close/, "no close-button markup remains");
 assert.match(
   view,
-  /className="home-digest__media-chrome"[\s\S]*className="home-digest__media-label"[\s\S]*News[\s\S]*className="home-digest__media-close"[\s\S]*home-digest__track home-digest__track--media/,
-  "news row chrome labels the media lane and keeps the close button outside the moving track",
+  /className="home-digest__media-chrome"[\s\S]*className="home-digest__media-label"[\s\S]*News[\s\S]*home-digest__track home-digest__track--media/,
+  "news row chrome still labels the media lane outside the moving track",
 );
-assert.doesNotMatch(view, /title="Close news carousel"/, "news close uses aria-label only, avoiding native tooltip overlap");
 
 // ── Media cards support an image thumbnail (with icon fallback on error) ───────
 assert.match(view, /home-digest__thumb/, "media card renders an image thumbnail when available");
@@ -74,9 +72,16 @@ assert.match(css, /\.home-digest__thumb[\s\S]*?width: 46px/, "media thumbnail is
 assert.match(css, /\.home-digest__card--media[\s\S]*?padding-left/, "media cards are image-forward (thumbnail hugs the leading edge)");
 assert.match(css, /\.home-digest__media[\s\S]*?position: relative/, "media row anchors the close button");
 assert.match(css, /\.home-digest__media-chrome\s*\{[\s\S]*?display: flex[\s\S]*?justify-content: space-between/, "news row has static chrome outside the marquee track");
-assert.doesNotMatch(css, /\.home-digest__media-close[\s\S]*?position: absolute/, "news close button must not overlay the moving headline cards");
-assert.match(css, /\.home-digest__media-close\s*\{[^}]*pointer-events: auto/, "news close button is always directly clickable");
-assert.doesNotMatch(css, /\.home-digest__media-close\s*\{[^}]*opacity: 0/, "news close button must not be hidden behind hover-only reveal");
+assert.doesNotMatch(css, /home-digest__media-close/, "dead close-button CSS is removed with the inline dismiss");
+
+// ── Settings owns the opt-out: General section renders the switch ─────────────
+const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+assert.match(settings, /import \{ useHomeNewsEnabled, writeHomeNewsEnabled \} from "@\/lib\/home-news-pref"/, "settings imports the shared news pref");
+assert.match(
+  settings,
+  /label="News headlines"[\s\S]*?role="switch"[\s\S]*?aria-checked=\{newsEnabled\}[\s\S]*?writeHomeNewsEnabled\(!newsEnabled\)/,
+  "General settings exposes the News headlines switch backed by the pref",
+);
 
 // ── Wired into the home composer below "Jump back in" ─────────────────────────
 assert.match(composer, /import \{ HomeDigestCarousel \}/, "home composer imports the carousel");

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -19,6 +19,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import type { FeedItem } from "@/lib/rss";
 import { openExternalUrl } from "@/lib/open-external";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useHomeNewsEnabled } from "@/lib/home-news-pref";
 import { buildDigestCards, type DigestCard, type DigestRssCard } from "@/lib/home-digest";
 
 type Props = {
@@ -32,7 +33,8 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
   const [rss, setRss] = useState<FeedItem[]>([]);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [ready, setReady] = useState(false);
-  const [mediaDismissed, setMediaDismissed] = useState(false);
+  // News is opt-out in Settings → General (no inline dismiss on the row).
+  const newsEnabled = useHomeNewsEnabled();
 
   // Re-derives the digest from the latest inbox + RSS and re-stamps `nowMs` so
   // the count chips and "Nm ago" labels stay current instead of freezing at
@@ -84,21 +86,13 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
           <DigestRow cards={chatCards} onOpenSession={onOpenSession} duplicate />
         </div>
       ) : null}
-      {mediaCards.length > 0 && !mediaDismissed ? (
+      {mediaCards.length > 0 && newsEnabled ? (
         <div className="home-digest__media">
           <div className="home-digest__media-chrome">
             <span className="home-digest__media-label">
               <Icon name="ph:newspaper" width={12} aria-hidden />
               <span>News</span>
             </span>
-            <button
-              type="button"
-              className="home-digest__media-close"
-              aria-label="Close news carousel"
-              onClick={() => setMediaDismissed(true)}
-            >
-              <Icon name="ph:x-bold" width={11} aria-hidden />
-            </button>
           </div>
           <div className="home-digest__track home-digest__track--media" aria-label="Media headlines">
             <DigestRow cards={mediaCards} onOpenSession={onOpenSession} />

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -35,6 +35,7 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
 
 export const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "general", group: "Workspace", keywords: "workspace directory root folder project path" },
+  { section: "general", group: "Home", keywords: "news headlines rss carousel media home digest daily summary" },
   { section: "general", group: "Startup", keywords: "startup launch autostart open boot" },
   { section: "daemon", group: "Status", keywords: "daemon status running start stop restart hub server executor private network tailscale" },
   { section: "daemon", group: "Connection", keywords: "daemon hub server executor private network tailscale remote multihost multi host" },

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -23,6 +23,7 @@ import { FamiliarStudioProvider } from "@/lib/familiar-studio-context";
 import { APP_VERSION } from "@/lib/app-version";
 import { UpdateSettingsRow } from "@/components/update-available";
 import { useIsMobile } from "@/lib/use-viewport";
+import { useHomeNewsEnabled, writeHomeNewsEnabled } from "@/lib/home-news-pref";
 import { ThemeColorEditor } from "@/components/theme-color-editor";
 import { rgbaBytesToHex } from "@/lib/theme-token-hex";
 import { FontSettings } from "./settings-fonts";
@@ -350,11 +351,41 @@ function GeneralSection() {
           <WorkspacePathField />
         </SettingsRow>
       </SettingsGroup>
+      <SettingsGroup label="Home">
+        <HomeNewsToggle />
+      </SettingsGroup>
       <SettingsGroup label="Startup">
         <SettingsRow label="Launch at login" description="Start CovenCave when you log in." comingSoon />
         <SettingsRow label="Open to" description="Which view to show on launch." comingSoon />
       </SettingsGroup>
     </SettingsPage>
+  );
+}
+
+// News on Home is opt-out here rather than dismissible inline — the carousel
+// row carries no X, so this switch is the one place the choice lives (and it
+// persists across visits, unlike the old per-mount dismiss).
+function HomeNewsToggle() {
+  const newsEnabled = useHomeNewsEnabled();
+  return (
+    <SettingsRow
+      label="News headlines"
+      description="Show the News carousel on the Home screen's daily summary."
+    >
+      <button
+        type="button"
+        role="switch"
+        aria-checked={newsEnabled}
+        onClick={() => writeHomeNewsEnabled(!newsEnabled)}
+        className={`settings-mobile-switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+          newsEnabled
+            ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+            : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
+        }`}
+      >
+        {newsEnabled ? "On" : "Off"}
+      </button>
+    </SettingsRow>
   );
 }
 

--- a/src/lib/home-news-pref.test.ts
+++ b/src/lib/home-news-pref.test.ts
@@ -1,0 +1,38 @@
+// Home news pref — default-on opt-out backing the Settings → General switch
+// and the Home digest News row (which has no inline dismiss).
+import assert from "node:assert/strict";
+
+// Minimal window stub so the module's storage-backed cache is exercised.
+const store = new Map<string, string>();
+(globalThis as { window?: unknown }).window = {
+  localStorage: {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  },
+  addEventListener: () => {},
+  removeEventListener: () => {},
+};
+
+const { readHomeNewsEnabled, writeHomeNewsEnabled } = await import("./home-news-pref.ts");
+
+// Default is ON — absence of the key means enabled (opt-out semantics).
+assert.equal(readHomeNewsEnabled(), true, "news defaults to enabled");
+
+// Opting out persists "false" and flips the cached read.
+writeHomeNewsEnabled(false);
+assert.equal(readHomeNewsEnabled(), false, "opt-out is reflected immediately");
+assert.equal(store.get("cave:home-news-enabled"), "false", "opt-out persists to localStorage");
+
+// Re-enabling round-trips.
+writeHomeNewsEnabled(true);
+assert.equal(readHomeNewsEnabled(), true, "re-enable is reflected immediately");
+assert.equal(store.get("cave:home-news-enabled"), "true", "re-enable persists");
+
+// A literal "false" in storage on a cold cache reads as disabled; anything else
+// (junk, "true") reads enabled — matching the mobile-mode pref convention.
+store.set("cave:home-news-enabled", "false");
+writeHomeNewsEnabled(false); // reset cache to a known state via the public API
+assert.equal(readHomeNewsEnabled(), false);
+
+console.log("home-news-pref.test.ts: ok");

--- a/src/lib/home-news-pref.ts
+++ b/src/lib/home-news-pref.ts
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * Home news carousel preference — opt-out toggle for the News (media
+ * headlines) row of the home Daily-summary strip.
+ *
+ * Default ON; Settings → General owns the switch (the row itself has no
+ * inline dismiss). `cave:home-news-enabled` stores "false" to opt out —
+ * absence means enabled, matching the mobile-mode pref convention.
+ * useSyncExternalStore keeps every subscriber (the home carousel, the
+ * settings row) live-synced with same-tab writes and cross-tab storage
+ * events.
+ */
+
+import { useSyncExternalStore } from "react";
+
+const HOME_NEWS_KEY = "cave:home-news-enabled";
+
+let cached: boolean | null = null;
+const listeners = new Set<() => void>();
+
+function notify() { for (const fn of listeners) fn(); }
+
+function readFromStorage(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(HOME_NEWS_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+export function readHomeNewsEnabled(): boolean {
+  if (cached === null) cached = readFromStorage();
+  return cached;
+}
+
+export function writeHomeNewsEnabled(enabled: boolean) {
+  cached = enabled;
+  try {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(HOME_NEWS_KEY, enabled ? "true" : "false");
+    }
+  } catch {
+    /* private mode — the in-memory cache still drives this tab */
+  }
+  notify();
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  const onStorage = (e: StorageEvent) => {
+    if (e.key !== HOME_NEWS_KEY) return;
+    cached = null;
+    fn();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(fn);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+/** Live view of the pref — re-renders on same-tab writes and cross-tab changes. */
+export function useHomeNewsEnabled(): boolean {
+  return useSyncExternalStore(subscribe, readHomeNewsEnabled, () => true);
+}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -810,29 +810,6 @@
 .home-digest__track--media {
   animation-direction: reverse;
 }
-.home-digest__media-close {
-  display: grid;
-  place-items: center;
-  flex: 0 0 auto;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--radius-control);
-  border: 1px solid var(--border-hairline);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
-  color: var(--text-secondary);
-  pointer-events: auto;
-  transition: background 0.14s, color 0.14s, border-color 0.14s;
-}
-.home-digest__media-close:hover,
-.home-digest__media-close:focus-visible {
-  border-color: var(--border-strong);
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-}
-.home-digest__media-close:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 2px;
-}
 .home-digest:hover .home-digest__track,
 .home-digest:focus-within .home-digest__track {
   animation-play-state: paused;


### PR DESCRIPTION
## What

The News row of the home Daily-summary strip loses its X button; visibility is now a persistent, opt-out user setting.

- **`src/lib/home-news-pref.ts`** — default-on pref under `cave:home-news-enabled` ("false" = opted out, matching the mobile-mode convention), with a `useSyncExternalStore` hook so the carousel and the settings switch stay live-synced across tabs.
- **`home-digest-carousel.tsx`** — X button + per-mount `mediaDismissed` state removed (the old dismiss evaporated on every remount anyway); the row renders iff the pref is on. Dead `.home-digest__media-close` CSS removed.
- **Settings → General → Home** — new "News headlines" switch (`role=switch`, `--accent-presence(-foreground)` tokens), added to the settings search index.

## Verification

- `pnpm typecheck` ✓ · `check-tests-wired` (716) ✓ · `pnpm test:app` (532 files) ✓ · `pnpm build` ✓
- Live app: news row renders with **0** close buttons → settings switch flips On→Off persisting `false` → row disappears; guard tests updated + new pref unit test