### PR TITLE
feat(chat): code rail closed by default — the conversation owns the pane (cave-xsq.7)

### DIFF
--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -297,6 +297,6 @@ assert.match(
 );
 assert.match(
   chatSurface,
-  /if \(changeCountRootRef\.current !== root\) \{\s*\n\s*setChangeCount\(0\);/,
-  "changeCount resets on a real root change so the badge doesn't show the previous project's count",
+  /if \(changeCountRootRef\.current !== root\) \{\s*\n\s*setChangeCount\(null\);/,
+  "changeCount drops to null (unknown) on a real root change — clears the stale badge AND keeps first-load dirt from faking a fresh-batch reveal (cave-xsq.7)",
 );

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -281,16 +281,20 @@ export function ChatSurface({
   // project root. Mirrors session-changes-panel's /api/changes fetch (files
   // length), re-polled on the `cave:changes-refresh` edit signal and, while the
   // session is running, a light 5s interval gated on document visibility.
-  const [changeCount, setChangeCount] = useState(0);
+  // null = not yet loaded for this root. The distinction matters (cave-xsq.7):
+  // only a genuinely observed 0→N transition auto-reveals the closed-by-default
+  // rail, so pre-existing repo dirt arriving with the first load must come in
+  // over a null (unknown), not a fake zero.
+  const [changeCount, setChangeCount] = useState<number | null>(null);
   const changeCountRootRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!effectiveRailRoot) { setChangeCount(0); changeCountRootRef.current = null; return; }
+    if (!effectiveRailRoot) { setChangeCount(null); changeCountRootRef.current = null; return; }
     const root = effectiveRailRoot;
-    // On a root switch, clear the previous root's count while we load this one —
+    // On a root switch, drop to unknown while this root's count loads —
     // otherwise the badge lingers on the old project's number. (Only on a real
     // root change, so a sessionRunning toggle on the same root doesn't flash.)
     if (changeCountRootRef.current !== root) {
-      setChangeCount(0);
+      setChangeCount(null);
       changeCountRootRef.current = root;
     }
     let cancelled = false;
@@ -305,9 +309,12 @@ export function ChatSurface({
         const res = await fetch(`/api/changes?projectRoot=${encodeURIComponent(root)}`, { cache: "no-store" });
         const json = (await res.json().catch(() => ({}))) as { ok?: boolean; files?: unknown[] };
         if (cancelled) return;
-        setChangeCount(res.ok && json.ok ? (json.files?.length ?? 0) : 0);
+        // Failures stay `null` (unknown), never a fake zero — a transient
+        // error followed by a successful load must not read as a fresh 0→N
+        // edit batch and pop the closed-by-default rail open (cave-xsq.7).
+        setChangeCount(res.ok && json.ok ? (json.files?.length ?? 0) : null);
       } catch {
-        if (!cancelled) setChangeCount(0);
+        if (!cancelled) setChangeCount(null);
       } finally {
         inFlight = false;
       }
@@ -652,7 +659,7 @@ export function ChatSurface({
                 }}
               >
                 <Icon name="ph:code" width={16} aria-hidden />
-                {changeCount > 0 ? (
+                {(changeCount ?? 0) > 0 ? (
                   <span className="mobile-code-rail-toggle__badge">{changeCount}</span>
                 ) : null}
               </button>
@@ -755,7 +762,7 @@ export function ChatSurface({
                 >
                   {/* TODO: reconcile the duplicate Changes UI with RightPanel's SessionChangesPanel in a later PR of this arc */}
                   <WorkspaceRail
-                    changeCount={changeCount}
+                    changeCount={changeCount ?? 0}
                     activeTab={rail.activeTab}
                     pinned={rail.pinned}
                     projectRoot={effectiveRailRoot}
@@ -847,7 +854,7 @@ export function ChatSurface({
             aria-label="Code rail"
           >
             <WorkspaceRail
-              changeCount={changeCount}
+              changeCount={changeCount ?? 0}
               activeTab={rail.activeTab}
               pinned={rail.pinned}
               projectRoot={effectiveRailRoot}

--- a/src/components/mobile-code-rail.test.ts
+++ b/src/components/mobile-code-rail.test.ts
@@ -51,10 +51,11 @@ assert.match(
   "toggle button opens the sheet",
 );
 // The change-count badge rides the toggle when there are pending edits.
+// (changeCount is number|null since cave-xsq.7 — null coerces before compare.)
 assert.match(
   source,
-  /changeCount > 0[\s\S]{0,120}mobile-code-rail-toggle__badge/,
-  "toggle button shows the change-count badge when changeCount > 0",
+  /\(changeCount \?\? 0\) > 0[\s\S]{0,120}mobile-code-rail-toggle__badge/,
+  "toggle button shows the change-count badge when the loaded count is > 0",
 );
 
 // ── The sheet: cloned from chat-right-sheet ─────────────────────────────────

--- a/src/components/workspace-rail-wiring.test.ts
+++ b/src/components/workspace-rail-wiring.test.ts
@@ -127,8 +127,16 @@ assert.match(
 
 assert.match(
   source,
-  /<WorkspaceRail[\s\S]*?changeCount=\{changeCount\}[\s\S]*?activeTab=\{rail\.activeTab\}[\s\S]*?pinned=\{rail\.pinned\}[\s\S]*?onSelectTab=\{rail\.setActiveTab\}[\s\S]*?onTogglePin=\{rail\.togglePin\}[\s\S]*?onCollapse=\{\(\) => \{[\s\S]*?rail\.collapse\(\)/,
-  "WorkspaceRail receives changeCount + rail state/handlers; collapse also ends the browse peek",
+  /<WorkspaceRail[\s\S]*?changeCount=\{changeCount \?\? 0\}[\s\S]*?activeTab=\{rail\.activeTab\}[\s\S]*?pinned=\{rail\.pinned\}[\s\S]*?onSelectTab=\{rail\.setActiveTab\}[\s\S]*?onTogglePin=\{rail\.togglePin\}[\s\S]*?onCollapse=\{\(\) => \{[\s\S]*?rail\.collapse\(\)/,
+  "WorkspaceRail receives the null-coerced changeCount + rail state/handlers; collapse also ends the browse peek",
+);
+// Closed-by-default rail (cave-xsq.7): the count seeds as null (unknown) per
+// root and failures stay null, so pre-existing dirt arriving with the first
+// load can't fake the 0→N fresh-batch reveal.
+assert.match(
+  source,
+  /useState<number \| null>\(null\)/,
+  "changeCount seeds as null (not yet loaded) so first-load dirt can't fake a fresh batch",
 );
 
 assert.match(

--- a/src/lib/code-rail.test.ts
+++ b/src/lib/code-rail.test.ts
@@ -26,6 +26,28 @@ test("new AI edits (0→N) → open to Changes with the count", () => {
   assert.equal(r.activeTab, "changes");
 });
 
+// Closed-by-default (cave-xsq.7): only a genuinely OBSERVED 0→N transition is a
+// fresh batch. Pre-existing repo dirt arriving with the FIRST count load — the
+// previous tick saw null (unknown), not a real zero — must not pop the rail.
+test("first count load on a dirty repo does NOT auto-reveal (null → N is not a fresh batch)", () => {
+  const prev: CodeRailState = { available: true, open: false, activeTab: "files", changeCount: null };
+  const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: 12, dismissed: true }, prev);
+  assert.equal(r.available, true);
+  assert.equal(r.open, false, "pre-existing dirt stays closed — it isn't new agent edits");
+  assert.equal(r.activeTab, "files");
+});
+
+test("first render (prev = null) with a nonzero count does not auto-reveal either", () => {
+  const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: 5, dismissed: true }, null);
+  assert.equal(r.open, false, "no observed transition yet — nothing is 'fresh'");
+});
+
+test("unknown count (null) still counts the repo for availability, echoes null", () => {
+  const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: null }, null);
+  assert.equal(r.available, true);
+  assert.equal(r.changeCount, null, "null echoes so the next tick can tell unknown from a real zero");
+});
+
 test("new AI edits re-reveal even after a manual collapse", () => {
   const prev: CodeRailState = { available: true, open: false, activeTab: "files", changeCount: 0 };
   const r = resolveCodeRail({ ...base, hasRepo: true, changeCount: 2, dismissed: true }, prev);

--- a/src/lib/code-rail.ts
+++ b/src/lib/code-rail.ts
@@ -3,8 +3,11 @@ export type CodeRailTab = "changes" | "files" | "terminal";
 export type CodeRailSignals = {
   /** Active session is linked to a project/repo (session.project_root set). */
   hasRepo: boolean;
-  /** Number of pending AI edits (from /api/changes). 0 = none. */
-  changeCount: number;
+  /** Number of pending AI edits (from /api/changes). 0 = none. `null` = not yet
+   *  loaded for this root — pre-existing repo dirt arriving with the FIRST
+   *  count must not read as a fresh edit batch (cave-xsq.7): only a genuinely
+   *  observed 0→N transition auto-reveals the rail. */
+  changeCount: number | null;
   /** A pty/terminal session is running for this conversation. */
   terminalActive: boolean;
   /** User pinned the rail open (persisted preference). */
@@ -25,8 +28,10 @@ export type CodeRailState = {
   available: boolean;
   open: boolean;
   activeTab: CodeRailTab;
-  /** Echoed so the caller can feed it back as `prev` next tick. */
-  changeCount: number;
+  /** Echoed (null = count not yet loaded) so the caller can feed it back as
+   *  `prev` next tick — the 0→N reveal needs a REAL observed zero, not the
+   *  pre-load unknown. */
+  changeCount: number | null;
 };
 
 /**
@@ -39,16 +44,19 @@ export function resolveCodeRail(
   prev: CodeRailState | null,
 ): CodeRailState {
   const { hasRepo, changeCount, terminalActive, pinned, dismissed, browseActive } = signals;
-  const available = hasRepo || changeCount > 0 || terminalActive;
+  const available = hasRepo || (changeCount ?? 0) > 0 || terminalActive;
 
   if (!available) {
-    return { available: false, open: false, activeTab: prev?.activeTab ?? "files", changeCount: 0 };
+    return { available: false, open: false, activeTab: prev?.activeTab ?? "files", changeCount };
   }
 
-  // A fresh edit batch: changes went from 0 (or unknown) to > 0 — but never
-  // while browsing another project's files (its existing changes aren't new
-  // agent edits, and the peek explicitly wants the Files tab).
-  const newEdits = !browseActive && changeCount > 0 && (prev == null || prev.changeCount === 0);
+  // A fresh edit batch: a genuinely OBSERVED 0→N transition — the previous tick
+  // saw a real zero (not the pre-load `null` unknown), and now there are edits.
+  // Pre-existing repo dirt arriving with the first count load therefore does
+  // not auto-open the rail (cave-xsq.7), and a browse-at-root peek never
+  // reveals (its dirt isn't new agent edits — cave-z44).
+  const newEdits =
+    !browseActive && (changeCount ?? 0) > 0 && prev != null && prev.changeCount === 0;
 
   const open = pinned ? true : newEdits ? true : dismissed ? false : true;
 

--- a/src/lib/use-code-rail.test.ts
+++ b/src/lib/use-code-rail.test.ts
@@ -33,3 +33,17 @@ test("serializePinned round-trips", () => {
   assert.equal(parsePinned(serializePinned(true)), true);
   assert.equal(parsePinned(serializePinned(false)), false);
 });
+
+// Closed-by-default rail (cave-xsq.7): the hook seeds `dismissed` as TRUE so a
+// repo-linked session opens with the conversation owning the pane; the rail
+// opens on demand (pin / reopen / explicit focus target / a genuinely observed
+// fresh edit batch). Source pin — the initial useState is the contract.
+test("the rail rests closed: dismissed seeds true", async () => {
+  const { readFileSync } = await import("node:fs");
+  const src = readFileSync(new URL("./use-code-rail.ts", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /const \[dismissed, setDismissed\] = useState\(true\)/,
+    "dismissed defaults to true — the rail is closed at rest (cave-xsq.7)",
+  );
+});

--- a/src/lib/use-code-rail.ts
+++ b/src/lib/use-code-rail.ts
@@ -13,8 +13,10 @@ export function serializePinned(pinned: boolean): string {
 export type UseCodeRailArgs = {
   /** Active session's project_root (null/undefined = not repo-linked). */
   projectRoot: string | null | undefined;
-  /** Pending edit count for this session (0 = none). Caller polls /api/changes. */
-  changeCount: number;
+  /** Pending edit count for this session (0 = none, null = not yet loaded).
+   *  Caller polls /api/changes and must seed null per root so pre-existing
+   *  dirt can't fake a fresh-batch reveal (cave-xsq.7). */
+  changeCount: number | null;
   terminalActive: boolean;
   /** A "browse at root" peek is active — suppress the Changes auto-reveal so the
    *  browsed project stays on its Files tab (cave-z44). */
@@ -23,7 +25,12 @@ export type UseCodeRailArgs = {
 
 export function useCodeRail({ projectRoot, changeCount, terminalActive, browseActive }: UseCodeRailArgs) {
   const [pinned, setPinned] = useState(false);
-  const [dismissed, setDismissed] = useState(false);
+  // Closed at rest (cave-xsq.7): the conversation owns the pane by default.
+  // The rail opens on demand — pin, manual reopen, an explicit focus target
+  // (openCodeRailTarget calls reopen()), or a genuinely observed fresh edit
+  // batch (resolveCodeRail's 0→N reveal, which also clears this dismissal via
+  // the effect below).
+  const [dismissed, setDismissed] = useState(true);
   const [activeTab, setActiveTab] = useState<CodeRailTab>("files");
   const prevRef = useRef<CodeRailState | null>(null);
 

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, type Page } from "@playwright/test";
 
-// PR 1 / Task 4: the code rail (WorkspaceRail) auto-reveals beside the chat
-// conversation on the standalone chat surface when the active session is
-// repo-linked, tracks the pending-edit count from /api/changes (re-polled on
-// the cave:changes-refresh edit signal), and collapses to a slim reopen strip.
+// The code rail (WorkspaceRail) rests CLOSED beside the chat conversation
+// (cave-xsq.7 — the conversation owns the pane); a repo-linked session shows
+// the slim reopen strip instead. The rail opens on demand (strip / pin /
+// explicit focus target) and auto-reveals only on a genuinely observed 0→N
+// edit batch from /api/changes (re-polled on the cave:changes-refresh signal).
 // Daemon-less — onboarding dismissed, all endpoints mocked via page.route.
 
 const ISO = "2026-06-12T10:00:00.000Z";
@@ -85,26 +86,30 @@ test.describe("code rail beside chat", () => {
     await expect(page.locator(".workspace-rail")).toHaveCount(0);
   });
 
-  test("(b) repo session → rail visible; (c) edit signal reveals Changes badge; (d) collapse → reopen strip", async ({ page }) => {
+  test("(b) repo session → rail rests closed with the reopen strip; (c) a fresh 0→N edit batch auto-reveals with the Changes badge; (d) collapse → reopen strip", async ({ page }) => {
     const filesRef = { count: 0 };
     await routeChanges(page, filesRef);
     await base(page, [REPO_SESSION]);
     await openSession(page, "Refactor auth flow");
 
-    // (b) The rail auto-reveals for a repo-linked session even with no edits.
-    const rail = page.locator(".workspace-rail");
-    await expect(rail).toBeVisible({ timeout: 30_000 });
+    // (b) Closed by default (cave-xsq.7): a repo-linked session offers the slim
+    // reopen strip, but the conversation owns the pane — no rail at rest.
+    const reopen = page.locator(".workspace-rail-reopen");
+    await expect(reopen).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(".workspace-rail")).toHaveCount(0);
 
-    // (c) A fresh edit batch (2 files) arrives via the cave:changes-refresh
-    // signal → the Changes tab badge shows 2.
+    // (c) A genuinely observed fresh edit batch (the mocked count was a real 0,
+    // now 2 files arrive via the cave:changes-refresh signal) AUTO-REVEALS the
+    // rail with the Changes tab badge showing 2.
+    const rail = page.locator(".workspace-rail");
     filesRef.count = 2;
     await page.evaluate(() => window.dispatchEvent(new CustomEvent("cave:changes-refresh")));
+    await expect(rail).toBeVisible({ timeout: 15_000 });
     await expect(rail.locator(".workspace-rail__badge")).toHaveText("2", { timeout: 15_000 });
 
     // (d) Collapsing hides the rail and surfaces the slim reopen strip.
     await rail.getByRole("button", { name: "Collapse code rail" }).click();
     await expect(page.locator(".workspace-rail")).toHaveCount(0);
-    const reopen = page.locator(".workspace-rail-reopen");
     await expect(reopen).toBeVisible();
 
     // And the strip reopens the rail.
@@ -134,8 +139,10 @@ test.describe("code rail beside chat", () => {
     await base(page, [REPO_SESSION]);
     await openSession(page, "Refactor auth flow");
 
+    // Closed at rest (cave-xsq.7) — open the rail via the reopen strip.
+    await page.locator(".workspace-rail-reopen").click({ timeout: 30_000 });
     const rail = page.locator(".workspace-rail");
-    await expect(rail).toBeVisible({ timeout: 30_000 });
+    await expect(rail).toBeVisible({ timeout: 15_000 });
 
     // Switch to the Files tab — the placeholder is gone and the tree appears.
     await rail.getByRole("button", { name: "Files" }).click();
@@ -191,9 +198,10 @@ test.describe("code rail beside chat", () => {
     await routeChanges(page, filesRef);
     await base(page, [REPO_SESSION]);
     await openSession(page, "Refactor auth flow");
-    // Rail is the third-column Panel on desktop…
-    await expect(page.locator(".workspace-rail")).toBeVisible({ timeout: 30_000 });
-    // …and the mobile toggle affordance is absent.
+    // Closed at rest (cave-xsq.7) — the strip reopens the third-column Panel…
+    await page.locator(".workspace-rail-reopen").click({ timeout: 30_000 });
+    await expect(page.locator(".workspace-rail")).toBeVisible({ timeout: 15_000 });
+    // …and the mobile toggle affordance is absent on desktop.
     await expect(page.locator(".mobile-code-rail-toggle")).toHaveCount(0);
   });
 
@@ -209,8 +217,10 @@ test.describe("code rail beside chat", () => {
     await base(page, [REPO_SESSION]);
     await openSession(page, "Refactor auth flow");
 
+    // Closed at rest (cave-xsq.7) — open the rail via the reopen strip.
+    await page.locator(".workspace-rail-reopen").click({ timeout: 30_000 });
     const rail = page.locator(".workspace-rail");
-    await expect(rail).toBeVisible({ timeout: 30_000 });
+    await expect(rail).toBeVisible({ timeout: 15_000 });
 
     // The normal side rail has Changes/Files only; Terminal is reserved for
     // the user-expanded fullscreen rail.


### PR DESCRIPTION
**Phase 3.3** of the chat-first minimalism arc (epic `cave-xsq`), the first slice of the approved safer subset of Phase 3.

## Problem
The code rail opened **by default** on every repo-linked session, and the async change-count load made **pre-existing repo dirt** look like a fresh edit batch (0→N against a `prev.changeCount` seeded to 0) — auto-popping the rail on most real working repos. The conversation rarely owned its own pane.

## Change
- **`dismissed` seeds `true`** — the rail rests closed. It opens on: pin, the existing reopen strip, an explicit focus target (`openCodeRailTarget` calls `reopen()`, so file links and the Files drill-through are unchanged), or a fresh edit batch.
- **`changeCount` becomes `number | null`** (null = not yet loaded for this root; fetch failures stay null): the fresh-batch reveal now requires a **genuinely observed 0→N transition** (the previous tick saw a real zero). First-load dirt and root switches can't fake it — but *"the agent just edited files"* still auto-reveals to the Changes tab, and a fresh batch still overrides a manual collapse (pinned behaviors preserved).
- The right panel (Inspector/Debug/Changes) **already defaulted closed** — verified, no change.
- Pinned users keep their always-open preference.

## Verification
Live on a dirty repo (**30 pending changes**): rail closed at rest *after* the count loaded, reopen strip present, click opens it on demand. New pure-fn tests for the null semantics + a `dismissed`-default source pin; repointed 3 pins (wiring, mobile badge, root-reset). 560 app tests, typecheck, build green.

Part of epic `cave-xsq`; closes `cave-xsq.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)