### PR TITLE
refactor(session-changes): normalize icon-only buttons to the borderless IconButton (cave-4op)

### DIFF
--- a/src/components/session-changes-panel.test.ts
+++ b/src/components/session-changes-panel.test.ts
@@ -4,10 +4,14 @@
 // use the shared Button primitive, so their radius / height / focus ring /
 // disabled treatment come from one place.
 //
+// The bordered / bare icon-only buttons are normalized to the borderless
+// IconButton (the app-wide convention): file-row revert/delete, checkpoint
+// restore/delete, header Save, and the three alert dismiss "×" icons. Refresh
+// stays a raw <button> — its inner-glyph animate-spin can't ride the primitive.
+//
 // Deliberately left bespoke (not standard controls): the file-row and
-// checkpoint disclosure toggles, the dense two-step revert/restore confirm
-// buttons, the bordered / spin-animated header icon actions, and the alert
-// dismiss "×" icons. A follow-up can take the icon-button family.
+// checkpoint disclosure toggles, and the dense two-step revert / restore
+// confirm buttons (tiny, custom danger-tinted, confirm-flow).
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -54,4 +58,34 @@ assert.doesNotMatch(
   "no hand-rolled accent-bg action buttons remain in the footer",
 );
 
-console.log("session-changes-panel.test.ts: cave-4op footer control primitives ok");
+// ── cave-4op: icon-only buttons use the borderless IconButton primitive ──────
+assert.match(
+  src,
+  /import \{ IconButton \} from "@\/components\/ui\/icon-button"/,
+  "session-changes-panel imports the shared IconButton primitive",
+);
+assert.match(
+  src,
+  /<IconButton[\s\S]{0,80}icon=\{untracked \? "ph:trash" : "ph:arrow-counter-clockwise"\}[\s\S]{0,60}danger/,
+  "file-row revert/delete is a danger IconButton",
+);
+assert.match(
+  src,
+  /<IconButton[\s\S]{0,120}icon="ph:archive"[\s\S]{0,220}saveCheckpoint\(\)/,
+  "header Save is an IconButton wired to saveCheckpoint()",
+);
+assert.equal(
+  (src.match(/<IconButton[\s\S]{0,60}icon="ph:x-bold"/g) ?? []).length,
+  3,
+  "all three alert dismiss × are IconButtons",
+);
+// The bordered icon-button recipe is gone (normalized to the borderless primitive).
+assert.doesNotMatch(src, /const btn =/, "the bordered icon-button recipe (const btn) is removed");
+// Refresh stays a raw <button> so its inner-glyph spin animation survives.
+assert.match(
+  src,
+  /ph:arrows-clockwise[\s\S]{0,60}animate-spin/,
+  "Refresh stays a raw button to keep its inner-glyph spin",
+);
+
+console.log("session-changes-panel.test.ts: cave-4op footer + icon-button control primitives ok");

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -7,6 +7,7 @@ import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 import { SyntaxBlock } from "@/components/message-bubble";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { openExternalUrl } from "@/lib/open-external";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -200,16 +201,15 @@ function FileRow({
         <td className="whitespace-nowrap px-2 py-1.5 text-right font-mono text-[10px] tabular-nums">{diffCounts}</td>
         <td className="px-2 py-1.5 text-right">
           {confirmRevert ? null : (
-            <button
-              type="button"
+            <IconButton
+              icon={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"}
+              size="sm"
+              danger
               onClick={() => setConfirmRevert(true)}
               disabled={reverting}
               title={untracked ? `Delete ${file.path}` : `Revert ${file.path}`}
               aria-label={untracked ? `Delete untracked file ${file.path}` : `Revert ${file.path}`}
-              className="focus-ring inline-flex h-6 w-6 items-center justify-center rounded border border-[var(--border-hairline)] text-[var(--text-muted)] transition-all hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:bg-[color-mix(in_oklch,var(--color-danger)_14%,transparent)] hover:text-[var(--color-danger)] disabled:opacity-40"
-            >
-              <Icon name={untracked ? "ph:trash" : "ph:arrow-counter-clockwise"} width={11} aria-hidden />
-            </button>
+            />
           )}
         </td>
       </tr>
@@ -296,8 +296,6 @@ function CheckpointRow({
   // it's a single click.
   const [confirmRestore, setConfirmRestore] = useState(false);
   const label = checkpointLabel(cp.name);
-  const btn =
-    "focus-ring shrink-0 rounded border border-[var(--border-hairline)] px-1.5 py-0.5 text-[var(--text-muted)] transition-colors hover:text-[var(--text-primary)] disabled:opacity-40";
 
   return (
     <div className="flex items-center gap-2 rounded-md border border-[var(--border-hairline)] px-2 py-1.5">
@@ -332,26 +330,25 @@ function CheckpointRow({
         </span>
       ) : (
         <>
-          <button
-            type="button"
+          <IconButton
+            icon="ph:arrow-counter-clockwise"
+            size="sm"
+            className="shrink-0"
             disabled={busy}
             onClick={() => setConfirmRestore(true)}
             title={`Restore checkpoint ${label}`}
             aria-label={`Restore checkpoint ${label}`}
-            className={btn}
-          >
-            <Icon name="ph:arrow-counter-clockwise" width={11} aria-hidden />
-          </button>
-          <button
-            type="button"
+          />
+          <IconButton
+            icon="ph:trash"
+            size="sm"
+            danger
+            className="shrink-0"
             disabled={busy}
             onClick={onDelete}
             title={`Delete checkpoint ${label}`}
             aria-label={`Delete checkpoint ${label}`}
-            className={btn + " hover:border-[color-mix(in_oklch,var(--color-danger)_45%,transparent)] hover:text-[var(--color-danger)]"}
-          >
-            <Icon name="ph:trash" width={11} aria-hidden />
-          </button>
+          />
         </>
       )}
     </div>
@@ -804,17 +801,15 @@ export function SessionChangesInner({
             </p>
           </div>
           <span className="flex shrink-0 items-center gap-1">
-            <button
-              type="button"
+            <IconButton
+              icon="ph:archive"
+              size="sm"
+              className="shrink-0"
               onClick={() => void saveCheckpoint()}
               disabled={checkpointing || notARepo || !!error}
               title="Save patch checkpoint"
               aria-label="Save patch checkpoint"
-              className="focus-ring inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-transparent text-[var(--text-muted)] transition-colors hover:border-[var(--border-hairline)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-40"
-            >
-              <Icon name="ph:archive" width={11} aria-hidden />
-              <span className="sr-only">{checkpointing ? "Saving checkpoint" : "Checkpoint"}</span>
-            </button>
+            />
             <button
               type="button"
               onClick={() => void load()}
@@ -857,14 +852,13 @@ export function SessionChangesInner({
         {checkpointMessage && (
           <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-[color-mix(in_oklch,var(--accent-presence)_35%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)] px-2 py-1.5 text-[11px] text-[var(--accent-presence)]">
             <span className="min-w-0 truncate" title={checkpointMessage}>{checkpointMessage}</span>
-            <button
-              type="button"
-              className="focus-ring shrink-0"
+            <IconButton
+              icon="ph:x-bold"
+              size="xs"
+              className="shrink-0"
               aria-label="Dismiss checkpoint message"
               onClick={() => setCheckpointMessage(null)}
-            >
-              <Icon name="ph:x-bold" width={10} aria-hidden />
-            </button>
+            />
           </div>
         )}
 
@@ -879,14 +873,13 @@ export function SessionChangesInner({
                 revert: {actionError}
               </span>
             </span>
-            <button
-              type="button"
-              className="focus-ring shrink-0"
+            <IconButton
+              icon="ph:x-bold"
+              size="xs"
+              className="shrink-0"
               aria-label="Dismiss revert error"
               onClick={() => setActionError(null)}
-            >
-              <Icon name="ph:x-bold" width={10} aria-hidden />
-            </button>
+            />
           </div>
         )}
 
@@ -984,14 +977,13 @@ export function SessionChangesInner({
                     {postCommit.sha} · {postCommit.branch}
                   </span>
                 </span>
-                <button
-                  type="button"
-                  className="focus-ring shrink-0"
+                <IconButton
+                  icon="ph:x-bold"
+                  size="xs"
+                  className="shrink-0"
                   aria-label="Dismiss commit result"
                   onClick={() => setPostCommit(null)}
-                >
-                  <Icon name="ph:x-bold" width={10} aria-hidden />
-                </button>
+                />
               </div>
               {!prOpen && !postCommit.onDefaultBranch ? (
                 <Button


### PR DESCRIPTION
Follow-up to #2571 — the icon-button family of the working-tree **Session Changes** panel.

## What changed

Per an explicit design call, the panel's bordered / bare **icon-only** buttons are normalized to the shared, **borderless** `IconButton` — matching the app-wide convention (no other surface uses a bordered `IconButton`):

- **File-row revert / delete** → `danger` IconButton
- **Checkpoint restore** → IconButton, **checkpoint delete** → `danger` IconButton
- **Header Save** → IconButton
- The **three alert dismiss "×"** icons → IconButton

Also removes the now-unused bordered-icon recipe (`const btn`). This is a deliberate **visual change**: these buttons lose their borders to match the standard borderless treatment.

## Left raw / bespoke (documented in the test)

- **Refresh** stays a raw `<button>` — its inner-glyph `animate-spin` can't ride the primitive (`IconButton`'s `className` lands on the button, not the glyph).
- File-row / checkpoint **disclosure toggles** and the dense **two-step revert/restore confirm** buttons — not standard controls.

7 icon buttons converted; 9 raw `<button>` remain (toggles + dense confirm + Refresh).

## Preserved

- Handlers unchanged: `saveCheckpoint` / revert / restore / delete / dismiss setters. The behavioral pins in `comux-view-changes.test.ts` (`announce("File reverted…")`, `announce("Changes committed.")`) stay green.
- The header Save's dynamic `sr-only` label was already overridden by its `aria-label`, so dropping it changes nothing.

## Verification

- Co-located `session-changes-panel.test.ts` extended: pins the IconButton usage (danger revert/delete, 3× dismiss ×), that `const btn` is gone, and that **Refresh keeps its spin**.
- Sibling tests (`session-changes-totals`, `comux-view-changes`, `rail-files-panel`, `debug-pane`) pass.
- `pnpm typecheck` clean · `check:tests-wired` 750 · `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)