### PR TITLE
feat(dashboard): sortable/filterable insights + local space-usage analytics (cave-89b)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -659,6 +659,7 @@ export const SUITES = {
     "src/proxy-behavior.test.ts",
     "src/lib/server/memory-file-sources-coven-familiar.test.ts",
     "src/lib/server/memory-trash.test.ts",
+    "src/lib/server/space-usage.test.ts",
     "src/lib/server/theme-store.test.ts",
     "src/app/api/memory-coven-workspaces.test.ts",
     "src/app/api/memory-excerpt.test.ts",
@@ -777,6 +778,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/server/space-usage.test.ts",
   "src/lib/daily-narrative.test.ts",
   "src/lib/use-code-rail.test.ts",
   "src/lib/cave-familiar-images.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -149,6 +149,7 @@ const contracts: RouteContract[] = [
   { route: "/skills/directory/use", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/skills/local", methods: ["GET", "DELETE"], kind: "json" },
   { route: "/skills", methods: ["GET"], kind: "json" },
+  { route: "/space-usage", methods: ["GET"], kind: "json" },
   { route: "/theme", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/travel/client", methods: ["GET", "PATCH"], kind: "json", readsJson: true },
   { route: "/vault", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },

--- a/src/app/api/space-usage/route.ts
+++ b/src/app/api/space-usage/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { collectSpaceUsage } from "@/lib/server/space-usage";
+
+export const dynamic = "force-dynamic";
+
+/** Bounded local space-usage snapshot for the dashboard cockpit. Reads only
+ *  the fixed `~/.coven` area allow-list — no query-controlled paths. */
+export async function GET() {
+  try {
+    const areas = await collectSpaceUsage();
+    return NextResponse.json({ ok: true, areas, scannedAt: new Date().toISOString() });
+  } catch {
+    return NextResponse.json({ ok: false, areas: [] }, { status: 500 });
+  }
+}

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -120,4 +120,38 @@ assert.match(inbox, /\{allSelected \? "Clear" : "Select all"\}/, "the bulk bar o
 assert.match(inbox, /onClick=\{\(\) => void bulkAct\("done"\)\}/, "bulk Done is wired");
 assert.match(inbox, /void bulkAct\("snooze", minutes\)/, "bulk Snooze is wired through the menu");
 
+// ── cave-89b close-out: sortable/filterable tables + space usage + hoverable charts ──
+
+// The centerpiece table is sortable (accessible headers) and filterable.
+assert.match(cockpit, /sortInsightRows/, "insights table sorts through the pure helper");
+assert.match(cockpit, /filterInsightRows/, "insights table filters through the pure helper");
+assert.match(cockpit, /defaultInsightOrder/, "unsorted table keeps the curated ranking");
+assert.match(cockpit, /aria-sort=\{ariaSort\("confidence"\)\}/, "sortable headers expose aria-sort");
+assert.match(cockpit, /cockpit-sorthead/, "column headers are real buttons, not dead labels");
+assert.match(cockpit, /Filter familiars by name, role, or health/, "the filter input is labelled for AT");
+
+// Space usage: bounded local scan → sortable rows with cleanup drill-throughs.
+assert.match(cockpit, /\/api\/space-usage/, "cockpit pulls the bounded space-usage scan");
+assert.match(cockpit, /case "space"/, "a Space usage panel is wired into the layout switch");
+assert.match(cockpit, /SpaceUsagePanel/, "renders the space usage panel");
+assert.match(cockpit, /sortSpaceRows/, "space rows sort through the pure helper");
+assert.match(cockpit, /spaceUsageRows/, "space rows derive share + cleanup destinations");
+assert.match(cockpit, /formatBytes/, "sizes render as human-readable bytes");
+
+const spaceRouteUrl = new URL("./api/space-usage/route.ts", import.meta.url);
+assert.equal(existsSync(spaceRouteUrl), true, "space-usage API route exists");
+const spaceRoute = readFileSync(spaceRouteUrl, "utf8");
+assert.match(spaceRoute, /collectSpaceUsage/, "route delegates to the bounded server scanner");
+assert.match(spaceRoute, /force-dynamic/, "space-usage snapshot is never statically cached");
+
+// Diagrams expose hover/focus details and accessible summaries.
+const donut = readFileSync(new URL("../components/ui/charts/donut-chart.tsx", import.meta.url), "utf8");
+assert.match(donut, /<title>/, "donut slices carry native hover titles");
+assert.match(donut, /role: "img"/, "donut can expose an accessible summary");
+const heatmap = readFileSync(new URL("../components/ui/charts/heatmap.tsx", import.meta.url), "utf8");
+assert.match(heatmap, /<title>/, "heatmap cells carry native hover titles");
+assert.match(heatmap, /role: "img"/, "heatmap can expose an accessible summary");
+assert.match(cockpit, /ariaLabel=\{`Board status:/, "board donut passes a data summary to AT");
+assert.match(cockpit, /ariaLabel=\{`Confidence factors by familiar:/, "confidence heatmap passes a data summary to AT");
+
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -17,7 +17,10 @@ import { TrendChart } from "@/components/ui/charts/trend-chart";
 import { Heatmap } from "@/components/ui/charts/heatmap";
 import {
   familiarMiniProfiles, familiarLoadSeries, dashboardSignals, type DashboardSignal, type FamiliarMiniProfile,
+  defaultInsightOrder, sortInsightRows, filterInsightRows, type InsightSortKey, type SortDir,
+  spaceUsageRows, sortSpaceRows, formatBytes, type SpaceSortKey, type SpaceUsageRow,
 } from "@/lib/dashboard-analytics";
+import type { SpaceUsageArea } from "@/lib/server/space-usage";
 import {
   deriveCovenVitals, deriveCovenInsight, covenSessionsSeries,
   type FamiliarInsightRow, type CovenVitals,
@@ -52,9 +55,10 @@ type CockpitData = {
   upcoming: InboxItem[];
   sessions: SessionRow[];
   memory: CovenMemoryEntry[];
+  space: SpaceUsageArea[];
 };
 
-const EMPTY: CockpitData = { cards: [], familiars: [], github: [], upcoming: [], sessions: [], memory: [] };
+const EMPTY: CockpitData = { cards: [], familiars: [], github: [], upcoming: [], sessions: [], memory: [], space: [] };
 
 const EMPTY_STATS: FamiliarCardStats = { memoryCount: 0, latestMemory: null, lastSessionAt: null, sessionsLast7d: 0, hasActiveSession: false };
 
@@ -69,7 +73,7 @@ const LAYOUT_KEY = "cave:cockpit:layout:v2";
 type Layout = { main: string[]; rail: string[] };
 const DEFAULT_LAYOUT: Layout = {
   main: ["usage", "signals", "needs", "board", "today"],
-  rail: ["confidence", "agents", "load", "github", "agenda"],
+  rail: ["confidence", "agents", "load", "space", "github", "agenda"],
 };
 
 /** Merge a saved order with the defaults: keep known ids in saved order, append
@@ -176,6 +180,7 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     void getJson<{ items: InboxItem[] }>("/api/inbox?status=pending").then((r) => put("upcoming", r?.items ?? []));
     void getJson<{ sessions: SessionRow[] }>("/api/sessions/list").then((r) => put("sessions", r?.sessions ?? []));
     void getJson<{ entries: CovenMemoryEntry[] }>("/api/coven-memory").then((r) => put("memory", r?.entries ?? []));
+    void getJson<{ areas: SpaceUsageArea[] }>("/api/space-usage").then((r) => put("space", r?.areas ?? []));
     void Promise.all([
       getJson<{ items: GitHubItem[] }>("/api/github/activity"),
       getJson<{ items: GitHubItem[] }>("/api/github/assigned"),
@@ -431,6 +436,13 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
             )}
           </Panel>);
       }
+      case "space": {
+        const rows = spaceUsageRows(data.space);
+        return (
+          <Panel title="Space usage" icon="ph:database-bold" hint={rows.length ? formatBytes(rows.reduce((s, r) => s + r.bytes, 0)) : undefined}>
+            <SpaceUsagePanel rows={rows} loaded={ready.has("space")} />
+          </Panel>);
+      }
       case "github": return (
         <Panel title="GitHub" icon="ph:github-logo" count={data.github.length || undefined} hint={prsToReview.length ? `${prsToReview.length} to review` : undefined} href="/?mode=github">
           <GithubPanel items={data.github} loaded={ready.has("github")} />
@@ -662,29 +674,69 @@ function coverageSub(base: string, fetched: number, total: number, verb: "scored
 
 // ─── Familiar insights table (centerpiece) ────────────────────────────────────────
 
+/** Sortable column headers: click cycles default → desc → asc (numeric) or
+ *  default → asc → desc (name). The "default" order keeps the curated ranking
+ *  (confidence, then activity). */
+type InsightSort = { key: InsightSortKey; dir: SortDir } | null;
+
 function FamiliarInsightsTable({ rows, loaded }: { rows: FamiliarInsightRow[]; loaded: boolean }) {
-  const sorted = useMemo(
-    () => [...rows].sort((a, b) => {
-      // Scored familiars first (highest confidence), then by recent activity.
-      const ca = a.confidenceScore ?? -1, cb = b.confidenceScore ?? -1;
-      if (cb !== ca) return cb - ca;
-      return b.sessions7d - a.sessions7d;
-    }),
-    [rows],
+  const [sort, setSort] = useState<InsightSort>(null);
+  const [query, setQuery] = useState("");
+  const visible = useMemo(() => {
+    const filtered = filterInsightRows(rows, query);
+    return sort ? sortInsightRows(filtered, sort.key, sort.dir) : defaultInsightOrder(filtered);
+  }, [rows, sort, query]);
+
+  const cycleSort = (key: InsightSortKey, firstDir: SortDir) => {
+    setSort((prev) => {
+      if (!prev || prev.key !== key) return { key, dir: firstDir };
+      const second: SortDir = firstDir === "desc" ? "asc" : "desc";
+      return prev.dir === firstDir ? { key, dir: second } : null; // third click restores curated order
+    });
+  };
+  const ariaSort = (key: InsightSortKey): "ascending" | "descending" | "none" =>
+    sort?.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
+  const sortHeader = (key: InsightSortKey, label: string, firstDir: SortDir) => (
+    <button type="button" className={`cockpit-sorthead${sort?.key === key ? " is-sorted" : ""}`} onClick={() => cycleSort(key, firstDir)}>
+      {label}
+      <Icon name={sort?.key === key ? (sort.dir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"} aria-hidden />
+    </button>
   );
+
   if (!loaded) return <PanelSkeleton rows={4} />;
   if (rows.length === 0) return <EmptyState icon="ph:users-three-bold">No familiars in your coven yet.</EmptyState>;
   return (
-    <div className="cockpit-fam" role="table" aria-label="Familiar insights">
-      <div className="cockpit-fam__head" role="row">
-        <span role="columnheader">Familiar</span>
-        <span role="columnheader">Confidence</span>
-        <span role="columnheader">Activity</span>
-        <span role="columnheader" className="cockpit-fam__trendcol">7-day sessions</span>
-        <span role="columnheader" className="cockpit-fam__contractcol">Contract</span>
-        <span role="columnheader" className="cockpit-fam__lastcol">Last active</span>
-      </div>
-      {sorted.map((r) => (
+    <>
+      {rows.length > 3 ? (
+        <div className="cockpit-fam__tools">
+          <label className="cockpit-fam__filter">
+            <Icon name="ph:magnifying-glass" aria-hidden />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Filter familiars…"
+              aria-label="Filter familiars by name, role, or health"
+            />
+          </label>
+          {query && visible.length !== rows.length ? (
+            <span className="cockpit-fam__matchcount" role="status">{visible.length}/{rows.length}</span>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="cockpit-fam" role="table" aria-label="Familiar insights">
+        <div className="cockpit-fam__head" role="row">
+          <span role="columnheader" aria-sort={ariaSort("name")}>{sortHeader("name", "Familiar", "asc")}</span>
+          <span role="columnheader" aria-sort={ariaSort("confidence")}>{sortHeader("confidence", "Confidence", "desc")}</span>
+          <span role="columnheader" aria-sort={ariaSort("sessions")}>{sortHeader("sessions", "Activity", "desc")}</span>
+          <span role="columnheader" className="cockpit-fam__trendcol">7-day sessions</span>
+          <span role="columnheader" className="cockpit-fam__contractcol" aria-sort={ariaSort("contract")}>{sortHeader("contract", "Contract", "desc")}</span>
+          <span role="columnheader" className="cockpit-fam__lastcol" aria-sort={ariaSort("lastActive")}>{sortHeader("lastActive", "Last active", "desc")}</span>
+        </div>
+        {visible.length === 0 ? (
+          <p className="cockpit-muted cockpit-fam__nomatch">No familiars match “{query}”.</p>
+        ) : null}
+        {visible.map((r) => (
         <a key={r.id} className="cockpit-fam__row" role="row" href={`/dashboard/familiars/${encodeURIComponent(r.id)}/analytics`}>
           <span className="cockpit-fam__who" role="cell">
             <span className="cockpit-fam__avatar" style={{ background: r.color }}>
@@ -724,7 +776,8 @@ function FamiliarInsightsTable({ rows, loaded }: { rows: FamiliarInsightRow[]; l
           </span>
         </a>
       ))}
-    </div>
+      </div>
+    </>
   );
 }
 
@@ -776,6 +829,7 @@ function BoardSnapshot({ byStatus, total, active, loaded, familiars }: {
         data={segs.map(({ s, n }) => ({ label: STATUS_META[s].label, value: n, color: STATUS_META[s].color }))}
         size={132}
         thickness={18}
+        ariaLabel={`Board status: ${segs.map(({ s, n }) => `${STATUS_META[s].label} ${n}`).join(", ")}`}
       />
       <div className="cockpit-bar__legend">
         {segs.map(({ s, n }) => (
@@ -978,8 +1032,81 @@ function ConfidencePanel({ rows }: { rows: ConfidenceRow[] }) {
             </a>
           ))}
         </div>
-        <Heatmap rows={rows.map((r) => r.name)} cols={cols} cells={cells} colorFor={confidenceColor} height={Math.max(72, rows.length * 26)} />
+        <Heatmap
+          rows={rows.map((r) => r.name)}
+          cols={cols}
+          cells={cells}
+          colorFor={confidenceColor}
+          height={Math.max(72, rows.length * 26)}
+          ariaLabel={`Confidence factors by familiar: ${rows.map((r) => `${r.name} ${r.score}`).join(", ")}`}
+          cellTitle={(c) => `${c.row} · ${c.col}: ${Math.round(c.value * 100)}/100`}
+        />
       </div>
+    </div>
+  );
+}
+
+// ─── Space usage ─────────────────────────────────────────────────────────────────
+
+type SpaceSort = { key: SpaceSortKey; dir: SortDir };
+
+/** Local disk footprint per `~/.coven` area: sortable rows, share bars, and a
+ *  cleanup drill-through per area. Figures come from the bounded server scan. */
+function SpaceUsagePanel({ rows, loaded }: { rows: SpaceUsageRow[]; loaded: boolean }) {
+  const [sort, setSort] = useState<SpaceSort>({ key: "bytes", dir: "desc" });
+  const sorted = useMemo(() => sortSpaceRows(rows, sort.key, sort.dir), [rows, sort]);
+  if (!loaded) return <PanelSkeleton rows={3} />;
+  if (rows.length === 0) return <EmptyState icon="ph:database-bold">No local coven data found.</EmptyState>;
+
+  const cycle = (key: SpaceSortKey, firstDir: SortDir) =>
+    setSort((prev) => prev.key === key
+      ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+      : { key, dir: firstDir });
+  const ariaSort = (key: SpaceSortKey): "ascending" | "descending" | "none" =>
+    sort.key === key ? (sort.dir === "asc" ? "ascending" : "descending") : "none";
+  const head = (key: SpaceSortKey, label: string, firstDir: SortDir) => (
+    <button type="button" className={`cockpit-sorthead${sort.key === key ? " is-sorted" : ""}`} onClick={() => cycle(key, firstDir)}>
+      {label}
+      <Icon name={sort.key === key ? (sort.dir === "asc" ? "ph:caret-up" : "ph:caret-down") : "ph:caret-up-down"} aria-hidden />
+    </button>
+  );
+
+  return (
+    <div className="cockpit-space" role="table" aria-label="Local space usage by area">
+      <div className="cockpit-space__head" role="row">
+        <span role="columnheader" aria-sort={ariaSort("label")}>{head("label", "Area", "asc")}</span>
+        <span role="columnheader" aria-sort={ariaSort("bytes")}>{head("bytes", "Size", "desc")}</span>
+        <span role="columnheader" className="cockpit-space__filescol" aria-sort={ariaSort("files")}>{head("files", "Files", "desc")}</span>
+        <span role="columnheader" className="cockpit-space__lastcol" aria-sort={ariaSort("lastModified")}>{head("lastModified", "Updated", "desc")}</span>
+      </div>
+      {sorted.map((r) => {
+        const inner = (
+          <>
+            <span className="cockpit-space__area" role="cell" title={r.relPath}>
+              <b>{r.label}</b>
+              <span className="cockpit-space__path">{r.relPath}</span>
+            </span>
+            <span className="cockpit-space__size" role="cell">
+              <b>{formatBytes(r.bytes)}{r.truncated ? "+" : ""}</b>
+              <span className="cockpit-space__bar" aria-hidden>
+                <i style={{ width: `${Math.max(2, r.sharePct)}%` }} />
+              </span>
+            </span>
+            <span className="cockpit-space__files cockpit-space__filescol" role="cell">{r.files}{r.truncated ? "+" : ""}</span>
+            <span className="cockpit-space__last cockpit-space__lastcol" role="cell">
+              {r.lastModifiedMs ? (relativeTime(new Date(r.lastModifiedMs).toISOString()) || "just now") : "—"}
+            </span>
+          </>
+        );
+        // Areas a surface owns drill into that surface; the rest are plain rows.
+        return r.href ? (
+          <a key={r.id} className="cockpit-space__row cockpit-space__row--link" role="row" href={r.href} title={r.actionLabel ?? undefined}>
+            {inner}
+          </a>
+        ) : (
+          <span key={r.id} className="cockpit-space__row" role="row">{inner}</span>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/ui/charts/donut-chart.tsx
+++ b/src/components/ui/charts/donut-chart.tsx
@@ -15,15 +15,19 @@ export function DonutChart({
   data,
   size = 160,
   thickness = 22,
+  ariaLabel,
 }: {
   data: DonutDatum[];
   size?: number;
   thickness?: number;
+  /** When set, the chart SVG is exposed to AT as role="img" with this label (a
+   *  text summary of the data). Without it the SVG stays aria-hidden. */
+  ariaLabel?: string;
 }) {
   return (
     <div className="cave-chart cave-chart--donut" style={{ height: size }}>
       <ParentSize>
-        {({ width }) => <DonutInner width={width} size={size} thickness={thickness} data={data} />}
+        {({ width }) => <DonutInner width={width} size={size} thickness={thickness} data={data} ariaLabel={ariaLabel} />}
       </ParentSize>
     </div>
   );
@@ -34,11 +38,13 @@ function DonutInner({
   size,
   thickness,
   data,
+  ariaLabel,
 }: {
   width: number;
   size: number;
   thickness: number;
   data: DonutDatum[];
+  ariaLabel?: string;
 }) {
   const total = data.reduce((sum, d) => sum + d.value, 0);
   if (total <= 0 || width === 0) {
@@ -49,7 +55,7 @@ function DonutInner({
   const innerRadius = Math.max(0, radius - thickness);
 
   return (
-    <svg width={width} height={size} aria-hidden>
+    <svg width={width} height={size} {...(ariaLabel ? { role: "img", "aria-label": ariaLabel } : { "aria-hidden": true })}>
       <Group top={size / 2} left={width / 2}>
         <Pie
           data={data}
@@ -60,7 +66,10 @@ function DonutInner({
         >
           {(pie) =>
             pie.arcs.map((arc) => (
-              <path key={arc.data.label} d={pie.path(arc) ?? undefined} fill={arc.data.color} />
+              <path key={arc.data.label} d={pie.path(arc) ?? undefined} fill={arc.data.color}>
+                {/* Native SVG hover detail: "In review: 3 (25%)" */}
+                <title>{`${arc.data.label}: ${arc.data.value} (${Math.round((arc.data.value / total) * 100)}%)`}</title>
+              </path>
             ))
           }
         </Pie>

--- a/src/components/ui/charts/heatmap.tsx
+++ b/src/components/ui/charts/heatmap.tsx
@@ -18,18 +18,25 @@ export function Heatmap({
   cells,
   colorFor,
   height = 160,
+  ariaLabel,
+  cellTitle,
 }: {
   rows: string[];
   cols: string[];
   cells: HeatCell[];
   colorFor: (value: number) => string;
   height?: number;
+  /** When set, the chart SVG is exposed to AT as role="img" with this label (a
+   *  text summary of the data). Without it the SVG stays aria-hidden. */
+  ariaLabel?: string;
+  /** Hover/focus detail per cell; defaults to "row · col: value". */
+  cellTitle?: (cell: HeatCell) => string;
 }) {
   return (
     <div className="cave-chart cave-chart--heatmap" style={{ height }}>
       <ParentSize>
         {({ width }) => (
-          <HeatInner width={width} height={height} rows={rows} cols={cols} cells={cells} colorFor={colorFor} />
+          <HeatInner width={width} height={height} rows={rows} cols={cols} cells={cells} colorFor={colorFor} ariaLabel={ariaLabel} cellTitle={cellTitle} />
         )}
       </ParentSize>
     </div>
@@ -43,6 +50,8 @@ function HeatInner({
   cols,
   cells,
   colorFor,
+  ariaLabel,
+  cellTitle,
 }: {
   width: number;
   height: number;
@@ -50,6 +59,8 @@ function HeatInner({
   cols: string[];
   cells: HeatCell[];
   colorFor: (value: number) => string;
+  ariaLabel?: string;
+  cellTitle?: (cell: HeatCell) => string;
 }) {
   const margin = { top: 2, right: 2, bottom: 2, left: 2 };
   const iw = Math.max(0, width - margin.left - margin.right);
@@ -62,7 +73,7 @@ function HeatInner({
   const yScale = scaleBand({ domain: rows, range: [0, ih], padding: 0.06 });
 
   return (
-    <svg width={width} height={height} aria-hidden>
+    <svg width={width} height={height} {...(ariaLabel ? { role: "img", "aria-label": ariaLabel } : { "aria-hidden": true })}>
       <Group left={margin.left} top={margin.top}>
         {cells.map((c) => {
           const cx = xScale(c.col);
@@ -78,7 +89,10 @@ function HeatInner({
               height={yScale.bandwidth()}
               rx={2}
               fill={colorFor(c.value)}
-            />
+            >
+              {/* Native SVG hover detail per cell. */}
+              <title>{cellTitle ? cellTitle(c) : `${c.row} · ${c.col}: ${c.value}`}</title>
+            </rect>
           );
         })}
       </Group>

--- a/src/lib/dashboard-analytics.test.ts
+++ b/src/lib/dashboard-analytics.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { sessionsPerDay, familiarMiniProfiles, familiarLoadSeries, dashboardSignals } from "./dashboard-analytics.ts";
+import { sessionsPerDay, familiarMiniProfiles, familiarLoadSeries, dashboardSignals, defaultInsightOrder, sortInsightRows, filterInsightRows, spaceUsageRows, sortSpaceRows, formatBytes } from "./dashboard-analytics.ts";
 
 const NOW = Date.parse("2026-06-29T12:00:00Z");
 const day = (offset) => new Date(NOW - offset * 86400_000).toISOString();
@@ -85,5 +85,92 @@ assert.equal(
   "/dashboard/familiars/f1/analytics",
   "trending-down signal opens that familiar's analytics",
 );
+
+// ── Insights table: sort + filter (pure) ─
+const row = (id, over = {}) => ({
+  id, name: id, role: "familiar", color: "#a", emoji: null, avatarUrl: null, active: false,
+  confidenceScore: null, confidenceLabel: null, health: null, sessions7d: 0, trend: [],
+  contractPass: 0, contractTotal: 0, lastActiveAt: null, ...over,
+});
+const rows = [
+  row("alpha", { confidenceScore: 60, sessions7d: 1, contractPass: 1, contractTotal: 2, lastActiveAt: day(3) }),
+  row("bravo", { confidenceScore: 90, sessions7d: 5, contractPass: 2, contractTotal: 2, lastActiveAt: day(0), health: "active" }),
+  row("charlie", { sessions7d: 9, lastActiveAt: day(1), role: "scout" }), // unscored, no contract
+];
+
+assert.deepEqual(
+  defaultInsightOrder(rows).map((r) => r.id),
+  ["bravo", "alpha", "charlie"],
+  "default curated order: confidence desc, then activity",
+);
+assert.deepEqual(
+  sortInsightRows(rows, "sessions", "desc").map((r) => r.id),
+  ["charlie", "bravo", "alpha"],
+  "sessions desc",
+);
+assert.deepEqual(
+  sortInsightRows(rows, "name", "asc").map((r) => r.id),
+  ["alpha", "bravo", "charlie"],
+  "name asc",
+);
+assert.deepEqual(
+  sortInsightRows(rows, "confidence", "asc").map((r) => r.id),
+  ["alpha", "bravo", "charlie"],
+  "confidence asc ranks real scores; unscored rows sink even ascending",
+);
+assert.deepEqual(
+  sortInsightRows(rows, "contract", "desc").map((r) => r.id),
+  ["bravo", "alpha", "charlie"],
+  "contract sorts by pass ratio; contract-less rows sink",
+);
+assert.deepEqual(
+  sortInsightRows(rows, "lastActive", "desc").map((r) => r.id),
+  ["bravo", "charlie", "alpha"],
+  "lastActive desc puts most recent first",
+);
+assert.deepEqual(filterInsightRows(rows, " BRA ").map((r) => r.id), ["bravo"], "filter matches names case/space-insensitively");
+assert.deepEqual(filterInsightRows(rows, "scout").map((r) => r.id), ["charlie"], "filter matches roles");
+assert.deepEqual(filterInsightRows(rows, "active").map((r) => r.id), ["bravo"], "filter matches health buckets");
+assert.equal(filterInsightRows(rows, "").length, 3, "empty query keeps everything");
+
+// ── Space usage rows: share, sort, cleanup destinations, formatting ─
+const area = (id, label, bytes, files, over = {}) => ({
+  id, label, relPath: `~/.coven/${id}`, exists: true, bytes, files, lastModifiedMs: NOW - bytes, truncated: false, ...over,
+});
+const spaceAreas = [
+  area("memory", "Familiar memory", 3000, 3),
+  area("conversations", "Chat transcripts", 6000, 10),
+  area("trash", "Trash", 1000, 1, { truncated: true }),
+  area("flows", "Flows", 0, 0),                        // empty → dropped
+  { ...area("journal", "Journal", 0, 0), exists: false }, // missing → dropped
+];
+const spaceRows = spaceUsageRows(spaceAreas);
+assert.deepEqual(spaceRows.map((r) => r.id).sort(), ["conversations", "memory", "trash"], "empty and missing areas are dropped");
+assert.equal(spaceRows.find((r) => r.id === "conversations").sharePct, 60, "share is pct of total scanned bytes");
+assert.equal(spaceRows.find((r) => r.id === "memory").href, "/?mode=agents", "memory row carries a cleanup destination");
+assert.equal(spaceRows.find((r) => r.id === "trash").href, null, "areas without an owning surface stay plain rows");
+assert.equal(spaceRows.find((r) => r.id === "trash").truncated, true, "truncation flag survives to the row");
+
+assert.deepEqual(
+  sortSpaceRows(spaceRows, "bytes", "desc").map((r) => r.id),
+  ["conversations", "memory", "trash"],
+  "space rows sort by size desc",
+);
+assert.deepEqual(
+  sortSpaceRows(spaceRows, "label", "asc").map((r) => r.id),
+  ["conversations", "memory", "trash"],
+  "space rows sort by label asc",
+);
+assert.deepEqual(
+  sortSpaceRows(spaceRows, "files", "asc").map((r) => r.id),
+  ["trash", "memory", "conversations"],
+  "space rows sort by file count asc",
+);
+
+assert.equal(formatBytes(0), "0 B");
+assert.equal(formatBytes(512), "512 B");
+assert.equal(formatBytes(2048), "2.0 KB");
+assert.equal(formatBytes(1024 * 1024 * 34), "34 MB");
+assert.equal(formatBytes(1024 ** 3 * 1.5), "1.5 GB");
 
 console.log("dashboard-analytics.test.ts passed");

--- a/src/lib/dashboard-analytics.ts
+++ b/src/lib/dashboard-analytics.ts
@@ -8,6 +8,8 @@ import type { Familiar, SessionRow } from "@/lib/types";
 import type { GitHubItem } from "@/lib/github-tasks";
 import type { SparkPoint } from "@/components/ui/sparkline";
 import type { TrendSeries } from "@/components/ui/charts/trend-chart";
+import type { FamiliarInsightRow } from "@/lib/coven-analytics";
+import type { SpaceUsageArea } from "@/lib/server/space-usage";
 
 const DAY_MS = 86_400_000;
 
@@ -185,4 +187,158 @@ export function familiarLoadSeries(
     .sort((a, b) => b.total - a.total)
     .slice(0, topN)
     .map(({ id, label, color, points }) => ({ id, label, color, points }));
+}
+
+// ─── Familiar insights table: sort + filter (pure, DOM-free) ─────────────────────
+
+export type InsightSortKey = "name" | "confidence" | "sessions" | "contract" | "lastActive";
+export type SortDir = "asc" | "desc";
+
+function contractRatio(r: FamiliarInsightRow): number {
+  return r.contractTotal > 0 ? r.contractPass / r.contractTotal : -1;
+}
+
+function lastActiveMs(r: FamiliarInsightRow): number {
+  if (!r.lastActiveAt) return -1;
+  const t = Date.parse(r.lastActiveAt);
+  return Number.isFinite(t) ? t : -1;
+}
+
+/** Default cockpit ordering: scored familiars first (highest confidence), then
+ *  by recent activity — what the table shows before any header is clicked. */
+export function defaultInsightOrder(rows: FamiliarInsightRow[]): FamiliarInsightRow[] {
+  return [...rows].sort((a, b) => {
+    const ca = a.confidenceScore ?? -1, cb = b.confidenceScore ?? -1;
+    if (cb !== ca) return cb - ca;
+    return b.sessions7d - a.sessions7d;
+  });
+}
+
+/** Stable sort by a column. Unscored/never rows always sink to the bottom in
+ *  either direction — "sort by confidence asc" should rank real scores, not
+ *  lead with a wall of dashes. */
+export function sortInsightRows(
+  rows: FamiliarInsightRow[],
+  key: InsightSortKey,
+  dir: SortDir,
+): FamiliarInsightRow[] {
+  const sign = dir === "asc" ? 1 : -1;
+  const val = (r: FamiliarInsightRow): number | string | null => {
+    switch (key) {
+      case "name": return r.name.toLocaleLowerCase();
+      case "confidence": return r.confidenceScore;
+      case "sessions": return r.sessions7d;
+      case "contract": {
+        const ratio = contractRatio(r);
+        return ratio < 0 ? null : ratio;
+      }
+      case "lastActive": {
+        const t = lastActiveMs(r);
+        return t < 0 ? null : t;
+      }
+    }
+  };
+  return rows
+    .map((r, i) => ({ r, i }))
+    .sort((a, b) => {
+      const va = val(a.r), vb = val(b.r);
+      if (va === null && vb === null) return a.i - b.i;
+      if (va === null) return 1; // missing values sink regardless of direction
+      if (vb === null) return -1;
+      if (va < vb) return -1 * sign;
+      if (va > vb) return 1 * sign;
+      return a.i - b.i; // stable
+    })
+    .map((x) => x.r);
+}
+
+/** Case-insensitive substring filter over name / role / health label. */
+export function filterInsightRows(rows: FamiliarInsightRow[], query: string): FamiliarInsightRow[] {
+  const q = query.trim().toLocaleLowerCase();
+  if (!q) return rows;
+  return rows.filter((r) =>
+    r.name.toLocaleLowerCase().includes(q) ||
+    r.role.toLocaleLowerCase().includes(q) ||
+    (r.health ?? "").toLocaleLowerCase().includes(q),
+  );
+}
+
+// ─── Space usage (rows for the cockpit panel) ────────────────────────────────────
+
+export type SpaceUsageRow = {
+  id: string;
+  label: string;
+  relPath: string;
+  bytes: number;
+  files: number;
+  lastModifiedMs: number | null;
+  truncated: boolean;
+  /** 0–100 share of the total scanned bytes (for the inline bar). */
+  sharePct: number;
+  /** Where cleaning this area up happens, when a surface owns it. */
+  href: string | null;
+  actionLabel: string | null;
+};
+
+export type SpaceSortKey = "label" | "bytes" | "files" | "lastModified";
+
+/** Cleanup destinations per area — the surface where the data is managed. */
+const SPACE_ACTIONS: Record<string, { href: string; label: string }> = {
+  conversations: { href: "/?mode=agents", label: "Review sessions" },
+  workspaces: { href: "/?mode=agents", label: "Open familiars" },
+  memory: { href: "/?mode=agents", label: "Manage memory" },
+  knowledge: { href: "/?mode=agents", label: "Open vault" },
+  journal: { href: "/?mode=journal", label: "Open journal" },
+  flows: { href: "/?mode=flow", label: "Open flows" },
+  prompts: { href: "/?mode=marketplace", label: "Manage prompts" },
+  skills: { href: "/?mode=marketplace", label: "Manage skills" },
+};
+
+/** Turn scanned areas into display rows: drop missing/empty areas, compute the
+ *  share of the total, and attach each area's cleanup destination. */
+export function spaceUsageRows(areas: SpaceUsageArea[]): SpaceUsageRow[] {
+  const present = areas.filter((a) => a.exists && a.files > 0);
+  const total = present.reduce((sum, a) => sum + a.bytes, 0);
+  return present.map((a) => ({
+    id: a.id,
+    label: a.label,
+    relPath: a.relPath,
+    bytes: a.bytes,
+    files: a.files,
+    lastModifiedMs: a.lastModifiedMs,
+    truncated: a.truncated,
+    sharePct: total > 0 ? Math.round((a.bytes / total) * 100) : 0,
+    href: SPACE_ACTIONS[a.id]?.href ?? null,
+    actionLabel: SPACE_ACTIONS[a.id]?.label ?? null,
+  }));
+}
+
+/** Stable sort for the space-usage table (default: biggest first). */
+export function sortSpaceRows(rows: SpaceUsageRow[], key: SpaceSortKey, dir: SortDir): SpaceUsageRow[] {
+  const sign = dir === "asc" ? 1 : -1;
+  const val = (r: SpaceUsageRow): number | string =>
+    key === "label" ? r.label.toLocaleLowerCase()
+    : key === "bytes" ? r.bytes
+    : key === "files" ? r.files
+    : r.lastModifiedMs ?? -1;
+  return rows
+    .map((r, i) => ({ r, i }))
+    .sort((a, b) => {
+      const va = val(a.r), vb = val(b.r);
+      if (va < vb) return -1 * sign;
+      if (va > vb) return 1 * sign;
+      return a.i - b.i;
+    })
+    .map((x) => x.r);
+}
+
+/** Human byte size: 0 B, 512 B, 1.2 KB, 34 MB, 1.5 GB. One decimal under 10. */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = bytes;
+  let u = 0;
+  while (v >= 1024 && u < units.length - 1) { v /= 1024; u += 1; }
+  const text = u === 0 ? String(Math.round(v)) : v < 10 ? v.toFixed(1) : String(Math.round(v));
+  return `${text} ${units[u]}`;
 }

--- a/src/lib/server/space-usage.test.ts
+++ b/src/lib/server/space-usage.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { collectSpaceUsage } from "./space-usage.ts";
+
+// A fake coven home: memory files, a top-level state file, and a knowledge
+// area containing a symlink pointing OUTSIDE the home (must not be followed).
+const home = await mkdtemp(path.join(tmpdir(), "space-usage-"));
+await mkdir(path.join(home, "memory", "kitty"), { recursive: true });
+await writeFile(path.join(home, "memory", "kitty", "a.md"), "hello", "utf8"); // 5 B
+await writeFile(path.join(home, "memory", "note.md"), "hi", "utf8"); // 2 B
+await writeFile(path.join(home, "cave-board.json"), "{}", "utf8"); // 2 B top-level state
+
+const outside = await mkdtemp(path.join(tmpdir(), "space-usage-outside-"));
+await writeFile(path.join(outside, "big.bin"), "x".repeat(4096), "utf8");
+await mkdir(path.join(home, "knowledge"), { recursive: true });
+await symlink(outside, path.join(home, "knowledge", "link"));
+await writeFile(path.join(home, "knowledge", "k.md"), "abc", "utf8"); // 3 B
+
+const areas = await collectSpaceUsage(home);
+const byId = new Map(areas.map((a) => [a.id, a]));
+
+// Every allow-listed area reports, existing or not.
+for (const id of ["conversations", "workspaces", "memory", "knowledge", "journal", "flows", "prompts", "skills", "trash", "state"]) {
+  assert.ok(byId.has(id), `area ${id} is reported`);
+}
+
+const memory = byId.get("memory");
+assert.equal(memory.exists, true, "memory area exists");
+assert.equal(memory.files, 2, "memory counts nested files");
+assert.equal(memory.bytes, 7, "memory sums nested file sizes");
+assert.equal(typeof memory.lastModifiedMs, "number", "memory has a recency stamp");
+assert.equal(memory.truncated, false, "small area is not truncated");
+assert.equal(memory.relPath, "~/.coven/memory", "area shows a home-relative path");
+
+const state = byId.get("state");
+assert.equal(state.files, 1, "state counts only top-level files (no recursion into area dirs)");
+assert.equal(state.bytes, 2, "state sums only top-level files");
+
+const knowledge = byId.get("knowledge");
+assert.equal(knowledge.files, 1, "symlinked dir is not followed");
+assert.equal(knowledge.bytes, 3, "symlinked content is not counted");
+
+const conversations = byId.get("conversations");
+assert.equal(conversations.exists, false, "missing area reports exists=false");
+assert.equal(conversations.bytes, 0, "missing area reports zero bytes");
+assert.equal(conversations.lastModifiedMs, null, "missing area has no recency");
+
+console.log("space-usage.test.ts: ok");

--- a/src/lib/server/space-usage.ts
+++ b/src/lib/server/space-usage.ts
@@ -1,0 +1,121 @@
+/**
+ * Bounded local space-usage scan for the dashboard cockpit.
+ *
+ * Walks a fixed allow-list of `~/.coven` areas (never arbitrary paths) and
+ * reports bytes / file counts / recency per area. The walk is bounded — entry
+ * and depth caps per area — so a pathological directory can't hang the
+ * dashboard; a capped area is reported `truncated: true` rather than lying
+ * with a silently-partial number. Symlinks are never followed (a link out of
+ * `~/.coven` must not pull external trees into the tally).
+ */
+
+import { readdir, lstat } from "node:fs/promises";
+import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
+
+export type SpaceUsageArea = {
+  /** Stable id the client maps to a label + cleanup action. */
+  id: string;
+  label: string;
+  /** Path scanned, relative to the coven home (for display). */
+  relPath: string;
+  exists: boolean;
+  bytes: number;
+  files: number;
+  /** Most recent file mtime in the area (epoch ms), or null when empty. */
+  lastModifiedMs: number | null;
+  /** True when the walk hit an entry/depth cap — figures are a lower bound. */
+  truncated: boolean;
+};
+
+/** Fixed allow-list of scanned areas. `dir` is relative to the coven home;
+ *  `filesOnly` limits the walk to the top-level plain files (app-state JSON). */
+const AREAS: { id: string; label: string; dir: string; filesOnly?: boolean }[] = [
+  { id: "conversations", label: "Chat transcripts", dir: "cave-conversations" },
+  { id: "workspaces", label: "Familiar workspaces", dir: "workspaces" },
+  { id: "memory", label: "Familiar memory", dir: "memory" },
+  { id: "knowledge", label: "Knowledge vault", dir: "knowledge" },
+  { id: "journal", label: "Journal", dir: "journal" },
+  { id: "flows", label: "Flows", dir: "flows" },
+  { id: "prompts", label: "Prompt templates", dir: "prompts" },
+  { id: "skills", label: "Skills", dir: "skills" },
+  { id: "trash", label: "Trash", dir: ".trash" },
+  { id: "state", label: "App state", dir: ".", filesOnly: true },
+];
+
+const MAX_ENTRIES_PER_AREA = 20_000;
+const MAX_DEPTH = 10;
+
+type WalkTally = { bytes: number; files: number; lastModifiedMs: number | null; truncated: boolean };
+
+async function walk(root: string, filesOnly: boolean): Promise<WalkTally | null> {
+  const tally: WalkTally = { bytes: 0, files: 0, lastModifiedMs: null, truncated: false };
+  let visited = 0;
+  const stack: { dir: string; depth: number }[] = [{ dir: root, depth: 0 }];
+
+  // Confirm the root exists (and is a real directory, not a symlink).
+  try {
+    const st = await lstat(root);
+    if (!st.isDirectory()) return null;
+  } catch {
+    return null;
+  }
+
+  while (stack.length > 0) {
+    const { dir, depth } = stack.pop()!;
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue; // unreadable subdir: skip, keep the rest of the tally honest
+    }
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      if (++visited > MAX_ENTRIES_PER_AREA) {
+        tally.truncated = true;
+        return tally;
+      }
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (filesOnly) continue;
+        if (depth + 1 > MAX_DEPTH) {
+          tally.truncated = true;
+          continue;
+        }
+        stack.push({ dir: full, depth: depth + 1 });
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      try {
+        const st = await lstat(full);
+        tally.bytes += st.size;
+        tally.files += 1;
+        const mtime = st.mtimeMs;
+        if (tally.lastModifiedMs === null || mtime > tally.lastModifiedMs) tally.lastModifiedMs = mtime;
+      } catch {
+        // raced deletion: skip
+      }
+    }
+  }
+  return tally;
+}
+
+/** Scan every allow-listed area under `home` (defaults to the coven home). */
+export async function collectSpaceUsage(home = covenHome()): Promise<SpaceUsageArea[]> {
+  return Promise.all(
+    AREAS.map(async (area): Promise<SpaceUsageArea> => {
+      const root = area.dir === "." ? home : path.join(home, area.dir);
+      const tally = await walk(root, area.filesOnly ?? false);
+      return {
+        id: area.id,
+        label: area.label,
+        relPath: area.dir === "." ? "~/.coven" : `~/.coven/${area.dir}`,
+        exists: tally !== null,
+        bytes: tally?.bytes ?? 0,
+        files: tally?.files ?? 0,
+        lastModifiedMs: tally?.lastModifiedMs ?? null,
+        truncated: tally?.truncated ?? false,
+      };
+    }),
+  );
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -708,3 +708,69 @@ a.cockpit-signal--link:hover { background: var(--bg-hover); }
 .cockpit-usage__spark { height: 48px; }
 .cockpit-usage__legend { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 6px 14px; }
 .cockpit-usage__legend li { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; color: var(--text-secondary); }
+
+/* ── Sortable column headers (insights + space tables) ── */
+.cockpit-sorthead {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 0; margin: 0; border: 0; background: none; cursor: pointer;
+  font: inherit; letter-spacing: inherit; text-transform: inherit; color: inherit;
+  border-radius: 6px;
+}
+.cockpit-sorthead svg { width: 11px; height: 11px; opacity: 0.55; }
+.cockpit-sorthead:hover { color: var(--text-primary); }
+.cockpit-sorthead:hover svg { opacity: 1; }
+.cockpit-sorthead.is-sorted { color: var(--text-primary); }
+.cockpit-sorthead.is-sorted svg { opacity: 1; color: var(--accent-presence); }
+
+/* ── Insights table filter bar ── */
+.cockpit-fam__tools { display: flex; align-items: center; gap: 10px; padding: 0 10px 10px; }
+.cockpit-fam__filter {
+  display: inline-flex; align-items: center; gap: 6px; flex: 0 1 240px; min-width: 140px;
+  padding: 5px 10px; border-radius: 9px;
+  border: 1px solid var(--border-hairline); background: var(--bg-sunken, transparent);
+  color: var(--text-muted);
+}
+.cockpit-fam__filter:focus-within { border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border-hairline)); }
+.cockpit-fam__filter svg { width: 13px; height: 13px; flex: 0 0 auto; }
+.cockpit-fam__filter input {
+  flex: 1; min-width: 0; border: 0; background: none; outline: none;
+  font-size: 12px; color: var(--text-primary);
+}
+.cockpit-fam__filter input::placeholder { color: var(--text-muted); }
+.cockpit-fam__matchcount { font-size: 11px; color: var(--text-muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.cockpit-fam__nomatch { padding: 12px 10px; }
+
+/* ── Space usage table ── */
+.cockpit-space { display: flex; flex-direction: column; }
+.cockpit-space__head,
+.cockpit-space__row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(96px, 1.2fr) minmax(48px, 0.6fr) minmax(64px, 0.8fr);
+  align-items: center; gap: 10px;
+}
+.cockpit-space__head {
+  padding: 2px 8px 7px; border-bottom: 1px solid var(--border-hairline);
+  font-size: 9.5px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-muted);
+}
+.cockpit-space__row {
+  padding: 8px; border-radius: 9px; text-decoration: none; color: inherit;
+  transition: background .12s;
+}
+.cockpit-space__row--link:hover { background: var(--bg-hover); }
+.cockpit-space__row + .cockpit-space__row { border-top: 1px solid color-mix(in oklch, var(--border-hairline) 60%, transparent); }
+.cockpit-space__area { display: flex; flex-direction: column; min-width: 0; }
+.cockpit-space__area b { font-size: 12.5px; font-weight: 640; color: var(--text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cockpit-space__path { font-size: 10px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cockpit-space__size { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.cockpit-space__size b { font-size: 12px; font-weight: 680; color: var(--text-primary); font-variant-numeric: tabular-nums; }
+.cockpit-space__bar { display: block; height: 4px; border-radius: 2px; background: color-mix(in oklch, var(--border-hairline) 55%, transparent); overflow: hidden; }
+.cockpit-space__bar i { display: block; height: 100%; border-radius: 2px; background: var(--accent-presence); }
+.cockpit-space__files { font-size: 11.5px; color: var(--text-secondary); font-variant-numeric: tabular-nums; }
+.cockpit-space__last { font-size: 11px; color: var(--text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+@media (max-width: 620px) {
+  .cockpit-space__head, .cockpit-space__row {
+    grid-template-columns: minmax(0, 1.6fr) minmax(88px, 1.1fr);
+  }
+  .cockpit-space__filescol, .cockpit-space__lastcol { display: none; }
+}


### PR DESCRIPTION
Closes out the remaining acceptance gaps on bead **cave-89b** ("Overhaul dashboard into actionable analytics cockpit"): sortable/filterable primary tables and space-usage analytics, plus hover/accessible chart details.

## What changed

### Sortable + filterable Familiar Insights table (the primary work table)
- Column headers are now real buttons with `aria-sort`: Familiar, Confidence, Activity, Contract, Last active. Click cycles sorted ↔ reversed ↔ back to the curated default (confidence, then activity). Unscored/never rows always sink so ascending sorts rank real data.
- A filter input (shown when >3 familiars) matches name / role / health, with a live match count.
- Sorting/filtering is pure and DOM-free in `dashboard-analytics.ts` (`defaultInsightOrder`, `sortInsightRows`, `filterInsightRows`) — unit-tested without a renderer.

### Space usage panel (new)
- `src/lib/server/space-usage.ts`: **bounded** scan of a fixed `~/.coven` area allow-list (conversations, workspaces, memory, knowledge, journal, flows, prompts, skills, trash, top-level app state). Entry cap 20k / depth cap 10 per area, symlinks never followed, unreadable subdirs skipped; capped areas report `truncated: true` and render as `1.3 GB+` — an honest lower bound, never a silent lie.
- `GET /api/space-usage` (registered in the API contracts test; `force-dynamic`; no query-controlled paths).
- Cockpit panel with sortable columns (Area / Size / Files / Updated, default size-desc), share-of-total bars, and per-area **cleanup drill-throughs** to the surface that owns the data (memory → familiars, flows → flow surface, …). Areas without an owning surface stay plain rows.

### Hoverable, accessible diagrams
- Donut slices and heatmap cells now carry native `<title>` hover detail ("In review: 3 (25%)", "Sage · Accept: 82/100").
- Both primitives accept an `ariaLabel` that exposes the SVG as `role=img` with a data summary (wired for the board donut + confidence heatmap); without it they stay `aria-hidden` as before.

## Verification
- `pnpm typecheck` clean; `check:tests-wired` green (test wired into api suite + alias loader).
- `pnpm test:app` — 542 files passed. `api-contracts` — 147 route contracts passed.
- New tests: bounded scanner (temp home; symlink-escape not followed; top-level state non-recursive; missing areas honest), sort/filter/share/formatBytes derivations, cockpit wiring pins.
- Runtime QA on a live dev server: `/dashboard` 200; `/api/space-usage` returns real areas (workspaces correctly reports `truncated` at the cap); Playwright drove the space table — default size-desc, Size click flips to asc with `aria-sort=ascending`, Area click sorts alphabetically, linked rows carry cleanup hrefs. Desktop + 390px mobile screenshots reviewed (columns collapse per media query).

Bead: cave-89b (remaining gaps → implemented).