### PR TITLE
feat(chat): lean per-message metadata — name + time, extras on hover (cave-xsq.2)

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -335,8 +335,8 @@ const usageTurnRow =
 assert.ok(usageTurnRow, "TurnRow body should be extractable (CHAT-D12-02)");
 assert.match(
   usageTurnRow,
-  /className="cave-linear-turn-recency"[\s\S]{0,220}?title=\{exactTime\}[\s\S]{0,220}?\{recency\}[\s\S]{0,220}?<UsageText usage=\{turn\.usage\} costUsd=\{turn\.costUsd\} \/>/,
-  "Assistant turn meta row appends the muted usage/cost readout after the visible recency timestamp (CHAT-D12-02)",
+  /className="cave-linear-turn-recency"[\s\S]{0,220}?title=\{exactTime\}[\s\S]{0,220}?\{recency\}[\s\S]{0,700}?<UsageText usage=\{turn\.usage\} costUsd=\{turn\.costUsd\} \/>/,
+  "Assistant turn meta row keeps the muted usage/cost readout after the visible recency timestamp, now inside the reveal-on-hover extras cluster (CHAT-D12-02 / cave-xsq.2)",
 );
 
 // ── CHAT-D9-04: find highlight timer cleanup ──

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -224,8 +224,21 @@ assert.match(
 
 assert.match(
   turnRow,
-  /formatChatRecency\(turn\.createdAt, dtPrefs\)[\s\S]*cave-linear-turn-avatar-btn[\s\S]*<FamiliarIcon familiar=\{familiar\} size="xl" \/>[\s\S]*cave-linear-turn-name[\s\S]*familiar\.display_name[\s\S]*cave-linear-turn-crest[\s\S]*cave-linear-turn-recency/,
-  "Assistant turns should render a large circular avatar with author identity and recency",
+  /formatChatRecency\(turn\.createdAt, dtPrefs\)[\s\S]*cave-linear-turn-avatar-btn[\s\S]*<FamiliarIcon familiar=\{familiar\} size="xl" \/>[\s\S]*cave-linear-turn-name[\s\S]*familiar\.display_name[\s\S]*cave-linear-turn-recency[\s\S]*cave-linear-turn-meta-extra[\s\S]*cave-linear-turn-crest/,
+  "Assistant turns render a large circular avatar + name + recency, with the crest/role/usage extras in a trailing reveal-on-hover cluster (cave-xsq.2)",
+);
+// Lean meta (cave-xsq.2): the static extras collapse into a reveal-on-hover
+// cluster so the default row is just name + time; the turn content is the
+// reveal scope so hovering the message brings them back.
+assert.match(
+  turnRow,
+  /cave-linear-turn-content[^"]*reveal-scope/,
+  "the assistant turn content is the reveal scope for its meta extras",
+);
+assert.match(
+  turnRow,
+  /className="cave-linear-turn-meta-extra reveal-on-hover"/,
+  "crest/role/usage/peek live in a trailing reveal-on-hover cluster (name + time stay visible)",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5735,7 +5735,7 @@ function TurnRowImpl({
       data-turn-id={turn.id}
       className={`cave-linear-turn cave-linear-turn--assistant${found ? " cave-turn-found" : ""}`}
     >
-      <div className="cave-linear-turn-content text-[14px] leading-relaxed text-[var(--text-primary)] group/turn">
+      <div className="cave-linear-turn-content text-[14px] leading-relaxed text-[var(--text-primary)] group/turn reveal-scope">
         {/* Avatar (interactive) + right column */}
         <div className={`cave-linear-turn-avatar${expanded ? " is-selected" : ""}`} ref={avatarWrapRef}>
           <button
@@ -5758,14 +5758,14 @@ function TurnRowImpl({
           ) : null}
         </div>
         <div className="cave-linear-turn-right">
+          {/* Lean meta (cave-xsq.2): name + time (and transient live status /
+              error retry) stay visible; the static identity/usage extras —
+              crest, role, token usage, and the details peek — collapse into a
+              trailing cluster that reveals on turn hover / keyboard focus
+              (reveal-scope on the turn content above). Nothing is removed; the
+              default view just reads "Name · 2h ago" like ChatGPT. */}
           <div className="cave-linear-turn-meta">
             <span className="cave-linear-turn-name">{familiar.display_name}</span>
-            <span className="cave-linear-turn-crest" aria-hidden="true">
-              <Icon name="ph:sparkle" width={13} height={13} />
-            </span>
-            {familiar.role ? (
-              <span className="cave-linear-turn-badge">{familiar.role}</span>
-            ) : null}
             {turnStatus !== "complete" && !indicatorVisible && (
               <span className={`cave-turn-status cave-turn-status--${turnStatus}`}>
                 {lifecycleLabel(turnStatus)}
@@ -5792,18 +5792,26 @@ function TurnRowImpl({
                 {recency}
               </time>
             ) : null}
-            <UsageText usage={turn.usage} costUsd={turn.costUsd} />
-            {metaPeek ? (
-              <span
-                className="cave-turn-peek focus-ring"
-                title={metaPeek}
-                tabIndex={0}
-                role="note"
-                aria-label={`Turn details — ${metaPeek}`}
-              >
-                <Icon name="ph:info" width={11} aria-hidden />
+            <span className="cave-linear-turn-meta-extra reveal-on-hover">
+              <span className="cave-linear-turn-crest" aria-hidden="true">
+                <Icon name="ph:sparkle" width={13} height={13} />
               </span>
-            ) : null}
+              {familiar.role ? (
+                <span className="cave-linear-turn-badge">{familiar.role}</span>
+              ) : null}
+              <UsageText usage={turn.usage} costUsd={turn.costUsd} />
+              {metaPeek ? (
+                <span
+                  className="cave-turn-peek focus-ring"
+                  title={metaPeek}
+                  tabIndex={0}
+                  role="note"
+                  aria-label={`Turn details — ${metaPeek}`}
+                >
+                  <Icon name="ph:info" width={11} aria-hidden />
+                </span>
+              ) : null}
+            </span>
           </div>
 
           <div className="cave-linear-turn-body">

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -3425,6 +3425,17 @@ details[open] > .cave-tool-summary::before {
   line-height: 1.4;
 }
 
+/* Lean meta (cave-xsq.2): the trailing cluster of static extras (crest, role,
+   usage, details peek) that reveals on turn hover / focus via reveal-on-hover.
+   Its own inline-flex row keeps the extras aligned with the meta line's rhythm;
+   opacity-hidden by default so the visible row is just name + time. */
+.cave-linear-turn-meta-extra {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
 /* Per-turn provenance peek: a quiet ⓘ in the turn meta row whose title tooltip
    reveals model · cwd · duration · tokens · cost for that turn. Faint by
    default so the row stays clean; brightens on hover/focus. */


### PR DESCRIPTION
**Phase 1.2** of the chat-first minimalism arc (epic `cave-xsq`). Directly implements the confirmed *"Lean — name + hover actions"* choice.

## Problem
Every assistant turn rendered **9+ metadata elements** inline — name, sparkle crest, role badge, live status, retry, timestamp, token usage, details peek — so the transcript read data-rich rather than calm.

## Change
The meta row now splits into:
- **Always visible:** name + relative time (plus the transient live status chip and the error **Retry**, which must not hide behind hover).
- **Reveal on hover:** the static extras — crest, role badge, token usage, details ⓘ — collapse into a trailing `.cave-linear-turn-meta-extra` cluster marked `reveal-on-hover`, with the turn content as the `reveal-scope`.

Nothing is removed. The cluster uses the design-language §8 reveal contract (opacity-only, stays in the a11y tree + tabbable, keyboard parity via `:focus-within`, permanently visible on touch). The default row reads **"Name · 2h ago"** like ChatGPT; hovering the message brings the provenance back.

## Verification
Live: default extras `opacity: 0` (name + time only) → `opacity: 1` on turn hover; crest + peek confirmed inside the reveal cluster. Repointed the two order pins (`chat-view-polish`, `chat-view-lifecycle`). 558 app tests, typecheck, build green.

Part of epic `cave-xsq`; closes `cave-xsq.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)