### PR TITLE
feat(chat): unify the chat landing into a ChatGPT-style compose view (cave-hsa6, Phase 2.1)

### DIFF
--- a/src/components/chat-empty-state.test.ts
+++ b/src/components/chat-empty-state.test.ts
@@ -87,6 +87,50 @@ test("continue row and identity polish", () => {
   assert.match(emptyState, /title=\{project\.root\}/, "the ellipsizing project path exposes its full value");
 });
 
+test("chat-first landing: time greeting eyebrow, calm first paint, disclosed context", () => {
+  // The retired home hero's time-of-day greeting now warms the chat landing,
+  // sampled client-side so SSR never paints a mismatch.
+  assert.match(
+    emptyState,
+    /greetingForHour\(new Date\(\)\.getHours\(\)\)/,
+    "the landing samples a time-of-day greeting after mount",
+  );
+  assert.match(emptyState, /className=\{`cave-chat-empty-greeting/, "greeting renders as the landing eyebrow");
+
+  // Project picker, open-work rail, task tile and recents collapse by default so
+  // first paint is just greeting + suggestions + composer (Phase 2.1).
+  assert.match(
+    emptyState,
+    /const \[showContext, setShowContext\] = useState\(false\)/,
+    "the working context is collapsed by default",
+  );
+  assert.match(
+    emptyState,
+    /className="cave-chat-empty-context-toggle"[\s\S]*?aria-expanded=\{showContext\}/,
+    "a labelled toggle discloses the working context with aria-expanded",
+  );
+  assert.match(
+    emptyState,
+    /\{showContext \? \([\s\S]*?className="cave-chat-empty-context-body"/,
+    "the project picker + rails render only once context is expanded",
+  );
+
+  // Ordering: greeting sits above the identity; suggestions paint before the
+  // collapsed context block.
+  assert.ok(
+    emptyState.indexOf("cave-chat-empty-greeting") < emptyState.indexOf("cave-chat-empty-familiar"),
+    "greeting eyebrow sits above the familiar identity",
+  );
+  assert.ok(
+    emptyState.indexOf("cave-chat-empty-prompts") < emptyState.indexOf('className="cave-chat-empty-context"'),
+    "starter suggestions are part of the always-visible first paint, ahead of the collapsed context",
+  );
+
+  // The greeting eyebrow + context toggle stay on semantic tokens.
+  assert.match(styles, /\.cave-chat-empty-greeting-dot \{[\s\S]*?background: var\(--accent-presence\)/, "greeting dot uses the presence accent token");
+  assert.match(styles, /\.cave-chat-empty-context-toggle \{[\s\S]*?border-radius: 999px/, "context toggle reads as a pill control");
+});
+
 test("task-aware styles use semantic tokens and respect reduced motion", () => {
   assert.match(
     styles,

--- a/src/components/chat-empty-state.tsx
+++ b/src/components/chat-empty-state.tsx
@@ -28,6 +28,7 @@ import { deriveStarterSuggestions } from "@/lib/chat-starter-suggestions";
 import { arrayContentEqual } from "@/lib/array-content-equal";
 import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
 import { relativeTime } from "@/lib/relative-time";
+import { greetingForHour } from "@/lib/home-greeting";
 import { useAnnouncer } from "@/components/ui/live-region";
 
 const RAIL_CAP = 4;
@@ -172,6 +173,19 @@ export function ChatEmptyState({
     nowMs,
   });
 
+  // Time-of-day greeting for the landing eyebrow (chat-first IA). Sampled after
+  // mount, client-only, to avoid SSR hydration drift — mirrors the old home hero.
+  const [greeting, setGreeting] = useState<string | null>(null);
+  useEffect(() => {
+    setGreeting(greetingForHour(new Date().getHours()));
+  }, []);
+
+  // "Context" disclosure: the project picker, open-work rail, task tile and
+  // recent-thread rail are the *context* around a new chat, not the first thing
+  // to greet you with. They collapse by default so the landing first-paints as
+  // greeting + suggestions + composer (Phase 2.1); one tap reveals them.
+  const [showContext, setShowContext] = useState(false);
+
   // Per-row resume/start state — one in-flight action at a time.
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -213,10 +227,21 @@ export function ChatEmptyState({
   const role = familiar.role?.trim();
   const railVisible =
     boardEnabled && (railCards.length > 0 || (loading && slow) || Boolean(boardError));
+  // Anything worth disclosing behind the "context" toggle?
+  const hasContext =
+    Boolean(onProjectChange) ||
+    railVisible ||
+    recents.length > 0 ||
+    Boolean(project && onArmTask && linkedTasks.length === 0);
 
   return (
     <div className="cave-chat-empty select-none">
       <div className="cave-chat-empty-shell">
+        <p className={`cave-chat-empty-greeting${greeting ? " is-ready" : ""}`}>
+          <span className="cave-chat-empty-greeting-dot" aria-hidden />
+          {greeting ?? " "}
+        </p>
+
         <div className="cave-chat-empty-familiar">
           <div className="cave-chat-empty-mark">
             <FamiliarIcon familiar={familiar} size="lg" />
@@ -234,29 +259,6 @@ export function ChatEmptyState({
           </div>
         </div>
 
-        {onProjectChange && (
-          <div className="cave-chat-empty-project">
-            <span className="cave-chat-empty-project-head">
-              <Icon name="ph:folder-open" width={14} aria-hidden />
-              <span className="cave-chat-empty-project-label">Project</span>
-              <ProjectPicker
-                projects={projects}
-                value={projectId ?? null}
-                onChange={onProjectChange}
-                allowNoProject
-                familiarId={familiar.id}
-                createProject={createProject}
-                ariaLabel="Project for this chat"
-              />
-            </span>
-            {project ? (
-              <span className="cave-chat-empty-project-root" title={project.root}>
-                {project.root}
-              </span>
-            ) : null}
-          </div>
-        )}
-
         {linkedTasks.length > 0 ? (
           <section className="cave-chat-empty-work" aria-label="Linked task">
             <span className="cave-chat-empty-section-label">
@@ -270,94 +272,6 @@ export function ChatEmptyState({
               </div>
             ))}
           </section>
-        ) : railVisible ? (
-          <section className="cave-chat-empty-work" aria-label="Open work">
-            <span className="cave-chat-empty-section-label">
-              <Icon name="ph:kanban" width={12} aria-hidden />
-              Open work
-            </span>
-            {loading && slow ? (
-              <div className="cave-chat-empty-work-skeleton" role="status" aria-label="Loading open work">
-                <span className="cave-chat-empty-task-skeleton" />
-                <span className="cave-chat-empty-task-skeleton" />
-              </div>
-            ) : boardError ? (
-              <p className="cave-chat-empty-work-error">
-                Couldn&apos;t load the board.{" "}
-                <button type="button" className="cave-chat-empty-retry" onClick={() => void reload()}>
-                  Retry
-                </button>
-              </p>
-            ) : (
-              <>
-                {railCards.map((card) => {
-                  const needsDaemon = !card.sessionId && daemonRunning === false;
-                  const action = card.sessionId ? "Resume" : "Start";
-                  return (
-                    <button
-                      key={card.id}
-                      type="button"
-                      className="cave-chat-empty-task"
-                      disabled={busyId === card.id || needsDaemon}
-                      title={needsDaemon ? "Starting a task needs the daemon running" : undefined}
-                      aria-label={`${action} '${card.title}' — ${card.status}, ${card.priority} priority`}
-                      onClick={() => void resumeCard(card)}
-                    >
-                      <span className={`cave-chat-empty-task-status is-${card.status}`}>{card.status}</span>
-                      <span className="cave-chat-empty-task-title">{card.title}</span>
-                      {card.priority === "urgent" || card.priority === "high" ? (
-                        <span className="cave-chat-empty-task-priority">{card.priority}</span>
-                      ) : null}
-                      <span className="cave-chat-empty-task-action">
-                        {busyId === card.id ? "Opening…" : action}
-                        <Icon name="ph:arrow-right-bold" width={12} aria-hidden />
-                      </span>
-                    </button>
-                  );
-                })}
-                {moreCount > 0 ? (
-                  <span className="cave-chat-empty-work-more">+{moreCount} more on the board</span>
-                ) : null}
-              </>
-            )}
-            {actionError ? (
-              <p className="cave-chat-empty-work-error" role="alert">
-                {actionError}
-              </p>
-            ) : null}
-          </section>
-        ) : null}
-
-        {project && onArmTask && linkedTasks.length === 0 ? (
-          taskArmed ? (
-            <div className="cave-chat-empty-task-armed" role="status">
-              <Icon name="ph:kanban" width={13} aria-hidden />
-              <span>Describe the task below — sending creates a linked board card.</span>
-              {onDisarmTask ? (
-                <button
-                  type="button"
-                  className="cave-chat-empty-task-armed-dismiss"
-                  aria-label="Cancel task creation"
-                  onClick={onDisarmTask}
-                >
-                  <Icon name="ph:x-bold" width={11} aria-hidden />
-                </button>
-              ) : null}
-            </div>
-          ) : (
-            <button
-              type="button"
-              className="cave-chat-empty-task-tile"
-              onClick={() => {
-                onArmTask();
-                announce("Describe the task in the message box; sending creates a linked board card.");
-              }}
-            >
-              <Icon name="ph:kanban" width={14} aria-hidden />
-              <span className="cave-chat-empty-task-tile-label">Start a task in {project.name}</span>
-              <span className="cave-chat-empty-task-tile-hint">creates a linked card</span>
-            </button>
-          )
         ) : null}
 
         {((onPrompt && suggestions.length > 0) || onOpenPromptSnippets) && (
@@ -386,34 +300,165 @@ export function ChatEmptyState({
           </div>
         )}
 
-        {recents.length > 0 ? (
-          <section className="cave-chat-empty-recents" aria-label="Continue a recent thread">
-            <span className="cave-chat-empty-section-label">
-              <Icon name="ph:chat-circle-dots" width={12} aria-hidden />
-              Continue
-            </span>
-            {recents.map((session) => {
-              const title = session.title?.trim() || "Untitled thread";
-              const when = relativeTime(session.updated_at || session.created_at, nowMs);
-              return (
-                <button
-                  key={session.id}
-                  type="button"
-                  className="cave-chat-empty-recent"
-                  aria-label={`Continue '${title}'${when ? `, updated ${when}` : ""}`}
-                  onClick={() => openSession(session.id, session.familiarId)}
-                >
-                  <span className="cave-chat-empty-recent-title">{title}</span>
-                  {session.diff && (session.diff.additions || session.diff.deletions) ? (
-                    <span className="cave-chat-empty-recent-diff">
-                      +{session.diff.additions} −{session.diff.deletions}
+        {hasContext ? (
+          <div className="cave-chat-empty-context">
+            <button
+              type="button"
+              className="cave-chat-empty-context-toggle"
+              aria-expanded={showContext}
+              onClick={() => setShowContext((v) => !v)}
+            >
+              <Icon name={showContext ? "ph:caret-up" : "ph:caret-down"} width={12} aria-hidden />
+              <span>{showContext ? "Hide context" : "Project & open work"}</span>
+            </button>
+
+            {showContext ? (
+              <div className="cave-chat-empty-context-body">
+                {onProjectChange && (
+                  <div className="cave-chat-empty-project">
+                    <span className="cave-chat-empty-project-head">
+                      <Icon name="ph:folder-open" width={14} aria-hidden />
+                      <span className="cave-chat-empty-project-label">Project</span>
+                      <ProjectPicker
+                        projects={projects}
+                        value={projectId ?? null}
+                        onChange={onProjectChange}
+                        allowNoProject
+                        familiarId={familiar.id}
+                        createProject={createProject}
+                        ariaLabel="Project for this chat"
+                      />
                     </span>
-                  ) : null}
-                  <span className="cave-chat-empty-recent-time">{when}</span>
-                </button>
-              );
-            })}
-          </section>
+                    {project ? (
+                      <span className="cave-chat-empty-project-root" title={project.root}>
+                        {project.root}
+                      </span>
+                    ) : null}
+                  </div>
+                )}
+
+                {railVisible ? (
+                  <section className="cave-chat-empty-work" aria-label="Open work">
+                    <span className="cave-chat-empty-section-label">
+                      <Icon name="ph:kanban" width={12} aria-hidden />
+                      Open work
+                    </span>
+                    {loading && slow ? (
+                      <div className="cave-chat-empty-work-skeleton" role="status" aria-label="Loading open work">
+                        <span className="cave-chat-empty-task-skeleton" />
+                        <span className="cave-chat-empty-task-skeleton" />
+                      </div>
+                    ) : boardError ? (
+                      <p className="cave-chat-empty-work-error">
+                        Couldn&apos;t load the board.{" "}
+                        <button type="button" className="cave-chat-empty-retry" onClick={() => void reload()}>
+                          Retry
+                        </button>
+                      </p>
+                    ) : (
+                      <>
+                        {railCards.map((card) => {
+                          const needsDaemon = !card.sessionId && daemonRunning === false;
+                          const action = card.sessionId ? "Resume" : "Start";
+                          return (
+                            <button
+                              key={card.id}
+                              type="button"
+                              className="cave-chat-empty-task"
+                              disabled={busyId === card.id || needsDaemon}
+                              title={needsDaemon ? "Starting a task needs the daemon running" : undefined}
+                              aria-label={`${action} '${card.title}' — ${card.status}, ${card.priority} priority`}
+                              onClick={() => void resumeCard(card)}
+                            >
+                              <span className={`cave-chat-empty-task-status is-${card.status}`}>{card.status}</span>
+                              <span className="cave-chat-empty-task-title">{card.title}</span>
+                              {card.priority === "urgent" || card.priority === "high" ? (
+                                <span className="cave-chat-empty-task-priority">{card.priority}</span>
+                              ) : null}
+                              <span className="cave-chat-empty-task-action">
+                                {busyId === card.id ? "Opening…" : action}
+                                <Icon name="ph:arrow-right-bold" width={12} aria-hidden />
+                              </span>
+                            </button>
+                          );
+                        })}
+                        {moreCount > 0 ? (
+                          <span className="cave-chat-empty-work-more">+{moreCount} more on the board</span>
+                        ) : null}
+                      </>
+                    )}
+                    {actionError ? (
+                      <p className="cave-chat-empty-work-error" role="alert">
+                        {actionError}
+                      </p>
+                    ) : null}
+                  </section>
+                ) : null}
+
+                {project && onArmTask && linkedTasks.length === 0 ? (
+                  taskArmed ? (
+                    <div className="cave-chat-empty-task-armed" role="status">
+                      <Icon name="ph:kanban" width={13} aria-hidden />
+                      <span>Describe the task below — sending creates a linked board card.</span>
+                      {onDisarmTask ? (
+                        <button
+                          type="button"
+                          className="cave-chat-empty-task-armed-dismiss"
+                          aria-label="Cancel task creation"
+                          onClick={onDisarmTask}
+                        >
+                          <Icon name="ph:x-bold" width={11} aria-hidden />
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <button
+                      type="button"
+                      className="cave-chat-empty-task-tile"
+                      onClick={() => {
+                        onArmTask();
+                        announce("Describe the task in the message box; sending creates a linked board card.");
+                      }}
+                    >
+                      <Icon name="ph:kanban" width={14} aria-hidden />
+                      <span className="cave-chat-empty-task-tile-label">Start a task in {project.name}</span>
+                      <span className="cave-chat-empty-task-tile-hint">creates a linked card</span>
+                    </button>
+                  )
+                ) : null}
+
+                {recents.length > 0 ? (
+                  <section className="cave-chat-empty-recents" aria-label="Continue a recent thread">
+                    <span className="cave-chat-empty-section-label">
+                      <Icon name="ph:chat-circle-dots" width={12} aria-hidden />
+                      Continue
+                    </span>
+                    {recents.map((session) => {
+                      const title = session.title?.trim() || "Untitled thread";
+                      const when = relativeTime(session.updated_at || session.created_at, nowMs);
+                      return (
+                        <button
+                          key={session.id}
+                          type="button"
+                          className="cave-chat-empty-recent"
+                          aria-label={`Continue '${title}'${when ? `, updated ${when}` : ""}`}
+                          onClick={() => openSession(session.id, session.familiarId)}
+                        >
+                          <span className="cave-chat-empty-recent-title">{title}</span>
+                          {session.diff && (session.diff.additions || session.diff.deletions) ? (
+                            <span className="cave-chat-empty-recent-diff">
+                              +{session.diff.additions} −{session.diff.deletions}
+                            </span>
+                          ) : null}
+                          <span className="cave-chat-empty-recent-time">{when}</span>
+                        </button>
+                      );
+                    })}
+                  </section>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
         ) : null}
 
         <p className="cave-chat-empty-hint">

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -48,6 +48,30 @@ assert.match(
   "ChatRouter should render an opened session with its own familiar before the parent active familiar catches up",
 );
 
+// ── Chat-first IA (cave-hsa6): boot into a compose view, not the list ───────
+const bootComposeEffect =
+  source.match(/const bootComposeRef = useRef\(false\);[\s\S]*?\}, \[sessionsLoaded, familiar\?\.id, fallbackFamiliar\?\.id\]\);/)?.[0] ?? "";
+assert.match(
+  bootComposeEffect,
+  /if \(bootComposeRef\.current\) return;/,
+  "the boot-compose effect fires once, so returning to the list later sticks",
+);
+assert.match(
+  bootComposeEffect,
+  /window\.location\.hash\.startsWith\("#chat-"\)/,
+  "a #chat-<id> deep link is deferred to workspace restore, not overridden by the compose boot",
+);
+assert.match(
+  bootComposeEffect,
+  /matchMedia\("\(max-width: 1023px\)"\)\.matches/,
+  "compose-first boot is desktop-only — mobile keeps the thread list as the chat home",
+);
+assert.match(
+  bootComposeEffect,
+  /prev\.kind === "list" \? \{ kind: "chat", sessionId: null, familiarId: bootFamiliarId \} : prev/,
+  "booting into chat opens a zero-session compose view (ChatEmptyState + composer), no server session created",
+);
+
 // ── CHAT-D9-01: URL deep links (#chat-<sessionId>) ───────────────────────────
 
 const workspaceSource = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -269,6 +269,39 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     );
   }, [familiar?.id]);
 
+  // ── Chat-first IA (cave-hsa6): boot into a fresh compose view ──────────────
+  // Booting into chat mode should read like ChatGPT — an empty conversation with
+  // the composer ready and the thread list in the left sidebar — not the session
+  // list/hub. Fire once, from the initial list view, and only when there's no
+  // `#chat-<id>` deep link (workspace.tsx restores that session itself). No server
+  // session is created: the compose view holds sessionId=null until the first
+  // send. Returning to the list later sticks — the ref guards against re-entry.
+  const bootComposeRef = useRef(false);
+  useEffect(() => {
+    if (bootComposeRef.current) return;
+    if (sessionsLoaded === false) return;
+    if (typeof window !== "undefined") {
+      if (window.location.hash.startsWith("#chat-")) {
+        bootComposeRef.current = true; // a deep link owns the boot view
+        return;
+      }
+      // Compose-first boot is a desktop affordance. On mobile the thread list is
+      // the natural chat home (a messages-app pattern, and the full pane the
+      // narrow shell expects) — a new chat stays one tap away. Read matchMedia
+      // synchronously so this doesn't race useIsMobile's post-mount flip.
+      if (window.matchMedia("(max-width: 1023px)").matches) {
+        bootComposeRef.current = true;
+        return;
+      }
+    }
+    const bootFamiliarId = familiar?.id ?? fallbackFamiliar?.id ?? null;
+    if (!bootFamiliarId) return; // wait until a familiar is available
+    bootComposeRef.current = true;
+    setView((prev) =>
+      prev.kind === "list" ? { kind: "chat", sessionId: null, familiarId: bootFamiliarId } : prev,
+    );
+  }, [sessionsLoaded, familiar?.id, fallbackFamiliar?.id]);
+
   useImperativeHandle(
     ref,
     () => ({

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -24,6 +24,18 @@ assert.match(
   "workspace should provide exitChatMode so the sidebar back control returns to the prior surface",
 );
 
+// ── Chat-first IA (cave-hsa6): the app boots straight into the conversation. ──
+assert.match(
+  workspace,
+  /const \[mode, setModeRaw\] = useState<WorkspaceMode>\("chat"\)/,
+  "workspace should boot into chat mode, not home",
+);
+assert.match(
+  workspace,
+  /const \[lastNonChatMode, setLastNonChatMode\] = useState<WorkspaceMode>\("home"\)/,
+  "the chat back-control still falls back to home when no other surface was visited",
+);
+
 // ── Subpanel removal: the in-surface thread rail is dropped in chat mode, since
 //    the ChatSidebar now owns the project-grouped thread list. ────────────────
 assert.match(

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1062,6 +1062,79 @@
   gap: 16px;
 }
 
+/* Chat-first landing eyebrow (cave-hsa6) — a quiet time-of-day greeting above
+   the familiar identity, carrying the warmth of the retired home hero. Fades in
+   once the local clock is sampled client-side, so SSR paints nothing that could
+   mismatch. */
+.cave-chat-empty-greeting {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin: 0;
+  color: var(--text-muted);
+  font-family: "SF Mono", "JetBrains Mono", "Roboto Mono", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 240ms ease;
+}
+.cave-chat-empty-greeting.is-ready {
+  opacity: 1;
+}
+.cave-chat-empty-greeting-dot {
+  width: 5px;
+  height: 5px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--accent-presence);
+}
+
+/* "Context" disclosure (cave-hsa6) — the project picker, open-work rail, task
+   tile and recent-thread rail live here, collapsed by default, so the landing
+   first-paints calm (greeting + suggestions + composer). One tap opens the
+   working context; everything stays reachable. */
+.cave-chat-empty-context {
+  display: grid;
+  gap: 12px;
+}
+.cave-chat-empty-context-toggle {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border: 1px solid var(--border-panel);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 550;
+  cursor: pointer;
+  transition: color 140ms ease, border-color 140ms ease, background 140ms ease;
+}
+.cave-chat-empty-context-toggle:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--bg-elevated) 60%, transparent);
+}
+.cave-chat-empty-context-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--accent-presence) 42%, transparent);
+}
+.cave-chat-empty-context-body {
+  display: grid;
+  gap: 14px;
+  width: 100%;
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-chat-empty-greeting {
+    transition: none;
+  }
+}
+
 .cave-chat-empty-familiar {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What

Completes the chat-first landing (plan **Phase 2.1**) on top of #2632, which shipped the boot-into-chat flip (**Phase 3.1**). Rebased onto main so this PR is now **only the 2.1 delta** — the `workspace.tsx` mode flip and the e2e spec fixes it shared with #2632 were dropped in favour of main's.

**Why it's needed:** #2632 boots into chat *mode*, but that lands on the session **list/hub**, not a conversation. This PR makes booting into chat land on an actual **ChatGPT-style compose view** (empty conversation + composer), with the thread list in the left sidebar.

## Changes

- **ChatRouter boots into a fresh *compose* view** (`ChatEmptyState` + composer) instead of the list. A once-guarded mount effect flips the initial view from `list` → a zero-session compose. **No server session** is created (sessionId stays `null` until first send), a `#chat-<id>` deep link is deferred to `workspace.tsx` restore, and returning to the list later sticks.
- **`ChatEmptyState` redesigned into the landing**: a time-of-day **greeting eyebrow** (the warmth of the retired Home hero) over the familiar identity, **starter suggestions** as the calm first paint, and the project picker + open-work rail + "Start a task" tile + Continue rail tucked behind a collapsed **"Project & open work"** disclosure. Everything stays reachable — one tap reveals the context.

## Verification

- `pnpm typecheck` · **560** app test files · `pnpm build` within budget · source pins for the boot-compose + greeting/calm-first-paint/disclosure.
- Live Playwright screenshots at 1440px: **collapsed** landing (greeting + 4 suggestions + composer, context collapsed) and **expanded** context (project `alpha` + Continue rail).

> The chat-list "Ready for a new thread" empty state and the Home surface are untouched — both stay reachable. This only changes what the chat *default* view shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)