### PR TITLE
fix(code): unclip fullscreen rail, persist IDE layout, launchpad empty preview (cave-nv3)

### DIFF
--- a/src/components/rail-file-preview.tsx
+++ b/src/components/rail-file-preview.tsx
@@ -19,6 +19,11 @@ type Loaded =
   | { kind: "text"; content: string; size: number }
   | { kind: "image"; dataUrl: string; mimeType: string; size: number };
 
+type ChangedFile = { path: string; status: string; insertions?: number; deletions?: number };
+
+/** How many changed files the empty-state launchpad lists. */
+const LAUNCHPAD_CAP = 6;
+
 const MARKDOWN_EXTS = new Set(["md", "mdx", "markdown"]);
 
 function isMarkdownPath(path: string): boolean {
@@ -52,10 +57,14 @@ export function RailFilePreview({
   path,
   projectRoot,
   familiarId,
+  onOpenPath,
 }: {
   path: string | null;
   projectRoot: string | null;
   familiarId?: string | null;
+  /** Open a file from the empty state's changed-file launchpad (repo-relative
+   *  paths are resolved by the owner, same as focusPath events). */
+  onOpenPath?: (path: string) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -68,6 +77,27 @@ export function RailFilePreview({
   const [justSaved, setJustSaved] = useState(false);
   const [copied, setCopied] = useState(false);
   const { announce } = useAnnouncer();
+
+  // Empty-state launchpad: with nothing selected, the (otherwise dead) main
+  // pane offers the working tree's changed files as one-click opens. Fetched
+  // once each time the preview returns to empty — the same status endpoint the
+  // changes badge polls, so this adds no new backend surface.
+  const [changed, setChanged] = useState<ChangedFile[]>([]);
+  useEffect(() => {
+    if (path || !projectRoot || !onOpenPath) return;
+    let cancelled = false;
+    void fetch(`/api/changes?projectRoot=${encodeURIComponent(projectRoot)}`, { cache: "no-store" })
+      .then(async (res) => {
+        const json = (await res.json()) as { ok?: boolean; files?: ChangedFile[] };
+        if (cancelled || !json.ok || !Array.isArray(json.files)) return;
+        // Deleted files have nothing to preview — opening one would just 404.
+        setChanged(json.files.filter((f) => f.status !== "deleted").slice(0, LAUNCHPAD_CAP));
+      })
+      .catch(() => {
+        /* status is a garnish here — the plain hint still renders */
+      });
+    return () => { cancelled = true; };
+  }, [path, projectRoot, onOpenPath]);
 
   useEffect(() => {
     if (!path) {
@@ -184,7 +214,35 @@ export function RailFilePreview({
     return (
       <div className="workspace-rail__files-empty">
         <Icon name="ph:file" width={22} aria-hidden />
-        <p>Select a file to preview it here.</p>
+        <p>Select a file from the tree to preview it here.</p>
+        {onOpenPath && changed.length > 0 ? (
+          <div className="workspace-rail__empty-changes">
+            <p className="workspace-rail__empty-changes-title">Or pick up where the work is:</p>
+            <ul className="workspace-rail__empty-changes-list">
+              {changed.map((f) => (
+                <li key={f.path}>
+                  <button
+                    type="button"
+                    className="focus-ring workspace-rail__empty-change"
+                    onClick={() => onOpenPath(f.path)}
+                    title={f.path}
+                  >
+                    <Icon name="ph:git-diff" width={11} aria-hidden />
+                    <span className="workspace-rail__empty-change-name">{fileName(f.path)}</span>
+                    <span className="workspace-rail__empty-change-dir">
+                      {f.path.includes("/") ? f.path.slice(0, f.path.lastIndexOf("/")) : ""}
+                    </span>
+                    {typeof f.insertions === "number" || typeof f.deletions === "number" ? (
+                      <span className="workspace-rail__empty-change-stat">
+                        +{f.insertions ?? 0} −{f.deletions ?? 0}
+                      </span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
       </div>
     );
   }

--- a/src/components/rail-files-panel.test.ts
+++ b/src/components/rail-files-panel.test.ts
@@ -9,7 +9,7 @@ const preview = readFileSync(new URL("./rail-file-preview.tsx", import.meta.url)
 assert.match(panel, /export function RailFilesPanel\(/, "exports RailFilesPanel");
 assert.match(panel, /import \{ ProjectTree \} from "@\/components\/project-tree"/, "imports ProjectTree");
 assert.match(panel, /import \{ RailFilePreview \} from "@\/components\/rail-file-preview"/, "imports RailFilePreview");
-assert.match(panel, /import \{ Group, Panel, Separator \} from "react-resizable-panels"/, "fullscreen Files uses resizable panels");
+assert.match(panel, /import \{ Group, Panel, Separator, useDefaultLayout \} from "react-resizable-panels"/, "fullscreen Files uses resizable panels with layout persistence");
 assert.match(panel, /import \{ SeparatorHandle \} from "@\/components\/ui\/separator-handle"/, "fullscreen Files uses the shared resize handle");
 assert.match(panel, /import \{ SessionChangesPanel \} from "@\/components\/session-changes-panel"/, "fullscreen Files includes a far-right diffs panel");
 assert.match(panel, /isFullscreen = false/, "RailFilesPanel accepts a fullscreen layout flag");
@@ -25,6 +25,24 @@ assert.match(panel, /id="workspace-rail-files-editor"[\s\S]*?minSize="36%"[\s\S]
 assert.match(panel, /id="workspace-rail-files-diffs"[\s\S]*?defaultSize="340px"[\s\S]*?minSize="280px"[\s\S]*?SessionChangesPanel/, "diffs/changes are the far-right pane");
 assert.match(panel, /if \(!projectRoot\)/, "handles the null-projectRoot state");
 assert.match(panel, /No project linked/, "renders a muted no-project state");
+
+// The IDE split persists across sessions: id + all three panel ids registered,
+// and the layout props actually reach the Group.
+assert.match(panel, /id: "workspace-rail-files-ide"/, "the IDE layout persists under a stable id");
+assert.match(
+  panel,
+  /panelIds: \["workspace-rail-files-tree", "workspace-rail-files-editor", "workspace-rail-files-diffs"\]/,
+  "all three panes are registered for persistence",
+);
+assert.match(
+  panel,
+  /defaultLayout=\{defaultLayout\}\s+onLayoutChanged=\{onLayoutChanged\}/,
+  "the fullscreen Group restores and saves its layout",
+);
+// The preview's launchpad hands back repo-relative paths; the panel resolves
+// them against the project root (same normalization as focusPath events).
+assert.match(panel, /onOpenPath=\{openPath\}/, "the preview can open paths (launchpad)");
+assert.match(panel, /const openPath = useCallback/, "launchpad paths resolve through one helper");
 
 // ─── rail-file-preview.tsx (view + inline edit) ──────────────────────────────
 assert.match(preview, /export function RailFilePreview\(/, "exports RailFilePreview");
@@ -42,5 +60,26 @@ assert.match(preview, /const editable = file\?\.kind === "text" && !fileName\(pa
 assert.match(preview, /savingRef/, "in-flight guard blocks concurrent saves (Cmd-S vs button)");
 assert.match(preview, /onClick=\{startEditing\}/, "exposes an Edit affordance");
 assert.match(preview, /useAnnouncer/, "announces save success/failure to assistive tech");
+
+// Empty-state launchpad: the main pane offers changed files as one-click
+// opens instead of sitting dead until the tree is used.
+assert.match(preview, /\/api\/changes\?projectRoot=/, "the empty state fetches the working-tree status");
+assert.match(preview, /f\.status !== "deleted"/, "deleted files are excluded — nothing to preview");
+assert.match(preview, /const LAUNCHPAD_CAP = 6/, "the launchpad caps its list");
+assert.match(preview, /onClick=\{\(\) => onOpenPath\(f\.path\)\}/, "each changed file opens in the preview");
+assert.match(preview, /if \(path \|\| !projectRoot \|\| !onOpenPath\) return/, "the status fetch only runs for an empty, openable preview");
+
+// ─── cave-chat.css: fullscreen sizes to its containing block ─────────────────
+// .cave-mode-fade retains a transform (animation-fill-mode: both), so the mode
+// wrapper — not the viewport — is the containing block for the fixed rail.
+// width:100vw on top of that offset pushed the diffs pane off-screen; the rule
+// must size via inset alone. Root cause tracked as bead cave-cco.
+const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
+const fullscreenBlock = css.slice(
+  css.indexOf(".workspace-rail--fullscreen {"),
+  css.indexOf("}", css.indexOf(".workspace-rail--fullscreen {")),
+);
+assert.match(fullscreenBlock, /inset: 0/, "fullscreen fills via inset");
+assert.doesNotMatch(fullscreenBlock, /100vw|100vh/, "fullscreen never sizes to the viewport (containing-block offset would clip the right pane)");
 
 console.log("rail-files-panel.test.ts OK");

--- a/src/components/rail-files-panel.tsx
+++ b/src/components/rail-files-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Group, Panel, Separator } from "react-resizable-panels";
+import { useCallback, useEffect, useState } from "react";
+import { Group, Panel, Separator, useDefaultLayout } from "react-resizable-panels";
 import { Icon } from "@/lib/icon";
 import { ProjectTree } from "@/components/project-tree";
 import { RailFilePreview } from "@/components/rail-file-preview";
@@ -32,6 +32,29 @@ export function RailFilesPanel({
 }) {
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
+  // The fullscreen IDE split (tree / editor / diffs) persists across sessions —
+  // same react-resizable-panels persistence the chat split uses.
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: "workspace-rail-files-ide",
+    panelIds: ["workspace-rail-files-tree", "workspace-rail-files-editor", "workspace-rail-files-diffs"],
+  });
+
+  // Open a path selected outside the tree (the preview's changed-file
+  // launchpad hands back repo-relative paths) — resolve against the root the
+  // same way focusPath events are.
+  const openPath = useCallback(
+    (path: string) => {
+      setSelectedPath(
+        path.startsWith("/")
+          ? path
+          : projectRoot
+            ? `${projectRoot.replace(/\/$/, "")}/${path.replace(/^\.?\//, "")}`
+            : path,
+      );
+    },
+    [projectRoot],
+  );
+
   // A new project resets the selection so a stale file from the previous repo
   // doesn't linger in the preview.
   useEffect(() => {
@@ -60,7 +83,12 @@ export function RailFilesPanel({
   if (isFullscreen) {
     return (
       <div className="workspace-rail__files workspace-rail__files--ide">
-        <Group className="workspace-rail__files-ide-group" orientation="horizontal">
+        <Group
+          className="workspace-rail__files-ide-group"
+          orientation="horizontal"
+          defaultLayout={defaultLayout}
+          onLayoutChanged={onLayoutChanged}
+        >
           <Panel
             id="workspace-rail-files-tree"
             className="workspace-rail__files-tree-pane"
@@ -87,7 +115,7 @@ export function RailFilesPanel({
             minSize="36%"
           >
             <div className="workspace-rail__files-preview workspace-rail__files-preview--ide">
-              <RailFilePreview path={selectedPath} projectRoot={projectRoot} familiarId={familiarId} />
+              <RailFilePreview path={selectedPath} projectRoot={projectRoot} familiarId={familiarId} onOpenPath={openPath} />
             </div>
           </Panel>
           <Separator className="workspace-rail__files-separator shell-separator">
@@ -119,7 +147,7 @@ export function RailFilesPanel({
         />
       </div>
       <div className="workspace-rail__files-preview">
-        <RailFilePreview path={selectedPath} projectRoot={projectRoot} familiarId={familiarId} />
+        <RailFilePreview path={selectedPath} projectRoot={projectRoot} familiarId={familiarId} onOpenPath={openPath} />
       </div>
     </div>
   );

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4522,12 +4522,19 @@ details[open] > .cave-tool-summary::before {
   background: var(--bg-surface, var(--background));
 }
 
+/* Fullscreen fills its CONTAINING BLOCK via inset alone — no width/height.
+   .cave-mode-fade retains a transform after its entrance animation
+   (animation-fill-mode: both), so every mode wrapper is the containing block
+   for fixed descendants: the rail's origin sits AFTER the shell's icon rail.
+   With width:100vw stacked on that offset, the far-right diffs pane hung past
+   the window edge (clipped stat chips / cut "Diff" header). inset:0 sizes to
+   the containing block exactly — today the mode area (shell nav stays
+   reachable), and still correct if the retained transform ever goes away
+   (falls back to true viewport). Root cause tracked as bead cave-cco. */
 .workspace-rail--fullscreen {
   position: fixed;
   inset: 0;
   z-index: 80;
-  width: 100vw;
-  height: 100vh;
   background: var(--bg-base, var(--background));
   border: 0;
 }
@@ -4887,6 +4894,73 @@ details[open] > .cave-tool-summary::before {
   text-align: center;
   font-size: 12px;
   color: var(--text-muted);
+}
+
+/* Empty-state launchpad: the working tree's changed files as one-click opens,
+   so the main pane starts useful instead of dead space. Dashed = invitation. */
+.workspace-rail__empty-changes {
+  width: min(100%, 380px);
+  margin-top: 6px;
+  padding: 10px 12px;
+  border: 1px dashed var(--border-hairline);
+  border-radius: 10px;
+  text-align: left;
+}
+.workspace-rail__empty-changes-title {
+  margin: 0 0 6px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+.workspace-rail__empty-changes-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.workspace-rail__empty-change {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 4px 6px;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.workspace-rail__empty-change:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+.workspace-rail__empty-change > svg {
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+.workspace-rail__empty-change-name {
+  flex-shrink: 0;
+  font-weight: 500;
+}
+.workspace-rail__empty-change-dir {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  color: var(--text-muted);
+  font-size: 10.5px;
+}
+.workspace-rail__empty-change-stat {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
 }
 
 .workspace-rail__preview {


### PR DESCRIPTION
Optimizes the arrangement of the fullscreen code rail (the Files IDE view: tree / editor / diffs). Bead: cave-nv3. From a user screenshot showing the far-right worktree/diffs pane clipped off the window edge and a dead empty center pane.

## The clip (headline fix)

`.workspace-rail--fullscreen` sized itself with `position: fixed; inset: 0; width: 100vw; height: 100vh`. But `.cave-mode-fade` keeps a `transform: translateY(0)` forever after its entrance animation (`animation-fill-mode: both` retains the final keyframe), which makes every mode wrapper a **containing block for fixed descendants**. Measured live: the rail's origin sits at x=56 (after the shell's icon rail) while staying 1600px wide in a 1600px window — the diffs pane's right 56px (stat chips, half the "Diff" header, revert buttons, scrollbar) hung off-screen.

Fix: size via `inset: 0` alone. The rail now fills its containing block exactly — the mode area today (shell nav stays visible and usable, which the old geometry already implied), and degrades correctly to true viewport if the retained transform ever goes away. The same root cause previously forced the github-view card to portal to body; filed as **cave-cco** for a proper audit (changing the mode-fade keyframe shifts every fixed element inside surfaces from mode-relative to viewport-relative, so it deserves its own pass).

## Layout persistence

The tree/editor/diffs split now persists via `useDefaultLayout` from react-resizable-panels (id `workspace-rail-files-ide`), the same mechanism the chat split uses. Pane widths survive exiting/re-entering fullscreen and reloads. Verified live: tree dragged 280→370px, exit + re-enter → restored at 370px.

## Launchpad empty state

With no file selected the main pane used to be dead space with a one-line hint. It now also lists the working tree's changed files (from the existing `/api/changes?projectRoot=` status route — no new backend) as one-click opens: name, directory (tail-truncated), +ins/−del. Deleted files are excluded (nothing to preview), capped at 6, dashed-border invitation per the design language. `RailFilePreview` gains an optional `onOpenPath` prop; `RailFilesPanel` resolves repo-relative paths the same way focusPath events are resolved.

## Verification

- `tsc` clean · 540 app test files green (pins added: persistence wiring, launchpad behavior, and a CSS pin asserting the fullscreen block never reintroduces `100vw/100vh`) · build within bundle budget
- Live Playwright on a prod build with real data: `railRight === innerWidth` (was innerWidth+56), diffs pane fully visible at 340px, persistence round-trip, launchpad lists `.beads/interactions.jsonl +35 −0` and opens it on click
- Screenshot confirms the previously clipped FILE/DIFF headers, stat chips, checkpoints section, and commit box are all fully on-screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)