### PR TITLE
refactor(session-changes): standardize commit/PR footer buttons on the shared Button primitive (cave-4op)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -295,6 +295,7 @@ export const SUITES = {
     "src/components/comux-touch-wiring.test.ts",
     "src/components/comux-preview-crumbs.test.ts",
     "src/components/session-changes-totals.test.ts",
+    "src/components/session-changes-panel.test.ts",
     "src/components/project-tree-keynav.test.ts",
     "src/components/comux-pane-nav-wiring.test.ts",
     "src/components/a11y-audit-fixes.test.ts",

--- a/src/components/session-changes-panel.test.ts
+++ b/src/components/session-changes-panel.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+// cave-4op: the working-tree panel's footer outbound-action buttons — Commit
+// and Create pull request (primary), Create PR (secondary), Cancel (ghost) —
+// use the shared Button primitive, so their radius / height / focus ring /
+// disabled treatment come from one place.
+//
+// Deliberately left bespoke (not standard controls): the file-row and
+// checkpoint disclosure toggles, the dense two-step revert/restore confirm
+// buttons, the bordered / spin-animated header icon actions, and the alert
+// dismiss "×" icons. A follow-up can take the icon-button family.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./session-changes-panel.tsx", import.meta.url), "utf8");
+
+assert.match(
+  src,
+  /import \{ Button \} from "@\/components\/ui\/button"/,
+  "session-changes-panel imports the shared Button primitive",
+);
+
+// Scope to the commit/PR footer so the assertions can't be satisfied by an
+// unrelated <Button> elsewhere.
+const footerStart = src.indexOf("session-changes-panel__commit");
+assert.ok(footerStart >= 0, "the commit/PR footer region exists");
+const footer = src.slice(footerStart);
+
+assert.match(
+  footer,
+  /<Button[\s\S]{0,180}variant="primary"[\s\S]{0,220}commitChanges\(\)/,
+  "Commit is a primary Button that calls commitChanges()",
+);
+assert.match(
+  footer,
+  /<Button[\s\S]{0,180}variant="primary"[\s\S]{0,220}createPr\(\)/,
+  "Create pull request is a primary Button that calls createPr()",
+);
+assert.match(
+  footer,
+  /<Button[\s\S]{0,160}variant="secondary"[\s\S]{0,160}setPrOpen\(true\)/,
+  "Create PR is a secondary Button that opens the PR form",
+);
+assert.match(
+  footer,
+  /<Button[\s\S]{0,160}variant="ghost"[\s\S]{0,160}setPrOpen\(false\)/,
+  "Cancel is a ghost Button that closes the PR form",
+);
+
+// The hand-rolled accent-background action buttons are gone — the primary
+// variant now supplies that treatment via .ui-btn--primary.
+assert.doesNotMatch(
+  footer,
+  /bg-\[var\(--accent-presence\)\]/,
+  "no hand-rolled accent-bg action buttons remain in the footer",
+);
+
+console.log("session-changes-panel.test.ts: cave-4op footer control primitives ok");

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -6,6 +6,7 @@ import { arrayContentEqual } from "@/lib/array-content-equal";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { openExternalUrl } from "@/lib/open-external";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -993,13 +994,15 @@ export function SessionChangesInner({
                 </button>
               </div>
               {!prOpen && !postCommit.onDefaultBranch ? (
-                <button
-                  type="button"
-                  className="focus-ring mt-1.5 inline-flex items-center gap-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] font-medium text-[var(--text-primary)] hover:bg-[var(--bg-hover)]"
+                <Button
+                  variant="secondary"
+                  size="xs"
+                  leadingIcon="ph:git-pull-request"
+                  className="mt-1.5"
                   onClick={() => setPrOpen(true)}
                 >
-                  <Icon name="ph:git-pull-request" width={12} aria-hidden /> Create PR
-                </button>
+                  Create PR
+                </Button>
               ) : null}
             </div>
           ) : null}
@@ -1022,22 +1025,22 @@ export function SessionChangesInner({
                 className="focus-ring w-full resize-y rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] text-[var(--text-primary)]"
               />
               <div className="flex items-center gap-1.5">
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
+                  size="xs"
+                  leadingIcon="ph:git-pull-request"
                   disabled={!prTitle.trim() || creatingPr}
                   onClick={() => void createPr()}
-                  className="focus-ring inline-flex items-center gap-1 rounded bg-[var(--accent-presence)] px-2.5 py-1 text-[11px] font-medium text-[var(--accent-presence-foreground,white)] disabled:opacity-40"
                 >
-                  <Icon name="ph:git-pull-request" width={12} aria-hidden />
                   {creatingPr ? "Opening…" : "Create pull request"}
-                </button>
-                <button
-                  type="button"
-                  className="focus-ring rounded px-2 py-1 text-[11px] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
                   onClick={() => setPrOpen(false)}
                 >
                   Cancel
-                </button>
+                </Button>
               </div>
             </div>
           ) : null}
@@ -1055,16 +1058,17 @@ export function SessionChangesInner({
                 disabled={!canCommit || committing}
                 className="focus-ring min-w-0 flex-1 rounded border border-[var(--border-hairline)] bg-[var(--bg-base)] px-2 py-1 text-[11px] text-[var(--text-primary)] disabled:opacity-40"
               />
-              <button
-                type="button"
+              <Button
+                variant="primary"
+                size="xs"
+                leadingIcon="ph:git-diff"
                 disabled={!canCommit || !commitMsg.trim() || committing}
                 onClick={() => void commitChanges()}
                 title="Stage all changes and commit"
-                className="focus-ring inline-flex shrink-0 items-center gap-1 rounded bg-[var(--accent-presence)] px-2.5 py-1 text-[11px] font-medium text-[var(--accent-presence-foreground,white)] disabled:opacity-40"
+                className="shrink-0"
               >
-                <Icon name="ph:git-diff" width={12} aria-hidden />
                 {committing ? "Committing…" : "Commit"}
-              </button>
+              </Button>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
A new-surface slice of **cave-4op** (Standardize Cave controls) — the working-tree **Session Changes** panel.

## What changed

The panel's outbound-action **footer** moves from hand-rolled `<button>` markup to the shared `Button` primitive:

- **Commit** and **Create pull request** → `primary`
- **Create PR** → `secondary`
- **Cancel** → `ghost`

So their radius (`--radius-control`), height, focus ring, and disabled treatment come from one place.

## Left bespoke by design

Not standard controls — documented in the co-located test:

- File-row and checkpoint **disclosure toggles** (whole-row content: caret + status chip + filename).
- The dense two-step **revert / restore confirm** buttons (tiny, custom danger-tinted, confirm-flow).
- **Bordered / spin-animated header icon** actions — notably Refresh, whose inner-icon `animate-spin` the `IconButton` primitive can't carry (`className` lands on the button, not the glyph).
- The alert **dismiss "×"** icons.

A follow-up can take the icon-button family. 4 of 20 `<button>`s converted; 16 bespoke remain.

## Preserved

- Handlers unchanged: `commitChanges()` / `createPr()` / `setPrOpen(...)`. The behavioral pin in `comux-view-changes.test.ts` (`announce("Changes committed.")`) stays green.

## Verification

- New co-located, **CI-wired** `session-changes-panel.test.ts` asserts the footer uses the primitives (primary/secondary/ghost) and that no hand-rolled accent-bg action button remains.
- Sibling source-scan tests (`session-changes-totals`, `comux-view-changes`, `rail-files-panel`, `debug-pane`) pass.
- `pnpm typecheck` clean · `check:tests-wired` 749 · `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)