### PR TITLE
feat(familiars): expose the autoSelfReport toggle; cross-link the two orders (cave-v1z)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6818,6 +6818,8 @@ a.mobile-handoff__link:hover {
 }
 .familiar-studio-brain__row { display: flex; flex-direction: column; gap: 6px; }
 .familiar-studio-brain__label { font-size: var(--text-2xs); font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.06em; }
+.familiar-studio-brain__hint { margin: 6px 0 0; font-size: var(--text-2xs); line-height: 1.5; color: var(--text-muted); }
+.familiar-studio-brain__switch { align-self: flex-start; cursor: pointer; }
 .familiar-studio-brain__control { display: flex; min-width: 0; gap: 6px; align-items: flex-start; }
 .familiar-studio-brain__input {
   flex: 1;
@@ -6906,6 +6908,19 @@ a.mobile-handoff__link:hover {
 .familiar-studio-lifecycle { display: flex; flex-direction: column; gap: 18px; }
 .familiar-studio-lifecycle__section { display: flex; flex-direction: column; gap: 6px; }
 .familiar-studio-lifecycle__heading { font-size: 11px; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.04em; margin: 0; }
+.familiar-studio-lifecycle__hint { margin: 4px 0 8px; font-size: var(--text-2xs); line-height: 1.5; color: var(--text-muted); }
+.familiar-studio-lifecycle__hint-link {
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text-secondary);
+  font-size: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.familiar-studio-lifecycle__hint-link:hover { color: var(--text-primary); }
 .familiar-studio-lifecycle__hint { font-size: 12px; color: var(--text-muted); line-height: 1.4; margin: 0; }
 .familiar-studio-lifecycle__btn { display: inline-flex; align-items: center; gap: 6px; align-self: flex-start; background: var(--bg-raised); border: 1px solid var(--border-hairline); border-radius: 6px; padding: 6px 10px; color: var(--text-primary); font-size: 12px; cursor: pointer; }
 .familiar-studio-lifecycle__btn:hover { background: color-mix(in oklch, var(--text-primary) 8%, var(--bg-raised)); }

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -93,4 +93,13 @@ assert.match(
   "Brain workspace should collapse to one column on narrow surfaces",
 );
 
+// ── Reflection: autoSelfReport toggle (2026-07-06) ───────────────────────────
+// The config field was wired end-to-end (GET /api/familiars → chat-view's
+// session-close self-report) but had no UI. It saves through the tab's shared
+// /api/config patch helper; `null` deletes the key (resolved default: false).
+assert.match(source, /Auto self-report/, "Brain tab exposes the auto self-report toggle");
+assert.match(source, /role="switch"[\s\S]{0,80}aria-checked=\{draftAutoSelfReport\}/, "the toggle is a proper switch");
+assert.match(source, /autoSelfReport: next \? true : null/, "off deletes the config key instead of writing false");
+assert.match(source, /if \("autoSelfReport" in patch\) setDraftAutoSelfReport/, "failed saves revert the toggle draft");
+
 console.log("familiar-studio-brain-tab.test.ts: ok");

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -36,6 +36,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [draftVoiceProvider, setDraftVoiceProvider] = useState(familiar.voiceProvider ?? "");
   const [draftVoiceModel, setDraftVoiceModel] = useState(familiar.voiceModel ?? "");
   const [draftVoiceName, setDraftVoiceName] = useState(familiar.voiceName ?? "");
+  const [draftAutoSelfReport, setDraftAutoSelfReport] = useState(Boolean(familiar.autoSelfReport));
   const [toast, setToast] = useState<string | null>(null);
   const [manifest, setManifest] = useState<HarnessCapabilityManifest | null>(null);
   const [manifestState, setManifestState] = useState<"idle" | "loading" | "ready" | "error">("idle");
@@ -48,8 +49,9 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     setDraftVoiceProvider(familiar.voiceProvider ?? "");
     setDraftVoiceModel(familiar.voiceModel ?? "");
     setDraftVoiceName(familiar.voiceName ?? "");
+    setDraftAutoSelfReport(Boolean(familiar.autoSelfReport));
     setToast(null);
-  }, [familiar.id, familiar.harnessOverride, familiar.model, familiar.note, familiar.voiceProvider, familiar.voiceModel, familiar.voiceName]);
+  }, [familiar.id, familiar.harnessOverride, familiar.model, familiar.note, familiar.voiceProvider, familiar.voiceModel, familiar.voiceName, familiar.autoSelfReport]);
 
   useEffect(() => {
     let cancelled = false;
@@ -135,6 +137,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
         if ("voiceProvider" in patch) setDraftVoiceProvider(familiar.voiceProvider ?? "");
         if ("voiceModel" in patch) setDraftVoiceModel(familiar.voiceModel ?? "");
         if ("voiceName" in patch) setDraftVoiceName(familiar.voiceName ?? "");
+        if ("autoSelfReport" in patch) setDraftAutoSelfReport(Boolean(familiar.autoSelfReport));
       } else {
         reportDaemonSyncSuccess();
       }
@@ -237,7 +240,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
           {toast ? <p className="familiar-studio-brain__toast">{toast}</p> : null}
         </div>
 
-        <aside className="familiar-studio-brain__sidecar" aria-label="Voice and capabilities">
+        <aside className="familiar-studio-brain__sidecar" aria-label="Voice, reflection, and capabilities">
           <section className="familiar-studio-brain__card">
             <h3 className="familiar-studio-brain__card-title">Voice</h3>
             <label className="familiar-studio-brain__row">
@@ -303,6 +306,37 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                 </label>
               </>
             )}
