### PR TITLE
feat(quick-chat): multi-chat tabs + glassmorphic tray window (cave-m80j)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-process",
  "tauri-plugin-updater",
+ "window-vibrancy",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 # tray-icon moved to the desktop-only target block below — mobile (iOS/
 # Android) doesn't have a tray and trying to enable the feature there
 # breaks the build.
-tauri = { version = "2.11.2", features = ["unstable"] }
+tauri = { version = "2.11.2", features = ["unstable", "macos-private-api"] }
 tauri-plugin-log = "2"
 # tauri-plugin-notification supports iOS and Android out of the box, so
 # this stays cross-platform; the JS-side `native-notify` wrapper handles
@@ -47,10 +47,16 @@ tauri-plugin-os = "2"
 # Spelling it as "not(ios) and not(android)" is equivalent to
 # `cfg(desktop)` for the platforms we care about.
 [target.'cfg(not(any(target_os = "ios", target_os = "android")))'.dependencies]
-tauri = { version = "2.11.2", features = ["tray-icon"] }
+tauri = { version = "2.11.2", features = ["tray-icon", "macos-private-api"] }
 portable-pty = "0.8"
 # Desktop auto-update: the updater plugin checks/downloads/installs signed
 # release artifacts; process gives us relaunch() after an install. Both are
 # desktop-only (mobile updates via the App Store / TestFlight).
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+
+# OS-level glass for the quick-chat tray window: NSVisualEffectView vibrancy
+# behind the transparent webview on macOS (the only platform we apply it on;
+# the crate compiles everywhere and the call sites are cfg(target_os) gated).
+[target.'cfg(target_os = "macos")'.dependencies]
+window-vibrancy = "0.6"

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -293,7 +293,9 @@ test("loopback app webviews can drive native window drag for the seamless titleb
     "the shell titlebar must be a deep Tauri drag region",
   );
   assert.ok(
-    trayQuickChat.includes('<header className="quick-chat-overlay__header" data-tauri-drag-region="deep">'),
+    trayQuickChat.includes(
+      '<header className="quick-chat-overlay__header tray-quick-chat__header" data-tauri-drag-region="deep">',
+    ),
     "the quick-chat tray header must be a deep Tauri drag region so the decoration-less window can be moved",
   );
 });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,8 +92,19 @@ fn show_quick_chat_window(app: &tauri::AppHandle, quick_chat_url: &Url) {
         return;
     }
 
+    // On macOS the window opens transparent with an NSVisualEffectView behind
+    // it (applied after build), and `?glass=1` tells the page to drop its
+    // opaque background — the glassmorphic quick chat. Other platforms keep
+    // the opaque window and never receive the flag, so the page stays solid.
+    #[cfg(target_os = "macos")]
+    let quick_chat_url = {
+        let mut glass_url = quick_chat_url.clone();
+        glass_url.query_pairs_mut().append_pair("glass", "1");
+        glass_url
+    };
+
     let (x, y) = quick_chat_position(app);
