### PR TITLE
feat(md-editor): debounced autosave for knowledge & journal docs (cave-b2v)

### DIFF
--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -185,6 +185,10 @@ function KnowledgeMdEditor({
       sourceLabel="Knowledge vault"
       onSave={save}
       onCancel={onCancel}
+      // A new entry materializes on its first (manual) save, which re-keys and
+      // remounts this editor; only autosave once it exists so typing isn't
+      // interrupted mid-keystroke by that remount.
+      autoSave={entry != null}
     />
   );
 }
@@ -251,6 +255,7 @@ function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void
       showHeader={false}
       sourceLabel={`Journal · ${date}`}
       onSave={save}
+      autoSave
     />
   );
 }

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises";
 const shell = await readFile(new URL("./md-editor.tsx", import.meta.url), "utf8");
 const visual = await readFile(new URL("./md-editor-visual.tsx", import.meta.url), "utf8");
 const memory = await readFile(new URL("./memory-md-editor.tsx", import.meta.url), "utf8");
+const grimoire = await readFile(new URL("../grimoire-view.tsx", import.meta.url), "utf8");
 const css = await readFile(new URL("../../styles/md-editor.css", import.meta.url), "utf8");
 const globals = await readFile(new URL("../../app/globals.css", import.meta.url), "utf8");
 
