### PR TITLE
fix(shell): mode wrappers no longer trap position:fixed descendants (cave-cco)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3401,8 +3401,16 @@ textarea.required-inputs-control {
   from { opacity: 0; transform: translateY(4px); }
   to   { opacity: 1; transform: translateY(0); }
 }
+/* fill-mode MUST stay `backwards` (cave-cco): `both` retained the final
+   keyframe's transform forever, and any transform — even identity — makes
+   this wrapper the containing block for every position:fixed descendant.
+   Fixed overlays inside surfaces then resolved against the mode area
+   instead of the viewport, which forced portal-to-body workarounds (#537,
+   #1984, the github-view card, cave-nv3). During the 120ms entrance the
+   wrapper is still a containing block; after it, fixed descendants get the
+   true viewport. */
 .cave-mode-fade {
-  animation: cave-mode-in 120ms ease-out both;
+  animation: cave-mode-in 120ms ease-out backwards;
 }
 
 /* Left nav collapsed strip -- mirrors the agent tab on the right */

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -119,3 +119,23 @@ assert.doesNotMatch(salemBlock, /rgba\(124,\s*77,\s*255/, "salem surfaces should
 assert.doesNotMatch(salemBlock, /#(?:d1c4e9|e8e0f0|c9a7ff|d26bff|a855f7|a89ac0)\b/i, "salem surfaces should not hardcode old purple hex colors");
 
 console.log("globals.css.test.ts (salem tokens) OK");
+
+// The mode-transition wrapper must never RETAIN a transform after its
+// entrance animation: fill-mode `both` kept the final keyframe's transform
+// (even identity), turning every .cave-mode-fade into the containing block
+// for position:fixed descendants — fixed overlays inside surfaces resolved
+// against the mode area instead of the viewport and forced portal-to-body
+// workarounds (#537, #1984, github-view card, cave-nv3). Bead cave-cco.
+const modeFadeRule = css.match(/\.cave-mode-fade\s*\{([\s\S]*?)\}/)?.[1] ?? "";
+assert.match(
+  modeFadeRule,
+  /animation:\s*cave-mode-in\s+120ms\s+ease-out\s+backwards/,
+  ".cave-mode-fade must use fill-mode backwards (nothing retained after the entrance)",
+);
+assert.doesNotMatch(
+  modeFadeRule,
+  /\bboth\b|\bforwards\b/,
+  ".cave-mode-fade must not retain end-state animation styles (containing-block trap, cave-cco)",
+);
+
+console.log("globals.css.test.ts (mode-fade containing block) OK");

--- a/src/components/rail-files-panel.test.ts
+++ b/src/components/rail-files-panel.test.ts
@@ -70,10 +70,11 @@ assert.match(preview, /onClick=\{\(\) => onOpenPath\(f\.path\)\}/, "each changed
 assert.match(preview, /if \(path \|\| !projectRoot \|\| !onOpenPath\) return/, "the status fetch only runs for an empty, openable preview");
 
 // ─── cave-chat.css: fullscreen sizes to its containing block ─────────────────
-// .cave-mode-fade retains a transform (animation-fill-mode: both), so the mode
-// wrapper — not the viewport — is the containing block for the fixed rail.
-// width:100vw on top of that offset pushed the diffs pane off-screen; the rule
-// must size via inset alone. Root cause tracked as bead cave-cco.
+// Sizing via inset alone keeps this correct regardless of what the containing
+// block is: historically the mode wrapper (.cave-mode-fade retained a
+// transform), now the true viewport (root cause fixed in cave-cco). width/
+// height:100v* stacked on a containing-block offset is what clipped the
+// diffs pane — the rule must never size to viewport units.
 const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 const fullscreenBlock = css.slice(
   css.indexOf(".workspace-rail--fullscreen {"),

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4523,14 +4523,14 @@ details[open] > .cave-tool-summary::before {
 }
 
 /* Fullscreen fills its CONTAINING BLOCK via inset alone — no width/height.
-   .cave-mode-fade retains a transform after its entrance animation
-   (animation-fill-mode: both), so every mode wrapper is the containing block
-   for fixed descendants: the rail's origin sits AFTER the shell's icon rail.
-   With width:100vw stacked on that offset, the far-right diffs pane hung past
-   the window edge (clipped stat chips / cut "Diff" header). inset:0 sizes to
-   the containing block exactly — today the mode area (shell nav stays
-   reachable), and still correct if the retained transform ever goes away
-   (falls back to true viewport). Root cause tracked as bead cave-cco. */
+   Historically .cave-mode-fade retained a transform (fill-mode: both) and
+   every mode wrapper was the containing block for fixed descendants —
+   width:100vw stacked on the rail offset hung the diffs pane past the
+   window edge (clipped stat chips / cut "Diff" header). The root cause is
+   fixed (cave-cco, fill-mode: backwards), so this now sizes to the true
+   viewport; inset:0 was chosen precisely to stay correct across that
+   transition. Fullscreen covering the shell's icon rail matches the
+   portaled .chat-artifact--fullscreen precedent. */
 .workspace-rail--fullscreen {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Root cause

`.cave-mode-fade` — the wrapper around every workspace surface — animated in with `fill-mode: both`, permanently retaining the final keyframe's `transform: translateY(0)`. Any retained transform (even identity, computed `matrix(1,0,0,1,0,0)`) makes an element the **containing block for `position: fixed` descendants**, so every fixed overlay rendered inside a surface resolved against the mode area instead of the viewport. This single line forced portal-to-body workarounds four separate times: #537 (board task drawer), #1984 (chat lightbox/expand), the github-view profile card, and cave-nv3/#2526 (fullscreen code rail).

## Fix

`fill-mode: both` → `backwards` (one declaration, `globals.css:3404`). The 120ms fade/rise entrance is unchanged — wrappers remount per mode switch via `key={mode}` (already pinned in `comux-view-terminal.test.ts`) — but nothing is retained after it ends, so fixed descendants get the true viewport. New pin in `globals.css.test.ts` rejects `both`/`forwards` on this rule so the trap can't silently return.

## Audit (required by the bead, done before changing anything)

Exhaustive sweep of every `position: fixed` reachable inside the wrapper (CSS classes, Tailwind `fixed` utilities, inline styles):

- **No other containing-block sources**: `.cave-mode-fade`'s retained transform was the only one — no filters/perspective/contain on shell ancestors.
- **~23 elements unaffected**: portaled to `document.body` (lightboxes, popovers, inspector pane, voice overlay, drag ghosts…) or app-level siblings of the wrapper (command palette, toasts, quick chat, modals…).
- **19 inline fixed elements change coordinates — to the standard behavior**:
  - Modal scrims (capabilities, directory/cwd pickers, glyph picker, familiars overlays, github profile card, skill drawer, marketplace detail, dashboard snooze) now dim the **whole window** like `ui-modal-backdrop`, instead of leaving the nav rail clickable under an open modal.
  - Fullscreen viewers (`workspace-rail--fullscreen`, `journal-detail--fullscreen`, `flow-template-overlay`) now cover the viewport — matching the portaled `.chat-artifact--fullscreen` precedent. The rail's own `inset: 0` comment had explicitly pre-blessed this transition ("still correct if the retained transform ever goes away").
  - Mobile sheets (`chat-right-sheet`, `mobile-code-rail-sheet`) coincide — at <1024px the mode area ≈ viewport.
  - `journal-notice` toast centers on the viewport instead of the mode area (~28px shift).
  - **Repaired, not broken**: the artifact-comment FAB positions itself from `getBoundingClientRect()` (viewport coords) applied to a fixed element — pre-fix it was offset by the wrapper's origin; now it lands where it measures.

## Verification

- Live probes on the built app: settled computed transform on `.cave-mode-fade` is now `none` (was the identity matrix); a `fixed inset:0` probe inside the wrapper rects to the full 1440×900 viewport while the wrapper sits at (56,88); the entrance animation still runs (`cave-mode-in`, fill `backwards`). Screenshot confirmed an overlay dimming the full window including the icon rail.
- Gates: 541 app test files green, typecheck clean, 728 tests wired.
- Stale comments referencing the old behavior updated (`cave-chat.css`, `rail-files-panel.test.ts` — its inset-only assertions were transition-proof and stand).

Follow-up candidates (not in this PR): the four portal workarounds could now be simplified back to plain fixed rendering; left as-is since portals remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)