### PR TITLE
feat(workflow): Work Queue handoff-comment + evidence-gated close (cave-hlv.2)

### DIFF
--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -144,7 +144,9 @@ Lanes, ordered fix-first → land → review → bead-driven → waiting:
 - **Post-merge cleanup** — a merged PR whose bead is still open, with a **Close bead** action. (Detection is limited to beads still in the `ready` set; worktree/branch removal stays a CLI step.)
 - **Waiting** — draft, pending-checks, and blocked PRs; shown but never counted as actionable.
 
-Each card carries the familiar and surface labels, the bead id, live check/review state, and a stale flag (no update in 24h). A per-familiar rollup along the top filters the whole board to one familiar. The pure join lives in `src/lib/beads-work-queue.ts`; claim/close map to the `/api/beads` adapter with verification recorded in the bead, not a chat transcript.
+Each card carries the familiar and surface labels, the bead id, live check/review state, and a stale flag (no update in 24h). A per-familiar rollup along the top filters the whole board to one familiar. The pure join lives in `src/lib/beads-work-queue.ts`; claim/comment/close map to the `/api/beads` adapter with verification recorded in the bead, not a chat transcript.
+
+Every bead-backed card exposes a **Comment** affordance — an inline composer that appends a handoff note to the bead (⌘/Ctrl-Enter to send), so context lives on the bead instead of in chat. **Close is evidence-gated**: it appears only on a card that carries verification evidence — today a merged PR, cited on the card and in the close reason — so the queue never offers a bare close on work that hasn't demonstrably landed.
 
 ## Guardrails
 

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -130,11 +130,11 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   );
 
   const runAction = useCallback(
-    async (item: WorkQueueItem, action: "claim" | "close" | "comment", comment?: string) => {
+    async (item: WorkQueueItem, action: "claim" | "close" | "comment", comment?: string): Promise<boolean> => {
       const id = item.bead?.id;
-      if (!id) return;
+      if (!id) return false;
       const text = comment?.trim();
-      if (action === "comment" && !text) return; // never post an empty handoff note
+      if (action === "comment" && !text) return false; // never post an empty handoff note
       setBusyId(item.key);
       try {
         const body: Record<string, string> = { action, id };
@@ -155,8 +155,10 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
               : `Comment added to ${id}.`,
         );
         await load({ quiet: true });
+        return true;
       } catch (err) {
         announce(err instanceof Error ? err.message : `Could not ${action} ${id}`, "assertive");
+        return false;
       } finally {
         setBusyId(null);
       }
@@ -290,7 +292,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
                     onOpenUrl={onOpenUrl}
                     onClaim={() => void runAction(item, "claim")}
                     onClose={() => void runAction(item, "close")}
-                    onComment={(text) => void runAction(item, "comment", text)}
+                    onComment={(text) => runAction(item, "comment", text)}
                   />
                 ))}
               </ul>
