### PR TITLE
fix(chat): dismiss inline pickers on Esc + reset enhance/draft state on send (cave-zvr)

### DIFF
--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -1011,7 +1011,7 @@ assert.match(
 );
 assert.match(
   mentionSource,
-  /setInput\(""\);\s*\n\s*setAttachments\(\[\]\);\s*\n\s*setMentionedFiles\(\[\]\);/,
+  /setInput\(""\);[\s\S]{0,400}?setAttachments\(\[\]\);\s*\n\s*setMentionedFiles\(\[\]\);/,
   "Sending must clear staged mentions with the composer",
 );
 
@@ -1120,3 +1120,19 @@ assert.match(source, /ToolProjectRootContext/, "edit card resolves project root 
 assert.match(source, /"\/api\/changes"/, "Undo posts to the changes revert API");
 assert.match(source, /cave:changes-refresh/, "Undo notifies the changes panel to refresh");
 assert.match(globalsSrc, /\.cave-edit-card__undo/, "Undo button styling exists");
+
+// cave-zvr: composer send hygiene + picker Escape.
+// (3) send() clears the persisted draft synchronously — the 250ms debounced
+//     writer is cancelled if ChatView unmounts right after send, else the
+//     pre-send text reappears as a draft on return.
+assert.match(source, /setInput\(""\);\s*\n\s*\/\/[\s\S]*?writeComposerDraft\(""\);/, "send clears the persisted composer draft synchronously");
+// (2) send() resets the enhance strip so it doesn't linger over an empty
+//     composer and let Revert repopulate the already-sent message.
+assert.match(source, /writeComposerDraft\(""\);[\s\S]{0,400}?setEnhanceStatus\("idle"\);\s*\n\s*setEnhanceOriginal\(null\);/, "send resets the enhance (Prompt improved / Revert) state");
+// (1) the /model, /skill and /prompt inline pickers each dismiss on Escape
+//     (their footers advertise "esc cancel"); previously Esc fell through and
+//     cancelled a live stream. Together with the slash-menu branch that's 4.
+{
+  const escDismiss = source.match(/if \(e\.key === "Escape"\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setSlashDismissed\(true\);\s*\n\s*return;\s*\n\s*\}/g);
+  assert.ok(escDismiss && escDismiss.length >= 4, "the slash, model, skill and prompt pickers all dismiss on Escape (setSlashDismissed)");
+}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3958,8 +3958,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const outgoingText = buildQuotedPrompt(replyTarget, text);
     setReplyTarget(null);
     setInput("");
+    // Clear the persisted draft synchronously. The debounced writer (250ms) is
+    // cancelled if ChatView unmounts right after a send (navigating to another
+    // surface), which would leave the pre-send text in storage to reappear as an
+    // unsent draft on return.
+    writeComposerDraft("");
     setAttachments([]);
     setMentionedFiles([]);
+    // The enhance "Prompt improved / Revert" strip belongs to the draft just
+    // sent — reset it so it doesn't linger over the now-empty composer and let
+    // Revert repopulate the composer with the message the user already sent.
+    setEnhanceStatus("idle");
+    setEnhanceOriginal(null);
     // Branching: consume a pending branch parent set by editTurnInComposer.
     // Read-and-clear atomically so it only applies to THIS send.
     const branchParent = pendingBranchParent;
@@ -4359,6 +4369,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         }
         return;
       }
+      // Esc dismisses the picker (its footer advertises "esc cancel"); without
+      // this, Esc fell through to the busy branch and cancelled a live stream.
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setSlashDismissed(true);
+        return;
+      }
     }
     if (skillMenuActive && skillOptions) {
       const opts = skillOptions;
@@ -4384,6 +4401,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         if (s) invokeSkillOption(s);
         return;
       }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setSlashDismissed(true);
+        return;
+      }
     }
     if (promptMenuActive && promptOptions) {
       const opts = promptOptions;
@@ -4407,6 +4429,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         e.preventDefault();
         const p = opts[slashIdx];
         if (p) insertPrompt(p);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setSlashDismissed(true);
         return;
       }
     }


### PR DESCRIPTION
The three highest-impact items from the chat audit's lower-severity (P3) tier, all in the composer.

## Fixes
1. **Esc dismisses the `/model`·`/skill`·`/prompt` inline pickers.** Those branches handled Arrow/Tab/Enter but not Escape, and the shared slash-menu Esc branch is gated on slash/skill-command rows being present — which they aren't while an argument picker is open. So Esc fell through to the busy branch and **cancelled a live stream** instead of closing the picker. Each picker branch now dismisses via `setSlashDismissed(true)`, mirroring the slash branch.
2. **send() resets the enhance state.** It was cleared only by Revert and the thread-switch reset, so after enhancing + sending, the "Prompt improved / Revert" strip lingered over the empty composer and Revert repopulated it with the already-sent message.
3. **send() clears the persisted draft synchronously.** The draft is otherwise written only by a 250 ms debounced effect whose timer is cancelled on unmount — so send-then-navigate-away within 250 ms left the pre-send text to reappear as an unsent draft.

## Verification
- `tsc` clean; **full `test:app` (561 files) green**; build within budget.
- New source-scan pins in `chat-view-polish.test.ts` (all four pickers dismiss on Esc; send clears the draft + resets enhance).

## Scope
Closes cave-zvr. The remaining lower-impact items (model-state stale write, changeCount badge staleness, popstate deep-link indicator, `/clear`-mid-stream) are split into a follow-up P3 bead — the `/clear` background-re-persist part was already resolved by #2598.

🤖 Generated with [Claude Code](https://claude.com/claude-code)