### PR TITLE
fix(chat): don't let a backgrounded new-chat stream hijack the displayed thread (cave-8zq)

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -152,7 +152,7 @@ assert.match(
 
 assert.match(
   source,
-  /const liveGeneration = \{ sessionId: initialLiveSessionId, controller \}[\s\S]*?recordLiveChatGeneration\(\{\s*sessionId: liveGeneration\.sessionId,[\s\S]*?controller,[\s\S]*?turns: nextTurns/,
+  /const liveGeneration = \{ sessionId: initialLiveSessionId, originSessionId: initialLiveSessionId, controller \}[\s\S]*?recordLiveChatGeneration\(\{\s*sessionId: liveGeneration\.sessionId,[\s\S]*?controller,[\s\S]*?turns: nextTurns/,
   "sendRaw should persist the active stream snapshot with its abort controller",
 );
 
@@ -547,5 +547,27 @@ assert.match(
   /e\.key === "Enter" && !e\.shiftKey && !e\.nativeEvent\.isComposing/,
   "the composer's Enter-to-send is gated on !isComposing so IME candidate-confirm doesn't fire a half-composed message",
 );
+
+// New-chat background-generation isolation (cave-8zq): a generation started on
+// a brand-new chat carries an immutable originSessionId, and both the "session"
+// and "done" events only adopt the server-assigned id into the displayed
+// thread's currentSessionRef when the view is STILL on that origin thread.
+// Otherwise (user switched away during first-token latency) the late id would
+// splice the background stream into the wrong thread and mis-address the next
+// send — while onSessionStarted still fires so the router can register it.
+assert.match(
+  source,
+  /const liveGeneration = \{ sessionId: initialLiveSessionId, originSessionId: initialLiveSessionId, controller \}/,
+  "each generation records the immutable thread it started on (originSessionId)",
+);
+{
+  const guarded = source.match(
+    /if \(currentSessionRef\.current === liveGeneration\.originSessionId\) \{\s*\n\s*liveSessionIdRef\.current = ev\.sessionId;\s*\n\s*currentSessionRef\.current = ev\.sessionId;\s*\n\s*setHistoryState\("loaded"\);\s*\n\s*\}\s*\n\s*onSessionStarted\?\.\(ev\.sessionId\);/g,
+  );
+  assert.ok(
+    guarded && guarded.length === 2,
+    "both the session and done events gate currentSessionRef adoption on still owning the displayed thread, yet always notify onSessionStarted",
+  );
+}
 
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3555,7 +3555,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ],
     };
     const controller = new AbortController();
-    const liveGeneration = { sessionId: initialLiveSessionId, controller };
+    // `sessionId` mutates to the server-assigned id as events arrive;
+    // `originSessionId` stays the thread this generation started on, so a
+    // background generation (user switched threads mid-stream) can tell it no
+    // longer owns the displayed view and must not adopt its late session id.
+    const liveGeneration = { sessionId: initialLiveSessionId, originSessionId: initialLiveSessionId, controller };
     const runId = crypto.randomUUID();
     abortRef.current = controller;
     stopKeysRef.current = { runId, sessionId: initialLiveSessionId ?? null };
@@ -4049,15 +4053,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     ev: StreamEvent,
     assistantId: string,
     request: FailedSend,
-    liveGeneration: { sessionId: string | null; controller: AbortController },
+    liveGeneration: { sessionId: string | null; originSessionId: string | null; controller: AbortController },
   ) => {
     switch (ev.kind) {
       case "session": {
         liveGeneration.sessionId = ev.sessionId;
         if (ev.sessionId !== currentSessionRef.current) {
-          liveSessionIdRef.current = ev.sessionId;
-          currentSessionRef.current = ev.sessionId;
-          setHistoryState("loaded");
+          // Only adopt the new session id into THIS view's refs when the view is
+          // still on the thread this generation started from. If the user
+          // switched to another conversation before the id arrived (a new chat's
+          // first-token latency), this is a *background* generation: adopting its
+          // id would splice its chunks into the displayed thread and mis-address
+          // the next send (sendRaw reads currentSessionRef as initialLiveSessionId).
+          // Still notify onSessionStarted — the router promotes a still-open new
+          // chat but leaves an already-switched view alone (chat-router.tsx).
+          if (currentSessionRef.current === liveGeneration.originSessionId) {
+            liveSessionIdRef.current = ev.sessionId;
+            currentSessionRef.current = ev.sessionId;
+            setHistoryState("loaded");
+          }
           onSessionStarted?.(ev.sessionId);
         }
         if (taskArmedRef.current) {
@@ -4211,9 +4225,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         void refreshUsagePlan(ev.responseMetadata?.confirmedModel ?? ev.responseMetadata?.model ?? null);
         if (ev.sessionId && ev.sessionId !== currentSessionRef.current) {
           liveGeneration.sessionId = ev.sessionId;
-          liveSessionIdRef.current = ev.sessionId;
-          currentSessionRef.current = ev.sessionId;
-          setHistoryState("loaded");
+          // Same ownership guard as the "session" event: a background generation
+          // (user switched threads before this settled) must not overwrite the
+          // displayed thread's currentSessionRef. Still let the router register it.
+          if (currentSessionRef.current === liveGeneration.originSessionId) {
+            liveSessionIdRef.current = ev.sessionId;
+            currentSessionRef.current = ev.sessionId;
+            setHistoryState("loaded");
+          }
           onSessionStarted?.(ev.sessionId);
         }
         persistLiveTurns(turnsRef.current, assistantId, liveGeneration.controller, liveGeneration.sessionId);


### PR DESCRIPTION
The HIGH-severity finding deferred from the chat audit (PR #2594), now with a scoped fix + repro pins.

## The bug
`ChatView` is a single instance reused across threads, so `currentSessionRef` is shared. When a **brand-new chat's** send is in flight (`sessionId` still `null` during first-token latency) and the user **switches to another conversation**, the background stream's `session`/`done` events reassigned `currentSessionRef` to the *new chat's* id — even though the view had moved on. Consequences:
- The background stream's chunks splice into the **displayed** thread's transcript.
- `sendRaw` reads `currentSessionRef` as the next send's `initialLiveSessionId`, so the user's **next message is POSTed to the wrong session**.

## The fix
Each generation records the immutable thread it started on (`liveGeneration.originSessionId`). Both stream-event handlers now adopt the server-assigned session id into the displayed thread's refs (`currentSessionRef` / `liveSessionIdRef` / history state) **only when the view is still on that origin thread** (`currentSessionRef.current === originSessionId`). A background generation leaves the displayed thread's refs untouched. `onSessionStarted` still fires unconditionally, so the router promotes a still-open new chat or registers the session for the list — it already guards navigation (`chat-router.tsx`).

This also resolves the audit's related low-sev findings about a background stream mirroring/persisting the wrong turns, since those keyed off the corrupted `currentSessionRef`.

## Repro (pre-fix)
Open a new chat → send → immediately click another conversation during the model's first-token latency. The other thread's transcript receives the new chat's tokens, and the next message sent there lands in the wrong session.

## Verification
- `tsc` clean; **full `test:app` (560 files) green**; frontend build within budget.
- New source-scan pins in `chat-view-lifecycle.test.ts`: the immutable `originSessionId`, and that **both** the `session` and `done` events gate adoption on still owning the displayed thread while always notifying `onSessionStarted`.

Closes cave-8zq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)