### PR TITLE
fix(chat): thread-switch composer isolation + ownership-scoped stream teardown + IME-safe Enter

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -523,4 +523,29 @@ assert.match(
   "the history-load effect clears streaming state inherited from the previous thread",
 );
 
+// Thread-switch composer isolation (cave chat audit): ChatView is a single
+// instance reused across threads, so per-thread composer context must be reset
+// on session switch or it bleeds a reply-quote / attachments / branch-parent /
+// enhance-draft into the next conversation's next send.
+assert.match(
+  source,
+  /setMentionedFiles\(\[\]\);\s*\n\s*setRuntimeHost\(null\);[\s\S]{0,600}?setReplyTarget\(null\);\s*\n\s*setAttachments\(\[\]\);\s*\n\s*setPendingBranchParent\(undefined\);\s*\n\s*setEnhanceStatus\("idle"\);\s*\n\s*setEnhanceOriginal\(null\);/,
+  "the session-switch reset effect clears reply-target, attachments, pending branch parent, and enhance state so they don't leak across threads",
+);
+
+// Stream teardown must be ownership-scoped: a settling BACKGROUND stream must
+// not clobber a newer concurrent stream's abort/stop wiring or unlock the composer.
+assert.match(
+  source,
+  /if \(abortRef\.current === controller\) \{\s*\n\s*streamOwnerRef\.current = false;\s*\n\s*abortRef\.current = null;\s*\n\s*stopKeysRef\.current = \{ runId: null, sessionId: null \};\s*\n\s*setBusy\(false\);/,
+  "sendRaw's finally only tears down the shared stream wiring when it still owns the active controller",
+);
+
+// IME composition safety: the Enter that confirms a CJK/kana candidate must not send.
+assert.match(
+  source,
+  /e\.key === "Enter" && !e\.shiftKey && !e\.nativeEvent\.isComposing/,
+  "the composer's Enter-to-send is gated on !isComposing so IME candidate-confirm doesn't fire a half-composed message",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3713,11 +3713,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         raiseDebugError({ turnId: assistantId });
       }
     } finally {
-      streamOwnerRef.current = false;
+      // Always retire THIS generation's registry entry (keyed by session).
       clearLiveChatGeneration(liveGeneration.sessionId);
-      abortRef.current = null;
-      stopKeysRef.current = { runId: null, sessionId: null };
-      setBusy(false);
+      // But only tear down the SHARED stream wiring if we still own it. After a
+      // thread switch + a second send, a settling *background* stream must not
+      // null the newer stream's abort controller / stop keys or re-enable the
+      // composer — otherwise the newer response's Stop button goes dead and the
+      // composer falsely unlocks mid-stream. `controller` is this send's own
+      // AbortController (assigned to abortRef.current when the stream started).
+      if (abortRef.current === controller) {
+        streamOwnerRef.current = false;
+        abortRef.current = null;
+        stopKeysRef.current = { runId: null, sessionId: null };
+        setBusy(false);
+      }
     }
   };
 
@@ -4435,7 +4444,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       setInput("");
       return;
     }
-    if (e.key === "Enter" && !e.shiftKey) {
+    // `isComposing` is true for the Enter that confirms an IME candidate
+    // (CJK/pinyin/kana). Treating that Enter as "send" fires a half-composed,
+    // garbled message and destroys the candidate selection, so let the IME keep it.
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       void send();
       return;
@@ -4490,6 +4502,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     });
     setMentionedFiles([]);
     setRuntimeHost(null);
+    // ChatView is a single instance reused across threads (not keyed by
+    // sessionId in ChatRouter), so per-thread composer context must be cleared
+    // on switch or it bleeds into the next conversation's next send: a
+    // reply-quote and staged attachments would be injected into the wrong
+    // thread, a pending branch parent would mis-parent the turn onto a node
+    // that doesn't exist in the new tree, and the "Prompt improved / Revert"
+    // strip would resurrect the previous thread's pre-enhancement draft.
+    setReplyTarget(null);
+    setAttachments([]);
+    setPendingBranchParent(undefined);
+    setEnhanceStatus("idle");
+    setEnhanceOriginal(null);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, session?.project_root, projectRoot, firstProject?.id, linkedContext?.task?.projectId, linkedContext?.task?.cwd]);
 

--- a/src/lib/chat-recency.test.ts
+++ b/src/lib/chat-recency.test.ts
@@ -50,6 +50,17 @@ test("empty buckets are omitted; rows sort newest-first within a bucket", () => 
   assert.deepEqual(buckets[0].sessions.map((s) => s.id), ["t-new", "t-old"]);
 });
 
