### PR TITLE
fix(chat): un-wedge the transcript follow-pin + pin through late async layout (cave-3oew)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -31,6 +31,7 @@ export const SUITES = {
     "src/lib/page-drag.test.ts",
     "src/lib/sidebar-nav-state.test.ts",
     "src/components/chat-view-render-cap.test.ts",
+    "src/components/chat-view-scroll-pin.test.ts",
     "src/lib/perf/web-vitals-format.test.ts",
     "src/lib/app-version.test.ts",
     "src/lib/endpoint-validators.test.ts",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -635,7 +635,7 @@ assert.match(
 );
 
 // — CHAT-D10-01 + CHAT-D13-03: instant scroll pin, intent-based release —
-const pinEffect = source.match(/\/\/ Pin: while following[\s\S]*?\}, \[turns\]\);/)?.[0] ?? "";
+const pinEffect = source.match(/\/\/ Pin: while following[\s\S]*?\}, \[turns, schedulePin\]\);/)?.[0] ?? "";
 assert.match(
   pinEffect,
   /requestAnimationFrame\(\(\) => \{[\s\S]*el\.scrollTop = el\.scrollHeight/,
@@ -663,8 +663,8 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(e\.deltaY < 0 && followingRef\.current\) updateFollowing\(false\)/,
-  "Wheel-up (negative deltaY) is the user intent that detaches following",
+  /if \(e\.deltaY < 0 && followingRef\.current && scrollable\(\)\) updateFollowing\(false\)/,
+  "Wheel-up (negative deltaY) on a scrollable transcript is the user intent that detaches following",
 );
 assert.match(
   source,
@@ -678,7 +678,7 @@ assert.match(
 );
 assert.match(
   source,
-  /y > lastTouchY && followingRef\.current\) updateFollowing\(false\)/,
+  /y > lastTouchY && followingRef\.current && scrollable\(\)\) \{\s*updateFollowing\(false\)/,
   "Touch drag toward earlier content (finger moving down) detaches following",
 );
 assert.match(

--- a/src/components/chat-view-scroll-pin.test.ts
+++ b/src/components/chat-view-scroll-pin.test.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+// Transcript follow-pin (CHAT-D10-01/-D10-04): the chat never scrolls without
+// clear user intent. While `following`, the scroller stays glued to the bottom
+// through EVERY height change — turns mutations AND late async layout
+// (MarkdownBlock's mdToHtml promise, SyntaxBlock's shiki swap, mermaid,
+// images) — via a ResizeObserver feeding the same coalesced instant-rAF pin.
+// Release happens only on user input: wheel up, touch drag, PageUp/Home/
+// ArrowUp, or a scrollbar grab that actually moves up. These source-text
+// assertions guard that wiring (the behavior is exercised live; this catches
+// accidental removal).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// --- The pin executor: instant, coalesced, shared -------------------------
+
+assert.match(
+  src,
+  /const schedulePin = useCallback\(\(\) => \{\s*if \(!followingRef\.current\) return;\s*if \(pinFrameRef\.current !== null\) return;\s*pinFrameRef\.current = requestAnimationFrame\(/,
+  "schedulePin coalesces through pinFrameRef and re-checks following inside the rAF",
+);
+
+assert.match(
+  src,
+  /pinFrameRef\.current = null;\s*const el = scrollRef\.current;\s*if \(!el \|\| !followingRef\.current\) return;\s*el\.scrollTop = el\.scrollHeight;/,
+  "the pin is an instant scrollTop assignment — never a queued smooth scrollTo (CHAT-D10-01)",
+);
+
+assert.match(
+  src,
+  /useEffect\(\(\) => \{\s*schedulePin\(\);\s*\}, \[turns, schedulePin\]\);/,
+  "every turns mutation schedules a pin",
+);
+
+// The wedge that broke pinning entirely: StrictMode/Suspense re-run effects
+// while refs persist, so a cancel that leaves the stale rAF id in place makes
+// schedulePin's coalescing guard skip every future pin. Cancel MUST null.
+assert.match(
+  src,
+  /cancelAnimationFrame\(pinFrameRef\.current\);[\s\S]{0,400}?pinFrameRef\.current = null;/,
+  "the pin cleanup nulls pinFrameRef after cancelAnimationFrame (StrictMode/Suspense re-mount safety)",
+);
+
+// --- CHAT-D10-04: late async layout must not strand the viewport ----------
+
+assert.match(
+  src,
+  /new ResizeObserver\(\(\) => \{\s*if \(followingRef\.current\) schedulePin\(\);\s*\}\)/,
+  "a ResizeObserver re-pins on size changes ONLY while following — a released reader is never moved",
+);
+
+assert.match(
+  src,
+  /ro\.observe\(scroller\);\s*const thread = threadRef\.current;\s*if \(thread\) ro\.observe\(thread\);/,
+  "the observer watches both the scroller (composer/window resizes) and the thread (content growth)",
+);
+
+assert.match(
+  src,
+  /ref=\{threadRef\}\s*className="cave-chat-thread"/,
+  "threadRef is attached to the thread element the observer watches",
+);
+
+// --- Release on intent only ------------------------------------------------
+
+assert.match(
+  src,
+  /const scrollable = \(\) => el\.scrollHeight - el\.clientHeight > 1;/,
+  "release is gated on an actually-scrollable transcript (no stranded FAB on short chats)",
+);
+
+assert.match(
+  src,
+  /if \(e\.deltaY < 0 && followingRef\.current && scrollable\(\)\) updateFollowing\(false\);/,
+  "wheel up releases the pin",
+);
+
+assert.match(
+  src,
+  /if \(e\.target === el && e\.offsetX >= el\.clientWidth\) scrollbarGrab = true;/,
+  "a mousedown in the scrollbar gutter arms scrollbar-release (drags emit no wheel/touch/key events)",
+);
+
+assert.match(
+  src,
+  /if \(!scrollbarGrab \|\| !followingRef\.current\) return;\s*if \(el\.scrollHeight - el\.scrollTop - el\.clientHeight > 4\) updateFollowing\(false\);/,
+  "only an actual upward move during a scrollbar grab releases — programmatic pins never do",
+);
+
+console.log("chat-view-scroll-pin.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2263,6 +2263,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const turnsRef = useRef<Turn[]>([]);
   const tailRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const threadRef = useRef<HTMLDivElement | null>(null);
   // Scroll-pin state (CHAT-D10-01). `following` means "keep the transcript
   // pinned to the newest content". It releases on user INTENT (wheel up /
   // touch drag toward earlier content), never on mere scroll position — the
@@ -3212,12 +3213,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     };
   }, [sessionId, historyRetryKey, flowBackedSession]);
 
-  // Pin: while following, every turns mutation snaps the scroller to the
-  // bottom INSTANTLY (scrollTop assignment inside a rAF, coalescing multiple
-  // SSE chunks per frame). Never a queued smooth animation per chunk — that
-  // is the CHAT-D10-01 bug, and instant pinning also satisfies
+  // Pin: while following, snap the scroller to the bottom INSTANTLY
+  // (scrollTop assignment inside a rAF, coalescing multiple triggers per
+  // frame). Never a queued smooth animation per chunk — that is the
+  // CHAT-D10-01 bug, and instant pinning also satisfies
   // prefers-reduced-motion during streaming (CHAT-D13-03).
-  useEffect(() => {
+  const schedulePin = useCallback(() => {
     if (!followingRef.current) return;
     if (pinFrameRef.current !== null) return;
     pinFrameRef.current = requestAnimationFrame(() => {
@@ -3226,10 +3227,42 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       if (!el || !followingRef.current) return;
       el.scrollTop = el.scrollHeight;
     });
-  }, [turns]);
+  }, []);
+
+  useEffect(() => {
+    schedulePin();
+  }, [turns, schedulePin]);
+
+  // CHAT-D10-04: turns mutations are not the only thing that moves the tail.
+  // MarkdownBlock (async mdToHtml), SyntaxBlock (async shiki swap), mermaid,
+  // and images all change transcript height AFTER the final turns-driven pin
+  // lands — without this observer the viewport is left sitting above the
+  // bottom while `following` is still true ("the chat scrolled up by
+  // itself"). While following, ANY size change of the thread (content
+  // growth) or the scroller (composer/window resize) re-pins through the
+  // same coalesced rAF; while released it does nothing, so a reader's place
+  // is never disturbed.
+  useEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => {
+      if (followingRef.current) schedulePin();
+    });
+    ro.observe(scroller);
+    const thread = threadRef.current;
+    if (thread) ro.observe(thread);
+    return () => ro.disconnect();
+  }, [schedulePin]);
 
   useEffect(() => () => {
-    if (pinFrameRef.current !== null) cancelAnimationFrame(pinFrameRef.current);
+    if (pinFrameRef.current !== null) {
+      cancelAnimationFrame(pinFrameRef.current);
+      // MUST null: StrictMode (dev) and Suspense reveals re-run effects while
+      // refs persist. Leaving the cancelled id in place wedges the coalescing
+      // guard in schedulePin, and no pin ever runs again for the lifetime of
+      // the component — the "chat opens at the top and never follows" bug.
+      pinFrameRef.current = null;
+    }
   }, []);
 
   // A freshly opened chat (or session switch) follows by default; the pin
@@ -3244,14 +3277,18 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   // Release on intent: only USER input events detach following. Programmatic
   // pins (scrollTop assignment, FAB scrollTo) emit scroll events but never
-  // wheel/touch/key events, so they are structurally excluded from intent
-  // detection here.
+  // wheel/touch/key/scrollbar-grab events, so they are structurally excluded
+  // from intent detection here.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     let lastTouchY: number | null = null;
+    // A transcript that doesn't overflow can't be scrolled away from the
+    // bottom — releasing there would only strand the FAB with nothing to
+    // re-pin it (re-pin needs a scroll event that will never come).
+    const scrollable = () => el.scrollHeight - el.clientHeight > 1;
     const onWheel = (e: WheelEvent) => {
-      if (e.deltaY < 0 && followingRef.current) updateFollowing(false);
+      if (e.deltaY < 0 && followingRef.current && scrollable()) updateFollowing(false);
     };
     const onTouchStart = (e: TouchEvent) => {
       lastTouchY = e.touches[0]?.clientY ?? null;
@@ -3260,7 +3297,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       const y = e.touches[0]?.clientY;
       if (y === undefined) return;
       // Finger moving down the screen drags content down = scrolling up.
-      if (lastTouchY !== null && y > lastTouchY && followingRef.current) updateFollowing(false);
+      if (lastTouchY !== null && y > lastTouchY && followingRef.current && scrollable()) {
+        updateFollowing(false);
+      }
       lastTouchY = y;
     };
     const onKeyDown = (e: KeyboardEvent) => {
@@ -3268,15 +3307,38 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         updateFollowing(false);
       }
     };
