### PR TITLE
refactor(calendar): standardize jump-to-date mini-month controls on shared primitives (cave-4op)

### DIFF
--- a/src/components/calendar-view-polish.test.ts
+++ b/src/components/calendar-view-polish.test.ts
@@ -270,4 +270,28 @@ assert.match(
   "agenda empty-state actions are Buttons that keep the mobile hook",
 );
 
+// cave-4op mini-month micro-slice: the jump-to-date popover's month nav arrows
+// and its Today shortcut use the shared primitives. The day-cell grid stays
+// bespoke (date cells with today/anchor states, not standard controls).
+assert.match(
+  source,
+  /<IconButton[\s\S]{0,80}icon="ph:arrow-left-bold"[\s\S]{0,80}aria-label="Previous month"/,
+  "mini-month Previous is an IconButton",
+);
+assert.match(
+  source,
+  /<IconButton[\s\S]{0,80}icon="ph:arrow-right-bold"[\s\S]{0,80}aria-label="Next month"/,
+  "mini-month Next is an IconButton",
+);
+assert.match(
+  source,
+  /<Button[\s\S]{0,120}fullWidth[\s\S]{0,140}onClick=\{\(\) => onPick\(today\)\}[\s\S]{0,40}>\s*Today\s*<\/Button>/,
+  "mini-month Today is a fullWidth Button",
+);
+assert.doesNotMatch(
+  source,
+  /grid h-6 w-6 place-items-center rounded-md/,
+  "no hand-rolled mini-month nav-arrow markup remains",
+);
+
 console.log("calendar-view-polish.test.ts: month click-to-add + familiar colours + cave-4op control primitives ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1236,25 +1236,21 @@ function MiniMonthPopover({
       className="absolute top-full left-0 z-20 mt-2 w-[260px] rounded-lg border border-[var(--border-strong)] bg-[var(--bg-elevated)] p-3 shadow-2xl"
     >
       <div className="mb-2 flex items-center justify-between gap-2">
-        <button
-          type="button"
-          onClick={() => setView((d) => { const n = new Date(d); n.setMonth(n.getMonth() - 1); return n; })}
-          className="focus-ring grid h-6 w-6 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        <IconButton
+          icon="ph:arrow-left-bold"
           aria-label="Previous month"
-        >
-          <Icon name="ph:arrow-left-bold" width={10} />
-        </button>
+          size="sm"
+          onClick={() => setView((d) => { const n = new Date(d); n.setMonth(n.getMonth() - 1); return n; })}
+        />
         <span className="text-[12px] font-medium text-[var(--text-primary)]">
           {MONTHS[view.getMonth()]} {view.getFullYear()}
         </span>
-        <button
-          type="button"
-          onClick={() => setView((d) => { const n = new Date(d); n.setMonth(n.getMonth() + 1); return n; })}
-          className="focus-ring grid h-6 w-6 place-items-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        <IconButton
+          icon="ph:arrow-right-bold"
           aria-label="Next month"
-        >
-          <Icon name="ph:arrow-right-bold" width={10} />
-        </button>
+          size="sm"
+          onClick={() => setView((d) => { const n = new Date(d); n.setMonth(n.getMonth() + 1); return n; })}
+        />
       </div>
       <div className="mb-1 grid grid-cols-7 gap-px text-[9px] uppercase tracking-widest text-[var(--text-muted)]">
         {WEEKDAYS.map((wd) => <div key={wd} className="text-center">{wd.slice(0, 1)}</div>)}
@@ -1286,13 +1282,15 @@ function MiniMonthPopover({
           );
         })}
       </div>
-      <button
-        type="button"
+      <Button
+        variant="secondary"
+        size="sm"
+        fullWidth
         onClick={() => onPick(today)}
-        className="focus-ring mt-2 w-full rounded-md border border-[var(--border-hairline)] py-1 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+        className="mt-2"
       >
         Today
-      </button>
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
Micro-slice completing the **Calendar** surface's control standardization for **cave-4op** — after #2565 (detail panel + empty-state) and #2566 (toolbar).

## What changed

Converts the **MiniMonthPopover** (the toolbar's jump-to-date popover):

- **Prev / Next month** nav arrows → `IconButton` (sm = 24px, an exact match for the old `h-6 w-6`).
- **Today** shortcut → a full-width `Button`.

## Left bespoke by design

The month-grid **day cells** stay raw `<button>` — they're date cells carrying today/anchor/selected states, not standard controls (same rationale as the month-view cells).

## Preserved

- Handlers unchanged: `setView(month ± 1)`, `onPick(today)`.
- Popover focus-trap / `aria-label="Jump to date"` / heading toggle untouched.

## Verification

- `calendar-view-polish` / `calendar-actions` / `calendar-keyboard` tests pass. Adds mini-month pins asserting the primitives (both arrows + full-width Today) and that the raw `grid h-6 w-6 place-items-center` markup is gone.
- `pnpm typecheck` clean · `check:tests-wired` 748 · `git diff --check` clean.
- Rebased onto current `main` (post-#2566) so CI validates the integrated state.

After this, the Calendar surface's remaining raw `<button>`s are all genuinely bespoke content (item/deadline chips, draggable time-grid event blocks, month & mini-month date cells, "+N more" overflow) and the segmented view switcher — not standard controls. This closes out the calendar for cave-4op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)