### PR TITLE
fix(chat): system echoes survive mid-stream — appendSystem routes through the live registry (cave-7ft)

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3326,7 +3326,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       createdAt: new Date().toISOString(),
     };
     appendTurn(newTurn);
-    setTurns((prev) => [...prev, newTurn]);
+    // Route through the live registry (cave-7ft): while a response streams the
+    // registry is the source of truth — a raw setTurns append would be
+    // discarded when the next assistant_chunk mirrors the registry snapshot
+    // back. updateLiveTurns also keeps turnsRef in sync. Preserve the current
+    // leaf: mid-stream the registry's activeLeafId is the streaming assistant
+    // turn, and overwriting it with this view's (possibly stale) state would
+    // re-point the rendered branch.
+    const live = currentSessionRef.current ? liveChatRegistry.read(currentSessionRef.current) : null;
+    updateLiveTurns((prev) => [...prev, newTurn], live?.activeLeafId ?? activeLeafId);
   };
 
   const runCovenExec = async (subcommand: "doctor" | "daemon") => {

--- a/src/lib/conversation-tree.test.ts
+++ b/src/lib/conversation-tree.test.ts
@@ -39,6 +39,53 @@ test("resolveActivePath defends against a parent cycle", () => {
   assert.ok(path.length >= 1);
 });
 
+test("resolveActivePath weaves chain-less system echoes into the path by createdAt (cave-7ft)", () => {
+  // /help output appended while a reply streams: no parentId, so a pure
+  // ancestor walk from the streaming leaf would hide it.
+  const turns = [
+    t("u1", null, 1),
+    t("a1", "u1", 2),
+    { id: "sys1", role: "system", createdAt: "2026-06-23T00:00:03.000Z" },
+    t("u2", "a1", 4),
+    t("a2", "u2", 5),
+    { id: "sys2", role: "system", createdAt: "2026-06-23T00:00:06.000Z" },
+  ];
+  const path = resolveActivePath(turns, "a2");
+  assert.deepEqual(path.map((x) => x.id), ["u1", "a1", "sys1", "u2", "a2", "sys2"]);
+});
+
+test("resolveActivePath keeps same-timestamp user/assistant pair order when weaving echoes", () => {
+  // sendRaw stamps the user turn and its pending assistant with the same
+  // createdAt; weaving must not re-sort the chain (id tie-breaks are random).
+  const now = "2026-06-23T00:00:02.000Z";
+  const turns = [
+    { id: "z-user", parentId: null, role: "user", createdAt: now },
+    { id: "a-assistant", parentId: "z-user", role: "assistant", createdAt: now },
+    { id: "sys", role: "system", createdAt: "2026-06-23T00:00:03.000Z" },
+  ];
+  const path = resolveActivePath(turns, "a-assistant");
+  assert.deepEqual(path.map((x) => x.id), ["z-user", "a-assistant", "sys"]);
+});
+
+test("resolveActivePath excludes system turns that ARE in the ancestor chain from weaving", () => {
+  // A parented system turn is a normal chain member — it must appear exactly
+  // once, in chain position.
+  const turns = [
+    t("u1", null, 1),
+    { id: "sys", parentId: "u1", role: "system", createdAt: "2026-06-23T00:00:02.000Z" },
+    { id: "a1", parentId: "sys", role: "assistant", createdAt: "2026-06-23T00:00:03.000Z" },
+  ];
+  const path = resolveActivePath(turns, "a1");
+  assert.deepEqual(path.map((x) => x.id), ["u1", "sys", "a1"]);
+});
+
+test("resolveActivePath does not weave parentless USER turns (root branch siblings stay hidden)", () => {
+  // A second root user turn is an alternative branch, not an echo — weaving it
+  // into the active path would render both branches at once.
+  const turns = [t("u1", null, 1), t("a1", "u1", 2), t("u1b", null, 3), t("a1b", "u1b", 4)];
+  assert.deepEqual(resolveActivePath(turns, "a1").map((x) => x.id), ["u1", "a1"]);
+});
+
 test("siblingsOf returns ordered siblings and the 0-based index", () => {
   const turns = [t("u1", null, 1), t("a", "u1", 2), t("b", "u1", 3), t("c", "u1", 4)];
   const r = siblingsOf(turns, "b");

--- a/src/lib/conversation-tree.ts
+++ b/src/lib/conversation-tree.ts
@@ -12,6 +12,9 @@ export type TreeTurn = {
   id: string;
   parentId?: string | null;
   createdAt?: string;
+  /** Optional role. Only "system" affects path resolution: chain-less system
+   *  echoes are woven into the active path (see resolveActivePath). */
+  role?: string;
 };
 
 function byCreatedAt<T extends TreeTurn>(turns: T[]): T[] {
@@ -27,6 +30,11 @@ function byCreatedAt<T extends TreeTurn>(turns: T[]): T[] {
  * The chain from `activeLeafId` up to the root, returned root-first. Falls back
  * to a createdAt linearization when the leaf is missing, and guards against
  * cycles (a corrupt parent ring) by stopping when it revisits a node.
+ *
+ * Chain-less system turns (role "system", no parentId — e.g. /help output or
+ * coven-exec echoes appended client-side) are not ancestors of any leaf, so a
+ * pure ancestor walk would hide them whenever a leaf is set (notably while a
+ * reply streams, cave-7ft). They are woven back into the path by createdAt.
  */
 export function resolveActivePath<T extends TreeTurn>(turns: T[], activeLeafId: string): T[] {
   const byId = new Map(turns.map((x) => [x.id, x]));
@@ -41,7 +49,26 @@ export function resolveActivePath<T extends TreeTurn>(turns: T[], activeLeafId: 
     const parentId: string | null | undefined = current.parentId;
     current = parentId ? byId.get(parentId) : undefined;
   }
-  return chain.reverse();
+  chain.reverse();
+  const orphanSystems = turns.filter(
+    (x) => x.role === "system" && x.parentId == null && !seen.has(x.id),
+  );
+  if (orphanSystems.length === 0) return chain;
+  // Insert each echo before the first chain turn created strictly after it.
+  // No full re-sort: user/assistant pairs share a createdAt stamp, so sorting
+  // the chain itself would tie-break on random ids and could swap them.
+  const at = (x: T) => (x.createdAt ? Date.parse(x.createdAt) : 0);
+  for (const sys of byCreatedAt(orphanSystems)) {
+    let idx = chain.length;
+    for (let i = 0; i < chain.length; i++) {
+      if (at(chain[i]) > at(sys)) {
+        idx = i;
+        break;
+      }
+    }
+    chain.splice(idx, 0, sys);
+  }
+  return chain;
 }
 
 /**


### PR DESCRIPTION
## Problem (cave-7ft)
Running `/help` (or a coven-exec echo) while a reply is streaming briefly shows output, then it vanishes on the next token:

1. `appendSystem` used raw `setTurns` — never the live registry, never `turnsRef`. Mid-stream the registry is the source of truth, so the next `assistant_chunk`'s `advance` + mirror discarded the just-appended system turn.
2. Even a registry-routed system turn would stay invisible: it has no `parentId`, and `resolveActivePath` renders only the ancestor chain of `activeLeafId` (which is the streaming assistant turn mid-stream).

## Fix
- `appendSystem` now routes through `updateLiveTurns`, preserving the registry's `activeLeafId` so the rendered branch is never re-pointed by stale component state.
- `resolveActivePath` weaves chain-less **system** turns into the path by `createdAt` — positional insertion, never a re-sort (user/assistant pairs share a createdAt stamp; id tie-breaks are random). Parentless **user** turns (root branch siblings) remain excluded.

## Verification
- 5 new assertions in `conversation-tree.test.ts` (weave order, same-timestamp pair order, parented system turns, root-sibling exclusion)
- `pnpm test:app` — 560 files pass; `pnpm test:api` — 126 files pass; `pnpm typecheck` clean

Closes cave-7ft (beads). The /clear variant was fixed separately in PR #2607.