### PR TITLE
feat(familiars): expose the autoSelfReport toggle in Brain + ordering cross-links (cave-v1z)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6811,6 +6811,12 @@ a.mobile-handoff__link:hover {
   font-size: var(--text-sm);
   font-weight: 600;
 }
+.familiar-studio-brain__hint {
+  margin: var(--space-2) 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
 .familiar-studio-brain__field-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -93,4 +93,39 @@ assert.match(
   "Brain workspace should collapse to one column on narrow surfaces",
 );
 
+// ── autoSelfReport toggle + ordering cross-links (cave-v1z) ──────────────────
+
+assert.match(
+  source,
+  /role="switch"[\s\S]{0,120}aria-checked=\{draftAutoSelfReport\}/,
+  "auto self-report must be a real switch with checked state exposed to AT",
+);
+assert.match(
+  source,
+  /save\(\{ autoSelfReport: next \? true : null \}\)/,
+  "off must delete the config key (daemon default is off), not store false",
+);
+assert.match(
+  source,
+  /if \("autoSelfReport" in patch\) setDraftAutoSelfReport\(familiar\.autoSelfReport \?\? false\)/,
+  "a failed save must revert the switch to the last-known value",
+);
+
+// Reciprocal ordering hints: each ordering surface names the other.
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+assert.match(
+  shell,
+  /order pinned familiars appear in the avatar strip[\s\S]{0,200}Familiars → Lifecycle/,
+  "the Appearance pin-order hint should point at the Lifecycle roster order",
+);
+const lifecycle = readFileSync(
+  new URL("./familiar-studio-lifecycle-tab.tsx", import.meta.url),
+  "utf8",
+);
+assert.match(
+  lifecycle,
+  /listed across the app[\s\S]{0,200}Settings → Appearance → Pin order/,
+  "the Lifecycle roster hint should point at the Appearance pin order",
+);
+
 console.log("familiar-studio-brain-tab.test.ts: ok");

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -36,6 +36,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
   const [draftVoiceProvider, setDraftVoiceProvider] = useState(familiar.voiceProvider ?? "");
   const [draftVoiceModel, setDraftVoiceModel] = useState(familiar.voiceModel ?? "");
   const [draftVoiceName, setDraftVoiceName] = useState(familiar.voiceName ?? "");
+  const [draftAutoSelfReport, setDraftAutoSelfReport] = useState(familiar.autoSelfReport ?? false);
   const [toast, setToast] = useState<string | null>(null);
   const [manifest, setManifest] = useState<HarnessCapabilityManifest | null>(null);
   const [manifestState, setManifestState] = useState<"idle" | "loading" | "ready" | "error">("idle");
@@ -48,8 +49,9 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     setDraftVoiceProvider(familiar.voiceProvider ?? "");
     setDraftVoiceModel(familiar.voiceModel ?? "");
     setDraftVoiceName(familiar.voiceName ?? "");
+    setDraftAutoSelfReport(familiar.autoSelfReport ?? false);
     setToast(null);
-  }, [familiar.id, familiar.harnessOverride, familiar.model, familiar.note, familiar.voiceProvider, familiar.voiceModel, familiar.voiceName]);
+  }, [familiar.id, familiar.harnessOverride, familiar.model, familiar.note, familiar.voiceProvider, familiar.voiceModel, familiar.voiceName, familiar.autoSelfReport]);
 
   useEffect(() => {
     let cancelled = false;
@@ -135,6 +137,7 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
         if ("voiceProvider" in patch) setDraftVoiceProvider(familiar.voiceProvider ?? "");
         if ("voiceModel" in patch) setDraftVoiceModel(familiar.voiceModel ?? "");
         if ("voiceName" in patch) setDraftVoiceName(familiar.voiceName ?? "");
+        if ("autoSelfReport" in patch) setDraftAutoSelfReport(familiar.autoSelfReport ?? false);
       } else {
         reportDaemonSyncSuccess();
       }
@@ -237,7 +240,47 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
           {toast ? <p className="familiar-studio-brain__toast">{toast}</p> : null}
         </div>
 
-        <aside className="familiar-studio-brain__sidecar" aria-label="Voice and capabilities">
+        <aside className="familiar-studio-brain__sidecar" aria-label="Behavior, voice, and capabilities">
+          <section className="familiar-studio-brain__card">
+            <h3 className="familiar-studio-brain__card-title">Behavior</h3>
+            <div className="familiar-studio-brain__row">
+              <span
+                className="familiar-studio-brain__label"
+                id="familiar-studio-brain-auto-self-report-label"
+              >
+                Auto self-report
+              </span>
+              <div className="familiar-studio-brain__control">
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={draftAutoSelfReport}
+                  aria-labelledby="familiar-studio-brain-auto-self-report-label"
+                  onClick={() => {
+                    const next = !draftAutoSelfReport;
+                    setDraftAutoSelfReport(next);
+                    // Off is the daemon default — store true, delete on false so
+                    // the config file doesn't accumulate redundant keys.
+                    void save({ autoSelfReport: next ? true : null });
+                  }}
+                  className={`focus-ring relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full transition-colors duration-150 ${
+                    draftAutoSelfReport ? "bg-[var(--accent-presence)]" : "bg-[var(--bg-elevated)]"
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none mt-0.5 inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-150 ${
+                      draftAutoSelfReport ? "translate-x-4" : "translate-x-0.5"
+                    }`}
+                  />
+                </button>
+              </div>
+            </div>
+            <p className="familiar-studio-brain__hint">
+              When a chat thread wraps up, {familiar.display_name} writes a short self-report to
+              its thread signals automatically.
+            </p>
+          </section>
+
           <section className="familiar-studio-brain__card">
             <h3 className="familiar-studio-brain__card-title">Voice</h3>
             <label className="familiar-studio-brain__row">

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -66,6 +66,10 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
     <div className="familiar-studio-lifecycle">
       <section>
         <h3 className="familiar-studio-lifecycle__heading">Active</h3>
+        <p className="familiar-studio-lifecycle__hint">
+          Reorder to set how familiars are listed across the app. The avatar strip&apos;s pinned
+          subset keeps its own order in Settings → Appearance → Pin order.
+        </p>
         {active.map((f, i) => (
           <FamiliarRow
             key={f.id}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1606,7 +1606,8 @@ function AppearanceSection() {
                   Pin order
                 </div>
                 <div className="text-[11px] text-[var(--text-muted)]">
-                  Drag to set the order pinned familiars appear in the avatar strip.
+                  Drag to set the order pinned familiars appear in the avatar strip. The roster
+                  order everywhere else is set in Familiars → Lifecycle.
                 </div>
               </div>
               <FamiliarPinOrder />


### PR DESCRIPTION
## Summary

Bead `cave-v1z` — two small familiar-studio gaps:

- **autoSelfReport was wired but unsettable.** The roster surfaces it and chat auto-writes a thread self-report on close when it's on (`chat-view.tsx`), but no UI could set it. The Brain tab now has a **Behavior** card with a `role=switch` row: on stores `true` through the tab's existing `/api/config` PATCH helper; off sends `null` so the key is **deleted** (daemon default is off — no redundant `false` keys accumulate in the config). Failed saves revert the switch, same as the tab's other draft fields.
- **Reciprocal ordering hints.** Appearance → Pin order now says the roster order lives in Familiars → Lifecycle, and the Lifecycle roster hint points back at Appearance → Pin order. Neither control moved (pinned decision).

## Test plan

- Pins appended to `familiar-studio-brain-tab.test.ts`: switch + `aria-checked`, null-delete save shape, failure revert, both hint copies — green; all pre-existing Brain-tab pins untouched and green
- Full app suite 531 ✓ · `tsc --noEmit` ✓ · minimalism accent-white invariant unaffected (knob pattern matches the projects-tab switch)
- **Verified live** (worktree server + Playwright, PATCH bodies captured): ON → `{"familiars":{"nova":{"autoSelfReport":true}}}` persisted to `cave-config.json`; state survives reload; OFF → `{"autoSelfReport":null}` → 200 → key deleted; config left clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)