### PR TITLE
fix(group-chat): ignore IME-composition Enter in composer, mention picker, and rename (cave-hkls)

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -218,4 +218,18 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
     /replies: transcript\.filter\(/,
     "the O(userTurns × transcript) per-token grouping shape must not return",
   );
+
+  // cave-hkls: the Enter that confirms an IME candidate (CJK input) must never
+  // broadcast the draft, pick a mention, or commit a rename — ChatView has the
+  // same guard on its composer.
+  assert.match(
+    view,
+    /if \(e\.nativeEvent\.isComposing\) return;[\s\S]{0,220}?if \(mentionOpen\) \{/,
+    "the composer ignores keydowns while an IME composition is in progress",
+  );
+  assert.match(
+    view,
+    /if \(e\.nativeEvent\.isComposing\) return;\s*\n\s*if \(e\.key === "Enter"\) \(e\.target as HTMLInputElement\)\.blur\(\);/,
+    "the coven rename input ignores the IME-confirm Enter",
+  );
 });

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -743,6 +743,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                       setRenaming(false);
                     }}
                     onKeyDown={(e) => {
+                      if (e.nativeEvent.isComposing) return;
                       if (e.key === "Enter") (e.target as HTMLInputElement).blur();
                       if (e.key === "Escape") setRenaming(false);
                     }}
@@ -1001,6 +1002,11 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   onClick={syncMention}
                   onBlur={() => setMention(null)}
                   onKeyDown={(e) => {
+                    // `isComposing` is true for the Enter/Tab that confirms an
+                    // IME candidate (CJK input) — confirming a character must
+                    // never pick a mention or broadcast the half-composed
+                    // draft. Mirrors ChatView's composer guard.
+                    if (e.nativeEvent.isComposing) return;
                     if (mentionOpen) {
                       if (e.key === "ArrowDown") {
                         e.preventDefault();


### PR DESCRIPTION
## Problem (cave-hkls, from the group-chat audit)
The group-chat composer checked `e.key === "Enter"` (send) and `Enter`/`Tab` (mention pick) without `e.nativeEvent.isComposing` — for CJK/IME users, the Enter that confirms a candidate **broadcast the half-composed draft to the whole coven**. ChatView already guards this exact case (chat-view.tsx composer). The coven rename input had the same hole: IME-confirm Enter blurred and saved the name early.

## Fix
Early-return from all three onKeyDown handlers while `e.nativeEvent.isComposing` is true (arrow/escape keys during composition belong to the IME too), mirroring ChatView.

## Verification
- 2 new source pins in `group-chat-view.test.ts` (composer + rename guards) — 5/5 tests pass
- `pnpm typecheck` clean

Closes cave-hkls (beads).