### PR TITLE
fix(chat): /skill picker renders one row per skill id — no duplicate React keys (cave-rru2)

### DIFF
--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -29,6 +29,20 @@ assert.equal(skillSlashOptions("/skills verify", SKILLS).length, 1, "/skills als
 assert.equal(skillSlashOptions("/skill nomatch", SKILLS).length, 0, "no match → empty (not null)");
 assert.equal(skillSlashOptions("/model gpt", SKILLS), null, "a different command → null");
 
+// The scan returns the same skill from several roots (~/.claude/skills +
+// ~/.agents/skills copies). The picker must render one row per id — composers
+// key list items by s.id, so a duplicate here is a duplicate React key AND a
+// doubled menu row (seen live: two `brainstorming` entries).
+const MULTI_ROOT = [
+  { id: "brainstorming", name: "brainstorming", familiar: "user", path: "/u/.claude/skills/brainstorming/SKILL.md" },
+  { id: "code-review", name: "code-review", familiar: "user" },
+  { id: "brainstorming", name: "brainstorming", familiar: "agents-user", path: "/u/.agents/skills/brainstorming/SKILL.md" },
+];
+const dedupedPick = skillSlashOptions("/skill ", MULTI_ROOT);
+assert.deepEqual(dedupedPick.map((s) => s.id), ["brainstorming", "code-review"], "one row per skill id");
+assert.equal(dedupedPick[0].familiar, "user", "first scan root (scope precedence) wins");
+assert.equal(skillSlashOptions("/skill brains", MULTI_ROOT).length, 1, "filtering operates on the deduped list");
+
 // ── resolveSkillArg: exact then substring ────────────────────────────────────
 assert.equal(resolveSkillArg("verify", SKILLS)?.id, "verify", "exact name");
 assert.equal(resolveSkillArg("CODE-REVIEW", SKILLS)?.id, "code-review", "case-insensitive exact");
@@ -48,6 +62,14 @@ const list = formatSkillList(SKILLS);
 assert.match(list, /Available skills/, "list has a header");
 assert.match(list, /deep-research/, "list includes each skill");
 assert.match(formatSkillList([]), /No skills found/, "empty list is explained");
+assert.equal(
+  formatSkillList([
+    { id: "brainstorming", name: "brainstorming" },
+    { id: "brainstorming", name: "brainstorming" },
+  ]).match(/brainstorming/g).length,
+  2, // once in "name — `id`" form on a single line
+  "the bare /skills system message lists a multi-root skill once",
+);
 
 // ── resolveSkillInvocation: whole name first, then first-token + args ────────
 assert.deepEqual(

--- a/src/lib/slash-skill.ts
+++ b/src/lib/slash-skill.ts
@@ -27,6 +27,22 @@ export type SkillOption = {
 const SKILLS_RE = /^\/skills\s*(.*)$/i;
 const SKILL_ARG_RE = /^\/skill\s+(.*)$/i;
 
+/** One row per skill id, first scope wins. /api/skills/local concatenates
+ *  several scan roots and the Skills CLI installs the same skill under both
+ *  ~/.claude/skills and ~/.agents/skills, so raw lists carry duplicates —
+ *  rendering them keys React children by a now-non-unique `s.id` and shows
+ *  every such skill twice. Scan order already encodes scope precedence. */
+export function dedupeSkillsById(skills: SkillOption[]): SkillOption[] {
+  const seen = new Set<string>();
+  const out: SkillOption[] = [];
+  for (const s of skills) {
+    if (seen.has(s.id)) continue;
+    seen.add(s.id);
+    out.push(s);
+  }
+  return out;
+}
+
 function filterSkills(skills: SkillOption[], partial: string): SkillOption[] {
   const q = partial.trim().toLowerCase();
   if (!q) return skills;
@@ -45,7 +61,7 @@ export function skillSlashOptions(text: string, skills: SkillOption[]): SkillOpt
   const t = text.trimStart();
   const m = t.match(SKILLS_RE) ?? t.match(SKILL_ARG_RE);
   if (!m) return null;
-  return filterSkills(skills, m[1]);
+  return filterSkills(dedupeSkillsById(skills), m[1]);
 }
 
 /** Resolve a typed /skill argument to a concrete skill: exact id/name match
@@ -90,19 +106,15 @@ export function buildSkillPrompt(skill: SkillOption, args?: string): string {
 /** Skills surfaced directly in the top-level slash menu — typing `/revi`
  *  matches the code-review skill without the /skill prefix. Gated to 3+ typed
  *  characters so `/` and two-letter prefixes keep the command menu clean, and
- *  capped so skills complement rather than crowd the commands. The scan can
- *  return the same skill from several roots (user + agents copies) — one row
- *  per id, first scope wins, so dupes don't eat the five slots. */
+ *  capped so skills complement rather than crowd the commands. Deduped so
+ *  multi-root copies don't eat the five slots. */
 export function skillCommandMatches(prefix: string, skills: SkillOption[]): SkillOption[] {
   if (!prefix.startsWith("/")) return [];
   const q = prefix.slice(1).toLowerCase();
   if (q.length < 3) return [];
-  const seen = new Set<string>();
   const out: SkillOption[] = [];
-  for (const s of skills) {
+  for (const s of dedupeSkillsById(skills)) {
     if (!(s.id.toLowerCase().includes(q) || s.name.toLowerCase().includes(q))) continue;
-    if (seen.has(s.id)) continue;
-    seen.add(s.id);
     out.push(s);
     if (out.length === 5) break;
   }
@@ -111,10 +123,11 @@ export function skillCommandMatches(prefix: string, skills: SkillOption[]): Skil
 
 /** One-line-per-skill list for the bare `/skill` / `/skills` system message. */
 export function formatSkillList(skills: SkillOption[]): string {
-  if (skills.length === 0) {
+  const unique = dedupeSkillsById(skills);
+  if (unique.length === 0) {
     return "No skills found. Add skills under your Coven skills directory or ~/.claude/skills, then try `/skill` again.";
   }
-  const lines = skills.map(
+  const lines = unique.map(
     (s) => `  ○ ${s.name} — \`${s.id}\`${s.description ? ` — ${s.description}` : ""}`,
   );
   return `Available skills (type \`/skill <name>\` or pick from the menu):\n${lines.join("\n")}`;


### PR DESCRIPTION
## Problem

React console error on Home: `Encountered two children with the same key, 'brainstorming'` from `home-slash-menu.tsx:49` — and the same latent bug in `chat-view.tsx:5227`. Both `/skill` pickers key rows by `s.id`.

Root cause: `/api/skills/local` concatenates five scan roots with no dedup, and the Skills CLI installs the same skill under both `~/.claude/skills` and `~/.agents/skills`. Live probe: 77 entries, **20 duplicated ids**. So beyond the key warning, every multi-root skill rendered **twice** in the picker.

`skillCommandMatches` already handled this ("one row per id, first scope wins") — but `skillSlashOptions` (the `/skill `/`/skills` picker) and `formatSkillList` (the bare `/skills` system message) didn't.

## Fix

Extract `dedupeSkillsById` in `src/lib/slash-skill.ts` and apply it in `skillSlashOptions` (before filtering), `formatSkillList`, and `skillCommandMatches` (replacing its inline seen-set). Scan order already encodes scope precedence, so first-wins keeps `global > user > codex > agents` semantics. Fixes both composers with no component changes; the skill-browser management surface (which legitimately lists per-path copies for deletion) is untouched.

## Validation

- `slash-skill.test.ts` — new pins: one row per id, first scope wins, filtering operates on the deduped list, `/skills` message lists a multi-root skill once
- `pnpm typecheck` ✓ · full app suite running (posted before merge)

Bead: cave-rru2

🤖 Generated with [Claude Code](https://claude.com/claude-code)