### PR TITLE
feat(chat): prompt snippets — /prompt picker, snippets modal, file-based templates (cave-r8n)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -97,6 +97,14 @@ enum SlashCatalog {
                      description: "Show every available skill to pick from.",
                      section: .chat,
                      availability: .desktopOnly, action: .desktopOnly("Skills")),
+        SlashCommand(name: "/prompt", aliases: ["/snippets"], hint: "insert a prompt",
+                     description: "Drop a starter prompt into the composer for editing.",
+                     argPlaceholder: "name", section: .chat,
+                     availability: .desktopOnly, action: .desktopOnly("Prompts")),
+        SlashCommand(name: "/prompts", hint: "browse prompts",
+                     description: "Show every prompt template to pick from.",
+                     section: .chat,
+                     availability: .desktopOnly, action: .desktopOnly("Prompts")),
 
         // MARK: Familiar
         SlashCommand(name: "/familiar", aliases: ["/agent"], hint: "switch",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -249,6 +249,7 @@ export const SUITES = {
     "src/lib/slash-commands.test.ts",
     "src/lib/slash-model.test.ts",
     "src/lib/slash-skill.test.ts",
+    "src/lib/slash-prompt.test.ts",
     "src/lib/cave-canvas.test.ts",
     "src/components/journal/journal-view.test.ts",
     "src/lib/journal.test.ts",
@@ -680,6 +681,7 @@ export const SUITES = {
     "src/lib/server/session-project-roots.test.ts",
     "src/lib/server/familiar-avatar.test.ts",
     "src/lib/server/skill-scan.test.ts",
+    "src/lib/server/prompt-scan.test.ts",
   ],
   mobile: [
     "src/lib/mobile-access-token.test.ts",
@@ -811,6 +813,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/project-paths.test.ts",
   "src/lib/server/skill-file-paths.test.ts",
   "src/lib/server/skills-directory.test.ts",
+  "src/lib/server/prompt-scan.test.ts",
   "src/lib/server/agent-attachments.test.ts",
   "src/lib/server/session-project-roots.test.ts",
   "src/lib/server/familiar-avatar.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -125,6 +125,7 @@ const contracts: RouteContract[] = [
   { route: "/projects/seed", methods: ["POST"], kind: "json" },
   { route: "/projects", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/prompt/enhance", methods: ["POST"], kind: "json", readsJson: true },
+  { route: "/prompts", methods: ["GET"], kind: "json" },
   { route: "/roles", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/roles/workflows", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/retro-runs", methods: ["GET"], kind: "json" },

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -1,0 +1,46 @@
+/**
+ * GET /api/prompts
+ *
+ * Prompt templates for the chat composer's /prompt picker and the Prompt
+ * snippets modal. Merges three sources by id (user > pack > builtin):
+ *  1. built-in defaults (src/lib/prompt-defaults.ts)
+ *  2. installed marketplace prompt packs (marketplace/plugins/<id>/prompts/) —
+ *     install is track-only (cave-config marketplace.installed), so packs are
+ *     resolved here at scan time rather than copied on install
+ *  3. the user's own ~/.coven/prompts/*.md files
+ * Read-only.
+ */
+
+import { NextResponse } from "next/server";
+import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
+import { loadConfig } from "@/lib/cave-config";
+import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
+import { mergePrompts, scanPromptsDir } from "@/lib/server/prompt-scan";
+import type { PromptOption } from "@/lib/slash-prompt";
+
+export const dynamic = "force-dynamic";
+
+const MARKETPLACE_PLUGINS_DIR = path.join(process.cwd(), "marketplace", "plugins");
+
+export async function GET() {
+  const user: PromptOption[] = [];
+  await scanPromptsDir(path.join(covenHome(), "prompts"), "user", user);
+
+  const packs: PromptOption[] = [];
+  try {
+    const cfg = await loadConfig();
+    // Installed ids were validated against the catalog allowlist on install;
+    // the shape guard keeps a hand-edited config from escaping the plugins dir.
+    const installed = Object.keys(cfg.marketplace.installed).filter((id) => /^[\w.-]+$/.test(id));
+    await Promise.all(
+      installed.map((id) =>
+        scanPromptsDir(path.join(MARKETPLACE_PLUGINS_DIR, id, "prompts"), `pack:${id}`, packs),
+      ),
+    );
+  } catch {
+    // Config unreadable → built-ins + user files still serve.
+  }
+
+  return NextResponse.json({ ok: true, prompts: mergePrompts(BUILTIN_PROMPTS, user, packs) });
+}

--- a/src/components/chat-empty-state.tsx
+++ b/src/components/chat-empty-state.tsx
@@ -88,6 +88,7 @@ type LinkedTask = NonNullable<ChatLinkedContext["tasks"]>[number];
 export function ChatEmptyState({
   familiar,
   onPrompt,
+  onOpenPromptSnippets,
   projectId,
   onProjectChange,
   projects,
@@ -104,6 +105,8 @@ export function ChatEmptyState({
 }: {
   familiar: Familiar;
   onPrompt?: (text: string) => void;
+  /** Opens the Prompt snippets modal (templates dropped into the composer). */
+  onOpenPromptSnippets?: () => void;
   /** Selected predetermined project for the chat runtime root. */
   projectId?: string | null;
   /** Updates the project used for the next send. */
@@ -357,9 +360,9 @@ export function ChatEmptyState({
           )
         ) : null}
 
-        {onPrompt && suggestions.length > 0 && (
+        {((onPrompt && suggestions.length > 0) || onOpenPromptSnippets) && (
           <div className="cave-chat-empty-prompts" aria-label="Starter prompts">
-            {suggestions.map((suggestion) => (
+            {onPrompt && suggestions.map((suggestion) => (
               <button
                 key={suggestion.id}
                 type="button"
@@ -370,6 +373,16 @@ export function ChatEmptyState({
                 <Icon name="ph:arrow-right-bold" width={13} aria-hidden />
               </button>
             ))}
+            {onOpenPromptSnippets && (
+              <button
+                type="button"
+                onClick={onOpenPromptSnippets}
+                className="cave-chat-empty-prompt"
+              >
+                <Icon name="ph:chat-centered-text" width={13} aria-hidden />
+                <span>Prompt snippets</span>
+              </button>
+            )}
           </div>
         )}
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -63,6 +63,15 @@ import {
   buildSkillPrompt,
   type SkillOption,
 } from "@/lib/slash-skill";
+import {
+  promptSlashOptions,
+  resolvePromptArg,
+  formatPromptList,
+  promptInsertion,
+  type PromptOption,
+} from "@/lib/slash-prompt";
+import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
+import { PromptSnippetsModal, promptIconName } from "@/components/prompt-snippets-modal";
 import { catalogForRuntime } from "@/lib/runtime-models";
 import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
@@ -2702,6 +2711,26 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       alive = false;
     };
   }, []);
+  // Prompt templates for the `/prompt` / `/prompts` picker and the Prompt
+  // snippets modal. Seeded with the built-ins so the picker works instantly
+  // (and offline); the fetch layers in ~/.coven/prompts files and installed
+  // marketplace prompt packs.
+  const [prompts, setPrompts] = useState<PromptOption[]>(BUILTIN_PROMPTS);
+  const [promptSnippetsOpen, setPromptSnippetsOpen] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/prompts", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
+      })
+      .catch(() => {
+        /* offline → built-in templates only */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
   // While typing "/model <partial>", the menu shows model options instead of
   // commands (an inline picker). null ⇒ not in /model arg position.
   const modelHarness = modelState?.harness ?? familiar.harness ?? "claude";
@@ -2726,10 +2755,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     [input, skills, slashDismissed],
   );
   const skillMenuActive = (skillOptions?.length ?? 0) > 0;
-  // The slash-command, /model and /skill pickers are mutually exclusive inline
-  // listboxes sharing one listbox id, so the composer's combobox ARIA tracks
-  // whichever is open (was: slash-only, leaving the pickers unannounced).
-  const menuOpen = modelMenuActive || skillMenuActive || slashSuggestions.length > 0;
+  // Inline `/prompt` / `/prompts` picker — null ⇒ not in a prompt-picker position.
+  const promptOptions = useMemo(
+    () => (slashDismissed ? null : promptSlashOptions(input, prompts)),
+    [input, prompts, slashDismissed],
+  );
+  const promptMenuActive = (promptOptions?.length ?? 0) > 0;
+  // The slash-command, /model, /skill and /prompt pickers are mutually
+  // exclusive inline listboxes sharing one listbox id, so the composer's
+  // combobox ARIA tracks whichever is open.
+  const menuOpen = modelMenuActive || skillMenuActive || promptMenuActive || slashSuggestions.length > 0;
   // Stable per-mount listbox id — the home composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
@@ -3279,6 +3314,26 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     }
   };
 
+  // Drop a prompt template into the composer for editing — never a send. When
+  // the body carries a {{placeholder}}, select the first one so typing
+  // replaces it; otherwise park the caret at the end.
+  const insertPrompt = (p: PromptOption) => {
+    const ins = promptInsertion(p);
+    setInput(ins.text);
+    setSlashIdx(0);
+    announce("Prompt inserted — edit and send.");
+    requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      if (ins.selectStart !== undefined && ins.selectEnd !== undefined) {
+        el.setSelectionRange(ins.selectStart, ins.selectEnd);
+      } else {
+        el.setSelectionRange(ins.text.length, ins.text.length);
+      }
+    });
+  };
+
   const intentFromSlash = (raw: string): boolean => {
     const trimmed = raw.trim();
     if (!trimmed.startsWith("/")) return false;
@@ -3338,6 +3393,23 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       // Invoke by sending a directive to the active familiar's harness, which
       // owns Skill execution (mirrors the /run prompt-send pattern).
       setTimeout(() => sendRaw(buildSkillPrompt(skill)), 0);
+      return true;
+    }
+    if (command === "/prompt" || command === "/prompts") {
+      if (!args.trim()) {
+        // Bare /prompt or /prompts: list everything (the inline picker shows
+        // the same list while typing; this is the submitted fallback).
+        appendSystem(formatPromptList(prompts));
+        setInput("");
+        return true;
+      }
+      const prompt = resolvePromptArg(args, prompts);
+      if (!prompt) {
+        appendSystem(`Unknown prompt "${args.trim()}". Type /prompts to list the options.`);
+        setInput("");
+        return true;
+      }
+      insertPrompt(prompt);
       return true;
     }
     if (command === "/doctor" || command === "/daemon") {
@@ -4197,6 +4269,31 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
     }
+    if (promptMenuActive && promptOptions) {
+      const opts = promptOptions;
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSlashIdx((i) => Math.min(i + 1, opts.length - 1));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSlashIdx((i) => Math.max(i - 1, 0));
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const p = opts[slashIdx];
+        if (p) setInput(`/prompt ${p.id}`);
+        return;
+      }
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        const p = opts[slashIdx];
+        if (p) insertPrompt(p);
+        return;
+      }
+    }
     if (slashSuggestions.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -4577,6 +4674,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   setInput(text);
                   inputRef.current?.focus();
                 }}
+                onOpenPromptSnippets={() => setPromptSnippetsOpen(true)}
                 projectId={projectIdDraft}
                 onProjectChange={setProjectIdDraft}
                 projects={projects}
@@ -4915,6 +5013,37 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
               </div>
             </div>
+          ) : promptMenuActive && promptOptions ? (
+            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
+              <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Prompts">
+                {promptOptions.map((p, i) => {
+                  const active = i === slashIdx;
+                  return (
+                    <li key={p.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        ref={active ? activeSlashOptionRef : null}
+                        onMouseEnter={() => setSlashIdx(i)}
+                        onClick={() => insertPrompt(p)}
+                        className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                          active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
+                        }`}
+                      >
+                        <Icon name={promptIconName(p.icon)} width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                        <span className="text-[var(--text-primary)]">{p.name}</span>
+                        <span className="flex-1 truncate text-[11px] text-[var(--text-muted)]">
+                          {p.description || p.id}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[10px] text-[var(--text-muted)]">
+                {keys.up}{keys.down} navigate · {keys.enter} insert · Tab complete · esc cancel
+              </div>
+            </div>
           ) : slashSuggestions.length > 0 ? (
             <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Slash commands">
@@ -5129,6 +5258,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   >
                     <Icon name="ph:microphone" width={15} aria-hidden />
                   </button>
+                  <button
+                    type="button"
+                    className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
+                    title="Prompt snippets"
+                    aria-label="Prompt snippets"
+                    onClick={() => setPromptSnippetsOpen(true)}
+                  >
+                    <Icon name="ph:chat-centered-text" width={14} aria-hidden />
+                  </button>
                   <ComposerOptionsMenu
                     hostValue={composerHostValue}
                     onHostPick={setRuntimeHost}
@@ -5218,6 +5356,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           onClose={() => setVoiceCallOpen(false)}
         />
       )}
+      <PromptSnippetsModal
+        open={promptSnippetsOpen}
+        onClose={() => setPromptSnippetsOpen(false)}
+        prompts={prompts}
+        onPick={(p) => {
+          setPromptSnippetsOpen(false);
+          insertPrompt(p);
+        }}
+      />
       <Modal
         open={debugModalOpen}
         onClose={() => setDebugModalOpen(false)}

--- a/src/components/prompt-snippets-modal.tsx
+++ b/src/components/prompt-snippets-modal.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Modal } from "@/components/ui/modal";
+import { Icon, ICON_NAMES, type IconName } from "@/lib/icon";
+import type { PromptOption } from "@/lib/slash-prompt";
+
+const FALLBACK_ICON: IconName = "ph:chat-centered-text";
+
+/** Prompt icons come from data (frontmatter / catalog), so validate against
+ *  the curated icon set and fall back rather than trusting the string. */
+export function promptIconName(icon?: string): IconName {
+  return icon && (ICON_NAMES as readonly string[]).includes(icon)
+    ? (icon as IconName)
+    : FALLBACK_ICON;
+}
+
+type PromptSnippetsModalProps = {
+  open: boolean;
+  onClose: () => void;
+  prompts: PromptOption[];
+  /** Picking a template drops it into the composer — the caller inserts. */
+  onPick: (prompt: PromptOption) => void;
+};
+
+/** "Prompt snippets" picker — a starter prompt dropped into the composer for
+ *  editing, never sent. Dumb component: fetching stays in the caller. */
+export function PromptSnippetsModal({ open, onClose, prompts, onPick }: PromptSnippetsModalProps) {
+  return (
+    <Modal open={open} onClose={onClose} breadcrumb={["Chat", "Prompt snippets"]}>
+      <p className="mb-3 text-sm text-[var(--text-muted)]">
+        Pick a starter prompt to drop into the composer.
+      </p>
+      {prompts.length === 0 ? (
+        <p className="text-sm text-[var(--text-muted)]">
+          No prompt templates found. Add .md files under ~/.coven/prompts or install a prompt
+          pack from the Marketplace.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1" aria-label="Prompt snippets">
+          {prompts.map((p) => (
+            <li key={p.id}>
+              <button
+                type="button"
+                className="focus-ring flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-[var(--bg-raised)]"
+                onClick={() => onPick(p)}
+              >
+                <Icon
+                  name={promptIconName(p.icon)}
+                  width={16}
+                  className="mt-0.5 shrink-0 text-[var(--text-muted)]"
+                  aria-hidden
+                />
+                <span className="min-w-0">
+                  <span className="block text-sm font-medium text-[var(--text-primary)]">
+                    {p.name}
+                  </span>
+                  {p.description ? (
+                    <span className="block text-xs text-[var(--text-muted)]">{p.description}</span>
+                  ) : null}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Modal>
+  );
+}

--- a/src/lib/prompt-defaults.ts
+++ b/src/lib/prompt-defaults.ts
@@ -1,0 +1,40 @@
+import type { PromptOption } from "./slash-prompt";
+
+/**
+ * Built-in prompt templates — always available, even before the user authors
+ * files under ~/.coven/prompts or installs a marketplace prompt pack. A user
+ * file or pack template with the same id overrides these (see mergePrompts in
+ * src/lib/server/prompt-scan.ts). Client-safe: the chat composer seeds its
+ * picker with this list so prompts work offline.
+ *
+ * Icons must come from the curated set in src/lib/icon.tsx.
+ */
+export const BUILTIN_PROMPTS: PromptOption[] = [
+  {
+    id: "code-review",
+    name: "Code review",
+    description: "Audit the current change for regressions, dropped edge cases, and missing tests.",
+    icon: "ph:list-checks-bold",
+    body:
+      "Review the current change. Look for regressions, dropped edge cases, and missing tests. Call out anything that would surprise the next reader, and end with a short must-fix list.",
+    source: "builtin",
+  },
+  {
+    id: "implementation-plan",
+    name: "Implementation plan",
+    description: "Outline an approach before touching code so the diff stays focused.",
+    icon: "ph:note-pencil",
+    body:
+      "Before touching code, outline an implementation plan for {{what to build}}. Name the files involved, the order of changes, the risks, and how we verify it works.",
+    source: "builtin",
+  },
+  {
+    id: "explain-this",
+    name: "Explain this",
+    description: "Walk through how the selected code works and link to the key files.",
+    icon: "ph:book-open",
+    body:
+      "Explain how {{file or function}} works. Walk through the flow step by step, link the key files, and note anything non-obvious a newcomer would miss.",
+    source: "builtin",
+  },
+];

--- a/src/lib/server/prompt-scan.test.ts
+++ b/src/lib/server/prompt-scan.test.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { scanPromptsDir, mergePrompts } from "./prompt-scan.ts";
+
+const root = await mkdtemp(path.join(tmpdir(), "prompt-scan-"));
+try {
+  const dir = path.join(root, "prompts");
+  await mkdir(dir);
+
+  await writeFile(
+    path.join(dir, "code-review.md"),
+    `---
+name: Code review
+description: Audit the current change
+icon: ph:list-checks-bold
+tags:
+  - review
+  - quality
+---
+Review the current change. End with a must-fix list.
+`,
+  );
+  // Frontmatter only, no body → nothing to insert, must be skipped.
+  await writeFile(path.join(dir, "empty.md"), `---\nname: Empty\n---\n`);
+  // No frontmatter at all → id/name fall back to the filename.
+  await writeFile(path.join(dir, "bare-note.md"), "Just a body, no frontmatter.\n");
+  // Non-markdown files are ignored.
+  await writeFile(path.join(dir, "ignore.txt"), "not a template");
+
+  const out = [];
+  await scanPromptsDir(dir, "user", out);
+
+  assert.equal(out.length, 2, "body-less and non-md files are skipped");
+  const review = out.find((p) => p.id === "code-review");
+  assert.ok(review, "template id comes from the filename");
+  assert.equal(review.name, "Code review", "name from frontmatter");
+  assert.equal(review.description, "Audit the current change", "description from frontmatter");
+  assert.equal(review.icon, "ph:list-checks-bold", "icon from frontmatter");
+  assert.deepEqual(review.tags, ["review", "quality"], "tags list parsed");
+  assert.equal(review.body, "Review the current change. End with a must-fix list.", "body excludes frontmatter");
+  assert.equal(review.source, "user", "source is threaded through");
+  assert.equal(review.path, path.join(dir, "code-review.md"), "absolute path recorded");
+
+  const bare = out.find((p) => p.id === "bare-note");
+  assert.ok(bare, "frontmatter-less file still scans");
+  assert.equal(bare.name, "bare-note", "name falls back to the filename");
+  assert.equal(bare.body, "Just a body, no frontmatter.", "whole file is the body");
+
+  // Missing directory is silent (first run: ~/.coven/prompts doesn't exist).
+  const missing = [];
+  await scanPromptsDir(path.join(root, "nope"), "user", missing);
+  assert.equal(missing.length, 0, "missing dir → empty, no throw");
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+// ── mergePrompts: user > pack > builtin, keyed by id ─────────────────────────
+const builtin = [
+  { id: "a", name: "A builtin", body: "b", source: "builtin" },
+  { id: "b", name: "B builtin", body: "b", source: "builtin" },
+];
+const packs = [
+  { id: "b", name: "B pack", body: "b", source: "pack:essentials" },
+  { id: "c", name: "C pack", body: "b", source: "pack:essentials" },
+];
+const user = [{ id: "c", name: "C user", body: "b", source: "user" }];
+
+const merged = mergePrompts(builtin, user, packs);
+assert.equal(merged.length, 3, "merged by id");
+assert.equal(merged.find((p) => p.id === "a")?.source, "builtin", "builtin survives when unshadowed");
+assert.equal(merged.find((p) => p.id === "b")?.source, "pack:essentials", "pack overrides builtin");
+assert.equal(merged.find((p) => p.id === "c")?.source, "user", "user overrides pack");
+assert.deepEqual(mergePrompts(builtin, []), builtin, "packs param is optional");
+
+console.log("prompt-scan.test.ts: ok");

--- a/src/lib/server/prompt-scan.ts
+++ b/src/lib/server/prompt-scan.ts
@@ -1,0 +1,70 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { parseFrontmatter, parseListField } from "./skill-scan";
+import type { PromptOption } from "../slash-prompt";
+
+/**
+ * Flat prompt-template scanner. A template is a single .md file — YAML
+ * frontmatter (name, description, optional icon/tags) plus a body that is
+ * dropped into the composer verbatim. Used by /api/prompts for the user's
+ * ~/.coven/prompts directory and for installed marketplace prompt packs
+ * (marketplace/plugins/<id>/prompts/). Reuses the SKILL.md frontmatter parser.
+ */
+
+export type PromptSource = PromptOption["source"];
+
+export async function scanPromptsDir(
+  dir: string,
+  source: PromptSource,
+  out: PromptOption[],
+): Promise<void> {
+  let files: string[] = [];
+  try {
+    const dirents = await readdir(dir, { withFileTypes: true });
+    files = dirents
+      .filter((e) => (e.isFile() || e.isSymbolicLink()) && e.name.endsWith(".md"))
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return;
+  }
+
+  for (const file of files) {
+    try {
+      const text = await readFile(path.join(dir, file), "utf8");
+      const fm = parseFrontmatter(text);
+      // Body = everything after the frontmatter block; a template with no body
+      // has nothing to insert, so it is skipped rather than served empty.
+      const body = text.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "").trim();
+      if (!body) continue;
+      const id = path.basename(file, ".md");
+      const tags = parseListField(text, "tags");
+      out.push({
+        id,
+        name: fm.name ?? id,
+        description: fm.description,
+        icon: fm.icon,
+        tags: tags.length ? tags : undefined,
+        body,
+        source,
+        path: path.join(dir, file),
+      });
+    } catch {
+      continue;
+    }
+  }
+}
+
+/** Merge template lists by id — user files override packs, packs override
+ *  built-ins — so a user can retune a shipped template without forking it. */
+export function mergePrompts(
+  builtin: PromptOption[],
+  user: PromptOption[],
+  packs: PromptOption[] = [],
+): PromptOption[] {
+  const byId = new Map<string, PromptOption>();
+  for (const p of builtin) byId.set(p.id, p);
+  for (const p of packs) byId.set(p.id, p);
+  for (const p of user) byId.set(p.id, p);
+  return [...byId.values()];
+}

--- a/src/lib/server/skill-scan.ts
+++ b/src/lib/server/skill-scan.ts
@@ -72,7 +72,7 @@ export function parseFrontmatter(text: string): Record<string, string> {
   return fm;
 }
 
-function parseListField(text: string, field: string): string[] {
+export function parseListField(text: string, field: string): string[] {
   const match = text.match(new RegExp(`\\n${field}:\\s*\\n((?:\\s*-[^\\n]*\\n?)*)`));
   if (!match) return [];
   return match[1].match(/- (.+)/g)?.map(m => m.slice(2).trim()) ?? [];

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -28,6 +28,8 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/model", aliases: ["/m"], hint: "switch model", description: "Switch the active model — pass an id or pick from the menu; bare /model lists them.", argPlaceholder: "model", section: "chat" },
   { name: "/skill", hint: "run a skill", description: "Invoke a skill — pass a name or pick from the menu as you type.", argPlaceholder: "name", section: "chat" },
   { name: "/skills", hint: "browse skills", description: "Show every available skill to pick from.", section: "chat" },
+  { name: "/prompt", aliases: ["/snippets"], hint: "insert a prompt", description: "Drop a starter prompt into the composer for editing.", argPlaceholder: "name", section: "chat" },
+  { name: "/prompts", hint: "browse prompts", description: "Show every prompt template to pick from.", section: "chat" },
 
   // Familiar
   { name: "/familiar", aliases: ["/agent"], hint: "switch", description: "Open the familiar picker. Pass a name to switch directly.", argPlaceholder: "name", section: "familiar" },

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -1,0 +1,89 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  promptSlashOptions,
+  resolvePromptArg,
+  promptInsertion,
+  formatPromptList,
+} from "./slash-prompt.ts";
+import { BUILTIN_PROMPTS } from "./prompt-defaults.ts";
+
+const PROMPTS = [
+  { id: "code-review", name: "Code review", description: "Audit the current change", body: "Review the current change.", source: "builtin" },
+  { id: "implementation-plan", name: "Implementation plan", description: "Outline an approach", body: "Plan {{what to build}} first.", source: "builtin" },
+  { id: "explain-this", name: "Explain this", description: "Walk through the code", body: "Explain how this works.", source: "user" },
+];
+
+// ── promptSlashOptions: null outside picker position, list/filter inside ─────
+assert.equal(promptSlashOptions("hello", PROMPTS), null, "plain text → null (command menu)");
+assert.equal(promptSlashOptions("/prompt", PROMPTS), null, "bare /prompt (no space) → null so both commands show in the menu");
+assert.deepEqual(promptSlashOptions("/prompt ", PROMPTS), PROMPTS, "/prompt <space> → full list");
+assert.deepEqual(promptSlashOptions("/prompts", PROMPTS), PROMPTS, "/prompts → full list (show all)");
+assert.deepEqual(promptSlashOptions("/prompts ", PROMPTS), PROMPTS, "/prompts <space> → full list");
+const filtered = promptSlashOptions("/prompt review", PROMPTS);
+assert.equal(filtered.length, 1, "/prompt review filters to one");
+assert.equal(filtered[0].id, "code-review", "filter matches name/description");
+assert.equal(promptSlashOptions("/prompts explain", PROMPTS).length, 1, "/prompts also accepts a trailing filter");
+assert.equal(promptSlashOptions("/prompt nomatch", PROMPTS).length, 0, "no match → empty (not null)");
+assert.equal(promptSlashOptions("/skill rev", PROMPTS), null, "a different command → null");
+
+// ── resolvePromptArg: exact then substring ───────────────────────────────────
+assert.equal(resolvePromptArg("explain-this", PROMPTS)?.id, "explain-this", "exact id");
+assert.equal(resolvePromptArg("CODE REVIEW", PROMPTS)?.id, "code-review", "case-insensitive exact name");
+assert.equal(resolvePromptArg("plan", PROMPTS)?.id, "implementation-plan", "substring");
+assert.equal(resolvePromptArg("", PROMPTS), null, "empty → null");
+assert.equal(resolvePromptArg("zzz", PROMPTS), null, "unknown → null");
+
+// ── promptInsertion: insert-for-editing, first {{placeholder}} selected ──────
+const plain = promptInsertion(PROMPTS[0]);
+assert.equal(plain.text, "Review the current change.", "insertion carries the body verbatim");
+assert.equal(plain.selectStart, undefined, "no placeholder → no selection range");
+const templated = promptInsertion(PROMPTS[1]);
+assert.equal(templated.text.slice(templated.selectStart, templated.selectEnd), "{{what to build}}", "first placeholder is selected");
+
+// ── formatPromptList ─────────────────────────────────────────────────────────
+const list = formatPromptList(PROMPTS);
+assert.match(list, /Available prompts/, "list has a header");
+assert.match(list, /drops the template into the composer/, "list explains insert-not-send");
+assert.match(list, /code-review/, "list includes each prompt");
+assert.match(formatPromptList([]), /No prompt templates found/, "empty list is explained");
+
+// ── Built-in defaults ────────────────────────────────────────────────────────
+assert.ok(BUILTIN_PROMPTS.length >= 3, "ships at least the three starter templates");
+for (const id of ["code-review", "implementation-plan", "explain-this"]) {
+  const p = BUILTIN_PROMPTS.find((x) => x.id === id);
+  assert.ok(p, `built-in "${id}" exists`);
+  assert.ok(p.body.trim().length > 0, `built-in "${id}" has a body`);
+  assert.equal(p.source, "builtin", `built-in "${id}" is marked builtin`);
+}
+
+// ── Catalog + composer wiring (source-text) ──────────────────────────────────
+const slashCmds = await readFile(new URL("./slash-commands.ts", import.meta.url), "utf8");
+assert.match(slashCmds, /name: "\/prompt",[\s\S]*?argPlaceholder: "name"/, "/prompt is registered with an arg placeholder");
+assert.match(slashCmds, /name: "\/prompts"/, "/prompts is registered");
+
+const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+assert.match(chatView, /promptSlashOptions\(input, prompts\)/, "chat-view computes the inline /prompt options");
+assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0;/, "chat-view menuOpen includes the prompt picker");
+assert.match(chatView, /command === "\/prompt" \|\| command === "\/prompts"/, "chat-view dispatches /prompt and /prompts");
+assert.match(chatView, /role="listbox" aria-label="Prompts"/, "chat-view renders a Prompts listbox");
+assert.match(chatView, /fetch\("\/api\/prompts"/, "chat-view sources templates from /api/prompts");
+assert.match(chatView, /useState<PromptOption\[\]>\(BUILTIN_PROMPTS\)/, "picker is seeded with the built-ins so it works offline");
+// The core contract: picking a prompt INSERTS into the composer — never sends.
+assert.match(chatView, /const insertPrompt = \(p: PromptOption\)/, "chat-view has the shared insert helper");
+assert.doesNotMatch(chatView, /sendRaw\([^)]*promptInsertion/, "prompt insertion is never routed into sendRaw");
+assert.doesNotMatch(chatView, /sendRaw\([^)]*\.body\b/, "a template body is never sent directly");
+assert.match(chatView, /aria-label="Prompt snippets"/, "composer has the Prompt snippets trigger");
+assert.match(chatView, /onOpenPromptSnippets=\{\(\) => setPromptSnippetsOpen\(true\)\}/, "empty state can open the snippets modal");
+
+// ── Prompt snippets modal ────────────────────────────────────────────────────
+const modal = await readFile(new URL("../components/prompt-snippets-modal.tsx", import.meta.url), "utf8");
+assert.match(modal, /Pick a starter prompt to drop into the composer\./, "modal keeps the insert-not-send subtitle");
+assert.match(modal, /export function promptIconName/, "icon names from data are validated against the curated set");
+assert.match(modal, /breadcrumb=\{\["Chat", "Prompt snippets"\]\}/, "modal is built on the shared Modal primitive");
+
+const emptyState = await readFile(new URL("../components/chat-empty-state.tsx", import.meta.url), "utf8");
+assert.match(emptyState, /onOpenPromptSnippets/, "empty state exposes the snippets entry point");
+
+console.log("slash-prompt.test.ts: ok");

--- a/src/lib/slash-prompt.ts
+++ b/src/lib/slash-prompt.ts
@@ -1,0 +1,90 @@
+// Helpers for the `/prompt` and `/prompts` slash commands and the Prompt
+// snippets modal — the inline autocomplete options shown while typing,
+// resolving a typed argument to a template, and the composer insertion. Pure +
+// client-safe: the prompt list is passed in (fetched from /api/prompts) so this
+// never pulls server code into the bundle. Mirrors slash-skill.ts, with one
+// deliberate difference: picking a prompt INSERTS its body into the composer
+// for editing — it never sends.
+
+export type PromptOption = {
+  id: string;
+  name: string;
+  description?: string;
+  /** Phosphor icon name — validated against the curated set at render. */
+  icon?: string;
+  tags?: string[];
+  /** Template text dropped into the composer. May contain {{placeholder}} tokens. */
+  body: string;
+  /** Where the template came from: shipped default, ~/.coven/prompts file, or
+   *  an installed marketplace prompt pack. */
+  source: "builtin" | "user" | `pack:${string}`;
+  /** Absolute path for file-backed templates. */
+  path?: string;
+};
+
+// `/prompts` is the no-arg "show everything" picker; it also accepts a trailing
+// filter. `/prompt ` (with a space) is the per-arg autocomplete. Bare `/prompt`
+// (no space) matches neither so the command menu shows both commands first.
+const PROMPTS_RE = /^\/prompts\s*(.*)$/i;
+const PROMPT_ARG_RE = /^\/prompt\s+(.*)$/i;
+
+function filterPrompts(prompts: PromptOption[], partial: string): PromptOption[] {
+  const q = partial.trim().toLowerCase();
+  if (!q) return prompts;
+  return prompts.filter(
+    (p) =>
+      p.id.toLowerCase().includes(q) ||
+      p.name.toLowerCase().includes(q) ||
+      (p.description?.toLowerCase().includes(q) ?? false),
+  );
+}
+
+/** Prompt options for the inline autocomplete when the composer is in
+ *  `/prompt <partial>` or `/prompts [<partial>]` position. Returns null when
+ *  the text isn't a prompt picker, so callers fall back to the command menu. */
+export function promptSlashOptions(text: string, prompts: PromptOption[]): PromptOption[] | null {
+  const t = text.trimStart();
+  const m = t.match(PROMPTS_RE) ?? t.match(PROMPT_ARG_RE);
+  if (!m) return null;
+  return filterPrompts(prompts, m[1]);
+}
+
+/** Resolve a typed /prompt argument to a concrete template: exact id/name
+ *  match first, then a substring match. Returns null for an empty/unknown
+ *  argument. */
+export function resolvePromptArg(arg: string, prompts: PromptOption[]): PromptOption | null {
+  const a = arg.trim().toLowerCase();
+  if (!a) return null;
+  const exact = prompts.find((p) => p.id.toLowerCase() === a || p.name.toLowerCase() === a);
+  if (exact) return exact;
+  const partial = prompts.find(
+    (p) => p.id.toLowerCase().includes(a) || p.name.toLowerCase().includes(a),
+  );
+  return partial ?? null;
+}
+
+export type PromptInsertion = {
+  text: string;
+  /** When the body carries a {{placeholder}}, the range of the first one so
+   *  the caller can select it — typing then replaces the placeholder. */
+  selectStart?: number;
+  selectEnd?: number;
+};
+
+/** The composer insertion for a picked template. Never a send. */
+export function promptInsertion(p: PromptOption): PromptInsertion {
+  const m = p.body.match(/\{\{[^{}]*\}\}/);
+  if (!m || m.index === undefined) return { text: p.body };
+  return { text: p.body, selectStart: m.index, selectEnd: m.index + m[0].length };
+}
+
+/** One-line-per-prompt list for the bare `/prompt` / `/prompts` system message. */
+export function formatPromptList(prompts: PromptOption[]): string {
+  if (prompts.length === 0) {
+    return "No prompt templates found. Add .md files under ~/.coven/prompts or install a prompt pack from the Marketplace, then try `/prompts` again.";
+  }
+  const lines = prompts.map(
+    (p) => `  ○ ${p.name} — \`${p.id}\`${p.description ? ` — ${p.description}` : ""}`,
+  );
+  return `Available prompts (type \`/prompt <name>\` or pick from the menu — picking drops the template into the composer):\n${lines.join("\n")}`;
+}

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -48,7 +48,7 @@ assert.match(slashCmds, /name: "\/skills"/, "/skills is registered");
 
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 assert.match(chatView, /skillSlashOptions\(input, skills\)/, "chat-view computes the inline /skill options");
-assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| slashSuggestions\.length > 0;/, "chat-view menuOpen includes the skill picker");
+assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0;/, "chat-view menuOpen includes the skill picker");
 assert.match(chatView, /command === "\/skill" \|\| command === "\/skills"/, "chat-view dispatches /skill and /skills");
 assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill\)\)/, "chat-view invokes a skill by sending the skill prompt");
 assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");


