### PR TITLE
chore(release): stamp v0.0.148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.148] - 2026-07-07
+
+> 🔗 **Grimoire grows up** — the markdown editor gains a full `[[wiki-link]]` system (parser, outgoing chips, and a graph viewer), multi-tab editing, Open-in-Grimoire cross-links, live-follow of agent writes, and a diff-based 409 conflict resolver. Chat picks up a centered reading column, leaner per-message metadata, and create-task-from-chat. Plus more cave-4op button standardization and the legacy avatar store's retirement.
+
+Feature release on top of v0.0.147.
+
+### Features
+- **Grimoire: `[[wiki-links]]`** (#2587, #2588, #2597, cave-xr0). A wiki-link parser + resolver, outgoing-link chips below the editor, and a cross-document graph viewer.
+- **Grimoire: multi-tab editing** (#2582, cave-90u). Open several documents at once, persisted across reloads.
+- **Grimoire: Open-in-Grimoire cross-links + delete/trash actions** (#2580, cave-kv3).
+- **Markdown editor: live-follow agent writes** (#2583, cave-e3b). Open memory docs update as agents write them.
+- **Markdown editor: 409 conflict resolver** (#2577, cave-utl). A diff view with keep-mine / take-theirs / merge, replacing cancel-and-reopen.
+- **Chat: centered reading column + leaner metadata** (#2589, #2596, cave-xsq). A focused reading width, and name-plus-time per message with extras on hover.
+- **Chat: create task from chat** (#2595, cave-px7). Turn a chat turn into a board task with a source audit trail.
+
+### Refactors
+- **Control standardization** (#2591, #2584, #2581, cave-4op). Board banner actions, the GitHub profile card, and the onboarding CTAs move onto the shared `Button`.
+- **Marketplace: ultra-minimal Recommended cards** (#2586). Flat cards, chrome on hover.
+- **Retire the legacy browser-local avatar store** (#2590, cave-154). The operator avatar is server-backed now.
+
+### Fixes
+- **Chat: thread-switch isolation** (#2594). Composer state and stream teardown scope per thread, with IME-safe Enter.
+- **Popovers stack above the board task drawer** (#2579).
+
 ## [0.0.147] - 2026-07-07
 
 > ⚡ **Faster and steadier** — memory inventory gets a 130x speedup, the markdown editor picks up debounced autosave for knowledge & journal docs, and the Work Queue surfaces a "Needs attention" strip for stale and unlinked PRs. Plus a round of session-changes and automations button refactors onto shared primitives.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.147"
+version = "0.0.148"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.147"
+version = "0.0.148"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.147</string>
+	<string>0.0.148</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.147</string>
+	<string>0.0.148</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.147</string>
+	<string>0.0.148</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.147</string>
+	<string>0.0.148</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Feature release on top of v0.0.147. Bumps all six version locations and adds the v0.0.148 CHANGELOG entry.

## Highlights since v0.0.147

- **Grimoire `[[wiki-links]]`** — parser + resolver, outgoing chips, graph viewer (#2587, #2588, #2597, cave-xr0)
- **Grimoire multi-tab editing** (#2582, cave-90u) + **Open-in-Grimoire cross-links** (#2580, cave-kv3)
- **Markdown editor** — live-follow agent writes (#2583, cave-e3b), 409 conflict resolver (#2577, cave-utl)
- **Chat** — centered reading column (#2589), lean per-message metadata (#2596), create-task-from-chat (#2595), thread-switch isolation (#2594)
- **cave-4op** control standardization — board / GitHub / onboarding buttons (#2591, #2584, #2581)
- **Retire the legacy avatar store** (#2590, cave-154); marketplace card refresh (#2586)

Excludes the still-open chat PRs #2598/#2599 (their owning sessions self-merge).

## Gate

Local build gate passed: `install --frozen-lockfile`, `typecheck` (0 errors), `build` (bundle-budget within budget, largest 992 KB). Six version locations bumped (package.json, tauri.conf.json, Cargo.toml, Cargo.lock, Info.ios.plist, gen/apple/app_iOS/Info.plist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)