+    // Scrollbar drags emit no wheel/touch/key events, so without this a
+    // scrollbar scroll-up left `following` armed and the next SSE chunk
+    // yanked the reader straight back to the bottom. A grab lands on the
+    // scroller itself with its X past the content box (the gutter, LTR);
+    // only an actual upward move during the grab releases, so clicking the
+    // padding or grabbing without moving changes nothing.
+    let scrollbarGrab = false;
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.target === el && e.offsetX >= el.clientWidth) scrollbarGrab = true;
+    };
+    const onMouseUp = () => {
+      scrollbarGrab = false;
+    };
+    const onScroll = () => {
+      if (!scrollbarGrab || !followingRef.current) return;
+      if (el.scrollHeight - el.scrollTop - el.clientHeight > 4) updateFollowing(false);
+    };
     el.addEventListener("wheel", onWheel, { passive: true });
     el.addEventListener("touchstart", onTouchStart, { passive: true });
     el.addEventListener("touchmove", onTouchMove, { passive: true });
     el.addEventListener("keydown", onKeyDown);
+    el.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mouseup", onMouseUp);
+    el.addEventListener("scroll", onScroll, { passive: true });
     return () => {
       el.removeEventListener("wheel", onWheel);
       el.removeEventListener("touchstart", onTouchStart);
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("keydown", onKeyDown);
+      el.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("mouseup", onMouseUp);
+      el.removeEventListener("scroll", onScroll);
     };
   }, [updateFollowing]);
 
