### PR TITLE
docs(release): hyperlink Install asset names to their download URLs

### DIFF
--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -10,6 +10,11 @@
 # previous tag is auto-detected via `git tag --sort=-version:refname` when
 # the second argument is omitted.
 #
+# The Install section hyperlinks each platform's asset name to its
+# releases/download/<tag>/<asset> URL (DMGs keep the `v` prefix; AppImage/MSI
+# use the bare version number), so users can click straight through to the
+# download instead of hunting the assets list.
+#
 # Designed to be run both in CI (release.yml's checksums job re-renders the
 # body after all artifacts have uploaded) and locally for backfilling old
 # releases via `gh release edit <tag> --notes-file -`.
@@ -82,6 +87,13 @@ else
   echo
 fi
 
+# ── Asset download URLs ──────────────────────────────────────────────────────
+# Each Install line hyperlinks the asset name to its release-download URL so
+# users can click straight through. DMG assets carry the `v` prefix
+# (CovenCave-vX.Y.Z-<arch>.dmg); AppImage/MSI assets use the bare version
+# number (CovenCave_X.Y.Z_...). Keep these in sync with release.yml's uploads.
+DL="https://github.com/$REPO/releases/download/$VERSION"
+
 cat <<INSTALL
 
 ## Install
@@ -90,18 +102,18 @@ INSTALL
 
 if [ "$arch_split" = "true" ]; then
   cat <<INSTALL_NEW
-- **macOS (Apple Silicon):** download \`CovenCave-$VERSION-aarch64.dmg\`, open it, drag CovenCave.app to Applications.
-- **macOS (Intel):** download \`CovenCave-$VERSION-x86_64.dmg\`, open it, drag CovenCave.app to Applications.
+- **macOS (Apple Silicon):** download [\`CovenCave-$VERSION-aarch64.dmg\`]($DL/CovenCave-$VERSION-aarch64.dmg), open it, drag CovenCave.app to Applications.
+- **macOS (Intel):** download [\`CovenCave-$VERSION-x86_64.dmg\`]($DL/CovenCave-$VERSION-x86_64.dmg), open it, drag CovenCave.app to Applications.
 INSTALL_NEW
 else
   cat <<INSTALL_LEGACY
-- **macOS:** download \`CovenCave-$VERSION.dmg\`, open it, drag CovenCave.app to Applications.
+- **macOS:** download [\`CovenCave-$VERSION.dmg\`]($DL/CovenCave-$VERSION.dmg), open it, drag CovenCave.app to Applications.
 INSTALL_LEGACY
 fi
 
 cat <<INSTALL_REST
-- **Linux:** download the AppImage asset, \`chmod +x CovenCave_*.AppImage\`, then run it.
-- **Windows:** download the \`.msi\` and double-click to install.
+- **Linux:** download the [AppImage asset]($DL/CovenCave_${VER_NUM}_amd64.AppImage), \`chmod +x CovenCave_*.AppImage\`, then run it.
+- **Windows:** download the [\`.msi\`]($DL/CovenCave_${VER_NUM}_x64_en-US.msi) and double-click to install.
 
 ## Verify checksums
 


### PR DESCRIPTION
## Problem
`scripts/release-notes.sh` renders the canonical GitHub Release body (via `release.yml`'s "Set release notes" step). Its **Install** section emitted bare backtick filenames with no links, so users had to scroll down to the assets list to actually download. The hand-formatted **v0.0.144** body linked each one — but the generator never did, so every automated release since reverted to plain text.

## Fix
Wrap each platform's asset name in a Markdown link to its `releases/download/<tag>/<asset>` URL.

**Before:**
```
- **macOS (Apple Silicon):** download `CovenCave-v0.0.147-aarch64.dmg`, open it, drag CovenCave.app to Applications.
```
**After:**
```
- **macOS (Apple Silicon):** download [`CovenCave-v0.0.147-aarch64.dmg`](https://github.com/OpenCoven/coven-cave/releases/download/v0.0.147/CovenCave-v0.0.147-aarch64.dmg), open it, drag CovenCave.app to Applications.
```

- DMG assets keep the `v` prefix (`CovenCave-vX.Y.Z-<arch>.dmg`)
- AppImage/MSI use the bare version number (`CovenCave_X.Y.Z_amd64.AppImage`, `CovenCave_X.Y.Z_x64_en-US.msi`)
- Legacy single-arch (<0.0.54) macOS line gets the same treatment

## Verification
- ✅ `bash -n` syntax clean
- ✅ Rendered v0.0.147 body matches the v0.0.144 hand-formatted target **byte-for-byte**
- ✅ All three generated download URLs resolve **HTTP 200**

Existing live releases (v0.0.147, .146, .145) will be backfilled by re-running the script against each tag after merge.