### PR TITLE
feat(workflow): Familiar Work Queue — beads + PR control tower (cave-hlv.4)

### DIFF
--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -130,14 +130,21 @@ gate above, not authority to merge.
 
 ## Cave Adapter
 
-Cave exposes a local `/api/beads` adapter for UI surfaces. It shells out to `bd` through argv arrays and reads JSON from `bd ready --json`, `bd show <id> --json`, and mutation commands. Mutations stay local-only and must use bounded JSON bodies.
+Cave exposes a local `/api/beads` adapter for UI surfaces. It shells out to `bd` through argv arrays and reads JSON from `bd ready --json`, `bd show <id> --json`, and mutation commands (`claim`, `comment`, `close`). A sibling `/api/beads/prs` route is the browser-facing half of the PR bridge: it shells `gh` server-side and returns the same classified open-PR summaries the CLI patrol produces, plus a light list of recently-merged PRs for cleanup detection. Both routes are local-origin- and path-guarded; mutations use bounded JSON bodies.
 
-The first UI should be a Familiar Work Queue:
+## Familiar Work Queue
 
-- Ready beads grouped by priority and blocker state.
-- Owner, familiar label, surface label, branch/worktree, PR, and Linear link visible on each card.
-- Claim, comment, and close actions mapped to the local adapter.
-- Verification evidence shown before close, not hidden in a chat transcript.
+The **Work Queue** surface (nav rail, or `?mode=familiar-work-queue`) is the PR control tower. It fuses ready beads with the bridge's open-PR lanes into one per-familiar, per-surface view — and, per the epic's design note, it invents no PR truth of its own: every lane comes from `/api/beads` + `/api/beads/prs`.
+
+Lanes, ordered fix-first → land → review → bead-driven → waiting:
+
+- **Checks failing** / **Changes requested** — open PRs that need work before more review.
+- **Needs review** / **Ready to merge** — approved-and-green PRs show a *merge eligible* badge, never a merge button: merge authority still follows repository policy (see the merge gate above).
+- **No open PR** — ready beads no PR references yet (epics excluded), with a **Claim** action.
+- **Post-merge cleanup** — a merged PR whose bead is still open, with a **Close bead** action. (Detection is limited to beads still in the `ready` set; worktree/branch removal stays a CLI step.)
+- **Waiting** — draft, pending-checks, and blocked PRs; shown but never counted as actionable.
+
+Each card carries the familiar and surface labels, the bead id, live check/review state, and a stale flag (no update in 24h). A per-familiar rollup along the top filters the whole board to one familiar. The pure join lives in `src/lib/beads-work-queue.ts`; claim/close map to the `/api/beads` adapter with verification recorded in the bead, not a chat transcript.
 
 ## Guardrails
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -55,6 +55,7 @@ export const SUITES = {
     "src/lib/github-checks.test.ts",
     "src/lib/beads-pr-management.test.ts",
     "src/lib/beads-pr-patrol.test.ts",
+    "src/lib/beads-work-queue.test.ts",
     "src/components/gh-review-actions.test.ts",
     "src/lib/gfm-autolink.test.ts",
     "src/lib/gh-diff.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -19,6 +19,7 @@ type RouteContract = {
 const contracts: RouteContract[] = [
   { route: "/app/latest-release", methods: ["GET"], kind: "json" },
   { route: "/beads", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true, pathGuard: true },
+  { route: "/beads/prs", methods: ["GET"], kind: "json", localOriginGuard: true, pathGuard: true },
   { route: "/board/[id]/chat", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/board/[id]/lifecycle", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/board/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/beads/prs/route.ts
+++ b/src/app/api/beads/prs/route.ts
@@ -1,0 +1,97 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { NextResponse } from "next/server";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import { resolveRepoRoot } from "@/lib/server/issue-worktree-provision";
+import {
+  extractBeadIds,
+  summarizePullRequest,
+  type GitHubPullRequestInput,
+} from "@/lib/beads-pr-management";
+import type { MergedPrRef } from "@/lib/beads-work-queue";
+
+// Browser-facing half of the PR bridge (cave-hlv.4). The Familiar Work Queue
+// surface can't shell `gh`, so this route runs it server-side and hands the
+// classified summaries to the client. It is the ONLY PR-truth source the queue
+// UI reads — the client never invents PR state (per the epic's design note).
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const execFileAsync = promisify(execFile);
+const GH_TIMEOUT_MS = 30_000;
+const MAX_GH_BUFFER = 16 * 1024 * 1024;
+
+// Fields the lane classifier (summarizePullRequest) depends on. Kept in sync
+// with scripts/beads-pr-shared.ts's GH_PR_FIELDS — the CLI patrol and this
+// route must classify identically.
+const OPEN_PR_FIELDS =
+  "number,title,url,isDraft,headRefName,baseRefName,mergeStateStatus,reviewDecision,statusCheckRollup,updatedAt,body,labels";
+// Merged PRs only feed the post-merge-cleanup lane, which needs just identity
+// + bead links, so we request a lighter field set.
+const MERGED_PR_FIELDS = "number,title,url,headRefName,body,labels,mergedAt";
+const MERGED_PR_LIMIT = "30";
+
+async function ghPrList(repoRoot: string, args: string[]): Promise<unknown> {
+  const { stdout } = await execFileAsync("gh", args, {
+    cwd: repoRoot, // cwd's repo → gh targets the right OWNER/REPO without hardcoding
+    env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+    timeout: GH_TIMEOUT_MS,
+    maxBuffer: MAX_GH_BUFFER,
+  });
+  const parsed = JSON.parse(stdout.trim() || "[]");
+  if (!Array.isArray(parsed)) throw new Error("gh pr list returned non-array JSON");
+  return parsed;
+}
+
+function toMergedRef(pr: GitHubPullRequestInput & { mergedAt?: string | null }): MergedPrRef {
+  return {
+    number: pr.number,
+    title: pr.title,
+    url: pr.url,
+    beadIds: extractBeadIds(pr),
+    mergedAt: pr.mergedAt ?? null,
+  };
+}
+
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const url = new URL(req.url);
+  const root = await resolveRepoRoot(url.searchParams.get("projectRoot") || process.cwd());
+  if (!root.ok) {
+    if ((root.error || "path not allowed") === "path not allowed") {
+      return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+    }
+    return NextResponse.json({ ok: false, error: root.error }, { status: root.status });
+  }
+
+  try {
+    const [openRaw, mergedRaw] = await Promise.all([
+      ghPrList(root.repoRoot, ["pr", "list", "--state", "open", "--limit", "100", "--json", OPEN_PR_FIELDS]),
+      ghPrList(root.repoRoot, [
+        "pr",
+        "list",
+        "--state",
+        "merged",
+        "--limit",
+        MERGED_PR_LIMIT,
+        "--json",
+        MERGED_PR_FIELDS,
+      ]),
+    ]);
+
+    const open = (openRaw as GitHubPullRequestInput[]).map(summarizePullRequest);
+    const merged = (mergedRaw as Array<GitHubPullRequestInput & { mergedAt?: string | null }>).map(toMergedRef);
+
+    return NextResponse.json({ ok: true, projectRoot: root.repoRoot, open, merged });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    const unavailable = err.code === "ENOENT";
+    return NextResponse.json(
+      { ok: false, error: unavailable ? "gh unavailable" : err.message || "gh command failed" },
+      { status: unavailable ? 500 : 502 },
+    );
+  }
+}

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+import "@/styles/familiar-work-queue.css";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon, type IconName } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { usePausablePoll } from "@/lib/use-pausable-poll";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import {
+  buildWorkQueue,
+  type ReadyBead,
+  type MergedPrRef,
+  type WorkQueue,
+  type WorkQueueItem,
+  type WorkQueueLaneKey,
+} from "@/lib/beads-work-queue";
+import type { PullRequestSummary } from "@/lib/beads-pr-management";
+
+type Props = {
+  familiars?: ResolvedFamiliar[];
+  onOpenUrl?: (url: string) => void;
+};
+
+const LANE_ICON: Record<WorkQueueLaneKey, IconName> = {
+  "checks-failing": "ph:warning-circle",
+  "changes-requested": "ph:chat-circle-dots",
+  "needs-review": "ph:magnifying-glass",
+  "ready-to-merge": "ph:git-merge",
+  waiting: "ph:hourglass",
+  "no-open-PR": "ph:git-branch",
+  "post-merge-cleanup": "ph:sparkle",
+};
+
+// Lanes whose accent reads as "act now" get a warm tint; waiting stays quiet.
+const LANE_TONE: Record<WorkQueueLaneKey, "urgent" | "ready" | "neutral" | "quiet"> = {
+  "checks-failing": "urgent",
+  "changes-requested": "urgent",
+  "needs-review": "neutral",
+  "ready-to-merge": "ready",
+  waiting: "quiet",
+  "no-open-PR": "neutral",
+  "post-merge-cleanup": "ready",
+};
+
+async function fetchQueue(signal: AbortSignal): Promise<WorkQueue> {
+  const [beadsRes, prsRes] = await Promise.all([
+    fetch("/api/beads?mode=ready", { cache: "no-store", signal }),
+    fetch("/api/beads/prs", { cache: "no-store", signal }),
+  ]);
+  const beadsJson = await beadsRes.json();
+  const prsJson = await prsRes.json();
+  if (!prsJson.ok) throw new Error(prsJson.error || "PR bridge unavailable");
+  const readyBeads: ReadyBead[] = beadsJson.ok && Array.isArray(beadsJson.data) ? beadsJson.data : [];
+  const open: PullRequestSummary[] = Array.isArray(prsJson.open) ? prsJson.open : [];
+  const merged: MergedPrRef[] = Array.isArray(prsJson.merged) ? prsJson.merged : [];
+  return buildWorkQueue(readyBeads, open, merged, { nowMs: Date.now() });
+}
+
+export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
+  const { announce } = useAnnouncer();
+  const [queue, setQueue] = useState<WorkQueue | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [familiarFilter, setFamiliarFilter] = useState<string | null>(null);
+  const loadSeq = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const load = useCallback(
+    async (opts?: { quiet?: boolean }) => {
+      const quiet = opts?.quiet === true;
+      const seq = ++loadSeq.current;
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      try {
+        const next = await fetchQueue(ctrl.signal);
+        if (seq !== loadSeq.current) return; // a newer load won
+        setQueue(next);
+        setError(null);
+      } catch (err) {
+        if (ctrl.signal.aborted || seq !== loadSeq.current) return;
+        if (!quiet) setError(err instanceof Error ? err.message : "Failed to load the work queue");
+      } finally {
+        if (seq === loadSeq.current) setHasLoaded(true);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    void load();
+    return () => abortRef.current?.abort();
+  }, [load]);
+
+  // Announce the actionable count once the first load settles.
+  const announcedRef = useRef(false);
+  useEffect(() => {
+    if (!hasLoaded || announcedRef.current || !queue) return;
+    announcedRef.current = true;
+    announce(
+      queue.total === 0
+        ? "Work queue is clear — no open PRs or ready beads."
+        : `Work queue loaded: ${queue.actionable} actionable of ${queue.total}.`,
+    );
+  }, [hasLoaded, queue, announce]);
+
+  usePausablePoll(() => void load({ quiet: true }), 30_000, { pauseWhileInputActive: true });
+
+  const familiarName = useCallback(
+    (key: string) => {
+      if (key === "unassigned") return "Unassigned";
+      const match = familiars.find((f) => f.id === key || f.display_name?.toLowerCase() === key);
+      return match?.display_name ?? key.charAt(0).toUpperCase() + key.slice(1);
+    },
+    [familiars],
+  );
+
+  const runAction = useCallback(
+    async (item: WorkQueueItem, action: "claim" | "close") => {
+      const id = item.bead?.id;
+      if (!id) return;
+      setBusyId(item.key);
+      try {
+        const body: Record<string, string> = { action, id };
+        if (action === "close") body.reason = item.merged ? `Merged in PR #${item.merged.number}` : "Completed";
+        const res = await fetch("/api/beads", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        if (!json.ok) throw new Error(json.error || `${action} failed`);
+        announce(action === "claim" ? `Claimed ${id}.` : `Closed ${id}.`);
+        await load({ quiet: true });
+      } catch (err) {
+        announce(err instanceof Error ? err.message : `Could not ${action} ${id}`, "assertive");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [announce, load],
+  );
+
+  const visibleLanes = useMemo(() => {
+    if (!queue) return [];
+    if (!familiarFilter) return queue.lanes;
+    return queue.lanes
+      .map((lane) => ({ ...lane, items: lane.items.filter((i) => i.familiar === familiarFilter) }))
+      .filter((lane) => lane.items.length > 0);
+  }, [queue, familiarFilter]);
+
+  if (!hasLoaded) {
+    return (
+      <div className="fwq" aria-busy>
+        <div className="fwq-head">
+          <h2 className="fwq-title">Familiar Work Queue</h2>
+        </div>
+        <div className="fwq-body">
+          <SkeletonRows count={6} />
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !queue) {
+    return (
+      <div className="fwq">
+        <div className="fwq-body">
+          <EmptyState
+            icon="ph:warning-circle"
+            headline="Couldn't load the work queue"
+            subtitle={error}
+            actions={
+              <Button variant="secondary" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
+                Retry
+              </Button>
+            }
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const q = queue!;
+
+  return (
+    <div className="fwq">
+      <div className="fwq-head">
+        <div className="fwq-head-main">
+          <h2 className="fwq-title">Familiar Work Queue</h2>
+          <p className="fwq-sub">
+            {q.total === 0
+              ? "No open PRs or ready beads."
+              : `${q.actionable} actionable · ${q.total} total${q.stale ? ` · ${q.stale} stale` : ""}`}
+          </p>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          leadingIcon="ph:arrow-clockwise"
+          onClick={() => void load()}
+          aria-label="Refresh work queue"
+        >
+          Refresh
+        </Button>
+      </div>
+
+      {q.byFamiliar.length > 0 ? (
+        <div className="fwq-familiars" role="group" aria-label="Filter by familiar">
+          <button
+            type="button"
+            className={`fwq-chip${familiarFilter === null ? " is-active" : ""}`}
+            aria-pressed={familiarFilter === null}
+            onClick={() => setFamiliarFilter(null)}
+          >
+            All <span className="fwq-chip-count">{q.total}</span>
+          </button>
+          {q.byFamiliar.map((r) => (
+            <button
+              key={r.familiar}
+              type="button"
+              className={`fwq-chip${familiarFilter === r.familiar ? " is-active" : ""}`}
+              aria-pressed={familiarFilter === r.familiar}
+              onClick={() => setFamiliarFilter((cur) => (cur === r.familiar ? null : r.familiar))}
+              title={`${r.actionable} actionable of ${r.total}`}
+            >
+              {familiarName(r.familiar)}
+              <span className="fwq-chip-count">{r.actionable}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="fwq-body">
+        {q.total === 0 ? (
+          <EmptyState
+            icon="ph:check-circle"
+            headline="Queue is clear"
+            subtitle="No open PRs need attention and no ready beads are waiting to ship."
+          />
+        ) : visibleLanes.length === 0 ? (
+          <EmptyState
+            icon="ph:funnel"
+            headline={`Nothing for ${familiarName(familiarFilter ?? "")}`}
+            subtitle="Clear the filter to see the whole queue."
+            actions={
+              <Button variant="secondary" onClick={() => setFamiliarFilter(null)}>
+                Show all
+              </Button>
+            }
+          />
+        ) : (
+          visibleLanes.map((lane) => (
+            <section key={lane.key} className={`fwq-lane fwq-lane--${LANE_TONE[lane.key]}`} aria-label={lane.title}>
+              <header className="fwq-lane-head">
+                <Icon name={LANE_ICON[lane.key]} width={15} aria-hidden />
+                <span className="fwq-lane-title">{lane.title}</span>
+                <span className="fwq-lane-count">{lane.items.length}</span>
+              </header>
+              <ul className="fwq-cards">
+                {lane.items.map((item) => (
+                  <WorkQueueCard
+                    key={item.key}
+                    item={item}
+                    familiarLabel={familiarName(item.familiar)}
+                    busy={busyId === item.key}
+                    onOpenUrl={onOpenUrl}
+                    onClaim={() => void runAction(item, "claim")}
+                    onClose={() => void runAction(item, "close")}
+                  />
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WorkQueueCard({
+  item,
+  familiarLabel,
+  busy,
+  onOpenUrl,
+  onClaim,
+  onClose,
+}: {
+  item: WorkQueueItem;
+  familiarLabel: string;
+  busy: boolean;
+  onOpenUrl?: (url: string) => void;
+  onClaim: () => void;
+  onClose: () => void;
+}) {
+  const beadId = item.bead?.id ?? null;
+  const title = item.pr?.title ?? item.merged?.title ?? item.bead?.title ?? "Untitled";
+  const prNumber = item.pr?.number ?? item.merged?.number ?? null;
+  const url = item.pr?.url ?? item.merged?.url ?? null;
+
+  return (
+    <li className={`fwq-card${item.stale ? " is-stale" : ""}`}>
+      <div className="fwq-card-main">
+        <div className="fwq-card-title">
+          {prNumber != null ? <span className="fwq-pr-num">#{prNumber}</span> : null}
+          <span className="fwq-card-name">{title}</span>
+        </div>
+        <div className="fwq-card-meta">
+          <span className="fwq-tag fwq-tag--familiar">{familiarLabel}</span>
+          {item.surface ? <span className="fwq-tag">{item.surface}</span> : null}
+          {beadId ? <span className="fwq-tag fwq-tag--bead">{beadId}</span> : null}
+          {item.bead && !item.pr && !item.merged ? (
+            <span className="fwq-tag">P{item.bead.priority}</span>
+          ) : null}
+          {item.pr ? (
+            <>
+              <span className={`fwq-tag fwq-tag--check-${item.pr.checkStatus ?? "unknown"}`}>
+                checks {item.pr.checkStatus ?? "unknown"}
+              </span>
+              {item.pr.reviewDecision && item.pr.reviewDecision !== "UNKNOWN" ? (
+                <span className="fwq-tag">{item.pr.reviewDecision.toLowerCase().replace(/_/g, " ")}</span>
+              ) : null}
+              {item.lane === "ready-to-merge" ? <span className="fwq-tag fwq-tag--ready">merge eligible</span> : null}
+            </>
+          ) : null}
+          {item.stale ? <span className="fwq-tag fwq-tag--stale">stale</span> : null}
+        </div>
+      </div>
+      <div className="fwq-card-actions">
+        {url ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            trailingIcon="ph:arrow-square-out"
+            onClick={() => onOpenUrl?.(url)}
+            disabled={!onOpenUrl}
+          >
+            {item.merged ? "Merged PR" : "Open PR"}
+          </Button>
+        ) : null}
+        {item.lane === "no-open-PR" && beadId ? (
+          <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:hand" onClick={onClaim}>
+            Claim
+          </Button>
+        ) : null}
+        {item.lane === "post-merge-cleanup" && beadId ? (
+          <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:check" onClick={onClose}>
+            Close bead
+          </Button>
+        ) : null}
+      </div>
+    </li>
+  );
+}

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -73,3 +73,10 @@ export const AutomationsView = dynamic(
   timed("automations", () => import("@/components/automations-view").then((m) => m.AutomationsView)),
   { ssr: false, loading: SurfaceFallback },
 );
+
+export const FamiliarWorkQueueView = dynamic(
+  timed("familiar-work-queue", () =>
+    import("@/components/familiar-work-queue-view").then((m) => m.FamiliarWorkQueueView),
+  ),
+  { ssr: false, loading: SurfaceFallback },
+);

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -40,6 +40,7 @@ export type FolderMode =
   | "flow"
   | "submissions"
   | "capabilities"
+  | "familiar-work-queue"
   | "journal";
 
 export type SidebarMinimalProps = {
@@ -107,6 +108,7 @@ const FOLDER_MODES: Array<{
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.
   { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
+  { id: "familiar-work-queue", label: "Work Queue", iconName: "ph:list-checks-bold", description: "Ready beads and the PR control tower, by familiar", quiet: true },
 ];
 
 // Rows actually rendered in the sidebar — everything except on-demand surfaces

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -47,6 +47,7 @@ import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
 import {
   BoardView,
   CalendarView,
+  FamiliarWorkQueueView,
   GitHubView,
   MarketplaceView,
 } from "@/components/lazy-surfaces";
@@ -138,6 +139,7 @@ const WORKSPACE_MODE_TITLES: Record<WorkspaceMode, string> = {
   flow: "Flow",
   submissions: "Submissions",
   capabilities: "Capabilities",
+  "familiar-work-queue": "Work Queue",
   journal: "Journal",
 };
 
@@ -2094,6 +2096,8 @@ export function Workspace() {
         familiars={resolvedFamiliars}
         onOpenChat={(familiarId) => startFamiliarChat(familiarId)}
       />
+    ) : mode === "familiar-work-queue" ? (
+      <FamiliarWorkQueueView familiars={resolvedFamiliars} onOpenUrl={openUrlInAppBrowser} />
     ) : mode === "submissions" ? (
       <OpenCovenSubmissionPage />
     ) : (

--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -1,0 +1,151 @@
+// @ts-nocheck
+// Familiar Work Queue model (cave-hlv.4) — the pure bead↔PR join: lane mapping,
+// per-familiar/per-surface labelling, stale + unlinked flags, no-open-PR and
+// post-merge-cleanup derivation. Clock injected for determinism.
+import assert from "node:assert/strict";
+
+const { buildWorkQueue, isActionableLane, laneTitle } = await import("./beads-work-queue.ts");
+
+const NOW = Date.parse("2026-07-07T12:00:00Z");
+const HOURS = 3_600_000;
+
+function pr(number, lane, { beads = [], updatedAgoHours = 1 } = {}) {
+  return {
+    number,
+    title: `PR ${number}`,
+    url: `https://github.com/OpenCoven/coven-cave/pull/${number}`,
+    lane,
+    beadIds: beads,
+    checkStatus: lane === "checks-failing" ? "failing" : "passing",
+    reviewDecision: "APPROVED",
+    mergeStateStatus: "CLEAN",
+    headRefName: `feat/pr-${number}`,
+    updatedAt: new Date(NOW - updatedAgoHours * HOURS).toISOString(),
+  };
+}
+
+function bead(id, { priority = 2, labels = [], type = "feature", assignee = null } = {}) {
+  return { id, title: `Bead ${id}`, priority, status: "open", assignee, issue_type: type, labels, updated_at: null };
+}
+
+// ── Open PRs map to lanes and join to their bead for familiar/surface ─────────
+{
+  const beads = [bead("cave-aa1", { labels: ["familiar:kitty", "surface:github"] })];
+  const prs = [
+    pr(1, "checks-failing", { beads: ["cave-aa1"] }),
+    pr(2, "ready-to-merge", { beads: ["cave-bb2"] }),
+    pr(3, "needs-review", { beads: [] }),
+    pr(4, "draft", { beads: [] }),
+    pr(5, "changes-requested", { beads: ["cave-aa1"] }),
+    pr(6, "checks-pending", { beads: [] }),
+    pr(7, "blocked", { beads: [] }),
+  ];
+  const q = buildWorkQueue(beads, prs, [], { nowMs: NOW });
+  const laneOf = Object.fromEntries(q.lanes.map((l) => [l.key, l.items.map((i) => i.key)]));
+  assert.deepEqual(laneOf["checks-failing"], ["pr:1"], "failing PR in its lane");
+  assert.deepEqual(laneOf["changes-requested"], ["pr:5"]);
+  assert.deepEqual(laneOf["needs-review"], ["pr:3"]);
+  assert.deepEqual(laneOf["ready-to-merge"], ["pr:2"]);
+  assert.deepEqual(laneOf.waiting, ["pr:4", "pr:6", "pr:7"], "draft/pending/blocked fold into waiting");
+
+  const failing = q.lanes.find((l) => l.key === "checks-failing").items[0];
+  assert.equal(failing.familiar, "kitty", "PR joined to bead's familiar label");
+  assert.equal(failing.surface, "github", "PR joined to bead's surface label");
+
+  const review = q.lanes.find((l) => l.key === "needs-review").items[0];
+  assert.equal(review.familiar, "unassigned", "bead-less PR is unassigned");
+  assert.equal(review.surface, null);
+
+  assert.deepEqual(q.unlinked, [3, 4, 6, 7], "bead-less open PRs are flagged unlinked");
+  // waiting is not actionable; the four PR-action lanes are (2 with beads, but
+  // count is by item: failing+changes+review+ready = 4).
+  assert.equal(q.actionable, 4, "actionable excludes waiting");
+}
+
+// ── Lane ordering: fix-first → land → review → bead lanes → waiting ──────────
+{
+  const prs = [pr(1, "draft"), pr(2, "ready-to-merge"), pr(3, "checks-failing"), pr(4, "needs-review")];
+  const q = buildWorkQueue([], prs, [], { nowMs: NOW });
+  assert.deepEqual(
+    q.lanes.map((l) => l.key),
+    ["checks-failing", "needs-review", "ready-to-merge", "waiting"],
+    "lanes render in fix→land→review→waiting order, empty lanes dropped",
+  );
+}
+
+// ── no-open-PR: ready beads unreferenced by any open PR; epics excluded ──────
+{
+  const beads = [
+    bead("cave-x1", { labels: ["familiar:nova", "surface:ios"] }),
+    bead("cave-x2", { labels: ["familiar:kitty"] }), // has an open PR → not here
+    bead("cave-epic", { type: "epic", labels: ["familiar:nova"] }), // container, excluded
+  ];
+  const prs = [pr(9, "needs-review", { beads: ["cave-x2"] })];
+  const q = buildWorkQueue(beads, prs, [], { nowMs: NOW });
+  const noPr = q.lanes.find((l) => l.key === "no-open-PR");
+  assert.deepEqual(noPr.items.map((i) => i.bead.id), ["cave-x1"], "only the unreferenced non-epic bead");
+  assert.equal(noPr.items[0].familiar, "nova");
+  assert.equal(noPr.items[0].surface, "ios");
+}
+
+// ── post-merge-cleanup: merged PR whose bead is still open (in ready set) ────
+{
+  const beads = [bead("cave-open", { labels: ["familiar:kitty"] })];
+  const merged = [
+    { number: 50, title: "landed", url: "u/50", beadIds: ["cave-open"], mergedAt: "2026-07-07T00:00:00Z" },
+    { number: 51, title: "landed+closed bead", url: "u/51", beadIds: ["cave-closed"], mergedAt: "x" },
+    { number: 52, title: "no bead", url: "u/52", beadIds: [], mergedAt: "x" },
+  ];
+  const q = buildWorkQueue(beads, [], merged, { nowMs: NOW });
+  const cleanup = q.lanes.find((l) => l.key === "post-merge-cleanup");
+  assert.deepEqual(cleanup.items.map((i) => i.merged.number), [50], "only merged PRs whose bead is still open");
+  assert.equal(cleanup.items[0].familiar, "kitty");
+  assert.ok(isActionableLane("post-merge-cleanup"), "cleanup is actionable");
+  // A bead awaiting cleanup must NOT also appear in no-open-PR (it HAS a PR —
+  // it just merged). Otherwise it double-counts.
+  assert.equal(q.lanes.find((l) => l.key === "no-open-PR"), undefined, "cleanup bead is not in no-open-PR");
+  assert.equal(q.total, 1, "cave-open counted once, in cleanup only");
+}
+
+// ── Stale flag + rollup by familiar ──────────────────────────────────────────
+{
+  const beads = [
+    bead("cave-k", { labels: ["familiar:kitty"] }),
+    bead("cave-n", { labels: ["familiar:nova"] }),
+  ];
+  const prs = [
+    pr(1, "checks-failing", { beads: ["cave-k"], updatedAgoHours: 40 }), // stale
+    pr(2, "needs-review", { beads: ["cave-n"], updatedAgoHours: 2 }),
+  ];
+  const q = buildWorkQueue(beads, prs, [], { nowMs: NOW, staleAfterHours: 24 });
+  assert.equal(q.stale, 1, "one stale PR at the 24h window");
+  const failing = q.lanes.find((l) => l.key === "checks-failing").items[0];
+  assert.equal(failing.stale, true, "the 40h PR is stale");
+
+  const kitty = q.byFamiliar.find((r) => r.familiar === "kitty");
+  const nova = q.byFamiliar.find((r) => r.familiar === "nova");
+  assert.equal(kitty.actionable, 1);
+  assert.equal(kitty.laneCounts["checks-failing"], 1);
+  assert.equal(nova.laneCounts["needs-review"], 1);
+  // Tie on actionable(1) → alphabetical: kitty before nova.
+  assert.deepEqual(q.byFamiliar.map((r) => r.familiar), ["kitty", "nova"]);
+}
+
+// ── unassigned familiar always trails the rollup ─────────────────────────────
+{
+  const prs = [pr(1, "needs-review", { beads: [] }), pr(2, "checks-failing", { beads: [] })];
+  const q = buildWorkQueue([], prs, [], { nowMs: NOW });
+  assert.equal(q.byFamiliar.at(-1).familiar, "unassigned", "unassigned sorts last");
+}
+
+// ── falls back to assignee when no familiar: label ───────────────────────────
+{
+  const beads = [bead("cave-z", { labels: ["surface:daemon"], assignee: "Cody" })];
+  const q = buildWorkQueue(beads, [], [], { nowMs: NOW });
+  const item = q.lanes.find((l) => l.key === "no-open-PR").items[0];
+  assert.equal(item.familiar, "cody", "assignee lowercased when no familiar: label");
+  assert.equal(item.surface, "daemon");
+}
+
+assert.equal(laneTitle("ready-to-merge"), "Ready to merge");
+console.log("beads-work-queue.test.ts: ok");

--- a/src/lib/beads-work-queue.ts
+++ b/src/lib/beads-work-queue.ts
@@ -1,0 +1,262 @@
+// Familiar Work Queue model (cave-hlv.4) — the pure join that fuses ready
+// beads with the PR bridge's classified open PRs into a per-familiar,
+// per-surface control tower. All PR truth comes from the bridge summaries
+// (src/lib/beads-pr-management.ts); this module only groups and labels — it
+// never re-derives lane/check/review state itself.
+import { isStalePr } from "./beads-pr-patrol.ts";
+import type { PullRequestSummary } from "./beads-pr-management.ts";
+
+/** Subset of a `bd ready --json` row the queue reads. */
+export type ReadyBead = {
+  id: string;
+  title: string;
+  priority: number;
+  status: string;
+  assignee?: string | null;
+  issue_type?: string | null;
+  labels?: string[] | null;
+  updated_at?: string | null;
+};
+
+/** A recently-merged PR, reduced to what the cleanup lane needs. */
+export type MergedPrRef = {
+  number: number;
+  title: string;
+  url: string;
+  beadIds: string[];
+  mergedAt: string | null;
+};
+
+// The named lanes the epic's acceptance requires the surface to be able to
+// show, plus a truthful `waiting` bucket for draft/pending/blocked PRs (shown
+// but never counted as actionable).
+export type WorkQueueLaneKey =
+  | "checks-failing"
+  | "changes-requested"
+  | "needs-review"
+  | "ready-to-merge"
+  | "waiting"
+  | "no-open-PR"
+  | "post-merge-cleanup";
+
+export type WorkQueueItem = {
+  key: string;
+  lane: WorkQueueLaneKey;
+  /** familiar:<x> label, or "unassigned". */
+  familiar: string;
+  /** surface:<y> label, or null. */
+  surface: string | null;
+  pr?: PullRequestSummary;
+  bead?: ReadyBead;
+  merged?: MergedPrRef;
+  /** PR-backed items only: no activity within the stale window. */
+  stale?: boolean;
+};
+
+export type WorkQueueLane = {
+  key: WorkQueueLaneKey;
+  title: string;
+  items: WorkQueueItem[];
+};
+
+export type FamiliarRollup = {
+  familiar: string;
+  total: number;
+  actionable: number;
+  laneCounts: Partial<Record<WorkQueueLaneKey, number>>;
+};
+
+export type WorkQueue = {
+  lanes: WorkQueueLane[];
+  byFamiliar: FamiliarRollup[];
+  total: number;
+  actionable: number;
+  stale: number;
+  /** Open PRs mentioning no bead — invisible to the queue join. */
+  unlinked: number[];
+};
+
+const LANE_TITLES: Record<WorkQueueLaneKey, string> = {
+  "checks-failing": "Checks failing",
+  "changes-requested": "Changes requested",
+  "needs-review": "Needs review",
+  "ready-to-merge": "Ready to merge",
+  waiting: "Waiting — draft, pending checks, blocked",
+  "no-open-PR": "No open PR",
+  "post-merge-cleanup": "Post-merge cleanup",
+};
+
+// Render/scan order: fix first, then land, then review, then the bead-driven
+// lanes, then waiting last.
+const LANE_ORDER: WorkQueueLaneKey[] = [
+  "checks-failing",
+  "changes-requested",
+  "needs-review",
+  "ready-to-merge",
+  "no-open-PR",
+  "post-merge-cleanup",
+  "waiting",
+];
+
+// Every lane except `waiting` is something a familiar can act on right now.
+const ACTIONABLE_LANES: ReadonlySet<WorkQueueLaneKey> = new Set(
+  LANE_ORDER.filter((lane) => lane !== "waiting"),
+);
+
+function prLaneToQueueLane(prLane: PullRequestSummary["lane"]): WorkQueueLaneKey {
+  switch (prLane) {
+    case "checks-failing":
+      return "checks-failing";
+    case "changes-requested":
+      return "changes-requested";
+    case "needs-review":
+      return "needs-review";
+    case "ready-to-merge":
+      return "ready-to-merge";
+    // draft, checks-pending, blocked
+    default:
+      return "waiting";
+  }
+}
+
+function labelValue(labels: string[] | null | undefined, prefix: string): string | null {
+  for (const label of labels ?? []) {
+    if (label.startsWith(prefix)) return label.slice(prefix.length);
+  }
+  return null;
+}
+
+function familiarOf(bead: ReadyBead | undefined): string {
+  if (!bead) return "unassigned";
+  return labelValue(bead.labels, "familiar:") ?? (bead.assignee?.toLowerCase() || "unassigned");
+}
+
+function surfaceOf(bead: ReadyBead | undefined): string | null {
+  return labelValue(bead?.labels, "surface:");
+}
+
+export function buildWorkQueue(
+  readyBeads: ReadyBead[],
+  openPrs: PullRequestSummary[],
+  mergedPrs: MergedPrRef[],
+  opts: { nowMs: number; staleAfterHours?: number },
+): WorkQueue {
+  const staleAfterHours = opts.staleAfterHours ?? 24;
+  const beadById = new Map<string, ReadyBead>();
+  for (const bead of readyBeads) beadById.set(bead.id.toLowerCase(), bead);
+
+  const items: WorkQueueItem[] = [];
+  let staleCount = 0;
+  const unlinked: number[] = [];
+  const beadIdsWithOpenPr = new Set<string>();
+
+  // 1. Open PRs → their lane, joined to a ready bead when one is referenced.
+  for (const pr of openPrs) {
+    if (pr.beadIds.length === 0) unlinked.push(pr.number);
+    const bead = pr.beadIds.map((id) => beadById.get(id)).find(Boolean);
+    for (const id of pr.beadIds) beadIdsWithOpenPr.add(id);
+    const stale = isStalePr(pr, opts.nowMs, staleAfterHours);
+    if (stale) staleCount += 1;
+    items.push({
+      key: `pr:${pr.number}`,
+      lane: prLaneToQueueLane(pr.lane),
+      familiar: familiarOf(bead),
+      surface: surfaceOf(bead),
+      pr,
+      bead,
+      stale,
+    });
+  }
+
+  // 2. Recently-merged PRs whose bead is still open (present in the ready set)
+  //    → the merge landed but the bead wasn't closed. Truthful with the data
+  //    on hand; a claimed-but-unclosed bead that dropped out of `ready` won't
+  //    appear here (documented limitation — worktree/branch cleanup stays CLI).
+  //    Runs before the no-open-PR pass so a bead awaiting cleanup is not ALSO
+  //    listed as "needs a PR".
+  const beadIdsInCleanup = new Set<string>();
+  for (const merged of mergedPrs) {
+    const bead = merged.beadIds.map((id) => beadById.get(id)).find(Boolean);
+    if (!bead) continue;
+    beadIdsInCleanup.add(bead.id.toLowerCase());
+    items.push({
+      key: `merged:${merged.number}`,
+      lane: "post-merge-cleanup",
+      familiar: familiarOf(bead),
+      surface: surfaceOf(bead),
+      merged,
+      bead,
+    });
+  }
+
+  // 3. Ready beads with no PR (open or awaiting cleanup) referencing them →
+  //    work still waiting to ship.
+  for (const bead of readyBeads) {
+    const id = bead.id.toLowerCase();
+    if (beadIdsWithOpenPr.has(id) || beadIdsInCleanup.has(id)) continue;
+    if (bead.issue_type === "epic") continue; // epics are containers, not queue work
+    items.push({
+      key: `bead:${bead.id}`,
+      lane: "no-open-PR",
+      familiar: familiarOf(bead),
+      surface: surfaceOf(bead),
+      bead,
+    });
+  }
+
+  const lanes: WorkQueueLane[] = LANE_ORDER.map((key) => ({
+    key,
+    title: LANE_TITLES[key],
+    items: items
+      .filter((item) => item.lane === key)
+      .sort((a, b) => itemSortKey(a).localeCompare(itemSortKey(b))),
+  })).filter((lane) => lane.items.length > 0);
+
+  const actionable = items.filter((item) => ACTIONABLE_LANES.has(item.lane)).length;
+
+  return {
+    lanes,
+    byFamiliar: rollupByFamiliar(items),
+    total: items.length,
+    actionable,
+    stale: staleCount,
+    unlinked: unlinked.sort((a, b) => a - b),
+  };
+}
+
+// Stable, deterministic ordering within a lane: PRs by number, beads by
+// priority then id — no wall-clock, so the render is reproducible.
+function itemSortKey(item: WorkQueueItem): string {
+  if (item.pr) return `0:${String(item.pr.number).padStart(8, "0")}`;
+  if (item.merged) return `0:${String(item.merged.number).padStart(8, "0")}`;
+  if (item.bead) return `1:${item.bead.priority}:${item.bead.id}`;
+  return `2:${item.key}`;
+}
+
+function rollupByFamiliar(items: WorkQueueItem[]): FamiliarRollup[] {
+  const map = new Map<string, FamiliarRollup>();
+  for (const item of items) {
+    let rollup = map.get(item.familiar);
+    if (!rollup) {
+      rollup = { familiar: item.familiar, total: 0, actionable: 0, laneCounts: {} };
+      map.set(item.familiar, rollup);
+    }
+    rollup.total += 1;
+    if (ACTIONABLE_LANES.has(item.lane)) rollup.actionable += 1;
+    rollup.laneCounts[item.lane] = (rollup.laneCounts[item.lane] ?? 0) + 1;
+  }
+  // "unassigned" trails; otherwise most-actionable first, then by name.
+  return [...map.values()].sort((a, b) => {
+    if (a.familiar === "unassigned") return 1;
+    if (b.familiar === "unassigned") return -1;
+    return b.actionable - a.actionable || a.familiar.localeCompare(b.familiar);
+  });
+}
+
+export function laneTitle(key: WorkQueueLaneKey): string {
+  return LANE_TITLES[key];
+}
+
+export function isActionableLane(key: WorkQueueLaneKey): boolean {
+  return ACTIONABLE_LANES.has(key);
+}

--- a/src/lib/workspace-mode.ts
+++ b/src/lib/workspace-mode.ts
@@ -13,4 +13,5 @@ export type WorkspaceMode =
   | "flow"
   | "submissions"
   | "capabilities"
+  | "familiar-work-queue"
   | "journal";

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -1,0 +1,269 @@
+/* Familiar Work Queue (cave-hlv.4) — the beads + PR control tower surface.
+   All colour comes from semantic tokens so the surface tracks every theme;
+   the lane tones are color-mix tints over the shared status tokens. */
+
+.fwq {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-base, var(--background));
+  color: var(--text-primary, var(--foreground));
+  container-type: inline-size; /* enables the narrow-surface @container rule */
+}
+
+.fwq-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.fwq-head-main {
+  min-width: 0;
+}
+
+.fwq-title {
+  font: 600 15px/1.2 var(--font-sans);
+  margin: 0;
+}
+
+.fwq-sub {
+  margin: 3px 0 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+/* Per-familiar rollup: filter chips, roving via native buttons. */
+.fwq-familiars {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.fwq-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    background var(--duration-fast, 120ms) var(--ease-standard, ease),
+    border-color var(--duration-fast, 120ms) var(--ease-standard, ease);
+}
+
+.fwq-chip:hover {
+  background: var(--bg-hover);
+}
+
+.fwq-chip.is-active {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--text-primary);
+}
+
+.fwq-chip:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus);
+  outline-offset: 2px;
+}
+
+.fwq-chip-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.fwq-chip.is-active .fwq-chip-count {
+  color: var(--accent-presence);
+}
+
+.fwq-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px 20px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+/* ── Lanes ──────────────────────────────────────────────────────────────── */
+.fwq-lane {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel, 12px);
+  background: var(--bg-raised, var(--bg-elevated));
+  overflow: hidden;
+}
+
+.fwq-lane-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.fwq-lane-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.fwq-lane-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--bg-hover);
+}
+
+/* Lane tones: a thin accent strip + tinted header, driven by status tokens. */
+.fwq-lane--urgent .fwq-lane-head {
+  color: var(--color-warning);
+  background: color-mix(in oklch, var(--color-warning) 8%, transparent);
+}
+.fwq-lane--ready .fwq-lane-head {
+  color: var(--color-success);
+  background: color-mix(in oklch, var(--color-success) 8%, transparent);
+}
+.fwq-lane--neutral .fwq-lane-head {
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 8%, transparent);
+}
+.fwq-lane--quiet .fwq-lane-head {
+  color: var(--text-muted);
+}
+
+.fwq-cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── Cards ──────────────────────────────────────────────────────────────── */
+.fwq-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.fwq-card:last-child {
+  border-bottom: 0;
+}
+
+.fwq-card.is-stale {
+  background: color-mix(in oklch, var(--color-warning) 5%, transparent);
+}
+
+.fwq-card-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.fwq-card-title {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  min-width: 0;
+}
+
+.fwq-pr-num {
+  font: 600 12px/1 var(--font-mono);
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.fwq-card-name {
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fwq-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-top: 5px;
+}
+
+/* Tag recipe (§ design language): 6–18% fill, 30–45% border, solid text. */
+.fwq-tag {
+  font-size: 11px;
+  line-height: 1.5;
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.fwq-tag--familiar {
+  border-color: color-mix(in oklch, var(--accent-presence) 32%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--accent-presence);
+}
+
+.fwq-tag--bead {
+  font-family: var(--font-mono);
+}
+
+.fwq-tag--check-passing {
+  color: var(--color-success);
+  border-color: color-mix(in oklch, var(--color-success) 30%, transparent);
+}
+
+.fwq-tag--check-failing {
+  color: var(--color-danger);
+  border-color: color-mix(in oklch, var(--color-danger) 34%, transparent);
+  background: color-mix(in oklch, var(--color-danger) 8%, transparent);
+}
+
+.fwq-tag--check-pending {
+  color: var(--color-warning);
+  border-color: color-mix(in oklch, var(--color-warning) 30%, transparent);
+}
+
+.fwq-tag--ready {
+  color: var(--color-success);
+  border-color: color-mix(in oklch, var(--color-success) 34%, transparent);
+  background: color-mix(in oklch, var(--color-success) 8%, transparent);
+}
+
+.fwq-tag--stale {
+  color: var(--color-warning);
+  border-color: color-mix(in oklch, var(--color-warning) 40%, transparent);
+  background: color-mix(in oklch, var(--color-warning) 10%, transparent);
+}
+
+.fwq-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Narrow surface (split tile / mobile): stack card body over actions. */
+@container (max-width: 560px) {
+  .fwq-card {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .fwq-card-actions {
+    justify-content: flex-end;
+  }
+}

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Familiar Work Queue (cave-hlv.4) — the beads + PR control tower surface.
+// Drives the mode entirely off mocked /api/beads (ready beads) and
+// /api/beads/prs (the bridge's classified open + merged PRs). The surface owns
+// no PR truth of its own, so mocking those two endpoints fully determines the
+// lanes. Daemon-less (COVEN_CAVE_E2E=1); navigation is via the cave:navigate-mode
+// event since Work Queue is a quiet, shortcut-less destination.
+
+const READY_BEADS = [
+  { id: "cave-aa1", title: "Harden the sync path", priority: 1, status: "open", issue_type: "feature", labels: ["familiar:kitty", "surface:github"], updated_at: null },
+  { id: "cave-bb2", title: "iOS profile avatar", priority: 2, status: "open", issue_type: "feature", labels: ["familiar:nova", "surface:ios"], updated_at: null },
+  { id: "cave-open", title: "Merged but unclosed", priority: 2, status: "open", issue_type: "feature", labels: ["familiar:kitty"], updated_at: null },
+  { id: "cave-epic", title: "An epic container", priority: 1, status: "open", issue_type: "epic", labels: ["familiar:nova"], updated_at: null },
+];
+
+const NOW = Date.now();
+const iso = (hoursAgo: number) => new Date(NOW - hoursAgo * 3_600_000).toISOString();
+
+// These are already-classified bridge summaries (the endpoint runs the classifier).
+const OPEN_PRS = [
+  { number: 101, title: "Fix the flaky sync", url: "https://gh/pull/101", lane: "checks-failing", beadIds: ["cave-aa1"], checkStatus: "failing", reviewDecision: "UNKNOWN", mergeStateStatus: "BLOCKED", headRefName: "fix/cave-aa1", updatedAt: iso(40) },
+  { number: 102, title: "Ship the widget", url: "https://gh/pull/102", lane: "ready-to-merge", beadIds: ["cave-cc9"], checkStatus: "passing", reviewDecision: "APPROVED", mergeStateStatus: "CLEAN", headRefName: "feat/cave-cc9", updatedAt: iso(2) },
+  { number: 103, title: "Unlinked spike", url: "https://gh/pull/103", lane: "needs-review", beadIds: [], checkStatus: "passing", reviewDecision: "UNKNOWN", mergeStateStatus: "CLEAN", headRefName: "spike/x", updatedAt: iso(3) },
+];
+
+const MERGED_PRS = [
+  { number: 90, title: "Landed change", url: "https://gh/pull/90", beadIds: ["cave-open"], mergedAt: iso(1) },
+];
+
+async function gotoWorkQueue(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:active-familiar", "kitty");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        familiars: [
+          { id: "kitty", display_name: "Kitty", role: "Builder", status: "active", icon: "ph:sparkle-fill" },
+          { id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" },
+        ],
+      },
+    }),
+  );
+  await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions: [] } }));
+  // Regex matchers (not globs): glob `?` matches any char, so `/api/beads?…`
+  // would also catch `/api/beads/prs`. These are unambiguous — /prs vs the
+  // ?-queried ready list.
+  await page.route(/\/api\/beads\/prs/, (route) =>
+    route.fulfill({ json: { ok: true, open: OPEN_PRS, merged: MERGED_PRS } }),
+  );
+  await page.route(/\/api\/beads\?/, (route) => route.fulfill({ json: { ok: true, data: READY_BEADS } }));
+
+  await page.goto("/");
+  await page.waitForTimeout(500);
+  await page.evaluate(() =>
+    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })),
+  );
+  await page.waitForSelector(".fwq", { timeout: 30_000 });
+}
+
+test.describe("familiar work queue (PR control tower)", () => {
+  test("renders lanes from the beads + PR bridge and exposes cleanup/claim actions", async ({ page }) => {
+    await gotoWorkQueue(page);
+    const fwq = page.locator(".fwq");
+
+    // Header actionable count: 101(fail) + 102(ready) + 103(review) + cave-bb2(no-PR) + 90(cleanup) = 5 actionable.
+    await expect(fwq.getByText(/5 actionable/)).toBeVisible();
+
+    // Every acceptance lane the mock populates renders, in fix→land→review→bead order.
+    await expect(fwq.getByRole("region", { name: "Checks failing" })).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "Needs review" })).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "Ready to merge" })).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "No open PR" })).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "Post-merge cleanup" })).toBeVisible();
+
+    // PR + bead identity surfaces truthfully.
+    await expect(fwq.getByText("#101")).toBeVisible();
+    await expect(fwq.getByText("cave-aa1", { exact: true })).toBeVisible();
+    // Stale PR (40h) is flagged.
+    await expect(fwq.getByText("stale", { exact: true }).first()).toBeVisible();
+
+    // The epic is excluded from the queue (containers aren't work).
+    await expect(fwq.getByText("An epic container")).toHaveCount(0);
+
+    // Familiar rollup chips (label-derived) act as filters.
+    const kittyChip = fwq.getByRole("button", { name: /Kitty/ });
+    await expect(kittyChip).toBeVisible();
+    await expect(fwq.getByRole("button", { name: /Nova/ })).toBeVisible();
+
+    // Cleanup lane offers "Close bead"; no-open-PR lane offers "Claim".
+    const cleanup = fwq.getByRole("region", { name: "Post-merge cleanup" });
+    await expect(cleanup.getByRole("button", { name: "Close bead" })).toBeVisible();
+    const noPr = fwq.getByRole("region", { name: "No open PR" });
+    await expect(noPr.getByRole("button", { name: "Claim" })).toBeVisible();
+
+    // Filtering by Nova drops Kitty-owned lanes (checks-failing was Kitty's).
+    await page.getByRole("button", { name: /Nova/ }).click();
+    await expect(fwq.getByRole("region", { name: "Checks failing" })).toHaveCount(0);
+    await expect(fwq.getByRole("region", { name: "No open PR" })).toBeVisible(); // cave-bb2 is Nova's
+  });
+
+  test("claiming a no-open-PR bead posts to the beads adapter", async ({ page }) => {
+    let claimBody: unknown = null;
+    await page.route("**/api/beads", async (route) => {
+      // POST claim/close land here (the GET ready list uses the ?-suffixed matcher).
+      if (route.request().method() === "POST") {
+        claimBody = route.request().postDataJSON();
+        await route.fulfill({ json: { ok: true, data: { id: "cave-bb2", status: "in_progress" } } });
+        return;
+      }
+      await route.fulfill({ json: { ok: true, data: READY_BEADS } });
+    });
+    await gotoWorkQueue(page);
+
+    const noPr = page.locator(".fwq").getByRole("region", { name: "No open PR" });
+    await noPr.getByRole("button", { name: "Claim" }).click();
+    await expect.poll(() => claimBody).toEqual({ action: "claim", id: "cave-bb2" });
+  });
+});


