### PR TITLE
refactor(calendar): standardize toolbar controls on shared Button/IconButton primitives (cave-4op)

### DIFF
--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -142,8 +142,8 @@ assert.doesNotMatch(
 );
 assert.equal(
   (source.match(/Add event/g) ?? []).length,
-  2, // aria-label + button label of the single toolbar button
-  "Exactly one Add event button (toolbar), counted via its label + aria-label",
+  1, // the single toolbar button's visible label (now a shared <Button>, no redundant aria-label)
+  "Exactly one Add event button (toolbar)",
 );
 assert.match(
   source,
@@ -152,14 +152,22 @@ assert.match(
 );
 assert.match(
   source,
-  /inline-flex h-7 items-center rounded-md border[\s\S]{0,200}Today/,
-  "Today button matches the h-7 toolbar height",
+  /<Button[\s\S]{0,200}className="calendar-toolbar-button"\s*>\s*Today\s*<\/Button>/,
+  "Today is the shared Button primitive, keeping the toolbar mobile hook",
 );
 assert.match(
   source,
-  /aria-label="Add event"/,
-  "Toolbar Add event button is labeled",
+  /<Button[\s\S]{0,220}leadingIcon="ph:plus-bold"[\s\S]{0,160}>\s*Add event\s*<\/Button>/,
+  "Toolbar Add event is the shared Button primitive with its label",
 );
+
+// cave-4op toolbar slice: the nav arrows are shared IconButtons and the raw
+// hand-rolled toolbar control markup is gone. The segmented view switcher and
+// the heading / jump-to-date trigger stay bespoke (a segmented control and a
+// text trigger, not standard buttons).
+assert.match(source, /<IconButton[\s\S]{0,80}icon="ph:arrow-left-bold"[\s\S]{0,80}aria-label="Previous"/, "toolbar Previous is an IconButton");
+assert.match(source, /<IconButton[\s\S]{0,80}icon="ph:arrow-right-bold"[\s\S]{0,80}aria-label="Next"/, "toolbar Next is an IconButton");
+assert.doesNotMatch(source, /grid h-7 w-7 place-items-center rounded-md text-\[var\(--text-muted\)\]/, "no hand-rolled toolbar nav-arrow markup remains");
 
 // ───────── Mobile toolbar hit areas ─────────
 assert.match(source, /calendar-toolbar/, "Calendar toolbar should expose a stable mobile hook");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1629,26 +1629,26 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
       <div className="calendar-toolbar flex shrink-0 flex-wrap items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-3 sm:gap-3 sm:px-6">
         <div className="flex shrink-0 items-center gap-1">
           {/* Nav arrows */}
-          <button
-            onClick={() => navigate(-1)}
+          <IconButton
+            icon="ph:arrow-left-bold"
             aria-label="Previous"
-            className="calendar-toolbar-icon focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-          >
-            <Icon name="ph:arrow-left-bold" width={12} />
-          </button>
-          <button
+            onClick={() => navigate(-1)}
+            className="calendar-toolbar-icon"
+          />
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => setAnchor(new Date())}
-            className="calendar-toolbar-button focus-ring inline-flex h-7 items-center rounded-md border border-[var(--border-hairline)] px-2.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)]"
+            className="calendar-toolbar-button"
           >
             Today
-          </button>
-          <button
-            onClick={() => navigate(1)}
+          </Button>
+          <IconButton
+            icon="ph:arrow-right-bold"
             aria-label="Next"
-            className="calendar-toolbar-icon focus-ring grid h-7 w-7 place-items-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-          >
-            <Icon name="ph:arrow-right-bold" width={12} />
-          </button>
+            onClick={() => navigate(1)}
+            className="calendar-toolbar-icon"
+          />
         </div>
 
         {/* Heading + pending pill + jump-to-date popover */}
@@ -1696,15 +1696,15 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
         </div>
 
         {onAddEntry ? (
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon="ph:plus-bold"
             onClick={() => onAddEntry({ fireAt: defaultEntryFireAt(anchor) })}
-            aria-label="Add event"
-            className="calendar-toolbar-button focus-ring inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-2 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="calendar-toolbar-button shrink-0"
           >
-            <Icon name="ph:plus-bold" width={10} />
             Add event
-          </button>
+          </Button>
         ) : null}
       </div>
 


### PR DESCRIPTION
Follow-up to #2565 — the **toolbar** slice of **cave-4op** (Standardize Cave controls) on the Calendar surface.

## What changed

Converts the Calendar's main toolbar row from hand-rolled `<button>` markup to the shared primitives:

- **Prev / Next nav arrows** → `IconButton` (md = 28px, an exact match for the old `h-7 w-7`).
- **Today** and **Add event** → `Button` (secondary; Add event keeps its `ph:plus-bold` leading icon).

## Left bespoke by design

- **Segmented view switcher** (Agenda/Day/Week/Month) — a segmented-control pattern (connected, shared border, `aria-pressed`), not individual buttons; its existing `h-7` pin is unchanged.
- **Heading / jump-to-date trigger** — a text trigger for the mini-month popover, not a standard control.
- Content chips, draggable event blocks, month & mini-month date cells — out of scope as in #2565.

17 raw `<button>`s remain (all of the above); 4 toolbar controls converted here, 8 in #2565.

## Preserved

- The `calendar-toolbar-*` mobile hit-target hooks (media-query `min-height/width: var(--touch-target)`) are kept via `className` on the converted controls.
- `navigate()` / `setAnchor(new Date())` / `onAddEntry(...)` handlers unchanged.

## Verification

- `calendar-view-polish` / `calendar-actions` / `calendar-keyboard` tests pass. Updated the toolbar pins to assert the primitives (Today, Add event, both arrows) and that the raw `grid h-7 w-7 place-items-center` nav-arrow markup is gone; the segmented-switcher pin is untouched.
- `pnpm typecheck` clean · `check:tests-wired` 748 · `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)