### PR TITLE
fix(settings): show only section labels in the left nav (cave-iwb)

### DIFF
--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -262,10 +262,10 @@ assert.match(
   "SettingsShell should expose a dedicated desktop sidebar class",
 );
 
-assert.match(
+assert.doesNotMatch(
   source,
   /className="settings-nav__description/,
-  "Settings nav items should show concise descriptions, not only labels",
+  "Settings nav items should show only the section label, not a second-row description",
 );
 
 assert.match(

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -319,10 +319,7 @@ export function SettingsShell() {
                   width={showPicker ? 18 : 13}
                   className={section === s.id && !showPicker ? "text-[var(--accent-presence-foreground)] opacity-70" : "text-[var(--text-muted)]"}
                 />
-                <span className="flex flex-1 flex-col">
-                  <span>{s.label}</span>
-                  <span className="settings-nav__description">{s.description}</span>
-                </span>
+                <span className="flex-1">{s.label}</span>
                 {showPicker ? (
                   <Icon name="ph:caret-right" width={14} className="text-[var(--text-muted)]" />
                 ) : null}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -181,24 +181,6 @@
   margin-bottom: 10px;
 }
 
-.settings-nav__item {
-  min-height: 48px;
-}
-
-.settings-nav__item[aria-current="page"] .settings-nav__description {
-  color: var(--accent-presence-foreground);
-  opacity: 0.78;
-}
-
-.settings-nav__description {
-  display: -webkit-box;
-  overflow: hidden;
-  margin-top: 1px;
-  line-height: 1.25;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-}
-
 .settings-shell__content {
   scroll-padding-top: 18px;
 }


### PR DESCRIPTION
## Summary

The `/settings` left-panel nav stacked each section's one-line description under its label. Per request, the nav item now renders **only the section label** — the second-row description is gone.

**Before:** `Profile` / *Your name, image, and details familiars know you by.*
**After:** `Profile`

## Changes
- `settings-shell.tsx` — nav item renders just `{s.label}` (dropped the `settings-nav__description` span and the two-row column wrapper).
- `dashboard.css` — removed the now-dead `.settings-nav__description` rules (incl. the `aria-current` color override) and the `min-height: 48px` two-row floor on `.settings-nav__item`, so desktop rows sit at their compact single-line height. The mobile picker keeps its own `--touch-target` min-height (applied inline), so touch targets are unaffected.
- `settings-shell-polish.test.ts` — inverted the source-scan pin: the nav should now show labels only.

**Kept:** the `description` field on `SECTIONS` — it still powers the per-section `SettingsOverview` header in the content pane, so that data isn't dead.

## Verification
- `settings-shell-polish` + `settings-overview` tests pass; `tsc --noEmit` clean; prod build green.
- Driven live in a browser at 1200×860: the sidebar renders all 7 sections (Profile, General, Daemon, Familiars, Phone, Appearance, About) as single icon+label rows, and `document.querySelector('.settings-nav__description')` is `null`.

Bead: cave-iwb

🤖 Generated with [Claude Code](https://claude.com/claude-code)