### PR DESCRIPTION
## What

The capstone UI for the beads PR-management epic (cave-hlv). A **new workspace surface** — nav rail, or `?mode=familiar-work-queue` — that fuses ready beads with the PR bridge's classified open PRs into one per-familiar, per-surface **control tower**. Per the epic's design note, it invents no PR truth of its own: every lane is backed by `/api/beads` + the new `/api/beads/prs`.

Because the Familiar Work Queue surface (hlv.2) was frozen/never built, this PR delivers that substrate too — the workspace mode, the sidebar destination, and the queue model — with the PR control tower on top. (Noted on both beads.)

## Lanes

Ordered fix-first → land → review → bead-driven → waiting:

| Lane | Source | Action |
|------|--------|--------|
| **Checks failing** / **Changes requested** | open PRs (bridge) | Open PR |
| **Needs review** | open PRs (bridge) | Open PR |
| **Ready to merge** | open PRs (bridge) | `merge eligible` badge — **no merge button** (merge authority follows repo policy) |
| **No open PR** | ready beads no PR references yet (epics excluded) | **Claim** |
| **Post-merge cleanup** | merged PR whose bead is still open | **Close bead** |
| **Waiting** | draft / pending-checks / blocked PRs | shown, never counted actionable |

Each card carries the familiar + surface labels, bead id, live check/review state, and a 24h **stale** flag. A per-familiar rollup along the top filters the whole board to one familiar.

