### PR TITLE
a11y(flow): honor prefers-reduced-motion for React Flow controls + viewport pan/zoom (cave-sky3)

### DIFF
--- a/src/components/flow/flow-canvas.test.ts
+++ b/src/components/flow/flow-canvas.test.ts
@@ -108,4 +108,12 @@ assert.match(templateGallery, /disabled=\{busy != null\}/, "template creation di
 assert.match(view, /onUse=\{\(id\) => fromTemplate\(id\)\}/, "FlowTemplateGallery receives the template creation promise");
 assert.doesNotMatch(nodeCatalog, /<button\b/, "NodeCatalogPanel should not hand-roll button controls");
 
+// ── Reduced motion (cave-sky3): React Flow's own chrome must honour it too ──
+// The Controls buttons and the viewport pan/zoom transition (fitView/zoomTo)
+// ship no reduced-motion flag of their own, so flow.css must zero them.
+const rmBlock = styles.match(/@media \(prefers-reduced-motion: reduce\) \{[\s\S]*?\.react-flow__viewport[\s\S]*?\}\s*\}/)?.[0] ?? "";
+assert.match(rmBlock, /\.react-flow__controls-button/, "reduced-motion zeros the Flow controls-button transitions");
+assert.match(rmBlock, /\.react-flow__viewport[\s\S]*?transition: none !important/, "reduced-motion zeros the viewport pan/zoom transition (beats React Flow's inline transition)");
+assert.match(styles, /@media \(prefers-reduced-motion: reduce\) \{ \.flow-run-step-spin \{ animation: none; \} \}/, "the existing run-step spinner guard stays");
+
 console.log("flow-canvas.test.ts OK");

--- a/src/styles/flow.css
+++ b/src/styles/flow.css
@@ -179,7 +179,23 @@
   color: var(--text-primary);
   border-color: color-mix(in oklch, var(--accent-presence) 55%, var(--border));
 }
-@media (prefers-reduced-motion: reduce) { .flow-edge-add { transition: none; } }
+/* Reduced-motion (design-language a11y non-negotiable): zero the mid-edge "+"
+   fade AND React Flow's own chrome motion — the Controls buttons' hover/press
+   transitions and the viewport pan/zoom transition that @xyflow/react runs
+   during fitView / zoomTo (it ships no reduced-motion flag of its own). The
+   `!important` on the viewport/pane beats the inline `transition` React Flow
+   sets while animating. Complements the .flow-run-step-spin guard below. */
+@media (prefers-reduced-motion: reduce) {
+  .flow-edge-add,
+  .flow-canvas .react-flow__controls-button {
+    transition: none;
+  }
+  .flow-canvas .react-flow__viewport,
+  .flow-canvas .react-flow__pane {
+    transition: none !important;
+    animation: none !important;
+  }
+}
 
 /* ---- Node card ---------------------------------------------------------- */
 .flow-node {


### PR DESCRIPTION
## What

`flow.css` already guarded the mid-edge "+" fade and the run-step spinner, but two motion sources were unguarded under `prefers-reduced-motion`:
- the **React Flow Controls buttons'** hover/press transitions, and
- the **viewport pan/zoom transition** `@xyflow/react` runs during `fitView` / `zoomTo` — it ships no reduced-motion flag of its own.

Extend the reduced-motion block to zero both. The `!important` on `.react-flow__viewport` / `.react-flow__pane` beats the inline `transition` React Flow sets while animating the viewport. Design-language a11y makes reduced-motion mandatory.

Pinned in `flow-canvas.test.ts` (controls-button + viewport rules present; the existing run-step spinner guard preserved).

## Verification

`typecheck` · **569** app test files · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)