### PR TITLE
fix(api): retry transient daemon flakes on the familiars GET (cave-4po)

### DIFF
--- a/src/app/api/familiars/route.test.ts
+++ b/src/app/api/familiars/route.test.ts
@@ -4,6 +4,14 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
+// One transient daemon flake (stalled probe / mid-restart) must not 503 the
+// roster — the GET opts into the single transient retry (cave-4po).
+assert.match(
+  source,
+  /retryTransient: true/,
+  "Familiars GET should retry once on a transient daemon failure",
+);
+
 assert.match(
   source,
   /const configEntry = config\.familiars\[f\.id\] \?\? \{\}/,

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -32,6 +32,9 @@ export async function GET() {
   const [res, config] = await Promise.all([
     callDaemon<(DaemonFamiliar & { emoji?: string; icon?: string })[]>({
       path: "/api/v1/familiars",
+      // One transient daemon flake (stalled status probe / mid-restart) must
+      // not 503 every surface keyed on the roster — retry once (cave-4po).
+      retryTransient: true,
     }),
     loadConfig(),
   ]);

--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -10,6 +10,7 @@ const {
   resolveDaemonSocketPath,
   daemonTargetForConfig,
   callDaemonTarget,
+  isTransientDaemonFailure,
   normalizeHubUrl,
 } = await import("./coven-daemon.ts");
 
@@ -272,6 +273,70 @@ const {
   });
   assert.equal(target.mode, "unconfigured-hub");
   assert.equal(target.error, "server hub URL is not configured");
+}
+
+// ── Transient-failure classification (cave-4po) ──
+{
+  assert.equal(isTransientDaemonFailure({ ok: false, status: 0, data: null, error: "daemon timeout" }), true, "timeout is transient");
+  assert.equal(isTransientDaemonFailure({ ok: false, status: 0, data: null, error: "daemon offline" }), true, "offline (mid-restart) is transient");
+  assert.equal(isTransientDaemonFailure({ ok: true, status: 200, data: null }), false, "success is not transient");
+  assert.equal(isTransientDaemonFailure({ ok: false, status: 500, data: null }), false, "a real daemon HTTP error is not transient");
+  assert.equal(isTransientDaemonFailure({ ok: false, status: 0, data: null, error: "socket exists but not readable" }), false, "permission errors are not transient");
+}
+
+// ── retryTransient: one stalled GET recovers on the second attempt ──
+{
+  let hits = 0;
+  const server = createServer((req, res) => {
+    hits += 1;
+    const reply = () => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ ok: true }));
+    };
+    if (hits === 1) setTimeout(reply, 1000); // stall the first attempt past its timeout
+    else reply();
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const target = { mode: "hub", label: "Server hub", url: `http://127.0.0.1:${address.port}` };
+  try {
+    const flaky = await callDaemonTarget(target, { path: "/api/v1/familiars", timeoutMs: 300, retryTransient: true });
+    assert.equal(flaky.ok, true, "a transient stall recovers via the single retry");
+    assert.equal(hits, 2, "exactly one retry fired");
+
+    hits = 0; // next request pair: without the flag, no retry
+    const plain = await callDaemonTarget(target, { path: "/api/v1/familiars", timeoutMs: 300 });
+    assert.equal(plain.ok, false, "without retryTransient the stall still fails");
+    assert.equal(plain.error, "daemon timeout");
+    assert.equal(hits, 1, "no retry without the opt-in");
+
+    hits = 0; // POSTs never retry even when asked — non-idempotent
+    const post = await callDaemonTarget(target, { method: "POST", path: "/api/v1/familiars", body: {}, timeoutMs: 300, retryTransient: true });
+    assert.equal(post.ok, false, "POST does not retry");
+    assert.equal(hits, 1, "non-idempotent methods fire exactly once");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+// ── retryTransient does not mask real daemon errors ──
+{
+  const server = createServer((req, res) => {
+    res.statusCode = 500;
+    res.end(JSON.stringify({ error: "boom" }));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  try {
+    const res = await callDaemonTarget(
+      { mode: "hub", label: "Server hub", url: `http://127.0.0.1:${address.port}` },
+      { path: "/api/v1/familiars", timeoutMs: 300, retryTransient: true },
+    );
+    assert.equal(res.ok, false, "HTTP 500 still fails");
+    assert.equal(res.status, 500, "real daemon status codes pass through unretried");
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
 }
 
 console.log("coven-daemon.test.ts: ok");

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -151,6 +151,11 @@ export type DaemonRequest = {
   path: string;
   body?: unknown;
   timeoutMs?: number;
+  /** Retry once (short backoff, capped timeout) when the failure is transient
+   *  — a timed-out probe or a daemon mid-restart. Only honored for GETs:
+   *  non-idempotent methods must never fire twice. Off by default so no
+   *  existing call site changes behavior. */
+  retryTransient?: boolean;
 };
 
 export type DaemonResponse<T = unknown> = {
@@ -165,12 +170,42 @@ export async function callDaemon<T = unknown>({
   path: reqPath,
   body,
   timeoutMs = 4000,
+  retryTransient = false,
 }: DaemonRequest): Promise<DaemonResponse<T>> {
   const target = await loadDaemonTarget();
-  return callDaemonTarget<T>(target, { method, path: reqPath, body, timeoutMs });
+  return callDaemonTarget<T>(target, { method, path: reqPath, body, timeoutMs, retryTransient });
 }
 
+/** True when a failed daemon response looks transient — the socket call never
+ *  produced an HTTP status (timeout, or the offline shapes a daemon restart
+ *  passes through). A real daemon HTTP error (4xx/5xx) is NOT transient. */
+export function isTransientDaemonFailure(res: DaemonResponse<unknown>): boolean {
+  return !res.ok && res.status === 0 && (res.error === "daemon timeout" || res.error === "daemon offline");
+}
+
+/** Cap for the second attempt: a healthy daemon answers in milliseconds, so
+ *  the retry never needs the full first-attempt budget. */
+const RETRY_TIMEOUT_CAP_MS = 2000;
+const RETRY_BACKOFF_MS = 200;
+
 export async function callDaemonTarget<T = unknown>(
+  target: DaemonTarget,
+  request: DaemonRequest,
+): Promise<DaemonResponse<T>> {
+  const { method = "GET", timeoutMs = 4000, retryTransient = false } = request;
+  const first = await callDaemonTargetOnce<T>(target, request);
+  if (!retryTransient || method !== "GET" || !isTransientDaemonFailure(first)) return first;
+  // One transient flake (a stalled status probe, a daemon mid-restart) should
+  // not surface as a 503 to every panel keyed on this route. Give the daemon a
+  // beat, then re-ask once with a capped budget.
+  await new Promise((r) => setTimeout(r, RETRY_BACKOFF_MS));
+  return callDaemonTargetOnce<T>(target, {
+    ...request,
+    timeoutMs: Math.min(timeoutMs, RETRY_TIMEOUT_CAP_MS),
+  });
+}
+
+async function callDaemonTargetOnce<T = unknown>(
   target: DaemonTarget,
   {
     method = "GET",


### PR DESCRIPTION
Fixes bead **cave-4po**: `GET /api/familiars` intermittently returns 503 after ~5.6s.

## Root cause
The route makes a single `callDaemon` (4s timeout) with no retry. A transiently stalled daemon status probe — or a daemon mid-restart — times out that one call, and the route 503s the entire roster. Every cockpit/dashboard panel keyed on familiars degrades with it. The observed ~5.6s = 4s daemon timeout + route/app overhead.

**Repro** (fake unix-socket daemon stalling every 3rd request past the client timeout): 3/9 calls failed with `daemon timeout` at ~4.1s. With the fix: **9/9 succeed** (worst case ~4.2s success).

## Fix
`callDaemon`/`callDaemonTarget` gain an **opt-in** `retryTransient` flag:
- retries **exactly once**, **GET-only** (non-idempotent methods never fire twice)
- only for transient failures (`status 0` + `daemon timeout`/`daemon offline` via new `isTransientDaemonFailure`); real daemon HTTP errors (4xx/5xx) pass through unretried, so the honest daemon-offline states from #2511 stay honest
- 200ms backoff; second attempt capped at 2s

Only the familiars GET opts in; all other call sites are behavior-unchanged.

## Verification
- New unit tests: transient classification; live socket-server retry (stall → recover, exactly 2 hits); no retry without opt-in; POST never retries; HTTP 500 not masked.
- Route source pin: familiars GET carries `retryTransient: true`.
- `pnpm typecheck` clean; `test:app` 549 files, `test:api` 124 files green.