### PR TITLE
feat(grimoire): outgoing [[wiki-link]] chips below the editor (cave-xr0, slice 2)

### DIFF
--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -68,4 +68,20 @@ assert.match(view, /replaceTab\(key, \{ kind: "knowledge", id: saved\.id \}\)/, 
 assert.match(view, /const evictIndex = tabs\.findIndex/, "over-cap opens evict the oldest non-active tab");
 assert.match(view, /fromHash/, "a #grimoire: deep link merges into (and activates within) the restored tab set");
 
+// ── cave-xr0 slice 2: outgoing [[wiki-link]] chips ──────────────────────────
+// The open doc's resolved wiki-links render as a chip row below the editor,
+// resolved against the loaded doc lists (no server index); resolved chips
+// navigate via openDoc, unresolved ones render dashed + inert.
+assert.match(view, /from "@\/lib\/wiki-link-resolve"/, "grimoire-view uses the wiki-link resolver engine");
+assert.match(view, /function GrimoireDocLinks\(/, "there is a doc-links chip component");
+assert.match(view, /resolveOutgoingLinks\(markdown, docIndex\)/, "chips come from resolving the open doc's markdown against the index");
+assert.match(
+  view,
+  /docIndex = useMemo<WikiDocIndex>\([\s\S]{0,220}memory:[\s\S]{0,40}m\.fullPath/,
+  "the doc index maps memory entries by fullPath (the same path openDoc navigates to)",
+);
+assert.match(view, /onClick=\{\(\) => onOpen\(ref\)\}/, "a resolved chip navigates to its doc");
+assert.match(view, /title="No matching Grimoire doc"[\s\S]{0,160}border-dashed/, "an unresolved link renders dashed + inert with a hint");
+assert.match(view, /<GrimoireDocLinks\b[\s\S]{0,160}onOpen=\{openDoc\}/, "the chip row is wired to openDoc for the active doc");
+
 console.log("grimoire-view.test: ok");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -29,6 +29,8 @@ import { useConfirm } from "@/components/ui/confirm-dialog";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useMemoryFile } from "@/lib/use-memory-file";
+import { resolveOutgoingLinks, type WikiDocIndex } from "@/lib/wiki-link-resolve";
 
 // ── Navigator model ──────────────────────────────────────────────────────────
 
@@ -354,6 +356,103 @@ function NavRow({
   );
 }
 
+// ── Wiki-link chips ──────────────────────────────────────────────────────────
+
+/** The open doc's outgoing [[wiki-links]], resolved against the loaded docs and
+ *  shown as a chip row below the editor. Resolved chips navigate; unresolved
+ *  ones (no matching doc) render dashed + inert. Mounted only for the active
+ *  doc, so exactly one doc's content is read at a time. */
+function GrimoireDocLinks({
+  selection,
+  knowledge,
+  docIndex,
+  onOpen,
+}: {
+  selection: GrimoireSelection;
+  knowledge: KnowledgeEntry[];
+  docIndex: WikiDocIndex;
+  onOpen: (sel: GrimoireSelection) => void;
+}) {
+  // useMemoryFile is a hook, so it's always called; a null path is a no-op.
+  const memoryPath = selection.kind === "memory" ? selection.path : null;
+  const memFile = useMemoryFile(memoryPath, { reveal: true });
+
+  const [journalMd, setJournalMd] = useState<string | null>(null);
+  useEffect(() => {
+    if (selection.kind !== "journal") {
+      setJournalMd(null);
+      return;
+    }
+    let cancelled = false;
+    setJournalMd(null);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/journal?date=${encodeURIComponent(selection.date)}`, { cache: "no-store" });
+        const json = await res.json();
+        if (!cancelled) setJournalMd(json.ok ? (json.entry?.reflection ?? "") : "");
+      } catch {
+        if (!cancelled) setJournalMd("");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selection]);
+
+  const markdown =
+    selection.kind === "knowledge"
+      ? knowledge.find((k) => k.id === selection.id)?.body ?? ""
+      : selection.kind === "memory"
+        ? memFile.text ?? ""
+        : selection.kind === "journal"
+          ? journalMd ?? ""
+          : "";
+
+  const links = useMemo(() => {
+    const seen = new Set<string>();
+    const out: ReturnType<typeof resolveOutgoingLinks> = [];
+    for (const link of resolveOutgoingLinks(markdown, docIndex)) {
+      const key = link.target.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push(link);
+    }
+    return out;
+  }, [markdown, docIndex]);
+
+  if (links.length === 0) return null;
+
+  return (
+    <div className="grimoire-doc-links flex shrink-0 flex-wrap items-center gap-1.5 border-t border-[var(--border-hairline)] px-3 py-2">
+      <span className="inline-flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-[var(--text-muted)]">
+        <Icon name="ph:link" width={11} aria-hidden />
+        Links
+      </span>
+      {links.map((link, i) => {
+        const { ref, display } = link;
+        return ref ? (
+          <button
+            key={i}
+            type="button"
+            onClick={() => onOpen(ref)}
+            className="focus-ring rounded-full border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:border-[color-mix(in_oklch,var(--accent-presence)_50%,var(--border-hairline))] hover:text-[var(--text-primary)]"
+          >
+            {display}
+          </button>
+        ) : (
+          <span
+            key={i}
+            title="No matching Grimoire doc"
+            className="rounded-full border border-dashed border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)]"
+          >
+            {display}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
 // ── Surface ──────────────────────────────────────────────────────────────────
 
 export function GrimoireView() {
@@ -536,6 +635,16 @@ export function GrimoireView() {
   const loading = knowledge === null || memory === null || journal === null;
   const selectedKey = selection ? selectionKey(selection) : null;
 
+  // Index of every loaded doc, used to resolve a doc's outgoing [[wiki-links]].
+  const docIndex = useMemo<WikiDocIndex>(
+    () => ({
+      knowledge: (knowledge ?? []).map((k) => ({ id: k.id, title: k.title })),
+      memory: (memory ?? []).map((m) => ({ path: m.fullPath })),
+      journal: (journal ?? []).map((j) => ({ date: j.date })),
+    }),
+    [knowledge, memory, journal],
+  );
+
   /** Human tab label for a selection (falls back to ids/paths). */
   const tabTitle = useCallback(
     (sel: GrimoireSelection): string => {
@@ -645,6 +754,15 @@ export function GrimoireView() {
             </div>
           ) : null}
         </div>
+        {selection && selection.kind !== "knowledge-new" ? (
+          <GrimoireDocLinks
+            key={selectedKey ?? ""}
+            selection={selection}
+            knowledge={knowledge ?? []}
+            docIndex={docIndex}
+            onOpen={openDoc}
+          />
+        ) : null}
       </div>
     );
 


### PR DESCRIPTION
Second slice of **cave-xr0** — surfaces a Grimoire doc's outgoing `[[wiki-links]]` as a navigable chip row, built on the slice-1 parser/resolver engine (#2587).

## What

A **`GrimoireDocLinks`** chip strip renders beneath the editor for the active doc:
- Reads the open doc's markdown — knowledge from the already-loaded list, memory via the shared `useMemoryFile` hook, journal via `/api/journal` — and parses + resolves its wiki-links with `resolveOutgoingLinks(markdown, docIndex)`.
- `docIndex` is built from the navigator's loaded lists; **memory is keyed by `fullPath`** so a chip navigates to the exact doc the nav opens.
- **Resolved** chips open their doc via the existing `openDoc()` bridge. **Unresolved** links render dashed + inert with a "No matching Grimoire doc" hint.
- De-duped by target; the whole strip hides when a doc has no links.
- Mounted only for the active doc → exactly one doc's content is read at a time.

## Design notes

- **No editor/plugin work.** Milkdown Crepe exposes no plugin API, so rather than risk in-WYSIWYG decoration, the links live in the detail panel — and thus work in **both** VISUAL and MARKDOWN modes.
- Reuses existing infra end-to-end: the resolver from slice 1, `useMemoryFile`, and `openDoc()`. No new deps, no new server routes.

## Verification

- `grimoire-view.test.ts` extended with a chips guard (resolver import, `GrimoireDocLinks`, `resolveOutgoingLinks(markdown, docIndex)`, memory-by-`fullPath`, resolved→`openDoc`, dashed unresolved). Passes alongside `wiki-link-parser`/`wiki-link-resolve`.
- `pnpm typecheck` clean · `check:tests-wired` 753 · `git diff --check` clean.
- Rendered check deferred: the engine is exhaustively unit-tested and the wiring is type-checked + source-pinned; a manual screenshot needs a seeded `[[link]]` doc + full build.

## Remaining on cave-xr0

3. **Graph viewer** — a `/api/grimoire/links` index (for backlinks across the vault) + an `@xyflow/react` graph as a Grimoire tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)