### PR TITLE
refactor(calendar): standardize action controls on shared Button/IconButton primitives (cave-4op)

### DIFF
--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -207,4 +207,59 @@ assert.match(source, /borderLeftColor: accent, borderLeftWidth: 3/, "the accent 
 assert.match(source, /legendFamiliars\.length >= 2/, "the colour legend only shows when ≥2 familiars are in view");
 assert.match(source, /aria-label="Familiar colour legend"/, "the legend is labelled");
 
-console.log("calendar-view-polish.test.ts: month click-to-add + familiar colours ok");
+// ───────── cave-4op: action controls use the shared Button / IconButton primitives ─────────
+// The Calendar's *action controls* — the item detail panel (Close/Open/Done/
+// Dismiss) and the empty-state / agenda actions (Add task, Show past, Hide
+// past) — are standardized onto the shared primitives so their radius, height,
+// focus ring, and disabled treatment come from one place (cave-4op). Bespoke
+// *content* elements (item/deadline chips, draggable time-grid events, month &
+// mini-month date cells) and the tightly-pinned toolbar / segmented switcher
+// are deliberately out of scope here — they are not standard controls.
+assert.match(
+  source,
+  /import \{ Button \} from "@\/components\/ui\/button"/,
+  "calendar imports the shared Button primitive",
+);
+assert.match(
+  source,
+  /import \{ IconButton \} from "@\/components\/ui\/icon-button"/,
+  "calendar imports the shared IconButton primitive",
+);
+
+/** Slice out a top-level function body by name, up to the next function decl. */
+function fnRegion(name) {
+  const m = new RegExp(`function ${name}\\(`).exec(source);
+  assert.ok(m, `${name} must exist`);
+  const after = source.slice(m.index + m[0].length);
+  const next = /\n(?:export )?function \w+\(/.exec(after);
+  return after.slice(0, next ? next.index : after.length);
+}
+
+// No raw <button> survives in the standardized control clusters.
+for (const name of ["EmptyScheduleState", "AgendaView", "ItemDetailPanel"]) {
+  assert.doesNotMatch(
+    fnRegion(name),
+    /<button\b/,
+    `${name} action controls use <Button>/<IconButton>, not a raw <button>`,
+  );
+}
+
+const detail = fnRegion("ItemDetailPanel");
+assert.match(detail, /<IconButton\b[\s\S]*?aria-label="Close"/, "detail panel Close is an IconButton");
+assert.match(detail, /<Button\b[\s\S]*?variant="primary"/, "detail panel Open is a primary Button");
+assert.match(detail, /<Button\b[\s\S]*?variant="secondary"[\s\S]*?Done/, "detail panel Done is a secondary Button");
+assert.match(detail, /<IconButton\b[\s\S]*?aria-label="Dismiss"/, "detail panel Dismiss is an IconButton");
+
+// The empty-state / agenda actions keep their mobile hook while using the primitive.
+assert.match(
+  fnRegion("EmptyScheduleState"),
+  /<Button\b[\s\S]*?className="calendar-empty-action"/,
+  "empty-schedule Add action is a Button that keeps the mobile hook",
+);
+assert.match(
+  fnRegion("AgendaView"),
+  /<Button\b[\s\S]*?className="calendar-empty-action"/,
+  "agenda empty-state actions are Buttons that keep the mobile hook",
+);
+
+console.log("calendar-view-polish.test.ts: month click-to-add + familiar colours + cave-4op control primitives ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -11,6 +11,8 @@ import { formatClock, formatDate, readDateTimePrefs } from "@/lib/datetime-forma
 import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { itemDate, packEventColumns } from "@/lib/calendar-layout";
 import { familiarInScope } from "@/lib/familiar-multiselect";
@@ -266,14 +268,14 @@ function EmptyScheduleState({
       <Icon name={icon} className="text-3xl opacity-30" />
       <span>{label}</span>
       {onAddEntry ? (
-        <button
-          type="button"
+        <Button
+          size="sm"
+          leadingIcon="ph:plus"
           onClick={onAddEntry}
-          className="calendar-empty-action inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 text-[11px] font-medium text-[var(--text-primary)] transition-colors hover:bg-[var(--bg-elevated)]"
+          className="calendar-empty-action"
         >
-          <Icon name="ph:plus" width={12} />
           Add task or event
-        </button>
+        </Button>
       ) : null}
     </div>
   );
@@ -338,23 +340,23 @@ function AgendaView({
         <Icon name="ph:calendar-blank" width={32} className="text-[var(--text-muted)]" />
         <div>Nothing scheduled upcoming.</div>
         {pastCount > 0 && !showPast ? (
-          <button
-            type="button"
+          <Button
+            size="sm"
             onClick={() => setShowPast(true)}
-            className="calendar-empty-action focus-ring rounded-md border border-[var(--border-hairline)] px-3 py-1 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-empty-action"
           >
             Show {pastCount} past item{pastCount !== 1 ? "s" : ""}
-          </button>
+          </Button>
         ) : null}
         {onAddEntry ? (
-          <button
-            type="button"
+          <Button
+            size="sm"
+            leadingIcon="ph:plus"
             onClick={() => onAddEntry({ fireAt: defaultEntryFireAt(anchor) })}
-            className="calendar-empty-action focus-ring inline-flex items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-3 py-1 text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-empty-action"
           >
-            <Icon name="ph:plus" width={11} />
             Add task or event
-          </button>
+          </Button>
         ) : null}
       </div>
     );
@@ -364,13 +366,14 @@ function AgendaView({
     <div className="flex flex-col gap-6 overflow-y-auto px-3 py-4 sm:px-6">
       {showPast ? (
         <div className="-mb-2 flex justify-end">
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="xs"
             onClick={() => setShowPast(false)}
-            className="calendar-empty-action focus-ring rounded-md px-2 py-0.5 text-[10px] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-empty-action"
           >
             Hide past
-          </button>
+          </Button>
         </div>
       ) : null}
       {groups.map(({ date, items: groupItems, deadlines: groupDeadlines }) => {
@@ -1360,13 +1363,13 @@ function ItemDetailPanel({
               {item.title}
             </span>
           </div>
-          <button
-            onClick={onClose}
+          <IconButton
+            icon="ph:x"
             aria-label="Close"
-            className="focus-ring shrink-0 rounded text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-          >
-            <Icon name="ph:x" width={14} />
-          </button>
+            size="sm"
+            onClick={onClose}
+            className="shrink-0"
+          />
         </div>
 
         <div className="flex flex-col gap-3 px-4 py-3 text-[12px] text-[var(--text-secondary)] overflow-y-auto flex-1">
@@ -1402,23 +1405,27 @@ function ItemDetailPanel({
 
         <div className="flex flex-col gap-2 border-t border-[var(--border-hairline)] px-4 py-3">
           {openLabel && onOpen ? (
-            <button
+            <Button
+              variant="primary"
+              size="sm"
+              fullWidth
+              leadingIcon="ph:arrow-square-out"
               onClick={() => { onOpen(item); onClose(); }}
-              className="focus-ring inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-[var(--accent-presence)] px-3 py-1.5 text-[11px] text-[var(--accent-presence-foreground)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)]"
             >
-              <Icon name="ph:arrow-square-out" width={12} />
               {openLabel}
-            </button>
+            </Button>
           ) : null}
           <div className="flex items-center gap-2">
             {!isDone && onComplete ? (
-              <button
+              <Button
+                variant="secondary"
+                size="sm"
+                leadingIcon="ph:check"
                 onClick={() => { onComplete(item.id); announce(`Marked "${item.title}" done`); onClose(); }}
-                className="focus-ring inline-flex flex-1 items-center justify-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-1.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                className="flex-1"
               >
-                <Icon name="ph:check" width={12} />
                 Done
-              </button>
+              </Button>
             ) : null}
             {onSnooze ? (
               <SnoozeMenu
@@ -1427,14 +1434,13 @@ function ItemDetailPanel({
               />
             ) : null}
             {onDismiss ? (
-              <button
-                onClick={() => { onDismiss(item.id); announce(`Dismissed "${item.title}"`); onClose(); }}
+              <IconButton
+                icon="ph:trash"
                 aria-label="Dismiss"
-                className="focus-ring inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-[var(--border-hairline)] text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                onClick={() => { onDismiss(item.id); announce(`Dismissed "${item.title}"`); onClose(); }}
+                className="shrink-0"
                 title="Dismiss"
-              >
-                <Icon name="ph:trash" width={12} />
-              </button>
+              />
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
Incremental slice of **cave-4op** (Standardize Cave controls), on the **Calendar** surface.

## What changed

Converts the Calendar's two **action-control clusters** from hand-rolled `<button>` markup to the shared `Button` / `IconButton` primitives, so radius (`--radius-control`), height, focus ring, and disabled treatment come from one place:

- **Item detail panel** — Close → `IconButton`, Open → primary `Button`, Done → secondary `Button`, Dismiss → `IconButton`.
- **Empty-state / agenda actions** — "Add task or event" (×2), "Show N past items", "Hide past" → `Button`.

8 of the surface's 29 `<button>`s. The remaining 21 are **intentionally left as-is** and documented in the test:

- Bespoke **content** elements — item/deadline chips, draggable time-grid event blocks (`data-calendar-event`, absolute-positioned, keyboard-reschedulable), month & mini-month date cells, "+N more" overflow — these are not standard controls and the primitives would regress their drag/positioning/layout.
- The **toolbar / segmented view switcher** — tightly pinned to raw markup + mobile CSS hooks (`calendar-toolbar-*`); a follow-up slice can take it cleanly.

## Preserved (no behavior change)

- Every `onClick` handler body is byte-identical → the behavioral pins in `calendar-actions.test.ts` (`onComplete(id); announce(...); onClose()`, etc.) stay green.
- The `calendar-empty-action` mobile hit-target hook is kept via `className` on the converted empty-state actions.

## Verification

- `calendar-view-polish.test.ts` / `calendar-actions.test.ts` / `calendar-keyboard.test.ts` — pass. Adds a scoped guard to the polish test: the `EmptyScheduleState`, `AgendaView`, and `ItemDetailPanel` regions carry **no raw `<button>`** and use the primitives.
- `pnpm typecheck` — clean (primitive prop types check, incl. `IconButton`'s required `aria-label`).
- `pnpm check:tests-wired` — 743 wired.
- `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)