### PR TITLE
fix(terminal): make the find-bar match counter non-live; fix stale mirror comment (cave-eatw)

### DIFF
--- a/src/components/bottom-terminal-sr-mirror.test.ts
+++ b/src/components/bottom-terminal-sr-mirror.test.ts
@@ -117,4 +117,17 @@ assert.match(
   "cursor blink tracks prefers-reduced-motion changes without a remount",
 );
 
+// The find-bar match counter must NOT be a second polite live region beside
+// the SR mirror — updating on every keystroke it produced double/overlapping
+// announcements (cave-eatw). It's tied to the find input via aria-describedby
+// instead, so AT can still discover the count on demand. The only polite
+// regions are the startup status overlay and the SR mirror.
+assert.equal(
+  (source.match(/aria-live="polite"/g) ?? []).length,
+  2,
+  "exactly two polite live regions: startup status + SR mirror (the find counter is non-live)",
+);
+assert.match(source, /aria-describedby=\{findCountId\}/, "the find input references the match counter via aria-describedby");
+assert.match(source, /id=\{findCountId\}/, "the match counter carries the descriptor id");
+
 console.log("bottom-terminal-sr-mirror.test.ts OK");

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useTauriPlatform } from "@/lib/tauri-platform";
 import { useIsCoarsePointer } from "@/lib/use-viewport";
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
@@ -249,6 +249,8 @@ export function BottomTerminal({
   const [findOpen, setFindOpen] = useState(false);
   const [findQuery, setFindQuery] = useState("");
   const [findInfo, setFindInfo] = useState<{ index: number; count: number }>({ index: 0, count: 0 });
+  // Ties the (non-live) match counter to the find input via aria-describedby.
+  const findCountId = useId();
   // Touch accessory key bar: soft keyboards lack Esc/Tab/Ctrl/arrows. Only shown
   // on coarse pointers. Ctrl is sticky — the toggle flips ctrlStickyRef, and the
   // onData handler (set up once at mount) reads the ref to transform the next
@@ -360,10 +362,10 @@ export function BottomTerminal({
     (bytes: Uint8Array) => {
       if (!decoderRef.current) return;
       // Keep decoding even while hidden so the streaming decoder state stays
-      // consistent — but don't re-render the (aria-hidden) mirror off-screen: a
-      // busy background stream otherwise re-rendered the 50-line mirror every
-      // 250ms while the terminal wasn't even visible. Buffer (bounded) and drain
-      // when the pane is next shown.
+      // consistent — but don't re-render the (sr-only, aria-live=polite) mirror
+      // off-screen: a busy background stream otherwise re-rendered the 50-line
+      // mirror every 250ms while the terminal wasn't even visible. Buffer
+      // (bounded) and drain when the pane is next shown.
       const text = stripAnsi(
         decoderRef.current.decode(bytes, { stream: true }),
       );
@@ -886,9 +888,18 @@ export function BottomTerminal({
             }}
             placeholder="Find in terminal…"
             aria-label="Find in terminal"
+            aria-describedby={findCountId}
             className="focus-ring-inset w-44 bg-transparent text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
           />
-          <span className="min-w-[34px] text-right text-[10px] tabular-nums text-[var(--text-muted)]" aria-live="polite">
+          {/* Match counter is deliberately NOT a live region: the SR mirror
+              region below is already aria-live=polite, and a second polite
+              region updating on every keystroke produced double/overlapping
+              announcements. aria-describedby on the input keeps the count
+              discoverable to AT without competing announcements. */}
+          <span
+            id={findCountId}
+            className="min-w-[34px] text-right text-[10px] tabular-nums text-[var(--text-muted)]"
+          >
             {findInfo.count > 0 ? `${findInfo.index}/${findInfo.count}` : findQuery ? "0/0" : ""}
           </span>
           <button type="button" onClick={() => runFind(-1)} title="Previous match (⇧⏎)" aria-label="Previous match"


### PR DESCRIPTION
Closes bead `cave-eatw` — the two items deferred out of `cave-r7l0` (terminal audit) while cave-2956/cave-p767 were actively editing `bottom-terminal.tsx`. Both merged, so this lands the remainder.

## Changes

1. **Find-bar double live region:** the ⌘F match counter (`1/5`) was a second `aria-live=polite` region beside the SR mirror; on rapid typing both fired → double/overlapping announcements. The counter is now **non-live** and referenced from the find input via `aria-describedby` (React `useId`), keeping the count discoverable to AT without competing announcements.
2. **Stale comment:** the mirror comment said "(aria-hidden)" — it's actually `sr-only` + `aria-live=polite`.

## Validation

- `bottom-terminal-sr-mirror.test.ts` extended: pins exactly two polite regions in the file (startup status + SR mirror) and the `aria-describedby`/`id` wiring
- ws-bridge + sr-mirror tests pass; `pnpm typecheck` clean