### PR TITLE
feat(home): world-class visual pass — presence eyebrow, hearth glow, resume affordance

### DIFF
--- a/docs/specs/2026-07-06-home-worldclass-design.md
+++ b/docs/specs/2026-07-06-home-worldclass-design.md
@@ -1,0 +1,62 @@
+# Home — World-Class Visual Pass Design
+
+**Date:** 2026-07-06
+**Surface:** workspace `mode: "home"` → `src/components/home-composer.tsx` + `src/components/home/*` + `src/styles/home-composer.css`
+**Goal:** Give the cold-start surface a distinctive, intentional visual identity — hierarchy, warmth, and one memorable signature — without touching the composer's heavily-pinned functional skeleton (destination pills, slash menus, attachments, project/agent pickers, centering math).
+
+## Constraints honored
+
+The home composer carries dense source-regex contracts (`home-composer.test.ts`,
+`home-composer-polish.test.ts`, `home-composer-centering.test.ts`,
+`home-columns.test.ts`, `home-composer-mobile-gaps.test.ts`). This pass keeps:
+
+- The `.cave-composer-panel` shared chrome and full footer structure.
+- The viewport-centering transform/clamp math and the `min(1200px, 100%)` caps.
+- The Continue/News two-column footer contracts (resume-first, opt-out news,
+  no marquee) and the `home-col-card--primary` treatment.
+- The headline copy — "What should we build in {project}?" — now split so the
+  project name renders in its own accent-tinted span (test updated to match).
+
+## What changed
+
+1. **Presence eyebrow.** A JetBrains-Mono uppercase greeting ("Good morning" /
+   "Good afternoon" / "Good evening" / "Deep night in the cave") with a glowing
+   accent dot sits above the headline. The greeting derives from the pure
+   `src/lib/home-greeting.ts` (`greetingForHour`) and is sampled **after mount**
+   so SSR markup stays deterministic — it fades in via `.is-ready`, with a
+   reserved `min-height` so the headline never shifts. The mono eyebrow against
+   the Fredoka display face is the surface's deliberate type pairing.
+
+2. **Accent-tinted project name.** The headline's project name renders in a
+   `home-composer-headline-project` span mixed toward `--accent-presence` —
+   presence lives in the name of the place you're working.
+
+3. **Hearth glow (the signature).** `.home-halo` — a soft radial lavender aura
+   behind the composer card, breathing on a 9s scale loop and brightening while
+   the composer holds focus. It's the "accent is presence" rule made ambient:
+   the cave reads lit because a familiar is home. Static under
+   `prefers-reduced-motion: reduce`; damped opacity in light mode.
+
+4. **Structure-as-information pills.** Suggested prompts that resume real board
+   tasks (`task:` ids) show a kanban icon in the presence tint; curated
+   starters keep the sparkle. Hover states lift toward the accent.
+
+5. **Resume affordance.** The newest session's Continue card gets a
+   presence-tinted fill plus an always-visible "Resume →" chip (no hover-only
+   reveal, so it reads on touch). The arrow nudges on hover, motion-gated.
+
+6. **Page-load choreography.** One orchestrated entrance: hero → composer →
+   pills → columns rise in a 460ms staggered sequence (`home-rise`,
+   `backwards` fill), fully collapsed under reduced motion.
+
+7. **Rhythm + empty states.** Cards move to `--radius-card`, column gap 24px,
+   and the Continue empty state becomes a centered dashed invitation card.
+
+## Verification
+
+- `pnpm test:app` (543 files) green; new `src/lib/home-greeting.test.ts` wired
+  into `scripts/run-tests.mjs`.
+- `pnpm typecheck` clean; `pnpm build` within bundle budget.
+- Playwright screenshots (prod server, demo mode + mocked
+  `/api/sessions/list` & `/api/rss`): dark 1600×1000, light 1600×1000,
+  mobile 390×844, focus state; console clean of hydration errors.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -73,6 +73,7 @@ export const SUITES = {
     "src/lib/rss.test.ts",
     "src/lib/home-feed.test.ts",
     "src/lib/home-news-pref.test.ts",
+    "src/lib/home-greeting.test.ts",
     "src/lib/secret-validators.test.ts",
     "src/components/chat-project-sidebar-dnd.test.ts",
     "src/components/chat-sidebar-wiring.test.ts",

--- a/src/components/home-columns.test.ts
+++ b/src/components/home-columns.test.ts
@@ -47,4 +47,15 @@ assert.match(css, /\.home-columns\s*\{[\s\S]*?grid-template-columns: repeat\(aut
 assert.match(css, /@media \(max-width: 720px\)\s*\{[\s\S]*?\.home-columns\s*\{[\s\S]*?grid-template-columns: 1fr/,
   "columns stack on narrow viewports");
 
+// Resume affordance on the newest session is always visible — never a
+// hover-only reveal, so it reads on touch devices too.
+assert.match(cont, /home-col-card__go/, "primary card carries a visible Resume affordance");
+
+// The home entrance choreography and ambient halo motion are opt-in on
+// prefers-reduced-motion: no-preference (reduced motion gets a static page).
+assert.match(css, /@media \(prefers-reduced-motion: no-preference\)\s*\{[\s\S]*?animation: home-rise/,
+  "entrance choreography is gated on no-preference");
+assert.match(css, /@media \(prefers-reduced-motion: no-preference\)\s*\{[\s\S]*?animation: home-halo-breathe/,
+  "halo breathing is gated on no-preference");
+
 console.log("home-columns.test.ts: ok");

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -35,8 +35,33 @@ assert.match(
 
 assert.match(
   source,
-  /home-composer-headline[\s\S]*?\{`What should we build in \$\{selectedProject\?\.name \?\? "Coven Cave"\}\?`\}/,
-  "HomeComposer headline should reflect the selected project name",
+  /home-composer-headline[\s\S]*?\{"What should we build in "\}[\s\S]*?home-composer-headline-project[\s\S]*?\{selectedProject\?\.name \?\? "Coven Cave"\}/,
+  "HomeComposer headline should reflect the selected project name (accent-tinted project span)",
+);
+
+// ── Hero presence eyebrow ────────────────────────────────────────────────────
+// The greeting samples the client clock AFTER mount (SSR markup must stay
+// deterministic), fades in via .is-ready, and derives from the pure
+// greetingForHour helper so the boundaries unit-test exactly.
+assert.match(
+  source,
+  /import \{ greetingForHour \} from "@\/lib\/home-greeting"/,
+  "the hero greeting derives from the pure home-greeting helper",
+);
+assert.match(
+  source,
+  /const \[greeting, setGreeting\] = useState<string \| null>\(null\);[\s\S]*?useEffect\(\(\) => \{\s*setGreeting\(greetingForHour\(new Date\(\)\.getHours\(\)\)\);\s*\}, \[\]\)/,
+  "the greeting is sampled after mount so SSR/client markup can't drift",
+);
+assert.match(
+  source,
+  /home-composer-eyebrow\$\{greeting \? " is-ready" : ""\}/,
+  "the eyebrow fades in via .is-ready once the client greeting lands",
+);
+assert.match(
+  source,
+  /className="home-halo" aria-hidden/,
+  "the hearth-glow halo renders behind the composer card and is hidden from AT",
 );
 
 // Project selector lives in the composer toolbar so the user can choose which

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -70,6 +70,7 @@ import {
   type CommandThinkingEffort,
 } from "@/lib/command-controls";
 import { buildPromptEnhancement } from "@/lib/prompt-enhancer";
+import { greetingForHour } from "@/lib/home-greeting";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -163,6 +164,12 @@ export function HomeComposer({
   // open purely as a function of the text). Reset whenever the text changes so
   // typing a fresh command token re-opens them.
   const [slashDismissed, setSlashDismissed] = useState(false);
+  // Time-of-day greeting for the hero eyebrow. Sampled after mount (client
+  // clock) so SSR markup stays deterministic — the eyebrow fades in once set.
+  const [greeting, setGreeting] = useState<string | null>(null);
+  useEffect(() => {
+    setGreeting(greetingForHour(new Date().getHours()));
+  }, []);
   const { announce } = useAnnouncer();
   // Stable per-mount listbox id — the chat composer mounts its own slash menu,
   // so ids must be unique across simultaneously mounted composers.
@@ -843,16 +850,31 @@ export function HomeComposer({
   return (
     <div className="home-composer-root">
 
-      {/* Headline */}
+      {/* Headline — mono presence eyebrow over the display face; the project
+          name carries the accent tint (presence lives in the place you're
+          working). */}
       <div className="home-composer-hero">
+        <p className={`home-composer-eyebrow${greeting ? " is-ready" : ""}`}>
+          <span className="home-composer-eyebrow-dot" aria-hidden />
+          {greeting ?? "\u00A0"}
+        </p>
         <h1 className="home-composer-headline">
-          {`What should we build in ${selectedProject?.name ?? "Coven Cave"}?`}
+          {"What should we build in "}
+          <span className="home-composer-headline-project">
+            {selectedProject?.name ?? "Coven Cave"}
+          </span>
+          ?
         </h1>
       </div>
 
       {/* Composer card — wrapped so the slash menu can render above the
           card without being clipped by the card's `overflow: hidden`. */}
       <div className="home-composer-card-wrap">
+
+        {/* Hearth glow — the ambient presence halo behind the composer. It
+            breathes slowly and brightens while the composer holds focus
+            (static under prefers-reduced-motion). */}
+        <div className="home-halo" aria-hidden />
 
         {/* Slash suggestion popover — anchored above the card so it doesn't
             push the rest of the layout when it opens. */}

--- a/src/components/home/home-continue-column.tsx
+++ b/src/components/home/home-continue-column.tsx
@@ -73,6 +73,12 @@ export function HomeContinueColumn({ sessions, familiarNameById, onOpenSession }
                   <span className="home-col-card__title">{title}</span>
                   {subtitle ? <span className="home-col-card__meta">{subtitle}</span> : null}
                 </span>
+                {i === 0 ? (
+                  <span className="home-col-card__go" aria-hidden>
+                    Resume
+                    <Icon name="ph:arrow-right-bold" width={11} aria-hidden />
+                  </span>
+                ) : null}
               </button>
             </li>
           );

--- a/src/components/home/home-suggestions.tsx
+++ b/src/components/home/home-suggestions.tsx
@@ -55,18 +55,23 @@ export function HomeSuggestions({ projectName, onPick }: Props) {
 
   return (
     <div className="home-suggestions" role="group" aria-label="Suggested prompts">
-      {suggestions.map((s) => (
-        <button
-          key={s.id}
-          type="button"
-          className="home-suggestion-pill focus-ring"
-          onClick={() => onPick(s.prompt)}
-          title={s.prompt}
-        >
-          <Icon name="ph:sparkle" width={11} aria-hidden />
-          <span className="home-suggestion-label">{s.prompt}</span>
-        </button>
-      ))}
+      {suggestions.map((s) => {
+        // "task:" pills resume real board work; starters are fresh prompts.
+        // The icon encodes the difference so the row scans at a glance.
+        const isTask = s.id.startsWith("task:");
+        return (
+          <button
+            key={s.id}
+            type="button"
+            className={`home-suggestion-pill focus-ring${isTask ? " home-suggestion-pill--task" : ""}`}
+            onClick={() => onPick(s.prompt)}
+            title={s.prompt}
+          >
+            <Icon name={isTask ? "ph:kanban" : "ph:sparkle"} width={11} aria-hidden />
+            <span className="home-suggestion-label">{s.prompt}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/lib/home-greeting.test.ts
+++ b/src/lib/home-greeting.test.ts
@@ -1,0 +1,16 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { greetingForHour } from "./home-greeting.ts";
+
+// Boundaries: [5,12) morning · [12,18) afternoon · [18,22) evening · else night.
+assert.equal(greetingForHour(5), "Good morning");
+assert.equal(greetingForHour(11), "Good morning");
+assert.equal(greetingForHour(12), "Good afternoon");
+assert.equal(greetingForHour(17), "Good afternoon");
+assert.equal(greetingForHour(18), "Good evening");
+assert.equal(greetingForHour(21), "Good evening");
+assert.equal(greetingForHour(22), "Deep night in the cave");
+assert.equal(greetingForHour(0), "Deep night in the cave");
+assert.equal(greetingForHour(4), "Deep night in the cave");
+
+console.log("home-greeting.test.ts: ok");

--- a/src/lib/home-greeting.ts
+++ b/src/lib/home-greeting.ts
@@ -1,0 +1,10 @@
+// Pure time-of-day greeting for the home hero's eyebrow. Deterministic on the
+// hour so it unit-tests exactly; the component samples the local clock after
+// mount (client-only) to avoid SSR hydration drift.
+
+export function greetingForHour(hour: number): string {
+  if (hour >= 5 && hour < 12) return "Good morning";
+  if (hour >= 12 && hour < 18) return "Good afternoon";
+  if (hour >= 18 && hour < 22) return "Good evening";
+  return "Deep night in the cave";
+}

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -60,6 +60,49 @@
   margin-bottom: 18px;
 }
 
+/* Mono presence eyebrow — the cave greets you before asking for intent. It
+   samples the client clock after mount, so it fades in via .is-ready (the
+   reserved min-height keeps the headline from shifting). */
+.home-composer-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 0 12px;
+  min-height: 15px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  opacity: 0;
+  transition: opacity 400ms var(--ease-standard);
+}
+
+.home-composer-eyebrow.is-ready {
+  opacity: 1;
+}
+
+/* Presence dot — the brand accent means "something is alive here". */
+.home-composer-eyebrow-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  box-shadow: 0 0 8px color-mix(in oklch, var(--accent-presence) 70%, transparent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .home-composer-eyebrow-dot {
+    animation: home-dot-pulse 4.5s var(--ease-standard) infinite;
+  }
+}
+
+@keyframes home-dot-pulse {
+  0%, 100% { box-shadow: 0 0 6px color-mix(in oklch, var(--accent-presence) 50%, transparent); }
+  50% { box-shadow: 0 0 12px color-mix(in oklch, var(--accent-presence) 85%, transparent); }
+}
+
 .home-composer-headline {
   font-family: var(--font-fredoka, "Fredoka", system-ui, sans-serif);
   font-weight: 500;
@@ -68,6 +111,11 @@
   color: color-mix(in oklch, var(--text-primary) 88%, var(--text-muted));
   letter-spacing: -0.02em;
   margin: 0 0 6px;
+}
+
+/* The active project name carries the presence tint. */
+.home-composer-headline-project {
+  color: color-mix(in oklch, var(--accent-presence) 78%, var(--text-primary));
 }
 
 .home-composer-sub {
@@ -85,6 +133,48 @@
   max-width: min(1200px, 100%);
   margin-inline: auto;
   container-type: inline-size;
+}
+
+/* ── Hearth glow — the page's signature ──────────────────────────────────────
+ *   A soft lavender halo behind the composer: the accent-is-presence rule made
+ *   ambient. It breathes slowly, brightens while the composer holds focus, and
+ *   holds still under prefers-reduced-motion. Kept inside the page padding so
+ *   it never trips horizontal overflow on the scrollable root. */
+.home-halo {
+  position: absolute;
+  inset: -110px -20px -70px;
+  z-index: -1;
+  pointer-events: none;
+  background: radial-gradient(
+    46% 68% at 50% 44%,
+    color-mix(in oklch, var(--accent-presence) 22%, transparent),
+    transparent 72%
+  );
+  opacity: 0.75;
+  transition: opacity 600ms var(--ease-standard);
+}
+
+.home-composer-card-wrap:focus-within .home-halo {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .home-halo {
+    animation: home-halo-breathe 9s var(--ease-standard) infinite alternate;
+  }
+}
+
+@keyframes home-halo-breathe {
+  from { transform: scale(0.97); }
+  to { transform: scale(1.04); }
+}
+
+/* Light mode: the halo tints rather than glows — damp it. */
+[data-mode="light"] .home-halo {
+  opacity: 0.5;
+}
+[data-mode="light"] .home-composer-card-wrap:focus-within .home-halo {
+  opacity: 0.75;
 }
 
 /* ── Composer card ─────────────────────────────────────────────────────────
@@ -786,12 +876,36 @@
   font-size: 12px;
   line-height: 1.3;
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition: background-color 120ms ease, color 120ms ease,
+    border-color 120ms ease, transform 120ms var(--ease-standard);
+}
+
+.home-suggestion-pill svg {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  transition: color 120ms ease;
+}
+
+/* Task-continuation pills point back at real board work — their icon carries
+   the presence tint so resumable work reads differently from fresh starters. */
+.home-suggestion-pill--task svg {
+  color: var(--accent-presence);
 }
 
 .home-suggestion-pill:hover {
-  background: var(--bg-raised);
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-raised));
+  border-color: color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
   color: var(--text-primary);
+}
+
+.home-suggestion-pill:hover svg {
+  color: var(--accent-presence);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .home-suggestion-pill:hover {
+    transform: translateY(-1px);
+  }
 }
 
 .home-suggestion-label {
@@ -811,10 +925,10 @@
 .home-columns {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-  gap: 20px;
+  gap: 24px;
   width: 100%;
   max-width: 860px;
-  margin-top: 8px;
+  margin-top: 12px;
 }
 
 @media (max-width: 720px) {
@@ -850,8 +964,12 @@
 
 .home-col__empty {
   margin: 0;
+  padding: 14px 16px;
   font-size: 12px;
   color: var(--text-muted);
+  text-align: center;
+  border: 1px dashed var(--border-hairline);
+  border-radius: var(--radius-card);
 }
 
 .home-col-card {
@@ -859,9 +977,9 @@
   align-items: center;
   gap: 9px;
   width: 100%;
-  padding: 8px 10px;
+  padding: 9px 12px;
   border: 1px solid var(--border-hairline);
-  border-radius: 10px;
+  border-radius: var(--radius-card);
   background: transparent;
   text-align: left;
   cursor: pointer;
@@ -870,10 +988,46 @@
 
 .home-col-card:hover {
   background: var(--bg-raised);
+  border-color: var(--border-strong);
 }
 
+/* The newest session is the resume card: presence-tinted, with a visible
+   Resume affordance (no hover-only reveal — it must read on touch too). */
 .home-col-card--primary {
+  background: color-mix(in oklch, var(--accent-presence) 7%, transparent);
   border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+}
+
+.home-col-card--primary:hover {
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 60%, var(--border-hairline));
+}
+
+.home-col-card__go {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex: none;
+  margin-left: auto;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--accent-presence);
+  white-space: nowrap;
+}
+
+.home-col-card__go svg {
+  transition: transform 120ms var(--ease-standard);
+}
+
+.home-col-card--primary:hover .home-col-card__go svg {
+  transform: translateX(2px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .home-col-card--primary:hover .home-col-card__go svg {
+    transform: none;
+  }
 }
 
 .home-col-card__icon {
@@ -897,6 +1051,7 @@
   display: flex;
   flex-direction: column;
   gap: 1px;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -914,4 +1069,28 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* ── Page-load choreography ───────────────────────────────────────────────────
+ *   One orchestrated entrance: hero, composer, pills, columns rise in sequence
+ *   (backwards fill keeps late rows invisible until their turn). Collapsed
+ *   entirely under prefers-reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+  .home-composer-hero,
+  .home-suggestions,
+  .home-columns {
+    animation: home-rise 460ms var(--ease-decelerate) backwards;
+  }
+  .home-composer-card-wrap {
+    animation: home-rise 460ms var(--ease-decelerate) 60ms backwards;
+  }
+  .home-suggestions { animation-delay: 140ms; }
+  .home-columns { animation-delay: 220ms; }
+}
+
+@keyframes home-rise {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
 }


### PR DESCRIPTION
## What

Redesigns the home (cold-start) surface for a distinctive, intentional look while honoring every pinned functional contract (composer skeleton, centering math, column contracts).

- **Presence eyebrow** — mono uppercase time-aware greeting (`Good evening` …) with a glowing accent dot above the Fredoka headline. Pure `greetingForHour` lib, sampled post-mount (no SSR drift), fades in with reserved height (no CLS).
- **Accent-tinted project name** in the headline — presence lives in the place you're working.
- **Hearth glow (signature)** — a breathing lavender radial halo behind the composer that brightens on focus. "Accent is presence" made ambient. Static under reduced motion; damped in light mode.
- **Informational pills** — board-task continuations get a kanban icon in the presence tint vs sparkle starters.
- **Resume affordance** — newest Continue card gets a presence-tinted fill + always-visible `Resume →` chip (touch-safe).
- **Entrance choreography** — hero → composer → pills → columns staggered rise; collapsed under `prefers-reduced-motion`.
- Rhythm polish: `--radius-card` cards, refined hover states, dashed invitation empty state.

Design spec: `docs/specs/2026-07-06-home-worldclass-design.md`

## Verification

- `pnpm test:app` — 543 test files green (new `home-greeting.test.ts` wired into `run-tests.mjs`)
- `pnpm typecheck` clean · `pnpm build` within bundle budget · `check-tests-wired` green
- `tests/board-attachments.spec.ts` e2e (home composer surface) green locally
- Playwright screenshots against the prod server (demo + mocked sessions/rss): dark & light 1600×1000, mobile 390×844, focus state — console clean of hydration errors