### PR TITLE
feat(chat): create board task from chat with source audit trail (cave-px7)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -375,6 +375,8 @@ export const SUITES = {
     "src/components/opencoven-submission-panel.test.ts",
     "src/components/opencoven-submissions-navigation.test.ts",
     "src/components/chat-linked-context.test.ts",
+    "src/components/chat-task-handoff-wiring.test.ts",
+    "src/lib/chat-task-handoff.test.ts",
     "src/components/group-chat-view.test.ts",
     "src/lib/group-chat.test.ts",
     "src/components/chat-send-routes-links.test.ts",

--- a/src/components/chat-task-handoff-wiring.test.ts
+++ b/src/components/chat-task-handoff-wiring.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+// Chat → board task handoff wiring (cave-px7). The pure payload logic is
+// unit-tested in src/lib/chat-task-handoff.test.ts; this guards the UI wiring:
+// the task-link picker offers "New task from this chat" when the chat surface
+// hands it a handoff context, and chat-view actually supplies that context
+// (turns + familiar + project) so the created card is linked and auditable.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const picker = await readFile(new URL("./task-link-picker.tsx", import.meta.url), "utf8");
+const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// ── picker: create-from-chat row ─────────────────────────────────────────────
+assert.match(
+  picker,
+  /import \{ createTaskFromChat, type ChatHandoffContext \} from "@\/lib\/chat-task-handoff"/,
+  "picker should use the shared chat-task-handoff helper, not an inline fetch",
+);
+assert.match(
+  picker,
+  /handoff\?: ChatHandoffContext \| null/,
+  "handoff context is an optional prop — the picker still works link-only",
+);
+assert.match(
+  picker,
+  /createTaskFromChat\(\{\s*sessionId,\s*context: handoff,\s*title: query\.trim\(\) \|\| undefined,?\s*\}\)/,
+  "the typed search query doubles as the new task's title",
+);
+assert.match(
+  picker,
+  /\{handoff \? \(\s*<button[\s\S]*?New task from this chat/,
+  "the create row only renders when a handoff context is supplied",
+);
+assert.match(
+  picker,
+  /aria-label=\{\s*query\.trim\(\)\s*\? `Create a new task "\$\{query\.trim\(\)\}" from this chat`\s*: "Create a new task from this chat"/,
+  "the create row keeps an accessible name",
+);
+assert.match(
+  picker,
+  /if \(!result\.ok \|\| !result\.card\) throw new Error\(result\.error \?\? "Failed to create task"\);\s*onAssigned\(result\.card\);\s*onClose\(\);/,
+  "a created card flows through the same onAssigned path as a linked one, so the header chip appears immediately",
+);
+
+// ── chat-view: supplies the handoff context ──────────────────────────────────
+assert.match(
+  chatView,
+  /import type \{ ChatHandoffContext \} from "@\/lib\/chat-task-handoff"/,
+  "chat-view imports the handoff context type",
+);
+assert.match(
+  chatView,
+  /handoff=\{\{ turns, familiarId: familiar\.id \?\? null, projectId: projectIdDraft \}\}/,
+  "chat-view hands the picker its turns plus the chat's familiar and project",
+);
+assert.match(
+  chatView,
+  /<TaskLinkPicker[\s\S]*?handoff=\{handoff\}/,
+  "LinkedContextRow forwards the handoff context to the picker",
+);
+
+console.log("chat-task-handoff-wiring.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -30,6 +30,7 @@ import {
   shouldShowChatArchiveNudge,
 } from "@/lib/chat-archive-nudge";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
+import type { ChatHandoffContext } from "@/lib/chat-task-handoff";
 import type { Card } from "@/lib/cave-board-types";
 import { TaskLinkPicker } from "@/components/task-link-picker";
 import { openExternalUrl } from "@/lib/open-external";
@@ -1700,11 +1701,15 @@ function LinkedContextRow({
   onOpenTask,
   sessionId,
   onLinkedContextChange,
+  handoff,
 }: {
   linkedContext: ChatLinkedContext | null;
   onOpenTask?: (cardId: string) => void;
   sessionId?: string | null;
   onLinkedContextChange?: (updater: (prev: ChatLinkedContext | null) => ChatLinkedContext | null) => void;
+  /** Recent turns + familiar/project for the picker's "New task from this chat"
+   *  handoff (cave-px7). Absent → the picker only links existing tasks. */
+  handoff?: ChatHandoffContext | null;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const task = linkedContext?.task ?? null;
@@ -1758,6 +1763,7 @@ function LinkedContextRow({
               linkedIds={linkedIds}
               onAssigned={onAssigned}
               onClose={() => setPickerOpen(false)}
+              handoff={handoff}
             />
           ) : null}
         </span>
@@ -4712,6 +4718,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           onOpenTask={onOpenTask}
           sessionId={sessionId}
           onLinkedContextChange={setLinkedContext}
+          handoff={{ turns, familiarId: familiar.id ?? null, projectId: projectIdDraft }}
         />
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />

--- a/src/components/task-link-picker.tsx
+++ b/src/components/task-link-picker.tsx
@@ -3,23 +3,32 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import type { Card } from "@/lib/cave-board-types";
+import { createTaskFromChat, type ChatHandoffContext } from "@/lib/chat-task-handoff";
 
 /**
  * Popover for linking an existing board task to the current chat. Lists the
  * board's cards (minus those already linked to this session) and, on pick,
  * PATCHes the card's `sessionId` to this chat — the chat→task assign side that
  * mirrors the board's "Start chat from task" flow.
+ *
+ * When the chat surface supplies a `handoff` context (recent turns + the
+ * chat's familiar/project), the picker also offers "New task from this chat":
+ * a one-click chat→board handoff that creates an inbox card pre-linked to this
+ * session, carrying a transcript excerpt and source audit trail in its notes
+ * (see chat-task-handoff.ts). The search query doubles as the new card's title.
  */
 export function TaskLinkPicker({
   sessionId,
   linkedIds,
   onAssigned,
   onClose,
+  handoff,
 }: {
   sessionId: string;
   linkedIds: Set<string>;
   onAssigned: (card: Card) => void;
   onClose: () => void;
+  handoff?: ChatHandoffContext | null;
 }) {
   const [cards, setCards] = useState<Card[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -69,6 +78,26 @@ export function TaskLinkPicker({
       .slice(0, 50);
   }, [cards, linkedIds, query]);
 
+  const createFromChat = async () => {
+    if (!handoff) return;
+    setBusyId("__new__");
+    setError(null);
+    try {
+      const result = await createTaskFromChat({
+        sessionId,
+        context: handoff,
+        title: query.trim() || undefined,
+      });
+      if (!result.ok || !result.card) throw new Error(result.error ?? "Failed to create task");
+      onAssigned(result.card);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create task");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
   const assign = async (card: Card) => {
     setBusyId(card.id);
     setError(null);
@@ -111,6 +140,27 @@ export function TaskLinkPicker({
         <div className="px-2.5 py-1.5 text-[11px] text-[var(--color-danger,#ef4444)]">{error}</div>
       ) : null}
       <div className="max-h-[16rem] overflow-y-auto py-1">
+        {handoff ? (
+          <button
+            type="button"
+            disabled={busyId !== null}
+            onClick={() => void createFromChat()}
+            aria-label={
+              query.trim()
+                ? `Create a new task "${query.trim()}" from this chat`
+                : "Create a new task from this chat"
+            }
+            className="flex w-full items-center gap-2 border-b border-[var(--border-hairline)] px-2.5 py-1.5 text-left text-[12px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] disabled:opacity-50"
+          >
+            <Icon name="ph:plus" width={12} className="shrink-0 text-[var(--accent-presence)]" />
+            <span className="min-w-0 flex-1 truncate">
+              {query.trim() ? `New task: “${query.trim()}”` : "New task from this chat"}
+            </span>
+            <span className="shrink-0 text-[var(--text-muted)]">
+              {busyId === "__new__" ? "creating…" : "inbox"}
+            </span>
+          </button>
+        ) : null}
         {cards === null ? (
           <div className="px-2.5 py-2 text-[11px] text-[var(--text-muted)]">Loading tasks…</div>
         ) : results.length === 0 ? (

--- a/src/lib/chat-task-handoff.test.ts
+++ b/src/lib/chat-task-handoff.test.ts
@@ -1,0 +1,150 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+const {
+  handoffTurns,
+  deriveTaskTitleFromTurns,
+  buildChatExcerpt,
+  buildChatHandoffNotes,
+  createTaskFromChat,
+} = await import("./chat-task-handoff.ts");
+
+const t = (id, role, text, extra = {}) => ({ id, role, text, ...extra });
+
+// ── handoffTurns filtering ───────────────────────────────────────────────────
+{
+  const turns = [
+    t("u1", "user", "do the thing"),
+    t("s1", "system", "system chrome"),
+    t("a1", "assistant", "on it"),
+    t("a2", "assistant", "streaming…", { pending: true }),
+    t("a3", "assistant", "boom", { error: true }),
+    t("u2", "user", "   "),
+  ];
+  assert.deepEqual(
+    handoffTurns(turns).map((x) => x.id),
+    ["u1", "a1"],
+    "system, pending, errored, and blank turns are dropped",
+  );
+}
+
+// ── title derivation ─────────────────────────────────────────────────────────
+{
+  const turns = [
+    t("a0", "assistant", "welcome!"),
+    t("u1", "user", "Fix the flaky board test\nIt fails on CI only."),
+  ];
+  assert.equal(
+    deriveTaskTitleFromTurns(turns),
+    "Fix the flaky board test",
+    "title is the first line of the first USER turn",
+  );
+}
+assert.equal(
+  deriveTaskTitleFromTurns([t("a1", "assistant", "only assistant spoke")]),
+  "only assistant spoke",
+  "falls back to the first usable turn of any role",
+);
+assert.equal(deriveTaskTitleFromTurns([]), "Task from chat", "empty chat gets a generic title");
+{
+  const long = "x".repeat(200);
+  const title = deriveTaskTitleFromTurns([t("u1", "user", long)]);
+  assert.ok(title.length <= 80, "long titles are truncated");
+  assert.ok(title.endsWith("…"), "truncated titles end with an ellipsis");
+}
+
+// ── excerpt ──────────────────────────────────────────────────────────────────
+{
+  const turns = Array.from({ length: 10 }, (_, i) => t(`u${i}`, "user", `message ${i}`));
+  const excerpt = buildChatExcerpt(turns, { maxTurns: 3 });
+  assert.equal(
+    excerpt,
+    "user: message 7\n\nuser: message 8\n\nuser: message 9",
+    "excerpt keeps the LAST maxTurns turns, role-prefixed",
+  );
+}
+{
+  const excerpt = buildChatExcerpt([t("a1", "assistant", "y".repeat(2000))]);
+  assert.ok(excerpt.length < 800, "each turn's text is truncated");
+  assert.ok(excerpt.startsWith("assistant: "), "turns carry their role");
+}
+assert.equal(buildChatExcerpt([]), "", "no usable turns → empty excerpt");
+
+// ── notes / audit block ──────────────────────────────────────────────────────
+{
+  const turns = [
+    t("u1", "user", "first ask"),
+    t("a1", "assistant", "an answer"),
+    t("u2", "user", "follow-up"),
+  ];
+  const notes = buildChatHandoffNotes({
+    sessionId: "sess-123",
+    turns,
+    capturedAt: "2026-07-07T12:00:00.000Z",
+    maxTurns: 2,
+  });
+  assert.match(notes, /^Source: chat session sess-123$/m, "notes name the source session");
+  assert.match(notes, /^Turns: 2 of 3 \(a1 → u2\)$/m, "notes record which turns were captured");
+  assert.match(notes, /^Captured: 2026-07-07T12:00:00\.000Z$/m, "notes record when");
+  assert.match(notes, /Transcript excerpt:\n\nassistant: an answer\n\nuser: follow-up/, "notes end with the excerpt");
+}
+{
+  const notes = buildChatHandoffNotes({ sessionId: "s", turns: [], capturedAt: "now" });
+  assert.ok(!notes.includes("Transcript excerpt"), "no excerpt section when there are no turns");
+  assert.match(notes, /Source: chat session s/, "audit block survives an empty chat");
+}
+
+// ── createTaskFromChat ───────────────────────────────────────────────────────
+{
+  let captured = null;
+  globalThis.fetch = async (url, init) => {
+    captured = { url, body: JSON.parse(init.body) };
+    return { ok: true, json: async () => ({ ok: true, card: { id: "card-1", title: captured.body.title } }) };
+  };
+  const res = await createTaskFromChat({
+    sessionId: "sess-9",
+    context: {
+      turns: [t("u1", "user", "ship the widget")],
+      familiarId: "fam-1",
+      projectId: "proj-1",
+    },
+  });
+  assert.equal(res.ok, true, "create succeeds");
+  assert.equal(res.card.id, "card-1", "the created card is returned");
+  assert.equal(captured.url, "/api/board", "posts to the board API");
+  assert.equal(captured.body.status, "inbox", "new card lands in inbox");
+  assert.equal(captured.body.sessionId, "sess-9", "card is linked to the source chat");
+  assert.equal(captured.body.familiarId, "fam-1", "card inherits the chat's familiar");
+  assert.equal(captured.body.projectId, "proj-1", "card inherits the chat's project");
+  assert.deepEqual(captured.body.labels, ["chat-handoff"], "card is labeled as a chat handoff");
+  assert.equal(captured.body.title, "ship the widget", "title derived from the turns");
+  assert.match(captured.body.notes, /Source: chat session sess-9/, "notes carry the audit block");
+}
+{
+  let captured = null;
+  globalThis.fetch = async (_url, init) => {
+    captured = JSON.parse(init.body);
+    return { ok: true, json: async () => ({ ok: true, card: { id: "c" } }) };
+  };
+  await createTaskFromChat({
+    sessionId: "s",
+    context: { turns: [t("u1", "user", "derived would be this")] },
+    title: "  Explicit title  ",
+  });
+  assert.equal(captured.title, "Explicit title", "an explicit title wins over derivation, trimmed");
+  assert.equal(captured.familiarId, null, "familiar defaults to null");
+}
+{
+  globalThis.fetch = async () => ({ ok: false, status: 400, json: async () => ({ ok: false, error: "title required" }) });
+  const res = await createTaskFromChat({ sessionId: "s", context: { turns: [] } });
+  assert.deepEqual(res, { ok: false, error: "title required" }, "API errors surface");
+}
+{
+  globalThis.fetch = async () => {
+    throw new Error("offline");
+  };
+  const res = await createTaskFromChat({ sessionId: "s", context: { turns: [] } });
+  assert.deepEqual(res, { ok: false, error: "offline" }, "network failures are caught");
+}
+
+console.log("chat-task-handoff.test.ts: ok");

--- a/src/lib/chat-task-handoff.ts
+++ b/src/lib/chat-task-handoff.ts
@@ -1,0 +1,144 @@
+// Chat → board task handoff (cave-px7): let useful chat work become board work
+// without manual copy/paste. The pure helpers here derive a card title from the
+// conversation and build notes that carry an auditable "Source" block — the
+// session id, which turns were captured, and when — plus a bounded transcript
+// excerpt. `createTaskFromChat` POSTs the assembled card to /api/board with
+// `sessionId` already set, so the new card is linked to this chat from birth:
+// the chat header's task chips pick it up, and the board's task-chat dispatch
+// (`buildInitialTaskChatPrompt` + `taskContextForSession`) can send it to a
+// familiar with the captured context included.
+
+import type { Card } from "@/lib/cave-board-types";
+
+export type HandoffTurn = {
+  id: string;
+  role: "user" | "assistant" | "system";
+  text: string;
+  createdAt?: string;
+  pending?: boolean;
+  error?: boolean;
+};
+
+/** What the chat surface hands to the picker: the visible turns plus the
+ *  chat's current familiar/project so the new card inherits them. */
+export type ChatHandoffContext = {
+  turns: HandoffTurn[];
+  familiarId?: string | null;
+  projectId?: string | null;
+};
+
+const TITLE_MAX = 80;
+const DEFAULT_EXCERPT_TURNS = 6;
+const TURN_TEXT_MAX = 700;
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text;
+}
+
+/** Turns worth carrying onto a card: settled user/assistant turns with real
+ *  text. System chrome, in-flight (pending) and failed turns are dropped. */
+export function handoffTurns(turns: HandoffTurn[]): HandoffTurn[] {
+  return turns.filter(
+    (turn) =>
+      (turn.role === "user" || turn.role === "assistant") &&
+      !turn.pending &&
+      !turn.error &&
+      turn.text.trim().length > 0,
+  );
+}
+
+/** Card title from the conversation: the first line of the first user turn
+ *  (what the user asked for), truncated. Falls back to the first turn of any
+ *  role, then to a generic title, so this never returns an empty string. */
+export function deriveTaskTitleFromTurns(turns: HandoffTurn[]): string {
+  const usable = handoffTurns(turns);
+  const source = usable.find((turn) => turn.role === "user") ?? usable[0];
+  const firstLine = source?.text
+    .split("\n")
+    .map((line) => line.trim())
+    .find(Boolean);
+  return firstLine ? truncate(firstLine, TITLE_MAX) : "Task from chat";
+}
+
+/** Bounded transcript excerpt: the LAST `maxTurns` usable turns (recent work is
+ *  what's being handed off), each prefixed with its role and truncated so a
+ *  long chat can't bloat the board file. */
+export function buildChatExcerpt(
+  turns: HandoffTurn[],
+  { maxTurns = DEFAULT_EXCERPT_TURNS }: { maxTurns?: number } = {},
+): string {
+  return handoffTurns(turns)
+    .slice(-maxTurns)
+    .map((turn) => `${turn.role}: ${truncate(turn.text.trim(), TURN_TEXT_MAX)}`)
+    .join("\n\n");
+}
+
+/** Card notes with the audit trail: which session and turns the card was cut
+ *  from and when, followed by the excerpt itself. */
+export function buildChatHandoffNotes({
+  sessionId,
+  turns,
+  capturedAt,
+  maxTurns = DEFAULT_EXCERPT_TURNS,
+}: {
+  sessionId: string;
+  turns: HandoffTurn[];
+  capturedAt: string;
+  maxTurns?: number;
+}): string {
+  const usable = handoffTurns(turns);
+  const included = usable.slice(-maxTurns);
+  const lines = [
+    `Source: chat session ${sessionId}`,
+    included.length
+      ? `Turns: ${included.length} of ${usable.length} (${included[0].id} → ${included[included.length - 1].id})`
+      : null,
+    `Captured: ${capturedAt}`,
+  ].filter((line): line is string => Boolean(line));
+  const excerpt = buildChatExcerpt(turns, { maxTurns });
+  return excerpt ? `${lines.join("\n")}\n\nTranscript excerpt:\n\n${excerpt}` : lines.join("\n");
+}
+
+/** Create a board card from the current chat. The card lands in `inbox`,
+ *  linked to this chat (`sessionId`) and inheriting the chat's familiar and
+ *  project, with source-context notes for auditability. */
+export async function createTaskFromChat({
+  sessionId,
+  context,
+  title,
+  capturedAt,
+}: {
+  sessionId: string;
+  context: ChatHandoffContext;
+  /** Explicit title (e.g. the picker's typed query); derived from the turns when omitted. */
+  title?: string;
+  capturedAt?: string;
+}): Promise<{ ok: boolean; card?: Card; error?: string }> {
+  const notes = buildChatHandoffNotes({
+    sessionId,
+    turns: context.turns,
+    capturedAt: capturedAt ?? new Date().toISOString(),
+  });
+  try {
+    const res = await fetch("/api/board", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: title?.trim() || deriveTaskTitleFromTurns(context.turns),
+        notes,
+        status: "inbox" as const,
+        sessionId,
+        familiarId: context.familiarId ?? null,
+        projectId: context.projectId ?? null,
+        labels: ["chat-handoff"],
+      }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) {
+      return { ok: false, error: data?.error ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, card: data.card as Card };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : "Network error" };
+  }
+}


### PR DESCRIPTION
## What

Adds the missing **create-task-from-chat** handoff action (bead `cave-px7`; taken over from stalled session `86e002b9` — origin board task *Add task handoff actions from chat*).

The chat header's task picker (`+` chip → TaskLinkPicker) now offers **New task from this chat**:

- one click creates an **inbox** card **pre-linked to the session** (`sessionId`), inheriting the chat's **familiar** and **project**
- card notes carry an **auditable Source block**: session id, captured turn ids/range, capture timestamp, plus a bounded transcript excerpt (last 6 settled turns, per-turn truncation)
- the picker's typed query doubles as the new card's title; otherwise the title derives from the first user turn

## Why the other handoff actions aren't in this diff

- **Attach chat → existing task** already ships (TaskLinkPicker PATCHes `sessionId`)
- **Send task → familiar with context** already ships (board task-chat dispatch via `buildInitialTaskChatPrompt` + `taskContextForSession`)

This closes the create + auditability gap and wires all three together: the created card flows through the same `onAssigned` path (header chip appears immediately), and the board dispatch carries the captured context to the chosen familiar.

## Changes

- `src/lib/chat-task-handoff.ts` — pure helpers: `handoffTurns` (drops system/pending/errored/blank), `deriveTaskTitleFromTurns`, `buildChatExcerpt`, `buildChatHandoffNotes`, `createTaskFromChat`
- `src/components/task-link-picker.tsx` — optional `handoff` prop + a11y-labeled create row (link-only behavior unchanged when absent)
- `src/components/chat-view.tsx` — passes `{ turns, familiarId, projectId }` through `LinkedContextRow`
- Tests: `src/lib/chat-task-handoff.test.ts` (unit, incl. stubbed-fetch payload assertions), `src/components/chat-task-handoff-wiring.test.ts` (wiring guard); both wired into `run-tests.mjs` app suite

## Verification

- `node --experimental-strip-types src/lib/chat-task-handoff.test.ts` → ok
- `node --experimental-strip-types src/components/chat-task-handoff-wiring.test.ts` → ok
- Affected existing tests pass: chat-linked-context, chat-view, chat-view-first-class, board-chat-link, chat-surface-polish
- `node scripts/check-tests-wired.mjs` → 755 wired
- `pnpm typecheck` → clean