### PR TITLE
feat(board): align the Tasks header to the shared compact chrome (cave-gnki)

### DIFF
--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -12,12 +12,16 @@
    same rules fire there too. */
 .board-shell { display:flex; flex-direction:column; height:100%; overflow:hidden; background:var(--bg-base); color:var(--text-primary); container:board / inline-size; }
 
-.board-header { display:flex; align-items:center; gap:10px; padding:10px 16px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; flex-wrap:nowrap; }
-.board-header-title { flex:0 0 auto; font-size:14px; font-weight:600; color:var(--text-primary); }
+/* Compact chrome (matches .surface-compact-header / .gh-compact-header): one
+   slim 40px band; --board-control-h shrinks header controls to the shared 26px
+   without touching the same classes reused outside the band (inspector, gantt).
+   The mobile container query below re-inflates everything to touch targets. */
+.board-header { display:flex; align-items:center; gap:8px; padding:5px 12px; min-height:40px; --board-control-h:26px; border-bottom:1px solid var(--border-hairline); flex-shrink:0; flex-wrap:nowrap; }
+.board-header-title { flex:0 0 auto; font-size:12px; font-weight:600; color:var(--text-primary); }
 .board-header-controls { display:flex; align-items:center; gap:6px; margin-left:auto; flex:0 0 auto; flex-wrap:nowrap; }
 .board-search-wrap { position:relative; display:flex; align-items:center; flex:1 1 auto; min-width:0; max-width:620px; margin-left:8px; }
 .board-search-icon { position:absolute; left:9px; color:var(--text-muted); pointer-events:none; }
-.board-search-input { width:100%; height:30px; padding:0 30px 0 30px; border-radius:var(--radius-control); border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-primary); outline:none; transition:background .12s,border-color .12s; }
+.board-search-input { width:100%; height:var(--board-control-h,30px); padding:0 30px 0 30px; border-radius:var(--radius-control); border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-primary); outline:none; transition:background .12s,border-color .12s; }
 .board-search-input::placeholder { color:var(--text-muted); }
 .board-search-input:focus { border-color:color-mix(in oklch,var(--accent-presence) 52%,transparent); background:var(--bg-hover); }
 .board-search-kbd { position:absolute; right:7px; display:flex; align-items:center; justify-content:center; min-width:16px; height:16px; padding:0 4px; border:1px solid var(--border-hairline); border-radius:4px; background:var(--bg-base); color:var(--text-muted); font-family:var(--font-mono); font-size:10px; line-height:1; pointer-events:none; }
@@ -25,7 +29,7 @@
 .board-search-clear:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-search-clear:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 
-.board-toolbar-btn { display:inline-flex; align-items:center; gap:5px; height:30px; padding:0 10px; border-radius:var(--radius-control); border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:12px; font-weight:450; cursor:pointer; transition:background .12s,color .12s,border-color .12s; white-space:nowrap; }
+.board-toolbar-btn { display:inline-flex; align-items:center; gap:5px; height:var(--board-control-h,30px); padding:0 10px; border-radius:var(--radius-control); border:1px solid var(--border-strong); background:var(--bg-raised); color:var(--text-secondary); font-size:12px; font-weight:450; cursor:pointer; transition:background .12s,color .12s,border-color .12s; white-space:nowrap; }
 .board-toolbar-btn:hover { background:var(--bg-hover); color:var(--text-primary); }
 .board-toolbar-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:1px; }
 .board-toolbar-btn--active { background:color-mix(in oklch,var(--accent-presence) 14%,var(--bg-raised)); border-color:color-mix(in oklch,var(--accent-presence) 40%,transparent); color:var(--text-primary); }
@@ -37,20 +41,20 @@
 .board-group-toggle { display:flex; border:1px solid var(--border-strong); border-radius:var(--radius-control); overflow:hidden; }
 /* Leading zoom glyph so the compact D/W/M reads as a timeline zoom, not a range filter. */
 .board-group-toggle .cg-zoom-cell { display:flex; align-items:center; padding:0 4px 0 8px; background:var(--bg-raised); color:var(--text-muted); border-right:1px solid var(--border-strong); }
