### PR TITLE
perf(group-chat): throttle transcript persistence, cap stored tail, single-pass thread grouping (cave-lh78)

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -176,4 +176,46 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
       "both broadcast and retryReply guard their abort/busy cleanup on still owning the controller",
     );
   }
+
+  // cave-lh78: persistence is throttled (one localStorage write per interval,
+  // not one per streaming token), owner-guarded (the stale commit right after
+  // a coven switch must not write the old transcript under the new key), and
+  // flushed on switch/unmount so no settled tail is lost.
+  assert.match(
+    view,
+    /if \(!activeId \|\| transcriptOwnerRef\.current !== activeId\) return;/,
+    "the persist effect skips saves until the swap effect has loaded the active coven's transcript",
+  );
+  assert.match(
+    view,
+    /pendingSaveRef\.current = \{ groupId: activeId, turns: transcript \};[\s\S]{0,240}?window\.setTimeout\(/,
+    "persistence coalesces streaming updates behind a timer instead of writing per token",
+  );
+  assert.match(
+    view,
+    /flushPendingSave\(\);\s*\n\s*transcriptOwnerRef\.current = activeId;/,
+    "switching covens flushes the outgoing coven's pending save, then adopts ownership",
+  );
+  assert.match(
+    view,
+    /useEffect\(\(\) => \(\) => flushPendingSave\(\), \[flushPendingSave\]\);/,
+    "unmount flushes the pending transcript save",
+  );
+  assert.match(
+    view,
+    /if \(pendingSaveRef\.current\?\.groupId === id\) \{/,
+    "deleting a coven drops its queued save so a later flush cannot resurrect the transcript",
+  );
+  // Thread grouping is a single pass (a Map keyed by replyTo), not a nested
+  // filter per user turn — it recomputes on every streaming token.
+  assert.match(
+    view,
+    /const repliesByUser = new Map<string, GroupReply\[\]>\(\);/,
+    "threads are grouped in one pass over the transcript",
+  );
+  assert.doesNotMatch(
+    view,
+    /replies: transcript\.filter\(/,
+    "the O(userTurns × transcript) per-token grouping shape must not return",
+  );
 });

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -111,6 +111,23 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // without re-creating its callback on every streaming token.
   const transcriptRef = useRef<GroupTurn[]>(transcript);
   transcriptRef.current = transcript;
+  // Which group the in-memory transcript belongs to (set by the swap effect).
+  // The persist effect must not save until the swap has caught up, or the
+  // previous coven's turns get written under the new coven's key.
+  const transcriptOwnerRef = useRef<string | null>(null);
+  // Throttled persistence: the newest un-persisted transcript, tagged with
+  // its group id so a flush after a coven switch still targets the right key.
+  const pendingSaveRef = useRef<{ groupId: string; turns: GroupTurn[] } | null>(null);
+  const saveTimerRef = useRef<number | null>(null);
+  const flushPendingSave = useCallback(() => {
+    if (saveTimerRef.current != null) {
+      window.clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    const pending = pendingSaveRef.current;
+    pendingSaveRef.current = null;
+    if (pending) saveTranscript(pending.groupId, pending.turns);
+  }, []);
 
   const byId = useMemo(() => {
     const m = new Map<string, ResolvedFamiliar>();
@@ -142,17 +159,37 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     abortRef.current?.abort();
     abortRef.current = null;
     setBusy(false);
+    // Persist the outgoing coven's tail before swapping — the pending record
+    // carries ITS group id, so this can never write under the new coven's key.
+    flushPendingSave();
+    transcriptOwnerRef.current = activeId;
     if (!activeId) {
       setTranscript([]);
       return;
     }
     setTranscript(loadTranscript(activeId));
-  }, [activeId]);
+  }, [activeId, flushPendingSave]);
 
-  // --- persist transcript on settle ---------------------------------------
+  // --- persist transcript (throttled) --------------------------------------
+  // Streaming produces a transcript state update per SSE token, from several
+  // familiars concurrently; JSON.stringifying the whole transcript into
+  // localStorage on each one is heavy synchronous main-thread work. Coalesce
+  // to at most one write per interval, with the pending record flushed on
+  // coven switch and unmount so no settled tail is lost. The owner guard
+  // skips the stale commit right after a switch, where this effect still
+  // sees the PREVIOUS coven's transcript against the new activeId (writing
+  // it would clobber the new coven's stored transcript).
   useEffect(() => {
-    if (activeId) saveTranscript(activeId, transcript);
-  }, [activeId, transcript]);
+    if (!activeId || transcriptOwnerRef.current !== activeId) return;
+    pendingSaveRef.current = { groupId: activeId, turns: transcript };
+    if (saveTimerRef.current == null) {
+      saveTimerRef.current = window.setTimeout(() => {
+        saveTimerRef.current = null;
+        flushPendingSave();
+      }, 400);
+    }
+  }, [activeId, transcript, flushPendingSave]);
+  useEffect(() => () => flushPendingSave(), [flushPendingSave]);
 
   // --- autoscroll to newest, but only when the reader is already at the bottom
   // Streaming replies grow the transcript constantly; force-scrolling on every
