### PR TITLE
fix(desktop): un-deny the native in-app updater for the loopback main webview (cave-51yk)

### DIFF
--- a/scripts/check-tests-wired.mjs
+++ b/scripts/check-tests-wired.mjs
@@ -32,7 +32,8 @@ function walk(dir, acc) {
     return acc; // dir may not exist
   }
   for (const entry of entries) {
-    if (entry.name === "node_modules" || entry.name === ".next" || entry.name.startsWith(".")) continue;
+    // "target" and "gen" are src-tauri build-output dirs (huge, gitignored).
+    if (entry.name === "node_modules" || entry.name === ".next" || entry.name === "target" || entry.name === "gen" || entry.name.startsWith(".")) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) walk(full, acc);
     else if (/\.test\.(ts|mjs)$/.test(entry.name)) acc.push(path.relative(root, full).split(path.sep).join("/"));
@@ -40,7 +41,13 @@ function walk(dir, acc) {
   return acc;
 }
 
-const onDisk = [...walk(path.join(root, "src"), []), ...walk(path.join(root, "scripts"), [])].sort();
+const onDisk = [
+  ...walk(path.join(root, "src"), []),
+  ...walk(path.join(root, "scripts"), []),
+  // src-tauri source pins (capability ACLs, release runtime) were invisible to
+  // this guard and sat orphaned — never running in any CI suite — for weeks.
+  ...walk(path.join(root, "src-tauri"), []),
+].sort();
 
 const referenced = new Set();
 for (const files of Object.values(SUITES)) {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -42,6 +42,8 @@ export const SUITES = {
     "src/lib/open-external.test.ts",
     "src/lib/coven-version.test.ts",
     "src/components/update-available.test.ts",
+    "src-tauri/permissions/desktop-permissions.test.mjs",
+    "src-tauri/release-runtime.test.mjs",
     "src/components/open-coven-tools-update.test.ts",
     "src/lib/workflow-run-prompt.test.ts",
     "src/lib/workflow-step-progress.test.ts",

--- a/src-tauri/capabilities/loopback-updater.json
+++ b/src-tauri/capabilities/loopback-updater.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "loopback-updater",
+  "description": "lets the trusted main loopback webview run the native in-app updater end to end: check, download, install, and relaunch, plus platform/arch reads for installer fallback selection",
+  "platforms": [
+    "linux",
+    "macOS",
+    "windows"
+  ],
+  "webviews": [
+    "main"
+  ],
+  "remote": {
+    "urls": [
+      "http://localhost:*/*",
+      "http://127.0.0.1:*/*",
+      "http://[\\:\\:1]:*/*"
+    ]
+  },
+  "permissions": [
+    "updater:default",
+    "process:allow-restart",
+    "os:allow-platform",
+    "os:allow-arch"
+  ]
+}

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -415,7 +415,9 @@ test("terminal commands use Tauri camelCase command arguments", () => {
   );
   assert.match(
     bottomTerminal,
-    /invoke\("pty_resize", \{[\s\S]*threadId: threadId,[\s\S]*cols:[\s\S]*rows:/,
+    // cols/rows may be longhand (`cols: cols`) or shorthand (`cols,`) — #2651
+    // moved to shorthand and this pin (then unwired from CI) silently drifted.
+    /invoke\("pty_resize", \{[\s\S]*threadId: threadId,[\s\S]*cols[,:][\s\S]*rows[,:]/,
     "pty_resize must pass threadId so desktop resize reaches Rust",
   );
   assert.match(

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -12,6 +12,9 @@ const loopbackMainEventsCapability = JSON.parse(
 const loopbackWindowDragCapability = JSON.parse(
   readFileSync(new URL("../capabilities/loopback-window-drag.json", import.meta.url), "utf8"),
 );
+const loopbackUpdaterCapability = JSON.parse(
+  readFileSync(new URL("../capabilities/loopback-updater.json", import.meta.url), "utf8"),
+);
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
@@ -21,6 +24,7 @@ const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx"
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
 const shellTsx = readFileSync(new URL("../../src/components/shell.tsx", import.meta.url), "utf8");
 const trayQuickChat = readFileSync(new URL("../../src/components/tray-quick-chat.tsx", import.meta.url), "utf8");
+const updateAvailable = readFileSync(new URL("../../src/components/update-available.tsx", import.meta.url), "utf8");
 
 const requiredPermissionIds = [
   "allow-pty-start",
@@ -56,9 +60,27 @@ const requiredCommands = [
   "shell_open",
 ];
 
+// Node 22 (CI's runtime) has no global URLPattern, so match capability
+// remote URL patterns component-wise the way Tauri's urlpattern crate does
+// for the simple `scheme://host:port/path` + `*` shapes this repo uses.
+// Backslash escapes in patterns (e.g. the IPv6 colons in
+// "http://[\:\:1]:*/*") are URLPattern literal escapes — strip them first.
+function originMatchesPattern(pattern, origin) {
+  const literal = pattern.replace(/\\(.)/g, "$1");
+  const parts = /^([a-z][a-z0-9+.-]*|\*):\/\/(\[[^\]]*\]|[^:/]*)(?::([^/]*))?(\/.*)?$/i.exec(literal);
+  assert.ok(parts, `unsupported capability URL pattern shape: ${pattern}`);
+  const [, scheme, host, port, path] = parts;
+  const url = new URL(origin);
+  const schemeOk = scheme === "*" || url.protocol === `${scheme.toLowerCase()}:`;
+  const hostOk = host === "*" || url.hostname.toLowerCase() === host.toLowerCase();
+  const portOk = port === "*" || (port ?? "") === url.port;
+  const pathOk = path === undefined || path === "/*" || url.pathname === path;
+  return schemeOk && hostOk && portOk && pathOk;
+}
+
 function capabilityAllowsOrigin(capability, origin) {
   const patterns = capability.remote?.urls ?? [];
-  return patterns.some((pattern) => new URLPattern(pattern).test(origin));
+  return patterns.some((pattern) => originMatchesPattern(pattern, origin));
 }
 
 function assertCapabilityDoesNotGrant(capability, deniedPermissions) {
@@ -295,6 +317,72 @@ test("loopback app webviews can drive native window drag for the seamless titleb
   assert.ok(
     trayQuickChat.includes('<header className="quick-chat-overlay__header" data-tauri-drag-region="deep">'),
     "the quick-chat tray header must be a deep Tauri drag region so the decoration-less window can be moved",
+  );
+});
+
+// Like window drag above, the in-app updater runs from the loopback main
+// webview — a REMOTE execution context where the local-only default.json
+// grants (updater:default / process:default) never apply. Without this
+// remote-scoped capability every plugin-updater check() throws an ACL denial
+// and update-available.tsx falls back to "Open installer in Browser", which
+// defeats the whole in-app update experience. Scoped to webviews:["main"]
+// (not windows) so in-app browser child webviews that a user navigates to a
+// localhost page can never invoke install/relaunch IPC.
+test("the trusted main loopback webview can run the native in-app updater", () => {
+  assert.deepEqual(
+    loopbackUpdaterCapability.webviews,
+    ["main"],
+    "updater/relaunch IPC must be limited to the trusted main webview — never in-app browser child webviews on loopback origins",
+  );
+  assert.equal(
+    loopbackUpdaterCapability.windows,
+    undefined,
+    "scope by webview label, not window label — browser child webviews live inside the main window",
+  );
+  assert.deepEqual(
+    loopbackUpdaterCapability.platforms,
+    ["linux", "macOS", "windows"],
+    "updater permissions are desktop-only and must not leak into mobile Tauri builds",
+  );
+  for (const origin of [
+    "http://127.0.0.1:3000/",
+    "http://localhost:3000/",
+    "http://[::1]:3000/",
+    "http://127.0.0.1:64203/",
+    "http://localhost:64203/",
+    "http://[::1]:64203/",
+  ]) {
+    assert.ok(
+      capabilityAllowsOrigin(loopbackUpdaterCapability, origin),
+      `loopback origin ${origin} must be allowed to run the native updater`,
+    );
+  }
+  assert.equal(
+    capabilityAllowsOrigin(loopbackUpdaterCapability, "http://example.com:64203/"),
+    false,
+    "remote non-loopback origins should stay denied",
+  );
+  assert.deepEqual(
+    loopbackUpdaterCapability.permissions,
+    ["updater:default", "process:allow-restart", "os:allow-platform", "os:allow-arch"],
+    "grant exactly check/download/install (updater:default), relaunch, and the platform/arch reads used to pick installer fallbacks — nothing else (no process:allow-exit)",
+  );
+
+  // The web side must actually drive the native path: check() from
+  // plugin-updater, downloadAndInstall on the returned update, and relaunch()
+  // from plugin-process. If a refactor drops any of these the capability
+  // grant is dead weight and users silently regress to browser downloads.
+  assert.ok(
+    updateAvailable.includes('await import("@tauri-apps/plugin-updater")'),
+    "update-available.tsx must check for updates through the native plugin-updater",
+  );
+  assert.ok(
+    updateAvailable.includes("downloadAndInstall"),
+    "update-available.tsx must install through the native updater download",
+  );
+  assert.ok(
+    updateAvailable.includes('await import("@tauri-apps/plugin-process")'),
+    "update-available.tsx must relaunch through plugin-process after installing",
   );
 });
 

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -51,6 +51,16 @@ assert.doesNotMatch(
   "native updater check failures must not be silently collapsed into the browser fallback path",
 );
 
+// Banner: long-running desktops re-check periodically — a mount-only check
+// would leave always-on instances permanently unaware of new releases.
+assert.match(src, /setInterval\(runCheck, RECHECK_INTERVAL_MS\)/, "banner re-checks for updates on an interval");
+assert.match(src, /clearInterval\(interval\)/, "banner re-check interval is torn down on unmount");
+assert.match(
+  src,
+  /if \(installing\) return;/,
+  "a periodic re-check must not clobber an in-flight install's progress banner",
+);
+
 // Banner: dismissible CTA, persisted per version.
 assert.match(src, /pushBanner\(/, "pushes a shell banner when an update is available");
 assert.match(src, /cave:update:dismissed:/, "persists dismissal keyed by version");

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -148,9 +148,15 @@ async function resolveUpdate(): Promise<Resolved> {
   return { kind: "current" };
 }
 
+// The cave is a long-running control-room app and releases ship several times
+// a week, so a mount-only check would leave open instances permanently unaware
+// of new versions. Re-check on this cadence (per-version dismissals still hold).
+const RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
 /**
- * Desktop-only. On mount, checks for an update and (if available and not
- * dismissed for that version) shows a dismissible shell banner. Renders nothing.
+ * Desktop-only. On mount and every RECHECK_INTERVAL_MS thereafter, checks for
+ * an update and (if available and not dismissed for that version) shows a
+ * dismissible shell banner. Renders nothing.
  */
 export function UpdateBannerTrigger() {
   const isDesktop = useIsTauriDesktop();
@@ -159,52 +165,65 @@ export function UpdateBannerTrigger() {
   useEffect(() => {
     if (!isDesktop) return;
     let cancelled = false;
-    void resolveUpdate().then((r) => {
-      if (cancelled || r.kind === "current") return;
-      if (isDismissed(r.version)) return;
+    // While an install is downloading, a periodic re-check must not clobber
+    // the progress banner (they share BANNER_ID) with a fresh "available" one.
+    let installing = false;
 
-      pushBanner({
-        id: BANNER_ID,
-        severity: r.kind === "native-unavailable" ? "warning" : "info",
-        title:
-          r.kind === "native-unavailable"
-            ? `Native updater unavailable — v${r.version}`
-            : `Update available — v${r.version}`,
-        cta: {
-          label: r.kind === "native" ? "Install & restart" : "Open installer in Browser",
-          onClick: () => {
-            if (r.kind === "native") {
-              pushBanner({ id: BANNER_ID, severity: "info", title: `Preparing update v${r.version}…` });
-              void installNativeUpdate(r.update, (pct) => {
-                pushBanner({
-                  id: BANNER_ID,
-                  severity: "info",
-                  title: `Downloading update v${r.version}… ${pct}%`,
+    const runCheck = () => {
+      if (installing) return;
+      void resolveUpdate().then((r) => {
+        if (cancelled || installing || r.kind === "current") return;
+        if (isDismissed(r.version)) return;
+
+        pushBanner({
+          id: BANNER_ID,
+          severity: r.kind === "native-unavailable" ? "warning" : "info",
+          title:
+            r.kind === "native-unavailable"
+              ? `Native updater unavailable — v${r.version}`
+              : `Update available — v${r.version}`,
+          cta: {
+            label: r.kind === "native" ? "Install & restart" : "Open installer in Browser",
+            onClick: () => {
+              if (r.kind === "native") {
+                installing = true;
+                pushBanner({ id: BANNER_ID, severity: "info", title: `Preparing update v${r.version}…` });
+                void installNativeUpdate(r.update, (pct) => {
+                  pushBanner({
+                    id: BANNER_ID,
+                    severity: "info",
+                    title: `Downloading update v${r.version}… ${pct}%`,
+                  });
+                }).catch((err) => {
+                  installing = false;
+                  const reason = err instanceof Error ? err.message : "";
+                  pushBanner({
+                    id: BANNER_ID,
+                    severity: "warning",
+                    title: reason
+                      ? `Update failed (${reason})`
+                      : "Update failed",
+                    cta: { label: "Open release page in Browser", onClick: openReleasePageInBrowser },
+                    onDismiss: () => markDismissed(r.version),
+                  });
                 });
-              }).catch((err) => {
-                const reason = err instanceof Error ? err.message : "";
-                pushBanner({
-                  id: BANNER_ID,
-                  severity: "warning",
-                  title: reason
-                    ? `Update failed (${reason})`
-                    : "Update failed",
-                  cta: { label: "Open release page in Browser", onClick: openReleasePageInBrowser },
-                  onDismiss: () => markDismissed(r.version),
-                });
-              });
-            } else if (r.kind === "native-unavailable") {
-              openReleasePageInBrowser();
-            } else {
-              openInAppBrowserUrl(r.url);
-            }
+              } else if (r.kind === "native-unavailable") {
+                openReleasePageInBrowser();
+              } else {
+                openInAppBrowserUrl(r.url);
+              }
+            },
           },
-        },
-        onDismiss: () => markDismissed(r.version),
+          onDismiss: () => markDismissed(r.version),
+        });
       });
-    });
+    };
+
+    runCheck();
+    const interval = window.setInterval(runCheck, RECHECK_INTERVAL_MS);
     return () => {
       cancelled = true;
+      window.clearInterval(interval);
       dismissBanner(BANNER_ID);
     };
   }, [isDesktop, pushBanner, dismissBanner]);


### PR DESCRIPTION
## Problem

The in-app updater (#604, polished in #2138) never actually ran natively in the packaged app. The main window loads `http://127.0.0.1:<port>` (`WebviewUrl::External`, `src-tauri/src/lib.rs:1176`), which Tauri's capability ACL treats as a **remote** execution context. `updater:default` and `process:default` were only granted in `capabilities/default.json`, which is `"local": true` — local capabilities never apply to remote contexts. This is the same root-cause class as the titlebar-drag denial fixed in #2464.

Result: every `plugin-updater check()` threw an ACL denial, `update-available.tsx` caught it as "native unavailable", and every user was routed to **Open installer in Browser** — external navigation instead of the intended one-click *Install & restart*.

## Fix

- **New `loopback-updater` capability** granting `updater:default`, `process:allow-restart`, and `os:allow-platform`/`os:allow-arch` (used to pick per-platform installer fallbacks) to loopback origins. Scoped to `webviews: ["main"]` — deliberately *not* `windows: ["main"]` — so in-app browser child webviews that a user navigates to a localhost page can never invoke install/relaunch IPC (same trust boundary as `loopback-main-events`).
- **Pins in `desktop-permissions.test.mjs`**, mirroring the drag-capability test: origins, exact permission list, webview scoping, and the frontend's native check/downloadAndInstall/relaunch path.
- **That test file could never run in CI**: it used global `URLPattern`, absent on Node 22 (CI's runtime), and it was wired into no suite. Replaced the matcher with a component-wise one for the `scheme://host:port/path` + `*` shapes capabilities use, wired the file (plus the equally orphaned `src-tauri/release-runtime.test.mjs`) into the `app` suite, and taught `check-tests-wired` to walk `src-tauri/` (skipping `target`/`gen`) so tauri-side pins can't silently orphan again.
- **Periodic re-check (6h)** in `UpdateBannerTrigger`: the cave is a long-running control-room app and releases ship several times a week, so a mount-only check left always-on instances permanently unaware of updates. Re-checks skip while an install is in flight so they don't clobber the shared-id progress banner; per-version dismissals still hold.

## Validation

- `node --test src-tauri/permissions/desktop-permissions.test.mjs` — 11/11 pass
- `cargo check --locked` — passes (tauri-build validates the new capability)
- `pnpm typecheck` + full `app` suite — 562 test files pass, including the two newly wired ones
- `node scripts/check-tests-wired.mjs` — all 757 test files wired

Bead: cave-51yk

🤖 Generated with [Claude Code](https://claude.com/claude-code)