### PR TITLE
feat(chat): demote Group from a co-equal chat tab to a quiet icon (cave-xsq.5)

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -81,12 +81,18 @@ assert.match(
   "ChatSurface should label the secondary primary tab Projects instead of Traces",
 );
 
-// Group Chat ("coven") is folded in as a first-class scope tab (retiring the
-// standalone groupchat page); it renders GroupChatView for the coven scope.
-assert.match(
+// Group Chat ("coven") is demoted from a co-equal tab (cave-xsq.5): it's a quiet
+// icon-button on the right of the scope-tab row that switches to the coven scope,
+// not a third tab — so the default surface reads as Sessions / Projects.
+assert.doesNotMatch(
   chatSurface,
   /\{\s*id:\s*"coven",\s*label:\s*"Group"/,
-  "ChatSurface should expose the Group Chat tab",
+  "Group is no longer a co-equal scope tab",
+);
+assert.match(
+  chatSurface,
+  /className=\{`chat-scope-group-btn[\s\S]*onClick=\{\(\) => setScope\("coven"\)\}/,
+  "ChatSurface exposes Group as a demoted icon-button that switches to the coven scope",
 );
 assert.match(
   chatSurface,

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -604,35 +604,49 @@ export function ChatSurface({
             items={[
               { id: "conversation", label: "Sessions" },
               { id: "projects", label: "Projects" },
-              { id: "coven", label: "Group", icon: "ph:users-three", title: "Group chat — broadcast one prompt to a coven of familiars" },
             ]}
           />
-          {/* Mobile / narrow-pane code-rail toggle. On desktop the rail is a
-              third column; below the breakpoint there's no room, so it opens
-              as a right-edge slide-over sheet (below). Mirrors the mobile
-              right-sheet affordance placement. Scoped to the conversation tab
-              so it doesn't hover over the Projects list. */}
-          {mobileRail && scope === "conversation" && (
+          <div className="flex items-center gap-1.5">
+            {/* Group demoted from a co-equal tab (cave-xsq.5): the default chat
+                surface reads as a conversation (Sessions / Projects), and Group
+                — broadcast one prompt to a coven — is a quiet icon here instead.
+                Still one click, still activated by CHAT_OPEN_COVEN_EVENT. */}
             <button
               type="button"
-              className="mobile-code-rail-toggle focus-ring"
-              aria-label={mobileRailOpen ? "Hide code rail" : "Show code rail"}
-              aria-haspopup="dialog"
-              aria-expanded={mobileRailOpen}
-              onClick={() => {
-                // Mutually exclusive with the right-panel sheet: two z-[200]
-                // aria-modal overlays on the same edge would stack and confuse
-                // AT. Opening the code rail dismisses the other sheet.
-                if (!mobileRailOpen) onSetRightPanel?.(null);
-                setMobileRailOpen((v) => !v);
-              }}
+              className={`chat-scope-group-btn focus-ring${scope === "coven" ? " is-active" : ""}`}
+              aria-label="Group chat — broadcast one prompt to a coven of familiars"
+              aria-pressed={scope === "coven"}
+              title="Group chat — broadcast one prompt to a coven of familiars"
+              onClick={() => setScope("coven")}
             >
-              <Icon name="ph:code" width={16} aria-hidden />
-              {changeCount > 0 ? (
-                <span className="mobile-code-rail-toggle__badge">{changeCount}</span>
-              ) : null}
+              <Icon name="ph:users-three" width={16} aria-hidden />
             </button>
-          )}
+            {/* Mobile / narrow-pane code-rail toggle. On desktop the rail is a
+                third column; below the breakpoint there's no room, so it opens
+                as a right-edge slide-over sheet (below). Scoped to the
+                conversation tab so it doesn't hover over the Projects list. */}
+            {mobileRail && scope === "conversation" && (
+              <button
+                type="button"
+                className="mobile-code-rail-toggle focus-ring"
+                aria-label={mobileRailOpen ? "Hide code rail" : "Show code rail"}
+                aria-haspopup="dialog"
+                aria-expanded={mobileRailOpen}
+                onClick={() => {
+                  // Mutually exclusive with the right-panel sheet: two z-[200]
+                  // aria-modal overlays on the same edge would stack and confuse
+                  // AT. Opening the code rail dismisses the other sheet.
+                  if (!mobileRailOpen) onSetRightPanel?.(null);
+                  setMobileRailOpen((v) => !v);
+                }}
+              >
+                <Icon name="ph:code" width={16} aria-hidden />
+                {changeCount > 0 ? (
+                  <span className="mobile-code-rail-toggle__badge">{changeCount}</span>
+                ) : null}
+              </button>
+            )}
+          </div>
         </div>
 
         {scope === "memory" ? (

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -117,8 +117,8 @@ test("Group Chat is a tab inside the Chat surface, not a standalone page", () =>
   );
   assert.match(
     chatSurface,
-    /\{\s*id:\s*"coven",\s*label:\s*"Group"/,
-    "ChatSurface exposes a Group tab",
+    /chat-scope-group-btn[\s\S]*onClick=\{\(\) => setScope\("coven"\)\}/,
+    "ChatSurface exposes Group as a demoted icon-button (not a co-equal tab) that opens the coven scope (cave-xsq.5)",
   );
   assert.match(
     chatSurface,

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4667,6 +4667,35 @@ details[open] > .cave-tool-summary::before {
   border-color: color-mix(in oklch, var(--composer-pill-gold, oklch(0.81 0.105 83)) 42%, transparent);
   background: color-mix(in oklch, var(--composer-pill-gold, oklch(0.81 0.105 83)) 12%, transparent);
 }
+
+/* Demoted Group entry (cave-xsq.5): a quiet icon on the right of the scope-tab
+   row, muted at rest, accent-tinted when Group is the active scope — so Group
+   stays one click away without competing with Sessions / Projects as a tab. */
+.chat-scope-group-btn {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+.chat-scope-group-btn:hover {
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--foreground) 6%, transparent);
+}
+.chat-scope-group-btn.is-active {
+  color: var(--accent-presence);
+  border-color: color-mix(in oklch, var(--accent-presence) 42%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
 .mobile-code-rail-toggle__badge {
   position: absolute;
   top: -3px;


### PR DESCRIPTION
**Phase 2.3** of the chat-first minimalism arc (epic `cave-xsq`) — the first "consolidate" slice.

## Change
The chat scope row showed **Sessions · Projects · Group** as three co-equal tabs, so the default surface read as a tabbed workspace. Group is now dropped from the tab items and relocated as a quiet `.chat-scope-group-btn` icon on the right of the row — muted at rest, accent-tinted when the coven scope is active.

**Nothing is removed:** Group chat still opens in one click, still renders `GroupChatView`, and is still activated by `CHAT_OPEN_COVEN_EVENT` / the palette. The default tabs read as just **Sessions · Projects**.

## Verification
Live: tab labels = `[Sessions, Projects]`; the Group icon is present and inactive by default; clicking it activates the coven scope and renders the group view. Repointed the two "coven tab" pins (`chat-surface`, `group-chat-view`). 561 app tests, typecheck, build green.

Part of epic `cave-xsq`; closes `cave-xsq.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)