### PR TITLE
feat(ios): read the operator profile — show name/avatar instead of "You" (cave-8xb)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -156,6 +156,45 @@ struct CaveClient {
         return URL(string: path, relativeTo: base)?.absoluteURL
     }
 
+    // MARK: - Operator profile
+
+    /// The human operator's profile (name + avatar metadata) from
+    /// `GET /api/profile`. Read-only on iOS; editing lives in the desktop's
+    /// Settings → Profile.
+    func operatorProfile() async throws -> OperatorProfile {
+        let req = try request("api/profile")
+        let (data, resp) = try await data(for: req)
+        try Self.check(resp)
+        do {
+            return try JSONDecoder().decode(OperatorProfileResponse.self, from: data).operatorProfile
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+    }
+
+    /// URL for the operator's server avatar image (`GET /api/profile/avatar`),
+    /// cache-busted by `updatedAt` so a new desktop upload invalidates the
+    /// image. A plain image load can't set an `Authorization` header, so when
+    /// the desktop enforces a mobile access token it is attached as a
+    /// `coven_access_token` query param — the same credential the server
+    /// accepts from the query string (server.ts). `nil` when unconfigured.
+    func operatorAvatarURL(updatedAt: String?) -> URL? {
+        guard let base = connection.baseURL,
+              var comps = URLComponents(
+                url: base.appendingPathComponent("api/profile/avatar"),
+                resolvingAgainstBaseURL: false)
+        else { return nil }
+        var items: [URLQueryItem] = []
+        if let updatedAt, !updatedAt.isEmpty {
+            items.append(URLQueryItem(name: "v", value: updatedAt))
+        }
+        if let token = CaveConnection.accessToken {
+            items.append(URLQueryItem(name: "coven_access_token", value: token))
+        }
+        if !items.isEmpty { comps.queryItems = items }
+        return comps.url
+    }
+
     // MARK: - Sessions
 
     func sessions(includeArchived: Bool = false) async throws -> [SessionRow] {

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -161,6 +161,33 @@ final class AppModel {
         }
     }
 
+    // MARK: - Operator profile
+
+    /// The human operator's profile (`GET /api/profile`), mirrored from the
+    /// desktop so the operator's own chat turns show their name/avatar instead
+    /// of a generic "You". `nil` until it loads (disconnected / pre-fetch).
+    var operatorProfile: OperatorProfile?
+
+    /// Name to show for the operator's messages — the profile name, or "You".
+    var operatorDisplayName: String { operatorProfile?.displayName ?? "You" }
+
+    /// Server avatar image URL for the operator, or `nil` when none is set (the
+    /// UI falls back to name initials). Cache-busted by the profile's mtime.
+    var operatorAvatarURL: URL? {
+        guard let client, operatorProfile?.avatarPresent == true else { return nil }
+        return client.operatorAvatarURL(updatedAt: operatorProfile?.avatarUpdatedAt)
+    }
+
+    /// Fetch the operator profile. Best-effort: on failure the last snapshot
+    /// stands (chat keeps showing the current name rather than flashing to
+    /// "You" on a transient poll miss), mirroring `loadTheme`.
+    func loadOperatorProfile() async {
+        guard let client else { return }
+        if let profile = try? await client.operatorProfile() {
+            if operatorProfile != profile { operatorProfile = profile }
+        }
+    }
+
     /// Apply a fetched/published snapshot: refresh the chrome palette and record
     /// the active theme id + mode for the picker. Only assigns on change so an
     /// unchanged poll stays a cheap no-op (no needless view invalidation).
@@ -694,6 +721,10 @@ final class AppModel {
     func validateConnectionOnForeground() async {
         guard connection != nil, connectionState == .connected else { return }
         if let client, await client.ping() {
+            // Profile first (the just-succeeded ping proves the current token is
+            // valid), then the rolling token renewal + queue flush stay adjacent
+            // — the offline-compose flush invariant pins that pair.
+            await loadOperatorProfile()
             await refreshAccessTokenIfNeeded()
             flushQueuedMessages()
             return
@@ -710,6 +741,7 @@ final class AppModel {
         if projectsLoaded { await loadProjects() }
         if journalLoaded { await loadJournal() }
         await loadTheme()
+        await loadOperatorProfile()
     }
 
     /// `quiet` probes without first flipping the state to `.checking`, so a
@@ -747,6 +779,7 @@ final class AppModel {
             } else {
                 await loadFamiliars()
                 await loadTheme()
+                await loadOperatorProfile()
             }
         case .unauthorized:
             connectionState = .needsAuth(pairingMessage())

--- a/apps/ios/CovenCave/CovenCave/State/OperatorProfile.swift
+++ b/apps/ios/CovenCave/CovenCave/State/OperatorProfile.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// The human operator's profile, read from the desktop's `GET /api/profile`.
+///
+/// iOS is **read-only** here — editing lives in the desktop's Settings →
+/// Profile (see docs/superpowers/specs/2026-07-06-user-profile-design.md).
+/// Reading it lets the operator's own chat turns show their real name and
+/// avatar instead of a generic "You".
+struct OperatorProfile: Equatable {
+    var name: String?
+    var pronouns: String?
+    var avatarPresent: Bool
+    /// Server-side mtime token; used only to cache-bust the avatar image URL so
+    /// a new upload on the desktop invalidates a cached image.
+    var avatarUpdatedAt: String?
+
+    /// The label to show for the operator's messages. Trimmed; falls back to
+    /// "You" when no name is set, so an empty profile reads exactly as before.
+    var displayName: String {
+        let trimmed = (name ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "You" : trimmed
+    }
+}
+
+/// Envelope for `GET /api/profile`:
+/// `{ ok, profile: { name?, pronouns?, … }, avatar: { present, updatedAt? } }`.
+/// Unknown profile fields (bio, timezone, links) are ignored — iOS only needs
+/// name + avatar for display.
+struct OperatorProfileResponse: Decodable {
+    struct Profile: Decodable {
+        var name: String?
+        var pronouns: String?
+    }
+    struct Avatar: Decodable {
+        var present: Bool
+        var updatedAt: String?
+    }
+    var ok: Bool
+    var profile: Profile?
+    var avatar: Avatar?
+
+    var operatorProfile: OperatorProfile {
+        OperatorProfile(
+            name: profile?.name,
+            pronouns: profile?.pronouns,
+            avatarPresent: avatar?.present ?? false,
+            avatarUpdatedAt: avatar?.updatedAt
+        )
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/AvatarView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AvatarView.swift
@@ -10,6 +10,10 @@ struct AvatarView: View {
     /// corner when the familiar reports a status. Opt-in so it only appears on
     /// "who's around" surfaces (chat list, header), not every avatar.
     var showStatus: Bool = false
+    /// Name used for the initials fallback when `familiar` is nil — e.g. the
+    /// human operator, who has no `Familiar` record. Ignored when `familiar`
+    /// is set.
+    var fallbackName: String? = nil
 
     var body: some View {
         let color = Theme.color(for: familiar)
@@ -47,7 +51,7 @@ struct AvatarView: View {
     }
 
     private func initials(_ color: Color) -> some View {
-        Text(Theme.initials(familiar?.displayName ?? "?"))
+        Text(Theme.initials(familiar?.displayName ?? fallbackName ?? "?"))
             .font(.system(size: size * 0.4, weight: .semibold, design: .rounded))
             .foregroundStyle(color)
     }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -229,7 +229,9 @@ struct ChatView: View {
                                       onOpenReader: { openReader(text: $0, familiar: message.familiarId.flatMap(app.familiar)) },
                                       onForward: { beginForward($0) },
                                       onRetry: canRetry(message) ? { retryAssistant(message) } : nil,
-                                      onReply: { beginReply($0) })
+                                      onReply: { beginReply($0) },
+                                      operatorName: app.operatorDisplayName,
+                                      operatorAvatarURL: app.operatorAvatarURL)
                         .id(message.id)
                     }
                     Color.clear.frame(height: 1).id("bottom")
@@ -798,7 +800,7 @@ struct ChatView: View {
     /// Display name for a message's author, used in the reply banner/quote.
     private func replyAuthor(_ message: DisplayMessage) -> String {
         switch message.role {
-        case .user: return "You"
+        case .user: return app.operatorDisplayName
         case .system: return "System"
         case .assistant: return message.familiarId.flatMap(app.familiar)?.displayName ?? "Familiar"
         }
@@ -852,7 +854,7 @@ struct ChatView: View {
     private func forwardSenderName(for message: DisplayMessage) -> String {
         switch message.role {
         case .user:
-            return "You"
+            return app.operatorDisplayName
         case .assistant:
             return app.familiar(message.familiarId ?? "")?.displayName ?? "Assistant"
         case .system:

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -578,7 +578,7 @@ struct ThreadRow: View {
     private var previewText: String {
         guard let last = lastMessage else { return "Tap to start chatting" }
         if last.streaming && last.text.isEmpty { return "…" }
-        let prefix = last.role == .user ? "You: " : ""
+        let prefix = last.role == .user ? "\(app.operatorDisplayName): " : ""
         return prefix + last.text.replacingOccurrences(of: "\n", with: " ")
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -15,6 +15,13 @@ struct MessageBubble: View {
     /// Quote this message into the composer — swipe the bubble right, or use the
     /// long-press menu. nil hides the action.
     var onReply: ((DisplayMessage) -> Void)? = nil
+    /// The human operator's display name, shown above their own bubbles in
+    /// group threads (mirrors the familiar name row). Defaults to "You" so a
+    /// missing profile reads exactly as before.
+    var operatorName: String = "You"
+    /// The operator's server avatar image URL for that same row; nil falls back
+    /// to name initials.
+    var operatorAvatarURL: URL? = nil
 
     /// Horizontal offset while swiping right to reply.
     @State private var replyDrag: CGFloat = 0
@@ -202,6 +209,15 @@ struct MessageBubble: View {
                         .foregroundStyle(Theme.color(for: familiar))
                         .padding(.leading, 4)
                 }
+                // The operator gets the same name row above their own bubbles in
+                // a group thread, so a multi-person transcript attributes every
+                // turn — not just the familiars'.
+                if isUser, isGroup {
+                    Text(operatorName)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(Theme.color(for: nil))
+                        .padding(.trailing, 4)
+                }
                 if !message.attachmentDataUrls.isEmpty {
                     attachmentImages
                         .contextMenu { messageActions }
@@ -252,6 +268,12 @@ struct MessageBubble: View {
                 if !isUser, isLast, !message.streaming, !parsed.suggestions.isEmpty {
                     SuggestionPills(suggestions: parsed.suggestions, onTap: onSuggestion)
                 }
+            }
+
+            // Operator avatar sits at the trailing edge, mirroring the familiar
+            // avatar on the leading edge for assistant bubbles.
+            if isUser, isGroup {
+                AvatarView(familiar: nil, url: operatorAvatarURL, size: 28, fallbackName: operatorName)
             }
 
             if !isUser { Spacer(minLength: 48) }

--- a/scripts/ios-message-forwarding.test.mjs
+++ b/scripts/ios-message-forwarding.test.mjs
@@ -33,8 +33,8 @@ assert.match(
 
 assert.match(
   chat,
-  /private func forwardSenderName\(for message: DisplayMessage\) -> String \{[\s\S]*case \.user:[\s\S]*return "You"[\s\S]*case \.assistant:[\s\S]*app\.familiar[\s\S]*displayName[\s\S]*case \.system:[\s\S]*return "System"/,
-  "forwarding should attribute the original sender as You, the familiar display name, or System",
+  /private func forwardSenderName\(for message: DisplayMessage\) -> String \{[\s\S]*case \.user:[\s\S]*return app\.operatorDisplayName[\s\S]*case \.assistant:[\s\S]*app\.familiar[\s\S]*displayName[\s\S]*case \.system:[\s\S]*return "System"/,
+  "forwarding attributes the original sender as the operator name (cave-8xb), the familiar display name, or System",
 );
 
 assert.match(

--- a/scripts/ios-operator-profile.test.mjs
+++ b/scripts/ios-operator-profile.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Source-invariant pins for the iOS operator-profile feature (cave-8xb): iOS
+// reads GET /api/profile and shows the operator's name/avatar in chat instead
+// of a generic "You". These guard the wiring against silent regressions.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+const profile = await read("apps/ios/CovenCave/CovenCave/State/OperatorProfile.swift");
+const client = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const chatView = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+const bubble = await read("apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift");
+const avatar = await read("apps/ios/CovenCave/CovenCave/Views/AvatarView.swift");
+const chatsHome = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
+
+// --- Model: decodes the /api/profile envelope, falls back to "You" -----------
+assert.match(profile, /struct OperatorProfileResponse: Decodable/, "response envelope is decodable");
+assert.match(profile, /struct Avatar: Decodable \{[\s\S]*?var present: Bool[\s\S]*?var updatedAt: String\?/, "avatar metadata is decoded");
+assert.match(
+  profile,
+  /return trimmed\.isEmpty \? "You" : trimmed/,
+  "displayName falls back to \"You\" when the name is empty (empty profile reads as before)",
+);
+
+// --- Client: GET /api/profile + a query-authed avatar URL --------------------
+assert.match(client, /func operatorProfile\(\) async throws -> OperatorProfile/, "client fetches the profile");
+assert.match(client, /request\("api\/profile"\)/, "hits GET /api/profile");
+assert.match(client, /func operatorAvatarURL\(updatedAt: String\?\) -> URL\?/, "builds the avatar image URL");
+assert.match(
+  client,
+  /URLQueryItem\(name: "coven_access_token", value: token\)/,
+  "attaches the access token as a query param so a header-less image load still authenticates",
+);
+assert.match(
+  client,
+  /URLQueryItem\(name: "v", value: updatedAt\)/,
+  "cache-busts the avatar by the profile's updatedAt",
+);
+
+// --- AppModel: state, helpers, and hydration on connect/foreground -----------
+assert.match(model, /var operatorProfile: OperatorProfile\?/, "AppModel holds the operator profile");
+assert.match(model, /var operatorDisplayName: String \{ operatorProfile\?\.displayName \?\? "You" \}/, "display-name helper");
+assert.match(model, /func loadOperatorProfile\(\) async/, "load method exists");
+assert.match(model, /if operatorProfile != profile \{ operatorProfile = profile \}/, "assign-on-change (no needless invalidation)");
+// Hydrated on the connect path, on a full surface refresh, and on foreground.
+const loadCalls = model.match(/await loadOperatorProfile\(\)/g) ?? [];
+assert.ok(loadCalls.length >= 3, `loadOperatorProfile is called on connect, refresh, and foreground (found ${loadCalls.length})`);
+
+// --- Chat: "You" author labels route through the operator name ---------------
+assert.match(
+  chatView,
+  /case \.user: return app\.operatorDisplayName/,
+  "reply author uses the operator name, not a hard-coded You",
+);
+assert.match(
+  chatView,
+  /case \.user:\s*\n\s*return app\.operatorDisplayName/,
+  "forward sender uses the operator name",
+);
+assert.match(
+  chatView,
+  /operatorName: app\.operatorDisplayName,\s*\n\s*operatorAvatarURL: app\.operatorAvatarURL/,
+  "the message bubble receives the operator name + avatar",
+);
+assert.match(chatsHome, /\\\(app\.operatorDisplayName\): /, "chat-list preview prefixes user turns with the operator name");
+
+// The markdown export sentinel stays "You" (round-trips with the importer).
+assert.match(model, /case \.user: who = "You"/, "export keeps the You/System sentinels for round-tripping");
+
+// --- Bubble + avatar: operator gets a name row + avatar in group threads ------
+assert.match(bubble, /var operatorName: String = "You"/, "bubble defaults operatorName to You");
+assert.match(
+  bubble,
+  /if isUser, isGroup \{\s*\n\s*AvatarView\(familiar: nil, url: operatorAvatarURL, size: 28, fallbackName: operatorName\)/,
+  "operator avatar renders at the trailing edge in group threads",
+);
+assert.match(avatar, /var fallbackName: String\? = nil/, "AvatarView gained a fallbackName for the record-less operator");
+assert.match(
+  avatar,
+  /Theme\.initials\(familiar\?\.displayName \?\? fallbackName \?\? "\?"\)/,
+  "initials fall back to the operator name when there is no Familiar",
+);
+
+console.log("ios-operator-profile.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -738,6 +738,7 @@ export const SUITES = {
     "scripts/ios-connection-stability.test.mjs",
     "scripts/ios-legacy-token-migration.test.mjs",
     "scripts/ios-offline-compose.test.mjs",
+    "scripts/ios-operator-profile.test.mjs",
     "scripts/ios-connect-paste.test.mjs",
     "scripts/ios-connect-screen-ux.test.mjs",
     "scripts/ios-theme-list-background.test.mjs",


### PR DESCRIPTION
## What

Follow-up to cave-5aw (#2541), which added the server-side operator profile. The iOS app now reads `GET /api/profile` and shows the operator's real **name and avatar** in chat instead of a hard-coded `"You"`.

## Changes

- **`OperatorProfile.swift`** (new) — decodes the `{ ok, profile, avatar }` envelope; `displayName` falls back to `"You"` so an empty profile reads exactly as before.
- **`CaveClient`** — `operatorProfile()` (GET `/api/profile`) and `operatorAvatarURL(updatedAt:)`. A plain `AsyncImage` load can't set an `Authorization` header, so the avatar URL carries the access token as a `coven_access_token` query param (the server accepts it from the query string, server.ts:185) plus a `v=<updatedAt>` cache-bust.
- **`AppModel`** — `operatorProfile` state + `operatorDisplayName` / `operatorAvatarURL` helpers + `loadOperatorProfile()`, hydrated on connect, on a full surface refresh, and on a foreground ping-success (assign-on-change to avoid needless invalidation).
- **`ChatView`** — reply/forward author labels for `.user` route through `operatorDisplayName`; the name + avatar URL flow into `MessageBubble`.
- **`MessageBubble`** — in group threads the operator gets the same name row + a **trailing** avatar that familiars get on the leading edge, so a multi-person transcript attributes every turn.
- **`AvatarView`** — a `fallbackName` drives initials for the record-less operator (no `Familiar`); the server image loads when reachable and falls back to initials otherwise.
- **`ChatsHomeView`** — the chat-list preview prefixes user turns with the operator name.

## Scope / decisions

- **Read-only by design** — editing lives in the desktop's Settings → Profile (the spec lists an iOS editor as out of scope).
- The markdown-export `"You"`/`"System"` sentinels stay put — the importer round-trips on them, so they're serialization markers, not display labels.
- Avatar auth degrades gracefully: if the desktop enforces a token the query param authenticates the image; either way a failed/absent image falls back to name initials.

## Verification

- **`xcodebuild` for iPhone 16 Pro compiles clean** — no new warnings or errors (only pre-existing WebView/QRScanner warnings remain). The SourceKit errors seen while editing were worktree false positives (no generated `.xcodeproj` module context).
- New source-pin test `scripts/ios-operator-profile.test.mjs` (envelope decode, `"You"` fallback, query-authed avatar URL, hydration call sites, the group-thread author row) — **mobile suite 73 files green, 742 wired**.
- Updated the `ios-message-forwarding` pin to the new operator-name attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)