@@ -263,6 +300,15 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     (id: string) => {
       const next = removeGroup(groupsRef.current, id);
       persistGroups(next);
+      // Drop any throttled save queued for this coven — flushing it later
+      // (e.g. on the switch below) would resurrect the just-deleted transcript.
+      if (pendingSaveRef.current?.groupId === id) {
+        pendingSaveRef.current = null;
+        if (saveTimerRef.current != null) {
+          window.clearTimeout(saveTimerRef.current);
+          saveTimerRef.current = null;
+        }
+      }
       if (typeof localStorage !== "undefined") {
         try {
           localStorage.removeItem(`cave:group-chat:transcript:${id}`);
@@ -574,14 +620,21 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
 
   // --- derived transcript view --------------------------------------------
   // Group replies under the user turn they answer for a clean threaded layout.
+  // Single pass: this memo recomputes on every streaming token, so the old
+  // users.map(… transcript.filter …) shape was O(userTurns × transcript).
   const threads = useMemo(() => {
-    const users = transcript.filter((t): t is GroupUserTurn => t.role === "user");
-    return users.map((u) => ({
-      user: u,
-      replies: transcript.filter(
-        (t): t is GroupReply => t.role === "assistant" && t.replyTo === u.id,
-      ),
-    }));
+    const users: GroupUserTurn[] = [];
+    const repliesByUser = new Map<string, GroupReply[]>();
+    for (const t of transcript) {
+      if (t.role === "user") {
+        users.push(t);
+        continue;
+      }
+      const bucket = repliesByUser.get(t.replyTo);
+      if (bucket) bucket.push(t);
+      else repliesByUser.set(t.replyTo, [t]);
+    }
+    return users.map((u) => ({ user: u, replies: repliesByUser.get(u.id) ?? [] }));
   }, [transcript]);
 
   const participants = activeGroup

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -16,6 +16,7 @@ import {
   findActiveMention,
   matchMentions,
   applyMention,
+  capTranscript,
   type GroupTurn,
   type GroupReply,
   type MentionableFamiliar,
@@ -386,4 +387,47 @@ test("renderCovenContext: returns '' for empty, only-own, or unsettled transcrip
 test("renderCovenContext: falls back to the raw id when a name is unknown", () => {
   const out = renderCovenContext(roundTranscript(), "nova", []);
   assert.match(out, /charm said:/); // no name map → raw id
+});
+
+// --- capTranscript (cave-lh78: bound persisted transcript growth) ----------
+
+test("capTranscript: under the cap returns the same turns (identity preserved)", () => {
+  const turns = [user("u1", "hi"), reply("r1", "nova", "u1", "hello")];
+  assert.equal(capTranscript(turns, 10), turns);
+});
+
+test("capTranscript: keeps the trailing max turns", () => {
+  const turns: GroupTurn[] = [];
+  for (let i = 0; i < 30; i++) {
+    turns.push(user(`u${i}`, `q${i}`));
+    turns.push(reply(`r${i}`, "nova", `u${i}`, `a${i}`));
+  }
+  const capped = capTranscript(turns, 10);
+  assert.equal(capped.length, 10);
+  assert.equal(capped[0].id, "u25");
+  assert.equal(capped[capped.length - 1].id, "r29");
+});
+
+test("capTranscript: drops leading orphaned replies whose user turn fell off", () => {
+  const turns: GroupTurn[] = [
+    user("u1", "q1"),
+    reply("r1a", "nova", "u1", "a"),
+    reply("r1b", "charm", "u1", "b"),
+    user("u2", "q2"),
+    reply("r2", "nova", "u2", "c"),
+  ];
+  // Cap of 4 keeps [r1a, r1b, u2, r2]; the tail starts mid-thread (r1a/r1b
+  // have no visible user turn) so it is trimmed to the first complete thread.
+  const capped = capTranscript(turns, 4);
+  assert.equal(capped[0].id, "u2");
+  assert.deepEqual(capped.map((t) => t.id), ["u2", "r2"]);
+});
+
+test("capTranscript: an all-reply tail (no user turn survives) collapses to empty", () => {
+  const turns: GroupTurn[] = [
+    user("u1", "q1"),
+    reply("r1", "nova", "u1", "a"),
+    reply("r2", "charm", "u1", "b"),
+  ];
+  assert.deepEqual(capTranscript(turns, 2), []);
 });

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -15,6 +15,11 @@
 
 const GROUPS_KEY = "cave:group-chat:groups:v1";
 const TRANSCRIPTS_KEY_PREFIX = "cave:group-chat:transcript:";
+/** Max turns kept in a persisted transcript. The roundtable prompt already
+ *  windows history far tighter than this, so capping the stored tail loses
+ *  nothing the model sees — it only bounds localStorage growth (and the cost
+ *  of re-serializing the transcript on save). */
+export const TRANSCRIPT_CAP = 200;
 
 /** A saved group of familiars chatted with together. */
 export type CovenGroup = {
@@ -501,10 +506,25 @@ export function loadTranscript(groupId: string): GroupTurn[] {
     const raw = localStorage.getItem(TRANSCRIPTS_KEY_PREFIX + groupId);
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? (parsed as GroupTurn[]) : [];
+    // Cap on load too so a legacy oversized transcript shrinks the first time
+    // it is opened instead of being re-serialized whole on every save.
+    return Array.isArray(parsed) ? capTranscript(parsed as GroupTurn[], TRANSCRIPT_CAP) : [];
   } catch {
     return [];
   }
+}
+
+/**
+ * Keep at most the trailing `max` turns, then drop any leading assistant
+ * replies whose user turn fell off the front — an orphaned reply has no
+ * thread to render under, so persisting it would only strand invisible data.
+ * Pure and exported for tests.
+ */
+export function capTranscript(turns: GroupTurn[], max: number): GroupTurn[] {
+  const tail = turns.length > max ? turns.slice(turns.length - max) : turns;
+  const firstUser = tail.findIndex((t) => t.role === "user");
+  if (firstUser <= 0) return firstUser === 0 ? tail : [];
+  return tail.slice(firstUser);
 }
 
 export function saveTranscript(groupId: string, turns: GroupTurn[]): void {
@@ -515,7 +535,10 @@ export function saveTranscript(groupId: string, turns: GroupTurn[]): void {
     const settled = turns.filter(
       (t) => t.role === "user" || (t as GroupReply).status === "done" || (t as GroupReply).status === "error",
     );
-    localStorage.setItem(TRANSCRIPTS_KEY_PREFIX + groupId, JSON.stringify(settled));
+    localStorage.setItem(
+      TRANSCRIPTS_KEY_PREFIX + groupId,
+      JSON.stringify(capTranscript(settled, TRANSCRIPT_CAP)),
+    );
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Problem (cave-lh78, from the group-chat audit)
- The persist effect depended on `[activeId, transcript]` with no coalescing → **every SSE token from every concurrently-streaming familiar** JSON.stringified the whole transcript into localStorage (sync main-thread work × N streams).
- `threads` memo was `users.map(u => transcript.filter(...))` — O(userTurns × transcript), recomputed per token.
- Transcripts grew unbounded toward the ~5MB quota, making each write progressively heavier.

## Fix
- **Throttled, owner-guarded persistence**: pending save coalesces behind a 400ms timer; flushed on coven switch and unmount so no settled tail is lost. The pending record carries its own `groupId` and the effect skips until `transcriptOwnerRef` matches `activeId`.
- **Also fixes cave-oe4b** (tightly coupled — same effect): the stale commit right after a coven switch could save the OLD coven's transcript under the NEW coven's key (permanent transcript loss if unmounted in that window). Owner guard + id-tagged pending record eliminate it. Deleting a coven drops its queued save so a flush can't resurrect the removed transcript.
- **`capTranscript` (exported, pure)**: keeps the trailing 200 turns trimmed to a complete thread (no leading orphaned replies), applied on save *and* load (legacy oversized transcripts shrink on first open). The roundtable prompt windows history far tighter, so the model sees nothing less.
- **Single-pass thread grouping** via a `Map` keyed by `replyTo`.

## Verification
- 4 new `capTranscript` unit tests + 7 new source pins in `group-chat-view.test.ts`
- `pnpm test:app` — 562 files pass · `pnpm typecheck` clean

Closes cave-lh78 and cave-oe4b (beads).