### PR TITLE
fix(nav): honest Schedules top-bar button and split-open sidebar state (re-land #2501)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -29,6 +29,7 @@ export const SUITES = {
     "src/lib/use-code-rail.test.ts",
     "src/lib/workspace-tiles.test.ts",
     "src/lib/page-drag.test.ts",
+    "src/lib/sidebar-nav-state.test.ts",
     "src/components/chat-view-render-cap.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -8,7 +8,7 @@ const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "ut
 const menuBarSwitcherRule = globals.match(/\.menu-bar__group--chat \.familiar-switcher__trigger\s*\{([\s\S]*?)\}/)?.[1] ?? "";
 
 // The bar provides desktop top chrome: chat with familiars, global
-// context-aware search, and view tasks/inbox. It is a labelled landmark so
+// context-aware search, and view tasks/schedules. It is a labelled landmark so
 // screen readers can find it.
 assert.match(
   source,
@@ -95,8 +95,8 @@ assert.doesNotMatch(
   "desktop menu-bar familiar selector must not use content-width sizing after the label/caret were removed",
 );
 
-// Right group — tasks. A Tasks button (board) and an Inbox button, each with a
-// live count badge that is hidden at zero.
+// Right group — tasks. A Tasks button (board) and a Schedules button, each
+// with a live count badge that is hidden at zero.
 assert.match(
   source,
   /className="menu-bar__task focus-ring"[\s\S]*onClick=\{onViewTasks\}/,
@@ -107,15 +107,34 @@ assert.match(
   /taskCount > 0 \? <span className="menu-bar__badge">\{fmtBadge\(taskCount\)\}<\/span> : null/,
   "the Tasks badge shows the open-task count and hides at zero",
 );
+// The old "Inbox" button was dishonest: workspace mode "inbox" IS the
+// Schedules surface (calendar + crons) and no dedicated inbox surface exists
+// (inbox items live in the notification bell). The button now says what it
+// does: Schedules, calendar icon, schedule needs-you badge.
 assert.match(
   source,
-  /onClick=\{onViewInbox\}/,
-  "the Inbox button jumps to the inbox",
+  /onClick=\{onViewSchedules\}/,
+  "the Schedules button jumps to the Schedules surface",
 );
 assert.match(
   source,
-  /inboxCount > 0 \? \(\s*<span className="menu-bar__badge menu-bar__badge--alert">/,
-  "the Inbox badge shows the attention count and hides at zero",
+  /aria-label=\{scheduleNeedsCount > 0 \? `View schedules — \$\{scheduleNeedsCount\} need attention` : "View schedules"\}/,
+  "the Schedules button is announced as schedules, not inbox",
+);
+assert.match(
+  source,
+  /<Icon name="ph:calendar-check"[\s\S]{0,120}<span>Schedules<\/span>/,
+  "the Schedules button matches the sidebar's Schedules label + icon",
+);
+assert.doesNotMatch(
+  source,
+  /"View inbox"|<span>Inbox<\/span>|ph:tray/,
+  "no top-bar control claims to be an Inbox — there is no inbox surface to land on",
+);
+assert.match(
+  source,
+  /scheduleNeedsCount > 0 \? \(\s*<span className="menu-bar__badge menu-bar__badge--alert">/,
+  "the Schedules badge shows the needs-you count and hides at zero",
 );
 
 // Wiring in the workspace: the bar mounts in the Shell topBar slot with the
@@ -127,13 +146,13 @@ assert.match(
 );
 assert.match(
   workspace,
-  /onViewInbox=\{\(\) => setMode\("inbox"\)\}/,
-  "View inbox switches to the inbox surface",
+  /onViewSchedules=\{\(\) => setMode\("inbox"\)\}/,
+  "View schedules switches to the Schedules surface (workspace mode id 'inbox')",
 );
 assert.match(
   workspace,
-  /taskCount=\{boardTaskCount\}[\s\S]*inboxCount=\{inboxBadgeCount\}/,
-  "the bar is fed the live board task count and inbox badge count",
+  /taskCount=\{boardTaskCount\}[\s\S]*scheduleNeedsCount=\{scheduleNeedsCount\}/,
+  "the bar is fed the live board task count and the schedule needs-you count (same source as the sidebar Schedules badge)",
 );
 assert.match(
   workspace,

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -15,8 +15,8 @@ type Props = {
   responseNeeded?: Set<string>;
   /** Open task count (board cards not yet done) — drives the Tasks badge. */
   taskCount: number;
-  /** Items needing attention — drives the Inbox badge. */
-  inboxCount: number;
+  /** Schedule items needing attention — drives the Schedules badge. */
+  scheduleNeedsCount: number;
   /** Open the shared context-aware search palette. */
   onOpenSearch: () => void;
   /** Shared top-search query, mirrored with the mobile top bar and palette. */
@@ -32,8 +32,8 @@ type Props = {
   onEnrichTasks?: () => void;
   enrichingTasks?: boolean;
   enrichProgress?: { done: number; total: number } | null;
-  /** Jump to the inbox / schedules. */
-  onViewInbox: () => void;
+  /** Jump to the Schedules surface (calendar + crons). */
+  onViewSchedules: () => void;
   /** Open the quick-chat dropdown (anchored under its trigger in this bar). */
   onOpenQuickChat?: () => void;
 };
@@ -47,7 +47,7 @@ function fmtBadge(n: number): string {
 
 /**
  * A slim, always-visible desktop top menu bar with the familiar selector,
- * global search, and task/inbox counters. It is the desktop counterpart to the
+ * global search, and task/schedule counters. It is the desktop counterpart to the
  * mobile `.top-bar` (which stays hidden ≥1024px); this bar is hidden below
  * 1024px so the two never both render.
  */
@@ -58,7 +58,7 @@ export function FamiliarMenuBar({
   sessions,
   responseNeeded,
   taskCount,
-  inboxCount,
+  scheduleNeedsCount,
   onOpenSearch,
   searchQuery,
   onSearchQueryChange,
@@ -67,7 +67,7 @@ export function FamiliarMenuBar({
   onEnrichTasks,
   enrichingTasks,
   enrichProgress,
-  onViewInbox,
+  onViewSchedules,
   onOpenQuickChat,
 }: Props) {
   const enrichLabel = enrichingTasks
@@ -159,16 +159,20 @@ export function FamiliarMenuBar({
           <span>Tasks</span>
           {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
         </button>
+        {/* This button lands on the Schedules surface (workspace mode "inbox"
+            is the Schedules view — calendar + crons), so it is labelled
+            Schedules and badged with the schedule needs-you count. There is no
+            dedicated Inbox surface; inbox items live in the notification bell. */}
         <button
           type="button"
           className="menu-bar__task focus-ring"
-          onClick={onViewInbox}
-          aria-label={inboxCount > 0 ? `View inbox — ${inboxCount} need attention` : "View inbox"}
+          onClick={onViewSchedules}
+          aria-label={scheduleNeedsCount > 0 ? `View schedules — ${scheduleNeedsCount} need attention` : "View schedules"}
         >
-          <Icon name="ph:tray" width={22} height={22} aria-hidden />
-          <span>Inbox</span>
-          {inboxCount > 0 ? (
-            <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(inboxCount)}</span>
+          <Icon name="ph:calendar-check" width={22} height={22} aria-hidden />
+          <span>Schedules</span>
+          {scheduleNeedsCount > 0 ? (
+            <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(scheduleNeedsCount)}</span>
           ) : null}
         </button>
       </div>

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -62,10 +62,18 @@ assert.doesNotMatch(
 );
 assert.doesNotMatch(sidebar, /addons\?\.roles/, "The roles add-on gate is retired from the sidebar");
 assert.doesNotMatch(palette, /addons\?\.roles/, "The roles add-on gate is retired from the command palette");
+// The roles/capabilities → marketplace aliasing moved into the pure row-state
+// helper (lib/sidebar-nav-state) that the sidebar derives every row from.
+const sidebarNavState = await readFile(new URL("../lib/sidebar-nav-state.ts", import.meta.url), "utf8");
+assert.match(
+  sidebarNavState,
+  /roles: "marketplace",\s*\n\s*capabilities: "marketplace",/,
+  "The Marketplace entry stays lit while a deep-linked roles/capabilities mode is active",
+);
 assert.match(
   sidebar,
-  /fm\.id === "marketplace" && \(mode === "roles" \|\| mode === "capabilities"\)/,
-  "The Marketplace entry stays lit while a deep-linked roles/capabilities mode is active",
+  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
+  "Sidebar rows derive their highlight (including the marketplace aliasing) from sidebarRowState",
 );
 
 // Settings: no separate plugins section, and the roles add-on toggle is gone

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const automations = readFileSync(new URL("./automations-view.tsx", import.meta.url), "utf8");
+const menuBar = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
@@ -32,6 +33,24 @@ assert.match(
   notificationBell,
   /Open Schedules/,
   "Notification bell routes users to the renamed Schedules surface",
+);
+// The desktop menu bar button that opens this surface (mode "inbox") says
+// Schedules — an "Inbox" label would be dishonest since the slim surface has
+// no inbox tab and inbox items live in the notification bell instead.
+assert.match(
+  menuBar,
+  /<Icon name="ph:calendar-check"[\s\S]{0,120}<span>Schedules<\/span>/,
+  "Desktop menu bar names the surface Schedules with the calendar-check icon",
+);
+assert.doesNotMatch(
+  menuBar,
+  /<span>Inbox<\/span>|"View inbox"/,
+  "Desktop menu bar no longer advertises a nonexistent Inbox surface",
+);
+assert.match(
+  workspace,
+  /onViewSchedules=\{\(\) => setMode\("inbox"\)\}/,
+  "Menu-bar Schedules button routes to the Schedules surface (mode id 'inbox')",
 );
 assert.match(
   slashCommands,

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -365,8 +365,8 @@ assert.match(
 );
 assert.match(
   source,
-  /`\$\{label\} — \$\{description\}( \(\$\{kbd\}\))?\$\{dragHint\}`/,
-  "title combines label + description (+ shortcut when present) + drag-to-split hint",
+  /`\$\{label\} — \$\{description\}( \(\$\{kbd\}\))?\$\{dragHint\}\$\{splitHint\}`/,
+  "title combines label + description (+ shortcut when present) + drag-to-split hint + open-in-split hint",
 );
 
 // The app version renders as the bottommost sidebar element — one
@@ -415,6 +415,48 @@ assert.match(
   styles,
   /\.sidebar-folder-row--quiet-lead \{[^}]*margin-top: var\(--space-3\);/,
   "the quiet cluster opens with spacing, not a hairline divider",
+);
+
+// ── Split-open marker ────────────────────────────────────────────────────────
+// Drag-to-split opens a page beside the primary WITHOUT changing `mode`, so
+// active alone would leave the highlight stale. Rows derive a three-way state
+// (active / split / idle) from the pure lib/sidebar-nav-state helper (unit
+// tests in src/lib/sidebar-nav-state.test.ts), and workspace feeds the open
+// split-page modes.
+assert.match(
+  source,
+  /import \{ sidebarRowState, type SidebarRowState \} from "@\/lib\/sidebar-nav-state"/,
+  "row highlight derivation lives in the pure, unit-tested sidebar-nav-state helper",
+);
+assert.match(
+  source,
+  /state=\{sidebarRowState\(fm\.id, mode, props\.splitPageModes\)\}/,
+  "each row derives active/split/idle from mode + open split pages",
+);
+assert.match(
+  source,
+  /sidebar-folder-row--split/,
+  "rows open in a split carry the --split modifier class",
+);
+assert.match(
+  source,
+  /splitPageModes\?: readonly string\[\]/,
+  "SidebarMinimal accepts the open split-page modes",
+);
+assert.match(
+  workspace,
+  /const splitPageModes = useMemo\([\s\S]{0,220}t\.kind === "page"[\s\S]{0,120}\[splitTargets\],?\s*\n\s*\)/,
+  "workspace derives splitPageModes from the live split tiles",
+);
+assert.match(
+  workspace,
+  /<SidebarMinimal\s+mode=\{mode\}\s+splitPageModes=\{splitPageModes\}/,
+  "workspace threads splitPageModes into the sidebar",
+);
+assert.match(
+  styles,
+  /\.sidebar-folder-row--split \{[^}]*color-mix\(in oklch, var\(--accent-presence\)/,
+  "the split marker reuses the active accent at a lighter wash",
 );
 
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -18,6 +18,7 @@ import {
   emitPageDragEnd,
   isSplittablePage,
 } from "@/lib/page-drag";
+import { sidebarRowState, type SidebarRowState } from "@/lib/sidebar-nav-state";
 import { RecentActivityRollup } from "@/components/recent-activity-rollup";
 import { APP_VERSION } from "@/lib/app-version";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -45,6 +46,10 @@ export type FolderMode =
 
 export type SidebarMinimalProps = {
   mode: string;
+  /** Page modes currently open as secondary split tiles (drag-to-split).
+   *  Their rows get a lighter "open in split" wash instead of the active fill,
+   *  so the highlight stays honest when a page renders beside the primary. */
+  splitPageModes?: readonly string[];
   sessions: SessionRow[];
   activeSessionId?: string | null;
   onNewChat: () => void;
@@ -122,7 +127,7 @@ function FolderRow({
   id,
   label,
   iconName,
-  active,
+  state,
   badge,
   kbd,
   description,
@@ -133,7 +138,7 @@ function FolderRow({
   id: string;
   label: string;
   iconName: Parameters<typeof Icon>[0]["name"];
-  active: boolean;
+  state: SidebarRowState;
   badge?: string;
   kbd?: string;
   description?: string;
@@ -143,6 +148,8 @@ function FolderRow({
   quietLead?: boolean;
   onClick: () => void;
 }) {
+  const active = state === "active";
+  const split = state === "split";
   // Splittable pages can be dragged into the main area to open beside the
   // current surface (desktop snap-to-split). Non-clickable drags don't fire the
   // onClick, so navigation by click is unaffected.
@@ -150,15 +157,16 @@ function FolderRow({
   // Native title doubles as a desktop hover tooltip and a touch long-press
   // hint, and is exposed to AT as the button's accessible description.
   const dragHint = draggable ? " · drag into the page to split" : "";
+  const splitHint = split ? " · open in split" : "";
   const title = description
     ? kbd
-      ? `${label} — ${description} (${kbd})${dragHint}`
-      : `${label} — ${description}${dragHint}`
+      ? `${label} — ${description} (${kbd})${dragHint}${splitHint}`
+      : `${label} — ${description}${dragHint}${splitHint}`
     : undefined;
   return (
     <button
       type="button"
-      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}${quiet ? " sidebar-folder-row--quiet" : ""}${quietLead ? " sidebar-folder-row--quiet-lead" : ""}`}
+      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}${split ? " sidebar-folder-row--split" : ""}${quiet ? " sidebar-folder-row--quiet" : ""}${quietLead ? " sidebar-folder-row--quiet-lead" : ""}`}
       aria-current={active ? "page" : undefined}
       title={title}
       draggable={draggable || undefined}
@@ -240,9 +248,10 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             id={fm.id}
             label={fm.label}
             iconName={fm.iconName}
-            // Roles and Capabilities are sections of the Marketplace hub, so keep
-            // the Marketplace entry lit when those modes are active.
-            active={mode === fm.id || (fm.id === "marketplace" && (mode === "roles" || mode === "capabilities"))}
+            // Active follows the primary mode (Roles/Capabilities keep the
+            // Marketplace hub lit); pages open as split tiles get a lighter
+            // "open in split" state instead. Derivation in lib/sidebar-nav-state.
+            state={sidebarRowState(fm.id, mode, props.splitPageModes)}
             badge={fm.badge?.(props)}
             kbd={fm.kbd}
             description={fm.description}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1892,9 +1892,18 @@ export function Workspace() {
     startFamiliarChat(activeId, projectRoot);
   }, [activeId, startFamiliarChat]);
 
+  // Page modes currently open as split tiles — the sidebar marks their rows
+  // "open in split" so the active highlight stays honest after drag-to-split
+  // (dropping opens the page beside the primary WITHOUT changing `mode`).
+  const splitPageModes = useMemo(
+    () => splitTargets.filter((t): t is Extract<SplitTarget, { kind: "page" }> => t.kind === "page").map((t) => t.mode),
+    [splitTargets],
+  );
+
   const sidebar = (
     <SidebarMinimal
       mode={mode}
+      splitPageModes={splitPageModes}
       sessions={sessions}
       activeSessionId={routerRef.current?.currentSessionId() ?? null}
       onNewChat={() => {
@@ -2194,7 +2203,7 @@ export function Workspace() {
               sessions={sessions}
               responseNeeded={responseNeeded}
               taskCount={boardTaskCount}
-              inboxCount={inboxBadgeCount}
+              scheduleNeedsCount={scheduleNeedsCount}
               onOpenSearch={() => setPaletteOpen(true)}
               searchQuery={topSearchQuery}
               onSearchQueryChange={(query) => {
@@ -2206,7 +2215,7 @@ export function Workspace() {
               onEnrichTasks={handleEnrichTasks}
               enrichingTasks={enrichingTasks}
               enrichProgress={enrichProgress}
-              onViewInbox={() => setMode("inbox")}
+              onViewSchedules={() => setMode("inbox")}
               onOpenQuickChat={() => setQuickChatOpen(true)}
             />
             <TopBar

--- a/src/lib/sidebar-nav-state.test.ts
+++ b/src/lib/sidebar-nav-state.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { sidebarRowState } from "./sidebar-nav-state.ts";
+
+test("the row matching the primary mode is active", () => {
+  assert.equal(sidebarRowState("board", "board"), "active");
+  assert.equal(sidebarRowState("home", "board"), "idle");
+});
+
+test("switching mode moves the active highlight", () => {
+  assert.equal(sidebarRowState("marketplace", "marketplace"), "active");
+  assert.equal(sidebarRowState("marketplace", "home"), "idle");
+  assert.equal(sidebarRowState("home", "home"), "active");
+});
+
+test("Roles/Capabilities keep the Marketplace hub row lit", () => {
+  assert.equal(sidebarRowState("marketplace", "roles"), "active");
+  assert.equal(sidebarRowState("marketplace", "capabilities"), "active");
+});
+
+test("a page open as a split tile gets the split marker, not active", () => {
+  // Drag-to-split opens a page beside the primary WITHOUT changing mode —
+  // the old row must stay active and the split page must be marked "split".
+  assert.equal(sidebarRowState("marketplace", "home", ["marketplace"]), "split");
+  assert.equal(sidebarRowState("home", "home", ["marketplace"]), "active");
+  assert.equal(sidebarRowState("board", "home", ["marketplace"]), "idle");
+});
+
+test("active wins over split when a mode is somehow both", () => {
+  // The workspace clears redundant splits, but the derivation stays defensive.
+  assert.equal(sidebarRowState("board", "board", ["board"]), "active");
+});
+
+test("no split modes provided behaves like an empty list", () => {
+  assert.equal(sidebarRowState("board", "home"), "idle");
+  assert.equal(sidebarRowState("board", "home", []), "idle");
+});

--- a/src/lib/sidebar-nav-state.ts
+++ b/src/lib/sidebar-nav-state.ts
@@ -1,0 +1,36 @@
+/**
+ * sidebar-nav-state — pure derivation of a sidebar nav row's visual state.
+ *
+ * A row is:
+ *   - "active" when its mode is the primary workspace surface (Roles and
+ *     Capabilities are sections of the Marketplace hub, so they keep the
+ *     Marketplace row lit);
+ *   - "split"  when its page is currently open as a secondary split tile
+ *     (drag-to-split) but is NOT the primary surface — the workspace clears
+ *     redundant splits, but active still wins here defensively;
+ *   - "idle"   otherwise.
+ *
+ * Kept as a pure function (no React) so the highlight rules are unit-testable.
+ */
+
+export type SidebarRowState = "active" | "split" | "idle";
+
+/** Modes that light up a row other than their own (hub sections → hub row). */
+const MODE_ALIASES: Record<string, string> = {
+  roles: "marketplace",
+  capabilities: "marketplace",
+};
+
+function normalizeMode(mode: string): string {
+  return MODE_ALIASES[mode] ?? mode;
+}
+
+export function sidebarRowState(
+  rowId: string,
+  activeMode: string,
+  splitPageModes?: readonly string[],
+): SidebarRowState {
+  if (normalizeMode(activeMode) === rowId) return "active";
+  if (splitPageModes?.some((m) => normalizeMode(m) === rowId)) return "split";
+  return "idle";
+}

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -525,6 +525,14 @@
   margin-top: var(--space-3);
 }
 
+/* Row whose page is open as a secondary split tile (drag-to-split) but is not
+   the primary surface: a lighter wash of the active accent so it reads
+   "open, not focused" instead of stealing the active highlight. */
+.sidebar-folder-row--split {
+  background: color-mix(in oklch, var(--accent-presence) 4%, transparent);
+  box-shadow: inset 2px 0 0 color-mix(in oklch, var(--accent-presence) 45%, transparent);
+}
+
 .sidebar-folder-icon {
   flex-shrink: 0;
   opacity: 0.6;
@@ -535,6 +543,7 @@
 }
 
 .sidebar-folder-row--active .sidebar-folder-icon,
+.sidebar-folder-row--split .sidebar-folder-icon,
 .sidebar-folder-row:hover .sidebar-folder-icon {
   opacity: 1;
 }


### PR DESCRIPTION
Re-lands #2501 by @mithril-logic verbatim (squash of `pull/2501/head` onto current main — clean merge, no adaptation needed). Fork PRs cannot satisfy the required **CodeQL** default-setup check, so #2501 sat unmergeable with all 11 runnable checks green and an approving review.

Review (approved on the original): the mislabeled top-bar "Inbox" button verified against current main (lands on the Schedules surface — calendar/crons tabs, title already "Schedules"); badge swap to `scheduleNeedsCount` loses no escalation visibility (bell + mobile tabs still carry `inboxBadgeCount`); the `sidebarRowState` helper composes correctly with the workspace's redundant-split-clearing effect and has meaningful unit tests.

Contributor credit preserved via Co-authored-by trailer.