### PR TITLE
chore(release): stamp v0.0.145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.145] - 2026-07-07
+
+> 🛠️ **The work queue grows up** — the Familiar Work Queue lands as a beads + PR control tower with handoff notes and evidence-gated close, iOS finally reads your operator profile (name/avatar instead of "You"), and Projects gets a Files drill-through into the code rail. Plus a solid batch of daemon-resilience, dashboard, proxy, and nav fixes.
+
+Feature release on top of v0.0.144.
+
+### Features
+- **Familiar Work Queue — beads + PR control tower** (#2547, cave-hlv.4). The epic's control-tower slice: a unified view over beads and open PRs.
+- **Work queue: handoff notes + evidence-gated close** (#2553, cave-hlv.2). Cards carry handoff notes, and closing requires evidence — no silent completions.
+- **iOS reads the operator profile** (#2550, cave-8xb). The iOS surface shows your name and avatar from the operator profile instead of a hard-coded "You".
+- **Projects: Files drill-through into the code rail** (#2548, cave-z44). Jump from a project in the hub straight into its files in the code rail.
+
+### Fixes
+- **Daemon: bound and settle every call; retry transient GETs** (#2551, cave-4po). Every daemon call is now bounded and settled, with automatic retry on transient GET failures.
+- **nav: honest Schedules top-bar button + split-open sidebar state** (#2555, re-land #2501). The Schedules button reflects real state and the sidebar opens split correctly.
+- **browser: close native webviews on surface leave** (#2545, re-land #2500). Native webviews are torn down on leave instead of parked 1×1 offscreen.
+- **dashboard: dedupe stalled-PR signals by URL + cap the Signals panel** (#2543, cave-2it). Stalled-PR signals de-dupe by URL and the panel is length-capped.
+- **proxy: accept the real listen port in the CSRF origin gate on port fallback** (#2544, cave-5sg). The CSRF origin gate honors the actual listen port when the dev server falls back.
+- **settings: show only section labels in the left nav** (#2549, cave-iwb). The settings left nav drops the description row for a cleaner label-only list.
+
+### Tests & docs
+- **e2e: dashboard cockpit interaction contracts** (#2554, cave-1if).
+- **docs: clarify Tauri dev startup** (#2546).
+
 ## [0.0.144] - 2026-07-06
 
 > ✨ **A home that feels like yours** — the cold-start surface gets a world-class visual pass (presence eyebrow, breathing hearth glow, resume affordance), and a new **server-side operator profile** lets you set your name, pronouns, bio, timezone, links, and avatar once — surfaced across chat and handed to your familiars as startup context.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.144",
+  "version": "0.0.145",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.144"
+version = "0.0.145"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.144"
+version = "0.0.145"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.144</string>
+	<string>0.0.145</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.144</string>
+	<string>0.0.145</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.144</string>
+	<string>0.0.145</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.144</string>
+	<string>0.0.145</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.144",
+  "version": "0.0.145",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release stamp for **v0.0.145**.

Bumps all six version locations (package.json, Cargo.toml, Cargo.lock app entry, tauri.conf.json, Info.ios.plist, gen/apple Info.plist) from 0.0.144 → 0.0.145 and adds the CHANGELOG entry.

### Included since v0.0.144
**Features**
- **#2547** — feat(workflow): Familiar Work Queue — beads + PR control tower (cave-hlv.4)
- **#2553** — feat(workflow): handoff notes + evidence-gated close in the work queue (cave-hlv.2)
- **#2550** — feat(ios): read the operator profile — show name/avatar instead of "You" (cave-8xb)
- **#2548** — feat(projects): Files drill-through from the hub into the code rail (cave-z44)

**Fixes**
- **#2551** — fix(daemon): bound and settle every daemon call; retry transient GET failures (cave-4po)
- **#2555** — fix(nav): honest Schedules top-bar button and split-open sidebar state (re-land #2501)
- **#2545** — fix(browser): close native webviews on surface leave (re-land #2500)
- **#2543** — fix(dashboard): dedupe stalled-PR signals by URL + cap the Signals panel (cave-2it)
- **#2544** — fix(proxy): accept the real listen port in the CSRF origin gate on port fallback (cave-5sg)
- **#2549** — fix(settings): show only section labels in the left nav (cave-iwb)

**Tests & docs**
- **#2554** — test(e2e): dashboard cockpit interaction contracts (cave-1if)
- **#2546** — docs: clarify Tauri dev startup

Stamp-only PR; no code changes.