### PR TITLE
feat(work-queue): world-class pass — truthful degradation, freshness, poll perf, cleanup dedup, composer focus (cave-d3pg)

### DIFF
--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -8,6 +8,8 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { useMinuteTick } from "@/lib/use-minute-tick";
+import { relativeTime } from "@/lib/relative-time";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   buildWorkQueue,
@@ -47,18 +49,43 @@ const LANE_TONE: Record<WorkQueueLaneKey, "urgent" | "ready" | "neutral" | "quie
   "post-merge-cleanup": "ready",
 };
 
-async function fetchQueue(signal: AbortSignal): Promise<WorkQueue> {
-  const [beadsRes, prsRes] = await Promise.all([
-    fetch("/api/beads?mode=ready", { cache: "no-store", signal }),
-    fetch("/api/beads/prs", { cache: "no-store", signal }),
+type FetchedQueue = {
+  queue: WorkQueue;
+  /** False when the beads adapter failed and the queue is PRs-only. */
+  beadsOk: boolean;
+};
+
+// The PR bridge is the queue's spine — its failure fails the load. The beads
+// adapter instead DEGRADES the queue to PRs-only (the no-open-PR and
+// post-merge-cleanup lanes need the ready set), but the degradation is
+// reported via `beadsOk` so the surface can say so rather than silently
+// rendering fewer lanes.
+async function fetchQueue(signal: AbortSignal): Promise<FetchedQueue> {
+  const [beadsSettled, prsSettled] = await Promise.allSettled([
+    fetch("/api/beads?mode=ready", { cache: "no-store", signal }).then((res) => res.json()),
+    fetch("/api/beads/prs", { cache: "no-store", signal }).then((res) => res.json()),
   ]);
-  const beadsJson = await beadsRes.json();
-  const prsJson = await prsRes.json();
+  if (prsSettled.status === "rejected") throw prsSettled.reason;
+  const prsJson = prsSettled.value;
   if (!prsJson.ok) throw new Error(prsJson.error || "PR bridge unavailable");
-  const readyBeads: ReadyBead[] = beadsJson.ok && Array.isArray(beadsJson.data) ? beadsJson.data : [];
+
+  let readyBeads: ReadyBead[] = [];
+  let beadsOk = false;
+  if (beadsSettled.status === "fulfilled" && beadsSettled.value.ok && Array.isArray(beadsSettled.value.data)) {
+    readyBeads = beadsSettled.value.data;
+    beadsOk = true;
+  }
   const open: PullRequestSummary[] = Array.isArray(prsJson.open) ? prsJson.open : [];
   const merged: MergedPrRef[] = Array.isArray(prsJson.merged) ? prsJson.merged : [];
-  return buildWorkQueue(readyBeads, open, merged, { nowMs: Date.now() });
+  return { queue: buildWorkQueue(readyBeads, open, merged, { nowMs: Date.now() }), beadsOk };
+}
+
+// Content equality for the poll: the queue is a plain, deterministically-built
+// object graph, so serialized comparison is exact. Keeping the previous state
+// identity on a no-change poll stops the 30s tick from re-rendering every
+// lane/card (and resetting nothing) for an identical picture.
+function sameQueue(a: WorkQueue, b: WorkQueue): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
 }
 
 export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
@@ -66,6 +93,10 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   const [queue, setQueue] = useState<WorkQueue | null>(null);
   const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [beadsDegraded, setBeadsDegraded] = useState(false);
+  // ISO timestamp of the last successful load — the header's truthfulness
+  // signal. If quiet polls fail, this readout ages instead of lying "fresh".
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [familiarFilter, setFamiliarFilter] = useState<string | null>(null);
   // Beads that got a handoff note THIS session — Close unlocks immediately
@@ -73,28 +104,32 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   const [evidenceAdded, setEvidenceAdded] = useState<Set<string>>(() => new Set());
   const loadSeq = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
+  // Re-render ~once a minute so the header freshness and per-card ages stay
+  // truthful between polls (the equality guard below keeps queue state stable,
+  // so nothing else would tick them).
+  useMinuteTick();
 
-  const load = useCallback(
-    async (opts?: { quiet?: boolean }) => {
-      const quiet = opts?.quiet === true;
-      const seq = ++loadSeq.current;
-      abortRef.current?.abort();
-      const ctrl = new AbortController();
-      abortRef.current = ctrl;
-      try {
-        const next = await fetchQueue(ctrl.signal);
-        if (seq !== loadSeq.current) return; // a newer load won
-        setQueue(next);
-        setError(null);
-      } catch (err) {
-        if (ctrl.signal.aborted || seq !== loadSeq.current) return;
-        if (!quiet) setError(err instanceof Error ? err.message : "Failed to load the work queue");
-      } finally {
-        if (seq === loadSeq.current) setHasLoaded(true);
-      }
-    },
-    [],
-  );
+  const load = useCallback(async () => {
+    const seq = ++loadSeq.current;
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    try {
+      const { queue: next, beadsOk } = await fetchQueue(ctrl.signal);
+      if (seq !== loadSeq.current) return; // a newer load won
+      setQueue((prev) => (prev && sameQueue(prev, next) ? prev : next));
+      setBeadsDegraded(!beadsOk);
+      setError(null);
+      setLastUpdated(new Date().toISOString());
+    } catch (err) {
+      if (ctrl.signal.aborted || seq !== loadSeq.current) return;
+      // Keep whatever data is on screen — the render picks between the
+      // full-surface empty state (no data yet) and the inline refresh banner.
+      setError(err instanceof Error ? err.message : "Failed to load the work queue");
+    } finally {
+      if (seq === loadSeq.current) setHasLoaded(true);
+    }
+  }, []);
 
   useEffect(() => {
     void load();
@@ -113,7 +148,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
     );
   }, [hasLoaded, queue, announce]);
 
-  usePausablePoll(() => void load({ quiet: true }), 30_000, { pauseWhileInputActive: true });
+  usePausablePoll(() => void load(), 30_000, { pauseWhileInputActive: true });
 
   const familiarName = useCallback(
     (key: string) => {
@@ -140,7 +175,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         const json = await res.json();
         if (!json.ok) throw new Error(json.error || `${action} failed`);
         announce(action === "claim" ? `Claimed ${id}.` : `Closed ${id}.`);
-        await load({ quiet: true });
+        await load();
       } catch (err) {
         announce(err instanceof Error ? err.message : `Could not ${action} ${id}`, "assertive");
       } finally {
@@ -169,7 +204,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         if (!json.ok) throw new Error(json.error || "comment failed");
         setEvidenceAdded((prev) => new Set(prev).add(id.toLowerCase()));
         announce(`Handoff note added to ${id}.`);
-        await load({ quiet: true });
+        await load();
         return true;
       } catch (err) {
         announce(err instanceof Error ? err.message : `Could not add a note to ${id}`, "assertive");
@@ -226,14 +261,15 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
   return (
     <div className="fwq">
       {/* Compact header — the shared .surface-compact band (GitHub / Schedules /
-          Marketplace / Tasks / Grimoire): small title, live summary inline,
-          Refresh on the right. */}
+          Marketplace / Tasks / Grimoire): small title, live summary inline
+          (with a truthful "updated Xm ago" readout), Refresh on the right. */}
       <header className="surface-compact-header">
         <h1 className="surface-compact-title">Work Queue</h1>
         <p className="surface-compact-summary">
           {q.total === 0
             ? "No open PRs or ready beads."
             : `${q.actionable} actionable · ${q.total} total${q.stale ? ` · ${q.stale} stale` : ""}`}
+          {lastUpdated ? <span className="fwq-updated"> · updated {relativeTime(lastUpdated)}</span> : null}
         </p>
         <div className="surface-compact-actions">
           <Button
@@ -274,6 +310,26 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
         </div>
       ) : null}
 
