### PR TITLE
fix(chat): suggestion pills wrap in uniform rows — 4 is 2×2, never 3+1, cap at 4 (cave-wrso)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8801,15 +8801,19 @@ a.mobile-handoff__link:hover {
 
 /* ── Chat next-path suggestion chips ─────────────────────────────────────────
    Clickable next-step chips under an assistant reply (parsed from the
-   <coven:next-paths> block); clicking sends the suggestion as the next turn. */
+   <coven:next-paths> block); clicking sends the suggestion as the next turn.
+   Rows stay UNIFORM — 1, 2, or 3 chips per row, keyed off the row's chip
+   count (data-count): 2 and 4 chips pair into two columns (4 = 2×2, never a
+   3+1 orphan), and only an exactly-3 row spreads to three columns. */
 .cave-next-paths {
   display: grid; grid-template-columns: 1fr; gap: 6px; margin-top: 10px; width: 100%;
 }
 @container chatturn (min-width: 540px) {
-  .cave-next-paths { grid-template-columns: repeat(2, 1fr); }
+  .cave-next-paths[data-count="2"],
+  .cave-next-paths[data-count="4"] { grid-template-columns: repeat(2, 1fr); }
 }
 @container chatturn (min-width: 760px) {
-  .cave-next-paths { grid-template-columns: repeat(3, 1fr); }
+  .cave-next-paths[data-count="3"] { grid-template-columns: repeat(3, 1fr); }
 }
 .cave-next-path {
   display: inline-flex; align-items: center; width: 100%; max-width: 100%;

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -1098,6 +1098,29 @@ assert.match(
   "the first follow-up is marked as the recommended next step",
 );
 
+// Suggestion pills lay out in UNIFORM rows — 1, 2, or 3 per row, keyed off the
+// chip count: 2 and 4 chips pair into two columns (4 = 2×2, never a 3+1 orphan
+// wrap) and only an exactly-3 row spreads to three columns (cave-wrso).
+assert.match(
+  source,
+  /className="cave-next-paths" data-count=\{nextPaths\.length\}/,
+  "the chip row stamps its count so CSS can key columns off it",
+);
+assert.match(
+  globalsSrc,
+  /\.cave-next-paths\[data-count="2"\],\s*\n\s*\.cave-next-paths\[data-count="4"\] \{ grid-template-columns: repeat\(2, 1fr\); \}/,
+  "2 and 4 chips pair into two columns (4 renders 2×2)",
+);
+assert.match(
+  globalsSrc,
+  /\.cave-next-paths\[data-count="3"\] \{ grid-template-columns: repeat\(3, 1fr\); \}/,
+  "only an exactly-3 row spreads to three columns",
+);
+assert.ok(
+  !/\.cave-next-paths \{ grid-template-columns: repeat\(/.test(globalsSrc),
+  "no count-blind multi-column rule survives (it produced 3+1 orphan wraps)",
+);
+
 // File picker resets its value synchronously so re-selecting the same file (or
 // re-attaching after the CSV / 10-cap early returns) still fires onChange.
 assert.ok(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -6049,7 +6049,9 @@ function TurnRowImpl({
                 element (click to send), so they sit closest to the composer and
                 aren't pushed up the turn by the tool-activity section. */}
             {nextPaths.length > 0 && !turn.pending ? (
-              <div className="cave-next-paths">
+              // data-count keys the row layout: pills lay out 1, 2, or 3 per
+              // row — 4 pills pair into a 2×2, never a 3+1 orphan wrap.
+              <div className="cave-next-paths" data-count={nextPaths.length}>
                 {nextPaths.map((s, i) => {
                   // The agent lists next steps best-first, so flag the top one as
                   // the recommendation (green pulsing border + leading dot).

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -35,7 +35,11 @@ test("GroupChatView broadcasts via /api/chat/send and reuses pure helpers", () =
     "strips the next-paths block and parses suggestions from coven replies",
   );
   // Parsed suggestions render as click-to-send chips that broadcast the line.
-  assert.match(view, /className="cave-next-paths/, "renders the next-paths chip row");
+  assert.match(
+    view,
+    /className="cave-next-paths mt-1\.5" data-count=\{suggestions\.length\}/,
+    "renders the next-paths chip row, stamping its count for the uniform-rows layout",
+  );
   assert.match(view, /onClick=\{\(\) => void broadcast\(s\)\}/, "clicking a chip broadcasts the suggestion");
 });
 

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -955,7 +955,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                   </div>
                                 ) : null}
                                 {r.status === "done" && suggestions.length > 0 ? (
-                                  <div className="cave-next-paths mt-1.5">
+                                  <div className="cave-next-paths mt-1.5" data-count={suggestions.length}>
                                     {suggestions.map((s, i) => {
                                       // The agent lists next steps best-first, so
                                       // flag the top one as the recommendation.

--- a/src/lib/next-paths.test.ts
+++ b/src/lib/next-paths.test.ts
@@ -31,4 +31,10 @@ assert.equal(buildNextPathsDirective(0), "");
   assert.equal(r.visible, "Answer.");
   assert.deepEqual(r.suggestions, ["Run the tests", "Open a"]);
 }
+// over-eager agent -> at most 4 pills ever surface (the chip-row product cap)
+{
+  const lines = ["One", "Two", "Three", "Four", "Five", "Six"].map((s) => `- ${s}`).join("\n");
+  const r = extractNextPaths(`Answer.\n<coven:next-paths>\n${lines}\n</coven:next-paths>`);
+  assert.deepEqual(r.suggestions, ["One", "Two", "Three", "Four"]);
+}
 console.log("next-paths.test.ts: ok");

--- a/src/lib/next-paths.ts
+++ b/src/lib/next-paths.ts
@@ -53,7 +53,9 @@ export function extractNextPaths(text: string): { visible: string; suggestions: 
     .split(/\r?\n/)
     .map((l) => l.replace(/^\s*[-*•]\s*/, "").trim())
     .filter((l) => l.length > 0 && !l.startsWith("first next step") && !l.startsWith("second next step"))
-    .slice(0, 6);
+    // At most 4 pills ever render — the chip row's product cap (an over-eager
+    // agent that lists more gets trimmed, not a fifth row).
+    .slice(0, DEFAULT_NEXT_PATHS_COUNT);
   const visible = (text.slice(0, open) + text.slice(blockEnd)).replace(/\s+$/, "");
   return { visible, suggestions };
 }


### PR DESCRIPTION
## Summary

The suggestion pills under assistant replies (`.cave-next-paths`) laid out on a width-only container-query grid — 1/2/3 columns purely by turn width — so **4 chips on a wide turn wrapped as a 3+1 orphan**. Per the layout rule: pills come **1, 2, or 3 per row, rows stay uniform, 4 chips render 2×2 (never 3+1), and at most 4 pills ever show**.

- `extractNextPaths` caps parsed suggestions at `DEFAULT_NEXT_PATHS_COUNT` (4, was 6) — a fifth pill never renders even from an over-eager agent.
- The chip row stamps `data-count` (chat + group chat) and the grid keys columns off it:
  - `data-count="2"` / `data-count="4"` → two columns at ≥540px (4 = 2×2)
  - `data-count="3"` → three columns at ≥760px (one row of three)
  - otherwise (and on narrow turns) → single column
- No count-blind multi-column rule survives; group chat (no `chatturn` container ancestor) keeps its stacked single-column fallback.

Complements #2642, which shaped the *count* ("2 or 4, never 3") — this shapes the *rows*.

## Testing

- `next-paths.test.ts` — new cap assertion (6 parsed lines → 4 suggestions) + existing parse/streaming cases green.
- `chat-view-polish.test.ts` — pins `data-count` stamping, the 2/4→2-col and 3→3-col rules, and the absence of any count-blind `repeat(` rule.
- `group-chat-view.test.ts` — pin updated for the stamped chip row; all 5 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)