### PR TITLE
feat(projects): Files drill-through from the hub into the code rail (cave-z44)

### DIFF
--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -268,15 +268,24 @@ export function ChatSurface({
   const railProjectRoot = activeSession?.project_root ?? null;
   const sessionRunning = activeSession?.status === "running";
 
-  // changeCount = number of pending working-tree files for the active session's
+  // "Browse at root" override (cave-z44): the Projects hub drills into an
+  // arbitrary project's files by asking the rail to browse THAT root instead of
+  // the active session's. A bounded peek — every rail signal (availability,
+  // change count, the Files/Changes tabs) follows the override while it's set,
+  // so the rail stays internally coherent, and it clears on session change or a
+  // manual collapse (see below) so the rail snaps back to the session.
+  const [browseRootOverride, setBrowseRootOverride] = useState<string | null>(null);
+  const effectiveRailRoot = browseRootOverride ?? railProjectRoot;
+
+  // changeCount = number of pending working-tree files for the rail's effective
   // project root. Mirrors session-changes-panel's /api/changes fetch (files
   // length), re-polled on the `cave:changes-refresh` edit signal and, while the
   // session is running, a light 5s interval gated on document visibility.
   const [changeCount, setChangeCount] = useState(0);
   const changeFetchInFlight = useRef(false);
   useEffect(() => {
-    if (!railProjectRoot) { setChangeCount(0); return; }
-    const root = railProjectRoot;
+    if (!effectiveRailRoot) { setChangeCount(0); return; }
+    const root = effectiveRailRoot;
     let cancelled = false;
     const load = async () => {
       if (changeFetchInFlight.current) return;
@@ -306,13 +315,18 @@ export function ChatSurface({
       window.removeEventListener("cave:changes-refresh", onRefresh);
       if (intervalId !== undefined) window.clearInterval(intervalId);
     };
-  }, [railProjectRoot, sessionRunning]);
+  }, [effectiveRailRoot, sessionRunning]);
 
   // Once the Terminal tab has been opened, keep the rail available (terminalActive)
   // even if the session has no repo and no edits — otherwise switching away would
   // yank the running pty. Flips false→true once; never resets → no render loop.
   const [terminalOpened, setTerminalOpened] = useState(false);
-  const rail = useCodeRail({ projectRoot: railProjectRoot, changeCount, terminalActive: terminalOpened });
+  const rail = useCodeRail({
+    projectRoot: effectiveRailRoot,
+    changeCount,
+    terminalActive: terminalOpened,
+    browseActive: browseRootOverride !== null,
+  });
   const [codeRailFocus, setCodeRailFocus] = useState<PendingCodeRailOpen | null>(null);
   useEffect(() => {
     if (rail.activeTab === "terminal" && rail.open) setTerminalOpened(true);
@@ -339,6 +353,9 @@ export function ChatSurface({
       }
     }
     setTerminalOpened(false);
+    // Engaging a different session ends any "browse at root" peek — the rail
+    // follows the session again (cave-z44).
+    setBrowseRootOverride(null);
   }, [snapshot.sessionId, terminalOpened]);
   const showCodeRail = rail.available && rail.open && !isMobile && !paneNarrow;
 
@@ -372,6 +389,9 @@ export function ChatSurface({
 
   const openCodeRailTarget = useCallback((target: PendingCodeRailOpen) => {
     setScope("conversation");
+    // A "files" target may carry a browse root (Projects hub drill-through);
+    // any other open (a session file, a diff) returns the rail to the session.
+    setBrowseRootOverride(target.kind === "files" ? (target.root ?? null) : null);
     rail.reopen();
     rail.setActiveTab(target.kind === "changes" ? "changes" : "files");
     setCodeRailFocus(target);
@@ -392,11 +412,21 @@ export function ChatSurface({
       if (!detail?.path) return;
       openCodeRailTarget({ kind: "changes", path: detail.path, nonce: Date.now() });
     };
+    // Projects hub → "Browse files": drill into a project's tree with no file
+    // selected. workspace.tsx bridges this event to chat mode from other
+    // surfaces; this listener handles it when the chat surface is already up.
+    const onBrowseProjectFiles = (event: Event) => {
+      const detail = (event as CustomEvent<{ root?: string }>).detail;
+      if (!detail?.root) return;
+      openCodeRailTarget({ kind: "files", root: detail.root, nonce: Date.now() });
+    };
     window.addEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
     window.addEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+    window.addEventListener("cave:browse-project-files", onBrowseProjectFiles as EventListener);
     return () => {
       window.removeEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
       window.removeEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+      window.removeEventListener("cave:browse-project-files", onBrowseProjectFiles as EventListener);
     };
   }, [openCodeRailTarget]);
 
@@ -703,13 +733,13 @@ export function ChatSurface({
                     changeCount={changeCount}
                     activeTab={rail.activeTab}
                     pinned={rail.pinned}
-                    projectRoot={railProjectRoot}
+                    projectRoot={effectiveRailRoot}
                     familiarId={snapshot.familiar?.id ?? null}
                     sessionId={snapshot.sessionId ?? null}
                     focus={codeRailFocus}
                     onSelectTab={rail.setActiveTab}
                     onTogglePin={rail.togglePin}
-                    onCollapse={rail.collapse}
+                    onCollapse={() => { setBrowseRootOverride(null); rail.collapse(); }}
                   />
                 </Panel>
               </>
@@ -795,14 +825,14 @@ export function ChatSurface({
               changeCount={changeCount}
               activeTab={rail.activeTab}
               pinned={rail.pinned}
-              projectRoot={railProjectRoot}
+              projectRoot={effectiveRailRoot}
               familiarId={snapshot.familiar?.id ?? null}
               sessionId={snapshot.sessionId ?? null}
               focus={codeRailFocus}
               hidePin
               onSelectTab={rail.setActiveTab}
               onTogglePin={rail.togglePin}
-              onCollapse={() => setMobileRailOpen(false)}
+              onCollapse={() => { setBrowseRootOverride(null); setMobileRailOpen(false); }}
             />
           </div>
         </div>

--- a/src/components/mobile-code-rail.test.ts
+++ b/src/components/mobile-code-rail.test.ts
@@ -91,11 +91,11 @@ assert.match(
 
 // ── WorkspaceRail hosted in the sheet with onCollapse → close ───────────────
 // The sheet mounts WorkspaceRail with the same feed as desktop, but onCollapse
-// closes the overlay (mobile "collapse" == dismiss) and the pin control is
-// hidden (meaningless in a sheet).
+// closes the overlay (mobile "collapse" == dismiss; it also ends a browse peek)
+// and the pin control is hidden (meaningless in a sheet).
 assert.match(
   source,
-  /<WorkspaceRail[\s\S]*?hidePin[\s\S]*?onCollapse=\{\(\)\s*=>\s*setMobileRailOpen\(false\)\}[\s\S]*?\/>/,
+  /<WorkspaceRail[\s\S]*?hidePin[\s\S]*?onCollapse=\{\(\)\s*=>\s*\{[\s\S]*?setMobileRailOpen\(false\)[\s\S]*?\}\}[\s\S]*?\/>/,
   "sheet WorkspaceRail hides the pin and maps onCollapse to closing the sheet",
 );
 

--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -399,6 +399,20 @@ export function ProjectDetail({
             <PopoverItem icon={copiedRoot ? "ph:check" : "ph:copy"} onSelect={() => void copyRoot()}>
               Copy path
             </PopoverItem>
+            <PopoverItem
+              icon="ph:file-code"
+              onSelect={() => {
+                // Drill into this project's file tree via the code rail. The
+                // event is bridged to chat mode by workspace.tsx (cave-z44);
+                // the rail browses project.root with nothing selected.
+                window.dispatchEvent(
+                  new CustomEvent("cave:browse-project-files", { detail: { root: project.root } }),
+                );
+                announce(`Browsing files in ${project.name}.`);
+              }}
+            >
+              Browse files
+            </PopoverItem>
             <PopoverSeparator />
             <PopoverItem icon="ph:trash-bold" danger onSelect={() => setConfirmDelete(true)}>
               Delete project…

--- a/src/components/projects/projects-hub.test.ts
+++ b/src/components/projects/projects-hub.test.ts
@@ -66,9 +66,17 @@ assert.match(detail, /aria-pressed=\{!project\.color\}/, "the auto swatch report
 // Chrome budget (§8): ≤2 always-visible header actions + one overflow menu.
 assert.match(detail, /import \{ OverflowMenu \} from "@\/components\/ui\/overflow-menu"/, "secondary actions live in the shared OverflowMenu");
 assert.match(detail, /OverflowMenu ariaLabel=\{`More actions for \$\{project\.name\}`\}/, "the overflow trigger is named per project");
-for (const item of ["Rename", "Change folder…", "Copy path", "Delete project…"]) {
+for (const item of ["Rename", "Change folder…", "Copy path", "Browse files", "Delete project…"]) {
   assert.match(detail, new RegExp(item.replace("…", "…")), `overflow offers ${item}`);
 }
+// cave-z44: "Browse files" drills into the project's tree via the code rail by
+// dispatching a cross-surface event workspace.tsx bridges to chat mode. It
+// carries only the root, and stays in the overflow (keeps the ≤2-visible budget).
+assert.match(
+  detail,
+  /new CustomEvent\("cave:browse-project-files", \{ detail: \{ root: project\.root \} \}\)/,
+  "Browse files dispatches the browse event with the project root",
+);
 // Delete is a two-step confirm with an accessible container.
 assert.match(detail, /role="alertdialog"[\s\S]{0,80}?aria-label=\{`Delete \$\{project\.name\}\?`\}/, "delete confirm is an alertdialog");
 // Switching projects resets edit drafts/confirms (no leakage across selections).

--- a/src/components/workspace-chat-handoff.test.ts
+++ b/src/components/workspace-chat-handoff.test.ts
@@ -175,6 +175,41 @@ assert.match(
   /if \(!pendingCodeRailOpen\) return[\s\S]*openCodeRailTarget\(pendingCodeRailOpen\)[\s\S]*onPendingCodeRailOpenHandled\(\)/,
   "ChatSurface should consume pending file/diff opens after mounting",
 );
+
+// cave-z44: Projects hub "Browse files" drills into a project ROOT (no file).
+// The shared type carries an optional root; Workspace bridges the event from
+// non-chat modes; ChatSurface consumes it directly when already mounted and
+// arms the browse override.
+assert.match(
+  pendingCodeRailOpenLib,
+  /kind: "files";[\s\S]*root\?: string;/,
+  "the shared type carries an optional browse root on the files open",
+);
+assert.match(
+  workspace,
+  /window\.addEventListener\("cave:browse-project-files", onBrowseProjectFiles as EventListener\)/,
+  "Workspace bridges the Projects-hub browse-files event into chat mode",
+);
+assert.match(
+  workspace,
+  /onBrowseProjectFiles = \(e: Event\) => \{[\s\S]*if \(modeRef\.current === "chat"\) return;[\s\S]*if \(!detail\?\.root\) return;[\s\S]*setPendingCodeRailOpen\(\{ kind: "files", root: detail\.root, nonce: Date\.now\(\) \}\)[\s\S]*setMode\("chat"\)/,
+  "Workspace preserves the browse root and switches to chat",
+);
+assert.match(
+  chatSurface,
+  /onBrowseProjectFiles[\s\S]*if \(!detail\?\.root\) return;[\s\S]*openCodeRailTarget\(\{ kind: "files", root: detail\.root, nonce: Date\.now\(\) \}\)/,
+  "ChatSurface directly consumes the browse-files event when already mounted",
+);
+assert.match(
+  chatSurface,
+  /window\.addEventListener\("cave:browse-project-files", onBrowseProjectFiles as EventListener\)/,
+  "ChatSurface listens for the browse-files event",
+);
+assert.match(
+  chatSurface,
+  /setBrowseRootOverride\(target\.kind === "files" \? \(target\.root \?\? null\) : null\)/,
+  "openCodeRailTarget arms the browse override from a files target's root and clears it otherwise",
+);
 assert.match(
   chatSurface,
   /<WorkspaceRail[\s\S]*focus=\{codeRailFocus\}/,

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -77,7 +77,32 @@ assert.match(
 assert.doesNotMatch(
   source,
   /const railProjectRoot = (?!activeSession\?\.project_root)/,
-  "standalone files/changes rail must not drift to a selected or fallback project root",
+  "railProjectRoot itself stays session-pure (the override lives in a separate binding)",
+);
+
+// cave-z44: the Projects hub can drill into any project's files. The rail's
+// EFFECTIVE root is the browse override when set, else the session root — one
+// binding every rail signal (availability, changeCount, WorkspaceRail) reads,
+// so a peek stays internally coherent. Cleared on session change + collapse.
+assert.match(
+  source,
+  /const effectiveRailRoot = browseRootOverride \?\? railProjectRoot;/,
+  "the rail's effective root is the browse override, falling back to the session root",
+);
+assert.match(
+  source,
+  /useCodeRail\(\s*\{\s*projectRoot:\s*effectiveRailRoot/,
+  "useCodeRail is keyed on the effective (override-aware) root so a peek makes the rail available",
+);
+assert.match(
+  source,
+  /browseActive:\s*browseRootOverride !== null/,
+  "useCodeRail is told when a browse peek is active so it suppresses the Changes auto-reveal",
+);
+assert.match(
+  source,
+  /setBrowseRootOverride\(null\)[\s\S]{0,200}?\}, \[snapshot\.sessionId, terminalOpened\]\)/,
+  "the browse override is cleared when the active session changes",
 );
 
 assert.match(
@@ -102,14 +127,20 @@ assert.match(
 
 assert.match(
   source,
-  /<WorkspaceRail[\s\S]*?changeCount=\{changeCount\}[\s\S]*?activeTab=\{rail\.activeTab\}[\s\S]*?pinned=\{rail\.pinned\}[\s\S]*?onSelectTab=\{rail\.setActiveTab\}[\s\S]*?onTogglePin=\{rail\.togglePin\}[\s\S]*?onCollapse=\{rail\.collapse\}/,
-  "WorkspaceRail receives changeCount + rail state/handlers",
+  /<WorkspaceRail[\s\S]*?changeCount=\{changeCount\}[\s\S]*?activeTab=\{rail\.activeTab\}[\s\S]*?pinned=\{rail\.pinned\}[\s\S]*?onSelectTab=\{rail\.setActiveTab\}[\s\S]*?onTogglePin=\{rail\.togglePin\}[\s\S]*?onCollapse=\{\(\) => \{[\s\S]*?rail\.collapse\(\)/,
+  "WorkspaceRail receives changeCount + rail state/handlers; collapse also ends the browse peek",
 );
 
 assert.match(
   source,
-  /<WorkspaceRail[\s\S]*?projectRoot=\{railProjectRoot\}/,
-  "WorkspaceRail Files tab receives the same active-session project root",
+  /<WorkspaceRail[\s\S]*?projectRoot=\{effectiveRailRoot\}/,
+  "WorkspaceRail Files tab receives the effective (override-aware) project root",
+);
+// The manual collapse handler ends a browse peek so reopening shows the session.
+assert.match(
+  source,
+  /onCollapse=\{\(\) => \{ setBrowseRootOverride\(null\); rail\.collapse\(\); \}\}/,
+  "collapsing the rail clears the browse override",
 );
 
 // Collapsed state renders a reopen strip.

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -568,11 +568,22 @@ export function Workspace() {
     };
     const onOpenProjectFile = (e: Event) => enqueue("files", e);
     const onOpenFileDiff = (e: Event) => enqueue("changes", e);
+    // Projects hub → "Browse files": carries a project ROOT (not a file path);
+    // ChatSurface browses that root with nothing selected (cave-z44).
+    const onBrowseProjectFiles = (e: Event) => {
+      if (modeRef.current === "chat") return;
+      const detail = (e as CustomEvent<{ root?: string }>).detail;
+      if (!detail?.root) return;
+      setPendingCodeRailOpen({ kind: "files", root: detail.root, nonce: Date.now() });
+      setMode("chat");
+    };
     window.addEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
     window.addEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+    window.addEventListener("cave:browse-project-files", onBrowseProjectFiles as EventListener);
     return () => {
       window.removeEventListener("cave:open-project-file", onOpenProjectFile as EventListener);
       window.removeEventListener("cave:open-file-diff", onOpenFileDiff as EventListener);
+      window.removeEventListener("cave:browse-project-files", onBrowseProjectFiles as EventListener);
     };
   }, []);
 

--- a/src/lib/code-rail.test.ts
+++ b/src/lib/code-rail.test.ts
@@ -66,3 +66,19 @@ test("activeTab persists when no signals change", () => {
   const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: 2 }, prev);
   assert.equal(r.activeTab, "changes");
 });
+
+// cave-z44: browsing another project's files must NOT be hijacked by that
+// project's pre-existing working-tree changes (which look like a 0→N batch).
+test("browse peek: existing changes do not auto-reveal Changes (stays on Files)", () => {
+  const prev: CodeRailState = { available: true, open: true, activeTab: "files", changeCount: 0 };
+  const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: 5, browseActive: true }, prev);
+  assert.equal(r.available, true);
+  assert.equal(r.open, true);
+  assert.equal(r.activeTab, "files", "the browse keeps the Files tab despite a fresh non-zero count");
+});
+
+test("browse peek off: the same 0→N transition still reveals Changes", () => {
+  const prev: CodeRailState = { available: true, open: true, activeTab: "files", changeCount: 0 };
+  const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: 5 }, prev);
+  assert.equal(r.activeTab, "changes", "without a browse the reveal behavior is unchanged");
+});

--- a/src/lib/code-rail.ts
+++ b/src/lib/code-rail.ts
@@ -11,6 +11,13 @@ export type CodeRailSignals = {
   pinned: boolean;
   /** User collapsed the rail for the current reason. */
   dismissed: boolean;
+  /**
+   * A "browse at root" peek is active (Projects hub → Files, cave-z44). The
+   * browsed project's pre-existing working-tree changes are NOT a fresh agent
+   * edit batch, so they must not auto-reveal the Changes tab and steal the
+   * explicit Files intent.
+   */
+  browseActive?: boolean;
 };
 
 export type CodeRailState = {
@@ -31,15 +38,17 @@ export function resolveCodeRail(
   signals: CodeRailSignals,
   prev: CodeRailState | null,
 ): CodeRailState {
-  const { hasRepo, changeCount, terminalActive, pinned, dismissed } = signals;
+  const { hasRepo, changeCount, terminalActive, pinned, dismissed, browseActive } = signals;
   const available = hasRepo || changeCount > 0 || terminalActive;
 
   if (!available) {
     return { available: false, open: false, activeTab: prev?.activeTab ?? "files", changeCount: 0 };
   }
 
-  // A fresh edit batch: changes went from 0 (or unknown) to > 0.
-  const newEdits = changeCount > 0 && (prev == null || prev.changeCount === 0);
+  // A fresh edit batch: changes went from 0 (or unknown) to > 0 — but never
+  // while browsing another project's files (its existing changes aren't new
+  // agent edits, and the peek explicitly wants the Files tab).
+  const newEdits = !browseActive && changeCount > 0 && (prev == null || prev.changeCount === 0);
 
   const open = pinned ? true : newEdits ? true : dismissed ? false : true;
 

--- a/src/lib/pending-code-rail-open.ts
+++ b/src/lib/pending-code-rail-open.ts
@@ -1,8 +1,14 @@
 export type PendingCodeRailOpen =
   | {
       kind: "files";
-      path: string;
+      // Omitted for a "browse at root" open (Projects hub → Files): the Files
+      // tab shows the tree with nothing selected. Present for a file open.
+      path?: string;
       line?: number;
+      // When set, the code rail browses THIS project root instead of the active
+      // session's — a bounded "peek" that lets the Projects hub drill into any
+      // project's files (cave-z44). Cleared on session change / rail collapse.
+      root?: string;
       nonce: number;
     }
   | {

--- a/src/lib/use-code-rail.ts
+++ b/src/lib/use-code-rail.ts
@@ -16,9 +16,12 @@ export type UseCodeRailArgs = {
   /** Pending edit count for this session (0 = none). Caller polls /api/changes. */
   changeCount: number;
   terminalActive: boolean;
+  /** A "browse at root" peek is active — suppress the Changes auto-reveal so the
+   *  browsed project stays on its Files tab (cave-z44). */
+  browseActive?: boolean;
 };
 
-export function useCodeRail({ projectRoot, changeCount, terminalActive }: UseCodeRailArgs) {
+export function useCodeRail({ projectRoot, changeCount, terminalActive, browseActive }: UseCodeRailArgs) {
   const [pinned, setPinned] = useState(false);
   const [dismissed, setDismissed] = useState(false);
   const [activeTab, setActiveTab] = useState<CodeRailTab>("files");
@@ -30,7 +33,7 @@ export function useCodeRail({ projectRoot, changeCount, terminalActive }: UseCod
   }, []);
 
   const state = resolveCodeRail(
-    { hasRepo: Boolean(projectRoot), changeCount, terminalActive, pinned, dismissed },
+    { hasRepo: Boolean(projectRoot), changeCount, terminalActive, pinned, dismissed, browseActive },
     prevRef.current,
   );
 


### PR DESCRIPTION
Adds a **"Browse files"** action to the Projects-hub ProjectDetail overflow that opens the code rail's Files tab on any project's tree. This was deferred from the hub redesign (PR3 #2522) because the rail's focus mechanism required a concrete *file* path while the hub only has a project *root*.

## What changed

- **Browse-at-root open** — `PendingCodeRailOpen`'s `files` kind now carries an optional `root` (and its `path` is optional). A new `cave:browse-project-files` event — bridged to chat mode by `workspace.tsx`, consumed directly by `chat-surface` when already mounted (same dual pattern as `cave:open-project-file`) — opens the Files tab with **nothing selected**: the tree at the chosen root, the preview in its empty state.
- **Browse-root override** — the rail is otherwise bound to the active session's `project_root`. A bounded "peek" override drives the whole `effectiveRailRoot` (availability, the change-count poll, and the `WorkspaceRail`) so every tab stays coherent on the *browsed* project. Cleared on session change or a manual collapse, so the rail snaps back to the session.
- **Suppress the Changes auto-reveal while browsing** — a peeked project's *existing* working-tree changes aren't a fresh agent edit batch, so `resolveCodeRail`'s `0→N` reveal is gated off via a `browseActive` signal. Without this the rail yanks to Changes the moment you browse a project with uncommitted work; the explicit Files intent now wins.
- **Chrome budget** — ProjectDetail keeps its documented ≤2-visible + overflow budget; "Browse files" lives in the overflow next to "Copy path".

## Verification

Live (Projects hub → **Cast Codes** → **Browse files**):
- the rail opens on the **Files** tab (not Changes, despite cast-codes having working-tree changes);
- `/api/project-tree` fetches the **cast-codes** root, and the tree shows its real files (`app`, `src`, `channels`, `Cargo.toml`, …);
- the preview shows the empty "Select a file from the tree" state;
- the rail becomes available even with **no active repo session** (override alone drives it).

Source pins repointed (`workspace-rail-wiring`, `workspace-chat-handoff`, `mobile-code-rail`, `projects-hub`) + new `code-rail` behavior tests for the browse suppression. Full suite (548 files), typecheck, and production build green.

Note: the `workspace.tsx` bridge mirrors the existing `open-project-file` dual pattern for symmetry/future-proofing; today's sole caller (ProjectDetail) is always in chat mode, so `chat-surface`'s own listener handles it.

Closes bead `cave-z44`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)