### PR TITLE
feat(chat): skill discoverability + autofill — argument hints, Skills in the command menu (cave-4qv)

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -568,7 +568,7 @@ assert.doesNotMatch(
 
 // — CHAT-D2-01: slash menu keyboard contract ("↵ run · Tab complete · esc cancel") —
 const composerKey = source.match(/const onComposerKey = [\s\S]*?\n  \};/)?.[0] ?? "";
-const slashBranch = composerKey.match(/if \(slashSuggestions\.length > 0\) \{[\s\S]*?\n    \}/)?.[0] ?? "";
+const slashBranch = composerKey.match(/if \(slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0\) \{[\s\S]*?\n    \}/)?.[0] ?? "";
 
 assert.match(
   slashBranch,
@@ -952,7 +952,7 @@ assert.match(
 );
 assert.ok(
   mentionComposerKey.indexOf("if (mentionOpen) {") <
-    mentionComposerKey.indexOf("if (slashSuggestions.length > 0) {"),
+    mentionComposerKey.indexOf("if (slashSuggestions.length > 0 || skillCommandRows.length > 0) {"),
   "The mention branch must run before the slash branch in onComposerKey",
 );
 assert.ok(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -58,9 +58,10 @@ import { DebugPane } from "@/components/debug-pane";
 import { modelSlashOptions, resolveModelArg, formatModelList } from "@/lib/slash-model";
 import {
   skillSlashOptions,
-  resolveSkillArg,
+  resolveSkillInvocation,
   formatSkillList,
   buildSkillPrompt,
+  skillCommandMatches,
   type SkillOption,
 } from "@/lib/slash-skill";
 import {
@@ -2770,10 +2771,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     [input, prompts, slashDismissed],
   );
   const promptMenuActive = (promptOptions?.length ?? 0) > 0;
+  // Skills surfaced directly in the command menu — typing `/revi` finds the
+  // code-review skill without the /skill prefix. Same first-token-only rule as
+  // slashMatches so arg positions never double-render.
+  const skillCommandRows: SkillOption[] = useMemo(() => {
+    if (slashDismissed) return [];
+    const t = input.trimStart();
+    const firstWord = t.split(/\s/)[0] ?? "";
+    if (!firstWord.startsWith("/") || t.includes(" ")) return [];
+    return skillCommandMatches(firstWord, skills);
+  }, [input, skills, slashDismissed]);
   // The slash-command, /model, /skill and /prompt pickers are mutually
   // exclusive inline listboxes sharing one listbox id, so the composer's
   // combobox ARIA tracks whichever is open.
-  const menuOpen = modelMenuActive || skillMenuActive || promptMenuActive || slashSuggestions.length > 0;
+  const menuOpen = modelMenuActive || skillMenuActive || promptMenuActive || slashSuggestions.length > 0 || skillCommandRows.length > 0;
   // Stable per-mount listbox id — the home composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
   const slashListboxId = useId();
@@ -2947,9 +2958,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   }, [input]);
 
   useEffect(() => {
-    if (slashSuggestions.length === 0) return;
+    if (slashSuggestions.length === 0 && skillCommandRows.length === 0) return;
     activeSlashOptionRef.current?.scrollIntoView({ block: "nearest" });
-  }, [slashIdx, slashSuggestions.length]);
+  }, [slashIdx, slashSuggestions.length, skillCommandRows.length]);
 
   useEffect(() => {
     if (mentionMatches.length === 0) return;
@@ -3345,6 +3356,24 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     });
   };
 
+  // Invoke a picked skill (from the /skill picker or the command menu's Skills
+  // group). A skill with an argument-hint autofills `/skill <id> ` so the user
+  // can type arguments; picking again on the filled text (or a hint-less
+  // skill) sends the invocation directive. Mirrors the command menu's
+  // autocomplete-then-run Enter pattern.
+  const invokeSkillOption = (s: SkillOption) => {
+    const filled = `/skill ${s.id}`;
+    if (s.argumentHint && input.trim().toLowerCase() !== filled.toLowerCase()) {
+      setInput(`${filled} `);
+      inputRef.current?.focus();
+      return;
+    }
+    setInput("");
+    setSlashIdx(0);
+    setTimeout(() => sendRaw(buildSkillPrompt(s)), 0);
+    inputRef.current?.focus();
+  };
+
   const intentFromSlash = (raw: string): boolean => {
     const trimmed = raw.trim();
     if (!trimmed.startsWith("/")) return false;
@@ -3394,16 +3423,23 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         setInput("");
         return true;
       }
