### PR TITLE
feat(marketplace): adopt the shared compact header band (cave-uxi3)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8045,11 +8045,12 @@ a.mobile-handoff__link:hover {
   }
 }
 
-/* ── Schedules compact header ────────────────────────────────────────────────
+/* ── Surface compact header ──────────────────────────────────────────────────
    One slim topmost band (title · tabs · summary · filter · actions) mirroring
-   the GitHub surface's gh-compact-header, so operational surfaces share the
-   same minimalist chrome. Wraps gracefully on narrow widths. */
-.schedules-compact-header {
+   the GitHub surface's gh-compact-header, so operational surfaces (Schedules,
+   Marketplace, …) share the same minimalist chrome. Wraps gracefully on
+   narrow widths. */
+.surface-compact-header {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -8059,14 +8060,14 @@ a.mobile-handoff__link:hover {
   border-bottom: 1px solid var(--border-hairline);
 }
 
-.schedules-compact-title {
+.surface-compact-title {
   margin-right: 2px;
   font-size: 12px;
   font-weight: 600;
   color: var(--text-primary);
 }
 
-.schedules-compact-summary {
+.surface-compact-summary {
   display: flex;
   min-width: 0;
   flex-wrap: wrap;
@@ -8076,15 +8077,15 @@ a.mobile-handoff__link:hover {
   color: var(--text-muted);
 }
 
-.schedules-compact-actions {
+.surface-compact-actions {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-left: auto;
 }
 
-/* Keep the inline crons filter band-sized instead of full-width. */
-.schedules-compact-search {
+/* Keep an inline filter band-sized instead of full-width. */
+.surface-compact-search {
   flex: 0 1 220px;
   min-width: 140px;
 }

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -2281,10 +2281,10 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             ONE slim topmost band — mirrors the GitHub surface's
             gh-compact-header so operational surfaces share the same
             minimalist chrome. */}
-        <div className="schedules-compact-header">
-          <h1 className="schedules-compact-title">Schedules</h1>
+        <div className="surface-compact-header">
+          <h1 className="surface-compact-title">Schedules</h1>
           <Tabs
-            className="schedules-compact-tabs"
+            className="surface-compact-tabs"
             variant="segment"
             size="sm"
             ariaLabel="Schedules tabs"
@@ -2297,7 +2297,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             ] satisfies TabItem<AutomationTab>[]}
           />
           {activeTab !== "calendar" && initialLoadDone && summary.active + summary.paused > 0 && (
-            <p className="schedules-compact-summary">
+            <p className="surface-compact-summary">
               <span className="inline-flex items-center gap-1.5">
                 <span aria-hidden className="h-1.5 w-1.5 rounded-full" style={{ background: "var(--accent-presence)" }} />
                 {summary.active} active
@@ -2308,12 +2308,12 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
               )}
             </p>
           )}
-          <div className="schedules-compact-actions">
+          <div className="surface-compact-actions">
             {/* Text filter for the crons tab. Gated on the UNfiltered presence
                 of rows so filtering to zero never hides the box (you can still
                 clear). */}
             {activeTab !== "calendar" && initialLoadDone && !reminderSelect.selectMode && codexAutos.length > 0 ? (
-              <div className="schedules-compact-search">
+              <div className="surface-compact-search">
                 <SearchInput
                   value={query}
                   onValueChange={setQuery}

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -389,22 +389,25 @@ export function MarketplaceViewSurface({
     // viewport, so the surface also adapts inside a narrow drag-to-split pane
     // on a wide screen (same pattern as chat's chatlist/composer containers).
     <section className="marketplace-view @container/marketplace flex min-h-0 flex-1 flex-col bg-[var(--bg-base)]">
-      {/* Slim header — one row: section tabs (live counts, subtitle as
-          tooltip) plus the scoped search. The shared Tabs primitive supplies
+      {/* Compact header — one slim topmost band (shared .surface-compact
+          chrome with Schedules and the GitHub surface): small title, size-sm
+          segment section tabs (live counts, subtitle as tooltip), scoped
+          search on the right. The shared Tabs primitive supplies
           role=tablist/tab, roving tabindex, and the marketplace-tab / panel
           aria wiring via idPrefix. */}
-      <header className="border-b border-[var(--border-hairline)] px-4 @min-[560px]/marketplace:px-6">
-        <div className="flex flex-wrap items-end justify-between gap-x-4">
-          <div className="-mx-3 min-w-0 overflow-x-auto">
-            <Tabs
-              items={sectionTabs}
-              value={section}
-              onChange={selectSection}
-              ariaLabel="Marketplace sections"
-              idPrefix="marketplace"
-              bordered={false}
-            />
-          </div>
+      <header className="surface-compact-header">
+        <h1 className="surface-compact-title">Marketplace</h1>
+        <Tabs
+          items={sectionTabs}
+          value={section}
+          onChange={selectSection}
+          ariaLabel="Marketplace sections"
+          idPrefix="marketplace"
+          variant="segment"
+          size="sm"
+          className="surface-compact-tabs"
+        />
+        <div className="surface-compact-actions">
           {section !== "capabilities" ? (
             <SearchInput
               ref={searchRef}
@@ -412,17 +415,17 @@ export function MarketplaceViewSurface({
               onValueChange={setQuery}
               onClear={() => setQuery("")}
               placeholder={SEARCH_LABEL[section]}
-              containerClassName="my-1.5 w-full self-center @min-[680px]/marketplace:w-72"
+              containerClassName="surface-compact-search"
               aria-label={SEARCH_LABEL[section]}
             />
           ) : null}
         </div>
-        {activeError ? (
-          <p role="alert" className="mb-3 rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
-            {activeError}
-          </p>
-        ) : null}
       </header>
+      {activeError ? (
+        <p role="alert" className="mx-4 mt-3 rounded-md border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-2 text-[12px] text-[var(--danger-text)]">
+          {activeError}
+        </p>
+      ) : null}
 
       {section === "browse" ? (
         <div


### PR DESCRIPTION
Applies the same compact header shipped for Schedules (#2627) to the Marketplace hub, completing the shared minimalist chrome across GitHub / Schedules / Marketplace.

## Before → After
- **Before:** slim-but-bespoke row — default-size underline tabs, no title, search with its own container-query sizing.
- **After:** the shared ONE-band chrome: small **Marketplace** title · `size="sm"` segment tabs (Browse / Skills / Capabilities, live counts, hints as tooltips) · scoped search inline right, band-sized. Error banner moves below the band.

## Implementation
- `marketplace-view.tsx`: header restructured onto the shared classes.
- `globals.css`: the just-shipped `.schedules-compact-*` generalizes to **`.surface-compact-*`** (two consumers now); `automations-view.tsx` updated to the new names — zero visual change on Schedules.
- All `roles-tools-navigation` pins preserved (`items={sectionTabs}` first, ariaLabel/idPrefix aria wiring, SearchInput shape + `SEARCH_LABEL` aria-label, tabpanels untouched).

## Verification
- `tsc` clean; **full `test:app` (560 files) green** (marketplace + schedules pinned tests unchanged); build within budget.
- Screenshotted live: 46px band identical to Schedules, Browse(118)/Skills/Capabilities pills, inline search.

Closes cave-uxi3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)