### PR TITLE
fix(shell): mode-fade releases its transform — fixed overlays get the real viewport back (cave-cco)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3397,12 +3397,26 @@ textarea.required-inputs-control {
 }
 
 /* ── UX-004: Mode transition crossfade ──────────────────────────────────── */
+/* fill-mode is `backwards`, NOT `both`/`forwards`, and the `to` frame has no
+   transform. A forwards fill keeps every animated property actively applied at
+   its final value forever — and because transform is animated (from-frame),
+   Chromium holds an IDENTITY transform on the wrapper for the life of the
+   surface (verified: omitting transform from `to` alone still computes
+   matrix(1,0,0,1,0,0) under `both`). Any applied transform, even identity,
+   makes the mode wrapper the containing block for position:fixed descendants:
+   fixed overlays inside surfaces resolved against the mode area (origin after
+   the shell rail / below the top bar) instead of the viewport — the bug behind
+   the #537 / #1984 / github hover-card portal workarounds and the #2526
+   fullscreen code-rail clip. With `backwards` the animation releases on
+   finish (end state equals base state, so nothing jumps) and the containing
+   block exists only during the 120ms entrance. Pinned in
+   rail-files-panel.test.ts. */
 @keyframes cave-mode-in {
   from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  to   { opacity: 1; }
 }
 .cave-mode-fade {
-  animation: cave-mode-in 120ms ease-out both;
+  animation: cave-mode-in 120ms ease-out backwards;
 }
 
 /* Left nav collapsed strip -- mirrors the agent tab on the right */

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -1101,12 +1101,13 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
   if (typeof document === "undefined") return null;
 
   // Portal to <body> so the drawer's `position: fixed` resolves against the
