### PR TITLE
fix(chat): stale-state fixes on rapid thread/root switch + /clear teardown (cave-b63)

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -363,4 +363,13 @@ assert.match(
   "cave-turn-found must disable its animation under prefers-reduced-motion (static tint instead)",
 );
 
+// cave-b63 (3): Back/Forward into a #chat-<id> before sessions load shows the
+// "Opening chat…" takeover (the popstate not-loaded branch arms the pending
+// flag, matching the mount-restore path).
+assert.match(
+  workspaceSource,
+  /pendingChatDeepLinkRef\.current = sid;\s*\n\s*\/\/[\s\S]*?setChatDeepLinkPending\(true\);/,
+  "the popstate deep-link-not-loaded branch shows the Opening chat… indicator",
+);
+
 console.log("chat-router-switching.test.ts: ok");

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -279,3 +279,18 @@ assert.match(
   /onAgentsNewChat[\s\S]*modeRef\.current === "chat"[\s\S]*return/,
   "Workspace skips the bridge when already in chat (ChatSurface owns it) to avoid double-open",
 );
+
+// cave-b63 (2): the change-count fetch dedupe is per effect-run (local), not a
+// cross-run ref — so a quick root switch's new fetch isn't blocked by the old
+// root's still-in-flight fetch (which left the badge showing a stale count), and
+// the count resets on a real root change.
+assert.match(
+  chatSurface,
+  /let inFlight = false;[\s\S]*?const load = async \(\) => \{\s*\n\s*if \(inFlight\) return;/,
+  "change-count fetch dedupe is scoped per effect-run, not a cross-run ref",
+);
+assert.match(
+  chatSurface,
+  /if \(changeCountRootRef\.current !== root\) \{\s*\n\s*setChangeCount\(0\);/,
+  "changeCount resets on a real root change so the badge doesn't show the previous project's count",
+);

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -282,14 +282,25 @@ export function ChatSurface({
   // length), re-polled on the `cave:changes-refresh` edit signal and, while the
   // session is running, a light 5s interval gated on document visibility.
   const [changeCount, setChangeCount] = useState(0);
-  const changeFetchInFlight = useRef(false);
+  const changeCountRootRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!effectiveRailRoot) { setChangeCount(0); return; }
+    if (!effectiveRailRoot) { setChangeCount(0); changeCountRootRef.current = null; return; }
     const root = effectiveRailRoot;
+    // On a root switch, clear the previous root's count while we load this one —
+    // otherwise the badge lingers on the old project's number. (Only on a real
+    // root change, so a sessionRunning toggle on the same root doesn't flash.)
+    if (changeCountRootRef.current !== root) {
+      setChangeCount(0);
+      changeCountRootRef.current = root;
+    }
     let cancelled = false;
+    // Coalesce the initial load with refresh-event / interval loads for THIS
+    // root only. A previous cross-run ref wrongly blocked the new root's first
+    // load when the old root's fetch was still in flight, leaving a stale count.
+    let inFlight = false;
     const load = async () => {
-      if (changeFetchInFlight.current) return;
-      changeFetchInFlight.current = true;
+      if (inFlight) return;
+      inFlight = true;
       try {
         const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(root)}`, { cache: "no-store" });
         const json = (await res.json().catch(() => ({}))) as { ok?: boolean; files?: unknown[] };
@@ -298,7 +309,7 @@ export function ChatSurface({
       } catch {
         if (!cancelled) setChangeCount(0);
       } finally {
-        changeFetchInFlight.current = false;
+        inFlight = false;
       }
     };
     void load();

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -570,4 +570,31 @@ assert.match(
   );
 }
 
+// cave-b63 (1): model-state / usage-plan refreshes gate their setState on a
+// caller predicate so a fetch resolving after a thread switch can't overwrite
+// the new thread's model/plan; the effects pass () => !cancelled.
+assert.match(
+  source,
+  /refreshModelState = useCallback\(async \(shouldApply: \(\) => boolean = \(\) => true\)[\s\S]*?if \(shouldApply\(\)\) setModelState\(next\);/,
+  "refreshModelState only applies its result when the caller's shouldApply() allows it",
+);
+assert.match(
+  source,
+  /void refreshModelState\(\(\) => !cancelled\);/,
+  "the model-state effect vetoes a stale apply via () => !cancelled",
+);
+assert.match(
+  source,
+  /void refreshUsagePlan\(undefined, \(\) => !cancelled\);/,
+  "the usage-plan effect vetoes a stale apply via () => !cancelled",
+);
+
+// cave-b63 (4): /clear tears down any in-flight stream first (cancelSend) so the
+// live registry doesn't mirror the cleared turns back on the next chunk.
+assert.match(
+  source,
+  /if \(command === "\/clear"\) \{\s*\n\s*\/\/[\s\S]*?cancelSend\(\);\s*\n\s*liveSessionIdRef\.current = null;\s*\n\s*setTurns\(\[\]\);/,
+  "/clear cancels an in-flight stream before clearing the transcript",
+);
+
 console.log("chat-view-lifecycle.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2306,23 +2306,26 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     if (el) el.scrollTop = Math.max(0, el.scrollHeight - anchor);
   }, [historyExpanded]);
 
-  const refreshModelState = useCallback(async (): Promise<ChatModelState | null> => {
+  // `shouldApply` lets a caller (the effect below) veto the setState after the
+  // await — a fetch that resolves after a thread switch must not overwrite the
+  // new thread's model. Non-effect callers omit it and always apply.
+  const refreshModelState = useCallback(async (shouldApply: () => boolean = () => true): Promise<ChatModelState | null> => {
     const params = new URLSearchParams({ familiarId: familiar.id });
     if (sessionId) params.set("sessionId", sessionId);
     try {
       const res = await fetch(`/api/chat/model-state?${params.toString()}`, { cache: "no-store" });
       const json = (await res.json()) as { ok?: boolean; state?: ChatModelState };
       const next = json.ok && json.state ? json.state : null;
-      setModelState(next);
+      if (shouldApply()) setModelState(next);
       return next;
     } catch {
-      setModelState(null);
+      if (shouldApply()) setModelState(null);
       return null;
     }
   }, [familiar.id, sessionId]);
 
   const refreshUsagePlan = useCallback(
-    async (modelOverride?: string | null): Promise<ChatUsagePlanSnapshot | null> => {
+    async (modelOverride?: string | null, shouldApply: () => boolean = () => true): Promise<ChatUsagePlanSnapshot | null> => {
       const params = new URLSearchParams({ familiarId: familiar.id });
       if (sessionId) params.set("sessionId", sessionId);
       const model =
@@ -2335,10 +2338,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         const res = await fetch(`/api/chat/usage?${params.toString()}`, { cache: "no-store" });
         const json = (await res.json()) as { ok?: boolean; snapshot?: ChatUsagePlanSnapshot };
         const next = json.ok && json.snapshot ? json.snapshot : null;
-        setUsagePlan(next);
+        if (shouldApply()) setUsagePlan(next);
         return next;
       } catch {
-        setUsagePlan(null);
+        if (shouldApply()) setUsagePlan(null);
         return null;
       }
     },
@@ -2347,12 +2350,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
-      const next = await refreshModelState();
-      // refreshModelState already set state; guard only against a stale familiar
-      // swap landing after unmount/re-fetch.
-      if (cancelled && next) return;
-    })();
+    // Gate the setState on !cancelled so a fetch resolving after a thread switch
+    // (refreshModelState is memoized on [familiar.id, sessionId]) can't overwrite
+    // the new thread's model with the previous one's.
+    void refreshModelState(() => !cancelled);
     return () => {
       cancelled = true;
     };
@@ -2360,10 +2361,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
-      const next = await refreshUsagePlan();
-      if (cancelled && next) return;
-    })();
+    void refreshUsagePlan(undefined, () => !cancelled);
     return () => {
       cancelled = true;
     };
@@ -3400,6 +3398,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     const command = canonicalize(token) ?? token;
 
     if (command === "/clear") {
+      // Tear down any in-flight stream first (no-op when idle). Otherwise the
+      // live registry stays the source of truth and the next assistant_chunk
+      // mirrors the just-cleared turns back, while busy stays set.
+      cancelSend();
       liveSessionIdRef.current = null;
       setTurns([]);
       setActiveLeafId("");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1502,6 +1502,9 @@ export function Workspace() {
         }
         if (!sessionsLoadedRef.current) {
           pendingChatDeepLinkRef.current = sid;
+          // Show the "Opening chat…" takeover while sessions settle, matching the
+          // mount-restore path; the deep-link resolver clears it on found/stale.
+          setChatDeepLinkPending(true);
           return;
         }
         clearChatHash();


### PR DESCRIPTION
The lower-severity remainder from the chat audit — four stale-state-on-switch bugs, each verified in source before fixing.

## Fixes
1. **Model-state / usage-plan stale write.** `refreshModelState`/`refreshUsagePlan` called `setState` unconditionally, so the effect's post-await `cancelled` guard was a no-op — a fetch resolving after a fast thread switch overwrote the new thread's model chip / usage readout. They now gate `setState` on a `shouldApply` predicate; the effects pass `() => !cancelled`. (Non-effect callers are unchanged.)
2. **changeCount badge staleness.** chat-surface used a cross-run `changeFetchInFlight` ref that blocked the **new** rail root's first fetch while the old root's was in flight, leaving the previous project's count on the badge. The dedupe is now scoped to the effect run, and the count resets on a real root change.
3. **Popstate deep-link indicator.** The workspace popstate handler stashed a not-yet-loaded `#chat-<id>` but never set `chatDeepLinkPending`, so Back/Forward into a chat before sessions loaded showed a Home/list flash instead of the "Opening chat…" takeover. One line, matching the mount path.
4. **`/clear` mid-stream.** `/clear` cleared the transcript without tearing down an in-flight stream, so the live registry mirrored the cleared turns back on the next chunk (and `busy` stayed set). It now calls `cancelSend()` first (a no-op when idle).

## Verification
- `tsc` clean; **full `test:app` (561 files) green**; build within budget.
- New source-scan pins in `chat-view-lifecycle`, `chat-surface`, and `chat-router-switching` tests.

## Scope
Closes cave-b63. The related `/help` `appendSystem`-mid-stream revert (it bypasses the live registry — a deeper refactor) is tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)