### PR TITLE
fix(quick-chat): harden the chat box + dedupe overlay/tray internals (cave-72r)

### DIFF
--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 const source = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
 
 assert.match(source, /StandardSelect/, "quick-chat select helper should delegate to StandardSelect");
-assert.doesNotMatch(source, /PopoverBody|PopoverItem|anchorRef|useState\(false\)/, "quick-chat select helper should not maintain its own popover implementation");
+assert.doesNotMatch(source, /PopoverBody|PopoverItem|anchorRef/, "quick-chat select helper should not maintain its own popover implementation");
 assert.match(source, /renderValue=/, "quick-chat select helper should keep its compact trigger rendering through StandardSelect");
 
 // Shared conversation thread — used by both the in-app dropdown and the tray.
@@ -14,5 +14,88 @@ assert.match(source, /import \{ MarkdownBlock \} from "@\/components\/message-bu
 assert.match(source, /copyText\(message\.text\)/, "each familiar reply can be copied to the clipboard");
 assert.match(source, /aria-live="polite"/, "the thread is a polite live region so streamed replies are announced");
 assert.match(source, /quick-chat-caret|quick-chat-typing/, "streaming turns show a caret / thinking affordance");
+
+// ── Shared building blocks: one source of truth for both surfaces ────────────
+// The overlay and the tray render the same header identity, controls row, and
+// composer — drift between the two (e.g. hint copy, focus behavior) was a bug.
+for (const name of [
+  "QuickChatIdentity",
+  "QuickChatControlsRow",
+  "QuickChatComposer",
+  "useSuggestionPicker",
+]) {
+  assert.match(
+    source,
+    new RegExp(`export function ${name}`),
+    `controls export the shared ${name} used by both quick-chat surfaces`,
+  );
+}
+assert.match(
+  source,
+  /export const QUICK_CHAT_SUGGESTIONS/,
+  "the one-tap starter suggestions are defined once and shared",
+);
+assert.match(
+  source,
+  /loading \? "Loading familiars…" : familiar \? `@\$\{familiar\.id\}` : "No familiar selected"/,
+  "the shared header identity shows a loading state while the roster loads",
+);
+assert.match(
+  source,
+  /loading && familiars\.length === 0\s*\?\s*\[\{ value: "", label: "Loading…", disabled: true \}\]/,
+  "the shared familiar select shows a disabled Loading placeholder while the roster is empty",
+);
+assert.match(
+  source,
+  /CONTROL_SELECT_CLASS =\s*\n?\s*"[^"]*rounded-\[var\(--radius-control\)\]/,
+  "selector controls use the shared control radius token",
+);
+assert.doesNotMatch(source, /rounded-md/, "controls avoid hard-coded md radius");
+assert.ok(source.includes('import { Button } from "@/components/ui/button"'), "controls use the shared Button primitive");
+assert.ok(source.includes('import { IconButton } from "@/components/ui/icon-button"'), "controls use the shared IconButton primitive");
+assert.doesNotMatch(source, /<button\b/, "controls do not hand-roll button controls");
+
+// ── Composer: Enter sends, Shift+Enter newline, IME left alone ────────────────
+assert.match(
+  source,
+  /\(event\.metaKey \|\| event\.ctrlKey\) && event\.key === "Enter"/,
+  "the shared composer sends on Cmd/Ctrl+Enter",
+);
+assert.match(
+  source,
+  /event\.key === "Enter" && !event\.shiftKey && !event\.nativeEvent\.isComposing/,
+  "plain Enter sends, Shift+Enter inserts a newline, IME composition is left alone",
+);
+assert.match(
+  source,
+  /requestAnimationFrame\(\(\) => composerRef\.current\?\.focus\(\)\)/,
+  "picking a suggestion moves the caret into the composer (both surfaces, via useSuggestionPicker)",
+);
+
+// ── Thread auto-scroll must not fight the user ────────────────────────────────
+// Follow-along only sticks while the user is at the bottom; scrolling up to
+// reread during a streaming reply stays put, and a new turn re-engages it.
+assert.match(
+  source,
+  /stickRef\.current = el\.scrollHeight - el\.scrollTop - el\.clientHeight < 48/,
+  "the thread tracks whether the user is near the bottom",
+);
+assert.match(
+  source,
+  /if \(el && stickRef\.current\) el\.scrollTop = el\.scrollHeight/,
+  "streamed tokens only auto-scroll while the user is following along",
+);
+assert.match(
+  source,
+  /stickRef\.current = true;\s*\}, \[messages\.length\]\)/,
+  "a new turn re-engages follow-along scrolling",
+);
+
+// ── Copy affordance resets ────────────────────────────────────────────────────
+assert.match(
+  source,
+  /setTimeout\(\(\) => setCopied\(false\), 1500\)/,
+  "the copied ✓ hands the button back to copy after a beat (it used to stick forever)",
+);
 
 console.log("quick-chat-controls.test.ts OK");

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  COMMAND_RESPONSE_SPEED_OPTIONS,
+  COMMAND_THINKING_OPTIONS,
+  type CommandResponseSpeed,
+  type CommandThinkingEffort,
+} from "@/lib/command-controls";
 import { Icon, type IconName } from "@/lib/icon";
 import type { Familiar } from "@/lib/types";
 import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
@@ -11,6 +17,13 @@ import { copyText } from "@/lib/clipboard";
 import type { QuickChatMessage } from "@/lib/use-quick-chat";
 
 export type QuickChatSelectOption<T extends string> = StandardSelectOption<T>;
