### PR TITLE
refactor(automations): route remaining Schedules row actions through the shared RowActionButton (cave-4op)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -110,8 +110,8 @@ assert.match(source, /actions\.togglePauseReminder\(item\)/, "the reminder row e
 assert.match(source, /item\.kind !== "daily-summary"/, "daily-summary rows get no run/pause actions");
 assert.match(
   source,
-  /entry\.name[\s\S]*?aria-label=\{`Run \$\{entry\.name\} now`\}/,
-  "unified automation row actions render below the automation name",
+  /entry\.name[\s\S]*?label=\{`Run \$\{entry\.name\} now`\}/,
+  "unified automation row Run action routes through RowActionButton (label → aria-label)",
 );
 assert.match(
   source,
@@ -120,8 +120,22 @@ assert.match(
 );
 assert.match(
   source,
-  /aria-label=\{`Run \$\{name\} now`\}/,
-  "the managed row's Run button carries a distinct accessible name (not just \"Run\"/\"…\")",
+  /label=\{`Run \$\{name\} now`\}/,
+  "the managed row's Run action carries a distinct accessible name (not just \"Run\"/\"…\")",
+);
+
+// cave-4op: every Schedules row action (Run / Pause / Open) routes through the
+// shared RowActionButton (a ghost Button primitive), which now supports a
+// disabled/busy state — no row hand-rolls its own <button> action.
+assert.match(
+  source,
+  /function RowActionButton\(\{ icon, label, text, onClick, disabled \}/,
+  "RowActionButton accepts a disabled/busy state",
+);
+assert.doesNotMatch(
+  source,
+  /<button[\s\S]{0,220}aria-label=\{`Run \$\{(entry\.name|name)\} now`\}/,
+  "no hand-rolled Run row-action buttons remain — they use RowActionButton",
 );
 
 console.log("automations-view.test.ts: ok");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -435,13 +435,14 @@ const ScheduleActionsContext = createContext<ScheduleActions | null>(null);
 // Always-visible labeled row action — the same affordance the All/Flows rows
 // use, so every tab exposes identical controls. Rendered as a sibling of the
 // row's own button (never nested), so a click can't also open the detail panel.
-function RowActionButton({ icon, label, text, onClick }: { icon: IconName; label: string; text: string; onClick: () => void }) {
+function RowActionButton({ icon, label, text, onClick, disabled }: { icon: IconName; label: string; text: string; onClick: () => void; disabled?: boolean }) {
   return (
     <Button
       variant="ghost"
       size="xs"
       aria-label={label}
       onClick={onClick}
+      disabled={disabled}
       className="shrink-0 rounded-[var(--radius-control)] px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)]"
       style={{ color: "var(--text-secondary)" }}
       leadingIcon={icon}
@@ -1510,29 +1511,21 @@ function AutomationEntryRow({
           </span>
         </button>
         <span className="mt-1.5 flex items-center gap-1">
-          <button
-            type="button"
-            disabled={busy}
+          <RowActionButton
+            icon="ph:play"
+            label={`Run ${entry.name} now`}
+            text={busy ? "…" : "Run"}
             onClick={() => onRun(entry)}
-            aria-label={`Run ${entry.name} now`}
-            className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)] disabled:opacity-50"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <Icon name="ph:play" width={11} aria-hidden />
-            {busy ? "…" : "Run"}
-          </button>
+            disabled={busy}
+          />
           {onTogglePause && (
-            <button
-              type="button"
-              disabled={busy}
+            <RowActionButton
+              icon={entryPaused ? "ph:play" : "ph:pause"}
+              label={`${entryPaused ? "Resume" : "Pause"} ${entry.name}`}
+              text={entryPaused ? "Resume" : "Pause"}
               onClick={() => onTogglePause(entry)}
-              aria-label={`${entryPaused ? "Resume" : "Pause"} ${entry.name}`}
-              className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)] disabled:opacity-50"
-              style={{ color: "var(--text-secondary)" }}
-            >
-              <Icon name={entryPaused ? "ph:play" : "ph:pause"} width={11} aria-hidden />
-              {entryPaused ? "Resume" : "Pause"}
-            </button>
+              disabled={busy}
+            />
           )}
         </span>
       </span>
@@ -1605,39 +1598,28 @@ function ManagedAutomationRow({
         <span className="block truncate text-[13px] font-medium" style={{ color: "var(--text-primary)" }}>{name}</span>
         <span className="mt-0.5 block truncate text-[11px]" style={{ color: "var(--text-muted)" }}>{meta}</span>
         <span className="mt-1.5 flex items-center gap-1">
-          <button
-            type="button"
-            disabled={busy}
+          <RowActionButton
+            icon="ph:play"
+            label={`Run ${name} now`}
+            text={busy ? "…" : "Run"}
             onClick={onRun}
-            aria-label={`Run ${name} now`}
-            className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)] disabled:opacity-50"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <Icon name="ph:play" width={11} aria-hidden />
-            {busy ? "…" : "Run"}
-          </button>
+            disabled={busy}
+          />
           {onTogglePause && (
-            <button
-              type="button"
-              disabled={busy}
+            <RowActionButton
+              icon={paused ? "ph:play" : "ph:pause"}
+              label={`${paused ? "Resume" : "Pause"} ${name}`}
+              text={paused ? "Resume" : "Pause"}
               onClick={onTogglePause}
-              aria-label={`${paused ? "Resume" : "Pause"} ${name}`}
-              className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)] disabled:opacity-50"
-              style={{ color: "var(--text-secondary)" }}
-            >
-              <Icon name={paused ? "ph:play" : "ph:pause"} width={11} aria-hidden />
-              {paused ? "Resume" : "Pause"}
-            </button>
+              disabled={busy}
+            />
           )}
-          <button
-            type="button"
+          <RowActionButton
+            icon="ph:arrow-square-out"
+            label={`Open ${name}`}
+            text="Open"
             onClick={onOpen}
-            className="focus-ring inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[color-mix(in_oklch,var(--foreground)_10%,transparent)]"
-            style={{ color: "var(--text-secondary)" }}
-          >
-            <Icon name="ph:arrow-square-out" width={11} aria-hidden />
-            Open
-          </button>
+          />
         </span>
       </span>
     </div>


### PR DESCRIPTION
A cave-4op slice on the **Schedules / Automations** surface (its detail panel was already standardized in a prior pass).

## What changed

Two rows — the unified **"All" list row** (`AutomationEntryRow`) and the **managed-automation row** (`ManagedAutomationRow`) — hand-rolled their **Run / Pause / Open** `<button>`s instead of using **`RowActionButton`**, the surface's own row-action component (a `ghost` `Button` primitive) already used by the reminder, cron, and codex rows.

- Adds an optional **`disabled`** prop to `RowActionButton` (for the busy state the raw buttons needed).
- Routes all **5** buttons through it → every Schedules row action now shares one styling + a11y source.

5 of the 12 remaining raw `<button>`s converted; `RowActionButton` uses 4 → 9.

## Left bespoke (not standard controls)

The full-row **open/select navigation** buttons, the create-menu items (`role="menuitem"`), the **template cards**, and the inline error **Retry** — 7 raw `<button>`s remain, all genuinely bespoke.

## Preserved

- Handlers and accessible names unchanged — `RowActionButton` maps `label` → `aria-label`. The behavioral pin (`{name}</span> … onClick={onRun} … onClick={onOpen}`) stays green.

## Verification

- `automations-view` / `automation-create-dialog` / `automation-familiar-select` tests pass. Updated the two Run-action pins from `aria-label=` → `label=`, and added guards that `RowActionButton` accepts `disabled` and that no row hand-rolls a Run `<button>`.
- `pnpm typecheck` clean · `check:tests-wired` 750 · `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)