### PR TITLE
fix(calendar): reconcile the open event detail panel with live items (cave-latd)

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -110,4 +110,25 @@ assert.ok((view.match(/aria-current=\{isToday \? "date" : undefined\}/g) ?? []).
 // Horizontal arrows don't page the period out from under a focused grid event.
 assert.match(view, /if \(target\.closest\('\[data-calendar-event="true"\]'\)\) break;/, "a focused event keeps its own Arrow handling");
 
+// ───────── Detail panel reconciles with live items (cave-latd) ─────────
+// `selectedItem` is a snapshot captured at click; an effect keyed on
+// [items, selectedItem?.id] adopts the fresh copy when it changes and closes
+// the panel when the item is gone — so it never shows stale status/fireAt and
+// never lingers over a deleted id (acting on which fires against nothing).
+assert.match(
+  view,
+  /const fresh = items\.find\(\(it\) => it\.id === selectedItem\.id\)/,
+  "the open detail panel looks up its fresh copy in the live items prop",
+);
+assert.match(
+  view,
+  /JSON\.stringify\(fresh\) !== JSON\.stringify\(selectedItem\)\) setSelectedItem\(fresh\)/,
+  "the reconciler adopts the fresh item only when its content changed",
+);
+assert.match(
+  view,
+  /const fresh = items\.find[\s\S]{0,220}\} else \{\s*\n\s*setSelectedItem\(null\)/,
+  "a deleted item closes the panel instead of lingering over a dead id",
+);
+
 console.log("calendar-actions.test.ts: ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1460,6 +1460,22 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   const [pickerOpen, setPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Keep the open event detail panel in sync with live updates. `selectedItem`
+  // is a snapshot captured at click; without this, an SSE update/delete (or a
+  // mutation from elsewhere) leaves the panel showing stale status/fireAt/body,
+  // and a deleted item's panel lingers over a dead id — acting on it (Done /
+  // Snooze / Dismiss) fires a mutation against nothing. Mirrors the reconciler
+  // in automations-view.tsx: adopt the fresh item when it differs, else close.
+  useEffect(() => {
+    if (!selectedItem) return;
+    const fresh = items.find((it) => it.id === selectedItem.id);
+    if (fresh) {
+      if (JSON.stringify(fresh) !== JSON.stringify(selectedItem)) setSelectedItem(fresh);
+    } else {
+      setSelectedItem(null);
+    }
+  }, [items, selectedItem?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Force agenda on phone-class viewports: the day/week/month grids all
   // have a `min-w-[560px]` floor, which would overflow a 360px screen.
   // Lets the user swap back to a grid once they're on a tablet+.


### PR DESCRIPTION
## What

From the calendar-surface audit. The event detail panel renders from `selectedItem`, a **snapshot captured at click time** (`calendar-view.tsx:1459`). Nothing reconciled it against the incoming `items` prop, so with the panel open:
- an SSE update/delete (or a mutation from elsewhere) left it showing **stale** status / fireAt / body, and
- a **deleted** item's panel lingered over a dead id — so Done / Snooze / Dismiss fired a mutation against nothing.

## Fix

Add the same reconciler the sibling consumer already documents (`automations-view.tsx:1848`): an effect keyed on `[items, selectedItem?.id]` that **adopts the fresh item** when its content changed and **closes the panel** when the item is gone.

Pinned in `calendar-actions.test.ts` (fresh-lookup, adopt-on-change, close-on-delete).

## Verification

`typecheck` · **562** app test files · `build` within budget. (Also filed the audit's other findings as beads: cave-nsmi a11y-HIGH, cave-zqsj a11y-MED, cave-6xer polish.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)