### PR TITLE
feat(nav): chat-first hierarchy — Journal + Grimoire join the quiet cluster (cave-xsq.8)

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -392,10 +392,26 @@ assert.match(
   "The 56px rail has no room for text — the version line hides there",
 );
 
-// Quiet cluster (§8): occasional destinations (Marketplace, GitHub) stay in the
-// same flat list but render muted-until-hover, with the first quiet row opening
-// a spacing gap instead of a divider. (Browser is now navHidden, so Marketplace
-// leads the quiet cluster.)
+// Quiet cluster (§8): occasional destinations stay in the same flat list but
+// render muted-until-hover, with the first quiet row opening a spacing gap.
+// Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
+// ⌘-numbered daily set (Home ⌘1 · Chat ⌘2 · Tasks ⌘3 · Schedules ⌘4); Journal
+// and Grimoire lead the quiet cluster, followed by Marketplace/GitHub/Work Queue.
+assert.match(
+  source,
+  /\{ id: "journal",[^}]*quiet: true \}/,
+  "Journal is in the quiet cluster (cave-xsq.8)",
+);
+assert.match(
+  source,
+  /\{ id: "grimoire",[^}]*quiet: true \}/,
+  "Grimoire is in the quiet cluster (cave-xsq.8)",
+);
+assert.match(
+  source,
+  /id: "inbox",[\s\S]*?\{ id: "journal"/,
+  "the ⌘-numbered prominent cluster (…Schedules) renders above the quiet cluster",
+);
 assert.match(
   source,
   /\{ id: "marketplace",[^}]*quiet: true \}/,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -104,9 +104,14 @@ const FOLDER_MODES: Array<{
   // Group Chat ("coven") is no longer a standalone destination — it lives as the
   // Group tab inside Chat. The `groupchat` mode still exists as a redirect target.
   { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
-  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — opens in Settings" },
-  { id: "grimoire", label: "Grimoire", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents" },
   { id: "inbox", label: "Schedules", iconName: "ph:calendar-check", kbd: "⌘4", description: "Calendar and crons in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
+  // Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
+  // ⌘-numbered daily destinations (Home · Chat · Tasks · Schedules — Schedules
+  // also carries the needs-you badge). Journal and Grimoire join the quiet
+  // cluster: same flat list, same reachability (rows, palette, deep links),
+  // just muted-until-hover so the conversation-first surfaces read first.
+  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — opens in Settings", quiet: true },
+  { id: "grimoire", label: "Grimoire", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
   // Browser is summoned on demand (a clicked link/URL opens it, plus ⌘5 and the
   // ⌘K palette) rather than navigated to daily, so it's kept in the list for
   // those launchers but hidden from the sidebar rows.


### PR DESCRIPTION
**Phase 3.2** of the chat-first minimalism arc (epic `cave-xsq`) — the second slice of the approved safer Phase-3 subset.

## Change
The sidebar's prominent cluster is now exactly the **⌘-numbered daily set** — Home ⌘1 · Chat ⌘2 · Tasks ⌘3 · Schedules ⌘4 (Schedules also carries the needs-you badge). **Journal + Grimoire** move down to lead the existing quiet cluster alongside Marketplace, GitHub, and Work Queue.

Pure reuse of the §8 `quiet` pattern: same flat list, same roving tabindex, same click targets, still in the ⌘K palette and deep links — quiet rows just render muted-until-hover, and the first one opens the spacing gap. **Nothing is removed or relocated**; the nav simply reads conversation-first.

## Verification
Live on the expanded rail, rows resolve to:
`prominent [Home, Chat, Tasks, Schedules] → quiet [Journal, Grimoire, Marketplace, GitHub, Work Queue]`
New pins for the rule + cluster order. 560 app tests, typecheck, build green.

Part of epic `cave-xsq`; closes `cave-xsq.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)