### PR TITLE
fix(terminal): reap the WS-transport shell on tab close, not after a 5-min grace (cave-wujw)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -240,6 +240,13 @@ function onWsMessage(threadId, data) {
     if (cols > 0 && rows > 0) {
       session.pty.resize(cols, rows);
     }
+  } else if (tag === 5) {
+    if (session.detachTimer) clearTimeout(session.detachTimer);
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+    }
   }
 }
 function adoptSession(session, ws, cols, rows) {

--- a/server.ts
+++ b/server.ts
@@ -346,6 +346,18 @@ function onWsMessage(threadId: string, data: RawData): void {
     if (cols > 0 && rows > 0) {
       session.pty.resize(cols, rows);
     }
+  } else if (tag === 0x05) {
+    // Explicit tab-close (client sent a kill frame): reap the shell NOW rather
+    // than detaching with a grace window. Without this, a WS-transport tab close
+    // just drops the socket, which the close handler treats as a transient
+    // detach — leaking the shell (and its foreground job) for DETACH_GRACE_MS.
+    if (session.detachTimer) clearTimeout(session.detachTimer);
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+      // Already gone.
+    }
   }
 }
 

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -319,6 +319,11 @@ assert.match(
   /removeSession[\s\S]{0,900}pty_stop/,
   "closing a tab is the one place the desktop PTY is killed",
 );
+assert.match(
+  source,
+  /killPtyBridge\(`cave\.comux\.\$\{removedId\}`\)/,
+  "closing a tab also reaps the WS-transport shell (killPtyBridge, scoped to removedId) so it doesn't leak for the detach grace (cave-wujw)",
+);
 
 // Tab rename: Escape aborts (restores the label), and blank/whitespace names
 // are rejected so a cleared tab keeps its label.

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -5,6 +5,7 @@ import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { BottomTerminal } from "@/components/bottom-terminal";
+import { killPtyBridge } from "@/lib/pty-ws-bridge";
 import { Icon } from "@/lib/icon";
 import { copyText } from "@/lib/clipboard";
 import { ProjectTree, type ProjectTreeHandle } from "@/components/project-tree";
@@ -719,6 +720,14 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
           )
           .catch(() => {});
       }
+      // WS transport (browser / iOS / Android): the desktop pty_stop above only
+      // reaps native-IPC shells. Without this, closing a tab merely drops the
+      // socket — which the server treats as a transient detach — so the shell
+      // (and its foreground job) leaks for the full detach grace (~5 min).
+      // killPtyBridge sends an explicit kill frame; it is a no-op when no WS
+      // bridge is registered for the threadId (i.e. the desktop transport), so
+      // running it unconditionally is safe.
+      killPtyBridge(`cave.comux.${removedId}`);
     },
     [sessions],
   );

--- a/src/lib/pty-ws-bridge.test.ts
+++ b/src/lib/pty-ws-bridge.test.ts
@@ -51,3 +51,29 @@ assert.match(
   "a prior (possibly zombie) socket is torn down before re-dialing",
 );
 console.log("pty-ws-bridge iOS-resume assertions: ok");
