### PR TITLE
fix(group-chat): race-safe recordSession + abort in-flight broadcast on coven switch (cave-z4s)

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -148,4 +148,32 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
   // A failed familiar reply can be retried in place.
   assert.match(view, /const retryReply = useCallback/, "failed replies can be retried");
   assert.match(view, /onClick=\{\(\) => void retryReply\(r\)\}/, "the Retry control re-runs a single familiar");
+
+  // cave-z4s (1): a broadcast streams every familiar concurrently, so recordSession
+  // must compose on the LATEST groups via a functional setGroups (persisting
+  // inside the updater) rather than reading the render-synced groupsRef — else
+  // concurrent session events dropped each other's session ids (last write wins).
+  assert.match(
+    view,
+    /const recordSession = useCallback\([\s\S]*?setGroups\(\(prev\) => \{[\s\S]*?const next = upsertGroup\(prev, setGroupSession\([\s\S]*?saveGroups\(next\);[\s\S]*?return next;[\s\S]*?\}\);[\s\S]*?onSessionStarted\?\.\(sessionId\);\s*\n\s*\},\s*\n?\s*\[onSessionStarted\]/,
+    "recordSession updates groups functionally + persists inside the updater and no longer reads the stale groupsRef (race-safe)",
+  );
+
+  // cave-z4s (2): switching covens aborts the in-flight broadcast (no leaked
+  // stream / stuck bubbles), and both stream-cleanup paths only clear the shared
+  // abort/busy wiring when they still own the active controller.
+  assert.match(
+    view,
+    /swap transcript when the active group changes[\s\S]*?abortRef\.current\?\.abort\(\);\s*\n\s*abortRef\.current = null;\s*\n\s*setBusy\(false\);/,
+    "changing the active coven aborts any in-flight broadcast before loading the new transcript",
+  );
+  {
+    const guarded = view.match(
+      /if \(abortRef\.current === controller\) \{\s*\n\s*abortRef\.current = null;\s*\n\s*setBusy\(false\);\s*\n\s*\}/g,
+    );
+    assert.ok(
+      guarded && guarded.length === 2,
+      "both broadcast and retryReply guard their abort/busy cleanup on still owning the controller",
+    );
+  }
 });

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -134,6 +134,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
 
   // --- swap transcript when the active group changes ----------------------
   useEffect(() => {
+    // Switching covens abandons any in-flight broadcast on the previous one.
+    // Abort it (otherwise its streams keep running and their tokens no-op
+    // against the newly-loaded transcript — a leaked stream) and clear the
+    // busy/abort state so the new coven starts clean. The previous coven keeps
+    // its last-saved transcript; returning to it offers retry on any partial.
+    abortRef.current?.abort();
+    abortRef.current = null;
+    setBusy(false);
     if (!activeId) {
       setTranscript([]);
       return;
@@ -224,14 +232,23 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
 
   const recordSession = useCallback(
     (groupId: string, familiarId: string, sessionId: string) => {
-      const current = groupsRef.current.find((g) => g.id === groupId);
-      if (!current || current.sessions[familiarId] === sessionId) return;
-      persistGroups(
-        upsertGroup(groupsRef.current, setGroupSession(current, familiarId, sessionId, nowIso())),
-      );
+      // A broadcast streams every familiar concurrently, so several session/done
+      // events can land in the same tick. Reading the render-synced groupsRef
+      // let each call rebase on the SAME stale groups, and the last write dropped
+      // the others' session ids. Update functionally instead so every record
+      // composes on the latest state; persist inside the updater. onSessionStarted
+      // is fired unconditionally (idempotent list refresh) so a session is never
+      // missed — we can't reliably read "did it change" back out of the updater.
+      setGroups((prev) => {
+        const current = prev.find((g) => g.id === groupId);
+        if (!current || current.sessions[familiarId] === sessionId) return prev;
+        const next = upsertGroup(prev, setGroupSession(current, familiarId, sessionId, nowIso()));
+        saveGroups(next);
+        return next;
+      });
       onSessionStarted?.(sessionId);
     },
-    [persistGroups, onSessionStarted],
+    [onSessionStarted],
   );
 
   // --- group CRUD ----------------------------------------------------------
@@ -434,8 +451,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
           ),
         ),
       );
-      abortRef.current = null;
-      setBusy(false);
+      // Only clear the shared abort/busy wiring if this broadcast still owns it.
+      // A coven switch (or a newer broadcast) may have replaced abortRef while
+      // this one was aborting; clearing unconditionally would kill the newer
+      // stream's Stop and unlock the composer mid-response.
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setBusy(false);
+      }
       // The streaming bubbles are visual-only — announce the outcome for AT.
       const failed = settled.filter((r) => r.status === "error").length;
       const total = settled.length;
@@ -501,8 +524,11 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         }),
         controller.signal,
       );
-      abortRef.current = null;
-      setBusy(false);
+      // Ownership-guarded (see broadcast): don't clobber a newer stream's wiring.
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setBusy(false);
+      }
       const name = byId.get(fresh.familiarId)?.display_name ?? "Familiar";
       announce(
         settled.status === "error" ? `${name} failed again.` : `${name} replied.`,


### PR DESCRIPTION
From the chat surface audit (P2, two verified group-chat concurrency bugs).

## Bugs
1. **`recordSession` dropped familiars' session ids.** A broadcast streams every familiar concurrently, so several `session`/`done` events land in the same tick. `recordSession` read the render-synced `groupsRef` and rebuilt the group from it, so each concurrent call rebased on the **same stale groups** — last write wins, dropping the others' session ids. Those familiars then lost session continuity (next turn started fresh).
2. **Switching covens leaked the in-flight broadcast.** The swap effect replaced the transcript without aborting; the old streams kept running and their tokens no-op'd against the new transcript (leaked stream + bubbles stuck streaming).

## Fixes
- `recordSession` updates groups **functionally** (composes on the latest state) and persists inside the updater — no stale-ref rebase.
- The active-coven swap effect **aborts** the in-flight broadcast and clears busy/abort state before loading the new transcript.
- Since a switch (or newer broadcast) can replace `abortRef` while an older broadcast is still settling, both the broadcast and `retryReply` cleanups now only clear the shared abort/busy wiring when they **still own the controller** (`abortRef.current === controller`) — the same ownership guard shipped for the main chat surface (#2594).

## Verification
- `tsc` clean; **full `test:app` (561 files) green**; build within budget.
- New source-scan pins in `group-chat-view.test.ts`: functional race-safe `recordSession`; abort-on-coven-switch; both cleanups ownership-guarded.

Closes cave-z4s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)