### PR TITLE
fix(connection): transport drops no longer kill the turn; legacy tokens migrate (cave-id5)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -758,9 +758,21 @@ final class AppModel {
     /// the current token keeps working until it actually expires, at which
     /// point refreshConnection lands in `.needsAuth` with re-pair guidance.
     private func refreshAccessTokenIfNeeded() async {
-        guard let client,
-              let token = CaveConnection.accessToken,
-              let expiry = CaveInvite.tokenExpiry(token) else { return }
+        guard let client, let token = CaveConnection.accessToken else { return }
+        guard let expiry = CaveInvite.tokenExpiry(token) else {
+            // Legacy raw-secret pairing: no expiry, so the rolling renewal
+            // below can never fire and the device stays on a never-expiring
+            // credential forever. The refresh route accepts the raw secret as
+            // a valid credential precisely to offer this migration path —
+            // exchange it once for a signed 30-day token. After the swap the
+            // stored token has an expiry, so this branch never runs again; on
+            // failure (offline, tokenless server) the raw secret keeps
+            // working and the next connect retries.
+            if let fresh = await client.refreshAccessToken() {
+                CaveConnection.saveAccessToken(fresh)
+            }
+            return
+        }
         let renewalWindow: TimeInterval = 7 * 24 * 3600
         let secondsUntilExpiry = expiry.timeIntervalSinceNow
         guard secondsUntilExpiry > 0 && secondsUntilExpiry < renewalWindow else { return }

--- a/scripts/ios-legacy-token-migration.test.mjs
+++ b/scripts/ios-legacy-token-migration.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Legacy raw-secret pairings never expire, so the rolling renewal never fired
+// for them and a paired device stayed on the never-expiring credential
+// forever (cave-id5). The app now exchanges a no-expiry token once for a
+// signed 30-day one — the server's refresh route accepts the raw secret as a
+// valid credential precisely to offer this migration path. After the swap the
+// stored token has an expiry, so the branch self-disarms.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+
+// The no-expiry branch must migrate (refresh + persist), not bail out early.
+const migration = model.match(
+  /guard let expiry = CaveInvite\.tokenExpiry\(token\) else \{[\s\S]*?refreshAccessToken\(\)[\s\S]*?saveAccessToken\(fresh\)[\s\S]*?return\s*\}/,
+);
+assert.ok(
+  migration,
+  "tokenExpiry==nil (legacy raw secret) must refresh once to a signed token instead of returning early",
+);
+
+// The old guard folded the expiry parse into the multi-let and silently
+// skipped legacy tokens — it must not come back.
+assert.doesNotMatch(
+  model,
+  /let token = CaveConnection\.accessToken,\s*\n?\s*let expiry = CaveInvite\.tokenExpiry\(token\) else \{ return \}/,
+  "legacy raw-secret tokens must not be skipped by the renewal guard",
+);
+
+// The rolling 7-day renewal for signed tokens stays intact alongside.
+assert.match(
+  model,
+  /let renewalWindow: TimeInterval = 7 \* 24 \* 3600/,
+  "signed-token rolling renewal window survives the migration change",
+);
+
+console.log("ios-legacy-token-migration.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -560,6 +560,7 @@ export const SUITES = {
     "src/lib/message-feedback.test.ts",
     "src/lib/server/message-feedback-store.test.ts",
     "src/components/detail-split-host.test.ts",
+    "src/lib/server/chat-stop-registry.test.ts",
   ],
   api: [
     "scripts/dependency-policy.test.mjs",
@@ -720,6 +721,7 @@ export const SUITES = {
     "scripts/ios-auto-reconnect.test.mjs",
     "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connection-stability.test.mjs",
+    "scripts/ios-legacy-token-migration.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-connect-screen-ux.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -31,6 +31,7 @@ const contracts: RouteContract[] = [
   { route: "/chat/model-state", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/search", methods: ["GET"], kind: "json" },
   { route: "/chat/send", methods: ["POST"], kind: "stream", readsJson: true },
+  { route: "/chat/stop", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/chat/usage", methods: ["GET"], kind: "json" },
   { route: "/codex-automations/[id]", methods: ["GET", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/codex-automations/[id]/run", methods: ["POST"], kind: "json", localOriginGuard: true },
@@ -289,23 +290,51 @@ for (const contract of contracts) {
   );
 }
 
-// CHAT-D5-02: cancelling a streaming response (Esc/Stop) must persist an
-// honest cancelled record — the partial text streamed so far, or a minimal
-// "(cancelled)" marker — never the fabricated empty-response error
-// diagnostic. Both adapter paths (coven stream-json and the OpenClaw bridge)
-// carry the guard, so a reload shows the cancel, not a harness error.
+// CHAT-D5-02 (amended by cave-id5): cancelling a streaming response is an
+// explicit POST /api/chat/stop — it SIGTERMs the harness and persists an
+// honest cancelled record (the partial text streamed so far, or a minimal
+// "(cancelled)" marker), never the fabricated empty-response error
+// diagnostic. A bare `req.signal` abort is a TRANSPORT DROP, not a cancel:
+// the harness keeps running (bounded by the detach cap) and the finished
+// turn persists for resync. Both adapter paths (coven stream-json and the
+// OpenClaw bridge) carry the guard.
 {
   const sendSource = readFileSync(
     path.join(apiRoot, "chat", "send", "route.ts"),
     "utf8",
   );
-  const abortReads = [
-    ...sendSource.matchAll(/const cancelledByUser = (?:args\.)?req\.signal\.aborted;/g),
+  const stopReads = [
+    ...sendSource.matchAll(/const cancelledByUser = runHandle\.stopRequested;/g),
   ];
   assert.equal(
-    abortReads.length,
+    stopReads.length,
     2,
-    "/chat/send: both adapter paths must detect a user abort before synthesizing diagnostics",
+    "/chat/send: both adapter paths must detect a deliberate stop (not a bare abort) before synthesizing diagnostics",
+  );
+  assert.doesNotMatch(
+    sendSource,
+    /const cancelledByUser = (?:args\.)?req\.signal\.aborted;/,
+    "/chat/send: a bare transport abort must never be read as a user cancel",
+  );
+  const runRegistrations = [...sendSource.matchAll(/= registerChatRun\(/g)];
+  assert.equal(
+    runRegistrations.length,
+    2,
+    "/chat/send: both adapter paths must register with the stop registry",
+  );
+  assert.match(
+    sendSource,
+    /setTimeout\(kill(?:Child|CurrentChild), CHAT_DETACH_MAX_MS\)/,
+    "/chat/send: a transport drop must arm the detach cap instead of killing immediately",
+  );
+  const stopSource = readFileSync(
+    path.join(apiRoot, "chat", "stop", "route.ts"),
+    "utf8",
+  );
+  assert.match(
+    stopSource,
+    /requestChatStop/,
+    "/chat/stop must resolve stops through the shared run registry",
   );
   const guardedDiagnostics = [
     ...sendSource.matchAll(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -40,6 +40,11 @@ import {
   readKnowledgeVaultForPrompt,
 } from "@/lib/server/knowledge-vault";
 import { parseAgentAttachments } from "@/lib/server/agent-attachments";
+import {
+  registerChatRun,
+  unregisterChatRun,
+  type ChatRunHandle,
+} from "@/lib/server/chat-stop-registry";
 import { buildNextPathsDirective } from "@/lib/next-paths";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { loadProjects } from "@/lib/cave-projects";
@@ -108,9 +113,22 @@ import { deriveTravelClientStatus } from "@/lib/travel-client-state";
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
+// A transport drop no longer kills the harness (deliberate Stop goes through
+// /api/chat/stop), but a detached run must not outlive its usefulness forever
+// — SIGTERM the child if it is still running this long after the client
+// vanished. Long enough for any real reply to finish, short enough to bound
+// runaway children nobody is listening to.
+const CHAT_DETACH_MAX_MS = Math.max(
+  60_000,
+  Number(process.env.COVEN_CAVE_CHAT_DETACH_MAX_MS ?? 10 * 60_000) || 10 * 60_000,
+);
+
 type SendBody = {
   familiarId: string;
   prompt?: string;
+  /** Per-send client token for /api/chat/stop — lets Stop target this run
+   *  before the server has assigned/echoed a conversation id. */
+  runId?: string;
   sessionId?: string;
   projectRoot?: string;
   modelOverride?: string;
@@ -745,12 +763,22 @@ function openClawChatResponse(args: {
 
       let stdout = "";
       let stderr = "";
-      const onAbort = () => {
+      const killChild = () => {
         try {
           child.kill("SIGTERM");
         } catch {
           /* ignore */
         }
+      };
+      // Deliberate Stop arrives via /api/chat/stop (which kills through this
+      // registration); a bare transport abort means the client vanished — let
+      // the turn finish server-side so resync recovers the full reply, bounded
+      // by the detach cap in case nothing ever comes back for it.
+      const runHandle = registerChatRun([args.body.runId, conversationId], killChild);
+      let detachKillTimer: ReturnType<typeof setTimeout> | null = null;
+      const onAbort = () => {
+        if (runHandle.stopRequested || detachKillTimer != null) return;
+        detachKillTimer = setTimeout(killChild, CHAT_DETACH_MAX_MS);
       };
       args.req.signal.addEventListener("abort", onAbort, { once: true });
 
@@ -774,10 +802,14 @@ function openClawChatResponse(args: {
           responseMetadata,
         });
         args.req.signal.removeEventListener("abort", onAbort);
+        if (detachKillTimer != null) clearTimeout(detachKillTimer);
+        unregisterChatRun(runHandle);
         close();
       });
       child.on("close", async (code) => {
         args.req.signal.removeEventListener("abort", onAbort);
+        if (detachKillTimer != null) clearTimeout(detachKillTimer);
+        unregisterChatRun(runHandle);
         const durationMs = Date.now() - startedAt;
         // Identity stays cave-owned: the gateway's internal session id is
         // surfaced as diagnostics only, never adopted as the conversation
@@ -795,11 +827,13 @@ function openClawChatResponse(args: {
           durationMs,
         );
 
-        // User cancel (CHAT-D5-02): a stopped response SIGTERMs the bridge,
-        // so stdout is usually empty or truncated JSON. Persist an honest
-        // cancelled marker — never raw truncated output or the fabricated
-        // "returned no text" error diagnostic.
-        const cancelledByUser = args.req.signal.aborted;
+        // User cancel (CHAT-D5-02): a deliberate Stop (/api/chat/stop)
+        // SIGTERMs the bridge, so stdout is usually empty or truncated JSON.
+        // Persist an honest cancelled marker — never raw truncated output or
+        // the fabricated "returned no text" error diagnostic. A bare transport
+        // abort is NOT a cancel: the turn ran to completion above and persists
+        // as a normal reply the client recovers on resync.
+        const cancelledByUser = runHandle.stopRequested;
 
         if (stdout.trim()) {
           try {
@@ -1470,6 +1504,24 @@ export async function POST(req: Request) {
         }
       };
 
+      // One registration covers both attempts (resume retry replaces the
+      // child): /api/chat/stop kills whichever child is current and flags the
+      // run as user-cancelled. A bare transport abort no longer kills — the
+      // turn finishes and persists, bounded by the detach cap.
+      let currentChild: ReturnType<typeof spawn> | null = null;
+      const killCurrentChild = () => {
+        try {
+          currentChild?.kill("SIGTERM");
+        } catch {
+          /* ignore */
+        }
+      };
+      const runHandle: ChatRunHandle = registerChatRun(
+        [body.runId, body.sessionId],
+        killCurrentChild,
+      );
+      let detachKillTimer: ReturnType<typeof setTimeout> | null = null;
+
       const runAttempt = (spawnArgs: string[]): Promise<void> =>
         new Promise((resolve) => {
           const attemptStartedAt = Date.now();
@@ -1503,12 +1555,12 @@ export async function POST(req: Request) {
                 });
               })();
 
+          currentChild = child;
           const onAbort = () => {
-            try {
-              child.kill("SIGTERM");
-            } catch {
-              /* ignore */
-            }
+            // Transport drop, not Stop — arm the detach cap and let the turn
+            // finish. Deliberate stops kill through the registry instead.
+            if (runHandle.stopRequested || detachKillTimer != null) return;
+            detachKillTimer = setTimeout(killCurrentChild, CHAT_DETACH_MAX_MS);
           };
           req.signal.addEventListener("abort", onAbort, { once: true });
 
@@ -1609,15 +1661,17 @@ export async function POST(req: Request) {
       }
 
       // User cancel (CHAT-D5-02): when the client stops the response
-      // (Esc/Stop), req.signal aborts and the harness child gets SIGTERM —
+      // (Esc/Stop → POST /api/chat/stop), the harness child gets SIGTERM —
       // usually before any "result" event. Without this guard the
       // empty-response diagnostic below fabricates an auth-hint error and
       // saves it, so reloading the chat rewrote the user's cancel into a
       // harness error. Persist the honest record instead: the partial text
       // streamed so far (or a minimal "(cancelled)" marker), never an error,
       // and skip the diagnostic SSE chunk — the client already rendered its
-      // own cancelled state and is gone.
-      const cancelledByUser = req.signal.aborted;
+      // own cancelled state and is gone. A bare transport abort (signal loss,
+      // closed tab) is NOT a cancel: the turn ran to completion and persists
+      // as a normal reply the client recovers on resync.
+      const cancelledByUser = runHandle.stopRequested;
       if (cancelledByUser) {
         if (!assistantText.trim()) assistantText = "(cancelled)";
         result.is_error = false;
@@ -1754,6 +1808,8 @@ export async function POST(req: Request) {
       // exited (including any resume retry), so nothing can still be reading
       // the saved images. Failures just leave files in tmpdir.
       cleanupImageTempFiles(imageFilePaths);
+      if (detachKillTimer != null) clearTimeout(detachKillTimer);
+      unregisterChatRun(runHandle);
       await sleep(20);
       close();
     },

--- a/src/app/api/chat/stop/route.ts
+++ b/src/app/api/chat/stop/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { requestChatStop } from "@/lib/server/chat-stop-registry";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/chat/stop — deliberate cancel for an in-flight /api/chat/send run.
+ *
+ * Clients used to signal Stop by aborting the SSE request, but a transport
+ * drop (phone loses signal, laptop lid closes) produces the exact same abort,
+ * and the harness was SIGTERMed either way. Stop is now an explicit call:
+ * the send route only treats a run as user-cancelled when this endpoint
+ * flagged it; a bare abort lets the turn finish server-side and persist, so
+ * the client recovers the full reply on resync.
+ *
+ * Body: `{ runId?, sessionId? }` — runId is the per-send client token (works
+ * before the server has assigned a conversation id), sessionId the
+ * conversation key. Either may match; `stopped: false` means nothing was in
+ * flight under those keys (already finished — not an error).
+ */
+export async function POST(req: Request) {
+  let body: { runId?: string; sessionId?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    // Malformed body → nothing to stop; fall through to the not-found reply.
+  }
+
+  const keys = [body.runId, body.sessionId].filter(
+    (key): key is string => typeof key === "string" && key.length > 0,
+  );
+  if (keys.length === 0) {
+    return NextResponse.json({ ok: false, error: "runId or sessionId required" }, { status: 400 });
+  }
+
+  const stopped = keys.some((key) => requestChatStop(key));
+  return NextResponse.json({ ok: true, stopped });
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2378,6 +2378,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const activeSlashOptionRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  /** Keys for POST /api/chat/stop — a deliberate Stop must be an explicit
+   *  server call; a bare fetch abort now reads as a transport drop and the
+   *  turn finishes server-side. runId targets a run this instance started
+   *  (works before the server assigns a session id); sessionId covers
+   *  adopted streams (remount mid-generation) where the runId is unknown. */
+  const stopKeysRef = useRef<{ runId: string | null; sessionId: string | null }>({
+    runId: null,
+    sessionId: null,
+  });
   const initialPromptSentRef = useRef(false);
   /** True while THIS instance's sendRaw reader loop is running. The owner
    *  applies stream events itself (handleEvent), so it never needs the
@@ -2953,6 +2962,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // branch below re-arms busy/abortRef if THIS thread is the one streaming.
     setBusy(false);
     abortRef.current = null;
+    stopKeysRef.current = { runId: null, sessionId: null };
     setLinkedContext(null);
     // An armed "Start a task" belongs to the thread it was armed on.
     taskArmedRef.current = false;
@@ -2971,6 +2981,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setActiveLeafId(live.activeLeafId);
       setFlowTranscriptFallback(null);
       abortRef.current = live.controller;
+      stopKeysRef.current = { runId: null, sessionId };
       setHistoryState("loaded");
       setBusy(true);
       // Adopting a stream this instance did not start (remount mid-
@@ -3429,7 +3440,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     };
     const controller = new AbortController();
     const liveGeneration = { sessionId: initialLiveSessionId, controller };
+    const runId = crypto.randomUUID();
     abortRef.current = controller;
+    stopKeysRef.current = { runId, sessionId: initialLiveSessionId ?? null };
     streamOwnerRef.current = true;
     refetchOnSettleRef.current = null;
     const nextTurns = [...turnsRef.current, userTurn, assistantTurn];
@@ -3454,6 +3467,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         body: JSON.stringify({
           familiarId: familiar.id,
           prompt: submitPrompt,
+          runId,
           ...(outgoingAttachments.length ? { attachments: stripPreviewOnlyAttachmentFieldsKeepingImages(outgoingAttachments) } : {}),
           ...(origin ? { origin } : {}),
           sessionId: liveGeneration.sessionId,
@@ -3592,11 +3606,28 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       streamOwnerRef.current = false;
       clearLiveChatGeneration(liveGeneration.sessionId);
       abortRef.current = null;
+      stopKeysRef.current = { runId: null, sessionId: null };
       setBusy(false);
     }
   };
 
   const cancelSend = () => {
+    const { runId, sessionId } = stopKeysRef.current;
+    if (runId || sessionId) {
+      // Deliberate Stop is an explicit server call (kills the harness and
+      // persists the honest cancelled record); the abort below only tears
+      // down this client's stream.
+      void fetch("/api/chat/stop", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          ...(runId ? { runId } : {}),
+          ...(sessionId ? { sessionId } : {}),
+        }),
+      }).catch(() => {
+        /* best-effort — the server's detach cap still bounds the run */
+      });
+    }
     abortRef.current?.abort();
   };
 

--- a/src/lib/server/chat-stop-registry.test.ts
+++ b/src/lib/server/chat-stop-registry.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// Chat stop registry — the /api/chat/stop ↔ /api/chat/send contract that
+// tells a deliberate Stop apart from a bare transport drop (cave-id5).
+import assert from "node:assert/strict";
+
+const { registerChatRun, unregisterChatRun, requestChatStop } = await import(
+  "./chat-stop-registry.ts"
+);
+
+// Deliberate stop: kills through the registration and flags the handle.
+{
+  let kills = 0;
+  const handle = registerChatRun(["run-1", "session-1"], () => {
+    kills += 1;
+  });
+  assert.equal(handle.stopRequested, false, "fresh runs are not stop-flagged");
+  assert.equal(requestChatStop("run-1"), true, "stop resolves by runId");
+  assert.equal(kills, 1, "stop SIGTERMs through the registered kill");
+  assert.equal(handle.stopRequested, true, "the handle records the deliberate stop");
+  assert.equal(requestChatStop("session-1"), true, "stop also resolves by session key");
+  assert.equal(kills, 2, "kill is safe to invoke repeatedly");
+  unregisterChatRun(handle);
+}
+
+// Nothing in flight → stopped: false (an already-finished run is not an error).
+assert.equal(requestChatStop("run-1"), false, "unregistered keys report nothing to stop");
+assert.equal(requestChatStop("session-1"), false, "unregister drops every key");
+
+// Null/empty keys are skipped — a brand-new chat has no session id yet.
+{
+  const handle = registerChatRun([null, undefined, "", "run-2"], () => {});
+  assert.deepEqual(handle.keys, ["run-2"], "only truthy keys register");
+  unregisterChatRun(handle);
+}
+
+// A follow-up turn re-registers the same conversation key; the finished older
+// run's cleanup must not evict the newer registration.
+{
+  const first = registerChatRun(["session-3"], () => {});
+  const second = registerChatRun(["session-3"], () => {});
+  unregisterChatRun(first);
+  assert.equal(
+    requestChatStop("session-3"),
+    true,
+    "newer registration survives the older run's cleanup",
+  );
+  assert.equal(second.stopRequested, true, "the stop lands on the newer run");
+  unregisterChatRun(second);
+}
+
+// A throwing kill doesn't break the stop path (child already exited).
+{
+  const handle = registerChatRun(["run-4"], () => {
+    throw new Error("ESRCH");
+  });
+  assert.equal(requestChatStop("run-4"), true, "stop succeeds when the child is already gone");
+  assert.equal(handle.stopRequested, true, "the cancel flag still lands");
+  unregisterChatRun(handle);
+}
+
+console.log("chat-stop-registry.test.ts: ok");

--- a/src/lib/server/chat-stop-registry.ts
+++ b/src/lib/server/chat-stop-registry.ts
@@ -1,0 +1,63 @@
+// In-flight chat run registry: lets an explicit POST /api/chat/stop kill a
+// streaming harness child, so a transport drop (phone loses signal, tab
+// closes) can be told apart from a deliberate Stop. Before this, both surfaced
+// as the same `req.signal` abort and the harness was SIGTERMed either way —
+// a phone that lost signal mid-reply could only ever recover a partial turn.
+//
+// Per-process state, matching the single-server posture of the rest of the
+// chat stack (same exposure as withInboxLock).
+
+type ChatRunEntry = {
+  handle: ChatRunHandle;
+  kill: () => void;
+};
+
+export type ChatRunHandle = {
+  /** Set when a deliberate stop arrived via /api/chat/stop. The send route
+   *  reads this — not `req.signal.aborted` — to decide cancel semantics. */
+  stopRequested: boolean;
+  /** Registry keys this run is reachable under (runId, conversation id). */
+  keys: string[];
+};
+
+const active = new Map<string, ChatRunEntry>();
+
+/** Register a streaming run under every non-empty key. `kill` must be safe to
+ *  call more than once and after child exit. */
+export function registerChatRun(
+  keys: Array<string | null | undefined>,
+  kill: () => void,
+): ChatRunHandle {
+  const handle: ChatRunHandle = { stopRequested: false, keys: [] };
+  const entry: ChatRunEntry = { handle, kill };
+  for (const key of keys) {
+    if (!key) continue;
+    active.set(key, entry);
+    handle.keys.push(key);
+  }
+  return handle;
+}
+
+/** Drop a run from the registry (child exited or request settled). */
+export function unregisterChatRun(handle: ChatRunHandle): void {
+  for (const key of handle.keys) {
+    // Another run may have re-registered the same conversation key (e.g. a
+    // follow-up turn) — only delete entries that still point at this handle.
+    if (active.get(key)?.handle === handle) active.delete(key);
+  }
+  handle.keys.length = 0;
+}
+
+/** Deliberate user stop: mark the run cancelled and SIGTERM its child.
+ *  Returns false when nothing is in flight under the key. */
+export function requestChatStop(key: string): boolean {
+  const entry = active.get(key);
+  if (!entry) return false;
+  entry.handle.stopRequested = true;
+  try {
+    entry.kill();
+  } catch {
+    /* child already gone */
+  }
+  return true;
+}


### PR DESCRIPTION
## What

Two follow-ups deferred from the iOS connection overhaul (#2465), tracked as **cave-id5**:

### 1. Transport drops no longer kill the in-flight turn

Before: a client transport drop mid-`/api/chat/send` (phone loses signal, tab closes) fired the same `req.signal` abort as a deliberate Stop, and the harness child was SIGTERMed either way — a phone that lost signal mid-reply could only ever recover a partial turn via resync.

Now:
- **Deliberate Stop is an explicit `POST /api/chat/stop`**, resolved through a new in-flight run registry (`src/lib/server/chat-stop-registry.ts`), keyed by a per-send client `runId` (works before the server assigns a session id) and the conversation id (covers adopted streams after a remount).
- **A bare abort reads as a transport drop**: the harness keeps running, the finished turn persists, and the client recovers the full reply through the existing resync path. A detach cap (`COVEN_CAVE_CHAT_DETACH_MAX_MS`, default 10 min, floor 60 s) bounds children nobody is listening to.
- Both adapter paths (coven stream-json incl. the resume-retry child swap, and the OpenClaw bridge) carry the change; CHAT-D5-02 cancel semantics now key off `runHandle.stopRequested`.
- Web `cancelSend()` calls the stop route (best-effort) then aborts as before. iOS has no Stop affordance, so every iOS abort was a transport artifact — pure win there. Quick-chat overlay closes also become detached turns that land in the thread instead of dying, bounded by the same cap.

### 2. iOS legacy raw-secret pairings migrate to signed tokens

`refreshAccessTokenIfNeeded()` previously skipped tokens with no expiry, so raw-secret pairings never rotated onto the signed 30-day rolling tokens. The no-expiry branch now exchanges the secret once via `/api/mobile-token/refresh` (which accepts the raw secret exactly as this migration path); after the swap the stored token has an expiry and the branch self-disarms. Failures keep the still-valid secret and retry next connect.

### Scope note

Item (3) of cave-id5 (iOS offline compose/queue) is a real feature, split to **cave-u6k**.

## Tests

- New `src/lib/server/chat-stop-registry.test.ts` (stop/unregister/re-register/throwing-kill semantics)
- New `scripts/ios-legacy-token-migration.test.mjs` Swift source pins; both wired into `run-tests.mjs`
- CHAT-D5-02 contract pins rewritten for stop-registry semantics; `/chat/stop` added to the route contract inventory
- Gates: 540 app + 71 mobile test files green, `tsc --noEmit` clean, all 725 test files wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)