### PR TITLE
perf(memory): 130x faster memory inventory — head reads, pooled I/O, mtime cache (cave-od4)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -675,6 +675,7 @@ export const SUITES = {
     "src/lib/server/memory-file-sources-coven-familiar.test.ts",
     "src/lib/server/memory-trash.test.ts",
     "src/lib/server/memory-file-write.test.ts",
+    "src/lib/server/memory-file-inventory.test.ts",
     "src/lib/server/space-usage.test.ts",
     "src/lib/server/theme-store.test.ts",
     "src/app/api/memory-coven-workspaces.test.ts",
@@ -796,6 +797,7 @@ const STRIP_TYPES_MJS = new Set([
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
   "src/lib/server/space-usage.test.ts",
+  "src/lib/server/memory-file-inventory.test.ts",
   "src/lib/daily-narrative.test.ts",
   "src/lib/use-code-rail.test.ts",
   "src/lib/cave-familiar-images.test.ts",

--- a/src/app/api/memory-coven-workspaces.test.ts
+++ b/src/app/api/memory-coven-workspaces.test.ts
@@ -8,7 +8,7 @@ const inventory = await readFile(
 assert.match(source, /listMemoryFileEntries/, "route returns the shared memory file inventory");
 assert.match(
   inventory,
-  /scanCovenFamiliarWorkspaces/,
+  /collectCovenFamiliarWorkspaces/,
   "memory inventory surfaces coven familiar workspace memory",
 );
 assert.match(inventory, /workspaces.*familiars|"familiars"/, "scans the coven familiars dir");

--- a/src/lib/server/memory-file-inventory.test.ts
+++ b/src/lib/server/memory-file-inventory.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// os.homedir() honours $HOME on POSIX — point the inventory at a tmp home
+// BEFORE importing the module under test.
+const home = await mkdtemp(path.join(tmpdir(), "meminv-"));
+process.env.HOME = home;
+
+const { listMemoryFileEntries, readExcerpt } = await import("./memory-file-inventory.ts");
+
+const memDir = path.join(home, ".coven", "memory");
+await mkdir(memDir, { recursive: true });
+const noteFile = path.join(memDir, "note.md");
+await writeFile(
+  noteFile,
+  "---\nsource_context: chat with kitty\n---\n\nFirst body line of the note.\n",
+  "utf8",
+);
+await writeFile(path.join(memDir, "plain.md"), "Plain body, no frontmatter.", "utf8");
+await utimes(noteFile, new Date("2026-01-02T00:00:00Z"), new Date("2026-01-02T00:00:00Z"));
+
+// ── readExcerpt operates on a bounded head string ────────────────────────────
+assert.equal(readExcerpt("---\nx: y\n---\nBody here."), "Body here.");
+assert.equal(readExcerpt("   "), undefined);
+assert.equal(readExcerpt(`Long ${"x".repeat(400)}`)?.length, 200, "excerpt capped at 200 chars");
+
+// ── Scan finds files with excerpt + source context from the head read ───────
+const first = await listMemoryFileEntries();
+const note = first.find((e) => e.fullPath === noteFile);
+assert.ok(note, "note.md is inventoried");
+assert.equal(note.excerpt, "First body line of the note.");
+assert.equal(note.sourceContext, "chat with kitty");
+assert.equal(note.relPath, "note.md");
+assert.ok(first.some((e) => e.excerpt === "Plain body, no frontmatter."), "plain file excerpted");
+
+// ── Concurrent callers share one in-flight scan ──────────────────────────────
+{
+  const [a, b] = await Promise.all([listMemoryFileEntries(), listMemoryFileEntries()]);
+  assert.equal(a, b, "concurrent scans coalesce to the same result");
+}
+
+// ── Unchanged files reuse cached entries; changed files rebuild ─────────────
+{
+  const second = await listMemoryFileEntries();
+  const cachedNote = second.find((e) => e.fullPath === noteFile);
+  assert.equal(cachedNote, note, "unchanged file reuses the cached entry object");
+
+  await writeFile(noteFile, "---\nsource_context: retro\n---\n\nRewritten body.\n", "utf8");
+  await utimes(noteFile, new Date("2026-01-03T00:00:00Z"), new Date("2026-01-03T00:00:00Z"));
+  const third = await listMemoryFileEntries();
+  const rebuilt = third.find((e) => e.fullPath === noteFile);
+  assert.ok(rebuilt && rebuilt !== note, "mtime change invalidates the cache");
+  assert.equal(rebuilt.excerpt, "Rewritten body.");
+  assert.equal(rebuilt.sourceContext, "retro");
+}
+
+// ── Deleted files drop out (cache evicted) ───────────────────────────────────
+{
+  await rm(noteFile);
+  const after = await listMemoryFileEntries();
+  assert.ok(!after.some((e) => e.fullPath === noteFile), "deleted file leaves the inventory");
+}
+
+// ── Sorted newest-first ──────────────────────────────────────────────────────
+{
+  const entries = await listMemoryFileEntries();
+  const sorted = [...entries].sort((a, b) => (a.modified < b.modified ? 1 : -1));
+  assert.deepEqual(entries.map((e) => e.fullPath), sorted.map((e) => e.fullPath), "newest first");
+}
+
+console.log("memory-file-inventory.test: ok");

--- a/src/lib/server/memory-file-inventory.ts
+++ b/src/lib/server/memory-file-inventory.ts
@@ -1,4 +1,4 @@
-import { readFile, readdir, stat } from "node:fs/promises";
+import { open, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { parseMemorySourceContext } from "@/lib/memory-source-context";
@@ -28,25 +28,97 @@ export type MemoryEntry = {
   familiarId?: string;
 };
 
-async function readSourceContext(filePath: string): Promise<string | undefined> {
+// ── Bounded head reads ────────────────────────────────────────────────────────
+// Both derived fields (frontmatter `source_context` and the 200-char excerpt)
+// only need the top of the file, but the scan used to read every file fully —
+// twice. On a real inventory (~1900 files, some large) that made a cold
+// GET /api/memory take ~25s. One 8KB head read per file covers both.
+
+const HEAD_BYTES = 8192;
+
+async function readHead(filePath: string): Promise<string | undefined> {
+  let handle;
   try {
-    return parseMemorySourceContext(await readFile(/* turbopackIgnore: true */ filePath, "utf8"));
+    handle = await open(/* turbopackIgnore: true */ filePath, "r");
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const { bytesRead } = await handle.read(buf, 0, HEAD_BYTES, 0);
+    return buf.subarray(0, bytesRead).toString("utf8");
   } catch {
     return undefined;
+  } finally {
+    await handle?.close().catch(() => {});
   }
 }
 
-async function readExcerpt(filePath: string): Promise<string | undefined> {
-  try {
-    const raw = await readFile(/* turbopackIgnore: true */ filePath, "utf8");
-    const body = raw.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-    return body.slice(0, 200) || undefined;
-  } catch {
-    return undefined;
-  }
+/** Body excerpt from a file head: frontmatter stripped, first 200 chars. */
+export function readExcerpt(head: string): string | undefined {
+  const body = head.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+  return body.slice(0, 200) || undefined;
 }
 
-async function walk(dir: string, acc: MemoryEntry[], baseDir: string) {
+// ── Entry cache ───────────────────────────────────────────────────────────────
+// Rebuilding an entry is the expensive part (head read + classification), so
+// completed entries are cached keyed by (size, mtimeMs) and reused while the
+// file is unchanged. Repeat scans then cost one readdir walk + one stat per
+// file. Entries for files that vanished are evicted after each scan.
+
+const entryCache = new Map<string, { size: number; mtimeMs: number; entry: MemoryEntry }>();
+
+type BuildOverrides = { relPath?: string; familiarIdFallback?: string };
+
+async function buildEntry(
+  fullPath: string,
+  baseDir: string,
+  overrides: BuildOverrides = {},
+): Promise<MemoryEntry | null> {
+  let s;
+  try {
+    s = await stat(/* turbopackIgnore: true */ fullPath);
+  } catch {
+    return null;
+  }
+  if (!s.isFile()) return null;
+
+  const cached = entryCache.get(fullPath);
+  if (cached && cached.mtimeMs === s.mtimeMs && cached.size === s.size) {
+    return cached.entry;
+  }
+
+  const classification = classifyMemoryFilePath(fullPath);
+  if (!classification) return null;
+
+  const head = await readHead(fullPath);
+  const sourceContext = head === undefined ? undefined : parseMemorySourceContext(head);
+  const excerpt = head === undefined ? undefined : readExcerpt(head);
+  const familiarId = classification.familiarId ?? overrides.familiarIdFallback;
+
+  const entry: MemoryEntry = {
+    root: classification.root,
+    rootLabel: classification.rootLabel,
+    relPath: overrides.relPath ?? path.relative(baseDir, fullPath),
+    fullPath,
+    size: s.size,
+    modified: s.mtime.toISOString(),
+    sourceId: classification.sourceId,
+    sourceKind: classification.sourceKind,
+    sourceKindLabel: classification.sourceKindLabel,
+    rootPath: classification.rootPath,
+    ...(classification.origin ? { origin: classification.origin } : {}),
+    ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
+    ...(classification.runtimeId ? { runtimeId: classification.runtimeId } : {}),
+    ...(sourceContext ? { sourceContext } : {}),
+    ...(excerpt ? { excerpt } : {}),
+    ...(familiarId ? { familiarId } : {}),
+  };
+  entryCache.set(fullPath, { size: s.size, mtimeMs: s.mtimeMs, entry });
+  return entry;
+}
+
+// ── Candidate collection (cheap) + pooled entry builds ───────────────────────
+
+type Candidate = { fullPath: string; baseDir: string; overrides?: BuildOverrides };
+
+async function walk(dir: string, acc: Candidate[], baseDir: string, overrides?: BuildOverrides) {
   let items;
   try {
     items = await readdir(dir, { withFileTypes: true });
@@ -57,40 +129,31 @@ async function walk(dir: string, acc: MemoryEntry[], baseDir: string) {
     if (item.name.startsWith(".")) continue;
     const full = path.join(dir, item.name);
     if (item.isDirectory()) {
-      await walk(full, acc, baseDir);
+      await walk(full, acc, baseDir, overrides);
     } else if (item.isFile() && /\.(md|markdown|txt|json)$/i.test(item.name)) {
-      try {
-        const s = await stat(full);
-        const classification = classifyMemoryFilePath(full);
-        if (!classification) continue;
-        const sourceContext = await readSourceContext(full);
-        const excerpt = await readExcerpt(full);
-        acc.push({
-          root: classification.root,
-          rootLabel: classification.rootLabel,
-          relPath: path.relative(baseDir, full),
-          fullPath: full,
-          size: s.size,
-          modified: s.mtime.toISOString(),
-          sourceId: classification.sourceId,
-          sourceKind: classification.sourceKind,
-          sourceKindLabel: classification.sourceKindLabel,
-          rootPath: classification.rootPath,
-          ...(classification.origin ? { origin: classification.origin } : {}),
-          ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
-          ...(classification.runtimeId ? { runtimeId: classification.runtimeId } : {}),
-          ...(sourceContext ? { sourceContext } : {}),
-          ...(excerpt ? { excerpt } : {}),
-          ...(classification.familiarId ? { familiarId: classification.familiarId } : {}),
-        });
-      } catch {
-        /* skip */
-      }
+      acc.push({ fullPath: full, baseDir, ...(overrides ? { overrides } : {}) });
     }
   }
 }
 
-async function scanFamiliarWorkspaces(acc: MemoryEntry[]) {
+const BUILD_CONCURRENCY = 64;
+
+async function buildEntries(candidates: Candidate[]): Promise<MemoryEntry[]> {
+  const results: (MemoryEntry | null)[] = new Array(candidates.length).fill(null);
+  let next = 0;
+  const worker = async () => {
+    while (next < candidates.length) {
+      const index = next;
+      next += 1;
+      const c = candidates[index];
+      results[index] = await buildEntry(c.fullPath, c.baseDir, c.overrides);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(BUILD_CONCURRENCY, candidates.length) }, worker));
+  return results.filter((e): e is MemoryEntry => e !== null);
+}
+
+async function collectFamiliarWorkspaces(acc: Candidate[]) {
   const workspacesDir = path.join(homedir(), ".openclaw", "workspace");
   let items;
   try {
@@ -103,36 +166,16 @@ async function scanFamiliarWorkspaces(acc: MemoryEntry[]) {
     const familiarId = item.name;
     const memDir = path.join(workspacesDir, familiarId, "memory");
     const indexFile = path.join(workspacesDir, familiarId, "MEMORY.md");
-    try {
-      const s = await stat(/* turbopackIgnore: true */ indexFile);
-      const classification = classifyMemoryFilePath(indexFile);
-      if (!classification) continue;
-      const sourceContext = await readSourceContext(indexFile);
-      const excerpt = await readExcerpt(indexFile);
-      acc.push({
-        root: classification.root,
-        rootLabel: classification.rootLabel,
-        relPath: "MEMORY.md",
-        fullPath: indexFile,
-        size: s.size,
-        modified: s.mtime.toISOString(),
-        sourceId: classification.sourceId,
-        sourceKind: classification.sourceKind,
-        sourceKindLabel: classification.sourceKindLabel,
-        rootPath: classification.rootPath,
-        ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
-        ...(sourceContext ? { sourceContext } : {}),
-        ...(excerpt ? { excerpt } : {}),
-        familiarId: classification.familiarId ?? familiarId,
-      });
-    } catch {
-      /* no MEMORY.md for this familiar */
-    }
-    await walk(memDir, acc, memDir);
+    acc.push({
+      fullPath: indexFile,
+      baseDir: path.join(workspacesDir, familiarId),
+      overrides: { relPath: "MEMORY.md", familiarIdFallback: familiarId },
+    });
+    await walk(memDir, acc, memDir, { familiarIdFallback: familiarId });
   }
 }
 
-async function scanCovenFamiliarWorkspaces(acc: MemoryEntry[]) {
+async function collectCovenFamiliarWorkspaces(acc: Candidate[]) {
   const familiarsDir = path.join(homedir(), ".coven", "workspaces", "familiars");
   let items;
   try {
@@ -147,46 +190,50 @@ async function scanCovenFamiliarWorkspaces(acc: MemoryEntry[]) {
   }
 }
 
-export async function listMemoryFileEntries(): Promise<MemoryEntry[]> {
-  const entries: MemoryEntry[] = [];
+async function scanMemoryFileEntries(): Promise<MemoryEntry[]> {
+  const candidates: Candidate[] = [];
 
   for (const source of memoryFileSourcesForHome()) {
     try {
       const s = await stat(/* turbopackIgnore: true */ source.rootPath);
       if (s.isDirectory()) {
-        await walk(source.rootPath, entries, source.rootPath);
-        continue;
+        await walk(source.rootPath, candidates, source.rootPath);
+      } else if (s.isFile()) {
+        candidates.push({
+          fullPath: source.rootPath,
+          baseDir: path.dirname(source.rootPath),
+          overrides: { relPath: path.basename(source.rootPath) },
+        });
       }
-      if (!s.isFile()) continue;
-      const classification = classifyMemoryFilePath(source.rootPath);
-      if (!classification) continue;
-      const sourceContext = await readSourceContext(source.rootPath);
-      const excerpt = await readExcerpt(source.rootPath);
-      entries.push({
-        root: classification.root,
-        rootLabel: classification.rootLabel,
-        relPath: path.basename(source.rootPath),
-        fullPath: source.rootPath,
-        size: s.size,
-        modified: s.mtime.toISOString(),
-        sourceId: classification.sourceId,
-        sourceKind: classification.sourceKind,
-        sourceKindLabel: classification.sourceKindLabel,
-        rootPath: classification.rootPath,
-        ...(classification.origin ? { origin: classification.origin } : {}),
-        ...(classification.harnessId ? { harnessId: classification.harnessId } : {}),
-        ...(classification.runtimeId ? { runtimeId: classification.runtimeId } : {}),
-        ...(sourceContext ? { sourceContext } : {}),
-        ...(excerpt ? { excerpt } : {}),
-      });
     } catch {
       /* missing memory source */
     }
   }
 
-  await scanFamiliarWorkspaces(entries);
-  await scanCovenFamiliarWorkspaces(entries);
+  await collectFamiliarWorkspaces(candidates);
+  await collectCovenFamiliarWorkspaces(candidates);
+
+  const entries = await buildEntries(candidates);
+
+  // Evict cache entries for files that no longer exist on disk.
+  const seen = new Set(candidates.map((c) => c.fullPath));
+  for (const key of entryCache.keys()) {
+    if (!seen.has(key)) entryCache.delete(key);
+  }
 
   entries.sort((a, b) => (a.modified < b.modified ? 1 : -1));
   return entries;
+}
+
+// Concurrent callers (the Grimoire navigator, memory view, and chat scoping
+// can all ask at once) share a single in-flight scan instead of stampeding
+// the filesystem.
+let inFlightScan: Promise<MemoryEntry[]> | null = null;
+
+export async function listMemoryFileEntries(): Promise<MemoryEntry[]> {
+  if (inFlightScan) return inFlightScan;
+  inFlightScan = scanMemoryFileEntries().finally(() => {
+    inFlightScan = null;
+  });
+  return inFlightScan;
 }


### PR DESCRIPTION
## Problem

`GET /api/memory` took **~25s cold** on a real inventory (1862 files) — the Grimoire navigator (#2562) and memory view sat on skeletons the whole time. The scan fully read every file **twice** (once for frontmatter `source_context`, once for the excerpt), one file at a time.

## Fix (`src/lib/server/memory-file-inventory.ts`)

- **One bounded 8KB head read per file** — both derived fields only need the top of the file
- **64-wide concurrency pool** for entry builds (walk collects candidates cheaply first)
- **(size, mtimeMs) entry cache** — repeat scans cost a walk + stat per file; entries for vanished files are evicted each scan
- **In-flight coalescing** — concurrent callers (navigator + memory view + chat scoping) share one scan

## Measured (same 1862-file inventory, prod server)

| | before | after |
|---|---|---|
| cold `GET /api/memory` | 25.8s | **5.1s** (≈4.5s of that is Next's one-time route init) |
| warm `GET /api/memory` | 25.8s | **0.19s** |
| raw scan (outside Next) | — | 0.58s cold / 25ms cached |

Output parity verified: identical entry count, excerpt count, and source-context count.

## Tests

New behavioral test (`memory-file-inventory.test.ts`, tmp-HOME): head-read excerpts + source context, cache invalidation on mtime change, eviction on delete, in-flight coalescing, newest-first sort. Wired into `test:api` with the alias loader. `test:api` 126 ✓ · `test:app` 554 ✓ · typecheck ✓ · build ✓.

Closes bead `cave-od4`.