### PR TITLE
perf(familiars): single 30s memory poll — embedded memory view mirrors the parent feed (cave-5dnw)

### DIFF
--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -50,6 +50,22 @@ export type FileMemoryEntry = {
   familiarId?: string;
 };
 
+/**
+ * Memory data supplied by a parent that already fetches /api/coven-memory +
+ * /api/memory (FamiliarsView polls them for its roster stats). Passing this
+ * makes the view a mirror of the parent's single 30s poll instead of running
+ * a duplicate fetch+poll of the same two endpoints. Standalone mounts
+ * (companion rail, studio tab) omit it and keep self-fetching.
+ */
+export type MemoryFeed = {
+  covenEntries: CovenMemoryEntry[];
+  fileEntries: FileMemoryEntry[];
+  error: string | null;
+  loaded: boolean;
+  lastLoadedAt: string | null;
+  reload: () => Promise<void>;
+};
+
 type Props = {
   familiars: Familiar[];
   activeFamiliar: Familiar | null;
@@ -60,6 +76,8 @@ type Props = {
   lockToFamiliar?: boolean;
   /** Compact header for narrow surfaces like the companion rail. */
   compact?: boolean;
+  /** Parent-owned memory data; suppresses this view's own fetch + poll. */
+  feed?: MemoryFeed;
 };
 
 type CovenMemoryResponse =
@@ -124,7 +142,7 @@ function memoryMatches(entry: CovenMemoryEntry | FileMemoryEntry, query: string)
   ].some((value) => value.toLowerCase().includes(query));
 }
 
-export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, limit, lockToFamiliar, compact }: Props) {
+export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFile, limit, lockToFamiliar, compact, feed }: Props) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   const [covenEntries, setCovenEntries] = useState<CovenMemoryEntry[]>([]);
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
@@ -169,6 +187,12 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   }, []);
 
   const load = useCallback(async () => {
+    // Parent-fed mode: the parent owns the fetch; its fresh data flows back
+    // in through the mirror effect below.
+    if (feed) {
+      await feed.reload();
+      return;
+    }
     try {
       const [covenRes, fileRes] = await Promise.all([
         fetch("/api/coven-memory", { cache: "no-store" }),
@@ -192,7 +216,21 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
       setLoaded(true);
       setLastLoadedAt(new Date().toISOString());
     }
-  }, []);
+  }, [feed]);
+
+  // Mirror parent-fed data into the local state the rest of the view (and the
+  // optimistic-delete overlay) already works against. The pending-delete filter
+  // keeps a parent poll landing inside the 4s undo window from resurrecting the
+  // optimistically-removed row — same guard the self-fetching path applies.
+  useEffect(() => {
+    if (!feed) return;
+    const pendingDelete = pendingDeletePathRef.current;
+    setCovenEntries(feed.covenEntries.filter((e) => e.path !== pendingDelete));
+    setFileEntries(feed.fileEntries.filter((e) => e.fullPath !== pendingDelete));
+    setError(feed.error);
+    if (feed.loaded) setLoaded(true);
+    setLastLoadedAt(feed.lastLoadedAt);
+  }, [feed]);
 
   const handleDelete = useCallback(
     (path: string, key: string, source: "coven" | "file") => {
@@ -209,9 +247,12 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
         // Delete committed server-side; stop filtering (unless a newer delete
         // has already claimed the slot).
         if (pendingDeletePathRef.current === path) pendingDeletePathRef.current = null;
+        // Parent-fed mode: refresh the parent's cache so its mirror (and the
+        // roster stats it derives) reflect the deletion promptly.
+        if (feed) void feed.reload();
       });
     },