-      const skill = resolveSkillArg(args, skills);
-      if (!skill) {
+      const invocation = resolveSkillInvocation(args, skills);
+      if (!invocation) {
         appendSystem(`Unknown skill "${args.trim()}". Type /skills to list the options.`);
         setInput("");
+        return true;
+      }
+      const { skill, args: skillArgs } = invocation;
+      // A hinted skill submitted without arguments (and not already the exact
+      // `/skill <id>` form — that means "run it anyway") autofills for editing.
+      if (skill.argumentHint && !skillArgs && trimmed.toLowerCase() !== `/skill ${skill.id}`.toLowerCase()) {
+        setInput(`/skill ${skill.id} `);
         return true;
       }
       setInput("");
       // Invoke by sending a directive to the active familiar's harness, which
       // owns Skill execution (mirrors the /run prompt-send pattern).
-      setTimeout(() => sendRaw(buildSkillPrompt(skill)), 0);
+      setTimeout(() => sendRaw(buildSkillPrompt(skill, skillArgs)), 0);
       return true;
     }
     if (command === "/prompt" || command === "/prompts") {
@@ -4292,11 +4328,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         const s = opts[slashIdx];
-        if (s) {
-          setInput("");
-          setSlashIdx(0);
-          setTimeout(() => sendRaw(buildSkillPrompt(s)), 0);
-        }
+        if (s) invokeSkillOption(s);
         return;
       }
     }
@@ -4325,10 +4357,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
     }
-    if (slashSuggestions.length > 0) {
+    if (slashSuggestions.length > 0 || skillCommandRows.length > 0) {
+      // One roving index across commands, then the Skills group beneath them.
+      const total = slashSuggestions.length + skillCommandRows.length;
+      const skillAt = (i: number): SkillOption | undefined =>
+        skillCommandRows[i - slashSuggestions.length];
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setSlashIdx((i) => Math.min(i + 1, slashSuggestions.length - 1));
+        setSlashIdx((i) => Math.min(i + 1, total - 1));
         return;
       }
       if (e.key === "ArrowUp") {
@@ -4339,12 +4375,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       if (e.key === "Tab") {
         e.preventDefault();
         const cmd = slashSuggestions[slashIdx];
+        const s = skillAt(slashIdx);
         if (cmd) setInput(cmd.name + (cmd.argPlaceholder ? " " : ""));
+        else if (s) setInput(`/skill ${s.id} `);
         return;
       }
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         const cmd = slashSuggestions[slashIdx];
+        const s = skillAt(slashIdx);
         // If the highlighted command takes an argument and the input isn't
         // the exact command yet, autocomplete first (like Tab) so the user
         // can fill in args; otherwise run the highlighted suggestion — not
@@ -4353,6 +4392,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           setInput(cmd.name + " ");
         } else if (cmd) {
           intentFromSlash(cmd.name);
+        } else if (s) {
+          invokeSkillOption(s);
         }
         return;
       }
@@ -5017,13 +5058,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         tabIndex={-1}
                         ref={active ? activeSlashOptionRef : null}
                         onMouseEnter={() => setSlashIdx(i)}
