### PR TITLE
feat(grimoire): Open-in-Grimoire cross-links + delete/trash actions (cave-kv3)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -503,6 +503,7 @@ export const SUITES = {
     "src/lib/md-doc-stats.test.ts",
     "src/components/md-editor/md-editor.test.ts",
     "src/components/grimoire-view.test.ts",
+    "src/lib/grimoire-link.test.ts",
     "src/lib/server/coven-memory-path.test.ts",
     "src/lib/recent-colors.test.ts",
 	    "src/components/ui/color-picker.test.ts",

--- a/src/components/familiars-memory-reader.tsx
+++ b/src/components/familiars-memory-reader.tsx
@@ -5,6 +5,7 @@ import { copyText } from "@/lib/clipboard";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { useMemoryFile } from "@/lib/use-memory-file";
 import { MemoryMdEditor } from "@/components/md-editor/memory-md-editor";
+import { openGrimoireDoc } from "@/lib/grimoire-link";
 import type { MemoryRow } from "@/lib/memory-rows";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
@@ -192,6 +193,17 @@ export function MemoryReaderPane({
             <Icon name="ph:file-text" width={11} aria-hidden />
             Open file
           </button>
+          {row.contentPath ? (
+            <button
+              type="button"
+              onClick={() => openGrimoireDoc("memory", row.contentPath!)}
+              title="Open in the Grimoire editor"
+              className="focus-ring inline-flex h-6 items-center gap-1 rounded border border-[var(--border-hairline)] px-1.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+            >
+              <Icon name="ph:book-open" width={11} aria-hidden />
+              Grimoire
+            </button>
+          ) : null}
         </div>
       </div>
       {editing && row.contentPath ? (

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -36,8 +36,20 @@ assert.match(view, /reflectedBy: state\?\.reflectedBy \?\? null/, "journal saves
 // ── Deep link + responsive master-detail ─────────────────────────────────────
 
 assert.match(view, /#grimoire:/, "selection is deep-linkable via #grimoire:<kind>:<id>");
+assert.match(view, /GRIMOIRE_HASH_PREFIX/, "hash prefix is shared with cross-surface links (grimoire-link.ts)");
 assert.match(view, /decodeURIComponent/, "hash ids are URL-decoded");
 assert.match(view, /aria-label="Back to document list"/, "compact widths get a back affordance");
 assert.match(view, /@container\/grimoire/, "layout adapts via container queries");
+
+// ── Delete/trash actions (cave-kv3) ──────────────────────────────────────────
+
+assert.match(view, /useConfirm\(\)/, "destructive actions confirm through the shared dialog");
+assert.match(view, /\/api\/memory\/delete/, "memory files archive through the trash API");
+assert.match(view, /\/api\/knowledge\?id=\$\{encodeURIComponent\(selection\.id\)\}/, "knowledge entries delete through their API");
+assert.match(view, /\/api\/journal\?date=\$\{encodeURIComponent\(selection\.date\)\}/, "journal reflections delete through their API");
+assert.match(view, /Move to trash/, "memory delete is labelled as restorable trash");
+assert.match(view, /danger: true/, "the confirm renders its destructive style");
+assert.match(view, /setSelection\(null\);\s*void load\(\)/, "a successful delete clears the selection and reloads the navigator");
+assert.match(view, /deleteError \? \(\s*<span role="alert"/, "delete failures are announced");
 
 console.log("grimoire-view.test: ok");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -24,6 +24,8 @@ import { MdEditor, type MdEditorSaveResult } from "@/components/md-editor/md-edi
 import { MemoryMdEditor } from "@/components/md-editor/memory-md-editor";
 import { parseMdDocument, serializeMdDocument, type MdDocument } from "@/lib/md-frontmatter";
 import { relativeTime } from "@/lib/relative-time";
+import { GRIMOIRE_HASH_PREFIX } from "@/lib/grimoire-link";
+import { useConfirm } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -62,8 +64,6 @@ function selectionKey(sel: GrimoireSelection): string {
   if (sel.kind === "journal") return `journal:${sel.date}`;
   return "knowledge-new";
 }
-
-const GRIMOIRE_HASH_PREFIX = "#grimoire:";
 
 function readGrimoireHash(): GrimoireSelection | null {
   if (typeof window === "undefined") return null;
@@ -304,6 +304,9 @@ export function GrimoireView() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [selection, setSelection] = useState<GrimoireSelection | null>(() => readGrimoireHash());
+  const confirm = useConfirm();
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const load = useCallback(async () => {
     setLoadError(null);
@@ -329,6 +332,56 @@ export function GrimoireView() {
   useEffect(() => {
     writeGrimoireHash(selection);
   }, [selection]);
+
+  // Reset any stale delete feedback when the selection changes.
+  useEffect(() => {
+    setDeleteError(null);
+  }, [selection]);
+
+  // Delete/trash the selected document. Memory files archive to the memory
+  // trash (restorable via POST /api/memory/restore); knowledge entries and
+  // journal reflections delete through their APIs.
+  const deleteSelection = useCallback(async () => {
+    if (!selection || selection.kind === "knowledge-new" || deleting) return;
+    const label =
+      selection.kind === "memory"
+        ? "Move this memory file to the trash?"
+        : selection.kind === "knowledge"
+          ? "Delete this knowledge entry?"
+          : `Delete the journal reflection for ${selection.date}?`;
+    const body =
+      selection.kind === "memory"
+        ? "The file moves to the Cave's memory trash and can be restored from there."
+        : "This can't be undone.";
+    if (!(await confirm({ title: label, body, confirmLabel: selection.kind === "memory" ? "Move to trash" : "Delete", danger: true }))) {
+      return;
+    }
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res =
+        selection.kind === "memory"
+          ? await fetch("/api/memory/delete", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ path: selection.path }),
+            })
+          : selection.kind === "knowledge"
+            ? await fetch(`/api/knowledge?id=${encodeURIComponent(selection.id)}`, { method: "DELETE" })
+            : await fetch(`/api/journal?date=${encodeURIComponent(selection.date)}`, { method: "DELETE" });
+      const json = await res.json();
+      if (!json.ok) {
+        setDeleteError(json.error ?? "Delete failed");
+        return;
+      }
+      setSelection(null);
+      void load();
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Delete failed");
+    } finally {
+      setDeleting(false);
+    }
+  }, [confirm, deleting, load, selection]);
 
   const q = query.trim().toLowerCase();
   const matches = useCallback(
@@ -514,16 +567,39 @@ export function GrimoireView() {
       >
         {selection ? (
           <div className="flex h-full min-h-0 flex-col">
-            <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-1.5 @min-[880px]/grimoire:hidden">
+            <div
+              className={`flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-1.5 ${
+                selection.kind === "knowledge-new" ? "@min-[880px]/grimoire:hidden" : ""
+              }`}
+            >
               <button
                 type="button"
                 onClick={() => setSelection(null)}
                 aria-label="Back to document list"
-                className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)] @min-[880px]/grimoire:hidden"
               >
                 <Icon name="ph:arrow-left" width={13} aria-hidden />
               </button>
-              <span className="text-[11px] text-[var(--text-secondary)]">Documents</span>
+              <span className="text-[11px] text-[var(--text-secondary)] @min-[880px]/grimoire:hidden">Documents</span>
+              <span className="min-w-0 flex-1" />
+              {deleteError ? (
+                <span role="alert" className="min-w-0 truncate text-[10px] text-[var(--color-warning)]">
+                  {deleteError}
+                </span>
+              ) : null}
+              {selection.kind !== "knowledge-new" ? (
+                <button
+                  type="button"
+                  onClick={() => void deleteSelection()}
+                  disabled={deleting}
+                  className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[10px] text-[var(--text-secondary)] enabled:hover:border-[var(--color-danger)]/40 enabled:hover:bg-[var(--color-danger)]/10 enabled:hover:text-[var(--color-danger)] disabled:opacity-50"
+                >
+                  <Icon name="ph:trash" width={11} aria-hidden />
+                  {deleting
+                    ? selection.kind === "memory" ? "Moving…" : "Deleting…"
+                    : selection.kind === "memory" ? "Move to trash" : "Delete"}
+                </button>
+              ) : null}
             </div>
             <div className="min-h-0 flex-1">{detail}</div>
           </div>

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -15,6 +15,7 @@ import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
 import type { AdapterReport } from "@/lib/harness-adapters";
 import { scopeMemoryFilesToFamiliar } from "@/lib/memory-file-scope";
+import { openGrimoireDoc } from "@/lib/grimoire-link";
 import { formatTimestamp, readDateTimePrefs } from "@/lib/datetime-format";
 
 type Tab = "memory" | "familiar" | "analytics" | "inbox";
@@ -462,6 +463,14 @@ function MemoryFileView({ path, file, reveal, totalRedactions, onRevealToggle, o
         ← back
       </button>
       <div className="flex-1 truncate font-mono text-[var(--text-secondary)]">{filename}</div>
+      <button
+        onClick={() => openGrimoireDoc("memory", path)}
+        title="Open in the Grimoire editor"
+        aria-label="Open in Grimoire"
+        className="rounded p-1 text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] transition-colors"
+      >
+        <Icon name="ph:book-open" width={13} />
+      </button>
       <button
         onClick={() => setFullscreen((v) => !v)}
         title={fullscreen ? "Exit fullscreen" : "Open fullscreen"}

--- a/src/lib/grimoire-link.test.ts
+++ b/src/lib/grimoire-link.test.ts
@@ -1,0 +1,35 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { grimoireHash, GRIMOIRE_HASH_PREFIX } from "./grimoire-link.ts";
+
+// ── Pure hash builder ────────────────────────────────────────────────────────
+
+assert.equal(GRIMOIRE_HASH_PREFIX, "#grimoire:", "prefix matches the grimoire-view deep-link format");
+assert.equal(grimoireHash("knowledge", "my-entry"), "#grimoire:knowledge:my-entry");
+assert.equal(grimoireHash("journal", "2026-07-07"), "#grimoire:journal:2026-07-07");
+assert.equal(
+  grimoireHash("memory", "/Users/x/.coven/memory/notes.md"),
+  "#grimoire:memory:%2FUsers%2Fx%2F.coven%2Fmemory%2Fnotes.md",
+  "ids are URL-encoded so paths survive the hash",
+);
+
+// ── Consumers: cross-surface "Open in Grimoire" links (cave-kv3) ─────────────
+
+const lib = await readFile(new URL("./grimoire-link.ts", import.meta.url), "utf8");
+const reader = await readFile(new URL("../components/familiars-memory-reader.tsx", import.meta.url), "utf8");
+const inspector = await readFile(new URL("../components/inspector-pane.tsx", import.meta.url), "utf8");
+
+assert.match(
+  lib,
+  /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "grimoire" \} \}\)/,
+  "navigation rides the Workspace's cave:navigate-mode bridge",
+);
+assert.match(lib, /window\.history\.replaceState/, "the hash is written before the mode switch");
+
+assert.match(reader, /openGrimoireDoc\("memory", row\.contentPath/, "memory reader links its file to the Grimoire");
+assert.match(reader, /row\.contentPath \?/, "reader only offers the link when the file path resolved");
+assert.match(inspector, /openGrimoireDoc\("memory", path\)/, "chat inspector's memory file view links to the Grimoire");
+assert.match(inspector, /aria-label="Open in Grimoire"/, "inspector link is labelled");
+
+console.log("grimoire-link.test: ok");

--- a/src/lib/grimoire-link.ts
+++ b/src/lib/grimoire-link.ts
@@ -1,0 +1,28 @@
+"use client";
+
+/**
+ * Cross-surface deep links into the Grimoire.
+ *
+ * The Grimoire surface selects a document on entry from a
+ * `#grimoire:<kind>:<id>` location hash (see grimoire-view.tsx). Other
+ * surfaces — the memory reader, the chat inspector's memory tab — use these
+ * helpers to land on a document: write the hash, then announce the mode
+ * switch through the Workspace's `cave:navigate-mode` bridge.
+ */
+
+export type GrimoireDocKind = "knowledge" | "memory" | "journal";
+
+export const GRIMOIRE_HASH_PREFIX = "#grimoire:";
+
+/** The `#grimoire:<kind>:<id>` hash for a document. */
+export function grimoireHash(kind: GrimoireDocKind, id: string): string {
+  return `${GRIMOIRE_HASH_PREFIX}${kind}:${encodeURIComponent(id)}`;
+}
+
+/** Navigate the workspace to the Grimoire with the given document selected. */
+export function openGrimoireDoc(kind: GrimoireDocKind, id: string): void {
+  if (typeof window === "undefined") return;
+  const base = window.location.pathname + window.location.search;
+  window.history.replaceState(null, "", `${base}${grimoireHash(kind, id)}`);
+  window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "grimoire" } }));
+}


### PR DESCRIPTION
## What

Follow-up to #2562 (bead `cave-kv3`) — the Grimoire gains inbound cross-links and outbound destructive actions.

### Open in Grimoire (cross-surface links)
- New `src/lib/grimoire-link.ts`: `grimoireHash(kind, id)` + `openGrimoireDoc(kind, id)` — writes the existing `#grimoire:<kind>:<id>` deep-link hash (grimoire-view now imports the shared prefix) and switches surfaces through the Workspace's `cave:navigate-mode` bridge
- **Memory reader** (`familiars-memory-reader`): a *Grimoire* button next to *Open file*, shown when the row has a resolvable `contentPath`
- **Chat inspector** memory file view (`inspector-pane`): an *Open in Grimoire* icon button in the file header

### Delete/trash in the Grimoire detail
The detail strip (previously mobile-only back bar, now always visible for existing docs) gains a per-kind destructive action, confirmed via the shared `ConfirmDialog`:
- **Memory** → *Move to trash* via `POST /api/memory/delete` (restorable memory trash; protected/structural paths surface the server's 409/403 error inline)
- **Knowledge** → *Delete* via `DELETE /api/knowledge?id=`
- **Journal** → *Delete* via `DELETE /api/journal?date=`

Success clears the selection and reloads the navigator; failures render an inline `role=alert`.

## Verification
- `pnpm typecheck` ✓
- `pnpm check:tests-wired` ✓ (751 wired; new `grimoire-link.test.ts`)
- `pnpm test:app` ✓ 556 files (grimoire-view source assertions extended for delete actions + shared hash prefix)