### PR TITLE
feat(marketplace): merge the Skills filter rail and leaderboard into one panel (cave-8hn)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12026,25 +12026,23 @@ details[open] > .cave-edit-card__summary::before {
   min-height: 0;
   background: var(--bg-base);
 }
+/* Filter strip — lives INSIDE the merged list panel (below the leaderboard
+   header): labeled groups flow inline as wrapping chip rows. */
 .skill-browser__rail {
-  flex: 0 0 224px;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 12px 10px;
-  overflow-y: auto;
-  border-right: 1px solid var(--border-hairline);
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  padding: 2px 2px 10px;
+  border-bottom: 1px solid var(--border-hairline);
 }
-/* Each filter panel (categories, browse, topics, rank, agents) is one labeled
-   group in the rail; hairlines keep the groups reading as separate panels. */
 .skill-browser__rail-group {
+  flex: 0 1 auto;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
-}
-.skill-browser__rail-group + .skill-browser__rail-group {
-  border-top: 1px solid var(--border-hairline);
-  padding-top: 12px;
 }
 .skill-browser__rail-label {
   margin: 0;
@@ -12056,10 +12054,12 @@ details[open] > .cave-edit-card__summary::before {
   color: var(--text-muted);
 }
 .skill-browser__cat {
+  flex: 0 0 auto;
   display: flex;
   align-items: center;
-  gap: 9px;
-  padding: 8px 10px;
+  gap: 7px;
+  padding: 5px 9px;
+  white-space: nowrap;
   border-radius: 8px;
   border: 1px solid transparent;
   background: transparent;
@@ -12078,11 +12078,13 @@ details[open] > .cave-edit-card__summary::before {
 }
 .skill-browser__cat-icon { flex: 0 0 auto; color: var(--text-muted); }
 .skill-browser__cat.is-active .skill-browser__cat-icon { color: var(--accent-presence); }
-.skill-browser__cat-label { flex: 1; min-width: 0; }
+.skill-browser__cat-label { flex: 0 0 auto; }
 .skill-browser__cat-count { flex: 0 0 auto; font-variant-numeric: tabular-nums; font-size: 12px; color: var(--text-muted); }
 
 .skill-browser__list {
-  flex: 0 0 300px;
+  /* Merged panel (leaderboard header + filter strip + ranked list) absorbs
+     the old 224px rail's width alongside the previous 300px list. */
+  flex: 0 0 420px;
   min-width: 0;
   display: flex;
   flex-direction: column;
@@ -12605,53 +12607,23 @@ details[open] > .cave-edit-card__summary::before {
 @media (prefers-reduced-motion: reduce) { .skill-browser__skeleton span { animation: none; } }
 
 @media (max-width: 900px) {
-  /* Narrow panes: the rail becomes a horizontal strip spanning the top and
-     the browser re-lays as a grid (strip / list · detail). The rail is the
-     ONLY filter control — hiding it stranded 681-900px panes with whatever
-     filters were last picked and no way to change them. */
+  /* Narrow panes: the merged panel and the detail pane share the width as a
+     two-column grid (the filter strip already lives inside the panel). */
   .skill-browser {
     display: grid;
     grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
   }
-  .skill-browser__rail {
-    grid-column: 1 / -1;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 6px 16px;
-    overflow: visible;
-    padding: 8px 10px;
-    border-right: 0;
-    border-bottom: 1px solid var(--border-hairline);
-  }
-  /* Groups flow inline (label then chips) and wrap as the pane narrows. */
-  .skill-browser__rail-group {
-    flex: 0 1 auto;
-    flex-direction: row;
-    align-items: center;
-    flex-wrap: wrap;
-  }
-  .skill-browser__rail-group + .skill-browser__rail-group {
-    border-top: 0;
-    padding-top: 0;
-  }
-  .skill-browser__rail-label { flex: 0 0 auto; }
-  .skill-browser__cat {
-    flex: 0 0 auto;
-    padding: 5px 9px;
-    white-space: nowrap;
-  }
-  .skill-browser__cat-label { flex: 0 0 auto; }
 }
 @media (max-width: 680px) {
-  /* Single column: strip / list / detail (the ≤900px grid handles columns). */
+  /* Single column: merged panel over detail. */
   .skill-browser {
+    display: grid;
     grid-template-columns: minmax(0, 1fr);
-    grid-template-rows: auto minmax(0, 1.2fr) minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1.2fr) minmax(0, 1fr);
   }
-  .skill-browser__rail { grid-column: 1; }
-  /* Phone widths: one full-width row per group; the group owns the sideways
-     scroll (the categories group has no inner chip container). */
+  /* Phone widths: one full-width row per filter group; the group owns the
+     sideways scroll (the categories group has no inner chip container). */
   .skill-browser__rail-group {
     flex: 1 1 100%;
     flex-wrap: nowrap;

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -6,11 +6,18 @@ const src = readFileSync(new URL("./skill-browser.tsx", import.meta.url), "utf8"
 const hub = readFileSync(new URL("./marketplace-view.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
-// ── Three-column browser: rail · list · detail ───────────────────────────────
+// ── Merged discovery panel (header + filters + list) · detail pane ──────────
 assert.match(src, /export function SkillBrowser\(/, "exports the SkillBrowser component");
-assert.match(src, /className="skill-browser__rail"/, "renders the category rail");
-assert.match(src, /className="skill-browser__list"/, "renders the card list");
+assert.match(src, /className="skill-browser__rail"/, "renders the filter strip");
+assert.match(src, /className="skill-browser__list"/, "renders the merged discovery panel");
 assert.match(src, /className="skill-browser__detail"/, "renders the detail pane");
+// Merged panel: the leaderboard header and the filter strip both live INSIDE
+// the list panel (panel opens, then header, then filters) — not beside it.
+assert.ok(
+  src.indexOf('className="skill-browser__list"') < src.indexOf('className="skill-browser__leaderboard"') &&
+    src.indexOf('className="skill-browser__leaderboard"') < src.indexOf('className="skill-browser__rail"'),
+  "leaderboard header and filter strip are nested inside the merged list panel, header first",
+);
 
 // Category rail: All / Installed / Claude Code / Generic with derived counts.
 assert.match(src, /label: "All Skills"/, "rail has an All Skills entry");
@@ -192,8 +199,13 @@ assert.match(css, /\.skill-browser__card \{[\s\S]*?min-height: 72px;/, "skill ca
 assert.match(css, /\.skill-browser__card\.is-active \{/, "the selected card is highlighted");
 assert.match(
   css,
-  /@media \(max-width: 900px\)[\s\S]*?\.skill-browser__rail \{[\s\S]*?flex-direction: row/,
-  "the rail becomes a horizontal strip on small screens — it is the only category control, so it must never be display:none",
+  /\.skill-browser__rail \{[\s\S]*?flex-direction: row/,
+  "the filter strip is a horizontal chip row inside the merged panel at every width",
+);
+assert.doesNotMatch(
+  css,
+  /\.skill-browser__rail[^{]*\{[^}]*display:\s*none/,
+  "the filter strip is the only category control, so it must never be display:none",
 );
 
 console.log("skill-browser.test.ts OK");

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -615,9 +615,37 @@ export function SkillBrowser({
 
   return (
     <div className="skill-browser" role="group" aria-label="Skill browser">
-      {/* ── Filter rail — every filter panel lives here, grouped under a
-             labeled section, so the list column is just the leaderboard. ── */}
-      <nav className="skill-browser__rail" aria-label="Skill filters">
+      {/* ── Merged panel — leaderboard header, then the filter strip, then
+             the ranked list. One panel owns discovery end-to-end; the detail
+             pane sits beside it. ── */}
+      <div className="skill-browser__list">
+        <div className="skill-browser__leaderboard">
+          <div>
+            <p className="skill-browser__leaderboard-kicker">Skills Leaderboard</p>
+            <p className="skill-browser__leaderboard-title">{formatCount(skills.reduce((sum, skill) => sum + (skill.installsAllTime ?? 0), 0))} installs tracked</p>
+          </div>
+          <div className="skill-browser__ecosystem">
+            <div className="skill-browser__ecosystem-command">
+              {/* The command tracks the selection — say so, or a generic
+                  "Try it now" silently changes meaning three columns over. */}
+              <span>{selected ? `Install ${selected.name}` : "Try it now"}</span>
+              <code title={ecosystemCommand}>{ecosystemCommand}</code>
+            </div>
+            <div className="skill-browser__agent-strip" aria-label="Available for these agents">
+              {FEATURED_AGENT_LABELS.map((name) => (
+                <span key={name}>{name}</span>
+              ))}
+            </div>
+            <nav className="skill-browser__directory-links" aria-label="Skills directory links">
+              {SKILLS_DIRECTORY_LINKS.map((link) => (
+                <a key={link.href} href={link.href} target="_blank" rel="noreferrer">
+                  {link.label}
+                </a>
+              ))}
+            </nav>
+          </div>
+        </div>
+        <nav className="skill-browser__rail" aria-label="Skill filters">
         <div className="skill-browser__rail-group" role="group" aria-label="Skill categories">
           <p className="skill-browser__rail-label">Categories</p>
           {RAIL.map((cat) => {
@@ -722,36 +750,7 @@ export function SkillBrowser({
             </div>
           </div>
         ) : null}
-      </nav>
-
-      {/* ── Card list ────────────────────────────────────────────────── */}
-      <div className="skill-browser__list">
-        <div className="skill-browser__leaderboard">
-          <div>
-            <p className="skill-browser__leaderboard-kicker">Skills Leaderboard</p>
-            <p className="skill-browser__leaderboard-title">{formatCount(skills.reduce((sum, skill) => sum + (skill.installsAllTime ?? 0), 0))} installs tracked</p>
-          </div>
-          <div className="skill-browser__ecosystem">
-            <div className="skill-browser__ecosystem-command">
-              {/* The command tracks the selection — say so, or a generic
-                  "Try it now" silently changes meaning three columns over. */}
-              <span>{selected ? `Install ${selected.name}` : "Try it now"}</span>
-              <code title={ecosystemCommand}>{ecosystemCommand}</code>
-            </div>
-            <div className="skill-browser__agent-strip" aria-label="Available for these agents">
-              {FEATURED_AGENT_LABELS.map((name) => (
-                <span key={name}>{name}</span>
-              ))}
-            </div>
-            <nav className="skill-browser__directory-links" aria-label="Skills directory links">
-              {SKILLS_DIRECTORY_LINKS.map((link) => (
-                <a key={link.href} href={link.href} target="_blank" rel="noreferrer">
-                  {link.label}
-                </a>
-              ))}
-            </nav>
-          </div>
-        </div>
+        </nav>
         {!loaded ? (
           <div className="skill-browser__note" role="status">
             Loading skills…


### PR DESCRIPTION
## Summary

Per request (screenshot): the Skills tab showed **two panels** — a separate left filter rail and the Skills Leaderboard. They're now **one panel**: leaderboard header → inline filter chip groups → ranked list, with the detail pane beside it.

- JSX: the filter `<nav>` moved inside `.skill-browser__list`, below the leaderboard header (all filters, counts, and aria groups unchanged)
- CSS: the ≤900px horizontal-strip treatment promoted to the base; merged panel takes 420px; media queries simplify (≤900px: panel | detail grid; ≤680px: stacked) with phone-width per-group chip scrolling preserved
- Tests: structural assertions updated + a new nesting invariant (header before filters, both inside the panel); the never-display:none guard for the filter strip retained

## Verification
- `skill-browser.test.ts`, `roles-tools-navigation.test.ts`, `minimalism-invariants.test.ts` pass; full `pnpm test:app` 550 files green; `pnpm typecheck` + `pnpm build` (bundle budget) clean
- Visual: built and served the branch, drove Marketplace → Skills with Playwright — single merged panel renders with live directory data (screenshot verified)

Bead: cave-8hn