@@ -4818,6 +4880,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       <ToolProjectRootContext.Provider value={session?.project_root ?? projectRoot ?? null}>
       <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
         <div
+          ref={threadRef}
           className="cave-chat-thread"
           role="log"
           aria-label="Conversation"


### PR DESCRIPTION
## Problem

The chat scrolls up (and sometimes yanks down) without the user asking. Reported as: *"it scrolls up without user inputting it to do so."*

## Root causes (three, all in the transcript follow-pin)

1. **The wedge — the pin never ran at all in dev.** The pin's unmount cleanup cancelled a pending rAF **without nulling `pinFrameRef`**. StrictMode (dev) and Suspense reveals re-run effects while refs persist, so `schedulePin`'s coalescing guard (`pinFrameRef.current !== null`) saw the stale cancelled id and skipped **every pin for the lifetime of the surface**. Since `dev-app.sh` runs the dev server, the chat literally never pinned in daily use: threads open at the top, streams don't follow. Instrumented proof: a `scrollTop`-setter interceptor logged **zero** writes across a full thread open on unmodified `origin/main`. (The sibling `foundFrameRef` cleanup already cancels-and-nulls — this brings the pin in line.)

2. **Late async layout stranded the viewport.** The pin only re-fired on `turns` mutations, but `MarkdownBlock` (async `mdToHtml`), `SyntaxBlock` (async shiki swap), mermaid, and images land height changes *after* the final mutation — the viewport was left sitting above the tail with `following` still true. A `ResizeObserver` on the thread + scroller now re-pins through the same coalesced instant-rAF path while following. A released reader is never moved (observer no-ops when not following).

