### PR TITLE
fix(md-editor): light-theme legibility for Crepe inline code + code blocks (cave-nar)

### DIFF
--- a/src/components/code-editor-theme.ts
+++ b/src/components/code-editor-theme.ts
@@ -1,0 +1,115 @@
+/**
+ * Cave CodeMirror theme — the mood-c editor palette shared by every CodeMirror
+ * surface: the Projects file editor (code-editor.tsx), the MdEditor MARKDOWN
+ * mode, and the Milkdown Crepe code blocks inside MdEditor VISUAL mode.
+ *
+ * Derived from the app's canonical Shiki theme (src/styles/shiki/mood-c-dark.json)
+ * so edit mode matches read-mode code blocks exactly. The code surface stays
+ * dark in every app theme (light modes included), so these are fixed inks,
+ * not theme tokens.
+ */
+
+import { EditorView, type Extension } from "@uiw/react-codemirror";
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+import moodCTheme from "@/styles/shiki/mood-c-dark.json";
+
+type MoodTheme = {
+  colors: Record<string, string>;
+  tokenColors: { scope: string[]; settings: { foreground?: string; fontStyle?: string } }[];
+};
+const mood = moodCTheme as MoodTheme;
+
+function moodColor(scope: string, fallback: string): string {
+  for (const tc of mood.tokenColors) {
+    if (tc.scope.includes(scope) && tc.settings.foreground) return tc.settings.foreground;
+  }
+  return fallback;
+}
+
+export const moodInk = mood.colors["editor.foreground"] ?? "#c9c2dc";
+const gutterInk = mood.colors["editorLineNumber.foreground"] ?? "#4a4560";
+const gutterActiveInk = mood.colors["editorLineNumber.activeForeground"] ?? "#7a6fa0";
+
+const C = {
+  comment: moodColor("comment", "#4a4560"),
+  keyword: moodColor("keyword", "#b388ff"),
+  func: moodColor("entity.name.function", "#d4a9ff"),
+  type: moodColor("entity.name.type", "#c5aaff"),
+  param: moodColor("variable.parameter", "#e8d8ff"),
+  string: moodColor("string", "#a8c8ff"),
+  constant: moodColor("constant.numeric", "#ffb3c6"),
+  property: moodColor("support.type.property-name", "#9dd5ff"),
+  attribute: moodColor("entity.other.attribute-name", "#b8d8ff"),
+  punct: moodColor("punctuation", "#8070a0"),
+  operator: moodColor("operator", "#c09ef0"),
+  inserted: moodColor("markup.inserted", "#89ddff"),
+  deleted: moodColor("markup.deleted", "#ff8a9b"),
+  changed: moodColor("markup.changed", "#ffcc80"),
+};
+
+// Lezer tag → mood-c scope mapping. Lezer and TextMate slice the token space
+// differently, so this is the closest-role match, not a 1:1 translation.
+export const moodHighlight = HighlightStyle.define([
+  { tag: [t.comment, t.lineComment, t.blockComment, t.docComment], color: C.comment, fontStyle: "italic" },
+  { tag: [t.keyword, t.controlKeyword, t.moduleKeyword, t.operatorKeyword, t.definitionKeyword, t.modifier, t.self], color: C.keyword },
+  { tag: [t.function(t.variableName), t.function(t.propertyName), t.macroName], color: C.func },
+  { tag: [t.typeName, t.className, t.namespace, t.standard(t.tagName)], color: C.type },
+  { tag: [t.variableName, t.definition(t.variableName)], color: moodInk },
+  { tag: [t.local(t.variableName), t.special(t.variableName)], color: C.param },
+  { tag: [t.string, t.special(t.string), t.regexp, t.character, t.docString], color: C.string },
+  { tag: [t.number, t.bool, t.null, t.atom, t.literal, t.escape, t.constant(t.variableName), t.standard(t.variableName), t.unit, t.color], color: C.constant },
+  { tag: [t.propertyName, t.definition(t.propertyName), t.tagName, t.labelName], color: C.property },
+  { tag: [t.attributeName, t.attributeValue], color: C.attribute },
+  { tag: [t.punctuation, t.separator, t.bracket, t.derefOperator, t.meta], color: C.punct },
+  { tag: [t.operator, t.compareOperator, t.arithmeticOperator, t.logicOperator, t.bitwiseOperator, t.updateOperator, t.definitionOperator, t.typeOperator], color: C.operator },
+  { tag: t.inserted, color: C.inserted },
+  { tag: t.deleted, color: C.deleted },
+  { tag: t.changed, color: C.changed },
+  { tag: t.heading, color: C.func, fontWeight: "600" },
+  { tag: [t.link, t.url], color: C.property, textDecoration: "underline" },
+  { tag: t.emphasis, fontStyle: "italic" },
+  { tag: t.strong, fontWeight: "600" },
+  { tag: t.strikethrough, textDecoration: "line-through" },
+  { tag: t.invalid, color: C.deleted },
+]);
+
+// Editor frame themed to the app so it reads as part of the Cave rather than
+// a generic dark box: the background rides --code-surface (shared with the
+// read-mode blocks) and the caret/selection carry the theme accent. Text and
+// gutter inks come from the mood-c palette, NOT theme tokens — the code
+// surface is dark even in light app themes, where --text-primary is dark ink.
+export const caveEditorFrame = EditorView.theme(
+  {
+    "&": {
+      backgroundColor: "var(--code-surface)",
+      color: moodInk,
+      height: "100%",
+      fontSize: "12px",
+    },
+    ".cm-content": {
+      fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
+      caretColor: "var(--accent-presence)",
+    },
+    ".cm-gutters": {
+      backgroundColor: "var(--code-surface)",
+      color: gutterInk,
+      border: "none",
+    },
+    ".cm-activeLine": { backgroundColor: "color-mix(in oklch, white 4%, transparent)" },
+    ".cm-activeLineGutter": {
+      backgroundColor: "color-mix(in oklch, white 4%, transparent)",
+      color: gutterActiveInk,
+    },
+    "&.cm-focused .cm-cursor": { borderLeftColor: "var(--accent-presence)" },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
+      backgroundColor: "color-mix(in oklch, var(--accent-presence) 28%, transparent)",
+    },
+    ".cm-scroller": { fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace' },
+  },
+  { dark: true },
+);
+
+/** Frame + syntax highlighting in one extension, for consumers that take a
+ *  single `theme` slot (e.g. Milkdown Crepe's code-block feature). */
+export const caveCodeMirrorTheme: Extension = [caveEditorFrame, syntaxHighlighting(moodHighlight)];