## Pieces

- **`/api/beads/prs`** (new) — the browser-facing half of the bridge: shells `gh` server-side and returns the same classified summaries the CLI patrol produces, plus a light list of recently-merged PRs for cleanup detection. Local-origin + path guarded (added to `api-contracts.test.ts`).
- **`src/lib/beads-work-queue.ts`** (new, pure) — the bead↔PR join: lane mapping, per-familiar/per-surface labelling, stale + unlinked flags, no-open-PR and post-merge-cleanup derivation. Clock injected; deterministic ordering (no wall-clock).
- **`FamiliarWorkQueueView` + `familiar-work-queue.css`** — code-split surface, semantic tokens only (tracks all 16 themes), `useAnnouncer`, 30s pausable poll, container query for narrow/split layout.
- **Wiring** — `WorkspaceMode` + sidebar `FolderMode` unions, `WORKSPACE_MODE_TITLES`, lazy-surfaces export, `renderSurface` branch, docs section in `beads-familiars.md`.

## Truthfulness / limits

- Every lane derives from bridge summaries + `bd ready`; the UI never re-classifies PR state.
- `ready-to-merge` is a queue, not merge authority — no merge button, consistent with the patrol/merge-gate docs.
- **Post-merge-cleanup** detection is limited to beads still in the `ready` set (a claimed-but-unclosed bead that dropped out of `ready` won't show); worktree/branch removal stays a CLI step. Documented in code + docs.

## Verification

- **Pure lib test** (`beads-work-queue.test.ts`): lane join, per-familiar rollup, stale/unlinked flags, and the **cleanup-vs-no-open-PR dedup** (a bead with only a merged PR belongs in cleanup only — a bug a first e2e run surfaced, now fixed + pinned).
- **Playwright spec** (`familiar-work-queue.spec.ts`, self-contained, mocked `/api/beads` + `/api/beads/prs`): asserts every acceptance lane renders, the familiar filter narrows the board, and **Claim** posts `{action:"claim", id}` to the adapter — 2 passing.
- tsc clean · 741 tests wired · 549 app tests · api contracts pass · visually verified the rendered surface.

Closes the cave-hlv.4 slice. Remaining epic work: hlv.2 (queue substrate — largely delivered here) and hlv.3, both deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)