### PR TITLE
feat(shell): boot into Chat — the conversation is the front door (cave-hsa6)

### DIFF
--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -16,10 +16,18 @@ assert.match(
   "WorkspaceMode union keeps \"agents\" for internal familiar detail flows",
 );
 
+// Chat-first boot (cave-hsa6): the app opens on the conversation. Home remains
+// one step away — the chat Back control's lastNonChatMode still defaults to
+// "home", and ⌘1 / nav / deep links reach it as before.
 assert.match(
   workspace,
-  /useState<WorkspaceMode>\("home"\)/,
-  "Default workspace mode should land on Home after removing Familiars from Work nav",
+  /const \[mode, setModeRaw\] = useState<WorkspaceMode>\("chat"\)/,
+  "Default workspace mode lands on Chat (chat-first boot, cave-hsa6)",
+);
+assert.match(
+  workspace,
+  /const \[lastNonChatMode, setLastNonChatMode\] = useState<WorkspaceMode>\("home"\)/,
+  "the chat Back control still returns to Home by default",
 );
 
 // The "Coven" surface (docs-pane) was purged — its docs/feedback/social live as

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -281,7 +281,12 @@ export function Workspace() {
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [topSearchQuery, setTopSearchQuery] = useState("");
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  const [mode, setModeRaw] = useState<WorkspaceMode>("home");
+  // Chat-first boot (cave-hsa6): the app opens on the conversation — the chat
+  // surface with the thread sidebar (a fresh session lands on the task-aware
+  // empty state). Home stays one step away (⌘1 / nav / the chat Back control,
+  // whose lastNonChatMode below still defaults to "home"). Deep links (?mode=,
+  // #chat-…) and cave:navigate-mode override this as before.
+  const [mode, setModeRaw] = useState<WorkspaceMode>("chat");
   // Group Chat retired its standalone page — it's now a tab inside the Chat
   // surface. Any request for the legacy `groupchat` mode (nav, deep link,
   // palette, keyboard, drag-to-split) is redirected to chat and opens the Group

--- a/tests/board-attachments.spec.ts
+++ b/tests/board-attachments.spec.ts
@@ -18,6 +18,9 @@ test("home composer files stage and display as chips with remove controls", asyn
 
   await page.goto("/");
   await page.waitForSelector(".shell-frame", { timeout: 60000 });
+  // The app boots into Chat (cave-hsa6); this spec exercises the HOME composer,
+  // so navigate there explicitly.
+  await page.keyboard.press("Meta+1");
   await page.waitForSelector(".hc-textarea", { timeout: 60000 });
 
   // ── Stage two files ──────────────────────────────────────────────────────────

--- a/tests/board-touch.spec.ts
+++ b/tests/board-touch.spec.ts
@@ -17,7 +17,9 @@ test("touch long-press drag moves a card between columns", async ({ page }) => {
     window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3.two-pane", "1");
   });
   await page.goto("/"); await page.waitForSelector(".shell-frame", { timeout: 60000 });
-  await page.locator(".sidebar-nav-scroll").getByRole("button", { name: /^Tasks\b/ }).click();
+  // The app boots into Chat (cave-hsa6), where the sidebar is the thread list —
+  // reach Tasks via its ⌘3 shortcut instead of a mode-list row.
+  await page.keyboard.press("Meta+3");
   await page.waitForSelector(".board-kanban-card", { timeout: 60000 });
 
   const card = page.locator(".board-kanban-card").first();

--- a/tests/keyboard-shortcuts.spec.ts
+++ b/tests/keyboard-shortcuts.spec.ts
@@ -14,9 +14,10 @@ async function gotoApp(page: Page) {
   });
   await page.goto("/");
   // Wait until the workspace has hydrated — the global keydown handler is
-  // attached in a useEffect, so a key pressed before hydration is lost. The
-  // home composer textbox is a reliable "interactive now" signal.
-  await page.getByRole("textbox").first().waitFor({ state: "visible", timeout: 30_000 });
+  // attached in a useEffect, so a key pressed before hydration is lost. The app
+  // boots into Chat (cave-hsa6); the always-present top-bar search input (role
+  // searchbox) is the reliable "interactive now" signal on every boot surface.
+  await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
   await page.waitForTimeout(500);
 }
 
@@ -54,9 +55,11 @@ test.describe("keyboard shortcuts sheet", () => {
 
   test("? does nothing while typing in a text field", async ({ page }) => {
     await gotoApp(page);
-    const composer = page.getByRole("textbox").first();
-    await composer.click();
-    await composer.pressSequentially("?");
+    // Any editable target exercises the guard; the top-bar search input is the
+    // one always present on the chat boot surface (cave-hsa6).
+    const editable = page.getByRole("searchbox").first();
+    await editable.click();
+    await editable.pressSequentially("?");
     // The guard (isEditableTarget) must suppress the sheet so "?" types normally.
     await expect(sheet(page)).toBeHidden();
   });

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -96,14 +96,14 @@ test.describe("onboarding wizard", () => {
 
   test("stays hidden once dismissed", async ({ page }) => {
     await gotoApp(page, FRESH_STATUS, { dismissed: true });
-    await page.getByRole("textbox").first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
     await page.waitForTimeout(1_000);
     await expect(wizard(page)).toHaveCount(0);
   });
 
   test("does not relaunch for a set-up machine whose daemon is merely stopped", async ({ page }) => {
     await gotoApp(page, DAEMON_DOWN_VETERAN_STATUS);
-    await page.getByRole("textbox").first().waitFor({ state: "visible", timeout: 30_000 });
+    await page.getByRole("searchbox").first().waitFor({ state: "visible", timeout: 30_000 });
     await page.waitForTimeout(1_000);
     await expect(wizard(page)).toHaveCount(0);
   });


### PR DESCRIPTION
The first of the two **deferred chat-first IA decisions** (user-approved; bead `cave-hsa6`), completing the chat-first minimalism arc's endgame.

## Change
The app booted into Home; the default workspace mode is now **`chat`** — every launch opens on the conversation (chat surface + thread sidebar; a fresh session lands on the task-aware empty state). **Home remains one step away**: ⌘1, the nav row, and the chat Back control (`lastNonChatMode` still defaults to `"home"`). `?mode=` / `#chat-…` deep links and `cave:navigate-mode` override as before.

## E2E fallout, fixed to the new reality
Five specs assumed `goto("/")` lands on Home:
- `keyboard-shortcuts` + `onboarding-wizard` waited on `getByRole("textbox")` as the "app is interactive" signal — Home's composer was a textbox; the chat boot's only always-present input is the **top-bar search (role `searchbox`)**. Swapped.
- `board-attachments` targets the *Home* composer → navigates ⌘1 first.
- `board-touch` clicked the sidebar mode list, which chat mode swaps for the thread list → uses ⌘3.
- `chat-task-chip-nav` needed **no change** — its full-run failure was parallel-load flake (passes clean solo and on retry).

## The second deferred item — deliberately not a component merge
Home's composer **already hands off to chat on submit** (`onStartChat → startFamiliarChat`), so the "parallel chat surface" concern is structurally resolved; with chat as the boot surface, Home settles into its daily-brief role. A 1,264-line merge of `home-composer.tsx` into the chat empty state would risk clobbering other sessions' active Home work (#2514 et al.) for no user-facing delta — documented in the bead.

## Verification
Live on the prod build: `goto("/")` → chat surface + thread sidebar, no Home hero; ⌘1 lands on Home. Full desktop e2e locally: **36 passed / 0 failed** (1 retry-flake noted above). 560 app tests, typecheck, 755 wired, build green.

Closes bead `cave-hsa6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)