### PR TITLE
fix(github): remove @familiar tagging from the comment composer (cave-803)

### DIFF
--- a/src/app/api/github/comment/route.ts
+++ b/src/app/api/github/comment/route.ts
@@ -3,8 +3,7 @@
  *
  * Posts a comment to an issue or pull-request conversation timeline
  * (REST `POST /repos/{owner}/{repo}/issues/{number}/comments`). Used by the
- * GitHub surface composer, including the familiar-tagging flow where the body
- * already carries the `@familiar` mention text.
+ * GitHub surface reply composer; the body is posted verbatim.
  *
  * Requires a PAT — the public API cannot write. The PAT is read-only from env,
  * never echoed to the client, never logged.

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -1023,7 +1023,7 @@ function PersonChip({ person, prefix }: { person: GitHubPerson; prefix?: string 
   );
 }
 
-// ── Comments + review threads (read · resolve · tag a familiar) ───────────────
+// ── Comments + review threads (read · resolve · reply) ───────────────────────
 
 type GhReaction = { content: string; count: number };
 
@@ -1206,17 +1206,15 @@ function ReviewEntry({ review, repo }: { review: GhReview; repo: string }) {
 
 /**
  * Reads the conversation timeline + inline PR review threads, resolves threads
- * (PAT only), and posts a reply with optional `@familiar` tagging. The whole
- * surface is reused verbatim by the native iOS app via the same API routes.
+ * (PAT only), and posts a reply. The whole surface is reused verbatim by the
+ * native iOS app via the same API routes.
  */
 function GitHubComments({
   item,
   detail,
-  familiars,
 }: {
   item: GitHubItem;
   detail: ItemDetail | null;
-  familiars: Familiar[];
 }) {
   const [state, setState] = useState<CommentsState>({ status: "idle" });
   const [tick, setTick] = useState(0);
@@ -1225,7 +1223,6 @@ function GitHubComments({
   const { announce } = useAnnouncer();
   const [postError, setPostError] = useState<string | null>(null);
   const [showResolved, setShowResolved] = useState(false);
-  const [familiarPickerOpen, setFamiliarPickerOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const repo = item.repo;
@@ -1236,7 +1233,6 @@ function GitHubComments({
   useEffect(() => {
     setDraft("");
     setPostError(null);
-    setFamiliarPickerOpen(false);
   }, [repo, number]);
 
   useEffect(() => {
@@ -1311,29 +1307,6 @@ function GitHubComments({
       // Revert by refetching the authoritative state.
       setTick((n) => n + 1);
     }
-  }
-
-  function insertMention(familiar: Familiar) {
-    const handle = (familiar.name ?? familiar.display_name).replace(/\s+/g, "-");
-    const mention = `@${handle}`;
-    const el = textareaRef.current;
-    if (!el) {
-      setDraft((d) => (d ? `${d} ${mention} ` : `${mention} `));
-    } else {
-      const start = el.selectionStart ?? draft.length;
-      const end = el.selectionEnd ?? draft.length;
-      const before = draft.slice(0, start);
-      const after = draft.slice(end);
-      const spacer = before && !before.endsWith(" ") ? " " : "";
-      const next = `${before}${spacer}${mention} ${after}`;
-      setDraft(next);
-      requestAnimationFrame(() => {
-        el.focus();
-        const pos = before.length + spacer.length + mention.length + 1;
-        el.setSelectionRange(pos, pos);
-      });
-    }
-    setFamiliarPickerOpen(false);
   }
 
   async function postComment() {
@@ -1474,7 +1447,7 @@ function GitHubComments({
                 className="gh-composer-input"
                 aria-label="Reply to this thread"
                 aria-keyshortcuts="Meta+Enter Control+Enter"
-                placeholder="Reply… use @ to tag a familiar (⌘↵ to send)"
+                placeholder="Reply… (⌘↵ to send)"
                 value={draft}
                 onChange={(e) => setDraft(e.target.value)}
                 onKeyDown={(e) => {
@@ -1487,39 +1460,6 @@ function GitHubComments({
               />
               {postError && <p className="gh-composer-error" role="alert">{postError}</p>}
               <div className="gh-composer-actions">
-                <div className="gh-composer-tag">
-                  <button
-                    type="button"
-                    className="gh-composer-tag-btn"
-                    onClick={() => setFamiliarPickerOpen((v) => !v)}
-                    aria-expanded={familiarPickerOpen}
-                    title="Tag a familiar"
-                    disabled={familiars.length === 0}
-                  >
-                    <Icon name="ph:at" width={12} />
-                    Tag familiar
-                  </button>
-                  {familiarPickerOpen && (
-                    <div className="gh-composer-tag-menu" role="menu">
-                      {familiars.map((f) => (
-                        <button
-                          key={f.id}
-                          type="button"
-                          role="menuitem"
-                          className="gh-composer-tag-item"
-                          onClick={() => insertMention(f)}
-                        >
-                          <span
-                            className="gh-task-chip-dot"
-                            style={{ background: f.color ?? "var(--accent-presence)" }}
-                            aria-hidden
-                          />
-                          {f.display_name}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
                 <Button
                   size="sm"
                   variant="primary"
@@ -2158,7 +2098,7 @@ function GitHubItemGlassPanel({
 
         <GitHubChecks item={item} />
 
-        <GitHubComments item={item} detail={detail} familiars={familiars} />
+        <GitHubComments item={item} detail={detail} />
 
         <div className="gh-glass-section">
           <div className="gh-glass-section-title">Linked work</div>

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1352,62 +1352,9 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
 .gh-composer-actions {
   display:flex;
   align-items:center;
-  justify-content:space-between;
+  justify-content:flex-end;
   gap:8px;
   margin-top:6px;
-}
-.gh-composer-tag { position:relative; }
-.gh-composer-tag-btn {
-  display:inline-flex;
-  align-items:center;
-  gap:4px;
-  padding:3px 9px;
-  border-radius:7px;
-  border:1px solid var(--border-hairline);
-  background:transparent;
-  color:var(--text-muted);
-  font-size:11px;
-  font-weight:550;
-  cursor:pointer;
-}
-.gh-composer-tag-btn:hover:not(:disabled) {
-  color:var(--text-secondary);
-  background:var(--bg-raised);
-}
-.gh-composer-tag-btn:disabled { opacity:0.4; cursor:default; }
-.gh-composer-tag-menu {
-  position:absolute;
-  bottom:calc(100% + 4px);
-  left:0;
-  z-index:20;
-  min-width:160px;
-  max-height:220px;
-  overflow-y:auto;
-  padding:4px;
-  border:1px solid var(--border-hairline);
-  border-radius:10px;
-  background:var(--bg-elevated);
-  box-shadow:0 8px 24px rgba(0,0,0,0.28);
-  display:flex;
-  flex-direction:column;
-  gap:2px;
-}
-.gh-composer-tag-item {
-  display:flex;
-  align-items:center;
-  gap:7px;
-  padding:5px 8px;
-  border-radius:7px;
-  background:none;
-  border:none;
-  color:var(--text-secondary);
-  font-size:12px;
-  text-align:left;
-  cursor:pointer;
-}
-.gh-composer-tag-item:hover {
-  background:var(--bg-hover);
-  color:var(--text-primary);
 }
 
 /* ── Person chip → clickable profile ─────────────────────────────────────── */


### PR DESCRIPTION
## Why

The GitHub PR/issue reply composer had a **Tag familiar** button + `@`-mention picker that inserted `@familiar` handles into the comment body. **It doesn't work as planned:** GitHub only recognizes real `@github-username` mentions, so a familiar name posts as inert plain text — it neither notifies nor routes anyone. The `/api/github/comment` route posts the body verbatim (no parsing/routing), so this was a dead affordance. The iOS app already dropped it (pinned by `scripts/ios-github-comment-attach.test.mjs`); this brings the web surface in line.

## Removed (from the `GitHubComments` composer)

- `familiarPickerOpen` state + its reset
- the `insertMention()` helper
- the `.gh-composer-tag` button + picker menu block
- the "use @ to tag a familiar" placeholder → plain "Reply… (⌘↵ to send)"
- the now-unused `familiars` prop (+ its call-site pass-through)
- the `.gh-composer-tag*` CSS; the lone Comment button is now right-aligned
- refreshed two doc comments + the `/api/github/comment` route header

## Untouched (separate, working features)

- **Plain reply posting** — textarea, `postComment`, Comment button
- The **`github-action-popover`** chat/assign quick actions
- The **`useFamiliars`** hook (still used by those popovers)
- **Group chat's** own `@`-tag targeting (a different surface/feature)

## Verification

`typecheck` clean · **550 app tests** · **743 wired**. No test constructs `GitHubComments`; the only tag-familiar test pin (`ios-github-comment-attach`) asserts the iOS composer stays tag-free and continues to pass.

Net: **+7 / −121**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)