### PR TITLE
feat(work-queue): adopt the shared compact header band (cave-lh2v)

### DIFF
--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -192,9 +192,9 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   if (!hasLoaded) {
     return (
       <div className="fwq" aria-busy>
-        <div className="fwq-head">
-          <h2 className="fwq-title">Familiar Work Queue</h2>
-        </div>
+        <header className="surface-compact-header">
+          <h1 className="surface-compact-title">Work Queue</h1>
+        </header>
         <div className="fwq-body">
           <SkeletonRows count={6} />
         </div>
@@ -225,25 +225,28 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
 
   return (
     <div className="fwq">
-      <div className="fwq-head">
-        <div className="fwq-head-main">
-          <h2 className="fwq-title">Familiar Work Queue</h2>
-          <p className="fwq-sub">
-            {q.total === 0
-              ? "No open PRs or ready beads."
-              : `${q.actionable} actionable · ${q.total} total${q.stale ? ` · ${q.stale} stale` : ""}`}
-          </p>
+      {/* Compact header — the shared .surface-compact band (GitHub / Schedules /
+          Marketplace / Tasks / Grimoire): small title, live summary inline,
+          Refresh on the right. */}
+      <header className="surface-compact-header">
+        <h1 className="surface-compact-title">Work Queue</h1>
+        <p className="surface-compact-summary">
+          {q.total === 0
+            ? "No open PRs or ready beads."
+            : `${q.actionable} actionable · ${q.total} total${q.stale ? ` · ${q.stale} stale` : ""}`}
+        </p>
+        <div className="surface-compact-actions">
+          <Button
+            variant="ghost"
+            size="sm"
+            leadingIcon="ph:arrow-clockwise"
+            onClick={() => void load()}
+            aria-label="Refresh work queue"
+          >
+            Refresh
+          </Button>
         </div>
-        <Button
-          variant="ghost"
-          size="sm"
-          leadingIcon="ph:arrow-clockwise"
-          onClick={() => void load()}
-          aria-label="Refresh work queue"
-        >
-          Refresh
-        </Button>
-      </div>
+      </header>
 
       {q.byFamiliar.length > 0 ? (
         <div className="fwq-familiars" role="group" aria-label="Filter by familiar">

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -12,29 +12,8 @@
   container-type: inline-size; /* enables the narrow-surface @container rule */
 }
 
-.fwq-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 16px 20px 12px;
-  border-bottom: 1px solid var(--border-hairline);
-}
-
-.fwq-head-main {
-  min-width: 0;
-}
-
-.fwq-title {
-  font: 600 15px/1.2 var(--font-sans);
-  margin: 0;
-}
-
-.fwq-sub {
-  margin: 3px 0 0;
-  font-size: 12px;
-  color: var(--text-muted);
-}
+/* The head is now the shared .surface-compact-header band (globals.css) —
+   the old .fwq-head/.fwq-title/.fwq-sub chrome retired with it. */
 
 /* Per-familiar rollup: filter chips, roving via native buttons. */
 .fwq-familiars {


### PR DESCRIPTION
Sixth surface on the shared compact chrome: **GitHub → Schedules (#2627) → Marketplace (#2631) → Tasks (#2634) → Grimoire (#2636) → Work Queue**.

## Change
- `.fwq-head` (15px "Familiar Work Queue" + subtitle + Refresh, 16/20 padding) → the shared `.surface-compact-header` band: small **Work Queue** title (h2 → h1), the "N actionable · N total · N stale" summary inline, Refresh (ghost `sm`) on the right. Loading-state head converted too.
- Dead `.fwq-head`/`.fwq-title`/`.fwq-sub` CSS retired from `familiar-work-queue.css`.
- Familiar filter chips + attention strip unchanged below the band.

## Verification
- `tsc` clean; **full `test:app` (560 files) green**; build within budget.
- `tests/familiar-work-queue.spec.ts` passes — its `/N actionable/` and lane assertions are untouched (two first-attempt flakes were the known `gotoWorkQueue` cold-compile warm-up, green on retry).

Closes cave-lh2v.

🤖 Generated with [Claude Code](https://claude.com/claude-code)