@@ -317,7 +319,7 @@ function WorkQueueCard({
   onOpenUrl?: (url: string) => void;
   onClaim: () => void;
   onClose: () => void;
-  onComment: (text: string) => void;
+  onComment: (text: string) => Promise<boolean>;
 }) {
   const [composerOpen, setComposerOpen] = useState(false);
   const [draft, setDraft] = useState("");
@@ -329,10 +331,11 @@ function WorkQueueCard({
   // never offers a bare close without proof the work landed (cave-hlv.2).
   const evidence = closeEvidence(item);
 
-  const submitComment = () => {
+  const submitComment = async () => {
     const text = draft.trim();
     if (!text) return;
-    onComment(text);
+    const ok = await onComment(text);
+    if (!ok) return;
     setDraft("");
     setComposerOpen(false);
   };
@@ -420,7 +423,7 @@ function WorkQueueCard({
           }}
         >
           <textarea
-            className="fwq-composer-input"
+            className="fwq-composer-input focus-ring"
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
             placeholder={`Handoff note for ${beadId}…`}

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -59,6 +59,16 @@ async function fetchQueue(signal: AbortSignal): Promise<WorkQueue> {
   return buildWorkQueue(readyBeads, open, merged, { nowMs: Date.now() });
 }
 
+/**
+ * The verification evidence that justifies closing a bead from the queue — a
+ * merged PR. Returns the human-readable evidence string, or `null` when there
+ * is none, in which case the Close affordance is withheld: the queue never
+ * offers a bare "close" without proof the work actually landed (cave-hlv.2).
+ */
+function closeEvidence(item: WorkQueueItem): string | null {
+  return item.merged ? `Merged in PR #${item.merged.number}` : null;
+}
+
 export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   const { announce } = useAnnouncer();
   const [queue, setQueue] = useState<WorkQueue | null>(null);
@@ -120,13 +130,16 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   );
 
   const runAction = useCallback(
-    async (item: WorkQueueItem, action: "claim" | "close") => {
+    async (item: WorkQueueItem, action: "claim" | "close" | "comment", comment?: string) => {
       const id = item.bead?.id;
       if (!id) return;
+      const text = comment?.trim();
+      if (action === "comment" && !text) return; // never post an empty handoff note
       setBusyId(item.key);
       try {
         const body: Record<string, string> = { action, id };
-        if (action === "close") body.reason = item.merged ? `Merged in PR #${item.merged.number}` : "Completed";
+        if (action === "close") body.reason = closeEvidence(item) ?? "Completed";
+        if (action === "comment" && text) body.comment = text;
         const res = await fetch("/api/beads", {
           method: "POST",
           headers: { "content-type": "application/json" },
@@ -134,7 +147,13 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         });
         const json = await res.json();
         if (!json.ok) throw new Error(json.error || `${action} failed`);
-        announce(action === "claim" ? `Claimed ${id}.` : `Closed ${id}.`);
+        announce(
+          action === "claim"
+            ? `Claimed ${id}.`
+            : action === "close"
+              ? `Closed ${id}.`
+              : `Comment added to ${id}.`,
+        );
         await load({ quiet: true });
       } catch (err) {
         announce(err instanceof Error ? err.message : `Could not ${action} ${id}`, "assertive");
@@ -271,6 +290,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
                     onOpenUrl={onOpenUrl}
                     onClaim={() => void runAction(item, "claim")}
                     onClose={() => void runAction(item, "close")}
+                    onComment={(text) => void runAction(item, "comment", text)}
                   />
                 ))}
               </ul>
@@ -289,6 +309,7 @@ function WorkQueueCard({
   onOpenUrl,
   onClaim,
   onClose,
+  onComment,
 }: {
   item: WorkQueueItem;
   familiarLabel: string;
@@ -296,63 +317,148 @@ function WorkQueueCard({
   onOpenUrl?: (url: string) => void;
   onClaim: () => void;
   onClose: () => void;
+  onComment: (text: string) => void;
 }) {
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [draft, setDraft] = useState("");
   const beadId = item.bead?.id ?? null;
   const title = item.pr?.title ?? item.merged?.title ?? item.bead?.title ?? "Untitled";
   const prNumber = item.pr?.number ?? item.merged?.number ?? null;
   const url = item.pr?.url ?? item.merged?.url ?? null;
+  // Close is gated on real evidence (a merged PR), not just a lane — the queue
+  // never offers a bare close without proof the work landed (cave-hlv.2).
+  const evidence = closeEvidence(item);
+
+  const submitComment = () => {
+    const text = draft.trim();
+    if (!text) return;
+    onComment(text);
+    setDraft("");
+    setComposerOpen(false);
+  };
 
   return (
     <li className={`fwq-card${item.stale ? " is-stale" : ""}`}>
-      <div className="fwq-card-main">
-        <div className="fwq-card-title">
-          {prNumber != null ? <span className="fwq-pr-num">#{prNumber}</span> : null}
-          <span className="fwq-card-name">{title}</span>
+      <div className="fwq-card-row">
+        <div className="fwq-card-main">
+          <div className="fwq-card-title">
+            {prNumber != null ? <span className="fwq-pr-num">#{prNumber}</span> : null}
+            <span className="fwq-card-name">{title}</span>
+          </div>
+          <div className="fwq-card-meta">
+            <span className="fwq-tag fwq-tag--familiar">{familiarLabel}</span>
+            {item.surface ? <span className="fwq-tag">{item.surface}</span> : null}
+            {beadId ? <span className="fwq-tag fwq-tag--bead">{beadId}</span> : null}
+            {item.bead && !item.pr && !item.merged ? (
+              <span className="fwq-tag">P{item.bead.priority}</span>
+            ) : null}
+            {item.pr ? (
+              <>
+                <span className={`fwq-tag fwq-tag--check-${item.pr.checkStatus ?? "unknown"}`}>
+                  checks {item.pr.checkStatus ?? "unknown"}
+                </span>
+                {item.pr.reviewDecision && item.pr.reviewDecision !== "UNKNOWN" ? (
+                  <span className="fwq-tag">{item.pr.reviewDecision.toLowerCase().replace(/_/g, " ")}</span>
+                ) : null}
+                {item.lane === "ready-to-merge" ? <span className="fwq-tag fwq-tag--ready">merge eligible</span> : null}
+              </>
+            ) : null}
+            {evidence ? <span className="fwq-tag fwq-tag--evidence">{evidence}</span> : null}
+            {item.stale ? <span className="fwq-tag fwq-tag--stale">stale</span> : null}
+          </div>
         </div>
-        <div className="fwq-card-meta">
-          <span className="fwq-tag fwq-tag--familiar">{familiarLabel}</span>
-          {item.surface ? <span className="fwq-tag">{item.surface}</span> : null}
-          {beadId ? <span className="fwq-tag fwq-tag--bead">{beadId}</span> : null}
-          {item.bead && !item.pr && !item.merged ? (
-            <span className="fwq-tag">P{item.bead.priority}</span>
+        <div className="fwq-card-actions">
+          {url ? (
+            <Button
+              variant="ghost"
+              size="xs"
+              trailingIcon="ph:arrow-square-out"
+              onClick={() => onOpenUrl?.(url)}
+              disabled={!onOpenUrl}
+            >
+              {item.merged ? "Merged PR" : "Open PR"}
+            </Button>
           ) : null}
-          {item.pr ? (
-            <>
-              <span className={`fwq-tag fwq-tag--check-${item.pr.checkStatus ?? "unknown"}`}>
-                checks {item.pr.checkStatus ?? "unknown"}
-              </span>
-              {item.pr.reviewDecision && item.pr.reviewDecision !== "UNKNOWN" ? (
-                <span className="fwq-tag">{item.pr.reviewDecision.toLowerCase().replace(/_/g, " ")}</span>
-              ) : null}
-              {item.lane === "ready-to-merge" ? <span className="fwq-tag fwq-tag--ready">merge eligible</span> : null}
-            </>
+          {beadId ? (
+            <Button
+              variant="ghost"
+              size="xs"
+              leadingIcon="ph:chat-circle-dots"
+              onClick={() => setComposerOpen((open) => !open)}
+              aria-expanded={composerOpen}
+              aria-label={`Add a handoff note to ${beadId}`}
+            >
+              Comment
+            </Button>
           ) : null}
-          {item.stale ? <span className="fwq-tag fwq-tag--stale">stale</span> : null}
+          {item.lane === "no-open-PR" && beadId ? (
+            <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:hand" onClick={onClaim}>
+              Claim
+            </Button>
+          ) : null}
+          {evidence && beadId ? (
+            <Button
+              variant="secondary"
+              size="xs"
+              loading={busy}
+              leadingIcon="ph:check"
+              onClick={onClose}
+              title={`Close ${beadId} — verified: ${evidence}`}
+            >
+              Close bead
+            </Button>
+          ) : null}
         </div>
       </div>
-      <div className="fwq-card-actions">
-        {url ? (
-          <Button
-            variant="ghost"
-            size="xs"
-            trailingIcon="ph:arrow-square-out"
-            onClick={() => onOpenUrl?.(url)}
-            disabled={!onOpenUrl}
-          >
-            {item.merged ? "Merged PR" : "Open PR"}
-          </Button>
-        ) : null}
-        {item.lane === "no-open-PR" && beadId ? (
-          <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:hand" onClick={onClaim}>
-            Claim
-          </Button>
-        ) : null}
-        {item.lane === "post-merge-cleanup" && beadId ? (
-          <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:check" onClick={onClose}>
-            Close bead
-          </Button>
-        ) : null}
-      </div>
+
+      {composerOpen && beadId ? (
+        <form
+          className="fwq-composer"
+          onSubmit={(e) => {
+            e.preventDefault();
+            submitComment();
+          }}
+        >
+          <textarea
+            className="fwq-composer-input"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder={`Handoff note for ${beadId}…`}
+            rows={2}
+            aria-label={`Handoff note for ${beadId}`}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                submitComment();
+              }
+            }}
+          />
+          <div className="fwq-composer-actions">
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                setComposerOpen(false);
+                setDraft("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="secondary"
+              size="xs"
+              loading={busy}
+              disabled={!draft.trim()}
+              leadingIcon="ph:arrow-up-bold"
+            >
+              Add note
+            </Button>
+          </div>
+        </form>
+      ) : null}
     </li>
   );
 }

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -291,12 +291,6 @@
   font-size: 13px;
 }
 
-.fwq-composer-input:focus-visible {
-  outline: var(--ring-width, 2px) solid var(--ring-focus);
-  outline-offset: 1px;
-  border-color: transparent;
-}
-
 .fwq-composer-actions {
   display: flex;
   justify-content: flex-end;

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -153,11 +153,18 @@
 /* ── Cards ──────────────────────────────────────────────────────────────── */
 .fwq-card {
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+/* The identity + actions row; the comment composer stacks beneath it. */
+.fwq-card-row {
+  display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--border-hairline);
 }
 
 .fwq-card:last-child {
@@ -250,6 +257,13 @@
   background: color-mix(in oklch, var(--color-warning) 10%, transparent);
 }
 
+/* Verification evidence that justifies a close (a merged PR). */
+.fwq-tag--evidence {
+  color: var(--color-success);
+  border-color: color-mix(in oklch, var(--color-success) 30%, transparent);
+  background: color-mix(in oklch, var(--color-success) 7%, transparent);
+}
+
 .fwq-card-actions {
   display: flex;
   align-items: center;
@@ -257,9 +271,41 @@
   flex-shrink: 0;
 }
 
+/* ── Handoff-note composer ──────────────────────────────────────────────── */
+.fwq-composer {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fwq-composer-input {
+  width: 100%;
+  resize: vertical;
+  min-height: 48px;
+  padding: 7px 9px;
+  border-radius: var(--radius-control, 8px);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-base, var(--background));
+  color: var(--text-primary);
+  font: inherit;
+  font-size: 13px;
+}
+
+.fwq-composer-input:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.fwq-composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
 /* Narrow surface (split tile / mobile): stack card body over actions. */
 @container (max-width: 560px) {
-  .fwq-card {
+  .fwq-card-row {
     flex-direction: column;
     align-items: stretch;
   }

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -58,7 +58,9 @@ async function gotoWorkQueue(page: Page) {
   await page.evaluate(() =>
     window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })),
   );
-  await page.waitForSelector(".fwq", { timeout: 30_000 });
+  // Generous: the first navigation cold-compiles the whole surface under
+  // `next dev`, which can exceed 30s on a loaded CI box before .fwq mounts.
+  await page.waitForSelector(".fwq", { timeout: 45_000 });
 }
 
 test.describe("familiar work queue (PR control tower)", () => {
@@ -96,6 +98,13 @@ test.describe("familiar work queue (PR control tower)", () => {
     const noPr = fwq.getByRole("region", { name: "No open PR" });
     await expect(noPr.getByRole("button", { name: "Claim" })).toBeVisible();
 
+    // Close is EVIDENCE-gated: the cleanup card cites its merged PR, and Close
+    // appears nowhere else (a bare bead with no landed work can't be closed).
+    await expect(cleanup.getByText("Merged in PR #90")).toBeVisible();
+    await expect(fwq.getByRole("button", { name: "Close bead" })).toHaveCount(1);
+    // Every bead-backed card exposes a handoff-note affordance.
+    await expect(fwq.getByRole("button", { name: "Add a handoff note to cave-aa1" })).toBeVisible();
+
     // Filtering by Nova drops Kitty-owned lanes (checks-failing was Kitty's).
     await page.getByRole("button", { name: /Nova/ }).click();
     await expect(fwq.getByRole("region", { name: "Checks failing" })).toHaveCount(0);
@@ -118,5 +127,31 @@ test.describe("familiar work queue (PR control tower)", () => {
     const noPr = page.locator(".fwq").getByRole("region", { name: "No open PR" });
     await noPr.getByRole("button", { name: "Claim" }).click();
     await expect.poll(() => claimBody).toEqual({ action: "claim", id: "cave-bb2" });
+  });
+
+  test("adding a handoff note posts a comment to the beads adapter", async ({ page }) => {
+    let commentBody: unknown = null;
+    await page.route("**/api/beads", async (route) => {
+      if (route.request().method() === "POST") {
+        commentBody = route.request().postDataJSON();
+        await route.fulfill({ json: { ok: true, data: { id: "cave-aa1" } } });
+        return;
+      }
+      await route.fulfill({ json: { ok: true, data: READY_BEADS } });
+    });
+    await gotoWorkQueue(page);
+    const fwq = page.locator(".fwq");
+
+    // Open the composer on the failing PR's card (bead cave-aa1), type, send.
+    await fwq.getByRole("button", { name: "Add a handoff note to cave-aa1" }).click();
+    const composer = fwq.locator(".fwq-composer");
+    await composer.getByRole("textbox", { name: "Handoff note for cave-aa1" }).fill("needs a rebase before merge");
+    await composer.getByRole("button", { name: "Add note" }).click();
+
+    await expect
+      .poll(() => commentBody)
+      .toEqual({ action: "comment", id: "cave-aa1", comment: "needs a rebase before merge" });
+    // Composer closes after a successful send.
+    await expect(fwq.locator(".fwq-composer")).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## What

Completes **cave-hlv.2**'s remaining two acceptance deltas on the Familiar Work Queue surface that hlv.4 (#2547) shipped. The queue can now **claim, comment, and close**, with close gated on verification evidence — the surface itself is **not rebuilt**, only these two affordances added.

hlv.2's acceptance: *"Cave can show ready beads, claim a bead, add a handoff comment, and expose close affordance only when verification evidence is present."* Show + claim came from hlv.4; this PR adds the comment and the evidence gate.

## Changes

- **Handoff comment** — every bead-backed card gets a **Comment** affordance that opens an inline composer (⌘/Ctrl-Enter to send) and POSTs `{action:"comment", id, comment}` to `/api/beads`. Context lands on the bead, not in a chat transcript. Empty notes are never sent; the composer closes on success.
- **Evidence-gated close** — the Close affordance is now driven by `closeEvidence(item)` (a merged PR), **not** lane membership. It appears only on a card that carries real evidence, cites that evidence both on the card (a success chip) and in the close reason, and is withheld everywhere else — so the queue never offers a bare close on work that hasn't demonstrably landed.
- The card became a column (identity/actions row + optional composer); the narrow-surface stacking moved to the inner row. Docs updated (`beads-familiars.md`).

## Verification

- Extended `tests/familiar-work-queue.spec.ts`: the composer opens, fills, POSTs the comment, and closes; the cleanup card shows its evidence chip (`Merged in PR #90`) while **Close appears on exactly one card**. All 3 spec tests pass.
- `typecheck` clean · **549 app tests** · **742 wired** · pure `beads-work-queue` lib green.
- Bumped the surface's cold-compile mount timeout (30s→45s) to cut CI flake on the heavier surface's first navigation.

## Epic

Delivers the frozen hlv.2's last deltas. The cave-hlv epic's queue-UI work is now complete across hlv.4 + hlv.2; only hlv.3 (GitHub/Linear visibility bridge) remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)