### PR TITLE
fix(terminal): keyboard-operable tab strip + per-pane AT labels + reduced-motion cursor (cave-p767)

### DIFF
--- a/src/components/bottom-terminal-sr-mirror.test.ts
+++ b/src/components/bottom-terminal-sr-mirror.test.ts
@@ -72,4 +72,30 @@ assert.match(source, /decorations:\s*searchDecorations\(\)/, "search decorations
 assert.match(source, /if \(!activeRef\.current\) \{[\s\S]{0,180}return;/, "the SR mirror doesn't re-render while the pane is hidden");
 assert.match(source, /if \(active\) \{\s*\n\s*flushMirror\(\);/, "buffered output is drained into the mirror when the pane becomes active");
 
+// ── Terminal a11y (cave-p767) ──
+// Per-pane labels: split panes must be distinguishable to AT — the region and
+// its SR mirror are both named after the pane when a label is threaded in.
+assert.match(
+  source,
+  /aria-label=\{label \? `Terminal: \$\{label\}` : "Terminal"\}/,
+  "the terminal region is named after its pane label",
+);
+assert.match(
+  source,
+  /aria-label=\{label \? `Terminal output: \$\{label\}` : "Terminal output"\}/,
+  "the SR mirror region is named after its pane label",
+);
+// Reduced motion: the blinking cursor is continuous motion — off under
+// prefers-reduced-motion, both at creation and reactively on change.
+assert.match(
+  source,
+  /cursorBlink: !handlers\.reducedMotion/,
+  "cursor blink is disabled at creation under prefers-reduced-motion",
+);
+assert.match(
+  source,
+  /term\.options\.cursorBlink = !reducedMotion/,
+  "cursor blink tracks prefers-reduced-motion changes without a remount",
+);
+
 console.log("bottom-terminal-sr-mirror.test.ts OK");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTauriPlatform } from "@/lib/tauri-platform";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { TerminalKeyBar } from "@/components/terminal-key-bar";
 import { PtyWsBridge } from "@/lib/pty-ws-bridge";
 import { Icon } from "@/lib/icon";
@@ -94,6 +95,8 @@ async function createXterm(
     onResults: (index: number, count: number) => void;
     /** ⌘F / Ctrl+F pressed inside the terminal — open the find bar. */
     onRequestFind: () => void;
+    /** prefers-reduced-motion at creation time — disables cursor blink. */
+    reducedMotion?: boolean;
   },
 ): Promise<XtermBundle> {
   const [{ Terminal }, { FitAddon }, { WebLinksAddon }, { SearchAddon }] = await Promise.all([
@@ -108,7 +111,9 @@ async function createXterm(
       'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace',
     fontSize: 12,
     lineHeight: 1.2,
-    cursorBlink: true,
+    // A permanently blinking cursor is exactly the kind of continuous motion
+    // prefers-reduced-motion opts out of; kept in sync after creation too.
+    cursorBlink: !handlers.reducedMotion,
     // Required for the search addon's match decorations (highlights + count).
     allowProposedApi: true,
     theme: {
@@ -149,6 +154,7 @@ export function BottomTerminal({
   active = true,
   projectRoot,
   paneId,
+  label,
   registerWriter,
   onUserInput,
 }: {
@@ -157,6 +163,9 @@ export function BottomTerminal({
   projectRoot?: string;
   /** Stable id for comux's broadcast registry (defaults to threadId). */
   paneId?: string;
+  /** Human-readable pane name (the comux tab/pane label) so AT can tell split
+   *  panes apart — names the terminal region and its screen-reader mirror. */
+  label?: string;
   /** Register/unregister this pane's PTY writer so broadcast can fan input in. */
   registerWriter?: (paneId: string, write: ((data: string) => void) | null) => void;
   /** Called with every keystroke (post Ctrl-transform) so comux can mirror it
@@ -194,6 +203,16 @@ export function BottomTerminal({
   // typed character into its control code. clearCtrlRef lets that handler reset
   // the visual state from inside its stable closure.
   const isCoarse = useIsCoarsePointer();
+  // Reactive: flipping the OS setting stops/starts the blink without a
+  // remount (xterm applies option changes live). The ref feeds the async
+  // createXterm calls so the initial value is right without re-running them.
+  const reducedMotion = usePrefersReducedMotion();
+  const reducedMotionRef = useRef(reducedMotion);
+  reducedMotionRef.current = reducedMotion;
+  useEffect(() => {
+    const term = termRef.current;
+    if (term) term.options.cursorBlink = !reducedMotion;
+  }, [reducedMotion]);
   const [ctrlActive, setCtrlActive] = useState(false);
   const ctrlStickyRef = useRef(false);
   const clearCtrlRef = useRef<() => void>(() => {});
@@ -395,6 +414,7 @@ export function BottomTerminal({
       const { term, fit, search } = await createXterm(wrap, {
         onResults: (index, count) => setFindInfo({ index, count }),
         onRequestFind: openFind,
+        reducedMotion: reducedMotionRef.current,
       });
       termRef.current = term;
       searchRef.current = search;
@@ -576,6 +596,7 @@ export function BottomTerminal({
       const { term, fit, search } = await createXterm(wrap, {
         onResults: (index, count) => setFindInfo({ index, count }),
         onRequestFind: openFind,
+        reducedMotion: reducedMotionRef.current,
       });
       termRef.current = term;
       searchRef.current = search;
@@ -779,9 +800,10 @@ export function BottomTerminal({
         className="min-h-0 w-full flex-1 overflow-hidden"
         style={{ background: "oklch(0.11 0.022 293)", padding: "6px 8px" }}
         // xterm renders into an opaque <canvas>; label the region so AT can name
-        // it (live output is exposed via the screen-reader mirror below).
+        // it (live output is exposed via the screen-reader mirror below). The
+        // pane label keeps split panes distinguishable.
         role="group"
-        aria-label="Terminal"
+        aria-label={label ? `Terminal: ${label}` : "Terminal"}
         // Clicking anywhere in the terminal area refocuses xterm so keyboard
         // input is routed correctly without the user having to click exactly
         // on the cursor.
@@ -870,7 +892,7 @@ export function BottomTerminal({
         role="region"
         aria-live="polite"
         aria-atomic="false"
-        aria-label="Terminal output"
+        aria-label={label ? `Terminal output: ${label}` : "Terminal output"}
       >
         {mirrorLines.map((line, i) => (
           <div key={i}>{line}</div>

--- a/src/components/comux-view-terminal.test.ts
+++ b/src/components/comux-view-terminal.test.ts
@@ -333,4 +333,43 @@ assert.match(
   "renameSession ignores blank/whitespace-only names",
 );
 
+// ── Terminal a11y (cave-p767): tab strip is a real keyboard-operable tablist ──
+assert.match(
+  source,
+  /role="tablist"\s*\n\s*aria-orientation="horizontal"\s*\n\s*aria-label="Terminal sessions"/,
+  "the tab strip is a labeled horizontal tablist",
+);
+assert.match(
+  source,
+  /role="tab"\s*\n\s*aria-selected=\{i === currentIdx\}\s*\n\s*tabIndex=\{i === currentIdx \? 0 : -1\}/,
+  "each terminal tab is role=tab with aria-selected and roving tabindex",
+);
+assert.match(
+  source,
+  /if \(e\.target !== e\.currentTarget\) return;/,
+  "roving tablist keys ignore keystrokes bubbling from the rename textbox",
+);
+assert.match(
+  source,
+  /e\.key === "ArrowRight" \? \(i === last \? 0 : i \+ 1\)\s*\n\s*: e\.key === "ArrowLeft" \? \(i === 0 \? last : i - 1\)\s*\n\s*: e\.key === "Home" \? 0\s*\n\s*: e\.key === "End" \? last/,
+  "Arrow/Home/End move between tabs (selection follows focus, wrapping)",
+);
+assert.match(
+  source,
+  /if \(e\.key === "F2"\) \{[\s\S]{0,180}?\[data-terminal-tab-rename\]/,
+  "F2 on a tab enters the inline rename",
+);
+assert.match(
+  source,
+  /role="textbox"\s*\n\s*aria-label=\{`Rename terminal \$\{s\.label\} — Enter saves, Escape cancels`\}/,
+  "the contentEditable rename span is an aria-labeled textbox with discoverable save/cancel",
+);
+// Per-pane region labels: visible pane and keepalive pane both name their
+// BottomTerminal after the session so AT can tell split panes apart.
+assert.equal(
+  (source.match(/label=\{s\.label\}/g) ?? []).length,
+  2,
+  "both BottomTerminal instances (visible + keepalive) thread the pane label",
+);
+
 console.log("comux terminal chord/close assertions: ok");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1420,6 +1420,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                 active={active && isActive}
                 projectRoot={s.projectRoot ?? selectedProjectRoot ?? daemonProjectRoot}
                 paneId={s.id}
+                label={s.label}
                 registerWriter={registerPaneWriter}
                 onUserInput={handlePaneInput}
               />
@@ -1485,11 +1486,19 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
         <div className="flex flex-1 flex-col min-h-0">
           {/* Session tab strip */}
           <div className="comux-terminal-tab-strip flex items-center gap-2 border-b border-[var(--border-hairline)] bg-[var(--bg-raised)]/20 px-2 py-1 text-[11px]">
-            <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">
+            <div
+              className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto"
+              role="tablist"
+              aria-orientation="horizontal"
+              aria-label="Terminal sessions"
+            >
               {sessions.map((s, i) => (
                 <div
                   key={s.id}
                   draggable
+                  role="tab"
+                  aria-selected={i === currentIdx}
+                  tabIndex={i === currentIdx ? 0 : -1}
                   className={`comux-terminal-tab group flex cursor-pointer items-center gap-1 rounded px-2 py-0.5 transition-colors ${
                     i === currentIdx
                       ? "bg-[var(--bg-base)] text-[var(--text-primary)]"
@@ -1497,6 +1506,37 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                   }${tabDropTargetId === s.id ? " comux-terminal-tab--drop-target" : ""}`}
                   data-terminal-tab-id={s.id}
                   onClick={() => selectSession(i)}
+                  onKeyDown={(e) => {
+                    // Roving tablist keys act on the tab itself; keystrokes
+                    // inside the rename textbox (a child) must not re-route.
+                    if (e.target !== e.currentTarget) return;
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      selectSession(i);
+                      return;
+                    }
+                    if (e.key === "F2") {
+                      e.preventDefault();
+                      e.currentTarget.querySelector<HTMLElement>("[data-terminal-tab-rename]")?.focus();
+                      return;
+                    }
+                    const last = sessions.length - 1;
+                    const next =
+                      e.key === "ArrowRight" ? (i === last ? 0 : i + 1)
+                      : e.key === "ArrowLeft" ? (i === 0 ? last : i - 1)
+                      : e.key === "Home" ? 0
+                      : e.key === "End" ? last
+                      : null;
+                    if (next === null || next === i) return;
+                    e.preventDefault();
+                    // Selection follows focus (WAI-ARIA tabs pattern). The
+                    // keyed node persists across the re-render, so focusing
+                    // it synchronously is safe.
+                    selectSession(next);
+                    document
+                      .querySelector<HTMLElement>(`[data-terminal-tab-id="${window.CSS.escape(sessions[next].id)}"]`)
+                      ?.focus();
+                  }}
                   onDragStart={(e) => {
                     e.dataTransfer.effectAllowed = "move";
                     e.dataTransfer.setData(TERMINAL_SESSION_DRAG_TYPE, s.id);
@@ -1535,6 +1575,9 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                   <span
                     contentEditable
                     suppressContentEditableWarning
+                    role="textbox"
+                    aria-label={`Rename terminal ${s.label} — Enter saves, Escape cancels`}
+                    data-terminal-tab-rename
                     onBlur={(e) =>
                       renameSession(i, e.currentTarget.textContent ?? s.label)
                     }
@@ -1550,7 +1593,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                         (e.target as HTMLElement).blur();
                       }
                     }}
-                    title="Click to rename · Enter to save · Esc to cancel"
+                    title="Click or F2 to rename · Enter to save · Esc to cancel"
                     className="max-w-[120px] truncate rounded-[3px] px-0.5 outline-none focus:bg-[var(--bg-base)] focus:ring-1 focus:ring-[var(--accent-presence)]"
                   >
                     {s.label}
@@ -1668,6 +1711,7 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                       threadId={`cave.comux.${s.id}`}
                       active={false}
                       projectRoot={s.projectRoot ?? selectedProjectRoot ?? daemonProjectRoot}
+                      label={s.label}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Problem (cave-p767, from the terminal audit)
1. **HIGH** — the terminal tab strip was click-only `<div onClick>`s: no role, no tabIndex, no aria-selected. Keyboard users couldn't switch terminals; AT got no tab semantics (WCAG 2.1.1, 1.3.1, 4.1.2).
2. The rename span was a bare `contentEditable` with only a `title`.
3. Every terminal region was `aria-label="Terminal"` + mirror `"Terminal output"` — split panes indistinguishable to AT.
4. `cursorBlink: true` wasn't gated on `prefers-reduced-motion`.

## Fix
- **Tablist**: `role=tablist` (labeled, horizontal) + `role=tab`/`aria-selected`/roving `tabIndex` per tab. Arrow/Home/End with selection-follows-focus (wrapping), Enter/Space select, **F2** enters the inline rename. Keystrokes bubbling from the rename textbox are ignored by the roving handler. Drag-reorder, drag-to-split, and the ⌘N/⌘W chords are untouched — all pre-existing test pins still pass.
- **Rename**: `role=textbox` + aria-label naming the tab and its save/cancel keys (`Enter saves, Escape cancels`); title updated to mention F2.
- **Pane labels**: `BottomTerminal` gains a `label` prop, threaded from the comux session in both the visible pane and keepalive instances → `Terminal: <name>` / `Terminal output: <name>`.
- **Reduced motion**: `usePrefersReducedMotion()` gates `cursorBlink` at creation (through `createXterm`) and reactively via `term.options.cursorBlink` on preference change — no remount.

## Verification
- New assertions in `comux-view-terminal.test.ts` (7) and `bottom-terminal-sr-mirror.test.ts` (4)
- `pnpm test:app` — 560 files pass · `pnpm typecheck` clean

Closes cave-p767 (beads).