--- a/src/components/code-editor.test.ts
+++ b/src/components/code-editor.test.ts
@@ -30,31 +30,36 @@ assert.match(editor, /key: "Escape", run: \(\) => \{ onCancel\(\); return true; 
 // Syntax colors come from the SAME palette as read mode (Shiki mood-c-dark).
 // Without an explicit HighlightStyle, CodeMirror falls back to its default
 // syntax palette, which is designed for LIGHT backgrounds (#a11 strings,
-// #940 comments) — unreadable on the dark --code-surface.
+// #940 comments) — unreadable on the dark --code-surface. The palette +
+// editor frame now live in code-editor-theme.ts, shared with the MdEditor
+// (MARKDOWN mode + Milkdown Crepe code blocks).
+const theme = await readFile(new URL("./code-editor-theme.ts", import.meta.url), "utf8");
 assert.ok(pkg.dependencies["@codemirror/language"], "@codemirror/language dep present for HighlightStyle");
 assert.ok(pkg.dependencies["@lezer/highlight"], "@lezer/highlight dep present for lezer tags");
 assert.match(
-  editor,
+  theme,
   /import \{ HighlightStyle, syntaxHighlighting \} from "@codemirror\/language"/,
-  "editor imports HighlightStyle/syntaxHighlighting",
+  "theme module imports HighlightStyle/syntaxHighlighting",
 );
 assert.match(
-  editor,
+  theme,
   /import moodCTheme from "@\/styles\/shiki\/mood-c-dark\.json"/,
   "syntax palette single source of truth is the shiki mood-c-dark theme json",
 );
-assert.match(editor, /const moodHighlight = HighlightStyle\.define\(/, "a HighlightStyle maps lezer tags to the mood-c palette");
-assert.match(editor, /syntaxHighlighting\(moodHighlight\)/, "the highlight style is installed as an editor extension");
+assert.match(theme, /export const moodHighlight = HighlightStyle\.define\(/, "a HighlightStyle maps lezer tags to the mood-c palette");
+assert.match(theme, /syntaxHighlighting\(moodHighlight\)/, "the highlight style ships in the combined theme extension");
+assert.match(editor, /syntaxHighlighting\(moodHighlight\)/, "the editor installs the shared highlight style");
 // The code surface stays dark in EVERY app theme (light modes included), so
 // editor text/gutter inks must be fixed mood-c inks, not theme text tokens
 // (--text-primary is a dark ink in light themes → dark-on-dark).
-assert.doesNotMatch(editor, /color: "var\(--text-primary\)"/, "editor ink must not ride theme text tokens on the fixed-dark code surface");
-assert.doesNotMatch(editor, /color: "var\(--text-muted\)"/, "gutter ink must not ride theme text tokens on the fixed-dark code surface");
+assert.doesNotMatch(theme, /color: "var\(--text-primary\)"/, "editor ink must not ride theme text tokens on the fixed-dark code surface");
+assert.doesNotMatch(theme, /color: "var\(--text-muted\)"/, "gutter ink must not ride theme text tokens on the fixed-dark code surface");
 
 // Editor chrome is themed to the app's CSS tokens (not the generic dark theme).
-assert.match(editor, /const appTheme = EditorView\.theme\(/, "a CodeMirror theme is defined from app tokens");
-assert.match(editor, /backgroundColor: "var\(--code-surface\)"/, "editor background matches the read code surface via --code-surface");
-assert.match(editor, /caretColor: "var\(--accent-presence\)"/, "caret uses the app accent token");
+assert.match(theme, /export const caveEditorFrame = EditorView\.theme\(/, "a CodeMirror theme is defined from app tokens");
+assert.match(theme, /backgroundColor: "var\(--code-surface\)"/, "editor background matches the read code surface via --code-surface");
+assert.match(theme, /caretColor: "var\(--accent-presence\)"/, "caret uses the app accent token");
+assert.match(editor, /from "@\/components\/code-editor-theme"/, "the editor consumes the shared theme module");
 assert.match(editor, /theme=\{appTheme\}/, "the editor uses the app theme");
 
 // comux uses CodeEditor in edit mode — the plain textarea is gone.

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -3,115 +3,13 @@
 import { useMemo } from "react";
 import CodeMirror, { EditorView, keymap, type Extension } from "@uiw/react-codemirror";
 import { loadLanguage, type LanguageName } from "@uiw/codemirror-extensions-langs";
-import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
-import { tags as t } from "@lezer/highlight";
-import moodCTheme from "@/styles/shiki/mood-c-dark.json";
+import { syntaxHighlighting } from "@codemirror/language";
+import { caveEditorFrame, moodHighlight } from "@/components/code-editor-theme";
 
-// ---------------------------------------------------------------------------
-// Syntax palette — derived from the app's canonical Shiki theme so edit mode
-// matches the read-mode preview and chat code blocks exactly: one palette
-// (src/styles/shiki/mood-c-dark.json), two highlighters. Without an explicit
-// HighlightStyle, CodeMirror falls back to its default syntax colors, which
-// are designed for LIGHT backgrounds (#a11 strings, #940 comments) and are
-// unreadable on the dark --code-surface. The code surface stays dark in every
-// app theme (light modes included), so these are fixed inks, not theme tokens.
-// ---------------------------------------------------------------------------
-
-type MoodTheme = {
-  colors: Record<string, string>;
-  tokenColors: { scope: string[]; settings: { foreground?: string; fontStyle?: string } }[];
-};
-const mood = moodCTheme as MoodTheme;
-
-function moodColor(scope: string, fallback: string): string {
-  for (const tc of mood.tokenColors) {
-    if (tc.scope.includes(scope) && tc.settings.foreground) return tc.settings.foreground;
-  }
-  return fallback;
-}
-
-const ink = mood.colors["editor.foreground"] ?? "#c9c2dc";
-const gutterInk = mood.colors["editorLineNumber.foreground"] ?? "#4a4560";
-const gutterActiveInk = mood.colors["editorLineNumber.activeForeground"] ?? "#7a6fa0";
-
-const C = {
-  comment: moodColor("comment", "#4a4560"),
-  keyword: moodColor("keyword", "#b388ff"),
-  func: moodColor("entity.name.function", "#d4a9ff"),
-  type: moodColor("entity.name.type", "#c5aaff"),
-  param: moodColor("variable.parameter", "#e8d8ff"),
-  string: moodColor("string", "#a8c8ff"),
-  constant: moodColor("constant.numeric", "#ffb3c6"),
-  property: moodColor("support.type.property-name", "#9dd5ff"),
-  attribute: moodColor("entity.other.attribute-name", "#b8d8ff"),
-  punct: moodColor("punctuation", "#8070a0"),
-  operator: moodColor("operator", "#c09ef0"),
-  inserted: moodColor("markup.inserted", "#89ddff"),
-  deleted: moodColor("markup.deleted", "#ff8a9b"),
-  changed: moodColor("markup.changed", "#ffcc80"),
-};
-
-// Lezer tag → mood-c scope mapping. Lezer and TextMate slice the token space
-// differently, so this is the closest-role match, not a 1:1 translation.
-const moodHighlight = HighlightStyle.define([
-  { tag: [t.comment, t.lineComment, t.blockComment, t.docComment], color: C.comment, fontStyle: "italic" },
-  { tag: [t.keyword, t.controlKeyword, t.moduleKeyword, t.operatorKeyword, t.definitionKeyword, t.modifier, t.self], color: C.keyword },
-  { tag: [t.function(t.variableName), t.function(t.propertyName), t.macroName], color: C.func },
-  { tag: [t.typeName, t.className, t.namespace, t.standard(t.tagName)], color: C.type },
-  { tag: [t.variableName, t.definition(t.variableName)], color: ink },
-  { tag: [t.local(t.variableName), t.special(t.variableName)], color: C.param },
-  { tag: [t.string, t.special(t.string), t.regexp, t.character, t.docString], color: C.string },
-  { tag: [t.number, t.bool, t.null, t.atom, t.literal, t.escape, t.constant(t.variableName), t.standard(t.variableName), t.unit, t.color], color: C.constant },
-  { tag: [t.propertyName, t.definition(t.propertyName), t.tagName, t.labelName], color: C.property },
-  { tag: [t.attributeName, t.attributeValue], color: C.attribute },
-  { tag: [t.punctuation, t.separator, t.bracket, t.derefOperator, t.meta], color: C.punct },
-  { tag: [t.operator, t.compareOperator, t.arithmeticOperator, t.logicOperator, t.bitwiseOperator, t.updateOperator, t.definitionOperator, t.typeOperator], color: C.operator },
-  { tag: t.inserted, color: C.inserted },
-  { tag: t.deleted, color: C.deleted },
-  { tag: t.changed, color: C.changed },
-  { tag: t.heading, color: C.func, fontWeight: "600" },
-  { tag: [t.link, t.url], color: C.property, textDecoration: "underline" },
-  { tag: t.emphasis, fontStyle: "italic" },
-  { tag: t.strong, fontWeight: "600" },
-  { tag: t.strikethrough, textDecoration: "line-through" },
-  { tag: t.invalid, color: C.deleted },
-]);
-
-// Editor frame themed to the app so it reads as part of the Cave rather than
-// a generic dark box: the background rides --code-surface (shared with the
-// read-mode blocks) and the caret/selection carry the theme accent. Text and
-// gutter inks come from the mood-c palette, NOT theme tokens — the code
-// surface is dark even in light app themes, where --text-primary is dark ink.
-const appTheme = EditorView.theme(
-  {
-    "&": {
-      backgroundColor: "var(--code-surface)",
-      color: ink,
-      height: "100%",
-      fontSize: "12px",
-    },
-    ".cm-content": {
-      fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace',
-      caretColor: "var(--accent-presence)",
-    },
-    ".cm-gutters": {
-      backgroundColor: "var(--code-surface)",
-      color: gutterInk,
-      border: "none",
-    },
-    ".cm-activeLine": { backgroundColor: "color-mix(in oklch, white 4%, transparent)" },
-    ".cm-activeLineGutter": {
-      backgroundColor: "color-mix(in oklch, white 4%, transparent)",
-      color: gutterActiveInk,
-    },
-    "&.cm-focused .cm-cursor": { borderLeftColor: "var(--accent-presence)" },
-    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, .cm-content ::selection": {
-      backgroundColor: "color-mix(in oklch, var(--accent-presence) 28%, transparent)",
-    },
-    ".cm-scroller": { fontFamily: 'ui-monospace, "SF Mono", Menlo, Consolas, monospace' },
-  },
-  { dark: true },
-);
+// The mood-c palette + editor frame live in code-editor-theme.ts so the same
+// theme drives this editor, the MdEditor MARKDOWN mode, and the Milkdown
+// Crepe code blocks in MdEditor VISUAL mode.
+const appTheme = caveEditorFrame;
 
 // File extension → CodeMirror language. Mirrors the extensions the Projects
 // file preview already accepts; anything unmapped just edits as plain text.

--- a/src/components/md-editor/md-editor-visual.tsx
+++ b/src/components/md-editor/md-editor-visual.tsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useRef } from "react";
 import { Crepe } from "@milkdown/crepe";
+import { caveCodeMirrorTheme } from "@/components/code-editor-theme";
 import "@milkdown/crepe/theme/common/style.css";
 import "@milkdown/crepe/theme/frame-dark.css";
 
@@ -51,6 +52,12 @@ export default function MdEditorVisual({ defaultValue, readOnly, onChange, onSav
         [Crepe.Feature.AI]: false,
         [Crepe.Feature.Latex]: false,
         [Crepe.Feature.TopBar]: false,
+      },
+      featureConfigs: {
+        // Code blocks use the Cave's CodeMirror theme (mood-c palette on the
+        // always-dark --code-surface) instead of Crepe's bundled one-dark
+        // colors, which don't adapt to app themes.
+        [Crepe.Feature.CodeMirror]: { theme: caveCodeMirrorTheme },
       },
     });
     crepe.on((listener) => {

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -41,6 +41,7 @@ assert.match(visual, /\[Crepe\.Feature\.TopBar\]: false/, "Crepe top bar disable
 assert.match(visual, /void crepe\.destroy\(\)/, "Crepe destroyed on unmount");
 assert.match(visual, /setReadonly/, "read-only state forwarded to Crepe");
 assert.match(visual, /@milkdown\/crepe\/theme\/common\/style\.css/, "crepe common theme imported");
+assert.match(visual, /\[Crepe\.Feature\.CodeMirror\]: \{ theme: caveCodeMirrorTheme \}/, "code blocks use the shared Cave CodeMirror theme, not Crepe's bundled one-dark");
 
 // ── Memory wiring: reveal load + guarded PUT ─────────────────────────────────
 
@@ -83,6 +84,19 @@ assert.doesNotMatch(
 
 assert.match(css, /--crepe-color-primary: var\(--accent-presence\)/, "crepe accent mapped to app accent");
 assert.match(css, /--crepe-color-on-background: var\(--text-primary\)/, "crepe ink mapped to app ink");
+// Light-theme legibility (cave-nar): inline code is the app's theme-aware
+// lavender pill, and code blocks keep the always-dark --code-surface with
+// fixed light-on-dark chrome inks — never the old fixed-dark inline mapping.
+assert.match(css, /--crepe-color-inline-code: color-mix\(in oklch, var\(--accent-presence\) 85%, var\(--text-primary\)\)/, "inline code ink is theme-aware");
+assert.match(css, /--crepe-color-inline-area: color-mix\(in oklch, var\(--accent-presence\) 14%, transparent\)/, "inline code pill bg is theme-aware");
+assert.doesNotMatch(css, /--crepe-color-inline-area: var\(--code-surface\)/, "inline code must NOT ride the fixed-dark code surface");
+assert.match(css, /\.milkdown-code-block \{[\s\S]*?background: var\(--code-surface\)/, "code blocks stay on the always-dark code surface");
 assert.match(globals, /@import "\.\.\/styles\/md-editor\.css"/, "md-editor.css imported in globals");
+
+// The shared CodeMirror theme is one module for all three editor surfaces.
+const sharedTheme = await readFile(new URL("../code-editor-theme.ts", import.meta.url), "utf8");
+assert.match(sharedTheme, /export const caveCodeMirrorTheme/, "shared theme exported");
+const codeEditor = await readFile(new URL("../code-editor.tsx", import.meta.url), "utf8");
+assert.match(codeEditor, /from "@\/components\/code-editor-theme"/, "code-editor consumes the shared theme");
 
 console.log("md-editor.test: ok");

--- a/src/styles/md-editor.css
+++ b/src/styles/md-editor.css
@@ -22,16 +22,46 @@
   --crepe-color-on-secondary: var(--text-primary);
   --crepe-color-inverse: var(--bg-elevated);
   --crepe-color-on-inverse: var(--text-primary);
-  --crepe-color-inline-code: var(--accent-presence-soft);
+  /* Inline code: the app's soft lavender pill (cave-chat.css `:not(pre) > code`)
+   * — theme-aware, unlike the old --code-surface mapping, which is a fixed
+   * DARK surface and rendered inline code as an unreadable dark blob on light
+   * themes. */
+  --crepe-color-inline-code: color-mix(in oklch, var(--accent-presence) 85%, var(--text-primary));
+  --crepe-color-inline-area: color-mix(in oklch, var(--accent-presence) 14%, transparent);
   --crepe-color-error: var(--color-warning, #ff8a9b);
   --crepe-color-hover: var(--bg-hover);
   --crepe-color-selected: color-mix(in oklch, var(--accent-presence) 22%, transparent);
-  --crepe-color-inline-area: var(--code-surface);
   --crepe-font-title: inherit;
   --crepe-font-default: inherit;
   --crepe-font-code: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 
   height: 100%;
+  background: transparent;
+}
+
+/* Code blocks: the Cave keeps code on the always-dark --code-surface in every
+ * app theme (same convention as read-mode blocks and the Projects editor).
+ * The CodeMirror instance inside gets the mood-c theme via the Crepe
+ * code-mirror feature config (md-editor-visual.tsx); here the surrounding
+ * block chrome (language picker, copy/preview tools) is re-scoped to fixed
+ * light-on-dark inks so it stays readable on the dark surface in light mode. */
+.md-editor-visual .milkdown .milkdown-code-block {
+  --crepe-color-surface: transparent;
+  --crepe-color-surface-low: color-mix(in oklch, white 8%, transparent);
+  --crepe-color-on-surface: #c9c2dc;
+  --crepe-color-on-surface-variant: #8f86ab;
+  --crepe-color-outline: color-mix(in oklch, white 18%, transparent);
+  --crepe-color-hover: color-mix(in oklch, white 10%, transparent);
+  --crepe-color-background: var(--code-surface);
+
+  background: var(--code-surface);
+  border-radius: 10px;
+}
+
+.md-editor-visual .milkdown .milkdown-code-block .cm-editor {
+  background: transparent;
+}
+.md-editor-visual .milkdown .milkdown-code-block .cm-gutters {
   background: transparent;
 }
 


### PR DESCRIPTION
## What

Verified the MdEditor/Crepe surface on light app themes (`coven-mode=light`) per bead `cave-nar` and fixed the two real breaks found:

| issue | cause | fix |
|---|---|---|
| Inline code = unreadable dark blob | `--crepe-color-inline-area` mapped to `--code-surface` (fixed dark) | theme-aware lavender pill, same recipe as `cave-chat.css` `:not(pre) > code` |
| Code block = one-dark colors on a pale surface + stray dark gutter chip | Crepe's bundled CodeMirror theme ignores app themes | shared `code-editor-theme.ts` (mood-c palette extracted from `code-editor.tsx`) injected via Crepe's code-mirror `theme` config; block stays on the always-dark `--code-surface` with chrome re-scoped to fixed light-on-dark inks |

One CodeMirror theme now drives all three editor surfaces (Projects editor, MdEditor MARKDOWN mode, Crepe code blocks). Single `@codemirror/*` instance confirmed (no extension dual-package hazard).

## Verification

- Playwright screenshots on the built app in **light and dark** modes: inline code readable, code blocks match the app's read-mode convention, no dark regression
- `pnpm typecheck` ✓ · `pnpm build` ✓ (bundle in budget) · `test:app` 555 ✓ (code-editor + md-editor contract tests updated for the extraction, with the same fixed-ink protections)

Closes bead `cave-nar`.