### PR TITLE
fix(calendar): month view is a real ARIA grid with 2-D roving day cells (cave-zqsj)

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -55,7 +55,23 @@ assert.match(view, /now && isSameDay\(col\.date, now\) &&/, "the now-line only r
 assert.ok((view.match(/const now = useNow\(\)/g) ?? []).length >= 5, "every grid sub-view uses useNow for today");
 
 // ───────── Month-cell keyboard access ─────────
-assert.match(view, /role="button"[\s\S]*?tabIndex=\{0\}[\s\S]*?onKeyDown=\{\(e\) => \{[\s\S]*?Enter[\s\S]*?onDayClick/, "Month day cells must be keyboard-operable");
+// (cave-zqsj) The month is a real ARIA grid: grid → header row of
+// columnheaders + a rowgroup of week rows → roving gridcells (←/→ = day,
+// ↑/↓ = week). Cells previously were role="button" divs WRAPPING nested
+// buttons — invalid — with no row/position semantics and no 2-D arrow nav.
+assert.match(view, /role="grid"\s*\n\s*aria-label=\{`\$\{MONTHS\[anchor\.getMonth\(\)\]\} \$\{anchor\.getFullYear\(\)\}`\}/, "the month grid is a labelled ARIA grid");
+assert.match(view, /<div role="row" className="mb-1 grid grid-cols-7">\s*\n\s*\{WEEKDAYS\.map[\s\S]{0,160}role="columnheader"/, "weekday headers are columnheaders in a row");
+assert.match(view, /role="rowgroup"[\s\S]{0,220}\{weeks\.map\(\(week, wi\) => \(\s*\n\s*<div key=\{wi\} role="row"/, "day cells render as one ARIA row per week");
+assert.match(view, /role="gridcell"\s*\n\s*data-month-cell="true"\s*\n\s*tabIndex=\{-1\}[\s\S]*?onKeyDown=\{\(e\) => \{[\s\S]*?Enter[\s\S]*?onCell/, "month day cells are roving gridcells, keyboard-operable");
+assert.match(view, /itemSelector: '\[data-month-cell="true"\]',\s*\n\s*columns: 7,/, "month cells rove 2-D over a 7-column grid");
+assert.match(view, /if \(anchorIndex >= 0\) setActiveIndex\(anchorIndex\)/, "the grid's tab stop follows the anchor day");
+// (cave-zqsj) The selected/anchor day was colour-or-nothing; it now carries
+// aria-selected + a ", selected" label token (mirroring the mini-month), and
+// the week header names today instead of a bg tint alone.
+assert.match(view, /aria-selected=\{isAnchor \|\| undefined\}/, "the anchor day is aria-selected");
+assert.match(view, /\$\{isAnchor \? ", selected" : ""\}`\}/, "the anchor day is named selected");
+assert.match(view, /aria-current=\{now && isSameDay\(col\.date, now\) \? "date" : undefined\}/, "the week header today-column carries aria-current");
+assert.match(view, /\{now && isSameDay\(col\.date, now\) && <span className="sr-only">, today<\/span>\}/, "the week header today-column has a text token");
 // Month cells list a day's items in chronological order, like every other view.
 assert.match(view, /list\.sort\(\(a, b\) => \(itemDate\(a\)\?\.getTime\(\) \?\? 0\) - \(itemDate\(b\)\?\.getTime\(\) \?\? 0\)\)/, "Month items are sorted by time");
 // Month deadline overflow surfaces a "+N due" affordance instead of dropping silently.
@@ -110,8 +126,9 @@ assert.match(view, /aria-label=\{`\$\{deadline\.title\}, task deadline/, "deadli
 assert.match(view, /function MiniMonthPopover[\s\S]*?useFocusTrap\(true, ref, \{ onEscape: onClose \}\)/, "MiniMonthPopover traps focus");
 // Today is conveyed with aria-current, not colour alone (month cell + mini-month).
 assert.ok((view.match(/aria-current=\{isToday \? "date" : undefined\}/g) ?? []).length >= 2, "today is marked with aria-current=\"date\"");
-// Horizontal arrows don't page the period out from under a focused grid event.
-assert.match(view, /if \(target\.closest\('\[data-calendar-event="true"\]'\)\) break;/, "a focused event keeps its own Arrow handling");
+// Horizontal arrows don't page the period out from under a focused grid event
+// or month day-cell (both own their arrows via roving nav).
+assert.match(view, /if \(target\.closest\('\[data-calendar-event="true"\], \[data-month-cell="true"\]'\)\) break;/, "a focused event or month cell keeps its own Arrow handling");
 
 // ───────── Detail panel reconciles with live items (cave-latd) ─────────
 // `selectedItem` is a snapshot captured at click; an effect keyed on

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1002,6 +1002,7 @@ function WeekView({
           {columns.map((col, i) => (
             <div
               key={i}
+              aria-current={now && isSameDay(col.date, now) ? "date" : undefined}
               className={`group relative flex-1 min-w-[80px] px-2 py-2 text-center ${
                 now && isSameDay(col.date, now) ? "bg-[color-mix(in_oklch,var(--accent-presence)_10%,transparent)]" : ""
               }`}
@@ -1026,6 +1027,7 @@ function WeekView({
                 }`}
               >
                 {col.date.getDate()}
+                {now && isSameDay(col.date, now) && <span className="sr-only">, today</span>}
               </div>
             </div>
           ))}
@@ -1073,6 +1075,21 @@ function MonthView({
 
   // 6 weeks × 7 days grid
   const cells = Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+  const weeks = Array.from({ length: 6 }, (_, w) => cells.slice(w * 7, w * 7 + 7));
+
+  // 2-D roving focus over the day cells (←/→ = day, ↑/↓ = week), per the
+  // WAI-ARIA grid pattern. The tab stop follows the anchor day — the roving
+  // default of "first cell" would land on the previous month's tail.
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const { setActiveIndex } = useRovingTabIndex({
+    containerRef: gridRef,
+    itemSelector: '[data-month-cell="true"]',
+    columns: 7,
+  });
+  const anchorIndex = cells.findIndex((d) => isSameDay(d, anchor));
+  useEffect(() => {
+    if (anchorIndex >= 0) setActiveIndex(anchorIndex);
+  }, [anchorIndex, setActiveIndex]);
 
   const byDay = useMemo(() => {
     const map = new Map<string, InboxItem[]>();
@@ -1107,25 +1124,35 @@ function MonthView({
     <div className="flex flex-1 flex-col overflow-hidden px-2 pb-3 sm:px-4 sm:pb-4">
       {/* Weekday headers */}
       <div className="min-h-0 flex-1 overflow-x-auto">
-        <div className="flex h-full min-w-[560px] flex-col">
-          <div className="mb-1 grid grid-cols-7">
+        <div
+          ref={gridRef}
+          role="grid"
+          aria-label={`${MONTHS[anchor.getMonth()]} ${anchor.getFullYear()}`}
+          className="flex h-full min-w-[560px] flex-col"
+        >
+          <div role="row" className="mb-1 grid grid-cols-7">
             {WEEKDAYS.map((wd) => (
               <div
                 key={wd}
+                role="columnheader"
                 className="py-1 text-center text-[10px] uppercase tracking-wider text-[var(--text-secondary)]"
               >
                 {wd}
               </div>
             ))}
           </div>
-          {/* Day cells */}
-          <div className="grid flex-1 grid-cols-7 grid-rows-6 gap-px overflow-hidden rounded-lg bg-[var(--border-hairline)]">
-            {cells.map((day, i) => {
+          {/* Day cells — one row per week (flex-col + gap-px reproduces the
+              old grid-rows-6 hairline lattice while giving SRs real rows). */}
+          <div role="rowgroup" className="flex flex-1 flex-col gap-px overflow-hidden rounded-lg bg-[var(--border-hairline)]">
+            {weeks.map((week, wi) => (
+            <div key={wi} role="row" className="grid flex-1 grid-cols-7 gap-px">
+            {week.map((day) => {
               const key = startOfDay(day).toISOString();
               const dayItems = byDay.get(key) ?? [];
               const dayDeadlines = deadlinesByDay.get(key) ?? [];
               const isCurrentMonth = day.getMonth() === anchor.getMonth();
               const isToday = now ? isSameDay(day, now) : false;
+              const isAnchor = isSameDay(day, anchor);
 
               // Clicking an empty part of a current-month day pre-fills the add
               // form for that day; the date number still navigates into the day.
@@ -1137,11 +1164,13 @@ function MonthView({
               };
               return (
                 <div
-                  key={i}
-                  role="button"
-                  tabIndex={0}
+                  key={key}
+                  role="gridcell"
+                  data-month-cell="true"
+                  tabIndex={-1}
+                  aria-selected={isAnchor || undefined}
                   aria-current={isToday ? "date" : undefined}
-                  aria-label={`${canAdd ? `Add a reminder on ${fmtDateHeading(day)}` : fmtDateHeading(day)}${itemsSuffix}`}
+                  aria-label={`${canAdd ? `Add a reminder on ${fmtDateHeading(day)}` : fmtDateHeading(day)}${itemsSuffix}${isAnchor ? ", selected" : ""}`}
                   onClick={onCell}
                   onKeyDown={(e) => {
                     if (e.key === "Enter" || e.key === " ") {
@@ -1225,6 +1254,8 @@ function MonthView({
                 </div>
               );
             })}
+            </div>
+            ))}
           </div>
         </div>
       </div>
@@ -1606,10 +1637,11 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
       const tag = target.tagName.toLowerCase();
       if (["input", "textarea", "select"].includes(tag) || target.isContentEditable) return;
       switch (e.key) {
-        // A focused grid event owns its own Arrow handling (roving nav +
-        // Alt+↑/↓ reschedule); don't also page the whole period out from under it.
-        case "ArrowLeft":  if (target.closest('[data-calendar-event="true"]')) break; e.preventDefault(); navigate(-1); break;
-        case "ArrowRight": if (target.closest('[data-calendar-event="true"]')) break; e.preventDefault(); navigate(1);  break;
+        // A focused grid event or month day-cell owns its own Arrow handling
+        // (roving nav + Alt+↑/↓ reschedule); don't also page the whole period
+        // out from under it.
+        case "ArrowLeft":  if (target.closest('[data-calendar-event="true"], [data-month-cell="true"]')) break; e.preventDefault(); navigate(-1); break;
+        case "ArrowRight": if (target.closest('[data-calendar-event="true"], [data-month-cell="true"]')) break; e.preventDefault(); navigate(1);  break;
         case "t": case "T": setAnchor(new Date()); break;
         case "d": case "D": setViewMode("day");    break;
         case "w": case "W": setViewMode("week");   break;

--- a/src/lib/use-roving-tabindex.test.ts
+++ b/src/lib/use-roving-tabindex.test.ts
@@ -79,4 +79,16 @@ assert.match(
   "roving ignores modified arrow keys",
 );
 
+// 2-D grid roving (cave-zqsj): with `columns` set, ↑/↓ move by a whole row,
+// and a row-step off the top/bottom edge stays put instead of clamping (which
+// would slide the focus into a different column).
+assert.match(source, /columns\?\: number/, "hook exposes a columns option for grid roving");
+assert.match(source, /move\(columns \?\? 1\)/, "ArrowDown moves a whole row in grid mode");
+assert.match(source, /move\(-\(columns \?\? 1\)\)/, "ArrowUp moves a whole row in grid mode");
+assert.match(
+  source,
+  /columns && Math\.abs\(delta\) > 1 && \(next < 0 \|\| next >= items\.length\)/,
+  "a grid row-step off the edge is a no-op, not a clamp",
+);
+
 console.log("use-roving-tabindex.test.ts OK");

--- a/src/lib/use-roving-tabindex.ts
+++ b/src/lib/use-roving-tabindex.ts
@@ -13,6 +13,13 @@ type Options = {
   orientation?: Orientation;
   /** Wrap from last → first / first → last. Default false. */
   loop?: boolean;
+  /**
+   * Items per visual row. When set, ↑/↓ move by a whole row while ←/→ still
+   * move by one — the WAI-ARIA grid pattern (e.g. a month calendar's 7-column
+   * day grid). A row-step off the top/bottom edge stays put rather than
+   * clamping, so the focus never slides into a different column.
+   */
+  columns?: number;
 };
 
 /**
@@ -29,6 +36,7 @@ export function useRovingTabIndex({
   itemSelector,
   orientation = "both",
   loop = false,
+  columns,
 }: Options) {
   const [activeIndex, setActiveIndex] = useState(0);
   const activeRef = useRef(0);
@@ -80,6 +88,10 @@ export function useRovingTabIndex({
       let next = activeRef.current + delta;
       if (loop) {
         next = (next + items.length) % items.length;
+      } else if (columns && Math.abs(delta) > 1 && (next < 0 || next >= items.length)) {
+        // Grid row-step off the top/bottom edge: stay put (clamping would
+        // slide the focus into a different column).
+        return;
       } else {
         next = Math.max(0, Math.min(items.length - 1, next));
       }
@@ -108,12 +120,12 @@ export function useRovingTabIndex({
         case "ArrowDown":
           if (!vert) return;
           e.preventDefault();
-          move(1);
+          move(columns ?? 1);
           break;
         case "ArrowUp":
           if (!vert) return;
           e.preventDefault();
-          move(-1);
+          move(-(columns ?? 1));
           break;
         case "ArrowRight":
           if (!horiz) return;
@@ -138,7 +150,7 @@ export function useRovingTabIndex({
 
     container.addEventListener("keydown", onKey);
     return () => container.removeEventListener("keydown", onKey);
-  }, [containerRef, getItems, loop, orientation]);
+  }, [containerRef, getItems, loop, orientation, columns]);
 
   return { activeIndex, setActiveIndex };
 }


### PR DESCRIPTION
## Summary

From the calendar-audit bead `cave-zqsj`. The month view was a CSS grid of 42 `<div role="button" tabIndex={0}>` cells: screen readers got no grid dimensions or row/column position, each cell invalidly WRAPPED nested interactive buttons (day number, chips, overflow), there were 42 raw tab stops with no intra-grid arrow navigation, and ←/→ paged the whole month out from under a focused cell.

**Structure.** `MonthView` now renders a labelled `role=grid` → a header `role=row` of `columnheader`s → a `rowgroup` of six `role=row` weeks → `role=gridcell` day cells. The old `grid-rows-6` single-grid lattice is reproduced with `flex-col + gap-px` rows (verified pixel-equal: all six rows 113px in the live app).

**2-D roving.** `useRovingTabIndex` gains a `columns` option — ↑/↓ move a whole row, and a row-step off the top/bottom edge stays put instead of clamping (which would slide focus into a different column). The month roves with `columns: 7`, one tab stop that follows the anchor day. The global ←/→ month-pager now skips targets inside a day cell, mirroring the existing grid-event guard.

**Selection is no longer color-only (WCAG 1.4.1).** The anchor day carries `aria-selected` + a ", selected" label token (exactly what the mini-month popover already did), and the week header's today column gets `aria-current="date"` + an sr-only ", today" instead of a bg tint alone.

## Verification (live app, prod build, Playwright probes)

- Month grid: 7 rows (header + 6 weeks), 7 columnheaders, 42 gridcells, exactly **1** tab stop, `aria-selected`/`aria-current` each present once
- ArrowRight: Jul 8 → Jul 9; ArrowDown: Jul 9 → Jul 16 (same column); the month heading did **not** page during roving
- Week header: `aria-current` + text token present
- Month + Week screenshots pixel-faithful (lattice, chips, today ring, legend)

## Test plan

- [x] Pins updated (`role="button"` cell pin → gridcell/roving pins) and added in `calendar-actions.test.ts`; new `columns` pins in `use-roving-tabindex.test.ts`
- [x] Full `pnpm test:app` (563 files) + `pnpm typecheck` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)