### PR TITLE
fix(chat-list): bulk select/delete must not act on rows hidden in a collapsed section (cave-t3v)

### DIFF
--- a/src/components/chat-list-collapse.test.ts
+++ b/src/components/chat-list-collapse.test.ts
@@ -14,4 +14,21 @@ assert.match(src, /label="Sessions"[\s\S]*?onToggle=\{\(\) => toggleSection\("se
 assert.match(src, /rowCollapsed/, "rows compute a rowCollapsed flag");
 assert.match(src, /!rowCollapsed && \(/, "collapsed section's rows are not rendered");
 
+// cave-t3v: bulk select/delete must act on VISIBLE rows only. displayIds keeps
+// collapsed rows (for drag); visibleIds drops rows in a collapsed section, and
+// the select-all / count / bulk-delete / bulk-archive paths all key off it — so
+// "Select all" + Delete can never remove chats hidden in a collapsed section.
+assert.match(
+  src,
+  /const visibleIds = useMemo\(\(\) => \{\s*\n\s*if \(effectiveSelection !== "all" \|\| collapsedSections\.size === 0\) return displayIds;\s*\n\s*return displayIds\.filter\(\s*\n\s*\(id\) => !collapsedSections\.has\(isSessionPinned\(pinnedIds, id\) \? "pinned" : "sessions"\),/,
+  "visibleIds excludes rows in a collapsed section",
+);
+assert.doesNotMatch(
+  src,
+  /allVisibleSelected = displayIds|selectedVisibleCount = displayIds|new Set\(displayIds\.filter\(\(id\) => selectedIds/,
+  "select-all, the visible count, and bulk delete no longer key off displayIds (which includes collapsed rows)",
+);
+assert.match(src, /allVisibleSelected = visibleIds/, "select-all is computed from the visible rows");
+assert.match(src, /const idSet = new Set\(visibleIds\.filter\(\(id\) => selectedIds\.has\(id\)\)\)/, "bulk delete only removes selected rows that are currently visible");
+
 console.log("chat-list-collapse.test.ts: ok");

--- a/src/components/chat-list-delete.test.ts
+++ b/src/components/chat-list-delete.test.ts
@@ -338,7 +338,7 @@ assert.match(source, /useUndoDelete<SessionRow\[\]>\(\)/, "bulk delete routes th
 assert.match(source, /scheduleBulkDelete\(\s*removed,/, "bulk delete schedules the batch through the undo window");
 assert.match(source, /const hidden = new Set\(\(deletePending\?\.item \?\? \[\]\)\.map\(\(s\) => s\.id\)\)/, "pending-deleted rows are hidden from the list until commit");
 assert.match(source, /<UndoToast[\s\S]{0,160}onUndo=\{undoBulkDelete\}[\s\S]{0,40}onDismiss=\{commitBulkDelete\}/, "an undo toast offers to restore the batch");
-assert.match(source, /const allVisibleSelected = displayIds\.length > 0 && displayIds\.every\(\(id\) => selectedIds\.has\(id\)\)/, "select-all is visible-aware");
+assert.match(source, /const allVisibleSelected = visibleIds\.length > 0 && visibleIds\.every\(\(id\) => selectedIds\.has\(id\)\)/, "select-all is visible-aware (excludes collapsed rows)");
 assert.match(source, /\{allVisibleSelected \? "Clear" : "Select all"\}/, "toolbar offers select-all / clear");
 
 console.log("chat-list-delete.test.ts: ok");

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -507,6 +507,18 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     () => displayGroups.flatMap((group) => group.sessions.map((session) => session.id)),
     [displayGroups],
   );
+  // `displayIds` keeps rows in collapsed sections (they stay in DOM order for
+  // drag/sort). Bulk select/delete must act only on rows the user can actually
+  // SEE, or "Select all" + Delete would silently remove chats hidden inside a
+  // collapsed section (data loss). The collapsible Pinned/Sessions sections only
+  // exist in the flat "All" view; there a row is hidden when its section is
+  // collapsed. Mirrors the per-row `rowCollapsed` computed during render.
+  const visibleIds = useMemo(() => {
+    if (effectiveSelection !== "all" || collapsedSections.size === 0) return displayIds;
+    return displayIds.filter(
+      (id) => !collapsedSections.has(isSessionPinned(pinnedIds, id) ? "pinned" : "sessions"),
+    );
+  }, [displayIds, effectiveSelection, collapsedSections, pinnedIds]);
   const visibleRows = useMemo(
     () => scopedGroups.reduce((n, g) => n + g.sessions.length, 0),
     [scopedGroups],
@@ -621,21 +633,24 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       return next;
     });
   const exitSelect = () => { setSelectMode(false); setSelectedIds(new Set()); };
-  // Visible-aware select-all: acts on the rows currently shown (displayIds).
-  const allVisibleSelected = displayIds.length > 0 && displayIds.every((id) => selectedIds.has(id));
+  // Visible-aware select-all: acts on the rows currently shown (visibleIds,
+  // which excludes rows in a collapsed section).
+  const allVisibleSelected = visibleIds.length > 0 && visibleIds.every((id) => selectedIds.has(id));
   const toggleSelectAllVisible = () =>
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (allVisibleSelected) displayIds.forEach((id) => next.delete(id));
-      else displayIds.forEach((id) => next.add(id));
+      if (allVisibleSelected) visibleIds.forEach((id) => next.delete(id));
+      else visibleIds.forEach((id) => next.add(id));
       return next;
     });
-  const selectedVisibleCount = displayIds.filter((id) => selectedIds.has(id)).length;
+  const selectedVisibleCount = visibleIds.filter((id) => selectedIds.has(id)).length;
 
   // Deferred + undoable: hide the selected chats now, fire the DELETEs only
   // after the undo window, refetch once. Undo restores the whole batch.
   const bulkDelete = () => {
-    const idSet = new Set(displayIds.filter((id) => selectedIds.has(id)));
+    // Only delete rows that are both selected AND currently visible — a section
+    // collapsed after selecting must protect its now-hidden chats from deletion.
+    const idSet = new Set(visibleIds.filter((id) => selectedIds.has(id)));
     const removed = mine.filter((s) => idSet.has(s.id));
     if (removed.length === 0) return;
     setError(null);
@@ -660,7 +675,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
   };
 
   const bulkArchive = async (archived: boolean) => {
-    const ids = displayIds.filter((id) => selectedIds.has(id));
+    const ids = visibleIds.filter((id) => selectedIds.has(id));
     if (ids.length === 0) return;
     setBulkBusy(true);
     setError(null);


### PR DESCRIPTION
From the chat surface audit (P2 data-loss finding).

## The bug
In the flat "All" chat list, the Pinned/Sessions sections can be collapsed. But "Select all", the selected count, `bulkDelete`, and `bulkArchive` all keyed off `displayIds`, which deliberately keeps rows in collapsed sections (they stay in DOM order for drag/sort). So: **collapse a section → "Select all" → Delete, and the hidden chats got deleted too** — silent data loss, with the "N selected" counter including off-screen rows.

## The fix
A `visibleIds` memo drops rows in a collapsed section (only the flat "All" view has the collapsible sections; it mirrors the per-row `rowCollapsed` computed during render). Select-all, the count, `bulkDelete`, and `bulkArchive` now key off `visibleIds`. `displayIds` still drives drag/`SortableContext`. Bulk delete also intersects with `visibleIds`, so a section collapsed **after** selecting protects its now-hidden chats.

## Verification
- `tsc` clean; **full `test:app` (560 files) green**; frontend build within budget.
- Source-scan pins added in `chat-list-collapse.test.ts` (visibleIds excludes collapsed rows; select/bulk no longer key off `displayIds`); the select-all pin in `chat-list-delete.test.ts` updated to `visibleIds`.

Closes cave-t3v. (Note: the pin/order-divergence sub-item mentioned in the bead is left for a separate change; this PR is the data-loss fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)