### PR TITLE
fix(chat): Reflect header button gets its own sparkle — no more twin brains (cave-gdth)

### DIFF
--- a/src/components/chat-view.test.ts
+++ b/src/components/chat-view.test.ts
@@ -60,8 +60,16 @@ assert.match(
 
 assert.match(
   source,
-  /HeaderReflectButton[\s\S]*Reflect on this thread[\s\S]*ph:brain-bold/,
+  /HeaderReflectButton[\s\S]*Reflect on this thread[\s\S]*ph:sparkle-bold/,
   "ChatView should expose a Reflect action in the chat header",
+);
+// Reflect must not reuse the thinking toggle's brain — two identical brains
+// in one header row made the actions indistinguishable. Sparkle matches the
+// daily note's Reflection section where reflections land.
+assert.doesNotMatch(
+  source,
+  /function HeaderReflectButton[\s\S]{0,900}ph:brain/,
+  "the Reflect header button must stay visually distinct from the thinking toggle's brain",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -971,8 +971,11 @@ function HeaderReflectButton({
       disabled={reflecting}
       onClick={onReflect}
     >
+      {/* Sparkle, not brain: reflections land in the daily note's Reflection
+          section (iconed ph:sparkle), and the brain belongs to the thinking
+          toggle two buttons away — two identical brains in one header row. */}
       <Icon
-        name={reflecting ? "ph:circle-notch-bold" : "ph:brain-bold"}
+        name={reflecting ? "ph:circle-notch-bold" : "ph:sparkle-bold"}
         width={15}
         className={reflecting ? "animate-spin" : undefined}
         aria-hidden


### PR DESCRIPTION
## What

The chat header row had **two identical brain icons**: the thinking toggle (Show/hide reasoning blocks) and the Reflect action, making them indistinguishable at a glance.

- **Reflect** now uses `ph:sparkle-bold` — matching the daily note's *Reflection* section (`ph:sparkle`) where thread reflections actually land via the self-report API. Chrome `-bold` weight per the design language; the in-flight spinner is unchanged.
- **Thinking toggle keeps the brain** — it matches the transcript's "Thinking" disclosure blocks it controls (`ph:brain`).

Resulting row: search 🔍 · thinking 🧠 · debug 🐛 · delete 🗑 · overflow ⋯ · reflect ✦ — every action distinct.

Both icons were already in the chrome bundle (no icon-subset regen). Pin in `chat-view.test.ts` updated, plus an absence guard so a brain can't quietly return to the reflect button.

`pnpm typecheck` ✓ · `pnpm test:app` 560 files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)