### PR TITLE
docs(terminal): pin the keepalive visibility invariant (cave-hnn5 verified false positive)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3134,6 +3134,8 @@ textarea.required-inputs-control {
 .comux-terminal-keepalive {
   position: absolute;
   inset: 0;
+  /* visibility (never opacity/clip): keeps xterm's helper textarea inside the
+     aria-hidden wrapper unfocusable — see cave-hnn5 pin. */
   visibility: hidden;
   pointer-events: none;
 }

--- a/src/components/comux-broadcast-wiring.test.ts
+++ b/src/components/comux-broadcast-wiring.test.ts
@@ -42,4 +42,14 @@ assert.equal((term.match(/writerRef\.current = \(d\) =>/g) || []).length, 2, "ex
 assert.match(css, /\.comux-terminal-pane\[data-broadcast="true"\]/, "broadcast pane ring styled");
 assert.match(css, /\.comux-terminal-toolbar-button\[data-broadcast-active="true"\]/, "broadcast toggle styled");
 
+// ── Keepalive a11y invariant (cave-hnn5) ────────────────────────────────────
+// The keepalive wrapper hides inactive sessions' panes with visibility:hidden.
+// That's the load-bearing property: xterm's helper textarea only opacity-hides
+// itself, so it's the inherited visibility that keeps it unfocusable inside
+// the aria-hidden wrapper (WCAG 4.1.2). Swapping the hiding mechanism to
+// opacity/clip would strand focusable content in aria-hidden — if you change
+// it, add `inert` to the wrapper.
+assert.match(comux, /className="comux-terminal-keepalive" aria-hidden="true"/, "keepalive wrapper is aria-hidden");
+assert.match(css, /\.comux-terminal-keepalive \{[^}]*visibility: hidden/s, "keepalive hides via visibility, keeping descendants unfocusable");
+
 console.log("comux-broadcast-wiring.test.ts passed");

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1714,6 +1714,12 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
                     ? renderTerminalNode({ kind: "leaf", sessionId: zoomedSessionId })
                     : renderTerminalNode(terminalLayout.root)
                   : null}
+                {/* a11y invariant (cave-hnn5): the keepalive class hides via
+                    visibility:hidden, which makes every descendant — including
+                    xterm's helper textarea, which only opacity-hides itself —
+                    unfocusable AND hidden from AT. So this aria-hidden never
+                    hides focusable content. If the CSS ever moves to
+                    opacity/clip hiding, add `inert` here. */}
                 <div className="comux-terminal-keepalive" aria-hidden="true">
                   {hiddenPaneSessions.map((s) => (
                     <BottomTerminal


### PR DESCRIPTION
## Summary

Bead `cave-hnn5` claimed the hidden keepalive terminal panes violate WCAG 4.1.2: an `aria-hidden="true"` wrapper containing xterm's focusable helper textarea.

**Verified false.** `.comux-terminal-keepalive` hides via `visibility: hidden` (globals.css), and visibility-hidden descendants are unfocusable per spec — they're skipped by Tab and `.focus()` no-ops. xterm's helper textarea only opacity-hides itself (`opacity: 0` + offscreen, no `visibility` override anywhere in xterm.css or our styles), so the inherited `visibility` is exactly what keeps it out of the tab order. No focusable content is stranded inside `aria-hidden`; adding `inert` would be a no-op today.

**What this PR does instead:** encodes the invariant so it can't silently break — this finding has now been raised twice (terminal audit deferred it; the backlog re-verify confirmed it wrongly), and the failure mode is real *if* someone ever swaps the hiding mechanism to opacity/clip (e.g. to keep canvases painting):

- comments at both sites (the JSX wrapper and the CSS rule) naming the dependency
- pins in `comux-broadcast-wiring.test.ts` (which already reads both sources) asserting the wrapper stays `aria-hidden` and the class keeps `visibility: hidden`, with instructions to add `inert` if that changes

## Test plan

- [x] `comux-broadcast-wiring.test.ts` passes with the new pins; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)