### PR TITLE
feat(marketplace): prompt packs — 4th plugin kind + Essentials pack (cave-qze)

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -5291,6 +5291,63 @@
           "Every doc ships with a Definition of Done checklist near the top plus an owner, last-updated date, and review schedule."
         ]
       }
+    },
+    {
+      "name": "prompt-pack-essentials",
+      "displayName": "Prompt Pack: Essentials",
+      "version": "0.1.0",
+      "description": "Starter prompt templates for everyday development chat — debugging, tests, refactors, PR prose. Installed templates appear under /prompts and the Prompt snippets picker.",
+      "category": "Productivity",
+      "keywords": [
+        "prompts",
+        "templates",
+        "snippets",
+        "composer"
+      ],
+      "capabilities": [
+        "prompts"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "prompts": [
+        {
+          "id": "debug-this",
+          "name": "Debug this",
+          "description": "Reproduce, isolate, and fix a bug with evidence before the patch.",
+          "icon": "ph:list-checks-bold",
+          "body": "Debug {{the problem}}. Reproduce it first, isolate the root cause with evidence, then propose the smallest fix. Show the failing case passing before you call it done."
+        },
+        {
+          "id": "write-tests",
+          "name": "Write tests",
+          "description": "Add focused tests around a file or behavior, edge cases included.",
+          "icon": "ph:list-checks-bold",
+          "body": "Write tests for {{file or behavior}}. Cover the happy path, the edge cases most likely to regress, and one failure mode. Match the project's existing test style and wiring."
+        },
+        {
+          "id": "refactor-safely",
+          "name": "Refactor safely",
+          "description": "Restructure code without changing behavior, verified as you go.",
+          "icon": "ph:note-pencil",
+          "body": "Refactor {{target}} without changing behavior. List the risks first, move in small verifiable steps, and run the relevant tests after each step."
+        },
+        {
+          "id": "pr-description",
+          "name": "PR description",
+          "description": "Draft a reviewer-ready pull request description from the current branch.",
+          "icon": "ph:note-pencil",
+          "body": "Draft a pull request description for the current branch: what changed and why, anything reviewers should look at closely, how it was verified, and any follow-ups deliberately left out."
+        },
+        {
+          "id": "release-notes",
+          "name": "Release notes",
+          "description": "Turn recent merges into user-facing release notes.",
+          "icon": "ph:book-open",
+          "body": "Draft release notes from the merges since {{last release}}. Group by user-facing area, lead each item with the benefit, and keep internal-only changes in a short footnote section."
+        }
+      ]
     }
   ]
 }

--- a/marketplace/exports/codex/marketplace.json
+++ b/marketplace/exports/codex/marketplace.json
@@ -1407,6 +1407,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Knowledge & Docs"
+    },
+    {
+      "name": "prompt-pack-essentials",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/prompt-pack-essentials"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -1760,6 +1760,21 @@
       },
       "trust": "reference-local",
       "roleAffinity": []
+    },
+    {
+      "name": "prompt-pack-essentials",
+      "displayName": "Prompt Pack: Essentials",
+      "category": "Productivity",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prompt-pack-essentials"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": []
     }
   ]
 }

--- a/marketplace/plugins/prompt-pack-essentials/.codex-plugin/plugin.json
+++ b/marketplace/plugins/prompt-pack-essentials/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "prompt-pack-essentials",
+  "version": "0.1.0",
+  "description": "Starter prompt templates for everyday development chat \u2014 debugging, tests, refactors, PR prose. Installed templates appear under /prompts and the Prompt snippets picker.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prompt Pack: Essentials",
+    "shortDescription": "Starter prompt templates for everyday development chat \u2014 debugging, tests, refactors, PR prose. Installed templates appear under /prompts and the Prompt snippets picker.",
+    "longDescription": "Starter prompt templates for everyday development chat \u2014 debugging, tests, refactors, PR prose. Installed templates appear under /prompts and the Prompt snippets picker.",
+    "developerName": "OpenCoven",
+    "category": "Productivity",
+    "capabilities": [
+      "prompts",
+      "templates",
+      "snippets",
+      "composer"
+    ],
+    "defaultPrompt": "Help me use Prompt Pack: Essentials safely."
+  }
+}

