### PR TITLE
chore(release): stamp v0.0.151

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.151] - 2026-07-08
+
+> 🔁 **Updates that update themselves** — the native in-app updater finally works in packaged builds: check, download with progress, install, and relaunch without ever leaving the cave. Plus a rounder terminal: tabs you can drive from the keyboard, an SR mirror that follows visibility, and shells that end when their tab does.
+
+Patch release on top of v0.0.150.
+
+### Fixes
+- **Desktop: the native in-app updater is no longer ACL-denied** (#2654, cave-51yk). The updater/relaunch permissions only existed in the local-only capability, but the main window runs from the loopback origin — a remote ACL context — so every native check silently failed and update prompts fell back to browser downloads. A remote-scoped `loopback-updater` capability (trusted main webview only) restores one-click *Install & restart*, and the update banner now re-checks every 6 hours so long-running caves hear about new releases. Users on ≤ v0.0.150 make one final browser-download update to this release; every update after is fully in-app.
+- **Terminal: keyboard-operable tab strip + per-pane AT labels + reduced-motion cursor** (#2652, cave-p767).
+- **Terminal: the screen-reader mirror follows pane visibility instead of focus, and `pty_resize` is throttled** (#2651, cave-2956).
+- **Terminal: WS-transport shells are reaped on tab close** instead of lingering for a 5-minute grace (#2649, cave-wujw).
+
+### Internal
+- `src-tauri` test files (capability ACL pins, release-runtime pins) are now wired into the CI app suite — they previously ran nowhere, which is how the updater denial and a drifted terminal pin went unnoticed (#2654, #2653).
+
 ## [0.0.150] - 2026-07-08
 
 > 🔮 **The Summoning Circle** — familiar creation leaves the setup wizard for a gamified in-app rite: choose a vessel (this machine, SSH, or an OpenClaw agent), name it, give it form, and summon — then return to the circle to enhance. Chat becomes the front door, seven surfaces adopt the shared compact chrome, and Windows launching gets sturdier.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.150",
+  "version": "0.0.151",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.150"
+version = "0.0.151"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.150"
+version = "0.0.151"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.150</string>
+	<string>0.0.151</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.150</string>
+	<string>0.0.151</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.150</string>
+	<string>0.0.151</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.150</string>
+	<string>0.0.151</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.150",
+  "version": "0.0.151",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.150. Bumps all six version locations (package.json, Cargo.toml, Cargo.lock, tauri.conf.json, both iOS Info.plists) and adds the v0.0.151 CHANGELOG entry for the 5 commits since v0.0.150.

**Headline: updates that update themselves** (#2654, cave-51yk) — the native in-app updater was ACL-denied in every packaged build (updater/process grants lived only in the local-only capability; the main window runs from the remote loopback context), so all update prompts fell back to browser downloads. This release ships the `loopback-updater` capability restoring one-click *Install & restart*, plus a 6-hour update re-check. Also: terminal tab-strip keyboard operability (#2652), SR-mirror visibility + pty_resize throttle (#2651), WS shell reaping on tab close (#2649), and the previously-orphaned `src-tauri` tests wired into CI (#2653/#2654).

Local gate: `cargo check --locked` ✓ (compiles `app v0.0.151`) · typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.151` on the merge commit → release.yml builds the notarized DMG + AppImage + MSI and publishes `latest.json`; final verification via `node scripts/verify-release-updater.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)