### PR TITLE
fix(code): file preview fills the pane instead of clamping at 520px (cave-7zg)

### DIFF
--- a/src/components/rail-file-preview.tsx
+++ b/src/components/rail-file-preview.tsx
@@ -313,7 +313,16 @@ export function RailFilePreview({
           </div>
         )}
       </header>
-      <div className={`workspace-rail__preview-body${editing ? " workspace-rail__preview-body--edit" : ""}`}>
+      <div
+        className={`workspace-rail__preview-body${editing ? " workspace-rail__preview-body--edit" : ""}${
+          // Reading a highlighted code file: let the pane own the height so the
+          // block fills it and scrolls internally, instead of keeping the chat
+          // transcript's 520px clamp + "Show more" footer (see cave-chat.css).
+          !loading && !error && !editing && file?.kind === "text" && !isMarkdownPath(path)
+            ? " workspace-rail__preview-body--code"
+            : ""
+        }`}
+      >
         {loading ? (
           <div className="workspace-rail__preview-skeleton" aria-busy="true" aria-label="Loading file">
             {["94%", "82%", "97%", "70%", "88%", "60%"].map((w, i) => (

--- a/src/components/rail-files-panel.test.ts
+++ b/src/components/rail-files-panel.test.ts
@@ -69,6 +69,17 @@ assert.match(preview, /const LAUNCHPAD_CAP = 6/, "the launchpad caps its list");
 assert.match(preview, /onClick=\{\(\) => onOpenPath\(f\.path\)\}/, "each changed file opens in the preview");
 assert.match(preview, /if \(path \|\| !projectRoot \|\| !onOpenPath\) return/, "the status fetch only runs for an empty, openable preview");
 
+// Code-file fit: reading a highlighted file lifts SyntaxBlock's chat clamp so
+// the block fills the pane instead of stopping at 520px with a dead "Show
+// more" footer (bead cave-7zg). The modifier only applies to the read-mode
+// SyntaxBlock branch — markdown, images, editor, loading, and error keep the
+// plain padded body.
+assert.match(
+  preview,
+  /!loading && !error && !editing && file\?\.kind === "text" && !isMarkdownPath\(path\)\s*\?\s*" workspace-rail__preview-body--code"/,
+  "the --code fill modifier is gated to the read-mode SyntaxBlock branch",
+);
+
 // ─── cave-chat.css: fullscreen sizes to its containing block ─────────────────
 // .cave-mode-fade retains a transform (animation-fill-mode: both), so the mode
 // wrapper — not the viewport — is the containing block for the fixed rail.
@@ -81,5 +92,22 @@ const fullscreenBlock = css.slice(
 );
 assert.match(fullscreenBlock, /inset: 0/, "fullscreen fills via inset");
 assert.doesNotMatch(fullscreenBlock, /100vw|100vh/, "fullscreen never sizes to the viewport (containing-block offset would clip the right pane)");
+
+// ─── cave-chat.css: --code preview fills the pane (cave-7zg) ──────────────────
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \.cave-code-wrap \{[^}]*max-height: none/,
+  "--code lifts the chat transcript's 520px clamp on the code wrap",
+);
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \.cave-code-expand \{[^}]*display: none/,
+  "--code hides the Show more footer (nothing to expand once unclamped)",
+);
+assert.match(
+  css,
+  /\.workspace-rail__preview-body--code \{[^}]*overflow: hidden/,
+  "--code body stops double-scrolling — the wrap scrolls internally",
+);
 
 console.log("rail-files-panel.test.ts OK");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -5066,6 +5066,33 @@ details[open] > .cave-tool-summary::before {
   min-height: 0;
 }
 
+/* Reading a highlighted code file: the pane, not the chat transcript, owns the
+   height. Lift SyntaxBlock's chat clamp (max-height: min(60vh, 520px)) so the
+   block shrink-fits the body and scrolls internally — short files keep their
+   natural height, long files fill the pane with the sticky header reachable.
+   Mirrors the --edit editor fill above. */
+.workspace-rail__preview-body--code {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.workspace-rail__preview-body--code .cave-syntax-block {
+  display: flex;
+  flex-direction: column;
+  flex: 0 1 auto;
+  min-height: 0;
+}
+.workspace-rail__preview-body--code .cave-code-wrap {
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: none;
+}
+/* With the clamp lifted there is nothing to expand — the footer would be a
+   no-op button pinned over the last visible line. */
+.workspace-rail__preview-body--code .cave-code-expand {
+  display: none;
+}
+
 .workspace-rail__preview-skeleton {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Reading a code file in the Files rail (including the fullscreen IDE view) rendered through chat's `SyntaxBlock`, which kept the transcript's height clamp (`max-height: min(60vh, 520px)` on `.cave-code-wrap`) and its "Show more" footer. In a dedicated preview pane that meant a half-height block with dead space below, a no-op expand button pinned over the last visible line, and nested scroll containers (pane + wrap).

## What changed

- `workspace-rail__preview-body--code` modifier, applied only on the read-mode SyntaxBlock branch (not markdown, images, editor, loading, or error states)
- Scoped CSS lifts the clamp: the wrap shrink-fits the pane (`flex: 0 1 auto` + `min-height: 0` + `max-height: none`) and scrolls internally — short files keep their natural height, long files fill the pane with the sticky header reachable; the body stops double-scrolling
- `.cave-code-expand` hidden in this context — with the clamp lifted there is nothing to expand
- Chat transcripts and every other SyntaxBlock consumer (tool I/O, inspector) are untouched

## Verification

- Live Playwright against real data (fullscreen Files IDE, `package.json` open): wrap `max-height: none`, block fills the pane (1062px in a 1082px body, gap = padding), internal scroll active, expand footer hidden
- Source pins added to `rail-files-panel.test.ts`; full suite (541 files), typecheck, and production build green

Closes bead `cave-7zg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)