### PR TITLE
refactor(marketplace): ultra-minimal Recommended-groups cards (flat, chrome-on-hover)

### DIFF
--- a/src/components/marketplace/collection-strip.tsx
+++ b/src/components/marketplace/collection-strip.tsx
@@ -39,22 +39,24 @@ export function CollectionStrip({ collections, plugins, onOpen }: Props) {
               key={collection.id}
               type="button"
               onClick={() => onOpen(collection.id)}
-              className="focus-ring group flex flex-col gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-panel)] p-4 text-left transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--bg-raised)]"
+              className="focus-ring group flex flex-col gap-1.5 rounded-lg border border-transparent px-3 py-3 text-left transition-colors hover:border-[var(--border-hairline)] hover:bg-[color-mix(in_oklch,var(--foreground)_4%,transparent)]"
             >
-              <div className="flex items-center justify-between gap-2">
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--bg-elevated)]">
-                  <Icon name={collection.icon} width={18} className="text-[var(--text-primary)]" />
+              <span className="flex items-center gap-2">
+                <Icon name={collection.icon} width={15} aria-hidden className="shrink-0 text-[var(--text-secondary)]" />
+                <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[var(--text-primary)]">
+                  {collection.title}
                 </span>
                 <Icon
                   name="ph:caret-right"
-                  width={14}
+                  width={13}
                   aria-hidden
-                  className="text-[var(--text-muted)] transition-transform group-hover:translate-x-0.5"
+                  className="shrink-0 text-[var(--text-muted)] opacity-0 transition-[opacity,transform] group-hover:translate-x-0.5 group-hover:opacity-100 group-focus-visible:opacity-100"
                 />
-              </div>
-              <span className="text-[14px] font-semibold text-[var(--text-primary)]">{collection.title}</span>
-              <span className="line-clamp-2 text-[12px] text-[var(--text-muted)]">{collection.description}</span>
-              <span className="mt-1 text-[11px] text-[var(--text-muted)]">
+              </span>
+              <span className="line-clamp-2 text-[12px] leading-snug text-[var(--text-muted)]">
+                {collection.description}
+              </span>
+              <span className="text-[11px] text-[var(--text-muted)] opacity-80">
                 {members.length} {members.length === 1 ? "plugin" : "plugins"}
                 {added > 0 ? ` · ${added} added` : ""}
               </span>


### PR DESCRIPTION
Restyles the marketplace **Recommended groups** cards (`CollectionStrip`) to an ultra-minimal, flat, typographic look.

## Before → After

| Element | Before | After |
|---------|--------|-------|
| Card container | filled `bg-panel` + hairline border + `p-4` | transparent & borderless at rest; hairline + 4% foreground tint on **hover only** |
| Icon | 36px `bg-elevated` box w/ 18px glyph | bare 15px muted glyph, inline with the title |
| Caret | always visible, top-right | hover / focus-visible only, slides in |
| Title | 14px semibold | 13px medium |
| Layout | icon-box row → stacked | icon + title on one line, tighter gaps |

At rest the six groups are flat text blocks on the base background; hover/focus reveals the container chrome. Keyboard focus keeps the focus ring, and `line-clamp-2` / stats are unchanged.

**Pure styling** — same `onOpen(collection.id)` behavior and content, no logic touched.

## Verification

- Rendered from a prod build of this branch and screenshotted (rest + hover) — confirmed the flat rest state and the hover reveal (hairline + tint + caret).
- `pnpm typecheck` clean. No test covers `CollectionStrip` (pure presentational component).

🤖 Generated with [Claude Code](https://claude.com/claude-code)