### PR TITLE
chore(terminal): remove two dead exports (cave-r7l0)

### DIFF
--- a/src/lib/terminal-broadcast.test.ts
+++ b/src/lib/terminal-broadcast.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { broadcastTargetIds, broadcastIsActionable } from "./terminal-broadcast.ts";
+import { broadcastTargetIds } from "./terminal-broadcast.ts";
 
 assert.deepEqual(broadcastTargetIds(["a", "b", "c"], "a"), ["b", "c"]);
 assert.deepEqual(broadcastTargetIds(["a", "b", "c"], "b"), ["a", "c"]);
@@ -9,9 +9,5 @@ assert.deepEqual(broadcastTargetIds([], "a"), []);
 assert.deepEqual(broadcastTargetIds(["a", "b", "b", "c", "a"], "a"), ["b", "c"]);
 assert.deepEqual(broadcastTargetIds(["a", "", "b"], "a"), ["b"]);
 assert.deepEqual(broadcastTargetIds(["a", "b"], "ghost"), ["a", "b"]);
-assert.equal(broadcastIsActionable(true, 2), true);
-assert.equal(broadcastIsActionable(true, 1), false, "single pane → nothing to broadcast to");
-assert.equal(broadcastIsActionable(false, 5), false, "disabled → never");
-assert.equal(broadcastIsActionable(true, 0), false);
 
 console.log("terminal-broadcast.test.ts passed");

--- a/src/lib/terminal-broadcast.ts
+++ b/src/lib/terminal-broadcast.ts
@@ -20,8 +20,3 @@ export function broadcastTargetIds(
   }
   return out;
 }
-
-/** Broadcast only does something useful with two or more live panes. */
-export function broadcastIsActionable(enabled: boolean, paneCount: number): boolean {
-  return enabled && paneCount > 1;
-}

--- a/src/lib/terminal-layout.test.ts
+++ b/src/lib/terminal-layout.test.ts
@@ -12,7 +12,6 @@ import {
   renameTerminalSession,
   reorderTerminalSessions,
   splitTerminalPane,
-  terminalLayoutSessionIds,
   terminalLayoutVisibleSessionIds,
   type TerminalLayoutState,
 } from "./terminal-layout.ts";
@@ -23,6 +22,13 @@ function session(id: string, label = id, projectRoot = `/tmp/${id}`) {
 
 function ids(state: TerminalLayoutState): string[] {
   return terminalLayoutVisibleSessionIds(state);
+}
+
+// The full session (tab) list, in tab order — what reorder/close mutate. Read
+// inline off `state.sessions` now that the terminalLayoutSessionIds helper (dead
+// in production) is gone.
+function sessionIds(state: TerminalLayoutState): string[] {
+  return state.sessions.map((session) => session.id);
 }
 
 {
@@ -110,7 +116,7 @@ function ids(state: TerminalLayoutState): string[] {
   state = removeTerminalPaneView(state, "b");
 
   assert.deepEqual(ids(state), ["a"], "removing a split hides the pane from the tree");
-  assert.deepEqual(terminalLayoutSessionIds(state), ["a", "b"], "removing a split does not close the shell session");
+  assert.deepEqual(sessionIds(state), ["a", "b"], "removing a split does not close the shell session");
   assert.equal(state.activeSessionId, "a", "focus falls back to a visible session");
 
   state = focusTerminalSession(state, "b");
@@ -135,7 +141,7 @@ function ids(state: TerminalLayoutState): string[] {
   const next = reorderTerminalSessions(state, "c", "a");
 
   assert.deepEqual(
-    terminalLayoutSessionIds(next),
+    sessionIds(next),
     ["c", "a", "b"],
     "dropping a terminal tab onto another tab reorders only the tab list",
   );
@@ -153,7 +159,7 @@ function ids(state: TerminalLayoutState): string[] {
   state = renameTerminalSession(state, "b", "Build");
   state = closeTerminalSession(state, "a");
 
-  assert.deepEqual(terminalLayoutSessionIds(state), ["b"], "closing removes the session record");
+  assert.deepEqual(sessionIds(state), ["b"], "closing removes the session record");
   assert.deepEqual(ids(state), ["b"], "closing collapses singleton branches");
   assert.equal(state.sessions[0].label, "Build", "renames stay on the session record");
   assert.equal(state.activeSessionId, "b", "closing active pane chooses the surviving visible session");
@@ -163,7 +169,7 @@ function ids(state: TerminalLayoutState): string[] {
   let state = createTerminalLayout([session("a"), session("b")], "a");
   state = closeTerminalSession(state, "a");
 
-  assert.deepEqual(terminalLayoutSessionIds(state), ["b"], "closing removes only the requested session");
+  assert.deepEqual(sessionIds(state), ["b"], "closing removes only the requested session");
   assert.deepEqual(ids(state), ["b"], "closing the last visible pane reattaches a remaining hidden session");
   assert.equal(state.activeSessionId, "b", "the reattached session receives focus");
 }

--- a/src/lib/terminal-layout.ts
+++ b/src/lib/terminal-layout.ts
@@ -258,10 +258,6 @@ export function normalizeTerminalLayout(state: TerminalLayoutState): TerminalLay
   };
 }
 
-export function terminalLayoutSessionIds(state: TerminalLayoutState): string[] {
-  return state.sessions.map((session) => session.id);
-}
-
 export function terminalLayoutVisibleSessionIds(state: TerminalLayoutState): string[] {
   return visibleIds(state.root).filter((id, index, ids) => ids.indexOf(id) === index);
 }


### PR DESCRIPTION
## What

From the terminal-surface audit. Two exports were referenced **only by their own tests** (grep-proven), never in production:

- `terminalLayoutSessionIds` (`terminal-layout.ts`) — production reads tab order off `state.sessions` directly and uses `terminalLayoutVisibleSessionIds` for the tree.
- `broadcastIsActionable` (`terminal-broadcast.ts`) — comux computes the broadcast gate inline (`broadcast && visiblePaneSessionIds.length > 1`).

Delete both. The layout tests keep their reorder/close **tab-order** coverage via a local `sessionIds` helper (inline `state.sessions.map`), so no coverage is lost; the broadcast helper's trivial asserts are dropped.

Scoped to these two lib files only — the audit's find-bar live-region nit in `bottom-terminal.tsx` is **deferred** to avoid colliding with the a11y (cave-p767) and perf (cave-2956) passes actively editing that file.

## Verification

`typecheck` · **560** app test files · `build` within budget. 19 lines removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)