### PR TITLE
fix(code): readable syntax colors in the editor + language-highlighted diffs (cave-t6g)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "test:supply-chain": "node scripts/dependency-policy.test.mjs"
   },
   "dependencies": {
+    "@codemirror/language": "6.12.3",
     "@create-markdown/core": "2.0.3",
     "@create-markdown/preview": "2.0.3",
     "@create-markdown/preview-mermaid": "2.0.3",
@@ -62,6 +63,7 @@
     "@dnd-kit/utilities": "3.2.2",
     "@iconify-json/ph": "1.2.2",
     "@iconify/react": "6.0.2",
+    "@lezer/highlight": "1.2.3",
     "@tailwindcss/browser": "4.3.1",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-notification": "2.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@codemirror/language':
+        specifier: 6.12.3
+        version: 6.12.3
       '@create-markdown/core':
         specifier: 2.0.3
         version: 2.0.3
@@ -38,6 +41,9 @@ importers:
       '@iconify/react':
         specifier: 6.0.2
         version: 6.0.2(react@19.2.7)
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
       '@tailwindcss/browser':
         specifier: 4.3.1
         version: 4.3.1

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -335,4 +335,37 @@ assert.match(
   "cave-diff-meta CSS rule is defined for hunk-header chrome",
 );
 
+// ── Language-aware diffs: content highlighted in the file's grammar ─────────
+// A diff whose +++/--- header names a highlightable file renders its content
+// through that language's grammar (not the flat whole-line `diff` grammar);
+// the +/- markers are re-attached as a dim .cave-diff-marker span so the DOM
+// text — what the Copy button reads — stays byte-identical to the raw diff.
+assert.match(
+  bubbleSource,
+  /const diffLang = isDiff \? diffContentLang\(code\) : "text"/,
+  "renderCodeBlock resolves the diff's content grammar from its file headers",
+);
+assert.match(
+  bubbleSource,
+  /function classifyDiffLines\(/,
+  "diff lines are classified (add/del/ctx/meta/hunk) for language-aware rendering",
+);
+assert.match(
+  bubbleSource,
+  /<span class="cave-diff-marker">\$\{dl\.marker\}<\/span>/,
+  "stripped +/- markers are re-attached as a cave-diff-marker span",
+);
+assert.match(
+  styles,
+  /\.cave-diff-marker\s*\{/,
+  "cave-diff-marker CSS rule is defined",
+);
+// Shiki failure fallback renders the ORIGINAL diff text — the language-aware
+// line map must be dropped there or markers would be attached twice.
+assert.match(
+  bubbleSource,
+  /highlighted = `<pre><code>\$\{escHtml\(code\)\}<\/code><\/pre>`;\s*\n\s*diffLines = null/,
+  "highlight-failure fallback clears diffLines so markers are not doubled",
+);
+
 console.log("chat-header-row.test.ts: ok");

--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -27,6 +27,30 @@ assert.match(
 );
 assert.match(editor, /key: "Escape", run: \(\) => \{ onCancel\(\); return true; \}/, "Escape cancels from inside the editor");
 
+// Syntax colors come from the SAME palette as read mode (Shiki mood-c-dark).
+// Without an explicit HighlightStyle, CodeMirror falls back to its default
+// syntax palette, which is designed for LIGHT backgrounds (#a11 strings,
+// #940 comments) — unreadable on the dark --code-surface.
+assert.ok(pkg.dependencies["@codemirror/language"], "@codemirror/language dep present for HighlightStyle");
+assert.ok(pkg.dependencies["@lezer/highlight"], "@lezer/highlight dep present for lezer tags");
+assert.match(
+  editor,
+  /import \{ HighlightStyle, syntaxHighlighting \} from "@codemirror\/language"/,
+  "editor imports HighlightStyle/syntaxHighlighting",
+);
+assert.match(
+  editor,
+  /import moodCTheme from "@\/styles\/shiki\/mood-c-dark\.json"/,
+  "syntax palette single source of truth is the shiki mood-c-dark theme json",
+);
+assert.match(editor, /const moodHighlight = HighlightStyle\.define\(/, "a HighlightStyle maps lezer tags to the mood-c palette");
+assert.match(editor, /syntaxHighlighting\(moodHighlight\)/, "the highlight style is installed as an editor extension");
+// The code surface stays dark in EVERY app theme (light modes included), so
+// editor text/gutter inks must be fixed mood-c inks, not theme text tokens
+// (--text-primary is a dark ink in light themes → dark-on-dark).
+assert.doesNotMatch(editor, /color: "var\(--text-primary\)"/, "editor ink must not ride theme text tokens on the fixed-dark code surface");
+assert.doesNotMatch(editor, /color: "var\(--text-muted\)"/, "gutter ink must not ride theme text tokens on the fixed-dark code surface");
+
 // Editor chrome is themed to the app's CSS tokens (not the generic dark theme).
 assert.match(editor, /const appTheme = EditorView\.theme\(/, "a CodeMirror theme is defined from app tokens");
 assert.match(editor, /backgroundColor: "var\(--code-surface\)"/, "editor background matches the read code surface via --code-surface");

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -3,17 +3,90 @@
 import { useMemo } from "react";
 import CodeMirror, { EditorView, keymap, type Extension } from "@uiw/react-codemirror";
 import { loadLanguage, type LanguageName } from "@uiw/codemirror-extensions-langs";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+import moodCTheme from "@/styles/shiki/mood-c-dark.json";
 
-// Editor chrome themed to the app's tokens so it reads as part of the Cave
-// rather than a generic dark box. Only the frame is themed here (background,
-// gutter, cursor, selection, active line); the default dark syntax palette
-// still colors the code. `dark: true` keeps CodeMirror's dark-mode defaults
-// for anything not overridden.
+// ---------------------------------------------------------------------------
+// Syntax palette — derived from the app's canonical Shiki theme so edit mode
+// matches the read-mode preview and chat code blocks exactly: one palette
+// (src/styles/shiki/mood-c-dark.json), two highlighters. Without an explicit
+// HighlightStyle, CodeMirror falls back to its default syntax colors, which
+// are designed for LIGHT backgrounds (#a11 strings, #940 comments) and are
+// unreadable on the dark --code-surface. The code surface stays dark in every
+// app theme (light modes included), so these are fixed inks, not theme tokens.
+// ---------------------------------------------------------------------------
+
+type MoodTheme = {
+  colors: Record<string, string>;
+  tokenColors: { scope: string[]; settings: { foreground?: string; fontStyle?: string } }[];
+};
+const mood = moodCTheme as MoodTheme;
+
+function moodColor(scope: string, fallback: string): string {
+  for (const tc of mood.tokenColors) {
+    if (tc.scope.includes(scope) && tc.settings.foreground) return tc.settings.foreground;
+  }
+  return fallback;
+}
+
+const ink = mood.colors["editor.foreground"] ?? "#c9c2dc";
+const gutterInk = mood.colors["editorLineNumber.foreground"] ?? "#4a4560";
+const gutterActiveInk = mood.colors["editorLineNumber.activeForeground"] ?? "#7a6fa0";
+
+const C = {
+  comment: moodColor("comment", "#4a4560"),
+  keyword: moodColor("keyword", "#b388ff"),
+  func: moodColor("entity.name.function", "#d4a9ff"),
+  type: moodColor("entity.name.type", "#c5aaff"),
+  param: moodColor("variable.parameter", "#e8d8ff"),
+  string: moodColor("string", "#a8c8ff"),
+  constant: moodColor("constant.numeric", "#ffb3c6"),
+  property: moodColor("support.type.property-name", "#9dd5ff"),
+  attribute: moodColor("entity.other.attribute-name", "#b8d8ff"),
+  punct: moodColor("punctuation", "#8070a0"),
+  operator: moodColor("operator", "#c09ef0"),
+  inserted: moodColor("markup.inserted", "#89ddff"),
+  deleted: moodColor("markup.deleted", "#ff8a9b"),
+  changed: moodColor("markup.changed", "#ffcc80"),
+};
+
+// Lezer tag → mood-c scope mapping. Lezer and TextMate slice the token space
+// differently, so this is the closest-role match, not a 1:1 translation.
+const moodHighlight = HighlightStyle.define([
+  { tag: [t.comment, t.lineComment, t.blockComment, t.docComment], color: C.comment, fontStyle: "italic" },
+  { tag: [t.keyword, t.controlKeyword, t.moduleKeyword, t.operatorKeyword, t.definitionKeyword, t.modifier, t.self], color: C.keyword },
+  { tag: [t.function(t.variableName), t.function(t.propertyName), t.macroName], color: C.func },
+  { tag: [t.typeName, t.className, t.namespace, t.standard(t.tagName)], color: C.type },
+  { tag: [t.variableName, t.definition(t.variableName)], color: ink },
+  { tag: [t.local(t.variableName), t.special(t.variableName)], color: C.param },
+  { tag: [t.string, t.special(t.string), t.regexp, t.character, t.docString], color: C.string },
+  { tag: [t.number, t.bool, t.null, t.atom, t.literal, t.escape, t.constant(t.variableName), t.standard(t.variableName), t.unit, t.color], color: C.constant },
+  { tag: [t.propertyName, t.definition(t.propertyName), t.tagName, t.labelName], color: C.property },
+  { tag: [t.attributeName, t.attributeValue], color: C.attribute },
+  { tag: [t.punctuation, t.separator, t.bracket, t.derefOperator, t.meta], color: C.punct },
+  { tag: [t.operator, t.compareOperator, t.arithmeticOperator, t.logicOperator, t.bitwiseOperator, t.updateOperator, t.definitionOperator, t.typeOperator], color: C.operator },
+  { tag: t.inserted, color: C.inserted },
+  { tag: t.deleted, color: C.deleted },
+  { tag: t.changed, color: C.changed },
+  { tag: t.heading, color: C.func, fontWeight: "600" },
+  { tag: [t.link, t.url], color: C.property, textDecoration: "underline" },
+  { tag: t.emphasis, fontStyle: "italic" },
+  { tag: t.strong, fontWeight: "600" },
+  { tag: t.strikethrough, textDecoration: "line-through" },
+  { tag: t.invalid, color: C.deleted },
+]);
+
+// Editor frame themed to the app so it reads as part of the Cave rather than
+// a generic dark box: the background rides --code-surface (shared with the
+// read-mode blocks) and the caret/selection carry the theme accent. Text and
+// gutter inks come from the mood-c palette, NOT theme tokens — the code
+// surface is dark even in light app themes, where --text-primary is dark ink.
 const appTheme = EditorView.theme(
   {
     "&": {
       backgroundColor: "var(--code-surface)",
-      color: "var(--text-primary)",
+      color: ink,
       height: "100%",
       fontSize: "12px",
     },
@@ -23,13 +96,13 @@ const appTheme = EditorView.theme(
     },
     ".cm-gutters": {
       backgroundColor: "var(--code-surface)",
-      color: "var(--text-muted)",
+      color: gutterInk,
       border: "none",
     },
-    ".cm-activeLine": { backgroundColor: "color-mix(in oklch, var(--foreground) 4%, transparent)" },
+    ".cm-activeLine": { backgroundColor: "color-mix(in oklch, white 4%, transparent)" },
     ".cm-activeLineGutter": {
-      backgroundColor: "color-mix(in oklch, var(--foreground) 4%, transparent)",
-      color: "var(--text-secondary)",
+      backgroundColor: "color-mix(in oklch, white 4%, transparent)",
+      color: gutterActiveInk,
     },
     "&.cm-focused .cm-cursor": { borderLeftColor: "var(--accent-presence)" },
     "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
@@ -105,6 +178,7 @@ export function CodeEditor({ value, filename, onChange, onSave, onCancel }: Prop
   const extensions = useMemo<Extension[]>(() => {
     const list: Extension[] = [
       EditorView.lineWrapping,
+      syntaxHighlighting(moodHighlight),
       // High-precedence so Mod-s / Escape win over default bindings.
       keymap.of([
         { key: "Mod-s", preventDefault: true, run: () => { onSave(); return true; } },

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -34,7 +34,7 @@ import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type 
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
-import { SHIKI_LANGS, resolveShikiLang } from "@/lib/code-lang";
+import { SHIKI_LANGS, resolveShikiLang, diffContentLang } from "@/lib/code-lang";
 import { parseFileRef } from "@/lib/file-ref";
 import { toggleCodeBlockCollapse } from "@/lib/code-block-collapse";
 import { wireMermaidDiagrams } from "./mermaid-viewer";
@@ -116,31 +116,69 @@ function plainTextFromHtmlLine(line: string): string {
   return doc.body.textContent ?? "";
 }
 
+// ── Language-aware diff rendering ────────────────────────────────────────────
+// A structured diff names its file in the `+++ b/<path>` header; when that
+// file has a real grammar we highlight the diff's CONTENT in that language
+// and re-attach the +/- markers as muted chrome, so an edit card or Review
+// modal reads like code with add/remove strips instead of a flat wall of
+// uniformly "inserted"-colored lines. Diffs whose target has no resolvable
+// grammar keep the bundled `diff` grammar (whole-line coloring) below.
+
+type DiffLineKind = "add" | "del" | "ctx" | "meta" | "hunk";
+type DiffLine = { kind: DiffLineKind; raw: string; marker: string | null; content: string };
+
+const DIFF_META_RE =
+  /^(\+\+\+ |--- |diff --git |index |new file|deleted file|rename |similarity |old mode|new mode|Binary files|\\ No newline)/;
+
+function classifyDiffLines(code: string): DiffLine[] {
+  return code.split("\n").map((raw): DiffLine => {
+    // Meta and @@ hunk rows are blanked out of the document the language
+    // grammar sees (content: "") so they can't derail the parse; the raw text
+    // is re-substituted as muted chrome when the lines are wrapped.
+    if (/^@@/.test(raw)) return { kind: "hunk", raw, marker: null, content: "" };
+    if (DIFF_META_RE.test(raw)) return { kind: "meta", raw, marker: null, content: "" };
+    if (raw.startsWith("+")) return { kind: "add", raw, marker: "+", content: raw.slice(1) };
+    if (raw.startsWith("-")) return { kind: "del", raw, marker: "-", content: raw.slice(1) };
+    if (raw.startsWith(" ")) return { kind: "ctx", raw, marker: " ", content: raw.slice(1) };
+    // e.g. the "… (N more lines truncated)" cap marker — pass through as-is.
+    return { kind: "ctx", raw, marker: null, content: raw };
+  });
+}
+
 async function renderCodeBlock(
   code: string,
   info: string,
 ): Promise<string> {
   const { lang, filename } = parseFenceInfo(info);
+  const isDiff = lang === "diff";
+  const diffLang = isDiff ? diffContentLang(code) : "text";
+  let diffLines = isDiff && diffLang !== "text" ? classifyDiffLines(code) : null;
 
   let highlighted: string;
   try {
     const hl = await getHighlighter();
-    highlighted = hl.codeToHtml(code, {
+    // Language-aware diffs feed the grammar the diff's content with markers
+    // stripped and meta rows blanked — one line per original line, so the
+    // highlighted output stays index-aligned with the classification.
+    const doc = diffLines ? diffLines.map((l) => l.content).join("\n") : code;
+    highlighted = hl.codeToHtml(doc, {
       // resolveShikiLang maps both fence names (`typescript`) AND bare file
       // extensions (`ts`, `tsx`, `rs`) to a loadable grammar — without it the
       // Projects file preview, which passes raw extensions, fell back to the
       // unhighlighted "text" grammar for every file.
-      lang: resolveShikiLang(lang),
+      lang: diffLines ? diffLang : resolveShikiLang(lang),
       theme: "mood-c-dark",
     });
   } catch (err) {
     console.error("[renderCodeBlock] Shiki highlight failed", err);
+    // Fallback renders the ORIGINAL code (markers intact) — drop the
+    // language-aware line map so markers aren't re-attached twice.
     highlighted = `<pre><code>${escHtml(code)}</code></pre>`;
+    diffLines = null;
   }
 
   const lines = code.split("\n");
   const showLineNums = lines.length > 5;
-  const isDiff = lang === "diff";
 
   // Build line-numbered version by splitting Shiki's output into lines.
   // Shiki wraps each token in <span>; the outer <pre><code> contains one
@@ -155,12 +193,28 @@ async function renderCodeBlock(
         // Remove trailing empty line Shiki adds
         if (rawLines[rawLines.length - 1] === "") rawLines.pop();
         const wrappedLines = rawLines.map((line: string, i: number) => {
-          // CHAT-D8-03: `+++ b/file` / `--- a/file` headers are metadata, not
-          // additions/deletions — exclude them from the +/- gutter strips and
-          // mute `@@` hunk headers instead of leaving them content-colored.
-          const plainLine = plainTextFromHtmlLine(line);
-          const gutterClass = isDiff
-            ? /^@@/.test(plainLine)
+          let content = line;
+          let gutterClass = "";
+          const dl = diffLines?.[i];
+          if (dl) {
+            // Language-aware diff: meta/@@ rows were blanked for the grammar —
+            // restore the raw text as muted chrome. +/- markers come back as a
+            // dim leading span, so the DOM text (what Copy reads) stays
+            // byte-identical to the raw diff.
+            if (dl.kind === "meta" || dl.kind === "hunk") {
+              content = `<span>${escHtml(dl.raw)}</span>`;
+              gutterClass = " cave-diff-meta";
+            } else {
+              const marker = dl.marker ? `<span class="cave-diff-marker">${dl.marker}</span>` : "";
+              content = `${marker}${line}`;
+              gutterClass = dl.kind === "add" ? " cave-diff-add" : dl.kind === "del" ? " cave-diff-del" : "";
+            }
+          } else if (isDiff) {
+            // CHAT-D8-03: `+++ b/file` / `--- a/file` headers are metadata, not
+            // additions/deletions — exclude them from the +/- gutter strips and
+            // mute `@@` hunk headers instead of leaving them content-colored.
+            const plainLine = plainTextFromHtmlLine(line);
+            gutterClass = /^@@/.test(plainLine)
               ? " cave-diff-meta"
               : /^(\+\+\+ |--- )/.test(plainLine)
               ? ""
@@ -168,14 +222,14 @@ async function renderCodeBlock(
               ? " cave-diff-add"
               : /^-/.test(plainLine)
               ? " cave-diff-del"
-              : ""
-            : "";
+              : "";
+          }
           const lineNum = showLineNums
             ? `<span class="cave-ln" aria-hidden="true">${i + 1}</span>`
             : "";
           // data-line lets surfaces (e.g. the Projects search) scroll a code
           // block to a specific 1-based line. Harmless to chat code blocks.
-          return `<span class="cave-line${gutterClass}" data-line="${i + 1}">${lineNum}${line}</span>`;
+          return `<span class="cave-line${gutterClass}" data-line="${i + 1}">${lineNum}${content}</span>`;
         });
         return `${co}${wrappedLines.join("")}${cc}`;
       });

--- a/src/lib/code-lang.test.ts
+++ b/src/lib/code-lang.test.ts
@@ -5,6 +5,7 @@ import {
   resolveShikiLang,
   isHighlightableLang,
   resolveLangLabel,
+  diffContentLang,
 } from "./code-lang.ts";
 
 // ---------------------------------------------------------------------------
@@ -108,5 +109,46 @@ assert.equal(resolveLangLabel("fs"), "F#", "fs → F# label");
 assert.equal(resolveLangLabel("lock"), "LOCK", "unknown short ext shows uppercased badge");
 assert.equal(resolveLangLabel("env"), "ENV", "env shows uppercased badge");
 assert.equal(resolveLangLabel(""), "Text", "empty input shows Text");
+
+// ---------------------------------------------------------------------------
+// diffContentLang — grammar for the code INSIDE a unified diff, from headers.
+// ---------------------------------------------------------------------------
+
+assert.equal(
+  diffContentLang("--- a/src/lib/foo.ts\n+++ b/src/lib/foo.ts\n-old\n+new"),
+  "typescript",
+  "ts target → typescript grammar",
+);
+assert.equal(
+  diffContentLang("+++ b//Users/buns/repo/src/lib/stream-events.ts\n+import x"),
+  "typescript",
+  "write-style diff with absolute (double-slash) path resolves",
+);
+assert.equal(
+  diffContentLang("--- /dev/null\n+++ b/pkg/main.rs\n+fn main() {}"),
+  "rust",
+  "/dev/null old side is skipped; new side wins",
+);
+assert.equal(
+  diffContentLang("--- a/Dockerfile\n+++ b/Dockerfile\n+FROM node"),
+  "dockerfile",
+  "extensionless well-known basename resolves via its bare name",
+);
+assert.equal(
+  diffContentLang("--- a/foo.xyzzy\n+++ b/foo.xyzzy\n+data"),
+  "text",
+  "unknown extension falls back to text (flat diff grammar)",
+);
+assert.equal(diffContentLang("+just\n-lines"), "text", "no headers → text");
+assert.equal(
+  diffContentLang("--- a/change.diff\n+++ b/change.diff\n+--- x"),
+  "text",
+  "a .diff target keeps flat mode (no diff-in-diff recursion)",
+);
+assert.equal(
+  diffContentLang("+++ b/src/app.py\t2026-07-06 12:00:00\n+x = 1"),
+  "python",
+  "trailing tab+timestamp after the path is tolerated",
+);
 
 console.log("code-lang.test.ts ✓");

--- a/src/lib/code-lang.ts
+++ b/src/lib/code-lang.ts
@@ -143,6 +143,31 @@ export function isHighlightableLang(input: string | null | undefined): boolean {
   return resolveShikiLang(input) !== "text";
 }
 
+/**
+ * Best-effort grammar for the code INSIDE a unified diff, read from its
+ * `+++ b/<path>` / `--- a/<path>` file headers. The bundled `diff` grammar
+ * colors whole lines by +/- status only — flat, token-less output. When a
+ * header names a file whose extension (or bare name, e.g. Dockerfile)
+ * resolves to a real grammar, callers can highlight the diff's content in
+ * that language and keep the +/- chrome as line strips instead.
+ * Returns "text" when no header names a highlightable file.
+ */
+export function diffContentLang(diffText: string): ShikiLang {
+  for (const line of diffText.split("\n", 10)) {
+    const m = /^(?:\+\+\+|---) (?:[ab]\/)?(.+)$/.exec(line);
+    if (!m) continue;
+    // `git diff` may append a tab + timestamp after the path.
+    const path = m[1].split("\t")[0].trim();
+    if (!path || path === "/dev/null") continue;
+    const base = path.split("/").pop() ?? "";
+    const token = base.includes(".") ? base.split(".").pop() ?? "" : base;
+    const lang = resolveShikiLang(token);
+    // A `.diff` target would re-enter diff rendering — keep flat mode there.
+    if (lang !== "text" && lang !== "diff") return lang;
+  }
+  return "text";
+}
+
 // Human-facing display names for the resolved grammar — surfaced as the
 // language badge in the Projects preview header. Keyed by canonical id.
 const LANG_LABELS: Partial<Record<ShikiLang, string>> = {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -802,6 +802,17 @@
 .cave-diff-meta span {
   color: var(--text-muted) !important;
 }
+/* Language-highlighted diffs re-attach the leading +/- as its own span so the
+   code keeps its token colors; tint the marker to match its line's strip. */
+.cave-diff-marker {
+  color: var(--text-muted);
+}
+.cave-diff-add .cave-diff-marker {
+  color: oklch(0.6 0.15 170 / 90%);
+}
+.cave-diff-del .cave-diff-marker {
+  color: oklch(0.55 0.2 15 / 90%);
+}
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    COPY BUTTON


### PR DESCRIPTION
## What

Two user-reported code-rendering regressions (screenshots showed unreadable dark-red/brown syntax ink in the file editor, and flat single-color diff modals):

1. **CodeMirror file editor** (Projects preview / code-rail edit mode) set no `HighlightStyle`, so CodeMirror's default **light-background** syntax palette (`#a11` strings, `#940` comments) rendered on the dark `--code-surface`. The editor now derives a `HighlightStyle` from `src/styles/shiki/mood-c-dark.json` — the same single-source palette Shiki uses for read mode and chat code blocks. Frame inks (text/gutter/active-line) also move off theme text tokens, since the code surface stays dark even in light app themes.

2. **SyntaxBlock diffs** (edit cards, in-chat Review modal, Changes rail) rendered through the `diff` grammar — whole-line +/- coloring only. `renderCodeBlock` now resolves the target grammar from the diff's `+++`/`---` headers (`diffContentLang`) and highlights the diff's **content** in that language; `+`/`-` markers come back as a dim `.cave-diff-marker` span tinted to the line's strip, so Copy output stays byte-identical. Meta/`@@` rows are blanked for the grammar (line alignment) and restored as muted chrome. Unresolvable targets and the Shiki-failure fallback keep the flat path.

**Deps:** `@codemirror/language` + `@lezer/highlight` added as direct deps, pinned to the exact versions already in the lockfile (pnpm can't import transitive packages).

## Verification

- Production build + Playwright with mocked `project-file`/`changes` routes: editor tokens sample to the mood-c inks (keyword `#b388ff`, string `#a8c8ff`, comment `#4a4560`); diff lines show language tokens over the add/del strips with muted headers and tinted markers.
- `pnpm typecheck` clean; `pnpm test:app` 531 files green; `check:tests-wired` green.
- New pins: mood-c-derived HighlightStyle + no theme-text-token inks (code-editor.test.ts), language-aware diff path + fallback marker-doubling guard (chat-header-row.test.ts), `diffContentLang` unit cases (code-lang.test.ts).

Bead: cave-t6g

🤖 Generated with [Claude Code](https://claude.com/claude-code)