### PR TITLE
fix(calendar): anchor the now-line tick to the wall-clock minute (cave-6xer)

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -46,6 +46,9 @@ assert.doesNotMatch(view, /minHeight: 20/, "Old fixed 20px event height must be 
 // re-ticks each minute, so today-highlights + the now-line don't mismatch SSR
 // and the current-time indicator tracks the clock.
 assert.match(view, /function useNow\(\): Date \| null \{[\s\S]*?setInterval\(\(\) => setNow\(new Date\(\)\), 60_000\)/, "useNow ticks every minute");
+// (cave-6xer) The first tick is aligned to the next wall-clock minute — a
+// mount-anchored interval left the now-line up to ~60s stale at each rollover.
+assert.match(view, /setTimeout\(\(\) => \{[\s\S]{0,120}?\}, 60_000 - \(Date\.now\(\) % 60_000\)\)/, "useNow aligns its first tick to the wall-clock minute");
 assert.match(view, /now && isSameDay\(col\.date, now\) &&/, "the now-line only renders once `now` resolves, derived from TimeGrid's own clock");
 // The grid sub-views derive "today" from useNow (hydration-safe + live), not a
 // render-time `new Date()` (Agenda, Day, Week, Month, TimeGrid).

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -146,8 +146,17 @@ function useNow(): Date | null {
   const [now, setNow] = useState<Date | null>(null);
   useEffect(() => {
     setNow(new Date());
-    const id = setInterval(() => setNow(new Date()), 60_000);
-    return () => clearInterval(id);
+    // Anchor ticks to the wall-clock minute (a mount-anchored interval left
+    // the now-line and Today highlight up to ~60s behind at each rollover).
+    let interval: ReturnType<typeof setInterval> | null = null;
+    const align = setTimeout(() => {
+      setNow(new Date());
+      interval = setInterval(() => setNow(new Date()), 60_000);
+    }, 60_000 - (Date.now() % 60_000));
+    return () => {
+      clearTimeout(align);
+      if (interval) clearInterval(interval);
+    };
   }, []);
   return now;
 }
@@ -176,6 +185,8 @@ function defaultEntryFireAt(day: Date): string {
   // opens on the day the user actually clicked.
   if (isSameDay(day, now)) {
     const slot = new Date(now);
+    // The +5 is a buffer: a slot boundary under 5 minutes away is skipped for
+    // the one after it (:56-59 → :15 past). setMinutes(75) carries the hour.
     slot.setMinutes(Math.ceil((slot.getMinutes() + 5) / 15) * 15, 0, 0);
     return slot.toISOString();
   }


### PR DESCRIPTION
## Summary

From the calendar-audit bead `cave-6xer` (two findings; one real, one verified false):

**Real: the now-line drifted off the wall-clock minute.** `useNow`'s `setInterval(60_000)` was anchored to mount time, so the current-time indicator and the Today highlight lagged the real clock by up to ~60 seconds at every minute boundary (most visibly at day rollover). The first tick is now aligned to the next wall-clock `:00` via `setTimeout(60_000 - Date.now() % 60_000)`, then the usual 60-second interval takes over.

**Verified NOT a defect: the Add default-time ":56-59 band".** The bead claimed clicking Add at 15:58 defaults to 17:15 (a +1h15m jump) and suggested a `%60`. Verified in node: `setMinutes(75)` carries the hour correctly, so 15:58 → **16:15** — exactly what the deliberate +5-minute buffer intends (a slot boundary under 5 minutes away is skipped for the next one). Applying the suggested `%60` would have introduced a real bug (15:15, in the past). Documented at the call site so audits don't re-flag it.

## Test plan

- [x] New pin in `calendar-actions.test.ts` for the wall-clock alignment; the existing `useNow` interval pin still holds
- [x] All calendar test files + full `pnpm test:app` green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)