### PR TITLE
fix(dashboard): dedupe stalled-PR signals by URL + cap the Signals panel (cave-2it)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -101,6 +101,11 @@ assert.match(cockpit, /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(r
 assert.match(cockpit, /s\.href \?/, "actionable signals render as links");
 assert.match(cockpit, /openExternalUrl\(s\.href!\)/, "external signal links route through the external-URL helper");
 
+// Signals stay scannable: the list is capped and the overflow drills through.
+assert.match(cockpit, /const SIGNALS_CAP = 8/, "signals panel caps the visible list");
+assert.match(cockpit, /signals\.slice\(0, SIGNALS_CAP\)/, "only the top signals render");
+assert.match(cockpit, /\+\{hidden\} more — review on the GitHub surface/, "overflow collapses into a drill-through row");
+
 // KPI deltas carry meaning, not just direction: each vital declares the
 // direction that reads as "good", so a rise in confidence is colored as
 // progress while a rise in "Needs you" is colored as load.

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -961,10 +961,17 @@ function whenLabel(iso: string, now: Date): string {
 // ─── Signals ─────────────────────────────────────────────────────────────────────
 
 const SIGNAL_ICON: Record<DashboardSignal["severity"], IconName> = { warn: "ph:warning", info: "ph:info" };
+
+// Keep the panel scannable: the stalest drift leads, the long tail collapses
+// into a drill-through instead of swamping the column.
+const SIGNALS_CAP = 8;
+
 function SignalsPanel({ signals }: { signals: DashboardSignal[] }) {
+  const shown = signals.slice(0, SIGNALS_CAP);
+  const hidden = signals.length - shown.length;
   return (
     <ul className="cockpit-signals">
-      {signals.map((s) => {
+      {shown.map((s) => {
         const inner = (
           <>
             <Icon name={SIGNAL_ICON[s.severity]} className="cockpit-signal__icon" aria-hidden />
@@ -989,6 +996,14 @@ function SignalsPanel({ signals }: { signals: DashboardSignal[] }) {
           </li>
         );
       })}
+      {hidden > 0 ? (
+        <li>
+          <a className="cockpit-signal cockpit-signal--more" href="/?mode=github">
+            <Icon name="ph:arrow-right-bold" className="cockpit-signal__icon" aria-hidden />
+            <span className="cockpit-signal__text">+{hidden} more — review on the GitHub surface</span>
+          </a>
+        </li>
+      ) : null}
     </ul>
   );
 }

--- a/src/lib/dashboard-analytics.test.ts
+++ b/src/lib/dashboard-analytics.test.ts
@@ -48,7 +48,7 @@ assert.ok(series[0].points.every((p) => typeof p.x === "number" && typeof p.y ==
 
 // ── dashboardSignals: stalled PR + trending-down familiar ─
 const ghItem = (id, kind, updatedOffset, state, title) => ({
-  id, kind, title, repo: "o/r", url: "#", state, updatedAt: day(updatedOffset),
+  id, kind, title, repo: "o/r", url: `https://gh/o/r/${id}`, state, updatedAt: day(updatedOffset),
 });
 const sigGithub = [
   ghItem("p1", "pr", 9, "open", "Old PR"),          // stalled (>7d)
@@ -78,13 +78,26 @@ assert.equal(dashboardSignals({ github: [], sessions: [], familiars: [], nowMs: 
 
 // ── Signals are actionable: each carries the destination to act on it ─
 const stalled = signals.find((s) => s.id === "pr-stalled-p1");
-assert.equal(stalled.href, "#", "stalled-PR signal links to the PR's own URL");
+assert.equal(stalled.href, "https://gh/o/r/p1", "stalled-PR signal links to the PR's own URL");
 assert.equal(stalled.external, true, "PR links leave the app via the external opener");
 assert.equal(
   signals.find((s) => s.id === "familiar-down-f1").href,
   "/dashboard/familiars/f1/analytics",
   "trending-down signal opens that familiar's analytics",
 );
+
+// ── Stalled-PR signals dedupe by URL and lead with the stalest ─
+// The same PR arrives from /api/github/activity (id "pr-<n>") and
+// /api/github/assigned (raw "<n>") — id-keyed merging can't collapse it.
+const dupGithub = [
+  { id: "pr-77", kind: "pr", title: "Same PR", repo: "o/r", url: "https://gh/o/r/pull/77", state: "open", updatedAt: day(20) },
+  { id: "77", kind: "review_request", title: "Same PR", repo: "o/r", url: "https://gh/o/r/pull/77", state: "open", updatedAt: day(12) },
+  { id: "pr-9", kind: "pr", title: "Older PR", repo: "o/r", url: "https://gh/o/r/pull/9", state: "open", updatedAt: day(40) },
+];
+const dupSignals = dashboardSignals({ github: dupGithub, sessions: [], familiars: [], nowMs: NOW });
+assert.equal(dupSignals.length, 2, "same-URL PR rows collapse to one signal");
+assert.match(dupSignals[1].text, /stalled 12d: Same PR/, "the freshest updatedAt wins, so staleness is not overstated");
+assert.match(dupSignals[0].text, /stalled 40d: Older PR/, "stalled signals lead with the stalest PR");
 
 // ── Insights table: sort + filter (pure) ─
 const row = (id, over = {}) => ({

--- a/src/lib/dashboard-analytics.ts
+++ b/src/lib/dashboard-analytics.ts
@@ -117,21 +117,35 @@ export function dashboardSignals(input: {
   const out: DashboardSignal[] = [];
 
   // PR stalled > 7 days (open PRs / review requests with a stale updatedAt).
+  // The same PR can arrive from both /api/github/activity (id "pr-<n>") and
+  // /api/github/assigned (raw "<n>"), so the cockpit's id-keyed merge can't
+  // collapse them — dedupe here by URL (the stable cross-endpoint key),
+  // keeping the freshest updatedAt so staleness is never overstated.
+  const stalledByUrl = new Map<string, GitHubItem>();
   for (const g of github) {
     if (g.kind !== "pr" && g.kind !== "review_request") continue;
     if (g.state === "closed") continue;
     const t = Date.parse(g.updatedAt);
     if (!Number.isFinite(t)) continue;
-    const days = Math.floor((nowMs - t) / DAY_MS);
-    if (days > STALE_PR_DAYS) {
-      out.push({
-        id: `pr-stalled-${g.id}`,
-        severity: "warn",
-        text: `PR stalled ${days}d: ${g.title}`,
-        href: g.url,
-        external: true,
-      });
-    }
+    const key = g.url || g.id;
+    const prev = stalledByUrl.get(key);
+    if (!prev || t > Date.parse(prev.updatedAt)) stalledByUrl.set(key, g);
+  }
+  const stalled: { g: GitHubItem; days: number }[] = [];
+  for (const g of stalledByUrl.values()) {
+    const days = Math.floor((nowMs - Date.parse(g.updatedAt)) / DAY_MS);
+    if (days > STALE_PR_DAYS) stalled.push({ g, days });
+  }
+  // Stalest first — when the panel caps the list, the worst drift leads.
+  stalled.sort((a, b) => b.days - a.days);
+  for (const { g, days } of stalled) {
+    out.push({
+      id: `pr-stalled-${g.id}`,
+      severity: "warn",
+      text: `PR stalled ${days}d: ${g.title}`,
+      href: g.url,
+      external: true,
+    });
   }
 
   // Familiar trending down: active in the prior window, quiet in the last 3 days.

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -565,6 +565,9 @@ a.cockpit-kpi:hover { border-color: var(--border-strong); transform: translateY(
 .cockpit-signal__text { min-width: 0; }
 a.cockpit-signal--link { text-decoration: none; }
 a.cockpit-signal--link:hover { background: var(--bg-hover); }
+a.cockpit-signal--more { text-decoration: none; color: var(--text-muted); }
+a.cockpit-signal--more:hover { background: var(--bg-hover); color: var(--text-primary); }
+.cockpit-signal--more .cockpit-signal__icon { color: var(--text-muted); }
 
 /* Confidence heatmap */
 .cockpit-confidence { display: flex; flex-direction: column; gap: 6px; }


### PR DESCRIPTION
Populated-state QA (Playwright, mocked APIs) of the dashboard cockpit found two real defects in the **Signals** strip. Bead: **cave-2it**.

## Defects
1. **Duplicate stalled-PR rows** — the same PR arrives from `/api/github/activity` with id `pr-<n>` and from `/api/github/assigned` with raw `<n>`; the cockpit merges GitHub items by id, so both survive and each produces its own 'PR stalled' signal (visible as doubled rows in the QA screenshot).
2. **Unbounded, unordered panel** — 29 signal rows swamped the main column, with no staleness ordering.

## Fix
- `dashboardSignals` (pure) now dedupes stalled-PR candidates **by URL** — the stable cross-endpoint key — keeping the freshest `updatedAt` so staleness is never overstated, and emits them **stalest-first**.
- `SignalsPanel` caps at **8** rows; the overflow collapses into a muted `+N more — review on the GitHub surface` drill-through (`/?mode=github`).

## Verification
- New unit assertions: same-URL rows collapse to one signal, freshest `updatedAt` wins, stalest leads; page pins for the cap + overflow row. Fixture URLs made distinct (the old shared `'#'` placeholder would have masked this bug class).
- `pnpm typecheck` clean; `pnpm test:app` — 548 files passed.
- Live worktree dev-server QA: 10 stalled PRs duplicated across both endpoints (20 items) → 8 visible signals, stalest first, `+2 more` drill-through row.