-                        onClick={() => {
-                          setInput("");
-                          setSlashIdx(0);
-                          const skill = s;
-                          setTimeout(() => sendRaw(buildSkillPrompt(skill)), 0);
-                          inputRef.current?.focus();
-                        }}
+                        onClick={() => invokeSkillOption(s)}
                         className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
                           active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
                         }`}
@@ -5033,6 +5068,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         <span className="flex-1 truncate text-[11px] text-[var(--text-muted)]">
                           {s.description || s.id}
                         </span>
+                        {s.argumentHint ? (
+                          <span className="font-mono text-[10px] text-[var(--text-muted)]">
+                            {s.argumentHint}
+                          </span>
+                        ) : null}
                       </button>
                     </li>
                   );
@@ -5075,7 +5115,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 {keys.up}{keys.down} navigate · {keys.enter} insert · Tab complete · esc cancel
               </div>
             </div>
-          ) : slashSuggestions.length > 0 ? (
+          ) : slashSuggestions.length > 0 || skillCommandRows.length > 0 ? (
             <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-base)] shadow-xl">
               <ul className="max-h-64 overflow-y-auto py-1" id={slashListboxId} role="listbox" aria-label="Slash commands">
                 {slashSuggestions.map((cmd, i) => {
@@ -5107,6 +5147,40 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         {cmd.argPlaceholder ? (
                           <span className="font-mono text-[10px] text-[var(--text-muted)]">
                             {cmd.argPlaceholder}
+                          </span>
+                        ) : null}
+                      </button>
+                    </li>
+                  );
+                })}
+                {skillCommandRows.length > 0 ? (
+                  <li role="presentation" className="mt-1 border-t border-[var(--border-hairline)] px-3 pb-1 pt-2 text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+                    Skills
+                  </li>
+                ) : null}
+                {skillCommandRows.map((s, i) => {
+                  const idx = slashSuggestions.length + i;
+                  const active = idx === slashIdx;
+                  return (
+                    <li key={`skill-${s.id}`} role="option" id={`${slashListboxId}-opt-${idx}`} aria-selected={active}>
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        ref={active ? activeSlashOptionRef : null}
+                        onMouseEnter={() => setSlashIdx(idx)}
+                        onClick={() => invokeSkillOption(s)}
+                        className={`flex w-full items-center gap-3 px-3 py-2 text-left text-sm transition-colors ${
+                          active ? "bg-[var(--bg-raised)]/60" : "hover:bg-[var(--bg-raised)]/50"
+                        }`}
+                      >
+                        <Icon name="ph:sparkle" width={13} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
+                        <span className="text-[var(--text-primary)]">{s.name}</span>
+                        <span className="flex-1 truncate text-xs text-[var(--text-muted)]">
+                          {s.description || s.id}
+                        </span>
+                        {s.argumentHint ? (
+                          <span className="font-mono text-[10px] text-[var(--text-muted)]">
+                            {s.argumentHint}
                           </span>
                         ) : null}
                       </button>

--- a/src/components/skill-detail-preview.tsx
+++ b/src/components/skill-detail-preview.tsx
@@ -32,6 +32,11 @@ export function SkillDetailPreview({ skill }: { skill: SkillOption | null }) {
       ) : (
         <p className="skill-preview__desc skill-preview__desc--muted">No description provided.</p>
       )}
+      {skill.argumentHint ? (
+        <p className="skill-preview__desc skill-preview__desc--muted">
+          Arguments: <code>{skill.argumentHint}</code>
+        </p>
+      ) : null}
       {skill.tags?.length ? (
         <div className="skill-preview__tags">
           {skill.tags.slice(0, 8).map((t) => (

--- a/src/lib/server/skill-scan.ts
+++ b/src/lib/server/skill-scan.ts
@@ -28,6 +28,12 @@ export type LocalSkillEntry = {
    * permissions when the skill is attached to a workflow.
    */
   permissions?: string[];
+  /**
+   * Frontmatter `argument-hint` (Claude Code convention, e.g. `[pr-number]`).
+   * Drives the composer's autofill: a hinted skill inserts `/skill <id> ` for
+   * argument editing instead of sending immediately.
+   */
+  argumentHint?: string;
   path: string;
   familiar: LocalSkillScope;
 };
@@ -106,6 +112,7 @@ export async function scanSkillsDir(dir: string, familiar: LocalSkillScope, out:
         kind: fm.kind,
         tags: tags.length ? tags : (fm.tags ? [fm.tags] : []),
         permissions: permissions.length ? permissions : undefined,
+        argumentHint: fm["argument-hint"],
         owner: fm.owner,
         repo: fm.repo,
         packageName: fm.package,

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -65,7 +65,7 @@ assert.match(slashCmds, /name: "\/prompts"/, "/prompts is registered");
 
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 assert.match(chatView, /promptSlashOptions\(input, prompts\)/, "chat-view computes the inline /prompt options");
-assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0;/, "chat-view menuOpen includes the prompt picker");
+assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "chat-view menuOpen includes the prompt picker");
 assert.match(chatView, /command === "\/prompt" \|\| command === "\/prompts"/, "chat-view dispatches /prompt and /prompts");
 assert.match(chatView, /role="listbox" aria-label="Prompts"/, "chat-view renders a Prompts listbox");
 assert.match(chatView, /fetch\("\/api\/prompts"/, "chat-view sources templates from /api/prompts");

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -4,7 +4,9 @@ import { readFile } from "node:fs/promises";
 import {
   skillSlashOptions,
   resolveSkillArg,
+  resolveSkillInvocation,
   buildSkillPrompt,
+  skillCommandMatches,
   formatSkillList,
 } from "./slash-skill.ts";
 
@@ -36,10 +38,42 @@ assert.equal(resolveSkillArg("zzz", SKILLS), null, "unknown → null");
 
 // ── buildSkillPrompt / formatSkillList ───────────────────────────────────────
 assert.equal(buildSkillPrompt(SKILLS[0]), 'Use the "deep-research" skill.', "invocation prompt names the skill");
+assert.equal(buildSkillPrompt(SKILLS[0], "  "), 'Use the "deep-research" skill.', "blank args → plain directive");
+assert.equal(
+  buildSkillPrompt(SKILLS[1], "src/foo.ts"),
+  'Use the "code-review" skill with: src/foo.ts',
+  "typed arguments ride along after the directive",
+);
 const list = formatSkillList(SKILLS);
 assert.match(list, /Available skills/, "list has a header");
 assert.match(list, /deep-research/, "list includes each skill");
 assert.match(formatSkillList([]), /No skills found/, "empty list is explained");
+
+// ── resolveSkillInvocation: whole name first, then first-token + args ────────
+assert.deepEqual(
+  resolveSkillInvocation("code-review", SKILLS),
+  { skill: SKILLS[1], args: "" },
+  "bare name resolves with empty args",
+);
+assert.deepEqual(
+  resolveSkillInvocation("code-review src/foo.ts please", SKILLS),
+  { skill: SKILLS[1], args: "src/foo.ts please" },
+  "first token resolves, remainder becomes the skill's arguments",
+);
+assert.equal(resolveSkillInvocation("nope at-all", SKILLS), null, "unknown head → null");
+assert.equal(resolveSkillInvocation("zzz", SKILLS), null, "unknown single token → null");
+
+// ── skillCommandMatches: top-level menu discovery ────────────────────────────
+assert.deepEqual(skillCommandMatches("/revi", SKILLS).map((s) => s.id), ["code-review"], "3+ chars matches by substring");
+assert.deepEqual(skillCommandMatches("/re", SKILLS), [], "under 3 typed chars stays out of the menu");
+assert.deepEqual(skillCommandMatches("revi", SKILLS), [], "non-slash text never matches");
+const MANY = Array.from({ length: 9 }, (_, i) => ({ id: `review-${i}`, name: `review-${i}` }));
+assert.equal(skillCommandMatches("/review", MANY).length, 5, "capped at 5 rows");
+const DUPED = [
+  { id: "code-review", name: "code-review", familiar: "user" },
+  { id: "code-review", name: "code-review", familiar: "agents-user" },
+];
+assert.equal(skillCommandMatches("/review", DUPED).length, 1, "same skill from two scan roots renders once");
 
 // ── Catalog + composer wiring (source-text) ──────────────────────────────────
 const slashCmds = await readFile(new URL("./slash-commands.ts", import.meta.url), "utf8");
@@ -48,11 +82,19 @@ assert.match(slashCmds, /name: "\/skills"/, "/skills is registered");
 
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 assert.match(chatView, /skillSlashOptions\(input, skills\)/, "chat-view computes the inline /skill options");
-assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0;/, "chat-view menuOpen includes the skill picker");
+assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "chat-view menuOpen includes the skill picker and the Skills group");
 assert.match(chatView, /command === "\/skill" \|\| command === "\/skills"/, "chat-view dispatches /skill and /skills");
-assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill\)\)/, "chat-view invokes a skill by sending the skill prompt");
+assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill, skillArgs\)\)/, "typed /skill arguments are forwarded into the invocation");
+assert.match(chatView, /sendRaw\(buildSkillPrompt\(s\)\)/, "picking a skill sends the invocation directive");
+assert.match(chatView, /const invokeSkillOption = \(s: SkillOption\)/, "chat-view shares one skill-invoke helper across picker, menu and clicks");
+assert.match(chatView, /s\.argumentHint && input\.trim\(\)\.toLowerCase\(\) !== filled\.toLowerCase\(\)/, "a hinted skill autofills /skill <id> for argument editing instead of sending");
+assert.match(chatView, /skillCommandMatches\(firstWord, skills\)/, "chat-view surfaces skills in the top-level command menu");
 assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");
 assert.match(chatView, /fetch\("\/api\/skills\/local"/, "chat-view sources skills from the local skill scan");
+
+// argument-hint flows from SKILL.md frontmatter to the picker metadata.
+const scan = await readFile(new URL("./server/skill-scan.ts", import.meta.url), "utf8");
+assert.match(scan, /argumentHint: fm\["argument-hint"\]/, "skill-scan maps the argument-hint frontmatter key");
 
 // ── Skill detail preview in the picker ───────────────────────────────────────
 const preview = await readFile(new URL("../components/skill-detail-preview.tsx", import.meta.url), "utf8");
@@ -61,6 +103,7 @@ assert.match(preview, /skill\.description/, "preview shows the full description"
 assert.match(preview, /skill\.tags\?\.length/, "preview shows tags when present");
 assert.match(preview, /skill\.path/, "preview shows the skill path");
 assert.match(preview, /skill\.familiar/, "preview shows the skill scope");
+assert.match(preview, /skill\.argumentHint/, "preview shows the argument hint when present");
 
 const homeComposer = await readFile(new URL("../components/home-composer.tsx", import.meta.url), "utf8");
 for (const [label, src] of [["chat-view", chatView], ["home-composer", homeComposer]]) {

--- a/src/lib/slash-skill.ts
+++ b/src/lib/slash-skill.ts
@@ -16,6 +16,9 @@ export type SkillOption = {
   tags?: string[];
   /** Absolute path to the skill directory (shown muted in the preview). */
   path?: string;
+  /** SKILL.md `argument-hint` (e.g. `[pr-number]`). A hinted skill autofills
+   *  `/skill <id> ` for argument editing instead of sending immediately. */
+  argumentHint?: string;
 };
 
 // `/skills` is the no-arg "show everything" picker; it also accepts a trailing
@@ -58,10 +61,52 @@ export function resolveSkillArg(arg: string, skills: SkillOption[]): SkillOption
   return partial ?? null;
 }
 
+/** Resolve a typed `/skill` argument that may carry trailing arguments after
+ *  the skill name. The whole string is tried first (multi-word names keep
+ *  working), then the first token as the name with the remainder as the
+ *  skill's arguments. Returns null when nothing resolves. */
+export function resolveSkillInvocation(
+  arg: string,
+  skills: SkillOption[],
+): { skill: SkillOption; args: string } | null {
+  const whole = resolveSkillArg(arg, skills);
+  if (whole) return { skill: whole, args: "" };
+  const t = arg.trim();
+  const sp = t.indexOf(" ");
+  if (sp <= 0) return null;
+  const skill = resolveSkillArg(t.slice(0, sp), skills);
+  return skill ? { skill, args: t.slice(sp + 1).trim() } : null;
+}
+
 /** The message sent to the active familiar to invoke a skill. The harness owns
- *  Skill execution, so this is a plain directive naming the skill. */
-export function buildSkillPrompt(skill: SkillOption): string {
-  return `Use the "${skill.name}" skill.`;
+ *  Skill execution, so this is a plain directive naming the skill; typed
+ *  arguments (from `/skill <name> <args>`) ride along after it. */
+export function buildSkillPrompt(skill: SkillOption, args?: string): string {
+  const a = args?.trim();
+  if (!a) return `Use the "${skill.name}" skill.`;
+  return `Use the "${skill.name}" skill with: ${a}`;
+}
+
+/** Skills surfaced directly in the top-level slash menu — typing `/revi`
+ *  matches the code-review skill without the /skill prefix. Gated to 3+ typed
+ *  characters so `/` and two-letter prefixes keep the command menu clean, and
+ *  capped so skills complement rather than crowd the commands. The scan can
+ *  return the same skill from several roots (user + agents copies) — one row
+ *  per id, first scope wins, so dupes don't eat the five slots. */
+export function skillCommandMatches(prefix: string, skills: SkillOption[]): SkillOption[] {
+  if (!prefix.startsWith("/")) return [];
+  const q = prefix.slice(1).toLowerCase();
+  if (q.length < 3) return [];
+  const seen = new Set<string>();
+  const out: SkillOption[] = [];
+  for (const s of skills) {
+    if (!(s.id.toLowerCase().includes(q) || s.name.toLowerCase().includes(q))) continue;
+    if (seen.has(s.id)) continue;
+    seen.add(s.id);
+    out.push(s);
+    if (out.length === 5) break;
+  }
+  return out;
 }
 
 /** One-line-per-skill list for the bare `/skill` / `/skills` system message. */


### PR DESCRIPTION
## What

Completes the slash-command arc (#2523 prompt snippets, #2525 marketplace prompt packs) — skills are now easy to **find** and **autofill**:

- **`argument-hint` frontmatter** (Claude Code convention) flows scan → `/api/skills/local` → `SkillOption`. Rendered as a muted mono suffix in `/skill` picker rows and an `Arguments:` line in the detail preview.
- **Insert-for-editing**: picking a hinted skill autofills `/skill <id> ` so you can type arguments — never an instant send. Picking again on the filled text runs it. All three invoke paths (picker Enter, row click, typed submit) share one `invokeSkillOption` helper. Hint-less skills keep today's instant-send.
- **Arguments forward into the invocation**: `buildSkillPrompt(skill, args)` → `Use the "<name>" skill with: <args>`; `resolveSkillInvocation()` splits `/skill <name> <args>` with whole-string name matching still winning (multi-word names unaffected).
- **Skills in the top-level menu**: typing 3+ chars after `/` (e.g. `/revi`) surfaces up to 5 matching skills in a "Skills" group under the commands — no `/skill` prefix needed. Deduped by id across scan roots (the same skill installed in `~/.claude/skills` and `~/.agents/skills` renders once). One roving index spans commands + skills; Tab fills `/skill <id> `.
- `SLASH_COMMANDS` stays pure-static — `canonicalize`/`formatHelp`/TUI + iOS parity untouched.

## Verification

- `pnpm typecheck`; full `pnpm test:app` (541) + `pnpm test:api` (119) green (true exit codes, not tail-piped). Extended `slash-skill.test.ts` (args prompt, `resolveSkillInvocation`, `skillCommandMatches` incl. cap + dedupe, argument-hint scan pin, insert-not-send pins); updated sliced pins in `chat-view-polish.test.ts` and the shared `menuOpen` pin.
- Live on a prod build with `/api/chat/send` intercepted: `/higgs` → Skills group with hint suffixes; Enter fills `/skill higgsfield-generate ` (0 sends); typed args → `Use the "higgsfield-generate" skill with: a red fox at dawn`; `/skill brainstorming` Enter → instant `Use the "brainstorming" skill.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)