### PR TITLE
chore(release): stamp v0.0.146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.146] - 2026-07-07
+
+> 📝 **Write where you think** — a new OpenKnowledge-style markdown editor lands across memory, knowledge, and journal, and the marketplace folds its Skills filter rail and leaderboard into one panel. Plus a Gantt scroll fix, cleaner GitHub comments, and a calendar controls refactor onto shared primitives.
+
+Feature release on top of v0.0.145.
+
+### Features
+- **Grimoire: OpenKnowledge-style markdown editor** (#2562). A unified markdown editing surface for memory, knowledge, and journal entries.
+- **Marketplace: unified Skills panel** (#2563, cave-8hn). The Skills filter rail and leaderboard merge into a single panel.
+
+### Fixes
+- **tasks: Gantt timeline scrolls on one bounded viewport** (#2559, cave-hsh). The Gantt timeline now scrolls within a single bounded viewport instead of overflowing.
+- **github: remove @familiar tagging from the comment composer** (#2560, cave-803). The GitHub comment composer no longer injects @familiar tags.
+
+### Refactors & chores
+- **calendar: standardize toolbar, action, and jump-to-date mini-month controls on shared Button/IconButton primitives** (#2565, #2566, #2567, cave-4op).
+- **marketplace: hide the Roles section for now** (#2564, cave-8vy).
+
 ## [0.0.145] - 2026-07-07
 
 > 🛠️ **The work queue grows up** — the Familiar Work Queue lands as a beads + PR control tower with handoff notes and evidence-gated close, iOS finally reads your operator profile (name/avatar instead of "You"), and Projects gets a Files drill-through into the code rail. Plus a solid batch of daemon-resilience, dashboard, proxy, and nav fixes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.145",
+  "version": "0.0.146",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.145"
+version = "0.0.146"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.145"
+version = "0.0.146"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.145</string>
+	<string>0.0.146</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.145</string>
+	<string>0.0.146</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.145</string>
+	<string>0.0.146</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.145</string>
+	<string>0.0.146</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.145",
+  "version": "0.0.146",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release stamp for **v0.0.146**.

Bumps all six version locations (package.json, Cargo.toml, Cargo.lock app entry, tauri.conf.json, Info.ios.plist, gen/apple Info.plist) from 0.0.145 → 0.0.146 and adds the CHANGELOG entry.

**Pre-release verification:** local `pnpm typecheck` clean + full `pnpm build` green (next build + server bundle + bundle-budget within budget: shell 447 KB / 650 KB, largest chunk 992 KB / 2400 KB), on top of green CI on the tip.

### Included since v0.0.145
**Features**
- **#2562** — feat(grimoire): OpenKnowledge-style markdown editor for memory, knowledge, and journal
- **#2563** — feat(marketplace): merge the Skills filter rail and leaderboard into one panel (cave-8hn)

**Fixes**
- **#2559** — fix(tasks): make the Gantt timeline scroll on one bounded viewport (cave-hsh)
- **#2560** — fix(github): remove @familiar tagging from the comment composer (cave-803)

**Refactors & chores**
- **#2565, #2566, #2567** — refactor(calendar): standardize toolbar/action/jump-to-date controls on shared Button/IconButton primitives (cave-4op)
- **#2564** — chore(marketplace): hide the Roles section for now (cave-8vy)

Stamp-only PR; no code changes.