### PR TITLE
docs: clarify Tauri dev startup (re-land #2530)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,52 @@
 - Do not push directly to `main`; use the protected PR path for repository changes.
 - Before release or TestFlight work, reconcile through clean `main`, then verify from that state.
 
+## Starting The Tauri Desktop App
+
+Use the desktop shell when validating native-only surfaces such as the terminal,
+browser pane, window chrome, sidecar behavior, updater wiring, or Tauri
+permissions. Do not open Codex browser previews for this repo; use the native
+Tauri window, or the user's default browser for web-only checks.
+
+Preferred dev command:
+
+```bash
+bash scripts/dev-app.sh
+```
+
+Run it in the foreground from your repo checkout or worktree and leave that
+terminal attached. Stop it with `Ctrl-C`. The wrapper:
+
+- picks the first free loopback port in `3000..3010`, or honors `PORT=3001`
+- starts the Next custom dev server on that port when needed
+- writes a temporary Tauri config so `devUrl` points at the actual port
+- runs `pnpm exec tauri dev` against the desktop shell
+
+Expected early output looks like:
+
+```text
+[dev:app] port 3001 is free
+[dev:app] starting dev server on 3001
+Running BeforeDevCommand (`PORT=3001 pnpm dev`)
+> Ready on http://127.0.0.1:3001
+Running DevCommand (`cargo run --no-default-features --color always --`)
+```
+
+First launch may spend several minutes downloading and compiling Rust crates
+before the window appears. Treat Cargo `Compiling ...` lines as progress, not a
+hang. If port `3000` is occupied, for example by Docker, the wrapper should move
+to `3001`; if all ports in the range are occupied, free one or run with an
+explicit port:
+
+```bash
+PORT=3007 bash scripts/dev-app.sh
+```
+
+`pnpm dev:app` calls the same wrapper. Prefer the direct `bash` form in agent
+handoffs because its logs make the startup sequence and selected port obvious.
+Do not background the command when the goal is to verify the app started; a
+detached wrapper can exit without leaving useful Tauri logs.
+
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:970c3bf2 -->
 ## Beads Issue Tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,52 @@ cd .worktrees/<branch> && pnpm install   # ~10s with pnpm's CAS store
 
 **After `gh pr merge --squash --delete-branch`:** remote-side cleanup is automatic; local-side is NOT. Manually `git worktree remove <path>` then `git branch -D <branch>`, then `git worktree list` to verify.
 
+## Starting the Tauri desktop app
+
+Use the desktop shell when validating native-only surfaces such as the terminal,
+browser pane, window chrome, sidecar behavior, updater wiring, or Tauri
+permissions. Do not open Codex browser previews for this repo; use the native
+Tauri window, or the user's default browser for web-only checks.
+
+Preferred dev command:
+
+```bash
+bash scripts/dev-app.sh
+```
+
+Run it in the foreground from your repo checkout or worktree and leave that
+terminal attached. Stop it with `Ctrl-C`. The wrapper:
+
+- picks the first free loopback port in `3000..3010`, or honors `PORT=3001`
+- starts the Next custom dev server on that port when needed
+- writes a temporary Tauri config so `devUrl` points at the actual port
+- runs `pnpm exec tauri dev` against the desktop shell
+
+Expected early output looks like:
+
+```text
+[dev:app] port 3001 is free
+[dev:app] starting dev server on 3001
+Running BeforeDevCommand (`PORT=3001 pnpm dev`)
+> Ready on http://127.0.0.1:3001
+Running DevCommand (`cargo run --no-default-features --color always --`)
+```
+
+First launch may spend several minutes downloading and compiling Rust crates
+before the window appears. Treat Cargo `Compiling ...` lines as progress, not a
+hang. If port `3000` is occupied, for example by Docker, the wrapper should move
+to `3001`; if all ports in the range are occupied, free one or run with an
+explicit port:
+
+```bash
+PORT=3007 bash scripts/dev-app.sh
+```
+
+`pnpm dev:app` calls the same wrapper. Prefer the direct `bash` form in agent
+handoffs because its logs make the startup sequence and selected port obvious.
+Do not background the command when the goal is to verify the app started; a
+detached wrapper can exit without leaving useful Tauri logs.
+
 ## Diagnosing concurrent sessions
 
 If git operations keep colliding with surprise pulls/merges, multiple Claude sessions are likely on the same checkout. Diagnose:

--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ pnpm dev
 Run against the Tauri desktop shell:
 
 ```bash
-pnpm dev:app
+bash scripts/dev-app.sh
 ```
+
+The wrapper picks a free loopback port in `3000..3010`, starts the custom Next
+dev server when needed, and points `tauri dev` at the selected port. First launch
+can take several minutes while Cargo downloads and compiles Rust crates. Use
+`PORT=3007 bash scripts/dev-app.sh` to force a specific port. `pnpm dev:app`
+calls the same wrapper.
 
 Build:
 


### PR DESCRIPTION
Re-lands #2530 by @oxfern verbatim (squash of `pull/2530/head` onto current main). Fork PRs cannot satisfy the required **CodeQL** check (default setup never reports on fork/docs-only heads), so #2530 sat BLOCKED with every runnable check green.

Docs verified against `scripts/dev-app.sh` (port range 3000–3010, PORT override, temp Tauri devUrl config). Credit preserved via Co-authored-by trailer.