### PR TITLE
feat(workflow): Work Queue "Needs attention" strip for stale + unlinked PRs (cave-x1j)

### DIFF
--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -12,6 +12,7 @@ import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   buildWorkQueue,
   hasVerificationEvidence,
+  type AttentionItem,
   type ReadyBead,
   type MergedPrRef,
   type WorkQueue,
@@ -270,6 +271,8 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         </div>
       ) : null}
 
+      {q.attention.length > 0 ? <AttentionStrip items={q.attention} onOpenUrl={onOpenUrl} /> : null}
+
       <div className="fwq-body">
         {q.total === 0 ? (
           <EmptyState
@@ -319,6 +322,66 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         )}
       </div>
     </div>
+  );
+}
+
+/**
+ * Repo-wide housekeeping callout for the two gaps the CLI patrol flags: open
+ * PRs with no linked bead (invisible to the queue) and/or gone stale. Global —
+ * NOT filtered by the familiar chips, since an unlinked PR has no familiar and
+ * this is repo hygiene, not one familiar's queue.
+ */
+function AttentionStrip({
+  items,
+  onOpenUrl,
+}: {
+  items: AttentionItem[];
+  onOpenUrl?: (url: string) => void;
+}) {
+  const unlinkedCount = items.filter((i) => i.unlinked).length;
+  const staleCount = items.filter((i) => i.stale).length;
+  const summary = [
+    unlinkedCount ? `${unlinkedCount} unlinked` : null,
+    staleCount ? `${staleCount} stale` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <section className="fwq-attention" aria-label="PRs needing attention">
+      <header className="fwq-attention-head">
+        <Icon name="ph:warning-circle" width={14} aria-hidden />
+        <span className="fwq-attention-title">Needs attention</span>
+        <span className="fwq-attention-summary">{summary}</span>
+      </header>
+      <ul className="fwq-attention-list">
+        {items.map(({ pr, unlinked, stale }) => (
+          <li key={pr.number} className="fwq-attention-item">
+            <div className="fwq-attention-main">
+              <span className="fwq-pr-num">#{pr.number}</span>
+              <span className="fwq-attention-name">{pr.title}</span>
+            </div>
+            <div className="fwq-attention-tags">
+              {unlinked ? (
+                <span className="fwq-tag fwq-tag--unlinked" title="No linked bead — invisible to the queue">
+                  no bead
+                </span>
+              ) : null}
+              {stale ? <span className="fwq-tag fwq-tag--stale">stale</span> : null}
+            </div>
+            <Button
+              variant="ghost"
+              size="xs"
+              trailingIcon="ph:arrow-square-out"
+              onClick={() => onOpenUrl?.(pr.url)}
+              disabled={!onOpenUrl}
+            >
+              Open PR
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </section>
   );
 }
 

--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -164,4 +164,30 @@ assert.equal(
   "notes without a comment are not verification evidence",
 );
 
+// ── Attention: unlinked and/or stale open PRs, with the PR summary (cave-x1j) ─
+{
+  const beads = [bead("cave-a", { labels: ["familiar:kitty"] })];
+  const prs = [
+    pr(1, "needs-review", { beads: ["cave-a"], updatedAgoHours: 40 }), // stale, linked
+    pr(2, "checks-failing", { beads: [], updatedAgoHours: 40 }), // unlinked AND stale
+    pr(3, "needs-review", { beads: [] }), // unlinked only (fresh)
+    pr(4, "ready-to-merge", { beads: ["cave-a"], updatedAgoHours: 1 }), // clean → excluded
+  ];
+  const q = buildWorkQueue(beads, prs, [], { nowMs: NOW, staleAfterHours: 24 });
+  assert.deepEqual(q.attention.map((a) => a.pr.number), [1, 2, 3], "clean PRs excluded; sorted by number");
+  const byNum = Object.fromEntries(q.attention.map((a) => [a.pr.number, a]));
+  assert.deepEqual({ u: byNum[1].unlinked, s: byNum[1].stale }, { u: false, s: true }, "#1 stale only");
+  assert.deepEqual({ u: byNum[2].unlinked, s: byNum[2].stale }, { u: true, s: true }, "#2 unlinked AND stale");
+  assert.deepEqual({ u: byNum[3].unlinked, s: byNum[3].stale }, { u: true, s: false }, "#3 unlinked only");
+  assert.ok(q.attention.every((a) => a.pr.title && a.pr.url), "carries the PR summary for display");
+
+  const clean = buildWorkQueue(
+    beads,
+    [pr(9, "ready-to-merge", { beads: ["cave-a"], updatedAgoHours: 1 })],
+    [],
+    { nowMs: NOW, staleAfterHours: 24 },
+  );
+  assert.deepEqual(clean.attention, [], "no unlinked/stale PRs → empty attention");
+}
+
 console.log("beads-work-queue.test.ts: ok");

--- a/src/lib/beads-work-queue.ts
+++ b/src/lib/beads-work-queue.ts
@@ -83,6 +83,17 @@ export type FamiliarRollup = {
   laneCounts: Partial<Record<WorkQueueLaneKey, number>>;
 };
 
+/**
+ * An open PR that needs housekeeping attention regardless of lane — the two
+ * gaps the CLI patrol flags: no linked bead (invisible to the queue) and/or no
+ * activity within the stale window. A PR can be both.
+ */
+export type AttentionItem = {
+  pr: PullRequestSummary;
+  unlinked: boolean;
+  stale: boolean;
+};
+
 export type WorkQueue = {
   lanes: WorkQueueLane[];
   byFamiliar: FamiliarRollup[];
@@ -91,6 +102,8 @@ export type WorkQueue = {
   stale: number;
   /** Open PRs mentioning no bead — invisible to the queue join. */
   unlinked: number[];
+  /** Open PRs that are unlinked and/or stale, with the PR summary for display. */
+  attention: AttentionItem[];
 };
 
 const LANE_TITLES: Record<WorkQueueLaneKey, string> = {
@@ -165,15 +178,18 @@ export function buildWorkQueue(
   const items: WorkQueueItem[] = [];
   let staleCount = 0;
   const unlinked: number[] = [];
+  const attention: AttentionItem[] = [];
   const beadIdsWithOpenPr = new Set<string>();
 
   // 1. Open PRs → their lane, joined to a ready bead when one is referenced.
   for (const pr of openPrs) {
-    if (pr.beadIds.length === 0) unlinked.push(pr.number);
+    const isUnlinked = pr.beadIds.length === 0;
+    if (isUnlinked) unlinked.push(pr.number);
     const bead = pr.beadIds.map((id) => beadById.get(id)).find(Boolean);
     for (const id of pr.beadIds) beadIdsWithOpenPr.add(id);
     const stale = isStalePr(pr, opts.nowMs, staleAfterHours);
     if (stale) staleCount += 1;
+    if (isUnlinked || stale) attention.push({ pr, unlinked: isUnlinked, stale });
     items.push({
       key: `pr:${pr.number}`,
       lane: prLaneToQueueLane(pr.lane),
@@ -238,6 +254,7 @@ export function buildWorkQueue(
     actionable,
     stale: staleCount,
     unlinked: unlinked.sort((a, b) => a - b),
+    attention: attention.sort((a, b) => a.pr.number - b.pr.number),
   };
 }
 

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -86,6 +86,88 @@
   color: var(--accent-presence);
 }
 
+/* ── Attention strip (unlinked / stale PRs — repo hygiene) ───────────────── */
+.fwq-attention {
+  margin: 12px 20px 0;
+  border: 1px solid color-mix(in oklch, var(--color-warning) 34%, transparent);
+  border-radius: var(--radius-panel, 12px);
+  background: color-mix(in oklch, var(--color-warning) 7%, transparent);
+  overflow: hidden;
+}
+
+.fwq-attention-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-warning);
+  border-bottom: 1px solid color-mix(in oklch, var(--color-warning) 20%, transparent);
+}
+
+.fwq-attention-title {
+  flex-shrink: 0;
+}
+
+.fwq-attention-summary {
+  color: var(--text-muted);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.fwq-attention-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fwq-attention-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 12px;
+  border-bottom: 1px solid color-mix(in oklch, var(--color-warning) 12%, transparent);
+}
+
+.fwq-attention-item:last-child {
+  border-bottom: 0;
+}
+
+.fwq-attention-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+}
+
+.fwq-attention-name {
+  font-size: 13px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fwq-attention-tags {
+  display: flex;
+  gap: 5px;
+  flex-shrink: 0;
+}
+
+/* Unlinked (no bead) reads as informational, distinct from the warning stale. */
+.fwq-tag--unlinked {
+  color: var(--text-secondary);
+  border-color: var(--border-strong, var(--border-hairline));
+}
+
+@container (max-width: 560px) {
+  .fwq-attention-item {
+    flex-wrap: wrap;
+  }
+}
+
 .fwq-body {
   flex: 1;
   min-height: 0;

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -83,8 +83,12 @@ test.describe("familiar work queue (PR control tower)", () => {
     await expect(fwq.getByRole("region", { name: "No open PR" })).toBeVisible();
     await expect(fwq.getByRole("region", { name: "Post-merge cleanup" })).toBeVisible();
 
-    // PR + bead identity surfaces truthfully.
-    await expect(fwq.getByText("#101")).toBeVisible();
+    // PR + bead identity surfaces truthfully. Scope #101 to its lane: a stale PR
+    // also appears in the "Needs attention" strip, so a bare getByText matches
+    // two elements and trips Playwright's strict mode.
+    await expect(
+      fwq.getByRole("region", { name: "Checks failing" }).getByText("#101"),
+    ).toBeVisible();
     await expect(fwq.getByText("cave-aa1", { exact: true })).toBeVisible();
     // Stale PR (40h) is flagged.
     await expect(fwq.getByText("stale", { exact: true }).first()).toBeVisible();

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -158,4 +158,43 @@ test.describe("familiar work queue (PR control tower)", () => {
     // …and Close unlocks (optimistic, without waiting for a re-read).
     await expect(cleanup.getByRole("button", { name: "Close bead" })).toBeEnabled();
   });
+
+  test("Attention strip surfaces stale and unlinked open PRs", async ({ page }) => {
+    await gotoWorkQueue(page);
+    const strip = page.locator(".fwq").getByRole("region", { name: "PRs needing attention" });
+    await expect(strip).toBeVisible();
+
+    // #101 is 40h old (stale, linked); #103 has no bead (unlinked, fresh).
+    const stale = strip.locator(".fwq-attention-item", { hasText: "#101" });
+    await expect(stale.getByText("stale", { exact: true })).toBeVisible();
+    const unlinked = strip.locator(".fwq-attention-item", { hasText: "#103" });
+    await expect(unlinked.getByText("no bead", { exact: true })).toBeVisible();
+
+    // A clean, linked, fresh PR (#102) is NOT flagged.
+    await expect(strip.locator(".fwq-attention-item", { hasText: "#102" })).toHaveCount(0);
+    // Each row can jump to the PR.
+    await expect(stale.getByRole("button", { name: "Open PR" })).toBeVisible();
+  });
+
+  test("Attention strip is absent when no PR is stale or unlinked", async ({ page }) => {
+    // Every open PR is fresh and linked → nothing to flag.
+    await page.addInitScript(() => {
+      window.localStorage.setItem("cave:onboarding:dismissed", "1");
+      window.localStorage.setItem("cave:active-familiar", "kitty");
+    });
+    await page.route("**/api/familiars**", (r) =>
+      r.fulfill({ json: { ok: true, familiars: [{ id: "kitty", display_name: "Kitty", role: "B", status: "active", icon: "ph:sparkle-fill" }] } }),
+    );
+    await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions: [] } }));
+    const freshPr = { number: 201, title: "All good", url: "https://gh/pull/201", lane: "ready-to-merge", beadIds: ["cave-aa1"], checkStatus: "passing", reviewDecision: "APPROVED", mergeStateStatus: "CLEAN", headRefName: "feat/cave-aa1", updatedAt: new Date().toISOString() };
+    await page.route(/\/api\/beads\/prs/, (r) => r.fulfill({ json: { ok: true, open: [freshPr], merged: [] } }));
+    await page.route(/\/api\/beads\?/, (r) =>
+      r.fulfill({ json: { ok: true, data: [{ id: "cave-aa1", title: "T", priority: 1, status: "open", issue_type: "feature", labels: ["familiar:kitty"] }] } }),
+    );
+    await page.goto("/");
+    await page.waitForTimeout(500);
+    await page.evaluate(() => window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })));
+    await page.waitForSelector(".fwq-lane", { timeout: 45_000 });
+    await expect(page.locator(".fwq-attention")).toHaveCount(0);
+  });
 });


