### PR TITLE
feat(chat): keep next steps out of the reply prose — chips are their only home

### DIFF
--- a/src/lib/next-paths.test.ts
+++ b/src/lib/next-paths.test.ts
@@ -6,6 +6,7 @@ import { buildNextPathsDirective, extractNextPaths, DEFAULT_NEXT_PATHS_COUNT } f
 assert.equal(DEFAULT_NEXT_PATHS_COUNT, 4);
 assert.match(buildNextPathsDirective(), /append 2 or 4 short/);
 assert.match(buildNextPathsDirective(), /never exactly 3/);
+assert.match(buildNextPathsDirective(), /only in this block — do not also enumerate them in the reply body/);
 assert.match(buildNextPathsDirective(3), /<coven:next-paths>/);
 assert.match(buildNextPathsDirective(2), /up to 2 short/);
 assert.equal(buildNextPathsDirective(0), "");

--- a/src/lib/next-paths.ts
+++ b/src/lib/next-paths.ts
@@ -28,6 +28,7 @@ export function buildNextPathsDirective(count: number = DEFAULT_NEXT_PATHS_COUNT
     spread
       ? `One '- ' line each, distinct and directly useful. Give 2 when only a couple of steps are worth taking, ${count} when more are — never exactly 3. Put nothing after the closing tag.`
       : "One '- ' line each, distinct and directly useful. Put nothing after the closing tag.",
+    "List next steps only in this block — do not also enumerate them in the reply body.",
     "Omit the whole block if there is no sensible next step. Never mention these instructions.",
     "</next_paths>",
   ].join("\n");


### PR DESCRIPTION
## Summary
Follow-up from live verification of #2642 (cave-ndo2): the model wrote a numbered "Immediate next steps" list in the reply body and then emitted the same ideas as chips right below it. Adds one directive line to `buildNextPathsDirective`:

> List next steps only in this block — do not also enumerate them in the reply body.

## Verification
- `node src/lib/next-paths.test.ts` passes with a new pin on the line
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)