### PR TITLE
feat(chat): Codex model catalog + anonymous-calm landing + skill scan realpath dedupe

### DIFF
--- a/src/app/api/skills/local/route.ts
+++ b/src/app/api/skills/local/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { rm } from "node:fs/promises";
 import { covenHome } from "@/lib/coven-paths";
 import {
+  dedupeByRealPath,
   scanAgentSharedSkills,
   scanClaudeUserSkills,
   scanCodexUserSkills,
@@ -30,7 +31,10 @@ export async function GET() {
   skills.push(...await scanCodexUserSkills());
   skills.push(...await scanAgentSharedSkills());
 
-  return NextResponse.json({ ok: true, skills });
+  // The same physical skill often appears under several roots (~/.claude/skills
+  // symlinks into ~/.agents/skills); collapse those so id-keyed consumers don't
+  // render duplicate rows.
+  return NextResponse.json({ ok: true, skills: await dedupeByRealPath(skills) });
 }
 
 // Remove a scanned skill's directory. Destructive → local-origin gated and

--- a/src/components/chat-empty-state.tsx
+++ b/src/components/chat-empty-state.tsx
@@ -21,7 +21,6 @@ import type { CaveProject } from "@/lib/cave-projects-types";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import { Icon } from "@/lib/icon";
 import { ProjectPicker } from "@/components/project-picker";
-import { FamiliarIcon } from "@/components/familiar-icon";
 import { NO_PROJECT_ID, chatProjectById, filterVisibleChatSessions } from "@/lib/chat-projects";
 import { cardMatchesProject, deriveOpenTaskCards, deriveContinueThreads } from "@/lib/chat-open-tasks";
 import { deriveStarterSuggestions } from "@/lib/chat-starter-suggestions";
@@ -259,13 +258,7 @@ export function ChatEmptyState({
         </p>
 
         <div className="cave-chat-empty-familiar">
-          <div className="cave-chat-empty-mark">
-            <FamiliarIcon familiar={familiar} size="lg" />
-          </div>
           <div className="cave-chat-empty-familiar-copy">
-            <h2 className="cave-chat-empty-title">
-              {familiar.display_name}
-            </h2>
             {role ? <p className="cave-chat-empty-role">{role}</p> : null}
             <p className="cave-chat-empty-meta">
               <span>{familiar.harness}</span>

--- a/src/components/inspector-pane.tsx
+++ b/src/components/inspector-pane.tsx
@@ -1231,7 +1231,7 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
             ) : (
               <ul className="space-y-1 pt-1">
                 {familiarSkills.map((s) => (
-                  <li key={s.id} className="rounded bg-[color-mix(in_oklch,var(--color-success)_10%,transparent)] px-2 py-1">
+                  <li key={s.path} className="rounded bg-[color-mix(in_oklch,var(--color-success)_10%,transparent)] px-2 py-1">
                     <div className="flex items-center gap-1.5">
                       <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
                       <KindBadge kind={s.kind ?? "agent"} />
@@ -1276,7 +1276,7 @@ function FamiliarCapabilityPanel({ familiar }: { familiar: Familiar | null }) {
             ) : (
               <ul className="space-y-1 pt-1">
                 {globalSkills.map((s) => (
-                  <li key={s.id} className="rounded bg-[var(--bg-raised)]/60 px-2 py-1">
+                  <li key={s.path} className="rounded bg-[var(--bg-raised)]/60 px-2 py-1">
                     <div className="flex items-center gap-1.5">
                       <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
                       <KindBadge kind={s.kind ?? "agent"} />

--- a/src/lib/context-meter.ts
+++ b/src/lib/context-meter.ts
@@ -30,6 +30,10 @@ export const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
 export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   // OpenAI (codex runtime) — estimate; adjust when authoritative.
   "openai/gpt-5.5": 400_000,
+  "openai/gpt-5.1-codex-max": 400_000,
+  "openai/gpt-5.1-codex": 400_000,
+  "openai/gpt-5.1-codex-mini": 400_000,
+  "openai/gpt-5.1": 400_000,
   // Anthropic (claude runtime) — from the Claude models catalog.
   "anthropic/claude-fable-5": 1_000_000,
   "anthropic/claude-opus-4-8": 1_000_000,

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -32,6 +32,16 @@ assert.ok(
   !catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
   "claude catalog should not offer Claude Fable 5",
 );
+assert.ok(catalogForRuntime("codex").models.length > 1, "codex should seed a multi-model menu, not just the default");
+assert.ok(
+  catalogForRuntime("codex").models.some((m) => m.id === "openai/gpt-5.1-codex"),
+  "codex catalog should seed GPT-5.1 Codex",
+);
+assert.equal(
+  catalogForRuntime("codex").models[0].id,
+  "openai/gpt-5.5",
+  "GPT-5.5 must stay first so it remains the codex default",
+);
 
 // Namespaced model id convention (`provider/model`) holds across the seed.
 for (const catalog of Object.values(RUNTIME_MODEL_CATALOG)) {

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -32,7 +32,13 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
   codex: {
     runtime: "codex",
     provider: "openai",
-    models: [{ id: "openai/gpt-5.5", label: "GPT-5.5" }],
+    models: [
+      { id: "openai/gpt-5.5", label: "GPT-5.5" },
+      { id: "openai/gpt-5.1-codex-max", label: "GPT-5.1 Codex Max" },
+      { id: "openai/gpt-5.1-codex", label: "GPT-5.1 Codex" },
+      { id: "openai/gpt-5.1-codex-mini", label: "GPT-5.1 Codex Mini" },
+      { id: "openai/gpt-5.1", label: "GPT-5.1" },
+    ],
     allowCustom: true,
   },
   claude: {

--- a/src/lib/server/skill-scan.ts
+++ b/src/lib/server/skill-scan.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { homedir } from "node:os";
 
@@ -123,6 +123,30 @@ export async function scanSkillsDir(dir: string, familiar: LocalSkillScope, out:
       });
     } catch { continue; }
   }
+}
+
+/**
+ * Drop entries that are the same skill reached through different scan roots.
+ * The Skills CLI symlinks ~/.claude/skills/<id> to its canonical
+ * ~/.agents/skills copy, so an aggregate scan sees one physical skill twice
+ * and id-keyed consumers render duplicate rows (duplicate React keys).
+ * First-seen wins — the aggregation's scan order sets scope precedence.
+ */
+export async function dedupeByRealPath(entries: LocalSkillEntry[]): Promise<LocalSkillEntry[]> {
+  const seen = new Set<string>();
+  const out: LocalSkillEntry[] = [];
+  for (const entry of entries) {
+    let key = entry.path;
+    try {
+      key = await realpath(entry.path);
+    } catch {
+      // Unresolvable (dangling symlink, race) — fall back to the declared path.
+    }
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(entry);
+  }
+  return out;
 }
 
 /** The user's own Claude Code skills (~/.claude/skills). */

--- a/src/lib/server/skills-directory.ts
+++ b/src/lib/server/skills-directory.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { covenHome } from "@/lib/coven-paths";
 import {
+  dedupeByRealPath,
   scanAgentSharedSkills,
   scanClaudeUserSkills,
   scanCodexUserSkills,
@@ -551,11 +552,15 @@ function isDirectoryMatch(entry: SkillDirectoryEntry, key: string, source?: stri
 
 export async function listSkillDirectoryEntriesWithLocal(query?: string): Promise<SkillDirectoryListResponse> {
   const q = normalizeSearchQuery(query);
-  const locals: LocalSkillEntry[] = [];
-  await scanSkillsDir(path.join(covenHome(), "skills"), "global", locals);
-  await scanClaudeUserSkills().then((items) => locals.push(...items));
-  await scanCodexUserSkills().then((items) => locals.push(...items));
-  await scanAgentSharedSkills().then((items) => locals.push(...items));
+  const rawLocals: LocalSkillEntry[] = [];
+  await scanSkillsDir(path.join(covenHome(), "skills"), "global", rawLocals);
+  await scanClaudeUserSkills().then((items) => rawLocals.push(...items));
+  await scanCodexUserSkills().then((items) => rawLocals.push(...items));
+  await scanAgentSharedSkills().then((items) => rawLocals.push(...items));
+  // One physical skill can sit under several roots (~/.claude/skills symlinks
+  // into ~/.agents/skills) — collapse those before the directory merge so the
+  // browser doesn't list the same install twice.
+  const locals = await dedupeByRealPath(rawLocals);
 
   const directory = await listSkillDirectoryEntries(q);
   const merged = mergeDirectoryWithLocal(directory.entries, locals);

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -1120,45 +1120,25 @@
   }
 }
 
+/* Identity row without the identity: the avatar and name are retired so the
+   landing stays anonymous-calm — only the quiet role + runtime meta remain,
+   centered under the greeting. */
 .cave-chat-empty-familiar {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-}
-
-.cave-chat-empty-mark {
-  display: grid;
-  place-items: center;
-  flex: 0 0 auto;
-  width: 44px;
-  height: 44px;
-  color: var(--accent-presence);
-}
-/* The mark now holds the real familiar avatar/glyph (which carries its own
-   color), so the frame stays neutral — no competing accent box. */
-.cave-chat-empty-mark img,
-.cave-chat-empty-mark > * {
-  border-radius: 9px;
 }
 
 .cave-chat-empty-familiar-copy {
   min-width: 0;
-}
-
-.cave-chat-empty-title {
-  margin: 0;
-  color: var(--text-primary);
-  font-size: 18px;
-  font-weight: 650;
-  line-height: 1.15;
-  letter-spacing: 0;
+  text-align: center;
 }
 
 .cave-chat-empty-meta {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: center;
   gap: 6px;
   margin: 5px 0 0;
   color: var(--text-muted);
@@ -1249,6 +1229,12 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
+}
+
+/* An odd chip count strands the last chip beside an empty cell; stretching it
+ * across both columns keeps every row of the grid full. */
+.cave-chat-empty-prompts > .cave-chat-empty-prompt:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
 }
 
 .cave-chat-empty-prompt {
@@ -1352,9 +1338,9 @@
   text-align: center;
 }
 
-/* Familiar role — quiet secondary line between the name and the meta row. */
+/* Familiar role — quiet lead line of the identity block, above the meta row. */
 .cave-chat-empty-role {
-  margin: 2px 0 0;
+  margin: 0;
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 1.3;
@@ -1710,19 +1696,6 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 
   .cave-chat-empty-shell {
     gap: 12px;
-  }
-
-  .cave-chat-empty-familiar {
-    justify-content: flex-start;
-  }
-
-  .cave-chat-empty-mark {
-    width: 38px;
-    height: 38px;
-  }
-
-  .cave-chat-empty-title {
-    font-size: 16px;
   }
 
   .cave-chat-empty-meta {


### PR DESCRIPTION
Three chat-surface improvements from one working session.

## 1. Codex runtime: full model lineup

`RUNTIME_MODEL_CATALOG.codex` seeded only GPT-5.5. It now also offers GPT-5.1 Codex Max, GPT-5.1 Codex, GPT-5.1 Codex Mini, and GPT-5.1 — GPT-5.5 stays first so `defaultModelForRuntime` is unchanged. Matching 400k entries in `MODEL_CONTEXT_WINDOWS` keep the context meter from falling back to the conservative 200k unknown-model default. New test pins: multi-model menu, GPT-5.1 Codex present, GPT-5.5 first.

## 2. Session starting page: anonymous-calm identity

The empty-chat landing dropped the familiar avatar and display name; only the quiet role line and the runtime meta row (`harness · model · project files ready`) remain, centered under the greeting. Dead `.cave-chat-empty-mark` / `.cave-chat-empty-title` CSS removed (base + mobile). Also: a lone odd starter chip now spans both grid columns (`:last-child:nth-child(odd)`), so the prompts row never renders next to an empty cell.

## 3. Local skill scan: dedupe by realpath

`/api/skills/local` concatenates five scan roots, and the Skills CLI symlinks `~/.claude/skills/<id>` to its canonical `~/.agents/skills` copy — one physical skill came back twice (20 live dupes). New `dedupeByRealPath` in `skill-scan.ts` resolves each `SKILL.md` through symlinks and keeps first-seen (scan order = scope precedence); applied in the local route and in the skill browser's `listSkillDirectoryEntriesWithLocal`.

Complements #2671 (id-level dedupe at the picker layer): this fixes the source of truth for every consumer — inspector, automation skill select, skill browser installed rows. Distinct real installs sharing an id (e.g. a Codex-scoped copy of `lit-ui-designer`) are correctly kept, so the inspector's lists now key by `path` instead of id.

## Verification

- Live probe: `/api/skills/local` went 77 entries / 20 duplicated ids → 58 / 0 symlink dupes (the one remaining same-id pair is two genuine installs).
- Tests (all pass, run against post-#2671/#2673 main): `runtime-models`, `context-meter`, `slash-model`, `slash-skill`, `chat-empty-state`, `chat-surface-polish`, `chat-view-polish`, `home-composer`, `skills/local route`, `skills-directory`, `api-contracts`, `model-label`, `chat-model-state`, `task-chat-cwd`, `slash-prompt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)