### PR TITLE
feat(ios): premium dark-first chat restyle — agent pill, + menu, empty-state starters, side drawer (cave-5y5q)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Theme/ChatChrome.swift
+++ b/apps/ios/CovenCave/CovenCave/Theme/ChatChrome.swift
@@ -1,0 +1,225 @@
+import SwiftUI
+
+// MARK: - Chat chrome — shared tokens + small reusable controls
+//
+// The restyled chat experience is built from a handful of repeated shapes:
+// circular glass icon buttons, capsule pill selectors, floating action menus,
+// and icon+label rows. They live here (next to Theme/Glass) so every screen
+// draws them identically instead of hand-rolling paddings per call site.
+//
+// Identity rules (arcane-terminal): near-black canvas comes from the published
+// theme's bgBase; surfaces are the existing glass levels; the accent (violet /
+// cyan depending on theme) appears ONLY on selected or active states via
+// `accentGlow(active:)` — never as ambient decoration.
+
+enum ChatChrome {
+    /// Standard circular control diameter (composer attach, header actions).
+    static let control: CGFloat = 34
+    /// Compact circular control (nav-bar trailing actions).
+    static let controlCompact: CGFloat = 30
+    /// Corner radius for floating menus / suggestion rows.
+    static let menuRadius: CGFloat = 20
+    /// Circular icon "well" inside menu rows.
+    static let iconWell: CGFloat = 34
+}
+
+// MARK: - CircularIconButton
+
+/// A round glass icon button — the app's standard tap target for icon-only
+/// actions. Always carries an accessibility label; the accent halo appears
+/// only while `active` (selected/recording/etc.), keeping accent usage sparse.
+struct CircularIconButton: View {
+    let systemImage: String
+    var size: CGFloat = ChatChrome.control
+    var active: Bool = false
+    var label: String
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: size * 0.44, weight: .semibold))
+                .foregroundStyle(active ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
+                .scaledControlFrame(size)
+                .glass(.control, in: Circle())
+                .accentGlow(active: active)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+}
+
+// MARK: - PillSelector
+
+/// A capsule chip that names a current choice and opens a picker: optional
+/// leading view (avatar/icon), label, optional chevron. Used for the chat
+/// header's agent pill and anywhere a compact "current value" control fits.
+struct PillSelector<Leading: View>: View {
+    var label: String
+    var sublabel: String? = nil
+    var chevron: Bool = true
+    var active: Bool = false
+    var accessibilityHint: String? = nil
+    var action: () -> Void
+    @ViewBuilder var leading: Leading
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                leading
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(label)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+                    if let sublabel {
+                        Text(sublabel)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                if chevron {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 5)
+            .glass(.control, in: Capsule())
+            .accentGlow(active: active)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityHint(accessibilityHint ?? "")
+    }
+}
+
+// MARK: - FloatingActionMenu
+
+/// One entry in the composer's floating "+" menu.
+struct FloatingAction: Identifiable {
+    let id: String
+    let systemImage: String
+    let label: String
+    let action: () -> Void
+}
+
+/// The rounded menu that floats above the composer when "+" is tapped:
+/// icon-well + label rows on an elevated glass panel. The presenting view owns
+/// the outside-tap scrim; rows dismiss on selection.
+struct FloatingActionMenu: View {
+    let actions: [FloatingAction]
+    var onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ForEach(actions) { item in
+                Button {
+                    onDismiss()
+                    item.action()
+                } label: {
+                    HStack(spacing: 12) {
+                        Image(systemName: item.systemImage)
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.primary)
+                            .frame(width: ChatChrome.iconWell, height: ChatChrome.iconWell)
+                            .glassFill(.raised, in: Circle())
+                        Text(item.label)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                        Spacer(minLength: 12)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 7)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(item.label)
+            }
+        }
+        .padding(6)
+        .frame(maxWidth: 260, alignment: .leading)
+        .glass(.elevated, in: RoundedRectangle(cornerRadius: ChatChrome.menuRadius, style: .continuous))
+        .accessibilityAddTraits(.isModal)
+    }
+}
+
+// MARK: - DrawerRow
+
+/// Icon + label row for the side drawer: quiet by default, accent-tinted only
+/// while it names the active destination.
+struct DrawerRow: View {
+    let systemImage: String
+    let label: String
+    var detail: String? = nil
+    var active: Bool = false
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(active ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
+                    .frame(width: 24)
+                Text(label)
+                    .font(.body)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                if let detail {
+                    Text(detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(active ? Color.accentColor.opacity(0.12) : .clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(active ? [.isSelected] : [])
+    }
+}
+
+// MARK: - EmptyChatSuggestionRow
+
+/// A spacious icon + short-label row for the empty chat state; tapping fills
+/// the composer so the user can tweak before sending.
+struct EmptyChatSuggestionRow: View {
+    let systemImage: String
+    let label: String
+    var action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 30, height: 30)
+                    .glassFill(.raised, in: Circle())
+                Text(label)
+                    .font(.subheadline)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
+                Spacer(minLength: 8)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .glass(.raised, in: RoundedRectangle(cornerRadius: ChatChrome.menuRadius, style: .continuous))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityHint("Fills the message field")
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/CameraPicker.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/CameraPicker.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import UIKit
+
+/// Minimal camera capture for the composer's attach menu. Wraps
+/// `UIImagePickerController` (camera source) — no custom capture pipeline —
+/// and hands the shot back for the same resize/stage path photo-library
+/// attachments use. Cancel simply dismisses. (`NSCameraUsageDescription` is
+/// already declared in Info.plist.)
+struct CameraPicker: UIViewControllerRepresentable {
+    var onCapture: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ controller: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        private let parent: CameraPicker
+        init(_ parent: CameraPicker) { self.parent = parent }
+
+        func imagePickerController(_ picker: UIImagePickerController,
+                                   didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                parent.onCapture(image)
+            }
+            parent.dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            parent.dismiss()
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatDrawer.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatDrawer.swift
@@ -1,0 +1,179 @@
+import SwiftUI
+
+/// Left slide-out drawer for the Chats tab: search, primary sections, pinned
+/// chats, and recents, with a floating New Chat button. The list behind stays
+/// visible — dimmed and nudged right — so the drawer reads as an overlay on
+/// the conversation surface rather than a page swap.
+///
+/// Presentation is owned by the host (`ChatsHomeView`) via `isOpen`; the scrim
+/// tap, a leftward drag, and every row selection dismiss it.
+struct ChatDrawer: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    @Binding var isOpen: Bool
+    /// Open a thread in the detail column (host-supplied so drawer stays dumb).
+    var openThread: (ChatThread) -> Void
+    var newChat: () -> Void
+
+    @State private var query = ""
+
+    private var pinnedThreads: [ChatThread] {
+        filtered(app.threads.filter { $0.pinned && !$0.archived })
+    }
+
+    /// Most recent unpinned conversations, newest first.
+    private var recentThreads: [ChatThread] {
+        filtered(app.threads.filter { !$0.pinned && !$0.archived })
+            .sorted { $0.updatedAt > $1.updatedAt }
+            .prefix(8).map { $0 }
+    }
+
+    private func filtered(_ threads: [ChatThread]) -> [ChatThread] {
+        let q = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !q.isEmpty else { return threads }
+        return threads.filter { $0.title.lowercased().contains(q) }
+    }
+
+    var body: some View {
+        GeometryReader { geo in
+            let width = min(geo.size.width * 0.84, 320)
+            ZStack(alignment: .leading) {
+                // Scrim: dismiss on outside tap; the content behind stays
+                // visible through it (goal: current chat dimmed, not hidden).
+                Color.black.opacity(isOpen ? 0.45 : 0)
+                    .ignoresSafeArea()
+                    .onTapGesture { close() }
+                    .accessibilityLabel("Close menu")
+                    .accessibilityAddTraits(.isButton)
+                    .allowsHitTesting(isOpen)
+
+                panel(width: width)
+                    .offset(x: isOpen ? 0 : -width - 24)
+            }
+            .animation(reduceMotion ? nil : .snappy(duration: 0.24), value: isOpen)
+        }
+        .accessibilityAddTraits(.isModal)
+        .accessibilityHidden(!isOpen)
+    }
+
+    private func close() { isOpen = false }
+
+    private func panel(width: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            searchField
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+                .padding(.bottom, 6)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    sectionHeader("Sections")
+                    DrawerRow(systemImage: "checklist", label: "Tasks") { go(.tasks) }
+                    DrawerRow(systemImage: "calendar", label: "Calendar") { go(.calendar) }
+                    DrawerRow(systemImage: "book.closed", label: "Diary") {
+                        close(); app.diaryPresented = true
+                    }
+                    DrawerRow(systemImage: "gearshape", label: "Settings") { go(.settings) }
+
+                    if !pinnedThreads.isEmpty {
+                        sectionHeader("Pinned")
+                        ForEach(pinnedThreads) { thread in
+                            DrawerRow(systemImage: "pin.fill", label: thread.title, active: true) {
+                                close(); openThread(thread)
+                            }
+                        }
+                    }
+
+                    if !recentThreads.isEmpty {
+                        sectionHeader("Recent")
+                        ForEach(recentThreads) { thread in
+                            DrawerRow(systemImage: "bubble.left", label: thread.title) {
+                                close(); openThread(thread)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, 8)
+                .padding(.bottom, 84)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(width: width)
+        .frame(maxHeight: .infinity)
+        .background(chrome.bgBase)
+        .overlay(alignment: .trailing) {
+            Rectangle().fill(chrome.border.opacity(0.6)).frame(width: 0.5).ignoresSafeArea()
+        }
+        // Floating New Chat near the lower edge, above the safe area.
+        .overlay(alignment: .bottomLeading) {
+            Button {
+                close(); newChat()
+            } label: {
+                Label("New Chat", systemImage: "square.and.pencil")
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 11)
+                    .glass(.elevated, in: Capsule())
+                    .accentGlow(active: true)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("New chat")
+            .padding(.leading, 14)
+            .padding(.bottom, 18)
+        }
+        .ignoresSafeArea(edges: .bottom)
+        // A leftward drag anywhere on the panel closes it (matches the native
+        // drawer gesture without a custom gesture recognizer stack).
+        .gesture(
+            DragGesture(minimumDistance: 24)
+                .onEnded { value in
+                    if value.translation.width < -40 { close() }
+                }
+        )
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.secondary)
+            TextField("Search chats", text: $query)
+                .textFieldStyle(.plain)
+                .font(.subheadline)
+                .autocorrectionDisabled()
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                }
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .glass(.control, in: Capsule())
+        .accessibilityLabel("Search chats")
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+            .padding(.horizontal, 14)
+            .padding(.top, 16)
+            .padding(.bottom, 4)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private func go(_ tab: AppTab) {
+        close()
+        app.selectedTab = tab
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift
@@ -123,12 +123,38 @@ struct ModelPickerSheet: View {
     let options: [ChatModelOption]
     let current: String
     let onSelect: (String) -> Void
+    /// Optional deeper-configuration hop: shown as a chevron row that hands
+    /// off to the familiar picker (the "agent" half of the model/agent pill).
+    var onSwitchFamiliar: (() -> Void)? = nil
 
     @Environment(\.dismiss) private var dismiss
+
+    private var currentOption: ChatModelOption? {
+        options.first(where: { $0.id == current }) ?? (current.isEmpty ? nil : ChatModelOption(id: current, label: current))
+    }
 
     var body: some View {
         NavigationStack {
             List {
+                // The active choice leads the sheet so "what am I talking to"
+                // is answered before any option scanning.
+                if let currentOption {
+                    Section("Current") {
+                        HStack(spacing: 12) {
+                            Image(systemName: "cpu")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(Color.accentColor)
+                                .frame(width: 32, height: 32)
+                                .background(Color.accentColor.opacity(0.14), in: Circle())
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(currentOption.label).font(.body.weight(.semibold))
+                                Text(currentOption.id).font(.caption2).foregroundStyle(.secondary)
+                            }
+                        }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("Current model: \(currentOption.label)")
+                    }
+                }
                 Section {
                     ForEach(options) { option in
                         Button {
@@ -149,8 +175,29 @@ struct ModelPickerSheet: View {
                         }
                         .buttonStyle(.plain)
                     }
+                } header: {
+                    Text("Models")
                 } footer: {
                     Text("Applies to this chat. The familiar uses the chosen model for its next replies.")
+                }
+                if let onSwitchFamiliar {
+                    Section("Agent") {
+                        Button {
+                            dismiss()
+                            onSwitchFamiliar()
+                        } label: {
+                            HStack {
+                                Text("Chat with another familiar").foregroundStyle(.primary)
+                                Spacer(minLength: 8)
+                                Image(systemName: "chevron.right")
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityHint("Opens the familiar picker")
+                    }
                 }
             }
             .themedListBackground()

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -41,6 +41,11 @@ struct ChatView: View {
     @State private var pendingImages: [PendingImage] = []
     /// How many images one message can carry.
     private let maxAttachments = 4
+    // Composer "+" menu and the attach destinations it fans out to.
+    @State private var showActionMenu = false
+    @State private var showPhotosPicker = false
+    @State private var showCamera = false
+    @State private var showFileImporter = false
     @State private var responseReader: ResponseReaderItem?
     // Tap-to-enlarge target (image attachment, or a table/diagram/image lifted
     // from the markdown WebView). Driven by the `.caveZoomContent` notification.
@@ -81,9 +86,20 @@ struct ChatView: View {
     var body: some View {
         VStack(spacing: 0) {
             messageScroll
-            if !thread.isGroup, let familiarId = thread.familiarIds.first {
-                ChatModelBar(thread: thread, familiarId: familiarId)
-            }
+                // While the "+" menu is up, the transcript becomes its scrim:
+                // a light dim signals the mode and any outside tap dismisses.
+                .overlay {
+                    if showActionMenu {
+                        Color.black.opacity(0.15)
+                            .ignoresSafeArea(edges: .top)
+                            .onTapGesture { showActionMenu = false }
+                            .accessibilityLabel("Close attach menu")
+                            .accessibilityAddTraits(.isButton)
+                    }
+                }
+            // Model access moved into the header's agent pill (and /model), so
+            // the composer anchors the screen with nothing between it and the
+            // transcript.
             composer
         }
         // Keep the conversation in a centred reading column on iPad.
@@ -97,13 +113,28 @@ struct ChatView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                VStack(spacing: 1) {
-                    Text(thread.title).font(.headline).lineLimit(1)
-                    if thread.isGroup {
-                        Text("\(thread.familiarIds.count) familiars")
-                            .font(.caption2).foregroundStyle(.secondary)
-                    } else if let role = app.familiar(thread.familiarIds.first ?? "")?.role {
-                        Text(role).font(.caption2).foregroundStyle(.secondary)
+                // Agent pill: who you're talking to, and (direct chats) the door
+                // to the model/agent picker. Groups keep a static pill — the
+                // fan-out has no single model to switch.
+                if thread.isGroup {
+                    PillSelector(label: thread.title,
+                                 sublabel: "\(thread.familiarIds.count) familiars",
+                                 chevron: false,
+                                 accessibilityHint: nil,
+                                 action: {}) {
+                        AvatarView(familiar: nil, size: 22,
+                                   fallbackName: thread.title)
+                    }
+                    .disabled(true)
+                } else {
+                    let familiar = app.familiar(thread.familiarIds.first ?? "")
+                    PillSelector(label: thread.title,
+                                 sublabel: familiar?.role,
+                                 accessibilityHint: "Opens the model and agent picker",
+                                 action: { Task { await switchModel("") } }) {
+                        AvatarView(familiar: familiar,
+                                   url: familiar.flatMap { app.client?.avatarURL(for: $0) },
+                                   size: 22)
                     }
                 }
             }
@@ -146,10 +177,10 @@ struct ChatView: View {
             CommandsSheet { command in prefill(command) }
         }
         .sheet(isPresented: $showModelPicker) {
-            ModelPickerSheet(options: modelPickerOptions, current: modelPickerCurrent) { id in
+            ModelPickerSheet(options: modelPickerOptions, current: modelPickerCurrent, onSelect: { id in
                 guard !thread.isGroup, let familiarId = thread.familiarIds.first else { return }
                 Task { await applyModel(id, familiarId: familiarId, sessionId: modelSessionId(familiarId)) }
-            }
+            }, onSwitchFamiliar: { showFamiliarPicker = true })
         }
         .sheet(isPresented: $showFamiliarPicker) {
             FamiliarPickerSheet { familiar in
@@ -255,14 +286,7 @@ struct ChatView: View {
             // A fresh thread with no messages shouldn't read as a blank void.
             .overlay {
                 if thread.messages.isEmpty {
-                    ContentUnavailableView {
-                        Label("Start the conversation", systemImage: "bubble.left.and.bubble.right")
-                    } description: {
-                        Text(thread.isGroup
-                             ? "Send a message to all \(thread.familiarIds.count) familiars."
-                             : "Send a message to \(app.familiar(thread.familiarIds.first ?? "")?.displayName ?? "this familiar") to begin.")
-                    }
-                    .allowsHitTesting(false)
+                    emptyState
                 }
             }
             // Track whether the user is parked at the latest message so a
@@ -302,10 +326,59 @@ struct ChatView: View {
         }
     }
 
+    // MARK: - Empty state
+
+    /// Spacious cold-start state: a quiet greeting up top, and a short stack of
+    /// starter rows in the lower half. Rows FILL the composer (focused, ready
+    /// to tweak) rather than firing a send — same convention as the desktop
+    /// quick-chat suggestions.
+    private var emptyState: some View {
+        VStack(spacing: 0) {
+            Spacer()
+            VStack(spacing: 10) {
+                Image(systemName: "bubble.left.and.bubble.right")
+                    .font(.system(size: 26, weight: .medium))
+                    .foregroundStyle(.secondary)
+                Text(thread.isGroup
+                     ? "Message all \(thread.familiarIds.count) familiars"
+                     : "Message \(app.familiar(thread.familiarIds.first ?? "")?.displayName ?? "your familiar")")
+                    .font(.title3.weight(.semibold))
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, 24)
+            Spacer()
+            VStack(spacing: 8) {
+                ForEach(emptySuggestions, id: \.label) { suggestion in
+                    EmptyChatSuggestionRow(systemImage: suggestion.icon, label: suggestion.label) {
+                        draft = suggestion.label
+                        composerFocused = true
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 18)
+        }
+    }
+
+    private var emptySuggestions: [(icon: String, label: String)] {
+        [
+            ("sparkles", "What can you help me with?"),
+            ("checklist", "Summarize my open tasks"),
+            ("calendar", "What's on my calendar today?"),
+            ("doc.text", "Draft a short status update"),
+        ]
+    }
+
     // MARK: - Composer
 
     private var composer: some View {
         VStack(spacing: 8) {
+            if showActionMenu {
+                FloatingActionMenu(actions: composerActions) { showActionMenu = false }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .transition(.scale(scale: 0.94, anchor: .bottomLeading).combined(with: .opacity))
+            }
             if showingSlashMenu {
                 SlashCommandMenu(commands: slashMatches) { command in pickFromMenu(command) }
                     .padding(.horizontal, 12)
@@ -328,6 +401,7 @@ struct ChatView: View {
             }
             composerBar
         }
+        .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showActionMenu)
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showingSlashMenu)
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: showingMentionMenu)
         .animation(reduceMotion ? nil : .snappy(duration: 0.18), value: pendingImages.count)
@@ -343,6 +417,35 @@ struct ChatView: View {
             // user's selection order.
             Task { for item in picked { await loadPickedImage(item) } }
         }
+        // The "+" menu's attach destinations. The pickers hang off the composer
+        // (not the menu rows) so the menu can dismiss before they present.
+        .photosPicker(isPresented: $showPhotosPicker,
+                      selection: $photoItems,
+                      maxSelectionCount: maxAttachments,
+                      matching: .images,
+                      photoLibrary: .shared())
+        .fullScreenCover(isPresented: $showCamera) {
+            CameraPicker { image in stage(image) }
+                .ignoresSafeArea()
+        }
+        .fileImporter(isPresented: $showFileImporter,
+                      allowedContentTypes: [.image],
+                      allowsMultipleSelection: true) { result in
+            guard case .success(let urls) = result else { return }
+            for url in urls { loadFileImage(url) }
+        }
+    }
+
+    /// The composer's "+" fan-out. Camera/Photos/Files all land in the same
+    /// staged-attachment path; Commands is the tool entry (same sheet as the
+    /// header's ⌘ affordance on desktop).
+    private var composerActions: [FloatingAction] {
+        [
+            FloatingAction(id: "camera", systemImage: "camera", label: "Camera") { showCamera = true },
+            FloatingAction(id: "photos", systemImage: "photo.on.rectangle", label: "Photos") { showPhotosPicker = true },
+            FloatingAction(id: "files", systemImage: "folder", label: "Files") { showFileImporter = true },
+            FloatingAction(id: "commands", systemImage: "command", label: "Commands") { showCommands = true },
+        ]
     }
 
     /// A scrollable row of attached-image thumbnails above the composer, each
@@ -387,34 +490,45 @@ struct ChatView: View {
     private func loadPickedImage(_ item: PhotosPickerItem) async {
         guard let data = try? await item.loadTransferable(type: Data.self),
               let image = UIImage(data: data) else { return }
+        await MainActor.run { stage(image) }
+    }
+
+    /// Load an image picked from the Files app (security-scoped) and stage it
+    /// through the same resize path as camera/photo attachments.
+    private func loadFileImage(_ url: URL) {
+        let scoped = url.startAccessingSecurityScopedResource()
+        defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+        guard let data = try? Data(contentsOf: url),
+              let image = UIImage(data: data) else { return }
+        stage(image)
+    }
+
+    /// One staging path for every attach source (photos, camera, files):
+    /// downscale for the upload cap, encode a `data:` URL, respect the
+    /// per-message attachment limit.
+    private func stage(_ image: UIImage) {
+        guard pendingImages.count < maxAttachments else { return }
         let resized = image.resizedForUpload()
         guard let jpeg = resized.jpegData(compressionQuality: 0.8) else { return }
         let dataUrl = "data:image/jpeg;base64,\(jpeg.base64EncodedString())"
-        await MainActor.run {
-            guard pendingImages.count < maxAttachments else { return }
-            // Unique per-image name so several attachments on one message don't
-            // collide server-side.
-            let name = "photo-\(UUID().uuidString.prefix(8)).jpg"
-            pendingImages.append(PendingImage(image: resized, dataUrl: dataUrl,
-                                              mimeType: "image/jpeg", name: name))
-            Haptics.tap()
-        }
+        // Unique per-image name so several attachments on one message don't
+        // collide server-side.
+        let name = "photo-\(UUID().uuidString.prefix(8)).jpg"
+        pendingImages.append(PendingImage(image: resized, dataUrl: dataUrl,
+                                          mimeType: "image/jpeg", name: name))
+        Haptics.tap()
     }
 
     private var composerBar: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            // Attach an image; the server delivers it to the familiar.
-            PhotosPicker(selection: $photoItems,
-                         maxSelectionCount: maxAttachments,
-                         matching: .images,
-                         photoLibrary: .shared()) {
-                Image(systemName: "plus")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 34, height: 34)
-                    .glassFill(.control, in: Circle())
+            // "+" opens the floating attach/tools menu (Camera · Photos ·
+            // Files · Commands) instead of jumping straight into one picker.
+            CircularIconButton(systemImage: showActionMenu ? "xmark" : "plus",
+                               active: showActionMenu,
+                               label: showActionMenu ? "Close attach menu" : "Attach or run a tool") {
+                composerFocused = false
+                showActionMenu.toggle()
             }
-            .accessibilityLabel("Attach images")
 
             // Hairline capsule with the field and a trailing control inside it:
             // a mic when empty, a filled send/run button once there's text.
@@ -433,6 +547,13 @@ struct ChatView: View {
                         guard !press.modifiers.contains(.shift) else { return .ignored }
                         guard canSend else { return .ignored }
                         send()
+                        return .handled
+                    }
+                    // Hardware Escape closes the "+" menu (outside tap and row
+                    // selection are the touch paths).
+                    .onKeyPress(keys: [.escape]) { _ in
+                        guard showActionMenu else { return .ignored }
+                        showActionMenu = false
                         return .handled
                     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -32,8 +32,25 @@ struct ChatsHomeView: View {
     @State private var editMode: EditMode = .inactive
     /// Reveal archived group chats in the list.
     @State private var showArchived = false
+    /// Left slide-out drawer (menu button in the header).
+    @State private var drawerOpen = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
+        ZStack(alignment: .leading) {
+            splitView
+                // The list stays visible behind the drawer — dimmed by the
+                // drawer's scrim and nudged right for depth (unless the user
+                // prefers reduced motion).
+                .offset(x: drawerOpen && !reduceMotion ? 16 : 0)
+                .animation(reduceMotion ? nil : .snappy(duration: 0.24), value: drawerOpen)
+            ChatDrawer(isOpen: $drawerOpen,
+                       openThread: { open(.thread($0)) },
+                       newChat: { showNewChat = true })
+        }
+    }
+
+    private var splitView: some View {
         NavigationSplitView {
             Group {
                 if app.familiars.isEmpty && app.threads.isEmpty {
@@ -147,9 +164,14 @@ struct ChatsHomeView: View {
     /// Large-title header pinned to the top, mirroring the Read / Tasks tabs
     /// so every tab's title aligns at the same flush position.
     private var header: some View {
-        HStack(alignment: .firstTextBaseline) {
+        HStack(spacing: 12) {
+            CircularIconButton(systemImage: "line.3.horizontal",
+                               active: drawerOpen,
+                               label: "Menu") {
+                drawerOpen = true
+            }
             Text("Chats")
-                .font(.largeTitle.weight(.bold))
+                .font(.title2.weight(.bold))
             Spacer()
             if canReorder {
                 Button(editMode.isEditing ? "Done" : "Reorder") {
@@ -161,10 +183,14 @@ struct ChatsHomeView: View {
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
             }
+            CircularIconButton(systemImage: "square.and.pencil",
+                               label: "New chat") {
+                showNewChat = true
+            }
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
-        .padding(.bottom, 12)
+        .padding(.bottom, 10)
         .glassChrome(.top)
     }
 

--- a/scripts/ios-chat-restyle.test.mjs
+++ b/scripts/ios-chat-restyle.test.mjs
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Chat restyle (cave-5y5q): the premium dark-first chat chrome — circular
+// glass icon buttons, the header agent pill, the composer's floating "+"
+// menu, the empty-state starter rows, and the Chats side drawer. These pins
+// hold the STRUCTURE of the restyle (a11y labels, dismissal paths, sparse
+// accent usage, reduced-motion guards); behavior pins (send/enqueue/reply)
+// live in their own ios-*.test.mjs files and are deliberately untouched.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const chrome = await read("apps/ios/CovenCave/CovenCave/Theme/ChatChrome.swift");
+const chatView = await read("apps/ios/CovenCave/CovenCave/Views/ChatView.swift");
+const drawer = await read("apps/ios/CovenCave/CovenCave/Views/ChatDrawer.swift");
+const home = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
+const modelControl = await read("apps/ios/CovenCave/CovenCave/Views/ChatModelControl.swift");
+const camera = await read("apps/ios/CovenCave/CovenCave/Views/CameraPicker.swift");
+
+// ── Reusable chrome: every icon-only control is labelled; accent is scarce ──
+assert.match(chrome, /struct CircularIconButton: View/, "circular icon button is a shared component");
+assert.match(chrome, /\.accessibilityLabel\(label\)/, "circular icon buttons always carry an accessibility label");
+assert.match(chrome, /\.accentGlow\(active: active\)/, "the accent halo only appears on active/selected state");
+assert.match(chrome, /struct PillSelector<Leading: View>: View/, "pill selector is a shared component");
+assert.match(chrome, /struct FloatingActionMenu: View/, "the composer + menu is a shared component");
+assert.match(
+  chrome,
+  /onDismiss\(\)\s*\n\s*item\.action\(\)/,
+  "floating-menu rows dismiss the menu on selection before acting",
+);
+assert.match(chrome, /struct DrawerRow: View/, "drawer rows are a shared component");
+assert.match(chrome, /accessibilityAddTraits\(active \? \[\.isSelected\] : \[\]\)/, "active drawer row is exposed as selected to AT");
+assert.match(chrome, /struct EmptyChatSuggestionRow: View/, "empty-state suggestion rows are a shared component");
+
+// ── ChatView header: the agent pill opens the model/agent picker ────────────
+assert.match(
+  chatView,
+  /PillSelector\(label: thread\.title,[\s\S]{0,200}?action: \{ Task \{ await switchModel\(""\) \} \}/,
+  "the direct-chat agent pill opens the model picker via the existing /model path",
+);
+assert.match(chatView, /if thread\.isGroup \{[\s\S]{0,300}?chevron: false/, "group chats keep a static pill (no single model to switch)");
+assert.doesNotMatch(chatView, /ChatModelBar\(thread:/, "the between-list model bar is retired — model access lives in the header pill");
+
+// ── Composer "+" menu: fan-out + all three dismissal paths ───────────────────
+assert.match(
+  chatView,
+  /FloatingAction\(id: "camera"[\s\S]{0,80}?showCamera = true/,
+  "+ menu offers Camera",
+);
+assert.match(chatView, /FloatingAction\(id: "photos"[\s\S]{0,100}?showPhotosPicker = true/, "+ menu offers Photos");
+assert.match(chatView, /FloatingAction\(id: "files"[\s\S]{0,80}?showFileImporter = true/, "+ menu offers Files");
+assert.match(chatView, /FloatingAction\(id: "commands"[\s\S]{0,90}?showCommands = true/, "+ menu offers the Commands tool entry");
+assert.match(
+  chatView,
+  /if showActionMenu \{\s*\n\s*Color\.black\.opacity\(0\.15\)[\s\S]{0,200}?onTapGesture \{ showActionMenu = false \}/,
+  "outside tap on the dimmed transcript dismisses the + menu",
+);
+assert.match(
+  chatView,
+  /onKeyPress\(keys: \[\.escape\]\) \{ _ in\s*\n\s*guard showActionMenu else \{ return \.ignored \}\s*\n\s*showActionMenu = false/,
+  "hardware Escape dismisses the + menu",
+);
+assert.match(chatView, /\.photosPicker\(isPresented: \$showPhotosPicker/, "Photos presents via the programmatic photosPicker modifier");
+assert.match(chatView, /\.fileImporter\(isPresented: \$showFileImporter/, "Files presents via fileImporter");
+assert.match(chatView, /func stage\(_ image: UIImage\)/, "camera/photos/files share one staging path");
+assert.match(camera, /UIImagePickerController/, "camera capture wraps the system picker (no custom pipeline)");
+
+// ── Empty state: starter rows FILL the composer (not auto-send) ─────────────
+assert.match(
+  chatView,
+  /EmptyChatSuggestionRow\(systemImage: suggestion\.icon, label: suggestion\.label\) \{\s*\n\s*draft = suggestion\.label\s*\n\s*composerFocused = true/,
+  "empty-state suggestions fill the composer for tweak-and-send",
+);
+
+// ── Model picker: current leads, deeper config is a chevron hop ──────────────
+assert.match(modelControl, /Section\("Current"\)/, "the picker names the current model at the top");
+assert.match(
+  modelControl,
+  /var onSwitchFamiliar: \(\(\) -> Void\)\? = nil/,
+  "the agent hop is optional so other call sites are unaffected",
+);
+assert.match(modelControl, /Chat with another familiar/, "deeper agent configuration is reachable from the picker");
+assert.match(chatView, /onSwitchFamiliar: \{ showFamiliarPicker = true \}/, "the picker's agent hop opens the familiar picker");
+
+// ── Side drawer: search, sections, pinned, recents, New Chat, dismissals ─────
+assert.match(drawer, /struct ChatDrawer: View/, "the drawer is its own component");
+assert.match(drawer, /TextField\("Search chats", text: \$query\)/, "the drawer leads with search");
+assert.match(drawer, /sectionHeader\("Sections"\)[\s\S]*?sectionHeader\("Pinned"\)[\s\S]*?sectionHeader\("Recent"\)/, "drawer groups: sections, pinned, recents — in that order");
+assert.match(drawer, /app\.selectedTab = tab/, "primary sections route through the existing tab selection");
+assert.match(drawer, /Label\("New Chat", systemImage: "square\.and\.pencil"\)/, "a floating New Chat button sits near the lower edge");
+assert.match(drawer, /onTapGesture \{ close\(\) \}/, "the scrim closes the drawer on outside tap");
+assert.match(drawer, /value\.translation\.width < -40 \{ close\(\) \}/, "a leftward drag closes the drawer");
+assert.match(drawer, /Color\.black\.opacity\(isOpen \? 0\.45 : 0\)/, "the list behind stays visible through a dim scrim, not hidden");
+assert.match(drawer, /reduceMotion \? nil : \.snappy/, "drawer animation respects reduced motion");
+
+// ── Chats home: menu + compose are labelled circular controls ────────────────
+assert.match(home, /CircularIconButton\(systemImage: "line\.3\.horizontal",[\s\S]{0,120}?label: "Menu"\)/, "the header menu button is a labelled circular control");
+assert.match(home, /CircularIconButton\(systemImage: "square\.and\.pencil",\s*\n\s*label: "New chat"\)/, "the header compose button is a labelled circular control");
+assert.match(home, /ChatDrawer\(isOpen: \$drawerOpen/, "the drawer overlays the chats home");
+assert.match(home, /drawerOpen && !reduceMotion \? 16 : 0/, "the content offsets behind the open drawer (reduced-motion aware)");
+
+console.log("ios-chat-restyle.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -715,6 +715,7 @@ export const SUITES = {
     "src/lib/mobile-handoff.test.ts",
     "src/lib/mobile-token-refresh.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
+    "scripts/ios-chat-restyle.test.mjs",
     "scripts/ios-code-browser-files.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
     "scripts/ios-no-canvas-tab.test.mjs",


### PR DESCRIPTION
Focused restyle of the native iOS chat experience toward modern AI-chat polish (spacious empty state, pill agent selector, floating attach menu, side drawer) while keeping the Coven identity: the published theme's near-black canvas + glass surfaces stay the base, and the accent appears **only on selected/active states**.

## Reusable chrome — `Theme/ChatChrome.swift`
`CircularIconButton` (always a11y-labelled; accent halo only while active) · `PillSelector` · `FloatingActionMenu` (icon-well rows, dismiss-on-select) · `DrawerRow` (`.isSelected` exposed to AT) · `EmptyChatSuggestionRow` · `ChatChrome` size/radius tokens.

## Chat screen
- **Agent pill** replaces the plain header title: avatar + name + role, chevron on direct chats → opens the model/agent picker via the existing `/model` path. Groups keep a static pill. The between-list `ChatModelBar` is retired — nothing sits between transcript and composer.
- **Empty state**: quiet greeting; four starter rows (icon + short label) in the lower half that **fill** the composer, focused and ready to tweak.
- **Composer "+"** opens a floating menu — **Camera** (new `UIImagePickerController` wrapper; permission already declared), **Photos** (programmatic `photosPicker`), **Files** (`fileImporter`, security-scoped), **Commands** (existing sheet). One shared `stage()` resize path. Dismiss: outside tap on the dimmed transcript, hardware Escape, row selection, or the toggled ×. Reduced-motion guards throughout.

## Model/agent picker
Current model leads the sheet (icon well + label + id) → options with checkmarks → optional "Chat with another familiar" chevron row (nil-safe for other call sites).

## Side drawer (Chats tab)
Circular Menu button (header left) slides in a left drawer: search · primary sections (Tasks/Calendar/Diary/Settings via existing `app.selectedTab`) · pinned chats · recents · floating **New Chat** — list stays visible **dimmed + offset** behind; scrim tap / drag-left dismissal; reduced-motion aware. Circular New Chat also joins the header right.

## Behavior preserved
Send/enqueue/offline, swipe-reply, slash + mention menus, draft persistence, dictation, iPad split view — **all pre-existing `ios-*.test.mjs` pins pass unchanged**.

## Verification
- `xcodebuild` (iOS Simulator) — **BUILD SUCCEEDED**
- Mobile suite — **74 test files green**, incl. new `scripts/ios-chat-restyle.test.mjs` (pins a11y labels, all dismissal paths, sparse-accent rule, reduced-motion guards, fill-not-send starters)
- Web `test:app` (560) + build within budget; `tsc` clean (web untouched)
- ⚠️ On-device visual review recommended: the chat UI needs a live daemon, so this change ships compile+pin verified, no simulator screenshot.

Closes cave-5y5q.

🤖 Generated with [Claude Code](https://claude.com/claude-code)