### PR TITLE
refactor(board): banner action buttons on the shared Button (cave-4op)

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -814,14 +814,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
             <span className="min-w-0 truncate">{error}</span>
           </span>
-          <button
-            type="button"
-            onClick={() => void load()}
-            className="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--color-danger)_38%,transparent)] bg-[var(--bg-base)]/35 px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[var(--bg-raised)]"
-          >
-            <Icon name="ph:arrow-clockwise" width={12} aria-hidden />
+          <Button variant="secondary" size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
             Retry
-          </button>
+          </Button>
         </div>
       )}
       {chatLinkError && (
@@ -844,14 +839,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
               Cleared {clearedBanner.snapshot.length} done task{clearedBanner.snapshot.length === 1 ? "" : "s"}
             </span>
           </span>
-          <button
-            type="button"
-            onClick={() => void handleUndoClear()}
-            className="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--text-muted)_38%,transparent)] bg-[var(--bg-base)]/35 px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[var(--bg-raised)]"
-          >
-            <Icon name="ph:arrow-counter-clockwise" width={12} aria-hidden />
+          <Button variant="secondary" size="xs" leadingIcon="ph:arrow-counter-clockwise" onClick={() => void handleUndoClear()}>
             Undo
-          </button>
+          </Button>
         </div>
       )}
       {rescheduleUndo && (
@@ -865,14 +855,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
               Rescheduled “{rescheduleUndo.title}”
             </span>
           </span>
-          <button
-            type="button"
-            onClick={handleUndoReschedule}
-            className="focus-ring inline-flex shrink-0 items-center gap-1.5 rounded-md border border-[color-mix(in_oklch,var(--text-muted)_38%,transparent)] bg-[var(--bg-base)]/35 px-2 py-1 text-[11px] font-medium transition-colors hover:bg-[var(--bg-raised)]"
-          >
-            <Icon name="ph:arrow-counter-clockwise" width={12} aria-hidden />
+          <Button variant="secondary" size="xs" leadingIcon="ph:arrow-counter-clockwise" onClick={handleUndoReschedule}>
             Undo
-          </button>
+          </Button>
         </div>
       )}
       {actionError && (


### PR DESCRIPTION
## What

The **board-view** slice of the app-wide control-standardization umbrella (cave-4op). Converted the three top-of-board **banner action buttons** — the error banner's **Retry**, the cleared-done banner's **Undo**, and the reschedule banner's **Undo** — from ad-hoc inline-Tailwind button recipes (the same recipe repeated three times) to the shared `<Button variant="secondary" size="xs">`.

## Left bespoke (documented for the next board slice)

- The grouping + view-mode **segmented switchers** (`board-group-toggle-btn` ×6, `board-view-toggle-btn` ×3) — segmented-control pattern, like the calendar switcher.
- The absolutely-positioned `board-search-clear` overlay inside the search field.
- The **class-pinned** toolbar/new-task buttons (`board-toolbar-btn` is shared with `board-inspector`; `board-new-card-btn` is pinned by `board-ux-polish` + `a11y-audit` tests) — those need pin-aware updates.
- Alert-dismiss `×` icons — an IconButton follow-up.

## Verification

Handlers (`load`, `handleUndoClear`, `handleUndoReschedule`) and button text are unchanged, so the clear-done/reschedule **behavioral pins stay green**. `typecheck` clean; `board-clear-done`, `board-ux-polish`, `board-schedule-window` tests pass; app suite + tests-wired running.

cave-4op stays **OPEN** (umbrella). Net **+6 / −21**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)