--- a/marketplace/plugins/prompt-pack-essentials/plugin.json
+++ b/marketplace/plugins/prompt-pack-essentials/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "prompt-pack-essentials",
+  "version": "0.1.0",
+  "description": "Starter prompt templates for everyday development chat \u2014 debugging, tests, refactors, PR prose. Installed templates appear under /prompts and the Prompt snippets picker.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "prompts",
+    "templates",
+    "snippets",
+    "composer"
+  ],
+  "capabilities": [
+    "prompts"
+  ],
+  "marketplaceId": "opencoven/prompt-pack-essentials",
+  "x-coven": {
+    "displayName": "Prompt Pack: Essentials",
+    "category": "Productivity",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  },
+  "prompts": [
+    "debug-this",
+    "write-tests",
+    "refactor-safely",
+    "pr-description",
+    "release-notes"
+  ]
+}

--- a/marketplace/plugins/prompt-pack-essentials/prompts/debug-this.md
+++ b/marketplace/plugins/prompt-pack-essentials/prompts/debug-this.md
@@ -1,0 +1,7 @@
+---
+name: Debug this
+description: Reproduce, isolate, and fix a bug with evidence before the patch.
+icon: ph:list-checks-bold
+---
+
+Debug {{the problem}}. Reproduce it first, isolate the root cause with evidence, then propose the smallest fix. Show the failing case passing before you call it done.

--- a/marketplace/plugins/prompt-pack-essentials/prompts/pr-description.md
+++ b/marketplace/plugins/prompt-pack-essentials/prompts/pr-description.md
@@ -1,0 +1,7 @@
+---
+name: PR description
+description: Draft a reviewer-ready pull request description from the current branch.
+icon: ph:note-pencil
+---
+
+Draft a pull request description for the current branch: what changed and why, anything reviewers should look at closely, how it was verified, and any follow-ups deliberately left out.

--- a/marketplace/plugins/prompt-pack-essentials/prompts/refactor-safely.md
+++ b/marketplace/plugins/prompt-pack-essentials/prompts/refactor-safely.md
@@ -1,0 +1,7 @@
+---
+name: Refactor safely
+description: Restructure code without changing behavior, verified as you go.
+icon: ph:note-pencil
+---
+
+Refactor {{target}} without changing behavior. List the risks first, move in small verifiable steps, and run the relevant tests after each step.

--- a/marketplace/plugins/prompt-pack-essentials/prompts/release-notes.md
+++ b/marketplace/plugins/prompt-pack-essentials/prompts/release-notes.md
@@ -1,0 +1,7 @@
+---
+name: Release notes
+description: Turn recent merges into user-facing release notes.
+icon: ph:book-open
+---
+
+Draft release notes from the merges since {{last release}}. Group by user-facing area, lead each item with the benefit, and keep internal-only changes in a short footnote section.

--- a/marketplace/plugins/prompt-pack-essentials/prompts/write-tests.md
+++ b/marketplace/plugins/prompt-pack-essentials/prompts/write-tests.md
@@ -1,0 +1,7 @@
+---
+name: Write tests
+description: Add focused tests around a file or behavior, edge cases included.
+icon: ph:list-checks-bold
+---
+
+Write tests for {{file or behavior}}. Cover the happy path, the edge cases most likely to regress, and one failure mode. Match the project's existing test style and wiring.

