### PR TITLE
fix(windows): resolve coven through PATH before the literal-name fallback (#2612)

### DIFF
--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -115,7 +115,7 @@ assert.match(
 
 assert.match(
   source,
-  /import \{ covenBin, covenSpawnEnv, refreshCovenSpawnEnv \} from "@\/lib\/coven-bin"/,
+  /import \{\s*covenBin,\s*covenSpawnEnv,\s*pickWindowsLauncher,\s*refreshCovenSpawnEnv,?\s*\} from "@\/lib\/coven-bin"/,
   "install route can refresh Cave's cached PATH before declaring npm missing",
 );
 

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -5,7 +5,12 @@ import { constants as fsConstants } from "node:fs";
 import { dirname, join } from "node:path";
 import { promisify } from "node:util";
 import { stripAnsi } from "@/lib/ansi";
-import { covenBin, covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
+import {
+  covenBin,
+  covenSpawnEnv,
+  pickWindowsLauncher,
+  refreshCovenSpawnEnv,
+} from "@/lib/coven-bin";
 import { callDaemon } from "@/lib/coven-daemon";
 
 export const dynamic = "force-dynamic";
@@ -98,7 +103,13 @@ async function commandPath(
         env,
         timeout: 1500,
       });
-      return { path: stdout.trim().split(/\r?\n/)[0] || null };
+      const lines = stdout.split(/\r?\n/);
+      return {
+        path:
+          process.platform === "win32"
+            ? pickWindowsLauncher(lines)
+            : lines.map((l) => l.trim()).find(Boolean) ?? null,
+      };
     } catch (err) {
       const code = (err as { code?: unknown }).code;
       if (code === 1) return { path: null };

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
-import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenSpawnEnv, pickWindowsLauncher } from "@/lib/coven-bin";
 import {
   openCovenToolStatuses,
   type OpenCovenToolStatus,
@@ -85,7 +85,10 @@ async function commandPath(binary: string): Promise<string | null> {
       env: covenSpawnEnv(),
       timeout: 1500,
     });
-    return stdout.trim().split(/\r?\n/)[0] || null;
+    const lines = stdout.split(/\r?\n/);
+    return process.platform === "win32"
+      ? pickWindowsLauncher(lines)
+      : lines.map((l) => l.trim()).find(Boolean) ?? null;
   } catch {
     return null;
   }

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { covenLaunchCommandForBinary, windowsPathFromRegQuery } from "./coven-bin.ts";
+import { covenLaunchCommandForBinary, pickWindowsLauncher, windowsPathFromRegQuery } from "./coven-bin.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 
@@ -138,6 +138,41 @@ assert.equal(
   ),
   null,
   "missing Path value yields null so the other hive still contributes",