3. **Scrollbar drags never released the pin.** Intent release covered wheel/touch/keys only; scrollbar drags emit none of those, so following stayed armed and the next SSE chunk yanked the reader back to the bottom. A mousedown on the scroller's own gutter followed by an actual upward move now releases. Wheel/touch release is also gated on an actually-scrollable transcript so short chats can't strand the FAB.

## Verification

Playwright drive (mocked 28-turn conversation, heavy fenced code + markdown) against **both** the dev server (StrictMode) and `NODE_ENV=production`:

| check | main | this branch |
|---|---|---|
| gap after async markdown/shiki settles | 9066px (stuck at top, scrollTop=0) | **0** |
| re-pin after synthetic 600px late growth | never | **0 within 300ms** |
| released reader moved by content growth | — | **not moved** |
| FAB returns to bottom + re-arms following | stuck 4299px short | **0, re-armed** |
| scrollbar-gutter drag up releases follow | never released | **releases** |

## Tests

- New `src/components/chat-view-scroll-pin.test.ts` (wired into `run-tests.mjs`): pins the cancel-and-null cleanup, the shared coalesced pin, the ResizeObserver-while-following contract, and the intent-release rules.
- `chat-view-polish.test.ts` pins updated for the gated release handlers.
- Full suite: 561 test files pass; `check:tests-wired` and `tsc --noEmit` clean.

Closes cave-3oew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)