+test("equal timestamps keep a stable, insertion-order arrangement (comparator returns 0)", () => {
+  // Same updated_at for every row: the sort comparator must return 0 for equal
+  // elements (not the old asymmetric `a < b ? 1 : -1`), so ordering is stable
+  // rather than engine-dependent.
+  const ts = daysAgoIso(0, 2);
+  const ids = ["a", "b", "c", "d", "e"];
+  const buckets = deriveChatRecencyBuckets(ids.map((id) => session(id, ts)), NOW_MS);
+  assert.deepEqual(buckets.map((b) => b.key), ["today"]);
+  assert.deepEqual(buckets[0].sessions.map((s) => s.id), ids);
+});
+
 test("created_at fallback; invalid timestamps → Older; future skew reads as today", () => {
   const created = deriveChatRecencyBuckets([session("c1", "", daysAgoIso(1))], NOW_MS);
   assert.deepEqual(created.map((b) => b.key), ["yesterday"]);

--- a/src/lib/chat-recency.ts
+++ b/src/lib/chat-recency.ts
@@ -52,9 +52,14 @@ export function deriveChatRecencyBuckets(
   sessions: SessionRow[],
   nowMs: number,
 ): ChatRecencyBucket[] {
-  const sorted = [...sessions].sort((a, b) =>
-    sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1,
-  );
+  const sorted = [...sessions].sort((a, b) => {
+    // Newest first. Return 0 for equal timestamps: `a < b ? 1 : -1` is
+    // asymmetric (both compare(a,b) and compare(b,a) yield -1 when equal),
+    // which violates the comparator contract and reorders same-timestamp rows.
+    const ta = sessionTimestamp(a);
+    const tb = sessionTimestamp(b);
+    return ta === tb ? 0 : tb > ta ? 1 : -1;
+  });
   const byKey = new Map<ChatRecencyBucketKey, SessionRow[]>();
   for (const session of sorted) {
     const key = bucketKeyFor(sessionTimestamp(session), nowMs);


### PR DESCRIPTION
From a focused audit of the chat surface (5 parallel readers + source verification). This PR ships the **confirmed, well-contained** fixes; higher-risk/complex findings are filed as beads (see bottom).

## Root cause
`ChatView` is **not keyed by session** (`chat-router.tsx`), so one instance is reused across threads — its per-thread state and shared stream wiring leak between conversations.

## Fixes
| # | Bug | Fix |
|---|-----|-----|
| 1 | Reply-quote, staged attachments, pending branch parent, and the enhance "Prompt improved/Revert" state leaked into the **next thread's next send** | The session-switch reset effect now clears all four (it already cleared `mentionedFiles`/`runtimeHost`) |
| 2 | A settling **background** stream (thread A, after switching to B and sending again) nulled B's abort controller/stop keys and unlocked the composer mid-stream — B's Stop button went dead | `sendRaw`'s `finally` only tears down the shared wiring when it still owns the active controller (`abortRef.current === controller`); the per-session registry entry is still always cleared |
| 3 | Enter that **confirms an IME (CJK/kana) candidate** sent a half-composed, garbled message | Enter-to-send gated on `!e.nativeEvent.isComposing` |
| 4 | `deriveChatRecencyBuckets` sort comparator was asymmetric (`a < b ? 1 : -1`), never returning 0 → same-timestamp chats could reorder | Comparator returns 0 for equal timestamps |

## Verification
- `tsc --noEmit` clean; **full `test:app` (558 files) green**; frontend build within budget.
- New source-scan pins in `chat-view-lifecycle.test.ts` (reset-effect clears the four; ownership-scoped teardown; `!isComposing` gate) + a same-timestamp case in `chat-recency.test.ts`.

## Deferred to beads (not fixed blind here)
- **P1** — new-chat stream hijacks `currentSessionRef` → wrong-thread splice + next message POSTed to the wrong session (needs a focused repro).
- **P2** — group-chat `recordSession` session-id race + no-abort on coven switch.
- **P2** — chat-list "Select all" acting on collapsed/hidden rows (data loss) + pin/order divergence between the list and project rail.
- **P3** — a lower-severity/plausible tier (Esc not dismissing `/model`·`/skill`·`/prompt` pickers, enhance-after-send linger, draft-debounce resurrection, model-state stale write, changeCount badge staleness, popstate deep-link indicator, `/clear`-mid-stream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)