### PR TITLE
feat(ios): offline compose — queue prose while disconnected, replay on reconnect (cave-u6k)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -695,6 +695,7 @@ final class AppModel {
         guard connection != nil, connectionState == .connected else { return }
         if let client, await client.ping() {
             await refreshAccessTokenIfNeeded()
+            flushQueuedMessages()
             return
         }
         guard connectionState == .connected else { return }
@@ -740,6 +741,7 @@ final class AppModel {
             }
             connectionState = .connected
             await refreshAccessTokenIfNeeded()
+            flushQueuedMessages()
             if reloadLoadedSurfaces {
                 await refreshLoadedSurfaces()
             } else {
@@ -750,6 +752,28 @@ final class AppModel {
             connectionState = .needsAuth(pairingMessage())
         case .none:
             connectionState = .unreachable("Couldn’t reach the desktop. Is it on the tailnet and running?")
+        }
+    }
+
+    /// Send every message composed while offline, oldest first per thread,
+    /// now that the desktop is reachable again. Fire-and-forget: replies
+    /// stream in like any send, and a re-drop mid-flush re-queues cleanly
+    /// (the next reconnect picks it back up). Guarded so overlapping
+    /// reconnect signals (foreground probe + path monitor) flush once.
+    private var flushingQueued = false
+    func flushQueuedMessages() {
+        guard let client, !flushingQueued else { return }
+        let pending = threads.filter { thread in thread.messages.contains { $0.isQueued } }
+        guard !pending.isEmpty else { return }
+        flushingQueued = true
+        Task {
+            defer { flushingQueued = false }
+            for thread in pending {
+                await thread.replayQueued(client: client) { [weak self] in
+                    guard let self else { return }
+                    self.touch(thread)
+                }
+            }
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -16,6 +16,11 @@ struct DisplayMessage: Identifiable, Codable, Hashable {
     var createdAt: Date = Date()
     /// Image attachments sent with this (user) message, as `data:` URLs.
     var attachmentDataUrls: [String] = []
+    /// Composed while the desktop was unreachable; waiting for reconnect.
+    /// Optional so messages persisted before offline compose still decode.
+    var queued: Bool?
+
+    var isQueued: Bool { queued == true }
 }
 
 /// Plain Codable snapshot used for on-disk persistence.
@@ -101,8 +106,9 @@ final class ChatThread: Identifiable, Hashable {
             $0.isEmpty ? nil : $0
         } ?? trimmed
 
-        messages.append(DisplayMessage(role: .user, familiarId: nil, text: shown,
-                                       attachmentDataUrls: attachments.map(\.dataUrl)))
+        let userMessage = DisplayMessage(role: .user, familiarId: nil, text: shown,
+                                         attachmentDataUrls: attachments.map(\.dataUrl))
+        messages.append(userMessage)
         updatedAt = Date()
         onChange()
 
@@ -113,7 +119,61 @@ final class ChatThread: Identifiable, Hashable {
             let messageId = placeholder.id
             Task { await self.stream(familiarId: familiarId, prompt: trimmed,
                                      attachments: attachments, into: messageId,
+                                     userMessageId: userMessage.id,
                                      client: client, onChange: onChange) }
+        }
+    }
+
+    /// Offline compose: park the prose on the thread as a `queued` user
+    /// message — no placeholder bubbles, nothing touches the network. It
+    /// persists with the thread and `replayQueued` sends it on the next
+    /// reconnect. Prose only: slash commands never route here.
+    func enqueue(_ text: String, attachments: [CaveClient.ChatAttachment] = []) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || !attachments.isEmpty else { return }
+        var message = DisplayMessage(role: .user, familiarId: nil, text: trimmed,
+                                     attachmentDataUrls: attachments.map(\.dataUrl))
+        message.queued = true
+        messages.append(message)
+        updatedAt = Date()
+    }
+
+    /// Send every queued (offline-composed) message through the normal
+    /// fan-out, oldest first, now that the desktop is reachable. Before
+    /// re-sending, ask the server whether the turn already landed — the
+    /// original send may have reached it right as the transport died — and
+    /// adopt the existing reply instead of doubling the turn. Sequential so
+    /// turns land in compose order; a re-drop mid-replay re-queues through
+    /// the stream error path and the next reconnect picks it back up.
+    func replayQueued(client: CaveClient, onChange: @escaping () -> Void) async {
+        guard !replayingQueued else { return }
+        replayingQueued = true
+        defer { replayingQueued = false }
+        while let queuedMessage = messages.first(where: { $0.isQueued }) {
+            let queuedId = queuedMessage.id
+            let prompt = queuedMessage.text
+            let attachments = Self.attachments(fromDataUrls: queuedMessage.attachmentDataUrls)
+            mutate(queuedId) { $0.queued = false }
+            updatedAt = Date()
+            onChange()
+            for familiarId in familiarIds {
+                if await adoptServerTurnIfPresent(prompt: prompt, familiarId: familiarId,
+                                                  client: client) {
+                    onChange()
+                    continue
+                }
+                let placeholder = DisplayMessage(role: .assistant, familiarId: familiarId,
+                                                 text: "", streaming: true)
+                // Replies slot in before any still-queued later prompts so the
+                // transcript keeps compose order.
+                let insertAt = messages.firstIndex(where: { $0.isQueued }) ?? messages.endIndex
+                messages.insert(placeholder, at: insertAt)
+                await stream(familiarId: familiarId, prompt: prompt,
+                             attachments: attachments, into: placeholder.id,
+                             userMessageId: queuedId, client: client, onChange: onChange)
+                // Re-queued mid-replay (offline again) — stop; don't spin.
+                if messages.first(where: { $0.id == queuedId })?.isQueued == true { return }
+            }
         }
     }
 
@@ -186,14 +246,19 @@ final class ChatThread: Identifiable, Hashable {
         updatedAt = Date()
     }
 
+    private var replayingQueued = false
+
     private func stream(familiarId: String, prompt: String,
                         attachments: [CaveClient.ChatAttachment] = [], into messageId: String,
+                        userMessageId: String? = nil,
                         client: CaveClient, onChange: @escaping () -> Void) async {
         let body = CaveClient.SendBody(familiarId: familiarId, prompt: prompt,
                                        sessionId: sessionIds[familiarId],
                                        attachments: attachments.isEmpty ? nil : attachments)
+        var receivedAnyEvent = false
         do {
             for try await event in client.sendStream(body) {
+                receivedAnyEvent = true
                 switch event {
                 case .session(let sid):
                     if !sid.isEmpty { sessionIds[familiarId] = sid }
@@ -221,9 +286,20 @@ final class ChatThread: Identifiable, Hashable {
             let recovered = await resyncInterruptedTurn(familiarId: familiarId, prompt: prompt,
                                                         into: messageId, client: client)
             if !recovered {
-                mutate(messageId) {
-                    if $0.text.isEmpty { $0.text = error.localizedDescription }
-                    $0.isError = true; $0.streaming = false
+                if let userMessageId, !receivedAnyEvent, Self.isOfflineTransportError(error) {
+                    // The send never reached the server (no route, DNS failure,
+                    // refused connection — and not a single SSE event came
+                    // back): queue the prompt for the next reconnect instead
+                    // of dead-ending in a red bubble. Ambiguous failures
+                    // (timeouts, drops after first byte) stay on the error
+                    // path — replaying those could double the turn.
+                    messages.removeAll { $0.id == messageId }
+                    mutate(userMessageId) { $0.queued = true }
+                } else {
+                    mutate(messageId) {
+                        if $0.text.isEmpty { $0.text = error.localizedDescription }
+                        $0.isError = true; $0.streaming = false
+                    }
                 }
             }
         }
@@ -256,6 +332,56 @@ final class ChatThread: Identifiable, Hashable {
             $0.streaming = false
         }
         return true
+    }
+
+    /// Connect-level failures where the request provably never reached the
+    /// server — safe to queue without risking a duplicate turn. Anything
+    /// ambiguous (timeouts, drops after first byte) is excluded: for those
+    /// the resync/error path decides.
+    nonisolated static func isOfflineTransportError(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .notConnectedToInternet, .cannotFindHost, .cannotConnectToHost,
+             .dnsLookupFailed, .networkConnectionLost, .dataNotAllowed,
+             .internationalRoamingOff:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// True when the conversation's tail already carries this exact prompt —
+    /// the original send made it through before the transport died, so
+    /// replaying would double the turn. Adopts the server's reply (when the
+    /// harness already answered) into the transcript. New sessions can't
+    /// have the turn.
+    private func adoptServerTurnIfPresent(prompt: String, familiarId: String,
+                                          client: CaveClient) async -> Bool {
+        guard let sessionId = sessionIds[familiarId], !sessionId.isEmpty else { return false }
+        guard let convo = try? await client.conversation(sessionId: sessionId),
+              let lastUser = convo.turns.lastIndex(where: { $0.role == "user" }),
+              convo.turns[lastUser].text == prompt else { return false }
+        if let reply = convo.turns[(lastUser + 1)...].last(where: { $0.role == "assistant" }) {
+            let insertAt = messages.firstIndex(where: { $0.isQueued }) ?? messages.endIndex
+            messages.insert(DisplayMessage(role: .assistant, familiarId: familiarId,
+                                           text: reply.text, isError: reply.isError ?? false),
+                            at: insertAt)
+            updatedAt = Date()
+        }
+        return true
+    }
+
+    /// Rebuild sendable attachments from persisted `data:` URLs (the only
+    /// attachment form a queued message keeps). Names are synthesized — the
+    /// server only needs the mime type and payload.
+    nonisolated static func attachments(fromDataUrls dataUrls: [String]) -> [CaveClient.ChatAttachment] {
+        dataUrls.enumerated().map { index, dataUrl in
+            let mime = dataUrl.dropFirst("data:".count).prefix(while: { $0 != ";" && $0 != "," })
+            let ext = mime.split(separator: "/").last.map(String.init) ?? "png"
+            return CaveClient.ChatAttachment(name: "queued-\(index + 1).\(ext)",
+                                             mimeType: mime.isEmpty ? "image/png" : String(mime),
+                                             dataUrl: dataUrl)
+        }
     }
 
     private func mutate(_ messageId: String, _ body: (inout DisplayMessage) -> Void) {

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -522,6 +522,15 @@ struct ChatView: View {
             pendingImages = []
             replyingTo = nil
             Haptics.tap()
+            // Offline compose: park the message on the thread instead of
+            // dead-ending in a transport error — it sends automatically on
+            // the next reconnect (AppModel.flushQueuedMessages).
+            if app.connectionState != .connected {
+                thread.enqueue(outgoing, attachments: attachments)
+                app.touch(thread)
+                app.showToast("Queued — sends when reconnected", systemImage: "clock")
+                return
+            }
             thread.send(outgoing, attachments: attachments, client: client) { app.touch(thread) }
         }
     }
@@ -529,6 +538,12 @@ struct ChatView: View {
     /// Tap a follow-up suggestion chip → send it as the next message.
     private func sendSuggestion(_ text: String) {
         guard let client = app.client else { return }
+        if app.connectionState != .connected {
+            thread.enqueue(text)
+            app.touch(thread)
+            app.showToast("Queued — sends when reconnected", systemImage: "clock")
+            return
+        }
         thread.send(text, client: client) { app.touch(thread) }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -232,6 +232,16 @@ struct MessageBubble: View {
                     .accessibilityLabel("Retry sending this message")
                 }
 
+                // Composed offline: a quiet clock chip, not an error — the
+                // message sends itself on the next reconnect.
+                if isUser, message.isQueued {
+                    Label("Queued — sends when reconnected", systemImage: "clock")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.trailing, 6)
+                        .accessibilityLabel("Queued. Sends when the desktop is reachable again.")
+                }
+
                 if !message.streaming {
                     Text(timestampText)
                         .font(.caption2)

--- a/scripts/ios-offline-compose.test.mjs
+++ b/scripts/ios-offline-compose.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Offline compose (cave-u6k): composing while the phone has no route to the
+// desktop used to dead-end in a transport error. Prose now parks on the
+// thread as a `queued` user message — persisted across restarts via the
+// normal thread snapshot — and replays through the ordinary send fan-out on
+// the next reconnect, with a server-tail check so a send that actually made
+// it through isn't doubled.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const thread = await read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const chatView = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+const bubble = await read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift");
+
+// --- Model: queued is an OPTIONAL Codable field (old snapshots must decode) --
+assert.match(
+  thread,
+  /var queued: Bool\?/,
+  "DisplayMessage.queued must be optional so pre-feature snapshots still decode",
+);
+assert.match(
+  thread,
+  /var isQueued: Bool \{ queued == true \}/,
+  "isQueued reads the optional safely",
+);
+
+// --- Compose path: offline branches to enqueue, never to the network --------
+assert.match(
+  chatView,
+  /if app\.connectionState != \.connected \{[\s\S]{0,220}?thread\.enqueue\(outgoing, attachments: attachments\)/,
+  "ChatView.send parks prose on the thread when disconnected",
+);
+assert.match(
+  chatView,
+  /showToast\("Queued — sends when reconnected", systemImage: "clock"\)/,
+  "queueing is announced with a toast",
+);
+assert.match(
+  chatView,
+  /if app\.connectionState != \.connected \{[\s\S]{0,120}?thread\.enqueue\(text\)/,
+  "suggestion chips queue offline too",
+);
+assert.match(
+  thread,
+  /func enqueue\(_ text: String, attachments: \[CaveClient\.ChatAttachment\] = \[\]\)/,
+  "ChatThread.enqueue exists for offline compose",
+);
+
+// --- Transport-failure conversion: only when provably unsent ----------------
+assert.match(
+  thread,
+  /if let userMessageId, !receivedAnyEvent, Self\.isOfflineTransportError\(error\)/,
+  "a failed send queues ONLY when no SSE event arrived and the error is connect-level",
+);
+assert.match(
+  thread,
+  /messages\.removeAll \{ \$0\.id == messageId \}\s*\n\s*mutate\(userMessageId\) \{ \$0\.queued = true \}/,
+  "queue-conversion removes the placeholder bubble and flags the user message",
+);
+assert.match(
+  thread,
+  /case \.notConnectedToInternet, \.cannotFindHost, \.cannotConnectToHost,\s*\n\s*\.dnsLookupFailed, \.networkConnectionLost, \.dataNotAllowed,\s*\n\s*\.internationalRoamingOff:/,
+  "offline classification is a closed connect-level set (timeouts excluded)",
+);
+assert.doesNotMatch(
+  thread,
+  /\.timedOut[\s\S]{0,80}?return true/,
+  "timeouts are ambiguous (the request may have reached the server) — never queue them",
+);
+
+// --- Replay: reconnect flush, in order, duplicate-safe -----------------------
+assert.match(
+  model,
+  /connectionState = \.connected\s*\n\s*await refreshAccessTokenIfNeeded\(\)\s*\n\s*flushQueuedMessages\(\)/,
+  "reconnect (refreshConnection .found) flushes the offline queue",
+);
+assert.match(
+  model,
+  /await refreshAccessTokenIfNeeded\(\)\s*\n\s*flushQueuedMessages\(\)\s*\n\s*return/,
+  "the foreground ping-success path flushes too",
+);
+assert.match(
+  model,
+  /guard let client, !flushingQueued else \{ return \}/,
+  "overlapping reconnect signals flush once",
+);
+assert.match(
+  thread,
+  /func replayQueued\(client: CaveClient, onChange: @escaping \(\) -> Void\) async/,
+  "ChatThread.replayQueued drives the reconnect send",
+);
+assert.match(
+  thread,
+  /if await adoptServerTurnIfPresent\(prompt: prompt, familiarId: familiarId,/,
+  "replay checks the server's conversation tail before re-sending (no duplicate turns)",
+);
+assert.match(
+  thread,
+  /convo\.turns\[lastUser\]\.text == prompt/,
+  "the duplicate check anchors on the exact prompt text",
+);
+assert.match(
+  thread,
+  /if messages\.first\(where: \{ \$0\.id == queuedId \}\)\?\.isQueued == true \{ return \}/,
+  "a re-drop mid-replay stops the flush instead of spinning",
+);
+
+// --- UI: queued reads as waiting, not as an error ----------------------------
+assert.match(
+  bubble,
+  /if isUser, message\.isQueued \{\s*\n\s*Label\("Queued — sends when reconnected", systemImage: "clock"\)/,
+  "queued user messages carry a quiet clock chip",
+);
+assert.match(
+  bubble,
+  /accessibilityLabel\("Queued\. Sends when the desktop is reachable again\."\)/,
+  "the queued state is announced to assistive tech",
+);
+
+console.log("ios-offline-compose.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -722,6 +722,7 @@ export const SUITES = {
     "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connection-stability.test.mjs",
     "scripts/ios-legacy-token-migration.test.mjs",
+    "scripts/ios-offline-compose.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-connect-screen-ux.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",


### PR DESCRIPTION
## What

Composing while the phone has no route to the desktop used to dead-end in a transport error (red bubble, prompt effectively lost to a manual retry). This PR gives iOS an offline compose story — **cave-u6k**, split from cave-id5.

### Design

- **Queued state lives on the message.** `DisplayMessage.queued: Bool?` (optional, so pre-feature snapshots keep decoding — the `archived: Bool?` idiom). Persistence across app restarts rides the existing `persistThreads()` snapshot; no new storage.
- **Two ways into the queue:**
  1. Composer branch: `connectionState != .connected` → `thread.enqueue(...)`, toast "Queued — sends when reconnected". Suggestion chips too.
  2. Transport conversion: a send that fails with a **connect-level URLError** (`notConnectedToInternet`, `cannotFindHost`, `cannotConnectToHost`, `dnsLookupFailed`, `networkConnectionLost`, `dataNotAllowed`, `internationalRoamingOff`) **before any SSE event arrived**, after the existing resync fails → placeholder bubble removed, user message flagged queued. Timeouts and post-first-byte drops deliberately stay on the resync/error path — those may have reached the server, and replaying could double the turn.
- **Replay on reconnect.** `AppModel.flushQueuedMessages()` fires from both reconnect completion points (`refreshConnection` `.found` branch — which also covers `connectWithRetry` and the NWPathMonitor recovery — and the foreground ping-success path), single-flight guarded. Per thread, queued messages replay **oldest-first, sequentially** through the normal send fan-out so turns land in compose order.
- **Duplicate safety.** Before re-sending, `adoptServerTurnIfPresent` checks the conversation tail: if the server's last user turn is exactly this prompt, the original send made it through — the existing reply is adopted into the transcript instead of re-sending. Going offline mid-replay re-queues via the same conversion path and halts the flush; the next reconnect resumes.
- **UI:** queued user bubbles carry a quiet clock chip with an a11y label — reads as waiting, not as an error.

### Scope notes

- Prose only — slash commands never reach the queue path.
- The Retry button on failed replies keeps its existing semantics (no offline conversion there); a retried bubble has different duplicate-risk anatomy.
- Attachments survive queueing as the persisted `data:` URLs; names are re-synthesized on replay (server only needs mime + payload).

## Verification

- New `scripts/ios-offline-compose.test.mjs` source pins (model optionality, closed offline-error set, zero-event guard, both flush sites, dup check, halt-on-redrop, chip a11y) — wired into the mobile suite
- Full gates: 72 mobile + 540 app test files green, `tsc --noEmit` clean, all 726 test files wired
- **Full iOS compile**: `xcodegen` + `xcodebuild -sdk iphonesimulator` build succeeded (catches type errors source pins can't)

🤖 Generated with [Claude Code](https://claude.com/claude-code)