### PR DESCRIPTION
## What

Prompt templates in chat — pick a starter prompt and it is **dropped into the composer for editing, never auto-sent**:

- **`/prompt <name>` + `/prompts`** inline picker mirroring `/skill` (typeahead filter, `↑↓ / Enter insert / Tab complete`). `/snippets` aliases `/prompt`. If the template body carries a `{{placeholder}}`, the first one is selected after insert so typing replaces it.
- **"Prompt snippets" modal** (shared `Modal` primitive, focus-trapped) with the reference layout — icon + name + description rows, subtitle "Pick a starter prompt to drop into the composer." Reachable from a new composer utility-row button and an empty-state pill.
- **Template sources**, merged by id (user > pack > builtin) via new `GET /api/prompts`:
  1. built-ins: Code review / Implementation plan / Explain this (`src/lib/prompt-defaults.ts`)
  2. `~/.coven/prompts/*.md` — frontmatter `name`/`description`/`icon`/`tags`, body = template (scanner reuses the SKILL.md frontmatter parser)
  3. installed marketplace prompt packs, resolved at scan time from `marketplace/plugins/<id>/prompts/` (pack authoring + the marketplace "Prompts" kind land in the follow-up, cave-qze)
- Composer seeds from the built-ins, so the picker works offline/before the fetch resolves.
- iOS slash catalog gains `/prompt` + `/prompts` as desktop-only entries (required by the `ios-slash-commands` parity pin).

## Deliberately out of scope

- **Home composer untouched** — PR #2514 is decomposing it; `/prompt` in the home slash menu is currently a silent no-op there. Home parity is tracked in cave-6tu and follows once #2514 merges.
- Marketplace prompt packs + `PluginKind "prompt"` — cave-qze (the API-side pack scan is already wired here).
- Skill autofill / argument hints — cave-4qv.

## Verification

- `pnpm typecheck`, `pnpm check:tests-wired`, full `pnpm test:app` (540 files) and `pnpm test:api` (119 files) green, including new `slash-prompt.test.ts` + `prompt-scan.test.ts` and the iOS parity test.
- Live-verified on a prod build with Playwright: `/prompt ` opens the 3-row picker; Enter inserts without sending (asserted transcript unchanged); toolbar button opens the modal with the subtitle; picking "Implementation plan" inserts and selects `{{what to build}}`; `/api/prompts` serves the merged list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)