### PR TITLE
chore(release): stamp v0.0.143

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.143] - 2026-07-06
+
+> 🧹 **A tighter, more honest cockpit** — the dashboard's Familiar Insights table becomes sortable and filterable, a new space-usage panel gives you an honest read on where `~/.coven` disk is going (with cleanup drill-throughs), and the quick-chat box gets a hardening pass. Behind the scenes, a twice-daily PR triage patrol lands to keep the review queue from rotting.
+
+Patch release on top of v0.0.142. Ships dashboard analytics polish, local space-usage analytics, a quick-chat hardening pass, and the morning/evening PR triage patrol.
+
+### Features
+- **Sortable + filterable dashboard insights, plus local space-usage analytics** (#2538). The Familiar Insights table gets real `aria-sort` column headers (click cycles sorted ↔ reversed ↔ curated default) and a live-count filter; a new space-usage panel does a bounded, symlink-safe scan of `~/.coven` and reports honest lower bounds (`1.3 GB+` when capped) with per-area cleanup drill-throughs. Donut/heatmap diagrams gain hover detail and accessible `role=img` summaries.
+- **Morning/evening PR triage patrol** (#2536). `pnpm beads:prs:patrol` sweeps every open PR into a window-ordered digest — mornings lead with *Fix first*, evenings with *Ready to land* — and flags stale + unlinked PRs. `--apply` mirrors linked PR state into beads; the patrol itself never merges.
+
+### Fixes
+- **Quick-chat hardening** (#2537). Hardened the quick-chat box and de-duplicated the overlay/tray internals.
+
 ## [0.0.142] - 2026-07-06
 
 > 📊 **Analytics you can actually steer by** — familiar analytics and growth pages get pulse trends, drill-through KPIs, and a triage roster, while the marketplace gets an ultraminimal header and a full functionality pass. On iPad, **The Diary** arrives: an experimental Apple Pencil handwriting surface.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.142"
+version = "0.0.143"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.142"
+version = "0.0.143"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,9 +15,20 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.142</string>
+	<string>0.0.143</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>opencoven</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>opencoven</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.142</string>
+	<string>0.0.143</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
@@ -63,17 +74,6 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>opencoven</string>
-			</array>
-			<key>CFBundleURLName</key>
-			<string>opencoven</string>
-		</dict>
 	</array>
 </dict>
 </plist>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,9 +15,20 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.142</string>
+	<string>0.0.143</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>opencoven</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>opencoven</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.142</string>
+	<string>0.0.143</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
@@ -63,17 +74,6 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>opencoven</string>
-			</array>
-			<key>CFBundleURLName</key>
-			<string>opencoven</string>
-		</dict>
 	</array>
 </dict>
 </plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.142",
+  "version": "0.0.143",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release stamp for **v0.0.143**.

Bumps all six version locations (package.json, Cargo.toml, Cargo.lock app entry, tauri.conf.json, Info.ios.plist, gen/apple Info.plist) from 0.0.142 → 0.0.143 and adds the CHANGELOG entry.

### Included since v0.0.142
- **#2538** — feat(dashboard): sortable/filterable insights + local space-usage analytics (cave-89b)
- **#2536** — feat(workflow): morning/evening PR triage patrol (cave-hlv.7)
- **#2537** — fix(quick-chat): harden the chat box + dedupe overlay/tray internals (cave-72r)

Stamp-only PR; no code changes.