### PR TITLE
fix(windows): rebuild spawn PATH from the registry instead of a login shell (#2613)

### DIFF
--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { covenLaunchCommandForBinary } from "./coven-bin.ts";
+import { covenLaunchCommandForBinary, windowsPathFromRegQuery } from "./coven-bin.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 
@@ -86,6 +86,58 @@ assert.deepEqual(
   covenLaunchCommandForBinary(fallbackShim, "win32"),
   { command: process.execPath, fixedArgs: [fallbackScript] },
   "Windows .cmd shims fall back to the standard npm global coven.js location",
+);
+
+// Windows has no $SHELL, so the login-shell PATH probe always failed there
+// and refreshCovenSpawnEnv() could never see PATH entries added after launch
+// (e.g. npm's global dir right after the onboarding installer runs). The
+// registry is where those entries actually land.
+assert.match(
+  source,
+  /process\.platform === "win32"\s*\?\s*windowsRegistryPath\(\)\s*:\s*loginShellPath\(\)/,
+  "Windows spawn PATH comes from the registry, not a POSIX login-shell probe",
+);
+
+assert.match(
+  source,
+  /HKLM\\\\SYSTEM\\\\CurrentControlSet\\\\Control\\\\Session Manager\\\\Environment[\s\S]*HKCU\\\\Environment/,
+  "registry PATH merges the machine hive before the user hive, matching Windows' own order",
+);
+
+const regExpandOutput = [
+  "",
+  "HKEY_CURRENT_USER\\Environment",
+  "    Path    REG_EXPAND_SZ    %USERPROFILE%\\go\\bin;C:\\Program Files\\Git\\cmd;%COVEN_UNSET%\\bin",
+  "",
+].join("\r\n");
+
+assert.equal(
+  windowsPathFromRegQuery(regExpandOutput, { USERPROFILE: "C:\\Users\\annie" }),
+  "C:\\Users\\annie\\go\\bin;C:\\Program Files\\Git\\cmd;%COVEN_UNSET%\\bin",
+  "REG_EXPAND_SZ values expand %VAR% and leave unknown variables intact, like Windows does",
+);
+
+assert.equal(
+  windowsPathFromRegQuery(regExpandOutput, { UserProfile: "C:\\Users\\annie" }),
+  "C:\\Users\\annie\\go\\bin;C:\\Program Files\\Git\\cmd;%COVEN_UNSET%\\bin",
+  "%VAR% expansion is case-insensitive, like Windows env lookup",
+);
+
+assert.equal(
+  windowsPathFromRegQuery(
+    "HKEY_CURRENT_USER\\Environment\r\n    PATH    REG_SZ    %USERPROFILE%\\bin;C:\\tools\r\n",
+    { USERPROFILE: "C:\\Users\\annie" },
+  ),
+  "%USERPROFILE%\\bin;C:\\tools",
+  "REG_SZ values are returned verbatim (Windows does not expand them either)",
+);
+
+assert.equal(
+  windowsPathFromRegQuery(
+    "ERROR: The system was unable to find the specified registry key or value.",
+  ),
+  null,
+  "missing Path value yields null so the other hive still contributes",
 );
 
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -118,6 +118,61 @@ function loginShellPath(): string | null {
 }
 
 /**
+ * Parse the `Path` value out of `reg query <key> /v Path` output. For
+ * REG_EXPAND_SZ values, expand %VAR% references against `env`
+ * (case-insensitively, leaving unknown variables intact — both matching
+ * Windows' own expansion); REG_SZ values are returned verbatim.
+ * Exported for tests.
+ */
+export function windowsPathFromRegQuery(
+  output: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const match = /^\s*Path\s+(REG_SZ|REG_EXPAND_SZ)\s+(.+)$/im.exec(output);
+  const type = match?.[1];
+  const value = match?.[2]?.trim();
+  if (!type || !value) return null;
+  if (type.toUpperCase() !== "REG_EXPAND_SZ") return value;
+  const lookup = new Map(
+    Object.entries(env).map(([key, val]) => [key.toUpperCase(), val] as const),
+  );
+  return value.replace(
+    /%([^%;=]+)%/g,
+    (whole, name: string) => lookup.get(name.toUpperCase()) ?? whole,
+  );
+}
+
+// Windows equivalent of loginShellPath(): SHELL is unset there, so the
+// login-shell probe always fails and refreshCovenSpawnEnv() could never see
+// PATH entries added after launch. Installers (including our onboarding
+// `npm i -g @opencoven/cli` flow) register new tool dirs by editing the
+// machine/user Path in the registry and broadcasting WM_SETTINGCHANGE —
+// which already-running processes never receive. Re-reading the registry is
+// how a refresh actually picks those up without an app restart.
+function windowsRegistryPath(): string | null {
+  // Machine PATH first, then user PATH — the same order Windows itself uses
+  // when it builds a process environment.
+  const keys = [
+    "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment",
+    "HKCU\\Environment",
+  ];
+  const parts: string[] = [];
+  for (const key of keys) {
+    try {
+      const out = execFileSync("reg", ["query", key, "/v", "Path"], {
+        encoding: "utf-8",
+        timeout: 2000,
+      });
+      const value = windowsPathFromRegQuery(out);
+      if (value) parts.push(value);
+    } catch {
+      /* key or value missing — keep whatever the other hive provides */
+    }
+  }
+  return parts.length > 0 ? parts.join(path.delimiter) : null;
+}
+
+/**
  * Resolve the absolute path to the `coven` binary. If nothing is found,
  * returns the literal string "coven" so callers can still spawn — the OS
  * will resolve via PATH and surface a "not found" error to the user.
@@ -210,11 +265,12 @@ export function covenLaunchCommand(): CovenLaunchCommand {
  */
 export function covenSpawnEnv(): NodeJS.ProcessEnv {
   if (cachedPath === null) {
-    const fromShell = loginShellPath();
+    const fromSystem =
+      process.platform === "win32" ? windowsRegistryPath() : loginShellPath();
     const prependedDirs = candidateDirs();
     const parts = [
       ...prependedDirs,
-      ...(fromShell ? fromShell.split(path.delimiter) : []),
+      ...(fromSystem ? fromSystem.split(path.delimiter) : []),
       ...(process.env.PATH ? process.env.PATH.split(path.delimiter) : []),
     ];
     const seen = new Set<string>();


### PR DESCRIPTION
Re-land of #2613 by @mithril-logic (fork PRs cannot satisfy the required CodeQL default-setup check).

Windows has no $SHELL, so the login-shell PATH probe always failed and refreshCovenSpawnEnv() never saw PATH entries added after launch. Read the machine+user Path from the registry instead, expanding REG_EXPAND_SZ like Windows does.