### PR TITLE
chore(release): stamp v0.0.149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.149] - 2026-07-07
+
+> 🩹 **Chat polish** — prompt snippets fold into the composer's Options menu, and group chat gains a race-safe session recorder that aborts an in-flight broadcast when you switch covens.
+
+Release on top of v0.0.148.
+
+### Features
+- **Chat: prompt snippets in the Options menu** (#2602, cave-xsq.4). The snippet picker moves into the composer's Options menu.
+
+### Fixes
+- **Group chat: race-safe session recording** (#2603, cave-z4s). `recordSession` is race-safe and aborts an in-flight broadcast on a coven switch.
+
 ## [0.0.148] - 2026-07-07
 
 > 🔗 **Grimoire grows up** — the markdown editor gains a full `[[wiki-link]]` system (parser, outgoing chips, and a graph viewer), multi-tab editing, Open-in-Grimoire cross-links, live-follow of agent writes, and a diff-based 409 conflict resolver. Chat picks up a centered reading column, leaner per-message metadata, and create-task-from-chat. Plus more cave-4op button standardization and the legacy avatar store's retirement.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.148"
+version = "0.0.149"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.148"
+version = "0.0.149"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.148</string>
+	<string>0.0.149</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.148</string>
+	<string>0.0.149</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.148</string>
+	<string>0.0.149</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.148</string>
+	<string>0.0.149</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.148",
+  "version": "0.0.149",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release on top of v0.0.148. Bumps all six version locations and adds the v0.0.149 CHANGELOG entry.

## Since v0.0.148
- **Chat: prompt snippets in the Options menu** (#2602, cave-xsq.4)
- **Group chat: race-safe session recording** (#2603, cave-z4s) — `recordSession` is race-safe and aborts an in-flight broadcast on a coven switch.

Local build gate passed: `install --frozen-lockfile`, `typecheck` (0 errors), `build` (bundle-budget within budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)