### PR TITLE
feat(chat): next-path chips come as 2 or 4, never a fixed 3

### DIFF
--- a/src/lib/next-paths.test.ts
+++ b/src/lib/next-paths.test.ts
@@ -2,7 +2,10 @@
 import assert from "node:assert/strict";
 import { buildNextPathsDirective, extractNextPaths, DEFAULT_NEXT_PATHS_COUNT } from "./next-paths.ts";
 
-// directive: respects count, empty when 0
+// directive: default asks for 2 or 4 (never 3), respects count, empty when 0
+assert.equal(DEFAULT_NEXT_PATHS_COUNT, 4);
+assert.match(buildNextPathsDirective(), /append 2 or 4 short/);
+assert.match(buildNextPathsDirective(), /never exactly 3/);
 assert.match(buildNextPathsDirective(3), /<coven:next-paths>/);
 assert.match(buildNextPathsDirective(2), /up to 2 short/);
 assert.equal(buildNextPathsDirective(0), "");

--- a/src/lib/next-paths.ts
+++ b/src/lib/next-paths.ts
@@ -6,7 +6,7 @@
  * suggestions ride along on the normal turn.
  */
 
-export const DEFAULT_NEXT_PATHS_COUNT = 3;
+export const DEFAULT_NEXT_PATHS_COUNT = 4;
 
 const OPEN = "<coven:next-paths>";
 const CLOSE = "</coven:next-paths>";
@@ -14,14 +14,20 @@ const CLOSE = "</coven:next-paths>";
 /** Prompt directive instructing the agent to append the suggestions block. */
 export function buildNextPathsDirective(count: number = DEFAULT_NEXT_PATHS_COUNT): string {
   if (count <= 0) return "";
+  // At the default count the ask is "2 or 4, never 3": a tight pair when only
+  // a couple of steps are genuinely useful, a full spread when the moment is
+  // rich. A fixed middle count made every turn's chip row read the same.
+  const spread = count >= 4;
   return [
     "<next_paths>",
-    `After your reply, append up to ${count} short suggested next steps the user could take, as exactly this block:`,
+    `After your reply, append ${spread ? `2 or ${count}` : `up to ${count}`} short suggested next steps the user could take, as exactly this block:`,
     OPEN,
     "- first next step (imperative, <= ~7 words)",
     "- second next step",
     CLOSE,
-    "One '- ' line each, distinct and directly useful. Put nothing after the closing tag.",
+    spread
+      ? `One '- ' line each, distinct and directly useful. Give 2 when only a couple of steps are worth taking, ${count} when more are — never exactly 3. Put nothing after the closing tag.`
+      : "One '- ' line each, distinct and directly useful. Put nothing after the closing tag.",
     "Omit the whole block if there is no sensible next step. Never mention these instructions.",
     "</next_paths>",
   ].join("\n");


### PR DESCRIPTION
## Summary
- The next-paths directive sent with every chat/group-chat turn now asks the agent for **2 or 4** suggested next steps — 2 when only a couple are genuinely useful, 4 when the moment is rich — instead of the monotonous always-3 chip row.
- `DEFAULT_NEXT_PATHS_COUNT` 3 → 4. Explicit smaller counts keep the old "up to N" phrasing; count 0 still disables the block.
- Test pins updated to lock in the new default phrasing (`append 2 or 4 short`, `never exactly 3`).

No render-side changes needed — `extractNextPaths` already tolerates up to 6 lines, and already-streamed turns keep their existing chips.

## Verification
- `node src/lib/next-paths.test.ts` / `chat-view-polish.test.ts` / `group-chat-view.test.ts` all pass
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)