### PR DESCRIPTION
## What

The Familiar Work Queue's model already computed the two gaps the **CLI patrol** flags — **stale** PRs (no activity in the window) and **unlinked** PRs (no bead → invisible to the queue) — but the surface only showed a stale *count* in the header and **never surfaced unlinked PRs at all**. This closes that patrol↔UI parity gap with an actionable **"Needs attention"** strip at the top of the queue.

## Changes

- **Model** (`beads-work-queue.ts`) — added `AttentionItem` + `WorkQueue.attention`, each carrying the PR summary + `unlinked`/`stale` flags, collected in the open-PR loop and sorted by number. **Backward-compatible**: the existing `stale` count and `unlinked[]` fields are untouched.
- **View** — an `AttentionStrip` between the familiar filter and the lanes, shown only when non-empty. Each row: `#num · title · reason chips (no bead / stale) · Open PR`. Deliberately **global** (not familiar-filtered) — an unlinked PR has no familiar, and this is repo hygiene rather than one familiar's queue. The same PRs still appear in their lanes below; the strip is an additive callout, matching how the CLI patrol lists these separately.
- **CSS** — a warning-toned `.fwq-attention*` callout; `.fwq-tag--unlinked` reads neutral (informational) vs the warning `stale` tag.

## Verification

- **Model test**: stale-only / unlinked-only / both / clean-excluded / empty.
- **Two Playwright specs**: the strip lists the right PRs with an Open-PR action, and is **absent** when everything is fresh + linked.
- typecheck clean · **554 app tests** · **748 wired** · **screenshot confirmed** the render (#101 `stale`, #103 `no bead`, #108 `no bead`+`stale`; the clean #102 excluded; summary "2 unlinked · 2 stale").

Self-proposed follow-on to the beads PR-management epic (hlv.4/#2547 + hlv.2/#2553). Net **+228 / −1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)