+);
+
+// `where` lists npm's extensionless POSIX launcher before the .cmd shim, and
+// a bare Windows spawn can only execute .exe/.com — so the picker must
+// prefer real launchers or spawn("coven") ENOENTs with the CLI on PATH.
+assert.equal(
+  pickWindowsLauncher(["C:\\node\\coven", "C:\\node\\coven.cmd", "C:\\shims\\coven.exe"]),
+  "C:\\shims\\coven.exe",
+  "a real .exe wins over shims and POSIX launchers",
+);
+
+assert.equal(
+  pickWindowsLauncher(["C:\\node\\coven", "C:\\node\\coven.cmd"]),
+  "C:\\node\\coven.cmd",
+  "npm's .cmd shim wins over the unspawnable extensionless launcher",
+);
+
+assert.equal(
+  pickWindowsLauncher(["C:\\node\\coven.CMD"]),
+  "C:\\node\\coven.CMD",
+  "extension matching is case-insensitive",
+);
+
+assert.equal(
+  pickWindowsLauncher(["", "  ", "C:\\node\\coven", ""]),
+  "C:\\node\\coven",
+  "falls back to the first non-blank entry when nothing spawnable exists",
+);
+
+assert.equal(pickWindowsLauncher([]), null, "empty `where` output yields null");
+
+assert.match(
+  source,
+  /execFileSync\("where", \["coven"\][\s\S]*pickWindowsLauncher/,
+  "covenBin falls back to `where` + launcher picking before the literal name on Windows",
 );
 
 console.log("coven-bin.test.ts: ok");

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -99,6 +99,22 @@ function candidateBinNames(): string[] {
   return process.platform === "win32" ? ["coven.cmd", "coven.exe", "coven"] : ["coven"];
 }
 
+/**
+ * Pick the spawnable launcher from `where` output. npm's global installs
+ * write three launchers per package (an extensionless POSIX script, a .cmd
+ * shim, and a .ps1), and `where` lists the extensionless one first — but a
+ * bare Windows spawn() can only execute .exe/.com, and a .cmd needs
+ * covenLaunchCommandForBinary() to convert it into a direct `node <script>`
+ * spawn. So prefer .exe/.com, then .cmd/.bat, and only then the first line
+ * (callers that merely display the path still get something).
+ */
+export function pickWindowsLauncher(lines: string[]): string | null {
+  const candidates = lines.map((line) => line.trim()).filter(Boolean);
+  const byExt = (...exts: string[]) =>
+    candidates.find((line) => exts.some((ext) => line.toLowerCase().endsWith(ext)));
+  return byExt(".exe", ".com") ?? byExt(".cmd", ".bat") ?? candidates[0] ?? null;
+}
+
 function loginShellPath(): string | null {
   // Read SHELL through a deliberately opaque accessor so Turbopack's static
   // analysis can't union the value with a string literal like "/bin/zsh"
@@ -207,6 +223,29 @@ export function covenBin(): string {
       } catch {
         /* not here; keep looking */
       }
+    }
+  }
+
+  // Nothing in the well-known dirs. On Windows, resolve through PATH with
+  // `where` before falling back to the literal name: npm installs the CLI
+  // as coven.cmd (plus an unspawnable extensionless POSIX script), and a
+  // bare spawn("coven") only resolves .exe/.com — so the literal fallback
+  // ENOENTs even when the CLI is plainly on PATH (scoop/winget node,
+  // cave-observed on Windows 11).
+  if (process.platform === "win32") {
+    try {
+      const out = execFileSync("where", ["coven"], {
+        encoding: "utf-8",
+        timeout: 1500,
+        env: covenSpawnEnv(),
+      });
+      const picked = pickWindowsLauncher(out.split(/\r?\n/));
+      if (picked) {
+        cachedBin = picked;
+        return cachedBin;
+      }
+    } catch {
+      /* not on PATH either — fall through to the literal fallback */
     }
   }
 

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -1,7 +1,12 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { compareSemver } from "@/lib/app-update";
-import { covenSpawnEnv, refreshCovenSpawnEnv } from "@/lib/coven-bin";
+import {
+  covenLaunchCommandForBinary,
+  covenSpawnEnv,
+  pickWindowsLauncher,
+  refreshCovenSpawnEnv,
+} from "@/lib/coven-bin";
 
 const execFileAsync = promisify(execFile);
 
@@ -58,7 +63,13 @@ async function commandPath(binary: string): Promise<string | null> {
         env,
         timeout: 1500,
       });
-      return stdout.trim().split(/\r?\n/)[0] || null;
+      const lines = stdout.split(/\r?\n/);
+      // `where` lists npm's unspawnable extensionless launcher first; the
+      // .cmd/.exe sibling is the one execFile can actually run (versions
+      // below, and callers that spawn the returned path).
+      return process.platform === "win32"
+        ? pickWindowsLauncher(lines)
+        : lines.map((l) => l.trim()).find(Boolean) ?? null;
     } catch {
       return null;
     }
@@ -80,8 +91,12 @@ function firstSemver(text: string): string | null {
 async function installedTool(tool: ToolSpec): Promise<InstalledTool | null> {
   const path = await commandPath(tool.binary);
   if (!path) return null;
+  // Node refuses to execFile a .cmd directly (EINVAL since the batch-file
+  // hardening); convert npm cmd-shims to a direct `node <script>` exec so
+  // the version probe works on Windows instead of silently reporting null.
+  const { command, fixedArgs } = covenLaunchCommandForBinary(path);
   try {
-    const { stdout, stderr } = await execFileAsync(path, tool.versionArgs, {
+    const { stdout, stderr } = await execFileAsync(command, [...fixedArgs, ...tool.versionArgs], {
       env: covenSpawnEnv(),
       timeout: 2500,
     });


### PR DESCRIPTION
Re-land of #2612 by @mithril-logic (fork PRs cannot satisfy the required CodeQL default-setup check).

On Windows, covenBin() now resolves through `where` + pickWindowsLauncher() (preferring .exe/.com, then .cmd/.bat) before the literal-name fallback, since a bare spawn("coven") cannot execute npm's extensionless launcher. Version probes convert .cmd shims via covenLaunchCommandForBinary().

Additional commit on top of the original: updates the source-pin assertion in src/app/api/onboarding/install/route.test.ts for the new multi-line import — this is what failed Frontend build on #2612.