-    match WebviewWindowBuilder::new(
+    let builder = WebviewWindowBuilder::new(
         app,
         QUICK_CHAT_WINDOW_LABEL,
         WebviewUrl::External(quick_chat_url.clone()),
@@ -101,16 +112,32 @@ fn show_quick_chat_window(app: &tauri::AppHandle, quick_chat_url: &Url) {
     .title("CovenCave Quick Chat")
     .inner_size(QUICK_CHAT_WIDTH, QUICK_CHAT_HEIGHT)
     .min_inner_size(340.0, 420.0)
-    .resizable(false)
+    // Resizable since the window holds multiple chats now — the min size
+    // keeps a single tab's composer + thread usable.
+    .resizable(true)
     .decorations(false)
     .always_on_top(true)
     .skip_taskbar(true)
     .position(x, y)
     .shadow(true)
-    .disable_drag_drop_handler()
-    .build()
-    {
+    .disable_drag_drop_handler();
+
+    #[cfg(target_os = "macos")]
+    let builder = builder.transparent(true);
+
+    match builder.build() {
         Ok(window) => {
+            #[cfg(target_os = "macos")]
+            {
+                use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
+                // 14.0 matches .tray-quick-chat__frame's border-radius so the
+                // vibrancy layer and the DOM frame round together.
+                if let Err(e) =
+                    apply_vibrancy(&window, NSVisualEffectMaterial::HudWindow, None, Some(14.0))
+                {
+                    log::warn!("[cave] quick chat vibrancy unavailable: {}", e);
+                }
+            }
             let _ = window.show();
             let _ = window.set_focus();
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
   "app": {
     "windows": [],
     "withGlobalTauri": true,
+    "macOSPrivateApi": true,
     "security": {
       "csp": null
     }

--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -6,17 +6,33 @@ const component = readFileSync(new URL("./tray-quick-chat.tsx", import.meta.url)
 const page = readFileSync(new URL("../app/quick-chat/page.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const controls = readFileSync(new URL("./quick-chat-controls.tsx", import.meta.url), "utf8");
-// Quick-chat state + send logic now lives in the shared useQuickChat hook,
-// consumed by both the Tauri window (this component) and the in-app overlay.
+// Quick-chat state + send logic lives in the shared useQuickChat hook — one
+// instance per tab, so every quick chat holds its own thread.
 const hook = readFileSync(new URL("../lib/use-quick-chat.ts", import.meta.url), "utf8");
+const glassCss = readFileSync(new URL("../styles/quick-chat-glass.css", import.meta.url), "utf8");
+const shell = readFileSync(new URL("../../src-tauri/src/lib.rs", import.meta.url), "utf8");
+const tauriConf = readFileSync(new URL("../../src-tauri/tauri.conf.json", import.meta.url), "utf8");
+const cargo = readFileSync(new URL("../../src-tauri/Cargo.toml", import.meta.url), "utf8");
 
 assert.match(
   page,
   /import \{ TrayQuickChat \} from "@\/components\/tray-quick-chat"/,
   "quick-chat route renders the tray quick chat component",
 );
-assert.match(component, /useQuickChat\(\)/, "tray quick chat consumes the shared useQuickChat hook");
+assert.match(
+  component,
+  /useQuickChat\(\{ preferredFamiliarId: initialFamiliarId \}\)/,
+  "each tab pane runs its own useQuickChat, opening on the familiar it inherited",
+);
 assert.match(hook, /fetch\("\/api\/familiars"/, "quick chat loads the familiar roster");
+// Suspense hide / StrictMode re-runs effects with refs preserved: the roster
+// effect's cleanup must abort AND un-latch (unless a load completed), or a
+// tab pane that suspends on a cold chunk sticks on "Loading…" forever.
+assert.match(
+  hook,
+  /controller\.abort\(\);\s*\n\s*if \(!rosterLoadedRef\.current\) rosterStartedRef\.current = false;/,
+  "the roster load un-latches on cleanup so an effect re-run refetches",
+);
 assert.match(
   hook,
   /resolveQuickChatTarget\(draft, familiars, selectedFamiliarId\)/,
@@ -27,8 +43,99 @@ assert.match(
   /streamFamiliarText\(\{[\s\S]*familiarId: target\.familiarId,[\s\S]*prompt: target\.prompt/,
   "quick chat sends through the sanctioned familiar chat bridge",
 );
-// The tray renders its controls and composer through the shared pieces — the
-// command-control options live once, in quick-chat-controls.
+
+// ── Multiple quick chats ─────────────────────────────────────────────────────
+// The add button (and ⌘/Ctrl+N) opens a new chat that inherits the ACTIVE
+// tab's familiar — a new chat starts on who you're already talking to.
+assert.match(
+  component,
+  /const inherited = reportsRef\.current\[activeIdRef\.current\]\?\.familiar\?\.id \?\? null/,
+  "a new tab inherits the active tab's selected familiar",
+);
+assert.match(component, /aria-label="New chat"/, "the header exposes an add-chat button");
+assert.match(
+  component,
+  /if \(key === "n"\) \{\s*\n\s*event\.preventDefault\(\);\s*\n\s*addTab\(\)/,
+  "⌘/Ctrl+N opens a new quick chat",
+);
+assert.match(
+  component,
+  /else if \(key === "w"\) \{\s*\n\s*event\.preventDefault\(\);\s*\n\s*closeTab\(activeIdRef\.current\)/,
+  "⌘/Ctrl+W closes the active quick chat",
+);
+
+// Tabs are real tabs to assistive tech, and background panes stay mounted so
+// an in-flight reply keeps streaming behind the active tab.
+assert.match(component, /role="tablist" aria-label="Quick chats"/, "the tab strip is a labelled tablist");
+assert.match(component, /role="tab"/, "each chat pill is a tab");
+assert.match(component, /role="tabpanel"/, "each chat body is a tabpanel");
+assert.match(component, /hidden=\{!active\}/, "background tabs hide without unmounting");
+assert.match(
+  glassCss,
+  /\.tray-quick-chat__pane\[hidden\] \{\s*\n\s*display: none;/,
+  "the pane's display:flex must not defeat the hidden attribute",
+);
+
+// ── Closing the quick chat ───────────────────────────────────────────────────
+assert.match(component, /aria-label="Close quick chat"/, "the header exposes a window close button");
+assert.match(
+  component,
+  /getCurrentWindow\(\)\.hide\(\)/,
+  "closing hides the tray window through the Tauri window API",
+);
+assert.match(
+  component,
+  /if \(next\.length === 0\) \{[\s\S]{0,400}void hideTrayWindow\(\)/,
+  "closing the last chat closes the quick chat itself (with a fresh tab waiting behind it)",
+);
+
+// ── Glassmorphism ────────────────────────────────────────────────────────────
+// The Rust shell only sends ?glass=1 when it actually made the window
+// transparent with vibrancy behind it (macOS); the page mirrors it on <html>.
+assert.match(
+  component,
+  /get\("glass"\) === "1"/,
+  "the page reads the glass handshake from the window URL",
+);
+assert.match(
+  glassCss,
+  /html\[data-glass\],\s*\nhtml\[data-glass\] body \{\s*\n\s*background: transparent !important;/,
+  "glass mode clears the opaque page background",
+);
+assert.match(glassCss, /backdrop-filter: blur/, "glass surfaces blur the content beneath them");
+assert.match(
+  glassCss,
+  /@media \(prefers-reduced-transparency: reduce\)/,
+  "reduced-transparency users get solid surfaces back",
+);
+assert.match(
+  shell,
+  /let builder = builder\.transparent\(true\);/,
+  "the quick-chat window opens transparent on macOS",
+);
+assert.match(
+  shell,
+  /apply_vibrancy\(&window, NSVisualEffectMaterial::HudWindow, None, Some\(14\.0\)\)/,
+  "macOS puts NSVisualEffectView vibrancy behind the transparent window, rounded to match the CSS frame",
+);
+assert.match(
+  shell,
+  /append_pair\("glass", "1"\)/,
+  "the shell tells the page it is running over vibrancy",
+);
+assert.match(
+  tauriConf,
+  /"macOSPrivateApi": true/,
+  "transparent webviews on macOS require the private API flag",
+);
+assert.match(cargo, /window-vibrancy = "0\.6"/, "the vibrancy crate is pinned");
+assert.match(
+  cargo,
+  /\[target\.'cfg\(target_os = "macos"\)'\.dependencies\]\s*\nwindow-vibrancy/,
+  "window-vibrancy stays scoped to the macOS target",
+);
+
+// ── Shared pieces (one source of truth with the overlay-era components) ─────
 assert.match(component, /<QuickChatControlsRow/, "tray renders the shared controls row");
 assert.match(component, /<QuickChatComposer/, "tray renders the shared composer");
 assert.match(
@@ -51,10 +158,13 @@ assert.match(
   /\(event\.metaKey \|\| event\.ctrlKey\) && event\.key === "Enter"/,
   "the shared composer sends the draft on Cmd/Ctrl+Enter",
 );
-// The tray suggestion chips focus the composer after filling it — the overlay
-// always did; the tray drifting apart was a bug.
 assert.match(component, /useSuggestionPicker\(setDraft\)/, "tray suggestion picks land the caret in the composer");
-assert.match(component, /autoFocus/, "the tray window focuses its composer on open (no focus trap to fight)");
+assert.match(component, /autoFocus=\{active\}/, "the active tab focuses its composer (no focus trap to fight)");
+assert.match(
+  component,
+  /requestAnimationFrame\(\(\) => composerRef\.current\?\.focus\(\)\)/,
+  "switching tabs lands the caret in the newly active composer",
+);
 assert.match(
   component,
   /emit\("quick-chat:open-session"/,

--- a/src/components/tray-quick-chat.tsx
+++ b/src/components/tray-quick-chat.tsx
@@ -1,17 +1,229 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import "@/styles/quick-chat-glass.css";
 import { IconButton } from "@/components/ui/icon-button";
+import { Icon } from "@/lib/icon";
+import type { Familiar } from "@/lib/types";
 import { useQuickChat } from "@/lib/use-quick-chat";
 import {
+  FamiliarMark,
   QuickChatComposer,
   QuickChatControlsRow,
-  QuickChatIdentity,
   QuickChatThread,
   useSuggestionPicker,
 } from "@/components/quick-chat-controls";
 
+/**
+ * The standalone quick-chat tray window (frameless, always-on-top; created by
+ * show_quick_chat_window in src-tauri/src/lib.rs).
+ *
+ * Holds MULTIPLE quick chats at once: a tab strip in the header, the add
+ * button (or ⌘/Ctrl+N) opens a fresh chat that inherits the active tab's
+ * familiar, ⌘/Ctrl+W or the pill's × closes one, and closing the last chat
+ * hides the whole window (as does the header's close button). Every pane
+ * stays mounted while hidden so a familiar can keep streaming a reply in a
+ * background tab.
+ *
+ * Glass: the Rust shell opens this window transparent with OS vibrancy behind
+ * it on macOS and appends `?glass=1` — the handshake below flips
+ * `html[data-glass]`, which quick-chat-glass.css uses to clear the opaque
+ * page background and layer translucency. Other platforms stay opaque.
+ */
+
+type TabDescriptor = {
+  id: number;
+  /** Familiar the tab opens on — inherited from the active tab at creation. */
+  initialFamiliarId: string | null;
+};
+
+type TabReport = {
+  familiar: Familiar | null;
+  sessionId: string | null;
+  sending: boolean;
+};
+
+async function hideTrayWindow(): Promise<void> {
+  try {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await getCurrentWindow().hide();
+  } catch {
+    // Plain browser (e2e/dev): window.close is a no-op for tabs the script
+    // didn't open, which is fine — there is no tray window to hide.
+    window.close();
+  }
+}
+
 export function TrayQuickChat() {
+  // Glass handshake — only the Rust shell that actually made the window
+  // transparent (macOS vibrancy) sends ?glass=1; a plain browser never gets
+  // a translucent background it can't back with a blur.
+  useEffect(() => {
+    if (new URLSearchParams(window.location.search).get("glass") === "1") {
+      document.documentElement.dataset.glass = "1";
+    }
+  }, []);
+
+  const seqRef = useRef(2);
+  const [tabs, setTabs] = useState<TabDescriptor[]>([{ id: 1, initialFamiliarId: null }]);
+  const [activeId, setActiveId] = useState(1);
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
+  const activeIdRef = useRef(activeId);
+  activeIdRef.current = activeId;
+  // Per-tab live state, reported up by each pane (familiar for the pill,
+  // sending for the pulse dot, sessionId for the open-in-app hand-off).
+  const reportsRef = useRef<Record<number, TabReport>>({});
+  const [reports, setReports] = useState<Record<number, TabReport>>({});
+
+  const handleReport = useCallback((id: number, report: TabReport) => {
+    reportsRef.current = { ...reportsRef.current, [id]: report };
+    setReports(reportsRef.current);
+  }, []);
+
+  // A new chat starts on the familiar the user is already talking to — the
+  // active tab's current pick — not on a cold default.
+  const addTab = useCallback(() => {
+    const inherited = reportsRef.current[activeIdRef.current]?.familiar?.id ?? null;
+    const id = seqRef.current++;
+    setTabs((prev) => [...prev, { id, initialFamiliarId: inherited }]);
+    setActiveId(id);
+  }, []);
+
+  const closeTab = useCallback((id: number) => {
+    const prev = tabsRef.current;
+    const idx = prev.findIndex((tab) => tab.id === id);
+    if (idx === -1) return;
+    const next = prev.filter((tab) => tab.id !== id);
+    const { [id]: dropped, ...rest } = reportsRef.current;
+    reportsRef.current = rest;
+    setReports(rest);
+    if (next.length === 0) {
+      // Closing the last chat closes the quick chat itself; a fresh tab
+      // (keeping the familiar) waits behind it for the next summon.
+      const fresh = { id: seqRef.current++, initialFamiliarId: dropped?.familiar?.id ?? null };
+      setTabs([fresh]);
+      setActiveId(fresh.id);
+      void hideTrayWindow();
+      return;
+    }
+    setTabs(next);
+    if (activeIdRef.current === id) {
+      setActiveId(next[Math.max(0, idx - 1)]?.id ?? next[0].id);
+    }
+  }, []);
+
+  // ⌘/Ctrl+N opens a chat, ⌘/Ctrl+W closes the active one. This window owns
+  // the whole page, so a global listener can't collide with app surfaces.
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) return;
+      const key = event.key.toLowerCase();
+      if (key === "n") {
+        event.preventDefault();
+        addTab();
+      } else if (key === "w") {
+        event.preventDefault();
+        closeTab(activeIdRef.current);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [addTab, closeTab]);
+
+  return (
+    <main className="tray-quick-chat min-h-screen text-[var(--fg-primary)]">
+      <h1 className="sr-only">Quick chat</h1>
+      <section className="tray-quick-chat__frame">
+        {/* The tray window is created with decorations(false) (see lib.rs), so
+            without a drag region it cannot be moved at all. Tauri's injected
+            drag.js turns any empty-chrome press in this subtree into a native
+            window drag (`deep` semantics; buttons still block it), gated by
+            capabilities/loopback-window-drag.json. Inert in plain browsers. */}
+        <header className="quick-chat-overlay__header tray-quick-chat__header" data-tauri-drag-region="deep">
+          <div role="tablist" aria-label="Quick chats" className="quick-tabs">
+            {tabs.map((tab) => {
+              const report = reports[tab.id];
+              const active = tab.id === activeId;
+              const label = report?.familiar?.display_name ?? "New chat";
+              return (
+                <div key={tab.id} className={`quick-tab${active ? " quick-tab--active" : ""}`}>
+                  <button
+                    type="button"
+                    role="tab"
+                    id={`quick-tab-${tab.id}`}
+                    aria-selected={active}
+                    aria-controls={`quick-tab-panel-${tab.id}`}
+                    title={label}
+                    className="focus-ring quick-tab__button"
+                    onClick={() => setActiveId(tab.id)}
+                  >
+                    {report?.familiar ? (
+                      <FamiliarMark familiar={report.familiar} size="sm" />
+                    ) : (
+                      <Icon name="ph:chat-circle-dots" width={14} aria-hidden />
+                    )}
+                    <span className="quick-tab__label">{label}</span>
+                    {report?.sending ? (
+                      <span className="quick-tab__pulse" role="img" aria-label="Replying…" />
+                    ) : null}
+                  </button>
+                  <IconButton
+                    icon="ph:x"
+                    size="xs"
+                    aria-label={`Close chat with ${label}`}
+                    title="Close chat (⌘W)"
+                    className="quick-tab__close"
+                    onClick={() => closeTab(tab.id)}
+                  />
+                </div>
+              );
+            })}
+            <IconButton
+              icon="ph:plus"
+              size="sm"
+              aria-label="New chat"
+              title="New chat (⌘N)"
+              onClick={addTab}
+            />
+          </div>
+          <IconButton
+            icon="ph:x"
+            size="sm"
+            aria-label="Close quick chat"
+            title="Close quick chat"
+            onClick={() => void hideTrayWindow()}
+          />
+        </header>
+
+        {tabs.map((tab) => (
+          <QuickChatTabPane
+            key={tab.id}
+            tabId={tab.id}
+            active={tab.id === activeId}
+            initialFamiliarId={tab.initialFamiliarId}
+            onReport={handleReport}
+          />
+        ))}
+      </section>
+    </main>
+  );
+}
+
+// One quick chat. Stays mounted while its tab is in the background — `hidden`
+// only hides the DOM, so an in-flight reply keeps streaming behind the
+// active tab.
+function QuickChatTabPane({
+  tabId,
+  active,
+  initialFamiliarId,
+  onReport,
+}: {
+  tabId: number;
+  active: boolean;
+  initialFamiliarId: string | null;
+  onReport: (id: number, report: TabReport) => void;
+}) {
   const {
     familiars,
     selectedFamiliarId,
@@ -20,7 +232,6 @@ export function TrayQuickChat() {
     draft,
     setDraft,
     messages,
-    hasThread,
     error,
     sessionId,
     sendState,
@@ -31,12 +242,23 @@ export function TrayQuickChat() {
     setResponseSpeed,
     send,
     cancel,
-    newThread,
     regenerate,
-  } = useQuickChat();
+  } = useQuickChat({ preferredFamiliarId: initialFamiliarId });
 
   const sending = sendState === "sending";
   const { composerRef, pickSuggestion } = useSuggestionPicker(setDraft);
+
+  useEffect(() => {
+    onReport(tabId, { familiar: selectedFamiliar, sessionId, sending });
+  }, [tabId, onReport, selectedFamiliar, sessionId, sending]);
+
+  // Switching to this tab lands the caret in its composer, mirroring the
+  // autoFocus a freshly opened window gets.
+  useEffect(() => {
+    if (!active) return;
+    const raf = requestAnimationFrame(() => composerRef.current?.focus());
+    return () => cancelAnimationFrame(raf);
+  }, [active, composerRef]);
 
   const openFullSession = useCallback(async () => {
     if (!sessionId) return;
@@ -49,74 +271,60 @@ export function TrayQuickChat() {
   }, [selectedFamiliarId, sessionId]);
 
   return (
-    <main className="min-h-screen bg-[var(--bg-base)] text-[var(--fg-primary)]">
-      <section className="flex min-h-screen flex-col border border-[var(--border-hairline)] bg-[var(--bg-panel)]">
-        {/* The tray window is created with decorations(false) (see lib.rs), so
-            without a drag region it cannot be moved at all. Tauri's injected
-            drag.js turns any empty-chrome press in this subtree into a native
-            window drag (`deep` semantics; the icon buttons still block it),
-            gated by capabilities/loopback-window-drag.json. Inert in plain
-            browsers. */}
-        <header className="quick-chat-overlay__header" data-tauri-drag-region="deep">
-          <QuickChatIdentity familiar={selectedFamiliar} loading={loading} as="h1" />
-          <div className="flex items-center gap-1">
+    <section
+      role="tabpanel"
+      id={`quick-tab-panel-${tabId}`}
+      aria-labelledby={`quick-tab-${tabId}`}
+      hidden={!active}
+      className="tray-quick-chat__pane"
+    >
+      <QuickChatControlsRow
+        loading={loading}
+        familiars={familiars}
+        selectedFamiliarId={selectedFamiliarId}
+        onPickFamiliar={setSelectedFamiliarId}
+        thinkingEffort={thinkingEffort}
+        onThinkingEffortChange={setThinkingEffort}
+        responseSpeed={responseSpeed}
+        onResponseSpeedChange={setResponseSpeed}
+        sending={sending}
+      />
+
+      <QuickChatThread
+        messages={messages}
+        familiar={selectedFamiliar}
+        onSuggestion={pickSuggestion}
+        onRegenerate={sending ? undefined : regenerate}
+      />
+
+      <QuickChatComposer
+        error={error}
+        draft={draft}
+        onDraftChange={setDraft}
+        onSend={() => void send()}
+        onCancel={cancel}
+        sending={sending}
+        disabled={loading}
+        familiar={selectedFamiliar}
+        inputId={`quick-chat-draft-${tabId}`}
+        composerRef={composerRef}
+        autoFocus={active}
+        leading={
+          <div className="flex min-w-0 items-center gap-1.5">
             <IconButton
-              onClick={newThread}
-              disabled={!hasThread}
-              icon="ph:plus"
-              aria-label="New chat"
-              title="New chat"
-              size="sm"
-            />
-            <IconButton
-              onClick={openFullSession}
-              disabled={!sessionId}
               icon="ph:arrow-square-out"
+              size="xs"
               aria-label="Open in CovenCave"
               title="Open in CovenCave"
-              size="sm"
+              disabled={!sessionId}
+              onClick={() => void openFullSession()}
             />
-          </div>
-        </header>
-
-        <QuickChatControlsRow
-          loading={loading}
-          familiars={familiars}
-          selectedFamiliarId={selectedFamiliarId}
-          onPickFamiliar={setSelectedFamiliarId}
-          thinkingEffort={thinkingEffort}
-          onThinkingEffortChange={setThinkingEffort}
-          responseSpeed={responseSpeed}
-          onResponseSpeedChange={setResponseSpeed}
-          sending={sending}
-        />
-
-        <QuickChatThread
-          messages={messages}
-          familiar={selectedFamiliar}
-          onSuggestion={pickSuggestion}
-          onRegenerate={sending ? undefined : regenerate}
-        />
-
-        <QuickChatComposer
-          error={error}
-          draft={draft}
-          onDraftChange={setDraft}
-          onSend={() => void send()}
-          onCancel={cancel}
-          sending={sending}
-          disabled={loading}
-          familiar={selectedFamiliar}
-          inputId="quick-chat-draft"
-          composerRef={composerRef}
-          autoFocus
-          leading={
             <p className="min-w-0 truncate text-xs text-[var(--fg-muted)]">
-              @id switches familiars · Enter to send
+              @id switches familiars · ⌘N new chat
             </p>
-          }
-        />
-      </section>
-    </main>
+          </div>
+        }
+      />
+    </section>
   );
 }

--- a/src/lib/use-quick-chat.ts
+++ b/src/lib/use-quick-chat.ts
@@ -129,9 +129,12 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
   // without threading it through a state updater.
   const selectedIdRef = useRef<string | null>(selectedFamiliarId);
   selectedIdRef.current = selectedFamiliarId;
-  // Roster-load bookkeeping: fire once (latched on `enabled`), abort on unmount.
+  // Roster-load bookkeeping: fire once (latched on `enabled`), abort via the
+  // effect's own cleanup. `rosterLoadedRef` marks a COMPLETED load so the
+  // cleanup can tell "hide mid-fetch" (un-latch, the re-run must refetch)
+  // from "hide after success" (stay latched, the roster is already in state).
   const rosterStartedRef = useRef(false);
-  const rosterAbortRef = useRef<AbortController | null>(null);
+  const rosterLoadedRef = useRef(false);
 
   const nextId = useCallback((prefix: string) => `${prefix}-${msgSeqRef.current++}`, []);
 
@@ -152,7 +155,6 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     if (!enabled || rosterStartedRef.current) return;
     rosterStartedRef.current = true;
     const controller = new AbortController();
-    rosterAbortRef.current = controller;
     setLoading(true);
     void (async () => {
       try {
@@ -163,6 +165,7 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
         const next = (json?.familiars ?? []) as Familiar[];
         const stored = readLastFamiliar();
         const preferred = preferredRef.current;
+        rosterLoadedRef.current = true;
         setError(null);
         setFamiliars(next);
         // Default priority: the workspace's active familiar, then the last
@@ -184,6 +187,16 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
         if (!controller.signal.aborted) setLoading(false);
       }
     })();
+    return () => {
+      // Suspense hide / StrictMode re-runs this effect with REFS PRESERVED
+      // (setup → cleanup → setup). Abort the in-flight load, and un-latch
+      // unless a load already completed — otherwise the re-run early-returns
+      // on the stale latch and the pane shows "Loading…" forever. Hit for
+      // real: a tab pane mounted after boot suspends on a cold chunk, the
+      // hide aborted its roster fetch, and the reveal never refetched.
+      controller.abort();
+      if (!rosterLoadedRef.current) rosterStartedRef.current = false;
+    };
   }, [enabled]);
 
   // Follow the workspace's active familiar as it changes — until the user has
@@ -194,11 +207,11 @@ export function useQuickChat(options?: UseQuickChatOptions): UseQuickChat {
     setSelectedFamiliarId(preferredFamiliarId);
   }, [preferredFamiliarId, familiars]);
 
-  // Abort any in-flight stream + roster load when the consumer unmounts.
+  // Abort any in-flight stream when the consumer unmounts. (The roster load
+  // aborts through its own effect cleanup above.)
   useEffect(() => {
     return () => {
       abortRef.current?.abort();
-      rosterAbortRef.current?.abort();
     };
   }, []);
 

--- a/src/styles/quick-chat-glass.css
+++ b/src/styles/quick-chat-glass.css
@@ -1,0 +1,201 @@
+/* ── Quick chat tray: multi-tab frame + glassmorphism ───────────────────────
+   The Rust shell opens the tray window transparent with OS vibrancy behind
+   it on macOS and appends ?glass=1; TrayQuickChat mirrors that as
+   html[data-glass]. With the flag, surfaces go translucent over the vibrancy
+   layer and the header/composer pick up backdrop blur so content scrolling
+   beneath them reads with depth. Without it (plain browser, Linux, Windows)
+   everything stays opaque on the same tokens. */
+
+html[data-glass],
+html[data-glass] body {
+  background: transparent !important;
+}
+
+.tray-quick-chat {
+  background: var(--bg-base);
+}
+
+html[data-glass] .tray-quick-chat {
+  background: transparent;
+}
+
+.tray-quick-chat__frame {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  background: var(--bg-panel);
+  border: 1px solid var(--border-hairline);
+}
+
+html[data-glass] .tray-quick-chat__frame {
+  /* Matches the 14px radius apply_vibrancy() rounds the window layer to. */
+  border-radius: 14px;
+  border-color: color-mix(in oklch, var(--foreground) 18%, transparent);
+  background: color-mix(in oklch, var(--bg-panel) 58%, transparent);
+}
+
+/* Header carries the tab strip; under glass it blurs the thread scrolling
+   beneath it. */
+.tray-quick-chat__header {
+  gap: var(--space-2);
+}
+
+html[data-glass] .tray-quick-chat__header {
+  background: color-mix(in oklch, var(--bg-panel) 35%, transparent);
+  backdrop-filter: blur(14px) saturate(1.25);
+  -webkit-backdrop-filter: blur(14px) saturate(1.25);
+}
+
+/* ── Tab strip ── */
+.quick-tabs {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.quick-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.quick-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  min-width: 0;
+}
+
+.quick-tab--active {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
+
+html[data-glass] .quick-tab--active {
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.quick-tab__button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  padding: 2px var(--space-1) 2px 2px;
+  border-radius: 999px;
+  color: var(--text-secondary);
+}
+
+.quick-tab--active .quick-tab__button {
+  color: var(--text-primary);
+}
+
+.quick-tab__label {
+  max-width: 84px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+}
+
+/* Inactive tabs shrink to just the avatar so several chats fit in 390px. */
+.quick-tab:not(.quick-tab--active) .quick-tab__label {
+  display: none;
+}
+
+.quick-tab:not(.quick-tab--active) .quick-tab__close {
+  display: none;
+}
+
+.quick-tab:not(.quick-tab--active):hover .quick-tab__close,
+.quick-tab:not(.quick-tab--active):focus-within .quick-tab__close {
+  display: inline-flex;
+}
+
+.quick-tab__pulse {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  box-shadow: 0 0 6px color-mix(in oklch, var(--accent-presence) 60%, transparent);
+  animation: quick-tab-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes quick-tab-pulse {
+  50% {
+    opacity: 0.35;
+  }
+}
+
+/* ── Panes ── */
+.tray-quick-chat__pane {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+/* The display:flex above would otherwise beat the `hidden` attribute —
+   background tabs must stay mounted (streams keep flowing) but invisible. */
+.tray-quick-chat__pane[hidden] {
+  display: none;
+}
+
+/* ── Glass over the shared quick-chat pieces ── */
+html[data-glass] .quick-chat-overlay__controls,
+html[data-glass] .quick-chat-select__trigger {
+  background: color-mix(in oklch, var(--bg-base) 45%, transparent);
+}
+
+html[data-glass] .quick-chat-overlay__composer {
+  background: color-mix(in oklch, var(--bg-panel) 40%, transparent);
+  backdrop-filter: blur(14px) saturate(1.25);
+  -webkit-backdrop-filter: blur(14px) saturate(1.25);
+}
+
+html[data-glass] .quick-chat-overlay__input {
+  background: color-mix(in oklch, var(--bg-base) 50%, transparent);
+}
+
+html[data-glass] .quick-chat-bubble--familiar {
+  background: color-mix(in oklch, var(--bg-elevated) 68%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+html[data-glass] .quick-chat-bubble--user {
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+/* ── Accessibility fallbacks ── */
+@media (prefers-reduced-transparency: reduce) {
+  html[data-glass],
+  html[data-glass] body,
+  html[data-glass] .tray-quick-chat {
+    background: var(--bg-base) !important;
+  }
+
+  html[data-glass] .tray-quick-chat__frame,
+  html[data-glass] .tray-quick-chat__header,
+  html[data-glass] .quick-chat-overlay__composer,
+  html[data-glass] .quick-chat-bubble--familiar,
+  html[data-glass] .quick-chat-bubble--user {
+    background: var(--bg-panel);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quick-tab__pulse {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What

The standalone quick-chat tray window grows up: **multiple chats, closable, glass**.

### Multiple quick chats
- Tab strip in the header (real `tablist`/`tab`/`tabpanel` semantics); inactive tabs collapse to avatar pills so several fit in 390px; a pulse dot marks a tab whose familiar is mid-reply.
- **Add button or ⌘/Ctrl+N** opens a new chat that **inherits the active tab's selected familiar** (each pane reports its live familiar up; the new pane's `useQuickChat` opens on it) — verified live: tab 2 opened on Nova after tab 1 had Nova selected.
- **⌘/Ctrl+W** or the pill's × closes a chat; background panes stay mounted (`hidden`, with an explicit `[hidden]{display:none}` guard over the pane's flex display) so in-flight replies keep streaming; switching tabs lands the caret in that tab's composer.

### Closing the quick chat
- New header close button hides the tray window via the Tauri window API; **closing the last chat hides the window too**, leaving a fresh tab (same familiar) waiting for the next summon.

### Glassmorphism
- The Rust shell opens the window `transparent(true)` on macOS with **NSVisualEffectView vibrancy** behind it (`window-vibrancy` 0.6, `HudWindow`, radius 14 matching the CSS frame), and appends `?glass=1`; the page mirrors it as `html[data-glass]`.
- `quick-chat-glass.css`: translucent frame/header/composer/bubbles over the vibrancy layer, backdrop blur for depth under scrolling content, `prefers-reduced-transparency` solid fallback, reduced-motion story for the pulse. Non-mac platforms never get the flag and stay opaque.
- Requires `macOSPrivateApi: true` + the `macos-private-api` cargo feature (both included); window is resizable now that it holds several chats.

### Bug found & fixed while verifying (`use-quick-chat.ts`)
Suspense hide/reveal (and StrictMode) re-run effects **with refs preserved**: the roster effect's abort-on-cleanup left `rosterStartedRef` latched, so a tab pane mounted after boot that suspended on a cold chunk had its roster fetch aborted and never refetched — stuck on "Loading…" forever (traced live with instrumentation; server logs confirmed the request completed). The load now aborts via its own effect cleanup and un-latches unless a load completed, so the re-run refetches. Regression-pinned.

## Tests
- `tray-quick-chat.test.ts` rewritten: inheritance, ⌘N/⌘W, tablist semantics, keepalive-hidden guard, window hide, glass handshake + CSS pins (transparency, blur, reduced-transparency), Rust pins (transparent/vibrancy/glass=1), conf + cargo pins, and the roster un-latch regression pin.
- `pnpm typecheck` ✓ · `test:app` 560 files ✓ · `pnpm build` ✓ · `cargo check` ✓ · live multi-tab verification against the real roster API ✓ (screenshots in the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)