### PR TITLE
fix(tasks): make the Gantt timeline scroll on one bounded viewport (cave-hsh)

### DIFF
--- a/src/components/board-schedule-window.test.ts
+++ b/src/components/board-schedule-window.test.ts
@@ -161,6 +161,28 @@ assert.match(gantt, /const todayColLeftPx = todayX === null \? -9999 : todayX - 
 assert.match(gantt, /"--cg-weekend-shift" as string\]: `\$\{weekendShiftPx\}px`/, "weekend shift feeds the track via a CSS var");
 assert.match(gantt, /"--cg-today-x" as string\]: `\$\{todayColLeftPx\}px`/, "today column feeds the track via a CSS var");
 assert.match(styles, /\.cg-headstack/, "the header stacks the month band over the week ruler");
+
+// Scroll model (cave-hsh): the timeline is one bounded viewport that scrolls
+// BOTH axes, so the sticky header/left column stay put and neither scrollbar
+// drifts off-screen. The frame (.board-gantt) must NOT be the scroller — that
+// scrolled the whole chart as a block (header gone, h-bar below the fold).
+assert.match(
+  styles,
+  /\.board-gantt \{[^}]*display:\s*flex[^}]*flex-direction:\s*column[^}]*overflow:\s*hidden[^}]*\}/,
+  "the gantt frame is a non-scrolling flex column (controls · timeline · tray)",
+);
+assert.match(
+  styles,
+  /\.board-gantt__scroll \{\s*flex:\s*1;\s*min-height:\s*0;\s*overflow:\s*auto;\s*\}/,
+  "the timeline viewport is the single bounded both-axis scroller",
+);
+assert.doesNotMatch(
+  styles,
+  /\.board-gantt__scroll \{[^}]*overflow-y:\s*visible/,
+  "the viewport must not split the axes (overflow-y:visible broke the sticky header + hid the h-scrollbar)",
+);
+assert.match(styles, /\.cg-head \{[^}]*position:\s*sticky;\s*top:\s*0/, "the header sticks to the viewport top");
+assert.match(styles, /\.cg-left \{[^}]*position:\s*sticky;\s*left:\s*0/, "the task table sticks to the viewport left");
 assert.match(styles, /\.cg-month \{/, "month segments are styled");
 assert.match(styles, /var\(--cg-weekend-shift, 0px\) 0/, "weekend shading is offset by the CSS var");
 assert.match(styles, /var\(--cg-today-x, -9999px\)/, "the today column tint reads the CSS var");

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1924,7 +1924,16 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .board-gantt {
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  /* Frame, not the scroller: controls pinned at top, the timeline scroller
+     fills the middle, the unscheduled tray sits at the bottom. The timeline's
+     own bounded viewport (.board-gantt__scroll) owns BOTH scrollbars so the
+     sticky header/left-column stay put and the horizontal bar stays reachable
+     (cave-hsh). Previously .board-gantt scrolled the whole chart as one block,
+     which scrolled the header off-screen and parked the h-scrollbar below the
+     fold. */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   padding: 14px;
 }
 .board-gantt--empty {
@@ -1973,7 +1982,15 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
    Dense dark timeline: sticky left table (Group/Task · Owner · Start · End ·
    status dot) + a day/week grid with status-coloured bars, milestone diamonds,
    a red TODAY line, and a legend. Redefines .board-gantt-row__bar by category. */
-.board-gantt__scroll { overflow-x: auto; overflow-y: visible; }
+/* The single bounded scroll viewport for the whole timeline — both axes. As a
+   flex child it fills the frame's remaining height, so .cg-head (sticky top)
+   and .cg-left (sticky left) stay pinned while rows scroll under them and the
+   timeline pans, and both scrollbars stay on-screen (cave-hsh). */
+.board-gantt__scroll { flex: 1; min-height: 0; overflow: auto; }
+/* Controls (top) and the unscheduled tray (bottom) keep their natural height so
+   only the timeline viewport between them scrolls. */
+.board-gantt > .cg-controls,
+.board-gantt > .board-gantt-unscheduled { flex: 0 0 auto; }
 .cg {
   --cg-row-h: 26px;
   width: max-content;


### PR DESCRIPTION
The Tasks → **Gantt** view didn't scroll cleanly: the month/week header slid off-screen when you scrolled down, and the horizontal scrollbar sat below the fold.

## Root cause

Scrolling was split across two containers:
- `.board-gantt` (the frame) was `overflow: auto` and scrolled the **whole chart as a block** vertically.
- `.board-gantt__scroll` (the timeline) was `overflow-x: auto; overflow-y: visible` and scrolled horizontally.

So `.cg-head`'s `position: sticky; top: 0` was pinned to the wrong scroll ancestor (the header scrolled away), and the horizontal scrollbar lived at the bottom of the inner element — which was taller than the visible frame, putting the bar below the fold. (As a bonus gotcha, `overflow-x:auto` + `overflow-y:visible` computes to `overflow:auto` per spec, so the split didn't even do what it read like.)

## Fix

- `.board-gantt` → a **non-scrolling flex column**: controls (top) · timeline (fills) · unscheduled tray (bottom).
- `.board-gantt__scroll` → the **single bounded viewport** that scrolls **both axes** (`flex: 1; min-height: 0; overflow: auto`).

Now the sticky header stays pinned on vertical scroll, the sticky left task-table stays pinned on horizontal scroll, and both scrollbars are always on-screen.

## Verification

Live, short viewport (700px) with real board data:

| | before | after |
| --- | --- | --- |
| `.board-gantt` self-scrolls | yes (whole chart) | **no** (frame) |
| `.board-gantt__scroll` vertical | no | **yes** |
| `.board-gantt__scroll` horizontal | yes (below fold) | **yes** (on-screen) |
| header after scrolling down 200px | scrolls away | **stays flush to top** |
| left table after scrolling right 400px | — | **stays flush to left** |

CSS-only change; regression pins added to `board-schedule-window.test.ts` (frame is a non-scrolling flex column, viewport is the bounded both-axis scroller, header/left stay sticky). `tsc` clean · 743 wired · 550 app · build within budget.

Closes bead `cave-hsh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)