### PR TITLE
fix(proxy): accept the real listen port in the CSRF origin gate on port fallback (cave-5sg)

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -22,8 +22,16 @@ assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated \
 assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "tokenless app mode (COVEN_CAVE_TAILNET_TRUST) should relax the host gate for tailnet-forwarded requests");
 assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
 assert.match(source, /const referer = req\.headers\.get\("referer"\)/, "API referer gate should read the source referer header once");
-assert.match(source, /isAllowedRequestSource\(origin, expectedOrigin\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
-assert.match(source, /isAllowedRequestSource\(referer, expectedOrigin\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
+assert.match(source, /isAllowedRequestSourceAny\(origin, expectedOrigins\)/, "API origin gate should require same-origin sources unless header-CSRF-trusted");
+assert.match(source, /isAllowedRequestSourceAny\(referer, expectedOrigins\)/, "API referer gate should require same-origin sources unless header-CSRF-trusted");
+// Port-fallback CSRF fix (cave-5sg): the accepted-origin set is derived from
+// the request (nextUrl.origin is pinned to the configured, not the actual
+// listen port), so the browser Origin on a fallback port still passes.
+assert.match(
+  source,
+  /const expectedOrigins = expectedRequestOrigins\(\s*req\.nextUrl\.origin,\s*req\.nextUrl\.protocol,\s*requestHost,?\s*\)/,
+  "the origin gate must compare against origins derived from the request's own Host, not just the configured-port nextUrl.origin",
+);
 assert.match(source, /unsupported content-type/, "middleware should reject unsafe content types before body parsing");
 assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless-tailnet CSRF guard");
 assert.match(source, /missing request source/, "tokenless tailnet GET webhooks should reject absent Origin and Referer headers");
@@ -41,7 +49,7 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(!headerCsrfTrusted\) \{[\s\S]*?isAllowedRequestSource\(origin, expectedOrigin\)/,
+  /if \(!headerCsrfTrusted\) \{[\s\S]*?isAllowedRequestSourceAny\(origin, expectedOrigins\)/,
   "origin gate must run unless the request is header-CSRF-trusted",
 );
 assert.doesNotMatch(
@@ -56,8 +64,8 @@ assert.doesNotMatch(
 // `pnpm dev` if anything ever bound the dev server outside 127.0.0.1.
 {
   const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated || tailnetTrusted)");
-  const originIdx = source.indexOf("isAllowedRequestSource(origin, expectedOrigin)");
-  const refererIdx = source.indexOf("isAllowedRequestSource(referer, expectedOrigin)");
+  const originIdx = source.indexOf("isAllowedRequestSourceAny(origin, expectedOrigins)");
+  const refererIdx = source.indexOf("isAllowedRequestSourceAny(referer, expectedOrigins)");
   const contentTypeIdx = source.indexOf("unsupported content-type");
   const bypassIdx = source.indexOf("missing sidecar auth token");
   assert.ok(hostIdx > 0, "host check should be present");

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -19,7 +19,10 @@ import {
   isAllowedApiHost,
   sameOrigin,
   isAllowedRequestSource,
+  isAllowedRequestSourceAny,
+  expectedRequestOrigins,
   bearerFromReferer,
+  bearerFromRefererAny,
   shouldRequireMobileAccessCredential,
   timingSafeEqualString,
   isHtmlNavigationRequest,
@@ -194,6 +197,85 @@ assert.equal(
   true,
   "normal same-origin browser dev mode remains allowed",
 );
+
+// ─── expectedRequestOrigins / port-fallback CSRF (cave-5sg) ────────────────
+// server.ts constructs Next with the CONFIGURED port, then startListening()
+// falls back to the next free port when it's taken. req.nextUrl.origin stays
+// pinned to the configured port, so the real browser Origin (the fallback
+// port, carried by Host) must also be accepted or every /api request 403s.
+{
+  // Fell back 3457 -> 3458: nextUrl still says :3457, Host says :3458.
+  const origins = expectedRequestOrigins("http://127.0.0.1:3457", "http:", "127.0.0.1:3458");
+  assert.deepEqual(
+    origins,
+    ["http://127.0.0.1:3457", "http://127.0.0.1:3458"],
+    "both the configured-port origin and the real Host-derived origin are accepted",
+  );
+  assert.equal(
+    isAllowedRequestSourceAny("http://127.0.0.1:3458", origins),
+    true,
+    "the browser Origin on the real fallback port is now allowed (the bug)",
+  );
+  assert.equal(
+    isAllowedRequestSourceAny("http://127.0.0.1:3457", origins),
+    true,
+    "the stale configured-port origin still passes (Serve/forwarded-host path)",
+  );
+  assert.equal(
+    isAllowedRequestSourceAny("http://evil.example", origins),
+    false,
+    "a cross-site Origin matches neither and is rejected",
+  );
+  assert.equal(
+    isAllowedRequestSourceAny(null, origins),
+    true,
+    "an absent Origin/Referer still passes (matches sameOrigin null tolerance)",
+  );
+}
+{
+  // No Host header: fall back to nextUrl.origin alone, no phantom entries.
+  assert.deepEqual(
+    expectedRequestOrigins("http://127.0.0.1:3000", "http:", null),
+    ["http://127.0.0.1:3000"],
+  );
+  // Host equals the configured port: deduped to a single origin.
+  assert.deepEqual(
+    expectedRequestOrigins("http://127.0.0.1:3000", "http:", "127.0.0.1:3000"),
+    ["http://127.0.0.1:3000"],
+    "no duplicate when Host already matches nextUrl.origin",
+  );
+  // https preserved (never silently downgraded to http).
+  assert.deepEqual(
+    expectedRequestOrigins("https://cave.tailnet.example.ts.net", "https:", "cave.tailnet.example.ts.net"),
+    ["https://cave.tailnet.example.ts.net"],
+    "https scheme is preserved and deduped",
+  );
+  // Missing protocol defaults to http (loopback is never TLS on the socket).
+  assert.deepEqual(
+    expectedRequestOrigins("http://127.0.0.1:3457", null, "127.0.0.1:3458"),
+    ["http://127.0.0.1:3457", "http://127.0.0.1:3458"],
+    "absent protocol falls back to http:",
+  );
+}
+{
+  // A referer carrying the real fallback port still yields its token.
+  const origins = expectedRequestOrigins("http://127.0.0.1:3457", "http:", "127.0.0.1:3458");
+  assert.equal(
+    bearerFromRefererAny("http://127.0.0.1:3458/x?covenCaveToken=tok", origins),
+    "tok",
+    "token is extracted from a referer on the real fallback port",
+  );
+  assert.equal(
+    bearerFromRefererAny("http://127.0.0.1:3457/x?covenCaveToken=tok", origins),
+    "tok",
+    "token is still extracted from a configured-port referer",
+  );
+  assert.equal(
+    bearerFromRefererAny("http://evil.example/x?covenCaveToken=tok", origins),
+    null,
+    "a cross-origin referer never yields its token",
+  );
+}
 
 // ─── Native iOS app (tokenless, over Tailscale Serve) contract ─────────────
 // The native SwiftUI client (pnpm mobile:tailscale:app) is NOT a browser: it

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -78,6 +78,46 @@ export function isAllowedRequestSource(value: string | null, expectedOrigin: str
   return sameOrigin(value, expectedOrigin);
 }
 
+/**
+ * The origins a genuinely first-party request may declare, in the order they
+ * should be tried.
+ *
+ * `req.nextUrl.origin` is pinned to the port Next was CONSTRUCTED with —
+ * server.ts passes the configured `PORT` to `next({ port })` before the
+ * listener runs, and `startListening()` then falls back to the next free port
+ * when the configured one is taken. So on a fallback the browser's real Origin
+ * (the port it actually connected to, carried by the Host header) never equals
+ * `nextUrl.origin` and every /api request 403s "forbidden origin" (cave-5sg).
+ *
+ * The request's own Host header carries the real authority. The host gate in
+ * proxy() has already constrained it to loopback (or an authenticated /
+ * tailnet-trusted remote), so a Host-derived origin is a safe second accepted
+ * value: a cross-site browser attacker's Origin still won't match the Host
+ * (the browser sets both and cannot forge either), and DNS-rebinding is caught
+ * by the loopback host gate. `nextUrl.origin` is kept first so the
+ * Tailscale-Serve / forwarded-host path (where Next trusts x-forwarded-host)
+ * is entirely unchanged.
+ */
+export function expectedRequestOrigins(
+  nextUrlOrigin: string,
+  protocol: string | null,
+  host: string | null,
+): string[] {
+  const origins = [nextUrlOrigin];
+  if (host) {
+    const scheme = protocol && protocol.length > 0 ? protocol : "http:";
+    const derived = `${scheme}//${host}`;
+    if (derived !== nextUrlOrigin) origins.push(derived);
+  }
+  return origins;
+}
+
+/** True when `value` (an Origin/Referer) matches ANY accepted origin. An
+ *  absent value passes (mirrors sameOrigin's null tolerance). */
+export function isAllowedRequestSourceAny(value: string | null, expectedOrigins: string[]) {
+  return expectedOrigins.some((origin) => isAllowedRequestSource(value, origin));
+}
+
 export function shouldRequireMobileAccessCredential(
   _host: string | null,
   _hasSuppliedCredential: boolean,
@@ -98,6 +138,17 @@ export function bearerFromReferer(value: string | null, expectedOrigin: string) 
   } catch {
     return null;
   }
+}
+
+/** bearerFromReferer against ANY accepted origin — so a referer carrying the
+ *  real fallback port still yields its token when nextUrl.origin lags behind
+ *  (see expectedRequestOrigins). Returns the first token found. */
+export function bearerFromRefererAny(value: string | null, expectedOrigins: string[]) {
+  for (const origin of expectedOrigins) {
+    const token = bearerFromReferer(value, origin);
+    if (token) return token;
+  }
+  return null;
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,7 +12,10 @@ import {
   isAllowedApiHost,
   sameOrigin,
   isAllowedRequestSource,
+  isAllowedRequestSourceAny,
+  expectedRequestOrigins,
   bearerFromReferer,
+  bearerFromRefererAny,
   shouldRequireMobileAccessCredential,
   isHtmlNavigationRequest,
   accessGatePage,
@@ -167,8 +170,16 @@ export async function proxy(req: NextRequest) {
   // callers if the dev server were ever bound to anything other than
   // 127.0.0.1. The token equality check below is the only thing
   // legitimately optional in browser-dev mode.
-  const expectedOrigin = req.nextUrl.origin;
   const requestHost = req.headers.get("host");
+  // Accept the Origin/Referer against the configured-port origin (nextUrl,
+  // which the Serve/forwarded-host path relies on) AND the port the browser
+  // actually reached us on (from Host). The latter is what unbreaks a server
+  // that fell back to a free port — see expectedRequestOrigins (cave-5sg).
+  const expectedOrigins = expectedRequestOrigins(
+    req.nextUrl.origin,
+    req.nextUrl.protocol,
+    requestHost,
+  );
   const mobileAccessAuthenticated = mobileAccessToken
     ? Boolean(await mobileAccessVerification(req, mobileAccessToken))
     : false;
@@ -203,10 +214,10 @@ export async function proxy(req: NextRequest) {
   if (!headerCsrfTrusted) {
     const origin = req.headers.get("origin");
     const referer = req.headers.get("referer");
-    if (!isAllowedRequestSource(origin, expectedOrigin)) {
+    if (!isAllowedRequestSourceAny(origin, expectedOrigins)) {
       return jsonError(403, "forbidden origin");
     }
-    if (!isAllowedRequestSource(referer, expectedOrigin)) {
+    if (!isAllowedRequestSourceAny(referer, expectedOrigins)) {
       return jsonError(403, "forbidden referer");
     }
     // Production GET webhooks are intentionally state-changing: a matching
@@ -233,7 +244,7 @@ export async function proxy(req: NextRequest) {
   const suppliedToken =
     req.headers.get(TOKEN_HEADER) ??
     req.nextUrl.searchParams.get(TOKEN_PARAM) ??
-    bearerFromReferer(req.headers.get("referer"), expectedOrigin);
+    bearerFromRefererAny(req.headers.get("referer"), expectedOrigins);
   const sidecarAuthenticated = Boolean(sidecarToken) && suppliedToken === sidecarToken;
 
   if (!sidecarToken) {


### PR DESCRIPTION
When `server.ts` falls back to a free port (the configured `PORT` is taken, `startListening()` retries `port+1`), the page loads but **every** browser `/api/*` request returns `403 forbidden origin`.

## Root cause

`server.ts` constructs Next with the **configured** port (`next({ port })`) *before* the listener runs, so `req.nextUrl.origin` (proxy.ts) stays pinned to the configured port. The browser connects to the **actual** fallback port and sends `Origin`/`Host` for that port, so the same-origin CSRF gate compares against the wrong port and rejects it. `curl` with no `Origin` passed (null tolerated); `curl -H 'Origin: <configured-port>'` passed — which isolated the mismatch.

## Fix

Derive the accepted-origin set from the request itself (`expectedRequestOrigins`):
- keep `req.nextUrl.origin` **first**, so the Tailscale-Serve / forwarded-host path is entirely unchanged;
- add an origin built from the request's own `Host` header — the port the browser actually reached us on.

Safe because the host gate directly above already constrains `Host` to loopback (or an authenticated / tailnet-trusted remote): a cross-site browser attacker's `Origin` matches neither value (the browser sets both `Origin` and `Host` and can forge neither), and DNS-rebinding is caught by the loopback host gate. `Referer` and the referer-borne token path get the same treatment via `isAllowedRequestSourceAny` / `bearerFromRefererAny`.

## Verification

Live, against a server forced to fall back `3900 → 3901`:

| request | before | after |
| --- | --- | --- |
| `Origin: http://127.0.0.1:3901` (real port) | **403** | **200** |
| `Origin: http://127.0.0.1:3900` (configured) | 200 | 200 |
| `Origin: http://evil.example` | 403 | 403 |
| `Origin: http://127.0.0.1:9999` (other loopback port) | 403 | 403 |
| cross-origin `POST` | 403 | 403 |

New unit coverage in `proxy-behavior.test.ts` (fallback origin accepted, dedup, https preserved, cross-site rejected, referer-token extraction); `middleware.test.ts` source pins repointed. Full suite (548 files), typecheck, and production build green.

Closes bead `cave-5sg`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)