+          </section>
+
+          <section className="familiar-studio-brain__card">
+            <h3 className="familiar-studio-brain__card-title">Reflection</h3>
+            <div className="familiar-studio-brain__row">
+              <span className="familiar-studio-brain__label">Auto self-report</span>
+              <div className="familiar-studio-brain__control">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={draftAutoSelfReport}
+                  onClick={() => {
+                    const next = !draftAutoSelfReport;
+                    setDraftAutoSelfReport(next);
+                    // `null` deletes the key from cave-config (the resolved
+                    // default is false), keeping the file free of no-op entries.
+                    void save({ autoSelfReport: next ? true : null });
+                  }}
+                  className={`familiar-studio-brain__switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+                    draftAutoSelfReport
+                      ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+                      : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
+                  }`}
+                >
+                  {draftAutoSelfReport ? "On" : "Off"}
+                </button>
+              </div>
+            </div>
+            <p className="familiar-studio-brain__hint">
+              Writes a self-report to memory when a chat closes or is archived.
+            </p>
           </section>
 
           {harnessId ? (

--- a/src/components/familiar-studio-lifecycle-tab.test.ts
+++ b/src/components/familiar-studio-lifecycle-tab.test.ts
@@ -24,4 +24,9 @@ assert.match(source, /canMoveDown/, "Rows expose canMoveDown prop for disabled-e
 assert.match(source, /ph:arrow-up-bold/, "Move-up icon is wired");
 assert.match(source, /ph:arrow-down-bold/, "Move-down icon is wired");
 
+// The roster order here is distinct from the avatar-strip pin order in
+// Appearance — the hint cross-links so users find both (2026-07-06).
+assert.match(source, /avatar strip's pinned order/, "lifecycle hint disambiguates roster order from pin order");
+assert.match(source, /window\.location\.hash = "appearance"/, "lifecycle hint links to Appearance");
+
 console.log("familiar-studio-lifecycle-tab.test.ts: ok");

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -66,6 +66,20 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
     <div className="familiar-studio-lifecycle">
       <section>
         <h3 className="familiar-studio-lifecycle__heading">Active</h3>
+        <p className="familiar-studio-lifecycle__hint">
+          Sets the roster order across the app. The avatar strip's pinned order
+          is separate —{" "}
+          <button
+            type="button"
+            className="familiar-studio-lifecycle__hint-link focus-ring"
+            onClick={() => {
+              window.location.hash = "appearance";
+            }}
+          >
+            set it in Appearance
+          </button>
+          .
+        </p>
         {active.map((f, i) => (
           <FamiliarRow
             key={f.id}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1190,6 +1190,10 @@ function AppearanceSection() {
   const [activeTheme, setActiveTheme] = useState<ActiveTheme>("coven");
   const [mode, setMode] = useState<ModePref>("dark");
   const [customData, setCustomData] = useState<CustomThemeData | null>(null);
+  // Below the shell's FamiliarStudioProvider — lets the pin-order hint open
+  // Familiars directly on the Lifecycle tab (the app-wide roster order lives
+  // there, distinct from the avatar-strip pin order set here).
+  const { setActiveTab: setStudioTab } = useFamiliarStudio();
 
   // Mirror the active theme + resolved tokens to the daemon on change (and mount)
   // so cross-device clients can read it. Best-effort; failures are swallowed.
@@ -1576,6 +1580,18 @@ function AppearanceSection() {
                 </div>
                 <div className="text-[11px] text-[var(--text-muted)]">
                   Drag to set the order pinned familiars appear in the avatar strip.
+                  The app-wide roster order is separate —{" "}
+                  <button
+                    type="button"
+                    className="focus-ring underline underline-offset-2 hover:text-[var(--text-primary)]"
+                    onClick={() => {
+                      setStudioTab("lifecycle");
+                      window.location.hash = "familiars";
+                    }}
+                  >
+                    set it in Familiars › Lifecycle
+                  </button>
+                  .
                 </div>
               </div>
               <FamiliarPinOrder />


### PR DESCRIPTION
## What

Two Settings › Familiars gaps from the approved plan (PR 4 of 4):

1. **`autoSelfReport` had no UI.** The field flows through `GET /api/familiars` and is consumed by chat-view (writes a self-report to memory when a chat closes or is archived) — but nothing could turn it on. The Brain tab's sidecar gains a **Reflection** card with a `role="switch"` toggle using the tab's existing `/api/config` PATCH helper. Off sends `null` (deletes the key; resolved default is `false`), and failed saves revert the draft like every other Brain field.
2. **Ordering clarity.** The avatar-strip pin order (Appearance › Familiar switcher) and the app-wide roster order (Familiars › Lifecycle) are different objects in different sections with no cross-reference. Each now carries a one-line hint linking to the other — the Appearance link lands directly on the Lifecycle tab via the studio context. `FamiliarPinOrder` stays in Appearance (pinned by settings-appearance.test.ts, and pin order is conditional on the switcher style).

## Verification

- 531 test files green; new pins in `familiar-studio-brain-tab.test.ts` (switch semantics, null-delete save shape, failure revert) and `familiar-studio-lifecycle-tab.test.ts` (hint copy + link). `tsc` clean.
- Production build driven with Playwright: toggle click PATCHes `{"familiars":{"nova":{"autoSelfReport":true}}}` and flips `aria-checked`; Lifecycle hint navigates to `#appearance`.

Bead: cave-v1z

🤖 Generated with [Claude Code](https://claude.com/claude-code)