### PR TITLE
refactor(github): profile-card action buttons on the shared Button (cave-4op)

### DIFF
--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -879,13 +879,14 @@ function UserProfileCard({
       ) : state.status === "error" || !p ? (
         <div className="gh-profile-error">
           <p>Couldn’t load @{login}’s profile.</p>
-          <button
-            type="button"
-            className="gh-profile-open"
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon="ph:arrow-square-out"
             onClick={() => openExternalUrl(`https://github.com/${login}`)}
           >
-            <Icon name="ph:arrow-square-out" width={12} /> Open on GitHub
-          </button>
+            Open on GitHub
+          </Button>
         </div>
       ) : (
         <>
@@ -945,13 +946,14 @@ function UserProfileCard({
             )}
           </div>
 
-          <button
-            type="button"
-            className="gh-profile-open"
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon="ph:github-logo"
             onClick={() => openExternalUrl(p.htmlUrl ?? `https://github.com/${p.login}`)}
           >
-            <Icon name="ph:github-logo" width={13} /> View full profile
-          </button>
+            View full profile
+          </Button>
         </>
       )}
     </div>

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -1468,21 +1468,6 @@ pre.gh-diff--md code { display:block; padding:6px 0; background:none; }
   white-space:nowrap;
 }
 .gh-profile-link:hover { text-decoration:underline; }
-.gh-profile-open {
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  gap:6px;
-  padding:6px 10px;
-  border-radius:9px;
-  border:1px solid var(--border-hairline);
-  background:var(--bg-raised);
-  color:var(--text-secondary);
-  font-size:12px;
-  font-weight:550;
-  cursor:pointer;
-}
-.gh-profile-open:hover { background:var(--bg-hover); color:var(--text-primary); }
 
 /* ── Comment reactions ───────────────────────────────────────────────────── */
 .gh-reactions { display:flex; flex-wrap:wrap; gap:5px; margin-top:6px; }


### PR DESCRIPTION
## What

The **github-view** surface slice of the app-wide control-standardization umbrella (cave-4op). Converted the GitHub profile card's two full-width external-link actions — the error-state **"Open on GitHub"** and the **"View full profile"** footer — from raw `<button class="gh-profile-open">` to the shared `<Button variant="secondary">`, and removed the now-dead `.gh-profile-open` recipe from `board.css`.

## Left bespoke (by design)

- The inline `.gh-profile-link` blog/X chips — link-style (underline-on-hover), not action buttons.
- The keyboard-sortable column header — a raw `<button>` by necessity (documented in-file).

Handlers (`openExternalUrl`) are byte-unchanged.

## Verification

`typecheck` clean; `github-advanced` + `github-view-polish` tests green (no test pinned these buttons); app suite + tests-wired running.

## Coordination note

cave-4op is an actively-driven umbrella (another session landed the calendar, session-changes, automations, and settings slices today). This PR is scoped to **github-view only** to avoid their in-flight settings/popover slice; **cave-4op stays OPEN**. Net **+12 / −25**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)