### PR TITLE
style(chat): quiet the code-block header — drop the traffic-light dots (cave-8bfz)

### DIFF
--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -10,22 +10,18 @@ assert.doesNotMatch(
   "Terminal code chrome should not inject traffic lights before the language label",
 );
 
-assert.match(
+// Phase-4 minimalism (cave-8bfz): the decorative mac-window traffic-light dots
+// were dropped from the code header — no ornamental ::after chrome.
+assert.doesNotMatch(
   css,
-  /\.cave-code-header::after[\s\S]*box-shadow:/,
-  "Terminal code chrome should render traffic lights after the language label",
+  /\.cave-code-header::after/,
+  "The code header should not inject decorative traffic-light dots (Phase-4 minimalism)",
 );
 
 assert.match(
   css,
   /\.cave-code-lang[\s\S]*order:\s*0/,
-  "The language label should be first in terminal code headers",
-);
-
-assert.match(
-  css,
-  /\.cave-code-header::after[\s\S]*order:\s*1/,
-  "Traffic lights should sit immediately to the right of the language label",
+  "The language label should be first in code headers",
 );
 
 assert.match(

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -673,24 +673,9 @@
   backdrop-filter: blur(4px);
 }
 
-/* decorative traffic-light dots; BASH/lang stays first, then the dots. */
-.cave-code-header::after {
-  content: "";
-  display: block;
-  order: 1;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  background: color-mix(in oklch, var(--code-chrome-accent) 40%, oklch(0.4 0 0));
-  box-shadow:
-    16px 0 0 color-mix(in oklch, oklch(0.75 0.18 60) 40%, oklch(0.4 0 0)),
-    32px 0 0 color-mix(in oklch, oklch(0.65 0.18 170) 40%, oklch(0.4 0 0));
-  margin-left: 2px;
-  margin-right: 34px;
-  opacity: 0.65;
-}
-
+/* Phase-4 minimalism (cave-8bfz): the decorative mac-window traffic-light dots
+   were dropped from the code header — the language label + filename + Copy
+   button carry it, no ornamental chrome. */
 .cave-code-lang {
   order: 0;
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;


### PR DESCRIPTION
## What

Plan **Phase-4 minimalism**: remove the decorative mac-window **traffic-light dots** from the code-block header. The language label, filename, and Copy button carry it — no ornamental chrome.

```
before:   BASH  ● ● ●        file.ts   Copy
after:    BASH              file.ts   Copy
```

## Changes

- `cave-chat.css`: delete the `.cave-code-header::after` rule (the red dot + two more via `box-shadow`).
- `message-bubble-code-header.test.ts`: flip the two pins that asserted the `::after` dots exist → assert they're absent. The language-label order, copy-button placement (`order: 3`, `margin-left: auto`), sticky-header, and fixed-dark-chrome ink pins are untouched.

They were added in a broad markdown-polish pass, not as a defended design decision, and no other test pins them.

## Verification

`pnpm typecheck` · **560** app test files · `pnpm build` within bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)