### PR TITLE
fix(chat): each artifact in a multi-artifact turn titles from its own intro prose

### DIFF
--- a/src/components/chat-view-canvas-artifact.test.ts
+++ b/src/components/chat-view-canvas-artifact.test.ts
@@ -11,5 +11,10 @@ assert.match(src, /extractArtifactBlocks/, "uses extractArtifactBlocks to find b
 assert.match(src, /function splitTextForArtifacts/, "has the text→segments splitter");
 assert.match(src, /<ChatArtifactViewer\b/, "renders the viewer as a block segment");
 assert.match(src, /splitTextForArtifacts\(visible/, "splits the plain text path (no tools)");
+assert.match(
+  src,
+  /const preceding = text\.slice\(cursor, b\.index\)\.trim\(\)/,
+  "each artifact titles from the prose since the previous block, not the whole message",
+);
 
 console.log("chat-view canvas artifact wiring: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5604,7 +5604,10 @@ function splitTextForArtifacts(
       const pre = text.slice(cursor, b.index);
       if (pre.trim()) out.push({ kind: "text", text: pre });
     }
-    const preceding = text.slice(0, b.index).trim();
+    // Title from the prose since the PREVIOUS block (cursor), not the whole
+    // message — otherwise every artifact in a multi-artifact turn inherits
+    // the message's first line as its title.
+    const preceding = text.slice(cursor, b.index).trim();
     const title = preceding ? titleFromPrompt(preceding) : "Canvas artifact";
     out.push({
       kind: "block",


### PR DESCRIPTION
## Summary
Found during live verification of #2648 (cave-fgiw): with two artifacts in one message, both viewer headers showed the message's first line as their title. `splitTextForArtifacts` fed `titleFromPrompt` everything before the block (`text.slice(0, b.index)`); it now slices from the previous block's end (`cursor`), so each artifact titles from its own intro line. Back-to-back blocks (no prose between) keep the "Canvas artifact" fallback.

## Verification
- Ran the built app and drove a mocked two-artifact conversation: headers now read "Here is a signup card:" / "And a polished variant:" (previously both showed the first).
- `node src/components/chat-view-canvas-artifact.test.ts` passes with a new pin on the cursor slice; `tsc --noEmit` and `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)