### PR TITLE
feat(chat): instant compose boot + board-aware starter pills on the landing (cave-qvwu)

### DIFF
--- a/src/components/chat-empty-state.test.ts
+++ b/src/components/chat-empty-state.test.ts
@@ -131,6 +131,42 @@ test("chat-first landing: time greeting eyebrow, calm first paint, disclosed con
   assert.match(styles, /\.cave-chat-empty-context-toggle \{[\s\S]*?border-radius: 999px/, "context toggle reads as a pill control");
 });
 
+test("starter pills resume unassigned + own board work, marked as tasks (cave-qvwu)", () => {
+  // The pill card set is wider than the rail (unassigned cards are fair game —
+  // clicking routes the work to THIS familiar) but never another familiar's.
+  assert.match(
+    emptyState,
+    /\.filter\(\(card\) => !card\.familiarId \|\| card\.familiarId === familiar\.id\)/,
+    "resumable pills include unassigned cards but exclude other familiars' work",
+  );
+  assert.match(
+    emptyState,
+    /cardMatchesProject\(card, \{/,
+    "resumable pills reuse the shared project-scope filter (chat-open-tasks)",
+  );
+  assert.match(
+    emptyState,
+    /taskCards: resumableCards,/,
+    "the pill card set feeds deriveStarterSuggestions as taskCards",
+  );
+  // Task pills are visually distinct: leading kanban glyph + tinted variant.
+  assert.match(
+    emptyState,
+    /\{isTask && <Icon name="ph:kanban"/,
+    "task pills carry a leading kanban glyph",
+  );
+  assert.match(
+    emptyState,
+    /cave-chat-empty-prompt--task/,
+    "task pills opt into the tinted variant class",
+  );
+  assert.match(
+    styles,
+    /\.cave-chat-empty-prompt--task \{[\s\S]*?var\(--accent-presence\)/,
+    "the task-pill tint stays on the presence accent token",
+  );
+});
+
 test("task-aware styles use semantic tokens and respect reduced motion", () => {
   assert.match(
     styles,

--- a/src/components/chat-empty-state.tsx
+++ b/src/components/chat-empty-state.tsx
@@ -23,7 +23,7 @@ import { Icon } from "@/lib/icon";
 import { ProjectPicker } from "@/components/project-picker";
 import { FamiliarIcon } from "@/components/familiar-icon";
 import { NO_PROJECT_ID, chatProjectById, filterVisibleChatSessions } from "@/lib/chat-projects";
-import { deriveOpenTaskCards, deriveContinueThreads } from "@/lib/chat-open-tasks";
+import { cardMatchesProject, deriveOpenTaskCards, deriveContinueThreads } from "@/lib/chat-open-tasks";
 import { deriveStarterSuggestions } from "@/lib/chat-starter-suggestions";
 import { arrayContentEqual } from "@/lib/array-content-equal";
 import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
@@ -166,9 +166,25 @@ export function ChatEmptyState({
     excludeSessionId: sessionId,
     cap: CONTINUE_CAP,
   });
+  // Resumable pills take a wider net than the rail: unassigned cards are fair
+  // game (clicking a pill routes the work to THIS familiar), but another
+  // familiar's cards are not — that would misroute their work.
+  const resumableCards = cards
+    .filter((card) => cardMatchesProject(card, {
+      projectId: project?.id ?? null,
+      projectRoot: project?.root ?? null,
+    }))
+    .filter((card) => !card.familiarId || card.familiarId === familiar.id)
+    .map((card) => ({
+      id: card.id,
+      title: card.title,
+      status: card.status,
+      updatedAt: card.updatedAt,
+    }));
   const suggestions = deriveStarterSuggestions({
     cards: openCards,
     sessions: filterVisibleChatSessions(sessions, familiar.id),
+    taskCards: resumableCards,
     projectName: project?.name ?? null,
     nowMs,
   });
@@ -276,17 +292,21 @@ export function ChatEmptyState({
 
         {((onPrompt && suggestions.length > 0) || onOpenPromptSnippets) && (
           <div className="cave-chat-empty-prompts" aria-label="Starter prompts">
-            {onPrompt && suggestions.map((suggestion) => (
-              <button
-                key={suggestion.id}
-                type="button"
-                onClick={() => onPrompt(suggestion.text)}
-                className="cave-chat-empty-prompt"
-              >
-                <span>{suggestion.label}</span>
-                <Icon name="ph:arrow-right-bold" width={13} aria-hidden />
-              </button>
-            ))}
+            {onPrompt && suggestions.map((suggestion) => {
+              const isTask = suggestion.id.startsWith("task:");
+              return (
+                <button
+                  key={suggestion.id}
+                  type="button"
+                  onClick={() => onPrompt(suggestion.text)}
+                  className={`cave-chat-empty-prompt${isTask ? " cave-chat-empty-prompt--task" : ""}`}
+                >
+                  {isTask && <Icon name="ph:kanban" width={13} aria-hidden />}
+                  <span>{suggestion.label}</span>
+                  <Icon name="ph:arrow-right-bold" width={13} aria-hidden />
+                </button>
+              );
+            })}
             {onOpenPromptSnippets && (
               <button
                 type="button"
@@ -462,7 +482,7 @@ export function ChatEmptyState({
         ) : null}
 
         <p className="cave-chat-empty-hint">
-          Ready for the next thread.
+          Ready for the next thread — / for commands, @ for files.
         </p>
       </div>
     </div>

--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -50,11 +50,16 @@ assert.match(
 
 // ── Chat-first IA (cave-hsa6): boot into a compose view, not the list ───────
 const bootComposeEffect =
-  source.match(/const bootComposeRef = useRef\(false\);[\s\S]*?\}, \[sessionsLoaded, familiar\?\.id, fallbackFamiliar\?\.id\]\);/)?.[0] ?? "";
+  source.match(/const bootComposeRef = useRef\(false\);[\s\S]*?\}, \[familiar\?\.id, fallbackFamiliar\?\.id\]\);/)?.[0] ?? "";
 assert.match(
   bootComposeEffect,
   /if \(bootComposeRef\.current\) return;/,
   "the boot-compose effect fires once, so returning to the list later sticks",
+);
+assert.doesNotMatch(
+  bootComposeEffect,
+  /sessionsLoaded/,
+  "boot must not wait for the sessions fetch (cave-qvwu) — /api/sessions/list can take many seconds cold, and gating compose on it left users staring at the list skeletons; the compose landing needs only a familiar",
 );
 assert.match(
   bootComposeEffect,

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -43,6 +43,7 @@ type Props = {
   onSessionStarted?: () => void;
   onSessionsChanged?: () => void;
   sessionsLoaded?: boolean;
+  familiarsLoaded?: boolean;
   onSlashFromChat?: (command: string, args: string) => boolean;
   onOpenOnboarding?: () => void;
   pendingProjectRoot?: string | null;
@@ -93,6 +94,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onSessionStarted,
     onSessionsChanged,
     sessionsLoaded,
+    familiarsLoaded,
     onSlashFromChat,
     onOpenOnboarding,
     pendingProjectRoot,
@@ -276,10 +278,13 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   // `#chat-<id>` deep link (workspace.tsx restores that session itself). No server
   // session is created: the compose view holds sessionId=null until the first
   // send. Returning to the list later sticks — the ref guards against re-entry.
+  // Deliberately independent of the sessions fetch (cave-qvwu): a zero-session
+  // compose view needs only a familiar, and /api/sessions/list can take many
+  // seconds cold — waiting on it left users staring at the list skeletons. The
+  // `#chat-` latch below is synchronous, so deep links are unaffected.
   const bootComposeRef = useRef(false);
   useEffect(() => {
     if (bootComposeRef.current) return;
-    if (sessionsLoaded === false) return;
     if (typeof window !== "undefined") {
       if (window.location.hash.startsWith("#chat-")) {
         bootComposeRef.current = true; // a deep link owns the boot view
@@ -300,7 +305,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     setView((prev) =>
       prev.kind === "list" ? { kind: "chat", sessionId: null, familiarId: bootFamiliarId } : prev,
     );
-  }, [sessionsLoaded, familiar?.id, fallbackFamiliar?.id]);
+  }, [familiar?.id, fallbackFamiliar?.id]);
 
   useImperativeHandle(
     ref,
@@ -334,6 +339,18 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   );
 
   if (familiars.length === 0 && !familiar) {
+    // While the roster fetch is still in flight, hold a quiet frame — the
+    // "choose a familiar" copy below is wrong for a loading beat, and
+    // skeletons would just be another wall. Loaded-and-empty falls through.
+    if (familiarsLoaded === false) {
+      return (
+        <section
+          className="h-full bg-[var(--bg-base)]"
+          role="status"
+          aria-label="Loading familiars"
+        />
+      );
+    }
     // Empty-state copy is mode-aware: on phones the nav/sidebar/agent panels
     // are drawers behind a toggle, so "from the sidebar selector" / "left
     // panel" reads as broken. Point users at the drawer or the setup CTA

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -67,6 +67,7 @@ type Props = {
   daemonRunning: boolean;
   routerRef: RefObject<ChatRouterHandle | null>;
   sessionsLoaded?: boolean;
+  familiarsLoaded?: boolean;
   inboxItems: InboxItem[];
   inspectorOpen: boolean;
   rightPanel?: RightPanelKind | null;
@@ -192,6 +193,7 @@ export function ChatSurface({
   daemonRunning,
   routerRef,
   sessionsLoaded,
+  familiarsLoaded,
   inboxItems,
   inspectorOpen,
   rightPanel: rightPanelProp,
@@ -706,6 +708,7 @@ export function ChatSurface({
                   sessions={sessions}
                   daemonRunning={daemonRunning}
                   sessionsLoaded={sessionsLoaded}
+                  familiarsLoaded={familiarsLoaded}
                   compact={compactRail}
                   onSetActiveFamiliar={onSetActiveFamiliar}
                   onSessionStarted={onSessionStarted}

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -392,6 +392,19 @@ assert.match(
   /ph:microphone/,
   "desktop composer has a mic/voice button",
 );
+// Voice can only attach to a live session, so pre-session the button is
+// hidden rather than disabled-forever (design language: hide, don't disable —
+// the zero-turn landing must not show a dead affordance).
+assert.match(
+  source,
+  /\{sessionId \? \([\s\S]{0,400}aria-label="Voice"/,
+  "the voice button is conditionally rendered on sessionId (hidden pre-session)",
+);
+assert.doesNotMatch(
+  source,
+  /aria-label="Voice"[\s\S]{0,200}disabled=\{!sessionId\}/,
+  "the voice button must not be a permanently disabled affordance on the zero-turn landing",
+);
 
 assert.match(
   source,
@@ -579,8 +592,16 @@ assert.doesNotMatch(
 );
 assert.match(
   emptyStateSource,
-  /Ready for the next thread\./,
+  /Ready for the next thread — \/ for commands, @ for files\./,
   "Empty-state hint uses the redesigned launch-screen ready copy",
+);
+// Discoverability, dosed: one terse fragment for the composer's hidden powers.
+// ⌘K already lives in the hub footer and "↵ to send" in the placeholder —
+// repeating either here would exceed the dose.
+assert.match(
+  emptyStateSource,
+  /\/ for commands/,
+  "Empty-state hint surfaces the slash-command entry point (skills, prompts, /model)",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5462,16 +5462,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   >
                     <Icon name="ph:paperclip" width={14} aria-hidden />
                   </button>
-                  <button
-                    type="button"
-                    className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
-                    title="Voice"
-                    aria-label="Voice"
-                    disabled={!sessionId}
-                    onClick={() => setVoiceCallOpen(true)}
-                  >
-                    <Icon name="ph:microphone" width={15} aria-hidden />
-                  </button>
+                  {/* Voice needs a live session (the overlay attaches to it), so
+                      pre-session the button is hidden, not disabled-forever —
+                      it appears once the first send creates the session. */}
+                  {sessionId ? (
+                    <button
+                      type="button"
+                      className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
+                      title="Voice"
+                      aria-label="Voice"
+                      onClick={() => setVoiceCallOpen(true)}
+                    >
+                      <Icon name="ph:microphone" width={15} aria-hidden />
+                    </button>
+                  ) : null}
                   <ComposerOptionsMenu
                     hostValue={composerHostValue}
                     onHostPick={setRuntimeHost}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -270,6 +270,10 @@ export function Workspace() {
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
   const [familiarsError, setFamiliarsError] = useState<string | null>(null);
+  // false until the first /api/familiars fetch settles (success or error) —
+  // lets the chat boot view hold a quiet frame instead of flashing the
+  // "choose a familiar" empty-state copy while the roster is in flight.
+  const [familiarsLoaded, setFamiliarsLoaded] = useState(false);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   // false until the first /api/sessions/list fetch settles — lets the chat
   // list show a skeleton instead of flashing its empty state on boot.
@@ -692,6 +696,8 @@ export function Workspace() {
     } catch (err) {
       setFamiliars([]);
       setFamiliarsError(err instanceof Error ? err.message : "fetch failed");
+    } finally {
+      setFamiliarsLoaded(true);
     }
   }, []);
 
@@ -2095,6 +2101,7 @@ export function Workspace() {
         routerRef={routerRef}
         hideThreadRail
         sessionsLoaded={sessionsLoaded}
+        familiarsLoaded={familiarsLoaded}
         inboxItems={inboxItemsWithEphemeral}
         inspectorOpen={inspectorOpen}
         rightPanel={rightPanel}

--- a/src/lib/chat-open-tasks.ts
+++ b/src/lib/chat-open-tasks.ts
@@ -27,6 +27,20 @@ export type OpenTaskRail = {
   moreCount: number;
 };
 
+/** Whether a card belongs to the selected project scope. No project selected
+ *  matches everything; card.cwd is the fallback match for legacy cards that
+ *  predate projectId; an unscoped card (no project association) always
+ *  matches — it's still the familiar's work. */
+export function cardMatchesProject(
+  card: Card,
+  opts: { projectId?: string | null; projectRoot?: string | null },
+): boolean {
+  if (!opts.projectId) return true;
+  if (card.projectId) return card.projectId === opts.projectId;
+  if (card.cwd && opts.projectRoot) return card.cwd === opts.projectRoot;
+  return !card.cwd;
+}
+
 /** All of a familiar's open cards for the current project scope, active-first.
  *  Uncapped — feeds both the rail (capped below) and the starter suggestions
  *  (which need e.g. the full review count). */
@@ -43,13 +57,7 @@ export function deriveOpenTaskCards(
   return cards
     .filter((card) => card.familiarId === opts.familiarId)
     .filter((card) => STATUS_RANK.has(card.status))
-    .filter((card) => {
-      if (!opts.projectId) return true;
-      if (card.projectId) return card.projectId === opts.projectId;
-      if (card.cwd && opts.projectRoot) return card.cwd === opts.projectRoot;
-      // Unscoped card (no project association): still this familiar's work.
-      return !card.cwd;
-    })
+    .filter((card) => cardMatchesProject(card, opts))
     .sort((a, b) => {
       const status = (STATUS_RANK.get(a.status) ?? 9) - (STATUS_RANK.get(b.status) ?? 9);
       if (status !== 0) return status;

--- a/src/lib/chat-starter-suggestions.test.ts
+++ b/src/lib/chat-starter-suggestions.test.ts
@@ -69,3 +69,56 @@ test("caps at 4 and is deterministic for the same inputs", () => {
   assert.equal(a.length, 4);
   assert.deepEqual(a, b);
 });
+
+// ── taskCards → "Continue the task" pills (cave-qvwu) ───────────────────────
+
+const taskCard = (id, title, updatedAt, status = "inbox") => ({ id, title, status, updatedAt });
+
+test("task pills lead, use home's Continue-the-task copy, and cap at 2", () => {
+  const out = deriveStarterSuggestions({
+    cards: [reviewCard("r")],
+    sessions: [],
+    taskCards: [
+      taskCard("t1", "Fix login flow", "2026-07-05T10:00:00Z"),
+      taskCard("t2", "Wire the board rail", "2026-07-06T10:00:00Z"),
+      taskCard("t3", "Third open task", "2026-07-04T10:00:00Z"),
+    ],
+    projectName: "Cast Codes",
+    nowMs: NOW_MS,
+  });
+  // Newest-first, max 2 (buildHomeSuggestions heuristic), ahead of everything.
+  assert.deepEqual(out.slice(0, 2).map((s) => s.id), ["task:t2", "task:t1"]);
+  assert.equal(out[0].label, "Continue the task: Wire the board rail");
+  assert.equal(out[0].text, out[0].label);
+  assert.equal(out.length, 4);
+});
+
+test("only inbox/backlog taskCards become pills; starter padding never leaks in", () => {
+  const out = deriveStarterSuggestions({
+    cards: [],
+    sessions: [],
+    taskCards: [
+      taskCard("t1", "Running work", "2026-07-06T10:00:00Z", "running"),
+      taskCard("t2", "Backlog item", "2026-07-05T10:00:00Z", "backlog"),
+    ],
+    projectName: null,
+    nowMs: NOW_MS,
+  });
+  // The fallback pad only tops the row up to 2 entries, so one task pill
+  // gets a single fallback companion.
+  assert.deepEqual(out.map((s) => s.id), ["task:t2", "capabilities"]);
+  assert.ok(!out.some((s) => s.id.startsWith("starter:")));
+});
+
+test("absent taskCards behaves exactly as before", () => {
+  const args = {
+    cards: [reviewCard("a")],
+    sessions: [sessionAt(hoursAgoIso(1))],
+    projectName: "Cast Codes",
+    nowMs: NOW_MS,
+  };
+  assert.deepEqual(
+    deriveStarterSuggestions(args),
+    deriveStarterSuggestions({ ...args, taskCards: [] }),
+  );
+});

--- a/src/lib/chat-starter-suggestions.ts
+++ b/src/lib/chat-starter-suggestions.ts
@@ -6,6 +6,7 @@
 
 import type { Card } from "./cave-board-types.ts";
 import type { SessionRow } from "./types.ts";
+import { buildHomeSuggestions, type SuggestionCard } from "./home-suggestions.ts";
 
 export type StarterSuggestion = {
   id: string;
@@ -32,12 +33,23 @@ export function deriveStarterSuggestions(opts: {
   cards: Card[];
   /** Familiar-scoped sessions (already visibility-filtered). */
   sessions: SessionRow[];
+  /** Resumable board cards (unassigned + this familiar's, project-scoped) —
+   *  rendered as "Continue the task: X" pills ahead of the starters, via the
+   *  same heuristic the home composer uses (buildHomeSuggestions). */
+  taskCards?: SuggestionCard[];
   projectName?: string | null;
   nowMs: number;
   cap?: number;
 }): StarterSuggestion[] {
   const cap = opts.cap ?? 4;
   const out: StarterSuggestion[] = [];
+
+  // Task-resume pills lead — resuming named work beats a generic starter.
+  // buildHomeSuggestions owns the heuristic (inbox/backlog only, newest
+  // first, max 2); filtering to task: ids drops its starter padding.
+  for (const s of buildHomeSuggestions({ cards: opts.taskCards ?? [], max: cap })) {
+    if (s.id.startsWith("task:")) out.push({ id: s.id, label: s.prompt, text: s.prompt });
+  }
 
   const reviewCount = opts.cards.filter((card) => card.status === "review").length;
   if (reviewCount > 0) {

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1301,6 +1301,28 @@
   transform: translateX(2px);
 }
 
+/* Task-resume pills: existing board work is *present*, so the pill carries a
+ * quiet accent tint (standard recipe: low-% fill, mid-% border) and a leading
+ * kanban glyph. The label takes the slack so icon/label/arrow read as one
+ * left-aligned row instead of space-between drift. */
+.cave-chat-empty-prompt--task {
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
+}
+
+.cave-chat-empty-prompt--task span {
+  flex: 1;
+}
+
+.cave-chat-empty-prompt--task > svg:first-child {
+  color: var(--accent-presence);
+}
+
+/* Only the trailing arrow leans on hover — the kanban marker stays put. */
+.cave-chat-empty-prompt--task:hover > svg:first-child {
+  transform: none;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .cave-chat-empty-prompt,
   .cave-chat-empty-prompt svg {

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Verifies the chat boot landing (cave-qvwu): booting into `/` paints the
+// zero-turn compose view (ChatEmptyState + composer) without waiting for
+// /api/sessions/list — the fetch that used to gate the boot-compose effect
+// and left users on the ChatList skeleton wall for its full duration. Also
+// pins the landing polish that rode along: board-aware "Continue the task"
+// pills, the hidden-not-disabled pre-session Voice button, and the dosed
+// "/ for commands" discoverability hint.
+//
+// Desktop only (compose-first boot is a desktop affordance — mobile keeps
+// the thread list as the chat home). /api/familiars, /api/sessions/list and
+// /api/board are mocked; no daemon.
+
+const NOW = Date.now();
+const iso = (hoursAgo: number) => new Date(NOW - hoursAgo * 3_600_000).toISOString();
+
+const FAMILIARS = {
+  ok: true,
+  familiars: [
+    { id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" },
+  ],
+};
+
+const SESSION_S1 = {
+  id: "s1",
+  title: "Refactor auth flow",
+  status: "completed",
+  origin: "chat",
+  harness: "codex",
+  familiarId: "nova",
+  project_root: "/repo/alpha",
+  exit_code: null,
+  archived_at: null,
+  created_at: iso(2),
+  updated_at: iso(2),
+};
+
+// Unassigned inbox card — fair game for this familiar's resume pills.
+const BOARD = {
+  ok: true,
+  cards: [
+    {
+      id: "c1",
+      title: "Fix login flow",
+      status: "inbox",
+      priority: "medium",
+      familiarId: null,
+      projectId: null,
+      cwd: null,
+      createdAt: iso(6),
+      updatedAt: iso(5),
+    },
+  ],
+};
+
+async function seed(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) => route.fulfill({ json: FAMILIARS }));
+  await page.route("**/api/board**", (route) => route.fulfill({ json: BOARD }));
+}
+
+test.describe("chat boot landing", () => {
+  test("compose view paints before the sessions list resolves", async ({ page }) => {
+    await seed(page);
+    // Hold the sessions fetch hostage until the landing has painted — this
+    // proves the boot-compose path is independent of it, with zero timing
+    // flake (no fixed delays to outrun a cold-compile CI run).
+    let sessionsFulfilled = false;
+    let releaseSessions!: () => void;
+    const sessionsGate = new Promise<void>((resolve) => {
+      releaseSessions = resolve;
+    });
+    await page.route("**/api/sessions/list**", async (route) => {
+      await sessionsGate;
+      sessionsFulfilled = true;
+      await route.fulfill({ json: { ok: true, sessions: [SESSION_S1] } });
+    });
+
+    await page.goto("/");
+    await expect(page.locator(".cave-chat-empty")).toBeVisible({ timeout: 45_000 });
+    expect(sessionsFulfilled).toBe(false);
+
+    // Unblock the fetch and confirm the settled landing is intact.
+    releaseSessions();
+    await expect(page.locator(".cave-chat-empty-greeting")).toBeVisible();
+  });
+
+  test("a #chat deep link still shows the Opening-chat takeover until sessions settle", async ({ page }) => {
+    await seed(page);
+    let releaseSessions!: () => void;
+    const sessionsGate = new Promise<void>((resolve) => {
+      releaseSessions = resolve;
+    });
+    await page.route("**/api/sessions/list**", async (route) => {
+      await sessionsGate;
+      await route.fulfill({ json: { ok: true, sessions: [SESSION_S1] } });
+    });
+
+    await page.goto("/#chat-s1");
+    // The takeover owns the boot while the deep link is unresolved — the
+    // loosened compose gate must not flash a compose view over it.
+    const takeover = page.getByRole("status").filter({ hasText: "Opening chat…" });
+    await expect(takeover).toBeVisible({ timeout: 45_000 });
+    await expect(page.locator(".cave-chat-empty")).toHaveCount(0);
+
+    releaseSessions();
+    await expect(takeover).toHaveCount(0, { timeout: 15_000 });
+  });
+
+  test("landing offers a task-resume pill, hides Voice pre-session, and hints at / commands", async ({ page }) => {
+    await seed(page);
+    await page.route("**/api/sessions/list**", (route) =>
+      route.fulfill({ json: { ok: true, sessions: [] } }),
+    );
+
+    await page.goto("/");
+    const empty = page.locator(".cave-chat-empty");
+    await expect(empty).toBeVisible({ timeout: 45_000 });
+
+    // Board-aware pill: the unassigned inbox card surfaces as a task pill…
+    const pill = empty.getByRole("button", { name: /Continue the task: Fix login flow/ });
+    await expect(pill).toBeVisible();
+    await expect(pill).toHaveClass(/cave-chat-empty-prompt--task/);
+
+    // …that inserts into the composer, never auto-sends.
+    await pill.click();
+    const composer = page.getByPlaceholder(/Message Nova/);
+    await expect(composer).toHaveValue(/Continue the task: Fix login flow/);
+    await expect(empty).toBeVisible();
+
+    // Voice needs a session; pre-session it is hidden, not disabled.
+    await expect(page.getByRole("button", { name: "Voice" })).toHaveCount(0);
+
+    // Dosed discoverability: the ready line mentions the slash entry point.
+    await expect(empty.getByText("/ for commands", { exact: false })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What

Simplify-yet-empower pass on the chat boot landing (the chat-first zero-turn compose view from #2632/#2633). Four seams fixed:

1. **Instant first paint** — the boot-compose effect (`chat-router.tsx`) no longer waits for `/api/sessions/list` (16s cold in dev): the compose landing needs only a familiar, so users get greeting + identity + pills + composer immediately instead of the ChatList skeleton wall. The `#chat-<id>` deep-link latch is synchronous and the workspace-owned "Opening chat…" takeover is untouched (regression-pinned). While `/api/familiars` itself is in flight, ChatRouter holds a quiet `role=status` frame instead of flashing "choose a familiar" copy.
2. **Board-aware starter pills** — `deriveStarterSuggestions` gains `taskCards` and reuses `buildHomeSuggestions` (Home's exact inbox/backlog · newest-first · max-2 heuristic) for leading "Continue the task: X" pills. `ChatEmptyState` feeds it project-scoped **unassigned + own** cards — another familiar's cards would misroute their work (clicking a pill sends to *this* familiar). Task pills carry a kanban glyph and a quiet accent tint (tokens only).
3. **No dead affordance** — the composer mic was `disabled={!sessionId}`, i.e. permanently disabled on the landing. Now hidden pre-session (design language: hide, don't disable); it appears once the first send creates the session.
4. **Dosed discoverability** — the ready line becomes "Ready for the next thread — / for commands, @ for files." (⌘K and ↵ hints already live elsewhere; no new flourish).

## Tests

- `tests/chat-boot-landing.spec.ts` (new, desktop project): gates the sessions response on the landing having painted — a flake-free ordering proof that boot doesn't wait on sessions; pins the deep-link takeover, task-pill insert-not-send, hidden mic, and hint.
- `chat-starter-suggestions.test.ts` +3 cases (pill ordering/cap, inbox-backlog-only, absent-taskCards identity).
- `chat-empty-state.test.ts` +1 pin block (familiar filter, shared project filter, kanban glyph, tint token).
- `chat-router-switching.test.ts` boot pin now asserts the effect does **not** reference `sessionsLoaded`.
- `chat-view-polish.test.ts` pins the conditional Voice render and the new ready copy.

## Verification

- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` — 562 test files pass; `pnpm exec playwright test tests/chat-boot-landing.spec.ts` — 3/3.
- Visual check against a dev server with mocked board: task pills lead with tint + glyph, hint line present, no mic pre-session (screenshot in bead cave-qvwu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)