### PR TITLE
feat(workflow): handoff notes + evidence-gated close in the work queue (cave-hlv.2)

### DIFF
--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -11,6 +11,7 @@ import { usePausablePoll } from "@/lib/use-pausable-poll";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   buildWorkQueue,
+  hasVerificationEvidence,
   type ReadyBead,
   type MergedPrRef,
   type WorkQueue,
@@ -66,6 +67,9 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [familiarFilter, setFamiliarFilter] = useState<string | null>(null);
+  // Beads that got a handoff note THIS session — Close unlocks immediately
+  // without waiting for the poll to re-read comment_count (cave-hlv.2).
+  const [evidenceAdded, setEvidenceAdded] = useState<Set<string>>(() => new Set());
   const loadSeq = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -138,6 +142,37 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         await load({ quiet: true });
       } catch (err) {
         announce(err instanceof Error ? err.message : `Could not ${action} ${id}`, "assertive");
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [announce, load],
+  );
+
+  // Handoff note: appends a comment to the bead (the recorded verification
+  // evidence that unlocks Close). Returns whether it landed so the card's inline
+  // composer can stay open on failure. cave-hlv.2.
+  const runComment = useCallback(
+    async (item: WorkQueueItem, text: string): Promise<boolean> => {
+      const id = item.bead?.id;
+      const comment = text.trim();
+      if (!id || !comment) return false;
+      setBusyId(item.key);
+      try {
+        const res = await fetch("/api/beads", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "comment", id, comment }),
+        });
+        const json = await res.json();
+        if (!json.ok) throw new Error(json.error || "comment failed");
+        setEvidenceAdded((prev) => new Set(prev).add(id.toLowerCase()));
+        announce(`Handoff note added to ${id}.`);
+        await load({ quiet: true });
+        return true;
+      } catch (err) {
+        announce(err instanceof Error ? err.message : `Could not add a note to ${id}`, "assertive");
+        return false;
       } finally {
         setBusyId(null);
       }
@@ -268,9 +303,14 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
                     item={item}
                     familiarLabel={familiarName(item.familiar)}
                     busy={busyId === item.key}
+                    hasEvidence={
+                      !!item.bead &&
+                      (hasVerificationEvidence(item.bead) || evidenceAdded.has(item.bead.id.toLowerCase()))
+                    }
                     onOpenUrl={onOpenUrl}
                     onClaim={() => void runAction(item, "claim")}
                     onClose={() => void runAction(item, "close")}
+                    onComment={(text) => runComment(item, text)}
                   />
                 ))}
               </ul>
@@ -286,21 +326,40 @@ function WorkQueueCard({
   item,
   familiarLabel,
   busy,
+  hasEvidence,
   onOpenUrl,
   onClaim,
   onClose,
+  onComment,
 }: {
   item: WorkQueueItem;
   familiarLabel: string;
   busy: boolean;
+  hasEvidence: boolean;
   onOpenUrl?: (url: string) => void;
   onClaim: () => void;
   onClose: () => void;
+  onComment: (text: string) => Promise<boolean>;
 }) {
   const beadId = item.bead?.id ?? null;
   const title = item.pr?.title ?? item.merged?.title ?? item.bead?.title ?? "Untitled";
   const prNumber = item.pr?.number ?? item.merged?.number ?? null;
   const url = item.pr?.url ?? item.merged?.url ?? null;
+  const [composing, setComposing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const isCleanup = item.lane === "post-merge-cleanup";
+  // Close is exposed on the cleanup lane, but only once verification evidence
+  // (a handoff note) is on record — the operator adds one via the composer.
+  const closeBlocked = isCleanup && !hasEvidence;
+
+  const submitNote = async () => {
+    if (!draft.trim()) return;
+    const ok = await onComment(draft);
+    if (ok) {
+      setDraft("");
+      setComposing(false);
+    }
+  };
 
   return (
     <li className={`fwq-card${item.stale ? " is-stale" : ""}`}>
@@ -342,17 +401,82 @@ function WorkQueueCard({
             {item.merged ? "Merged PR" : "Open PR"}
           </Button>
         ) : null}
+        {beadId ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            leadingIcon="ph:note-pencil"
+            onClick={() => setComposing((v) => !v)}
+            aria-expanded={composing}
+            aria-label={`Add a handoff note to ${beadId}`}
+          >
+            Note
+          </Button>
+        ) : null}
         {item.lane === "no-open-PR" && beadId ? (
           <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:hand" onClick={onClaim}>
             Claim
           </Button>
         ) : null}
-        {item.lane === "post-merge-cleanup" && beadId ? (
-          <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:check" onClick={onClose}>
+        {isCleanup && beadId ? (
+          <Button
+            variant="secondary"
+            size="xs"
+            loading={busy}
+            leadingIcon="ph:check"
+            onClick={onClose}
+            disabled={closeBlocked}
+            title={closeBlocked ? "Add a handoff note to record verification before closing" : undefined}
+          >
             Close bead
           </Button>
         ) : null}
       </div>
+      {closeBlocked && !composing ? (
+        <p className="fwq-card-hint">Add a handoff note to record verification before closing.</p>
+      ) : null}
+      {composing && beadId ? (
+        <div className="fwq-note">
+          <textarea
+            className="fwq-note-input"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={`Handoff note for ${beadId} — what you verified…`}
+            aria-label={`Handoff note for ${beadId}`}
+            rows={2}
+            disabled={busy}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                void submitNote();
+              }
+            }}
+          />
+          <div className="fwq-note-actions">
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                setDraft("");
+                setComposing(false);
+              }}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="secondary"
+              size="xs"
+              loading={busy}
+              leadingIcon="ph:plus"
+              onClick={() => void submitNote()}
+              disabled={!draft.trim() || busy}
+            >
+              Add note
+            </Button>
+          </div>
+        </div>
+      ) : null}
     </li>
   );
 }

