### PR TITLE
feat(projects): git, tasks, and grants sections in the hub detail pane (cave-djz, PR2)

### DIFF
--- a/src/app/api/changes/route.test.ts
+++ b/src/app/api/changes/route.test.ts
@@ -16,4 +16,18 @@ assert.doesNotMatch(
   "changes route should use gitDiff for every git diff invocation",
 );
 
+
+// The status GET carries the current branch (Projects hub Git section) — from
+// the existing currentBranch() helper, omitted on unborn repos.
+assert.match(
+  source,
+  /branch = await currentBranch\(repoRoot\);/,
+  "listChanges resolves the current branch via the shared helper",
+);
+assert.match(
+  source,
+  /NextResponse\.json\(\{ ok: true, repo: true, repoRoot, branch, files \}\)/,
+  "the change-list response includes the branch field",
+);
+
 console.log("changes route.test.ts: ok");

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -239,7 +239,16 @@ async function listChanges(repoRoot: string): Promise<NextResponse> {
     /* no HEAD yet — list without counts */
   }
 
-  return NextResponse.json({ ok: true, repo: true, repoRoot, files });
+  // Current branch rides along so callers (the Projects hub's Git section)
+  // don't need a second git endpoint. Unborn repos have no HEAD — omit.
+  let branch: string | null = null;
+  try {
+    branch = await currentBranch(repoRoot);
+  } catch {
+    /* no HEAD yet */
+  }
+
+  return NextResponse.json({ ok: true, repo: true, repoRoot, branch, files });
 }
 
 async function diffFile(repoRoot: string, relPath: string, absPath: string): Promise<NextResponse> {

--- a/src/components/chat-surface-projects-tab.test.ts
+++ b/src/components/chat-surface-projects-tab.test.ts
@@ -27,6 +27,11 @@ assert.match(
 );
 assert.match(surface, /scope === "projects" \? \(/, "projects browse still renders ProjectsView as a sub-state of Chat");
 assert.match(surface, /<ProjectsView[\s\S]*?sessions=\{sessions\}/, "projects panel renders ProjectsView with sessions");
+assert.match(
+  surface,
+  /<ProjectsView[\s\S]*?familiars=\{familiars\}/,
+  "projects panel threads the familiar roster (Grants section chips)",
+);
 assert.match(surface, /onNewChat=\{startProjectChat\}/, "projects panel wires onNewChat to startProjectChat");
 assert.match(surface, /addEventListener\(CHAT_OPEN_PROJECTS_EVENT/, "listens for the reroute event");
 assert.match(surface, /onOpenProjectsTab=\{\(\) => setScope\("projects"\)\}/, "chat project rail can jump directly to the Projects tab");

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -616,7 +616,7 @@ export function ChatSurface({
             }}
           />
         ) : scope === "projects" ? (
-          <ProjectsView sessions={sessions} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
+          <ProjectsView sessions={sessions} familiars={familiars} onNewChat={startProjectChat} onSessionsChanged={onSessionsChanged} activeFamiliarId={activeFamiliarId} />
         ) : scope === "coven" ? (
           // Group Chat ("coven") lives here as a first-class chat tab instead of
           // a standalone surface. It broadcasts one prompt to several familiars,

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -13,13 +13,15 @@ import { useMinuteTick } from "@/lib/use-minute-tick";
 import { normalizeProjectRoot, sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
 import { deriveProjectStatus } from "@/lib/project-status";
 import { addChatProject } from "@/lib/chat-add-project";
-import type { SessionRow } from "@/lib/types";
+import type { Familiar, SessionRow } from "@/lib/types";
 import { stripLeadingTrailingEmoji } from "@/lib/cave-chat-titles";
 import { stripTaskPrefix } from "@/lib/projects/session-glyph";
 import { applyManualOrder, readSessionOrder } from "@/lib/chat-session-order";
 import { applyProjectOverrides, setProjectOverride, clearProjectOverride } from "@/lib/chat-project-overrides";
 import { useProjectOverrides } from "@/lib/use-project-overrides";
 import { useProjects } from "@/lib/use-projects";
+import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
+import type { Card } from "@/lib/cave-board-types";
 import {
   PROJECTS_SELECTED_KEY,
   parseStoredProjectId,
@@ -49,13 +51,15 @@ function pathBasename(p: string): string {
 
 type ProjectsViewProps = {
   sessions?: SessionRow[];
+  /** Familiar roster for the detail pane's Grants section. */
+  familiars?: Familiar[];
   onNewChat?: (projectRoot: string) => void;
   onSessionsChanged?: () => void;
   /** When set, only projects this familiar has been granted are shown. */
   activeFamiliarId?: string | null;
 };
 
-export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, activeFamiliarId = null }: ProjectsViewProps) {
+export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessionsChanged, activeFamiliarId = null }: ProjectsViewProps) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const minuteTick = useMinuteTick(); // keep "last active" relative times + the active filter current
   const {
@@ -154,6 +158,25 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
   useEffect(() => {
     setOrder(readSessionOrder());
   }, []);
+
+  // Board cards for the detail pane's Tasks section: ONE fetch per mount, then
+  // refetch on window refocus (throttled) — never per selection switch. The
+  // Tasks section filters client-side by projectId/cwd.
+  const [boardCards, setBoardCards] = useState<Card[]>([]);
+  const loadBoardCards = async () => {
+    try {
+      const res = await fetch("/api/board", { cache: "no-store" });
+      const json = await res.json();
+      if (json?.ok && Array.isArray(json.cards)) setBoardCards(json.cards as Card[]);
+    } catch {
+      /* transient — the Tasks section keeps the last known cards */
+    }
+  };
+  useEffect(() => {
+    void loadBoardCards();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  useRefreshOnFocus(loadBoardCards);
 
   // "/" jumps to the projects filter (GitHub-style) while this surface is shown,
   // unless the user is already typing in a field or holding a modifier.
@@ -686,6 +709,8 @@ export function ProjectsView({ sessions = [], onNewChat, onSessionsChanged, acti
                   project={selectedProject}
                   chats={chatsByRoot.get(normalizeProjectRoot(selectedProject.root)) ?? []}
                   allProjects={projects}
+                  boardCards={boardCards}
+                  familiars={familiars}
                   onRename={renameProject}
                   onUpdateRoot={updateRoot}
                   onUpdateColor={updateColor}

--- a/src/components/projects/detail-sections.tsx
+++ b/src/components/projects/detail-sections.tsx
@@ -1,0 +1,318 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { useChangesSummary } from "@/lib/use-changes-summary";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { grantKey } from "@/lib/permissions-console";
+import type { Familiar } from "@/lib/types";
+import type { Card } from "@/lib/cave-board-types";
+import type { CaveProject } from "@/lib/cave-projects-types";
+import { normalizeProjectRoot } from "@/lib/cave-projects-types";
+
+// The selected project's Git / Tasks / Grants sections (PR2 of the hub plan).
+// Polling discipline: ONLY the selected project's GitSection polls
+// /api/changes (via useChangesSummary — 5s, visibility-gated, single-flight);
+// board cards arrive once from the shell and are filtered client-side; grants
+// load once per selection and mutate optimistically.
+
+// ── Git ───────────────────────────────────────────────────────────────────────
+
+export function GitSection({
+  projectRoot,
+  sessionBranch,
+}: {
+  projectRoot: string;
+  /** Fallback branch from the newest session's git context, shown until the
+   *  authoritative /api/changes response lands. */
+  sessionBranch: string | null;
+}) {
+  const changes = useChangesSummary(projectRoot, true);
+  const branch = changes.branch ?? sessionBranch;
+
+  return (
+    <section className="projects-detail-section" aria-label="Git status">
+      <div className="projects-detail-section__title">
+        <span>Git</span>
+      </div>
+      {changes.loaded && changes.notARepo ? (
+        <p className="text-[11px] text-[var(--text-muted)]">Not a git repository.</p>
+      ) : (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-[var(--text-muted)]">
+          {branch ? (
+            <span className="inline-flex max-w-[16rem] items-center gap-1 truncate font-mono" title={`Branch: ${branch}`}>
+              <Icon name="ph:git-branch-bold" width={11} aria-hidden />
+              <span className="truncate">{branch}</span>
+            </span>
+          ) : null}
+          {!changes.loaded ? (
+            <span>Checking working tree…</span>
+          ) : changes.count > 0 ? (
+            <span
+              className="projects-session-chip projects-session-chip--running"
+              title={`${changes.count} uncommitted ${changes.count === 1 ? "file" : "files"}`}
+            >
+              <Icon name="ph:git-diff" width={10} aria-hidden />
+              {changes.count} changed {changes.count === 1 ? "file" : "files"}
+            </span>
+          ) : (
+            <span className="inline-flex items-center gap-1">
+              <Icon name="ph:check-bold" width={10} aria-hidden />
+              Working tree clean
+            </span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ── Tasks ─────────────────────────────────────────────────────────────────────
+
+const TASK_CAP = 5;
+
+/** Board cards belonging to a project: matched by stable projectId first, with
+ *  a normalized-cwd fallback for cards created before projects had ids. */
+export function cardsForProject(cards: Card[], project: CaveProject): Card[] {
+  const rootKey = normalizeProjectRoot(project.root);
+  return cards.filter(
+    (card) =>
+      card.projectId === project.id ||
+      (Boolean(card.cwd) && normalizeProjectRoot(card.cwd ?? "") === rootKey),
+  );
+}
+
+const CARD_STATUS_DOT: Record<string, string> = {
+  running: "bg-[var(--accent-presence)]",
+  review: "bg-[var(--color-warning)]",
+  blocked: "bg-[var(--color-danger)]",
+};
+
+export function TasksSection({
+  project,
+  cards,
+  onOpenBoard,
+}: {
+  project: CaveProject;
+  cards: Card[];
+  onOpenBoard?: () => void;
+}) {
+  const projectCards = useMemo(() => cardsForProject(cards, project), [cards, project]);
+  const open = useMemo(() => projectCards.filter((c) => c.status !== "done"), [projectCards]);
+  const doneCount = projectCards.length - open.length;
+  const runningCount = open.filter((c) => c.status === "running").length;
+
+  return (
+    <section className="projects-detail-section" aria-label={`Tasks for ${project.name}`}>
+      <div className="projects-detail-section__title">
+        <span>Tasks</span>
+        {open.length > 0 ? <span className="projects-list-row__count">{open.length}</span> : null}
+        {runningCount > 0 ? (
+          <span className="projects-session-chip projects-session-chip--running" title={`${runningCount} running`}>
+            <Icon name="ph:circle-notch-bold" width={9} className="animate-spin" aria-hidden />
+            {runningCount}
+          </span>
+        ) : null}
+        {onOpenBoard ? (
+          <span className="ml-auto">
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={onOpenBoard}
+              className="rounded-[var(--radius-control)] px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+            >
+              Open board →
+            </Button>
+          </span>
+        ) : null}
+      </div>
+      {open.length === 0 ? (
+        <div className="projects-detail-empty">
+          {doneCount > 0
+            ? `All ${doneCount} task${doneCount === 1 ? "" : "s"} done — add the next one on the board.`
+            : "No tasks for this project yet."}
+        </div>
+      ) : (
+        <>
+          <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
+            {open.slice(0, TASK_CAP).map((card) => (
+              <li key={card.id} className="flex items-center gap-2 px-1 py-1 text-[12px] text-[var(--text-secondary)]">
+                <span
+                  aria-hidden
+                  className={`h-1.5 w-1.5 shrink-0 rounded-full ${CARD_STATUS_DOT[card.status] ?? "bg-[var(--text-muted)]"}`}
+                />
+                <span className="min-w-0 flex-1 truncate" title={card.title}>
+                  {card.title}
+                </span>
+                <span className="shrink-0 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+                  {card.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {open.length > TASK_CAP ? (
+            <p className="mt-1 px-1 text-[10px] text-[var(--text-muted)]">
+              +{open.length - TASK_CAP} more on the board
+              {doneCount > 0 ? ` · ${doneCount} done` : ""}
+            </p>
+          ) : doneCount > 0 ? (
+            <p className="mt-1 px-1 text-[10px] text-[var(--text-muted)]">{doneCount} done</p>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}
+
+// ── Grants ────────────────────────────────────────────────────────────────────
+
+export function GrantsSection({
+  project,
+  familiars,
+}: {
+  project: CaveProject;
+  familiars: Familiar[];
+}) {
+  const { announce } = useAnnouncer();
+  const resolvedFamiliars = useResolvedFamiliars(familiars);
+  const [granted, setGranted] = useState<Set<string>>(() => new Set());
+  const [pending, setPending] = useState<Set<string>>(() => new Set());
+  const [supremeFamiliarId, setSupremeFamiliarId] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Load once per selection (this component remounts with the detail pane's
+  // project key) — grants are cheap and mutations are optimistic below.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/project-grants", { cache: "no-store" });
+        const json = await res.json();
+        if (cancelled) return;
+        const grants = Array.isArray(json?.grants) ? json.grants : [];
+        setGranted(
+          new Set(
+            grants
+              .filter((g: { projectId?: string }) => g.projectId === project.id)
+              .map((g: { familiarId: string; projectId: string }) => grantKey(g.familiarId, g.projectId)),
+          ),
+        );
+        setSupremeFamiliarId(typeof json?.supremeFamiliarId === "string" ? json.supremeFamiliarId : null);
+        setError(null);
+      } catch {
+        if (!cancelled) setError("Couldn't load project access.");
+      } finally {
+        if (!cancelled) setLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [project.id]);
+
+  // Optimistic toggle with revert-on-failure (same discipline as the Familiar
+  // Studio grant matrix — both drive /api/project-grants).
+  const toggle = useCallback(
+    async (familiarId: string, familiarName: string, next: boolean) => {
+      const key = grantKey(familiarId, project.id);
+      setPending((p) => new Set(p).add(key));
+      setGranted((g) => {
+        const copy = new Set(g);
+        if (next) copy.add(key);
+        else copy.delete(key);
+        return copy;
+      });
+      try {
+        const res = await fetch("/api/project-grants", {
+          method: next ? "POST" : "DELETE",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ targetFamiliarId: familiarId, projectId: project.id }),
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        setError(null);
+        announce(`${next ? "Granted" : "Revoked"} ${project.name} ${next ? "to" : "from"} ${familiarName}.`);
+      } catch {
+        // Revert on failure.
+        setGranted((g) => {
+          const copy = new Set(g);
+          if (next) copy.delete(key);
+          else copy.add(key);
+          return copy;
+        });
+        setError("Couldn't update that grant.");
+        announce("Couldn't update that grant.", "assertive");
+      } finally {
+        setPending((p) => {
+          const copy = new Set(p);
+          copy.delete(key);
+          return copy;
+        });
+      }
+    },
+    [project.id, project.name, announce],
+  );
+
+  return (
+    <section className="projects-detail-section" aria-label={`Familiar access to ${project.name}`}>
+      <div className="projects-detail-section__title">
+        <span>Grants</span>
+        {granted.size > 0 ? <span className="projects-list-row__count">{granted.size}</span> : null}
+      </div>
+      {error ? (
+        <p role="alert" className="mb-1.5 text-[11px] text-[var(--color-danger)]">
+          {error}
+        </p>
+      ) : null}
+      {!loaded ? (
+        <p className="text-[11px] text-[var(--text-muted)]">Loading access…</p>
+      ) : resolvedFamiliars.length === 0 ? (
+        <div className="projects-detail-empty">No familiars yet.</div>
+      ) : (
+        <ul className="m-0 flex list-none flex-wrap gap-1.5 p-0">
+          {resolvedFamiliars.map((familiar) => {
+            const key = grantKey(familiar.id, project.id);
+            const isSupremeFamiliar = familiar.id === supremeFamiliarId;
+            const has = isSupremeFamiliar || granted.has(key);
+            const busy = pending.has(key);
+            return (
+              <li key={familiar.id} className="m-0 list-none p-0">
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  disabled={busy || isSupremeFamiliar}
+                  onClick={() => void toggle(familiar.id, familiar.display_name, !has)}
+                  aria-pressed={has}
+                  title={
+                    isSupremeFamiliar
+                      ? `${familiar.display_name} is the supreme familiar — access to every project`
+                      : has
+                        ? `Revoke ${project.name} from ${familiar.display_name}`
+                        : `Grant ${project.name} to ${familiar.display_name}`
+                  }
+                  className={`h-7 gap-1.5 rounded-full border px-2 text-[11px] ${
+                    has
+                      ? "border-[color-mix(in_oklch,var(--accent-presence)_38%,var(--border-hairline))] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] text-[var(--text-primary)]"
+                      : "border-dashed border-[var(--border-hairline)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                  } ${busy ? "opacity-60" : ""}`}
+                >
+                  <FamiliarAvatar familiar={familiar} size="sm" />
+                  <span className="max-w-[9rem] truncate">{familiar.display_name}</span>
+                  {isSupremeFamiliar ? (
+                    <span className="text-[9px] uppercase tracking-wider text-[var(--text-muted)]">always</span>
+                  ) : (
+                    <Icon name={has ? "ph:check-bold" : "ph:plus-bold"} width={9} aria-hidden />
+                  )}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -18,13 +18,15 @@ import { FAMILIAR_IMAGE_ACCEPT, prepareFamiliarImage } from "@/lib/familiar-imag
 import { relativeTime } from "@/lib/relative-time";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { normalizeProjectRoot } from "@/lib/cave-projects-types";
-import type { SessionRow } from "@/lib/types";
+import type { Familiar, SessionRow } from "@/lib/types";
+import type { Card } from "@/lib/cave-board-types";
 import { disambiguateSessionTitles } from "@/lib/cave-chat-titles";
 import { deriveProjectStatus } from "@/lib/project-status";
 import { projectStats } from "@/lib/projects/project-stats";
 import { projectTint } from "@/lib/comux-projects";
 
 import { ProjectChatRow } from "./session-row";
+import { GitSection, TasksSection, GrantsSection } from "./detail-sections";
 import {
   CHAT_CAP,
   PROJECT_COLOR_SWATCHES,
@@ -42,6 +44,11 @@ type ProjectDetailProps = {
   project: CaveProject;
   chats: SessionRow[];
   allProjects: CaveProject[];
+  /** Board cards (all of them, fetched once by the shell) — filtered to this
+   *  project client-side by the Tasks section. */
+  boardCards: Card[];
+  /** Familiar roster for the Grants section's chips. */
+  familiars: Familiar[];
   onRename: (id: string, name: string) => Promise<boolean>;
   onUpdateRoot: (id: string, root: string) => Promise<boolean>;
   /** Set an explicit tile tint, or null to restore the auto root-hash tint. */
@@ -61,6 +68,8 @@ export function ProjectDetail({
   project,
   chats,
   allProjects,
+  boardCards,
+  familiars,
   onRename,
   onUpdateRoot,
   onUpdateColor,
@@ -87,8 +96,9 @@ export function ProjectDetail({
   const lastActiveIso =
     chats.reduce((acc, s) => (!acc || s.updated_at > acc ? s.updated_at : acc), "") || project.updatedAt;
   const lastActiveLabel = relativeTime(lastActiveIso);
-  // Until /api/changes serves the branch (PR2), show it from the most recent
-  // session's git context — populated by /api/sessions/list.
+  // Fallback branch from the most recent session's git context (populated by
+  // /api/sessions/list) — the Git section shows it until its authoritative
+  // /api/changes response lands.
   const branch = useMemo(() => {
     let latest: SessionRow | null = null;
     for (const s of chats) {
@@ -444,12 +454,6 @@ export function ProjectDetail({
             {stats.tasks}
           </span>
         ) : null}
-        {branch ? (
-          <span className="inline-flex max-w-[14rem] items-center gap-1 truncate font-mono" title={`Branch: ${branch}`}>
-            <Icon name="ph:git-branch-bold" width={10} aria-hidden />
-            <span className="truncate">{branch}</span>
-          </span>
-        ) : null}
         {lastActiveLabel ? <span title={`Last active ${lastActiveLabel}`}>{lastActiveLabel}</span> : null}
       </div>
 
@@ -630,6 +634,11 @@ export function ProjectDetail({
           </div>
         )}
       </section>
+
+      {/* ── Git · Tasks · Grants (PR2 sections) ──────────────────────────────── */}
+      <GitSection projectRoot={project.root} sessionBranch={branch} />
+      <TasksSection project={project} cards={boardCards} onOpenBoard={onOpenBoard} />
+      <GrantsSection project={project} familiars={familiars} />
     </div>
   );
 }

--- a/src/components/projects/projects-hub.test.ts
+++ b/src/components/projects/projects-hub.test.ts
@@ -8,13 +8,14 @@ import { readFileSync } from "node:fs";
 const shell = readFileSync(new URL("../projects-view.tsx", import.meta.url), "utf8");
 const list = readFileSync(new URL("./project-list.tsx", import.meta.url), "utf8");
 const detail = readFileSync(new URL("./project-detail.tsx", import.meta.url), "utf8");
+const sections = readFileSync(new URL("./detail-sections.tsx", import.meta.url), "utf8");
 const sessionRow = readFileSync(new URL("./session-row.tsx", import.meta.url), "utf8");
 const shared = readFileSync(new URL("./projects-shared.ts", import.meta.url), "utf8");
 const css = readFileSync(new URL("../../styles/projects.css", import.meta.url), "utf8");
 
 // ── The old table shell is gone; the hub replaced it ─────────────────────────
 assert.doesNotMatch(shell, /board-table|projects-table|<table|<thead|<colgroup/, "the spreadsheet table shell is fully retired");
-for (const src of [shell, list, detail, sessionRow]) {
+for (const src of [shell, list, detail, sections, sessionRow]) {
   assert.doesNotMatch(src, /@dnd-kit/, "no hub component ships dnd-kit");
 }
 
@@ -73,10 +74,9 @@ assert.match(detail, /role="alertdialog"[\s\S]{0,80}?aria-label=\{`Delete \$\{pr
 // Switching projects resets edit drafts/confirms (no leakage across selections).
 assert.match(detail, /useEffect\(\(\) => \{[\s\S]{0,240}?setConfirmDelete\(false\);[\s\S]{0,120}?\}, \[project\.id, project\.name, project\.root\]\)/, "drafts and confirms reset when the selection changes");
 
-// ── Interim git line: branch from the newest session's git context ──────────
-// (PR2 swaps this to /api/changes' branch field; the list pane must stay
-// fetch-free either way.)
-assert.match(detail, /s\.git\?\.branch/, "the detail head shows the branch from session git context");
+// ── Session-git branch fallback (the Git section's authoritative branch from
+// /api/changes wins once loaded); the list pane must stay fetch-free. ────────
+assert.match(detail, /s\.git\?\.branch/, "the detail derives a fallback branch from session git context");
 assert.doesNotMatch(list, /fetch\(/, "the list pane performs no fetches — status derives from sessions already in memory");
 assert.doesNotMatch(list, /\/api\/changes/, "the list pane never polls git changes");
 
@@ -92,5 +92,42 @@ assert.doesNotMatch(sessionRow, /useSortable|dots-six-vertical|Drag to reorder/,
 assert.match(sessionRow, /Move to project…/, "the explicit move flow replaces cross-project drag");
 assert.doesNotMatch(sessionRow, /density/, "session rows have one density — metadata chips always render");
 assert.match(sessionRow, /modelLabel\(session\.model\)/, "the model chip always renders when known");
+
+
+// ── PR2: Git / Tasks / Grants detail sections ────────────────────────────────
+// Polling gate: exactly ONE useChangesSummary call in the whole hub, fed the
+// SELECTED project's root — list rows must never poll git.
+assert.equal(
+  ([shell, list, detail, sections, sessionRow].join("\n").match(/useChangesSummary\(/g) ?? []).length,
+  1,
+  "exactly one component calls useChangesSummary",
+);
+assert.match(sections, /useChangesSummary\(projectRoot, true\)/, "the Git section polls only the selected root");
+assert.match(sections, /changes\.branch \?\? sessionBranch/, "the authoritative branch wins over the session-git fallback");
+assert.match(detail, /<GitSection projectRoot=\{project\.root\} sessionBranch=\{branch\}/, "the detail pane mounts the Git section");
+
+// Tasks: one board fetch in the SHELL (not per selection — the detail remounts
+// on every switch), refetched on window refocus, filtered client-side.
+assert.equal((shell.match(/fetch\("\/api\/board"/g) ?? []).length, 1, "the shell fetches the board exactly once per mount");
+assert.doesNotMatch(sections, /fetch\("\/api\/board"/, "the Tasks section never fetches — cards arrive from the shell");
+assert.match(shell, /useRefreshOnFocus\(loadBoardCards\)/, "board cards refetch on window refocus (throttled)");
+assert.match(
+  sections,
+  /card\.projectId === project\.id \|\|[\s\S]{0,120}?normalizeProjectRoot\(card\.cwd \?\? ""\) === rootKey/,
+  "cards match by stable projectId with a normalized-cwd fallback",
+);
+assert.match(sections, /const TASK_CAP = 5/, "the Tasks section caps the inline list");
+assert.match(sections, /Open board/, "the Tasks section drills through to the board");
+
+// Grants: optimistic toggle with revert, supreme-familiar read-only, announced.
+assert.match(sections, /method: next \? "POST" : "DELETE"/, "grant/revoke drive /api/project-grants");
+assert.match(sections, /targetFamiliarId: familiarId, projectId: project\.id/, "the grant body names the familiar and project");
+assert.match(sections, /\/\/ Revert on failure\./, "a failed mutation reverts the optimistic state");
+assert.match(sections, /familiar\.id === supremeFamiliarId/, "the supreme familiar renders as always-granted");
+assert.match(sections, /disabled=\{busy \|\| isSupremeFamiliar\}/, "supreme access can't be toggled off");
+assert.match(sections, /useAnnouncer\(\)/, "grant changes are announced to assistive tech");
+assert.match(sections, /announce\(`\$\{next \? "Granted" : "Revoked"\}/, "the announcement names the action");
+assert.match(detail, /<GrantsSection project=\{project\} familiars=\{familiars\}/, "the detail pane mounts the Grants section");
+assert.match(shell, /familiars=\{familiars\}/, "the shell threads the familiar roster down");
 
 console.log("projects-hub.test.ts: ok");

--- a/src/lib/use-changes-summary.ts
+++ b/src/lib/use-changes-summary.ts
@@ -23,12 +23,15 @@ type ChangesSummary = {
   loaded: boolean;
   /** The root is not a git repo (no diffs to show). */
   notARepo: boolean;
+  /** Current branch (null before load, when not a repo, or on an unborn HEAD). */
+  branch: string | null;
 };
 
 type ChangesResponse = {
   ok?: boolean;
   repo?: boolean;
   files?: unknown[];
+  branch?: string | null;
 };
 
 export function useChangesSummary(
@@ -38,6 +41,7 @@ export function useChangesSummary(
   const [count, setCount] = useState(0);
   const [loaded, setLoaded] = useState(false);
   const [notARepo, setNotARepo] = useState(false);
+  const [branch, setBranch] = useState<string | null>(null);
   const inFlight = useRef(false);
 
   useEffect(() => {
@@ -58,6 +62,7 @@ export function useChangesSummary(
         if (res.ok && json.ok) {
           setNotARepo(json.repo === false);
           setCount(Array.isArray(json.files) ? json.files.length : 0);
+          setBranch(typeof json.branch === "string" ? json.branch : null);
         }
       } catch {
         /* transient — keep the last known summary */
@@ -80,5 +85,5 @@ export function useChangesSummary(
     };
   }, [projectRoot, active]);
 
-  return { count, loaded, notARepo };
+  return { count, loaded, notARepo, branch };
 }


### PR DESCRIPTION
## What

Second phase of the Projects hub redesign (follows #2513). The detail pane gains the three data sections the old table never surfaced:

- **Git** — current branch + uncommitted-file count for the **selected project only**, via `useChangesSummary` (5s poll, visibility-gated, single-flight). `/api/changes` now returns `branch` (existing `currentBranch()` helper, omitted on unborn repos); the newest session's git context remains the pre-load fallback. The list pane stays completely fetch-free (pinned).
- **Tasks** — board cards filtered client-side (stable `projectId` first, normalized-`cwd` fallback), ≤5 inline with open/running counts, done tally, and an "Open board →" drill-through. **One** `/api/board` fetch per hub mount in the shell + refetch-on-focus — never per selection switch (the detail remounts per selection; pinned).
- **Grants** — familiar chips with optimistic grant/revoke toggles against `/api/project-grants` (revert on failure; supreme familiar shown as read-only "always"), matching the Familiar Studio matrix discipline, announced via `useAnnouncer`. `ChatSurface` threads the familiar roster down.

## Verification

- Full `test:app` suite green (535 files); `tsc` clean; build in budget. New pins: hub-wide polling gate (exactly one `useChangesSummary`), single board fetch + client filter, grant wiring + announcer, `branch` in the changes-route test, `familiars` prop in the chat-surface tab test.
- Live Playwright on the prod build against real data: Git section shows the actual branch + changed-file count per selected repo (`main · 1 changed file` on coven-cave, `2 changed files` on cast-codes); Tasks shows 19 open cards capped at 5 with the board drill-through; Grants renders its dashed empty state on a daemonless server (no familiars) — toggles exercise the same route the proven Familiar Studio matrix uses.

Bead: cave-djz · PR3 (polish/a11y/cleanup) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)