+
+// ── Explicit tab-close reaps the shell (cave-wujw) ────────────────────────────
+// Closing a terminal tab on the WS transport used to just drop the socket, which
+// the server treats as a transient DETACH — leaking the shell (and its
+// foreground job) for the full detach grace (~5 min). The bridge now sends an
+// explicit kill frame (0x05); a threadId→bridge registry lets the out-of-tree
+// tab-close handler reach the bridge it doesn't own.
+assert.match(src, /const activeBridges = new Map<string, PtyWsBridge>/, "a threadId→bridge registry exists for out-of-tree kills");
+assert.match(
+  src,
+  /export function killPtyBridge\(threadId: string\): void \{\s*\n\s*activeBridges\.get\(threadId\)\?\.kill\(\);/,
+  "killPtyBridge reaps by threadId (no-op when no WS bridge is registered — e.g. desktop native IPC)",
+);
+assert.match(src, /activeBridges\.set\(target\.threadId, this\)/, "open() registers the bridge by threadId");
+assert.match(
+  src,
+  /activeBridges\.get\(threadId\) === this\)\s*\{\s*\n\s*activeBridges\.delete\(threadId\)/,
+  "dispose() unregisters only its own entry",
+);
+assert.match(
+  src,
+  /kill\(\): void \{[\s\S]{0,220}send\(new Uint8Array\(\[0x05\]\)\)/,
+  "kill() sends the 0x05 kill frame over the open socket",
+);
+assert.match(src, /kill\(\): void \{[\s\S]{0,320}this\.dispose\(\)/, "kill() tears down after sending the frame");
+console.log("pty-ws-bridge kill-frame assertions: ok");

--- a/src/lib/pty-ws-bridge.ts
+++ b/src/lib/pty-ws-bridge.ts
@@ -9,6 +9,22 @@ type CloseHandler = (code: number, reason: string) => void;
 // terminal pane (every keypress is silently dropped).
 const CONNECT_TIMEOUT_MS = 8000;
 
+// Registry of live WS bridges keyed by threadId, so an out-of-tree caller (the
+// comux tab-close handler) can reap a shell without holding the bridge ref —
+// the bridge is created and owned inside BottomTerminal.
+const activeBridges = new Map<string, PtyWsBridge>();
+
+/**
+ * Explicit tab-close: tell the server to reap the shell for this threadId NOW,
+ * instead of letting the socket close detach with a grace window (which leaks
+ * the shell for minutes on the WS transport). No-op when no WS bridge is
+ * registered for the threadId — e.g. the desktop native-IPC transport, which
+ * reaps via `pty_stop` — so callers can invoke it unconditionally.
+ */
+export function killPtyBridge(threadId: string): void {
+  activeBridges.get(threadId)?.kill();
+}
+
 export class PtyWsBridge {
   private ws: WebSocket | null = null;
   private dataHandlers: DataHandler[] = [];
@@ -60,6 +76,7 @@ export class PtyWsBridge {
   private open(): Promise<void> {
     const target = this.lastConnect;
     if (!target) return Promise.reject(new Error("no connect parameters"));
+    activeBridges.set(target.threadId, this);
     // Tear down any prior socket before re-dialing. After an iOS app resume the
     // previous socket can be a zombie — readyState still reads OPEN but the
     // connection is dead, so it never fires close and silently swallows writes.
@@ -175,7 +192,30 @@ export class PtyWsBridge {
     this.ws.send(frame);
   }
 
+  /**
+   * Explicit tab-close: send the server a kill frame (0x05) so it reaps the
+   * shell immediately rather than detaching with a grace window, then tear
+   * down. Distinct from dispose() — a transient unmount / navigation, which must
+   * leave the shell alive so a remount can reattach. Sent over the still-open
+   * socket; close() below flushes it during the closing handshake.
+   */
+  kill(): void {
+    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+      try {
+        this.ws.send(new Uint8Array([0x05]));
+      } catch {
+        // Socket went away mid-close — dispose() tears down below; the server's
+        // detach grace still reaps the shell as a fallback.
+      }
+    }
+    this.dispose();
+  }
+
   dispose(): void {
+    const threadId = this.lastConnect?.threadId;
+    if (threadId && activeBridges.get(threadId) === this) {
+      activeBridges.delete(threadId);
+    }
     this.dataHandlers = [];
     this.exitHandlers = [];
     this.closeHandlers = [];

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -79,6 +79,12 @@ assert.match(src, /frame\[0\]\s*=\s*0x01/, "server sends output tag 0x01");
 assert.match(src, /frame\[0\]\s*=\s*0x02/, "server sends exit tag 0x02");
 assert.match(src, /tag === 0x03/, "server receives input tag 0x03");
 assert.match(src, /tag === 0x04/, "server receives resize tag 0x04");
+assert.match(src, /tag === 0x05/, "server receives an explicit kill tag 0x05 (cave-wujw)");
+assert.match(
+  src,
+  /tag === 0x05[\s\S]{0,500}sessions\.delete\(threadId\)[\s\S]{0,200}session\.pty\.kill\(\)/,
+  "the 0x05 kill frame reaps the shell immediately (clear detach timer, delete, kill), bypassing the grace window",
+);
 // Always loopback by default (both dev and prod)
 assert.match(src, /isAllowedUpgradeSource/, "server validates WebSocket upgrade host and origin");
 assert.match(src, /isLoopbackHost\(host\)/, "server only accepts loopback WebSocket hosts by default");


### PR DESCRIPTION
## What

From the terminal-surface audit. Closing a terminal tab only reaped the shell on **desktop** (`removeSession` invokes `pty_stop` behind a `__TAURI_INTERNALS__` guard). On the **WS transport** (browser / iOS / Android) closing a tab just dropped the socket, which the server treats as a transient **detach** — scheduling the kill only after `DETACH_GRACE_MS` (~5 min). So every closed tab leaked a live shell + its foreground job (`npm run dev`, `tail -f`) for minutes; churn piled up orphans.

## Fix — an explicit kill path for the WS transport

- **`server.ts`**: a new client→server kill frame (**`0x05`**) reaps the shell immediately (clears the detach timer, deletes the session, kills the PTY), bypassing the grace window. Rebuilt `server.mjs` (esbuild `--bundle=false`).
- **`pty-ws-bridge.ts`**: a `kill()` method sends `0x05` over the open socket then disposes; a module-level threadId→bridge registry + exported `killPtyBridge()` let the out-of-tree tab-close handler reach the bridge it doesn't own.
- **`comux-view.tsx`**: `removeSession` calls `killPtyBridge(\`cave.comux.${id}\`)` unconditionally — a no-op when no WS bridge is registered (desktop), so it composes with the existing native `pty_stop`.

`kill()` is deliberately distinct from `dispose()`: a transient unmount / navigation must still leave the shell alive for reattach (the keepalive contract), so **only the deliberate tab-close path kills**.

## Verification

`check:tests-wired` · `typecheck` · **560** app test files · `build` within budget. Source pins added on all three sides (server `0x05` reap, bridge `kill()`+registry, comux `removeSession`→`killPtyBridge`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)