### PR TITLE
feat(chat): centered reading column for the conversation (cave-xsq.1)

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -86,39 +86,40 @@ assert.match(
 );
 
 // ---------------------------------------------------------------------------
-// Full-width chat (2026-06-18) — supersedes the 2026-06-13 centered-column
-// decision: the thread spans the whole pane (width: 100%, max-width: 100%, no
-// auto centering) so the transcript lines up with the full-width header and
-// composer. The old 920px and 1180px reading-measure caps stay gone.
+// Centered reading column (cave-xsq.1) — supersedes the 2026-06-18 full-width
+// decision: the transcript + composer share ONE comfortable measure
+// (--cave-chat-measure) and sit in a centered column so long responses read
+// like ChatGPT instead of running edge-to-edge on a wide pane. The old 920px /
+// 1180px hardcoded caps stay gone (the measure is now a token).
 // ---------------------------------------------------------------------------
 
+assert.match(
+  css,
+  /\.cave-chat-linear \{[^}]*--cave-chat-measure:\s*[\d.]+rem/,
+  "the chat surface defines a shared reading measure token",
+);
 const linearThread = /\.cave-chat-linear \.cave-chat-thread \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearThread,
-  /width:\s*100%/,
-  "Linear thread must fill the pane (width: 100%)",
+  /max-width:\s*var\(--cave-chat-measure\)/,
+  "Linear thread caps to the shared reading measure",
 );
 assert.match(
   linearThread,
-  /max-width:\s*100%/,
-  "Linear thread must span full width (max-width: 100%)",
-);
-assert.doesNotMatch(
-  linearThread,
   /margin-inline:\s*auto/,
-  "Linear thread must not center (no margin-inline: auto)",
+  "Linear thread centers the reading column (margin-inline: auto)",
 );
 assert.doesNotMatch(
   linearThread,
   /max-width:\s*(?:min\(100%,\s*)?(?:920|1180)px/,
-  "The old reading-measure caps (920px / 1180px) must stay gone",
+  "the old hardcoded reading-measure caps (920px / 1180px) must stay gone",
 );
 
 const linearComposerShell = /\.cave-chat-linear \.cave-composer-shell \{[^}]*\}/.exec(css)?.[0] ?? "";
 assert.match(
   linearComposerShell,
-  /max-width:\s*100%/,
-  "Linear composer shell must share the thread's full-width measure so the input aligns with the column",
+  /max-width:\s*var\(--cave-chat-measure\)/,
+  "Linear composer shell shares the thread's reading measure so the input aligns under the column",
 );
 
 // ---------------------------------------------------------------------------

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2493,6 +2493,13 @@ details[open] > .cave-tool-summary::before {
 /* Dense linear session view */
 .cave-chat-linear {
   position: relative; /* anchors .cave-drop-overlay */
+  /* Centered reading column (cave-xsq.1): the conversation + composer share one
+     comfortable measure and sit in a centered column — the ChatGPT reading
+     model — instead of spanning the full pane (reverses the 2026-06-18
+     full-width choice below). ~46rem ≈ a ~72ch line at 14px. The header stays a
+     full-bleed bar (its divider spans the pane); only the reading/writing column
+     is capped + centered. */
+  --cave-chat-measure: 46rem;
   background:
     linear-gradient(to bottom, color-mix(in oklch, var(--bg-raised) 18%, transparent), transparent 150px),
     var(--bg-base);
@@ -3255,13 +3262,14 @@ details[open] > .cave-tool-summary::before {
 
 .cave-chat-linear .cave-chat-thread {
   gap: 0;
-  /* Full-width chat (2026-06-18): span the whole pane so the transcript lines
-     up with the full-width header and composer instead of sitting in a
-     centered reading column. */
+  /* Centered reading column (cave-xsq.1): cap the transcript to a comfortable
+     measure and center it, so long responses read like ChatGPT instead of
+     running edge-to-edge on a wide pane. The composer shares the same measure
+     (below) so the input lines up under the conversation. */
   width: 100%;
-  max-width: 100%;
+  max-width: var(--cave-chat-measure);
   margin-block: 0;
-  margin-inline: 0;
+  margin-inline: auto;
 }
 
 /* ── Turn rows ──────────────────────────────────────────────────────────── */
@@ -3528,9 +3536,9 @@ details[open] > .cave-tool-summary::before {
 }
 
 .cave-chat-linear .cave-composer-shell {
-  /* Shares the thread's full-width measure so the input lines up with the
-     conversation column; base rule centers via margin auto. */
-  max-width: 100%;
+  /* Shares the thread's centered measure (cave-xsq.1) so the input sits directly
+     under the conversation column; base rule centers via margin auto. */
+  max-width: var(--cave-chat-measure);
 }
 
 .cave-chat-linear .cave-composer-panel {


### PR DESCRIPTION
**Phase 1.1** of the chat-first minimalism arc (epic `cave-xsq`; plan `~/.claude/plans/purring-tickling-star.md`), the first slice toward a ChatGPT-grade conversation.

## Problem
The transcript and composer spanned the full pane (a deliberate 2026-06-18 full-width choice), so long responses ran edge-to-edge and read poorly on wide screens — the opposite of ChatGPT's calm, centered column.

## Change
- New `--cave-chat-measure` token (46rem ≈ a ~72ch line at 14px) on `.cave-chat-linear`.
- `.cave-chat-thread` and `.cave-composer-shell` cap to it and center (they already carried `margin: auto`).
- The header stays a **full-bleed bar** (its divider spans the pane); only the reading/writing column is capped. The composer now sits directly under the conversation at the same width.
- The reading-width **preference subsystem is untouched** — it still narrows `.cave-md` further for users who choose it. Rhythm (14px / 1.7 / per-turn padding) unchanged.

## Verification
Live at 3 widths:

| viewport | pane | thread / composer | result |
| --- | --- | --- | --- |
| desktop | 1384px | 736px, 324px each side | centered + aligned |
| tablet | 834px | 736px, 49px each side | centered |
| mobile | 390px | 366px (fills) | cap is a no-op, no regression |

Thread and composer share the exact same width and left edge, so the input lines up under the conversation. Repointed the full-width pin in `message-bubble-code-header.test.ts` to the new centered model. 558 app tests, typecheck, and build green.

Part of epic `cave-xsq`; closes `cave-xsq.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)