### PR TITLE
feat(chat): slim the settled header — provenance reveals on hover (cave-xsq.3)

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -195,8 +195,15 @@ assert.match(
 
 assert.match(
   source,
-  /<header className="cave-chat-linear-header"/,
-  "Chat header should use the dense linear session header",
+  /<header className="cave-chat-linear-header reveal-scope"/,
+  "Chat header uses the linear session header and is the reveal scope for its hover-quiet provenance (cave-xsq.3)",
+);
+// Slim header (cave-xsq.3): the settled provenance quiets to a reveal-on-hover
+// cluster so a resting header reads as just the conversation title.
+assert.match(
+  source,
+  /cave-chat-meta-line__provenance\$\{state === "complete" \? " reveal-on-hover" : ""\}/,
+  "the static meta provenance reveals on hover once the turn has settled (visible inline while streaming)",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1639,23 +1639,33 @@ function MetaLine({
         />
       ) : null}
       <span className="cave-chat-meta-line__meta" title={metaModel ?? undefined}>
-        {segments.map((seg, i) => (
-          <Fragment key={i}>
-            {i > 0 ? " · " : null}
-            {typeof seg === "string" ? (
-              seg
-            ) : (
-              <span className="cave-chat-meta-line__dir" title={seg.dir.title}>
-                <Icon name="ph:folder" width={11} aria-hidden />
-                {seg.dir.label}
-              </span>
-            )}
-          </Fragment>
-        ))}
+        {/* Slim header (cave-xsq.3): when the turn has settled, the static
+            provenance (model · runtime · dir · duration · usage · meters) is a
+            quiet reveal-on-hover cluster so the settled header reads as just the
+            conversation title — like ChatGPT. Live streaming state (elapsed,
+            "esc to cancel") stays visible; provenance shows inline while
+            streaming (no reveal class) so nothing is hidden mid-response. */}
+        <span
+          className={`cave-chat-meta-line__provenance${state === "complete" ? " reveal-on-hover" : ""}`}
+        >
+          {segments.map((seg, i) => (
+            <Fragment key={i}>
+              {i > 0 ? " · " : null}
+              {typeof seg === "string" ? (
+                seg
+              ) : (
+                <span className="cave-chat-meta-line__dir" title={seg.dir.title}>
+                  <Icon name="ph:folder" width={11} aria-hidden />
+                  {seg.dir.label}
+                </span>
+              )}
+            </Fragment>
+          ))}
+          {state === "complete" ? <ContextMeterChip usage={usage} model={metaModel} /> : null}
+          {state === "complete" ? <UsagePlanChip usagePlan={usagePlan} /> : null}
+        </span>
         {state === "streaming" && pendingSince ? <MetaLineElapsed since={pendingSince} /> : null}
         {state === "streaming" ? " · esc to cancel" : null}
-        {state === "complete" ? <ContextMeterChip usage={usage} model={metaModel} /> : null}
-        {state === "complete" ? <UsagePlanChip usagePlan={usagePlan} /> : null}
       </span>
       {children}
     </div>
@@ -4644,7 +4654,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           </div>
         </div>
       ) : null}
-      <header className="cave-chat-linear-header">
+      <header className="cave-chat-linear-header reveal-scope">
         <div className="cave-mobile-header-identity">
           <div className="cave-mobile-header-familiar">
                   <FamiliarIcon familiar={familiar} size="sm" />

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2584,6 +2584,17 @@ details[open] > .cave-tool-summary::before {
   letter-spacing: 0.01em;
 }
 
+/* Slim header (cave-xsq.3): the settled turn's static provenance
+   (model · runtime · dir · duration · usage · meters) rides inside __meta as a
+   reveal-on-hover cluster (header is the reveal-scope), so a resting header
+   reads as just the conversation title. Inline so it flows + truncates with the
+   meta line; the reveal-on-hover utility owns the opacity + touch/keyboard
+   parity. Only added on the complete state (see MetaLine), so live streaming
+   meta stays visible. */
+.cave-chat-meta-line__provenance {
+  display: inline;
+}
+
 /* CHAT-D3-06: ticking elapsed inside the streaming meta line. Tabular digits
    keep the line from jittering as the counter advances each second. */
 .cave-chat-meta-line__elapsed {


### PR DESCRIPTION
**Phase 1.3** of the chat-first minimalism arc (epic `cave-xsq`).

## Finding
The header already hover-reveals its quick actions (only the ⋮ kebab + find show at rest — `cave-chat.css` §"Ultra-minimal header"), so the audit's "6 visible buttons" overstated the at-rest clutter. The real remaining weight was the **always-on MetaLine provenance** — `model · runtime · dir · duration · usage · context/plan meters` — which also duplicated the model already shown in the identity subline.

## Change
Wrap that static provenance in `.cave-chat-meta-line__provenance`, which gets `reveal-on-hover` **only once the turn has settled** (`state === "complete"`), with the header as the `reveal-scope`. A resting settled header now reads as just the **conversation title + kebab**, like ChatGPT; hovering / keyboard focus / any touch device brings the provenance back. Live streaming state (elapsed, "esc to cancel") stays visible, and provenance shows inline while streaming so nothing is hidden mid-response. Reuses the design-language reveal contract (opacity-only, stays in the a11y tree).

## Verification
Live: settled header **57px**, provenance `opacity: 0` at rest → `1` on hover; only title + kebab visible at rest (screenshot: title left, ⋮ right). Repointed the header className pin. 560 app tests, typecheck, build green.

Note: the deeper row-count merge (identity + title into one bar) is deliberately left as a possible follow-up — the settled header is already calm without that surgery.

Part of epic `cave-xsq`; closes `cave-xsq.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)