--- a/scripts/sync-marketplace.py
+++ b/scripts/sync-marketplace.py
@@ -63,6 +63,22 @@ def skill_markdown(plugin: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def prompt_markdown(prompt: dict[str, Any]) -> str:
+    """One prompt-template .md — the same shape src/lib/server/prompt-scan.ts
+    reads (frontmatter name/description/icon/tags + body dropped into the
+    composer). Installed packs are resolved by /api/prompts at scan time."""
+    lines = ["---", f"name: {prompt['name']}"]
+    if prompt.get("description"):
+        lines.append(f"description: {prompt['description']}")
+    if prompt.get("icon"):
+        lines.append(f"icon: {prompt['icon']}")
+    if prompt.get("tags"):
+        lines.append("tags:")
+        lines.extend(f"  - {tag}" for tag in prompt["tags"])
+    lines.extend(["---", "", prompt["body"].rstrip(), ""])
+    return "\n".join(lines)
+
+
 def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
     manifest: dict[str, Any] = {
         "name": plugin["name"],
@@ -94,6 +110,8 @@ def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
         manifest["mcpServers"] = plugin["mcpServers"]
     if plugin.get("userConfig"):
         manifest["userConfig"] = plugin["userConfig"]
+    if plugin.get("prompts"):
+        manifest["prompts"] = [prompt["id"] for prompt in plugin["prompts"]]
     return manifest
 
 
@@ -107,7 +125,7 @@ def codex_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
         "interface": {
             "displayName": plugin["displayName"],
             "shortDescription": plugin["description"],
-            "longDescription": plugin["skill"]["description"],
+            "longDescription": plugin.get("skill", {}).get("description", plugin["description"]),
             "developerName": "OpenCoven",
             "category": plugin["category"],
             "capabilities": plugin.get("keywords", []),
@@ -125,8 +143,11 @@ def package_files(catalog: dict[str, Any]) -> dict[Path, str]:
         # files that should remain the source of truth. Their manifests and
         # exports are still generated from catalog.json, but sync must not
         # replace the authored skill body with the compact fallback template.
-        if plugin.get("skill", {}).get("managed") != "manual":
+        # Prompt packs may carry no skill at all — skip the SKILL.md then.
+        if plugin.get("skill") and plugin["skill"].get("managed") != "manual":
             files[package_dir / "skills" / plugin["name"] / "SKILL.md"] = skill_markdown(plugin)
+        for prompt in plugin.get("prompts", []):
+            files[package_dir / "prompts" / f"{prompt['id']}.md"] = prompt_markdown(prompt)
         files[package_dir / ".codex-plugin" / "plugin.json"] = dump_json(codex_manifest(plugin))
     return files
 

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -70,6 +70,7 @@ const KIND_TABS: ReadonlyArray<{ id: KindFilter; label: string }> = [
   { id: "api", label: "APIs" },
   { id: "mcp", label: "MCP servers" },
   { id: "skill", label: "Skills" },
+  { id: "prompt", label: "Prompts" },
 ];
 
 const SORT_OPTIONS: ReadonlyArray<{ id: SortKey; label: string }> = [

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -28,12 +28,14 @@ type Props = {
 function kindIcon(kind: MarketplacePlugin["kind"]) {
   if (kind === "mcp") return "ph:plug-bold";
   if (kind === "api") return "ph:cloud-bold";
+  if (kind === "prompt") return "ph:chat-centered-text";
   return "ph:sparkle-bold";
 }
 
 function kindLabel(kind: MarketplacePlugin["kind"]) {
   if (kind === "mcp") return "MCP";
   if (kind === "api") return "API";
+  if (kind === "prompt") return "Prompts";
   return "Skill";
 }
 

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -27,12 +27,14 @@ type Props = {
 function kindIcon(kind: MarketplacePlugin["kind"]) {
   if (kind === "mcp") return "ph:plug-bold";
   if (kind === "api") return "ph:cloud-bold";
+  if (kind === "prompt") return "ph:chat-centered-text";
   return "ph:sparkle-bold";
 }
 
 function kindLabel(kind: MarketplacePlugin["kind"]) {
   if (kind === "mcp") return "MCP server";
   if (kind === "api") return "API";
+  if (kind === "prompt") return "Prompt pack";
   return "Skill";
 }
 
@@ -183,6 +185,19 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
                 <span key={c} className="rounded-md border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)]">{c}</span>
               ))}
             </div>
+          </Section>
+        ) : null}
+
+        {plugin.prompts?.length ? (
+          <Section title="Prompt templates">
+            <div className="flex flex-wrap gap-1.5">
+              {plugin.prompts.map((p) => (
+                <span key={p} className="rounded-md border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)]">{p}</span>
+              ))}
+            </div>
+            <p className="mt-1.5 text-[12px] text-[var(--text-muted)]">
+              Added templates appear in chat under /prompts and the Prompt snippets picker.
+            </p>
           </Section>
         ) : null}
 

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -170,6 +170,16 @@ assert.equal(remoteMerged[0].remoteUrl, "https://mcp.linear.app/mcp");
 const ghRow = merged.find((p) => p.id === "github");
 assert.equal(ghRow.remoteUrl, undefined); // command-only mcpServer (no url) -> undefined
 
+// --- prompt packs: manifest prompts thread through to the card model ---
+const packMerged = mergeCatalog(
+  [{ name: "prompt-pack-essentials", displayName: "Prompt Pack: Essentials", category: "Productivity", trust: "official-local", policy: { installation: "AVAILABLE", authentication: "NONE" } }],
+  { "prompt-pack-essentials": { prompts: ["debug-this", "write-tests"] } },
+  {},
+);
+assert.equal(packMerged[0].kind, "prompt");
+assert.deepEqual(packMerged[0].prompts, ["debug-this", "write-tests"]);
+assert.equal(ghRow.prompts, undefined); // non-pack cards carry no prompts field
+
 // --- deriveKind ---
 assert.equal(deriveKind({ mcpServers: { x: { command: "npx" } } }), "mcp");
 assert.equal(deriveKind({ mcpServers: { x: { url: "https://e.x/mcp" } } }), "mcp");
@@ -177,6 +187,10 @@ assert.equal(deriveKind({ capabilities: ["network", "api"] }), "api");
 assert.equal(deriveKind({ keywords: ["api", "search"] }), "api");
 assert.equal(deriveKind({ mcpServers: {} }), "skill");
 assert.equal(deriveKind({}), "skill");
+assert.equal(deriveKind({ prompts: ["debug-this"] }), "prompt");
+assert.equal(deriveKind({ prompts: [] }), "skill"); // empty pack -> not a prompt kind
+// An MCP server wins over shipped prompts — the server defines the runtime shape.
+assert.equal(deriveKind({ prompts: ["a"], mcpServers: { x: { command: "npx" } } }), "mcp");
 assert.equal(merged.find((p) => p.id === "legacy").kind, "skill"); // no manifest -> skill
 
 // --- filterPlugins: kind + ids ---
@@ -187,14 +201,14 @@ assert.deepEqual(filterPlugins(merged, { ids: ["github", "legacy"] }).map((p) =>
 assert.deepEqual(filterPlugins(merged, { ids: ["github"], kind: "skill" }).map((p) => p.id), []);
 
 // --- countByKind ---
-assert.deepEqual(countByKind(merged), { api: 1, mcp: 2, skill: 1 });
+assert.deepEqual(countByKind(merged), { api: 1, mcp: 2, skill: 1, prompt: 0 });
 
 // --- groupPluginsByCategory ---
 const groups = groupPluginsByCategory(merged);
 assert.deepEqual(groups.map((g) => g.category), ["Developer Tools", "Other", "Web"]);
 assert.deepEqual(groups[0].plugins.map((p) => p.id), ["fetch", "github"]);
-assert.deepEqual(groups[0].counts, { api: 0, mcp: 2, skill: 0 });
-assert.deepEqual(groups.find((g) => g.category === "Web")?.counts, { api: 1, mcp: 0, skill: 0 });
+assert.deepEqual(groups[0].counts, { api: 0, mcp: 2, skill: 0, prompt: 0 });
+assert.deepEqual(groups.find((g) => g.category === "Web")?.counts, { api: 1, mcp: 0, skill: 0, prompt: 0 });
 
 // --- sortPlugins (returns a new array, never mutates) ---
 const before = merged.map((p) => p.id);
@@ -269,6 +283,18 @@ for (const [label, source] of [
   ["marketplace catalog-config", marketplaceCatalogConfig],
 ]) {
   assert.match(source, /sanitizeMarketplacePlugins/, `${label} should resolve ids through the familiar-safe marketplace catalog`);
+}
+
+// --- production prompt pack: card derives kind "prompt", template files exist ---
+const packCard = sanitizedProductionCards.find((p) => p.id === "prompt-pack-essentials");
+assert.ok(packCard, "prompt-pack-essentials should be a marketplace card");
+assert.equal(packCard.kind, "prompt");
+assert.ok((packCard.prompts?.length ?? 0) >= 5, "pack card lists its template ids");
+for (const pid of packCard.prompts ?? []) {
+  // Each declared template must exist where /api/prompts scans installed packs.
+  const md = readFileSync(new URL(`../../marketplace/plugins/prompt-pack-essentials/prompts/${pid}.md`, import.meta.url), "utf8");
+  assert.match(md, /^---\nname: /, `${pid}.md carries scanner-readable frontmatter`);
+  assert.ok(md.split("---")[2]?.trim().length > 0, `${pid}.md has a body to insert`);
 }
 
 console.log("marketplace-catalog.test.ts: ok");

--- a/src/lib/marketplace-catalog.ts
+++ b/src/lib/marketplace-catalog.ts
@@ -38,6 +38,10 @@ export type PluginManifest = {
   capabilities?: string[];
   userConfig?: Record<string, PluginUserConfigField>;
   mcpServers?: Record<string, { url?: string; type?: string; command?: string }>;
+  /** Prompt-template ids shipped by this plugin (a prompt pack). The files
+   *  live at marketplace/plugins/<id>/prompts/<pid>.md and are resolved by
+   *  /api/prompts at scan time once the pack is installed. */
+  prompts?: string[];
 };
 
 export type RequiredConfigField = {
@@ -83,7 +87,7 @@ export function remoteUrlFromManifest(manifest: PluginManifest): string | undefi
 
 export type InstalledMap = Record<string, { version: string; source: string; installedAt: string }>;
 
-export type PluginKind = "api" | "mcp" | "skill";
+export type PluginKind = "api" | "mcp" | "skill" | "prompt";
 
 export type MarketplacePlugin = {
   id: string;
@@ -106,17 +110,21 @@ export type MarketplacePlugin = {
   requiredConfig: RequiredConfigField[];
   configured: boolean;
   remoteUrl?: string;
+  /** Prompt-template ids for kind "prompt" packs (listed in the detail pane). */
+  prompts?: string[];
 };
 
 /**
  * "mcp" when the manifest declares any MCP server (stdio command or remote
- * url); "api" when it represents an HTTP/API-backed integration without an
- * MCP server; otherwise "skill" — a first-party procedure that runs inside
- * Coven Cave without an external server.
+ * url); "prompt" when it ships prompt templates (a prompt pack); "api" when
+ * it represents an HTTP/API-backed integration without an MCP server;
+ * otherwise "skill" — a first-party procedure that runs inside Coven Cave
+ * without an external server.
  */
 export function deriveKind(manifest: PluginManifest): PluginKind {
   const servers = manifest.mcpServers ?? {};
   if (Object.keys(servers).length > 0) return "mcp";
+  if ((manifest.prompts?.length ?? 0) > 0) return "prompt";
   const tags = [...(manifest.capabilities ?? []), ...(manifest.keywords ?? [])]
     .map((value) => value.toLowerCase());
   return tags.includes("api") ? "api" : "skill";
@@ -194,6 +202,7 @@ export function mergeCatalog(
         requiredConfig,
         configured: false,
         remoteUrl: remoteUrlFromManifest(manifest),
+        ...(manifest.prompts?.length ? { prompts: manifest.prompts } : {}),
       };
     })
     .sort((a, b) => a.displayName.localeCompare(b.displayName));
@@ -266,22 +275,24 @@ export function sortPlugins(plugins: MarketplacePlugin[], sort: SortKey): Market
   );
 }
 
-export function countByKind(plugins: MarketplacePlugin[]): { api: number; mcp: number; skill: number } {
+export function countByKind(plugins: MarketplacePlugin[]): { api: number; mcp: number; skill: number; prompt: number } {
   let api = 0;
   let mcp = 0;
   let skill = 0;
+  let prompt = 0;
   for (const p of plugins) {
     if (p.kind === "api") api += 1;
     else if (p.kind === "mcp") mcp += 1;
+    else if (p.kind === "prompt") prompt += 1;
     else skill += 1;
   }
-  return { api, mcp, skill };
+  return { api, mcp, skill, prompt };
 }
 
 export type MarketplaceCategoryGroup = {
   category: string;
   plugins: MarketplacePlugin[];
-  counts: { api: number; mcp: number; skill: number };
+  counts: { api: number; mcp: number; skill: number; prompt: number };
 };
 
 export function groupPluginsByCategory(plugins: MarketplacePlugin[]): MarketplaceCategoryGroup[] {


### PR DESCRIPTION
## What

Prompt templates become installable marketplace content (follow-up to #2523, which added the chat-side `/prompt` picker and `GET /api/prompts`):

- **`PluginKind` gains `"prompt"`** — `deriveKind()` returns it for manifests shipping `prompts[]` (an MCP server still wins precedence); `countByKind`/category counts, the Browse **"Prompts"** kind tab, card/detail icon + label (`ph:chat-centered-text`, "Prompts"/"Prompt pack"), and a detail-pane section listing the pack's template ids with a hint that they land under `/prompts` in chat.
- **`prompt-pack-essentials`** authored in `marketplace/catalog.json` (Productivity, official-local): `debug-this`, `write-tests`, `refactor-safely`, `pr-description`, `release-notes`.
- **`sync-marketplace.py`** now emits `plugins/<id>/prompts/<pid>.md` in exactly the frontmatter shape `src/lib/server/prompt-scan.ts` reads, adds `manifest.prompts` ids, and no longer assumes every plugin ships a skill (`skill_markdown` guarded; codex `longDescription` falls back to the plugin description). Regeneration is surgical — existing plugin output is byte-identical; `--check` passes.
- **Install stays track-only**: `/api/prompts` (#2523) resolves installed packs at scan time from `marketplace/plugins/<id>/prompts/`, so uninstall/upgrade need no file cleanup.

## Verification

- `pnpm typecheck`, full `pnpm test:app` (539) + `pnpm test:api` (118) green.
- `marketplace-catalog.test.ts` extended: deriveKind prompt cases + precedence, countByKind/group shapes with `prompt`, mergeCatalog prompts threading, and production assertions that the pack card derives kind `prompt` and every declared template file exists with scanner-readable frontmatter + body.
- `python3 scripts/sync-marketplace.py --check` → `marketplace_ok files=345 plugins=118`.

End-to-end install → `/prompts` in chat will be smoke-checked on main once this and #2523 are both merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)