### PR TITLE
[codex] fix Windows BrowserPane webview click interception

### DIFF
--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -77,6 +77,10 @@ type TauriBridge = {
   listen: <T = unknown>(event: string, cb: (e: { payload: T }) => void) => Promise<() => void>;
 };
 
+type TauriInternals = {
+  invoke?: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+};
+
 async function loadTauri(): Promise<TauriBridge | null> {
   if (typeof window === "undefined") return null;
   // @ts-expect-error Tauri runtime
@@ -84,6 +88,17 @@ async function loadTauri(): Promise<TauriBridge | null> {
   const { invoke } = await import("@tauri-apps/api/core");
   const { listen } = await import("@tauri-apps/api/event");
   return { invoke, listen };
+}
+
+function invokeNativeBrowserCloseAll(bridge: TauriBridge | null, label: string): void {
+  if (bridge) {
+    void bridge.invoke("browser_close_all", { label });
+    return;
+  }
+  const internals = typeof window === "undefined"
+    ? null
+    : (window as typeof window & { __TAURI_INTERNALS__?: TauriInternals }).__TAURI_INTERNALS__;
+  void internals?.invoke?.("browser_close_all", { label });
 }
 
 const HOME_URL = "https://opencoven.ai";
@@ -241,7 +256,7 @@ export type BrowserPaneHandle = {
   navigateTo: (url: string) => void;
 };
 
-export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activeFamiliarId?: string | null }>(function BrowserPane({ label = "default", activeFamiliarId = null }: { label?: string; activeFamiliarId?: string | null }, ref: React.Ref<BrowserPaneHandle>) {
+export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activeFamiliarId?: string | null; active?: boolean }>(function BrowserPane({ label = "default", activeFamiliarId = null, active = true }: { label?: string; activeFamiliarId?: string | null; active?: boolean }, ref: React.Ref<BrowserPaneHandle>) {
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const paneRef = useRef<HTMLDivElement | null>(null);
   const [bridge, setBridge] = useState<TauriBridge | null>(null);
@@ -328,10 +343,18 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
   bridgeRef.current = bridge;
   useEffect(() => {
     return () => {
-      void bridgeRef.current?.invoke("browser_close_all", { label });
+      invokeNativeBrowserCloseAll(bridgeRef.current, label);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Native child webviews are OS-level layers above the React DOM. If this pane
+  // is kept mounted while inactive, fail closed so stale browser layers cannot
+  // cover visible controls elsewhere in the app.
+  useEffect(() => {
+    if (active) return;
+    invokeNativeBrowserCloseAll(bridge, label);
+  }, [active, bridge, label]);
 
   // ── Page-load + title events ──────────────────────────────────────
   useEffect(() => {
@@ -405,7 +428,10 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
   // stale and overlapping the toolbar. Reconcile against the live rect
   // every frame instead, issuing IPC only when the rounded bounds change.
   useEffect(() => {
-    if (!bridge || !nativeBrowserAvailable) return;
+    if (!active || !bridge || !nativeBrowserAvailable) {
+      if (!active) invokeNativeBrowserCloseAll(bridge, label);
+      return;
+    }
     const surface = surfaceRef.current;
     if (!surface) return;
 
@@ -474,11 +500,11 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
       hideAll();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bridge, nativeBrowserAvailable, label, activeTabId, tabs.map((t) => t.id).join(",")]);
+  }, [active, bridge, nativeBrowserAvailable, label, activeTabId, tabs.map((t) => t.id).join(",")]);
 
   // ── Navigate active tab when URL changes ─────────────────────────
   useEffect(() => {
-    if (!bridge || !nativeBrowserAvailable || !activeTab) return;
+    if (!active || !bridge || !nativeBrowserAvailable || !activeTab) return;
     // Small delay to let panel layout fully settle before reading bounds
     const timer = setTimeout(() => {
       const surface = surfaceRef.current;
@@ -504,7 +530,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
     }, 80);
     return () => clearTimeout(timer);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bridge, nativeBrowserAvailable, activeTab?.url, activeTab?.id]);
+  }, [active, bridge, nativeBrowserAvailable, activeTab?.url, activeTab?.id]);
 
   // ── Localhost probe ───────────────────────────────────────────────
   // Each closed port logs an ERR_CONNECTION_REFUSED in the console (a no-cors

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 
 const pane = await readFile(new URL("./browser-pane.tsx", import.meta.url), "utf8");
 const globals = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const rustBrowser = await readFile(new URL("../../src-tauri/src/browser.rs", import.meta.url), "utf8");
 
 // ───────── Task 1: Keyboard hint footer + [ shortcut ─────────
@@ -34,7 +35,7 @@ assert.match(
 );
 assert.match(
   pane,
-  /function loadRailPinned\(\)[\s\S]*?if \(raw === "0"\) return false;[\s\S]*?return true;\n\}/,
+  /function loadRailPinned\(\)[\s\S]*?if \(raw === "0"\) return false;[\s\S]*?return true;\r?\n\}/,
   "loadRailPinned() must default to true (rail open) when no preference is stored",
 );
 assert.match(
@@ -156,8 +157,53 @@ assert.match(
 // surface. Unmount must CLOSE the pane's webviews, not hide them.
 assert.match(
   pane,
-  /useEffect\(\(\) => \{\s*\n\s*return \(\) => \{\s*\n\s*void bridgeRef\.current\?\.invoke\("browser_close_all", \{ label \}\);/,
-  "unmount cleanup closes the pane's native webviews (browser_close_all), not just hides them",
+  /function invokeNativeBrowserCloseAll\(bridge: TauriBridge \| null, label: string\): void/,
+  "BrowserPane has a direct native-webview close helper",
+);
+assert.match(
+  pane,
+  /invokeNativeBrowserCloseAll\(bridgeRef\.current, label\);/,
+  "unmount cleanup closes the pane's native webviews through the fail-closed helper",
+);
+assert.match(
+  pane,
+  /__TAURI_INTERNALS__\?: TauriInternals/,
+  "cleanup can call browser_close_all through Tauri internals before the async bridge is ready",
+);
+assert.match(
+  pane,
+  /active\?: boolean/,
+  "BrowserPane accepts an explicit active flag",
+);
+assert.match(
+  pane,
+  /if \(active\) return;[\s\S]{0,120}invokeNativeBrowserCloseAll\(bridge, label\);/,
+  "inactive BrowserPane instances close their native webviews",
+);
+assert.match(
+  pane,
+  /if \(!active \|\| !bridge \|\| !nativeBrowserAvailable\)/,
+  "bounds sync cannot re-show a native browser layer while inactive",
+);
+assert.match(
+  pane,
+  /if \(!active \|\| !bridge \|\| !nativeBrowserAvailable \|\| !activeTab\) return;/,
+  "navigation cannot create or re-seat native browser layers while inactive",
+);
+assert.match(
+  workspace,
+  /function closeAllNativeBrowserWebviews\(\): void/,
+  "Workspace has a native browser cleanup helper",
+);
+assert.match(
+  workspace,
+  /mode === "browser" \|\|[\s\S]{0,180}target\.kind === "browser" \|\| \(target\.kind === "page" && target\.mode === "browser"\)/,
+  "Workspace tracks browser visibility across primary and split panes",
+);
+assert.match(
+  workspace,
+  /if \(browserVisible\) return;[\s\S]{0,80}closeAllNativeBrowserWebviews\(\);/,
+  "Workspace closes stale native browser webviews when Browser is no longer visible",
 );
 assert.match(
   rustBrowser,
@@ -200,14 +246,14 @@ assert.match(pane, /if \(document\.visibilityState !== "visible" \|\| now - last
 
 // ───────── a11y: tab strip is a real tablist ─────────
 assert.match(pane, /role="tablist" aria-orientation="vertical"/, "tab strip is a tablist");
-assert.match(pane, /role="tab"\n\s*tabIndex=\{0\}/, "each tab uses role=tab");
+assert.match(pane, /role="tab"\r?\n\s*tabIndex=\{0\}/, "each tab uses role=tab");
 assert.match(pane, /aria-selected=\{isActive\}/, "the active tab is announced via aria-selected");
 assert.doesNotMatch(pane, /aria-pressed=\{isActive\}/, "tabs use aria-selected, not aria-pressed");
 assert.match(pane, /aria-label=\{`Close tab: \$\{title\}`\}/, "the close button names its tab");
 assert.match(pane, /aria-label="Address bar"/, "the address input is labeled");
 assert.match(pane, /inert=\{!toolbarOpen \|\| undefined\}/, "the collapsed toolbar is inert (its controls leave the tab order)");
 // quick-open palette is a focus-trapped dialog
-assert.match(qo, /role="dialog"\n\s*aria-modal="true"/, "quick-open palette is an aria-modal dialog");
+assert.match(qo, /role="dialog"\r?\n\s*aria-modal="true"/, "quick-open palette is an aria-modal dialog");
 assert.match(qo, /useFocusTrap\(true, cardRef, \{ onEscape: onClose/, "quick-open traps focus + restores it on close");
 
 console.log("browser-polish.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -100,6 +100,16 @@ import {
 
 type WorkspaceMode = WorkspaceModeFromDaemon;
 
+type WorkspaceTauriInternals = {
+  invoke?: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+};
+
+function closeAllNativeBrowserWebviews(): void {
+  if (typeof window === "undefined") return;
+  const internals = (window as typeof window & { __TAURI_INTERNALS__?: WorkspaceTauriInternals }).__TAURI_INTERNALS__;
+  void internals?.invoke?.("browser_close_all");
+}
+
 // What the drag-to-split secondary pane is showing: either a draggable page
 // (a workspace mode) or one of the companion surfaces (Salem / Memory /
 // Browser) that were re-homed here when the right rail was removed.
@@ -1912,6 +1922,17 @@ export function Workspace() {
     () => splitTargets.filter((t): t is Extract<SplitTarget, { kind: "page" }> => t.kind === "page").map((t) => t.mode),
     [splitTargets],
   );
+  const browserVisible = useMemo(
+    () =>
+      mode === "browser" ||
+      splitTargets.some((target) => target.kind === "browser" || (target.kind === "page" && target.mode === "browser")),
+    [mode, splitTargets],
+  );
+
+  useEffect(() => {
+    if (browserVisible) return;
+    closeAllNativeBrowserWebviews();
+  }, [browserVisible]);
 
   const sidebar = (
     <SidebarMinimal
@@ -2112,7 +2133,7 @@ export function Workspace() {
         }
       />
     ) : mode === "browser" ? (
-      <BrowserPane ref={browserPaneRef} label="main" activeFamiliarId={active?.id ?? null} />
+      <BrowserPane ref={browserPaneRef} label="main" activeFamiliarId={active?.id ?? null} active={browserVisible} />
     ) : mode === "github" ? (
       <GitHubView
         onJumpToSession={openFamiliarSession}
@@ -2173,7 +2194,7 @@ export function Workspace() {
     ) : target.kind === "memory" ? (
       <RailInspector familiar={active} onOpenFullView={() => setMode("agents")} />
     ) : (
-      <BrowserPane label="companion" activeFamiliarId={active?.id ?? null} />
+      <BrowserPane label="companion" activeFamiliarId={active?.id ?? null} active={browserVisible} />
     );
 
   const splitTiles: DetailSplitTile[] = splitTargets


### PR DESCRIPTION
## Summary
- Close native BrowserPane webviews when BrowserPane is inactive or unmounted so Windows native child webviews fail closed.
- Add a direct `__TAURI_INTERNALS__.invoke("browser_close_all")` fallback for cleanup before the async bridge ref is populated.
- Add workspace-level cleanup when browser mode/split panes are no longer visible, plus regression coverage for inactive cleanup and sync guards.

## Root cause
On Windows, WRY child webviews are native child windows above the DOM. A stale BrowserPane-native `WRY_WEBVIEW` could remain visible over React UI and intercept clicks; CSS or z-index cannot reliably fix that because the intercepting layer is outside the DOM stacking model.

## Validation
- `node --experimental-strip-types src/components/browser-polish.test.ts`
- `node --experimental-strip-types src/components/shell-edge-rails.test.ts`
- `node --experimental-strip-types src-tauri/permissions/desktop-permissions.test.mjs`
- `pnpm typecheck`
- `pnpm exec tauri build --no-bundle --config .codex-tauri-skip-prebuild.json`
- Launched `src-tauri/target/release/app.exe` on Windows for verification.
- Native window inspection on the corrected styled launch showed exactly one visible `WRY_WEBVIEW`, the main Tauri surface, with no stale BrowserPane overlay.

## Notes
MSI bundling was attempted, but WiX `light.exe` stalled for an extended period on this machine. The release executable build succeeded and was used for runtime verification.
