### PR TITLE
feat(chat): fold prompt snippets into the composer Options menu (cave-xsq.4)

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -312,6 +312,19 @@ assert.match(
   /<div className="cave-composer-utility-row">[\s\S]*aria-label="Attach images, videos, or files"[\s\S]*<Icon name="ph:paperclip"[\s\S]*aria-label="Voice"[\s\S]*<ComposerOptionsMenu/,
   "composer utility row keeps attach + voice, then the collapsed Options menu",
 );
+// Composer core (cave-xsq.4): the dedicated Prompt-snippets button is folded
+// into the Options overflow, so the resting utility row is just attach · voice ·
+// overflow. Snippets are still reachable — the menu opens with the action.
+assert.doesNotMatch(
+  source,
+  /aria-label="Prompt snippets"/,
+  "the standalone Prompt-snippets utility button is gone (folded into the Options menu)",
+);
+assert.match(
+  source,
+  /<ComposerOptionsMenu[\s\S]*onOpenPromptSnippets=\{\(\) => setPromptSnippetsOpen\(true\)\}/,
+  "the Options menu opens Prompt snippets as an action (nothing lost)",
+);
 assert.match(
   source,
   /sections=\{\[[\s\S]*label: "Access"[\s\S]*label: "Model"[\s\S]*label: "Thinking"[\s\S]*label: "Speed"/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5413,19 +5413,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   >
                     <Icon name="ph:microphone" width={15} aria-hidden />
                   </button>
-                  <button
-                    type="button"
-                    className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
-                    title="Prompt snippets"
-                    aria-label="Prompt snippets"
-                    onClick={() => setPromptSnippetsOpen(true)}
-                  >
-                    <Icon name="ph:chat-centered-text" width={14} aria-hidden />
-                  </button>
                   <ComposerOptionsMenu
                     hostValue={composerHostValue}
                     onHostPick={setRuntimeHost}
                     disabled={busy}
+                    onOpenPromptSnippets={() => setPromptSnippetsOpen(true)}
                     indicator={
                       permissionMode !== DEFAULT_PERMISSION_MODE ||
                       thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||

--- a/src/components/composer-options-menu.tsx
+++ b/src/components/composer-options-menu.tsx
@@ -86,6 +86,7 @@ export function ComposerOptionsMenu({
   sections,
   indicator,
   disabled,
+  onOpenPromptSnippets,
 }: {
   hostValue: string;
   onHostPick: (id: string) => void;
@@ -94,6 +95,10 @@ export function ComposerOptionsMenu({
   /** Show the "non-default" dot on the trigger (host-remote is added here). */
   indicator?: boolean;
   disabled?: boolean;
+  /** When set, the menu opens with a "Prompt snippets…" action at the top — the
+   *  composer's utility row folds its dedicated snippets button in here so the
+   *  resting row is just attach · voice · this overflow (cave-xsq.4). */
+  onOpenPromptSnippets?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
@@ -111,8 +116,8 @@ export function ComposerOptionsMenu({
         disabled={disabled}
         aria-haspopup="dialog"
         aria-expanded={open}
-        aria-label="Response settings"
-        title="Response settings"
+        aria-label="Composer options"
+        title="Composer options"
         onClick={() => {
           void load();
           setOpen((v) => !v);
@@ -127,10 +132,23 @@ export function ComposerOptionsMenu({
         anchorRef={anchorRef}
         placement="top-start"
         minWidth={288}
-        ariaLabel="Response settings"
+        ariaLabel="Composer options"
         className="composer-options__panel"
       >
-        <PopoverBody ariaLabel="Response settings">
+        <PopoverBody ariaLabel="Composer options">
+          {onOpenPromptSnippets ? (
+            <button
+              type="button"
+              className="composer-options__action focus-ring"
+              onClick={() => {
+                setOpen(false);
+                onOpenPromptSnippets();
+              }}
+            >
+              <Icon name="ph:chat-centered-text" width={14} aria-hidden />
+              Prompt snippets…
+            </button>
+          ) : null}
           <div className="composer-options__section">
             <span className="composer-options__label">Host</span>
             <ComposerHostChoices

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -74,8 +74,10 @@ assert.match(chatView, /useState<PromptOption\[\]>\(BUILTIN_PROMPTS\)/, "picker 
 assert.match(chatView, /const insertPrompt = \(p: PromptOption\)/, "chat-view has the shared insert helper");
 assert.doesNotMatch(chatView, /sendRaw\([^)]*promptInsertion/, "prompt insertion is never routed into sendRaw");
 assert.doesNotMatch(chatView, /sendRaw\([^)]*\.body\b/, "a template body is never sent directly");
-assert.match(chatView, /aria-label="Prompt snippets"/, "composer has the Prompt snippets trigger");
-assert.match(chatView, /onOpenPromptSnippets=\{\(\) => setPromptSnippetsOpen\(true\)\}/, "empty state can open the snippets modal");
+// Prompt snippets fold into the composer Options overflow (cave-xsq.4): no
+// standalone utility button, reachable via the menu's onOpenPromptSnippets.
+assert.match(chatView, /<ComposerOptionsMenu[\s\S]*onOpenPromptSnippets=\{\(\) => setPromptSnippetsOpen\(true\)\}/, "the composer Options menu opens Prompt snippets");
+assert.match(chatView, /onOpenPromptSnippets=\{\(\) => setPromptSnippetsOpen\(true\)\}/, "empty state / composer can open the snippets modal");
 
 // ── Prompt snippets modal ────────────────────────────────────────────────────
 const modal = await readFile(new URL("../components/prompt-snippets-modal.tsx", import.meta.url), "utf8");

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2413,6 +2413,25 @@ details[open] > .cave-tool-summary::before {
   padding: 4px;
 }
 
+/* Prompt-snippets action folded into the composer overflow (cave-xsq.4): a
+   full-width menu item at the top of the options panel, divided from the
+   settings sections below. */
+.composer-options__action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 6px;
+  border-radius: var(--radius-control);
+  border-bottom: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.composer-options__action:hover {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+}
+
 .composer-options__section {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
**Phase 1.4** — the final Phase 1 slice of the chat-first minimalism arc (epic `cave-xsq`).

## Finding
Like the header, the composer was already more minimal than the audit's "8–9 controls" implied — the power controls (Access · Model · Thinking · Speed · Host) already live behind the single Options trigger. The one stray utility button was **Prompt snippets**.

## Change
- `ComposerOptionsMenu` gains an optional `onOpenPromptSnippets` action, rendered at the top of the panel above the settings.
- The composer drops its dedicated snippets button and passes the action to the menu.
- Renamed the trigger from "Response settings" → **"Composer options"** (it now holds an action too; no test pinned the old label).

The resting utility row is now **attach · voice · Options** — ChatGPT-clean — with nothing lost (snippets open from the menu).

## Verification
Live: the utility row no longer carries a standalone "Prompt snippets" button (`hasStandaloneSnippets: false`); the Composer options trigger is present and passes `onOpenPromptSnippets`. 561 app tests, typecheck, build green; repointed the `slash-prompt` + `chat-view-polish` pins.

**This completes Phase 1** (centered column · lean messages · slim header · composer core). Part of epic `cave-xsq`; closes `cave-xsq.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)