### PR TITLE
feat(md-editor): 409 conflict UI — diff + keep-mine/take-theirs/merge (cave-utl)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -501,6 +501,7 @@ export const SUITES = {
     "src/components/familiars-memory-master-detail.test.ts",
     "src/lib/md-frontmatter.test.ts",
     "src/lib/md-doc-stats.test.ts",
+    "src/lib/line-diff.test.ts",
     "src/components/md-editor/md-editor.test.ts",
     "src/components/grimoire-view.test.ts",
     "src/lib/server/coven-memory-path.test.ts",

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -48,7 +48,13 @@ assert.match(memory, /reveal: true/, "editing loads the un-redacted file");
 assert.match(memory, /method: "PUT"/, "saves go through PUT /api/memory/file");
 assert.match(memory, /\/api\/memory\/file/, "memory save endpoint");
 assert.match(memory, /expectedMtimeMs/, "saves carry the mtime conflict baseline");
-assert.match(memory, /res\.status === 409/, "conflicts get a dedicated message");
+assert.match(memory, /res\.status === 409/, "conflicts get dedicated handling");
+assert.match(memory, /json\.currentMtimeMs/, "a 409 re-baselines on the server-reported disk mtime");
+assert.match(
+  memory,
+  /conflict: \{ currentText: json\.currentText \}/,
+  "a 409 forwards the disk text to the editor's conflict panel",
+);
 assert.match(memory, /<MdEditor\s/, "memory editor renders the shared MdEditor");
 assert.match(memory, /key=\{path\}/, "editor remounts per document path");
 
@@ -57,8 +63,8 @@ assert.match(memory, /key=\{path\}/, "editor remounts per document path");
 assert.match(shell, /autoSave = false/, "autoSave is opt-in, off by default");
 assert.match(
   shell,
-  /if \(!autoSave \|\| readOnly \|\| saving \|\| !dirty \|\| !raw\.trim\(\)\) return/,
-  "autosave skips when off, read-only, mid-save, clean, or empty",
+  /if \(!autoSave \|\| readOnly \|\| saving \|\| conflict !== null \|\| !dirty \|\| !raw\.trim\(\)\) return/,
+  "autosave skips when off, read-only, mid-save, conflicted, clean, or empty",
 );
 assert.match(
   shell,
@@ -78,6 +84,22 @@ assert.doesNotMatch(
   /autoSave/,
   "memory files stay explicit-save — agents write those roots concurrently (mtime conflicts)",
 );
+
+// ── Conflict panel: diff + keep-mine / take-theirs / merge (cave-utl) ────────
+
+assert.match(shell, /MdEditorConflictPanel/, "conflicts render a dedicated resolution panel");
+assert.match(shell, /aria-label="Resolve edit conflict"/, "the conflict panel is a labelled region");
+assert.match(shell, /diffLines\(theirs, mine\)/, "the panel diffs the disk version against the draft");
+assert.match(shell, /Keep my draft/, "keep-mine action offered");
+assert.match(shell, /Take disk version/, "take-theirs action offered");
+assert.match(shell, /Merge both/, "merge action offered");
+assert.match(shell, /mergeThreeWay\(baseline, rawRef\.current, current\.currentText\)/, "merge is a three-way merge from the saved baseline");
+assert.match(
+  shell,
+  /if \(merged\.conflicts > 0\) switchMode\("markdown"\)/,
+  "marker-bearing merges land in MARKDOWN mode where the markers are editable",
+);
+assert.match(shell, /setBaseline\(current\.currentText\)/, "take-theirs re-baselines on the disk text");
 
 // ── Theme: crepe vars ride the Cave tokens ───────────────────────────────────
 

--- a/src/components/md-editor/md-editor.tsx
+++ b/src/components/md-editor/md-editor.tsx
@@ -33,6 +33,7 @@ import {
   serializeMdDocument,
 } from "@/lib/md-frontmatter";
 import { computeMdDocStats, formatMdDocStats } from "@/lib/md-doc-stats";
+import { diffLines, mergeThreeWay, type LineDiffOp } from "@/lib/line-diff";
 
 const MdEditorVisual = dynamic(() => import("./md-editor-visual"), {
   ssr: false,
@@ -44,7 +45,13 @@ const MdEditorVisual = dynamic(() => import("./md-editor-visual"), {
 });
 
 export type MdEditorMode = "visual" | "markdown";
-export type MdEditorSaveResult = { ok: boolean; error?: string };
+
+/** A concurrent-write conflict reported by the transport (e.g. the memory
+ *  file API's 409): the document changed underneath the editor. `currentText`
+ *  is the version now on disk. */
+export type MdEditorConflict = { currentText: string };
+
+export type MdEditorSaveResult = { ok: boolean; error?: string; conflict?: MdEditorConflict };
 
 const MODE_PREF_KEY = "cave:md-editor:mode";
 
@@ -108,6 +115,9 @@ export function MdEditor({
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedFlash, setSavedFlash] = useState(false);
+  // A 409-style concurrent-write conflict: the transport reported the document
+  // changed underneath us. While set, the body shows the resolution panel.
+  const [conflict, setConflict] = useState<MdEditorConflict | null>(null);
   const rawRef = useRef(raw);
   rawRef.current = raw;
   const onChangeRef = useRef(onChange);
@@ -162,8 +172,11 @@ export function MdEditor({
       const result = await onSave(snapshot);
       if (result.ok) {
         setBaseline(snapshot);
+        setConflict(null);
         setSavedFlash(true);
         window.setTimeout(() => setSavedFlash(false), 1500);
+      } else if (result.conflict) {
+        setConflict(result.conflict);
       } else {
         setSaveError(result.error ?? "Save failed");
       }
@@ -174,20 +187,56 @@ export function MdEditor({
     }
   }, [onSave, readOnly, saving]);
 
+  // ── Conflict resolution ──────────────────────────────────────────────────
+  // Keep mine: overwrite the disk version with the draft (the transport
+  // re-baselined on the conflict, so a plain re-save lands). Take theirs:
+  // adopt the disk version and drop the draft. Merge: three-way merge of
+  // baseline/draft/disk; overlapping edits get git-style markers to resolve.
+  const resolveKeepMine = useCallback(() => {
+    setConflict(null);
+    void save();
+  }, [save]);
+
+  const resolveTakeTheirs = useCallback(() => {
+    setConflict((current) => {
+      if (current) {
+        updateRaw(current.currentText);
+        setBaseline(current.currentText);
+        setVisualEpoch((n) => n + 1);
+      }
+      return null;
+    });
+  }, [updateRaw]);
+
+  const resolveMerge = useCallback(() => {
+    setConflict((current) => {
+      if (current) {
+        const merged = mergeThreeWay(baseline, rawRef.current, current.currentText);
+        updateRaw(merged.text);
+        setVisualEpoch((n) => n + 1);
+        // Conflict markers are raw-text constructs — resolve them in MARKDOWN
+        // mode so the visual editor doesn't normalize them away.
+        if (merged.conflicts > 0) switchMode("markdown");
+      }
+      return null;
+    });
+  }, [baseline, switchMode, updateRaw]);
+
   // Autosave: persist a short while after typing stops (idempotent surfaces
   // only — see the `autoSave` prop doc). A ref keeps the effect from
   // re-subscribing on every `save` identity change; guarding on `saving` means
   // we never stack a second request on an in-flight one, and because `saving`
   // is a dependency the effect re-runs when a save settles and reschedules if
   // the doc advanced meanwhile. Empty docs are skipped — the save handlers
-  // reject them, so autosaving one would just flash an error.
+  // reject them, so autosaving one would just flash an error. An open conflict
+  // panel also pauses autosave: overwriting is an explicit choice.
   const saveRef = useRef(save);
   saveRef.current = save;
   useEffect(() => {
-    if (!autoSave || readOnly || saving || !dirty || !raw.trim()) return;
+    if (!autoSave || readOnly || saving || conflict !== null || !dirty || !raw.trim()) return;
     const timer = window.setTimeout(() => void saveRef.current(), AUTOSAVE_DEBOUNCE_MS);
     return () => window.clearTimeout(timer);
-  }, [autoSave, readOnly, saving, dirty, raw]);
+  }, [autoSave, readOnly, saving, conflict, dirty, raw]);
 
   const addTagsFromDraft = useCallback(() => {
     const additions = normalizeMdTags(tagDraft);
@@ -316,7 +365,16 @@ export function MdEditor({
       ) : null}
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        {mode === "visual" ? (
+        {conflict ? (
+          <MdEditorConflictPanel
+            mine={raw}
+            theirs={conflict.currentText}
+            onKeepMine={resolveKeepMine}
+            onTakeTheirs={resolveTakeTheirs}
+            onMerge={resolveMerge}
+            onDismiss={() => setConflict(null)}
+          />
+        ) : mode === "visual" ? (
           <MdEditorVisual
             key={visualEpoch}
             defaultValue={doc.body}
@@ -362,6 +420,150 @@ export function MdEditor({
           ) : null}
         </div>
         <span className="shrink-0 font-mono">{formatMdDocStats(stats)}</span>
+      </div>
+    </div>
+  );
+}
+
+// ── Conflict panel ───────────────────────────────────────────────────────────
+
+/** Collapse runs of unchanged lines longer than this to a "⋯ n unchanged" row
+ *  so the conflict diff stays focused on the divergence. */
+const CONFLICT_CTX_RUN = 4;
+
+type ConflictDiffRow =
+  | { kind: "op"; op: LineDiffOp }
+  | { kind: "skip"; count: number };
+
+function buildConflictRows(ops: LineDiffOp[]): ConflictDiffRow[] {
+  const rows: ConflictDiffRow[] = [];
+  let run: LineDiffOp[] = [];
+  const flush = (trailing: boolean) => {
+    if (run.length <= CONFLICT_CTX_RUN) {
+      for (const op of run) rows.push({ kind: "op", op });
+    } else if (trailing) {
+      // Keep a couple of context lines at the edge of a change, skip the rest.
+      for (const op of run.slice(0, 2)) rows.push({ kind: "op", op });
+      rows.push({ kind: "skip", count: run.length - 2 });
+    } else {
+      rows.push({ kind: "skip", count: run.length - 2 });
+      for (const op of run.slice(-2)) rows.push({ kind: "op", op });
+    }
+    run = [];
+  };
+  for (const op of ops) {
+    if (op.type === "ctx") {
+      run.push(op);
+    } else {
+      flush(false);
+      rows.push({ kind: "op", op });
+    }
+  }
+  flush(true);
+  return rows;
+}
+
+/**
+ * Concurrent-write conflict resolver: shows the difference between the disk
+ * version ("theirs") and the local draft ("mine") and offers the three
+ * resolutions. Rendered in place of the editor body while a conflict is open.
+ */
+function MdEditorConflictPanel({
+  mine,
+  theirs,
+  onKeepMine,
+  onTakeTheirs,
+  onMerge,
+  onDismiss,
+}: {
+  mine: string;
+  theirs: string;
+  onKeepMine: () => void;
+  onTakeTheirs: () => void;
+  onMerge: () => void;
+  onDismiss: () => void;
+}) {
+  // old = disk, new = draft: green rows are lines only in the draft, red rows
+  // are lines only on disk — i.e. the effect of choosing "Keep my draft".
+  const rows = useMemo(() => buildConflictRows(diffLines(theirs, mine)), [mine, theirs]);
+  const identical = rows.every((r) => r.kind === "skip" || r.op.type === "ctx");
+
+  return (
+    <div
+      role="region"
+      aria-label="Resolve edit conflict"
+      className="md-editor__conflict flex h-full min-h-0 flex-col"
+    >
+      <div className="shrink-0 space-y-1 border-b border-[var(--border-hairline)] px-4 py-3">
+        <p role="alert" className="inline-flex items-center gap-1.5 text-[12px] font-semibold text-[var(--color-warning)]">
+          <Icon name="ph:warning-circle" width={13} aria-hidden />
+          This document changed on disk while you were editing
+        </p>
+        <p className="text-[11px] text-[var(--text-muted)]">
+          {identical
+            ? "The disk version now matches your draft — you can safely take either."
+            : "Review the difference, then keep your draft, take the disk version, or merge the two."}
+          {" "}
+          <span className="md-editor__conflict-key md-editor__conflict-key--mine">your draft</span>
+          {" · "}
+          <span className="md-editor__conflict-key md-editor__conflict-key--theirs">on disk</span>
+        </p>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto px-2 py-2">
+        <div className="md-editor__conflict-diff font-mono text-[11px] leading-5" role="table" aria-label="Draft vs disk diff">
+          {rows.map((row, i) =>
+            row.kind === "skip" ? (
+              <div key={i} className="md-editor__conflict-line md-editor__conflict-line--skip" role="row">
+                ⋯ {row.count} unchanged line{row.count === 1 ? "" : "s"}
+              </div>
+            ) : (
+              <div
+                key={i}
+                role="row"
+                className={`md-editor__conflict-line md-editor__conflict-line--${row.op.type}`}
+              >
+                <span aria-hidden className="md-editor__conflict-marker">
+                  {row.op.type === "add" ? "+" : row.op.type === "del" ? "−" : " "}
+                </span>
+                {row.op.text || "\u00a0"}
+              </div>
+            ),
+          )}
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-1.5 border-t border-[var(--border-hairline)] px-3 py-2">
+        <button
+          type="button"
+          onClick={onKeepMine}
+          className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--color-warning)]/40 px-2 text-[11px] text-[var(--color-warning)] hover:bg-[var(--color-warning)]/10"
+        >
+          <Icon name="ph:floppy-disk-bold" width={11} aria-hidden />
+          Keep my draft
+        </button>
+        <button
+          type="button"
+          onClick={onTakeTheirs}
+          className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name="ph:arrow-counter-clockwise" width={11} aria-hidden />
+          Take disk version
+        </button>
+        <button
+          type="button"
+          onClick={onMerge}
+          className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          <Icon name="ph:git-merge" width={11} aria-hidden />
+          Merge both
+        </button>
+        <span className="flex-1" />
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="focus-ring inline-flex h-7 items-center rounded-md px-2 text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+        >
+          Back to editing
+        </button>
       </div>
     </div>
   );

--- a/src/components/md-editor/memory-md-editor.tsx
+++ b/src/components/md-editor/memory-md-editor.tsx
@@ -6,7 +6,10 @@
  * Loads the un-redacted file (`?reveal=1`) so a save can never write
  * `[REDACTED:…]` placeholders over real secrets, and saves through
  * `PUT /api/memory/file` carrying the loaded `mtimeMs` so concurrent agent
- * writes surface as a conflict instead of a lost update.
+ * writes surface as a conflict instead of a lost update. A 409 forwards the
+ * disk version to the editor's conflict panel (diff + keep-mine / take-theirs
+ * / merge) and re-baselines the expected mtime so the chosen resolution can
+ * land — while still guarding against writes that happen after the 409.
  *
  * Reused by the memory reader's edit mode and the Grimoire surface.
  */
@@ -47,13 +50,20 @@ export function MemoryMdEditor({
         });
         const json = await res.json();
         if (!json.ok) {
-          return {
-            ok: false,
-            error:
-              res.status === 409
-                ? "File changed on disk — cancel and reopen to pick up the latest version."
-                : json.error ?? "Save failed",
-          };
+          if (res.status === 409) {
+            // Conflict: re-baseline on the disk mtime the server reported so
+            // the user's resolution (overwrite / take / merge, then save) can
+            // land, and hand the disk text to the editor's conflict panel.
+            if (typeof json.currentMtimeMs === "number") mtimeRef.current = json.currentMtimeMs;
+            if (typeof json.currentText === "string") {
+              return { ok: false, conflict: { currentText: json.currentText } };
+            }
+            return {
+              ok: false,
+              error: "File changed on disk — cancel and reopen to pick up the latest version.",
+            };
+          }
+          return { ok: false, error: json.error ?? "Save failed" };
         }
         if (typeof json.mtimeMs === "number") mtimeRef.current = json.mtimeMs;
         onSaved?.(raw);

--- a/src/lib/line-diff.test.ts
+++ b/src/lib/line-diff.test.ts
@@ -1,0 +1,141 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  diffLines,
+  hasLineChanges,
+  mergeThreeWay,
+  CONFLICT_MARKER_MINE,
+  CONFLICT_MARKER_SEP,
+  CONFLICT_MARKER_THEIRS,
+} from "./line-diff.ts";
+
+// ── diffLines ────────────────────────────────────────────────────────────────
+
+assert.deepEqual(diffLines("", ""), [], "empty vs empty has no ops");
+
+assert.deepEqual(
+  diffLines("a\nb\nc", "a\nb\nc"),
+  [
+    { type: "ctx", text: "a" },
+    { type: "ctx", text: "b" },
+    { type: "ctx", text: "c" },
+  ],
+  "identical text is all context",
+);
+assert.equal(hasLineChanges(diffLines("a\nb", "a\nb")), false, "no changes detected on identical");
+
+assert.deepEqual(
+  diffLines("a\nb\nc", "a\nB\nc"),
+  [
+    { type: "ctx", text: "a" },
+    { type: "del", text: "b" },
+    { type: "add", text: "B" },
+    { type: "ctx", text: "c" },
+  ],
+  "a changed middle line is del+add between context",
+);
+
+assert.deepEqual(
+  diffLines("a\nc", "a\nb\nc"),
+  [
+    { type: "ctx", text: "a" },
+    { type: "add", text: "b" },
+    { type: "ctx", text: "c" },
+  ],
+  "insertions are adds",
+);
+
+assert.deepEqual(
+  diffLines("a\nb\nc", "c"),
+  [
+    { type: "del", text: "a" },
+    { type: "del", text: "b" },
+    { type: "ctx", text: "c" },
+  ],
+  "deletions are dels",
+);
+
+assert.deepEqual(
+  diffLines("", "x\ny"),
+  [
+    { type: "add", text: "x" },
+    { type: "add", text: "y" },
+  ],
+  "empty old is all adds",
+);
+
+// Trailing-newline handling: "a\n" is the line "a" plus an empty final line.
+assert.equal(hasLineChanges(diffLines("a\n", "a\n")), false, "trailing newline round-trips");
+assert.equal(hasLineChanges(diffLines("a", "a\n")), true, "added trailing newline is a change");
+
+// ── mergeThreeWay: clean merges ──────────────────────────────────────────────
+
+{
+  const base = "one\ntwo\nthree\nfour";
+  const mine = "ONE\ntwo\nthree\nfour"; // change at top
+  const theirs = "one\ntwo\nthree\nFOUR"; // change at bottom
+  const merged = mergeThreeWay(base, mine, theirs);
+  assert.equal(merged.conflicts, 0, "non-overlapping edits merge cleanly");
+  assert.equal(merged.text, "ONE\ntwo\nthree\nFOUR", "both sides' edits land");
+}
+
+{
+  const base = "a\nb\nc";
+  const merged = mergeThreeWay(base, base, base);
+  assert.equal(merged.conflicts, 0);
+  assert.equal(merged.text, base, "no-op merge returns base");
+}
+
+{
+  const base = "a\nb\nc";
+  const mine = "a\nb\nc\nmine-tail";
+  const merged = mergeThreeWay(base, mine, base);
+  assert.equal(merged.conflicts, 0);
+  assert.equal(merged.text, mine, "one-sided tail insertion is kept");
+}
+
+{
+  const base = "a\nb\nc";
+  const both = "a\nX\nc";
+  const merged = mergeThreeWay(base, both, both);
+  assert.equal(merged.conflicts, 0);
+  assert.equal(merged.text, both, "identical edits on both sides merge without conflict");
+}
+
+{
+  // One side deletes a line the other side left alone.
+  const base = "a\nb\nc";
+  const merged = mergeThreeWay(base, "a\nc", base);
+  assert.equal(merged.conflicts, 0);
+  assert.equal(merged.text, "a\nc", "one-sided deletion is kept");
+}
+
+// ── mergeThreeWay: conflicts ─────────────────────────────────────────────────
+
+{
+  const base = "a\nb\nc";
+  const merged = mergeThreeWay(base, "a\nMINE\nc", "a\nTHEIRS\nc");
+  assert.equal(merged.conflicts, 1, "overlapping different edits conflict");
+  assert.equal(
+    merged.text,
+    ["a", CONFLICT_MARKER_MINE, "MINE", CONFLICT_MARKER_SEP, "THEIRS", CONFLICT_MARKER_THEIRS, "c"].join("\n"),
+    "conflict block carries git-style markers",
+  );
+}
+
+{
+  // Two separate conflicting regions are counted separately.
+  const base = "a\nb\nc\nd\ne";
+  const merged = mergeThreeWay(base, "a\nM1\nc\nd\nM2", "a\nT1\nc\nd\nT2");
+  assert.equal(merged.conflicts, 2, "each overlapping region counts once");
+}
+
+{
+  // Whole-document divergence with no stable lines.
+  const merged = mergeThreeWay("base", "mine", "theirs");
+  assert.equal(merged.conflicts, 1);
+  assert.match(merged.text, /your draft/, "markers label the local side");
+  assert.match(merged.text, /on disk/, "markers label the disk side");
+}
+
+console.log("line-diff.test: ok");

--- a/src/lib/line-diff.ts
+++ b/src/lib/line-diff.ts
@@ -1,0 +1,181 @@
+// Line-based diff + three-way merge for the MdEditor conflict UI.
+//
+// When PUT /api/memory/file returns 409 (the file changed on disk while the
+// user edited), the editor shows the local draft against the disk version and
+// offers keep-mine / take-theirs / merge. This module provides the pure logic:
+// an LCS line diff for the visual comparison and a diff3-style merge that
+// combines non-overlapping edits and marks overlapping ones with git-style
+// conflict markers.
+//
+// Framework-free so it can be unit-tested directly.
+
+export type LineDiffOp = { type: "add" | "del" | "ctx"; text: string };
+
+/** Above this old×new size the LCS DP table is skipped and the whole changed
+ *  middle is reported as one del/add block (prefix/suffix still align). */
+const MAX_LCS_CELLS = 4_000_000;
+
+function splitLines(text: string): string[] {
+  return text === "" ? [] : text.split("\n");
+}
+
+/** Longest-common-subsequence match pairs between two line arrays, after
+ *  trimming the common prefix/suffix. Falls back to no interior matches when
+ *  the DP table would be too large. */
+function lcsPairs(a: string[], b: string[]): Array<[number, number]> {
+  let start = 0;
+  while (start < a.length && start < b.length && a[start] === b[start]) start++;
+  let endA = a.length;
+  let endB = b.length;
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA--;
+    endB--;
+  }
+
+  const pairs: Array<[number, number]> = [];
+  for (let i = 0; i < start; i++) pairs.push([i, i]);
+
+  const n = endA - start;
+  const m = endB - start;
+  if (n > 0 && m > 0 && n * m <= MAX_LCS_CELLS) {
+    // Classic LCS length table over the changed middle, then backtrack.
+    const width = m + 1;
+    const table = new Uint32Array((n + 1) * width);
+    for (let i = n - 1; i >= 0; i--) {
+      for (let j = m - 1; j >= 0; j--) {
+        table[i * width + j] =
+          a[start + i] === b[start + j]
+            ? table[(i + 1) * width + j + 1] + 1
+            : Math.max(table[(i + 1) * width + j], table[i * width + j + 1]);
+      }
+    }
+    let i = 0;
+    let j = 0;
+    while (i < n && j < m) {
+      if (a[start + i] === b[start + j]) {
+        pairs.push([start + i, start + j]);
+        i++;
+        j++;
+      } else if (table[(i + 1) * width + j] >= table[i * width + j + 1]) {
+        i++;
+      } else {
+        j++;
+      }
+    }
+  }
+
+  for (let k = 0; endA + k < a.length; k++) pairs.push([endA + k, endB + k]);
+  return pairs;
+}
+
+/** Line diff from `oldText` to `newText` as del/add/ctx ops in order. */
+export function diffLines(oldText: string, newText: string): LineDiffOp[] {
+  const a = splitLines(oldText);
+  const b = splitLines(newText);
+  const ops: LineDiffOp[] = [];
+  let ai = 0;
+  let bi = 0;
+  for (const [ma, mb] of lcsPairs(a, b)) {
+    while (ai < ma) ops.push({ type: "del", text: a[ai++] });
+    while (bi < mb) ops.push({ type: "add", text: b[bi++] });
+    ops.push({ type: "ctx", text: a[ai] });
+    ai++;
+    bi++;
+  }
+  while (ai < a.length) ops.push({ type: "del", text: a[ai++] });
+  while (bi < b.length) ops.push({ type: "add", text: b[bi++] });
+  return ops;
+}
+
+/** True when the two texts differ (fast path for the conflict panel). */
+export function hasLineChanges(ops: LineDiffOp[]): boolean {
+  return ops.some((op) => op.type !== "ctx");
+}
+
+export type ThreeWayMergeResult = { text: string; conflicts: number };
+
+export const CONFLICT_MARKER_MINE = "<<<<<<< your draft";
+export const CONFLICT_MARKER_SEP = "=======";
+export const CONFLICT_MARKER_THEIRS = ">>>>>>> on disk";
+
+/**
+ * diff3-style line merge of two descendants of `base`. Regions changed on only
+ * one side take that side; regions changed identically on both take either;
+ * overlapping different changes become a git-style conflict block (counted in
+ * `conflicts`) for the user to resolve in the editor.
+ */
+export function mergeThreeWay(base: string, mine: string, theirs: string): ThreeWayMergeResult {
+  const baseLines = splitLines(base);
+  const mineLines = splitLines(mine);
+  const theirsLines = splitLines(theirs);
+
+  // base-index → matched descendant index, per side.
+  const mineMap = new Map<number, number>(lcsPairs(baseLines, mineLines));
+  const theirsMap = new Map<number, number>(lcsPairs(baseLines, theirsLines));
+
+  const out: string[] = [];
+  let conflicts = 0;
+  let bi = 0; // base cursor
+  let mi = 0; // mine cursor
+  let ti = 0; // theirs cursor
+
+  const emitChunk = (mineChunk: string[], theirsChunk: string[], baseChunk: string[]) => {
+    const mineChanged =
+      mineChunk.length !== baseChunk.length || mineChunk.some((l, i) => l !== baseChunk[i]);
+    const theirsChanged =
+      theirsChunk.length !== baseChunk.length || theirsChunk.some((l, i) => l !== baseChunk[i]);
+    if (!mineChanged) {
+      out.push(...theirsChunk);
+    } else if (!theirsChanged) {
+      out.push(...mineChunk);
+    } else if (
+      mineChunk.length === theirsChunk.length &&
+      mineChunk.every((l, i) => l === theirsChunk[i])
+    ) {
+      out.push(...mineChunk);
+    } else {
+      conflicts++;
+      out.push(CONFLICT_MARKER_MINE, ...mineChunk, CONFLICT_MARKER_SEP, ...theirsChunk, CONFLICT_MARKER_THEIRS);
+    }
+  };
+
+  while (bi <= baseLines.length) {
+    // A "stable" base line is one both sides kept; chunks are the spans between
+    // stable lines (plus the tail past the last base line).
+    const stable = bi < baseLines.length && mineMap.has(bi) && theirsMap.has(bi);
+    if (stable) {
+      const mm = mineMap.get(bi)!;
+      const tm = theirsMap.get(bi)!;
+      emitChunk(mineLines.slice(mi, mm), theirsLines.slice(ti, tm), []);
+      out.push(baseLines[bi]);
+      mi = mm + 1;
+      ti = tm + 1;
+      bi++;
+      continue;
+    }
+    if (bi === baseLines.length) {
+      emitChunk(mineLines.slice(mi), theirsLines.slice(ti), []);
+      break;
+    }
+    // Collect the unstable base span and the descendant spans that replace it:
+    // everything up to (but not including) the next stable base line.
+    const chunkStart = bi;
+    while (bi < baseLines.length && !(mineMap.has(bi) && theirsMap.has(bi))) bi++;
+    const baseChunk = baseLines.slice(chunkStart, bi);
+    const mineEnd = bi < baseLines.length ? mineMap.get(bi)! : mineLines.length;
+    const theirsEnd = bi < baseLines.length ? theirsMap.get(bi)! : theirsLines.length;
+    emitChunk(mineLines.slice(mi, mineEnd), theirsLines.slice(ti, theirsEnd), baseChunk);
+    mi = mineEnd;
+    ti = theirsEnd;
+    if (bi < baseLines.length) {
+      out.push(baseLines[bi]);
+      mi++;
+      ti++;
+      bi++;
+    } else {
+      break;
+    }
+  }
+
+  return { text: out.join("\n"), conflicts };
+}

--- a/src/styles/md-editor.css
+++ b/src/styles/md-editor.css
@@ -52,3 +52,45 @@
 .md-editor-visual .milkdown .ProseMirror ::selection {
   background: color-mix(in oklch, var(--accent-presence) 28%, transparent);
 }
+
+/* ── Conflict panel (concurrent-write 409) ─────────────────────────────────
+ * Shown in place of the editor body when a save reports the document changed
+ * on disk. Green rows exist only in the local draft, red rows only on disk. */
+.md-editor__conflict-key {
+  border-radius: 3px;
+  padding: 0 4px;
+}
+.md-editor__conflict-key--mine {
+  background: color-mix(in oklch, var(--color-success, #3fb950) 18%, transparent);
+  color: var(--text-primary);
+}
+.md-editor__conflict-key--theirs {
+  background: color-mix(in oklch, var(--color-danger, #f85149) 18%, transparent);
+  color: var(--text-primary);
+}
+.md-editor__conflict-line {
+  display: flex;
+  gap: 8px;
+  padding: 0 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-muted);
+}
+.md-editor__conflict-marker {
+  flex-shrink: 0;
+  user-select: none;
+  opacity: 0.7;
+}
+.md-editor__conflict-line--add {
+  background: color-mix(in oklch, var(--color-success, #3fb950) 14%, transparent);
+  color: var(--text-primary);
+}
+.md-editor__conflict-line--del {
+  background: color-mix(in oklch, var(--color-danger, #f85149) 14%, transparent);
+  color: var(--text-primary);
+}
+.md-editor__conflict-line--skip {
+  padding: 2px 8px;
+  font-style: italic;
+  opacity: 0.7;
+}


### PR DESCRIPTION
## What

Follow-up to #2562 (bead `cave-utl`). When `PUT /api/memory/file` returns **409** (the file changed on disk while editing — agents write these roots too), the MdEditor previously dead-ended with *"cancel and reopen"*. It now opens a **conflict resolution panel** in place of the editor body:

- **Line diff** of the disk version vs the local draft (green = only in draft, red = only on disk; long unchanged runs collapse)
- **Keep my draft** — guarded overwrite: the transport re-baselines `expectedMtimeMs` on the 409's `currentMtimeMs`, so the overwrite still 409s again if the file moves *after* the conflict was shown
- **Take disk version** — adopts the disk text and re-baselines (editor clean)
- **Merge both** — diff3-style three-way merge from the saved baseline; non-overlapping edits combine, overlapping ones get git-style conflict markers and the editor drops to MARKDOWN mode to resolve them
- **Back to editing** dismisses the panel

### New `src/lib/line-diff.ts`
Framework-free LCS line diff + `mergeThreeWay` (with an O(n·m) guard that degrades to a whole-block change on huge files), unit-tested in `src/lib/line-diff.test.ts`.

### Editor plumbing
- `MdEditorSaveResult` gains an optional `conflict: { currentText }`
- `memory-md-editor` forwards the 409's `currentText`/`currentMtimeMs` (falls back to the old message if the server couldn't read the file)
- Autosave (knowledge/journal) pauses while a conflict panel is open

## Verification
- `pnpm typecheck` ✓
- `pnpm check:tests-wired` ✓ (751 wired)
- `pnpm test:app` ✓ 556 files (new `line-diff.test.ts` wired; md-editor source assertions extended for the panel)