### PR TITLE
feat(grimoire): [[wiki-link]] graph viewer (cave-xr0, slice 3)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -508,6 +508,7 @@ export const SUITES = {
     "src/lib/grimoire-link.test.ts",
     "src/lib/wiki-link-parser.test.ts",
     "src/lib/wiki-link-resolve.test.ts",
+    "src/lib/grimoire-graph.test.ts",
     "src/lib/server/coven-memory-path.test.ts",
     "src/lib/recent-colors.test.ts",
 	    "src/components/ui/color-picker.test.ts",
@@ -804,6 +805,7 @@ const STRIP_TYPES_MJS = new Set([
 const ALIAS_LOADER = new Set([
   "src/lib/wiki-link-parser.test.ts",
   "src/lib/wiki-link-resolve.test.ts",
+  "src/lib/grimoire-graph.test.ts",
   "src/lib/server/space-usage.test.ts",
   "src/lib/server/memory-file-inventory.test.ts",
   "src/lib/daily-narrative.test.ts",

--- a/src/components/grimoire-graph-view.tsx
+++ b/src/components/grimoire-graph-view.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+// The Grimoire link graph — doc nodes + [[wiki-link]] edges, rendered with
+// @xyflow/react (already in the app; CSS is imported globally). Lazy-loaded by
+// grimoire-view so this heavy dep only lands when the graph is opened.
+
+import { useCallback, useMemo, type MouseEvent } from "react";
+import { ReactFlow, Background, Controls, type Edge, type Node } from "@xyflow/react";
+import type { DocGraph } from "@/lib/grimoire-graph";
+import type { WikiDocRef } from "@/lib/wiki-link-resolve";
+import { EmptyState } from "@/components/ui/empty-state";
+
+const KIND_COLOR: Record<WikiDocRef["kind"], string> = {
+  knowledge: "var(--accent-presence)",
+  memory: "var(--color-warning)",
+  journal: "var(--text-secondary)",
+};
+
+export function GrimoireGraphView({
+  graph,
+  onOpen,
+}: {
+  graph: DocGraph;
+  onOpen: (ref: WikiDocRef) => void;
+}) {
+  const nodes = useMemo<Node[]>(
+    () =>
+      graph.nodes.map((n) => ({
+        id: n.id,
+        position: { x: n.x, y: n.y },
+        data: { label: n.title },
+        connectable: false,
+        style: {
+          fontSize: 11,
+          padding: "4px 9px",
+          borderRadius: 999,
+          border: `1px solid color-mix(in oklch, ${KIND_COLOR[n.kind]} 55%, var(--border-hairline))`,
+          background: `color-mix(in oklch, ${KIND_COLOR[n.kind]} 12%, var(--bg-raised))`,
+          color: "var(--text-primary)",
+          maxWidth: 180,
+        },
+      })),
+    [graph.nodes],
+  );
+
+  const edges = useMemo<Edge[]>(
+    () =>
+      graph.edges.map((e) => ({
+        id: e.id,
+        source: e.source,
+        target: e.target,
+        style: { stroke: "var(--border-strong)", strokeWidth: 1 },
+      })),
+    [graph.edges],
+  );
+
+  const refById = useMemo(() => {
+    const m = new Map<string, WikiDocRef>();
+    for (const n of graph.nodes) m.set(n.id, n.ref);
+    return m;
+  }, [graph.nodes]);
+
+  const onNodeClick = useCallback(
+    (_: MouseEvent, node: Node) => {
+      const ref = refById.get(node.id);
+      if (ref) onOpen(ref);
+    },
+    [refById, onOpen],
+  );
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className="grid h-full min-h-0 place-items-center p-8">
+        <EmptyState
+          icon="ph:link"
+          headline="No links yet"
+          subtitle="Reference another doc with [[its title]] to see it connected here."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grimoire-graph h-full w-full">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        onNodeClick={onNodeClick}
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.2}
+      >
+        <Background gap={22} color="var(--border-hairline)" />
+        <Controls showInteractive={false} position="bottom-right" />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -84,4 +84,20 @@ assert.match(view, /onClick=\{\(\) => onOpen\(ref\)\}/, "a resolved chip navigat
 assert.match(view, /title="No matching Grimoire doc"[\s\S]{0,160}border-dashed/, "an unresolved link renders dashed + inert with a hint");
 assert.match(view, /<GrimoireDocLinks\b[\s\S]{0,160}onOpen=\{openDoc\}/, "the chip row is wired to openDoc for the active doc");
 
+// ── cave-xr0 slice 3: the [[wiki-link]] graph view ──────────────────────────
+// A "Graph" toggle swaps the detail pane for a lazy-loaded @xyflow graph built
+// from the knowledge vault (bodies already loaded — no server scan); clicking a
+// node opens that doc.
+assert.match(view, /from "@\/lib\/grimoire-graph"/, "grimoire-view builds the link graph via the graph lib");
+assert.match(view, /import\("@\/components\/grimoire-graph-view"\)/, "the @xyflow graph is lazy-loaded (dynamic import)");
+assert.match(view, /ssr: false/, "the graph view is client-only (no SSR)");
+assert.match(view, /const graph = useMemo\([\s\S]{0,200}buildDocGraph\(/, "the graph is memoized from buildDocGraph");
+assert.match(view, /markdown: k\.body/, "the knowledge graph reads each entry's body (already loaded)");
+assert.match(view, /setShowGraph\(\(v\) => !v\)/, "a header toggle flips between docs and the graph");
+assert.match(
+  view,
+  /showGraph \? \([\s\S]{0,220}<GrimoireGraphView[\s\S]{0,200}onOpen=\{\(ref\) => \{[\s\S]{0,80}openDoc\(ref\)/,
+  "the graph replaces the detail pane and opens the clicked doc",
+);
+
 console.log("grimoire-view.test: ok");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -31,6 +31,21 @@ import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useMemoryFile } from "@/lib/use-memory-file";
 import { resolveOutgoingLinks, type WikiDocIndex } from "@/lib/wiki-link-resolve";
+import { buildDocGraph } from "@/lib/grimoire-graph";
+import dynamic from "next/dynamic";
+
+// @xyflow is heavy — lazy-load the graph so the dep only lands when it's opened.
+const GrimoireGraphView = dynamic(
+  () => import("@/components/grimoire-graph-view").then((m) => m.GrimoireGraphView),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="grid h-full min-h-0 place-items-center text-[11px] text-[var(--text-muted)]">
+        Loading graph…
+      </div>
+    ),
+  },
+);
 
 // ── Navigator model ──────────────────────────────────────────────────────────
 
@@ -461,6 +476,7 @@ export function GrimoireView() {
   const [journal, setJournal] = useState<JournalSummary[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [showGraph, setShowGraph] = useState(false);
   const confirm = useConfirm();
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -645,6 +661,23 @@ export function GrimoireView() {
     [knowledge, memory, journal],
   );
 
+  // The link graph over the knowledge vault (bodies are already loaded, so no
+  // extra fetch/scan). Memory/journal-as-source edges are a follow-up (they need
+  // full server content); memory/journal referenced *from* knowledge still show
+  // up as leaf nodes.
+  const graph = useMemo(
+    () =>
+      buildDocGraph(
+        (knowledge ?? []).map((k) => ({
+          ref: { kind: "knowledge" as const, id: k.id },
+          title: k.title,
+          markdown: k.body,
+        })),
+        docIndex,
+      ),
+    [knowledge, docIndex],
+  );
+
   /** Human tab label for a selection (falls back to ids/paths). */
   const tabTitle = useCallback(
     (sel: GrimoireSelection): string => {
@@ -776,14 +809,26 @@ export function GrimoireView() {
         <div className="shrink-0 space-y-2 border-b border-[var(--border-hairline)] p-3">
           <div className="flex items-center justify-between gap-2">
             <h2 className="text-[13px] font-semibold text-[var(--text-primary)]">Grimoire</h2>
-            <button
-              type="button"
-              onClick={() => openDoc({ kind: "knowledge-new" })}
-              className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
-            >
-              <Icon name="ph:plus" width={11} aria-hidden />
-              New entry
-            </button>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => setShowGraph((v) => !v)}
+                aria-pressed={showGraph}
+                title={showGraph ? "Back to documents" : "View the [[wiki-link]] graph"}
+                className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:link" width={11} aria-hidden />
+                {showGraph ? "Docs" : "Graph"}
+              </button>
+              <button
+                type="button"
+                onClick={() => openDoc({ kind: "knowledge-new" })}
+                className="focus-ring inline-flex h-7 items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[11px] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:plus" width={11} aria-hidden />
+                New entry
+              </button>
+            </div>
           </div>
           <input
             type="search"
@@ -887,10 +932,18 @@ export function GrimoireView() {
       </aside>
       <main
         className={`h-full min-h-0 min-w-0 flex-1 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 ${
-          selection ? "" : "hidden @min-[880px]/grimoire:block"
+          selection || showGraph ? "" : "hidden @min-[880px]/grimoire:block"
         }`}
       >
-        {selection ? (
+        {showGraph ? (
+          <GrimoireGraphView
+            graph={graph}
+            onOpen={(ref) => {
+              openDoc(ref);
+              setShowGraph(false);
+            }}
+          />
+        ) : selection ? (
           <div className="flex h-full min-h-0 flex-col">
             <div
               className={`flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-1.5 ${

--- a/src/lib/grimoire-graph.test.ts
+++ b/src/lib/grimoire-graph.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+const { buildDocGraph } = await import("./grimoire-graph.ts");
+
+const index = {
+  knowledge: [
+    { id: "a", title: "Alpha" },
+    { id: "b", title: "Beta" },
+  ],
+  memory: [{ path: "/root/notes.md" }],
+  journal: [],
+};
+
+const docs = [
+  // Alpha links Beta (by title), notes (memory basename), itself (dropped),
+  // a ghost (unresolved, dropped), and Beta again (dup edge collapsed).
+  { ref: { kind: "knowledge", id: "a" }, title: "Alpha", markdown: "[[Beta]] [[notes]] [[Alpha]] [[ghost]] [[Beta|again]]" },
+  { ref: { kind: "knowledge", id: "b" }, title: "Beta", markdown: "back to [[Alpha]]" },
+];
+
+const g = buildDocGraph(docs, index);
+
+// ── nodes: two sources + one memory leaf, deterministic id order ─────────────
+assert.deepEqual(
+  g.nodes.map((n) => n.id),
+  ["knowledge:a", "knowledge:b", "memory:/root/notes.md"],
+  "sources + a resolved memory leaf, stable-sorted by id",
+);
+assert.equal(g.nodes.find((n) => n.id === "memory:/root/notes.md").title, "notes", "leaf label is the link display text");
+assert.equal(g.nodes.find((n) => n.id === "knowledge:a").kind, "knowledge", "node carries its kind");
+for (const n of g.nodes) {
+  assert.ok(Number.isFinite(n.x) && Number.isFinite(n.y), "every node has finite layout coordinates");
+}
+
+// ── edges: a→b, a→memory, b→a; no self-loop, no ghost, no dup ────────────────
+const pairs = g.edges.map((e) => `${e.source}->${e.target}`).sort();
+assert.deepEqual(
+  pairs,
+  ["knowledge:a->knowledge:b", "knowledge:a->memory:/root/notes.md", "knowledge:b->knowledge:a"].sort(),
+  "resolved, de-duped, self-free edges",
+);
+assert.equal(g.edges.filter((e) => e.source === e.target).length, 0, "no self-loops");
+assert.equal(g.edges.filter((e) => e.target.includes("ghost")).length, 0, "unresolved links produce no edge");
+
+// ── degenerate cases ────────────────────────────────────────────────────────
+assert.deepEqual(buildDocGraph([], index), { nodes: [], edges: [] }, "empty input → empty graph");
+const solo = buildDocGraph([{ ref: { kind: "knowledge", id: "a" }, title: "Alpha", markdown: "no links" }], index);
+assert.equal(solo.nodes.length, 1, "a doc with no links is a lone node");
+assert.deepEqual({ x: solo.nodes[0].x, y: solo.nodes[0].y }, { x: 0, y: 0 }, "a single node sits at the origin");
+assert.equal(solo.edges.length, 0, "no links → no edges");
+
+console.log("grimoire-graph.test.ts: ok");

--- a/src/lib/grimoire-graph.ts
+++ b/src/lib/grimoire-graph.ts
@@ -1,0 +1,82 @@
+// Build a [[wiki-link]] graph over Grimoire docs, for the graph viewer (cave-xr0
+// slice 3). Pure + UI-agnostic: it turns a set of source docs (each with its
+// markdown) into nodes + directed edges, reusing the slice-1 parser/resolver.
+// Layout is a deterministic circle so @xyflow gets stable positions without a
+// layout dependency.
+
+import { extractWikiLinks } from "./wiki-link-parser";
+import {
+  resolveWikiLinkTarget,
+  docRefKey,
+  type WikiDocIndex,
+  type WikiDocRef,
+} from "./wiki-link-resolve";
+
+export type DocGraphNode = {
+  /** docRefKey(ref) — stable node id. */
+  id: string;
+  ref: WikiDocRef;
+  kind: WikiDocRef["kind"];
+  title: string;
+  x: number;
+  y: number;
+};
+
+export type DocGraphEdge = { id: string; source: string; target: string };
+
+export type DocGraph = { nodes: DocGraphNode[]; edges: DocGraphEdge[] };
+
+/** A source doc to graph: its ref, a display title, and its raw markdown. */
+export type GraphSourceDoc = { ref: WikiDocRef; title: string; markdown: string };
+
+/**
+ * Build a directed link graph from `docs`. Each source doc is a node; each of
+ * its resolved `[[wiki-links]]` becomes an edge source→target. A link target
+ * that resolves to a doc NOT in `docs` (e.g. a memory file referenced from a
+ * knowledge entry) is added as a leaf node so the edge lands somewhere;
+ * unresolved links and self-links are dropped, and duplicate edges collapse.
+ */
+export function buildDocGraph(docs: readonly GraphSourceDoc[], index: WikiDocIndex): DocGraph {
+  const labels = new Map<string, { ref: WikiDocRef; title: string }>();
+  for (const d of docs) labels.set(docRefKey(d.ref), { ref: d.ref, title: d.title });
+
+  const edges: DocGraphEdge[] = [];
+  const seen = new Set<string>();
+  for (const d of docs) {
+    const source = docRefKey(d.ref);
+    for (const link of extractWikiLinks(d.markdown)) {
+      const ref = resolveWikiLinkTarget(link.target, index);
+      if (!ref) continue;
+      const target = docRefKey(ref);
+      if (target === source) continue; // no self-loops
+      const id = `${source}=>${target}`;
+      if (seen.has(id)) continue; // one edge per ordered pair
+      seen.add(id);
+      // Leaf target (a resolved doc that isn't itself a source) — label it with
+      // the link's display text since we don't hold its full metadata here.
+      if (!labels.has(target)) labels.set(target, { ref, title: link.display });
+      edges.push({ id, source, target });
+    }
+  }
+
+  return { nodes: layoutCircle(labels), edges };
+}
+
+/** Deterministic circular layout, stable-sorted by node id. Radius grows with
+ *  node count so labels don't overlap on larger graphs. */
+function layoutCircle(labels: Map<string, { ref: WikiDocRef; title: string }>): DocGraphNode[] {
+  const entries = [...labels.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  const n = entries.length;
+  const radius = n <= 1 ? 0 : Math.max(140, Math.round((n * 48) / (2 * Math.PI)));
+  return entries.map(([id, v], i) => {
+    const angle = n <= 1 ? 0 : (2 * Math.PI * i) / n;
+    return {
+      id,
+      ref: v.ref,
+      kind: v.ref.kind,
+      title: v.title,
+      x: Math.round(Math.cos(angle) * radius),
+      y: Math.round(Math.sin(angle) * radius),
+    };
+  });
+}


### PR DESCRIPTION
Final slice of **cave-xr0** — a graph view of the Grimoire's `[[wiki-link]]` structure, on the slice-1 engine (#2587) and slice-2 chips (#2588).

## What

A **Graph / Docs** toggle in the Grimoire header swaps the detail pane for a link graph:
- **`grimoire-graph.ts`** (pure, tested) — `buildDocGraph(docs, index)` turns source docs + their markdown into **nodes + directed edges** via the slice-1 parser/resolver. Resolved-but-external targets (e.g. a memory file referenced from a knowledge entry) become **leaf nodes**; self / duplicate / unresolved links are dropped; a **deterministic circular layout** gives `@xyflow` stable positions with **no layout dependency**.
- **`grimoire-graph-view.tsx`** — the `@xyflow/react` canvas: nodes colored by kind (knowledge / memory / journal), edges, `Background` + `Controls`, `fitView`, non-draggable, attribution hidden, empty state. **Lazy-loaded** (`next/dynamic ssr:false`) so the heavy dep only lands when the graph is opened. Clicking a node → `openDoc`.
- **`grimoire-view.tsx`** — the toggle + the graph built **client-side from the already-loaded knowledge bodies** (no server scan, no new route).

## Scope

**v1 = the knowledge-vault graph.** Memory/journal-*as-source* edges would require reading full content across the whole vault (1900+ memory files) — a documented follow-up. Memory/journal docs still appear as **nodes** when a knowledge entry links to them. No new deps (`@xyflow` already powers Flow; its CSS is global) and no new server routes.

## Verification

- `grimoire-graph.test.ts` (nodes/edges, leaf creation, self/dup/unresolved dropping, deterministic layout, degenerate cases) + `grimoire-view.test.ts` graph guards (lazy dynamic import, `ssr:false`, `buildDocGraph` memo, header toggle, node-click→`openDoc`) pass.
- `pnpm typecheck` clean (incl. the `@xyflow` node/edge types) · `check:tests-wired` 756 · `git diff --check` clean.
- Rendered check deferred: the graph builder is exhaustively unit-tested, the `@xyflow` usage mirrors the existing `flow-canvas`, and CI's Frontend build compiles it — a manual screenshot needs a seeded vault of `[[wiki-linked]]` entries + a full build.

## cave-xr0 complete

1. #2587 link engine ✅ · 2. #2588 chips ✅ · **3. this PR — graph viewer.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)