### PR TITLE
fix(ui): stack popovers above the board task drawer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2694,7 +2694,12 @@ textarea.required-inputs-control {
 .ui-popover-portal {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  /* Popovers are the topmost transient layer: they must paint above every
+     dialog/drawer they can be opened from — including the board task drawer
+     (.board-drawer, z 300/301) — or the drawer's backdrop swallows the click
+     and closes the drawer instead. Kept below drag ghosts (1000) and
+     tooltips (9000). */
+  z-index: 400;
   pointer-events: none;
 }
 .ui-popover {

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -48,4 +48,27 @@ assert.match(
   "popover restores focus to the anchor when it would otherwise land on body",
 );
 
+// Stacking: popovers portal to <body>, so they compete with every other
+// portaled layer purely on z-index. The board task drawer (also portaled to
+// <body>) sits at z 300/301 — the popover portal must layer ABOVE it, or the
+// drawer's backdrop paints over the open menu and the click that "selects an
+// option" lands on the backdrop and closes the drawer instead (the Tasks
+// inspector's Status/Priority/Familiar/Project dropdowns were unusable).
+const globalsCss = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+const boardCss = readFileSync(new URL("../../styles/board.css", import.meta.url), "utf8");
+const portalZ = Number(
+  globalsCss.match(/\.ui-popover-portal\s*\{[^}]*?z-index:\s*(\d+)/)?.[1],
+);
+const drawerZ = Math.max(
+  ...[...boardCss.matchAll(/\.board-drawer(?:-backdrop)?\s*\{[^}]*?z-index:\s*(\d+)/g)].map(
+    (m) => Number(m[1]),
+  ),
+);
+assert.ok(Number.isFinite(portalZ), "found .ui-popover-portal z-index in globals.css");
+assert.ok(Number.isFinite(drawerZ), "found .board-drawer z-index in board.css");
+assert.ok(
+  portalZ > drawerZ,
+  `popover portal (z ${portalZ}) must stack above the board drawer (z ${drawerZ})`,
+);
+
 console.log("popover.test.ts: ok");


### PR DESCRIPTION
The Tasks inspector drawer's dropdowns (Status / Priority / Familiar / Project) were unusable: `StandardSelect` popovers portal to `<body>` at `z-index: 60` while `.board-drawer`/`.board-drawer-backdrop` sit at 300/301, so the backdrop painted over the open menu and the click that should select an option landed on the backdrop — closing the drawer instead.

**Fix:** raise `.ui-popover-portal` to `z-index: 400` — above every dialog/drawer a popover can be opened from, below drag ghosts (1000), the table lightbox (1000), the voice overlay (1200), and tooltips (9000). Audited the higher layers: none of them host `StandardSelect`/`Popover`.

**Test:** `popover.test.ts` gains a source-scan invariant that parses both z-indexes from CSS and asserts the portal stacks above the drawer, so this can't silently regress.

Verification: `node --experimental-strip-types src/components/ui/popover.test.ts` ✓ on current main.