### PR TITLE
fix(familiars): a11y polish on the settings studio panels (cave-u1b)

### DIFF
--- a/src/components/familiar-studio-look-tab.test.ts
+++ b/src/components/familiar-studio-look-tab.test.ts
@@ -51,4 +51,9 @@ assert.match(source, /Same runtime/, "Look tab should expose same-runtime color 
 assert.match(source, /Palette by familiar/, "Look tab should expose per-familiar palette distribution");
 assert.match(source, /Palette by runtime/, "Look tab should expose per-runtime palette distribution");
 
+// ── A11y state on color controls + toast live region (2026-07-06) ───────────
+assert.match(source, /aria-pressed=\{currentColor === preset\.color\}/, "accent swatches expose pressed state");
+assert.match(source, /aria-pressed=\{colorScope === "familiar"\}/, "scope buttons expose pressed state");
+assert.match(source, /className="familiar-studio-look__toast" role="status"/, "the upload toast is a live region");
+
 console.log("familiar-studio-look-tab.test.ts: ok");

--- a/src/components/familiar-studio-look-tab.tsx
+++ b/src/components/familiar-studio-look-tab.tsx
@@ -173,7 +173,7 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
             />
           </label>
         </div>
-        {toast ? <p className="familiar-studio-look__toast">{toast}</p> : null}
+        {toast ? <p className="familiar-studio-look__toast" role="status">{toast}</p> : null}
       </section>
 
       <section className="familiar-studio-look__section">
@@ -190,6 +190,7 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
         >
           <button
             type="button"
+            aria-pressed={colorScope === "familiar"}
             onClick={() => setColorScope("familiar")}
             className={`familiar-studio-look__scope-btn${colorScope === "familiar" ? " familiar-studio-look__scope-btn--active" : ""}`}
           >
@@ -197,6 +198,7 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
           </button>
           <button
             type="button"
+            aria-pressed={colorScope === "harness"}
             onClick={() => setColorScope("harness")}
             className={`familiar-studio-look__scope-btn${colorScope === "harness" ? " familiar-studio-look__scope-btn--active" : ""}`}
           >
@@ -210,6 +212,7 @@ export function FamiliarStudioLookTab({ familiar, allFamiliars }: Props) {
               key={preset.label}
               type="button"
               aria-label={`Use ${preset.label}`}
+              aria-pressed={currentColor === preset.color}
               title={preset.label}
               onClick={() => pickColor(preset.color)}
               className={`familiar-studio-look__swatch${currentColor === preset.color ? " familiar-studio-look__swatch--active" : ""}`}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -799,7 +799,7 @@ function FamiliarsSection({
   // configured" empty state never flashes before the roster loads.
   if (!loaded) {
     return (
-      <div className="settings-familiars-panel" role="status" aria-busy="true">
+      <div className="settings-familiars-panel" role="status" aria-busy="true" aria-label="Loading familiars">
         <SkeletonRows count={4} />
       </div>
     );

--- a/src/lib/familiar-image-upload.test.ts
+++ b/src/lib/familiar-image-upload.test.ts
@@ -26,4 +26,12 @@ assert.match(
   "user gets feedback when a large image is compressed successfully",
 );
 
+// ── Upload outcomes reach assistive tech (2026-07-06) ───────────────────────
+// The toast is visual-only; every outcome (success included, which never had
+// a toast) mirrors through the shared live region.
+assert.match(source, /useAnnouncer/, "the upload hook announces outcomes");
+assert.match(source, /announce\(res\.reason, "assertive"\)/, "store rejections announce assertively");
+assert.match(source, /announce\("Avatar updated\."\)/, "plain successes are announced");
+assert.match(source, /announce\(message, "assertive"\)/, "read/resize failures announce assertively");
+
 console.log("familiar-image-upload.test.ts: ok");

--- a/src/lib/familiar-image-upload.ts
+++ b/src/lib/familiar-image-upload.ts
@@ -6,6 +6,7 @@ import {
   setFamiliarImage,
   clearFamiliarImage,
 } from "@/lib/cave-familiar-images";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 export type PreparedFamiliarImage = {
   dataUrl: string;
@@ -104,6 +105,9 @@ const blobToDataUrl = fileToDataUrl;
  */
 export function useFamiliarImageUpload(familiarId: string) {
   const [toast, setToast] = useState<string | null>(null);
+  // The toast is visual-only; mirror outcomes through the shared live region
+  // so screen readers hear them too (success included — it never had a toast).
+  const { announce } = useAnnouncer();
 
   const onFile = useCallback(
     async (file: File) => {
@@ -113,14 +117,22 @@ export function useFamiliarImageUpload(familiarId: string) {
         const res = await setFamiliarImage(familiarId, prepared);
         if (!res.ok) {
           setToast(res.reason);
+          announce(res.reason, "assertive");
           return;
         }
-        if (prepared.downsized) setToast("Image was downsized for Cave.");
+        if (prepared.downsized) {
+          setToast("Image was downsized for Cave.");
+          announce("Avatar updated. Image was downsized for Cave.");
+        } else {
+          announce("Avatar updated.");
+        }
       } catch (err) {
-        setToast(err instanceof Error ? err.message : "Could not read image.");
+        const message = err instanceof Error ? err.message : "Could not read image.";
+        setToast(message);
+        announce(message, "assertive");
       }
     },
-    [familiarId],
+    [familiarId, announce],
   );
 
   const clear = useCallback(() => void clearFamiliarImage(familiarId), [familiarId]);


### PR DESCRIPTION
## What

A11y pass on the Familiars panels in Settings (PR 3 of the approved plan):

- **Upload outcomes reach assistive tech.** `useFamiliarImageUpload`'s toast was visual-only, and a plain successful upload produced no feedback at all. Every outcome now mirrors through the shared `useAnnouncer` live region — assertive for store rejections and read/resize failures, polite "Avatar updated." for successes (with the pinned "Image was downsized for Cave." literal kept intact). The Look tab's toast is now `role="status"`.
- **Pressed state on color controls**: accent swatches (`aria-pressed={currentColor === preset.color}`) and the This-familiar/Same-runtime scope buttons expose their active state (labels already existed).
- **Roster skeleton accessible name**: the `aria-busy` loading wrapper gains `aria-label="Loading familiars"`.

## Verification

- 532 test files green with new pins in `familiar-image-upload.test.ts` (announcer wiring, assertive failures, success announcement) and `familiar-studio-look-tab.test.ts` (aria-pressed, status toast). `tsc` clean.
- Pattern-copies of the house `useAnnouncer` approach (same as marketplace #2350); no behavior changes beyond announcements/attributes.

Bead: cave-u1b

🤖 Generated with [Claude Code](https://claude.com/claude-code)