--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -4,7 +4,9 @@
 // post-merge-cleanup derivation. Clock injected for determinism.
 import assert from "node:assert/strict";
 
-const { buildWorkQueue, isActionableLane, laneTitle } = await import("./beads-work-queue.ts");
+const { buildWorkQueue, isActionableLane, laneTitle, hasVerificationEvidence } = await import(
+  "./beads-work-queue.ts"
+);
 
 const NOW = Date.parse("2026-07-07T12:00:00Z");
 const HOURS = 3_600_000;
@@ -148,4 +150,18 @@ function bead(id, { priority = 2, labels = [], type = "feature", assignee = null
 }
 
 assert.equal(laneTitle("ready-to-merge"), "Ready to merge");
+
+// ── hasVerificationEvidence: a recorded comment gates Close (cave-hlv.2) ──────
+assert.equal(hasVerificationEvidence({ ...bead("cave-a"), comment_count: 1 }), true, "one comment = evidence");
+assert.equal(hasVerificationEvidence({ ...bead("cave-a"), comment_count: 3 }), true, "many comments = evidence");
+assert.equal(hasVerificationEvidence({ ...bead("cave-a"), comment_count: 0 }), false, "zero comments = no evidence");
+assert.equal(hasVerificationEvidence(bead("cave-a")), false, "absent comment_count = no evidence");
+assert.equal(hasVerificationEvidence(undefined), false, "no bead = no evidence");
+// notes alone (auto-populated planning text) must NOT count as evidence.
+assert.equal(
+  hasVerificationEvidence({ ...bead("cave-a"), notes: "some planning text", comment_count: 0 }),
+  false,
+  "notes without a comment are not verification evidence",
+);
+
 console.log("beads-work-queue.test.ts: ok");

--- a/src/lib/beads-work-queue.ts
+++ b/src/lib/beads-work-queue.ts
@@ -16,7 +16,24 @@ export type ReadyBead = {
   issue_type?: string | null;
   labels?: string[] | null;
   updated_at?: string | null;
+  /** Number of comments on the bead (`bd ready --json` includes this). Used as
+   *  the verification-evidence signal: a recorded handoff/verification comment
+   *  must exist before the queue exposes Close (cave-hlv.2). */
+  comment_count?: number | null;
 };
+
+/**
+ * True when a bead carries recorded verification evidence — i.e. at least one
+ * comment (a handoff/verification note). Deliberately NOT satisfied by `notes`
+ * (frequently auto-populated planning text) or by a merged PR alone (green CI
+ * is not a substitute for a recorded verification per the familiar PR
+ * protocol): the operator must add a handoff note, which the queue's inline
+ * composer writes as a comment. Gates the Close affordance on the
+ * post-merge-cleanup lane.
+ */
+export function hasVerificationEvidence(bead: ReadyBead | undefined | null): boolean {
+  return (bead?.comment_count ?? 0) > 0;
+}
 
 /** A recently-merged PR, reduced to what the cleanup lane needs. */
 export type MergedPrRef = {

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -153,6 +153,7 @@
 /* ── Cards ──────────────────────────────────────────────────────────────── */
 .fwq-card {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
@@ -257,6 +258,48 @@
   flex-shrink: 0;
 }
 
+/* Handoff-note affordances (cave-hlv.2): a full-width hint + inline composer
+   that wrap below the card's title/actions row. */
+.fwq-card-hint {
+  flex: 0 0 100%;
+  margin: 2px 0 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.fwq-note {
+  flex: 0 0 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.fwq-note-input {
+  width: 100%;
+  min-height: 44px;
+  resize: vertical;
+  padding: 7px 9px;
+  border-radius: var(--radius-control, 8px);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.fwq-note-input:focus-visible {
+  outline: 2px solid var(--ring-focus, var(--accent-presence));
+  outline-offset: 1px;
+}
+
+.fwq-note-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 /* Narrow surface (split tile / mobile): stack card body over actions. */
 @container (max-width: 560px) {
   .fwq-card {
@@ -265,5 +308,11 @@
   }
   .fwq-card-actions {
     justify-content: flex-end;
+  }
+  /* Column flow already stacks children full-width; the row-mode 100% basis
+     would otherwise resolve against the (vertical) main axis. */
+  .fwq-card-hint,
+  .fwq-note {
+    flex: 0 0 auto;
   }
 }

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -8,10 +8,12 @@ import { expect, test, type Page } from "@playwright/test";
 // event since Work Queue is a quiet, shortcut-less destination.
 
 const READY_BEADS = [
-  { id: "cave-aa1", title: "Harden the sync path", priority: 1, status: "open", issue_type: "feature", labels: ["familiar:kitty", "surface:github"], updated_at: null },
-  { id: "cave-bb2", title: "iOS profile avatar", priority: 2, status: "open", issue_type: "feature", labels: ["familiar:nova", "surface:ios"], updated_at: null },
-  { id: "cave-open", title: "Merged but unclosed", priority: 2, status: "open", issue_type: "feature", labels: ["familiar:kitty"], updated_at: null },
-  { id: "cave-epic", title: "An epic container", priority: 1, status: "open", issue_type: "epic", labels: ["familiar:nova"], updated_at: null },
+  { id: "cave-aa1", title: "Harden the sync path", priority: 1, status: "open", issue_type: "feature", labels: ["familiar:kitty", "surface:github"], updated_at: null, comment_count: 0 },
+  { id: "cave-bb2", title: "iOS profile avatar", priority: 2, status: "open", issue_type: "feature", labels: ["familiar:nova", "surface:ios"], updated_at: null, comment_count: 0 },
+  // cave-open is the post-merge-cleanup bead (merged PR #90). comment_count: 0
+  // means no recorded verification yet → Close is gated until a handoff note.
+  { id: "cave-open", title: "Merged but unclosed", priority: 2, status: "open", issue_type: "feature", labels: ["familiar:kitty"], updated_at: null, comment_count: 0 },
+  { id: "cave-epic", title: "An epic container", priority: 1, status: "open", issue_type: "epic", labels: ["familiar:nova"], updated_at: null, comment_count: 0 },
 ];
 
 const NOW = Date.now();
@@ -54,11 +56,16 @@ async function gotoWorkQueue(page: Page) {
   await page.route(/\/api\/beads\?/, (route) => route.fulfill({ json: { ok: true, data: READY_BEADS } }));
 
   await page.goto("/");
-  await page.waitForTimeout(500);
-  await page.evaluate(() =>
-    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })),
-  );
-  await page.waitForSelector(".fwq", { timeout: 30_000 });
+  // The shell must be mounted before the mode-switch listener exists; dispatch
+  // once the nav is present, then re-fire until the surface appears so a slow
+  // hydration (cold `next dev` compile) can't lose the event to a race.
+  await page.getByRole("navigation").first().waitFor({ timeout: 30_000 });
+  await expect(async () => {
+    await page.evaluate(() =>
+      window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })),
+    );
+    await expect(page.locator(".fwq")).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 30_000 });
 }
 
 test.describe("familiar work queue (PR control tower)", () => {
@@ -118,5 +125,37 @@ test.describe("familiar work queue (PR control tower)", () => {
     const noPr = page.locator(".fwq").getByRole("region", { name: "No open PR" });
     await noPr.getByRole("button", { name: "Claim" }).click();
     await expect.poll(() => claimBody).toEqual({ action: "claim", id: "cave-bb2" });
+  });
+
+  test("cleanup Close is gated on a handoff note; adding one posts a comment and unlocks it", async ({ page }) => {
+    let commentBody: unknown = null;
+    await page.route("**/api/beads", async (route) => {
+      if (route.request().method() === "POST") {
+        commentBody = route.request().postDataJSON();
+        await route.fulfill({ json: { ok: true, data: { id: "cave-open" } } });
+        return;
+      }
+      await route.fulfill({ json: { ok: true, data: READY_BEADS } });
+    });
+    await gotoWorkQueue(page);
+
+    const cleanup = page.locator(".fwq").getByRole("region", { name: "Post-merge cleanup" });
+    // No evidence yet → Close is disabled and the reason is spelled out.
+    await expect(cleanup.getByRole("button", { name: "Close bead" })).toBeDisabled();
+    await expect(cleanup.getByText(/Add a handoff note to record verification/)).toBeVisible();
+
+    // Record a handoff note through the inline composer.
+    await cleanup.getByRole("button", { name: /Add a handoff note to cave-open/ }).click();
+    await cleanup.getByRole("textbox", { name: /Handoff note for cave-open/ }).fill("Verified: lanes render, close gated.");
+    await cleanup.getByRole("button", { name: "Add note" }).click();
+
+    // The note posts as a comment on the bead…
+    await expect.poll(() => commentBody).toEqual({
+      action: "comment",
+      id: "cave-open",
+      comment: "Verified: lanes render, close gated.",
+    });
+    // …and Close unlocks (optimistic, without waiting for a re-read).
+    await expect(cleanup.getByRole("button", { name: "Close bead" })).toBeEnabled();
   });
 });


