### PR TITLE
feat(marketplace): vendor the second-brain-skills pack as six skill plugins (cave-47o)

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -5054,6 +5054,243 @@
           "**Don't reach for it for a single static single-line width** (use `ctx.measureText` directly) or for true CSS inline formatting (nested spans, `vertical-align`, ruby, bidi x-reconstruction)."
         ]
       }
+    },
+    {
+      "name": "brand-voice-generator",
+      "displayName": "Brand & Voice Generator",
+      "version": "0.1.0",
+      "description": "Generate brand-system and tone-of-voice files — colors, typography, assets, and writing voice — that power the PPTX Generator and other brand-aware skills.",
+      "category": "Design",
+      "keywords": [
+        "brand",
+        "voice",
+        "tone-of-voice",
+        "design-system",
+        "identity",
+        "content"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/coleam00/second-brain-skills",
+        "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/brand-voice-generator"
+      ],
+      "trust": "reference-local",
+      "skill": {
+        "managed": "manual",
+        "description": "Use when defining a brand identity or writing voice for content generation. Walks through brand basics, a ten-color system, typography, assets, voice discovery (five example voice templates from Technical Educator to Contrarian Thinker), and design philosophy, then generates brand.json, config.json, brand-system.md, and tone-of-voice.md — the source-of-truth files consumed by pptx-generator and other brand-aware skills.",
+        "useCases": [
+          "Setting up a brand for presentations or LinkedIn carousels before running pptx-generator.",
+          "Documenting a writing voice — personality, vocabulary, sentence patterns — so generated content sounds consistent everywhere.",
+          "Refreshing an existing brand system's colors, fonts, assets, or design philosophy in one pass."
+        ],
+        "guardrails": [
+          "Interview first, generate second — collect brand basics, colors, typography, and voice answers before writing any file, a few questions at a time.",
+          "Write the four canonical files (brand.json, config.json, brand-system.md, tone-of-voice.md) into the pptx-generator brands/{name}/ directory so downstream skills can discover them.",
+          "Treat the generated brand files as the single source of truth — edit them rather than restating brand rules inline in prompts."
+        ]
+      }
+    },
+    {
+      "name": "mcp-client",
+      "displayName": "Universal MCP Client",
+      "version": "0.1.0",
+      "description": "Connect to any MCP server (Zapier, GitHub, Sequential Thinking, …) with progressive disclosure — tool schemas load on demand instead of bloating the context window.",
+      "category": "Core MCP",
+      "keywords": [
+        "mcp",
+        "client",
+        "zapier",
+        "tools",
+        "progressive-disclosure",
+        "integrations"
+      ],
+      "capabilities": [
+        "shell",
+        "network",
+        "mcp"
+      ],
+      "sourceRefs": [
+        "https://github.com/coleam00/second-brain-skills",
+        "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/mcp-client",
+        "https://modelcontextprotocol.io"
+      ],
+      "trust": "reference-local",
+      "skill": {
+        "managed": "manual",
+        "description": "Use when interacting with external MCP servers — listing configured servers, discovering tools, reading one tool's schema, or executing a call — through a bundled Python client script instead of registering a server's full tool surface in context. Supports stdio (command + args), SSE, streamable HTTP, and Bearer-auth remote servers via a Claude-Desktop-compatible mcp-config.json.",
+        "useCases": [
+          "Calling a Zapier, GitHub, or filesystem MCP action without loading thousands of tokens of tool definitions upfront.",
+          "Listing a server's available tools, then fetching a single tool's schema on demand before executing it.",
+          "Wiring up a new MCP server by copying references/example-mcp-config.json and filling in url + api_key or command + args."
+        ],
+        "guardrails": [
+          "Keep real API keys in a local mcp-config.json copied from the example — never commit credentials or echo them into the transcript.",
+          "Fetch a tool's schema before calling it; don't guess parameter shapes.",
+          "State-changing MCP actions (send, create, delete) require explicit user approval before execution."
+        ]
+      }
+    },
+    {
+      "name": "pptx-generator",
+      "displayName": "PPTX Generator",
+      "version": "0.1.0",
+      "description": "Generate and edit on-brand presentation slides and LinkedIn carousels as PPTX/PDF with python-pptx and a reusable layout cookbook.",
+      "category": "Media & Creative",
+      "keywords": [
+        "pptx",
+        "presentations",
+        "slides",
+        "carousel",
+        "linkedin",
+        "python-pptx",
+        "branding"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files",
+        "shell"
+      ],
+      "sourceRefs": [
+        "https://github.com/coleam00/second-brain-skills",
+        "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/pptx-generator",
+        "https://python-pptx.readthedocs.io"
+      ],
+      "trust": "reference-local",
+      "skill": {
+        "managed": "manual",
+        "description": "Use when creating or editing presentation slides, LinkedIn carousels, or reusable slide layouts. Generates .pptx files compatible with PowerPoint, Google Slides, and Keynote (plus square 1:1 PDF carousels for LinkedIn) by composing layouts from a cookbook of python-pptx templates — title, two-column, stats, chart, code, quote, floating-cards, and more — styled by per-brand config under brands/{name}/ created with brand-voice-generator.",
+        "useCases": [
+          "Creating a slide deck or LinkedIn carousel for a brand defined under brands/ (set up via brand-voice-generator).",
+          "Editing an existing .pptx — updating copy, swapping layouts, or restyling slides to match the brand.",
+          "Adding a new reusable layout template to the cookbook or improving an existing one."
+        ],
+        "guardrails": [
+          "Resolve the brand first — read brands/{name}/brand.json and config.json; if the brand doesn't exist yet, run brand-voice-generator (or copy brands/template/) before generating slides.",
+          "Compose slides from cookbook layouts instead of hand-positioning shapes; recurring layout ideas belong in the cookbook as new templates.",
+          "Keep output portable — .pptx must open cleanly in PowerPoint, Google Slides, and Keynote, and LinkedIn carousels export as square 1:1 PDF."
+        ]
+      }
+    },
+    {
+      "name": "remotion",
+      "displayName": "Remotion Video",
+      "version": "0.1.0",
+      "description": "Create and edit programmatic videos in React with Remotion — compositions, animations, sequencing, audio, and captions backed by a 30-topic rules library.",
+      "category": "Media & Creative",
+      "keywords": [
+        "remotion",
+        "video",
+        "react",
+        "animation",
+        "composition",
+        "captions"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files",
+        "shell"
+      ],
+      "sourceRefs": [
+        "https://github.com/coleam00/second-brain-skills",
+        "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/remotion",
+        "https://www.remotion.dev/docs"
+      ],
+      "trust": "reference-local",
+      "skill": {
+        "managed": "manual",
+        "description": "Use before writing any Remotion code — creating or editing compositions, animations, sequences, transitions, audio, captions, charts, or 3D scenes in a React video project (remotion.config.ts, remotion-videos/*). A rules/ library carries topic-specific guidance for ~30 areas — timing and interpolation curves, sequencing and trimming, assets and fonts, Mediabunny media probing, TikTok-style captions, Lottie, Mapbox maps, TailwindCSS — plus ready-made typewriter and word-highlight text-animation components.",
+        "useCases": [
+          "Building a new video composition, animation, or transition sequence in a Remotion project.",
+          "Adding assets — images, video, audio, GIFs, fonts, or .srt captions — to compositions.",
+          "Diagnosing timing, duration, dimension, or decode problems in a render (calculate-metadata, can-decode, extract-frames rules)."
+        ],
+        "guardrails": [
+          "Read the matching rules/*.md topic file before writing code for that area — the rules encode Remotion-specific APIs that differ from plain React.",
+          "Drive all motion from the frame clock (useCurrentFrame + interpolate/spring), never CSS transitions or wall-clock timers.",
+          "Probe media with the Mediabunny helpers (duration, dimensions, decodability) instead of hardcoding metadata into compositions."
+        ]
+      }
+    },
+    {
+      "name": "skill-creator",
+      "displayName": "Skill Creator",
+      "version": "0.1.0",
+      "description": "Create and update skills that extend agents with specialized knowledge, workflows, and tools — init, author, validate, and package with bundled scripts.",
+      "category": "Agents & Harnesses",
+      "keywords": [
+        "skills",
+        "authoring",
+        "skill-creation",
+        "progressive-disclosure",
+        "packaging",
+        "agents"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files",
+        "shell"
+      ],
+      "sourceRefs": [
+        "https://github.com/coleam00/second-brain-skills",
+        "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/skill-creator",
+        "https://agentskills.io"
+      ],
+      "trust": "reference-local",
+      "skill": {
+        "managed": "manual",
+        "description": "Use when creating a new skill or updating an existing one. Guides the full process — understand the skill through concrete usage examples, plan reusable contents (scripts for deterministic work, references for documentation, assets for output files), initialize with scripts/init_skill.py, author a concise SKILL.md with trigger-rich frontmatter, then validate and package with the bundled scripts. Built on the progressive-disclosure principle: SKILL.md stays lean and detailed material moves to references/ loaded only when needed.",
+        "useCases": [
+          "Creating a new skill from concrete usage examples and packaging it for distribution.",
+          "Restructuring an existing skill — moving detail out of SKILL.md into references/, scripts/, and assets/.",
+          "Writing frontmatter descriptions that actually trigger — naming the concrete user phrases the skill should respond to."
+        ],
+        "guardrails": [
+          "Keep SKILL.md concise and move depth into references/ — the context window is shared with everything else the agent is doing.",
+          "Use scripts for deterministic, repeated operations instead of regenerating the same code in every session.",
+          "Follow the process in order — examples, plan, init, author, package — skipping a step only with a clear reason."
+        ]
+      }
+    },
+    {
+      "name": "sop-creator",
+      "displayName": "SOP & Runbook Creator",
+      "version": "0.1.0",
+      "description": "Create runbooks, playbooks, and technical documentation that people actually follow — scannable, actionable, specific, testable, and maintained.",
+      "category": "Knowledge & Docs",
+      "keywords": [
+        "sop",
+        "runbook",
+        "playbook",
+        "documentation",
+        "process",
+        "operations"
+      ],
+      "capabilities": [
+        "read_files",
+        "write_files"
+      ],
+      "sourceRefs": [
+        "https://github.com/coleam00/second-brain-skills",
+        "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/sop-creator"
+      ],
+      "trust": "reference-local",
+      "skill": {
+        "managed": "manual",
+        "description": "Use when documenting a repeatable technical or operational process — runbooks for incidents and on-call, deployment playbooks, troubleshooting guides, process SOPs, checklists, decision trees, and onboarding guides. Ships reference templates for each format plus writing rules that keep docs scannable and unambiguous: action-first numbered steps, exact names and thresholds instead of 'as needed', and a Definition of Done checklist near the top.",
+        "useCases": [
+          "Documenting a repeatable technical procedure as a runbook or standard SOP.",
+          "Formalizing an incident-response or deployment playbook with clear triggers and verification steps.",
+          "Restructuring an existing doc nobody follows into scannable, action-first steps with success criteria."
+        ],
+        "guardrails": [
+          "Pick the right format first — runbook, SOP, how-to, checklist, decision tree, or onboarding guide — from the references/ templates.",
+          "Every step is something you DO, with exact commands, names, owners, and thresholds — never 'as appropriate', 'regularly', or 'soon'.",
+          "Every doc ships with a Definition of Done checklist near the top plus an owner, last-updated date, and review schedule."
+        ]
+      }
     }
   ]
 }

--- a/marketplace/exports/codex/marketplace.json
+++ b/marketplace/exports/codex/marketplace.json
@@ -1335,6 +1335,78 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Design & UI"
+    },
+    {
+      "name": "brand-voice-generator",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/brand-voice-generator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Design"
+    },
+    {
+      "name": "mcp-client",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/mcp-client"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Core MCP"
+    },
+    {
+      "name": "pptx-generator",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/pptx-generator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Media & Creative"
+    },
+    {
+      "name": "remotion",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/remotion"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Media & Creative"
+    },
+    {
+      "name": "skill-creator",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/skill-creator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Agents & Harnesses"
+    },
+    {
+      "name": "sop-creator",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/sop-creator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Knowledge & Docs"
     }
   ]
 }

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -1670,6 +1670,96 @@
       },
       "trust": "official-local",
       "roleAffinity": []
+    },
+    {
+      "name": "brand-voice-generator",
+      "displayName": "Brand & Voice Generator",
+      "category": "Design",
+      "source": {
+        "source": "local",
+        "path": "./plugins/brand-voice-generator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": []
+    },
+    {
+      "name": "mcp-client",
+      "displayName": "Universal MCP Client",
+      "category": "Core MCP",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mcp-client"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": []
+    },
+    {
+      "name": "pptx-generator",
+      "displayName": "PPTX Generator",
+      "category": "Media & Creative",
+      "source": {
+        "source": "local",
+        "path": "./plugins/pptx-generator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": []
+    },
+    {
+      "name": "remotion",
+      "displayName": "Remotion Video",
+      "category": "Media & Creative",
+      "source": {
+        "source": "local",
+        "path": "./plugins/remotion"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": []
+    },
+    {
+      "name": "skill-creator",
+      "displayName": "Skill Creator",
+      "category": "Agents & Harnesses",
+      "source": {
+        "source": "local",
+        "path": "./plugins/skill-creator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": []
+    },
+    {
+      "name": "sop-creator",
+      "displayName": "SOP & Runbook Creator",
+      "category": "Knowledge & Docs",
+      "source": {
+        "source": "local",
+        "path": "./plugins/sop-creator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "reference-local",
+      "roleAffinity": []
     }
   ]
 }

--- a/marketplace/plugins/brand-voice-generator/.codex-plugin/plugin.json
+++ b/marketplace/plugins/brand-voice-generator/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "brand-voice-generator",
+  "version": "0.1.0",
+  "description": "Generate brand-system and tone-of-voice files \u2014 colors, typography, assets, and writing voice \u2014 that power the PPTX Generator and other brand-aware skills.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Brand & Voice Generator",
+    "shortDescription": "Generate brand-system and tone-of-voice files \u2014 colors, typography, assets, and writing voice \u2014 that power the PPTX Generator and other brand-aware skills.",
+    "longDescription": "Use when defining a brand identity or writing voice for content generation. Walks through brand basics, a ten-color system, typography, assets, voice discovery (five example voice templates from Technical Educator to Contrarian Thinker), and design philosophy, then generates brand.json, config.json, brand-system.md, and tone-of-voice.md \u2014 the source-of-truth files consumed by pptx-generator and other brand-aware skills.",
+    "developerName": "OpenCoven",
+    "category": "Design",
+    "capabilities": [
+      "brand",
+      "voice",
+      "tone-of-voice",
+      "design-system",
+      "identity",
+      "content"
+    ],
+    "defaultPrompt": "Help me use Brand & Voice Generator safely."
+  }
+}

--- a/marketplace/plugins/brand-voice-generator/NOTES.md
+++ b/marketplace/plugins/brand-voice-generator/NOTES.md
@@ -1,0 +1,22 @@
+# NOTES — Brand & Voice Generator
+
+## Provenance
+Vendored verbatim from [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills)
+(`.claude/skills/brand-voice-generator/`) at commit `75e1e9cd60ef46bffbd294fdfe4d0320cee2f563`
+(fetched 2026-07-06). Authored by Cole Medin (coleam00); the generated `plugin.json` author/license
+fields are stamped by `scripts/sync-marketplace.py` and do not reflect upstream authorship.
+
+## What's vendored
+The complete upstream skill: `SKILL.md` plus `references/` (brand-template, tone-template,
+voice-templates, color-presets). Nothing was excluded or modified.
+
+## How it fits
+This skill is the front door of the second-brain content pipeline: it interviews the user and
+generates `brand.json`, `config.json`, `brand-system.md`, and `tone-of-voice.md` into the
+`pptx-generator` pack's `brands/{name}/` directory, which `pptx-generator` then consumes for
+on-brand slides and carousels. Install the two together for the full flow.
+
+## Sync integration
+`skill.managed: "manual"` in `marketplace/catalog.json` — the authored SKILL.md is the source of
+truth; `sync-marketplace.py` generates only the manifests and never rewrites the skill body.
+Re-vendor by re-copying from upstream and updating the commit hash above.

--- a/marketplace/plugins/brand-voice-generator/plugin.json
+++ b/marketplace/plugins/brand-voice-generator/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "brand-voice-generator",
+  "version": "0.1.0",
+  "description": "Generate brand-system and tone-of-voice files \u2014 colors, typography, assets, and writing voice \u2014 that power the PPTX Generator and other brand-aware skills.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "brand",
+    "voice",
+    "tone-of-voice",
+    "design-system",
+    "identity",
+    "content"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/brand-voice-generator",
+  "x-coven": {
+    "displayName": "Brand & Voice Generator",
+    "category": "Design",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/coleam00/second-brain-skills",
+      "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/brand-voice-generator"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  }
+}

--- a/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/SKILL.md
+++ b/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: brand-voice-generator
+description: |
+  Generate tone-of-voice and brand-system files for use with the PPTX Generator and other brand-aware skills.
+
+  TRIGGERS - Use this skill when user says:
+  - "help me create a brand system" / "set up my brand"
+  - "generate my tone of voice" / "create my voice guidelines"
+  - "configure my brand for presentations" / "set up brand for slides"
+  - "create brand files" / "initialize my brand"
+  - Any request about defining brand identity, voice, or visual system for content creation
+
+  Creates brand.json, config.json, brand-system.md, and tone-of-voice.md files.
+---
+
+# Brand & Voice Generator
+
+Generate complete brand configuration files for use with the PPTX Generator and other brand-aware skills. This skill guides users through an interactive process to define their brand identity and writing voice.
+
+## What This Creates
+
+| File | Purpose | Used By |
+|------|---------|---------|
+| `brand.json` | Colors, fonts, assets | PPTX Generator, Excalidraw |
+| `config.json` | Output settings | PPTX Generator |
+| `brand-system.md` | Design philosophy & guidelines | All content skills |
+| `tone-of-voice.md` | Writing voice & personality | LinkedIn, X, PPTX content |
+
+## Output Location
+
+Files are created in:
+```
+.claude/skills/pptx-generator/brands/{brand-name}/
+```
+
+---
+
+## Process Overview
+
+1. **Gather Brand Basics** - Name, description, primary use case
+2. **Define Colors** - 10 color values for the complete system
+3. **Define Typography** - Heading, body, and code fonts
+4. **Define Assets** - Logo and icon paths
+5. **Discover Voice** - Personality, vocabulary, sentence patterns
+6. **Create Design Philosophy** - Core principles and signature elements
+7. **Generate Files** - Create all four files with gathered information
+8. **Verify Setup** - Confirm files are correctly placed
+
+---
+
+## Step 1: Gather Brand Basics
+
+Ask the user for:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **Brand name** | Folder name (lowercase, no spaces, hyphens OK) | `my-brand`, `acme-corp` |
+| **Display name** | Human-readable name | "My Brand", "ACME Corporation" |
+| **Description** | One-line brand description | "AI education content and community" |
+| **Primary use** | Main content type | presentations, social media, documentation |
+
+**Suggested question:**
+> "Let's set up your brand. What's your brand name? (This will be the folder name - use lowercase with hyphens, like 'my-brand')"
+
+---
+
+## Step 2: Define Colors
+
+Gather 10 color values. Colors should be hex codes WITHOUT the `#` prefix.
+
+### Required Colors
+
+| Color | Purpose | Guidance |
+|-------|---------|----------|
+| `background` | Main slide/page background | Dark themes: near-black. Light themes: white/off-white |
+| `background_alt` | Alternate background for variety | Slightly different shade of background |
+| `text` | Primary text color | High contrast against background |
+| `text_secondary` | Muted/secondary text | Slightly lower contrast than primary |
+| `accent` | Primary accent (CTAs, highlights) | Your signature brand color |
+| `accent_secondary` | Secondary accent | Complement to primary accent |
+| `accent_tertiary` | Third accent (optional variety) | Another complement, or same as secondary |
+| `code_bg` | Code block background | Darker than main background |
+| `card_bg` | Card/surface background | Between background and text |
+| `card_bg_alt` | Alternate card background | Slight variation of card_bg |
+
+### Color Discovery Questions
+
+If user doesn't have a full color system, guide them:
+
+1. "What's your signature brand color? (This becomes your primary accent)"
+2. "Do you prefer a dark theme (dark background, light text) or light theme?"
+3. "Do you have secondary colors, or should I suggest complements?"
+
+### Color Suggestions by Theme
+
+**For dark themes**, suggest:
+```
+background: 0a0a0a to 1a1a2e range
+text: f5f5f5 to ffffff range
+card_bg: 1a1a1a to 2d2d44 range
+```
+
+**For light themes**, suggest:
+```
+background: ffffff to f8f9fa range
+text: 1a1a1a to 333333 range
+card_bg: f0f0f0 to e8e8e8 range
+```
+
+---
+
+## Step 3: Define Typography
+
+Gather 3 font names:
+
+| Font | Purpose | Common Choices |
+|------|---------|----------------|
+| `heading` | Headlines, titles, buttons | Inter, Montserrat, Poppins, Roboto |
+| `body` | Body text, descriptions | Inter, Open Sans, Lato, Source Sans Pro |
+| `code` | Code blocks, terminal | JetBrains Mono, Fira Code, Monaco, Consolas |
+
+**Question:**
+> "What fonts should we use? I need a heading font, body font, and code/monospace font. Common choices are Inter for both heading and body, and JetBrains Mono for code."
+
+**Default if unsure:**
+- Heading: Inter
+- Body: Inter
+- Code: JetBrains Mono
+
+---
+
+## Step 4: Define Assets
+
+Gather asset paths (relative to brand folder):
+
+| Asset | Description | Common |
+|-------|-------------|--------|
+| `logo` | Primary logo file | `assets/logo.png` |
+| `logo_dark` | Logo variant for dark backgrounds (optional) | `null` or `assets/logo-dark.png` |
+| `icon` | Square icon (optional) | `null` or `assets/icon.png` |
+
+**Question:**
+> "Do you have a logo file? If so, you'll need to copy it to the brand folder. What's the filename? (e.g., 'logo.png')"
+
+If they have a logo, set path to `assets/logo.png` (they'll copy it there).
+If no logo, set to `null`.
+
+---
+
+## Step 5: Discover Voice
+
+This is the most important step for content quality. Guide the user through voice discovery.
+
+### Voice Discovery Questions
+
+Ask these questions to understand their voice:
+
+1. **Personality in 3 words:**
+   > "Describe your brand's personality in exactly 3 words. Examples: 'Bold, Technical, Approachable' or 'Calm, Authoritative, Helpful'"
+
+2. **Voice influences:**
+   > "Who are 2-3 creators, brands, or people whose communication style you admire? This helps me understand the vibe."
+
+3. **Vocabulary patterns:**
+   > "What words or phrases do you use often? Any pet phrases, intensifiers you like ('super', 'incredibly'), or words you naturally reach for?"
+
+4. **What to avoid:**
+   > "What kind of tone or phrases do you want to AVOID? (e.g., corporate speak, hype language, overly casual)"
+
+5. **Sentence style:**
+   > "Do you prefer: Short punchy sentences, longer flowing explanations, or a mix? Do you use contractions ('don't', 'can't') casually?"
+
+6. **Teaching style (if applicable):**
+   > "When explaining something complex, how do you approach it? Show process/iterations? Use analogies? Lead with practical then theory?"
+
+### Voice Templates Reference
+
+Read `references/voice-templates.md` for example voice configurations to show the user.
+
+---
+
+## Step 6: Create Design Philosophy
+
+Based on gathered information, help define:
+
+### Core Principles (3-4)
+
+Ask:
+> "What are 3-4 design principles that guide your visual choices? For example: 'Clean over flashy', 'Technical but approachable', 'Dark mode by default'"
+
+### Signature Elements
+
+Ask:
+> "Do you have any signature visual elements? Examples: Glass card effects, specific shadow styles, gradient patterns, geometric shapes, glow effects"
+
+If unsure, suggest based on their colors and theme.
+
+---
+
+## Step 7: Generate Files
+
+Create all four files using the gathered information.
+
+### brand.json
+
+```json
+{
+  "name": "{display_name}",
+  "description": "{description}",
+
+  "colors": {
+    "background": "{background}",
+    "background_alt": "{background_alt}",
+    "text": "{text}",
+    "text_secondary": "{text_secondary}",
+    "accent": "{accent}",
+    "accent_secondary": "{accent_secondary}",
+    "accent_tertiary": "{accent_tertiary}",
+    "code_bg": "{code_bg}",
+    "card_bg": "{card_bg}",
+    "card_bg_alt": "{card_bg_alt}"
+  },
+
+  "fonts": {
+    "heading": "{heading_font}",
+    "body": "{body_font}",
+    "code": "{code_font}"
+  },
+
+  "assets": {
+    "logo": "{logo_path}",
+    "logo_dark": {logo_dark_path},
+    "icon": {icon_path}
+  }
+}
+```
+
+### config.json
+
+```json
+{
+  "output": {
+    "directory": "output/{brand_name}",
+    "naming": "{name}-{date}",
+    "keep_parts": false
+  },
+  "generation": {
+    "slides_per_batch": 5,
+    "auto_combine": true,
+    "open_after_generate": false
+  },
+  "defaults": {
+    "slide_width_inches": 13.333,
+    "slide_height_inches": 7.5
+  }
+}
+```
+
+### tone-of-voice.md
+
+Use the template in `references/tone-template.md` and fill with gathered voice information.
+
+### brand-system.md
+
+Use the template in `references/brand-template.md` and fill with gathered design information.
+
+---
+
+## Step 8: Verify Setup
+
+After generating files:
+
+1. **List created files:**
+   ```
+   Glob: .claude/skills/pptx-generator/brands/{brand-name}/*
+   ```
+
+2. **Remind about assets:**
+   > "Don't forget to copy your logo file to `.claude/skills/pptx-generator/brands/{brand-name}/assets/`"
+
+3. **Suggest test:**
+   > "Try generating a simple presentation with: 'Create a 3-slide presentation for {brand-name} about [topic]'"
+
+---
+
+## Quick Mode
+
+If user just wants to get started quickly:
+
+1. Ask only for: brand name, signature color, and light/dark preference
+2. Generate sensible defaults for everything else
+3. Create minimal but functional files
+4. Tell them they can refine later
+
+**Quick mode trigger phrases:**
+- "quick setup"
+- "just the basics"
+- "minimal brand"
+- "get started fast"
+
+---
+
+## Updating Existing Brand
+
+If a brand already exists:
+
+1. **Read existing files first**
+2. **Ask what to update:**
+   - Colors only?
+   - Voice only?
+   - Everything?
+3. **Preserve unchanged sections**
+4. **Show diff of changes before writing**
+
+---
+
+## Checklist
+
+- [ ] Gather brand name and description
+- [ ] Collect all 10 color values (or suggest defaults)
+- [ ] Collect 3 font names (or use defaults)
+- [ ] Determine asset paths
+- [ ] Discover voice through questions
+- [ ] Define design principles
+- [ ] Generate brand.json
+- [ ] Generate config.json
+- [ ] Generate tone-of-voice.md
+- [ ] Generate brand-system.md
+- [ ] Create assets folder
+- [ ] Verify all files created
+- [ ] Remind user about logo copying
+- [ ] Suggest test generation

--- a/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/brand-template.md
+++ b/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/brand-template.md
@@ -1,0 +1,261 @@
+# Brand System Template
+
+Use this template to generate the brand-system.md file. Replace all `{placeholder}` values with gathered information.
+
+---
+
+```markdown
+# {brand_name} — Brand System
+
+> {brand_tagline}
+
+---
+
+## Brand Philosophy
+
+### Core Principles
+
+1. **{principle_1_name}**
+   {principle_1_description}
+
+2. **{principle_2_name}**
+   {principle_2_description}
+
+3. **{principle_3_name}**
+   {principle_3_description}
+
+{additional_principles}
+
+---
+
+## Logo
+
+### The {brand_name} Mark
+
+{logo_description}
+
+**Logo file**: `.claude/skills/pptx-generator/brands/{brand_folder}/assets/logo.png`
+
+**Usage rules:**
+- Maintain aspect ratio
+- Minimum clear space: 20% of logo width on all sides
+{additional_logo_rules}
+
+---
+
+## Color System
+
+### Primary Accent — {accent_name}
+
+The signature brand color. Used for primary actions, links, highlights.
+
+| Name | Hex | Use |
+|------|-----|-----|
+| {accent_name} | `#{accent}` | Primary buttons, links, highlights |
+| {accent_name} Dark | `#{accent_dark}` | Hover states, outlines |
+| {accent_name} Light | `#{accent_secondary}` | Secondary accents |
+
+**Rule:** {accent_usage_rule}
+
+### Theme Base
+
+**{theme_name} Theme (Default)**
+```
+Background:     #{background}
+Background Alt: #{background_alt}
+Surface:        #{card_bg}
+Text Primary:   #{text}
+Text Secondary: #{text_secondary}
+```
+
+{additional_color_notes}
+
+---
+
+## Typography
+
+### Font Stack
+
+- **Heading:** {heading_font} — {heading_description}
+- **Body:** {body_font} — {body_description}
+- **Code:** {code_font} — {code_description}
+
+### Typography Rules
+
+| Element | Font | Weight | Size |
+|---------|------|--------|------|
+| Display/Hero | {heading_font} | 700 | 36px+ |
+| H1 | {heading_font} | 700 | 30px |
+| H2 | {heading_font} | 600 | 24px |
+| Body | {body_font} | 400 | 16-18px |
+| Code | {code_font} | 400 | 14px |
+
+### Text Color Usage
+
+| Context | Color | Notes |
+|---------|-------|-------|
+| Headings | #{text} | Full contrast |
+| Body | #{text_secondary} | Comfortable reading |
+| Links | #{accent} | With hover effect |
+
+---
+
+## Spacing System
+
+**Base unit:** 4px
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `xs` | 4px | Tight spacing, icon gaps |
+| `sm` | 8px | Related elements |
+| `base` | 16px | Standard padding |
+| `lg` | 24px | Section padding |
+| `xl` | 32px | Card padding |
+| `2xl` | 48px | Section margins |
+
+**Rule:** When in doubt, use multiples of 8px.
+
+---
+
+## Buttons
+
+### Button Types
+
+| Type | Background | Text | Use |
+|------|------------|------|-----|
+| Primary | #{accent} | White | Main actions, CTAs |
+| Secondary | #{card_bg} | #{text} | Secondary actions |
+| Ghost | Transparent | #{text} | Tertiary actions |
+
+### Button Specs
+
+- **Font:** {heading_font}, 500 weight
+- **Border radius:** 8px
+- **Padding:** 8px 16px (standard), 12px 24px (large)
+
+---
+
+## Signature Elements
+
+{signature_elements_description}
+
+{signature_element_1}
+
+{signature_element_2}
+
+{signature_element_3}
+
+---
+
+## Diagrams
+
+### Color Palette for Diagrams
+
+| Semantic Purpose | Fill | Stroke |
+|------------------|------|--------|
+| Primary/Neutral | `#{accent}` | `#{accent_dark}` |
+| Secondary | `#{accent_secondary}` | `#{accent_dark}` |
+| Start/Trigger | `#FED7AA` | `#C2410C` |
+| End/Success | `#A7F3D0` | `#047857` |
+| Warning/Decision | `#FEF3C7` | `#B45309` |
+| Error/Stop | `#FECACA` | `#B91C1C` |
+
+### Diagram Rules
+
+- **Background:** {diagram_bg} for maximum readability
+- **Text color:** {diagram_text}
+- **Stroke width:** 2px
+- **Rule:** Always pair darker stroke with lighter fill
+
+---
+
+## Quick Reference
+
+### When to Use Primary Accent
+
+| Use {accent_name} | Don't Use |
+|-------------------|-----------|
+{accent_usage_table}
+
+### Font Usage
+
+| {heading_font} | {body_font} |
+|----------------|-------------|
+{font_usage_table}
+
+---
+
+*Last updated: {date}*
+```
+
+---
+
+## Filling the Template
+
+### brand_tagline
+One-line brand description.
+Example: "A complete design system for AI education content, community, and products."
+
+### principle_1/2/3_name and description
+Core design principles.
+Examples:
+- "Technical but Approachable" - "Complex topics made accessible without dumbing them down."
+- "Clean over Flashy" - "No unnecessary decoration. Every visual element has a purpose."
+- "Dark Mode by Default" - "Modern, developer-focused aesthetic."
+
+### logo_description
+Brief description of the logo.
+Example: "A stylized blue flame/droplet shape — fluid, dynamic, and modern."
+
+If no logo, write: "No logo configured. Add a logo to `assets/logo.png` when available."
+
+### accent_name
+A name for the primary accent color.
+Example: "Dynamous Blue", "Brand Orange", "Primary"
+
+### accent/accent_dark/accent_secondary
+Hex values without # prefix.
+
+### accent_usage_rule
+How to use the accent color.
+Example: "Dynamous Blue is the hero. Use for actions and emphasis. Don't dilute by overusing."
+
+### theme_name
+"Dark" or "Light" depending on the background color.
+
+### heading_description/body_description/code_description
+Brief description of each font's role.
+Example: "Clean, modern sans-serif for all UI and body text"
+
+### signature_elements_description
+Introduction to signature visual elements.
+Example: "These patterns define the Dynamous visual identity."
+
+### signature_element_1/2/3
+Descriptions of unique visual patterns.
+Examples:
+- Glass card effect with backdrop blur
+- Gradient backgrounds
+- Glow effects around primary elements
+
+If no signature elements defined, suggest based on colors:
+- For dark themes: glass effects, subtle glows
+- For light themes: clean shadows, crisp borders
+
+### diagram_bg
+Background color for diagrams.
+Dark brands usually use white (#FFFFFF) for diagram backgrounds.
+Light brands can match the brand background.
+
+### diagram_text
+Text color for diagrams.
+Usually a dark color for readability.
+
+### accent_usage_table
+Table rows showing when to use/not use accent.
+
+### font_usage_table
+Table rows showing when to use each font.
+
+### date
+Current date in YYYY-MM-DD format.

--- a/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/color-presets.md
+++ b/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/color-presets.md
@@ -1,0 +1,220 @@
+# Color Presets
+
+Quick color configurations for common brand themes.
+
+---
+
+## Dark Themes
+
+### Midnight Blue (Developer-focused)
+
+```json
+"colors": {
+  "background": "07090F",
+  "background_alt": "080A13",
+  "text": "FAFAFA",
+  "text_secondary": "CCCCCC",
+  "accent": "3B82F6",
+  "accent_secondary": "60A5FA",
+  "accent_tertiary": "0EA5E9",
+  "code_bg": "0A0C12",
+  "card_bg": "0D1117",
+  "card_bg_alt": "161B22"
+}
+```
+Good for: Tech, developer tools, AI/ML content
+
+### Catppuccin Mocha (Soft Dark)
+
+```json
+"colors": {
+  "background": "1e1e2e",
+  "background_alt": "181825",
+  "text": "cdd6f4",
+  "text_secondary": "bac2de",
+  "accent": "fab387",
+  "accent_secondary": "89b4fa",
+  "accent_tertiary": "a6e3a1",
+  "code_bg": "11111b",
+  "card_bg": "313244",
+  "card_bg_alt": "45475a"
+}
+```
+Good for: Creative, design, softer aesthetic
+
+### Pure Dark (High Contrast)
+
+```json
+"colors": {
+  "background": "000000",
+  "background_alt": "0a0a0a",
+  "text": "ffffff",
+  "text_secondary": "a3a3a3",
+  "accent": "f97316",
+  "accent_secondary": "fb923c",
+  "accent_tertiary": "fbbf24",
+  "code_bg": "0d0d0d",
+  "card_bg": "171717",
+  "card_bg_alt": "262626"
+}
+```
+Good for: Bold statements, high-impact content
+
+### GitHub Dark
+
+```json
+"colors": {
+  "background": "0d1117",
+  "background_alt": "010409",
+  "text": "c9d1d9",
+  "text_secondary": "8b949e",
+  "accent": "58a6ff",
+  "accent_secondary": "79c0ff",
+  "accent_tertiary": "a5d6ff",
+  "code_bg": "161b22",
+  "card_bg": "21262d",
+  "card_bg_alt": "30363d"
+}
+```
+Good for: Open source, developer communities
+
+---
+
+## Light Themes
+
+### Clean White
+
+```json
+"colors": {
+  "background": "ffffff",
+  "background_alt": "f9fafb",
+  "text": "111827",
+  "text_secondary": "4b5563",
+  "accent": "2563eb",
+  "accent_secondary": "3b82f6",
+  "accent_tertiary": "60a5fa",
+  "code_bg": "f3f4f6",
+  "card_bg": "f9fafb",
+  "card_bg_alt": "f3f4f6"
+}
+```
+Good for: Professional, corporate, documentation
+
+### Warm Paper
+
+```json
+"colors": {
+  "background": "fffbeb",
+  "background_alt": "fef3c7",
+  "text": "292524",
+  "text_secondary": "57534e",
+  "accent": "d97706",
+  "accent_secondary": "f59e0b",
+  "accent_tertiary": "fbbf24",
+  "code_bg": "f5f5f4",
+  "card_bg": "fafaf9",
+  "card_bg_alt": "f5f5f4"
+}
+```
+Good for: Content, publishing, creative writing
+
+### Cool Gray
+
+```json
+"colors": {
+  "background": "f8fafc",
+  "background_alt": "f1f5f9",
+  "text": "0f172a",
+  "text_secondary": "475569",
+  "accent": "0ea5e9",
+  "accent_secondary": "38bdf8",
+  "accent_tertiary": "7dd3fc",
+  "code_bg": "e2e8f0",
+  "card_bg": "f1f5f9",
+  "card_bg_alt": "e2e8f0"
+}
+```
+Good for: SaaS, modern apps, tech products
+
+---
+
+## Accent Color Options
+
+### By Brand Personality
+
+| Personality | Color | Hex | Usage |
+|-------------|-------|-----|-------|
+| Trust, Reliability | Blue | 3B82F6 | Tech, finance, enterprise |
+| Energy, Action | Orange | F97316 | Startups, CTAs, creative |
+| Growth, Success | Green | 22C55E | Health, sustainability, finance |
+| Creativity, Premium | Purple | 8B5CF6 | Design, luxury, creative tools |
+| Warning, Urgency | Red | EF4444 | News, alerts, sales |
+| Innovation, AI | Cyan | 06B6D4 | AI/ML, tech, futurism |
+
+### Complementary Pairs
+
+| Primary | Secondary | Style |
+|---------|-----------|-------|
+| 3B82F6 (Blue) | 60A5FA (Light Blue) | Monochromatic |
+| F97316 (Orange) | 3B82F6 (Blue) | Complementary |
+| 22C55E (Green) | 8B5CF6 (Purple) | Split complementary |
+| 8B5CF6 (Purple) | F59E0B (Amber) | Warm/cool contrast |
+| EF4444 (Red) | 10B981 (Emerald) | High contrast |
+
+---
+
+## Font Pairings
+
+### Developer-Focused
+- Heading: JetBrains Mono
+- Body: Inter
+- Code: JetBrains Mono
+
+### Professional/Corporate
+- Heading: Montserrat
+- Body: Open Sans
+- Code: Fira Code
+
+### Modern/Clean
+- Heading: Inter
+- Body: Inter
+- Code: JetBrains Mono
+
+### Creative/Friendly
+- Heading: Poppins
+- Body: Lato
+- Code: Monaco
+
+### Bold/Impact
+- Heading: Montserrat (Black weight)
+- Body: Source Sans Pro
+- Code: Consolas
+
+---
+
+## Quick Start Combos
+
+### "Developer Content Creator"
+- Theme: Midnight Blue (dark)
+- Accent: 3B82F6 (blue)
+- Fonts: Inter / Inter / JetBrains Mono
+
+### "Modern SaaS"
+- Theme: Cool Gray (light)
+- Accent: 0EA5E9 (cyan)
+- Fonts: Inter / Inter / Fira Code
+
+### "Bold Tech Influencer"
+- Theme: Pure Dark
+- Accent: F97316 (orange)
+- Fonts: Montserrat / Inter / JetBrains Mono
+
+### "Professional Services"
+- Theme: Clean White
+- Accent: 2563EB (blue)
+- Fonts: Montserrat / Open Sans / Fira Code
+
+### "Creative Studio"
+- Theme: Catppuccin Mocha
+- Accent: FAB387 (peach)
+- Fonts: Poppins / Lato / JetBrains Mono

--- a/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/tone-template.md
+++ b/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/tone-template.md
@@ -1,0 +1,197 @@
+# Tone of Voice Template
+
+Use this template to generate the tone-of-voice.md file. Replace all `{placeholder}` values with gathered information.
+
+---
+
+```markdown
+# {brand_name} — Tone of Voice
+
+> {voice_tagline}
+
+---
+
+## Voice Character
+
+{voice_character_description}
+
+---
+
+## Core Attributes
+
+### 1. {attribute_1_name}
+{attribute_1_description}
+
+### 2. {attribute_2_name}
+{attribute_2_description}
+
+### 3. {attribute_3_name}
+{attribute_3_description}
+
+---
+
+## Voice Influences
+
+{brand_name}'s voice draws from:
+
+{voice_influences_description}
+
+---
+
+## Vocabulary Patterns
+
+### Signature Words & Phrases
+{vocabulary_patterns}
+
+### Intensifiers
+{intensifiers}
+
+### Connectors & Transitions
+{connectors}
+
+---
+
+## Writing Guidelines
+
+### Do
+{do_guidelines}
+
+### Don't
+{dont_guidelines}
+
+---
+
+## Sentence Patterns
+
+### Opening Hooks
+{opening_hooks}
+
+### Explanations
+{explanation_style}
+
+### Transitions
+{transition_style}
+
+---
+
+## Example Phrases
+
+### Headlines
+{headline_examples}
+
+### CTAs
+{cta_examples}
+
+### Descriptions
+{description_examples}
+
+---
+
+## Voice Test
+
+Before publishing, ask:
+
+1. Does this sound like {brand_name} explaining this to a smart colleague?
+2. Are we using our signature vocabulary naturally (not forced)?
+3. Are we being direct and confident, not hedging?
+4. Would our audience feel "{audience_feeling}"?
+5. Is there a sharper, shorter way to say this?
+
+---
+
+## Quick Reference
+
+| Always | Never |
+| ------ | ----- |
+{quick_reference_table}
+
+---
+
+*Last updated: {date}*
+```
+
+---
+
+## Filling the Template
+
+### voice_tagline
+A one-line description of how this brand sounds.
+Example: "How Cole Medin sounds across all content."
+
+### voice_character_description
+2-3 sentences describing the brand personality.
+Example: "Cole's voice is genuinely excited about AI without tipping into hype. He teaches by showing iterations, admits when things don't work, and always grounds advice in what he's actually built."
+
+### attribute_1/2/3_name and description
+Three core attributes that define the voice.
+Examples:
+- "Confident" - "Takes positions and backs them up with experience. Doesn't hedge for politeness."
+- "Practical" - "Leads with what to do, then explains why. Every piece of advice is actionable."
+- "Honest" - "Admits limitations. Shows the messy middle, not just polished results."
+
+### voice_influences_description
+If the user mentioned influences, describe how they combine.
+Example: "Dan Koe's calm confidence + Network Chuck's energy + ThePrimeagen's developer credibility = {brand_name}"
+
+If no influences, describe the voice as a standalone character.
+
+### vocabulary_patterns
+Specific words and phrases this brand uses.
+Format as a bulleted list.
+
+### intensifiers
+Words used for emphasis.
+Example: "Super", "Really", "Incredibly", "Just"
+
+### connectors
+Transition words and phrases.
+Example: "So", "And here's the thing", "But honestly"
+
+### do_guidelines
+Bulleted list of positive writing guidance.
+Example:
+- Use contractions naturally
+- Be direct and confident
+- Include specific numbers
+
+### dont_guidelines
+Bulleted list of what to avoid.
+Example:
+- Don't hedge with qualifiers
+- Don't use corporate speak
+- Don't overpromise
+
+### opening_hooks
+Examples of how to start content.
+Format as bulleted examples.
+
+### explanation_style
+How to explain complex topics.
+
+### transition_style
+How to move between ideas.
+
+### headline_examples
+3-5 example headlines in the brand's voice.
+Format as bulleted list with quotes.
+
+### cta_examples
+3-5 example calls-to-action.
+Format as bulleted list with quotes.
+
+### description_examples
+2-3 example description/body copy samples.
+
+### audience_feeling
+How the audience should feel after consuming content.
+Example: "I can actually do this" or "Finally, someone who gets it"
+
+### quick_reference_table
+Table rows of always/never pairs.
+Example:
+| Be direct | Hedge excessively |
+| Use specific numbers | Make vague claims |
+| Admit limitations | Overpromise |
+
+### date
+Current date in YYYY-MM-DD format.

--- a/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/voice-templates.md
+++ b/marketplace/plugins/brand-voice-generator/skills/brand-voice-generator/references/voice-templates.md
@@ -1,0 +1,187 @@
+# Voice Templates
+
+Example voice configurations to help users discover their own voice.
+
+---
+
+## Example 1: Technical Educator
+
+**Voice Character:**
+Enthusiastic expert who teaches by showing, not telling. Admits limitations openly. Grounds everything in real experience.
+
+**Core Attributes:**
+1. **Practical** - Leads with action, theory second
+2. **Honest** - Shows the messy middle, not just results
+3. **Energetic** - Genuine excitement without hype
+
+**Vocabulary Patterns:**
+- "Super" as intensifier (super easy, super powerful)
+- "Honestly" / "Here's the thing" for authenticity
+- Contractions throughout (don't, can't, it's)
+- "So" to start sentences frequently
+
+**Do:**
+- Use specific numbers and examples
+- Show iterations, not just final results
+- Admit when something doesn't work
+- Address the audience directly ("you")
+
+**Don't:**
+- Overpromise or hype
+- Use corporate speak
+- Hedge with endless qualifiers
+- Hide limitations
+
+**Example Headlines:**
+- "The Simple Strategy to 100x AI Coding"
+- "Stop Vibe Coding. Start Building Systems."
+- "What NOT to Focus On When Building AI Agents"
+
+---
+
+## Example 2: Calm Authority
+
+**Voice Character:**
+Confident and measured. Lets expertise speak through specifics, not claims. Philosophical grounding beneath practical advice.
+
+**Core Attributes:**
+1. **Confident** - Takes positions without hedging
+2. **Measured** - No unnecessary exclamation points
+3. **Deep** - Connects practical to philosophical
+
+**Vocabulary Patterns:**
+- Minimal intensifiers
+- "The reality is..." for directness
+- Complete sentences, few fragments
+- Strategic use of "we" for inclusion
+
+**Do:**
+- Make complex ideas feel inevitable
+- Support claims with reasoning
+- Acknowledge nuance where real
+- Use rhythm and pacing intentionally
+
+**Don't:**
+- Shout or oversell
+- Use trendy buzzwords
+- Rush through explanations
+- Ignore counterarguments
+
+**Example Headlines:**
+- "Why Most AI Implementations Fail"
+- "The Difference Between Tools and Systems"
+- "A Framework for Thinking About Automation"
+
+---
+
+## Example 3: Builder's Perspective
+
+**Voice Character:**
+Developer-to-developer communication. Unfiltered opinions backed by code. Humor that's natural, not forced.
+
+**Core Attributes:**
+1. **Credible** - You've built this stuff
+2. **Direct** - No corporate filter
+3. **Real** - Willing to call out BS
+
+**Vocabulary Patterns:**
+- Technical terms used casually
+- "Look" / "Listen" to start points
+- Informal contractions and slang OK
+- Self-deprecating humor where natural
+
+**Do:**
+- Reference actual code and systems
+- Share real numbers and metrics
+- Disagree when warranted
+- Use humor naturally
+
+**Don't:**
+- Pretend to know what you don't
+- Polish away the rough edges
+- Avoid controversy artificially
+- Talk down to the audience
+
+**Example Headlines:**
+- "I Rewrote Our Entire Backend in a Weekend"
+- "This Architecture Pattern is Wrong. Here's Why."
+- "Stop Over-Engineering Your AI Agents"
+
+---
+
+## Example 4: Approachable Expert
+
+**Voice Character:**
+Makes the complex accessible without dumbing it down. Inclusive language that assumes intelligence but not prior knowledge.
+
+**Core Attributes:**
+1. **Inclusive** - Anyone can learn this
+2. **Clear** - Explains the "why" behind the "what"
+3. **Encouraging** - Progress over perfection
+
+**Vocabulary Patterns:**
+- "Let's" for collaborative feeling
+- "Think of it like..." for analogies
+- Questions to guide thinking
+- "The good news is..." for encouragement
+
+**Do:**
+- Use analogies and examples
+- Break complex topics into steps
+- Celebrate small wins
+- Anticipate confusion points
+
+**Don't:**
+- Use jargon without explaining
+- Assume prior knowledge
+- Rush through fundamentals
+- Make people feel dumb
+
+**Example Headlines:**
+- "A Gentle Introduction to AI Agents"
+- "Understanding RAG: A Complete Guide"
+- "You Don't Need to Be a PhD to Build AI"
+
+---
+
+## Example 5: Contrarian Thinker
+
+**Voice Character:**
+Challenges conventional wisdom with evidence. Not contrarian for engagement, but because you've seen what actually works.
+
+**Core Attributes:**
+1. **Challenging** - Questions assumptions
+2. **Evidence-based** - Backs up disagreements
+3. **Constructive** - Offers alternatives, not just criticism
+
+**Vocabulary Patterns:**
+- "Here's what actually works..."
+- "The conventional wisdom is wrong about..."
+- "I used to believe X, then I learned..."
+- Data and specific examples to support
+
+**Do:**
+- Challenge popular ideas with evidence
+- Provide alternative approaches
+- Show your work
+- Acknowledge when conventional wisdom IS right
+
+**Don't:**
+- Be contrarian for engagement
+- Attack people instead of ideas
+- Ignore legitimate counterpoints
+- Overclaim your alternative
+
+**Example Headlines:**
+- "RAG is Not the Answer. Here's What Is."
+- "Why I Stopped Using [Popular Tool]"
+- "The Uncomfortable Truth About AI Agents"
+
+---
+
+## Using These Templates
+
+1. **Mix and match** - Most voices combine elements from multiple templates
+2. **Find your ratio** - Maybe 50% Technical Educator + 30% Builder + 20% Calm Authority
+3. **Adapt, don't copy** - These are starting points, not scripts
+4. **Let your natural voice come through** - The template should enhance, not replace

--- a/marketplace/plugins/mcp-client/.codex-plugin/plugin.json
+++ b/marketplace/plugins/mcp-client/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "mcp-client",
+  "version": "0.1.0",
+  "description": "Connect to any MCP server (Zapier, GitHub, Sequential Thinking, \u2026) with progressive disclosure \u2014 tool schemas load on demand instead of bloating the context window.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Universal MCP Client",
+    "shortDescription": "Connect to any MCP server (Zapier, GitHub, Sequential Thinking, \u2026) with progressive disclosure \u2014 tool schemas load on demand instead of bloating the context window.",
+    "longDescription": "Use when interacting with external MCP servers \u2014 listing configured servers, discovering tools, reading one tool's schema, or executing a call \u2014 through a bundled Python client script instead of registering a server's full tool surface in context. Supports stdio (command + args), SSE, streamable HTTP, and Bearer-auth remote servers via a Claude-Desktop-compatible mcp-config.json.",
+    "developerName": "OpenCoven",
+    "category": "Core MCP",
+    "capabilities": [
+      "mcp",
+      "client",
+      "zapier",
+      "tools",
+      "progressive-disclosure",
+      "integrations"
+    ],
+    "defaultPrompt": "Help me use Universal MCP Client safely."
+  }
+}

--- a/marketplace/plugins/mcp-client/NOTES.md
+++ b/marketplace/plugins/mcp-client/NOTES.md
@@ -1,0 +1,26 @@
+# NOTES — Universal MCP Client
+
+## Provenance
+Vendored verbatim from [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills)
+(`.claude/skills/mcp-client/`) at commit `75e1e9cd60ef46bffbd294fdfe4d0320cee2f563`
+(fetched 2026-07-06). Authored by Cole Medin (coleam00); the generated `plugin.json` author/license
+fields are stamped by `scripts/sync-marketplace.py` and do not reflect upstream authorship.
+
+## What's vendored
+The complete upstream skill: `SKILL.md`, `scripts/mcp_client.py` (the Python client the skill
+drives), and `references/` (example config, MCP server notes, Python SDK notes). Nothing was
+excluded or modified.
+
+## Config & secrets
+The skill expects a user-created `references/mcp-config.json` (copied from
+`references/example-mcp-config.json`) holding real server URLs and API keys. Only the example
+ships here — a real config must never be committed. The script also honors `MCP_CONFIG_PATH`.
+
+## Runtime requirements
+`scripts/mcp_client.py` needs Python 3.10+ with the `mcp` package for stdio servers and network
+access for remote (SSE / streamable HTTP / Bearer) servers.
+
+## Sync integration
+`skill.managed: "manual"` in `marketplace/catalog.json` — the authored SKILL.md is the source of
+truth; `sync-marketplace.py` generates only the manifests and never rewrites the skill body.
+Re-vendor by re-copying from upstream and updating the commit hash above.

--- a/marketplace/plugins/mcp-client/plugin.json
+++ b/marketplace/plugins/mcp-client/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "mcp-client",
+  "version": "0.1.0",
+  "description": "Connect to any MCP server (Zapier, GitHub, Sequential Thinking, \u2026) with progressive disclosure \u2014 tool schemas load on demand instead of bloating the context window.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "mcp",
+    "client",
+    "zapier",
+    "tools",
+    "progressive-disclosure",
+    "integrations"
+  ],
+  "capabilities": [
+    "shell",
+    "network",
+    "mcp"
+  ],
+  "marketplaceId": "opencoven/mcp-client",
+  "x-coven": {
+    "displayName": "Universal MCP Client",
+    "category": "Core MCP",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/coleam00/second-brain-skills",
+      "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/mcp-client",
+      "https://modelcontextprotocol.io"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  }
+}

--- a/marketplace/plugins/mcp-client/skills/mcp-client/SKILL.md
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: mcp-client
+description: Universal MCP client for connecting to any MCP server with progressive disclosure. Wraps MCP servers as skills to avoid context window bloat from tool definitions. Use when interacting with external MCP servers (Zapier, Sequential Thinking, GitHub, filesystem, etc.), listing available tools, or executing MCP tool calls. Triggers on requests like "connect to Zapier", "use MCP server", "list MCP tools", "call Zapier action", "use sequential thinking", or any MCP server interaction.
+---
+
+# Universal MCP Client
+
+Connect to any MCP server with progressive disclosure - load tool schemas on-demand instead of dumping thousands of tokens into context upfront.
+
+## Skill Location
+
+This skill is located at: `.claude/skills/mcp-client/`
+
+**Script path:** `.claude/skills/mcp-client/scripts/mcp_client.py`
+
+## Configuration
+
+The script looks for config in this order:
+1. `MCP_CONFIG_PATH` env var (custom path)
+2. **`references/mcp-config.json`** (this skill's config - recommended)
+3. `.mcp.json` in project root
+4. `~/.claude.json`
+
+**Your config file:** `.claude/skills/mcp-client/references/mcp-config.json`
+
+Edit this file to add your API keys. The example file (`example-mcp-config.json`) is kept as a reference template.
+
+**If the user hasn't provided their Zapier API key yet, ask them for it.**
+
+## Running Commands
+
+All commands use the script at `.claude/skills/mcp-client/scripts/mcp_client.py`:
+
+```bash
+# List configured servers
+python .claude/skills/mcp-client/scripts/mcp_client.py servers
+
+# List tools from a server
+python .claude/skills/mcp-client/scripts/mcp_client.py tools <server_name>
+
+# Call a tool
+python .claude/skills/mcp-client/scripts/mcp_client.py call <server> <tool> '{"arg": "value"}'
+```
+
+## Workflow
+
+1. **Check config exists** - Run `servers` command. If error, create `.mcp.json`
+2. **List servers** - See what MCP servers are configured
+3. **List tools** - Get tool schemas from a specific server
+4. **Call tool** - Execute a tool with arguments
+
+## Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `servers` | List all configured MCP servers |
+| `tools <server>` | List tools with full parameter schemas |
+| `call <server> <tool> '<json>'` | Execute a tool with arguments |
+
+## Example: Zapier
+
+```bash
+# 1. List servers to confirm Zapier is configured
+python .claude/skills/mcp-client/scripts/mcp_client.py servers
+
+# 2. List Zapier tools
+python .claude/skills/mcp-client/scripts/mcp_client.py tools zapier
+
+# 3. Call a Zapier tool
+python .claude/skills/mcp-client/scripts/mcp_client.py call zapier <tool_name> '{"param": "value"}'
+```
+
+## Example: Sequential Thinking
+
+```bash
+# 1. List tools
+python .claude/skills/mcp-client/scripts/mcp_client.py tools sequential-thinking
+
+# 2. Use sequential thinking
+python .claude/skills/mcp-client/scripts/mcp_client.py call sequential-thinking sequentialthinking '{"thought": "Breaking down the problem...", "thoughtNumber": 1, "totalThoughts": 5, "nextThoughtNeeded": true}'
+```
+
+## Config Format
+
+Config file format (`references/mcp-config.json`):
+
+```json
+{
+  "mcpServers": {
+    "zapier": {
+      "url": "https://mcp.zapier.com/api/v1/connect",
+      "api_key": "your-api-key"
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}
+```
+
+**Transport detection:**
+- `url` + `api_key` → FastMCP with Bearer auth (Zapier)
+- `command` + `args` → stdio (local servers like sequential-thinking)
+- `url` ending in `/sse` → SSE transport
+- `url` ending in `/mcp` → Streamable HTTP
+
+## Error Handling
+
+Errors return JSON:
+```json
+{"error": "message", "type": "configuration|validation|connection"}
+```
+
+- `configuration` - Config file not found. Create `.mcp.json`
+- `validation` - Invalid server or tool name
+- `connection` - Failed to connect to server
+
+## Dependencies
+
+```bash
+pip install mcp fastmcp
+```
+
+## References
+
+- `references/example-mcp-config.json` - Template config file
+- `references/mcp-servers.md` - Common server configurations
+- `references/python-mcp-sdk.md` - Python SDK documentation

--- a/marketplace/plugins/mcp-client/skills/mcp-client/references/example-mcp-config.json
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/references/example-mcp-config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "zapier": {
+      "url": "https://mcp.zapier.com/api/v1/connect",
+      "api_key": "YOUR_MCP_API_KEY",
+      "_comment": "Get your API key from https://mcp.zapier.com/"
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    }
+  }
+}

--- a/marketplace/plugins/mcp-client/skills/mcp-client/references/mcp-servers.md
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/references/mcp-servers.md
@@ -1,0 +1,261 @@
+# Common MCP Server Configurations
+
+Reference configurations for popular MCP servers. Copy relevant sections to your `.mcp.json`.
+
+## Remote Servers (FastMCP/SSE/HTTP)
+
+### Zapier MCP
+
+Connects to 8,000+ apps with 30,000+ actions. Get your API key from [mcp.zapier.com](https://mcp.zapier.com/).
+
+**Current Format (FastMCP with Bearer Auth):**
+```json
+{
+  "zapier": {
+    "url": "https://mcp.zapier.com/api/v1/connect",
+    "api_key": "YOUR_MCP_API_KEY"
+  }
+}
+```
+
+**Getting Your API Key:**
+1. Go to [mcp.zapier.com](https://mcp.zapier.com/)
+2. Sign in with your Zapier account
+3. Configure which actions/apps to expose
+4. Copy the generated MCP API key
+
+**How it works:** The script uses FastMCP client with StreamableHttpTransport and Bearer token authentication. When `api_key` is present in config, it automatically uses this transport.
+
+**Security:** Treat your API key like a password - it grants access to your configured Zapier actions.
+
+**Token Cost:** One MCP tool call = 2 Zapier tasks from your plan quota.
+
+**Legacy SSE Format (if needed):**
+```json
+{
+  "zapier": {
+    "url": "https://actions.zapier.com/mcp/YOUR_MCP_SERVER_KEY/sse"
+  }
+}
+```
+
+---
+
+## Local Servers (stdio)
+
+### Sequential Thinking
+
+Structured problem-solving through dynamic, reflective thinking process. Useful for breaking down complex problems into steps.
+
+```json
+{
+  "sequential-thinking": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+  }
+}
+```
+
+**Docker Alternative:**
+```json
+{
+  "sequential-thinking": {
+    "command": "docker",
+    "args": ["run", "--rm", "-i", "mcp/sequentialthinking"]
+  }
+}
+```
+
+**Environment Variable:** Set `DISABLE_THOUGHT_LOGGING=true` to disable verbose output.
+
+**Tool:** `sequentialthinking`
+- `thought` (string): Current thinking step
+- `thoughtNumber` (int): Current step number
+- `totalThoughts` (int): Expected total steps
+- `nextThoughtNeeded` (bool): Whether more steps needed
+
+---
+
+### GitHub MCP
+
+Access GitHub repositories, issues, PRs, and more.
+
+```json
+{
+  "github": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-github"],
+    "env": {
+      "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxxxxxxxxxxx"
+    }
+  }
+}
+```
+
+**Getting Token:**
+1. Go to GitHub Settings > Developer Settings > Personal Access Tokens
+2. Generate token with appropriate scopes (repo, read:org, etc.)
+
+---
+
+### Filesystem MCP
+
+Read/write access to local filesystem paths.
+
+```json
+{
+  "filesystem": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/allowed/path"]
+  }
+}
+```
+
+**Security:** Only the specified path (and subdirectories) are accessible.
+
+---
+
+### Memory MCP
+
+Persistent key-value memory for conversations.
+
+```json
+{
+  "memory": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-memory"]
+  }
+}
+```
+
+---
+
+### PostgreSQL MCP
+
+Query PostgreSQL databases.
+
+```json
+{
+  "postgres": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-postgres"],
+    "env": {
+      "POSTGRES_CONNECTION_STRING": "postgresql://user:pass@host:5432/db"
+    }
+  }
+}
+```
+
+---
+
+### Brave Search MCP
+
+Web search via Brave Search API.
+
+```json
+{
+  "brave-search": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+    "env": {
+      "BRAVE_API_KEY": "your-api-key"
+    }
+  }
+}
+```
+
+---
+
+### Puppeteer MCP
+
+Browser automation for web scraping and testing.
+
+```json
+{
+  "puppeteer": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
+  }
+}
+```
+
+---
+
+## Custom Python Servers
+
+For custom MCP servers written in Python:
+
+```json
+{
+  "my-server": {
+    "command": "python",
+    "args": ["path/to/my_mcp_server.py"],
+    "env": {
+      "MY_API_KEY": "xxx",
+      "DEBUG": "true"
+    },
+    "cwd": "/path/to/working/directory"
+  }
+}
+```
+
+**With uv (recommended):**
+```json
+{
+  "my-server": {
+    "command": "uv",
+    "args": ["run", "my_mcp_server.py"],
+    "cwd": "/path/to/project"
+  }
+}
+```
+
+---
+
+## Full Example Config
+
+```json
+{
+  "mcpServers": {
+    "zapier": {
+      "url": "https://actions.zapier.com/mcp/YOUR_KEY/sse"
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxx"
+      }
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./data"]
+    }
+  }
+}
+```
+
+---
+
+## Transport Reference
+
+| Server Type | Transport | Config Key | Example |
+|-------------|-----------|------------|---------|
+| Remote (SSE) | SSE | `url` | `https://...../sse` |
+| Remote (HTTP) | Streamable HTTP | `url` | `https://...../mcp` |
+| Local (Node.js) | stdio | `command` | `npx` |
+| Local (Python) | stdio | `command` | `python` |
+| Local (Docker) | stdio | `command` | `docker` |
+
+---
+
+## Resources
+
+- [MCP Specification](https://modelcontextprotocol.io/specification/)
+- [Official MCP Servers](https://github.com/modelcontextprotocol/servers)
+- [Zapier MCP Guide](https://zapier.com/blog/zapier-mcp-guide/)
+- [Python MCP SDK](https://github.com/modelcontextprotocol/python-sdk)

--- a/marketplace/plugins/mcp-client/skills/mcp-client/references/python-mcp-sdk.md
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/references/python-mcp-sdk.md
@@ -1,0 +1,278 @@
+# Python MCP SDK Reference
+
+The official Python SDK for building and consuming MCP servers.
+
+## Installation
+
+```bash
+pip install mcp
+```
+
+**Current stable version:** 1.25.x (pin to `mcp>=1.25,<2` for stability)
+
+**Note:** v2 release anticipated Q1 2026. v1.x continues to receive bug fixes.
+
+## Core Concepts
+
+MCP (Model Context Protocol) provides a standardized way to connect AI models to external data sources and tools.
+
+**Think of it like USB-C for AI** - a universal connector that works across different tools and services.
+
+## Client Usage (Consuming MCP Servers)
+
+### Session Creation
+
+```python
+from mcp import ClientSession
+
+# For stdio transport
+from mcp import StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+server_params = StdioServerParameters(
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-github"],
+    env={"GITHUB_TOKEN": "xxx"}
+)
+
+async with stdio_client(server_params) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        # Use session...
+```
+
+### SSE Transport (Remote Servers)
+
+```python
+from mcp import ClientSession
+from mcp.client.sse import sse_client
+
+async with sse_client(url, headers=headers, timeout=30) as (read, write):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        # Use session...
+```
+
+### Streamable HTTP Transport
+
+```python
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+async with streamablehttp_client(url, headers=headers) as (read, write, _):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        # Use session...
+```
+
+### Listing Tools
+
+```python
+result = await session.list_tools()
+
+for tool in result.tools:
+    print(f"Tool: {tool.name}")
+    print(f"Description: {tool.description}")
+    print(f"Schema: {tool.inputSchema}")
+```
+
+### Calling Tools
+
+```python
+result = await session.call_tool("tool_name", {"arg1": "value1"})
+
+# Extract content
+for item in result.content:
+    if hasattr(item, 'text'):
+        print(item.text)
+    elif hasattr(item, 'data'):
+        print(item.data)
+```
+
+### Listing Resources
+
+```python
+result = await session.list_resources()
+
+for resource in result.resources:
+    print(f"Resource: {resource.uri}")
+    print(f"Name: {resource.name}")
+```
+
+### Reading Resources
+
+```python
+result = await session.read_resource("resource://uri")
+
+for content in result.contents:
+    print(content.text)
+```
+
+---
+
+## Server Creation (Building MCP Servers)
+
+### FastMCP (Recommended)
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers together."""
+    return a + b
+
+@mcp.resource("greeting://{name}")
+def get_greeting(name: str) -> str:
+    """Get a personalized greeting."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+### Tool Decorators
+
+```python
+@mcp.tool()
+def search_database(query: str, limit: int = 10) -> list[dict]:
+    """
+    Search the database for matching records.
+
+    Args:
+        query: Search query string
+        limit: Maximum results to return
+
+    Returns:
+        List of matching records
+    """
+    # Implementation
+    return results
+```
+
+**Type hints** are converted to JSON Schema automatically.
+
+### Resource Decorators
+
+```python
+@mcp.resource("config://settings")
+def get_settings() -> str:
+    """Return application settings as JSON."""
+    return json.dumps(settings)
+
+@mcp.resource("file://{path}")
+def read_file(path: str) -> str:
+    """Read a file from the filesystem."""
+    return Path(path).read_text()
+```
+
+### Prompt Decorators
+
+```python
+@mcp.prompt()
+def code_review(code: str, language: str = "python") -> str:
+    """Generate a code review prompt."""
+    return f"Please review this {language} code:\n\n```{language}\n{code}\n```"
+```
+
+---
+
+## Transport Configuration
+
+### stdio (Local Servers)
+
+Default for local subprocess servers.
+
+```python
+from mcp import StdioServerParameters
+
+params = StdioServerParameters(
+    command="python",
+    args=["server.py"],
+    env={"DEBUG": "true"},
+    cwd="/path/to/dir"
+)
+```
+
+### SSE (Remote - Legacy)
+
+Server-Sent Events for remote HTTP connections.
+
+```python
+from mcp.client.sse import sse_client
+
+async with sse_client(
+    url="https://example.com/mcp/sse",
+    headers={"Authorization": "Bearer token"},
+    timeout=60
+) as (read, write):
+    # ...
+```
+
+### Streamable HTTP (Remote - Modern)
+
+Modern HTTP transport with better connection handling.
+
+```python
+from mcp.client.streamable_http import streamablehttp_client
+
+async with streamablehttp_client(
+    url="https://example.com/mcp",
+    headers={"Authorization": "Bearer token"}
+) as (read, write, session_info):
+    # ...
+```
+
+---
+
+## Error Handling
+
+```python
+from mcp.types import McpError
+
+try:
+    result = await session.call_tool("tool", args)
+except McpError as e:
+    print(f"MCP Error: {e.code} - {e.message}")
+except ConnectionError as e:
+    print(f"Connection failed: {e}")
+except TimeoutError as e:
+    print(f"Request timed out: {e}")
+```
+
+---
+
+## Authentication
+
+MCP SDK supports OAuth 2.1 for resource server functionality.
+
+```python
+from mcp.server.auth import bearer_auth
+
+@mcp.tool()
+@bearer_auth(scopes=["read:data"])
+def protected_tool(data: str) -> str:
+    """A tool requiring authentication."""
+    return process(data)
+```
+
+---
+
+## Best Practices
+
+1. **Use context managers** - Always use `async with` for sessions
+2. **Handle errors** - Wrap calls in try/except for graceful degradation
+3. **Set timeouts** - Prevent hanging on unresponsive servers
+4. **Type your tools** - Let the SDK generate JSON Schema from type hints
+5. **Document tools** - Docstrings become tool descriptions
+
+---
+
+## Resources
+
+- [Python SDK GitHub](https://github.com/modelcontextprotocol/python-sdk)
+- [SDK Documentation](https://modelcontextprotocol.github.io/python-sdk/)
+- [PyPI Package](https://pypi.org/project/mcp/)
+- [MCP Specification](https://modelcontextprotocol.io/specification/)

--- a/marketplace/plugins/mcp-client/skills/mcp-client/scripts/mcp_client.py
+++ b/marketplace/plugins/mcp-client/skills/mcp-client/scripts/mcp_client.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+Universal MCP Client - Connect to any MCP server from config files.
+
+Supports all MCP transports:
+- stdio: Local subprocess servers
+- sse: HTTP + Server-Sent Events (remote)
+- streamable_http: Modern HTTP transport (remote)
+- fastmcp: FastMCP client with Bearer auth (Zapier, etc.)
+
+Config Resolution (priority order):
+1. MCP_CONFIG_PATH env var (path to config file)
+2. MCP_CONFIG env var (inline JSON)
+3. .mcp.json in current directory
+4. ~/.claude.json (Claude Code user config)
+
+Usage:
+    python mcp_client.py servers                           # List configured servers
+    python mcp_client.py tools <server>                    # List tools with schemas
+    python mcp_client.py call <server> <tool> '{"args"}'   # Execute a tool
+
+Environment:
+    MCP_CONFIG_PATH: Path to MCP config file
+    MCP_CONFIG: Inline JSON config (for simple setups)
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Optional
+from contextlib import asynccontextmanager
+
+
+# =============================================================================
+# Config Loading
+# =============================================================================
+
+def find_config_file() -> Optional[Path]:
+    """Find MCP config file in standard locations."""
+    # Priority 1: Environment variable path
+    if env_path := os.environ.get("MCP_CONFIG_PATH"):
+        path = Path(env_path).expanduser()
+        if path.exists():
+            return path
+
+    # Priority 2: mcp-config.json in skill's references folder (user's actual config)
+    script_dir = Path(__file__).parent
+    skill_config = script_dir.parent / "references" / "mcp-config.json"
+    if skill_config.exists():
+        return skill_config
+
+    # Priority 3: .mcp.json in current directory
+    local_config = Path(".mcp.json")
+    if local_config.exists():
+        return local_config
+
+    # Priority 4: ~/.claude.json (Claude Code config)
+    claude_config = Path.home() / ".claude.json"
+    if claude_config.exists():
+        return claude_config
+
+    return None
+
+
+def load_config() -> dict:
+    """Load MCP server configuration."""
+    # Priority 1: Inline JSON from environment
+    if env_config := os.environ.get("MCP_CONFIG"):
+        try:
+            config = json.loads(env_config)
+            return config.get("mcpServers", config)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid MCP_CONFIG JSON: {e}")
+
+    # Priority 2: Config file
+    config_path = find_config_file()
+    if not config_path:
+        raise FileNotFoundError(
+            "No MCP config found. Set MCP_CONFIG_PATH, MCP_CONFIG, "
+            "or create .mcp.json in the current directory."
+        )
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    # Handle both formats: {"mcpServers": {...}} and direct {...}
+    return config.get("mcpServers", config)
+
+
+def get_server_config(servers: dict, server_name: str) -> dict:
+    """Get configuration for a specific server."""
+    if server_name not in servers:
+        available = ", ".join(servers.keys())
+        raise ValueError(f"Server '{server_name}' not found. Available: {available}")
+    return servers[server_name]
+
+
+# =============================================================================
+# Transport Detection & Connection
+# =============================================================================
+
+def detect_transport(config: dict) -> str:
+    """Detect transport type from server config."""
+    # Explicit type takes precedence
+    if explicit_type := config.get("type"):
+        type_map = {
+            "stdio": "stdio",
+            "sse": "sse",
+            "http": "streamable_http",
+            "streamable_http": "streamable_http",
+            "streamable-http": "streamable_http",
+            "fastmcp": "fastmcp",
+        }
+        return type_map.get(explicit_type.lower(), explicit_type.lower())
+
+    # Infer from config keys
+    if "command" in config:
+        return "stdio"
+
+    if "url" in config:
+        # FastMCP when api_key is present (Zapier-style Bearer auth)
+        if "api_key" in config:
+            return "fastmcp"
+
+        url = config["url"]
+        if url.endswith("/mcp"):
+            return "streamable_http"
+        if url.endswith("/sse"):
+            return "sse"
+        # Default to SSE for remote servers
+        return "sse"
+
+    raise ValueError("Cannot detect transport: config must have 'command' or 'url'")
+
+
+@asynccontextmanager
+async def create_session(config: dict):
+    """Create MCP client session based on server config."""
+    transport = detect_transport(config)
+
+    if transport == "fastmcp":
+        # FastMCP client with Bearer auth (Zapier, etc.)
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        url = config["url"]
+        api_key = config["api_key"]
+
+        transport_obj = StreamableHttpTransport(
+            url,
+            headers={"Authorization": f"Bearer {api_key}"}
+        )
+        client = Client(transport=transport_obj)
+
+        async with client:
+            # Wrap FastMCP client in adapter for unified interface
+            yield FastMCPSessionAdapter(client)
+
+    elif transport == "stdio":
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        # Build environment with current env + config env
+        env = {**os.environ}
+        if config_env := config.get("env"):
+            env.update(config_env)
+
+        server_params = StdioServerParameters(
+            command=config["command"],
+            args=config.get("args", []),
+            env=env,
+            cwd=config.get("cwd"),
+        )
+
+        async with stdio_client(server_params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+    elif transport == "sse":
+        from mcp import ClientSession
+        from mcp.client.sse import sse_client
+
+        url = config["url"]
+        headers = config.get("headers")
+        timeout = config.get("timeout", 30)
+
+        async with sse_client(url, headers=headers, timeout=timeout) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+    elif transport == "streamable_http":
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamablehttp_client
+
+        url = config["url"]
+        headers = config.get("headers")
+        timeout = config.get("timeout", 30)
+
+        async with streamablehttp_client(url, headers=headers) as (read, write, _):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                yield session
+
+    else:
+        raise ValueError(f"Unsupported transport: {transport}")
+
+
+class FastMCPSessionAdapter:
+    """Adapter to give FastMCP Client a similar interface to mcp ClientSession."""
+
+    def __init__(self, client):
+        self.client = client
+
+    async def list_tools(self):
+        """List tools, returning object with .tools attribute."""
+        tools = await self.client.list_tools()
+        return type('ToolsResult', (), {'tools': tools})()
+
+    async def call_tool(self, name: str, arguments: dict):
+        """Call a tool and return result."""
+        result = await self.client.call_tool(name, arguments)
+        return result
+
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+def cmd_servers(servers: dict) -> list[dict]:
+    """List all configured MCP servers."""
+    result = []
+    for name, config in servers.items():
+        transport = detect_transport(config)
+        info = {
+            "name": name,
+            "transport": transport,
+        }
+        if transport == "stdio":
+            info["command"] = config.get("command")
+        else:
+            info["url"] = config.get("url")
+        result.append(info)
+    return result
+
+
+async def cmd_tools(servers: dict, server_name: str) -> list[dict]:
+    """List all tools from a server with full schemas."""
+    config = get_server_config(servers, server_name)
+
+    async with create_session(config) as session:
+        result = await session.list_tools()
+
+        tools = []
+        for tool in result.tools:
+            tools.append({
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.inputSchema,
+            })
+        return tools
+
+
+async def cmd_call(servers: dict, server_name: str, tool_name: str, arguments: dict) -> Any:
+    """Execute a tool on a server."""
+    config = get_server_config(servers, server_name)
+
+    async with create_session(config) as session:
+        result = await session.call_tool(tool_name, arguments)
+
+        # Extract content from result
+        if hasattr(result, 'content'):
+            contents = []
+            for item in result.content:
+                if hasattr(item, 'text'):
+                    contents.append(item.text)
+                elif hasattr(item, 'data'):
+                    contents.append({"type": "data", "data": item.data})
+                else:
+                    contents.append(str(item))
+            return contents[0] if len(contents) == 1 else contents
+        return result
+
+
+# =============================================================================
+# CLI Interface
+# =============================================================================
+
+def print_json(data: Any) -> None:
+    """Print data as formatted JSON."""
+    print(json.dumps(data, indent=2, default=str))
+
+
+def print_error(message: str, error_type: str = "error") -> None:
+    """Print error as JSON."""
+    print(json.dumps({"error": message, "type": error_type}))
+
+
+def print_usage():
+    """Print usage information."""
+    usage = """Usage: mcp_client.py <command> [args]
+
+Commands:
+    servers                           List configured MCP servers
+    tools <server>                    List tools with full schemas
+    call <server> <tool> '<json>'     Execute a tool with arguments
+
+Examples:
+    python mcp_client.py servers
+    python mcp_client.py tools github
+    python mcp_client.py call github search_repos '{"query": "python mcp"}'
+
+Config sources (checked in order):
+    1. MCP_CONFIG_PATH environment variable
+    2. MCP_CONFIG environment variable (inline JSON)
+    3. .mcp.json in current directory
+    4. ~/.claude.json"""
+    print(usage)
+
+
+async def main():
+    if len(sys.argv) < 2:
+        print_usage()
+        sys.exit(1)
+
+    command = sys.argv[1].lower()
+
+    if command in ("--help", "-h", "help"):
+        print_usage()
+        sys.exit(0)
+
+    # Load config
+    try:
+        servers = load_config()
+    except (FileNotFoundError, ValueError) as e:
+        print_error(str(e), "configuration")
+        sys.exit(1)
+
+    try:
+        if command == "servers":
+            result = cmd_servers(servers)
+            print_json(result)
+
+        elif command == "tools":
+            if len(sys.argv) < 3:
+                print_error("Usage: tools <server_name>", "usage")
+                sys.exit(1)
+            server_name = sys.argv[2]
+            result = await cmd_tools(servers, server_name)
+            print_json(result)
+
+        elif command == "call":
+            if len(sys.argv) < 4:
+                print_error("Usage: call <server> <tool> [json_args]", "usage")
+                sys.exit(1)
+            server_name = sys.argv[2]
+            tool_name = sys.argv[3]
+            args = {}
+            if len(sys.argv) >= 5:
+                try:
+                    args = json.loads(sys.argv[4])
+                except json.JSONDecodeError as e:
+                    print_error(f"Invalid JSON arguments: {e}", "invalid_args")
+                    sys.exit(1)
+            result = await cmd_call(servers, server_name, tool_name, args)
+            print_json(result)
+
+        else:
+            print_error(f"Unknown command: {command}", "usage")
+            print_usage()
+            sys.exit(1)
+
+    except ValueError as e:
+        print_error(str(e), "validation")
+        sys.exit(1)
+    except ConnectionError as e:
+        print_error(f"Connection failed: {e}", "connection")
+        sys.exit(1)
+    except Exception as e:
+        print_error(f"Error: {e}", "error")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/marketplace/plugins/pptx-generator/.codex-plugin/plugin.json
+++ b/marketplace/plugins/pptx-generator/.codex-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "pptx-generator",
+  "version": "0.1.0",
+  "description": "Generate and edit on-brand presentation slides and LinkedIn carousels as PPTX/PDF with python-pptx and a reusable layout cookbook.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "PPTX Generator",
+    "shortDescription": "Generate and edit on-brand presentation slides and LinkedIn carousels as PPTX/PDF with python-pptx and a reusable layout cookbook.",
+    "longDescription": "Use when creating or editing presentation slides, LinkedIn carousels, or reusable slide layouts. Generates .pptx files compatible with PowerPoint, Google Slides, and Keynote (plus square 1:1 PDF carousels for LinkedIn) by composing layouts from a cookbook of python-pptx templates \u2014 title, two-column, stats, chart, code, quote, floating-cards, and more \u2014 styled by per-brand config under brands/{name}/ created with brand-voice-generator.",
+    "developerName": "OpenCoven",
+    "category": "Media & Creative",
+    "capabilities": [
+      "pptx",
+      "presentations",
+      "slides",
+      "carousel",
+      "linkedin",
+      "python-pptx",
+      "branding"
+    ],
+    "defaultPrompt": "Help me use PPTX Generator safely."
+  }
+}

--- a/marketplace/plugins/pptx-generator/NOTES.md
+++ b/marketplace/plugins/pptx-generator/NOTES.md
@@ -1,0 +1,33 @@
+# NOTES — PPTX Generator
+
+## Provenance
+Vendored from [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills)
+(`.claude/skills/pptx-generator/`) at commit `75e1e9cd60ef46bffbd294fdfe4d0320cee2f563`
+(fetched 2026-07-06). Authored by Cole Medin (coleam00); the generated `plugin.json` author/license
+fields are stamped by `scripts/sync-marketplace.py` and do not reflect upstream authorship.
+
+## What's vendored vs excluded
+Vendored: `SKILL.md`, the full `cookbook/` of python-pptx layout templates (incl. `carousels/`),
+`generate-cookbook-preview.py`, and `brands/template/` (the scaffold SKILL.md reads when creating
+a new brand).
+
+Excluded deliberately:
+- `brands/dynamous/` — the upstream author's personal brand instance (incl. a 158 KB logo PNG).
+  `brands/` is user-generated content; users create their own with `brand-voice-generator`.
+- `cookbook-preview.pptx`, `font-test.pptx` — binary build artifacts. The preview can be
+  regenerated locally via `uv run generate-cookbook-preview.py` (SKILL.md documents this).
+
+## How it fits
+Consumes per-brand config (`brand.json`, `config.json`, `brand-system.md`, `tone-of-voice.md`)
+from `brands/{name}/`, created by the `brand-voice-generator` pack. Install the two together for
+the full flow.
+
+## Runtime requirements
+Python with `python-pptx` (the SKILL.md drives it via `uv run`). Fonts referenced by a brand must
+be installed locally for faithful rendering.
+
+## Sync integration
+`skill.managed: "manual"` in `marketplace/catalog.json` — the authored SKILL.md is the source of
+truth; `sync-marketplace.py` generates only the manifests and never rewrites the skill body.
+Re-vendor by re-copying from upstream (re-applying the exclusions above) and updating the commit
+hash.

--- a/marketplace/plugins/pptx-generator/plugin.json
+++ b/marketplace/plugins/pptx-generator/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "pptx-generator",
+  "version": "0.1.0",
+  "description": "Generate and edit on-brand presentation slides and LinkedIn carousels as PPTX/PDF with python-pptx and a reusable layout cookbook.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "pptx",
+    "presentations",
+    "slides",
+    "carousel",
+    "linkedin",
+    "python-pptx",
+    "branding"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell"
+  ],
+  "marketplaceId": "opencoven/pptx-generator",
+  "x-coven": {
+    "displayName": "PPTX Generator",
+    "category": "Media & Creative",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/coleam00/second-brain-skills",
+      "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/pptx-generator",
+      "https://python-pptx.readthedocs.io"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  }
+}

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/SKILL.md
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/SKILL.md
@@ -1,0 +1,1193 @@
+---
+name: pptx-generator
+description: |
+  Generate and edit presentation slides as PPTX files. Also create LinkedIn carousels and manage reusable slide layouts.
+
+  TRIGGERS - Use this skill when user says:
+  - "create slides for [brand]" / "generate presentation for [brand]" / "make slides for [brand]"
+  - "create a carousel for [brand]" / "linkedin carousel" / "make a carousel about [topic]"
+  - "edit this pptx" / "update the slides" / "modify this presentation"
+  - "create a new layout" / "add a layout to the cookbook" / "make a [type] layout template"
+  - "edit the [name] layout" / "update the cookbook" / "improve the [name] template"
+  - Any request mentioning slides, presentations, carousels, PPTX, or layouts with a brand name
+
+  Creates .pptx files compatible with PowerPoint, Google Slides, and Keynote.
+  Creates PDF carousels for LinkedIn (square 1:1 format).
+---
+
+# PPTX Slide Generator
+
+Generate professional, on-brand presentation slides using python-pptx. This skill supports:
+- **Slide Generation** - Create presentations for any brand in `brands/`
+- **Carousel Generation** - Create LinkedIn carousels (square format, exports to PDF)
+- **Slide Editing** - Modify existing PPTX files
+- **Layout Management** - Create, edit, update cookbook layouts
+
+**IMPORTANT:** All skill resources are in `.claude/skills/pptx-generator/`. Always use Glob patterns starting with `.claude/skills/pptx-generator/` to find files.
+
+---
+
+## ⚠️ CRITICAL: Batch Generation Rules
+
+**NEVER generate more than 5 slides at once.**
+
+| Rule | Details |
+|------|---------|
+| Max slides per batch | **5** (can be 1, 2, 3, 4, or 5) |
+| After each batch | **STOP and validate output** |
+| Validation required | Check: no duplicate titles, proper spacing, correct colors |
+| Continue when | Validation passes |
+| **After ALL batches** | **COMBINE into single file and DELETE part files** |
+
+This prevents token limit errors and catches quality issues early.
+
+**CRITICAL: Always clean up part files after combining.** The user should only see ONE final PPTX file, not multiple part files.
+
+---
+
+## ⚠️ PREREQUISITE: Brand Check
+
+**Before generating slides, check if any brands exist.**
+
+```
+Glob: .claude/skills/pptx-generator/brands/*/brand.json
+```
+
+**If NO brands found (only `template/` exists):**
+
+1. **STOP** - Do not proceed with slide generation
+2. **Ask the user:**
+   > "No brands are configured yet. Would you like me to help you create a brand first?
+   > I'll need your brand colors, fonts, and style guidelines to set this up."
+
+3. **If user wants to create a brand**, follow the **Creating a New Brand** section below.
+
+4. **If user declines**, explain that slides require a brand configuration and offer to use generic styling as a fallback.
+
+---
+
+## Creating a New Brand
+
+When no brands exist or user requests a new brand:
+
+### Step 1: Read the Template
+
+```
+Read: .claude/skills/pptx-generator/brands/template/README.md
+Read: .claude/skills/pptx-generator/brands/template/brand.json
+Read: .claude/skills/pptx-generator/brands/template/config.json
+```
+
+### Step 2: Gather Brand Information
+
+Ask the user for (or extract from provided materials):
+
+| Required | Description |
+|----------|-------------|
+| **Brand name** | Folder name (lowercase, no spaces) |
+| **Colors** | Background, text, accent colors (hex codes) |
+| **Fonts** | Heading font, body font, code font |
+
+| Optional | Description |
+|----------|-------------|
+| Output directory | Where to save generated files (default: `output/{brand}`) |
+| Logo | Path to logo file (PNG/SVG) |
+| Brand guidelines | Existing style guide or website to reference |
+| Tone of voice | Writing style, vocabulary preferences |
+
+### Step 3: Create Brand Files
+
+1. **Create the brand folder:**
+   ```bash
+   mkdir -p .claude/skills/pptx-generator/brands/{brand-name}
+   ```
+
+2. **Create brand.json** with the gathered values:
+   ```json
+   {
+     "name": "Brand Name",
+     "description": "One-line description",
+     "colors": {
+       "background": "hex-without-hash",
+       "background_alt": "hex-without-hash",
+       "text": "hex-without-hash",
+       "text_secondary": "hex-without-hash",
+       "accent": "hex-without-hash",
+       "accent_secondary": "hex-without-hash",
+       "accent_tertiary": "hex-without-hash",
+       "code_bg": "hex-without-hash",
+       "card_bg": "hex-without-hash",
+       "card_bg_alt": "hex-without-hash"
+     },
+     "fonts": {
+       "heading": "Font Name",
+       "body": "Font Name",
+       "code": "Monospace Font"
+     },
+     "assets": {
+       "logo": "assets/logo.png",
+       "logo_dark": null,
+       "icon": null
+     }
+   }
+   ```
+
+3. **Create config.json** with output settings:
+   ```json
+   {
+     "output": {
+       "directory": "output/{brand}",
+       "naming": "{name}-{date}",
+       "keep_parts": false
+     },
+     "generation": {
+       "slides_per_batch": 5,
+       "auto_combine": true,
+       "open_after_generate": false
+     },
+     "defaults": {
+       "slide_width_inches": 13.333,
+       "slide_height_inches": 7.5
+     }
+   }
+   ```
+
+4. **Create brand-system.md** - Copy from template and fill in brand guidelines
+
+5. **Create tone-of-voice.md** - Copy from template and fill in voice guidelines
+
+6. **Add assets** - Copy logo/images to `brands/{brand-name}/assets/`
+
+### Step 4: Verify
+
+After creating the brand, verify with:
+```
+Glob: .claude/skills/pptx-generator/brands/{brand-name}/*
+```
+
+Then proceed to slide generation.
+
+---
+
+## Skill Modes
+
+This skill operates in three modes:
+
+### Mode 1: Generate Presentation Slides
+User wants presentation slides (16:9) created using a brand's styling.
+→ Follow: Brand Discovery → Layout Selection → Content Adaptation → Execute
+→ Layouts in: `cookbook/*.py`
+
+### Mode 2: Generate LinkedIn Carousels
+User wants a LinkedIn carousel (square 1:1 format) for social media.
+→ Follow: Brand Discovery → Carousel Planning → Generate → Export PDF
+→ Layouts in: `cookbook/carousels/*.py`
+
+### Mode 3: Manage Cookbook Layouts
+User wants to create, edit, or improve layout templates.
+→ Follow: Layout CRUD Operations section
+
+---
+
+## Mode 1: Generate Presentation Slides
+
+### Step 1: Brand Discovery
+
+1. **List available brands:**
+   ```
+   Glob: .claude/skills/pptx-generator/brands/*/brand.json
+   ```
+   Extract unique brand names from paths (e.g., `brands/rasmus/...` → "rasmus")
+
+2. **Read the brand configuration files:**
+   ```
+   Read: .claude/skills/pptx-generator/brands/{brand-name}/brand.json
+   Read: .claude/skills/pptx-generator/brands/{brand-name}/config.json
+   ```
+   - `brand.json` - Colors, fonts, assets
+   - `config.json` - Output directory, generation settings
+
+3. **Read supporting markdown files for context:**
+   ```
+   Glob: .claude/skills/pptx-generator/brands/{brand-name}/*.md
+   ```
+   These provide voice, tone, and design philosophy.
+
+4. **Extract from brand files:**
+   - **From brand.json:** Colors (hex without #), fonts, asset paths
+   - **From config.json:** Output directory, slides per batch, naming convention
+   - **From markdown:** Voice, tone, vocabulary, visual principles
+
+If brand not found, list available brands and ask user to choose.
+
+### Step 2: Layout Discovery (READ ALL FRONTMATTERS)
+
+**⚠️ MANDATORY: Read ALL layout frontmatters before selecting any layout.**
+
+This step is critical for making informed layout decisions. You must understand what ALL layouts offer before choosing.
+
+**Step 2a: Discover all layouts:**
+```
+Glob: .claude/skills/pptx-generator/cookbook/*.py
+```
+
+**Step 2b: Read EVERY layout file** (not just one or two):
+
+For each `.py` file found, read the first 40 lines to extract the `# /// layout` frontmatter block. Build a mental map of:
+- What each layout is for (`purpose`, `best_for`)
+- What each layout should NOT be used for (`avoid_when`)
+- Limits and constraints (`max_*`, `min_*`, `*_max_chars`)
+
+**The frontmatter block** looks like this:
+
+```python
+# /// layout
+# name = "floating-cards-slide"
+# purpose = "Feature highlights, process steps, multiple equal items with depth"
+# best_for = [
+#     "Exactly 3 related features or concepts",
+#     "Process with 3 steps",
+# ]
+# avoid_when = [
+#     "More than 3 items - use multi-card-slide instead",
+#     "Long card titles (over 15 characters)",
+# ]
+# max_cards = 3
+# card_title_max_chars = 15
+# instructions = [
+#     "EXACTLY 3 cards required - no more, no less",
+#     "Card titles must be SHORT: 1-2 words, max 15 characters",
+# ]
+# ///
+```
+
+**Key frontmatter fields:**
+| Field | Description |
+|-------|-------------|
+| `name` | Layout identifier |
+| `purpose` | What this layout is for |
+| `best_for` | Ideal use cases (array) |
+| `avoid_when` | When NOT to use this layout (array) |
+| `max_*` / `min_*` | Item limits (cards, bullets, stats) |
+| `instructions` | Specific tips for using this layout |
+
+**Step 2c: Select layouts** (only AFTER reading all frontmatters):
+
+Now that you know all available layouts and their constraints:
+
+1. User specifies layout → Use that layout (but verify it fits the content)
+2. User describes content → Match to best-fitting `best_for` criteria
+3. **Check `avoid_when`** → Don't use a layout in situations it warns against
+4. **Respect limits** → If content exceeds `max_*`, use a different layout
+5. Multiple slides needed → Select appropriate layout for each
+6. No good fit → Create a custom layout (see Mode 2)
+
+**Example selection process:**
+- User wants "5 pillars of AI infrastructure"
+- You've read all frontmatters and know:
+  - `floating-cards-slide`: `max_cards = 3` → Won't work
+  - `multi-card-slide`: `max_cards = 5` → Perfect fit
+- Select `multi-card-slide`
+
+**Why read ALL frontmatters?**
+- Layouts reference each other in `avoid_when` (e.g., "use multi-card-slide instead")
+- You can't make the right choice without knowing all options
+- Prevents backtracking when a layout doesn't fit
+
+### Step 2d: Visual-First Layout Selection (CRITICAL FOR VARIETY)
+
+**🎨 DEFAULT TO VISUAL LAYOUTS. Content-slide is the LAST RESORT, not the default.**
+
+#### The Variety Problem
+
+The biggest mistake in presentation generation is **defaulting to content-slide** (title + bullets) whenever you have information to convey. This creates repetitive, boring presentations.
+
+**Common failure pattern:**
+- 11 out of 30 slides = content-slide (37% repetition)
+- User says "this lacks variety"
+- You think "but I used 11 different layout types!"
+- Reality: Layout variety exists, but distribution is terrible
+
+#### Variety Enforcement Rules
+
+**HARD LIMITS:**
+1. **Never use the same layout more than 2-3 times consecutively**
+2. **Content-slide should be <25% of total slides** (not 35-40%)
+3. **Visual layouts (cards, stats, columns, hero, diagonal) should be 50%+ of slides**
+4. **Section breaks are NOT variety** - they're structural (don't count toward variety)
+
+#### Decision Tree: "Should I Use content-slide?"
+
+Ask these questions IN ORDER before defaulting to content-slide:
+
+```
+Do I have 3-5 equal items?
+  YES → Use multi-card-slide (not content-slide)
+
+Do I have 2-4 big numbers/metrics?
+  YES → Use stats-slide (not content-slide)
+
+Am I comparing two things?
+  YES → Use two-column-slide (not content-slide)
+
+Do I have a central concept with surrounding items?
+  YES → Use circular-hero-slide (not content-slide)
+
+Do I have exactly 3 related items?
+  YES → Use floating-cards-slide (not content-slide)
+
+Do I have 1-3 words I want to emphasize dramatically?
+  YES → Use giant-focus-slide or bold-diagonal-slide (not content-slide)
+
+Do I have a powerful quote or principle?
+  YES → Use quote-slide (not content-slide)
+
+Is this the ONLY way to present this information?
+  YES → NOW you can use content-slide
+  NO → Go back through the decision tree
+```
+
+#### Transforming Bullets Into Visual Layouts
+
+**Example 1: "Validation Patterns"**
+
+❌ **BAD (content-slide):**
+```
+Title: Validation Patterns
+Bullets:
+- Run comprehensive test suites
+- Type checking and linting
+- Code review by humans and AI
+- Deployment previews
+```
+
+✅ **GOOD (multi-card-slide):**
+```
+Title: Validation Patterns
+Cards:
+1. Testing | Run comprehensive test suites after every change
+2. Linting | Type checking and formatting as guardrails
+3. Review | Human and AI code review process
+4. Preview | Deployment previews for visual regression
+```
+
+**Example 2: "Why PIV Works"**
+
+❌ **BAD (content-slide):**
+```
+Title: Why PIV Works
+Bullets:
+- Forces planning before implementation
+- Validation catches issues immediately
+- Iterative improvements compound
+- System gets smarter with every bug
+```
+
+✅ **GOOD (floating-cards-slide with 3 cards):**
+```
+Title: Why PIV Works
+Cards:
+1. Plan First | Forces architectural thinking before coding
+2. Fast Feedback | Validation catches issues immediately
+3. Compounds | System improves with every bug
+```
+(Note: Reduced from 4 to 3 items to fit floating-cards-slide `max_cards` limit)
+
+**Example 3: "Human-in-the-Loop Strategy"**
+
+❌ **BAD (content-slide):**
+```
+Title: Human-in-the-Loop Strategy
+Bullets:
+- In-the-loop: Human approves before execution
+- On-the-loop: Human reviews after completion
+- Code review remains critical
+- AI generates, humans validate
+```
+
+✅ **GOOD (two-column-slide):**
+```
+Title: Human-in-the-Loop Strategy
+Left: In-the-Loop
+- Human approves before execution
+- Critical for production changes
+- Quality gateway
+
+Right: On-the-Loop
+- Human reviews after completion
+- Faster iteration cycles
+- AI generates, human validates
+```
+
+#### Active Visual Thinking
+
+Before planning any slide, ask yourself:
+
+1. **"Can this be more visual?"** - The answer is almost always YES
+2. **"Have I used content-slide in the last 2 slides?"** - If yes, use something else
+3. **"Does this slide look like the previous slide?"** - If yes, change the layout
+4. **"Am I falling into a pattern?"** - Break it immediately
+5. **"Would this be more engaging as cards/columns/stats?"** - Usually yes
+
+#### When content-slide IS Appropriate
+
+Use content-slide ONLY when:
+- You've genuinely tried all other layouts and they don't fit
+- The information is inherently linear and textual (rare)
+- You need a "breather" slide between two complex visuals
+- You're at your layout distribution limits (already used all the visual ones recently)
+
+**Never use content-slide as your default thinking.**
+
+#### Quick Reference: Content Type → Best Layout
+
+| Content Type | Best Layout | Why |
+|--------------|-------------|-----|
+| 3-5 equal features/steps | multi-card-slide | Cards create visual hierarchy |
+| Exactly 3 featured items | floating-cards-slide | Elevated cards add depth |
+| 2-4 metrics/KPIs | stats-slide | Big numbers grab attention |
+| Before/after comparison | two-column-slide | Side-by-side shows contrast |
+| Hub concept with types | circular-hero-slide | Radiating pattern shows relationships |
+| Dramatic emphasis (1-3 words) | giant-focus-slide | Scale creates impact |
+| High-energy warning | bold-diagonal-slide | Dynamic shapes convey urgency |
+| Powerful quote/principle | quote-slide | Attribution adds authority |
+| List of related items | multi-card-slide | Better than bullets |
+| Process with steps | floating-cards-slide | Visual flow beats text |
+| Technical comparison | two-column-slide | Structured comparison |
+
+**Only use content-slide when:**
+- None of the above fit
+- Information is truly linear
+- Need a text-heavy breather between visual slides
+- Already hit variety limits
+
+### Step 3: Slide Planning (ALWAYS DO THIS)
+
+**Before generating ANY slides, create a written plan.**
+
+This applies to single slides, batches, and full presentations. Planning prevents:
+- Duplicate content across slides
+- Wrong layout choices
+- Missing key information
+- Poor flow and structure
+
+**Create a slide plan table:**
+
+```markdown
+| # | Layout | Title | Key Content | Notes |
+|---|--------|-------|-------------|-------|
+| 1 | title-slide | [Title] | [Subtitle, author] | Opening slide |
+| 2 | content-slide | [Title] | [3-4 bullet points] | Main concepts |
+| 3 | stats-slide | [Title] | [2-3 metrics] | Impact data |
+| ... | ... | ... | ... | ... |
+```
+
+**For each slide, specify:**
+- **Slide number** - Position in presentation
+- **Layout** - Which cookbook layout to use
+- **Title** - Exact title text (check for duplicates!)
+- **Key content** - Bullet points, stats, quotes, etc.
+- **Notes** - Any special considerations
+
+**Planning checklist:**
+- [ ] No duplicate titles across slides
+- [ ] Logical flow from slide to slide
+- [ ] Appropriate layout for each content type
+- [ ] Content fits the chosen layout
+- [ ] Batches are logically grouped (5 slides max each)
+- [ ] **VARIETY CHECK: Content-slide used <25% of total slides**
+- [ ] **VARIETY CHECK: No more than 2-3 consecutive slides with same layout**
+- [ ] **VARIETY CHECK: Visual layouts (cards, stats, columns, hero) are 50%+ of slides**
+- [ ] **VARIETY CHECK: Each content-slide was evaluated against decision tree first**
+
+**After planning, briefly present the plan before generating.**
+
+**Example of good variety distribution for 30-slide presentation:**
+- Content-slide: 6-7 slides (20-23%)
+- Section breaks: 5 slides (17%)
+- Visual layouts: 15-16 slides (50-53%)
+  - Multi-card: 3-4 slides
+  - Two-column: 2-3 slides
+  - Stats: 1-2 slides
+  - Floating-cards: 2-3 slides
+  - Circular-hero: 1-2 slides
+  - Giant-focus/Bold-diagonal: 2-3 slides
+  - Quote: 1 slide
+- Title/Closing: 2-3 slides (7-10%)
+
+### Step 4: Content Adaptation
+
+**For each slide in your plan:**
+
+#### Presentation Text Formatting Rules
+
+**IMPORTANT: Follow these rules for ALL slide text.**
+
+| Element | Rule | Example |
+|---------|------|---------|
+| Titles | No trailing periods or commas | "Why AI Matters" not "Why AI Matters." |
+| Subtitles | No trailing punctuation | "The future of coding" not "The future of coding." |
+| Bullet points | No trailing periods (unless full sentences) | "Faster development" not "Faster development." |
+| Headlines | Minimal punctuation, no ellipsis | "What's Next" not "What's Next..." |
+| Stats/Numbers | Clean format, no trailing punctuation | "50%" not "50%." |
+| CTAs | No trailing punctuation | "Get Started" not "Get Started." |
+| Labels | Short, no punctuation | "Step 1" not "Step 1:" |
+
+**Avoid:**
+- Trailing periods on titles, bullets, labels
+- Ellipsis (...) in headlines
+- Excessive commas in short phrases
+- Colons at end of labels/headers
+- Semicolons in bullet points
+
+**Exception:** Full sentence descriptions or quotes may use appropriate punctuation.
+
+#### Brand Value Mapping
+
+1. **Map brand.json values to layout placeholders:**
+
+   | Layout Placeholder | brand.json Path |
+   |--------------------|-----------------|
+   | `BRAND_BG` | `colors.background` |
+   | `BRAND_BG_ALT` | `colors.background_alt` |
+   | `BRAND_TEXT` | `colors.text` |
+   | `BRAND_TEXT_SECONDARY` | `colors.text_secondary` |
+   | `BRAND_ACCENT` | `colors.accent` |
+   | `BRAND_ACCENT_SECONDARY` | `colors.accent_secondary` |
+   | `BRAND_ACCENT_TERTIARY` | `colors.accent_tertiary` |
+   | `BRAND_CODE_BG` | `colors.code_bg` |
+   | `BRAND_CARD_BG` | `colors.card_bg` |
+   | `BRAND_CARD_BG_ALT` | `colors.card_bg_alt` |
+   | `BRAND_HEADING_FONT` | `fonts.heading` |
+   | `BRAND_BODY_FONT` | `fonts.body` |
+   | `BRAND_CODE_FONT` | `fonts.code` |
+
+   **Note:** All color values in brand.json are hex WITHOUT the `#` prefix.
+
+2. **Write content in brand's voice** (from tone-of-voice.md)
+3. **Preserve layout structure** (decorative elements, spacing, hierarchy)
+
+### Step 5: Batch Generation (CRITICAL)
+
+**MAXIMUM 5 SLIDES PER BATCH. This is a hard limit.**
+
+When generating multiple slides:
+1. Generate 1-5 slides in a single PPTX file
+2. **STOP and review the output** before generating more
+3. Only after validation passes, continue with the next batch
+4. Repeat until all slides are generated
+
+**Why batching matters:**
+- Prevents token limit errors
+- Allows quality checks between batches
+- Catches issues early before they propagate
+
+**⚠️ CRITICAL BACKGROUND BUG FIX:**
+
+**EVERY slide MUST have its background explicitly set.** If you don't set `slide.background.fill.solid()` and `slide.background.fill.fore_color.rgb`, the slide will use PowerPoint's default WHITE background, making text unreadable on dark-themed brands.
+
+**Mandatory for every slide:**
+```python
+slide = prs.slides.add_slide(prs.slide_layouts[6])
+slide.background.fill.solid()  # ← REQUIRED
+slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)  # ← REQUIRED
+```
+
+This is especially critical when:
+- Generating multiple batches (each batch is a new Presentation object)
+- Using helper functions to create slides
+- Combining separate PPTX files
+
+**Execution:**
+
+**PREFERRED: Use heredoc (no files created):**
+```bash
+uv run --with python-pptx==1.0.2 python << 'EOF'
+# [Adapted code with brand values and content]
+EOF
+```
+
+**IF heredoc fails (Windows issues): Use temp directory:**
+```bash
+# Create temp directory if needed
+mkdir -p .claude/skills/pptx-generator/.tmp
+
+# Write script to temp directory
+# (create file at .claude/skills/pptx-generator/.tmp/gen.py)
+
+# Execute
+uv run --with python-pptx==1.0.2 python .claude/skills/pptx-generator/.tmp/gen.py
+
+# MANDATORY: Clean up immediately after execution
+rm .claude/skills/pptx-generator/.tmp/gen.py
+```
+
+**CRITICAL: Never create Python files in the repository root.** Always use heredoc or temp directory within the skill folder.
+
+### Step 6: Quality Validation (MANDATORY)
+
+**After EVERY batch, validate before continuing:**
+
+1. **Open the generated PPTX** and visually inspect it
+2. **Check for these common issues:**
+
+| Issue | What to Look For | Fix |
+|-------|------------------|-----|
+| White background | Slide has white background instead of brand color | Add slide.background.fill.solid() and set fore_color.rgb |
+| Duplicate titles | Same title text appearing twice on a slide | Remove duplicate text boxes |
+| Spacing problems | Title too close to subtitle/content | Increase Y position of lower elements |
+| Text overflow | Content extending beyond slide bounds | Reduce font size or split content |
+| Missing elements | Decorative elements not rendering | Check shape positions and colors |
+| Wrong colors | Colors not matching brand | Verify hex values (no # prefix in code) |
+| Bad punctuation | Trailing periods/commas on titles/bullets | Remove unnecessary punctuation |
+
+3. **If issues found:**
+   - Fix the current batch before continuing
+   - Note the issue to avoid repeating in future batches
+
+4. **If validation passes:**
+   - Continue to next batch of slides
+
+### Step 7: Output
+
+**Use the output settings from config.json:**
+
+| Config Setting | Default | Description |
+|----------------|---------|-------------|
+| `output.directory` | `output/{brand}` | Where to save files |
+| `output.naming` | `{name}-{date}` | File naming pattern |
+| `output.keep_parts` | `false` | Keep part files after combining |
+
+**Resolve placeholders:**
+- `{brand}` → Brand folder name
+- `{name}` → Presentation name from user request
+- `{date}` → Current date (YYYY-MM-DD)
+
+```bash
+# Create output directory from config
+mkdir -p {resolved-output-directory}
+```
+
+**Batched generation workflow:**
+1. Generate each batch as `{name}-part1.pptx`, `{name}-part2.pptx`, etc.
+2. Validate each batch before continuing
+3. After ALL batches complete, **combine into final file** (if `auto_combine` is true)
+4. Delete part files (if `keep_parts` is false)
+
+### Step 8: Combine Batches (for multi-batch presentations)
+
+**🚨 CRITICAL BUG WARNING: BACKGROUND MUST BE SET WHEN COMBINING 🚨**
+
+When combining presentations, `add_slide()` creates slides with **DEFAULT WHITE BACKGROUNDS**. Shape copying does NOT copy the slide background property. You MUST explicitly set the background immediately after creating each new slide.
+
+**This is the most common source of white slides in combined presentations.**
+
+After all batches are validated, combine them into a single PPTX:
+
+```bash
+uv run --with python-pptx==1.0.2 python << 'SCRIPT'
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pathlib import Path
+import shutil
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+# Brand background color (get from brand.json)
+BRAND_BG = "REPLACE_WITH_BRAND_BACKGROUND"  # e.g., "07090F"
+
+# List all part files in order
+output_dir = Path("output/{brand-name}")
+part_files = sorted(output_dir.glob("{name}-part*.pptx"))
+
+if len(part_files) > 1:
+    # Start with first part as base
+    combined = Presentation(part_files[0])
+
+    # Add slides from remaining parts
+    for part_file in part_files[1:]:
+        part_prs = Presentation(part_file)
+        for slide in part_prs.slides:
+            # Copy slide layout and add to combined
+            blank_layout = combined.slide_layouts[6]
+            new_slide = combined.slides.add_slide(blank_layout)
+
+            # 🚨 CRITICAL: Set background IMMEDIATELY after creating slide
+            # PowerPoint defaults to WHITE background - this MUST be set before copying shapes
+            new_slide.background.fill.solid()
+            new_slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+            # Copy all shapes from source slide
+            for shape in slide.shapes:
+                # Clone shape to new slide
+                el = shape.element
+                new_slide.shapes._spTree.insert_element_before(
+                    el, 'p:extLst'
+                )
+
+    # Save combined file
+    combined.save(output_dir / "{name}-final.pptx")
+    print(f"Combined {len(part_files)} parts into {name}-final.pptx")
+
+    # MANDATORY: Clean up part files - user should only see final file
+    for part_file in part_files:
+        part_file.unlink()
+        print(f"Deleted {part_file.name}")
+else:
+    # Single part, just rename
+    shutil.move(part_files[0], output_dir / "{name}-final.pptx")
+SCRIPT
+```
+
+**Final output:** `output/{brand-name}/{name}-final.pptx`
+
+**Why this bug happens:**
+- `combined.slides.add_slide()` creates a NEW slide object with PowerPoint's default white background
+- `shapes._spTree.insert_element_before()` copies shapes (text, rectangles, images) but NOT the background
+- The background is a slide property, not a shape, so it must be set separately
+- Without explicit background setting, slides 6-30 (or however many are added after the base) will be white
+
+**Testing checklist after combining:**
+- [ ] Open the combined PPTX
+- [ ] Scroll through ALL slides (not just the first few)
+- [ ] Verify EVERY slide has the correct background color
+- [ ] If any white slides found, the combination code is missing the background setting
+
+---
+
+## Mode 2: Generate LinkedIn Carousels
+
+LinkedIn carousels are multi-page PDFs in square (1:1) format. Each page is a swipeable slide.
+
+### Carousel vs Presentation
+
+| Aspect | Presentation | Carousel |
+|--------|--------------|----------|
+| Dimensions | 16:9 (13.333" × 7.5") | 1:1 (7.5" × 7.5") |
+| Layouts | `cookbook/*.py` | `cookbook/carousels/*.py` |
+| Output | PPTX | PDF (via PPTX conversion) |
+| Slides | 10-50+ typical | 5-10 optimal |
+| Text size | Standard | Larger (mobile readable) |
+| Content | Detailed | One idea per slide |
+
+### Step 1: Brand Discovery
+
+Same as Mode 1 - read brand.json, config.json, and tone-of-voice.md.
+
+### Step 2: Carousel Layout Discovery
+
+**Discover carousel-specific layouts:**
+```
+Glob: .claude/skills/pptx-generator/cookbook/carousels/*.py
+```
+
+**Available carousel layouts:**
+
+| Layout | Purpose | Best For |
+|--------|---------|----------|
+| `hook-slide` | Opening attention-grabber | First slide only |
+| `single-point-slide` | One key point with explanation | Body content |
+| `numbered-point-slide` | Numbered list item with big number | Listicles, steps |
+| `quote-slide` | Quote with attribution | Social proof, insights |
+| `cta-slide` | Call to action | Last slide only |
+
+Read frontmatters to understand limits and constraints for each.
+
+### Step 3: Carousel Planning
+
+**Typical carousel structure (5-10 slides):**
+
+```markdown
+| # | Layout | Content |
+|---|--------|---------|
+| 1 | hook-slide | Attention-grabbing hook |
+| 2-8 | single-point or numbered-point | Body content |
+| 9/10 | cta-slide | Call to action |
+```
+
+**Carousel content rules:**
+- **One idea per slide** - Don't cram multiple points
+- **Large text** - Must be readable on mobile
+- **Short copy** - Max 50 chars for headlines, 150 for body
+- **Clear flow** - Each slide should make sense if viewed alone
+- **Strong hook** - First slide stops the scroll
+- **Clear CTA** - Last slide tells them what to do
+
+### Step 4: Generate Carousel
+
+**Carousel dimensions (square 1:1):**
+```python
+prs.slide_width = Inches(7.5)
+prs.slide_height = Inches(7.5)
+```
+
+Generate all slides as a single PPTX file (carousels are typically 5-10 slides, so batching rarely needed).
+
+**Execution:**
+```bash
+uv run --with python-pptx==1.0.2 python << 'SCRIPT'
+# Carousel generation code with 7.5" x 7.5" dimensions
+SCRIPT
+```
+
+### Step 5: Export to PDF
+
+LinkedIn requires PDF for carousel posts. Convert the PPTX to PDF:
+
+**Option A: Using LibreOffice (recommended)**
+```bash
+libreoffice --headless --convert-to pdf --outdir output/rasmus output/rasmus/carousel.pptx
+```
+
+**Option B: Using soffice**
+```bash
+soffice --headless --convert-to pdf output/rasmus/carousel.pptx
+```
+
+**Note:** LibreOffice must be installed. On macOS: `brew install --cask libreoffice`
+
+### Step 6: Output
+
+Save both files:
+- `output/{brand}/{name}-carousel.pptx` - Editable source
+- `output/{brand}/{name}-carousel.pdf` - LinkedIn-ready
+
+### Carousel Checklist
+
+- [ ] Read brand configuration
+- [ ] Read carousel layout frontmatters from `cookbook/carousels/`
+- [ ] Plan carousel structure (hook → body → CTA)
+- [ ] Keep text SHORT (check character limits in frontmatter)
+- [ ] Use 7.5" × 7.5" dimensions
+- [ ] Generate PPTX
+- [ ] Validate output
+- [ ] Export to PDF
+- [ ] Test PDF in LinkedIn preview
+
+---
+
+## Mode 3: Layout CRUD Operations
+
+### Creating New Layouts
+
+When user requests a new layout type:
+
+1. **Study existing layouts for patterns:**
+   ```
+   Glob: .claude/skills/pptx-generator/cookbook/*.py
+   ```
+   Read 2-3 layouts to understand:
+   - Code structure and imports
+   - How brand variables are used
+   - Decorative element patterns
+   - Positioning conventions
+
+2. **Design with these quality standards:**
+
+   **MUST be production-ready:**
+   - Professional, polished appearance
+   - Visually engaging (not plain or generic)
+   - Distinctive decorative elements
+   - Strong visual hierarchy
+   - Proper use of whitespace
+
+   **Use appropriate elements:**
+   - **Charts** - Pie, doughnut, bar, column for data visualization
+   - **Images** - Placeholder shapes for screenshots, photos
+   - **Shapes** - Circles, rectangles, parallelograms for visual interest
+   - **Cards** - Floating cards with shadows for depth
+   - **Geometric patterns** - Bold shapes anchored to corners/edges
+
+   **Avoid:**
+   - Plain text-only layouts
+   - Generic bullet points without styling
+   - Tiny decorative elements that don't make impact
+   - Centered-everything boring compositions
+
+3. **Write the layout file with detailed frontmatter:**
+
+   **⚠️ CRITICAL: The frontmatter is documentation for future AI agents.**
+
+   Every layout MUST include comprehensive frontmatter that teaches future AI agents:
+   - WHEN to use this layout (and when NOT to)
+   - HOW to use it correctly
+   - WHAT limits and constraints exist
+   - WHY certain choices matter
+
+   ```python
+   #!/usr/bin/env -S uv run
+   # /// script
+   # requires-python = ">=3.11"
+   # dependencies = [
+   #     "python-pptx==1.0.2",
+   # ]
+   # ///
+   # /// layout
+   # name = "layout-name"
+   # purpose = "When to use this layout - be specific"
+   # best_for = [
+   #     "Ideal use case 1",
+   #     "Ideal use case 2",
+   # ]
+   # avoid_when = [
+   #     "Situation to avoid 1 - and what to use instead",
+   #     "Situation to avoid 2 - and what to use instead",
+   # ]
+   # max_items = 5  # or other relevant limits
+   # instructions = [
+   #     "Specific tip 1",
+   #     "Specific tip 2",
+   # ]
+   # ///
+   """
+   LAYOUT: [Name]
+   PURPOSE: [When to use this layout - be specific]
+
+   CUSTOMIZE:
+   - [List customizable elements]
+   """
+
+   # ... implementation
+   ```
+
+   **Required frontmatter fields (be DETAILED and SPECIFIC):**
+
+   | Field | Description | Example |
+   |-------|-------------|---------|
+   | `name` | Layout identifier (matches filename) | `"multi-card-slide"` |
+   | `purpose` | Clear one-line description | `"Multiple items as cards in a row, 3-5 cards"` |
+   | `best_for` | **Detailed** array of ideal scenarios | `["Exactly 3 related features", "Process with 3 steps"]` |
+   | `avoid_when` | **Specific** situations with alternatives | `["More than 3 items - use multi-card-slide instead"]` |
+   | `instructions` | **Actionable** tips for correct usage | `["Card titles must be SHORT: 1-2 words, max 15 chars"]` |
+
+   **Optional but recommended fields:**
+   | Field | Description | Example |
+   |-------|-------------|---------|
+   | `max_*` / `min_*` | Hard limits on items | `max_cards = 3`, `min_surrounding_items = 4` |
+   | `*_max_chars` | Character limits for text | `card_title_max_chars = 15` |
+
+   **Writing good frontmatter:**
+
+   ✅ **DO:** Be specific and actionable
+   ```python
+   # avoid_when = [
+   #     "More than 3 items - use multi-card-slide instead",
+   #     "Long card titles (over 15 characters) - abbreviate or use content-slide",
+   # ]
+   # instructions = [
+   #     "EXACTLY 3 cards required - no more, no less",
+   #     "Card titles must be SHORT: 1-2 words, max 15 characters",
+   #     "If titles are too long, abbreviate or use different layout",
+   # ]
+   ```
+
+   ❌ **DON'T:** Be vague or unhelpful
+   ```python
+   # avoid_when = ["Too many items", "Wrong content"]
+   # instructions = ["Use correctly", "Follow the pattern"]
+   ```
+
+   **Think of frontmatter as teaching a colleague** - what would they need to know to use this layout correctly without asking you questions?
+
+4. **Save to cookbook:**
+   ```
+   .claude/skills/pptx-generator/cookbook/{layout-name}-slide.py
+   ```
+
+5. **Test by generating** a sample with the new layout
+
+### Editing Existing Layouts
+
+1. **Find the layout:**
+   ```
+   Glob: .claude/skills/pptx-generator/cookbook/*{name}*.py
+   ```
+
+2. **Read and understand current structure** including the frontmatter
+
+3. **Make modifications** while preserving:
+   - The script header format
+   - Brand variable naming conventions
+   - Docstring format (LAYOUT, PURPOSE, CUSTOMIZE)
+
+4. **Update the frontmatter** if your changes affect:
+   - What the layout is best for (`best_for`)
+   - When to avoid it (`avoid_when`)
+   - Item limits (`max_*`, `min_*`)
+   - Usage instructions (`instructions`)
+
+5. **Save back to the same file**
+
+6. **Test the modified layout**
+
+### Updating/Improving Layouts
+
+When asked to improve layout quality:
+
+1. **Analyze current weaknesses:**
+   - Is it visually engaging?
+   - Does it have enough decorative elements?
+   - Is there good visual hierarchy?
+   - Does it use space well?
+
+2. **Apply improvements:**
+   - Add bold geometric shapes
+   - Improve color usage
+   - Add depth (shadows, overlapping)
+   - Better typography sizing
+   - More distinctive decorative elements
+
+3. **Preserve functionality** - Don't break what works
+
+4. **Review and enhance frontmatter:**
+   - Are `best_for` and `avoid_when` still accurate?
+   - Do `instructions` reflect any new constraints?
+   - Add any lessons learned from the improvements
+   - Update limits if element sizes/counts changed
+
+### Deleting Layouts
+
+Simply remove the file:
+```bash
+rm .claude/skills/pptx-generator/cookbook/{layout-name}.py
+```
+
+---
+
+## Editing Existing PPTX Files
+
+When user provides an existing PPTX:
+
+1. **Read the file:**
+   ```python
+   from pptx import Presentation
+   prs = Presentation("path/to/existing.pptx")
+   ```
+
+2. **Analyze:** Number of slides, styling, content structure
+
+3. **Apply changes:** Add/remove slides, update content, modify styling
+
+4. **Save to output directory** (don't overwrite original unless requested)
+
+---
+
+## Technical Reference
+
+**Slide dimensions (16:9):**
+- Width: 13.333 inches
+- Height: 7.5 inches
+- Safe margins: 0.5 inches
+
+**Always use:**
+- Blank layout: `prs.slide_layouts[6]`
+- python-pptx version: 1.0.2
+
+**Common imports:**
+```python
+from pptx import Presentation
+from pptx.chart.data import CategoryChartData
+from pptx.dml.color import RGBColor
+from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+```
+
+**Chart types available:**
+- `XL_CHART_TYPE.PIE` - Pie chart
+- `XL_CHART_TYPE.DOUGHNUT` - Doughnut chart
+- `XL_CHART_TYPE.BAR_CLUSTERED` - Horizontal bars
+- `XL_CHART_TYPE.COLUMN_CLUSTERED` - Vertical columns
+- `XL_CHART_TYPE.LINE` - Line chart
+
+**Adding charts:**
+```python
+chart_data = CategoryChartData()
+chart_data.categories = ["A", "B", "C"]
+chart_data.add_series("Values", [10, 20, 30])
+
+slide.shapes.add_chart(
+    XL_CHART_TYPE.DOUGHNUT,
+    Inches(x), Inches(y),
+    Inches(width), Inches(height),
+    chart_data
+)
+```
+
+**Adding images:**
+```python
+slide.shapes.add_picture(
+    "path/to/image.png",
+    Inches(x), Inches(y),
+    width=Inches(w)  # Height auto-calculated
+)
+```
+
+---
+
+## Preview All Layouts
+
+To see all available layouts:
+```bash
+uv run .claude/skills/pptx-generator/generate-cookbook-preview.py
+```
+
+This generates `cookbook-preview.pptx` with every layout.
+
+---
+
+## Checklist
+
+**For Slide Generation:**
+- [ ] Read brand.json for colors/fonts
+- [ ] Read config.json for output directory and settings
+- [ ] Read markdown files for voice/tone
+- [ ] **Read ALL cookbook layout frontmatters** (first 40 lines of each .py):
+  - [ ] Glob all `.claude/skills/pptx-generator/cookbook/*.py`
+  - [ ] Read every file to extract `# /// layout` blocks
+  - [ ] Build understanding of all `best_for`, `avoid_when`, limits
+- [ ] **Then select layouts** based on complete knowledge:
+  - [ ] Match content to `best_for` criteria
+  - [ ] Respect `avoid_when` warnings
+  - [ ] Check `max_*` / `min_*` limits
+  - [ ] Follow `instructions` for chosen layouts
+- [ ] **Create slide plan table BEFORE generating:**
+  - [ ] List all slides with layout, title, content
+  - [ ] Check for duplicate titles
+  - [ ] Verify logical flow
+  - [ ] Group into batches (max 5 per batch)
+  - [ ] **VARIETY CHECK: Content-slide <25% of total**
+  - [ ] **VARIETY CHECK: No 3+ consecutive same-layout slides**
+  - [ ] **VARIETY CHECK: Visual layouts 50%+ of presentation**
+  - [ ] **VARIETY CHECK: Used decision tree to evaluate each content-slide**
+- [ ] Present plan briefly before proceeding
+- [ ] Apply brand colors and fonts
+- [ ] Write content in brand's voice
+- [ ] **Generate MAX 5 slides per batch** (or `slides_per_batch` from config)
+- [ ] Execute via UV REPL
+- [ ] **Validate output before continuing:**
+  - [ ] No duplicate titles
+  - [ ] Proper spacing between elements
+  - [ ] Content fits within bounds
+  - [ ] Colors match brand
+  - [ ] No trailing punctuation on titles/bullets
+- [ ] Save batch to output directory from config
+- [ ] Repeat for next batch if needed
+- [ ] **Combine all batches into final PPTX** (if `auto_combine` is true)
+- [ ] Clean up part files (if `keep_parts` is false)
+
+**For Creating Layouts:**
+- [ ] Study existing layouts for patterns
+- [ ] Design with production-ready quality
+- [ ] Include distinctive decorative elements
+- [ ] Use charts/images/shapes appropriately
+- [ ] **Add TOML-style frontmatter** with:
+  - [ ] `name`, `purpose`
+  - [ ] `best_for`, `avoid_when` arrays
+  - [ ] `instructions` array with usage tips
+  - [ ] `max_*` / `min_*` limits as needed
+- [ ] Write proper docstring (LAYOUT, PURPOSE, CUSTOMIZE)
+- [ ] Test the new layout

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/README.md
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/README.md
@@ -1,0 +1,100 @@
+# Brand Template
+
+Use this template to add a new brand to the PPTX generator skill.
+
+## Setup Instructions
+
+1. **Copy this folder** to a new folder with your brand name:
+   ```
+   cp -r template/ your-brand-name/
+   ```
+
+2. **Edit `brand.json`** with your brand's values:
+   - All color values should be hex codes WITHOUT the `#` prefix (e.g., `"1e1e2e"`)
+   - Font names should match fonts installed on the system
+   - Asset paths are relative to the brand folder
+
+3. **Edit `brand-system.md`** with your brand guidelines:
+   - This file provides context to the AI when generating content
+   - Include color rationale, typography rules, and visual principles
+
+4. **Edit `tone-of-voice.md`** with writing guidelines:
+   - This file guides the AI in writing slide content
+   - Include voice attributes, example phrases, and dos/don'ts
+
+5. **Add assets** to the `assets/` folder:
+   - `logo.png` - Primary logo
+   - `logo-dark.png` - Logo variant for dark backgrounds (optional)
+   - `icon.png` - Square icon (optional)
+
+6. **Edit `config.json`** with output and generation settings:
+   - Output directory (where PPTX files are saved)
+   - Batch generation settings
+   - File naming conventions
+
+## config.json Reference
+
+```json
+{
+  "output": {
+    "directory": "output/{brand}",  // Where to save files ({brand} = brand name)
+    "naming": "{name}-{date}",      // File naming pattern
+    "keep_parts": false             // Keep part files after combining?
+  },
+  "generation": {
+    "slides_per_batch": 5,          // Slides per batch (max 5)
+    "auto_combine": true,           // Auto-combine batches into final?
+    "open_after_generate": false    // Open file after generation?
+  },
+  "defaults": {
+    "slide_width_inches": 13.333,   // 16:9 aspect ratio
+    "slide_height_inches": 7.5
+  }
+}
+```
+
+**Placeholders for `directory` and `naming`:**
+- `{brand}` - Brand folder name
+- `{name}` - Presentation name (from user request)
+- `{date}` - Current date (YYYY-MM-DD)
+- `{timestamp}` - Unix timestamp
+
+## brand.json Reference
+
+```json
+{
+  "name": "Brand Name",
+  "description": "One-line brand description",
+
+  "colors": {
+    "background": "1e1e2e",      // Main slide background
+    "background_alt": "181825",  // Darker variant for contrast
+    "text": "cdd6f4",            // Primary text color
+    "text_secondary": "bac2de",  // Muted/secondary text
+    "accent": "fab387",          // Primary accent (CTAs, highlights)
+    "accent_secondary": "89b4fa", // Secondary accent (variety)
+    "accent_tertiary": "a6e3a1", // Third accent (optional)
+    "code_bg": "11111b",         // Code block background
+    "card_bg": "313244",         // Card/surface background
+    "card_bg_alt": "45475a"      // Alternate card background
+  },
+
+  "fonts": {
+    "heading": "JetBrains Mono", // Headlines, titles, buttons
+    "body": "Inter",             // Body text, descriptions
+    "code": "JetBrains Mono"     // Code blocks, terminal
+  },
+
+  "assets": {
+    "logo": "assets/logo.png",   // Path to primary logo
+    "logo_dark": null,           // Path to dark variant (or null)
+    "icon": null                 // Path to icon (or null)
+  }
+}
+```
+
+## Notes
+
+- Color hex codes should NOT include the `#` prefix
+- The AI reads both `brand.json` (for exact values) and the markdown files (for context)
+- Keep markdown files updated if you change values in `brand.json`

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/assets/.gitkeep
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/assets/.gitkeep
@@ -1,0 +1,5 @@
+# Place brand assets here:
+# - logo.png (primary logo)
+# - logo-dark.png (logo for dark backgrounds, if different)
+# - icon.png (square icon/favicon)
+# - Any other brand imagery

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/brand-system.md
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/brand-system.md
@@ -1,0 +1,70 @@
+# [Brand Name] — Brand System
+
+> REPLACE with a one-line brand description.
+
+---
+
+## Brand Philosophy
+
+### Core Principles
+
+1. **Principle One**
+   REPLACE with description.
+
+2. **Principle Two**
+   REPLACE with description.
+
+3. **Principle Three**
+   REPLACE with description.
+
+---
+
+## Color System
+
+### Primary Accent
+
+| Name | Hex | Use |
+|------|-----|-----|
+| Accent | `#REPLACE` | Primary buttons, links, highlights |
+| Accent Dark | `#REPLACE` | Hover states, outlines |
+| Accent Light | `#REPLACE` | Secondary accents |
+
+### Theme Base
+
+```
+Background:     #REPLACE
+Background Alt: #REPLACE
+Surface:        #REPLACE
+Text Primary:   #REPLACE
+Text Secondary: #REPLACE
+```
+
+---
+
+## Typography
+
+### Font Stack
+
+- **Heading:** REPLACE (headlines, titles, buttons)
+- **Body:** REPLACE (paragraphs, descriptions)
+- **Code:** REPLACE (code blocks, terminal)
+
+### Usage Guidelines
+
+| Element | Font | Weight | Size |
+|---------|------|--------|------|
+| Display | Heading | 700 | 36px+ |
+| H1 | Heading | 700 | 30px |
+| H2 | Heading | 600 | 24px |
+| Body | Body | 400 | 16-18px |
+| Code | Code | 400 | 14px |
+
+---
+
+## Signature Elements
+
+REPLACE: Describe any unique visual patterns, decorative elements, or signature design choices for this brand.
+
+---
+
+*Last updated: REPLACE*

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/brand.json
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/brand.json
@@ -1,0 +1,29 @@
+{
+  "name": "REPLACE",
+  "description": "REPLACE with a one-line description of the brand",
+
+  "colors": {
+    "background": "REPLACE",
+    "background_alt": "REPLACE",
+    "text": "REPLACE",
+    "text_secondary": "REPLACE",
+    "accent": "REPLACE",
+    "accent_secondary": "REPLACE",
+    "accent_tertiary": "REPLACE",
+    "code_bg": "REPLACE",
+    "card_bg": "REPLACE",
+    "card_bg_alt": "REPLACE"
+  },
+
+  "fonts": {
+    "heading": "REPLACE",
+    "body": "REPLACE",
+    "code": "REPLACE"
+  },
+
+  "assets": {
+    "logo": null,
+    "logo_dark": null,
+    "icon": null
+  }
+}

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/config.json
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/config.json
@@ -1,0 +1,16 @@
+{
+  "output": {
+    "directory": "output/{brand}",
+    "naming": "{name}-{date}",
+    "keep_parts": false
+  },
+  "generation": {
+    "slides_per_batch": 5,
+    "auto_combine": true,
+    "open_after_generate": false
+  },
+  "defaults": {
+    "slide_width_inches": 13.333,
+    "slide_height_inches": 7.5
+  }
+}

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/tone-of-voice.md
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/brands/template/tone-of-voice.md
@@ -1,0 +1,49 @@
+# [Brand Name] — Tone of Voice
+
+## Voice Character
+
+REPLACE: Describe the brand's personality in 2-3 sentences. How should it "sound" when speaking?
+
+## Core Attributes
+
+### 1. REPLACE Attribute
+REPLACE with description of how this attribute manifests in writing.
+
+### 2. REPLACE Attribute
+REPLACE with description.
+
+### 3. REPLACE Attribute
+REPLACE with description.
+
+---
+
+## Writing Guidelines
+
+### Do
+- REPLACE with positive writing guideline
+- REPLACE
+- REPLACE
+
+### Don't
+- REPLACE with what to avoid
+- REPLACE
+- REPLACE
+
+---
+
+## Example Phrases
+
+### Headlines
+- "REPLACE with example headline"
+- "REPLACE"
+
+### CTAs
+- "REPLACE with example CTA"
+- "REPLACE"
+
+### Descriptions
+- "REPLACE with example description style"
+
+---
+
+*Last updated: REPLACE*

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/bold-diagonal-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/bold-diagonal-slide.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "bold-diagonal-slide"
+# purpose = "High-energy statements, disruption themes, modern/dynamic feel"
+# best_for = [
+#     "Bold proclamations",
+#     "Disruption or change themes",
+#     "High-energy moments",
+#     "Startup/innovation vibes",
+# ]
+# avoid_when = [
+#     "Content needs structure or bullets",
+#     "Conservative/formal audience",
+#     "Already used multiple dynamic layouts",
+# ]
+# instructions = [
+#     "Headline should be punchy: 2-5 words maximum",
+#     "Subtext provides context but keep it brief",
+#     "Diagonal shapes create energy - use sparingly in presentation",
+#     "Text is right-aligned to balance the left diagonal shapes",
+# ]
+# ///
+"""
+LAYOUT: Bold Diagonal
+PURPOSE: High-energy statements, disruption themes, modern/dynamic feel
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HEADLINE: Bold statement (2-5 words)
+- SUBTEXT: Supporting context
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color (for primary diagonal)
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent (for layered diagonal)
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    HEADLINE = "REPLACE"              # bold statement (2-5 words)
+    SUBTEXT = "REPLACE"               # supporting context
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large diagonal accent block (using parallelogram)
+    # Create diagonal effect with rotated freeform or multiple shapes
+    # Since python-pptx doesn't support rotation easily, we fake it with overlapping shapes
+
+    # Main diagonal block (bottom-left to top-right feel)
+    # We'll create a series of rectangles to simulate diagonal
+    diagonal_colors = [BRAND_ACCENT, BRAND_ACCENT_SECONDARY]
+
+    # Large accent rectangle anchored to bottom-left, extending up
+    block1 = slide.shapes.add_shape(
+        MSO_SHAPE.PARALLELOGRAM,
+        Inches(-1), Inches(3),
+        Inches(8), Inches(5)
+    )
+    block1.fill.solid()
+    block1.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    block1.line.fill.background()
+
+    # Second parallelogram for layered effect
+    block2 = slide.shapes.add_shape(
+        MSO_SHAPE.PARALLELOGRAM,
+        Inches(-2), Inches(4.5),
+        Inches(7), Inches(4)
+    )
+    block2.fill.solid()
+    block2.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    block2.line.fill.background()
+
+    # Headline - positioned in the clear area (right side)
+    headline_box = slide.shapes.add_textbox(
+        Inches(5.5), Inches(2.0),
+        Inches(7.3), Inches(2.0)
+    )
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = HEADLINE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(64)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.RIGHT
+
+    # Subtext
+    subtext_box = slide.shapes.add_textbox(
+        Inches(5.5), Inches(4.2),
+        Inches(7.3), Inches(1.0)
+    )
+    p = subtext_box.text_frame.paragraphs[0]
+    p.text = SUBTEXT
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(24)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.alignment = PP_ALIGN.RIGHT
+
+    # Small accent detail - top right corner
+    corner = slide.shapes.add_shape(
+        MSO_SHAPE.RIGHT_TRIANGLE,
+        Inches(12.333), Inches(0),
+        Inches(1), Inches(1)
+    )
+    corner.fill.solid()
+    corner.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    corner.line.fill.background()
+
+    # Save
+    output = Path("bold-diagonal-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/cta-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/cta-slide.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "carousel-cta-slide"
+# format = "carousel"
+# dimensions = "square"
+# purpose = "Closing slide with call to action - the conversion slide"
+# best_for = [
+#     "Last slide of any carousel",
+#     "Follow/subscribe prompts",
+#     "Link to resource or content",
+#     "Summary with next step",
+# ]
+# avoid_when = [
+#     "First or middle slides - save CTA for the end",
+#     "Multiple CTAs - pick ONE action",
+#     "No clear action - every carousel needs a CTA",
+# ]
+# headline_max_chars = 30
+# cta_max_chars = 25
+# handle_max_chars = 20
+# instructions = [
+#     "HEADLINE should summarize value or prompt action - max 30 chars",
+#     "CTA_TEXT is the specific action - max 25 chars (e.g., 'Follow for more')",
+#     "HANDLE is your social handle - max 20 chars",
+#     "Keep it simple - one clear action beats multiple options",
+# ]
+# ///
+"""
+LAYOUT: Carousel CTA Slide
+PURPOSE: Closing slide with call to action
+FORMAT: Square (1:1) for LinkedIn carousels
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HEADLINE: Summary or prompt (max 30 chars)
+- CTA_TEXT: The action (max 25 chars)
+- HANDLE: Your social handle (max 20 chars)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS ===
+    BRAND_BG = "1e1e2e"
+    BRAND_BG_ALT = "181825"
+    BRAND_TEXT = "cdd6f4"
+    BRAND_TEXT_SECONDARY = "bac2de"
+    BRAND_ACCENT = "fab387"
+    BRAND_HEADING_FONT = "JetBrains Mono"
+    BRAND_BODY_FONT = "Inter"
+
+    # === CONTENT ===
+    HEADLINE = "REPLACE"  # Max 30 chars
+    CTA_TEXT = "REPLACE"  # Max 25 chars
+    HANDLE = "@RasmusWiding"  # Max 20 chars
+
+    # === SLIDE SETUP (Square 1:1) ===
+    prs = Presentation()
+    prs.slide_width = Inches(7.5)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Top accent bar
+    top_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(7.5), Inches(0.15)
+    )
+    top_bar.fill.solid()
+    top_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top_bar.line.fill.background()
+
+    # Bottom block
+    bottom_block = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(5.0),
+        Inches(7.5), Inches(2.5)
+    )
+    bottom_block.fill.solid()
+    bottom_block.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    bottom_block.line.fill.background()
+
+    # Headline
+    headline_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(2.0),
+        Inches(6.5), Inches(2.0)
+    )
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = HEADLINE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(44)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # CTA text
+    cta_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(5.3),
+        Inches(6.5), Inches(1.0)
+    )
+    tf = cta_box.text_frame
+    p = tf.paragraphs[0]
+    p.text = CTA_TEXT
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(28)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Handle
+    handle_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(6.3),
+        Inches(6.5), Inches(0.8)
+    )
+    tf = handle_box.text_frame
+    p = tf.paragraphs[0]
+    p.text = HANDLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(20)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Save
+    output = Path("carousel-cta-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/hook-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/hook-slide.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "carousel-hook-slide"
+# format = "carousel"
+# dimensions = "square"
+# purpose = "Opening slide to grab attention - the scroll-stopper"
+# best_for = [
+#     "First slide of any carousel",
+#     "Bold provocative statements",
+#     "Questions that create curiosity",
+#     "Controversial or surprising claims",
+# ]
+# avoid_when = [
+#     "Middle of carousel - use single-point-slide instead",
+#     "Long explanatory text - save that for body slides",
+#     "Multiple points - this is ONE hook only",
+# ]
+# hook_max_chars = 50
+# instructions = [
+#     "Hook text should be SHORT and PUNCHY - max 50 characters",
+#     "Use confrontational or curiosity-driven language",
+#     "Subtext is optional - only if it adds value",
+#     "This slide makes people stop scrolling",
+# ]
+# ///
+"""
+LAYOUT: Carousel Hook Slide
+PURPOSE: Opening slide that stops the scroll - bold statement or question
+FORMAT: Square (1:1) for LinkedIn carousels
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HOOK_TEXT: The attention-grabbing statement (max 50 chars)
+- SUBTEXT: Optional supporting line
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS ===
+    BRAND_BG = "1e1e2e"
+    BRAND_TEXT = "cdd6f4"
+    BRAND_TEXT_SECONDARY = "bac2de"
+    BRAND_ACCENT = "fab387"
+    BRAND_HEADING_FONT = "JetBrains Mono"
+    BRAND_BODY_FONT = "Inter"
+
+    # === CONTENT ===
+    HOOK_TEXT = "REPLACE"  # Max 50 chars, punchy
+    SUBTEXT = ""  # Optional
+
+    # === SLIDE SETUP (Square 1:1) ===
+    prs = Presentation()
+    prs.slide_width = Inches(7.5)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Top accent bar
+    top_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(7.5), Inches(0.15)
+    )
+    top_bar.fill.solid()
+    top_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top_bar.line.fill.background()
+
+    # Large hook text - centered vertically
+    hook_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(2.5),
+        Inches(6.5), Inches(2.5)
+    )
+    tf = hook_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = HOOK_TEXT
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(48)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Optional subtext
+    if SUBTEXT:
+        sub_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(5.2),
+            Inches(6.5), Inches(1.0)
+        )
+        tf = sub_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = SUBTEXT
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(24)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Bottom accent line
+    bottom_line = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(2.5), Inches(6.8),
+        Inches(2.5), Inches(0.06)
+    )
+    bottom_line.fill.solid()
+    bottom_line.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    bottom_line.line.fill.background()
+
+    # Save
+    output = Path("carousel-hook-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/numbered-point-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/numbered-point-slide.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "carousel-numbered-point-slide"
+# format = "carousel"
+# dimensions = "square"
+# purpose = "Numbered list item with big number - for listicle carousels"
+# best_for = [
+#     "Listicle content (5 tips, 7 mistakes, etc.)",
+#     "Step-by-step processes",
+#     "Ranked items",
+#     "Sequential content where order matters",
+# ]
+# avoid_when = [
+#     "Standalone points without sequence - use single-point-slide",
+#     "First slide - use hook-slide with the list premise",
+#     "Last slide - use cta-slide",
+# ]
+# point_text_max_chars = 60
+# supporting_max_chars = 100
+# instructions = [
+#     "NUMBER should be the position (1, 2, 3, etc.)",
+#     "POINT_TEXT is the main content - max 60 chars",
+#     "SUPPORTING_TEXT is optional explanation - max 100 chars",
+#     "Keep consistent numbering style across carousel",
+# ]
+# ///
+"""
+LAYOUT: Carousel Numbered Point Slide
+PURPOSE: Single numbered item from a list - big number with point
+FORMAT: Square (1:1) for LinkedIn carousels
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- NUMBER: The list position (1, 2, 3, etc.)
+- POINT_TEXT: The main point (max 60 chars)
+- SUPPORTING_TEXT: Optional explanation (max 100 chars)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS ===
+    BRAND_BG = "1e1e2e"
+    BRAND_BG_ALT = "181825"
+    BRAND_TEXT = "cdd6f4"
+    BRAND_TEXT_SECONDARY = "bac2de"
+    BRAND_ACCENT = "fab387"
+    BRAND_HEADING_FONT = "JetBrains Mono"
+    BRAND_BODY_FONT = "Inter"
+
+    # === CONTENT ===
+    NUMBER = "1"  # Position in list
+    POINT_TEXT = "REPLACE"  # Max 60 chars
+    SUPPORTING_TEXT = ""  # Optional, max 100 chars
+
+    # === SLIDE SETUP (Square 1:1) ===
+    prs = Presentation()
+    prs.slide_width = Inches(7.5)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Number block (left side)
+    num_block = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(2.5), Inches(7.5)
+    )
+    num_block.fill.solid()
+    num_block.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    num_block.line.fill.background()
+
+    # Big number
+    num_box = slide.shapes.add_textbox(
+        Inches(0), Inches(2.5),
+        Inches(2.5), Inches(2.5)
+    )
+    p = num_box.text_frame.paragraphs[0]
+    p.text = NUMBER
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(120)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Accent divider
+    divider = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(2.5), Inches(1.5),
+        Inches(0.08), Inches(4.5)
+    )
+    divider.fill.solid()
+    divider.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    divider.line.fill.background()
+
+    # Point text
+    point_box = slide.shapes.add_textbox(
+        Inches(3.0), Inches(2.2),
+        Inches(4.0), Inches(2.5)
+    )
+    tf = point_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = POINT_TEXT
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(32)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Supporting text
+    if SUPPORTING_TEXT:
+        support_box = slide.shapes.add_textbox(
+            Inches(3.0), Inches(4.8),
+            Inches(4.0), Inches(2.0)
+        )
+        tf = support_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = SUPPORTING_TEXT
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+
+    # Save
+    output = Path("carousel-numbered-point-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/quote-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/quote-slide.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "carousel-quote-slide"
+# format = "carousel"
+# dimensions = "square"
+# purpose = "Quote with attribution - for social proof or memorable statements"
+# best_for = [
+#     "Social proof from customers or experts",
+#     "Memorable statements worth highlighting",
+#     "Your own quotable insights",
+#     "Breaking up content with a different format",
+# ]
+# avoid_when = [
+#     "Long quotes over 120 characters - paraphrase instead",
+#     "Quotes that need context - add context in previous slide",
+#     "First slide - use hook-slide instead",
+# ]
+# quote_max_chars = 120
+# attribution_max_chars = 40
+# instructions = [
+#     "Quote should be IMPACTFUL and max 120 characters",
+#     "Attribution is optional but recommended for credibility",
+#     "Use quotation marks in the design, not the text",
+#     "If it's your own quote, attribution can be your handle",
+# ]
+# ///
+"""
+LAYOUT: Carousel Quote Slide
+PURPOSE: Featured quote with attribution
+FORMAT: Square (1:1) for LinkedIn carousels
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- QUOTE_TEXT: The quote (max 120 chars, no quotation marks)
+- ATTRIBUTION: Who said it (max 40 chars, optional)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS ===
+    BRAND_BG = "1e1e2e"
+    BRAND_TEXT = "cdd6f4"
+    BRAND_TEXT_SECONDARY = "bac2de"
+    BRAND_ACCENT = "fab387"
+    BRAND_ACCENT_SECONDARY = "89b4fa"
+    BRAND_HEADING_FONT = "JetBrains Mono"
+    BRAND_BODY_FONT = "Inter"
+
+    # === CONTENT ===
+    QUOTE_TEXT = "REPLACE"  # Max 120 chars, no quotation marks
+    ATTRIBUTION = ""  # Optional, max 40 chars
+
+    # === SLIDE SETUP (Square 1:1) ===
+    prs = Presentation()
+    prs.slide_width = Inches(7.5)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large opening quote mark
+    open_quote = slide.shapes.add_textbox(
+        Inches(0.3), Inches(1.0),
+        Inches(2.0), Inches(2.0)
+    )
+    p = open_quote.text_frame.paragraphs[0]
+    p.text = """
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(180)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+
+    # Quote text
+    quote_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(2.5),
+        Inches(6.5), Inches(3.0)
+    )
+    tf = quote_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = QUOTE_TEXT
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(28)
+    p.font.italic = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Attribution
+    if ATTRIBUTION:
+        attr_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(5.8),
+            Inches(6.5), Inches(0.8)
+        )
+        tf = attr_box.text_frame
+        p = tf.paragraphs[0]
+        p.text = f"— {ATTRIBUTION}"
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(18)
+        p.font.color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Bottom accent line
+    bottom_line = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(2.5), Inches(6.8),
+        Inches(2.5), Inches(0.06)
+    )
+    bottom_line.fill.solid()
+    bottom_line.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    bottom_line.line.fill.background()
+
+    # Save
+    output = Path("carousel-quote-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/single-point-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/carousels/single-point-slide.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "carousel-single-point-slide"
+# format = "carousel"
+# dimensions = "square"
+# purpose = "One key point with supporting text - the workhorse slide"
+# best_for = [
+#     "Main content slides in carousel body",
+#     "Single concept that needs explanation",
+#     "Key takeaways or insights",
+#     "Standalone valuable points",
+# ]
+# avoid_when = [
+#     "First slide - use hook-slide instead",
+#     "Last slide - use cta-slide instead",
+#     "Numbered lists - use numbered-point-slide instead",
+#     "Quotes - use quote-slide instead",
+# ]
+# headline_max_chars = 40
+# body_max_chars = 150
+# instructions = [
+#     "Headline should be the KEY POINT in 40 chars or less",
+#     "Body text expands on the headline - max 150 chars",
+#     "One idea per slide - if you have multiple, split them",
+#     "Make headline readable at thumbnail size",
+# ]
+# ///
+"""
+LAYOUT: Carousel Single Point Slide
+PURPOSE: One key point with supporting explanation
+FORMAT: Square (1:1) for LinkedIn carousels
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HEADLINE: The main point (max 40 chars)
+- BODY_TEXT: Supporting explanation (max 150 chars)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS ===
+    BRAND_BG = "1e1e2e"
+    BRAND_TEXT = "cdd6f4"
+    BRAND_TEXT_SECONDARY = "bac2de"
+    BRAND_ACCENT = "fab387"
+    BRAND_HEADING_FONT = "JetBrains Mono"
+    BRAND_BODY_FONT = "Inter"
+
+    # === CONTENT ===
+    HEADLINE = "REPLACE"  # Max 40 chars
+    BODY_TEXT = "REPLACE"  # Max 150 chars
+
+    # === SLIDE SETUP (Square 1:1) ===
+    prs = Presentation()
+    prs.slide_width = Inches(7.5)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Left accent bar
+    left_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(0.1), Inches(7.5)
+    )
+    left_bar.fill.solid()
+    left_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    left_bar.line.fill.background()
+
+    # Headline
+    headline_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(2.0),
+        Inches(6.5), Inches(2.0)
+    )
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = HEADLINE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(40)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Accent underline
+    underline = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.5), Inches(4.1),
+        Inches(2.0), Inches(0.06)
+    )
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    # Body text
+    body_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(4.5),
+        Inches(6.5), Inches(2.5)
+    )
+    tf = body_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = BODY_TEXT
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(24)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+
+    # Save
+    output = Path("carousel-single-point-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/chart-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/chart-slide.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "chart-slide"
+# purpose = "Data visualization, metrics breakdown, distribution charts"
+# best_for = [
+#     "Showing data distribution (pie/doughnut)",
+#     "Comparing categories (bar/column)",
+#     "Visualizing survey results",
+#     "Budget or resource allocation",
+# ]
+# avoid_when = [
+#     "More than 6 data categories - simplify first",
+#     "Trend over time - consider line chart (not in template)",
+#     "Exact numbers matter more than visual - use stats-slide",
+# ]
+# chart_types = ["pie", "bar", "column", "doughnut"]
+# max_categories = 6
+# instructions = [
+#     "Chart types: 'pie', 'bar', 'column', or 'doughnut'",
+#     "Keep to 3-6 categories for readability",
+#     "INSIGHT box on right explains the key takeaway",
+#     "Title should explain what the data represents",
+#     "Chart uses PowerPoint default theme colors",
+# ]
+# ///
+"""
+LAYOUT: Chart Slide
+PURPOSE: Data visualization, metrics breakdown, distribution charts
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: What the data shows
+- CHART_TYPE: "pie", "bar", "column", "doughnut"
+- CHART_DATA: List of (category, value) tuples
+- INSIGHT: Key takeaway from the data
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.chart.data import CategoryChartData
+from pptx.dml.color import RGBColor
+from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # what the data shows
+    CHART_TYPE = "REPLACE"            # "pie", "bar", "column", or "doughnut"
+    CHART_DATA = [
+        ("REPLACE", 0),               # (category, value) tuples
+        ("REPLACE", 0),
+        ("REPLACE", 0),
+        ("REPLACE", 0),
+    ]
+    INSIGHT = "REPLACE"               # key takeaway from the data
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.4),
+        Inches(12.333), Inches(0.8)
+    )
+    p = title_box.text_frame.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Accent underline
+    underline = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.5), Inches(1.2),
+        Inches(2.0), Inches(0.06)
+    )
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    # Prepare chart data
+    chart_data = CategoryChartData()
+    chart_data.categories = [item[0] for item in CHART_DATA]
+    chart_data.add_series("Values", [item[1] for item in CHART_DATA])
+
+    # Determine chart type
+    chart_types = {
+        "pie": XL_CHART_TYPE.PIE,
+        "bar": XL_CHART_TYPE.BAR_CLUSTERED,
+        "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
+        "doughnut": XL_CHART_TYPE.DOUGHNUT,
+    }
+    xl_chart_type = chart_types.get(CHART_TYPE, XL_CHART_TYPE.PIE)
+
+    # Add chart
+    chart_left = Inches(0.5)
+    chart_top = Inches(1.8)
+    chart_width = Inches(7.5)
+    chart_height = Inches(5.0)
+
+    chart_shape = slide.shapes.add_chart(
+        xl_chart_type, chart_left, chart_top, chart_width, chart_height, chart_data
+    )
+    chart = chart_shape.chart
+
+    # Style the chart
+    chart.has_legend = True
+    chart.legend.position = XL_LEGEND_POSITION.RIGHT
+    chart.legend.include_in_layout = False
+
+    # Note: Full chart styling (colors, fonts) requires more complex XML manipulation
+    # The chart will use PowerPoint's default theme colors
+
+    # Insight box (right side)
+    insight_bg = slide.shapes.add_shape(
+        MSO_SHAPE.ROUNDED_RECTANGLE,
+        Inches(8.5), Inches(2.5),
+        Inches(4.3), Inches(2.5)
+    )
+    insight_bg.fill.solid()
+    insight_bg.fill.fore_color.rgb = hex_to_rgb("313244")
+    insight_bg.line.fill.background()
+
+    # Insight label
+    insight_label = slide.shapes.add_textbox(
+        Inches(8.8), Inches(2.7),
+        Inches(3.7), Inches(0.5)
+    )
+    p = insight_label.text_frame.paragraphs[0]
+    p.text = "KEY INSIGHT"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(12)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+
+    # Insight text
+    insight_box = slide.shapes.add_textbox(
+        Inches(8.8), Inches(3.2),
+        Inches(3.7), Inches(1.5)
+    )
+    tf = insight_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = INSIGHT
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(18)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Bottom accent bar
+    bottom_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(7.35),
+        Inches(13.333), Inches(0.15)
+    )
+    bottom_bar.fill.solid()
+    bottom_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    bottom_bar.line.fill.background()
+
+    # Save
+    output = Path("chart-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/circular-hero-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/circular-hero-slide.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "circular-hero-slide"
+# purpose = "Central concept, core idea, focus point with surrounding context"
+# best_for = [
+#     "Core concept with 4-6 related aspects",
+#     "Hub-and-spoke relationships",
+#     "Central theme with supporting elements",
+#     "Ecosystem or component overview",
+# ]
+# avoid_when = [
+#     "Items are sequential (use process/timeline instead)",
+#     "More than 6 surrounding items",
+#     "Center concept needs long text",
+# ]
+# min_surrounding_items = 4
+# max_surrounding_items = 6
+# instructions = [
+#     "Center text should be 1-2 words maximum",
+#     "Surrounding items are positioned in a circle - keep them short",
+#     "4-6 surrounding items work best for visual balance",
+#     "All items should relate to the central concept",
+#     "Subtitle under center text is optional",
+# ]
+# ///
+"""
+LAYOUT: Circular Hero
+PURPOSE: Central concept, core idea, focus point with surrounding context
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- CENTER_TEXT: Word or short phrase in the circle
+- SURROUNDING_ITEMS: List of related concepts around the circle (4-6 items)
+"""
+
+from pathlib import Path
+import math
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color (for main circle)
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent (for surrounding dots)
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    CENTER_TEXT = "REPLACE"           # word or short phrase in the circle
+    SUBTITLE = "REPLACE"              # subtitle below center text
+    SURROUNDING_ITEMS = [
+        "REPLACE",                    # related concepts around the circle (4-6 items)
+        "REPLACE",
+        "REPLACE",
+        "REPLACE",
+        "REPLACE",
+        "REPLACE",
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Center coordinates
+    center_x = 6.666  # Middle of slide
+    center_y = 3.75   # Middle of slide
+
+    # Outer ring (subtle)
+    outer_ring = slide.shapes.add_shape(
+        MSO_SHAPE.OVAL,
+        Inches(center_x - 3.2), Inches(center_y - 3.2),
+        Inches(6.4), Inches(6.4)
+    )
+    outer_ring.fill.background()
+    outer_ring.line.color.rgb = hex_to_rgb("313244")
+    outer_ring.line.width = Pt(2)
+
+    # Main circle
+    circle_size = 3.5
+    main_circle = slide.shapes.add_shape(
+        MSO_SHAPE.OVAL,
+        Inches(center_x - circle_size/2), Inches(center_y - circle_size/2),
+        Inches(circle_size), Inches(circle_size)
+    )
+    main_circle.fill.solid()
+    main_circle.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    main_circle.line.fill.background()
+
+    # Center text
+    center_box = slide.shapes.add_textbox(
+        Inches(center_x - 1.75), Inches(center_y - 0.6),
+        Inches(3.5), Inches(1.0)
+    )
+    tf = center_box.text_frame
+    p = tf.paragraphs[0]
+    p.text = CENTER_TEXT
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(48)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_BG)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Subtitle below center
+    subtitle_box = slide.shapes.add_textbox(
+        Inches(center_x - 2), Inches(center_y + 0.4),
+        Inches(4), Inches(0.5)
+    )
+    p = subtitle_box.text_frame.paragraphs[0]
+    p.text = SUBTITLE
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(14)
+    p.font.color.rgb = hex_to_rgb(BRAND_BG)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Surrounding items positioned in a circle
+    num_items = len(SURROUNDING_ITEMS)
+    radius = 3.0  # Distance from center
+
+    for i, item in enumerate(SURROUNDING_ITEMS):
+        # Calculate position on circle
+        angle = (2 * math.pi * i / num_items) - math.pi / 2  # Start from top
+        item_x = center_x + radius * math.cos(angle)
+        item_y = center_y + radius * math.sin(angle)
+
+        # Small accent dot
+        dot = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(item_x - 0.1), Inches(item_y - 0.1),
+            Inches(0.2), Inches(0.2)
+        )
+        dot.fill.solid()
+        dot.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+        dot.line.fill.background()
+
+        # Item text - positioned based on which side of circle
+        text_width = 1.8
+        if item_x < center_x - 1:
+            text_x = item_x - text_width - 0.2
+            align = PP_ALIGN.RIGHT
+        elif item_x > center_x + 1:
+            text_x = item_x + 0.3
+            align = PP_ALIGN.LEFT
+        else:
+            text_x = item_x - text_width / 2
+            align = PP_ALIGN.CENTER
+
+        text_y = item_y - 0.2 if item_y < center_y else item_y - 0.1
+
+        item_box = slide.shapes.add_textbox(
+            Inches(text_x), Inches(text_y),
+            Inches(text_width), Inches(0.5)
+        )
+        p = item_box.text_frame.paragraphs[0]
+        p.text = item
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(16)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+        p.alignment = align
+
+    # Save
+    output = Path("circular-hero-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/closing-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/closing-slide.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "closing-slide"
+# purpose = "Final slide, call to action, contact info, thank you, next steps"
+# best_for = [
+#     "Presentation ending",
+#     "Call to action",
+#     "Contact information",
+#     "Next steps or resources",
+#     "Q&A slide",
+# ]
+# avoid_when = [
+#     "Not the final slide - use title-slide instead",
+#     "Need detailed content - this is for impact, not information",
+# ]
+# max_cta_items = 4
+# instructions = [
+#     "Headline should be actionable or memorable",
+#     "CTA items are optional - use for next steps or resources",
+#     "Subtext is for URL, email, or social handle",
+#     "Keep it simple - this is the lasting impression",
+# ]
+# ///
+"""
+LAYOUT: Closing/CTA Slide
+PURPOSE: Final slide, call to action, contact info, thank you, next steps
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HEADLINE: The takeaway or CTA (e.g., "Start Building Today", "Questions?")
+- SUBTEXT: Supporting info (e.g., URL, email, social handle)
+- CTA_ITEMS: Optional list of next steps or resources
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_BG_ALT = "REPLACE"          # slightly darker variant for contrast
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    HEADLINE = "REPLACE"              # takeaway or CTA (e.g., "Start Building Today")
+    SUBTEXT = "REPLACE"               # URL, email, or social handle
+    CTA_ITEMS = [
+        "REPLACE",                    # next steps or resources (2-4 items)
+        "REPLACE",
+        "REPLACE",
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large accent gradient-like block (bottom portion)
+    bottom_block = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(5.0),
+        Inches(13.333), Inches(2.5)
+    )
+    bottom_block.fill.solid()
+    bottom_block.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    bottom_block.line.fill.background()
+
+    # Top accent bar
+    top_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(13.333), Inches(0.12)
+    )
+    top_bar.fill.solid()
+    top_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top_bar.line.fill.background()
+
+    # Large headline - centered
+    headline_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(2.0),
+        Inches(12.33), Inches(1.5)
+    )
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = HEADLINE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(56)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Accent underline below headline
+    underline = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(5.5), Inches(3.6),
+        Inches(2.33), Inches(0.08)
+    )
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    # CTA Items (horizontal layout in bottom section)
+    if CTA_ITEMS:
+        num_items = len(CTA_ITEMS)
+        item_width = 12.0 / num_items
+        start_x = 0.66
+
+        for i, item in enumerate(CTA_ITEMS):
+            x_pos = start_x + (i * item_width)
+
+            # Number badge
+            badge = slide.shapes.add_shape(
+                MSO_SHAPE.OVAL,
+                Inches(x_pos + (item_width / 2) - 0.25), Inches(5.3),
+                Inches(0.5), Inches(0.5)
+            )
+            badge.fill.solid()
+            badge.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+            badge.line.fill.background()
+
+            badge_text = slide.shapes.add_textbox(
+                Inches(x_pos + (item_width / 2) - 0.25), Inches(5.35),
+                Inches(0.5), Inches(0.5)
+            )
+            p = badge_text.text_frame.paragraphs[0]
+            p.text = str(i + 1)
+            p.font.name = BRAND_HEADING_FONT
+            p.font.size = Pt(16)
+            p.font.bold = True
+            p.font.color.rgb = hex_to_rgb(BRAND_BG)
+            p.alignment = PP_ALIGN.CENTER
+
+            # Item text
+            item_box = slide.shapes.add_textbox(
+                Inches(x_pos), Inches(5.95),
+                Inches(item_width), Inches(0.8)
+            )
+            tf = item_box.text_frame
+            tf.word_wrap = True
+            p = tf.paragraphs[0]
+            p.text = item
+            p.font.name = BRAND_BODY_FONT
+            p.font.size = Pt(18)
+            p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+            p.alignment = PP_ALIGN.CENTER
+
+    # Subtext (URL/contact) - bottom center
+    if SUBTEXT:
+        subtext_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(7.0),
+            Inches(12.33), Inches(0.4)
+        )
+        p = subtext_box.text_frame.paragraphs[0]
+        p.text = SUBTEXT
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(14)
+        p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Save
+    output = Path("closing-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/code-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/code-slide.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "code-slide"
+# purpose = "Display code snippets, terminal output, configuration examples"
+# best_for = [
+#     "Showing code examples",
+#     "Terminal/CLI output",
+#     "Configuration snippets",
+#     "API request/response examples",
+# ]
+# avoid_when = [
+#     "Code is longer than 12 lines - split into multiple slides",
+#     "Code needs syntax highlighting (consider screenshot instead)",
+#     "Audience won't understand code - use pseudocode in content-slide",
+# ]
+# max_lines = 12
+# instructions = [
+#     "Keep code to 5-12 lines - less is better for readability",
+#     "Include language label badge (Python, TypeScript, etc.)",
+#     "Use caption to explain what the code does or key insight",
+#     "Remove unnecessary comments/whitespace to save space",
+#     "If code is complex, highlight the important part only",
+# ]
+# ///
+"""
+LAYOUT: Code Slide
+PURPOSE: Display code snippets, terminal output, configuration examples
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: What the code demonstrates
+- CODE_CONTENT: The actual code (keep it short, 5-12 lines ideal)
+- LANGUAGE_LABEL: Optional language badge (e.g., "Python", "TypeScript")
+- CAPTION: Optional explanation below code
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent (for code block)
+    BRAND_CODE_BG = "REPLACE"         # darker color for code block bg
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+    BRAND_CODE_FONT = "REPLACE"       # monospace font for code
+
+    # === CONTENT (from user request) ===
+    TITLE = "REPLACE"                 # what the code demonstrates
+    LANGUAGE_LABEL = "REPLACE"        # e.g., "Python", "TypeScript"
+    CODE_CONTENT = '''REPLACE'''      # the actual code (5-12 lines)
+    CAPTION = "REPLACE"               # explanation below code
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.4),
+        Inches(10.0), Inches(0.8)
+    )
+    p = title_box.text_frame.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(32)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Language label badge (top right of code block)
+    if LANGUAGE_LABEL:
+        badge_bg = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE,
+            Inches(11.5), Inches(1.15),
+            Inches(1.3), Inches(0.4)
+        )
+        badge_bg.fill.solid()
+        badge_bg.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+        badge_bg.line.fill.background()
+
+        badge_text = slide.shapes.add_textbox(
+            Inches(11.5), Inches(1.18),
+            Inches(1.3), Inches(0.4)
+        )
+        p = badge_text.text_frame.paragraphs[0]
+        p.text = LANGUAGE_LABEL
+        p.font.name = BRAND_CODE_FONT
+        p.font.size = Pt(12)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(BRAND_CODE_BG)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Code block background (terminal-like)
+    code_bg = slide.shapes.add_shape(
+        MSO_SHAPE.ROUNDED_RECTANGLE,
+        Inches(0.5), Inches(1.4),
+        Inches(12.33), Inches(4.8)
+    )
+    code_bg.fill.solid()
+    code_bg.fill.fore_color.rgb = hex_to_rgb(BRAND_CODE_BG)
+    code_bg.line.color.rgb = hex_to_rgb("313244")  # Subtle border
+
+    # Terminal chrome dots (top left of code block)
+    dot_colors = ["f38ba8", "f9e2af", "a6e3a1"]  # Red, yellow, green
+    for i, color in enumerate(dot_colors):
+        dot = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(0.8 + (i * 0.35)), Inches(1.65),
+            Inches(0.18), Inches(0.18)
+        )
+        dot.fill.solid()
+        dot.fill.fore_color.rgb = hex_to_rgb(color)
+        dot.line.fill.background()
+
+    # Code content
+    code_box = slide.shapes.add_textbox(
+        Inches(0.8), Inches(2.2),
+        Inches(11.7), Inches(3.8)
+    )
+    tf = code_box.text_frame
+    tf.word_wrap = False
+    p = tf.paragraphs[0]
+    p.text = CODE_CONTENT
+    p.font.name = BRAND_CODE_FONT
+    p.font.size = Pt(18)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.LEFT
+
+    # Caption below code
+    if CAPTION:
+        caption_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(6.4),
+            Inches(12.33), Inches(0.6)
+        )
+        p = caption_box.text_frame.paragraphs[0]
+        p.text = CAPTION
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(18)
+        p.font.italic = True
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Accent bar at bottom
+    bottom_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(7.35),
+        Inches(13.333), Inches(0.15)
+    )
+    bottom_bar.fill.solid()
+    bottom_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    bottom_bar.line.fill.background()
+
+    # Save
+    output = Path("code-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/content-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/content-slide.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "content-slide"
+# purpose = "Key points, takeaways, feature lists, explanations"
+# best_for = [
+#     "Listing 3-6 related points",
+#     "Feature lists",
+#     "Takeaways or summaries",
+#     "Step-by-step instructions",
+# ]
+# avoid_when = [
+#     "More than 6 bullet points - split into multiple slides",
+#     "Need visual comparisons",
+#     "Single big idea - use title-slide or giant-focus instead",
+# ]
+# max_bullets = 6
+# instructions = [
+#     "Keep bullets parallel in structure (all start with verbs, or all noun phrases)",
+#     "Title should describe WHAT these points prove, not 'Key Points'",
+#     "Each bullet should be 1-2 lines max",
+#     "No trailing periods on bullets unless full sentences",
+# ]
+# ///
+"""
+LAYOUT: Content Slide
+PURPOSE: Key points, takeaways, feature lists, explanations
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: What this slide proves or explains (not "Key Points")
+- BULLETS: 3-6 points, parallel structure, action-oriented
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # slide title
+    BULLETS = [
+        "REPLACE",                    # 3-6 bullet points
+        "REPLACE",
+        "REPLACE",
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Left accent bar (vertical stripe)
+    left_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(0.08), Inches(7.5)
+    )
+    left_bar.fill.solid()
+    left_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    left_bar.line.fill.background()
+
+    # Title with accent underline
+    title_box = slide.shapes.add_textbox(
+        Inches(0.6), Inches(0.5),
+        Inches(12.0), Inches(1.0)
+    )
+    tf = title_box.text_frame
+    p = tf.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Accent underline below title
+    underline = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.6), Inches(1.5),
+        Inches(2.5), Inches(0.06)
+    )
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    underline.line.fill.background()
+
+    # Bullets with custom styling
+    bullet_start_y = 2.0
+    bullet_spacing = 1.1
+
+    for i, bullet_text in enumerate(BULLETS):
+        y_pos = bullet_start_y + (i * bullet_spacing)
+
+        # Bullet indicator (small accent square)
+        indicator = slide.shapes.add_shape(
+            MSO_SHAPE.RECTANGLE,
+            Inches(0.6), Inches(y_pos + 0.15),
+            Inches(0.12), Inches(0.12)
+        )
+        indicator.fill.solid()
+        indicator.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+        indicator.line.fill.background()
+
+        # Bullet text
+        text_box = slide.shapes.add_textbox(
+            Inches(1.0), Inches(y_pos),
+            Inches(11.5), Inches(0.9)
+        )
+        tf = text_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = bullet_text
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(22)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Slide number indicator (bottom right)
+    num_box = slide.shapes.add_textbox(
+        Inches(12.5), Inches(7.0),
+        Inches(0.5), Inches(0.3)
+    )
+    p = num_box.text_frame.paragraphs[0]
+    p.text = "02"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(12)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.alignment = PP_ALIGN.RIGHT
+
+    # Save
+    output = Path("content-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/corner-anchor-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/corner-anchor-slide.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "corner-anchor-slide"
+# purpose = "Bold statement with strong visual anchor, asymmetric modern design"
+# best_for = [
+#     "Bold statements with supporting text",
+#     "Modern/asymmetric visual style",
+#     "Key points with emphasis",
+#     "Visual variety in presentation",
+# ]
+# avoid_when = [
+#     "Need lots of text or bullets",
+#     "Already used this layout recently",
+#     "Conservative/traditional audience",
+# ]
+# anchor_corners = ["top-left", "top-right", "bottom-left", "bottom-right"]
+# instructions = [
+#     "ANCHOR_CORNER determines where the large circle appears",
+#     "Text is positioned opposite to the anchor for balance",
+#     "Headline can be longer than title-slide (full statement)",
+#     "Body text provides supporting context or details",
+#     "Use sparingly for visual variety",
+# ]
+# ///
+"""
+LAYOUT: Corner Anchor
+PURPOSE: Bold statement with strong visual anchor, asymmetric modern design
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HEADLINE: Main statement
+- BODY_TEXT: Supporting paragraph or points
+- ANCHOR_CORNER: "top-left", "top-right", "bottom-left", "bottom-right"
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color (for main anchor shape)
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent (for layered shape)
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    HEADLINE = "REPLACE"              # main statement
+    BODY_TEXT = "REPLACE"             # supporting paragraph or points
+    ANCHOR_CORNER = "REPLACE"         # "top-left", "top-right", "bottom-left", "bottom-right"
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large anchor shape based on corner
+    anchor_size = 5.5
+    if ANCHOR_CORNER == "top-right":
+        # Large quarter circle in top-right
+        anchor = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(13.333 - anchor_size/2), Inches(-anchor_size/2),
+            Inches(anchor_size), Inches(anchor_size)
+        )
+        text_x, text_y = 0.8, 3.0
+        text_align = PP_ALIGN.LEFT
+    elif ANCHOR_CORNER == "top-left":
+        anchor = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(-anchor_size/2), Inches(-anchor_size/2),
+            Inches(anchor_size), Inches(anchor_size)
+        )
+        text_x, text_y = 5.5, 3.0
+        text_align = PP_ALIGN.RIGHT
+    elif ANCHOR_CORNER == "bottom-right":
+        anchor = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(13.333 - anchor_size/2), Inches(7.5 - anchor_size/2),
+            Inches(anchor_size), Inches(anchor_size)
+        )
+        text_x, text_y = 0.8, 1.5
+        text_align = PP_ALIGN.LEFT
+    else:  # bottom-left
+        anchor = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(-anchor_size/2), Inches(7.5 - anchor_size/2),
+            Inches(anchor_size), Inches(anchor_size)
+        )
+        text_x, text_y = 5.5, 1.5
+        text_align = PP_ALIGN.RIGHT
+
+    anchor.fill.solid()
+    anchor.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    anchor.line.fill.background()
+
+    # Secondary smaller shape for layering
+    small_anchor = slide.shapes.add_shape(
+        MSO_SHAPE.OVAL,
+        Inches(13.333 - 2.5), Inches(-0.5),
+        Inches(2.5), Inches(2.5)
+    )
+    small_anchor.fill.solid()
+    small_anchor.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    small_anchor.line.fill.background()
+
+    # Headline
+    headline_box = slide.shapes.add_textbox(
+        Inches(text_x), Inches(text_y),
+        Inches(7.0), Inches(1.5)
+    )
+    tf = headline_box.text_frame
+    p = tf.paragraphs[0]
+    p.text = HEADLINE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(56)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = text_align
+
+    # Accent line
+    if text_align == PP_ALIGN.LEFT:
+        line_x = text_x
+    else:
+        line_x = text_x + 7.0 - 2.5
+
+    accent_line = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(line_x), Inches(text_y + 1.6),
+        Inches(2.5), Inches(0.08)
+    )
+    accent_line.fill.solid()
+    accent_line.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    accent_line.line.fill.background()
+
+    # Body text
+    body_box = slide.shapes.add_textbox(
+        Inches(text_x), Inches(text_y + 2.0),
+        Inches(7.0), Inches(2.5)
+    )
+    tf = body_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = BODY_TEXT
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(20)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.alignment = text_align
+
+    # Save
+    output = Path("corner-anchor-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/floating-cards-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/floating-cards-slide.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "floating-cards-slide"
+# purpose = "Feature highlights, process steps, multiple equal items with depth"
+# best_for = [
+#     "Exactly 3 related features or concepts",
+#     "Process with 3 steps",
+#     "Three pillars or principles",
+#     "Visual depth and modern aesthetic",
+# ]
+# avoid_when = [
+#     "More than 3 items - use multi-card-slide instead",
+#     "Less than 3 items - use content-slide instead",
+#     "Long card titles (over 15 characters)",
+#     "Long descriptions needed",
+# ]
+# max_cards = 3
+# card_title_max_chars = 15
+# instructions = [
+#     "EXACTLY 3 cards required - no more, no less",
+#     "Card titles must be SHORT: 1-2 words, max 15 characters",
+#     "Descriptions should be 1-2 short sentences",
+#     "Cards overlap intentionally for depth - do not use for 4+ items",
+#     "If titles are too long, abbreviate or use different layout",
+# ]
+# ///
+"""
+LAYOUT: Floating Cards
+PURPOSE: Feature highlights, process steps, multiple equal items with depth
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: What these cards represent
+- CARDS: List of (title, description) tuples - EXACTLY 3 cards required
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_CARD_BG = "REPLACE"         # card background color
+    BRAND_CARD_BG_ALT = "REPLACE"     # alternate card background (for variety)
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color (card 1)
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent (card 2)
+    BRAND_ACCENT_TERTIARY = "REPLACE"   # tertiary accent (card 3)
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # what these cards represent
+    CARDS = [
+        ("REPLACE", "REPLACE"),       # (title, description) - 3 cards works best
+        ("REPLACE", "REPLACE"),
+        ("REPLACE", "REPLACE"),
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.5),
+        Inches(12.333), Inches(1.0)
+    )
+    p = title_box.text_frame.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(40)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Card configurations - staggered positions for depth
+    card_configs = [
+        {"x": 0.8, "y": 2.0, "accent": BRAND_ACCENT, "bg": BRAND_CARD_BG},
+        {"x": 4.5, "y": 2.4, "accent": BRAND_ACCENT_SECONDARY, "bg": BRAND_CARD_BG_ALT},
+        {"x": 8.2, "y": 1.8, "accent": BRAND_ACCENT_TERTIARY, "bg": BRAND_CARD_BG},
+    ]
+
+    card_width = 4.2
+    card_height = 4.0
+
+    for i, (card_title, card_desc) in enumerate(CARDS):
+        config = card_configs[i % len(card_configs)]
+        x = config["x"]
+        y = config["y"]
+        accent = config["accent"]
+        bg = config["bg"]
+
+        # Card shadow (offset rectangle)
+        shadow = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE,
+            Inches(x + 0.15), Inches(y + 0.15),
+            Inches(card_width), Inches(card_height)
+        )
+        shadow.fill.solid()
+        shadow.fill.fore_color.rgb = hex_to_rgb("11111b")
+        shadow.line.fill.background()
+
+        # Card background
+        card = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE,
+            Inches(x), Inches(y),
+            Inches(card_width), Inches(card_height)
+        )
+        card.fill.solid()
+        card.fill.fore_color.rgb = hex_to_rgb(bg)
+        card.line.fill.background()
+
+        # Accent bar at top of card
+        accent_bar = slide.shapes.add_shape(
+            MSO_SHAPE.RECTANGLE,
+            Inches(x + 0.3), Inches(y + 0.3),
+            Inches(0.8), Inches(0.12)
+        )
+        accent_bar.fill.solid()
+        accent_bar.fill.fore_color.rgb = hex_to_rgb(accent)
+        accent_bar.line.fill.background()
+
+        # Card number
+        num_box = slide.shapes.add_textbox(
+            Inches(x + 0.3), Inches(y + 0.6),
+            Inches(1.0), Inches(0.8)
+        )
+        p = num_box.text_frame.paragraphs[0]
+        p.text = f"0{i + 1}"
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(32)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(accent)
+
+        # Card title (with word wrap for longer titles)
+        card_title_box = slide.shapes.add_textbox(
+            Inches(x + 0.3), Inches(y + 1.5),
+            Inches(card_width - 0.6), Inches(1.0)
+        )
+        tf = card_title_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = card_title
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(20)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+        # Card description
+        card_desc_box = slide.shapes.add_textbox(
+            Inches(x + 0.3), Inches(y + 2.6),
+            Inches(card_width - 0.6), Inches(1.1)
+        )
+        tf = card_desc_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = card_desc
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(16)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+
+    # Save
+    output = Path("floating-cards-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/giant-focus-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/giant-focus-slide.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "giant-focus-slide"
+# purpose = "Single powerful word/number, dramatic emphasis, memorable moments"
+# best_for = [
+#     "Single impactful word or number",
+#     "Dramatic reveal moments",
+#     "Key statistics (e.g., '47%', '$1B')",
+#     "Memorable one-word themes",
+# ]
+# avoid_when = [
+#     "Need to explain context in detail",
+#     "More than 3 words needed",
+#     "Already used this layout recently",
+# ]
+# max_words = 3
+# instructions = [
+#     "BIG_TEXT should be 1-3 words maximum - ideally just ONE word",
+#     "Context above/below are optional but help frame the big text",
+#     "Use for dramatic effect - sparingly in a presentation",
+#     "Best for numbers, single concepts, or emotional words",
+# ]
+# ///
+"""
+LAYOUT: Giant Focus
+PURPOSE: Single powerful word/number, dramatic emphasis, memorable moments
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- BIG_TEXT: The single word or short phrase (1-3 words max)
+- CONTEXT_ABOVE: Small text above the big text
+- CONTEXT_BELOW: Small text below the big text
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color (for the giant text)
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    BIG_TEXT = "REPLACE"              # single word or short phrase (1-3 words max)
+    CONTEXT_ABOVE = "REPLACE"         # small text above the big text
+    CONTEXT_BELOW = "REPLACE"         # small text below the big text
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large background accent shape (subtle)
+    bg_circle = slide.shapes.add_shape(
+        MSO_SHAPE.OVAL,
+        Inches(3.5), Inches(0.5),
+        Inches(6.333), Inches(6.333)
+    )
+    bg_circle.fill.solid()
+    bg_circle.fill.fore_color.rgb = hex_to_rgb("232333")  # Very subtle
+    bg_circle.line.fill.background()
+
+    # Context above
+    if CONTEXT_ABOVE:
+        above_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(1.8),
+            Inches(12.333), Inches(0.6)
+        )
+        p = above_box.text_frame.paragraphs[0]
+        p.text = CONTEXT_ABOVE.upper()
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(14)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+        # Letter spacing would be nice but not supported
+
+    # GIANT TEXT
+    big_box = slide.shapes.add_textbox(
+        Inches(0), Inches(2.2),
+        Inches(13.333), Inches(3.5)
+    )
+    tf = big_box.text_frame
+    tf.word_wrap = False
+    p = tf.paragraphs[0]
+    p.text = BIG_TEXT
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(200)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Context below
+    if CONTEXT_BELOW:
+        below_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(5.6),
+            Inches(12.333), Inches(0.6)
+        )
+        p = below_box.text_frame.paragraphs[0]
+        p.text = CONTEXT_BELOW
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Accent line below context
+    accent_line = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(5.5), Inches(6.4),
+        Inches(2.333), Inches(0.04)
+    )
+    accent_line.fill.solid()
+    accent_line.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    accent_line.line.fill.background()
+
+    # Save
+    output = Path("giant-focus-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/image-caption-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/image-caption-slide.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "image-caption-slide"
+# purpose = "Screenshots, diagrams, photos with explanatory text"
+# best_for = [
+#     "Product screenshots",
+#     "Architecture diagrams",
+#     "Photos with context",
+#     "Visual demonstrations",
+# ]
+# avoid_when = [
+#     "No image available - use another layout",
+#     "Image needs full slide - create custom full-bleed layout",
+#     "Multiple images needed - consider a collage or multiple slides",
+# ]
+# instructions = [
+#     "Image displays on right, text on left (adjustable in code)",
+#     "If no image provided, shows styled placeholder",
+#     "Caption should explain what to notice in the image",
+#     "Image path should be absolute or relative to script location",
+# ]
+# ///
+"""
+LAYOUT: Image with Caption Slide
+PURPOSE: Screenshots, diagrams, photos with explanatory text
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- IMAGE_PATH: Path to the image file (PNG, JPG, etc.)
+- CAPTION: Explanation of what the image shows
+- TITLE: Optional title above image
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # title above image
+    CAPTION = "REPLACE"               # explanation of what the image shows
+    IMAGE_PATH = None                 # path to image file (PNG, JPG, etc.)
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Left side: Text content
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(1.5),
+        Inches(5.5), Inches(1.2)
+    )
+    tf = title_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Accent underline
+    underline = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.5), Inches(2.8),
+        Inches(2.0), Inches(0.06)
+    )
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    # Caption text
+    caption_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(3.2),
+        Inches(5.5), Inches(3.0)
+    )
+    tf = caption_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = CAPTION
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(20)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.line_spacing = 1.4
+
+    # Right side: Image placeholder
+    # If no image provided, show a styled placeholder
+    image_x = Inches(6.5)
+    image_y = Inches(0.8)
+    image_width = Inches(6.33)
+    image_height = Inches(5.9)
+
+    if IMAGE_PATH and Path(IMAGE_PATH).exists():
+        slide.shapes.add_picture(
+            str(IMAGE_PATH),
+            image_x, image_y,
+            width=image_width
+        )
+    else:
+        # Placeholder box (styled to look intentional)
+        placeholder = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE,
+            image_x, image_y,
+            image_width, image_height
+        )
+        placeholder.fill.solid()
+        placeholder.fill.fore_color.rgb = hex_to_rgb("181825")
+        placeholder.line.color.rgb = hex_to_rgb("313244")
+
+        # Placeholder icon (camera/image symbol made of shapes)
+        # Mountain shape (simplified image icon)
+        icon_center_x = 6.5 + (6.33 / 2)
+        icon_center_y = 0.8 + (5.9 / 2)
+
+        # Outer frame
+        frame = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE,
+            Inches(icon_center_x - 1.0), Inches(icon_center_y - 0.7),
+            Inches(2.0), Inches(1.4)
+        )
+        frame.fill.background()
+        frame.line.color.rgb = hex_to_rgb(BRAND_ACCENT)
+        frame.line.width = Pt(2)
+
+        # "Image" text
+        img_text = slide.shapes.add_textbox(
+            Inches(icon_center_x - 1.0), Inches(icon_center_y - 0.2),
+            Inches(2.0), Inches(0.5)
+        )
+        p = img_text.text_frame.paragraphs[0]
+        p.text = "IMAGE"
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(16)
+        p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Decorative corner accent (top right)
+    corner_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(12.833), Inches(0),
+        Inches(0.5), Inches(0.08)
+    )
+    corner_bar.fill.solid()
+    corner_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    corner_bar.line.fill.background()
+
+    corner_bar_v = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(13.253), Inches(0),
+        Inches(0.08), Inches(0.5)
+    )
+    corner_bar_v.fill.solid()
+    corner_bar_v.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    corner_bar_v.line.fill.background()
+
+    # Save
+    output = Path("image-caption-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/multi-card-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/multi-card-slide.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "multi-card-slide"
+# purpose = "Multiple items displayed as cards in a row, flexible 3-5 cards"
+# best_for = [
+#     "3-5 equal items (pillars, features, steps)",
+#     "Process steps displayed horizontally",
+#     "Feature comparison cards",
+#     "Team members or product tiers",
+# ]
+# avoid_when = [
+#     "Only 2 items - use two-column-slide instead",
+#     "More than 5 items - split across multiple slides",
+#     "Items need detailed descriptions - use content-slide",
+# ]
+# min_cards = 3
+# max_cards = 5
+# card_title_max_chars = 12
+# instructions = [
+#     "Supports 3, 4, or 5 cards - layout adjusts automatically",
+#     "Card titles must be SHORT: 1-2 words max (12 characters)",
+#     "Descriptions should be 1 short sentence",
+#     "Cards are evenly spaced with no overlap",
+#     "For longer titles, abbreviate or use content-slide",
+# ]
+# ///
+"""
+LAYOUT: Multi-Card Slide
+PURPOSE: Multiple items displayed as cards in a row, flexible 3-5 cards
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: What these cards represent
+- CARDS: List of (title, description) tuples - 3 to 5 cards supported
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_CARD_BG = "REPLACE"         # card background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # what these cards represent
+    CARDS = [
+        ("REPLACE", "REPLACE"),       # (title, description) - 3 to 5 cards
+        ("REPLACE", "REPLACE"),
+        ("REPLACE", "REPLACE"),
+        ("REPLACE", "REPLACE"),
+        ("REPLACE", "REPLACE"),
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.4),
+        Inches(12.333), Inches(0.9)
+    )
+    tf = title_box.text_frame
+    p = tf.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Accent underline below title
+    underline = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.5), Inches(1.35),
+        Inches(2.5), Inches(0.06)
+    )
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    # Calculate card dimensions based on number of cards
+    num_cards = len(CARDS)
+    margin = 0.5  # Left/right margin
+    gap = 0.3     # Gap between cards
+    total_width = 13.333 - (2 * margin) - ((num_cards - 1) * gap)
+    card_width = total_width / num_cards
+    card_height = 4.8
+    start_y = 1.8
+
+    # Alternate accent colors for variety
+    accent_colors = [BRAND_ACCENT, BRAND_ACCENT_SECONDARY, BRAND_ACCENT, BRAND_ACCENT_SECONDARY, BRAND_ACCENT]
+
+    for i, (card_title, card_desc) in enumerate(CARDS):
+        x = margin + (i * (card_width + gap))
+        y = start_y
+        accent = accent_colors[i % len(accent_colors)]
+
+        # Card background
+        card = slide.shapes.add_shape(
+            MSO_SHAPE.ROUNDED_RECTANGLE,
+            Inches(x), Inches(y),
+            Inches(card_width), Inches(card_height)
+        )
+        card.fill.solid()
+        card.fill.fore_color.rgb = hex_to_rgb(BRAND_CARD_BG)
+        card.line.fill.background()
+
+        # Accent bar at top of card
+        accent_bar = slide.shapes.add_shape(
+            MSO_SHAPE.RECTANGLE,
+            Inches(x), Inches(y),
+            Inches(card_width), Inches(0.1)
+        )
+        accent_bar.fill.solid()
+        accent_bar.fill.fore_color.rgb = hex_to_rgb(accent)
+        accent_bar.line.fill.background()
+
+        # Card number
+        num_box = slide.shapes.add_textbox(
+            Inches(x + 0.2), Inches(y + 0.3),
+            Inches(0.8), Inches(0.6)
+        )
+        p = num_box.text_frame.paragraphs[0]
+        p.text = f"0{i + 1}"
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(24)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(accent)
+
+        # Card title (with word wrap)
+        card_title_box = slide.shapes.add_textbox(
+            Inches(x + 0.2), Inches(y + 1.0),
+            Inches(card_width - 0.4), Inches(1.2)
+        )
+        tf = card_title_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = card_title
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(18)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+        # Card description (with word wrap)
+        card_desc_box = slide.shapes.add_textbox(
+            Inches(x + 0.2), Inches(y + 2.3),
+            Inches(card_width - 0.4), Inches(2.2)
+        )
+        tf = card_desc_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = card_desc
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(14)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+
+    # Save
+    output = Path("multi-card-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/quote-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/quote-slide.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "quote-slide"
+# purpose = "Testimonials, pull quotes, key statements, memorable phrases"
+# best_for = [
+#     "Customer testimonials",
+#     "Expert quotes",
+#     "Memorable statements to emphasize",
+#     "Social proof",
+# ]
+# avoid_when = [
+#     "Quote is longer than 3 sentences",
+#     "No clear attribution source",
+#     "Need to show data alongside the quote",
+# ]
+# instructions = [
+#     "Keep quotes to 1-3 sentences maximum",
+#     "Attribution format: '— Name, Title at Company'",
+#     "Choose quotes that support your narrative",
+#     "If quote is too long, extract the most powerful part",
+# ]
+# ///
+"""
+LAYOUT: Quote Slide
+PURPOSE: Testimonials, pull quotes, key statements, memorable phrases
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- QUOTE: The quote text (keep it punchy, 1-3 sentences max)
+- ATTRIBUTION: Who said it (name, title, company)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    QUOTE = "REPLACE"                 # the quote text (1-3 sentences)
+    ATTRIBUTION = "REPLACE"           # who said it (— Name, Title)
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large quote mark (decorative)
+    quote_mark = slide.shapes.add_textbox(
+        Inches(0.5), Inches(1.5),
+        Inches(2.0), Inches(2.0)
+    )
+    p = quote_mark.text_frame.paragraphs[0]
+    p.text = "\u201C"  # Left double quote mark
+    p.font.name = "Georgia"
+    p.font.size = Pt(200)
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    # Make it semi-transparent by using a muted version
+    # (python-pptx doesn't support opacity, so we use color)
+
+    # Left accent bar
+    accent_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(1.0), Inches(2.8),
+        Inches(0.12), Inches(2.5)
+    )
+    accent_bar.fill.solid()
+    accent_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    accent_bar.line.fill.background()
+
+    # Quote text
+    quote_box = slide.shapes.add_textbox(
+        Inches(1.5), Inches(2.8),
+        Inches(10.5), Inches(2.5)
+    )
+    tf = quote_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = QUOTE
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(36)
+    p.font.italic = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.LEFT
+
+    # Attribution
+    attr_box = slide.shapes.add_textbox(
+        Inches(1.5), Inches(5.5),
+        Inches(10.5), Inches(0.6)
+    )
+    p = attr_box.text_frame.paragraphs[0]
+    p.text = ATTRIBUTION
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(18)
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.LEFT
+
+    # Save
+    output = Path("quote-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/section-break-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/section-break-slide.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "section-break-slide"
+# purpose = "Transition between major sections, pause points, chapter markers"
+# best_for = [
+#     "Dividing presentation into major parts",
+#     "Signaling topic change",
+#     "Creating visual breathing room",
+#     "Numbered sections or chapters",
+# ]
+# avoid_when = [
+#     "Presentation is short (under 10 slides)",
+#     "No clear section divisions",
+#     "Already using title-slide for divisions",
+# ]
+# instructions = [
+#     "Section number is optional - use '01', '02' or 'Part 1', 'Part 2'",
+#     "Keep section title to 2-5 words",
+#     "Subtitle briefly previews what's coming",
+#     "Use consistently throughout the presentation",
+# ]
+# ///
+"""
+LAYOUT: Section Break Slide
+PURPOSE: Transition between major sections, pause points, chapter markers
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- SECTION_NUMBER: Optional numbering (e.g., "01", "Part 2")
+- SECTION_TITLE: The section name (bold, large)
+- SECTION_SUBTITLE: Brief description of what's coming (optional)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_BG_ALT = "REPLACE"          # slightly darker variant for contrast
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    SECTION_NUMBER = "REPLACE"        # e.g., "01", "Part 2"
+    SECTION_TITLE = "REPLACE"         # section name
+    SECTION_SUBTITLE = "REPLACE"      # brief description
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large accent block (left third of slide)
+    accent_block = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(4.5), Inches(7.5)
+    )
+    accent_block.fill.solid()
+    accent_block.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    accent_block.line.fill.background()
+
+    # Section number (large, in accent block)
+    if SECTION_NUMBER:
+        num_box = slide.shapes.add_textbox(
+            Inches(0.5), Inches(2.8),
+            Inches(3.5), Inches(1.5)
+        )
+        p = num_box.text_frame.paragraphs[0]
+        p.text = SECTION_NUMBER
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(120)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Vertical accent line (divider)
+    divider = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(4.5), Inches(1.5),
+        Inches(0.08), Inches(4.5)
+    )
+    divider.fill.solid()
+    divider.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    divider.line.fill.background()
+
+    # Section title (right side)
+    title_box = slide.shapes.add_textbox(
+        Inches(5.2), Inches(2.6),
+        Inches(7.5), Inches(1.5)
+    )
+    tf = title_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = SECTION_TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(44)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.LEFT
+
+    # Section subtitle (below title)
+    if SECTION_SUBTITLE:
+        subtitle_box = slide.shapes.add_textbox(
+            Inches(5.2), Inches(4.2),
+            Inches(7.5), Inches(1.0)
+        )
+        tf = subtitle_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = SECTION_SUBTITLE
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.LEFT
+
+    # Save
+    output = Path("section-break-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/stats-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/stats-slide.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "stats-slide"
+# purpose = "Big numbers, KPIs, impressive metrics, before/after comparisons"
+# best_for = [
+#     "Showcasing 2-4 key metrics",
+#     "Before/after comparisons",
+#     "ROI or impact numbers",
+#     "Quick wins or achievements",
+# ]
+# avoid_when = [
+#     "More than 4 statistics - pick the most impactful",
+#     "Numbers need detailed context - use content-slide instead",
+#     "Comparing complex datasets - use chart-slide instead",
+# ]
+# max_stats = 4
+# instructions = [
+#     "Values should be short: '47%', '3x', '$2.1M', not long sentences",
+#     "Labels explain what the number means in 2-5 words",
+#     "Title should frame WHY these numbers matter",
+#     "Most impactful stat should come first",
+# ]
+# ///
+"""
+LAYOUT: Stats/Metrics Slide
+PURPOSE: Big numbers, KPIs, impressive metrics, before/after comparisons
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: What these numbers prove
+- STATS: List of (value, label) tuples - 2-4 stats work best
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_ACCENT_SECONDARY = "REPLACE"  # secondary accent (for variety)
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # what these numbers prove
+    STATS = [
+        ("REPLACE", "REPLACE"),       # (value, label) - 2-4 stats
+        ("REPLACE", "REPLACE"),
+        ("REPLACE", "REPLACE"),
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Top accent line
+    top_line = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.5), Inches(0.3),
+        Inches(3.0), Inches(0.06)
+    )
+    top_line.fill.solid()
+    top_line.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top_line.line.fill.background()
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.6),
+        Inches(12.0), Inches(1.0)
+    )
+    p = title_box.text_frame.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Calculate spacing for stats
+    num_stats = len(STATS)
+    total_width = 12.0
+    stat_width = total_width / num_stats
+    start_x = 0.66
+
+    # Alternate accent colors for visual interest
+    accent_colors = [BRAND_ACCENT, BRAND_ACCENT_SECONDARY, "a6e3a1"]
+
+    for i, (value, label) in enumerate(STATS):
+        x_pos = start_x + (i * stat_width)
+        accent_color = accent_colors[i % len(accent_colors)]
+
+        # Value (big number)
+        value_box = slide.shapes.add_textbox(
+            Inches(x_pos), Inches(2.5),
+            Inches(stat_width - 0.3), Inches(1.8)
+        )
+        tf = value_box.text_frame
+        p = tf.paragraphs[0]
+        p.text = value
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(72)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(accent_color)
+        p.alignment = PP_ALIGN.CENTER
+
+        # Underline accent
+        underline = slide.shapes.add_shape(
+            MSO_SHAPE.RECTANGLE,
+            Inches(x_pos + 0.5), Inches(4.4),
+            Inches(stat_width - 1.3), Inches(0.06)
+        )
+        underline.fill.solid()
+        underline.fill.fore_color.rgb = hex_to_rgb(accent_color)
+        underline.line.fill.background()
+
+        # Label
+        label_box = slide.shapes.add_textbox(
+            Inches(x_pos), Inches(4.6),
+            Inches(stat_width - 0.3), Inches(1.0)
+        )
+        tf = label_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = label
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Subtle dividers between stats (optional visual)
+    for i in range(1, num_stats):
+        x_pos = start_x + (i * stat_width) - 0.15
+        divider = slide.shapes.add_shape(
+            MSO_SHAPE.RECTANGLE,
+            Inches(x_pos), Inches(2.8),
+            Inches(0.02), Inches(2.5)
+        )
+        divider.fill.solid()
+        divider.fill.fore_color.rgb = hex_to_rgb("313244")  # Subtle
+        divider.line.fill.background()
+
+    # Save
+    output = Path("stats-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/title-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/title-slide.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "title-slide"
+# purpose = "Opening slide, section opener, or standalone statement"
+# best_for = [
+#     "Presentation opening",
+#     "Section dividers",
+#     "Single powerful statement",
+#     "Workshop/talk titles",
+# ]
+# avoid_when = [
+#     "Need bullet points or details",
+#     "Showing data or comparisons",
+# ]
+# instructions = [
+#     "Keep headline to 3-8 words for impact",
+#     "Subtitle is optional - skip if headline is self-explanatory",
+#     "This slide sets the tone - make the headline memorable",
+# ]
+# ///
+"""
+LAYOUT: Title Slide
+PURPOSE: Opening slide, section opener, or standalone statement
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- HEADLINE: Main message (3-8 words, punchy)
+- SUBTITLE: Supporting context (optional)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === CONTENT (from user request, written in brand voice) ===
+    HEADLINE = "REPLACE"              # main message (3-8 words)
+    SUBTITLE = "REPLACE"              # supporting context
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Accent bar at top (subtle brand touch)
+    top_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(13.333), Inches(0.15)
+    )
+    top_bar.fill.solid()
+    top_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top_bar.line.fill.background()
+
+    # Headline - centered, impactful
+    headline_box = slide.shapes.add_textbox(
+        Inches(0.75), Inches(2.8),
+        Inches(11.83), Inches(1.8)
+    )
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = HEADLINE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(52)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Subtitle - below headline
+    if SUBTITLE:
+        subtitle_box = slide.shapes.add_textbox(
+            Inches(1.5), Inches(4.6),
+            Inches(10.33), Inches(1.0)
+        )
+        tf = subtitle_box.text_frame
+        p = tf.paragraphs[0]
+        p.text = SUBTITLE
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(24)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+
+    # Save
+    output = Path("title-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/two-column-slide.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/cookbook/two-column-slide.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+# /// layout
+# name = "two-column-slide"
+# purpose = "Before/after, pros/cons, old vs new, A vs B comparisons"
+# best_for = [
+#     "Before/after comparisons",
+#     "Pros vs cons",
+#     "Problem vs solution",
+#     "Old way vs new way",
+#     "Two contrasting approaches",
+# ]
+# avoid_when = [
+#     "Comparing more than 2 things - consider a table or multiple slides",
+#     "Items aren't truly comparable",
+#     "One side has much more content than the other",
+# ]
+# max_bullets_per_column = 4
+# instructions = [
+#     "Left column is typically 'before/problem/old' (muted or red-ish color)",
+#     "Right column is typically 'after/solution/new' (accent or green-ish color)",
+#     "Keep bullet counts balanced between columns",
+#     "Use color coding to reinforce the contrast",
+# ]
+# ///
+"""
+LAYOUT: Two-Column Comparison
+PURPOSE: Before/after, pros/cons, old vs new, A vs B comparisons
+
+CUSTOMIZE:
+- BRAND_* colors and fonts
+- TITLE: Frames the comparison
+- LEFT_HEADER, LEFT_BULLETS: The "before" or "problem" side
+- RIGHT_HEADER, RIGHT_BULLETS: The "after" or "solution" side
+- LEFT_COLOR, RIGHT_COLOR: Color coding (e.g., red vs green, muted vs accent)
+"""
+
+from pathlib import Path
+
+from pptx import Presentation
+from pptx.dml.color import RGBColor
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+def main() -> None:
+    # === BRAND COLORS (get from brands/{name}/brand-system.md) ===
+    BRAND_BG = "REPLACE"              # background color
+    BRAND_TEXT = "REPLACE"            # primary text color
+    BRAND_TEXT_SECONDARY = "REPLACE"  # secondary/muted text color
+    BRAND_ACCENT = "REPLACE"          # accent color
+    BRAND_HEADING_FONT = "REPLACE"    # heading font name
+    BRAND_BODY_FONT = "REPLACE"       # body font name
+
+    # === COLUMN COLORS (choose contrasting colors for comparison) ===
+    LEFT_COLOR = "REPLACE"            # problem/before side (e.g., red-ish)
+    RIGHT_COLOR = "REPLACE"           # solution/after side (e.g., green-ish)
+
+    # === CONTENT (from user request, written in brand voice) ===
+    TITLE = "REPLACE"                 # frames the comparison
+    LEFT_HEADER = "REPLACE"           # left column header
+    LEFT_BULLETS = [
+        "REPLACE",                    # left column points
+        "REPLACE",
+        "REPLACE",
+    ]
+    RIGHT_HEADER = "REPLACE"          # right column header
+    RIGHT_BULLETS = [
+        "REPLACE",                    # right column points
+        "REPLACE",
+        "REPLACE",
+    ]
+
+    # === SLIDE SETUP ===
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    # Background
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title bar background
+    title_bar = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0), Inches(0),
+        Inches(13.333), Inches(1.3)
+    )
+    title_bar.fill.solid()
+    title_bar.fill.fore_color.rgb = hex_to_rgb("181825")  # Slightly darker
+    title_bar.line.fill.background()
+
+    # Title
+    title_box = slide.shapes.add_textbox(
+        Inches(0.5), Inches(0.4),
+        Inches(12.33), Inches(0.8)
+    )
+    p = title_box.text_frame.paragraphs[0]
+    p.text = TITLE
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(32)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Center divider (vertical line with glow effect)
+    divider_glow = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(6.55), Inches(1.5),
+        Inches(0.23), Inches(5.5)
+    )
+    divider_glow.fill.solid()
+    divider_glow.fill.fore_color.rgb = hex_to_rgb("313244")
+    divider_glow.line.fill.background()
+
+    divider = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(6.63), Inches(1.5),
+        Inches(0.07), Inches(5.5)
+    )
+    divider.fill.solid()
+    divider.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    divider.line.fill.background()
+
+    # LEFT SIDE
+    # Header with color indicator
+    left_indicator = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(0.5), Inches(1.7),
+        Inches(0.15), Inches(0.5)
+    )
+    left_indicator.fill.solid()
+    left_indicator.fill.fore_color.rgb = hex_to_rgb(LEFT_COLOR)
+    left_indicator.line.fill.background()
+
+    left_header_box = slide.shapes.add_textbox(
+        Inches(0.85), Inches(1.65),
+        Inches(5.5), Inches(0.6)
+    )
+    p = left_header_box.text_frame.paragraphs[0]
+    p.text = LEFT_HEADER
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(24)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(LEFT_COLOR)
+
+    # Left bullets
+    for i, bullet in enumerate(LEFT_BULLETS):
+        y_pos = 2.5 + (i * 1.2)
+
+        # Bullet marker
+        marker = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(0.5), Inches(y_pos + 0.12),
+            Inches(0.1), Inches(0.1)
+        )
+        marker.fill.solid()
+        marker.fill.fore_color.rgb = hex_to_rgb(LEFT_COLOR)
+        marker.line.fill.background()
+
+        # Bullet text
+        text_box = slide.shapes.add_textbox(
+            Inches(0.85), Inches(y_pos),
+            Inches(5.5), Inches(1.0)
+        )
+        tf = text_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = bullet
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # RIGHT SIDE
+    # Header with color indicator
+    right_indicator = slide.shapes.add_shape(
+        MSO_SHAPE.RECTANGLE,
+        Inches(6.93), Inches(1.7),
+        Inches(0.15), Inches(0.5)
+    )
+    right_indicator.fill.solid()
+    right_indicator.fill.fore_color.rgb = hex_to_rgb(RIGHT_COLOR)
+    right_indicator.line.fill.background()
+
+    right_header_box = slide.shapes.add_textbox(
+        Inches(7.28), Inches(1.65),
+        Inches(5.5), Inches(0.6)
+    )
+    p = right_header_box.text_frame.paragraphs[0]
+    p.text = RIGHT_HEADER
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(24)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(RIGHT_COLOR)
+
+    # Right bullets
+    for i, bullet in enumerate(RIGHT_BULLETS):
+        y_pos = 2.5 + (i * 1.2)
+
+        # Bullet marker
+        marker = slide.shapes.add_shape(
+            MSO_SHAPE.OVAL,
+            Inches(6.93), Inches(y_pos + 0.12),
+            Inches(0.1), Inches(0.1)
+        )
+        marker.fill.solid()
+        marker.fill.fore_color.rgb = hex_to_rgb(RIGHT_COLOR)
+        marker.line.fill.background()
+
+        # Bullet text
+        text_box = slide.shapes.add_textbox(
+            Inches(7.28), Inches(y_pos),
+            Inches(5.5), Inches(1.0)
+        )
+        tf = text_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = bullet
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Save
+    output = Path("two-column-slide.pptx")
+    prs.save(output)
+    print(f"Created {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/pptx-generator/skills/pptx-generator/generate-cookbook-preview.py
+++ b/marketplace/plugins/pptx-generator/skills/pptx-generator/generate-cookbook-preview.py
@@ -1,0 +1,763 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "python-pptx==1.0.2",
+# ]
+# ///
+"""
+Generate a single preview deck with ALL cookbook layouts.
+Run this to see all available layouts in one presentation.
+
+Usage:
+    uv run generate-cookbook-preview.py
+"""
+
+from pathlib import Path
+import math
+
+from pptx import Presentation
+from pptx.chart.data import CategoryChartData
+from pptx.dml.color import RGBColor
+from pptx.enum.chart import XL_CHART_TYPE, XL_LEGEND_POSITION
+from pptx.enum.shapes import MSO_SHAPE
+from pptx.enum.text import PP_ALIGN, MSO_ANCHOR
+from pptx.util import Inches, Pt
+
+
+def hex_to_rgb(hex_color: str) -> RGBColor:
+    h = hex_color.lstrip("#")
+    return RGBColor(int(h[0:2], 16), int(h[2:4], 16), int(h[4:6], 16))
+
+
+# Brand colors (Rasmus brand for preview)
+BRAND_BG = "1e1e2e"
+BRAND_BG_ALT = "181825"
+BRAND_TEXT = "cdd6f4"
+BRAND_TEXT_SECONDARY = "bac2de"
+BRAND_ACCENT = "fab387"
+BRAND_ACCENT_SECONDARY = "89b4fa"
+BRAND_ACCENT_TERTIARY = "a6e3a1"
+BRAND_CARD_BG = "313244"
+BRAND_CODE_BG = "11111b"
+BRAND_HEADING_FONT = "JetBrains Mono"
+BRAND_BODY_FONT = "Inter"
+
+
+def add_slide_label(slide, label: str):
+    """Add a small label showing which layout this is."""
+    label_box = slide.shapes.add_textbox(
+        Inches(0.3), Inches(7.1),
+        Inches(4), Inches(0.3)
+    )
+    p = label_box.text_frame.paragraphs[0]
+    p.text = f"Layout: {label}"
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(10)
+    p.font.color.rgb = hex_to_rgb("6c7086")
+
+
+def create_title_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Accent bar at top
+    top_bar = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0), Inches(0), Inches(13.333), Inches(0.15))
+    top_bar.fill.solid()
+    top_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top_bar.line.fill.background()
+
+    # Headline
+    headline_box = slide.shapes.add_textbox(Inches(0.75), Inches(2.8), Inches(11.83), Inches(1.8))
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "Cookbook Preview"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(52)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Subtitle
+    subtitle_box = slide.shapes.add_textbox(Inches(1.5), Inches(4.6), Inches(10.33), Inches(1.0))
+    p = subtitle_box.text_frame.paragraphs[0]
+    p.text = "All available slide layouts"
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(24)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.alignment = PP_ALIGN.CENTER
+
+    add_slide_label(slide, "title-slide")
+
+
+def create_content_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Left accent bar
+    left_bar = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0), Inches(0), Inches(0.08), Inches(7.5))
+    left_bar.fill.solid()
+    left_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    left_bar.line.fill.background()
+
+    # Title
+    title_box = slide.shapes.add_textbox(Inches(0.6), Inches(0.5), Inches(12.0), Inches(1.0))
+    p = title_box.text_frame.paragraphs[0]
+    p.text = "Key Principles"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Underline
+    underline = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.6), Inches(1.5), Inches(2.5), Inches(0.06))
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    underline.line.fill.background()
+
+    # Bullets
+    bullets = ["Context beats prompting every time", "Iteration is not optional", "Ship fast, fix faster", "The model follows your lead"]
+    for i, bullet_text in enumerate(bullets):
+        y_pos = 2.0 + (i * 1.1)
+        indicator = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.6), Inches(y_pos + 0.15), Inches(0.12), Inches(0.12))
+        indicator.fill.solid()
+        indicator.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+        indicator.line.fill.background()
+
+        text_box = slide.shapes.add_textbox(Inches(1.0), Inches(y_pos), Inches(11.5), Inches(0.9))
+        tf = text_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = bullet_text
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(22)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    add_slide_label(slide, "content-slide")
+
+
+def create_two_column_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    LEFT_COLOR = "f38ba8"
+    RIGHT_COLOR = "a6e3a1"
+
+    # Title bar
+    title_bar = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0), Inches(0), Inches(13.333), Inches(1.3))
+    title_bar.fill.solid()
+    title_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    title_bar.line.fill.background()
+
+    title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.4), Inches(12.33), Inches(0.8))
+    p = title_box.text_frame.paragraphs[0]
+    p.text = "Before vs After"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(32)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Divider
+    divider = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(6.63), Inches(1.5), Inches(0.07), Inches(5.5))
+    divider.fill.solid()
+    divider.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    divider.line.fill.background()
+
+    # Left header
+    left_ind = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.5), Inches(1.7), Inches(0.15), Inches(0.5))
+    left_ind.fill.solid()
+    left_ind.fill.fore_color.rgb = hex_to_rgb(LEFT_COLOR)
+    left_ind.line.fill.background()
+
+    left_header = slide.shapes.add_textbox(Inches(0.85), Inches(1.65), Inches(5.5), Inches(0.6))
+    p = left_header.text_frame.paragraphs[0]
+    p.text = "The Old Way"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(24)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(LEFT_COLOR)
+
+    # Right header
+    right_ind = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(6.93), Inches(1.7), Inches(0.15), Inches(0.5))
+    right_ind.fill.solid()
+    right_ind.fill.fore_color.rgb = hex_to_rgb(RIGHT_COLOR)
+    right_ind.line.fill.background()
+
+    right_header = slide.shapes.add_textbox(Inches(7.28), Inches(1.65), Inches(5.5), Inches(0.6))
+    p = right_header.text_frame.paragraphs[0]
+    p.text = "The New Way"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(24)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(RIGHT_COLOR)
+
+    add_slide_label(slide, "two-column-slide")
+
+
+def create_quote_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large quote mark
+    quote_mark = slide.shapes.add_textbox(Inches(0.5), Inches(1.5), Inches(2.0), Inches(2.0))
+    p = quote_mark.text_frame.paragraphs[0]
+    p.text = "\u201C"
+    p.font.name = "Georgia"
+    p.font.size = Pt(200)
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+
+    # Accent bar
+    accent_bar = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(1.0), Inches(2.8), Inches(0.12), Inches(2.5))
+    accent_bar.fill.solid()
+    accent_bar.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    accent_bar.line.fill.background()
+
+    # Quote text
+    quote_box = slide.shapes.add_textbox(Inches(1.5), Inches(2.8), Inches(10.5), Inches(2.5))
+    tf = quote_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "The model isn't the bottleneck. You are."
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(36)
+    p.font.italic = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Attribution
+    attr_box = slide.shapes.add_textbox(Inches(1.5), Inches(5.5), Inches(10.5), Inches(0.6))
+    p = attr_box.text_frame.paragraphs[0]
+    p.text = "— Rasmus Widing"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(18)
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+
+    add_slide_label(slide, "quote-slide")
+
+
+def create_section_break_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large accent block
+    accent_block = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0), Inches(0), Inches(4.5), Inches(7.5))
+    accent_block.fill.solid()
+    accent_block.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    accent_block.line.fill.background()
+
+    # Section number
+    num_box = slide.shapes.add_textbox(Inches(0.5), Inches(2.8), Inches(3.5), Inches(1.5))
+    p = num_box.text_frame.paragraphs[0]
+    p.text = "02"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(120)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Divider
+    divider = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(4.5), Inches(1.5), Inches(0.08), Inches(4.5))
+    divider.fill.solid()
+    divider.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    divider.line.fill.background()
+
+    # Section title
+    title_box = slide.shapes.add_textbox(Inches(5.2), Inches(2.6), Inches(7.5), Inches(1.5))
+    tf = title_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "The Core Problem"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(44)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    add_slide_label(slide, "section-break-slide")
+
+
+def create_stats_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.6), Inches(12.0), Inches(1.0))
+    p = title_box.text_frame.paragraphs[0]
+    p.text = "The Results Speak"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    stats = [("10x", "Faster Development"), ("85%", "Less Boilerplate"), ("3hrs", "To Production")]
+    colors = [BRAND_ACCENT, BRAND_ACCENT_SECONDARY, BRAND_ACCENT_TERTIARY]
+    stat_width = 4.0
+
+    for i, ((value, label), color) in enumerate(zip(stats, colors)):
+        x_pos = 0.66 + (i * stat_width)
+
+        value_box = slide.shapes.add_textbox(Inches(x_pos), Inches(2.5), Inches(stat_width - 0.3), Inches(1.8))
+        p = value_box.text_frame.paragraphs[0]
+        p.text = value
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(72)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(color)
+        p.alignment = PP_ALIGN.CENTER
+
+        label_box = slide.shapes.add_textbox(Inches(x_pos), Inches(4.6), Inches(stat_width - 0.3), Inches(1.0))
+        tf = label_box.text_frame
+        tf.word_wrap = True
+        p = tf.paragraphs[0]
+        p.text = label
+        p.font.name = BRAND_BODY_FONT
+        p.font.size = Pt(20)
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+        p.alignment = PP_ALIGN.CENTER
+
+    add_slide_label(slide, "stats-slide")
+
+
+def create_code_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.4), Inches(10.0), Inches(0.8))
+    p = title_box.text_frame.paragraphs[0]
+    p.text = "The Pattern"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(32)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Code block background
+    code_bg = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(0.5), Inches(1.4), Inches(12.33), Inches(4.8))
+    code_bg.fill.solid()
+    code_bg.fill.fore_color.rgb = hex_to_rgb(BRAND_CODE_BG)
+    code_bg.line.color.rgb = hex_to_rgb("313244")
+
+    # Terminal dots
+    for i, color in enumerate(["f38ba8", "f9e2af", "a6e3a1"]):
+        dot = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(0.8 + (i * 0.35)), Inches(1.65), Inches(0.18), Inches(0.18))
+        dot.fill.solid()
+        dot.fill.fore_color.rgb = hex_to_rgb(color)
+        dot.line.fill.background()
+
+    # Code content
+    code_box = slide.shapes.add_textbox(Inches(0.8), Inches(2.2), Inches(11.7), Inches(3.8))
+    p = code_box.text_frame.paragraphs[0]
+    p.text = "def create_agent(config):\n    context = load_context(config.path)\n    return Agent(context=context)"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(18)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    add_slide_label(slide, "code-slide")
+
+
+def create_bold_diagonal_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Diagonal blocks
+    block1 = slide.shapes.add_shape(MSO_SHAPE.PARALLELOGRAM, Inches(-1), Inches(3), Inches(8), Inches(5))
+    block1.fill.solid()
+    block1.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    block1.line.fill.background()
+
+    block2 = slide.shapes.add_shape(MSO_SHAPE.PARALLELOGRAM, Inches(-2), Inches(4.5), Inches(7), Inches(4))
+    block2.fill.solid()
+    block2.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    block2.line.fill.background()
+
+    # Headline
+    headline_box = slide.shapes.add_textbox(Inches(5.5), Inches(2.0), Inches(7.3), Inches(2.0))
+    tf = headline_box.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "Break Everything"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(64)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.RIGHT
+
+    # Subtext
+    subtext_box = slide.shapes.add_textbox(Inches(5.5), Inches(4.2), Inches(7.3), Inches(1.0))
+    p = subtext_box.text_frame.paragraphs[0]
+    p.text = "Then rebuild it better"
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(24)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+    p.alignment = PP_ALIGN.RIGHT
+
+    add_slide_label(slide, "bold-diagonal-slide")
+
+
+def create_giant_focus_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Background circle
+    bg_circle = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(3.5), Inches(0.5), Inches(6.333), Inches(6.333))
+    bg_circle.fill.solid()
+    bg_circle.fill.fore_color.rgb = hex_to_rgb("232333")
+    bg_circle.line.fill.background()
+
+    # Context above
+    above_box = slide.shapes.add_textbox(Inches(0.5), Inches(1.8), Inches(12.333), Inches(0.6))
+    p = above_box.text_frame.paragraphs[0]
+    p.text = "NOT INCREMENTAL IMPROVEMENT"
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(14)
+    p.font.color.rgb = hex_to_rgb("6c7086")
+    p.alignment = PP_ALIGN.CENTER
+
+    # GIANT TEXT
+    big_box = slide.shapes.add_textbox(Inches(0), Inches(2.2), Inches(13.333), Inches(3.5))
+    p = big_box.text_frame.paragraphs[0]
+    p.text = "10x"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(200)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Context below
+    below_box = slide.shapes.add_textbox(Inches(0.5), Inches(5.6), Inches(12.333), Inches(0.6))
+    p = below_box.text_frame.paragraphs[0]
+    p.text = "Order of magnitude thinking"
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(20)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    add_slide_label(slide, "giant-focus-slide")
+
+
+def create_floating_cards_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.5), Inches(12.333), Inches(1.0))
+    p = title_box.text_frame.paragraphs[0]
+    p.text = "Three Pillars"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(40)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    cards = [("Context", "Feed the model what it needs"), ("Tools", "Give it ability to act"), ("Iteration", "Refine until done")]
+    configs = [
+        {"x": 0.8, "y": 2.0, "accent": BRAND_ACCENT},
+        {"x": 4.5, "y": 2.4, "accent": BRAND_ACCENT_SECONDARY},
+        {"x": 8.2, "y": 1.8, "accent": BRAND_ACCENT_TERTIARY},
+    ]
+
+    for i, ((title, desc), config) in enumerate(zip(cards, configs)):
+        x, y, accent = config["x"], config["y"], config["accent"]
+
+        # Shadow
+        shadow = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(x + 0.15), Inches(y + 0.15), Inches(4.0), Inches(3.8))
+        shadow.fill.solid()
+        shadow.fill.fore_color.rgb = hex_to_rgb("11111b")
+        shadow.line.fill.background()
+
+        # Card
+        card = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(x), Inches(y), Inches(4.0), Inches(3.8))
+        card.fill.solid()
+        card.fill.fore_color.rgb = hex_to_rgb(BRAND_CARD_BG)
+        card.line.fill.background()
+
+        # Accent bar
+        bar = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(x + 0.3), Inches(y + 0.3), Inches(0.8), Inches(0.12))
+        bar.fill.solid()
+        bar.fill.fore_color.rgb = hex_to_rgb(accent)
+        bar.line.fill.background()
+
+        # Number
+        num = slide.shapes.add_textbox(Inches(x + 0.3), Inches(y + 0.6), Inches(1.0), Inches(0.8))
+        p = num.text_frame.paragraphs[0]
+        p.text = f"0{i+1}"
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(32)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(accent)
+
+        # Title
+        t = slide.shapes.add_textbox(Inches(x + 0.3), Inches(y + 1.5), Inches(3.4), Inches(0.8))
+        p = t.text_frame.paragraphs[0]
+        p.text = title
+        p.font.name = BRAND_HEADING_FONT
+        p.font.size = Pt(24)
+        p.font.bold = True
+        p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    add_slide_label(slide, "floating-cards-slide")
+
+
+def create_circular_hero_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    center_x, center_y = 6.666, 3.75
+
+    # Outer ring
+    outer = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(center_x - 3.2), Inches(center_y - 3.2), Inches(6.4), Inches(6.4))
+    outer.fill.background()
+    outer.line.color.rgb = hex_to_rgb("313244")
+    outer.line.width = Pt(2)
+
+    # Main circle
+    main = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(center_x - 1.75), Inches(center_y - 1.75), Inches(3.5), Inches(3.5))
+    main.fill.solid()
+    main.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    main.line.fill.background()
+
+    # Center text
+    center = slide.shapes.add_textbox(Inches(center_x - 1.5), Inches(center_y - 0.4), Inches(3), Inches(1.0))
+    p = center.text_frame.paragraphs[0]
+    p.text = "Context"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(40)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_BG)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Surrounding items
+    items = ["Docs", "Examples", "Constraints", "History", "Tools", "Goals"]
+    for i, item in enumerate(items):
+        angle = (2 * math.pi * i / len(items)) - math.pi / 2
+        x = center_x + 2.8 * math.cos(angle)
+        y = center_y + 2.8 * math.sin(angle)
+
+        dot = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(x - 0.08), Inches(y - 0.08), Inches(0.16), Inches(0.16))
+        dot.fill.solid()
+        dot.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+        dot.line.fill.background()
+
+    add_slide_label(slide, "circular-hero-slide")
+
+
+def create_chart_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title_box = slide.shapes.add_textbox(Inches(0.5), Inches(0.4), Inches(12.333), Inches(0.8))
+    p = title_box.text_frame.paragraphs[0]
+    p.text = "Time Allocation"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Chart
+    chart_data = CategoryChartData()
+    chart_data.categories = ["Context", "Iteration", "Prompting", "Debugging"]
+    chart_data.add_series("Values", [40, 30, 20, 10])
+
+    chart_shape = slide.shapes.add_chart(XL_CHART_TYPE.DOUGHNUT, Inches(0.5), Inches(1.8), Inches(7.5), Inches(5.0), chart_data)
+    chart = chart_shape.chart
+    chart.has_legend = True
+    chart.legend.position = XL_LEGEND_POSITION.RIGHT
+
+    # Insight box
+    insight_bg = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(8.5), Inches(2.5), Inches(4.3), Inches(2.5))
+    insight_bg.fill.solid()
+    insight_bg.fill.fore_color.rgb = hex_to_rgb(BRAND_CARD_BG)
+    insight_bg.line.fill.background()
+
+    insight_label = slide.shapes.add_textbox(Inches(8.8), Inches(2.7), Inches(3.7), Inches(0.5))
+    p = insight_label.text_frame.paragraphs[0]
+    p.text = "KEY INSIGHT"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(12)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+
+    insight = slide.shapes.add_textbox(Inches(8.8), Inches(3.2), Inches(3.7), Inches(1.5))
+    tf = insight.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "40% of success comes from context engineering"
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(18)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    add_slide_label(slide, "chart-slide")
+
+
+def create_corner_anchor_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Large anchor circle (top-right)
+    anchor = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(13.333 - 2.75), Inches(-2.75), Inches(5.5), Inches(5.5))
+    anchor.fill.solid()
+    anchor.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    anchor.line.fill.background()
+
+    # Secondary circle
+    small = slide.shapes.add_shape(MSO_SHAPE.OVAL, Inches(13.333 - 2.5), Inches(-0.5), Inches(2.5), Inches(2.5))
+    small.fill.solid()
+    small.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT_SECONDARY)
+    small.line.fill.background()
+
+    # Headline
+    headline = slide.shapes.add_textbox(Inches(0.8), Inches(3.0), Inches(7.0), Inches(1.5))
+    p = headline.text_frame.paragraphs[0]
+    p.text = "Ship Faster"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(56)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Accent line
+    line = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.8), Inches(4.6), Inches(2.5), Inches(0.08))
+    line.fill.solid()
+    line.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    line.line.fill.background()
+
+    # Body
+    body = slide.shapes.add_textbox(Inches(0.8), Inches(5.0), Inches(7.0), Inches(2.0))
+    tf = body.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "The best code is code running in production, not perfect code in a branch."
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(20)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+
+    add_slide_label(slide, "corner-anchor-slide")
+
+
+def create_closing_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Bottom block
+    bottom = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0), Inches(5.0), Inches(13.333), Inches(2.5))
+    bottom.fill.solid()
+    bottom.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    bottom.line.fill.background()
+
+    # Top bar
+    top = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0), Inches(0), Inches(13.333), Inches(0.12))
+    top.fill.solid()
+    top.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    top.line.fill.background()
+
+    # Headline
+    headline = slide.shapes.add_textbox(Inches(0.5), Inches(2.0), Inches(12.33), Inches(1.5))
+    p = headline.text_frame.paragraphs[0]
+    p.text = "Start Building Today"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(56)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+    p.alignment = PP_ALIGN.CENTER
+
+    # Underline
+    underline = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(5.5), Inches(3.6), Inches(2.33), Inches(0.08))
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    add_slide_label(slide, "closing-slide")
+
+
+def create_image_caption_slide(prs):
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    slide.background.fill.solid()
+    slide.background.fill.fore_color.rgb = hex_to_rgb(BRAND_BG)
+
+    # Title
+    title = slide.shapes.add_textbox(Inches(0.5), Inches(1.5), Inches(5.5), Inches(1.2))
+    tf = title.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "See It In Action"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(36)
+    p.font.bold = True
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT)
+
+    # Underline
+    underline = slide.shapes.add_shape(MSO_SHAPE.RECTANGLE, Inches(0.5), Inches(2.8), Inches(2.0), Inches(0.06))
+    underline.fill.solid()
+    underline.fill.fore_color.rgb = hex_to_rgb(BRAND_ACCENT)
+    underline.line.fill.background()
+
+    # Caption
+    caption = slide.shapes.add_textbox(Inches(0.5), Inches(3.2), Inches(5.5), Inches(3.0))
+    tf = caption.text_frame
+    tf.word_wrap = True
+    p = tf.paragraphs[0]
+    p.text = "Real-time visibility into your agent's context window and decisions."
+    p.font.name = BRAND_BODY_FONT
+    p.font.size = Pt(20)
+    p.font.color.rgb = hex_to_rgb(BRAND_TEXT_SECONDARY)
+
+    # Image placeholder
+    placeholder = slide.shapes.add_shape(MSO_SHAPE.ROUNDED_RECTANGLE, Inches(6.5), Inches(0.8), Inches(6.33), Inches(5.9))
+    placeholder.fill.solid()
+    placeholder.fill.fore_color.rgb = hex_to_rgb(BRAND_BG_ALT)
+    placeholder.line.color.rgb = hex_to_rgb("313244")
+
+    # Placeholder text
+    img_text = slide.shapes.add_textbox(Inches(8.5), Inches(3.5), Inches(2.0), Inches(0.5))
+    p = img_text.text_frame.paragraphs[0]
+    p.text = "IMAGE"
+    p.font.name = BRAND_HEADING_FONT
+    p.font.size = Pt(16)
+    p.font.color.rgb = hex_to_rgb(BRAND_ACCENT)
+    p.alignment = PP_ALIGN.CENTER
+
+    add_slide_label(slide, "image-caption-slide")
+
+
+def main():
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+
+    # Generate all layouts
+    print("Generating cookbook preview...")
+    create_title_slide(prs)
+    create_content_slide(prs)
+    create_two_column_slide(prs)
+    create_quote_slide(prs)
+    create_section_break_slide(prs)
+    create_stats_slide(prs)
+    create_code_slide(prs)
+    create_bold_diagonal_slide(prs)
+    create_giant_focus_slide(prs)
+    create_floating_cards_slide(prs)
+    create_circular_hero_slide(prs)
+    create_chart_slide(prs)
+    create_corner_anchor_slide(prs)
+    create_closing_slide(prs)
+    create_image_caption_slide(prs)
+
+    output = Path("cookbook-preview.pptx")
+    prs.save(output)
+    print(f"Created {output} with {len(prs.slides)} slides")
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/remotion/.codex-plugin/plugin.json
+++ b/marketplace/plugins/remotion/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "remotion",
+  "version": "0.1.0",
+  "description": "Create and edit programmatic videos in React with Remotion \u2014 compositions, animations, sequencing, audio, and captions backed by a 30-topic rules library.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Remotion Video",
+    "shortDescription": "Create and edit programmatic videos in React with Remotion \u2014 compositions, animations, sequencing, audio, and captions backed by a 30-topic rules library.",
+    "longDescription": "Use before writing any Remotion code \u2014 creating or editing compositions, animations, sequences, transitions, audio, captions, charts, or 3D scenes in a React video project (remotion.config.ts, remotion-videos/*). A rules/ library carries topic-specific guidance for ~30 areas \u2014 timing and interpolation curves, sequencing and trimming, assets and fonts, Mediabunny media probing, TikTok-style captions, Lottie, Mapbox maps, TailwindCSS \u2014 plus ready-made typewriter and word-highlight text-animation components.",
+    "developerName": "OpenCoven",
+    "category": "Media & Creative",
+    "capabilities": [
+      "remotion",
+      "video",
+      "react",
+      "animation",
+      "composition",
+      "captions"
+    ],
+    "defaultPrompt": "Help me use Remotion Video safely."
+  }
+}

--- a/marketplace/plugins/remotion/NOTES.md
+++ b/marketplace/plugins/remotion/NOTES.md
@@ -1,0 +1,23 @@
+# NOTES — Remotion Video
+
+## Provenance
+Vendored from [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills)
+(`.claude/skills/remotion/`) at commit `75e1e9cd60ef46bffbd294fdfe4d0320cee2f563`
+(fetched 2026-07-06). The rules library originates from Remotion's own agent guidance
+(remotion.dev); packaged for second-brain-skills by Cole Medin (coleam00). The generated
+`plugin.json` author/license fields are stamped by `scripts/sync-marketplace.py` and do not
+reflect upstream authorship.
+
+## What's vendored
+The complete upstream skill: the skill entry file plus `rules/` — ~30 topic files (timing,
+sequencing, compositions, assets, audio, captions, charts, 3D, Lottie, maps, Tailwind, Mediabunny
+media probing) and `rules/assets/` ready-made text-animation/chart components.
+
+One rename: upstream ships the entry file as lowercase `skill.md`; it is `SKILL.md` here to match
+the marketplace pack layout. Content is unmodified — frontmatter keeps the upstream skill name
+`remotion-best-practices`.
+
+## Sync integration
+`skill.managed: "manual"` in `marketplace/catalog.json` — the authored SKILL.md is the source of
+truth; `sync-marketplace.py` generates only the manifests and never rewrites the skill body.
+Re-vendor by re-copying from upstream (re-applying the rename) and updating the commit hash above.

--- a/marketplace/plugins/remotion/plugin.json
+++ b/marketplace/plugins/remotion/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "remotion",
+  "version": "0.1.0",
+  "description": "Create and edit programmatic videos in React with Remotion \u2014 compositions, animations, sequencing, audio, and captions backed by a 30-topic rules library.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "remotion",
+    "video",
+    "react",
+    "animation",
+    "composition",
+    "captions"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell"
+  ],
+  "marketplaceId": "opencoven/remotion",
+  "x-coven": {
+    "displayName": "Remotion Video",
+    "category": "Media & Creative",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/coleam00/second-brain-skills",
+      "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/remotion",
+      "https://www.remotion.dev/docs"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  }
+}

--- a/marketplace/plugins/remotion/skills/remotion/SKILL.md
+++ b/marketplace/plugins/remotion/skills/remotion/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: remotion-best-practices
+description: |
+  Create and edit Remotion videos with domain-specific knowledge.
+  TRIGGERS - Use this skill when:
+  - User mentions "Remotion" in their request
+  - User references a Remotion project path (remotion-videos/*, contains remotion.config.ts)
+  - User asks to create, animate, or edit video content in a Remotion context
+  - User wants to build compositions, animations, or video sequences in React
+  Always invoke this skill BEFORE writing any Remotion code.
+metadata:
+  tags: remotion, video, react, animation, composition
+---
+
+## When to use
+
+Use this skill whenever you are working with Remotion projects. This includes:
+- Creating new video compositions or animations
+- Editing existing Remotion components
+- Adding assets (images, audio, video) to a Remotion project
+- Building animated sequences, transitions, or effects
+- Any task involving a Remotion project directory
+
+**Key triggers:** The word "Remotion", paths containing `remotion-videos/`, files like `remotion.config.ts`, or requests to create animated video content in React.
+
+## How to use
+
+Read individual rule files for detailed explanations and code examples:
+
+- [rules/3d.md](rules/3d.md) - 3D content in Remotion using Three.js and React Three Fiber
+- [rules/animations.md](rules/animations.md) - Fundamental animation skills for Remotion
+- [rules/assets.md](rules/assets.md) - Importing images, videos, audio, and fonts into Remotion
+- [rules/audio.md](rules/audio.md) - Using audio and sound in Remotion - importing, trimming, volume, speed, pitch
+- [rules/calculate-metadata.md](rules/calculate-metadata.md) - Dynamically set composition duration, dimensions, and props
+- [rules/can-decode.md](rules/can-decode.md) - Check if a video can be decoded by the browser using Mediabunny
+- [rules/charts.md](rules/charts.md) - Chart and data visualization patterns for Remotion
+- [rules/compositions.md](rules/compositions.md) - Defining compositions, stills, folders, default props and dynamic metadata
+- [rules/display-captions.md](rules/display-captions.md) - Displaying captions in Remotion with TikTok-style pages and word highlighting
+- [rules/extract-frames.md](rules/extract-frames.md) - Extract frames from videos at specific timestamps using Mediabunny
+- [rules/fonts.md](rules/fonts.md) - Loading Google Fonts and local fonts in Remotion
+- [rules/get-audio-duration.md](rules/get-audio-duration.md) - Getting the duration of an audio file in seconds with Mediabunny
+- [rules/get-video-dimensions.md](rules/get-video-dimensions.md) - Getting the width and height of a video file with Mediabunny
+- [rules/get-video-duration.md](rules/get-video-duration.md) - Getting the duration of a video file in seconds with Mediabunny
+- [rules/gifs.md](rules/gifs.md) - Displaying GIFs synchronized with Remotion's timeline
+- [rules/images.md](rules/images.md) - Embedding images in Remotion using the Img component
+- [rules/import-srt-captions.md](rules/import-srt-captions.md) - Importing .srt subtitle files into Remotion using @remotion/captions
+- [rules/lottie.md](rules/lottie.md) - Embedding Lottie animations in Remotion
+- [rules/measuring-dom-nodes.md](rules/measuring-dom-nodes.md) - Measuring DOM element dimensions in Remotion
+- [rules/measuring-text.md](rules/measuring-text.md) - Measuring text dimensions, fitting text to containers, and checking overflow
+- [rules/sequencing.md](rules/sequencing.md) - Sequencing patterns for Remotion - delay, trim, limit duration of items
+- [rules/tailwind.md](rules/tailwind.md) - Using TailwindCSS in Remotion
+- [rules/text-animations.md](rules/text-animations.md) - Typography and text animation patterns for Remotion
+- [rules/timing.md](rules/timing.md) - Interpolation curves in Remotion - linear, easing, spring animations
+- [rules/transcribe-captions.md](rules/transcribe-captions.md) - Transcribing audio to generate captions in Remotion
+- [rules/transitions.md](rules/transitions.md) - Scene transition patterns for Remotion
+- [rules/trimming.md](rules/trimming.md) - Trimming patterns for Remotion - cut the beginning or end of animations
+- [rules/videos.md](rules/videos.md) - Embedding videos in Remotion - trimming, volume, speed, looping, pitch
+- [rules/parameters.md](rules/parameters.md) - Make a video parametrizable by adding a Zod schema
+- [rules/maps.md](rules/maps.md) - Add a map using Mapbox and animate it

--- a/marketplace/plugins/remotion/skills/remotion/rules/3d.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/3d.md
@@ -1,0 +1,86 @@
+---
+name: 3d
+description: 3D content in Remotion using Three.js and React Three Fiber.
+metadata:
+  tags: 3d, three, threejs
+---
+
+# Using Three.js and React Three Fiber in Remotion
+
+Follow React Three Fiber and Three.js best practices.  
+Only the following Remotion-specific rules need to be followed:
+
+## Prerequisites
+
+First, the `@remotion/three` package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/three # If project uses npm
+bunx remotion add @remotion/three # If project uses bun
+yarn remotion add @remotion/three # If project uses yarn
+pnpm exec remotion add @remotion/three # If project uses pnpm
+```
+
+## Using ThreeCanvas
+
+You MUST wrap 3D content in `<ThreeCanvas>` and include proper lighting.  
+`<ThreeCanvas>` MUST have a `width` and `height` prop.
+
+```tsx
+import { ThreeCanvas } from "@remotion/three";
+import { useVideoConfig } from "remotion";
+
+const { width, height } = useVideoConfig();
+
+<ThreeCanvas width={width} height={height}>
+  <ambientLight intensity={0.4} />
+  <directionalLight position={[5, 5, 5]} intensity={0.8} />
+  <mesh>
+    <sphereGeometry args={[1, 32, 32]} />
+    <meshStandardMaterial color="red" />
+  </mesh>
+</ThreeCanvas>
+```
+
+## No animations not driven by `useCurrentFrame()`
+
+Shaders, models etc MUST NOT animate by themselves.  
+No animations are allowed unless they are driven by `useCurrentFrame()`.  
+Otherwise, it will cause flickering during rendering.  
+
+Using `useFrame()` from `@react-three/fiber` is forbidden.
+
+## Animate using `useCurrentFrame()`
+
+Use `useCurrentFrame()` to perform animations.
+
+```tsx
+const frame = useCurrentFrame();
+const rotationY = frame * 0.02;
+
+<mesh rotation={[0, rotationY, 0]}>
+  <boxGeometry args={[2, 2, 2]} />
+  <meshStandardMaterial color="#4a9eff" />
+</mesh>
+```
+
+## Using `<Sequence>` inside `<ThreeCanvas>`
+
+The `layout` prop of any `<Sequence>` inside a `<ThreeCanvas>` must be set to `none`.
+
+```tsx
+import { Sequence } from "remotion";
+import { ThreeCanvas } from "@remotion/three";
+
+const { width, height } = useVideoConfig();
+
+<ThreeCanvas width={width} height={height}>
+  <Sequence layout="none">
+    <mesh>
+      <boxGeometry args={[2, 2, 2]} />
+      <meshStandardMaterial color="#4a9eff" />
+    </mesh>
+  </Sequence>
+</ThreeCanvas>
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/animations.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/animations.md
@@ -1,0 +1,29 @@
+---
+name: animations
+description: Fundamental animation skills for Remotion
+metadata:
+  tags: animations, transitions, frames, useCurrentFrame
+---
+
+All animations MUST be driven by the `useCurrentFrame()` hook.  
+Write animations in seconds and multiply them by the `fps` value from `useVideoConfig()`.
+
+```tsx
+import { useCurrentFrame } from "remotion";
+
+export const FadeIn = () => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const opacity = interpolate(frame, [0, 2 * fps], [0, 1], {
+    extrapolateRight: 'clamp',
+  });
+ 
+  return (
+    <div style={{ opacity }}>Hello World!</div>
+  );
+};
+```
+
+CSS transitions or animations are FORBIDDEN - they will not render correctly.  
+Tailwind animation class names are FORBIDDEN - they will not render correctly.  

--- a/marketplace/plugins/remotion/skills/remotion/rules/assets.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/assets.md
@@ -1,0 +1,78 @@
+---
+name: assets
+description: Importing images, videos, audio, and fonts into Remotion
+metadata:
+  tags: assets, staticFile, images, fonts, public
+---
+
+# Importing assets in Remotion
+
+## The public folder
+
+Place assets in the `public/` folder at your project root.
+
+## Using staticFile()
+
+You MUST use `staticFile()` to reference files from the `public/` folder:
+
+```tsx
+import {Img, staticFile} from 'remotion';
+
+export const MyComposition = () => {
+  return <Img src={staticFile('logo.png')} />;
+};
+```
+
+The function returns an encoded URL that works correctly when deploying to subdirectories.
+
+## Using with components
+
+**Images:**
+
+```tsx
+import {Img, staticFile} from 'remotion';
+
+<Img src={staticFile('photo.png')} />;
+```
+
+**Videos:**
+
+```tsx
+import {Video} from '@remotion/media';
+import {staticFile} from 'remotion';
+
+<Video src={staticFile('clip.mp4')} />;
+```
+
+**Audio:**
+
+```tsx
+import {Audio} from '@remotion/media';
+import {staticFile} from 'remotion';
+
+<Audio src={staticFile('music.mp3')} />;
+```
+
+**Fonts:**
+
+```tsx
+import {staticFile} from 'remotion';
+
+const fontFamily = new FontFace('MyFont', `url(${staticFile('font.woff2')})`);
+await fontFamily.load();
+document.fonts.add(fontFamily);
+```
+
+## Remote URLs
+
+Remote URLs can be used directly without `staticFile()`:
+
+```tsx
+<Img src="https://example.com/image.png" />
+<Video src="https://remotion.media/video.mp4" />
+```
+
+## Important notes
+
+- Remotion components (`<Img>`, `<Video>`, `<Audio>`) ensure assets are fully loaded before rendering
+- Special characters in filenames (`#`, `?`, `&`) are automatically encoded

--- a/marketplace/plugins/remotion/skills/remotion/rules/assets/charts-bar-chart.tsx
+++ b/marketplace/plugins/remotion/skills/remotion/rules/assets/charts-bar-chart.tsx
@@ -1,0 +1,173 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const {fontFamily} = loadFont();
+
+const COLOR_BAR = '#D4AF37';
+const COLOR_TEXT = '#ffffff';
+const COLOR_MUTED = '#888888';
+const COLOR_BG = '#0a0a0a';
+const COLOR_AXIS = '#333333';
+
+// Ideal composition size: 1280x720
+
+const Title: React.FC<{children: React.ReactNode}> = ({children}) => (
+	<div style={{textAlign: 'center', marginBottom: 40}}>
+		<div style={{color: COLOR_TEXT, fontSize: 48, fontWeight: 600}}>
+			{children}
+		</div>
+	</div>
+);
+
+const YAxis: React.FC<{steps: number[]; height: number}> = ({
+	steps,
+	height,
+}) => (
+	<div
+		style={{
+			display: 'flex',
+			flexDirection: 'column',
+			justifyContent: 'space-between',
+			height,
+			paddingRight: 16,
+		}}
+	>
+		{steps
+			.slice()
+			.reverse()
+			.map((step) => (
+				<div
+					key={step}
+					style={{
+						color: COLOR_MUTED,
+						fontSize: 20,
+						textAlign: 'right',
+					}}
+				>
+					{step.toLocaleString()}
+				</div>
+			))}
+	</div>
+);
+
+const Bar: React.FC<{
+	height: number;
+	progress: number;
+}> = ({height, progress}) => (
+	<div
+		style={{
+			flex: 1,
+			display: 'flex',
+			flexDirection: 'column',
+			justifyContent: 'flex-end',
+		}}
+	>
+		<div
+			style={{
+				width: '100%',
+				height,
+				backgroundColor: COLOR_BAR,
+				borderRadius: '8px 8px 0 0',
+				opacity: progress,
+			}}
+		/>
+	</div>
+);
+
+const XAxis: React.FC<{
+	children: React.ReactNode;
+	labels: string[];
+	height: number;
+}> = ({children, labels, height}) => (
+	<div style={{flex: 1, display: 'flex', flexDirection: 'column'}}>
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'flex-end',
+				gap: 16,
+				height,
+				borderLeft: `2px solid ${COLOR_AXIS}`,
+				borderBottom: `2px solid ${COLOR_AXIS}`,
+				paddingLeft: 16,
+			}}
+		>
+			{children}
+		</div>
+		<div
+			style={{
+				display: 'flex',
+				gap: 16,
+				paddingLeft: 16,
+				marginTop: 12,
+			}}
+		>
+			{labels.map((label) => (
+				<div
+					key={label}
+					style={{
+						flex: 1,
+						textAlign: 'center',
+						color: COLOR_MUTED,
+						fontSize: 20,
+					}}
+				>
+					{label}
+				</div>
+			))}
+		</div>
+	</div>
+);
+
+export const MyAnimation = () => {
+	const frame = useCurrentFrame();
+	const {fps, height} = useVideoConfig();
+
+	const data = [
+		{month: 'Jan', price: 2039},
+		{month: 'Mar', price: 2160},
+		{month: 'May', price: 2327},
+		{month: 'Jul', price: 2426},
+		{month: 'Sep', price: 2634},
+		{month: 'Nov', price: 2672},
+	];
+
+	const minPrice = 2000;
+	const maxPrice = 2800;
+	const priceRange = maxPrice - minPrice;
+	const chartHeight = height - 280;
+	const yAxisSteps = [2000, 2400, 2800];
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: COLOR_BG,
+				padding: 60,
+				display: 'flex',
+				flexDirection: 'column',
+				fontFamily,
+			}}
+		>
+			<Title>Gold Price 2024</Title>
+
+			<div style={{display: 'flex', flex: 1}}>
+				<YAxis steps={yAxisSteps} height={chartHeight} />
+				<XAxis height={chartHeight} labels={data.map((d) => d.month)}>
+					{data.map((item, i) => {
+						const progress = spring({
+							frame: frame - i * 5 - 10,
+							fps,
+							config: {damping: 18, stiffness: 80},
+						});
+
+						const barHeight =
+							((item.price - minPrice) / priceRange) * chartHeight * progress;
+
+						return (
+							<Bar key={item.month} height={barHeight} progress={progress} />
+						);
+					})}
+				</XAxis>
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/marketplace/plugins/remotion/skills/remotion/rules/assets/text-animations-typewriter.tsx
+++ b/marketplace/plugins/remotion/skills/remotion/rules/assets/text-animations-typewriter.tsx
@@ -1,0 +1,100 @@
+import {
+	AbsoluteFill,
+	interpolate,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+const COLOR_BG = '#ffffff';
+const COLOR_TEXT = '#000000';
+const FULL_TEXT = 'From prompt to motion graphics. This is Remotion.';
+const PAUSE_AFTER = 'From prompt to motion graphics.';
+const FONT_SIZE = 72;
+const FONT_WEIGHT = 700;
+const CHAR_FRAMES = 2;
+const CURSOR_BLINK_FRAMES = 16;
+const PAUSE_SECONDS = 1;
+
+// Ideal composition size: 1280x720
+
+const getTypedText = ({
+	frame,
+	fullText,
+	pauseAfter,
+	charFrames,
+	pauseFrames,
+}: {
+	frame: number;
+	fullText: string;
+	pauseAfter: string;
+	charFrames: number;
+	pauseFrames: number;
+}): string => {
+	const pauseIndex = fullText.indexOf(pauseAfter);
+	const preLen =
+		pauseIndex >= 0 ? pauseIndex + pauseAfter.length : fullText.length;
+
+	let typedChars = 0;
+	if (frame < preLen * charFrames) {
+		typedChars = Math.floor(frame / charFrames);
+	} else if (frame < preLen * charFrames + pauseFrames) {
+		typedChars = preLen;
+	} else {
+		const postPhase = frame - preLen * charFrames - pauseFrames;
+		typedChars = Math.min(
+			fullText.length,
+			preLen + Math.floor(postPhase / charFrames),
+		);
+	}
+	return fullText.slice(0, typedChars);
+};
+
+const Cursor: React.FC<{
+	frame: number;
+	blinkFrames: number;
+	symbol?: string;
+}> = ({frame, blinkFrames, symbol = '\u258C'}) => {
+	const opacity = interpolate(
+		frame % blinkFrames,
+		[0, blinkFrames / 2, blinkFrames],
+		[1, 0, 1],
+		{extrapolateLeft: 'clamp', extrapolateRight: 'clamp'},
+	);
+
+	return <span style={{opacity}}>{symbol}</span>;
+};
+
+export const MyAnimation = () => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const pauseFrames = Math.round(fps * PAUSE_SECONDS);
+
+	const typedText = getTypedText({
+		frame,
+		fullText: FULL_TEXT,
+		pauseAfter: PAUSE_AFTER,
+		charFrames: CHAR_FRAMES,
+		pauseFrames,
+	});
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: COLOR_BG,
+			}}
+		>
+			<div
+				style={{
+					color: COLOR_TEXT,
+					fontSize: FONT_SIZE,
+					fontWeight: FONT_WEIGHT,
+					fontFamily: 'sans-serif',
+				}}
+			>
+				<span>{typedText}</span>
+				<Cursor frame={frame} blinkFrames={CURSOR_BLINK_FRAMES} />
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/marketplace/plugins/remotion/skills/remotion/rules/assets/text-animations-word-highlight.tsx
+++ b/marketplace/plugins/remotion/skills/remotion/rules/assets/text-animations-word-highlight.tsx
@@ -1,0 +1,108 @@
+import {loadFont} from '@remotion/google-fonts/Inter';
+import React from 'react';
+import {
+	AbsoluteFill,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+/*
+ * Highlight a word in a sentence with a spring-animated wipe effect.
+ */
+
+// Ideal composition size: 1280x720
+
+const COLOR_BG = '#ffffff';
+const COLOR_TEXT = '#000000';
+const COLOR_HIGHLIGHT = '#A7C7E7';
+const FULL_TEXT = 'This is Remotion.';
+const HIGHLIGHT_WORD = 'Remotion';
+const FONT_SIZE = 72;
+const FONT_WEIGHT = 700;
+const HIGHLIGHT_START_FRAME = 30;
+const HIGHLIGHT_WIPE_DURATION = 18;
+
+const {fontFamily} = loadFont();
+
+const Highlight: React.FC<{
+	word: string;
+	color: string;
+	delay: number;
+	durationInFrames: number;
+}> = ({word, color, delay, durationInFrames}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const highlightProgress = spring({
+		fps,
+		frame,
+		config: {damping: 200},
+		delay,
+		durationInFrames,
+	});
+	const scaleX = Math.max(0, Math.min(1, highlightProgress));
+
+	return (
+		<span style={{position: 'relative', display: 'inline-block'}}>
+			<span
+				style={{
+					position: 'absolute',
+					left: 0,
+					right: 0,
+					top: '50%',
+					height: '1.05em',
+					transform: `translateY(-50%) scaleX(${scaleX})`,
+					transformOrigin: 'left center',
+					backgroundColor: color,
+					borderRadius: '0.18em',
+					zIndex: 0,
+				}}
+			/>
+			<span style={{position: 'relative', zIndex: 1}}>{word}</span>
+		</span>
+	);
+};
+
+export const MyAnimation = () => {
+	const highlightIndex = FULL_TEXT.indexOf(HIGHLIGHT_WORD);
+	const hasHighlight = highlightIndex >= 0;
+	const preText = hasHighlight ? FULL_TEXT.slice(0, highlightIndex) : FULL_TEXT;
+	const postText = hasHighlight
+		? FULL_TEXT.slice(highlightIndex + HIGHLIGHT_WORD.length)
+		: '';
+
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor: COLOR_BG,
+				alignItems: 'center',
+				justifyContent: 'center',
+				fontFamily,
+			}}
+		>
+			<div
+				style={{
+					color: COLOR_TEXT,
+					fontSize: FONT_SIZE,
+					fontWeight: FONT_WEIGHT,
+				}}
+			>
+				{hasHighlight ? (
+					<>
+						<span>{preText}</span>
+						<Highlight
+							word={HIGHLIGHT_WORD}
+							color={COLOR_HIGHLIGHT}
+							delay={HIGHLIGHT_START_FRAME}
+							durationInFrames={HIGHLIGHT_WIPE_DURATION}
+						/>
+						<span>{postText}</span>
+					</>
+				) : (
+					<span>{FULL_TEXT}</span>
+				)}
+			</div>
+		</AbsoluteFill>
+	);
+};

--- a/marketplace/plugins/remotion/skills/remotion/rules/audio.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/audio.md
@@ -1,0 +1,172 @@
+---
+name: audio
+description: Using audio and sound in Remotion - importing, trimming, volume, speed, pitch
+metadata:
+  tags: audio, media, trim, volume, speed, loop, pitch, mute, sound, sfx
+---
+
+# Using audio in Remotion
+
+## Prerequisites
+
+First, the @remotion/media package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/media # If project uses npm
+bunx remotion add @remotion/media # If project uses bun
+yarn remotion add @remotion/media # If project uses yarn
+pnpm exec remotion add @remotion/media # If project uses pnpm
+```
+
+## Importing Audio
+
+Use `<Audio>` from `@remotion/media` to add audio to your composition.
+
+```tsx
+import { Audio } from "@remotion/media";
+import { staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Audio src={staticFile("audio.mp3")} />;
+};
+```
+
+Remote URLs are also supported:
+
+```tsx
+<Audio src="https://remotion.media/audio.mp3" />
+```
+
+By default, audio plays from the start, at full volume and full length.
+Multiple audio tracks can be layered by adding multiple `<Audio>` components.
+
+## Trimming
+
+Use `trimBefore` and `trimAfter` to remove portions of the audio. Values are in frames.
+
+```tsx
+const { fps } = useVideoConfig();
+
+return (
+  <Audio
+    src={staticFile("audio.mp3")}
+    trimBefore={2 * fps} // Skip the first 2 seconds
+    trimAfter={10 * fps} // End at the 10 second mark
+  />
+);
+```
+
+The audio still starts playing at the beginning of the composition - only the specified portion is played.
+
+## Delaying
+
+Wrap the audio in a `<Sequence>` to delay when it starts:
+
+```tsx
+import { Sequence, staticFile } from "remotion";
+import { Audio } from "@remotion/media";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Sequence from={1 * fps}>
+    <Audio src={staticFile("audio.mp3")} />
+  </Sequence>
+);
+```
+
+The audio will start playing after 1 second.
+
+## Volume
+
+Set a static volume (0 to 1):
+
+```tsx
+<Audio src={staticFile("audio.mp3")} volume={0.5} />
+```
+
+Or use a callback for dynamic volume based on the current frame:
+
+```tsx
+import { interpolate } from "remotion";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Audio
+    src={staticFile("audio.mp3")}
+    volume={(f) =>
+      interpolate(f, [0, 1 * fps], [0, 1], { extrapolateRight: "clamp" })
+    }
+  />
+);
+```
+
+The value of `f` starts at 0 when the audio begins to play, not the composition frame.
+
+## Muting
+
+Use `muted` to silence the audio. It can be set dynamically:
+
+```tsx
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+return (
+  <Audio
+    src={staticFile("audio.mp3")}
+    muted={frame >= 2 * fps && frame <= 4 * fps} // Mute between 2s and 4s
+  />
+);
+```
+
+## Speed
+
+Use `playbackRate` to change the playback speed:
+
+```tsx
+<Audio src={staticFile("audio.mp3")} playbackRate={2} /> {/* 2x speed */}
+<Audio src={staticFile("audio.mp3")} playbackRate={0.5} /> {/* Half speed */}
+```
+
+Reverse playback is not supported.
+
+## Looping
+
+Use `loop` to loop the audio indefinitely:
+
+```tsx
+<Audio src={staticFile("audio.mp3")} loop />
+```
+
+Use `loopVolumeCurveBehavior` to control how the frame count behaves when looping:
+
+- `"repeat"`: Frame count resets to 0 each loop (default)
+- `"extend"`: Frame count continues incrementing
+
+```tsx
+<Audio
+  src={staticFile("audio.mp3")}
+  loop
+  loopVolumeCurveBehavior="extend"
+  volume={(f) => interpolate(f, [0, 300], [1, 0])} // Fade out over multiple loops
+/>
+```
+
+## Pitch
+
+Use `toneFrequency` to adjust the pitch without affecting speed. Values range from 0.01 to 2:
+
+```tsx
+<Audio
+  src={staticFile("audio.mp3")}
+  toneFrequency={1.5} // Higher pitch
+/>
+<Audio
+  src={staticFile("audio.mp3")}
+  toneFrequency={0.8} // Lower pitch
+/>
+```
+
+Pitch shifting only works during server-side rendering, not in the Remotion Studio preview or in the `<Player />`.

--- a/marketplace/plugins/remotion/skills/remotion/rules/calculate-metadata.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/calculate-metadata.md
@@ -1,0 +1,104 @@
+---
+name: calculate-metadata
+description: Dynamically set composition duration, dimensions, and props
+metadata:
+  tags: calculateMetadata, duration, dimensions, props, dynamic
+---
+
+# Using calculateMetadata
+
+Use `calculateMetadata` on a `<Composition>` to dynamically set duration, dimensions, and transform props before rendering.
+
+```tsx
+<Composition id="MyComp" component={MyComponent} durationInFrames={300} fps={30} width={1920} height={1080} defaultProps={{videoSrc: 'https://remotion.media/video.mp4'}} calculateMetadata={calculateMetadata} />
+```
+
+## Setting duration based on a video
+
+Use the `getMediaMetadata()` function from the mediabunny/metadata skill to get the video duration:
+
+```tsx
+import {CalculateMetadataFunction} from 'remotion';
+import {getMediaMetadata} from '../get-media-metadata';
+
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({props}) => {
+  const {durationInSeconds} = await getMediaMetadata(props.videoSrc);
+
+  return {
+    durationInFrames: Math.ceil(durationInSeconds * 30),
+  };
+};
+```
+
+## Matching dimensions of a video
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({props}) => {
+  const {durationInSeconds, dimensions} = await getMediaMetadata(props.videoSrc);
+
+  return {
+    durationInFrames: Math.ceil(durationInSeconds * 30),
+    width: dimensions?.width ?? 1920,
+    height: dimensions?.height ?? 1080,
+  };
+};
+```
+
+## Setting duration based on multiple videos
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({props}) => {
+  const metadataPromises = props.videos.map((video) => getMediaMetadata(video.src));
+  const allMetadata = await Promise.all(metadataPromises);
+
+  const totalDuration = allMetadata.reduce((sum, meta) => sum + meta.durationInSeconds, 0);
+
+  return {
+    durationInFrames: Math.ceil(totalDuration * 30),
+  };
+};
+```
+
+## Setting a default outName
+
+Set the default output filename based on props:
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({props}) => {
+  return {
+    defaultOutName: `video-${props.id}.mp4`,
+  };
+};
+```
+
+## Transforming props
+
+Fetch data or transform props before rendering:
+
+```tsx
+const calculateMetadata: CalculateMetadataFunction<Props> = async ({props, abortSignal}) => {
+  const response = await fetch(props.dataUrl, {signal: abortSignal});
+  const data = await response.json();
+
+  return {
+    props: {
+      ...props,
+      fetchedData: data,
+    },
+  };
+};
+```
+
+The `abortSignal` cancels stale requests when props change in the Studio.
+
+## Return value
+
+All fields are optional. Returned values override the `<Composition>` props:
+
+- `durationInFrames`: Number of frames
+- `width`: Composition width in pixels
+- `height`: Composition height in pixels
+- `fps`: Frames per second
+- `props`: Transformed props passed to the component
+- `defaultOutName`: Default output filename
+- `defaultCodec`: Default codec for rendering

--- a/marketplace/plugins/remotion/skills/remotion/rules/can-decode.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/can-decode.md
@@ -1,0 +1,75 @@
+---
+name: can-decode
+description: Check if a video can be decoded by the browser using Mediabunny
+metadata:
+  tags: decode, validation, video, audio, compatibility, browser
+---
+
+# Checking if a video can be decoded
+
+Use Mediabunny to check if a video can be decoded by the browser before attempting to play it.
+
+## The `canDecode()` function
+
+This function can be copy-pasted into any project.
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const canDecode = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  try {
+    await input.getFormat();
+  } catch {
+    return false;
+  }
+
+  const videoTrack = await input.getPrimaryVideoTrack();
+  if (videoTrack && !(await videoTrack.canDecode())) {
+    return false;
+  }
+
+  const audioTrack = await input.getPrimaryAudioTrack();
+  if (audioTrack && !(await audioTrack.canDecode())) {
+    return false;
+  }
+
+  return true;
+};
+```
+
+## Usage
+
+```tsx
+const src = "https://remotion.media/video.mp4";
+const isDecodable = await canDecode(src);
+
+if (isDecodable) {
+  console.log("Video can be decoded");
+} else {
+  console.log("Video cannot be decoded by this browser");
+}
+```
+
+## Using with Blob
+
+For file uploads or drag-and-drop, use `BlobSource`:
+
+```tsx
+import { Input, ALL_FORMATS, BlobSource } from "mediabunny";
+
+export const canDecodeBlob = async (blob: Blob) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new BlobSource(blob),
+  });
+
+  // Same validation logic as above
+};
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/charts.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/charts.md
@@ -1,0 +1,58 @@
+---
+name: charts
+description: Chart and data visualization patterns for Remotion. Use when creating bar charts, pie charts, histograms, progress bars, or any data-driven animations.
+metadata:
+  tags: charts, data, visualization, bar-chart, pie-chart, graphs
+---
+
+# Charts in Remotion
+
+You can create bar charts in Remotion by using regular React code - HTML and SVG is allowed, as well as D3.js.
+
+## No animations not powered by `useCurrentFrame()`
+
+Disable all animations by third party libraries.  
+They will cause flickering during rendering.  
+Instead, drive all animations from `useCurrentFrame()`.
+
+## Bar Chart Animations
+
+See [Bar Chart Example](assets/charts/bar-chart.tsx) for a basic example implmentation.
+
+### Staggered Bars
+
+You can animate the height of the bars and stagger them like this:
+
+```tsx
+const STAGGER_DELAY = 5;
+const frame = useCurrentFrame();
+const {fps} = useVideoConfig();
+
+const bars = data.map((item, i) => {
+  const delay = i * STAGGER_DELAY;
+  const height = spring({
+    frame,
+    fps,
+    delay,
+    config: {damping: 200},
+  });
+  return <div style={{height: height * item.value}} />;
+});
+```
+
+## Pie Chart Animation
+
+Animate segments using stroke-dashoffset, starting from 12 o'clock.
+
+```tsx
+const frame = useCurrentFrame();
+const {fps} = useVideoConfig();
+
+const progress = interpolate(frame, [0, 100], [0, 1]);
+
+const circumference = 2 * Math.PI * radius;
+const segmentLength = (value / total) * circumference;
+const offset = interpolate(progress, [0, 1], [segmentLength, 0]);
+
+<circle r={radius} cx={center} cy={center} fill="none" stroke={color} strokeWidth={strokeWidth} strokeDasharray={`${segmentLength} ${circumference}`} strokeDashoffset={offset} transform={`rotate(-90 ${center} ${center})`} />;
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/compositions.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/compositions.md
@@ -1,0 +1,141 @@
+---
+name: compositions
+description: Defining compositions, stills, folders, default props and dynamic metadata
+metadata:
+  tags: composition, still, folder, props, metadata
+---
+
+A `<Composition>` defines the component, width, height, fps and duration of a renderable video.
+
+It normally is placed in the `src/Root.tsx` file.
+
+```tsx
+import {Composition} from 'remotion';
+import {MyComposition} from './MyComposition';
+
+export const RemotionRoot = () => {
+  return <Composition id="MyComposition" component={MyComposition} durationInFrames={100} fps={30} width={1080} height={1080} />;
+};
+```
+
+## Default Props
+
+Pass `defaultProps` to provide initial values for your component.  
+Values must be JSON-serializable (`Date`, `Map`, `Set`, and `staticFile()` are supported).
+
+```tsx
+import {Composition} from 'remotion';
+import {MyComposition, MyCompositionProps} from './MyComposition';
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="MyComposition"
+      component={MyComposition}
+      durationInFrames={100}
+      fps={30}
+      width={1080}
+      height={1080}
+      defaultProps={
+        {
+          title: 'Hello World',
+          color: '#ff0000',
+        } satisfies MyCompositionProps
+      }
+    />
+  );
+};
+```
+
+Use `type` declarations for props rather than `interface` to ensure `defaultProps` type safety.
+
+## Folders
+
+Use `<Folder>` to organize compositions in the sidebar.  
+Folder names can only contain letters, numbers, and hyphens.
+
+```tsx
+import {Composition, Folder} from 'remotion';
+
+export const RemotionRoot = () => {
+  return (
+    <>
+      <Folder name="Marketing">
+        <Composition id="Promo" /* ... */ />
+        <Composition id="Ad" /* ... */ />
+      </Folder>
+      <Folder name="Social">
+        <Folder name="Instagram">
+          <Composition id="Story" /* ... */ />
+          <Composition id="Reel" /* ... */ />
+        </Folder>
+      </Folder>
+    </>
+  );
+};
+```
+
+## Stills
+
+Use `<Still>` for single-frame images. It does not require `durationInFrames` or `fps`.
+
+```tsx
+import {Still} from 'remotion';
+import {Thumbnail} from './Thumbnail';
+
+export const RemotionRoot = () => {
+  return <Still id="Thumbnail" component={Thumbnail} width={1280} height={720} />;
+};
+```
+
+## Calculate Metadata
+
+Use `calculateMetadata` to make dimensions, duration, or props dynamic based on data.
+
+```tsx
+import {Composition, CalculateMetadataFunction} from 'remotion';
+import {MyComposition, MyCompositionProps} from './MyComposition';
+
+const calculateMetadata: CalculateMetadataFunction<MyCompositionProps> = async ({props, abortSignal}) => {
+  const data = await fetch(`https://api.example.com/video/${props.videoId}`, {
+    signal: abortSignal,
+  }).then((res) => res.json());
+
+  return {
+    durationInFrames: Math.ceil(data.duration * 30),
+    props: {
+      ...props,
+      videoUrl: data.url,
+    },
+  };
+};
+
+export const RemotionRoot = () => {
+  return (
+    <Composition
+      id="MyComposition"
+      component={MyComposition}
+      durationInFrames={100} // Placeholder, will be overridden
+      fps={30}
+      width={1080}
+      height={1080}
+      defaultProps={{videoId: 'abc123'}}
+      calculateMetadata={calculateMetadata}
+    />
+  );
+};
+```
+
+The function can return `props`, `durationInFrames`, `width`, `height`, `fps`, and codec-related defaults. It runs once before rendering begins.
+
+## Nesting compositions within another
+
+To add a composition within another composition, you can use the `<Sequence>` component with a `width` and `height` prop to specify the size of the composition.
+
+```tsx
+<AbsoluteFill>
+  <Sequence width={COMPOSITION_WIDTH} height={COMPOSITION_HEIGHT}>
+    <CompositionComponent />
+  </Sequence>
+</AbsoluteFill>
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/display-captions.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/display-captions.md
@@ -1,0 +1,126 @@
+---
+name: display-captions
+description: Displaying captions in Remotion with TikTok-style pages and word highlighting
+metadata:
+  tags: captions, subtitles, display, tiktok, highlight
+---
+
+# Displaying captions in Remotion
+
+This guide explains how to display captions in Remotion, assuming you already have captions in the `Caption` format.
+
+## Prerequisites
+
+First, the @remotion/captions package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/captions # If project uses npm
+bunx remotion add @remotion/captions # If project uses bun
+yarn remotion add @remotion/captions # If project uses yarn
+pnpm exec remotion add @remotion/captions # If project uses pnpm
+```
+
+## Creating pages
+
+Use `createTikTokStyleCaptions()` to group captions into pages. The `combineTokensWithinMilliseconds` option controls how many words appear at once:
+
+```tsx
+import {useMemo} from 'react';
+import {createTikTokStyleCaptions} from '@remotion/captions';
+import type {Caption} from '@remotion/captions';
+
+// How often captions should switch (in milliseconds)
+// Higher values = more words per page
+// Lower values = fewer words (more word-by-word)
+const SWITCH_CAPTIONS_EVERY_MS = 1200;
+
+const {pages} = useMemo(() => {
+  return createTikTokStyleCaptions({
+    captions,
+    combineTokensWithinMilliseconds: SWITCH_CAPTIONS_EVERY_MS,
+  });
+}, [captions]);
+```
+
+## Rendering with Sequences
+
+Map over the pages and render each one in a `<Sequence>`. Calculate the start frame and duration from the page timing:
+
+```tsx
+import {Sequence, useVideoConfig, AbsoluteFill} from 'remotion';
+import type {TikTokPage} from '@remotion/captions';
+
+const CaptionedContent: React.FC = () => {
+  const {fps} = useVideoConfig();
+
+  return (
+    <AbsoluteFill>
+      {pages.map((page, index) => {
+        const nextPage = pages[index + 1] ?? null;
+        const startFrame = (page.startMs / 1000) * fps;
+        const endFrame = Math.min(
+          nextPage ? (nextPage.startMs / 1000) * fps : Infinity,
+          startFrame + (SWITCH_CAPTIONS_EVERY_MS / 1000) * fps,
+        );
+        const durationInFrames = endFrame - startFrame;
+
+        if (durationInFrames <= 0) {
+          return null;
+        }
+
+        return (
+          <Sequence
+            key={index}
+            from={startFrame}
+            durationInFrames={durationInFrames}
+          >
+            <CaptionPage page={page} />
+          </Sequence>
+        );
+      })}
+    </AbsoluteFill>
+  );
+};
+```
+
+## Word highlighting
+
+A caption page contains `tokens` which you can use to highlight the currently spoken word:
+
+```tsx
+import {AbsoluteFill, useCurrentFrame, useVideoConfig} from 'remotion';
+import type {TikTokPage} from '@remotion/captions';
+
+const HIGHLIGHT_COLOR = '#39E508';
+
+const CaptionPage: React.FC<{page: TikTokPage}> = ({page}) => {
+  const frame = useCurrentFrame();
+  const {fps} = useVideoConfig();
+
+  // Current time relative to the start of the sequence
+  const currentTimeMs = (frame / fps) * 1000;
+  // Convert to absolute time by adding the page start
+  const absoluteTimeMs = page.startMs + currentTimeMs;
+
+  return (
+    <AbsoluteFill style={{justifyContent: 'center', alignItems: 'center'}}>
+      <div style={{fontSize: 80, fontWeight: 'bold', whiteSpace: 'pre'}}>
+        {page.tokens.map((token) => {
+          const isActive =
+            token.fromMs <= absoluteTimeMs && token.toMs > absoluteTimeMs;
+
+          return (
+            <span
+              key={token.fromMs}
+              style={{color: isActive ? HIGHLIGHT_COLOR : 'white'}}
+            >
+              {token.text}
+            </span>
+          );
+        })}
+      </div>
+    </AbsoluteFill>
+  );
+};
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/extract-frames.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/extract-frames.md
@@ -1,0 +1,229 @@
+---
+name: extract-frames
+description: Extract frames from videos at specific timestamps using Mediabunny
+metadata:
+  tags: frames, extract, video, thumbnail, filmstrip, canvas
+---
+
+# Extracting frames from videos
+
+Use Mediabunny to extract frames from videos at specific timestamps. This is useful for generating thumbnails, filmstrips, or processing individual frames.
+
+## The `extractFrames()` function
+
+This function can be copy-pasted into any project.
+
+```tsx
+import {
+  ALL_FORMATS,
+  Input,
+  UrlSource,
+  VideoSample,
+  VideoSampleSink,
+} from "mediabunny";
+
+type Options = {
+  track: { width: number; height: number };
+  container: string;
+  durationInSeconds: number | null;
+};
+
+export type ExtractFramesTimestampsInSecondsFn = (
+  options: Options
+) => Promise<number[]> | number[];
+
+export type ExtractFramesProps = {
+  src: string;
+  timestampsInSeconds: number[] | ExtractFramesTimestampsInSecondsFn;
+  onVideoSample: (sample: VideoSample) => void;
+  signal?: AbortSignal;
+};
+
+export async function extractFrames({
+  src,
+  timestampsInSeconds,
+  onVideoSample,
+  signal,
+}: ExtractFramesProps): Promise<void> {
+  using input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src),
+  });
+
+  const [durationInSeconds, format, videoTrack] = await Promise.all([
+    input.computeDuration(),
+    input.getFormat(),
+    input.getPrimaryVideoTrack(),
+  ]);
+
+  if (!videoTrack) {
+    throw new Error("No video track found in the input");
+  }
+
+  if (signal?.aborted) {
+    throw new Error("Aborted");
+  }
+
+  const timestamps =
+    typeof timestampsInSeconds === "function"
+      ? await timestampsInSeconds({
+          track: {
+            width: videoTrack.displayWidth,
+            height: videoTrack.displayHeight,
+          },
+          container: format.name,
+          durationInSeconds,
+        })
+      : timestampsInSeconds;
+
+  if (timestamps.length === 0) {
+    return;
+  }
+
+  if (signal?.aborted) {
+    throw new Error("Aborted");
+  }
+
+  const sink = new VideoSampleSink(videoTrack);
+
+  for await (using videoSample of sink.samplesAtTimestamps(timestamps)) {
+    if (signal?.aborted) {
+      break;
+    }
+
+    if (!videoSample) {
+      continue;
+    }
+
+    onVideoSample(videoSample);
+  }
+}
+```
+
+## Basic usage
+
+Extract frames at specific timestamps:
+
+```tsx
+await extractFrames({
+  src: "https://remotion.media/video.mp4",
+  timestampsInSeconds: [0, 1, 2, 3, 4],
+  onVideoSample: (sample) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = sample.displayWidth;
+    canvas.height = sample.displayHeight;
+    const ctx = canvas.getContext("2d");
+    sample.draw(ctx!, 0, 0);
+  },
+});
+```
+
+## Creating a filmstrip
+
+Use a callback function to dynamically calculate timestamps based on video metadata:
+
+```tsx
+const canvasWidth = 500;
+const canvasHeight = 80;
+const fromSeconds = 0;
+const toSeconds = 10;
+
+await extractFrames({
+  src: "https://remotion.media/video.mp4",
+  timestampsInSeconds: async ({ track, durationInSeconds }) => {
+    const aspectRatio = track.width / track.height;
+    const amountOfFramesFit = Math.ceil(
+      canvasWidth / (canvasHeight * aspectRatio)
+    );
+    const segmentDuration = toSeconds - fromSeconds;
+    const timestamps: number[] = [];
+
+    for (let i = 0; i < amountOfFramesFit; i++) {
+      timestamps.push(
+        fromSeconds + (segmentDuration / amountOfFramesFit) * (i + 0.5)
+      );
+    }
+
+    return timestamps;
+  },
+  onVideoSample: (sample) => {
+    console.log(`Frame at ${sample.timestamp}s`);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = sample.displayWidth;
+    canvas.height = sample.displayHeight;
+    const ctx = canvas.getContext("2d");
+    sample.draw(ctx!, 0, 0);
+  },
+});
+```
+
+## Cancellation with AbortSignal
+
+Cancel frame extraction after a timeout:
+
+```tsx
+const controller = new AbortController();
+
+setTimeout(() => controller.abort(), 5000);
+
+try {
+  await extractFrames({
+    src: "https://remotion.media/video.mp4",
+    timestampsInSeconds: [0, 1, 2, 3, 4],
+    onVideoSample: (sample) => {
+      using frame = sample;
+      const canvas = document.createElement("canvas");
+      canvas.width = frame.displayWidth;
+      canvas.height = frame.displayHeight;
+      const ctx = canvas.getContext("2d");
+      frame.draw(ctx!, 0, 0);
+    },
+    signal: controller.signal,
+  });
+
+  console.log("Frame extraction complete!");
+} catch (error) {
+  console.error("Frame extraction was aborted or failed:", error);
+}
+```
+
+## Timeout with Promise.race
+
+```tsx
+const controller = new AbortController();
+
+const timeoutPromise = new Promise<never>((_, reject) => {
+  const timeoutId = setTimeout(() => {
+    controller.abort();
+    reject(new Error("Frame extraction timed out after 10 seconds"));
+  }, 10000);
+
+  controller.signal.addEventListener("abort", () => clearTimeout(timeoutId), {
+    once: true,
+  });
+});
+
+try {
+  await Promise.race([
+    extractFrames({
+      src: "https://remotion.media/video.mp4",
+      timestampsInSeconds: [0, 1, 2, 3, 4],
+      onVideoSample: (sample) => {
+        using frame = sample;
+        const canvas = document.createElement("canvas");
+        canvas.width = frame.displayWidth;
+        canvas.height = frame.displayHeight;
+        const ctx = canvas.getContext("2d");
+        frame.draw(ctx!, 0, 0);
+      },
+      signal: controller.signal,
+    }),
+    timeoutPromise,
+  ]);
+
+  console.log("Frame extraction complete!");
+} catch (error) {
+  console.error("Frame extraction was aborted or failed:", error);
+}
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/fonts.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/fonts.md
@@ -1,0 +1,152 @@
+---
+name: fonts
+description: Loading Google Fonts and local fonts in Remotion
+metadata:
+  tags: fonts, google-fonts, typography, text
+---
+
+# Using fonts in Remotion
+
+## Google Fonts with @remotion/google-fonts
+
+The recommended way to use Google Fonts. It's type-safe and automatically blocks rendering until the font is ready.
+
+### Prerequisites
+
+First, the @remotion/google-fonts package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/google-fonts # If project uses npm
+bunx remotion add @remotion/google-fonts # If project uses bun
+yarn remotion add @remotion/google-fonts # If project uses yarn
+pnpm exec remotion add @remotion/google-fonts # If project uses pnpm
+```
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Lobster";
+
+const { fontFamily } = loadFont();
+
+export const MyComposition = () => {
+  return <div style={{ fontFamily }}>Hello World</div>;
+};
+```
+
+Preferrably, specify only needed weights and subsets to reduce file size:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Roboto";
+
+const { fontFamily } = loadFont("normal", {
+  weights: ["400", "700"],
+  subsets: ["latin"],
+});
+```
+
+### Waiting for font to load
+
+Use `waitUntilDone()` if you need to know when the font is ready:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Lobster";
+
+const { fontFamily, waitUntilDone } = loadFont();
+
+await waitUntilDone();
+```
+
+## Local fonts with @remotion/fonts
+
+For local font files, use the `@remotion/fonts` package.
+
+### Prerequisites
+
+First, install @remotion/fonts:
+
+```bash
+npx remotion add @remotion/fonts # If project uses npm
+bunx remotion add @remotion/fonts # If project uses bun
+yarn remotion add @remotion/fonts # If project uses yarn
+pnpm exec remotion add @remotion/fonts # If project uses pnpm
+```
+
+### Loading a local font
+
+Place your font file in the `public/` folder and use `loadFont()`:
+
+```tsx
+import { loadFont } from "@remotion/fonts";
+import { staticFile } from "remotion";
+
+await loadFont({
+  family: "MyFont",
+  url: staticFile("MyFont-Regular.woff2"),
+});
+
+export const MyComposition = () => {
+  return <div style={{ fontFamily: "MyFont" }}>Hello World</div>;
+};
+```
+
+### Loading multiple weights
+
+Load each weight separately with the same family name:
+
+```tsx
+import { loadFont } from "@remotion/fonts";
+import { staticFile } from "remotion";
+
+await Promise.all([
+  loadFont({
+    family: "Inter",
+    url: staticFile("Inter-Regular.woff2"),
+    weight: "400",
+  }),
+  loadFont({
+    family: "Inter",
+    url: staticFile("Inter-Bold.woff2"),
+    weight: "700",
+  }),
+]);
+```
+
+### Available options
+
+```tsx
+loadFont({
+  family: "MyFont", // Required: name to use in CSS
+  url: staticFile("font.woff2"), // Required: font file URL
+  format: "woff2", // Optional: auto-detected from extension
+  weight: "400", // Optional: font weight
+  style: "normal", // Optional: normal or italic
+  display: "block", // Optional: font-display behavior
+});
+```
+
+## Using in components
+
+Call `loadFont()` at the top level of your component or in a separate file that's imported early:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Montserrat";
+
+const { fontFamily } = loadFont("normal", {
+  weights: ["400", "700"],
+  subsets: ["latin"],
+});
+
+export const Title: React.FC<{ text: string }> = ({ text }) => {
+  return (
+    <h1
+      style={{
+        fontFamily,
+        fontSize: 80,
+        fontWeight: "bold",
+      }}
+    >
+      {text}
+    </h1>
+  );
+};
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/get-audio-duration.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/get-audio-duration.md
@@ -1,0 +1,58 @@
+---
+name: get-audio-duration
+description: Getting the duration of an audio file in seconds with Mediabunny
+metadata:
+  tags: duration, audio, length, time, seconds, mp3, wav
+---
+
+# Getting audio duration with Mediabunny
+
+Mediabunny can extract the duration of an audio file. It works in browser, Node.js, and Bun environments.
+
+## Getting audio duration
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const getAudioDuration = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  const durationInSeconds = await input.computeDuration();
+  return durationInSeconds;
+};
+```
+
+## Usage
+
+```tsx
+const duration = await getAudioDuration("https://remotion.media/audio.mp3");
+console.log(duration); // e.g. 180.5 (seconds)
+```
+
+## Using with local files
+
+For local files, use `FileSource` instead of `UrlSource`:
+
+```tsx
+import { Input, ALL_FORMATS, FileSource } from "mediabunny";
+
+const input = new Input({
+  formats: ALL_FORMATS,
+  source: new FileSource(file), // File object from input or drag-drop
+});
+
+const durationInSeconds = await input.computeDuration();
+```
+
+## Using with staticFile in Remotion
+
+```tsx
+import { staticFile } from "remotion";
+
+const duration = await getAudioDuration(staticFile("audio.mp3"));
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/get-video-dimensions.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/get-video-dimensions.md
@@ -1,0 +1,68 @@
+---
+name: get-video-dimensions
+description: Getting the width and height of a video file with Mediabunny
+metadata:
+  tags: dimensions, width, height, resolution, size, video
+---
+
+# Getting video dimensions with Mediabunny
+
+Mediabunny can extract the width and height of a video file. It works in browser, Node.js, and Bun environments.
+
+## Getting video dimensions
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const getVideoDimensions = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  const videoTrack = await input.getPrimaryVideoTrack();
+  if (!videoTrack) {
+    throw new Error("No video track found");
+  }
+
+  return {
+    width: videoTrack.displayWidth,
+    height: videoTrack.displayHeight,
+  };
+};
+```
+
+## Usage
+
+```tsx
+const dimensions = await getVideoDimensions("https://remotion.media/video.mp4");
+console.log(dimensions.width);  // e.g. 1920
+console.log(dimensions.height); // e.g. 1080
+```
+
+## Using with local files
+
+For local files, use `FileSource` instead of `UrlSource`:
+
+```tsx
+import { Input, ALL_FORMATS, FileSource } from "mediabunny";
+
+const input = new Input({
+  formats: ALL_FORMATS,
+  source: new FileSource(file), // File object from input or drag-drop
+});
+
+const videoTrack = await input.getPrimaryVideoTrack();
+const width = videoTrack.displayWidth;
+const height = videoTrack.displayHeight;
+```
+
+## Using with staticFile in Remotion
+
+```tsx
+import { staticFile } from "remotion";
+
+const dimensions = await getVideoDimensions(staticFile("video.mp4"));
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/get-video-duration.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/get-video-duration.md
@@ -1,0 +1,58 @@
+---
+name: get-video-duration
+description: Getting the duration of a video file in seconds with Mediabunny
+metadata:
+  tags: duration, video, length, time, seconds
+---
+
+# Getting video duration with Mediabunny
+
+Mediabunny can extract the duration of a video file. It works in browser, Node.js, and Bun environments.
+
+## Getting video duration
+
+```tsx
+import { Input, ALL_FORMATS, UrlSource } from "mediabunny";
+
+export const getVideoDuration = async (src: string) => {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new UrlSource(src, {
+      getRetryDelay: () => null,
+    }),
+  });
+
+  const durationInSeconds = await input.computeDuration();
+  return durationInSeconds;
+};
+```
+
+## Usage
+
+```tsx
+const duration = await getVideoDuration("https://remotion.media/video.mp4");
+console.log(duration); // e.g. 10.5 (seconds)
+```
+
+## Using with local files
+
+For local files, use `FileSource` instead of `UrlSource`:
+
+```tsx
+import { Input, ALL_FORMATS, FileSource } from "mediabunny";
+
+const input = new Input({
+  formats: ALL_FORMATS,
+  source: new FileSource(file), // File object from input or drag-drop
+});
+
+const durationInSeconds = await input.computeDuration();
+```
+
+## Using with staticFile in Remotion
+
+```tsx
+import { staticFile } from "remotion";
+
+const duration = await getVideoDuration(staticFile("video.mp4"));
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/gifs.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/gifs.md
@@ -1,0 +1,138 @@
+---
+name: gif
+description: Displaying GIFs, APNG, AVIF and WebP in Remotion
+metadata:
+  tags: gif, animation, images, animated, apng, avif, webp
+---
+
+# Using Animated images in Remotion
+
+## Basic usage
+
+Use `<AnimatedImage>` to display a GIF, APNG, AVIF or WebP image synchronized with Remotion's timeline:
+
+```tsx
+import {AnimatedImage, staticFile} from 'remotion';
+
+export const MyComposition = () => {
+  return <AnimatedImage src={staticFile('animation.gif')} width={500} height={500} />;
+};
+```
+
+Remote URLs are also supported (must have CORS enabled):
+
+```tsx
+<AnimatedImage src="https://example.com/animation.gif" width={500} height={500} />
+```
+
+## Sizing and fit
+
+Control how the image fills its container with the `fit` prop:
+
+```tsx
+// Stretch to fill (default)
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="fill" />
+
+// Maintain aspect ratio, fit inside container
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="contain" />
+
+// Fill container, crop if needed
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={300} fit="cover" />
+```
+
+## Playback speed
+
+Use `playbackRate` to control the animation speed:
+
+```tsx
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={2} /> {/* 2x speed */}
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} playbackRate={0.5} /> {/* Half speed */}
+```
+
+## Looping behavior
+
+Control what happens when the animation finishes:
+
+```tsx
+// Loop indefinitely (default)
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="loop" />
+
+// Play once, show final frame
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="pause-after-finish" />
+
+// Play once, then clear canvas
+<AnimatedImage src={staticFile("animation.gif")} width={500} height={500} loopBehavior="clear-after-finish" />
+```
+
+## Styling
+
+Use the `style` prop for additional CSS (use `width` and `height` props for sizing):
+
+```tsx
+<AnimatedImage
+  src={staticFile('animation.gif')}
+  width={500}
+  height={500}
+  style={{
+    borderRadius: 20,
+    position: 'absolute',
+    top: 100,
+    left: 50,
+  }}
+/>
+```
+
+## Getting GIF duration
+
+Use `getGifDurationInSeconds()` from `@remotion/gif` to get the duration of a GIF.
+
+```bash
+npx remotion add @remotion/gif # If project uses npm
+bunx remotion add @remotion/gif # If project uses bun
+yarn remotion add @remotion/gif # If project uses yarn
+pnpm exec remotion add @remotion/gif # If project uses pnpm
+```
+
+```tsx
+import {getGifDurationInSeconds} from '@remotion/gif';
+import {staticFile} from 'remotion';
+
+const duration = await getGifDurationInSeconds(staticFile('animation.gif'));
+console.log(duration); // e.g. 2.5
+```
+
+This is useful for setting the composition duration to match the GIF:
+
+```tsx
+import {getGifDurationInSeconds} from '@remotion/gif';
+import {staticFile, CalculateMetadataFunction} from 'remotion';
+
+const calculateMetadata: CalculateMetadataFunction = async () => {
+  const duration = await getGifDurationInSeconds(staticFile('animation.gif'));
+  return {
+    durationInFrames: Math.ceil(duration * 30),
+  };
+};
+```
+
+## Alternative
+
+If `<AnimatedImage>` does not work (only supported in Chrome and Firefox), you can use `<Gif>` from `@remotion/gif` instead.
+
+```bash
+npx remotion add @remotion/gif # If project uses npm
+bunx remotion add @remotion/gif # If project uses bun
+yarn remotion add @remotion/gif # If project uses yarn
+pnpm exec remotion add @remotion/gif # If project uses pnpm
+```
+
+```tsx
+import {Gif} from '@remotion/gif';
+import {staticFile} from 'remotion';
+
+export const MyComposition = () => {
+  return <Gif src={staticFile('animation.gif')} width={500} height={500} />;
+};
+```
+
+The `<Gif>` component has the same props as `<AnimatedImage>` but only supports GIF files.

--- a/marketplace/plugins/remotion/skills/remotion/rules/images.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/images.md
@@ -1,0 +1,130 @@
+---
+name: images
+description: Embedding images in Remotion using the <Img> component
+metadata:
+  tags: images, img, staticFile, png, jpg, svg, webp
+---
+
+# Using images in Remotion
+
+## The `<Img>` component
+
+Always use the `<Img>` component from `remotion` to display images:
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Img src={staticFile("photo.png")} />;
+};
+```
+
+## Important restrictions
+
+**You MUST use the `<Img>` component from `remotion`.** Do not use:
+
+- Native HTML `<img>` elements
+- Next.js `<Image>` component
+- CSS `background-image`
+
+The `<Img>` component ensures images are fully loaded before rendering, preventing flickering and blank frames during video export.
+
+## Local images with staticFile()
+
+Place images in the `public/` folder and use `staticFile()` to reference them:
+
+```
+my-video/
+├─ public/
+│  ├─ logo.png
+│  ├─ avatar.jpg
+│  └─ icon.svg
+├─ src/
+├─ package.json
+```
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+<Img src={staticFile("logo.png")} />
+```
+
+## Remote images
+
+Remote URLs can be used directly without `staticFile()`:
+
+```tsx
+<Img src="https://example.com/image.png" />
+```
+
+Ensure remote images have CORS enabled.
+
+For animated GIFs, use the `<Gif>` component from `@remotion/gif` instead.
+
+## Sizing and positioning
+
+Use the `style` prop to control size and position:
+
+```tsx
+<Img
+  src={staticFile("photo.png")}
+  style={{
+    width: 500,
+    height: 300,
+    position: "absolute",
+    top: 100,
+    left: 50,
+    objectFit: "cover",
+  }}
+/>
+```
+
+## Dynamic image paths
+
+Use template literals for dynamic file references:
+
+```tsx
+import { Img, staticFile, useCurrentFrame } from "remotion";
+
+const frame = useCurrentFrame();
+
+// Image sequence
+<Img src={staticFile(`frames/frame${frame}.png`)} />
+
+// Selecting based on props
+<Img src={staticFile(`avatars/${props.userId}.png`)} />
+
+// Conditional images
+<Img src={staticFile(`icons/${isActive ? "active" : "inactive"}.svg`)} />
+```
+
+This pattern is useful for:
+
+- Image sequences (frame-by-frame animations)
+- User-specific avatars or profile images
+- Theme-based icons
+- State-dependent graphics
+
+## Getting image dimensions
+
+Use `getImageDimensions()` to get the dimensions of an image:
+
+```tsx
+import { getImageDimensions, staticFile } from "remotion";
+
+const { width, height } = await getImageDimensions(staticFile("photo.png"));
+```
+
+This is useful for calculating aspect ratios or sizing compositions:
+
+```tsx
+import { getImageDimensions, staticFile, CalculateMetadataFunction } from "remotion";
+
+const calculateMetadata: CalculateMetadataFunction = async () => {
+  const { width, height } = await getImageDimensions(staticFile("photo.png"));
+  return {
+    width,
+    height,
+  };
+};
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/import-srt-captions.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/import-srt-captions.md
@@ -1,0 +1,67 @@
+---
+name: import-srt-captions
+description: Importing .srt subtitle files into Remotion using @remotion/captions
+metadata:
+  tags: captions, subtitles, srt, import, parse
+---
+
+# Importing .srt subtitles into Remotion
+
+If you have an existing `.srt` subtitle file, you can import it into Remotion using `parseSrt()` from `@remotion/captions`.
+
+## Prerequisites
+
+First, the @remotion/captions package needs to be installed.
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/captions # If project uses npm
+bunx remotion add @remotion/captions # If project uses bun
+yarn remotion add @remotion/captions # If project uses yarn
+pnpm exec remotion add @remotion/captions # If project uses pnpm
+```
+
+## Reading an .srt file
+
+Use `staticFile()` to reference an `.srt` file in your `public` folder, then fetch and parse it:
+
+```tsx
+import {useState, useEffect, useCallback} from 'react';
+import {AbsoluteFill, staticFile, useDelayRender} from 'remotion';
+import {parseSrt} from '@remotion/captions';
+import type {Caption} from '@remotion/captions';
+
+export const MyComponent: React.FC = () => {
+  const [captions, setCaptions] = useState<Caption[] | null>(null);
+  const {delayRender, continueRender, cancelRender} = useDelayRender();
+  const [handle] = useState(() => delayRender());
+
+  const fetchCaptions = useCallback(async () => {
+    try {
+      const response = await fetch(staticFile('subtitles.srt'));
+      const text = await response.text();
+      const {captions: parsed} = parseSrt({input: text});
+      setCaptions(parsed);
+      continueRender(handle);
+    } catch (e) {
+      cancelRender(e);
+    }
+  }, [continueRender, cancelRender, handle]);
+
+  useEffect(() => {
+    fetchCaptions();
+  }, [fetchCaptions]);
+
+  if (!captions) {
+    return null;
+  }
+
+  return <AbsoluteFill>{/* Use captions here */}</AbsoluteFill>;
+};
+```
+
+Remote URLs are also supported - you can `fetch()` a remote file via URL instead of using `staticFile()`.
+
+## Using imported captions
+
+Once parsed, the captions are in the `Caption` format and can be used with all `@remotion/captions` utilities.

--- a/marketplace/plugins/remotion/skills/remotion/rules/lottie.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/lottie.md
@@ -1,0 +1,68 @@
+---
+name: lottie
+description: Embedding Lottie animations in Remotion.
+metadata:
+  category: Animation
+---
+
+# Using Lottie Animations in Remotion
+
+## Prerequisites
+
+First, the @remotion/lottie package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/lottie # If project uses npm
+bunx remotion add @remotion/lottie # If project uses bun
+yarn remotion add @remotion/lottie # If project uses yarn
+pnpm exec remotion add @remotion/lottie # If project uses pnpm
+```
+
+## Displaying a Lottie file
+
+To import a Lottie animation:
+
+- Fetch the Lottie asset
+- Wrap the loading process in `delayRender()` and `continueRender()`
+- Save the animation data in a state
+- Render the Lottie animation using the `Lottie` component from the `@remotion/lottie` package
+
+```tsx
+import {Lottie, LottieAnimationData} from '@remotion/lottie';
+import {useEffect, useState} from 'react';
+import {cancelRender, continueRender, delayRender} from 'remotion';
+
+export const MyAnimation = () => {
+  const [handle] = useState(() => delayRender('Loading Lottie animation'));
+
+  const [animationData, setAnimationData] = useState<LottieAnimationData | null>(null);
+
+  useEffect(() => {
+    fetch('https://assets4.lottiefiles.com/packages/lf20_zyquagfl.json')
+      .then((data) => data.json())
+      .then((json) => {
+        setAnimationData(json);
+        continueRender(handle);
+      })
+      .catch((err) => {
+        cancelRender(err);
+      });
+  }, [handle]);
+
+  if (!animationData) {
+    return null;
+  }
+
+  return <Lottie animationData={animationData} />;
+};
+```
+
+## Styling and animating
+
+Lottie supports the `style` prop to allow styles and animations:
+
+```tsx
+return <Lottie animationData={animationData} style={{width: 400, height: 400}} />;
+```
+

--- a/marketplace/plugins/remotion/skills/remotion/rules/maps.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/maps.md
@@ -1,0 +1,403 @@
+---
+name: maps
+description: Make map animations with Mapbox
+metadata:
+  tags: map, map animation, mapbox
+---
+
+Maps can be added to a Remotion video with Mapbox.  
+The [Mapbox documentation](https://docs.mapbox.com/mapbox-gl-js/api/) has the API reference.
+
+## Prerequisites
+
+Mapbox and `@turf/turf` need to be installed.
+
+Search the project for lockfiles and run the correct command depending on the package manager:
+
+If `package-lock.json` is found, use the following command:
+
+```bash
+npm i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `bun.lock` is found, use the following command:
+
+```bash
+bun i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `yarn.lock` is found, use the following command:
+
+```bash
+yarn add mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+If `pnpm-lock.yaml` is found, use the following command:
+
+```bash
+pnpm i mapbox-gl @turf/turf @types/mapbox-gl
+```
+
+The user needs to create a free Mapbox account and create an access token by visiting https://console.mapbox.com/account/access-tokens/.
+
+The mapbox token needs to be added to the `.env` file:
+
+```txt title=".env"
+REMOTION_MAPBOX_TOKEN==pk.your-mapbox-access-token
+```
+
+## Adding a map
+
+Here is a basic example of a map in Remotion.
+
+```tsx
+import {useEffect, useMemo, useRef, useState} from 'react';
+import {AbsoluteFill, useDelayRender, useVideoConfig} from 'remotion';
+import mapboxgl, {Map} from 'mapbox-gl';
+
+export const lineCoordinates = [
+  [6.56158447265625, 46.059891147620725],
+  [6.5691375732421875, 46.05679376154153],
+  [6.5842437744140625, 46.05059898938315],
+  [6.594886779785156, 46.04702502069337],
+  [6.601066589355469, 46.0460718554722],
+  [6.6089630126953125, 46.0365370783104],
+  [6.6185760498046875, 46.018420689207964],
+];
+
+mapboxgl.accessToken = process.env.REMOTION_MAPBOX_TOKEN as string;
+
+export const MyComposition = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const {delayRender, continueRender} = useDelayRender();
+
+  const {width, height} = useVideoConfig();
+  const [handle] = useState(() => delayRender('Loading map...'));
+  const [map, setMap] = useState<Map | null>(null);
+
+  useEffect(() => {
+    const _map = new Map({
+      container: ref.current!,
+      zoom: 11.53,
+      center: [6.5615, 46.0598],
+      pitch: 65,
+      bearing: 0,
+      style: '⁠mapbox://styles/mapbox/standard',
+      interactive: false,
+      fadeDuration: 0,
+    });
+
+    _map.on('style.load', () => {
+      // Hide all features from the Mapbox Standard style
+      const hideFeatures = [
+        'showRoadsAndTransit',
+        'showRoads',
+        'showTransit',
+        'showPedestrianRoads',
+        'showRoadLabels',
+        'showTransitLabels',
+        'showPlaceLabels',
+        'showPointOfInterestLabels',
+        'showPointsOfInterest',
+        'showAdminBoundaries',
+        'showLandmarkIcons',
+        'showLandmarkIconLabels',
+        'show3dObjects',
+        'show3dBuildings',
+        'show3dTrees',
+        'show3dLandmarks',
+        'show3dFacades',
+      ];
+      for (const feature of hideFeatures) {
+        _map.setConfigProperty('basemap', feature, false);
+      }
+
+      _map.setConfigProperty('basemap', 'colorMotorways', 'rgba(0, 0, 0, 0)');
+      _map.setConfigProperty('basemap', 'colorRoads', 'rgba(0, 0, 0, 0)');
+      _map.setConfigProperty('basemap', 'colorTrunks', 'rgba(0, 0, 0, 0)');
+
+      _map.addSource('trace', {
+        type: 'geojson',
+        data: {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'LineString',
+            coordinates: lineCoordinates,
+          },
+        },
+      });
+      _map.addLayer({
+        type: 'line',
+        source: 'trace',
+        id: 'line',
+        paint: {
+          'line-color': 'black',
+          'line-width': 5,
+        },
+        layout: {
+          'line-cap': 'round',
+          'line-join': 'round',
+        },
+      });
+    });
+
+    _map.on('load', () => {
+      continueRender(handle);
+      setMap(_map);
+    });
+  }, [handle, lineCoordinates]);
+
+  const style: React.CSSProperties = useMemo(() => ({width, height, position: 'absolute'}), [width, height]);
+
+  return <AbsoluteFill ref={ref} style={style} />;
+};
+```
+
+The following is important in Remotion:
+
+- Animations must be driven by `useCurrentFrame()` and animations that Mapbox brings itself should be disabled. For example, the `fadeDuration` prop should be set to `0`, `interactive` should be set to `false`, etc.
+- Loading the map should be delayed using `useDelayRender()` and the map should be set to `null` until it is loaded.
+- The element containing the ref MUST have an explicit width and height and `position: "absolute"`.
+- Do not add a `_map.remove();` cleanup function.
+
+## Drawing lines
+
+Unless I request it, do not add a glow effect to the lines.
+Unless I request it, do not add additional points to the lines.
+
+## Map style
+
+By default, use the `mapbox://styles/mapbox/standard` style.  
+Hide the labels from the base map style.
+
+Unless I request otherwise, remove all features from the Mapbox Standard style.
+
+```tsx
+// Hide all features from the Mapbox Standard style
+const hideFeatures = [
+  'showRoadsAndTransit',
+  'showRoads',
+  'showTransit',
+  'showPedestrianRoads',
+  'showRoadLabels',
+  'showTransitLabels',
+  'showPlaceLabels',
+  'showPointOfInterestLabels',
+  'showPointsOfInterest',
+  'showAdminBoundaries',
+  'showLandmarkIcons',
+  'showLandmarkIconLabels',
+  'show3dObjects',
+  'show3dBuildings',
+  'show3dTrees',
+  'show3dLandmarks',
+  'show3dFacades',
+];
+for (const feature of hideFeatures) {
+  _map.setConfigProperty('basemap', feature, false);
+}
+
+_map.setConfigProperty('basemap', 'colorMotorways', 'transparent');
+_map.setConfigProperty('basemap', 'colorRoads', 'transparent');
+_map.setConfigProperty('basemap', 'colorTrunks', 'transparent');
+```
+
+## Animating the camera
+
+You can animate the camera along the line by adding a `useEffect` hook that updates the camera position based on the current frame.
+
+Unless I ask for it, do not jump between camera angles.
+
+```tsx
+import * as turf from '@turf/turf';
+import {interpolate} from 'remotion';
+import {Easing} from 'remotion';
+import {useCurrentFrame, useVideoConfig, useDelayRender} from 'remotion';
+
+const animationDuration = 20;
+const cameraAltitude = 4000;
+```
+
+```tsx
+const frame = useCurrentFrame();
+const {fps} = useVideoConfig();
+const {delayRender, continueRender} = useDelayRender();
+
+useEffect(() => {
+  if (!map) {
+    return;
+  }
+  const handle = delayRender('Moving point...');
+
+  const routeDistance = turf.length(turf.lineString(lineCoordinates));
+
+  const progress = interpolate(frame / fps, [0.00001, animationDuration], [0, 1], {
+    easing: Easing.inOut(Easing.sin),
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+  });
+
+  const camera = map.getFreeCameraOptions();
+
+  const alongRoute = turf.along(turf.lineString(lineCoordinates), routeDistance * progress).geometry.coordinates;
+
+  camera.lookAtPoint({
+    lng: alongRoute[0],
+    lat: alongRoute[1],
+  });
+
+  map.setFreeCameraOptions(camera);
+  map.once('idle', () => continueRender(handle));
+}, [lineCoordinates, fps, frame, handle, map]);
+```
+
+Notes:
+
+IMPORTANT: Keep the camera by default so north is up.
+IMPORTANT: For multi-step animations, set all properties at all stages (zoom, position, line progress) to prevent jumps. Override initial values.
+
+- The progress is clamped to a minimum value to avoid the line being empty, which can lead to turf errors
+- See [Timing](./timing.md) for more options for timing.
+- Consider the dimensions of the composition and make the lines thick enough and the label font size large enough to be legible for when the composition is scaled down.
+
+## Animating lines
+
+### Straight lines (linear interpolation)
+
+To animate a line that appears straight on the map, use linear interpolation between coordinates. Do NOT use turf's `lineSliceAlong` or `along` functions, as they use geodesic (great circle) calculations which appear curved on a Mercator projection.
+
+```tsx
+const frame = useCurrentFrame();
+const {durationInFrames} = useVideoConfig();
+
+useEffect(() => {
+  if (!map) return;
+
+  const animationHandle = delayRender('Animating line...');
+
+  const progress = interpolate(frame, [0, durationInFrames - 1], [0, 1], {
+    extrapolateLeft: 'clamp',
+    extrapolateRight: 'clamp',
+    easing: Easing.inOut(Easing.cubic),
+  });
+
+  // Linear interpolation for a straight line on the map
+  const start = lineCoordinates[0];
+  const end = lineCoordinates[1];
+  const currentLng = start[0] + (end[0] - start[0]) * progress;
+  const currentLat = start[1] + (end[1] - start[1]) * progress;
+
+  const lineData: GeoJSON.Feature<GeoJSON.LineString> = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'LineString',
+      coordinates: [start, [currentLng, currentLat]],
+    },
+  };
+
+  const source = map.getSource('trace') as mapboxgl.GeoJSONSource;
+  if (source) {
+    source.setData(lineData);
+  }
+
+  map.once('idle', () => continueRender(animationHandle));
+}, [frame, map, durationInFrames]);
+```
+
+### Curved lines (geodesic/great circle)
+
+To animate a line that follows the geodesic (great circle) path between two points, use turf's `lineSliceAlong`. This is useful for showing flight paths or the actual shortest distance on Earth.
+
+```tsx
+import * as turf from '@turf/turf';
+
+const routeLine = turf.lineString(lineCoordinates);
+const routeDistance = turf.length(routeLine);
+
+const currentDistance = Math.max(0.001, routeDistance * progress);
+const slicedLine = turf.lineSliceAlong(routeLine, 0, currentDistance);
+
+const source = map.getSource('route') as mapboxgl.GeoJSONSource;
+if (source) {
+  source.setData(slicedLine);
+}
+```
+
+## Markers
+
+Add labels, and markers where appropriate.
+
+```tsx
+_map.addSource('markers', {
+  type: 'geojson',
+  data: {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {name: 'Point 1'},
+        geometry: {type: 'Point', coordinates: [-118.2437, 34.0522]},
+      },
+    ],
+  },
+});
+
+_map.addLayer({
+  id: 'city-markers',
+  type: 'circle',
+  source: 'markers',
+  paint: {
+    'circle-radius': 40,
+    'circle-color': '#FF4444',
+    'circle-stroke-width': 4,
+    'circle-stroke-color': '#FFFFFF',
+  },
+});
+
+_map.addLayer({
+  id: 'labels',
+  type: 'symbol',
+  source: 'markers',
+  layout: {
+    'text-field': ['get', 'name'],
+    'text-font': ['DIN Pro Bold', 'Arial Unicode MS Bold'],
+    'text-size': 50,
+    'text-offset': [0, 0.5],
+    'text-anchor': 'top',
+  },
+  paint: {
+    'text-color': '#FFFFFF',
+    'text-halo-color': '#000000',
+    'text-halo-width': 2,
+  },
+});
+```
+
+Make sure they are big enough. Check the composition dimensions and scale the labels accordingly.
+For a composition size of 1920x1080, the label font size should be at least 40px.
+
+IMPORTANT: Keep the `text-offset` small enough so it is close to the marker. Consider the marker circle radius. For a circle radius of 40, this is a good offset:
+
+```tsx
+"text-offset": [0, 0.5],
+```
+
+## 3D buildings
+
+To enable 3D buildings, use the following code:
+
+```tsx
+_map.setConfigProperty('basemap', 'show3dObjects', true);
+_map.setConfigProperty('basemap', 'show3dLandmarks', true);
+_map.setConfigProperty('basemap', 'show3dBuildings', true);
+```
+
+## Rendering
+
+When rendering a map animation, make sure to render with the following flags:
+
+```
+npx remotion render --gl=angle --concurrency=1
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/measuring-dom-nodes.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/measuring-dom-nodes.md
@@ -1,0 +1,35 @@
+---
+name: measuring-dom-nodes
+description: Measuring DOM element dimensions in Remotion
+metadata:
+  tags: measure, layout, dimensions, getBoundingClientRect, scale
+---
+
+# Measuring DOM nodes in Remotion
+
+Remotion applies a `scale()` transform to the video container, which affects values from `getBoundingClientRect()`. Use `useCurrentScale()` to get correct measurements.
+
+## Measuring element dimensions
+
+```tsx
+import { useCurrentScale } from "remotion";
+import { useRef, useEffect, useState } from "react";
+
+export const MyComponent = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  const scale = useCurrentScale();
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const rect = ref.current.getBoundingClientRect();
+    setDimensions({
+      width: rect.width / scale,
+      height: rect.height / scale,
+    });
+  }, [scale]);
+
+  return <div ref={ref}>Content to measure</div>;
+};
+```
+

--- a/marketplace/plugins/remotion/skills/remotion/rules/measuring-text.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/measuring-text.md
@@ -1,0 +1,143 @@
+---
+name: measuring-text
+description: Measuring text dimensions, fitting text to containers, and checking overflow
+metadata:
+  tags: measure, text, layout, dimensions, fitText, fillTextBox
+---
+
+# Measuring text in Remotion
+
+## Prerequisites
+
+Install @remotion/layout-utils if it is not already installed:
+
+```bash
+npx remotion add @remotion/layout-utils # If project uses npm
+bunx remotion add @remotion/layout-utils # If project uses bun
+yarn remotion add @remotion/layout-utils # If project uses yarn
+pnpm exec remotion add @remotion/layout-utils # If project uses pnpm
+```
+
+## Measuring text dimensions
+
+Use `measureText()` to calculate the width and height of text:
+
+```tsx
+import { measureText } from "@remotion/layout-utils";
+
+const { width, height } = measureText({
+  text: "Hello World",
+  fontFamily: "Arial",
+  fontSize: 32,
+  fontWeight: "bold",
+});
+```
+
+Results are cached - duplicate calls return the cached result.
+
+## Fitting text to a width
+
+Use `fitText()` to find the optimal font size for a container:
+
+```tsx
+import { fitText } from "@remotion/layout-utils";
+
+const { fontSize } = fitText({
+  text: "Hello World",
+  withinWidth: 600,
+  fontFamily: "Inter",
+  fontWeight: "bold",
+});
+
+return (
+  <div
+    style={{
+      fontSize: Math.min(fontSize, 80), // Cap at 80px
+      fontFamily: "Inter",
+      fontWeight: "bold",
+    }}
+  >
+    Hello World
+  </div>
+);
+```
+
+## Checking text overflow
+
+Use `fillTextBox()` to check if text exceeds a box:
+
+```tsx
+import { fillTextBox } from "@remotion/layout-utils";
+
+const box = fillTextBox({ maxBoxWidth: 400, maxLines: 3 });
+
+const words = ["Hello", "World", "This", "is", "a", "test"];
+for (const word of words) {
+  const { exceedsBox } = box.add({
+    text: word + " ",
+    fontFamily: "Arial",
+    fontSize: 24,
+  });
+  if (exceedsBox) {
+    // Text would overflow, handle accordingly
+    break;
+  }
+}
+```
+
+## Best practices
+
+**Load fonts first:** Only call measurement functions after fonts are loaded.
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily, waitUntilDone } = loadFont("normal", {
+  weights: ["400"],
+  subsets: ["latin"],
+});
+
+waitUntilDone().then(() => {
+  // Now safe to measure
+  const { width } = measureText({
+    text: "Hello",
+    fontFamily,
+    fontSize: 32,
+  });
+})
+```
+
+**Use validateFontIsLoaded:** Catch font loading issues early:
+
+```tsx
+measureText({
+  text: "Hello",
+  fontFamily: "MyCustomFont",
+  fontSize: 32,
+  validateFontIsLoaded: true, // Throws if font not loaded
+});
+```
+
+**Match font properties:** Use the same properties for measurement and rendering:
+
+```tsx
+const fontStyle = {
+  fontFamily: "Inter",
+  fontSize: 32,
+  fontWeight: "bold" as const,
+  letterSpacing: "0.5px",
+};
+
+const { width } = measureText({
+  text: "Hello",
+  ...fontStyle,
+});
+
+return <div style={fontStyle}>Hello</div>;
+```
+
+**Avoid padding and border:** Use `outline` instead of `border` to prevent layout differences:
+
+```tsx
+<div style={{ outline: "2px solid red" }}>Text</div>
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/parameters.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/parameters.md
@@ -1,0 +1,98 @@
+---
+name: parameters
+description: Make a video parametrizable by adding a Zod schema
+metadata:
+  tags: parameters, zod, schema
+---
+
+To make a video parametrizable, a Zod schema can be added to a composition.
+
+First, `zod` must be installed - it must be exactly version `3.22.3`.
+
+Search the project for lockfiles and run the correct command depending on the package manager:
+
+If `package-lock.json` is found, use the following command:
+
+```bash
+npm i zod@3.22.3
+```
+
+If `bun.lockb` is found, use the following command:
+
+```bash
+bun i zod@3.22.3
+```
+
+If `yarn.lock` is found, use the following command:
+
+```bash
+yarn add zod@3.22.3
+```
+
+If `pnpm-lock.yaml` is found, use the following command:
+
+```bash
+pnpm i zod@3.22.3
+```
+
+Then, a Zod schema can be defined alongside the component:
+
+```tsx title="src/MyComposition.tsx"
+import {z} from 'zod';
+
+export const MyCompositionSchema = z.object({
+  title: z.string(),
+});
+
+const MyComponent: React.FC<z.infer<typeof MyCompositionSchema>> = () => {
+  return (
+    <div>
+      <h1>{props.title}</h1>
+    </div>
+  );
+};
+```
+
+In the root file, the schema can be passed to the composition:
+
+```tsx title="src/Root.tsx"
+import {Composition} from 'remotion';
+import {MycComponent, MyCompositionSchema} from './MyComposition';
+
+export const RemotionRoot = () => {
+  return <Composition id="MyComposition" component={MyComponent} durationInFrames={100} fps={30} width={1080} height={1080} defaultProps={{title: 'Hello World'}} schema={MyCompositionSchema} />;
+};
+```
+
+Now, the user can edit the parameter visually in the sidebar.
+
+All schemas that are supported by Zod are supported by Remotion.
+
+Remotion requires that the top-level type is a z.object(), because the collection of props of a React component is always an object.
+
+## Color picker
+
+For adding a color picker, use `zColor()` from `@remotion/zod-types`.
+
+If it is not installed, use the following command:
+
+```bash
+npx remotion add @remotion/zod-types # If project uses npm
+bunx remotion add @remotion/zod-types # If project uses bun
+yarn remotion add @remotion/zod-types # If project uses yarn
+pnpm exec remotion add @remotion/zod-types # If project uses pnpm
+```
+
+Then import `zColor` from `@remotion/zod-types`:
+
+```tsx
+import {zColor} from '@remotion/zod-types';
+```
+
+Then use it in the schema:
+
+```tsx
+export const MyCompositionSchema = z.object({
+  color: zColor(),
+});
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/sequencing.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/sequencing.md
@@ -1,0 +1,118 @@
+---
+name: sequencing
+description: Sequencing patterns for Remotion - delay, trim, limit duration of items
+metadata:
+  tags: sequence, series, timing, delay, trim
+---
+
+Use `<Sequence>` to delay when an element appears in the timeline.
+
+```tsx
+import { Sequence } from "remotion";
+
+const {fps} = useVideoConfig();
+
+<Sequence from={1 * fps} durationInFrames={2 * fps} premountFor={1 * fps}>
+  <Title />
+</Sequence>
+<Sequence from={2 * fps} durationInFrames={2 * fps} premountFor={1 * fps}>
+  <Subtitle />
+</Sequence>
+```
+
+This will by default wrap the component in an absolute fill element.  
+If the items should not be wrapped, use the `layout` prop:
+
+```tsx
+<Sequence layout="none">
+  <Title />
+</Sequence>
+```
+
+## Premounting
+
+This loads the component in the timeline before it is actually played.  
+Always premount any `<Sequence>`!
+
+```tsx
+<Sequence premountFor={1 * fps}>
+  <Title />
+</Sequence>
+```
+
+## Series
+
+Use `<Series>` when elements should play one after another without overlap.
+
+```tsx
+import {Series} from 'remotion';
+
+<Series>
+  <Series.Sequence durationInFrames={45}>
+    <Intro />
+  </Series.Sequence>
+  <Series.Sequence durationInFrames={60}>
+    <MainContent />
+  </Series.Sequence>
+  <Series.Sequence durationInFrames={30}>
+    <Outro />
+  </Series.Sequence>
+</Series>;
+```
+
+Same as with `<Sequence>`, the items will be wrapped in an absolute fill element by default when using `<Series.Sequence>`, unless the `layout` prop is set to `none`.
+
+### Series with overlaps
+
+Use negative offset for overlapping sequences:
+
+```tsx
+<Series>
+  <Series.Sequence durationInFrames={60}>
+    <SceneA />
+  </Series.Sequence>
+  <Series.Sequence offset={-15} durationInFrames={60}>
+    {/* Starts 15 frames before SceneA ends */}
+    <SceneB />
+  </Series.Sequence>
+</Series>
+```
+
+## Frame References Inside Sequences
+
+Inside a Sequence, `useCurrentFrame()` returns the local frame (starting from 0):
+
+```tsx
+<Sequence from={60} durationInFrames={30}>
+  <MyComponent />
+  {/* Inside MyComponent, useCurrentFrame() returns 0-29, not 60-89 */}
+</Sequence>
+```
+
+## Nested Sequences
+
+Sequences can be nested for complex timing:
+
+```tsx
+<Sequence from={0} durationInFrames={120}>
+  <Background />
+  <Sequence from={15} durationInFrames={90} layout="none">
+    <Title />
+  </Sequence>
+  <Sequence from={45} durationInFrames={60} layout="none">
+    <Subtitle />
+  </Sequence>
+</Sequence>
+```
+
+## Nesting compositions within another
+
+To add a composition within another composition, you can use the `<Sequence>` component with a `width` and `height` prop to specify the size of the composition.
+
+```tsx
+<AbsoluteFill>
+  <Sequence width={COMPOSITION_WIDTH} height={COMPOSITION_HEIGHT}>
+    <CompositionComponent />
+  </Sequence>
+</AbsoluteFill>
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/tailwind.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/tailwind.md
@@ -1,0 +1,11 @@
+---
+name: tailwind
+description: Using TailwindCSS in Remotion.
+metadata:
+---
+
+You can and should use TailwindCSS in Remotion, if TailwindCSS is installed in the project.
+
+Don't use `transition-*` or `animate-*` classes - always animate using the `useCurrentFrame()` hook.  
+
+Tailwind must be installed and enabled first in a Remotion project - fetch  https://www.remotion.dev/docs/tailwind using WebFetch for instructions.

--- a/marketplace/plugins/remotion/skills/remotion/rules/text-animations.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/text-animations.md
@@ -1,0 +1,20 @@
+---
+name: text-animations
+description: Typography and text animation patterns for Remotion.
+metadata:
+  tags: typography, text, typewriter, highlighter ken
+---
+
+## Text animations
+
+Based on `useCurrentFrame()`, reduce the string character by character to create a typewriter effect.
+
+## Typewriter Effect
+
+See [Typewriter](assets/text-animations-typewriter.tsx) for an advanced example with a blinking cursor and a pause after the first sentence.
+
+Always use string slicing for typewriter effects. Never use per-character opacity.
+
+## Word Highlighting
+
+See [Word Highlight](assets/text-animations-word-highlight.tsx) for an example for how a word highlight is animated, like with a highlighter pen.

--- a/marketplace/plugins/remotion/skills/remotion/rules/timing.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/timing.md
@@ -1,0 +1,179 @@
+---
+name: timing
+description: Interpolation curves in Remotion - linear, easing, spring animations
+metadata:
+  tags: spring, bounce, easing, interpolation
+---
+
+A simple linear interpolation is done using the `interpolate` function.
+
+```ts title="Going from 0 to 1 over 100 frames"
+import {interpolate} from 'remotion';
+
+const opacity = interpolate(frame, [0, 100], [0, 1]);
+```
+
+By default, the values are not clamped, so the value can go outside the range [0, 1].  
+Here is how they can be clamped:
+
+```ts title="Going from 0 to 1 over 100 frames with extrapolation"
+const opacity = interpolate(frame, [0, 100], [0, 1], {
+  extrapolateRight: 'clamp',
+  extrapolateLeft: 'clamp',
+});
+```
+
+## Spring animations
+
+Spring animations have a more natural motion.  
+They go from 0 to 1 over time.
+
+```ts title="Spring animation from 0 to 1 over 100 frames"
+import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+const frame = useCurrentFrame();
+const {fps} = useVideoConfig();
+
+const scale = spring({
+  frame,
+  fps,
+});
+```
+
+### Physical properties
+
+The default configuration is: `mass: 1, damping: 10, stiffness: 100`.  
+This leads to the animation having a bit of bounce before it settles.
+
+The config can be overwritten like this:
+
+```ts
+const scale = spring({
+  frame,
+  fps,
+  config: {damping: 200},
+});
+```
+
+The recommended configuration for a natural motion without a bounce is: `{ damping: 200 }`.
+
+Here are some common configurations:
+
+```tsx
+const smooth = {damping: 200}; // Smooth, no bounce (subtle reveals)
+const snappy = {damping: 20, stiffness: 200}; // Snappy, minimal bounce (UI elements)
+const bouncy = {damping: 8}; // Bouncy entrance (playful animations)
+const heavy = {damping: 15, stiffness: 80, mass: 2}; // Heavy, slow, small bounce
+```
+
+### Delay
+
+The animation starts immediately by default.  
+Use the `delay` parameter to delay the animation by a number of frames.
+
+```tsx
+const entrance = spring({
+  frame: frame - ENTRANCE_DELAY,
+  fps,
+  delay: 20,
+});
+```
+
+### Duration
+
+A `spring()` has a natural duration based on the physical properties.  
+To stretch the animation to a specific duration, use the `durationInFrames` parameter.
+
+```tsx
+const spring = spring({
+  frame,
+  fps,
+  durationInFrames: 40,
+});
+```
+
+### Combining spring() with interpolate()
+
+Map spring output (0-1) to custom ranges:
+
+```tsx
+const springProgress = spring({
+  frame,
+  fps,
+});
+
+// Map to rotation
+const rotation = interpolate(springProgress, [0, 1], [0, 360]);
+
+<div style={{rotate: rotation + 'deg'}} />;
+```
+
+### Adding springs
+
+Springs return just numbers, so math can be performed:
+
+```tsx
+const frame = useCurrentFrame();
+const {fps, durationInFrames} = useVideoConfig();
+
+const inAnimation = spring({
+  frame,
+  fps,
+});
+const outAnimation = spring({
+  frame,
+  fps,
+  durationInFrames: 1 * fps,
+  delay: durationInFrames - 1 * fps,
+});
+
+const scale = inAnimation - outAnimation;
+```
+
+## Easing
+
+Easing can be added to the `interpolate` function:
+
+```ts
+import {interpolate, Easing} from 'remotion';
+
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.inOut(Easing.quad),
+  extrapolateLeft: 'clamp',
+  extrapolateRight: 'clamp',
+});
+```
+
+The default easing is `Easing.linear`.  
+There are various other convexities:
+
+- `Easing.in` for starting slow and accelerating
+- `Easing.out` for starting fast and slowing down
+- `Easing.inOut`
+
+and curves (sorted from most linear to most curved):
+
+- `Easing.quad`
+- `Easing.sin`
+- `Easing.exp`
+- `Easing.circle`
+
+Convexities and curves need be combined for an easing function:
+
+```ts
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.inOut(Easing.quad),
+  extrapolateLeft: 'clamp',
+  extrapolateRight: 'clamp',
+});
+```
+
+Cubic bezier curves are also supported:
+
+```ts
+const value1 = interpolate(frame, [0, 100], [0, 1], {
+  easing: Easing.bezier(0.8, 0.22, 0.96, 0.65),
+  extrapolateLeft: 'clamp',
+  extrapolateRight: 'clamp',
+});
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/transcribe-captions.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/transcribe-captions.md
@@ -1,0 +1,19 @@
+---
+name: transcribe-captions
+description: Transcribing audio to generate captions in Remotion
+metadata:
+  tags: captions, transcribe, whisper, audio, speech-to-text
+---
+
+# Transcribing audio
+
+Remotion provides several built-in options for transcribing audio to generate captions:
+
+- `@remotion/install-whisper-cpp` - Transcribe locally on a server using Whisper.cpp. Fast and free, but requires server infrastructure.
+  https://remotion.dev/docs/install-whisper-cpp
+
+- `@remotion/whisper-web` - Transcribe in the browser using WebAssembly. No server needed and free, but slower due to WASM overhead.
+  https://remotion.dev/docs/whisper-web
+
+- `@remotion/openai-whisper` - Use OpenAI Whisper API for cloud-based transcription. Fast and no server needed, but requires payment.
+  https://remotion.dev/docs/openai-whisper/openai-whisper-api-to-captions

--- a/marketplace/plugins/remotion/skills/remotion/rules/transitions.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/transitions.md
@@ -1,0 +1,122 @@
+---
+name: transitions
+description: Fullscreen scene transitions for Remotion.
+metadata:
+  tags: transitions, fade, slide, wipe, scenes
+---
+
+## Fullscreen transitions
+
+Using `<TransitionSeries>` to animate between multiple scenes or clips.  
+This will absolutely position the children.
+
+## Prerequisites
+
+First, the @remotion/transitions package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/transitions # If project uses npm
+bunx remotion add @remotion/transitions # If project uses bun
+yarn remotion add @remotion/transitions # If project uses yarn
+pnpm exec remotion add @remotion/transitions # If project uses pnpm
+```
+
+## Example usage
+
+```tsx
+import {TransitionSeries, linearTiming} from '@remotion/transitions';
+import {fade} from '@remotion/transitions/fade';
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneA />
+  </TransitionSeries.Sequence>
+  <TransitionSeries.Transition presentation={fade()} timing={linearTiming({durationInFrames: 15})} />
+  <TransitionSeries.Sequence durationInFrames={60}>
+    <SceneB />
+  </TransitionSeries.Sequence>
+</TransitionSeries>;
+```
+
+## Available Transition Types
+
+Import transitions from their respective modules:
+
+```tsx
+import {fade} from '@remotion/transitions/fade';
+import {slide} from '@remotion/transitions/slide';
+import {wipe} from '@remotion/transitions/wipe';
+import {flip} from '@remotion/transitions/flip';
+import {clockWipe} from '@remotion/transitions/clock-wipe';
+```
+
+## Slide Transition with Direction
+
+Specify slide direction for enter/exit animations.
+
+```tsx
+import {slide} from '@remotion/transitions/slide';
+
+<TransitionSeries.Transition presentation={slide({direction: 'from-left'})} timing={linearTiming({durationInFrames: 20})} />;
+```
+
+Directions: `"from-left"`, `"from-right"`, `"from-top"`, `"from-bottom"`
+
+## Timing Options
+
+```tsx
+import {linearTiming, springTiming} from '@remotion/transitions';
+
+// Linear timing - constant speed
+linearTiming({durationInFrames: 20});
+
+// Spring timing - organic motion
+springTiming({config: {damping: 200}, durationInFrames: 25});
+```
+
+## Duration calculation
+
+Transitions overlap adjacent scenes, so the total composition length is **shorter** than the sum of all sequence durations.
+
+For example, with two 60-frame sequences and a 15-frame transition:
+
+- Without transitions: `60 + 60 = 120` frames
+- With transition: `60 + 60 - 15 = 105` frames
+
+The transition duration is subtracted because both scenes play simultaneously during the transition.
+
+### Getting the duration of a transition
+
+Use the `getDurationInFrames()` method on the timing object:
+
+```tsx
+import {linearTiming, springTiming} from '@remotion/transitions';
+
+const linearDuration = linearTiming({durationInFrames: 20}).getDurationInFrames({fps: 30});
+// Returns 20
+
+const springDuration = springTiming({config: {damping: 200}}).getDurationInFrames({fps: 30});
+// Returns calculated duration based on spring physics
+```
+
+For `springTiming` without an explicit `durationInFrames`, the duration depends on `fps` because it calculates when the spring animation settles.
+
+### Calculating total composition duration
+
+```tsx
+import {linearTiming} from '@remotion/transitions';
+
+const scene1Duration = 60;
+const scene2Duration = 60;
+const scene3Duration = 60;
+
+const timing1 = linearTiming({durationInFrames: 15});
+const timing2 = linearTiming({durationInFrames: 20});
+
+const transition1Duration = timing1.getDurationInFrames({fps: 30});
+const transition2Duration = timing2.getDurationInFrames({fps: 30});
+
+const totalDuration = scene1Duration + scene2Duration + scene3Duration - transition1Duration - transition2Duration;
+// 60 + 60 + 60 - 15 - 20 = 145 frames
+```

--- a/marketplace/plugins/remotion/skills/remotion/rules/trimming.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/trimming.md
@@ -1,0 +1,53 @@
+---
+name: trimming
+description: Trimming patterns for Remotion - cut the beginning or end of animations
+metadata:
+  tags: sequence, trim, clip, cut, offset
+---
+
+Use `<Sequence>` with a negative `from` value to trim the start of an animation.
+
+## Trim the Beginning
+
+A negative `from` value shifts time backwards, making the animation start partway through:
+
+```tsx
+import { Sequence, useVideoConfig } from "remotion";
+
+const fps = useVideoConfig();
+
+<Sequence from={-0.5 * fps}>
+  <MyAnimation />
+</Sequence>
+```
+
+The animation appears 15 frames into its progress - the first 15 frames are trimmed off.
+Inside `<MyAnimation>`, `useCurrentFrame()` starts at 15 instead of 0.
+
+## Trim the End
+
+Use `durationInFrames` to unmount content after a specified duration:
+
+```tsx
+
+<Sequence durationInFrames={1.5 * fps}>
+  <MyAnimation />
+</Sequence>
+```
+
+The animation plays for 45 frames, then the component unmounts.
+
+## Trim and Delay
+
+Nest sequences to both trim the beginning and delay when it appears:
+
+```tsx
+<Sequence from={30}>
+  <Sequence from={-15}>
+    <MyAnimation />
+  </Sequence>
+</Sequence>
+```
+
+The inner sequence trims 15 frames from the start, and the outer sequence delays the result by 30 frames.
+

--- a/marketplace/plugins/remotion/skills/remotion/rules/videos.md
+++ b/marketplace/plugins/remotion/skills/remotion/rules/videos.md
@@ -1,0 +1,171 @@
+---
+name: videos
+description: Embedding videos in Remotion - trimming, volume, speed, looping, pitch
+metadata:
+  tags: video, media, trim, volume, speed, loop, pitch
+---
+
+# Using videos in Remotion
+
+## Prerequisites
+
+First, the @remotion/media package needs to be installed.  
+If it is not, use the following command:
+
+```bash
+npx remotion add @remotion/media # If project uses npm
+bunx remotion add @remotion/media # If project uses bun
+yarn remotion add @remotion/media # If project uses yarn
+pnpm exec remotion add @remotion/media # If project uses pnpm
+```
+
+Use `<Video>` from `@remotion/media` to embed videos into your composition.
+
+```tsx
+import { Video } from "@remotion/media";
+import { staticFile } from "remotion";
+
+export const MyComposition = () => {
+  return <Video src={staticFile("video.mp4")} />;
+};
+```
+
+Remote URLs are also supported:
+
+```tsx
+<Video src="https://remotion.media/video.mp4" />
+```
+
+## Trimming
+
+Use `trimBefore` and `trimAfter` to remove portions of the video. Values are in seconds.
+
+```tsx
+const { fps } = useVideoConfig();
+
+return (
+  <Video
+    src={staticFile("video.mp4")}
+    trimBefore={2 * fps} // Skip the first 2 seconds
+    trimAfter={10 * fps} // End at the 10 second mark
+  />
+);
+```
+
+## Delaying
+
+Wrap the video in a `<Sequence>` to delay when it appears:
+
+```tsx
+import { Sequence, staticFile } from "remotion";
+import { Video } from "@remotion/media";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Sequence from={1 * fps}>
+    <Video src={staticFile("video.mp4")} />
+  </Sequence>
+);
+```
+
+The video will appear after 1 second.
+
+## Sizing and Position
+
+Use the `style` prop to control size and position:
+
+```tsx
+<Video
+  src={staticFile("video.mp4")}
+  style={{
+    width: 500,
+    height: 300,
+    position: "absolute",
+    top: 100,
+    left: 50,
+    objectFit: "cover",
+  }}
+/>
+```
+
+## Volume
+
+Set a static volume (0 to 1):
+
+```tsx
+<Video src={staticFile("video.mp4")} volume={0.5} />
+```
+
+Or use a callback for dynamic volume based on the current frame:
+
+```tsx
+import { interpolate } from "remotion";
+
+const { fps } = useVideoConfig();
+
+return (
+  <Video
+    src={staticFile("video.mp4")}
+    volume={(f) =>
+      interpolate(f, [0, 1 * fps], [0, 1], { extrapolateRight: "clamp" })
+    }
+  />
+);
+```
+
+Use `muted` to silence the video entirely:
+
+```tsx
+<Video src={staticFile("video.mp4")} muted />
+```
+
+## Speed
+
+Use `playbackRate` to change the playback speed:
+
+```tsx
+<Video src={staticFile("video.mp4")} playbackRate={2} /> {/* 2x speed */}
+<Video src={staticFile("video.mp4")} playbackRate={0.5} /> {/* Half speed */}
+```
+
+Reverse playback is not supported.
+
+## Looping
+
+Use `loop` to loop the video indefinitely:
+
+```tsx
+<Video src={staticFile("video.mp4")} loop />
+```
+
+Use `loopVolumeCurveBehavior` to control how the frame count behaves when looping:
+
+- `"repeat"`: Frame count resets to 0 each loop (for `volume` callback)
+- `"extend"`: Frame count continues incrementing
+
+```tsx
+<Video
+  src={staticFile("video.mp4")}
+  loop
+  loopVolumeCurveBehavior="extend"
+  volume={(f) => interpolate(f, [0, 300], [1, 0])} // Fade out over multiple loops
+/>
+```
+
+## Pitch
+
+Use `toneFrequency` to adjust the pitch without affecting speed. Values range from 0.01 to 2:
+
+```tsx
+<Video
+  src={staticFile("video.mp4")}
+  toneFrequency={1.5} // Higher pitch
+/>
+<Video
+  src={staticFile("video.mp4")}
+  toneFrequency={0.8} // Lower pitch
+/>
+```
+
+Pitch shifting only works during server-side rendering, not in the Remotion Studio preview or in the `<Player />`.

--- a/marketplace/plugins/skill-creator/.codex-plugin/plugin.json
+++ b/marketplace/plugins/skill-creator/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "skill-creator",
+  "version": "0.1.0",
+  "description": "Create and update skills that extend agents with specialized knowledge, workflows, and tools \u2014 init, author, validate, and package with bundled scripts.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Skill Creator",
+    "shortDescription": "Create and update skills that extend agents with specialized knowledge, workflows, and tools \u2014 init, author, validate, and package with bundled scripts.",
+    "longDescription": "Use when creating a new skill or updating an existing one. Guides the full process \u2014 understand the skill through concrete usage examples, plan reusable contents (scripts for deterministic work, references for documentation, assets for output files), initialize with scripts/init_skill.py, author a concise SKILL.md with trigger-rich frontmatter, then validate and package with the bundled scripts. Built on the progressive-disclosure principle: SKILL.md stays lean and detailed material moves to references/ loaded only when needed.",
+    "developerName": "OpenCoven",
+    "category": "Agents & Harnesses",
+    "capabilities": [
+      "skills",
+      "authoring",
+      "skill-creation",
+      "progressive-disclosure",
+      "packaging",
+      "agents"
+    ],
+    "defaultPrompt": "Help me use Skill Creator safely."
+  }
+}

--- a/marketplace/plugins/skill-creator/NOTES.md
+++ b/marketplace/plugins/skill-creator/NOTES.md
@@ -1,0 +1,22 @@
+# NOTES — Skill Creator
+
+## Provenance
+Vendored verbatim from [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills)
+(`.claude/skills/skill-creator/`) at commit `75e1e9cd60ef46bffbd294fdfe4d0320cee2f563`
+(fetched 2026-07-06). This is Anthropic's skill-creator skill (see the retained `LICENSE.txt`,
+which its frontmatter references) as redistributed by that repo. The generated `plugin.json`
+author/license fields are stamped by `scripts/sync-marketplace.py` and do not reflect upstream
+authorship — `LICENSE.txt` inside the skill directory is the operative license for the skill body.
+
+## What's vendored
+The complete upstream skill: `SKILL.md`, `LICENSE.txt`, `references/` (output patterns,
+workflows), and `scripts/` (`init_skill.py`, `package_skill.py`, `quick_validate.py`). Nothing
+was excluded or modified.
+
+## Runtime requirements
+The bundled scripts need Python 3; `package_skill.py` produces a distributable skill archive.
+
+## Sync integration
+`skill.managed: "manual"` in `marketplace/catalog.json` — the authored SKILL.md is the source of
+truth; `sync-marketplace.py` generates only the manifests and never rewrites the skill body.
+Re-vendor by re-copying from upstream and updating the commit hash above.

--- a/marketplace/plugins/skill-creator/plugin.json
+++ b/marketplace/plugins/skill-creator/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "skill-creator",
+  "version": "0.1.0",
+  "description": "Create and update skills that extend agents with specialized knowledge, workflows, and tools \u2014 init, author, validate, and package with bundled scripts.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "skills",
+    "authoring",
+    "skill-creation",
+    "progressive-disclosure",
+    "packaging",
+    "agents"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files",
+    "shell"
+  ],
+  "marketplaceId": "opencoven/skill-creator",
+  "x-coven": {
+    "displayName": "Skill Creator",
+    "category": "Agents & Harnesses",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/coleam00/second-brain-skills",
+      "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/skill-creator",
+      "https://agentskills.io"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  }
+}

--- a/marketplace/plugins/skill-creator/skills/skill-creator/LICENSE.txt
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/marketplace/plugins/skill-creator/skills/skill-creator/SKILL.md
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/SKILL.md
@@ -1,0 +1,356 @@
+---
+name: skill-creator
+description: Guide for creating effective skills. This skill should be used when users want to create a new skill (or update an existing skill) that extends Claude's capabilities with specialized knowledge, workflows, or tool integrations.
+license: Complete terms in LICENSE.txt
+---
+
+# Skill Creator
+
+This skill provides guidance for creating effective skills.
+
+## About Skills
+
+Skills are modular, self-contained packages that extend Claude's capabilities by providing
+specialized knowledge, workflows, and tools. Think of them as "onboarding guides" for specific
+domains or tasks—they transform Claude from a general-purpose agent into a specialized agent
+equipped with procedural knowledge that no model can fully possess.
+
+### What Skills Provide
+
+1. Specialized workflows - Multi-step procedures for specific domains
+2. Tool integrations - Instructions for working with specific file formats or APIs
+3. Domain expertise - Company-specific knowledge, schemas, business logic
+4. Bundled resources - Scripts, references, and assets for complex and repetitive tasks
+
+## Core Principles
+
+### Concise is Key
+
+The context window is a public good. Skills share the context window with everything else Claude needs: system prompt, conversation history, other Skills' metadata, and the actual user request.
+
+**Default assumption: Claude is already very smart.** Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" and "Does this paragraph justify its token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set Appropriate Degrees of Freedom
+
+Match the level of specificity to the task's fragility and variability:
+
+**High freedom (text-based instructions)**: Use when multiple approaches are valid, decisions depend on context, or heuristics guide the approach.
+
+**Medium freedom (pseudocode or scripts with parameters)**: Use when a preferred pattern exists, some variation is acceptable, or configuration affects behavior.
+
+**Low freedom (specific scripts, few parameters)**: Use when operations are fragile and error-prone, consistency is critical, or a specific sequence must be followed.
+
+Think of Claude as exploring a path: a narrow bridge with cliffs needs specific guardrails (low freedom), while an open field allows many routes (high freedom).
+
+### Anatomy of a Skill
+
+Every skill consists of a required SKILL.md file and optional bundled resources:
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter metadata (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled Resources (optional)
+    ├── scripts/          - Executable code (Python/Bash/etc.)
+    ├── references/       - Documentation intended to be loaded into context as needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+Every SKILL.md consists of:
+
+- **Frontmatter** (YAML): Contains `name` and `description` fields. These are the only fields that Claude reads to determine when the skill gets used, thus it is very important to be clear and comprehensive in describing what the skill is, and when it should be used.
+- **Body** (Markdown): Instructions and guidance for using the skill. Only loaded AFTER the skill triggers (if at all).
+
+#### Bundled Resources (optional)
+
+##### Scripts (`scripts/`)
+
+Executable code (Python/Bash/etc.) for tasks that require deterministic reliability or are repeatedly rewritten.
+
+- **When to include**: When the same code is being rewritten repeatedly or deterministic reliability is needed
+- **Example**: `scripts/rotate_pdf.py` for PDF rotation tasks
+- **Benefits**: Token efficient, deterministic, may be executed without loading into context
+- **Note**: Scripts may still need to be read by Claude for patching or environment-specific adjustments
+
+##### References (`references/`)
+
+Documentation and reference material intended to be loaded as needed into context to inform Claude's process and thinking.
+
+- **When to include**: For documentation that Claude should reference while working
+- **Examples**: `references/finance.md` for financial schemas, `references/mnda.md` for company NDA template, `references/policies.md` for company policies, `references/api_docs.md` for API specifications
+- **Use cases**: Database schemas, API documentation, domain knowledge, company policies, detailed workflow guides
+- **Benefits**: Keeps SKILL.md lean, loaded only when Claude determines it's needed
+- **Best practice**: If files are large (>10k words), include grep search patterns in SKILL.md
+- **Avoid duplication**: Information should live in either SKILL.md or references files, not both. Prefer references files for detailed information unless it's truly core to the skill—this keeps SKILL.md lean while making information discoverable without hogging the context window. Keep only essential procedural instructions and workflow guidance in SKILL.md; move detailed reference material, schemas, and examples to references files.
+
+##### Assets (`assets/`)
+
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+- **When to include**: When the skill needs files that will be used in the final output
+- **Examples**: `assets/logo.png` for brand assets, `assets/slides.pptx` for PowerPoint templates, `assets/frontend-template/` for HTML/React boilerplate, `assets/font.ttf` for typography
+- **Use cases**: Templates, images, icons, boilerplate code, fonts, sample documents that get copied or modified
+- **Benefits**: Separates output resources from documentation, enables Claude to use files without loading them into context
+
+#### What to Not Include in a Skill
+
+A skill should only contain essential files that directly support its functionality. Do NOT create extraneous documentation or auxiliary files, including:
+
+- README.md
+- INSTALLATION_GUIDE.md
+- QUICK_REFERENCE.md
+- CHANGELOG.md
+- etc.
+
+The skill should only contain the information needed for an AI agent to do the job at hand. It should not contain auxilary context about the process that went into creating it, setup and testing procedures, user-facing documentation, etc. Creating additional documentation files just adds clutter and confusion.
+
+### Progressive Disclosure Design Principle
+
+Skills use a three-level loading system to manage context efficiently:
+
+1. **Metadata (name + description)** - Always in context (~100 words)
+2. **SKILL.md body** - When skill triggers (<5k words)
+3. **Bundled resources** - As needed by Claude (Unlimited because scripts can be executed without reading into context window)
+
+#### Progressive Disclosure Patterns
+
+Keep SKILL.md body to the essentials and under 500 lines to minimize context bloat. Split content into separate files when approaching this limit. When splitting out content into other files, it is very important to reference them from SKILL.md and describe clearly when to read them, to ensure the reader of the skill knows they exist and when to use them.
+
+**Key principle:** When a skill supports multiple variations, frameworks, or options, keep only the core workflow and selection guidance in SKILL.md. Move variant-specific details (patterns, examples, configuration) into separate reference files.
+
+**Pattern 1: High-level guide with references**
+
+```markdown
+# PDF Processing
+
+## Quick start
+
+Extract text with pdfplumber:
+[code example]
+
+## Advanced features
+
+- **Form filling**: See [FORMS.md](FORMS.md) for complete guide
+- **API reference**: See [REFERENCE.md](REFERENCE.md) for all methods
+- **Examples**: See [EXAMPLES.md](EXAMPLES.md) for common patterns
+```
+
+Claude loads FORMS.md, REFERENCE.md, or EXAMPLES.md only when needed.
+
+**Pattern 2: Domain-specific organization**
+
+For Skills with multiple domains, organize content by domain to avoid loading irrelevant context:
+
+```
+bigquery-skill/
+├── SKILL.md (overview and navigation)
+└── reference/
+    ├── finance.md (revenue, billing metrics)
+    ├── sales.md (opportunities, pipeline)
+    ├── product.md (API usage, features)
+    └── marketing.md (campaigns, attribution)
+```
+
+When a user asks about sales metrics, Claude only reads sales.md.
+
+Similarly, for skills supporting multiple frameworks or variants, organize by variant:
+
+```
+cloud-deploy/
+├── SKILL.md (workflow + provider selection)
+└── references/
+    ├── aws.md (AWS deployment patterns)
+    ├── gcp.md (GCP deployment patterns)
+    └── azure.md (Azure deployment patterns)
+```
+
+When the user chooses AWS, Claude only reads aws.md.
+
+**Pattern 3: Conditional details**
+
+Show basic content, link to advanced content:
+
+```markdown
+# DOCX Processing
+
+## Creating documents
+
+Use docx-js for new documents. See [DOCX-JS.md](DOCX-JS.md).
+
+## Editing documents
+
+For simple edits, modify the XML directly.
+
+**For tracked changes**: See [REDLINING.md](REDLINING.md)
+**For OOXML details**: See [OOXML.md](OOXML.md)
+```
+
+Claude reads REDLINING.md or OOXML.md only when the user needs those features.
+
+**Important guidelines:**
+
+- **Avoid deeply nested references** - Keep references one level deep from SKILL.md. All reference files should link directly from SKILL.md.
+- **Structure longer reference files** - For files longer than 100 lines, include a table of contents at the top so Claude can see the full scope when previewing.
+
+## Skill Creation Process
+
+Skill creation involves these steps:
+
+1. Understand the skill with concrete examples
+2. Plan reusable skill contents (scripts, references, assets)
+3. Initialize the skill (run init_skill.py)
+4. Edit the skill (implement resources and write SKILL.md)
+5. Package the skill (run package_skill.py)
+6. Iterate based on real usage
+
+Follow these steps in order, skipping only if there is a clear reason why they are not applicable.
+
+### Step 1: Understanding the Skill with Concrete Examples
+
+Skip this step only when the skill's usage patterns are already clearly understood. It remains valuable even when working with an existing skill.
+
+To create an effective skill, clearly understand concrete examples of how the skill will be used. This understanding can come from either direct user examples or generated examples that are validated with user feedback.
+
+For example, when building an image-editor skill, relevant questions include:
+
+- "What functionality should the image-editor skill support? Editing, rotating, anything else?"
+- "Can you give some examples of how this skill would be used?"
+- "I can imagine users asking for things like 'Remove the red-eye from this image' or 'Rotate this image'. Are there other ways you imagine this skill being used?"
+- "What would a user say that should trigger this skill?"
+
+To avoid overwhelming users, avoid asking too many questions in a single message. Start with the most important questions and follow up as needed for better effectiveness.
+
+Conclude this step when there is a clear sense of the functionality the skill should support.
+
+### Step 2: Planning the Reusable Skill Contents
+
+To turn concrete examples into an effective skill, analyze each example by:
+
+1. Considering how to execute on the example from scratch
+2. Identifying what scripts, references, and assets would be helpful when executing these workflows repeatedly
+
+Example: When building a `pdf-editor` skill to handle queries like "Help me rotate this PDF," the analysis shows:
+
+1. Rotating a PDF requires re-writing the same code each time
+2. A `scripts/rotate_pdf.py` script would be helpful to store in the skill
+
+Example: When designing a `frontend-webapp-builder` skill for queries like "Build me a todo app" or "Build me a dashboard to track my steps," the analysis shows:
+
+1. Writing a frontend webapp requires the same boilerplate HTML/React each time
+2. An `assets/hello-world/` template containing the boilerplate HTML/React project files would be helpful to store in the skill
+
+Example: When building a `big-query` skill to handle queries like "How many users have logged in today?" the analysis shows:
+
+1. Querying BigQuery requires re-discovering the table schemas and relationships each time
+2. A `references/schema.md` file documenting the table schemas would be helpful to store in the skill
+
+To establish the skill's contents, analyze each concrete example to create a list of the reusable resources to include: scripts, references, and assets.
+
+### Step 3: Initializing the Skill
+
+At this point, it is time to actually create the skill.
+
+Skip this step only if the skill being developed already exists, and iteration or packaging is needed. In this case, continue to the next step.
+
+When creating a new skill from scratch, always run the `init_skill.py` script. The script conveniently generates a new template skill directory that automatically includes everything a skill requires, making the skill creation process much more efficient and reliable.
+
+Usage:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+The script:
+
+- Creates the skill directory at the specified path
+- Generates a SKILL.md template with proper frontmatter and TODO placeholders
+- Creates example resource directories: `scripts/`, `references/`, and `assets/`
+- Adds example files in each directory that can be customized or deleted
+
+After initialization, customize or remove the generated SKILL.md and example files as needed.
+
+### Step 4: Edit the Skill
+
+When editing the (newly-generated or existing) skill, remember that the skill is being created for another instance of Claude to use. Include information that would be beneficial and non-obvious to Claude. Consider what procedural knowledge, domain-specific details, or reusable assets would help another Claude instance execute these tasks more effectively.
+
+#### Learn Proven Design Patterns
+
+Consult these helpful guides based on your skill's needs:
+
+- **Multi-step processes**: See references/workflows.md for sequential workflows and conditional logic
+- **Specific output formats or quality standards**: See references/output-patterns.md for template and example patterns
+
+These files contain established best practices for effective skill design.
+
+#### Start with Reusable Skill Contents
+
+To begin implementation, start with the reusable resources identified above: `scripts/`, `references/`, and `assets/` files. Note that this step may require user input. For example, when implementing a `brand-guidelines` skill, the user may need to provide brand assets or templates to store in `assets/`, or documentation to store in `references/`.
+
+Added scripts must be tested by actually running them to ensure there are no bugs and that the output matches what is expected. If there are many similar scripts, only a representative sample needs to be tested to ensure confidence that they all work while balancing time to completion.
+
+Any example files and directories not needed for the skill should be deleted. The initialization script creates example files in `scripts/`, `references/`, and `assets/` to demonstrate structure, but most skills won't need all of them.
+
+#### Update SKILL.md
+
+**Writing Guidelines:** Always use imperative/infinitive form.
+
+##### Frontmatter
+
+Write the YAML frontmatter with `name` and `description`:
+
+- `name`: The skill name
+- `description`: This is the primary triggering mechanism for your skill, and helps Claude understand when to use the skill.
+  - Include both what the Skill does and specific triggers/contexts for when to use it.
+  - Include all "when to use" information here - Not in the body. The body is only loaded after triggering, so "When to Use This Skill" sections in the body are not helpful to Claude.
+  - Example description for a `docx` skill: "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. Use when Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks"
+
+Do not include any other fields in YAML frontmatter.
+
+##### Body
+
+Write instructions for using the skill and its bundled resources.
+
+### Step 5: Packaging a Skill
+
+Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder>
+```
+
+Optional output directory specification:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> ./dist
+```
+
+The packaging script will:
+
+1. **Validate** the skill automatically, checking:
+
+   - YAML frontmatter format and required fields
+   - Skill naming conventions and directory structure
+   - Description completeness and quality
+   - File organization and resource references
+
+2. **Package** the skill if validation passes, creating a .skill file named after the skill (e.g., `my-skill.skill`) that includes all files and maintains the proper directory structure for distribution. The .skill file is a zip file with a .skill extension.
+
+If validation fails, the script will report the errors and exit without creating a package. Fix any validation errors and run the packaging command again.
+
+### Step 6: Iterate
+
+After testing the skill, users may request improvements. Often this happens right after using the skill, with fresh context of how the skill performed.
+
+**Iteration workflow:**
+
+1. Use the skill on real tasks
+2. Notice struggles or inefficiencies
+3. Identify how SKILL.md or bundled resources should be updated
+4. Implement changes and test again

--- a/marketplace/plugins/skill-creator/skills/skill-creator/references/output-patterns.md
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/references/output-patterns.md
@@ -1,0 +1,82 @@
+# Output Patterns
+
+Use these patterns when skills need to produce consistent, high-quality output.
+
+## Template Pattern
+
+Provide templates for output format. Match the level of strictness to your needs.
+
+**For strict requirements (like API responses or data formats):**
+
+```markdown
+## Report structure
+
+ALWAYS use this exact template structure:
+
+# [Analysis Title]
+
+## Executive summary
+[One-paragraph overview of key findings]
+
+## Key findings
+- Finding 1 with supporting data
+- Finding 2 with supporting data
+- Finding 3 with supporting data
+
+## Recommendations
+1. Specific actionable recommendation
+2. Specific actionable recommendation
+```
+
+**For flexible guidance (when adaptation is useful):**
+
+```markdown
+## Report structure
+
+Here is a sensible default format, but use your best judgment:
+
+# [Analysis Title]
+
+## Executive summary
+[Overview]
+
+## Key findings
+[Adapt sections based on what you discover]
+
+## Recommendations
+[Tailor to the specific context]
+
+Adjust sections as needed for the specific analysis type.
+```
+
+## Examples Pattern
+
+For skills where output quality depends on seeing examples, provide input/output pairs:
+
+```markdown
+## Commit message format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Added user authentication with JWT tokens
+Output:
+```
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+```
+
+**Example 2:**
+Input: Fixed bug where dates displayed incorrectly in reports
+Output:
+```
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently across report generation
+```
+
+Follow this style: type(scope): brief description, then detailed explanation.
+```
+
+Examples help Claude understand the desired style and level of detail more clearly than descriptions alone.

--- a/marketplace/plugins/skill-creator/skills/skill-creator/references/workflows.md
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/references/workflows.md
@@ -1,0 +1,28 @@
+# Workflow Patterns
+
+## Sequential Workflows
+
+For complex tasks, break operations into clear, sequential steps. It is often helpful to give Claude an overview of the process towards the beginning of SKILL.md:
+
+```markdown
+Filling a PDF form involves these steps:
+
+1. Analyze the form (run analyze_form.py)
+2. Create field mapping (edit fields.json)
+3. Validate mapping (run validate_fields.py)
+4. Fill the form (run fill_form.py)
+5. Verify output (run verify_output.py)
+```
+
+## Conditional Workflows
+
+For tasks with branching logic, guide Claude through decision points:
+
+```markdown
+1. Determine the modification type:
+   **Creating new content?** → Follow "Creation workflow" below
+   **Editing existing content?** → Follow "Editing workflow" below
+
+2. Creation workflow: [steps]
+3. Editing workflow: [steps]
+```

--- a/marketplace/plugins/skill-creator/skills/skill-creator/scripts/init_skill.py
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/scripts/init_skill.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+Skill Initializer - Creates a new skill from template
+
+Usage:
+    init_skill.py <skill-name> --path <path>
+
+Examples:
+    init_skill.py my-new-skill --path skills/public
+    init_skill.py my-api-helper --path skills/private
+    init_skill.py custom-skill --path /custom/location
+"""
+
+import sys
+from pathlib import Path
+
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+---
+
+# {skill_title}
+
+## Overview
+
+[TODO: 1-2 sentences explaining what this skill enables]
+
+## Structuring This Skill
+
+[TODO: Choose the structure that best fits this skill's purpose. Common patterns:
+
+**1. Workflow-Based** (best for sequential processes)
+- Works well when there are clear step-by-step procedures
+- Example: DOCX skill with "Workflow Decision Tree" → "Reading" → "Creating" → "Editing"
+- Structure: ## Overview → ## Workflow Decision Tree → ## Step 1 → ## Step 2...
+
+**2. Task-Based** (best for tool collections)
+- Works well when the skill offers different operations/capabilities
+- Example: PDF skill with "Quick Start" → "Merge PDFs" → "Split PDFs" → "Extract Text"
+- Structure: ## Overview → ## Quick Start → ## Task Category 1 → ## Task Category 2...
+
+**3. Reference/Guidelines** (best for standards or specifications)
+- Works well for brand guidelines, coding standards, or requirements
+- Example: Brand styling with "Brand Guidelines" → "Colors" → "Typography" → "Features"
+- Structure: ## Overview → ## Guidelines → ## Specifications → ## Usage...
+
+**4. Capabilities-Based** (best for integrated systems)
+- Works well when the skill provides multiple interrelated features
+- Example: Product Management with "Core Capabilities" → numbered capability list
+- Structure: ## Overview → ## Core Capabilities → ### 1. Feature → ### 2. Feature...
+
+Patterns can be mixed and matched as needed. Most skills combine patterns (e.g., start with task-based, add workflow for complex operations).
+
+Delete this entire "Structuring This Skill" section when done - it's just guidance.]
+
+## [TODO: Replace with the first main section based on chosen structure]
+
+[TODO: Add content here. See examples in existing skills:
+- Code samples for technical skills
+- Decision trees for complex workflows
+- Concrete examples with realistic user requests
+- References to scripts/templates/references as needed]
+
+## Resources
+
+This skill includes example resource directories that demonstrate how to organize different types of bundled resources:
+
+### scripts/
+Executable code (Python/Bash/etc.) that can be run directly to perform specific operations.
+
+**Examples from other skills:**
+- PDF skill: `fill_fillable_fields.py`, `extract_form_field_info.py` - utilities for PDF manipulation
+- DOCX skill: `document.py`, `utilities.py` - Python modules for document processing
+
+**Appropriate for:** Python scripts, shell scripts, or any executable code that performs automation, data processing, or specific operations.
+
+**Note:** Scripts may be executed without loading into context, but can still be read by Claude for patching or environment adjustments.
+
+### references/
+Documentation and reference material intended to be loaded into context to inform Claude's process and thinking.
+
+**Examples from other skills:**
+- Product management: `communication.md`, `context_building.md` - detailed workflow guides
+- BigQuery: API reference documentation and query examples
+- Finance: Schema documentation, company policies
+
+**Appropriate for:** In-depth documentation, API references, database schemas, comprehensive guides, or any detailed information that Claude should reference while working.
+
+### assets/
+Files not intended to be loaded into context, but rather used within the output Claude produces.
+
+**Examples from other skills:**
+- Brand styling: PowerPoint template files (.pptx), logo files
+- Frontend builder: HTML/React boilerplate project directories
+- Typography: Font files (.ttf, .woff2)
+
+**Appropriate for:** Templates, boilerplate code, document templates, images, icons, fonts, or any files meant to be copied or used in the final output.
+
+---
+
+**Any unneeded directories can be deleted.** Not every skill requires all three types of resources.
+"""
+
+EXAMPLE_SCRIPT = '''#!/usr/bin/env python3
+"""
+Example helper script for {skill_name}
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for {skill_name}")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()
+'''
+
+EXAMPLE_REFERENCE = """# Reference Documentation for {skill_title}
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices
+"""
+
+EXAMPLE_ASSET = """# Example Asset File
+
+This placeholder represents where asset files would be stored.
+Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
+
+Asset files are NOT intended to be loaded into context, but rather used within
+the output Claude produces.
+
+Example asset files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Asset Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual assets can be any file type.
+"""
+
+
+def title_case_skill_name(skill_name):
+    """Convert hyphenated skill name to Title Case for display."""
+    return ' '.join(word.capitalize() for word in skill_name.split('-'))
+
+
+def init_skill(skill_name, path):
+    """
+    Initialize a new skill directory with template SKILL.md.
+
+    Args:
+        skill_name: Name of the skill
+        path: Path where the skill directory should be created
+
+    Returns:
+        Path to created skill directory, or None if error
+    """
+    # Determine skill directory path
+    skill_dir = Path(path).resolve() / skill_name
+
+    # Check if directory already exists
+    if skill_dir.exists():
+        print(f"❌ Error: Skill directory already exists: {skill_dir}")
+        return None
+
+    # Create skill directory
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=False)
+        print(f"✅ Created skill directory: {skill_dir}")
+    except Exception as e:
+        print(f"❌ Error creating directory: {e}")
+        return None
+
+    # Create SKILL.md from template
+    skill_title = title_case_skill_name(skill_name)
+    skill_content = SKILL_TEMPLATE.format(
+        skill_name=skill_name,
+        skill_title=skill_title
+    )
+
+    skill_md_path = skill_dir / 'SKILL.md'
+    try:
+        skill_md_path.write_text(skill_content)
+        print("✅ Created SKILL.md")
+    except Exception as e:
+        print(f"❌ Error creating SKILL.md: {e}")
+        return None
+
+    # Create resource directories with example files
+    try:
+        # Create scripts/ directory with example script
+        scripts_dir = skill_dir / 'scripts'
+        scripts_dir.mkdir(exist_ok=True)
+        example_script = scripts_dir / 'example.py'
+        example_script.write_text(EXAMPLE_SCRIPT.format(skill_name=skill_name))
+        example_script.chmod(0o755)
+        print("✅ Created scripts/example.py")
+
+        # Create references/ directory with example reference doc
+        references_dir = skill_dir / 'references'
+        references_dir.mkdir(exist_ok=True)
+        example_reference = references_dir / 'api_reference.md'
+        example_reference.write_text(EXAMPLE_REFERENCE.format(skill_title=skill_title))
+        print("✅ Created references/api_reference.md")
+
+        # Create assets/ directory with example asset placeholder
+        assets_dir = skill_dir / 'assets'
+        assets_dir.mkdir(exist_ok=True)
+        example_asset = assets_dir / 'example_asset.txt'
+        example_asset.write_text(EXAMPLE_ASSET)
+        print("✅ Created assets/example_asset.txt")
+    except Exception as e:
+        print(f"❌ Error creating resource directories: {e}")
+        return None
+
+    # Print next steps
+    print(f"\n✅ Skill '{skill_name}' initialized successfully at {skill_dir}")
+    print("\nNext steps:")
+    print("1. Edit SKILL.md to complete the TODO items and update the description")
+    print("2. Customize or delete the example files in scripts/, references/, and assets/")
+    print("3. Run the validator when ready to check the skill structure")
+
+    return skill_dir
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[2] != '--path':
+        print("Usage: init_skill.py <skill-name> --path <path>")
+        print("\nSkill name requirements:")
+        print("  - Hyphen-case identifier (e.g., 'data-analyzer')")
+        print("  - Lowercase letters, digits, and hyphens only")
+        print("  - Max 40 characters")
+        print("  - Must match directory name exactly")
+        print("\nExamples:")
+        print("  init_skill.py my-new-skill --path skills/public")
+        print("  init_skill.py my-api-helper --path skills/private")
+        print("  init_skill.py custom-skill --path /custom/location")
+        sys.exit(1)
+
+    skill_name = sys.argv[1]
+    path = sys.argv[3]
+
+    print(f"🚀 Initializing skill: {skill_name}")
+    print(f"   Location: {path}")
+    print()
+
+    result = init_skill(skill_name, path)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/skill-creator/skills/skill-creator/scripts/package_skill.py
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file of a skill folder
+
+Usage:
+    python utils/package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    python utils/package_skill.py skills/public/my-skill
+    python utils/package_skill.py skills/public/my-skill ./dist
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+from quick_validate import validate_skill
+
+
+def package_skill(skill_path, output_dir=None):
+    """
+    Package a skill folder into a .skill file.
+
+    Args:
+        skill_path: Path to the skill folder
+        output_dir: Optional output directory for the .skill file (defaults to current directory)
+
+    Returns:
+        Path to the created .skill file, or None if error
+    """
+    skill_path = Path(skill_path).resolve()
+
+    # Validate skill folder exists
+    if not skill_path.exists():
+        print(f"❌ Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"❌ Error: Path is not a directory: {skill_path}")
+        return None
+
+    # Validate SKILL.md exists
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"❌ Error: SKILL.md not found in {skill_path}")
+        return None
+
+    # Run validation before packaging
+    print("🔍 Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"❌ Validation failed: {message}")
+        print("   Please fix the validation errors before packaging.")
+        return None
+    print(f"✅ {message}\n")
+
+    # Determine output location
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    # Create the .skill file (zip format)
+    try:
+        with zipfile.ZipFile(skill_filename, 'w', zipfile.ZIP_DEFLATED) as zipf:
+            # Walk through the skill directory
+            for file_path in skill_path.rglob('*'):
+                if file_path.is_file():
+                    # Calculate the relative path within the zip
+                    arcname = file_path.relative_to(skill_path.parent)
+                    zipf.write(file_path, arcname)
+                    print(f"  Added: {arcname}")
+
+        print(f"\n✅ Successfully packaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"❌ Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python utils/package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  python utils/package_skill.py skills/public/my-skill")
+        print("  python utils/package_skill.py skills/public/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"📦 Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"   Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+
+    if result:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/marketplace/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
+++ b/marketplace/plugins/skill-creator/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills - minimal version
+"""
+
+import sys
+import os
+import re
+import yaml
+from pathlib import Path
+
+def validate_skill(skill_path):
+    """Basic validation of a skill"""
+    skill_path = Path(skill_path)
+
+    # Check SKILL.md exists
+    skill_md = skill_path / 'SKILL.md'
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    # Read and validate frontmatter
+    content = skill_md.read_text()
+    if not content.startswith('---'):
+        return False, "No YAML frontmatter found"
+
+    # Extract frontmatter
+    match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+    if not match:
+        return False, "Invalid frontmatter format"
+
+    frontmatter_text = match.group(1)
+
+    # Parse YAML frontmatter
+    try:
+        frontmatter = yaml.safe_load(frontmatter_text)
+        if not isinstance(frontmatter, dict):
+            return False, "Frontmatter must be a YAML dictionary"
+    except yaml.YAMLError as e:
+        return False, f"Invalid YAML in frontmatter: {e}"
+
+    # Define allowed properties
+    ALLOWED_PROPERTIES = {'name', 'description', 'license', 'allowed-tools', 'metadata'}
+
+    # Check for unexpected properties (excluding nested keys under metadata)
+    unexpected_keys = set(frontmatter.keys()) - ALLOWED_PROPERTIES
+    if unexpected_keys:
+        return False, (
+            f"Unexpected key(s) in SKILL.md frontmatter: {', '.join(sorted(unexpected_keys))}. "
+            f"Allowed properties are: {', '.join(sorted(ALLOWED_PROPERTIES))}"
+        )
+
+    # Check required fields
+    if 'name' not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if 'description' not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    # Extract name for validation
+    name = frontmatter.get('name', '')
+    if not isinstance(name, str):
+        return False, f"Name must be a string, got {type(name).__name__}"
+    name = name.strip()
+    if name:
+        # Check naming convention (hyphen-case: lowercase with hyphens)
+        if not re.match(r'^[a-z0-9-]+$', name):
+            return False, f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)"
+        if name.startswith('-') or name.endswith('-') or '--' in name:
+            return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+        # Check name length (max 64 characters per spec)
+        if len(name) > 64:
+            return False, f"Name is too long ({len(name)} characters). Maximum is 64 characters."
+
+    # Extract and validate description
+    description = frontmatter.get('description', '')
+    if not isinstance(description, str):
+        return False, f"Description must be a string, got {type(description).__name__}"
+    description = description.strip()
+    if description:
+        # Check for angle brackets
+        if '<' in description or '>' in description:
+            return False, "Description cannot contain angle brackets (< or >)"
+        # Check description length (max 1024 characters per spec)
+        if len(description) > 1024:
+            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+
+    return True, "Skill is valid!"
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+    
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)

--- a/marketplace/plugins/sop-creator/.codex-plugin/plugin.json
+++ b/marketplace/plugins/sop-creator/.codex-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "sop-creator",
+  "version": "0.1.0",
+  "description": "Create runbooks, playbooks, and technical documentation that people actually follow \u2014 scannable, actionable, specific, testable, and maintained.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "SOP & Runbook Creator",
+    "shortDescription": "Create runbooks, playbooks, and technical documentation that people actually follow \u2014 scannable, actionable, specific, testable, and maintained.",
+    "longDescription": "Use when documenting a repeatable technical or operational process \u2014 runbooks for incidents and on-call, deployment playbooks, troubleshooting guides, process SOPs, checklists, decision trees, and onboarding guides. Ships reference templates for each format plus writing rules that keep docs scannable and unambiguous: action-first numbered steps, exact names and thresholds instead of 'as needed', and a Definition of Done checklist near the top.",
+    "developerName": "OpenCoven",
+    "category": "Knowledge & Docs",
+    "capabilities": [
+      "sop",
+      "runbook",
+      "playbook",
+      "documentation",
+      "process",
+      "operations"
+    ],
+    "defaultPrompt": "Help me use SOP & Runbook Creator safely."
+  }
+}

--- a/marketplace/plugins/sop-creator/NOTES.md
+++ b/marketplace/plugins/sop-creator/NOTES.md
@@ -1,0 +1,17 @@
+# NOTES — SOP & Runbook Creator
+
+## Provenance
+Vendored verbatim from [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills)
+(`.claude/skills/sop-creator/`) at commit `75e1e9cd60ef46bffbd294fdfe4d0320cee2f563`
+(fetched 2026-07-06). Authored by Cole Medin (coleam00); the generated `plugin.json` author/license
+fields are stamped by `scripts/sync-marketplace.py` and do not reflect upstream authorship.
+
+## What's vendored
+The complete upstream skill: `SKILL.md` plus `references/` templates for each documentation
+format — runbook, standard SOP, how-to guide, onboarding guide, checklist, decision tree, and a
+combined templates file. Nothing was excluded or modified.
+
+## Sync integration
+`skill.managed: "manual"` in `marketplace/catalog.json` — the authored SKILL.md is the source of
+truth; `sync-marketplace.py` generates only the manifests and never rewrites the skill body.
+Re-vendor by re-copying from upstream and updating the commit hash above.

--- a/marketplace/plugins/sop-creator/plugin.json
+++ b/marketplace/plugins/sop-creator/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "sop-creator",
+  "version": "0.1.0",
+  "description": "Create runbooks, playbooks, and technical documentation that people actually follow \u2014 scannable, actionable, specific, testable, and maintained.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "sop",
+    "runbook",
+    "playbook",
+    "documentation",
+    "process",
+    "operations"
+  ],
+  "capabilities": [
+    "read_files",
+    "write_files"
+  ],
+  "marketplaceId": "opencoven/sop-creator",
+  "x-coven": {
+    "displayName": "SOP & Runbook Creator",
+    "category": "Knowledge & Docs",
+    "trust": "reference-local",
+    "sourceRefs": [
+      "https://github.com/coleam00/second-brain-skills",
+      "https://github.com/coleam00/second-brain-skills/tree/main/.claude/skills/sop-creator"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  }
+}

--- a/marketplace/plugins/sop-creator/skills/sop-creator/SKILL.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: sop-creator
+description: Create runbooks, playbooks, and technical documentation for engineering teams. Use when the user wants to document a process, create a runbook, build operational docs, or formalize any repeatable technical procedure. Triggers on requests like "create a runbook for...", "document this process", "write a playbook", or any technical documentation request.
+---
+
+# SOP & Runbook Creator
+
+Create practical documentation that people actually follow.
+
+## Philosophy
+
+**Nobody reads 50-page docs.** Make it scannable, actionable, and impossible to misunderstand.
+
+Core principles:
+- **Scannable** - Headers, bullets, tables. No walls of text.
+- **Actionable** - Every step is something you DO, not something you "consider"
+- **Specific** - Numbers, names, thresholds. No "as needed" or "when appropriate"
+- **Testable** - Clear success criteria. How do you know it worked?
+- **Maintained** - Owner, last updated, review schedule
+
+## SOP Categories
+
+Pick the right format for your use case:
+
+### Tech/Engineering
+| Type | When to Use |
+|------|-------------|
+| **Runbook** | Emergency response, incidents, on-call |
+| **Deployment Playbook** | Releases, migrations, maintenance |
+| **Troubleshooting Guide** | Debugging, diagnosis trees |
+| **How-To Guide** | One-off setup, configuration |
+| **ADR** | Architecture decisions |
+
+### Operations/Business
+| Type | When to Use |
+|------|-------------|
+| **Process SOP** | Repeatable business workflows |
+| **Checklist** | Quality control, verification |
+| **Decision Tree** | Complex if/then scenarios |
+| **Handoff Doc** | Role transitions, shift changes |
+
+### Content/Creative
+| Type | When to Use |
+|------|-------------|
+| **Production Workflow** | Content creation pipelines |
+| **Review Process** | Approval workflows |
+| **Publishing Checklist** | Pre-launch verification |
+
+### General
+| Type | When to Use |
+|------|-------------|
+| **Standard SOP** | Any repeatable process |
+| **Quick Reference** | Condensed version of longer SOP |
+| **Onboarding Guide** | New person ramping up |
+
+## Universal Structure
+
+Every SOP needs at minimum:
+
+```markdown
+# [What This Does]
+
+> **TL;DR:** One sentence - what, when, who.
+
+## Definition of Done
+
+This is complete when:
+- [ ] [Primary outcome]
+- [ ] [Verification step]
+- [ ] [Any handoff/notification]
+
+## When to Use This
+[Trigger conditions]
+
+## Prerequisites
+[What you need before starting]
+
+## The Process
+[Numbered steps - the actual work]
+
+## Verify Completion
+[Return to Definition of Done, confirm all checked]
+
+## When Things Go Wrong
+[Common issues and fixes]
+
+## Questions?
+[Who to contact]
+```
+
+**Definition of Done is the most important section.** Put it near the top. Make it a checklist. Be specific.
+
+## Writing Rules
+
+### Be Specific
+
+| Don't Write | Write Instead |
+|-------------|---------------|
+| "Contact the team" | "Message @sarah in #ops-team" |
+| "Wait until ready" | "Wait until status shows 'Complete' (~5 min)" |
+| "Review carefully" | "Check items A, B, C in the dashboard" |
+| "As appropriate" | "If value > 100" |
+| "Regularly" | "Every Monday at 9am" |
+| "Soon" | "Within 2 hours" |
+
+### Action-First Steps
+
+```markdown
+# Bad
+"The report should be reviewed before sending to ensure
+accuracy and completeness of all data fields."
+
+# Good
+1. Open the report in [System]
+2. Verify these fields are populated:
+   - [ ] Customer name
+   - [ ] Amount
+   - [ ] Date
+3. Click "Send"
+```
+
+### Warnings Come First
+
+```markdown
+# Bad
+1. Delete the old records
+   Note: This cannot be undone
+
+# Good
+> **WARNING:** This permanently deletes records. Export first if needed.
+
+1. Delete the old records
+```
+
+### Decision Points are Clear
+
+```markdown
+# Bad
+"Handle the request based on priority level"
+
+# Good
+**If priority is:**
+- **Critical:** Drop everything, handle now, notify manager
+- **High:** Handle within 4 hours
+- **Normal:** Handle within 24 hours
+- **Low:** Add to weekly batch
+```
+
+## Format Selection Guide
+
+Ask yourself:
+
+1. **Is this for emergencies?** → Runbook
+2. **Is this a complex multi-phase project?** → Playbook
+3. **Is this a simple repeated task?** → Standard SOP or Checklist
+4. **Does it have lots of if/then branching?** → Decision Tree
+5. **Is it for debugging?** → Troubleshooting Guide
+6. **Is it recording a decision?** → ADR
+7. **Is it for someone new?** → Onboarding Guide
+
+## Metadata (Keep it Light)
+
+```yaml
+---
+title: [Clear name]
+owner: [Person or team]
+last_updated: [Date]
+review_schedule: [quarterly/annually/as-needed]
+---
+```
+
+That's it. No document IDs, version matrices, or approval chains unless you actually need them.
+
+## Templates
+
+Each template is in `references/`:
+
+| Template | Use For |
+|----------|---------|
+| [runbook.md](references/runbook.md) | Incidents, emergencies, on-call |
+| [standard-sop.md](references/standard-sop.md) | Any repeatable process |
+| [how-to-guide.md](references/how-to-guide.md) | One-off tasks, setup |
+| [onboarding-guide.md](references/onboarding-guide.md) | New person ramping up |
+| [decision-tree.md](references/decision-tree.md) | Complex if/then flows |
+| [checklist.md](references/checklist.md) | QC, verification |
+
+**All templates have Definition of Done as the primary success criteria.**
+
+## Quality Checklist
+
+Before publishing:
+- [ ] Can someone unfamiliar follow this?
+- [ ] Are all steps actionable (verbs, not descriptions)?
+- [ ] Are specifics provided (names, numbers, thresholds)?
+- [ ] Is there a clear "done" state?
+- [ ] Is the owner/contact info current?
+- [ ] Has it been tested recently?
+
+## Anti-Patterns
+
+**Kill these:**
+- "Per company policy..." (just state what to do)
+- "It is recommended that..." (just say "do X")
+- "Please ensure..." (just say "check X")
+- Passive voice ("the form should be submitted" → "submit the form")
+- Describing what to do instead of showing it
+- Walls of text with no structure
+- Screenshots that will be outdated in a month
+
+**Do these:**
+- Start with the most common path
+- Put edge cases at the bottom
+- Link to related docs instead of duplicating
+- Use tables for reference info
+- Use checklists for verification steps
+- Include "I'm stuck" escape hatches

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/checklist.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/checklist.md
@@ -1,0 +1,60 @@
+# Checklist Template
+
+For: Quality control, verification, recurring tasks.
+
+```markdown
+---
+title: [Checklist Name]
+owner: [Person or team]
+last_updated: YYYY-MM-DD
+---
+
+# [Checklist Name]
+
+> **Use when:** [Trigger for using this checklist]
+
+**Date:** _______________
+**Completed by:** _______________
+
+---
+
+## Definition of Done
+
+This checklist is complete when:
+- [ ] All required items checked
+- [ ] Any failed items have follow-up logged
+- [ ] Sign-off completed
+
+---
+
+## Section 1: [Category]
+
+- [ ] [Item]
+- [ ] [Item]
+- [ ] [Item]
+
+## Section 2: [Category]
+
+- [ ] [Item]
+- [ ] [Item]
+- [ ] [Item]
+
+> **If any items fail:** [What to do]
+
+## Section 3: [Category]
+
+- [ ] [Item]
+- [ ] [Item]
+
+---
+
+## Sign-Off
+
+**All items complete:** [ ] Yes  [ ] No
+
+**Issues found:** _______________________
+
+**Follow-up needed:** [ ] Yes  [ ] No
+
+**Completed by:** _______ **Date:** _______
+```

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/decision-tree.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/decision-tree.md
@@ -1,0 +1,116 @@
+# Decision Tree Template
+
+For: Complex processes with conditional paths.
+
+```markdown
+---
+title: [Decision Process Name]
+owner: [Person or team]
+last_updated: YYYY-MM-DD
+---
+
+# [Decision Process Name]
+
+> **TL;DR:** How to handle [situation type]. Start at top, follow the path.
+
+## Definition of Done
+
+This process is complete when:
+- [ ] Correct path identified and followed
+- [ ] [Primary action completed]
+- [ ] [Outcome verified]
+- [ ] [Any notification/handoff done]
+
+---
+
+## Start Here
+
+**What are you dealing with?**
+
+| Situation | Go to |
+|-----------|-------|
+| [Situation A] | [Path A](#path-a) |
+| [Situation B] | [Path B](#path-b) |
+| [Situation C] | [Path C](#path-c) |
+| Not sure | [Assessment](#assessment) |
+
+---
+
+## Assessment
+
+**Question: [What to determine first]**
+
+- If **[Answer A]** → Go to [Path A](#path-a)
+- If **[Answer B]** → Go to [Path B](#path-b)
+- If **unclear** → [Who to ask]
+
+---
+
+## Path A
+
+**You're here because:** [Condition]
+
+### Do this:
+
+1. [Action]
+2. [Action]
+3. [Action]
+
+**Done when:** [Completion criteria]
+
+→ Go to [Verify Completion](#verify-completion)
+
+---
+
+## Path B
+
+**You're here because:** [Condition]
+
+### First, check [factor]:
+
+| If | Then |
+|----|------|
+| [Condition 1] | [Action] |
+| [Condition 2] | [Action] |
+| None of above | Escalate to [contact] |
+
+**Done when:** [Completion criteria]
+
+→ Go to [Verify Completion](#verify-completion)
+
+---
+
+## Path C
+
+**You're here because:** [Condition]
+
+> **Warning:** [Important caution if applicable]
+
+1. [Action]
+2. [Action]
+3. **Check:** [Verification point]
+   - OK → [Next action]
+   - NOT OK → Escalate to [contact]
+
+**Done when:** [Completion criteria]
+
+→ Go to [Verify Completion](#verify-completion)
+
+---
+
+## Verify Completion
+
+Return to Definition of Done and confirm:
+- [ ] Correct path identified and followed
+- [ ] [Primary action completed]
+- [ ] [Outcome verified]
+- [ ] [Any notification/handoff done]
+
+## Escalation
+
+**Escalate if:**
+- Stuck for more than [timeframe]
+- [Other trigger]
+
+**Contact:** [Person/channel]
+```

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/how-to-guide.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/how-to-guide.md
@@ -1,0 +1,68 @@
+# How-To Guide Template
+
+For: One-off tasks, setup, configuration.
+
+```markdown
+# How to [Do The Thing]
+
+> **TL;DR:** [What this accomplishes in one sentence]
+
+## Definition of Done
+
+You're done when:
+- [ ] [Primary success indicator]
+- [ ] [Verification step]
+- [ ] [Any cleanup/confirmation]
+
+## Prerequisites
+
+- [ ] [Access/tool needed]
+- [ ] [Permission needed]
+
+## Steps
+
+### 1. [First Step]
+
+```bash
+[command or action]
+```
+
+**Done when:** [Expected result]
+
+### 2. [Second Step]
+
+```bash
+[command or action]
+```
+
+**Done when:** [Expected result]
+
+### 3. [Final Step]
+
+```bash
+[command or action]
+```
+
+**Done when:** [Expected result]
+
+## Verify
+
+Confirm Definition of Done:
+```bash
+[verification command or check]
+```
+
+Expected: [What you should see]
+
+## Troubleshooting
+
+**Problem:** [Common issue]
+**Fix:** [Solution]
+
+## Undo
+
+If you need to revert:
+```bash
+[undo command]
+```
+```

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/onboarding-guide.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/onboarding-guide.md
@@ -1,0 +1,89 @@
+# Onboarding Guide Template
+
+For: Getting someone new up to speed.
+
+```markdown
+---
+title: [Role/Project] Onboarding
+owner: [Person or team]
+last_updated: YYYY-MM-DD
+---
+
+# [Role/Project] Onboarding
+
+> **Goal:** Get productive with [what] within [timeframe].
+
+**Point of contact:** [Name, how to reach them]
+
+## Definition of Done
+
+Onboarding is complete when:
+- [ ] All Day 1 access granted
+- [ ] Week 1 learning completed
+- [ ] First [task/project] completed independently
+- [ ] Can answer: [key question they should know]
+
+---
+
+## Day 1
+
+### Access
+- [ ] [System 1] - [what it's for]
+- [ ] [System 2] - [what it's for]
+- [ ] [Communication channel]
+
+### First Tasks
+- [ ] [Orientation task 1]
+- [ ] [Orientation task 2]
+- [ ] Meet with [person]
+
+**Day 1 done when:** All access working, met key people
+
+---
+
+## Week 1
+
+### Learn
+- [ ] [Document/resource 1]
+- [ ] [Document/resource 2]
+
+### Do
+- [ ] [Hands-on task 1]
+- [ ] [Hands-on task 2]
+
+### Meet
+| Who | Why |
+|-----|-----|
+| [Person 1] | [What you'll learn] |
+| [Person 2] | [What you'll learn] |
+
+**Week 1 done when:** Can explain [core concept], completed [task]
+
+---
+
+## Week 2-4
+
+### Projects
+| Project | Description | Help from |
+|---------|-------------|-----------|
+| [Project 1] | [What you'll do] | [Person] |
+
+### Processes to Learn
+- [ ] [Process 1] - [link]
+- [ ] [Process 2] - [link]
+
+**Onboarding done when:** Definition of Done checklist complete
+
+---
+
+## Resources
+
+- **Docs:** [location]
+- **Questions:** [where to ask]
+- **Escalations:** [who to contact]
+
+## FAQ
+
+**Q: [Common question]**
+A: [Answer]
+```

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/runbook.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/runbook.md
@@ -1,0 +1,86 @@
+# Runbook Template
+
+For: Incident response, on-call, emergency fixes.
+
+```markdown
+---
+title: [Service] [Issue Type] Runbook
+owner: [team-name]
+oncall: "#[oncall-channel]"
+last_tested: YYYY-MM-DD
+---
+
+# [Service] [Issue Type] Runbook
+
+> **TL;DR:** [One sentence: what this fixes and when to use it]
+
+## Definition of Done
+
+You're done when ALL of these are true:
+- [ ] [Primary success indicator - e.g., "Alert resolved"]
+- [ ] [Secondary indicator - e.g., "Error rate < 0.1%"]
+- [ ] [Verification step - e.g., "Health check returns 200"]
+- [ ] [Cleanup step - e.g., "Incident ticket updated"]
+
+## Symptoms
+
+You're here because:
+- [ ] Alert: `[alert-name]` firing
+- [ ] [Error message or log pattern]
+- [ ] [Dashboard showing X metric above/below Y]
+
+## Quick Diagnosis
+
+```bash
+# Check service status
+kubectl get pods -n [namespace] -l app=[service-name]
+
+# Check logs
+kubectl logs -n [namespace] deployment/[service-name] --tail=100 | grep -i error
+```
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| [Symptom 1] | [Cause] | [Action] |
+| [Symptom 2] | [Cause] | [Action] |
+
+## Mitigation Steps
+
+### 1. [First thing to try]
+
+```bash
+[command]
+```
+
+**Done when:** [How you know this step worked]
+
+### 2. [Second thing to try]
+
+```bash
+[command]
+```
+
+**Done when:** [Completion criteria]
+
+### 3. [If nothing else works]
+
+```bash
+[command]
+```
+
+**Done when:** [Completion criteria]
+
+## Escalation
+
+**Escalate if:**
+- Quick fixes don't work after [X] minutes
+- [Other escalation trigger]
+
+**Contact:** [Person/channel] via [method]
+
+## Post-Resolution
+
+- [ ] Verify Definition of Done checklist above
+- [ ] Update incident ticket with timeline
+- [ ] Schedule postmortem if needed
+```

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/standard-sop.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/standard-sop.md
@@ -1,0 +1,72 @@
+# Standard SOP Template
+
+For: Any repeatable process.
+
+```markdown
+---
+title: [Process Name]
+owner: [Person or team]
+last_updated: YYYY-MM-DD
+---
+
+# [Process Name]
+
+> **TL;DR:** [What this process does, in one sentence]
+
+## Definition of Done
+
+This process is complete when:
+- [ ] [Primary outcome achieved]
+- [ ] [Secondary outcome if applicable]
+- [ ] [Verification/confirmation step]
+- [ ] [Handoff/notification if needed]
+
+## When to Use This
+
+Use this when:
+- [Trigger condition 1]
+- [Trigger condition 2]
+
+## Before You Start
+
+- [ ] [Prerequisite 1]
+- [ ] [Prerequisite 2]
+
+## The Process
+
+### Step 1: [Action]
+
+1. [Specific action]
+2. [Specific action]
+
+**Done when:** [How you know this step is complete]
+
+### Step 2: [Action]
+
+1. [Specific action]
+2. [Specific action]
+
+**Done when:** [Completion criteria]
+
+### Step 3: [Action]
+
+1. [Specific action]
+2. [Specific action]
+
+**Done when:** [Completion criteria]
+
+## Verify Completion
+
+Go back to Definition of Done and confirm all items checked.
+
+## Common Issues
+
+| Problem | Solution |
+|---------|----------|
+| [Issue 1] | [Fix] |
+| [Issue 2] | [Fix] |
+
+## Questions?
+
+Contact: [Person/channel]
+```

--- a/marketplace/plugins/sop-creator/skills/sop-creator/references/templates.md
+++ b/marketplace/plugins/sop-creator/skills/sop-creator/references/templates.md
@@ -1,0 +1,12 @@
+# Templates
+
+| Template | Use For |
+|----------|---------|
+| [runbook.md](./runbook.md) | Incidents, emergencies, on-call |
+| [standard-sop.md](./standard-sop.md) | Any repeatable process |
+| [how-to-guide.md](./how-to-guide.md) | One-off tasks, setup |
+| [onboarding-guide.md](./onboarding-guide.md) | New person ramping up |
+| [decision-tree.md](./decision-tree.md) | Complex if/then flows |
+| [checklist.md](./checklist.md) | QC, verification |
+
+**All templates include Definition of Done as the key success criteria.**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
   ],
   "exclude": [
     "node_modules",
-    "src-tauri"
+    "src-tauri",
+    "marketplace/plugins"
   ]
 }


### PR DESCRIPTION
## What

Adds [coleam00/second-brain-skills](https://github.com/coleam00/second-brain-skills) to the marketplace as six reference-local, manually-managed skill packs:

| Plugin | Category | What it does |
|---|---|---|
| `brand-voice-generator` | Design | Generates brand-system + tone-of-voice files consumed by pptx-generator |
| `mcp-client` | Core MCP | Progressive-disclosure Python client for any MCP server |
| `pptx-generator` | Media & Creative | On-brand PPTX decks + LinkedIn carousels via python-pptx cookbook |
| `remotion` | Media & Creative | Remotion video authoring backed by a ~30-topic rules library |
| `skill-creator` | Agents & Harnesses | Anthropic's skill-creation guide (init/validate/package scripts) |
| `sop-creator` | Knowledge & Docs | Runbooks/SOPs/playbooks with per-format reference templates |

## How

- Six new `marketplace/catalog.json` entries with `skill.managed: "manual"` (the established pattern for hand-authored skill bodies — sync generates manifests but never rewrites SKILL.md).
- Each skill's full text content vendored under `marketplace/plugins/<name>/skills/<name>/` (SKILL.md, references/, scripts/, rules/, cookbook/, brands/template/) at upstream commit `75e1e9cd`.
- Excluded deliberately: the upstream author's personal brand instance (`brands/dynamous/`, incl. a 158 KB logo PNG) and two `.pptx` binary artifacts (regenerable via the vendored `generate-cookbook-preview.py`).
- `NOTES.md` per pack records provenance, exclusions, runtime requirements, and re-vendor steps.
- Manifests, `marketplace.json`, and the codex export regenerated with `scripts/sync-marketplace.py`.

## Notes for review

- **Attribution caveat:** `sync-marketplace.py` stamps `author: OpenCoven` / `license: GPL-3.0` on every generated `plugin.json` (same as existing reference-local entries like `github`). True upstream authorship (Cole Medin / Anthropic for skill-creator, which retains its `LICENSE.txt`) is recorded in each pack's `NOTES.md`. The upstream repo carries no top-level license; if that's a concern, happy to drop specific packs.
- `remotion`'s entry file was renamed `skill.md` → `SKILL.md` to match pack layout; frontmatter keeps the upstream name `remotion-best-practices`.
- `mcp-client` ships only `example-mcp-config.json` (placeholders); real configs with keys are user-local and never committed.
- No `src/` changes — the marketplace API reads these files at runtime; entries without `mcpServers` derive as kind `skill` automatically.

## Verification

- `python3 scripts/sync-marketplace.py --check` → `marketplace_ok files=338 plugins=117`
- `pnpm test:app` → 535 test file(s) passed
- Commit signed (`Good "git" signature`)

Tracked by bead `cave-47o`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)