-.board-group-toggle-btn { display:flex; align-items:center; justify-content:center; padding:0 10px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; font-size:12px; font-weight:500; transition:background .12s,color .12s; white-space:nowrap; }
+.board-group-toggle-btn { display:flex; align-items:center; justify-content:center; padding:0 10px; height:var(--board-control-h,28px); background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; font-size:12px; font-weight:500; transition:background .12s,color .12s; white-space:nowrap; }
 .board-group-toggle-btn+.board-group-toggle-btn { border-left:1px solid var(--border-strong); }
 .board-group-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }
 .board-group-toggle-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:-1px; z-index:1; position:relative; }
 .board-group-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
 .board-group-toggle-btn--solo { border:1px solid var(--border-strong); border-radius:var(--radius-control); }
 .board-view-toggle { display:flex; border:1px solid var(--border-strong); border-radius:var(--radius-control); overflow:hidden; }
-.board-view-toggle-btn { display:flex; align-items:center; justify-content:center; width:28px; height:28px; background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; transition:background .12s,color .12s; }
+.board-view-toggle-btn { display:flex; align-items:center; justify-content:center; width:var(--board-control-h,28px); height:var(--board-control-h,28px); background:var(--bg-raised); color:var(--text-muted); border:none; cursor:pointer; transition:background .12s,color .12s; }
 .board-view-toggle-btn+.board-view-toggle-btn { border-left:1px solid var(--border-strong); }
 .board-view-toggle-btn:hover { background:var(--bg-hover); color:var(--text-secondary); }
 .board-view-toggle-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:-1px; z-index:1; position:relative; }
 .board-view-toggle-btn--active { background:color-mix(in oklch,var(--accent-presence) 16%,var(--bg-raised)); color:var(--text-primary); }
 
-.board-new-card-btn { height:30px; padding:0 12px; border-radius:var(--radius-control); border:1px solid var(--border-strong); background:var(--accent-presence); color:var(--accent-presence-foreground); font-size:12px; font-weight:500; cursor:pointer; transition:background .12s,transform .1s; white-space:nowrap; }
+.board-new-card-btn { height:var(--board-control-h,30px); padding:0 12px; border-radius:var(--radius-control); border:1px solid var(--border-strong); background:var(--accent-presence); color:var(--accent-presence-foreground); font-size:12px; font-weight:500; cursor:pointer; transition:background .12s,transform .1s; white-space:nowrap; }
 .board-new-card-btn:hover { background:color-mix(in oklch, var(--accent-presence) 85%, #000); transform:scale(1.02); }
 .board-new-card-btn:focus-visible { outline:var(--ring-width) solid var(--ring-focus); outline-offset:2px; }
 


### PR DESCRIPTION
Completes the compact-header family across the operational surfaces: **GitHub → Schedules (#2627) → Marketplace (#2631) → Tasks**.

## Approach
The Tasks header was already one row, so this is **CSS-only** — align its metrics to the shared band instead of rewriting working toggles/search:
- Band: padding 10/16 → 5/12, gap 8, `min-height: 40px`; title 14 → 12px.
- `--board-control-h: 26px` on `.board-header` shrinks the header-scoped controls (search, toolbar buttons, group/view toggles, New task) to the family's 26px control height — the same pattern as `gh-compact-header`'s `--gh-control-h`.
- Heights use `var(--board-control-h, <previous>)` fallbacks, so the same classes reused **outside** the band (board-inspector actions, gantt toolbar) keep their sizes.
- Mobile container query untouched — it re-inflates to touch targets and its explicit heights still win.

## Verification
- Full `test:app` (560 files) green — board-ux-polish nowrap/wrap pins, familiar-scope, and mobile touch-target pins unchanged; build within budget.
- Measured live: **40px band, 26px controls**, matching Schedules/Marketplace exactly (screenshot verified).

Closes cave-gnki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)