### PR TITLE
fix(terminal): SR mirror follows visibility, not focus; throttle pty_resize (cave-2956)

### DIFF
--- a/src/components/bottom-terminal-sr-mirror.test.ts
+++ b/src/components/bottom-terminal-sr-mirror.test.ts
@@ -65,11 +65,30 @@ assert.match(source, /const \{ term, fit, search \} = await createXterm\(wrap, \
 assert.match(source, /^function searchDecorations\(\)/m, "searchDecorations is hoisted to module scope");
 assert.match(source, /decorations:\s*searchDecorations\(\)/, "search decorations are resolved when search runs");
 
-// The mirror must not re-render while the pane is backgrounded/hidden — a busy
+// The mirror must not re-render while the pane is HIDDEN (keepalive) — a busy
 // background stream otherwise re-renders the 50-line mirror every 250ms
 // off-screen. pushToMirror keeps decoding (decoder stays consistent) but skips
-// the flush when the pane isn't active, and drains on becoming active.
-assert.match(source, /if \(!activeRef\.current\) \{[\s\S]{0,180}return;/, "the SR mirror doesn't re-render while the pane is hidden");
-assert.match(source, /if \(active\) \{\s*\n\s*flushMirror\(\);/, "buffered output is drained into the mirror when the pane becomes active");
+// the flush when the pane isn't visible, and drains on reveal. Crucially it is
+// VISIBILITY — not focus — that gates the mirror: a visible-but-unfocused
+// split pane must keep announcing its output (cave-2956).
+assert.match(source, /if \(!visibleRef\.current\) \{[\s\S]{0,180}return;/, "the SR mirror doesn't re-render while the pane is hidden");
+assert.match(source, /if \(visible\) flushMirror\(\);/, "buffered output is drained into the mirror when the pane is shown");
+assert.doesNotMatch(source, /activeRef/, "focus (active) must not gate the SR mirror — visibility does");
+
+// Resize storms (cave-2956): the local refit stays per-observer-callback, but
+// the PTY push (SIGWINCH) is throttled, deduped on unchanged cols/rows, and
+// skipped entirely for hidden keepalive panes.
+assert.match(source, /function makeResizer\(/, "both transports share the throttled resizer");
+assert.match(source, /RESIZE_PUSH_DEBOUNCE_MS/, "the PTY resize push is debounced");
+assert.match(source, /if \(!isVisible\(\)\) return;/, "hidden panes fit locally but never push pty_resize");
+assert.match(source, /if \(cols === last\.cols && rows === last\.rows\) return;/, "unchanged dimensions don't reach the PTY");
+assert.equal((source.match(/makeResizer\(term, fit/g) ?? []).length, 2, "both the Tauri and WS transports use makeResizer");
+assert.equal((source.match(/resizer\.dispose\(\)/g) ?? []).length, 2, "both transports clear the pending resize push on cleanup");
+
+// comux threads a separate `visible` signal: true for every rendered split
+// pane (so unfocused siblings keep announcing), false only for keepalive.
+const comux = readFileSync(new URL("./comux-view.tsx", import.meta.url), "utf8");
+assert.match(comux, /active=\{active && isActive\}\s*\n\s*visible=\{active\}/, "split panes are visible whenever the surface is, focused or not");
+assert.match(comux, /active=\{false\}\s*\n\s*visible=\{false\}/, "keepalive mounts are explicitly not visible");
 
 console.log("bottom-terminal-sr-mirror.test.ts OK");

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -11,7 +11,7 @@ assert.match(src, /if \(platform !== "desktop"\) return;/, "Tauri IPC path remai
 assert.match(src, /if \(platform !== "browser" && platform !== "ios" && platform !== "android"\) return;/, "WS bridge path covers browser and Tauri-mobile");
 assert.match(src, /bridge\.connect\(threadId,\s*term\.cols,\s*term\.rows,\s*projectRootRef\.current\)/, "WS bridge connects with terminal dimensions and cwd");
 assert.match(src, /bridge\.write\(new TextEncoder\(\)\.encode\(data\)\)/, "terminal input flows to WS bridge");
-assert.match(src, /bridge\.resize\(term\.cols,\s*term\.rows\)/, "terminal resize flows to WS bridge");
+assert.match(src, /bridge\.resize\(cols,\s*rows\)/, "terminal resize flows to WS bridge (throttled via makeResizer)");
 assert.match(src, /bridge\.dispose\(\)/, "WS bridge is disposed on cleanup");
 
 console.log("bottom-terminal-ws-bridge.test.ts OK");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -22,10 +22,16 @@ import { useAnnouncer } from "@/components/ui/live-region";
 // (e.g. `cargo build`) don't flood SR or thrash React.
 const MIRROR_LINES = 50;
 const MIRROR_DEBOUNCE_MS = 250;
-// While the pane is backgrounded the mirror isn't re-rendered; cap the buffered
-// text so a busy background stream can't grow it without bound before the pane
-// is next active (the flush trims to MIRROR_LINES anyway).
+// While the pane is hidden (keepalive) the mirror isn't re-rendered; cap the
+// buffered text so a busy background stream can't grow it without bound before
+// the pane is next shown (the flush trims to MIRROR_LINES anyway).
 const MIRROR_PENDING_CAP = 16384;
+// ResizeObserver fires every frame during a divider drag / window resize, and
+// each callback used to push pty_resize immediately — a SIGWINCH storm to the
+// shell (and to every hidden keepalive pane, which keeps full size at inset:0).
+// The local xterm refit stays per-callback for smooth visuals; only the PTY
+// push is throttled to this window, and skipped when the size didn't change.
+const RESIZE_PUSH_DEBOUNCE_MS = 150;
 // The xterm lazy-import + PTY handshake is "a few seconds"; well past that with
 // no connection means startup hung (a wedged native command, a transport await
 // that never settled, or `platform` never resolving off "unknown"). Surface a
@@ -82,6 +88,45 @@ type XtermBundle = {
   fit: import("@xterm/addon-fit").FitAddon;
   search: import("@xterm/addon-search").SearchAddon;
 };
+
+// Shared resize handling for both transports: refit the local xterm on every
+// observer callback (cheap; keeps the canvas crisp during divider drags), but
+// throttle the PTY push (SIGWINCH to the shell) to RESIZE_PUSH_DEBOUNCE_MS and
+// skip it for hidden panes and unchanged cols/rows. Hidden keepalive panes sit
+// at inset:0 so they'd otherwise mirror every window resize straight to N
+// background shells.
+function makeResizer(
+  term: import("@xterm/xterm").Terminal,
+  fit: import("@xterm/addon-fit").FitAddon,
+  isVisible: () => boolean,
+  push: (cols: number, rows: number) => void,
+) {
+  let last = { cols: -1, rows: -1 };
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const fire = () => {
+    timer = null;
+    // Hidden pane: local fit already happened (so reveal is crisp); the PTY
+    // learns the size on the next visible resize instead.
+    if (!isVisible()) return;
+    const { cols, rows } = term;
+    if (cols === last.cols && rows === last.rows) return;
+    last = { cols, rows };
+    push(cols, rows);
+  };
+  const doResize = () => {
+    try {
+      fit.fit();
+    } catch { /* harmless mid-tear-down */ }
+    if (timer == null) timer = setTimeout(fire, RESIZE_PUSH_DEBOUNCE_MS);
+  };
+  const dispose = () => {
+    if (timer != null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  return { doResize, dispose };
+}
 
 // Build the xterm instance + addons shared by both transports (Tauri IPC and the
 // WebSocket bridge). The two effects differ only in how bytes flow to/from the
@@ -147,13 +192,20 @@ async function createXterm(
 export function BottomTerminal({
   threadId,
   active = true,
+  visible = active,
   projectRoot,
   paneId,
   registerWriter,
   onUserInput,
 }: {
   threadId: string;
+  /** This pane has keyboard focus (drives refit + refocus on activation). */
   active?: boolean;
+  /** This pane is rendered on-screen. True for EVERY pane of a visible split
+   *  (not just the focused one) so the screen-reader mirror keeps flowing for
+   *  visible-but-unfocused panes; false only for hidden keepalive mounts.
+   *  Defaults to `active` for single-pane hosts. */
+  visible?: boolean;
   projectRoot?: string;
   /** Stable id for comux's broadcast registry (defaults to threadId). */
   paneId?: string;
@@ -267,10 +319,12 @@ export function BottomTerminal({
   if (!decoderRef.current) {
     decoderRef.current = new TextDecoder("utf-8", { fatal: false });
   }
-  // Mirror `active` into a ref so the byte handlers (registered once per mount)
-  // can read the current value without re-subscribing.
-  const activeRef = useRef(active);
-  activeRef.current = active;
+  // Mirror `visible` into a ref so the byte handlers and resize observers
+  // (registered once per mount) can read the current value without
+  // re-subscribing. `active` (focus) deliberately does NOT gate the mirror:
+  // a visible-but-unfocused split pane must keep announcing output.
+  const visibleRef = useRef(visible);
+  visibleRef.current = visible;
 
   const flushMirror = useCallback(() => {
     flushTimerRef.current = null;
@@ -290,13 +344,13 @@ export function BottomTerminal({
       // consistent — but don't re-render the (aria-hidden) mirror off-screen: a
       // busy background stream otherwise re-rendered the 50-line mirror every
       // 250ms while the terminal wasn't even visible. Buffer (bounded) and drain
-      // when the pane is next active.
+      // when the pane is next shown.
       const text = stripAnsi(
         decoderRef.current.decode(bytes, { stream: true }),
       );
       if (!text) return;
       pendingMirrorRef.current += text;
-      if (!activeRef.current) {
+      if (!visibleRef.current) {
         if (pendingMirrorRef.current.length > MIRROR_PENDING_CAP) {
           pendingMirrorRef.current = pendingMirrorRef.current.slice(-MIRROR_PENDING_CAP);
         }
@@ -331,17 +385,22 @@ export function BottomTerminal({
   // Also forward every BottomTerminal log line back to Rust so we can read
   // them in the tauri-dev stderr without needing WebView devtools.
 
-  // Re-fit + refocus whenever this terminal becomes the active tab.
+  // Drain output buffered while the pane was hidden as soon as it's shown —
+  // independent of focus, so every pane of a revealed split resumes announcing.
+  useEffect(() => {
+    if (visible) flushMirror();
+  }, [visible, flushMirror]);
+
+  // Re-fit + refocus whenever this terminal becomes the active (focused) pane.
   useEffect(() => {
     if (active) {
-      flushMirror(); // drain output buffered while the pane was hidden
       const id = requestAnimationFrame(() => {
         fitRef.current?.();
         termRef.current?.focus();
       });
       return () => cancelAnimationFrame(id);
     }
-  }, [active, flushMirror]);
+  }, [active]);
 
   // Startup watchdog: covers every way the terminal can stall before `ready` —
   // a native pty_* command that never returns, a transport await that throws/
@@ -501,16 +560,14 @@ export function BottomTerminal({
       if (!disposed) setReady(true);
       term.focus();
 
-      const doResize = () => {
-        try {
-          fit.fit();
-          void bridge.invoke("pty_resize", {
-            threadId: threadId,
-            cols: term.cols,
-            rows: term.rows,
-          });
-        } catch { /* harmless mid-tear-down */ }
-      };
+      const resizer = makeResizer(term, fit, () => visibleRef.current, (cols, rows) => {
+        void bridge.invoke("pty_resize", {
+          threadId: threadId,
+          cols,
+          rows,
+        }).catch(() => { /* harmless mid-tear-down */ });
+      });
+      const doResize = resizer.doResize;
 
       // Refit on container size changes.
       const ro = new ResizeObserver(doResize);
@@ -524,6 +581,7 @@ export function BottomTerminal({
 
       cleanup = () => {
         ro.disconnect();
+        resizer.dispose();
         onDataDispose.dispose();
         unlistenData();
         unlistenExit();
@@ -687,14 +745,12 @@ export function BottomTerminal({
       });
       writerRef.current = (d) => bridge.write(new TextEncoder().encode(d));
 
-      const doResize = () => {
+      const resizer = makeResizer(term, fit, () => visibleRef.current, (cols, rows) => {
         try {
-          fit.fit();
-          bridge.resize(term.cols, term.rows);
-        } catch {
-          /* harmless mid-tear-down */
-        }
-      };
+          bridge.resize(cols, rows);
+        } catch { /* harmless mid-tear-down */ }
+      });
+      const doResize = resizer.doResize;
 
       const ro = new ResizeObserver(doResize);
       ro.observe(wrap);
@@ -732,6 +788,7 @@ export function BottomTerminal({
 
       cleanup = () => {
         ro.disconnect();
+        resizer.dispose();
         onDataDispose.dispose();
         if (typeof document !== "undefined") {
           document.removeEventListener("visibilitychange", onForeground);

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1418,6 +1418,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
               <BottomTerminal
                 threadId={`cave.comux.${s.id}`}
                 active={active && isActive}
+                visible={active}
                 projectRoot={s.projectRoot ?? selectedProjectRoot ?? daemonProjectRoot}
                 paneId={s.id}
                 registerWriter={registerPaneWriter}
@@ -1667,6 +1668,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       key={s.id}
                       threadId={`cave.comux.${s.id}`}
                       active={false}
+                      visible={false}
                       projectRoot={s.projectRoot ?? selectedProjectRoot ?? daemonProjectRoot}
                     />
                   ))}


### PR DESCRIPTION
Closes bead `cave-2956` (terminal audit, source-verified).

## Bug 1 — SR mirror silent on visible-but-unfocused split panes

comux split panes pass `active={active && isActive}`, and `BottomTerminal` gated its screen-reader mirror flush on `active` — conflating *hidden* with *unfocused*. A visible sibling pane running a build/log produced **no live-region updates until focused**.

**Fix:** `BottomTerminal` takes a separate `visible` prop (defaults to `active` for single-pane hosts like the rail):
- comux split panes: `visible={active}` — true for every rendered pane of a shown split
- keepalive mounts: `visible={false}`
- the mirror buffers when `!visible` and flushes on reveal; `active` (focus) still drives refit + refocus

## Bug 2 — unthrottled resize storm to shells

Both transports (Tauri IPC + WS bridge) ran `fit()` + `pty_resize`/`bridge.resize` per ResizeObserver callback with no throttle. Hidden keepalive panes are `inset:0; visibility:hidden` so they keep full size — every window resize SIGWINCH-spammed N background shells, and divider drags stormed the focused shell per frame.

**Fix:** shared `makeResizer` used by both transports:
- local xterm refit stays per-callback (crisp visuals during drags)
- PTY push debounced to 150ms and **deduped on unchanged cols/rows**
- push skipped entirely for hidden panes (they still fit locally so reveal is crisp)
- pending push timer cleared on cleanup in both transports

## Validation

- `bottom-terminal-sr-mirror.test.ts` extended: asserts visibility (not focus) gates the mirror, `makeResizer` throttle/dedupe/hidden-skip, both transports wired + disposed, and comux threads `visible` correctly
- `bottom-terminal-ws-bridge.test.ts` updated for the throttled resize path
- All terminal-adjacent tests pass (sr-mirror, ws-bridge, startup-watchdog, comux broadcast/chrome wiring, rail panel, mobile smoke, themed chrome, key bar)
- `pnpm typecheck` clean