### PR TITLE
fix(group-chat): a11y labels, keyboard-visible focus, per-coven composer drafts (cave-mpk4)

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -232,4 +232,36 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
     /if \(e\.nativeEvent\.isComposing\) return;\s*\n\s*if \(e\.key === "Enter"\) \(e\.target as HTMLInputElement\)\.blur\(\);/,
     "the coven rename input ignores the IME-confirm Enter",
   );
+
+  // cave-mpk4: labeling + keyboard-visible focus + per-coven drafts.
+  assert.match(
+    view,
+    /aria-label="Coven name — Enter saves, Escape cancels"/,
+    "the rename input is a labeled text field with discoverable save/cancel",
+  );
+  assert.match(
+    view,
+    /aria-label=\{`Rename coven: \$\{activeGroup\.name\}`\}/,
+    "the rename affordance names its action for AT, not just via title=",
+  );
+  {
+    // Every button inside the familiar picker and @mention popovers must carry
+    // the shared focus-ring class so keyboard focus is visible.
+    const options = view.match(/className="(?:focus-ring )?flex w-full items-center gap-2 rounded px-2 py-1\.5 text-left[^"]*"/g) ?? [];
+    assert.ok(options.length >= 2, "found the picker and mention option buttons");
+    assert.ok(
+      options.every((c) => c.includes("focus-ring")),
+      "picker and @mention options use the global focus-ring class",
+    );
+  }
+  assert.match(
+    view,
+    /if \(draftOwnerRef\.current\) draftsByGroupRef\.current\.set\(draftOwnerRef\.current, draftRef\.current\);[\s\S]{0,220}?setDraft\(activeId \? draftsByGroupRef\.current\.get\(activeId\) \?\? "" : ""\);/,
+    "switching covens stashes the outgoing draft and restores the incoming one (no cross-coven bleed)",
+  );
+  assert.match(
+    view,
+    /draftsByGroupRef\.current\.delete\(id\);/,
+    "deleting a coven drops its stashed draft",
+  );
 });

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -111,6 +111,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // without re-creating its callback on every streaming token.
   const transcriptRef = useRef<GroupTurn[]>(transcript);
   transcriptRef.current = transcript;
+  // Per-coven composer drafts: text typed for one coven must not silently
+  // become a pending message to another on switch. Stashed by the swap
+  // effect (in-memory only — a draft is not precious enough to persist).
+  const draftRef = useRef(draft);
+  draftRef.current = draft;
+  const draftsByGroupRef = useRef(new Map<string, string>());
+  const draftOwnerRef = useRef<string | null>(null);
   // Which group the in-memory transcript belongs to (set by the swap effect).
   // The persist effect must not save until the swap has caught up, or the
   // previous coven's turns get written under the new coven's key.
@@ -163,6 +170,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     // carries ITS group id, so this can never write under the new coven's key.
     flushPendingSave();
     transcriptOwnerRef.current = activeId;
+    // Swap the composer draft along with the transcript: stash the outgoing
+    // coven's draft and restore the incoming one's (or a clean slate).
+    if (draftOwnerRef.current !== activeId) {
+      if (draftOwnerRef.current) draftsByGroupRef.current.set(draftOwnerRef.current, draftRef.current);
+      draftOwnerRef.current = activeId;
+      setDraft(activeId ? draftsByGroupRef.current.get(activeId) ?? "" : "");
+      setMention(null);
+    }
     if (!activeId) {
       setTranscript([]);
       return;
@@ -309,6 +324,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
           saveTimerRef.current = null;
         }
       }
+      draftsByGroupRef.current.delete(id);
       if (typeof localStorage !== "undefined") {
         try {
           localStorage.removeItem(`cave:group-chat:transcript:${id}`);
@@ -736,7 +752,8 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                   <input
                     autoFocus
                     defaultValue={activeGroup.name}
-                    className="w-full rounded bg-transparent text-[15px] font-semibold outline-none"
+                    aria-label="Coven name — Enter saves, Escape cancels"
+                    className="focus-ring-inset w-full rounded bg-transparent text-[15px] font-semibold outline-none"
                     style={{ color: "var(--text-primary)" }}
                     onBlur={(e) => {
                       renameGroup(e.target.value);
@@ -751,9 +768,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                 ) : (
                   <button
                     type="button"
-                    className="truncate text-[15px] font-semibold"
+                    className="focus-ring truncate text-[15px] font-semibold"
                     style={{ color: "var(--text-primary)" }}
                     title="Rename coven"
+                    aria-label={`Rename coven: ${activeGroup.name}`}
                     onClick={() => setRenaming(true)}
                   >
                     {activeGroup.name}
@@ -803,7 +821,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                         <button
                           key={f.id}
                           type="button"
-                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-[var(--bg-raised)]"
+                          className="focus-ring flex w-full items-center gap-2 rounded px-2 py-1.5 text-left hover:bg-[var(--bg-raised)]"
                           onClick={() => toggleParticipant(f.id)}
                         >
                           <FamiliarAvatar familiar={f} size="md" className="rounded-full object-cover" />
@@ -1062,7 +1080,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                         <button
                           key={f.id}
                           type="button"
-                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left"
+                          className="focus-ring flex w-full items-center gap-2 rounded px-2 py-1.5 text-left"
                           style={i === mentionIndex ? { background: "var(--bg-raised)" } : undefined}
                           // Use mousedown so the textarea's onBlur doesn't fire first and close us.
                           onMouseDown={(e) => {


### PR DESCRIPTION
## Problem (cave-mpk4, from the group-chat audit)
1. The coven rename input had no aria-label — an unlabeled text field (WCAG 4.1.2).
2. The rename affordance said "Rename coven" only via `title=`; its accessible name was just the coven name, so AT users could not discover the action.
3. The familiar-picker and @mention option buttons were keyboard-focusable with **invisible focus** (no `.focus-ring`, the repo convention).
4. The composer draft was shared state across covens — text typed for coven A silently became a pending message to coven B on switch.

## Fix
- Rename input: `aria-label="Coven name — Enter saves, Escape cancels"` + `.focus-ring-inset`.
- Rename affordance: `aria-label={`Rename coven: ${name}`}` + `.focus-ring`.
- Picker/mention options: global `.focus-ring` class on both.
- Per-coven drafts: the swap effect stashes the outgoing coven's draft and restores the incoming one's (in-memory map); deleting a coven drops its stashed draft; the mention popover resets on switch.

## Verification
- 5 new source pins in `group-chat-view.test.ts` (labels, focus-ring on every option button, draft stash/restore, delete-drop) — 5/5 tests pass
- `pnpm test:app` — 563 files pass · `pnpm typecheck` clean

Closes cave-mpk4 (beads).