### PR TITLE
feat(grimoire): wiki-link parser + resolver — the [[wiki-link]] engine (cave-xr0, slice 1)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -504,6 +504,8 @@ export const SUITES = {
     "src/components/md-editor/md-editor.test.ts",
     "src/components/grimoire-view.test.ts",
     "src/lib/grimoire-link.test.ts",
+    "src/lib/wiki-link-parser.test.ts",
+    "src/lib/wiki-link-resolve.test.ts",
     "src/lib/server/coven-memory-path.test.ts",
     "src/lib/recent-colors.test.ts",
 	    "src/components/ui/color-picker.test.ts",
@@ -798,6 +800,8 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/wiki-link-parser.test.ts",
+  "src/lib/wiki-link-resolve.test.ts",
   "src/lib/server/space-usage.test.ts",
   "src/lib/server/memory-file-inventory.test.ts",
   "src/lib/daily-narrative.test.ts",

--- a/src/lib/wiki-link-parser.test.ts
+++ b/src/lib/wiki-link-parser.test.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+const { extractWikiLinks, uniqueWikiLinkTargets } = await import("./wiki-link-parser.ts");
+
+// ── basic + alias ───────────────────────────────────────────────────────────
+{
+  const [l] = extractWikiLinks("see [[Onboarding]] here");
+  assert.equal(l.target, "Onboarding", "target is the inner text");
+  assert.equal(l.display, "Onboarding", "display defaults to the target");
+  assert.equal(l.raw, "[[Onboarding]]", "raw keeps the brackets");
+  assert.equal(l.index, 4, "index is the offset in the source");
+}
+{
+  const [l] = extractWikiLinks("[[api-style-guide|the style guide]]");
+  assert.equal(l.target, "api-style-guide", "target is before the pipe");
+  assert.equal(l.display, "the style guide", "display is the alias after the pipe");
+}
+
+// ── whitespace + emptiness ──────────────────────────────────────────────────
+assert.equal(extractWikiLinks("[[  Trimmed Me  ]]")[0].target, "Trimmed Me", "target is trimmed");
+assert.deepEqual(extractWikiLinks("[[]] and [[   ]]"), [], "empty / blank targets are ignored");
+
+// ── multiple + de-dupe ──────────────────────────────────────────────────────
+assert.equal(extractWikiLinks("[[A]] then [[B]] then [[C]]").length, 3, "all links are returned");
+assert.deepEqual(
+  uniqueWikiLinkTargets("[[A]] [[a]] [[B]] [[b]] [[C]]"),
+  ["A", "B", "C"],
+  "unique targets are case-insensitive, first-seen order preserved",
+);
+
+// ── nested / malformed brackets never false-match ───────────────────────────
+assert.deepEqual(extractWikiLinks("[[a][b]]"), [], "adjacent single-bracket runs are not a wiki-link");
+assert.deepEqual(extractWikiLinks("[[a\nb]]"), [], "a target may not span lines");
+assert.deepEqual(extractWikiLinks("a single [bracket] and [[x"), [], "unterminated / single brackets ignored");
+
+// ── code regions are skipped ────────────────────────────────────────────────
+assert.deepEqual(extractWikiLinks("`[[x]]`"), [], "inline code is not scanned for links");
+assert.deepEqual(extractWikiLinks("```\n[[x]]\n```"), [], "fenced code is not scanned for links");
+assert.deepEqual(extractWikiLinks("~~~\n[[x]]\n~~~"), [], "tilde fences are skipped too");
+{
+  // A real link survives even when a code span nearby also contains one; the
+  // masked offset must still point at the real link in the original string.
+  const links = extractWikiLinks("before `[[ignored]]` then [[Real]] after");
+  assert.equal(links.length, 1, "only the non-code link is returned");
+  assert.equal(links[0].target, "Real", "the surviving link is the one outside code");
+  assert.equal(links[0].raw, "[[Real]]", "raw is sliced from the original at the right offset");
+}
+
+// ── cheap fast path ─────────────────────────────────────────────────────────
+assert.deepEqual(extractWikiLinks("no links here at all"), [], "strings without [[ return empty");
+assert.deepEqual(extractWikiLinks(""), [], "empty input is safe");
+
+console.log("wiki-link-parser.test.ts: ok");

--- a/src/lib/wiki-link-parser.ts
+++ b/src/lib/wiki-link-parser.ts
@@ -1,0 +1,73 @@
+// OpenKnowledge-style [[wiki-links]] between Grimoire docs (memory / knowledge /
+// journal). This module is the pure parser: it extracts link references from a
+// markdown string. Resolution of a target to a real doc lives in
+// `wiki-link-resolve.ts`, and navigation reuses `grimoire-link.ts`.
+
+export type WikiLink = {
+  /** The full raw match including the brackets, e.g. "[[Title|Alias]]". */
+  raw: string;
+  /** The link target, before any alias pipe, trimmed. e.g. "Title". */
+  target: string;
+  /** The text to display: the alias (after `|`) if present, else the target. */
+  display: string;
+  /** Character offset of the match start in the source markdown. */
+  index: number;
+};
+
+// A wiki-link is `[[target]]` or `[[target|display]]`. The inner text may not
+// span lines or contain the bracket characters (so `[[a][b]]` / `[[nested]]`
+// don't false-match) and the target may not be empty.
+const WIKI_LINK_RE = /\[\[([^[\]\n|]+?)(?:\|([^[\]\n]+?))?\]\]/g;
+
+// Mask a region (fenced code block or inline code span) with spaces of the SAME
+// length, so link offsets in the masked string still line up with the original.
+function blankOut(match: string): string {
+  return match.replace(/[^\n]/g, " ");
+}
+
+/**
+ * Extract `[[wiki-links]]` from a markdown string. Links inside fenced code
+ * blocks (``` / ~~~) and inline code spans (`…`) are ignored, so a `[[x]]` in a
+ * code sample is treated as literal text, not a link.
+ *
+ * Supports `[[Target]]` and `[[Target|Alias]]`. Duplicate targets are returned
+ * once per occurrence (callers de-dupe if they want unique links). The returned
+ * `index` is the offset into the ORIGINAL `markdown`, so callers can decorate or
+ * slice the source safely.
+ */
+export function extractWikiLinks(markdown: string): WikiLink[] {
+  if (!markdown || markdown.indexOf("[[") === -1) return [];
+
+  // Blank out code regions first so their contents can't match. Fenced blocks
+  // before inline spans (a fence can contain backticks). Length is preserved,
+  // so indices stay valid against the original string.
+  const masked = markdown
+    .replace(/```[\s\S]*?```|~~~[\s\S]*?~~~/g, blankOut)
+    .replace(/`[^`\n]*`/g, blankOut);
+
+  const links: WikiLink[] = [];
+  for (const m of masked.matchAll(WIKI_LINK_RE)) {
+    const index = m.index ?? 0;
+    const target = (m[1] ?? "").trim();
+    if (!target) continue;
+    const alias = m[2]?.trim();
+    // Slice the raw match from the ORIGINAL so the display keeps its real text.
+    const raw = markdown.slice(index, index + m[0].length);
+    links.push({ raw, target, display: alias && alias.length > 0 ? alias : target, index });
+  }
+  return links;
+}
+
+/** Unique link targets from a markdown string, preserving first-seen order.
+ *  Case-insensitive de-dupe (targets resolve case-insensitively downstream). */
+export function uniqueWikiLinkTargets(markdown: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const { target } of extractWikiLinks(markdown)) {
+    const key = target.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(target);
+  }
+  return out;
+}

--- a/src/lib/wiki-link-resolve.test.ts
+++ b/src/lib/wiki-link-resolve.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+const { resolveWikiLinkTarget, resolveOutgoingLinks, docRefKey } = await import("./wiki-link-resolve.ts");
+
+const index = {
+  knowledge: [
+    { id: "api-style-guide", title: "API Style Guide" },
+    { id: "no-title-entry", title: null },
+  ],
+  memory: [{ path: "personal/2024.md" }, { path: "/abs/root/notes.md" }],
+  journal: [{ date: "2026-07-07" }],
+};
+
+// ── knowledge: by id and by title, case-insensitive ─────────────────────────
+assert.deepEqual(resolveWikiLinkTarget("api-style-guide", index), { kind: "knowledge", id: "api-style-guide" }, "by slug id");
+assert.deepEqual(resolveWikiLinkTarget("API Style Guide", index), { kind: "knowledge", id: "api-style-guide" }, "by title");
+assert.deepEqual(resolveWikiLinkTarget("api style GUIDE".replace(" style", " Style"), index), { kind: "knowledge", id: "api-style-guide" }, "title is case-insensitive");
+assert.deepEqual(resolveWikiLinkTarget("no-title-entry", index), { kind: "knowledge", id: "no-title-entry" }, "a titleless entry still resolves by id");
+
+// ── memory: by basename, by relative path, extension optional ───────────────
+assert.deepEqual(resolveWikiLinkTarget("2024", index), { kind: "memory", path: "personal/2024.md" }, "by file basename");
+assert.deepEqual(resolveWikiLinkTarget("personal/2024", index), { kind: "memory", path: "personal/2024.md" }, "by relative path");
+assert.deepEqual(resolveWikiLinkTarget("notes", index), { kind: "memory", path: "/abs/root/notes.md" }, "basename of an absolute path");
+assert.deepEqual(resolveWikiLinkTarget("notes.md", index), { kind: "memory", path: "/abs/root/notes.md" }, ".md extension in the target is optional");
+
+// ── journal: only an existing ISO date ──────────────────────────────────────
+assert.deepEqual(resolveWikiLinkTarget("2026-07-07", index), { kind: "journal", date: "2026-07-07" }, "an existing journal day");
+assert.equal(resolveWikiLinkTarget("2026-01-01", index), null, "an ISO date with no journal entry is unresolved");
+
+// ── misses ──────────────────────────────────────────────────────────────────
+assert.equal(resolveWikiLinkTarget("does-not-exist", index), null, "unknown target is unresolved");
+assert.equal(resolveWikiLinkTarget("   ", index), null, "blank target is unresolved");
+
+// ── resolveOutgoingLinks: parse + resolve a doc body ────────────────────────
+const links = resolveOutgoingLinks("See [[API Style Guide]] and [[2024|last year]] and [[ghost]].", index);
+assert.equal(links.length, 3, "every link in the body is returned");
+assert.deepEqual(links[0].ref, { kind: "knowledge", id: "api-style-guide" }, "first link resolves to knowledge");
+assert.equal(links[1].display, "last year", "the alias display is carried through resolution");
+assert.deepEqual(links[1].ref, { kind: "memory", path: "personal/2024.md" }, "aliased link still resolves by target");
+assert.equal(links[2].ref, null, "an unresolved link keeps ref=null");
+
+// ── docRefKey ───────────────────────────────────────────────────────────────
+assert.equal(docRefKey({ kind: "knowledge", id: "x" }), "knowledge:x");
+assert.equal(docRefKey({ kind: "memory", path: "a/b.md" }), "memory:a/b.md");
+assert.equal(docRefKey({ kind: "journal", date: "2026-07-07" }), "journal:2026-07-07");
+
+console.log("wiki-link-resolve.test.ts: ok");

--- a/src/lib/wiki-link-resolve.ts
+++ b/src/lib/wiki-link-resolve.ts
@@ -1,0 +1,96 @@
+// Resolve `[[wiki-link]]` targets (from `wiki-link-parser.ts`) to real Grimoire
+// docs. Pure + UI-agnostic: it matches a target string against the doc lists
+// the Grimoire navigator already loads (knowledge vault / memory files /
+// journal days), so no server round-trip or full-vault index is needed to turn
+// a doc's outgoing links into navigable references.
+
+import { extractWikiLinks, type WikiLink } from "./wiki-link-parser";
+
+/** A resolved reference — the same shape the Grimoire deep-link bridge uses
+ *  (`grimoire-link.ts` / `GrimoireSelection`), minus the transient drafts. */
+export type WikiDocRef =
+  | { kind: "knowledge"; id: string }
+  | { kind: "memory"; path: string }
+  | { kind: "journal"; date: string };
+
+/** Minimal doc metadata the resolver matches against — a subset of the
+ *  navigator's loaded lists, so callers pass what they already have. */
+export type WikiDocIndex = {
+  knowledge: readonly { id: string; title?: string | null }[];
+  memory: readonly { path: string }[];
+  journal: readonly { date: string }[];
+};
+
+export type ResolvedWikiLink = WikiLink & {
+  /** The matched doc, or null when nothing in the index matches the target. */
+  ref: WikiDocRef | null;
+};
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function norm(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+/** Last path segment with any `.md`/`.markdown` extension stripped. */
+function baseName(path: string): string {
+  const seg = path.split(/[\\/]/).pop() ?? path;
+  return seg.replace(/\.(md|markdown)$/i, "");
+}
+
+function stripExt(path: string): string {
+  return path.replace(/\.(md|markdown)$/i, "");
+}
+
+/**
+ * Resolve a single wiki-link target to a doc ref, or null if unresolved.
+ *
+ * Match order is deterministic and mirrors how a person reads a `[[link]]`:
+ * an ISO date is a journal day; otherwise a knowledge entry (by id, then
+ * title); otherwise a memory file (by basename, then relative path). All
+ * comparisons are case-insensitive; `.md`/`.markdown` extensions are optional
+ * in the target.
+ */
+export function resolveWikiLinkTarget(target: string, index: WikiDocIndex): WikiDocRef | null {
+  const t = norm(target);
+  if (!t) return null;
+
+  // 1) Journal day — only when the target is literally an ISO date that exists.
+  if (ISO_DATE_RE.test(target.trim())) {
+    const day = index.journal.find((j) => j.date === target.trim());
+    if (day) return { kind: "journal", date: day.date };
+  }
+
+  // 2) Knowledge — by slug id, then by human title.
+  const byId = index.knowledge.find((k) => norm(k.id) === t);
+  if (byId) return { kind: "knowledge", id: byId.id };
+  const byTitle = index.knowledge.find((k) => k.title && norm(k.title) === t);
+  if (byTitle) return { kind: "knowledge", id: byTitle.id };
+
+  // 3) Memory — by file basename, then by full relative path (extension optional).
+  const tNoExt = norm(stripExt(target));
+  const byBase = index.memory.find((m) => norm(baseName(m.path)) === tNoExt);
+  if (byBase) return { kind: "memory", path: byBase.path };
+  const byPath = index.memory.find((m) => norm(stripExt(m.path)) === tNoExt);
+  if (byPath) return { kind: "memory", path: byPath.path };
+
+  return null;
+}
+
+/** Parse a doc's markdown and resolve every wiki-link in it (occurrence order,
+ *  duplicates kept — callers de-dupe if they want unique chips). */
+export function resolveOutgoingLinks(markdown: string, index: WikiDocIndex): ResolvedWikiLink[] {
+  return extractWikiLinks(markdown).map((link) => ({
+    ...link,
+    ref: resolveWikiLinkTarget(link.target, index),
+  }));
+}
+
+/** A stable string key for a doc ref (dedupe / comparison / graph node ids). */
+export function docRefKey(ref: WikiDocRef): string {
+  return ref.kind === "knowledge"
+    ? `knowledge:${ref.id}`
+    : ref.kind === "memory"
+      ? `memory:${ref.path}`
+      : `journal:${ref.date}`;
+}


### PR DESCRIPTION
First slice of **cave-xr0** (Grimoire: wiki-links + graph view) — the pure, tested **link engine** that the navigable-chip UI and the graph viewer build on.

## What

Two dependency-free libs, fully unit-tested:

- **`wiki-link-parser.ts`** — `extractWikiLinks(markdown)` parses `[[Target]]` and `[[Target|Alias]]`, returning `{raw, target, display, index}`. Fenced (```` ``` ````/`~~~`) and inline (`` ` ``) code are masked **length-preservingly** so a `[[x]]` in a code sample isn't a link and real links keep their true source offsets. Plus `uniqueWikiLinkTargets()`.
- **`wiki-link-resolve.ts`** — `resolveWikiLinkTarget(target, index)` → a `WikiDocRef` (`knowledge:id` | `memory:path` | `journal:date`) or `null`, matched **client-side** against the doc lists the Grimoire navigator already loads (no new server index). Deterministic order: ISO date → knowledge (id, then title) → memory (basename, then relpath); all case-insensitive, `.md`/`.markdown` optional. Plus `resolveOutgoingLinks()` and `docRefKey()`.

## Why a lib-only slice

`cave-xr0` is a large feature. This lands the correct, exhaustively-tested core in isolation, so the risky UI integration (an 819-line `grimoire-view.tsx`) and the graph viewer are separate, focused PRs on a solid base. The resolver reuses the existing `openGrimoireDoc()` deep-link bridge shape (`WikiDocRef` mirrors `GrimoireSelection`), and the graph will reuse `@xyflow/react` (already in the repo) — no new deps.

## Roadmap (this bead)

1. **This PR** — parser + resolver engine ✅
2. Detail-panel **outgoing-link chips** (navigate via `openGrimoireDoc`)
3. **Graph viewer** — `/api/grimoire/links` index (backlinks) + `@xyflow/react` graph as a Grimoire tab

## Verification

- `wiki-link-parser.test.ts` + `wiki-link-resolve.test.ts` pass (both wired into the `app` suite + `ALIAS_LOADER` set). Cover code-region skipping, alias/whitespace/malformed-bracket edge cases, and id/title/basename/path/date resolution.
- `pnpm typecheck` clean · `check:tests-wired` 753 · `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)