### PR TITLE
fix(ui): platform-aware search shortcut badge instead of hard-coded ⌘K (#2617)

### DIFF
--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -2,6 +2,7 @@
 
 import { Icon } from "@/lib/icon";
 import { FamiliarQuickSwitch } from "@/components/familiar-quick-switch";
+import { useKeySymbols } from "@/lib/platform-keys";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 
@@ -70,6 +71,7 @@ export function FamiliarMenuBar({
   onViewSchedules,
   onOpenQuickChat,
 }: Props) {
+  const keys = useKeySymbols();
   const enrichLabel = enrichingTasks
     ? enrichProgress
       ? `${enrichProgress.done}/${enrichProgress.total}`
@@ -119,7 +121,7 @@ export function FamiliarMenuBar({
           autoComplete="off"
           spellCheck={false}
         />
-        <kbd>⌘K</kbd>
+        <kbd>{keys.mod}K</kbd>
       </form>
 
       <div className="menu-bar__group menu-bar__group--tasks">

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -5,6 +5,7 @@ import { NotificationBell } from "@/components/notification-bell";
 import { FamiliarQuickSwitch } from "@/components/familiar-quick-switch";
 import { OverflowMenu } from "@/components/ui/overflow-menu";
 import { PopoverItem } from "@/components/ui/popover";
+import { useKeySymbols } from "@/lib/platform-keys";
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -64,6 +65,7 @@ const ENRICH_TASKS_TITLE =
   "Enhance assigned familiar tasks: update subtasks, dates, description, status, priority, links, issues, and chats";
 
 export function TopBar(props: Props) {
+  const keys = useKeySymbols();
   const {
     onOpenPalette,
     searchQuery,
@@ -163,7 +165,7 @@ export function TopBar(props: Props) {
           autoComplete="off"
           spellCheck={false}
         />
-        <kbd>⌘K</kbd>
+        <kbd>{keys.mod}K</kbd>
       </form>
 
       <div className="top-bar__actions">


### PR DESCRIPTION
Re-land of #2617 by @mithril-logic (fork PRs cannot satisfy the required CodeQL default-setup check).

Uses useKeySymbols() so the search kbd badge shows Ctrl+K on Windows/Linux and ⌘K on macOS.