-    [scheduleDelete],
+    [scheduleDelete, feed],
   );
 
   const handleUndoDelete = useCallback(() => {
@@ -222,10 +263,12 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
   }, [undoDelete, load]);
 
   useEffect(() => {
-    void load();
-  }, [load]);
-  // Pauses in a hidden tab; refreshes on return.
-  usePausablePoll(() => void load(), 30_000);
+    if (!feed) void load();
+  }, [load, feed]);
+  // Pauses in a hidden tab; refreshes on return. Disabled entirely in
+  // parent-fed mode — the parent's single poll covers both components
+  // (cave-5dnw: this used to double-fetch /api/coven-memory + /api/memory).
+  usePausablePoll(() => void load(), 30_000, { enabled: !feed });
 
   useEffect(() => {
     if (activeFamiliar?.id) setFamiliarFilter(activeFamiliar.id);

--- a/src/components/familiars-view.test.ts
+++ b/src/components/familiars-view.test.ts
@@ -54,6 +54,50 @@ assert.match(
   "Memory data refreshes on a 30s pausable poll (pauses in a hidden tab)",
 );
 
+// (cave-5dnw) FamiliarsView's poll is the ONLY memory poll while the studio is
+// open: the embedded FamiliarsMemoryView mounts consume the parent's data via
+// the memoryFeed prop instead of running a duplicate fetch+poll of the same
+// two endpoints.
+assert.match(
+  source,
+  /const memoryFeed = useMemo<MemoryFeed>\(/,
+  "FamiliarsView builds a single memoized memory feed",
+);
+assert.match(
+  source,
+  /reload: loadMemory,/,
+  "the feed exposes the parent's loader as reload",
+);
+assert.ok(
+  (source.match(/feed=\{memoryFeed\}/g) ?? []).length >= 2,
+  "both embedded FamiliarsMemoryView mounts (overlay + detail tab) receive the feed",
+);
+{
+  const memView = readFileSync(new URL("./familiars-memory-view.tsx", import.meta.url), "utf8");
+  assert.match(
+    memView,
+    /usePausablePoll\(\(\) => void load\(\), 30_000, \{ enabled: !feed \}\)/,
+    "FamiliarsMemoryView's own poll is disabled in parent-fed mode",
+  );
+  assert.match(
+    memView,
+    /if \(!feed\) void load\(\);/,
+    "FamiliarsMemoryView skips its initial self-fetch in parent-fed mode",
+  );
+  // The parent-fed mirror must keep the pending-delete filter, or a parent poll
+  // landing inside the 4s undo window resurrects the optimistically-removed row.
+  assert.match(
+    memView,
+    /setCovenEntries\(feed\.covenEntries\.filter\(\(e\) => e\.path !== pendingDelete\)\)/,
+    "the feed mirror filters the pending-delete path (coven entries)",
+  );
+  assert.match(
+    memView,
+    /setFileEntries\(feed\.fileEntries\.filter\(\(e\) => e\.fullPath !== pendingDelete\)\)/,
+    "the feed mirror filters the pending-delete path (file entries)",
+  );
+}
+
 assert.match(
   source,
   /buildFamiliarCardStats\(\{[\s\S]*familiars,[\s\S]*sessions,[\s\S]*covenEntries[\s\S]*\}\)/,

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -14,7 +14,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { FamiliarsMemoryView, MemoryFilesList } from "@/components/familiars-memory-view";
-import type { FileMemoryEntry } from "@/components/familiars-memory-view";
+import type { FileMemoryEntry, MemoryFeed } from "@/components/familiars-memory-view";
 import { FamiliarDailyNotes } from "@/components/familiar-daily-notes";
 import { HomeFeed } from "@/components/home/home-feed";
 import { Modal } from "@/components/ui/modal";
@@ -87,6 +87,7 @@ export function FamiliarsView({
   const [fileEntries, setFileEntries] = useState<FileMemoryEntry[]>([]);
   const [memoryError, setMemoryError] = useState<string | null>(null);
   const [memoryLoaded, setMemoryLoaded] = useState(false);
+  const [memoryLoadedAt, setMemoryLoadedAt] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const [previewFamiliar, setPreviewFamiliar] = useState<ResolvedFamiliar | null>(null);
@@ -145,6 +146,7 @@ export function FamiliarsView({
       setMemoryError(err instanceof Error ? err.message : "memory unavailable");
     } finally {
       setMemoryLoaded(true);
+      setMemoryLoadedAt(new Date().toISOString());
     }
   }, []);
 
@@ -153,6 +155,21 @@ export function FamiliarsView({
   }, [loadMemory]);
   // Pauses in a hidden tab; refreshes on return.
   usePausablePoll(() => void loadMemory(), 30_000);
+
+  // Single source of truth for the memory endpoints: the embedded
+  // FamiliarsMemoryView mounts consume this instead of running their own
+  // duplicate fetch + 30s poll of the same two APIs (cave-5dnw).
+  const memoryFeed = useMemo<MemoryFeed>(
+    () => ({
+      covenEntries,
+      fileEntries,
+      error: memoryError,
+      loaded: memoryLoaded,
+      lastLoadedAt: memoryLoadedAt,
+      reload: loadMemory,
+    }),
+    [covenEntries, fileEntries, memoryError, memoryLoaded, memoryLoadedAt, loadMemory],
+  );
 
   const stats = useMemo(
     () => buildFamiliarCardStats({ familiars, sessions, covenEntries }),
@@ -306,6 +323,7 @@ export function FamiliarsView({
               fileEntries={fileEntries}
               memoryError={memoryError}
               memoryLoaded={memoryLoaded}
+              memoryFeed={memoryFeed}
               onClose={backToRoster}
               onPreview={() => setPreviewFamiliar(selectedFamiliar)}
               onStartChat={() => onStartChat(selectedFamiliar.id)}
@@ -350,6 +368,7 @@ export function FamiliarsView({
         <FamiliarMemoryOverlay
           familiars={resolvedFamiliars}
           familiar={memoryFamiliar}
+          memoryFeed={memoryFeed}
           onClose={() => setViewMode(selectedFamiliarId ? "detail" : "roster")}
           onOpenMemoryFile={onOpenMemoryFile}
         />
@@ -521,11 +540,12 @@ function FamiliarRosterCard({
 type AgentMemoryOverlayProps = {
   familiars: ResolvedFamiliar[];
   familiar: ResolvedFamiliar;
+  memoryFeed: MemoryFeed;
   onClose: () => void;
   onOpenMemoryFile: (path: string) => void;
 };
 
-function FamiliarMemoryOverlay({ familiars, familiar, onClose, onOpenMemoryFile }: AgentMemoryOverlayProps) {
+function FamiliarMemoryOverlay({ familiars, familiar, memoryFeed, onClose, onOpenMemoryFile }: AgentMemoryOverlayProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   // Trap focus inside the panel + Escape-to-close + restore focus to the opener.
   useFocusTrap(true, panelRef, { onEscape: onClose });
@@ -557,6 +577,7 @@ function FamiliarMemoryOverlay({ familiars, familiar, onClose, onOpenMemoryFile 
           familiars={familiars}
           activeFamiliar={familiar}
           lockToFamiliar
+          feed={memoryFeed}
           onOpenMemoryFile={onOpenMemoryFile}
         />
       </div>
@@ -640,6 +661,7 @@ type AgentDetailPanelProps = {
   fileEntries: FileMemoryEntry[];
   memoryError: string | null;
   memoryLoaded: boolean;
+  memoryFeed: MemoryFeed;
   onClose: () => void;
   onPreview: () => void;
   onStartChat: () => void;
@@ -657,6 +679,7 @@ function FamiliarDetailPanel({
   fileEntries,
   memoryError,
   memoryLoaded,
+  memoryFeed,
   onClose,
   onPreview,
   onStartChat,
@@ -754,6 +777,7 @@ function FamiliarDetailPanel({
             familiars={familiars}
             activeFamiliar={familiar}
             lockToFamiliar
+            feed={memoryFeed}
             onOpenMemoryFile={onOpenMemoryFile}
           />
         ) : tab === "daily-notes" ? (


### PR DESCRIPTION
## Summary

Bead `cave-5dnw` (from the verified-backlog sweep). FamiliarsView polls `/api/coven-memory` + `/api/memory` every 30s for its roster stats, and every embedded `FamiliarsMemoryView` (memory overlay, detail-panel memory tab) independently ran the **same** fetch + 30s `usePausablePoll` — the studio double-fetched both endpoints every interval.

**Fix: a parent-owned feed.** FamiliarsView builds a memoized `MemoryFeed` (`covenEntries`, `fileEntries`, `error`, `loaded`, `lastLoadedAt`, `reload = loadMemory`) and threads it to the embedded mounts. In parent-fed mode `FamiliarsMemoryView`:
- mirrors the feed into its existing local state (everything downstream — filters, grouping, optimistic delete — is untouched),
- skips its initial self-fetch and disables its own poll via `usePausablePoll(..., { enabled: !feed })`,
- keeps the pending-delete filter in the mirror, so a parent poll landing inside the 4s undo window still cannot resurrect an optimistically-removed row (the guard from #2352),
- and on delete-commit calls `feed.reload()` so the parent cache — and the roster stats derived from it — reflect the deletion promptly.

**Standalone mounts unchanged.** `FamiliarsMemoryView` is also mounted without a parent poll (chat-surface companion rail, familiar-studio memory tab); those pass no `feed` and keep the exact self-fetching behavior they have today.

## Test plan

- [x] New pins in `familiars-view.test.ts`: single memoized feed, `reload: loadMemory`, both mounts receive `feed=`, child poll gated on `!feed`, mirror keeps both pending-delete filters
- [x] All familiars test files pass; full `pnpm test:app` (569 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)