### PR TITLE
feat(familiars): drag-to-reorder the Lifecycle roster + button-matched avatar radius (cave-f2vo)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6940,8 +6940,12 @@ a.mobile-handoff__link:hover {
 .familiar-studio-lifecycle__btn:hover { background: color-mix(in oklch, var(--text-primary) 8%, var(--bg-raised)); }
 .familiar-studio-lifecycle__btn--danger { color: var(--color-danger); }
 .familiar-studio-lifecycle__btn--confirm { background: var(--color-danger); color: var(--bg-base); border-color: transparent; }
-.familiar-studio-lifecycle__row { display: flex; gap: 4px; padding: 4px; border-radius: 6px; }
+.familiar-studio-lifecycle__row { display: flex; align-items: center; gap: 4px; padding: 4px; border-radius: 6px; }
 .familiar-studio-lifecycle__row:hover { background: var(--bg-raised); }
+.familiar-studio-lifecycle__row[data-dragging] { background: var(--bg-raised); box-shadow: var(--shadow-popover); opacity: 0.95; position: relative; z-index: 1; }
+.familiar-studio-lifecycle__grip { display: grid; place-items: center; width: 20px; height: 24px; flex-shrink: 0; background: transparent; border: none; color: var(--text-faint); cursor: grab; touch-action: none; }
+.familiar-studio-lifecycle__grip:hover { color: var(--text-secondary); }
+.familiar-studio-lifecycle__row[data-dragging] .familiar-studio-lifecycle__grip { cursor: grabbing; }
 .familiar-studio-lifecycle__row-main { display: flex; gap: 8px; align-items: center; flex: 1; background: transparent; border: none; padding: 4px 6px; cursor: pointer; color: var(--text-primary); font-size: 13px; }
 .familiar-studio-lifecycle__row-action { display: grid; place-items: center; width: 24px; height: 24px; border-radius: 4px; background: transparent; border: none; color: var(--text-secondary); cursor: pointer; }
 .familiar-studio-lifecycle__row-action:hover:not(:disabled) { color: var(--text-primary); background: var(--bg-base); }

--- a/src/components/familiar-avatar.test.ts
+++ b/src/components/familiar-avatar.test.ts
@@ -11,6 +11,9 @@ assert.match(source, /avatarImage/, "Must consume the avatarImage field");
 assert.match(source, /FamiliarGlyph/, "Must fall back to FamiliarGlyph when no image");
 assert.match(source, /<img/, "Must render an <img> for image avatars");
 assert.match(source, /alt=/, "img must have alt text for a11y");
+// The default avatar corner radius tracks the standardized control radius so
+// familiar icons match the shared Button/IconButton roundedness.
+assert.match(source, /rounded-\[var\(--radius-control\)\]/, "default avatar radius matches the standardized control radius");
 
 // The avatar image is preferred over the glyph, and EVERY image source is tried
 // before the glyph: a failed load advances through the source list (workspace

--- a/src/components/familiar-avatar.tsx
+++ b/src/components/familiar-avatar.tsx
@@ -49,7 +49,7 @@ export function FamiliarAvatar({ familiar, size = "md", className, title, expand
       alt={familiar.display_name}
       width={px}
       height={px}
-      className={className ?? "inline-block rounded-sm object-cover"}
+      className={className ?? "inline-block rounded-[var(--radius-control)] object-cover"}
       title={title}
       onError={() => setSrcIdx((i) => i + 1)}
     />

--- a/src/components/familiar-studio-lifecycle-tab.test.ts
+++ b/src/components/familiar-studio-lifecycle-tab.test.ts
@@ -24,6 +24,13 @@ assert.match(source, /canMoveDown/, "Rows expose canMoveDown prop for disabled-e
 assert.match(source, /ph:arrow-up-bold/, "Move-up icon is wired");
 assert.match(source, /ph:arrow-down-bold/, "Move-down icon is wired");
 
+// The active roster is also drag-reorderable (dnd-kit), alongside the arrows.
+assert.match(source, /DndContext/, "active roster is wrapped in a DndContext");
+assert.match(source, /SortableContext/, "active rows are sortable");
+assert.match(source, /useSortable/, "each active row hooks the sortable transform");
+assert.match(source, /ph:dots-six-vertical/, "each active row exposes a drag grip");
+assert.match(source, /arrayMove\(ids, oldIndex, newIndex\)/, "drag reorder moves the id then persists via setFamiliarOrder");
+
 // The roster order here is distinct from the avatar-strip pin order in
 // Appearance — the hint cross-links so users find both (2026-07-06).
 assert.match(source, /avatar strip's pinned order/, "lifecycle hint disambiguates roster order from pin order");

--- a/src/components/familiar-studio-lifecycle-tab.tsx
+++ b/src/components/familiar-studio-lifecycle-tab.tsx
@@ -1,6 +1,23 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Icon } from "@/lib/icon";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import {
@@ -31,6 +48,30 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
   // selected familiar's per-familiar controls (reset) below it.
   const active = allResolved.filter((f) => !(f.id in archived));
   const archivedList = allResolved.filter((f) => f.id in archived);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  // Rebuild the full roster order from a reordered active list, keeping archived
+  // familiars in their existing slots — the same order model the up/down arrows
+  // persist through.
+  function reorderTo(activeIds: string[]) {
+    let ai = 0;
+    const fullIds = allResolved.map((f) => (f.id in archived ? f.id : activeIds[ai++]));
+    setFamiliarOrder(fullIds);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active: dragged, over } = event;
+    if (!over || dragged.id === over.id) return;
+    const ids = active.map((f) => f.id);
+    const oldIndex = ids.indexOf(String(dragged.id));
+    const newIndex = ids.indexOf(String(over.id));
+    if (oldIndex < 0 || newIndex < 0) return;
+    reorderTo(arrayMove(ids, oldIndex, newIndex));
+  }
 
   function move(id: string, direction: "up" | "down") {
     const ids = allResolved.map((f) => f.id);
@@ -80,20 +121,28 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
           </button>
           .
         </p>
-        {active.map((f, i) => (
-          <FamiliarRow
-            key={f.id}
-            familiar={f}
-            isArchived={false}
-            canMoveUp={i > 0}
-            canMoveDown={i < active.length - 1}
-            onSelect={() => openFamiliarStudio(f.id, "identity")}
-            onArchive={() => archiveFamiliar(f.id)}
-            onUnarchive={() => unarchiveFamiliar(f.id)}
-            onMoveUp={() => move(f.id, "up")}
-            onMoveDown={() => move(f.id, "down")}
-          />
-        ))}
+        <DndContext
+          id="familiar-lifecycle-order"
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext items={active.map((f) => f.id)} strategy={verticalListSortingStrategy}>
+            {active.map((f, i) => (
+              <SortableFamiliarRow
+                key={f.id}
+                familiar={f}
+                canMoveUp={i > 0}
+                canMoveDown={i < active.length - 1}
+                onSelect={() => openFamiliarStudio(f.id, "identity")}
+                onArchive={() => archiveFamiliar(f.id)}
+                onUnarchive={() => unarchiveFamiliar(f.id)}
+                onMoveUp={() => move(f.id, "up")}
+                onMoveDown={() => move(f.id, "down")}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
       </section>
       {archivedList.length > 0 ? (
         <section>
@@ -135,6 +184,37 @@ export function FamiliarStudioLifecycleTab({ familiar, allResolved }: Props) {
   );
 }
 
+// Active rows are draggable; the sortable wrapper feeds the drag handle +
+// transform down into the shared FamiliarRow.
+function SortableFamiliarRow(props: {
+  familiar: ResolvedFamiliar;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onSelect: () => void;
+  onArchive: () => void;
+  onUnarchive: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: props.familiar.id,
+  });
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  };
+  return (
+    <FamiliarRow
+      {...props}
+      isArchived={false}
+      dragRef={setNodeRef}
+      dragStyle={style}
+      isDragging={isDragging}
+      dragHandle={{ ...attributes, ...listeners }}
+    />
+  );
+}
+
 function FamiliarRow({
   familiar,
   isArchived,
@@ -145,6 +225,10 @@ function FamiliarRow({
   onUnarchive,
   onMoveUp,
   onMoveDown,
+  dragRef,
+  dragStyle,
+  isDragging,
+  dragHandle,
 }: {
   familiar: ResolvedFamiliar;
   isArchived: boolean;
@@ -155,9 +239,28 @@ function FamiliarRow({
   onUnarchive: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  dragRef?: (node: HTMLElement | null) => void;
+  dragStyle?: CSSProperties;
+  isDragging?: boolean;
+  dragHandle?: Record<string, unknown>;
 }) {
   return (
-    <div className="familiar-studio-lifecycle__row">
+    <div
+      ref={dragRef}
+      style={dragStyle}
+      data-dragging={isDragging || undefined}
+      className="familiar-studio-lifecycle__row"
+    >
+      {dragHandle ? (
+        <button
+          type="button"
+          className="familiar-studio-lifecycle__grip focus-ring"
+          aria-label={`Drag to reorder ${familiar.display_name}`}
+          {...dragHandle}
+        >
+          <Icon name="ph:dots-six-vertical" width={13} aria-hidden />
+        </button>
+      ) : null}
       <button type="button" onClick={onSelect} className="familiar-studio-lifecycle__row-main">
         <FamiliarAvatar familiar={familiar} size="sm" />
         <span>{familiar.display_name}</span>


### PR DESCRIPTION
Two polish items on Settings → Familiars → Lifecycle:

**1. Drag-to-reorder the active roster** — dnd-kit sortable grip (⠿) mirroring the Appearance pin-order surface; drag persists through the same setFamiliarOrder path. The up/down arrows stay (keyboard/click, no regressions).

**2. Avatar roundedness** — FamiliarAvatar's default moves from near-square rounded-sm to --radius-control (8px), the shared Button/IconButton radius, so familiar icons match the buttons everywhere (28 default call sites; the 8 with explicit className unaffected). Global default change — say the word to scope it to just the Lifecycle list.

Verified: typecheck clean; familiar-studio-lifecycle-tab + familiar-avatar tests updated (drag wiring + radius pin) green; 560 app tests, 755 wired, bundle within budget. Drag pattern copied from the shipping familiar-pin-order surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)