@@ -50,6 +51,33 @@ assert.match(memory, /expectedMtimeMs/, "saves carry the mtime conflict baseline
 assert.match(memory, /res\.status === 409/, "conflicts get a dedicated message");
 assert.match(memory, /<MdEditor\s/, "memory editor renders the shared MdEditor");
 assert.match(memory, /key=\{path\}/, "editor remounts per document path");
+
+// ── Autosave: idempotent surfaces only (cave-b2v) ────────────────────────────
+
+assert.match(shell, /autoSave = false/, "autoSave is opt-in, off by default");
+assert.match(
+  shell,
+  /if \(!autoSave \|\| readOnly \|\| saving \|\| !dirty \|\| !raw\.trim\(\)\) return/,
+  "autosave skips when off, read-only, mid-save, clean, or empty",
+);
+assert.match(
+  shell,
+  /setTimeout\(\(\) => void saveRef\.current\(\), AUTOSAVE_DEBOUNCE_MS\)/,
+  "autosave is debounced and routes through the shared save path",
+);
+assert.match(shell, /clearTimeout\(timer\)/, "a pending autosave is cancelled on change/unmount");
+// Idempotent surfaces opt in; the mtime-guarded memory editor must NOT.
+assert.match(grimoire, /showHeader=\{false\}[\s\S]*?autoSave\b/, "the journal editor autosaves");
+assert.match(
+  grimoire,
+  /autoSave=\{entry != null\}/,
+  "knowledge autosaves only once the entry exists (a new entry's first save remounts)",
+);
+assert.doesNotMatch(
+  memory,
+  /autoSave/,
+  "memory files stay explicit-save — agents write those roots concurrently (mtime conflicts)",
+);
 
 // ── Theme: crepe vars ride the Cave tokens ───────────────────────────────────
 

--- a/src/components/md-editor/md-editor.tsx
+++ b/src/components/md-editor/md-editor.tsx
@@ -21,7 +21,10 @@
  */
 
 import dynamic from "next/dynamic";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** Trailing debounce before an autosave fires once typing pauses. */
+const AUTOSAVE_DEBOUNCE_MS = 1200;
 import { Icon } from "@/lib/icon";
 import { CodeEditor } from "@/components/code-editor";
 import {
@@ -77,6 +80,14 @@ export type MdEditorProps = {
   onCancel?: () => void;
   /** Observe every raw-document change (e.g. to mirror into caller state). */
   onChange?: (raw: string) => void;
+  /**
+   * Persist edits automatically a short while after typing stops, in addition
+   * to the explicit Save button. Only safe for **idempotent** surfaces whose
+   * `onSave` has no disruptive side effects (no editor remount/close) —
+   * knowledge and journal docs. Memory files stay explicit-save (agents write
+   * those roots concurrently; a silent autosave would race an mtime conflict).
+   */
+  autoSave?: boolean;
 };
 
 export function MdEditor({
@@ -87,6 +98,7 @@ export function MdEditor({
   onSave,
   onCancel,
   onChange,
+  autoSave = false,
 }: MdEditorProps) {
   const [raw, setRaw] = useState(value);
   const [baseline, setBaseline] = useState(value);
@@ -161,6 +173,21 @@ export function MdEditor({
       setSaving(false);
     }
   }, [onSave, readOnly, saving]);
+
+  // Autosave: persist a short while after typing stops (idempotent surfaces
+  // only — see the `autoSave` prop doc). A ref keeps the effect from
+  // re-subscribing on every `save` identity change; guarding on `saving` means
+  // we never stack a second request on an in-flight one, and because `saving`
+  // is a dependency the effect re-runs when a save settles and reschedules if
+  // the doc advanced meanwhile. Empty docs are skipped — the save handlers
+  // reject them, so autosaving one would just flash an error.
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  useEffect(() => {
+    if (!autoSave || readOnly || saving || !dirty || !raw.trim()) return;
+    const timer = window.setTimeout(() => void saveRef.current(), AUTOSAVE_DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [autoSave, readOnly, saving, dirty, raw]);
 
   const addTagsFromDraft = useCallback(() => {
     const additions = normalizeMdTags(tagDraft);
@@ -325,8 +352,13 @@ export function MdEditor({
               <Icon name="ph:check" width={11} aria-hidden />
               Saved
             </span>
+          ) : saving ? (
+            <span className="inline-flex items-center gap-1">
+              <Icon name="ph:floppy-disk-bold" width={11} aria-hidden />
+              Saving…
+            </span>
           ) : dirty && !readOnly ? (
-            <span>Unsaved changes</span>
+            <span>{autoSave ? "Autosaving…" : "Unsaved changes"}</span>
           ) : null}
         </div>
         <span className="shrink-0 font-mono">{formatMdDocStats(stats)}</span>


### PR DESCRIPTION
## What

Follow-up to the Grimoire editor (#2562). The shared `MdEditor` gains an opt-in **`autoSave`** prop: once typing pauses (1.2s trailing debounce), it persists through the same save path as the explicit Save button — so knowledge and journal edits aren't lost to a forgotten save.

## Scope (idempotent surfaces only)

| Surface | Autosave? | Why |
|---|---|---|
| **Journal** (grimoire) | ✅ `autoSave` | `onSaved` just refreshes the list; `key={date}` never remounts |
| **Knowledge** (grimoire) | ✅ `autoSave={entry != null}` | a new entry materializes on its first (manual) save, which re-keys + remounts — autosaving before it exists would interrupt typing mid-keystroke |
| **Memory** | ❌ (untouched) | agents write those roots concurrently; a silent autosave would race the mtime-conflict guard and lose an update |
| Journal-entries inline editor | ❌ (untouched) | its `onSave` exits edit mode, which autosave must not trigger |

## Mechanics

A ref-held `save` keeps the effect from resubscribing on every identity change; guarding on `saving` prevents stacking a second request on an in-flight one, and because `saving` is a dependency the effect re-runs when a save settles and **reschedules if the doc advanced meanwhile** (no lost tail edit, no save loop — the baseline catches up and `dirty` goes false). Empty docs are skipped (the handlers reject them). The footer now reads **Autosaving… / Saving… / Saved** so the state is legible.

## Verification

- `typecheck` clean · **555 app tests** · **750 wired**.
- Extended the `md-editor` source-scan test: the exact guard conditions (`!autoSave || readOnly || saving || !dirty || !raw.trim()`), the debounced `setTimeout` + `clearTimeout` cleanup, the two call-site enables, and the **invariant that memory never autosaves**.
- **Runtime e2e deferred**: no grimoire e2e harness exists and driving the rich CodeMirror/Crepe editor end-to-end is out of scope for this slice; the source test pins the behavior contract. Happy to add a grimoire spec as a follow-up.

Net **+67 / −2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)