### PR TITLE
feat(chat): artifact refine chips come as 2 or 4, never a fixed 3

### DIFF
--- a/src/lib/refine-suggestions.test.ts
+++ b/src/lib/refine-suggestions.test.ts
@@ -5,15 +5,25 @@ import {
   generateRefineSuggestions,
 } from "./refine-suggestions.ts";
 
-test("defaults are a small, stable trio", () => {
-  assert.equal(DEFAULT_REFINE_SUGGESTIONS.length, 3);
+test("defaults are a small, stable quartet — 2-or-4 policy, never 3", () => {
+  assert.equal(DEFAULT_REFINE_SUGGESTIONS.length, 4);
   assert.ok(DEFAULT_REFINE_SUGGESTIONS.every((s) => typeof s === "string" && s.length > 0));
 });
 
 test("always returns at least one suggestion, capped at the limit", () => {
   assert.ok(generateRefineSuggestions("", "html").length >= 1);
-  assert.ok(generateRefineSuggestions("", "html").length <= 3);
+  assert.ok(generateRefineSuggestions("", "html").length <= 4);
   assert.equal(generateRefineSuggestions("<button>hi</button>", "html", 2).length, 2);
+});
+
+test("generated row comes as a pair or a spread — never exactly 3", () => {
+  // A polished artifact that trips no rule (has @media, transitions, no
+  // form/button/svg) would pool exactly the 3 fallbacks — trimmed to 2.
+  const polished =
+    "<style>@media (min-width:600px){.a{color:red}} .b{transition:opacity .2s}</style><div>hi</div>";
+  assert.equal(generateRefineSuggestions(polished, "html").length, 2);
+  assert.notEqual(generateRefineSuggestions("", "html").length, 3);
+  assert.notEqual(generateRefineSuggestions("<button>hi</button>", "html").length, 3);
 });
 
 test("generated suggestions never duplicate the defaults", () => {

--- a/src/lib/refine-suggestions.ts
+++ b/src/lib/refine-suggestions.ts
@@ -19,6 +19,7 @@ export const DEFAULT_REFINE_SUGGESTIONS: readonly string[] = [
   "Polish the visual hierarchy, spacing, and alignment",
   "Improve accessibility — color contrast, labels, and focus states",
   "Add subtle motion and micro-interactions",
+  "Tighten the copy — shorter, clearer labels and headings",
 ];
 
 type Rule = {
@@ -69,12 +70,13 @@ const FALLBACKS: string[] = [
 /**
  * Up to `limit` context-aware suggestions for this artifact, de-duplicated
  * against the defaults so the two rows never repeat an idea. Always returns at
- * least one item by topping up from neutral fallbacks.
+ * least one item by topping up from neutral fallbacks. Like the chat next-path
+ * chips, the row comes as a pair or a spread — never exactly 3.
  */
 export function generateRefineSuggestions(
   code: string,
   kind: ArtifactKind = "html",
-  limit = 3,
+  limit = 4,
 ): string[] {
   const src = code ?? "";
   const taken = new Set(DEFAULT_REFINE_SUGGESTIONS.map((s) => s.toLowerCase()));
@@ -95,5 +97,8 @@ export function generateRefineSuggestions(
     if (out.length >= limit) break;
     add(fb);
   }
+  // 2-or-4 policy: when the pool lands on exactly 3, trim to a tight pair
+  // rather than showing the middling row.
+  if (out.length === 3) out.pop();
   return out;
 }


### PR DESCRIPTION
## Summary
Extends the 2-or-4 suggestion policy from the chat next-path chips (#2642) to the artifact Refine space:
- **Defaults row**: grows a fourth always-useful chip ("Tighten the copy — shorter, clearer labels and headings") — 3 → 4.
- **Generated row** (`generateRefineSuggestions`): default limit 3 → 4; when the heuristic pool lands on exactly 3 (e.g. a polished artifact that trips no rule and pools only the 3 fallbacks), it trims to a pair instead of showing the middling row. Explicit caller limits ≤ 2 behave as before.

## Verification
- `node --test src/lib/refine-suggestions.test.ts` — 8 pass / 0 fail, including new pins (quartet defaults; never-exactly-3 for the generated row)
- `tsc --noEmit` clean in the worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)