### PR TITLE
feat(home): prompt snippets + skill autofill parity in the home composer (cave-6tu)

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -337,8 +337,8 @@ for (const [name, src] of [
   // the slash term on its Escape-dismiss flag: `(!slashDismissed && …)`.)
   assert.match(
     src,
-    /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\|[\s\S]{0,40}slashSuggestions\.length > 0/,
-    `${name} combobox ARIA must reflect every inline menu (slash, /model, /skill)`,
+    /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\|[\s\S]{0,80}slashSuggestions\.length > 0/,
+    `${name} combobox ARIA must reflect every inline menu (slash, /model, /skill, /prompt)`,
   );
 }
 
@@ -349,8 +349,8 @@ for (const [name, src] of [
 // ARIA.
 assert.match(
   source,
-  /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\| \(!slashDismissed && slashSuggestions\.length > 0\);/,
-  "HomeComposer combobox ARIA reflects every inline menu (slash, /model, /skill)",
+  /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\|\s*\(!slashDismissed && \(slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0\)\);/,
+  "HomeComposer combobox ARIA reflects every inline menu (slash, /model, /skill, /prompt, Skills group)",
 );
 
 // ── /skill + /skills inline picker (mirrors /model) ──────────────────────────
@@ -361,7 +361,12 @@ assert.match(
   /<HomeSlashMenu[\s\S]*?ariaLabel="Skills"[\s\S]*?preview=\{<SkillDetailPreview/,
   "HomeComposer renders a Skills picker listbox (via HomeSlashMenu) with the skill detail preview",
 );
-assert.match(source, /buildSkillPrompt\(skill\)/, "HomeComposer invokes a skill by starting a chat with the skill prompt");
+assert.match(source, /buildSkillPrompt\(skill, args\)/, "HomeComposer invokes a skill by starting a chat with the skill prompt (typed arguments ride along)");
+assert.match(
+  source,
+  /skill\.argumentHint && !args && text\.trim\(\)\.toLowerCase\(\) !== filled\.toLowerCase\(\)/,
+  "A hinted skill autofills /skill <id> for argument editing instead of starting a chat",
+);
 
 // ── Destination pills are an accessible single-select radiogroup ─────────────
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -22,10 +22,18 @@ import { Icon, type IconName } from "@/lib/icon";
 import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
 import {
   skillSlashOptions,
-  resolveSkillArg,
+  resolveSkillInvocation,
   buildSkillPrompt,
+  skillCommandMatches,
   type SkillOption,
 } from "@/lib/slash-skill";
+import {
+  promptSlashOptions,
+  resolvePromptArg,
+  promptInsertion,
+  type PromptOption,
+} from "@/lib/slash-prompt";
+import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
 import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import { readComposerHistory, writeComposerHistory } from "@/lib/composer-history";
 import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
@@ -308,24 +316,89 @@ export function HomeComposer({
   }, []);
   const skillOptions = useMemo(() => skillSlashOptions(text, skills), [text, skills]);
   const skillMenuActive = !slashDismissed && (skillOptions?.length ?? 0) > 0;
-  // The inline listboxes (slash commands, /model, /skill) share the same listbox
-  // id, so the textarea's combobox ARIA tracks whichever is open.
+  // Prompt templates for the "/prompt <partial>" / "/prompts" picker. Seeded
+  // with the built-ins so it works instantly (and offline); the fetch layers
+  // in ~/.coven/prompts files and installed marketplace prompt packs.
+  const [prompts, setPrompts] = useState<PromptOption[]>(BUILTIN_PROMPTS);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/prompts", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
+      })
+      .catch(() => {
+        /* offline → built-in templates only */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const promptOptions = useMemo(() => promptSlashOptions(text, prompts), [text, prompts]);
+  const promptMenuActive = !slashDismissed && (promptOptions?.length ?? 0) > 0;
+  // Skills surfaced directly in the command menu — typing `/revi` finds the
+  // code-review skill without the /skill prefix. Same first-token-only rule
+  // as slashSuggestions; mirrors chat-view.
+  const skillCommandRows: SkillOption[] = useMemo(() => {
+    const t = text.trimStart();
+    const firstWord = t.split(/\s/)[0] ?? "";
+    if (!firstWord.startsWith("/") || t.includes(" ")) return [];
+    return skillCommandMatches(firstWord, skills);
+  }, [text, skills]);
+  // The inline listboxes (slash commands, /model, /skill, /prompt) share the
+  // same listbox id, so the textarea's combobox ARIA tracks whichever is open.
   const menuOpen =
-    modelMenuActive || skillMenuActive || (!slashDismissed && slashSuggestions.length > 0);
+    modelMenuActive || skillMenuActive || promptMenuActive ||
+    (!slashDismissed && (slashSuggestions.length > 0 || skillCommandRows.length > 0));
 
-  // Invoke a skill from home = open a new chat that asks the familiar to run it.
+  // Invoke a skill from home = open a new chat that asks the familiar to run
+  // it. A skill with an argument-hint autofills `/skill <id> ` for argument
+  // editing instead of starting immediately; picking again on the filled text
+  // (or a hint-less skill) starts the chat. Mirrors chat-view's
+  // invokeSkillOption.
   const invokeSkill = useCallback(
-    (skill: SkillOption) => {
+    (skill: SkillOption, args = "") => {
+      const filled = `/skill ${skill.id}`;
+      if (skill.argumentHint && !args && text.trim().toLowerCase() !== filled.toLowerCase()) {
+        setText(`${filled} `);
+        textareaRef.current?.focus();
+        return;
+      }
       if (!selectedFamiliarId) {
         onToast("No familiar selected — add one in Settings.");
         return;
       }
       setText("");
-      onStartChat(buildSkillPrompt(skill), selectedFamiliarId, selectedProject?.root ?? null, {
+      onStartChat(buildSkillPrompt(skill, args), selectedFamiliarId, selectedProject?.root ?? null, {
         initialControls: { thinkingEffort, responseSpeed, ...(runtimeHost ? { runtimeHost } : {}) },
       });
     },
-    [selectedFamiliarId, selectedProject, thinkingEffort, responseSpeed, runtimeHost, onStartChat, onToast],
+    [selectedFamiliarId, selectedProject, thinkingEffort, responseSpeed, runtimeHost, onStartChat, onToast, text],
+  );
+
+  // Drop a prompt template into the composer for editing — never a start.
+  // When the body carries a {{placeholder}}, select the first one so typing
+  // replaces it; otherwise park the caret at the end. Mirrors chat-view.
+  // (Distinct from insertPrompt below — the suggestion pills' plain-string
+  // insert.)
+  const insertPromptTemplate = useCallback(
+    (p: PromptOption) => {
+      const ins = promptInsertion(p);
+      setText(ins.text);
+      setSlashIdx(0);
+      announce("Prompt inserted — edit and send.");
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        if (ins.selectStart !== undefined && ins.selectEnd !== undefined) {
+          el.setSelectionRange(ins.selectStart, ins.selectEnd);
+        } else {
+          el.setSelectionRange(ins.text.length, ins.text.length);
+        }
+      });
+    },
+    [announce],
   );
 
   useEffect(() => {
@@ -513,13 +586,30 @@ export function HomeComposer({
           onToast("Type /skill <name>, or pick one from the menu.");
           return;
         }
-        const skill = resolveSkillArg(args, skills);
-        if (!skill) {
+        const invocation = resolveSkillInvocation(args, skills);
+        if (!invocation) {
           setText("");
           onToast(`Unknown skill "${args.trim()}".`);
           return;
         }
-        invokeSkill(skill);
+        invokeSkill(invocation.skill, invocation.args);
+        return;
+      }
+      if (command === "/prompt" || command === "/prompts") {
+        setHistory((prev) => [...prev, prompt]);
+        setHistoryIdx(-1);
+        if (!args.trim()) {
+          setText("");
+          onToast("Type /prompt <name>, or pick one from the menu.");
+          return;
+        }
+        const template = resolvePromptArg(args, prompts);
+        if (!template) {
+          setText("");
+          onToast(`Unknown prompt "${args.trim()}".`);
+          return;
+        }
+        insertPromptTemplate(template);
         return;
       }
       if (onSlash) {
@@ -608,6 +698,8 @@ export function HomeComposer({
     onToast,
     skills,
     invokeSkill,
+    prompts,
+    insertPromptTemplate,
   ]);
 
   const handleKeyDown = useCallback(
@@ -645,11 +737,29 @@ export function HomeComposer({
           return;
         }
       }
-      // Slash menu hotkeys take priority over history/submit when it's open
-      if (!slashDismissed && slashSuggestions.length > 0) {
+      // Inline prompt picker ("/prompt <partial>" or "/prompts") — Enter
+      // INSERTS the template into the composer for editing, never a start.
+      if (promptMenuActive && promptOptions) {
+        const opts = promptOptions;
+        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
+        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
+        if (e.key === "Tab") { e.preventDefault(); const p = opts[slashIdx]; if (p) setText(`/prompt ${p.id}`); return; }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const p = opts[slashIdx];
+          if (p) insertPromptTemplate(p);
+          return;
+        }
+      }
+      // Slash menu hotkeys take priority over history/submit when it's open.
+      // One roving index across commands, then the Skills group beneath them.
+      if (!slashDismissed && (slashSuggestions.length > 0 || skillCommandRows.length > 0)) {
+        const total = slashSuggestions.length + skillCommandRows.length;
+        const skillAt = (i: number): SkillOption | undefined =>
+          skillCommandRows[i - slashSuggestions.length];
         if (e.key === "ArrowDown") {
           e.preventDefault();
-          setSlashIdx((i) => Math.min(i + 1, slashSuggestions.length - 1));
+          setSlashIdx((i) => Math.min(i + 1, total - 1));
           return;
         }
         if (e.key === "ArrowUp") {
@@ -660,16 +770,21 @@ export function HomeComposer({
         if (e.key === "Tab") {
           e.preventDefault();
           const cmd = slashSuggestions[slashIdx];
+          const s = skillAt(slashIdx);
           if (cmd) setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
+          else if (s) setText(`/skill ${s.id} `);
           return;
         }
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           const cmd = slashSuggestions[slashIdx];
+          const s = skillAt(slashIdx);
           // If the input is an exact command (no args yet), run it directly;
           // otherwise autocomplete first so the user can fill in args.
           if (cmd && cmd.argPlaceholder && canonicalize(text.trim()) !== cmd.name) {
             setText(cmd.name + " ");
+          } else if (s) {
+            invokeSkill(s);
           } else {
             void handleSubmit();
           }
@@ -712,11 +827,15 @@ export function HomeComposer({
       skillMenuActive,
       skillOptions,
       invokeSkill,
+      promptMenuActive,
+      promptOptions,
+      insertPromptTemplate,
       onToast,
       menuOpen,
       slashDismissed,
       slashIdx,
       slashSuggestions,
+      skillCommandRows,
       text,
     ],
   );
@@ -768,24 +887,50 @@ export function HomeComposer({
             }}
             preview={<SkillDetailPreview skill={skillOptions[slashIdx] ?? skillOptions[0] ?? null} />}
           />
-        ) : !slashDismissed && slashSuggestions.length > 0 ? (
+        ) : promptMenuActive && promptOptions ? (
+          <HomeSlashMenu
+            listboxId={slashListboxId}
+            ariaLabel="Prompts"
+            items={promptOptions.map((p) => ({ key: p.id, name: p.name, desc: p.description || p.id }))}
+            activeIndex={slashIdx}
+            footer="↑↓ navigate · Enter insert · Tab complete · Esc cancel"
+            onHover={setSlashIdx}
+            onPick={(i) => {
+              const p = promptOptions[i];
+              if (p) insertPromptTemplate(p);
+            }}
+          />
+        ) : !slashDismissed && (slashSuggestions.length > 0 || skillCommandRows.length > 0) ? (
           <HomeSlashMenu
             listboxId={slashListboxId}
             ariaLabel="Slash commands"
-            items={slashSuggestions.map((cmd) => ({
-              key: cmd.name,
-              name: cmd.name,
-              desc: cmd.description,
-              arg: cmd.argPlaceholder || undefined,
-            }))}
+            items={[
+              ...slashSuggestions.map((cmd) => ({
+                key: cmd.name,
+                name: cmd.name,
+                desc: cmd.description,
+                arg: cmd.argPlaceholder || undefined,
+              })),
+              // Matching skills ride under the commands — one list, one index.
+              ...skillCommandRows.map((s) => ({
+                key: `skill-${s.id}`,
+                name: s.name,
+                desc: `Skill · ${s.description || s.id}`,
+                arg: s.argumentHint || undefined,
+              })),
+            ]}
             activeIndex={slashIdx}
             footer="↑↓ navigate · Enter run · Tab complete · type space to dismiss"
             onHover={setSlashIdx}
             onPick={(i) => {
               const cmd = slashSuggestions[i];
-              if (!cmd) return;
-              setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
-              textareaRef.current?.focus();
+              const s = skillCommandRows[i - slashSuggestions.length];
+              if (cmd) {
+                setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
+                textareaRef.current?.focus();
+              } else if (s) {
+                invokeSkill(s);
+              }
             }}
           />
         ) : null}

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -86,4 +86,13 @@ assert.match(modal, /breadcrumb=\{\["Chat", "Prompt snippets"\]\}/, "modal is bu
 const emptyState = await readFile(new URL("../components/chat-empty-state.tsx", import.meta.url), "utf8");
 assert.match(emptyState, /onOpenPromptSnippets/, "empty state exposes the snippets entry point");
 
+// ── Home composer parity ─────────────────────────────────────────────────────
+const homeComposer = await readFile(new URL("../components/home-composer.tsx", import.meta.url), "utf8");
+assert.match(homeComposer, /promptSlashOptions\(text, prompts\)/, "home computes the inline /prompt options");
+assert.match(homeComposer, /fetch\("\/api\/prompts"/, "home sources templates from /api/prompts");
+assert.match(homeComposer, /useState<PromptOption\[\]>\(BUILTIN_PROMPTS\)/, "home picker is seeded with the built-ins");
+assert.match(homeComposer, /command === "\/prompt" \|\| command === "\/prompts"/, "home dispatches /prompt and /prompts");
+assert.match(homeComposer, /const insertPromptTemplate = useCallback/, "home has the template-insert helper");
+assert.doesNotMatch(homeComposer, /onStartChat\([^)]*promptInsertion/, "a template body never starts a chat directly");
+
 console.log("slash-prompt.test.ts: ok");


### PR DESCRIPTION
## What

Final PR of the prompt-templates arc (#2523 chat snippets, #2525 marketplace packs, #2528 skill autofill) — home composer parity, built inside the #2514 command-center decomposition:

- **`/prompt <name>` + `/prompts` inline picker** (rendered via `HomeSlashMenu`): Enter **drops the template into the home composer for editing** — never starts a chat; the first `{{placeholder}}` is selected so typing replaces it. Seeded with built-ins, layered from `GET /api/prompts` (user files + installed packs).
- **Skills in the home command menu**: 3+ chars after `/` surfaces matching skills as `Skill · …` rows under the commands (`skillCommandMatches` — deduped across scan roots, capped at 5). One roving index spans commands + skills; Tab fills `/skill <id> `.
- **Hinted-skill autofill**: `invokeSkill` fills `/skill <id> ` for argument editing instead of starting immediately (mirrors chat's `invokeSkillOption`); `/skill <name> <args>` forwards args via `resolveSkillInvocation` → `buildSkillPrompt(skill, args)`.
- New helper named `insertPromptTemplate` to stay clear of #2514's suggestion-pill `insertPrompt(string)`.

## Verification

- `pnpm typecheck`; full `pnpm test:app` (541) + `pnpm test:api` (119) green with true exit codes.
- Pins updated in `home-composer.test.ts` (menuOpen shape, `buildSkillPrompt(skill, args)`, hinted-autofill) and home-parity pins added to `slash-prompt.test.ts` (insert-not-start, built-in seeding, `/prompt` dispatch).
- Live on a prod build with `/api/chat/send` intercepted: `/prompts` → 3-row picker on home; Enter inserts into the home textarea (0 sends, stays on home); `/higgs` → `Skill · …` rows; Enter fills `/skill higgsfield-generate ` (0 sends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)