+      {/* Truthful-degradation banners. Text is static (only the tooltip carries
+          the raw error) so role=alert doesn't re-announce every failing poll. */}
+      {error ? (
+        <div className="fwq-banner fwq-banner--danger" role="alert" title={error}>
+          <Icon name="ph:warning-circle" width={14} aria-hidden />
+          <span className="fwq-banner-text">Couldn&apos;t refresh the queue — showing earlier data.</span>
+          <Button variant="ghost" size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
+            Retry
+          </Button>
+        </div>
+      ) : null}
+      {beadsDegraded ? (
+        <div className="fwq-banner fwq-banner--warn" role="status">
+          <Icon name="ph:plugs" width={14} aria-hidden />
+          <span className="fwq-banner-text">
+            Beads adapter unavailable — showing PRs only; ready beads and post-merge cleanup are hidden.
+          </span>
+        </div>
+      ) : null}
+
       {q.attention.length > 0 ? <AttentionStrip items={q.attention} onOpenUrl={onOpenUrl} /> : null}
 
       <div className="fwq-body">
@@ -281,7 +337,11 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
           <EmptyState
             icon="ph:check-circle"
             headline="Queue is clear"
-            subtitle="No open PRs need attention and no ready beads are waiting to ship."
+            subtitle={
+              beadsDegraded
+                ? "No open PRs need attention. Bead lanes are unavailable right now."
+                : "No open PRs need attention and no ready beads are waiting to ship."
+            }
           />
         ) : visibleLanes.length === 0 ? (
           <EmptyState
@@ -413,18 +473,30 @@ function WorkQueueCard({
   const url = item.pr?.url ?? item.merged?.url ?? null;
   const [composing, setComposing] = useState(false);
   const [draft, setDraft] = useState("");
+  const noteInputRef = useRef<HTMLTextAreaElement | null>(null);
+  const noteButtonRef = useRef<HTMLButtonElement | null>(null);
   const isCleanup = item.lane === "post-merge-cleanup";
   // Close is exposed on the cleanup lane, but only once verification evidence
   // (a handoff note) is on record — the operator adds one via the composer.
   const closeBlocked = isCleanup && !hasEvidence;
 
+  // Keyboard/AT flow for the inline composer: focus lands in the textarea when
+  // it opens, and returns to the Note toggle whenever it closes (submit,
+  // Cancel, Escape) — otherwise focus drops to <body> on unmount.
+  useEffect(() => {
+    if (composing) noteInputRef.current?.focus();
+  }, [composing]);
+
+  const closeComposer = (opts?: { clearDraft?: boolean }) => {
+    if (opts?.clearDraft) setDraft("");
+    setComposing(false);
+    noteButtonRef.current?.focus();
+  };
+
   const submitNote = async () => {
     if (!draft.trim()) return;
     const ok = await onComment(draft);
-    if (ok) {
-      setDraft("");
-      setComposing(false);
-    }
+    if (ok) closeComposer({ clearDraft: true });
   };
 
   return (
@@ -453,6 +525,16 @@ function WorkQueueCard({
             </>
           ) : null}
           {item.stale ? <span className="fwq-tag fwq-tag--stale">stale</span> : null}
+          {item.pr?.updatedAt ? (
+            <span className="fwq-card-time" title={new Date(item.pr.updatedAt).toLocaleString()}>
+              updated {relativeTime(item.pr.updatedAt)}
+            </span>
+          ) : null}
+          {item.merged?.mergedAt ? (
+            <span className="fwq-card-time" title={new Date(item.merged.mergedAt).toLocaleString()}>
+              merged {relativeTime(item.merged.mergedAt)}
+            </span>
+          ) : null}
         </div>
       </div>
       <div className="fwq-card-actions">
@@ -469,6 +551,7 @@ function WorkQueueCard({
         ) : null}
         {beadId ? (
           <Button
+            ref={noteButtonRef}
             variant="ghost"
             size="xs"
             leadingIcon="ph:note-pencil"
@@ -504,6 +587,7 @@ function WorkQueueCard({
       {composing && beadId ? (
         <div className="fwq-note">
           <textarea
+            ref={noteInputRef}
             className="fwq-note-input"
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -516,18 +600,17 @@ function WorkQueueCard({
                 e.preventDefault();
                 void submitNote();
               }
+              // Escape closes but keeps the draft — an accidental Escape must
+              // not destroy typed verification text (Cancel is the clear).
+              if (e.key === "Escape") {
+                e.preventDefault();
+                e.stopPropagation();
+                closeComposer();
+              }
             }}
           />
           <div className="fwq-note-actions">
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => {
-                setDraft("");
-                setComposing(false);
-              }}
-              disabled={busy}
-            >
+            <Button variant="ghost" size="xs" onClick={() => closeComposer({ clearDraft: true })} disabled={busy}>
               Cancel
             </Button>
             <Button

--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -109,6 +109,30 @@ function bead(id, { priority = 2, labels = [], type = "feature", assignee = null
   assert.equal(q.total, 1, "cave-open counted once, in cleanup only");
 }
 
+// ── post-merge-cleanup skips beads with an open follow-up PR, and dedups ─────
+{
+  // cave-seq landed in PR 60 but a follow-up PR 61 is still open: Close would
+  // be premature, so the bead shows only via the open PR's lane.
+  const beads = [bead("cave-seq", { labels: ["familiar:kitty"] }), bead("cave-dup", { labels: ["familiar:nova"] })];
+  const prs = [pr(61, "needs-review", { beads: ["cave-seq"] })];
+  const merged = [
+    { number: 60, title: "landed first half", url: "u/60", beadIds: ["cave-seq"], mergedAt: "2026-07-07T00:00:00Z" },
+    // cave-dup landed across TWO merged PRs → one cleanup item, freshest first.
+    { number: 72, title: "landed part 2", url: "u/72", beadIds: ["cave-dup"], mergedAt: "2026-07-07T02:00:00Z" },
+    { number: 71, title: "landed part 1", url: "u/71", beadIds: ["cave-dup"], mergedAt: "2026-07-07T01:00:00Z" },
+  ];
+  const q = buildWorkQueue(beads, prs, merged, { nowMs: NOW });
+  const cleanup = q.lanes.find((l) => l.key === "post-merge-cleanup");
+  assert.deepEqual(
+    cleanup.items.map((i) => i.merged.number),
+    [72],
+    "open-follow-up bead skipped; duplicate merged refs collapse to the first (freshest) PR",
+  );
+  const review = q.lanes.find((l) => l.key === "needs-review");
+  assert.deepEqual(review.items.map((i) => i.bead.id), ["cave-seq"], "cave-seq stays in its open PR's lane");
+  assert.equal(q.total, 2, "each bead counted exactly once");
+}
+
 // ── Stale flag + rollup by familiar ──────────────────────────────────────────
 {
   const beads = [

--- a/src/lib/beads-work-queue.ts
+++ b/src/lib/beads-work-queue.ts
@@ -211,7 +211,14 @@ export function buildWorkQueue(
   for (const merged of mergedPrs) {
     const bead = merged.beadIds.map((id) => beadById.get(id)).find(Boolean);
     if (!bead) continue;
-    beadIdsInCleanup.add(bead.id.toLowerCase());
+    const beadId = bead.id.toLowerCase();
+    // A bead whose follow-up PR is still open is not ready to close — it
+    // already appears in that PR's lane, and prompting Close while work is in
+    // flight would be premature. Likewise a bead landed across several merged
+    // PRs is ONE cleanup, not competing Close prompts (first ref wins — `gh`
+    // lists most-recently-merged first, so the freshest PR names the close).
+    if (beadIdsWithOpenPr.has(beadId) || beadIdsInCleanup.has(beadId)) continue;
+    beadIdsInCleanup.add(beadId);
     items.push({
       key: `merged:${merged.number}`,
       lane: "post-merge-cleanup",

--- a/src/styles/familiar-work-queue.css
+++ b/src/styles/familiar-work-queue.css
@@ -147,6 +147,35 @@
   }
 }
 
+/* ── Truthful-degradation banners (refresh failed / beads adapter down) ──── */
+.fwq-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 20px 0;
+  padding: 7px 12px;
+  border-radius: var(--radius-panel, 12px);
+  font-size: 12px;
+}
+
+.fwq-banner--danger {
+  border: 1px solid color-mix(in oklch, var(--color-danger) 34%, transparent);
+  background: color-mix(in oklch, var(--color-danger) 7%, transparent);
+  color: var(--color-danger);
+}
+
+.fwq-banner--warn {
+  border: 1px solid color-mix(in oklch, var(--color-warning) 34%, transparent);
+  background: color-mix(in oklch, var(--color-warning) 7%, transparent);
+  color: var(--color-warning);
+}
+
+.fwq-banner-text {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-primary);
+}
+
 .fwq-body {
   flex: 1;
   min-height: 0;
@@ -310,6 +339,16 @@
   color: var(--color-warning);
   border-color: color-mix(in oklch, var(--color-warning) 40%, transparent);
   background: color-mix(in oklch, var(--color-warning) 10%, transparent);
+}
+
+/* Quiet per-item age ("updated 2h ago" / "merged 1h ago") — plain muted text,
+   not a pill, so it reads as metadata rather than a status. */
+.fwq-card-time {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .fwq-card-actions {

--- a/tests/familiar-work-queue.spec.ts
+++ b/tests/familiar-work-queue.spec.ts
@@ -75,6 +75,8 @@ test.describe("familiar work queue (PR control tower)", () => {
 
     // Header actionable count: 101(fail) + 102(ready) + 103(review) + cave-bb2(no-PR) + 90(cleanup) = 5 actionable.
     await expect(fwq.getByText(/5 actionable/)).toBeVisible();
+    // Freshness readout is truthful from the first load.
+    await expect(fwq.getByText(/updated just now/)).toBeVisible();
 
     // Every acceptance lane the mock populates renders, in fix→land→review→bead order.
     await expect(fwq.getByRole("region", { name: "Checks failing" })).toBeVisible();
@@ -148,10 +150,20 @@ test.describe("familiar work queue (PR control tower)", () => {
     await expect(cleanup.getByRole("button", { name: "Close bead" })).toBeDisabled();
     await expect(cleanup.getByText(/Add a handoff note to record verification/)).toBeVisible();
 
-    // Record a handoff note through the inline composer.
-    await cleanup.getByRole("button", { name: /Add a handoff note to cave-open/ }).click();
+    // Record a handoff note through the inline composer. Focus lands in the
+    // textarea on open; Escape closes and hands focus back to the toggle
+    // (keeping the draft); submit does the same once the note posts.
+    const noteToggle = cleanup.getByRole("button", { name: /Add a handoff note to cave-open/ });
+    await noteToggle.click();
+    const noteBox = cleanup.getByRole("textbox", { name: /Handoff note for cave-open/ });
+    await expect(noteBox).toBeFocused();
+    await noteBox.press("Escape");
+    await expect(noteBox).toHaveCount(0);
+    await expect(noteToggle).toBeFocused();
+    await noteToggle.click();
     await cleanup.getByRole("textbox", { name: /Handoff note for cave-open/ }).fill("Verified: lanes render, close gated.");
     await cleanup.getByRole("button", { name: "Add note" }).click();
+    await expect(noteToggle).toBeFocused();
 
     // The note posts as a comment on the bead…
     await expect.poll(() => commentBody).toEqual({
@@ -178,6 +190,79 @@ test.describe("familiar work queue (PR control tower)", () => {
     await expect(strip.locator(".fwq-attention-item", { hasText: "#102" })).toHaveCount(0);
     // Each row can jump to the PR.
     await expect(stale.getByRole("button", { name: "Open PR" })).toBeVisible();
+  });
+
+  test("beads adapter failure degrades to PRs-only with a visible notice", async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("cave:onboarding:dismissed", "1");
+      window.localStorage.setItem("cave:active-familiar", "kitty");
+    });
+    await page.route("**/api/familiars**", (r) =>
+      r.fulfill({ json: { ok: true, familiars: [{ id: "kitty", display_name: "Kitty", role: "B", status: "active", icon: "ph:sparkle-fill" }] } }),
+    );
+    await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions: [] } }));
+    await page.route(/\/api\/beads\/prs/, (r) => r.fulfill({ json: { ok: true, open: OPEN_PRS, merged: MERGED_PRS } }));
+    // The beads adapter is down (bd missing / not a beads workspace).
+    await page.route(/\/api\/beads\?/, (r) => r.fulfill({ status: 500, json: { ok: false, error: "bd unavailable" } }));
+
+    await page.goto("/");
+    await page.getByRole("navigation").first().waitFor({ timeout: 30_000 });
+    await expect(async () => {
+      await page.evaluate(() =>
+        window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })),
+      );
+      await expect(page.locator(".fwq")).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 30_000 });
+
+    const fwq = page.locator(".fwq");
+    // The degradation is SAID, not silent.
+    await expect(fwq.getByText(/Beads adapter unavailable/)).toBeVisible();
+    // PR lanes still render from the bridge…
+    await expect(fwq.getByRole("region", { name: "Checks failing" })).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "Needs review" })).toBeVisible();
+    // …but the bead-driven lanes are gone (no ready set to derive them from).
+    await expect(fwq.getByRole("region", { name: "No open PR" })).toHaveCount(0);
+    await expect(fwq.getByRole("region", { name: "Post-merge cleanup" })).toHaveCount(0);
+  });
+
+  test("failed refresh keeps earlier data and shows an inline retry banner", async ({ page }) => {
+    // Flip-switch rather than a call counter: dev-mode StrictMode double-mount
+    // (and focus refreshes) make the number of initial loads unpredictable.
+    let failPrs = false;
+    await page.addInitScript(() => {
+      window.localStorage.setItem("cave:onboarding:dismissed", "1");
+      window.localStorage.setItem("cave:active-familiar", "kitty");
+    });
+    await page.route("**/api/familiars**", (r) =>
+      r.fulfill({ json: { ok: true, familiars: [{ id: "kitty", display_name: "Kitty", role: "B", status: "active", icon: "ph:sparkle-fill" }] } }),
+    );
+    await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions: [] } }));
+    await page.route(/\/api\/beads\/prs/, (r) => {
+      if (failPrs) return r.fulfill({ status: 502, json: { ok: false, error: "gh exploded" } });
+      return r.fulfill({ json: { ok: true, open: OPEN_PRS, merged: MERGED_PRS } });
+    });
+    await page.route(/\/api\/beads\?/, (r) => r.fulfill({ json: { ok: true, data: READY_BEADS } }));
+
+    await page.goto("/");
+    await page.getByRole("navigation").first().waitFor({ timeout: 30_000 });
+    await expect(async () => {
+      await page.evaluate(() =>
+        window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "familiar-work-queue" } })),
+      );
+      await expect(page.locator(".fwq")).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 30_000 });
+
+    const fwq = page.locator(".fwq");
+    await expect(fwq.getByRole("region", { name: "Checks failing" })).toBeVisible();
+
+    failPrs = true;
+    await fwq.getByRole("button", { name: "Refresh work queue" }).click();
+    const banner = fwq.getByRole("alert");
+    await expect(banner).toContainText("Couldn't refresh the queue");
+    await expect(banner.getByRole("button", { name: "Retry" })).toBeVisible();
+    // Earlier data stays on screen — the failure does not blank the queue.
+    await expect(fwq.getByRole("region", { name: "Checks failing" })).toBeVisible();
+    await expect(fwq.getByRole("region", { name: "Post-merge cleanup" })).toBeVisible();
   });
 
   test("Attention strip is absent when no PR is stale or unlinked", async ({ page }) => {


### PR DESCRIPTION
Elevates the Familiar Work Queue to the bar the recent surface audits set. Builds atop #2638's compact header band (rebased; the freshness readout folds into its summary line).

## What changed

**Truthful degradation** — the control tower no longer hides its own failures:
- Beads-adapter failure previously degraded *silently* (queue showed PRs-only with no notice). Now: a warning banner says "Beads adapter unavailable — showing PRs only…", the clear-queue empty state hedges instead of claiming "no ready beads", and PR lanes keep working.
- A failed refresh with data on screen previously rendered *nothing* (error state only existed for the no-data case). Now: an inline `role=alert` banner with Retry; earlier data stays visible. Static banner text (raw error in the tooltip) so repeated failing polls don't re-announce to AT.
- The header gains an "updated Xm ago" readout (`useMinuteTick`) that ages honestly while quiet polls fail; PR/merged cards carry quiet "updated 2h ago"/"merged 1h ago" metadata.

**Poll perf** — the 30s poll rebuilt a fresh object graph every tick and re-rendered every lane/card for an identical picture. `setQueue` now keeps the previous state identity when serialized content is unchanged (the evals/marketplace audit pattern).

**Model correctness** (`beads-work-queue.ts` + unit tests):
- A bead with a merged PR *and* a still-open follow-up PR no longer gets a premature "Close bead" prompt in post-merge-cleanup — it stays in the open PR's lane.
- A bead landed across several merged PRs collapses to one cleanup item (freshest PR names the close reason).

**A11y** — the handoff-note composer now moves focus into the textarea on open and returns it to the Note toggle on Escape/Cancel/submit; Escape keeps the draft (accidental Escape must not destroy typed verification text).

## Verification
- `tsc` clean; 560-file `test:app` green post-rebase; model unit tests extended and green.
- Playwright spec extended (+2 tests, +focus assertions): 7/7 green locally against the self-started server, zero retries.
- Visually verified against a prod build: compact band + freshness, degraded warning banner, refresh-failure banner + Retry, composer focus ring — all four states screenshotted.

Bead: cave-d3pg (scope-split from cave-lh2v/#2638, which owned the header conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)