+
+// One-tap starters for a cold thread — they fill the composer, not send.
+export const QUICK_CHAT_SUGGESTIONS = [
+  "Summarize what needs my attention",
+  "Draft a short status update",
+  "What changed recently?",
+];
 
 function initials(familiar: Familiar): string {
   return (familiar.display_name || familiar.id)
@@ -29,6 +42,40 @@ export function FamiliarMark({ familiar, size = "sm" }: { familiar: Familiar; si
     <span className={`grid ${sizeClass} place-items-center rounded-[var(--radius-control)] bg-[var(--bg-elevated)] font-semibold text-[var(--fg-primary)]`}>
       {initials(familiar)}
     </span>
+  );
+}
+
+// ── Header identity ──────────────────────────────────────────────────────────
+// The avatar + name + handle block both quick-chat surfaces open with.
+
+export function QuickChatIdentity({
+  familiar,
+  loading,
+  as: Heading = "h2",
+}: {
+  familiar: Familiar | null;
+  loading: boolean;
+  /** Heading level — the tray window is a full page (h1), the overlay a dialog (h2). */
+  as?: "h1" | "h2";
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      {familiar ? (
+        <FamiliarMark familiar={familiar} size="md" />
+      ) : (
+        <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
+      )}
+      <div className="min-w-0">
+        <Heading className="truncate text-sm font-semibold">
+          {familiar ? familiar.display_name : "Quick chat"}
+        </Heading>
+        <p className="truncate text-xs text-[var(--fg-muted)]">
+          {/* While the roster loads, say so — "No familiar selected" reads
+              as an error/empty state when it's really just cold. */}
+          {loading ? "Loading familiars…" : familiar ? `@${familiar.id}` : "No familiar selected"}
+        </p>
+      </div>
+    </div>
   );
 }
 
@@ -72,6 +119,174 @@ export function QuickChatSelect<T extends string>({
   );
 }
 
+// ── Controls row ─────────────────────────────────────────────────────────────
+// Familiar picker + thinking-effort + response-speed selects — identical in the
+// in-app dropdown and the tray window.
+
+const CONTROL_SELECT_CLASS =
+  "min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none";
+
+export function QuickChatControlsRow({
+  loading,
+  familiars,
+  selectedFamiliarId,
+  onPickFamiliar,
+  thinkingEffort,
+  onThinkingEffortChange,
+  responseSpeed,
+  onResponseSpeedChange,
+  sending,
+}: {
+  loading: boolean;
+  familiars: Familiar[];
+  selectedFamiliarId: string | null;
+  onPickFamiliar: (id: string | null) => void;
+  thinkingEffort: CommandThinkingEffort;
+  onThinkingEffortChange: (value: CommandThinkingEffort) => void;
+  responseSpeed: CommandResponseSpeed;
+  onResponseSpeedChange: (value: CommandResponseSpeed) => void;
+  sending: boolean;
+}) {
+  return (
+    <div className="quick-chat-overlay__controls">
+      <QuickChatSelect
+        label="Familiar"
+        value={selectedFamiliarId ?? ""}
+        onChange={(next) => onPickFamiliar(next || null)}
+        disabled={loading || familiars.length === 0}
+        className="flex-1"
+        options={
+          loading && familiars.length === 0
+            ? [{ value: "", label: "Loading…", disabled: true }]
+            : familiars.map((familiar) => ({
+                value: familiar.id,
+                label: familiar.display_name,
+                leading: <FamiliarMark familiar={familiar} size="sm" />,
+              }))
+        }
+      />
+      <StandardSelect
+        label="Choose thinking effort"
+        value={thinkingEffort}
+        onChange={(next) => onThinkingEffortChange(next as CommandThinkingEffort)}
+        disabled={sending}
+        className={CONTROL_SELECT_CLASS}
+        options={COMMAND_THINKING_OPTIONS}
+      />
+      <StandardSelect
+        label="Choose response speed"
+        value={responseSpeed}
+        onChange={(next) => onResponseSpeedChange(next as CommandResponseSpeed)}
+        disabled={sending}
+        className={CONTROL_SELECT_CLASS}
+        options={COMMAND_RESPONSE_SPEED_OPTIONS}
+      />
+    </div>
+  );
+}
+
+// ── Composer ─────────────────────────────────────────────────────────────────
+// Error slot + textarea + actions row, shared by both surfaces. Enter sends;
+// Shift+Enter inserts a newline; ⌘/Ctrl+Enter always sends; IME composition is
+// left alone.
+
+export function QuickChatComposer({
+  error,
+  draft,
+  onDraftChange,
+  onSend,
+  onCancel,
+  sending,
+  disabled,
+  familiar,
+  inputId,
+  composerRef,
+  autoFocus,
+  leading,
+}: {
+  error: string | null;
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSend: () => void;
+  onCancel: () => void;
+  sending: boolean;
+  /** Blocks sending while true (e.g. the roster is still loading). */
+  disabled?: boolean;
+  familiar: Familiar | null;
+  inputId: string;
+  composerRef?: React.RefObject<HTMLTextAreaElement | null>;
+  autoFocus?: boolean;
+  /** Left slot of the actions row — a hint in the tray, Open-in-full-chat in the overlay. */
+  leading?: React.ReactNode;
+}) {
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      const cmdEnter = (event.metaKey || event.ctrlKey) && event.key === "Enter";
+      const plainEnter =
+        event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing;
+      if (cmdEnter || plainEnter) {
+        event.preventDefault();
+        if (!sending && draft.trim()) onSend();
+      }
+    },
+    [draft, onSend, sending],
+  );
+
+  return (
+    <footer className="quick-chat-overlay__composer">
+      {error ? (
+        <p className="quick-chat-overlay__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <textarea
+        ref={composerRef}
+        id={inputId}
+        value={draft}
+        autoFocus={autoFocus}
+        aria-label="Message"
+        onChange={(event) => onDraftChange(event.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder={familiar ? `Message @${familiar.id}…` : "@sage summarize what needs attention"}
+        className="quick-chat-overlay__input"
+      />
+      <div className="quick-chat-overlay__actions">
+        {leading}
+        <div className="flex items-center gap-2">
+          {sending ? (
+            <Button variant="secondary" size="sm" onClick={onCancel}>
+              Stop
+            </Button>
+          ) : null}
+          <Button
+            variant="primary"
+            size="sm"
+            leadingIcon="ph:sparkle"
+            onClick={onSend}
+            disabled={sending || disabled || !draft.trim()}
+          >
+            Send
+          </Button>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+/** Suggestion chips fill the composer, then move the caret into it so the user
+ *  can tweak-and-send. Returns the textarea ref to pass to QuickChatComposer. */
+export function useSuggestionPicker(setDraft: (value: string) => void) {
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+  const pickSuggestion = useCallback(
+    (value: string) => {
+      setDraft(value);
+      requestAnimationFrame(() => composerRef.current?.focus());
+    },
+    [setDraft],
+  );
+  return { composerRef, pickSuggestion };
+}
+
 // ── Conversation thread ──────────────────────────────────────────────────────
 // Shared between the in-app dropdown and the Tauri standalone window so the two
 // render identical turns. Owns its own scroll container + auto-scroll and marks
@@ -88,7 +303,14 @@ function QuickChatBubble({
   isLastAssistant: boolean;
   onRegenerate?: () => void;
 }) {
-  const [copied, setCopied] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Show the ✓ for a beat, then hand the button back to "copy".
+  useEffect(() => {
+    if (!copied) return;
+    const timer = window.setTimeout(() => setCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [copied]);
 
   if (message.role === "user") {
     return (
@@ -142,13 +364,13 @@ function QuickChatBubble({
         {canAct ? (
           <div className="quick-chat-turn__actions">
             <IconButton
-              icon={copied === message.id ? "ph:check" : "ph:copy"}
+              icon={copied ? "ph:check" : "ph:copy"}
               size="xs"
-              aria-label={copied === message.id ? "Copied" : "Copy reply"}
+              aria-label={copied ? "Copied" : "Copy reply"}
               title="Copy reply"
               onClick={() => {
                 void copyText(message.text).then((ok) => {
-                  if (ok) setCopied(message.id);
+                  if (ok) setCopied(true);
                 });
               }}
             />
@@ -172,28 +394,42 @@ export function QuickChatThread({
   messages,
   familiar,
   emptyIcon = "ph:chat-circle-dots",
-  emptyTitle,
-  emptyHint,
-  suggestions,
+  emptyTitle = familiar ? `Ask ${familiar.display_name} anything` : "Ask a familiar anything",
+  emptyHint = "Replies stream right here · @name to switch familiar · Enter to send",
+  suggestions = QUICK_CHAT_SUGGESTIONS,
   onSuggestion,
   onRegenerate,
 }: {
   messages: QuickChatMessage[];
   familiar: Familiar | null;
   emptyIcon?: IconName;
-  emptyTitle: string;
-  emptyHint: string;
+  emptyTitle?: string;
+  emptyHint?: string;
   suggestions?: string[];
   onSuggestion?: (value: string) => void;
   onRegenerate?: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  // Follow the stream only while the user is already at the bottom — pinning
+  // scrollTop on every token would fight scrolling up to reread earlier turns.
+  const stickRef = useRef(true);
   const lastText = messages.length > 0 ? messages[messages.length - 1].text : "";
+
+  const onScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    stickRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+  }, []);
+
+  // A new turn (sending / a reply starting) re-engages follow-along.
+  useEffect(() => {
+    stickRef.current = true;
+  }, [messages.length]);
 
   // Keep the newest turn in view as it streams.
   useEffect(() => {
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (el && stickRef.current) el.scrollTop = el.scrollHeight;
   }, [messages.length, lastText]);
 
   const lastAssistantId = (() => {
@@ -204,7 +440,7 @@ export function QuickChatThread({
   })();
 
   return (
-    <div ref={scrollRef} className="quick-chat-thread" aria-live="polite">
+    <div ref={scrollRef} onScroll={onScroll} className="quick-chat-thread" aria-live="polite">
       {messages.length === 0 ? (
         <div className="quick-chat-empty">
           <span className="quick-chat-empty__glyph" aria-hidden>
@@ -212,7 +448,7 @@ export function QuickChatThread({
           </span>
           <p className="quick-chat-empty__title">{emptyTitle}</p>
           <p className="quick-chat-empty__hint">{emptyHint}</p>
-          {suggestions && suggestions.length > 0 ? (
+          {suggestions.length > 0 ? (
             <div className="quick-chat-empty__chips">
               {suggestions.map((suggestion) => (
                 <Button

--- a/src/components/quick-chat-overlay.test.ts
+++ b/src/components/quick-chat-overlay.test.ts
@@ -6,11 +6,14 @@ const source = readFileSync(new URL("./quick-chat-overlay.tsx", import.meta.url)
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
 const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
+const controls = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
+const tray = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
+const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
-  /useQuickChat\(\{ preferredFamiliarId: activeFamiliarId \?\? null \}\)/,
-  "overlay shares the quick-chat state/send logic via useQuickChat, preferring the workspace's active familiar",
+  /useQuickChat\(\{ preferredFamiliarId: activeFamiliarId \?\? null, enabled: open \}\)/,
+  "overlay shares the quick-chat state/send logic via useQuickChat, preferring the workspace's active familiar and deferring the roster fetch until first open",
 );
 assert.match(
   source,
@@ -42,7 +45,6 @@ assert.match(
   /onOpenFullSession\?\.\(sessionId, selectedFamiliarId\)/,
   "overlay opens the saved session (the whole thread's context) in the full app",
 );
-const controls = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
 assert.match(
   controls,
   /aria-live="polite"/,
@@ -55,21 +57,25 @@ assert.match(
 );
 assert.match(
   source,
-  /\(event\.metaKey \|\| event\.ctrlKey\) && event\.key === "Enter"/,
-  "overlay textarea sends on Cmd/Ctrl+Enter",
-);
-assert.match(
-  source,
   /onClick=\{onClose\}/,
   "overlay backdrop / close button calls onClose",
 );
 
-// Workspace wires the overlay to its open state and the full-session opener.
-assert.match(
-  workspace,
-  /<QuickChatOverlay[\s\S]*onOpenFullSession=\{\(sid, fid\) =>/,
-  "workspace renders QuickChatOverlay and routes Open-in-full-chat to openFamiliarSession",
-);
+// ── Shared building blocks: overlay and tray must not drift apart ─────────────
+for (const [name, src] of [["overlay", source], ["tray", tray]]) {
+  for (const piece of ["<QuickChatIdentity", "<QuickChatControlsRow", "<QuickChatThread", "<QuickChatComposer", "useSuggestionPicker("]) {
+    assert.ok(src.includes(piece), `${name} composes the shared ${piece.replace(/[<(]/g, "")} from quick-chat-controls`);
+  }
+  assert.ok(src.includes('import { IconButton } from "@/components/ui/icon-button"'), `${name} icon buttons use the shared IconButton primitive`);
+  assert.doesNotMatch(src, /<button\b/, `${name} does not hand-roll button controls`);
+  assert.doesNotMatch(src, /rounded-md/, `${name} avoids hard-coded md radius in the quick-chat surface`);
+  assert.doesNotMatch(
+    src,
+    /Loading familiars…|label: "Loading…"|COMMAND_THINKING_OPTIONS|quick-chat-overlay__composer/,
+    `${name} does not duplicate header/controls/composer internals that live in quick-chat-controls`,
+  );
+}
+assert.ok(source.includes('import { Button } from "@/components/ui/button"'), "overlay still uses Button for Open-in-full-chat");
 
 // ── Dropdown-from-the-menubar: anchored under its trigger, on left click ──────
 assert.match(
@@ -103,6 +109,13 @@ assert.match(
   "the anchor position is kept in sync on resize",
 );
 
+// Workspace wires the overlay to its open state and the full-session opener.
+assert.match(
+  workspace,
+  /<QuickChatOverlay[\s\S]*onOpenFullSession=\{\(sid, fid\) =>/,
+  "workspace renders QuickChatOverlay and routes Open-in-full-chat to openFamiliarSession",
+);
+
 // ── ⌘J toggles quick chat from anywhere, and it's listed in the catalog ───────
 assert.match(
   workspace,
@@ -118,7 +131,6 @@ assert.match(
 assert.match(topBar, /aria-label="Quick chat"\s*\n\s*title="Quick chat \(⌘J\)"/, "mobile trigger tooltip shows the shortcut, aria-label stays clean");
 
 // ── Familiar default: workspace-active > last-used > first ───────────────────
-const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
 assert.match(
   hook,
   /\(preferred && next\.some\(\(familiar\) => familiar\.id === preferred\) \? preferred : null\) \?\?\s*\(stored && next\.some\(\(familiar\) => familiar\.id === stored\) \? stored : null\) \?\?\s*next\[0\]\?\.id/,
@@ -133,6 +145,11 @@ assert.match(
   hook,
   /setSelectedFamiliarId: pickFamiliar/,
   "manual picks flow through pickFamiliar so they override the active-familiar default",
+);
+assert.match(
+  hook,
+  /if \(target\.mention\) userPickedRef\.current = true;/,
+  "targeting a familiar via a leading @mention counts as a manual pick too",
 );
 assert.match(
   workspace,
@@ -165,48 +182,47 @@ for (const fn of ["newThread", "regenerate", "cancel"]) {
   assert.ok(hook.includes(`${fn},`), `the hook exposes ${fn}() to its consumers`);
 }
 
-console.log("quick-chat-overlay.test.ts OK");
+// ── Hardening: the fixes that keep the box honest ─────────────────────────────
+// Roster load waits for first use (the overlay mounts closed at boot and must
+// not duplicate the workspace's own /api/familiars fetch), checks res.ok, and
+// aborts on unmount.
+assert.match(
+  hook,
+  /if \(!enabled \|\| rosterStartedRef\.current\) return;/,
+  "the roster fetch is deferred until quick chat is actually opened (latched)",
+);
+assert.match(
+  hook,
+  /fetch\("\/api\/familiars", \{ signal: controller\.signal \}\)/,
+  "the roster fetch is abortable",
+);
+assert.match(
+  hook,
+  /if \(!res\.ok\) throw new Error\(`Failed to load familiars \(\$\{res\.status\}\)\.`\)/,
+  "a non-ok roster response surfaces a readable error, not a JSON-parse crash",
+);
+assert.match(
+  hook,
+  /rosterStartedRef\.current = false;\s*setError/,
+  "a failed roster load un-latches so closing and reopening retries it",
+);
+// The backing session is captured the moment the bridge announces it, so a
+// Stop mid-stream keeps the thread resumable and Open-in-full-chat working.
+assert.match(
+  hook,
+  /onSession: \(sid\) => \{\s*if \(controller\.signal\.aborted\) return;\s*sessionIdRef\.current = sid;\s*setSessionId\(sid\);/,
+  "the session id is captured mid-stream (guarded against late frames after newThread)",
+);
+// One turn in flight at a time; persisting the last familiar is best-effort.
+assert.match(
+  hook,
+  /if \(abortRef\.current\) return;\s*const target = resolveQuickChatTarget/,
+  "send() refuses to double-fire while a turn is streaming",
+);
+assert.match(
+  hook,
+  /function writeLastFamiliar\(id: string\): void \{\s*try \{/,
+  "localStorage writes are wrapped — a private-mode throw must not eat the user's message",
+);
 
-// ── Loading state: cold roster reads as "loading", not "no familiar" ──────────
-const tray = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
-for (const [name, src] of [["overlay", source], ["tray", tray]]) {
-  assert.match(
-    src,
-    /loading \? "Loading familiars…" : selectedFamiliar \? `@\$\{selectedFamiliar\.id\}` : "No familiar selected"/,
-    `${name} header shows a loading state while the roster loads`,
-  );
-}
-assert.match(
-  source,
-  /loading && familiars\.length === 0\s*\?\s*\[\{ value: "", label: "Loading…", disabled: true \}\]/,
-  "the familiar select shows a disabled Loading placeholder through StandardSelect options while empty",
-);
-assert.match(
-  tray,
-  /loading && familiars\.length === 0\s*\?\s*\[\{ value: "", label: "Loading…", disabled: true \}\]/,
-  "the tray familiar select shows a disabled Loading placeholder through StandardSelect options while empty",
-);
-for (const [name, src] of [["overlay", source], ["tray", tray]]) {
-  assert.ok(src.includes('import { Button } from "@/components/ui/button"'), `${name} action buttons use the shared Button primitive`);
-  assert.ok(src.includes('import { IconButton } from "@/components/ui/icon-button"'), `${name} icon buttons use the shared IconButton primitive`);
-  assert.doesNotMatch(
-    src,
-    /<button\b/,
-    `${name} does not hand-roll button controls`,
-  );
-  assert.match(
-    src,
-    /<StandardSelect[\s\S]{0,320}rounded-\[var\(--radius-control\)\]/,
-    `${name} selector controls use the shared control radius token`,
-  );
-  assert.doesNotMatch(
-    src,
-    /<StandardSelect[\s\S]{0,320}rounded-md/,
-    `${name} selector controls do not hard-code Tailwind's md radius`,
-  );
-  assert.doesNotMatch(
-    src,
-    /rounded-md/,
-    `${name} avoids hard-coded md radius in the quick-chat surface`,
-  );
-}
+console.log("quick-chat-overlay.test.ts OK");

--- a/src/components/quick-chat-overlay.tsx
+++ b/src/components/quick-chat-overlay.tsx
@@ -1,19 +1,17 @@
 "use client";
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import {
-  COMMAND_RESPONSE_SPEED_OPTIONS,
-  COMMAND_THINKING_OPTIONS,
-  type CommandResponseSpeed,
-  type CommandThinkingEffort,
-} from "@/lib/command-controls";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
-import { StandardSelect } from "@/components/ui/select";
-import { Icon } from "@/lib/icon";
 import { useQuickChat } from "@/lib/use-quick-chat";
 import { useFocusTrap } from "@/lib/use-focus-trap";
-import { FamiliarMark, QuickChatSelect, QuickChatThread } from "@/components/quick-chat-controls";
+import {
+  QuickChatComposer,
+  QuickChatControlsRow,
+  QuickChatIdentity,
+  QuickChatThread,
+  useSuggestionPicker,
+} from "@/components/quick-chat-controls";
 
 type Props = {
   open: boolean;
@@ -23,13 +21,6 @@ type Props = {
    *  pick in the popover still wins once made). */
   activeFamiliarId?: string | null;
 };
-
-// One-tap starters for a cold thread — they fill the composer, not send.
-const QUICK_CHAT_SUGGESTIONS = [
-  "Summarize what needs my attention",
-  "Draft a short status update",
-  "What changed recently?",
-];
 
 export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamiliarId }: Props) {
   const {
@@ -53,11 +44,13 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
     cancel,
     newThread,
     regenerate,
-  } = useQuickChat({ preferredFamiliarId: activeFamiliarId ?? null });
+    // The overlay mounts closed at app boot — defer the roster fetch until the
+    // dropdown is actually opened.
+  } = useQuickChat({ preferredFamiliarId: activeFamiliarId ?? null, enabled: open });
 
   const sending = sendState === "sending";
   const dialogRef = useRef<HTMLDivElement>(null);
-  const composerRef = useRef<HTMLTextAreaElement>(null);
+  const { composerRef, pickSuggestion } = useSuggestionPicker(setDraft);
 
   // Anchor the popover directly beneath its menubar trigger so it reads as a
   // dropdown from the bar (with a caret pointing up at the icon) rather than a
@@ -106,36 +99,13 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
     if (!open) return;
     const id = requestAnimationFrame(() => composerRef.current?.focus());
     return () => cancelAnimationFrame(id);
-  }, [open]);
-
-  const onTextareaKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const cmdEnter = (event.metaKey || event.ctrlKey) && event.key === "Enter";
-      // Enter sends; Shift+Enter inserts a newline; IME composition is left alone.
-      const plainEnter =
-        event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing;
-      if (cmdEnter || plainEnter) {
-        event.preventDefault();
-        if (!sending && draft.trim()) void send();
-      }
-    },
-    [draft, send, sending],
-  );
+  }, [open, composerRef]);
 
   const openFull = useCallback(() => {
     if (!sessionId) return;
     onOpenFullSession?.(sessionId, selectedFamiliarId);
     onClose();
   }, [onClose, onOpenFullSession, selectedFamiliarId, sessionId]);
-
-  const pickSuggestion = useCallback(
-    (value: string) => {
-      setDraft(value);
-      // Move the caret into the composer so the user can tweak-and-send.
-      requestAnimationFrame(() => composerRef.current?.focus());
-    },
-    [setDraft],
-  );
 
   if (!open) return null;
 
@@ -163,23 +133,7 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
         style={anchor ? { top: anchor.top, right: anchor.right } : undefined}
       >
         <header className="quick-chat-overlay__header">
-          <div className="flex min-w-0 items-center gap-2">
-            {selectedFamiliar ? (
-              <FamiliarMark familiar={selectedFamiliar} size="md" />
-            ) : (
-              <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
-            )}
-            <div className="min-w-0">
-              <h2 className="truncate text-sm font-semibold">
-                {selectedFamiliar ? selectedFamiliar.display_name : "Quick chat"}
-              </h2>
-              <p className="truncate text-xs text-[var(--fg-muted)]">
-                {/* While the roster loads, say so — "No familiar selected" reads
-                    as an error/empty state when it's really just cold. */}
-                {loading ? "Loading familiars…" : selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
-              </p>
-            </div>
-          </div>
+          <QuickChatIdentity familiar={selectedFamiliar} loading={loading} />
           <div className="flex items-center gap-1">
             <IconButton
               onClick={newThread}
@@ -199,69 +153,37 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
           </div>
         </header>
 
-        <div className="quick-chat-overlay__controls">
-          <QuickChatSelect
-            label="Familiar"
-            value={selectedFamiliarId ?? ""}
-            onChange={(next) => setSelectedFamiliarId(next || null)}
-            disabled={loading || familiars.length === 0}
-            className="flex-1"
-            options={
-              loading && familiars.length === 0
-                ? [{ value: "", label: "Loading…", disabled: true }]
-                : familiars.map((familiar) => ({
-                    value: familiar.id,
-                    label: familiar.display_name,
-                    leading: <FamiliarMark familiar={familiar} size="sm" />,
-                  }))
-            }
-          />
-          <StandardSelect
-            label="Choose thinking effort"
-            value={thinkingEffort}
-            onChange={(next) => setThinkingEffort(next as CommandThinkingEffort)}
-            disabled={sending}
-            className="min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
-            options={COMMAND_THINKING_OPTIONS}
-          />
-          <StandardSelect
-            label="Choose response speed"
-            value={responseSpeed}
-            onChange={(next) => setResponseSpeed(next as CommandResponseSpeed)}
-            disabled={sending}
-            className="min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
-            options={COMMAND_RESPONSE_SPEED_OPTIONS}
-          />
-        </div>
+        <QuickChatControlsRow
+          loading={loading}
+          familiars={familiars}
+          selectedFamiliarId={selectedFamiliarId}
+          onPickFamiliar={setSelectedFamiliarId}
+          thinkingEffort={thinkingEffort}
+          onThinkingEffortChange={setThinkingEffort}
+          responseSpeed={responseSpeed}
+          onResponseSpeedChange={setResponseSpeed}
+          sending={sending}
+        />
 
         <QuickChatThread
           messages={messages}
           familiar={selectedFamiliar}
-          emptyIcon="ph:chat-circle-dots"
-          emptyTitle={selectedFamiliar ? `Ask ${selectedFamiliar.display_name} anything` : "Ask a familiar anything"}
-          emptyHint="Replies stream right here · @name to switch familiar · Enter to send"
-          suggestions={QUICK_CHAT_SUGGESTIONS}
           onSuggestion={pickSuggestion}
           onRegenerate={sending ? undefined : regenerate}
         />
 
-        <footer className="quick-chat-overlay__composer">
-          {error ? (
-            <p className="quick-chat-overlay__error" role="alert">
-              {error}
-            </p>
-          ) : null}
-          <textarea
-            ref={composerRef}
-            id="quick-chat-overlay-draft"
-            value={draft}
-            aria-label="Message"
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={onTextareaKeyDown}
-            placeholder={selectedFamiliar ? `Message @${selectedFamiliar.id}…` : "@sage summarize what needs attention"}
-            className="quick-chat-overlay__input"
-          />
-          <div className="quick-chat-overlay__actions">
+        <QuickChatComposer
+          error={error}
+          draft={draft}
+          onDraftChange={setDraft}
+          onSend={() => void send()}
+          onCancel={cancel}
+          sending={sending}
+          disabled={loading}
+          familiar={selectedFamiliar}
+          inputId="quick-chat-overlay-draft"
+          composerRef={composerRef}
+          leading={
             <Button
               size="sm"
               variant="ghost"
@@ -271,24 +193,8 @@ export function QuickChatOverlay({ open, onClose, onOpenFullSession, activeFamil
             >
               Open in full chat
             </Button>
-            <div className="flex items-center gap-2">
-              {sending ? (
-                <Button variant="secondary" size="sm" onClick={cancel}>
-                  Stop
-                </Button>
-              ) : null}
-              <Button
-                variant="primary"
-                size="sm"
-                leadingIcon="ph:sparkle"
-                onClick={() => void send()}
-                disabled={sending || loading || !draft.trim()}
-              >
-                Send
-              </Button>
-            </div>
-          </div>
-        </footer>
+          }
+        />
       </div>
     </>
   );

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 const component = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url), "utf8");
 const page = readFileSync(new URL("../app/quick-chat/page.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+const controls = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
 // Quick-chat state + send logic now lives in the shared useQuickChat hook,
 // consumed by both the Tauri window (this component) and the in-app overlay.
 const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
@@ -15,7 +16,7 @@ assert.match(
   "quick-chat route renders the tray quick chat component",
 );
 assert.match(component, /useQuickChat\(\)/, "tray quick chat consumes the shared useQuickChat hook");
-assert.match(hook, /fetch\("\/api\/familiars"\)/, "quick chat loads the familiar roster");
+assert.match(hook, /fetch\("\/api\/familiars"/, "quick chat loads the familiar roster");
 assert.match(
   hook,
   /resolveQuickChatTarget\(draft, familiars, selectedFamiliarId\)/,
@@ -26,13 +27,17 @@ assert.match(
   /streamFamiliarText\(\{[\s\S]*familiarId: target\.familiarId,[\s\S]*prompt: target\.prompt/,
   "quick chat sends through the sanctioned familiar chat bridge",
 );
+// The tray renders its controls and composer through the shared pieces — the
+// command-control options live once, in quick-chat-controls.
+assert.match(component, /<QuickChatControlsRow/, "tray renders the shared controls row");
+assert.match(component, /<QuickChatComposer/, "tray renders the shared composer");
 assert.match(
-  component,
+  controls,
   /COMMAND_THINKING_OPTIONS/,
   "quick chat uses the shared thinking effort options",
 );
 assert.match(
-  component,
+  controls,
   /COMMAND_RESPONSE_SPEED_OPTIONS/,
   "quick chat uses the shared response speed options",
 );
@@ -42,15 +47,14 @@ assert.match(
   "quick chat forwards compact command controls to the familiar stream helper",
 );
 assert.match(
-  component,
-  /onKeyDown=\{onKeyDown\}/,
-  "tray textarea sends on Cmd/Ctrl+Enter via onKeyDown",
-);
-assert.match(
-  component,
+  controls,
   /\(event\.metaKey \|\| event\.ctrlKey\) && event\.key === "Enter"/,
-  "tray Cmd/Ctrl+Enter handler sends the draft",
+  "the shared composer sends the draft on Cmd/Ctrl+Enter",
 );
+// The tray suggestion chips focus the composer after filling it — the overlay
+// always did; the tray drifting apart was a bug.
+assert.match(component, /useSuggestionPicker\(setDraft\)/, "tray suggestion picks land the caret in the composer");
+assert.match(component, /autoFocus/, "the tray window focuses its composer on open (no focus trap to fight)");
 assert.match(
   component,
   /emit\("quick-chat:open-session"/,

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -1,25 +1,15 @@
 "use client";
 
 import { useCallback } from "react";
-import {
-  COMMAND_RESPONSE_SPEED_OPTIONS,
-  COMMAND_THINKING_OPTIONS,
-  type CommandResponseSpeed,
-  type CommandThinkingEffort,
-} from "@/lib/command-controls";
-import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
-import { StandardSelect } from "@/components/ui/select";
-import { Icon } from "@/lib/icon";
 import { useQuickChat } from "@/lib/use-quick-chat";
-import { FamiliarMark, QuickChatSelect, QuickChatThread } from "@/components/quick-chat-controls";
-
-// One-tap starters for a cold thread — they fill the composer, not send.
-const TRAY_SUGGESTIONS = [
-  "Summarize what needs my attention",
-  "Draft a short status update",
-  "What changed recently?",
-];
+import {
+  QuickChatComposer,
+  QuickChatControlsRow,
+  QuickChatIdentity,
+  QuickChatThread,
+  useSuggestionPicker,
+} from "@/components/quick-chat-controls";
 
 export function TrayQuickChat() {
   const {
@@ -46,20 +36,7 @@ export function TrayQuickChat() {
   } = useQuickChat();
 
   const sending = sendState === "sending";
-
-  const onKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      const cmdEnter = (event.metaKey || event.ctrlKey) && event.key === "Enter";
-      // Enter sends; Shift+Enter inserts a newline; IME composition is left alone.
-      const plainEnter =
-        event.key === "Enter" && !event.shiftKey && !event.nativeEvent.isComposing;
-      if (cmdEnter || plainEnter) {
-        event.preventDefault();
-        if (!sending && draft.trim()) void send();
-      }
-    },
-    [draft, send, sending],
-  );
+  const { composerRef, pickSuggestion } = useSuggestionPicker(setDraft);
 
   const openFullSession = useCallback(async () => {
     if (!sessionId) return;
@@ -81,22 +58,7 @@ export function TrayQuickChat() {
             gated by capabilities/loopback-window-drag.json. Inert in plain
             browsers. */}
         <header className="quick-chat-overlay__header" data-tauri-drag-region="deep">
-          <div className="flex min-w-0 items-center gap-2">
-            {selectedFamiliar ? (
-              <FamiliarMark familiar={selectedFamiliar} size="md" />
-            ) : (
-              <Icon name="ph:chat-circle-dots" width={20} aria-hidden />
-            )}
-            <div className="min-w-0">
-              <h1 className="truncate text-sm font-semibold">
-                {selectedFamiliar ? selectedFamiliar.display_name : "Quick Chat"}
-              </h1>
-              <p className="truncate text-xs text-[var(--fg-muted)]">
-                {/* Mirror the in-app overlay: loading is not "no familiar". */}
-                {loading ? "Loading familiars…" : selectedFamiliar ? `@${selectedFamiliar.id}` : "No familiar selected"}
-              </p>
-            </div>
-          </div>
+          <QuickChatIdentity familiar={selectedFamiliar} loading={loading} as="h1" />
           <div className="flex items-center gap-1">
             <IconButton
               onClick={newThread}
@@ -117,90 +79,43 @@ export function TrayQuickChat() {
           </div>
         </header>
 
-        <div className="quick-chat-overlay__controls">
-          <QuickChatSelect
-            label="Familiar"
-            value={selectedFamiliarId ?? ""}
-            onChange={(next) => setSelectedFamiliarId(next || null)}
-            disabled={loading || familiars.length === 0}
-            className="flex-1"
-            options={
-              loading && familiars.length === 0
-                ? [{ value: "", label: "Loading…", disabled: true }]
-                : familiars.map((familiar) => ({
-                    value: familiar.id,
-                    label: familiar.display_name,
-                    leading: <FamiliarMark familiar={familiar} size="sm" />,
-                  }))
-            }
-          />
-          <StandardSelect
-            label="Choose thinking effort"
-            value={thinkingEffort}
-            onChange={(next) => setThinkingEffort(next as CommandThinkingEffort)}
-            disabled={sending}
-            className="min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
-            options={COMMAND_THINKING_OPTIONS}
-          />
-          <StandardSelect
-            label="Choose response speed"
-            value={responseSpeed}
-            onChange={(next) => setResponseSpeed(next as CommandResponseSpeed)}
-            disabled={sending}
-            className="min-w-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1.5 text-xs outline-none"
-            options={COMMAND_RESPONSE_SPEED_OPTIONS}
-          />
-        </div>
+        <QuickChatControlsRow
+          loading={loading}
+          familiars={familiars}
+          selectedFamiliarId={selectedFamiliarId}
+          onPickFamiliar={setSelectedFamiliarId}
+          thinkingEffort={thinkingEffort}
+          onThinkingEffortChange={setThinkingEffort}
+          responseSpeed={responseSpeed}
+          onResponseSpeedChange={setResponseSpeed}
+          sending={sending}
+        />
 
         <QuickChatThread
           messages={messages}
           familiar={selectedFamiliar}
-          emptyIcon="ph:chat-circle-dots"
-          emptyTitle={selectedFamiliar ? `Ask ${selectedFamiliar.display_name} anything` : "Ask a familiar anything"}
-          emptyHint="Replies stream right here · @name to switch familiar · Enter to send"
-          suggestions={TRAY_SUGGESTIONS}
-          onSuggestion={setDraft}
+          onSuggestion={pickSuggestion}
           onRegenerate={sending ? undefined : regenerate}
         />
 
-        <footer className="quick-chat-overlay__composer">
-          {error ? (
-            <p className="quick-chat-overlay__error" role="alert">
-              {error}
-            </p>
-          ) : null}
-          <textarea
-            id="quick-chat-draft"
-            value={draft}
-            autoFocus
-            aria-label="Message"
-            onChange={(event) => setDraft(event.target.value)}
-            onKeyDown={onKeyDown}
-            placeholder={selectedFamiliar ? `Message @${selectedFamiliar.id}…` : "@sage summarize what needs attention"}
-            className="quick-chat-overlay__input"
-          />
-          <div className="quick-chat-overlay__actions">
+        <QuickChatComposer
+          error={error}
+          draft={draft}
+          onDraftChange={setDraft}
+          onSend={() => void send()}
+          onCancel={cancel}
+          sending={sending}
+          disabled={loading}
+          familiar={selectedFamiliar}
+          inputId="quick-chat-draft"
+          composerRef={composerRef}
+          autoFocus
+          leading={
             <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
-              @id switches familiars · ⌘↵ to send
+              @id switches familiars · Enter to send
             </p>
-            <div className="flex items-center gap-2">
-              {sending ? (
-                <Button variant="secondary" size="sm" onClick={cancel}>
-                  Stop
-                </Button>
-              ) : null}
-              <Button
-                variant="primary"
-                size="sm"
-                leadingIcon="ph:sparkle"
-                onClick={() => void send()}
-                disabled={sending || loading || !draft.trim()}
-              >
-                Send
-              </Button>
-            </div>
-          </div>
-        </footer>
+          }
+        />
       </section>
     </main>
   );

--- a/src/lib/familiar-stream.test.ts
+++ b/src/lib/familiar-stream.test.ts
@@ -108,4 +108,56 @@ describe("streamFamiliarText", () => {
     const { error } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
     assert.match(error ?? "", /chat bridge 502/);
   });
+
+  it("fires onSession as soon as the session frame arrives, before the stream completes", async () => {
+    globalThis.fetch = (async () => sseResponse([
+      frame({ kind: "session", sessionId: "sess-early" }),
+      frame({ kind: "assistant_chunk", text: "hi" }),
+      frame({ kind: "done", sessionId: "sess-early" }),
+    ])) as typeof fetch;
+
+    const seen: Array<{ id: string; textSoFar: string }> = [];
+    let textSoFar = "";
+    const { sessionId } = await streamFamiliarText({
+      familiarId: "nova",
+      prompt: "hi",
+      onText: (t) => { textSoFar = t; },
+      onSession: (id) => seen.push({ id, textSoFar }),
+    });
+
+    assert.equal(sessionId, "sess-early");
+    assert.ok(seen.length >= 1, "onSession fired");
+    assert.equal(seen[0].id, "sess-early");
+    assert.equal(seen[0].textSoFar, "", "the first onSession fired before any text streamed (a Stop mid-stream still knows its session)");
+  });
+
+  it("processes a final frame that arrives without its trailing blank line", async () => {
+    globalThis.fetch = (async () => sseResponse([
+      frame({ kind: "assistant_chunk", text: "tail" }),
+      `data: ${JSON.stringify({ kind: "done", sessionId: "sess-tail" })}\n`,
+    ])) as typeof fetch;
+
+    const { text, sessionId } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
+    assert.equal(text, "tail");
+    assert.equal(sessionId, "sess-tail", "the unterminated done frame is still processed");
+  });
+
+  it("decodes multi-byte characters split across stream chunks", async () => {
+    const bytes = new TextEncoder().encode(frame({ kind: "assistant_chunk", text: "héllo" }) + frame({ kind: "done" }));
+    // Split exactly between the two bytes of "é" (0xC3 0xA9).
+    const splitAt = bytes.indexOf(0xc3) + 1;
+    assert.ok(splitAt > 0, "test setup: the é byte pair is present");
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.slice(0, splitAt));
+        controller.enqueue(bytes.slice(splitAt));
+        controller.close();
+      },
+    });
+    globalThis.fetch = (async () => ({ ok: true, body }) as unknown as Response) as typeof fetch;
+
+    const { text, error } = await streamFamiliarText({ familiarId: "nova", prompt: "hi" });
+    assert.equal(text, "héllo");
+    assert.equal(error, null);
+  });
 });

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -22,6 +22,10 @@ export async function streamFamiliarText(opts: {
   /** Called with the accumulated assistant text after each streamed chunk,
    *  so callers can render the reply incrementally as it arrives. */
   onText?: (text: string) => void;
+  /** Called the moment the bridge announces the backing session id — before
+   *  the stream completes — so callers can keep the thread resumable even if
+   *  the run is aborted mid-stream. */
+  onSession?: (sessionId: string) => void;
 }): Promise<{ text: string; error: string | null; sessionId?: string }> {
   let res: Response;
   try {
@@ -50,27 +54,38 @@ export async function streamFamiliarText(opts: {
   let text = "";
   let error: string | null = null;
   let sessionId: string | undefined;
+
+  const noteSession = (id: string | undefined) => {
+    if (!id) return;
+    sessionId = id;
+    opts.onSession?.(id);
+  };
+  const handleFrame = (frame: string) => {
+    const ev = parseSseFrame(frame);
+    if (!ev) return;
+    if (ev.kind === "assistant_chunk") {
+      text += ev.text ?? "";
+      opts.onText?.(text);
+    } else if (ev.kind === "session") noteSession(ev.sessionId);
+    else if (ev.kind === "done") {
+      noteSession(ev.sessionId);
+      if (ev.isError) error = error ?? "the familiar reported an error";
+    } else if (ev.kind === "error") error = ev.message ?? "generation error";
+  };
+
   while (true) {
     const { value, done } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
     let idx;
     while ((idx = buffer.indexOf("\n\n")) >= 0) {
-      const frame = buffer.slice(0, idx);
+      handleFrame(buffer.slice(0, idx));
       buffer = buffer.slice(idx + 2);
-      const ev = parseSseFrame(frame);
-      if (!ev) continue;
-      if (ev.kind === "assistant_chunk") {
-        text += ev.text ?? "";
-        opts.onText?.(text);
-      }
-      else if (ev.kind === "session") sessionId = ev.sessionId;
-      else if (ev.kind === "done") {
-        if (ev.sessionId) sessionId = ev.sessionId;
-        if (ev.isError) error = error ?? "the familiar reported an error";
-      }
-      else if (ev.kind === "error") error = ev.message ?? "generation error";
     }
   }
+  // Flush the decoder (a multi-byte character can straddle the final chunk)
+  // and process a last frame that arrived without its trailing blank line.
+  buffer += decoder.decode();
+  if (buffer.trim()) handleFrame(buffer);
   return { text, error, sessionId };
 }

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -20,6 +20,24 @@ import type { Familiar } from "@/lib/types";
 
 const LAST_FAMILIAR_KEY = "cave.quick-chat.last-familiar";
 
+// localStorage can throw (private browsing, storage full) — remembering the
+// last familiar is a nicety and must never take down the send itself.
+function readLastFamiliar(): string | null {
+  try {
+    return typeof window !== "undefined" ? window.localStorage.getItem(LAST_FAMILIAR_KEY) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastFamiliar(id: string): void {
+  try {
+    window.localStorage.setItem(LAST_FAMILIAR_KEY, id);
+  } catch {
+    // Best-effort only.
+  }
+}
+
 export type QuickChatSendState = "idle" | "sending" | "done";
 
 export type QuickChatRole = "user" | "assistant";
@@ -66,10 +84,16 @@ export type UseQuickChatOptions = {
    *  last-used/first fallback. The user's manual pick in the popover still
    *  wins once made. */
   preferredFamiliarId?: string | null;
+  /** Defer the roster fetch until true (latched — flipping back to false does
+   *  not unload). The in-app popover mounts closed at boot and shouldn't
+   *  duplicate the workspace's own roster fetch; it passes its `open` flag.
+   *  Defaults to true (the tray window loads immediately). */
+  enabled?: boolean;
 };
 
 export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   const preferredFamiliarId = options?.preferredFamiliarId ?? null;
+  const enabled = options?.enabled ?? true;
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [selectedFamiliarId, setSelectedFamiliarId] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
@@ -94,8 +118,9 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   const lastUserPromptRef = useRef<string>("");
   // Monotonic id source for message keys (stable across renders).
   const msgSeqRef = useRef(0);
-  // Once the user explicitly picks a familiar in the UI, stop following the
-  // preferred (workspace-active) familiar — their choice is stickier.
+  // Once the user explicitly picks a familiar in the UI (or targets one with a
+  // leading @mention), stop following the preferred (workspace-active)
+  // familiar — their choice is stickier.
   const userPickedRef = useRef(false);
   // Latest preferred id for the one-shot roster load below (no effect re-run).
   const preferredRef = useRef<string | null>(preferredFamiliarId);
@@ -104,6 +129,9 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   // without threading it through a state updater.
   const selectedIdRef = useRef<string | null>(selectedFamiliarId);
   selectedIdRef.current = selectedFamiliarId;
+  // Roster-load bookkeeping: fire once (latched on `enabled`), abort on unmount.
+  const rosterStartedRef = useRef(false);
+  const rosterAbortRef = useRef<AbortController | null>(null);
 
   const nextId = useCallback((prefix: string) => `${prefix}-${msgSeqRef.current++}`, []);
 
@@ -121,18 +149,21 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   }, []);
 
   useEffect(() => {
-    let alive = true;
+    if (!enabled || rosterStartedRef.current) return;
+    rosterStartedRef.current = true;
+    const controller = new AbortController();
+    rosterAbortRef.current = controller;
+    setLoading(true);
     void (async () => {
       try {
-        const res = await fetch("/api/familiars");
+        const res = await fetch("/api/familiars", { signal: controller.signal });
+        if (!res.ok) throw new Error(`Failed to load familiars (${res.status}).`);
         const json = await res.json();
-        if (!alive) return;
+        if (controller.signal.aborted) return;
         const next = (json?.familiars ?? []) as Familiar[];
-        const stored =
-          typeof window !== "undefined"
-            ? window.localStorage.getItem(LAST_FAMILIAR_KEY)
-            : null;
+        const stored = readLastFamiliar();
         const preferred = preferredRef.current;
+        setError(null);
         setFamiliars(next);
         // Default priority: the workspace's active familiar, then the last
         // familiar used in quick chat, then the first in the roster.
@@ -143,15 +174,17 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
             null,
         );
       } catch (err) {
-        if (alive) setError((err as Error)?.message ?? "Failed to load familiars.");
+        if (!controller.signal.aborted) {
+          // Un-latch so closing and reopening retries a failed load (the
+          // roster route can flake) instead of wedging on the error forever.
+          rosterStartedRef.current = false;
+          setError((err as Error)?.message ?? "Failed to load familiars.");
+        }
       } finally {
-        if (alive) setLoading(false);
+        if (!controller.signal.aborted) setLoading(false);
       }
     })();
-    return () => {
-      alive = false;
-    };
-  }, []);
+  }, [enabled]);
 
   // Follow the workspace's active familiar as it changes — until the user has
   // explicitly picked one in the popover (their choice then sticks).
@@ -161,10 +194,11 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     setSelectedFamiliarId(preferredFamiliarId);
   }, [preferredFamiliarId, familiars]);
 
-  // Abort any in-flight stream when the consumer unmounts.
+  // Abort any in-flight stream + roster load when the consumer unmounts.
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
+      rosterAbortRef.current?.abort();
     };
   }, []);
 
@@ -197,6 +231,15 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
           reasoningEffort: thinkingEffort,
           responseSpeed,
           signal: controller.signal,
+          // Capture the backing session the moment the bridge announces it —
+          // if the user stops the stream mid-turn, the thread stays resumable
+          // and Open-in-full-chat still works. The aborted guard keeps a late
+          // frame from resurrecting a session newThread() just cleared.
+          onSession: (sid) => {
+            if (controller.signal.aborted) return;
+            sessionIdRef.current = sid;
+            setSessionId(sid);
+          },
           onText: (t) =>
             setMessages((prev) =>
               prev.map((m) => (m.id === assistantId ? { ...m, text: t } : m)),
@@ -219,10 +262,6 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
       }
 
       if (abortRef.current === controller) abortRef.current = null;
-      if (result.sessionId) {
-        sessionIdRef.current = result.sessionId;
-        setSessionId(result.sessionId);
-      }
       setMessages((prev) =>
         prev.map((m) =>
           m.id === assistantId
@@ -236,6 +275,9 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   );
 
   const send = useCallback(async () => {
+    // One turn in flight at a time — a second Send/Enter while streaming would
+    // race the abort bookkeeping and duplicate turns.
+    if (abortRef.current) return;
     const target = resolveQuickChatTarget(draft, familiars, selectedFamiliarId);
     setError(target.error);
     if (target.error || !target.familiarId) return;
@@ -250,12 +292,15 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
       if (threadFamiliarRef.current) setMessages([]);
     }
     threadFamiliarRef.current = target.familiarId;
+    // Targeting a familiar by @mention is as deliberate as picking it in the
+    // dropdown — stop following the workspace-active familiar afterwards.
+    if (target.mention) userPickedRef.current = true;
 
     const userText = draft.trim();
     lastUserPromptRef.current = draft;
     setDraft("");
     setSelectedFamiliarId(target.familiarId);
-    window.localStorage.setItem(LAST_FAMILIAR_KEY, target.familiarId);
+    writeLastFamiliar(target.familiarId);
     setMessages((prev) => [...prev, { id: nextId("u"), role: "user", text: userText }]);
 
     await deliver(target, resume);
@@ -263,7 +308,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
 
   const regenerate = useCallback(() => {
     const prompt = lastUserPromptRef.current;
-    if (!prompt || sendState === "sending") return;
+    if (!prompt || sendState === "sending" || abortRef.current) return;
     const target = resolveQuickChatTarget(prompt, familiars, selectedFamiliarId);
     if (target.error || !target.familiarId) return;
     // Drop the trailing assistant turn(s) after the last user turn, then re-run.


### PR DESCRIPTION
## Summary

Refactor + bug pass over the quick-chat box (the "Ask X anything" dropdown from the top-bar Chat button, and its Tauri tray twin).

### Bugs fixed

| Bug | Fix |
|---|---|
| Roster fetch fired at app **boot** for the closed popover (duplicate of the workspace's own `/api/familiars` call) | `useQuickChat` gained a latched `enabled` option; the overlay passes `open`, the tray keeps eager loading |
| A 500/503 roster response **silently rendered an empty picker** (`res.json()` of the error envelope) | `res.ok` check → readable `Failed to load familiars (N).` in the error slot; failure un-latches so close/reopen retries; fetch aborts on unmount |
| **Stop mid-stream lost the session** — follow-ups forked a fresh context, Open-in-full-chat stayed disabled | `streamFamiliarText` gained `onSession`; the hook captures the id the moment the bridge announces it (guarded against late frames after `newThread`) |
| SSE reader dropped an **unterminated final frame** and never flushed the `TextDecoder` (split multi-byte char truncated) | tail flush + final-frame processing |
| Unguarded `localStorage.setItem` in `send()` — a private-mode throw after `setDraft("")` **ate the message** | try/catch read/write helpers |
| `send()` had no re-entrancy guard | refuses to double-fire while a turn is in flight (regenerate too) |
| Thread auto-scroll pinned `scrollTop` **every token**, fighting scroll-up-to-reread | sticks only while near the bottom; new turn re-engages |
| Copy ✓ never reset | back to copy after 1.5s |
| `@mention` switch didn't count as a manual pick — workspace-active familiar could clobber it | mention sets the picked latch |
| Tray drift: suggestions didn't focus the composer; hint said "⌘↵ to send" though Enter sends | shared composer + `useSuggestionPicker`; hint corrected |

### Refactor

Header identity, controls row, and composer were copy-pasted between `quick-chat-overlay.tsx` and `tray-quick-chat.tsx`. They now live once in `quick-chat-controls.tsx` (`QuickChatIdentity`, `QuickChatControlsRow`, `QuickChatComposer`, `useSuggestionPicker`, shared `QUICK_CHAT_SUGGESTIONS`); both surfaces compose them. Source-scan pins moved/tightened accordingly.

### Verification

- `test:app` full suite green (541 files); 3 new `streamFamiliarText` unit tests (onSession timing, tail-frame flush, split multi-byte decode)
- `tsc --noEmit` clean; prod build green, bundle within budget
- Driven live in a browser: roster fetch observed **only after** first open (was at boot), suggestion chip fills + focuses the composer, Send enables, roster-failure state renders the readable error

Bead: cave-72r

🤖 Generated with [Claude Code](https://claude.com/claude-code)