### PR TITLE
chore(release): stamp v0.0.147

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.147] - 2026-07-07
+
+> ⚡ **Faster and steadier** — memory inventory gets a 130x speedup, the markdown editor picks up debounced autosave for knowledge & journal docs, and the Work Queue surfaces a "Needs attention" strip for stale and unlinked PRs. Plus a round of session-changes and automations button refactors onto shared primitives.
+
+Feature release on top of v0.0.146.
+
+### Features
+- **Work Queue: "Needs attention" strip** (#2568, cave-x1j). Surfaces stale and unlinked PRs at a glance.
+- **Markdown editor: debounced autosave** (#2574, cave-b2v). Knowledge and journal docs now save automatically as you type.
+
+### Performance
+- **Memory inventory: 130x faster** (#2570, cave-od4). Head reads, pooled I/O, and an mtime cache slash inventory time.
+
+### Refactors
+- **Session changes: shared button primitives** (#2571, #2572, cave-4op). Commit/PR footer buttons standardize on the shared `Button`, and icon-only buttons normalize to the borderless `IconButton`.
+- **Automations: shared row actions** (#2573, cave-4op). The remaining Schedules row actions route through the shared `RowActionButton`.
+
 ## [0.0.146] - 2026-07-07
 
 > 📝 **Write where you think** — a new OpenKnowledge-style markdown editor lands across memory, knowledge, and journal, and the marketplace folds its Skills filter rail and leaderboard into one panel. Plus a Gantt scroll fix, cleaner GitHub comments, and a calendar controls refactor onto shared primitives.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.146",
+  "version": "0.0.147",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.146"
+version = "0.0.147"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.146"
+version = "0.0.147"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.146</string>
+	<string>0.0.147</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.146</string>
+	<string>0.0.147</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.146</string>
+	<string>0.0.147</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.146</string>
+	<string>0.0.147</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.146",
+  "version": "0.0.147",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.147** across all six version locations + adds the CHANGELOG entry.

## What ships (6 commits since v0.0.146)
- **#2568** — Work Queue "Needs attention" strip for stale + unlinked PRs (cave-x1j)
- **#2574** — md-editor: debounced autosave for knowledge & journal docs (cave-b2v)
- **#2570** — memory: 130x faster memory inventory (cave-od4)
- **#2571 / #2572** — session-changes: standardize on shared Button / borderless IconButton (cave-4op)
- **#2573** — automations: route remaining Schedules row actions through shared RowActionButton (cave-4op)

## Local build gate (pre-tag, as requested)
- ✅ `pnpm install --frozen-lockfile` clean
- ✅ `pnpm typecheck` — 0 errors
- ✅ `pnpm build` — full `next build` + server bundle + **bundle-budget within budget** (shell 447 KB / 650 KB, largest chunk 992 KB / 2400 KB)

## Version locations bumped
package.json · Cargo.toml · Cargo.lock (app) · tauri.conf.json · Info.ios.plist · gen/apple Info.plist