### PR DESCRIPTION
Closes the two deltas left after PR #2547 (cave-hlv.4) delivered the Familiar Work Queue substrate. Per hlv.2's own note — **the surface is not rebuilt**; only the missing affordances from its acceptance are added: *"add a handoff comment"* and *"close only when verification evidence is present."*

## What changed

- **Handoff note** — an inline composer on every bead-backed card posts a comment through the existing `/api/beads` `comment` action (⌘/Ctrl+Enter submits), announced to assistive tech. This is the recorded verification evidence.
- **Evidence-gated close** — `hasVerificationEvidence(bead) = comment_count > 0`, deliberately **not** satisfied by auto-populated `notes` or a merged PR alone (green CI isn't a substitute for a recorded verification per the familiar PR protocol). The post-merge-cleanup **Close** button is disabled with a spelled-out hint until a handoff note lands; adding one unlocks it optimistically (no wait for the 30s poll to re-read `comment_count`). This ties the two deltas together: *add a note → Close unlocks.*
- `bd ready --json` already includes `comment_count`, so there's **no new fetch or backend change** — just a field added to the `ReadyBead` shape and a pure predicate in `beads-work-queue.ts`.

## Test-helper hardening (drive-by)

The shared e2e helper dispatched `cave:navigate-mode` only 500ms after `goto("/")`, racing the workspace's listener registration — flaky on a slow `next dev` compile (reproduced locally: all three tests, including the two unchanged ones, timed out at surface load). Now it waits for the shell nav, then poll-dispatches until `.fwq` appears. All three pass cleanly.

## Verification

- Pure lib test: `hasVerificationEvidence` cases (comment present/absent, notes-only rejected)
- Playwright spec (3 pass): the gate is disabled without evidence + the hint shows; the composer posts `{action:"comment", id, comment}`; Close unlocks after
- `tsc` clean · 741 wired · 549 app · production build within budget

Advances epic `cave-hlv`; addresses the reactivated `cave-hlv.2` deltas. Leaves only `cave-hlv.3` (GitHub + Linear visibility bridge, needs a Linear-auth decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)