-  // viewport, NOT the `.cave-mode-fade` mode wrapper. That wrapper retains a
-  // transform from its `cave-mode-in … both` animation, which silently makes
-  // it the containing block for fixed descendants — so an inline drawer
-  // anchored its `right:0`/`width:480px` to the (narrower, inset) detail panel
-  // instead of the window. Symptoms: a right-edge gap on desktop and left-
-  // clipped content on narrow viewports. Mirrors the ui/Modal portal pattern.
+  // viewport, NOT the `.cave-mode-fade` mode wrapper. That wrapper applies a
+  // transform during its 120ms entrance animation (it used to retain it
+  // forever — cave-cco), which makes it the containing block for fixed
+  // descendants: an inline drawer opened during the entrance would anchor its
+  // `right:0`/`width:480px` to the (narrower, inset) detail panel instead of
+  // the window. The portal also keeps the drawer above the shell's stacking
+  // contexts. Mirrors the ui/Modal portal pattern.
   return createPortal(
     <>
       <div className="board-drawer-backdrop" onClick={close} />

--- a/src/components/rail-files-panel.test.ts
+++ b/src/components/rail-files-panel.test.ts
@@ -70,16 +70,44 @@ assert.match(preview, /onClick=\{\(\) => onOpenPath\(f\.path\)\}/, "each changed
 assert.match(preview, /if \(path \|\| !projectRoot \|\| !onOpenPath\) return/, "the status fetch only runs for an empty, openable preview");
 
 // ─── cave-chat.css: fullscreen sizes to its containing block ─────────────────
-// .cave-mode-fade retains a transform (animation-fill-mode: both), so the mode
-// wrapper — not the viewport — is the containing block for the fixed rail.
-// width:100vw on top of that offset pushed the diffs pane off-screen; the rule
-// must size via inset alone. Root cause tracked as bead cave-cco.
+// The mode wrapper's entrance animation applies a transform for 120ms (it used
+// to retain it forever — cave-cco), making it the containing block for fixed
+// descendants in that window. inset-only sizing is correct under both regimes;
+// width:100vw stacked on a containing-block offset once pushed the diffs pane
+// off-screen (#2526).
 const css = readFileSync(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 const fullscreenBlock = css.slice(
   css.indexOf(".workspace-rail--fullscreen {"),
   css.indexOf("}", css.indexOf(".workspace-rail--fullscreen {")),
 );
 assert.match(fullscreenBlock, /inset: 0/, "fullscreen fills via inset");
+
+// ─── globals.css: the mode-fade animation must RELEASE its transform ─────────
+// cave-cco: a forwards fill (`both`/`forwards`) keeps every animated property
+// actively applied at its final value forever — transform is animated in the
+// from-frame, so Chromium holds an identity transform on the wrapper for the
+// life of the surface, turning every mode wrapper into a position:fixed
+// containing block (forced the #537/#1984/github-card portal workarounds and
+// the #2526 rail clip). Verified empirically: an opacity-only `to` frame under
+// `both` STILL computes matrix(1,0,0,1,0,0). The fill must stay `backwards`
+// and the to-frame transform-free.
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const modeInKeyframes = globals.slice(
+  globals.indexOf("@keyframes cave-mode-in"),
+  globals.indexOf("}", globals.indexOf("to", globals.indexOf("@keyframes cave-mode-in"))) + 1,
+);
+assert.match(modeInKeyframes, /from \{ opacity: 0; transform: translateY\(4px\); \}/, "the entrance still slides from 4px");
+assert.match(modeInKeyframes, /to\s*\{ opacity: 1; \}/, "the final frame is opacity-only");
+assert.doesNotMatch(
+  modeInKeyframes.slice(modeInKeyframes.indexOf("to")),
+  /transform/,
+  "no transform in the to-frame",
+);
+const fadeRule = globals.slice(
+  globals.indexOf(".cave-mode-fade {"),
+  globals.indexOf("}", globals.indexOf(".cave-mode-fade {")) + 1,
+);
+assert.match(fadeRule, /animation: cave-mode-in 120ms ease-out backwards;/, "fill-mode backwards — the animation releases; both/forwards would hold an identity transform and re-create the fixed containing block");
 assert.doesNotMatch(fullscreenBlock, /100vw|100vh/, "fullscreen never sizes to the viewport (containing-block offset would clip the right pane)");
 
 console.log("rail-files-panel.test.ts OK");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4522,15 +4522,12 @@ details[open] > .cave-tool-summary::before {
   background: var(--bg-surface, var(--background));
 }
 
-/* Fullscreen fills its CONTAINING BLOCK via inset alone — no width/height.
-   .cave-mode-fade retains a transform after its entrance animation
-   (animation-fill-mode: both), so every mode wrapper is the containing block
-   for fixed descendants: the rail's origin sits AFTER the shell's icon rail.
-   With width:100vw stacked on that offset, the far-right diffs pane hung past
-   the window edge (clipped stat chips / cut "Diff" header). inset:0 sizes to
-   the containing block exactly — today the mode area (shell nav stays
-   reachable), and still correct if the retained transform ever goes away
-   (falls back to true viewport). Root cause tracked as bead cave-cco. */
+/* Fullscreen fills via inset alone — never width:100vw/height:100vh. The mode
+   wrapper's entrance animation briefly applies a transform (containing block
+   for the first 120ms; permanent before cave-cco), and inset-only sizing is
+   correct under both regimes: it fills whatever the containing block is —
+   normally the true viewport — where a 100vw stacked on a containing-block
+   offset once hung the far-right diffs pane past the window edge (#2526). */
 .workspace-rail--fullscreen {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
Fixes the root cause behind four shipped portal workarounds (#537 board drawer, #1984 lightbox/expand overlays, the github hover card) and the #2526 fullscreen code-rail clip. Bead: cave-cco.

## Root cause

`.cave-mode-fade { animation: cave-mode-in 120ms ease-out both }` kept the entrance animation's transform applied **forever**, making every mode wrapper the containing block for `position: fixed` descendants. Any fixed overlay rendered inside a surface resolved against the mode area — origin after the shell's icon rail, below the top bar — instead of the viewport.

Two findings worth recording (both pinned in `rail-files-panel.test.ts`):

1. **Dropping `transform` from the `to` keyframe is not enough.** A forwards fill keeps every *animated* property actively applied at its final interpolated value — transform is animated in the from-frame, so Chromium holds an **identity** transform (`matrix(1,0,0,1,0,0)`) on the wrapper for the life of the surface. An applied identity transform still creates the containing block. Verified empirically on a prod build.
2. **`fill-mode: backwards` is the fix.** The animation releases on finish; its end state equals the base state (opacity 1, no transform), so nothing visually jumps. The containing block now exists only during the 120ms entrance.

## Blast-radius audit (before changing anything)

Classified every `position: fixed` element that can render inside a surface (two parallel sweeps + manual verification of the workspace.tsx mount points):

- **Portaled to body** (Modal, Popover, mobile drawer, board drawer, lightboxes, artifact viewer, voice overlay, inspector fullscreen, mermaid viewer, kanban touch ghost): unaffected; portals stay (they also escape stacking contexts and the transient 120ms window).
- **Mounted outside the mode wrapper** in workspace.tsx (command palette, onboarding overlay, inbox toasts, glyph picker, reminder modal, deep-link takeover): unaffected.
- **JS-coordinate elements inline in surfaces** (gh profile card, artifact comment FAB, quick-chat anchor math): these assume viewport coords and were silently offset — **now repaired**.
- **`inset-0` modals/backdrops inline in surfaces** (capabilities preview, familiars memory overlays, github PAT modal, quick-open, cwd picker, skill drawer, chat sheets, flow template overlay, dash snooze backdrop, workflow dialog): grow from mode-area to full viewport — correct for scrims, which should cover the nav too.
- **Right/bottom-anchored elements**: don't move (the mode area shares those edges with the viewport). **No inline top-anchored fixed elements exist** — the only category that could regress has zero members.
- The fullscreen code rail becomes **true viewport fullscreen** (covers shell + top bar) — what the toggle promises; its inset-only sizing from #2526 was designed to be correct under both regimes.

## Verification

- Live prod-build probe: computed transform on `.cave-mode-fade` is `none` after entrance across chat → board → dashboard switches (was identity matrix); fullscreen rail rect is exactly `0,0 → 1600,900`; ancestor walk finds **no remaining containing block**.
- Entrance animation unchanged visually (4px slide + fade still runs; missing keyframe properties interpolate to the underlying value).
- `tsc` clean · 541 app test files green · bundle in budget.
- Comments updated where the old behavior was documented (board-inspector portal rationale, cave-chat.css fullscreen rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)