### PR TITLE
fix(summoning): long vessel lists scroll inside the panel — no more footer collision (cave-hpsz)

### DIFF
--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -159,6 +159,27 @@ assert.doesNotMatch(
   "summoning-circle.css uses tokens, not hardcoded hex colors",
 );
 
+// ── Long vessel lists scroll INSIDE the panel (cave-hpsz) ────────────────────
+// With ~12 OpenClaw agents the list used to blow past the dialog's max-height
+// and paint through the Cancel/Continue footer: the panel was the scroller,
+// so flexbox shrank __content and its overflow escaped. The content is the
+// one scroller; the panel clips; the grid row may shrink below its content.
+assert.match(
+  css,
+  /\.summoning-panel \{[^}]*overflow: hidden;/,
+  "the panel clips — heading and footer stay pinned",
+);
+assert.match(
+  css,
+  /\.summoning-panel__content \{[^}]*overflow-y: auto;/,
+  "the stage content is the one scroller",
+);
+assert.match(
+  css,
+  /\.summoning-layout \{[^}]*grid-template-rows: minmax\(0, 1fr\);/s,
+  "the layout row can shrink below a long vessel list",
+);
+
 // ── The circle is the only creation path (dialog fully replaced) ────────────
 const familiarsView = await readFile(new URL("./familiars-view.tsx", import.meta.url), "utf8");
 const settingsShell = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");

--- a/src/styles/summoning-circle.css
+++ b/src/styles/summoning-circle.css
@@ -30,6 +30,7 @@
 .summoning-body {
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-height: 0;
   container-type: inline-size;
   container-name: summoning;
@@ -81,6 +82,10 @@
 .summoning-layout {
   display: grid;
   grid-template-columns: 320px minmax(0, 1fr);
+  /* minmax(0, …) lets the row shrink below its content — without it a long
+     vessel list (many OpenClaw agents) sized the row to the content and blew
+     the whole dialog past its max-height. */
+  grid-template-rows: minmax(0, 1fr);
   min-height: 0;
   flex: 1;
 }
@@ -96,6 +101,10 @@
   overflow-y: auto;
 }
 
+/* The panel itself never scrolls: the heading and the Cancel/Continue footer
+   stay pinned, and __content below is the one scroller. When the panel was
+   the scroller, flexbox shrank __content to the leftover space and its
+   overflow painted straight through the footer. */
 .summoning-panel {
   display: flex;
   flex-direction: column;
@@ -103,7 +112,7 @@
   min-width: 0;
   padding: var(--space-4);
   gap: var(--space-3);
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .summoning-panel__title {
@@ -137,8 +146,10 @@
 .summoning-panel__content {
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: var(--space-3);
   min-height: 0;
+  overflow-y: auto;
 }
 
 /* Stepper */
@@ -690,6 +701,9 @@
 @container summoning (max-width: 700px) {
   .summoning-layout {
     grid-template-columns: minmax(0, 1fr);
+    /* Stacked: the circle column keeps its natural height, the panel row
+       shrinks and scrolls its content. */
+    grid-template-rows: auto minmax(0, 1fr);
   }
 
   .summoning-stagecol {


### PR DESCRIPTION
## What

With a real OpenClaw roster (~12 agents) the summoning circle's vessel stage broke (user-reported screenshot): the agent list grew unbounded past the dialog's max-height, and the **Cancel/Continue footer painted on top of list rows** mid-list.

**Root cause**: `.summoning-panel` was the scroll container, so flexbox shrank `.summoning-panel__content` to the leftover space and its children — with default visible overflow — painted straight through the footer that layout placed right after the shrunken box.

**Fix (CSS only)**:
- `.summoning-panel__content` becomes the one scroller (`flex: 1; min-height: 0; overflow-y: auto`) — heading and footer stay pinned.
- `.summoning-panel` clips (`overflow: hidden`).
- `.summoning-layout` gets `grid-template-rows: minmax(0, 1fr)` (and `auto minmax(0,1fr)` in the stacked narrow-container variant) so the row can shrink below a long list; `.summoning-body` joins the flex chain (`flex: 1`).

Verified against a 12-agent mocked roster driving the real app: dialog holds its 760px cap, footer sits below the scrolling content (`footerBelowContent: true`, `footerInsideDialog: true`), the list scrolls, and the last agent is reachable and pickable (Continue enables). Also covers the enhancement rite and every other stage, since they share the same panel structure.

Regression pins added to `familiar-summoning-circle.test.ts` (panel clips / content scrolls / row minmax).

`pnpm typecheck` ✓ · `test:app` 563 files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)