### PR TITLE
perf(browser): lazy-load BrowserPane — last surface in the boot bundle (cave-masj)

### DIFF
--- a/src/components/browser-pane-hooks.test.ts
+++ b/src/components/browser-pane-hooks.test.ts
@@ -60,4 +60,30 @@ assert.doesNotMatch(
   "navigateTo must not call React hooks when invoked through the imperative ref",
 );
 
+// ── Lazy-loading (cave-masj) ─────────────────────────────────────────────────
+// BrowserPane was the last surface shipping in the boot bundle. It now loads
+// through lazy-surfaces, and its imperative handle rides the regular
+// `handleRef` prop because next/dynamic does not forward element refs.
+assert.match(
+  source,
+  /useImperativeHandle\(handleRef, \(\) => \(\{ navigateTo \}\)/,
+  "the imperative handle registers on the handleRef prop",
+);
+assert.doesNotMatch(source, /forwardRef/, "BrowserPane no longer uses forwardRef (handleRef prop instead)");
+{
+  const lazy = await readFile(new URL("./lazy-surfaces.tsx", import.meta.url), "utf8");
+  assert.match(
+    lazy,
+    /timed\("browser", \(\) => import\("@\/components\/browser-pane"\)\.then\(\(m\) => m\.BrowserPane\)\)/,
+    "lazy-surfaces exports a code-split BrowserPane",
+  );
+  const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+  assert.doesNotMatch(
+    workspace,
+    /import \{[^}]*BrowserPane[^}]*\} from "@\/components\/browser-pane"/,
+    "workspace must not statically import the BrowserPane component (type-only imports are fine)",
+  );
+  assert.match(workspace, /handleRef=\{browserPaneRef\}/, "workspace passes the handle through the handleRef prop");
+}
+
 console.log("browser-pane-hooks.test.ts: ok");

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
+import React, { useEffect, useRef, useState, useCallback, useImperativeHandle } from "react";
 import { Icon } from "@/lib/icon";
 import { IconButton } from "@/components/ui/icon-button";
 import { BrowserQuickOpen } from "@/components/browser-quick-open";
@@ -239,7 +239,10 @@ export type BrowserPaneHandle = {
   navigateTo: (url: string) => void;
 };
 
-export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activeFamiliarId?: string | null; active?: boolean }>(function BrowserPane({ label = "default", activeFamiliarId = null, active = true }: { label?: string; activeFamiliarId?: string | null; active?: boolean }, ref: React.Ref<BrowserPaneHandle>) {
+// The imperative handle rides a regular `handleRef` prop (not an element ref):
+// BrowserPane loads through next/dynamic (lazy-surfaces), whose wrapper does
+// not forward element refs — a plain prop crosses the boundary losslessly.
+export function BrowserPane({ label = "default", activeFamiliarId = null, active = true, handleRef }: { label?: string; activeFamiliarId?: string | null; active?: boolean; handleRef?: React.Ref<BrowserPaneHandle> }) {
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const paneRef = useRef<HTMLDivElement | null>(null);
   const [bridge, setBridge] = useState<TauriBridge | null>(null);
@@ -589,7 +592,7 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
     setToolbarOpen(false);
   };
 
-  useImperativeHandle(ref, () => ({ navigateTo }), [navigateTo]);
+  useImperativeHandle(handleRef, () => ({ navigateTo }), [navigateTo]);
 
   const h = historyRef.current[activeTabId] ?? { stack: [activeUrl], idx: 0 };
   const canBack = h.idx > 0;
@@ -927,4 +930,4 @@ export const BrowserPane = forwardRef<BrowserPaneHandle, { label?: string; activ
       </div>{/* end main area */}
     </div>
   );
-});
+}

--- a/src/components/lazy-surfaces.tsx
+++ b/src/components/lazy-surfaces.tsx
@@ -80,3 +80,10 @@ export const FamiliarWorkQueueView = dynamic(
   ),
   { ssr: false, loading: SurfaceFallback },
 );
+
+// BrowserPane's imperative handle crosses this boundary as the regular
+// `handleRef` prop — next/dynamic does not forward element refs (cave-masj).
+export const BrowserPane = dynamic(
+  timed("browser", () => import("@/components/browser-pane").then((m) => m.BrowserPane)),
+  { ssr: false, loading: SurfaceFallback },
+);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -42,12 +42,13 @@ import { recordFamiliarUsed } from "@/lib/familiar-quick-switch";
 import { toggleFamiliarSelection } from "@/lib/familiar-multiselect";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { ChooserModal, type ChooserOption } from "@/components/ui/chooser-modal";
-import { BrowserPane, type BrowserPaneHandle } from "@/components/browser-pane";
+import type { BrowserPaneHandle } from "@/components/browser-pane";
 // Heavy, mode-gated surfaces are code-split via @/components/lazy-surfaces so
 // their chunks (and deps like @xyflow/react, @uiw/react-codemirror) load on
 // first open instead of shipping in the main bundle. See lazy-surfaces.tsx.
 import {
   BoardView,
+  BrowserPane,
   CalendarView,
   FamiliarWorkQueueView,
   GitHubView,
@@ -2195,7 +2196,7 @@ export function Workspace() {
         }
       />
     ) : mode === "browser" ? (
-      <BrowserPane ref={browserPaneRef} label="main" activeFamiliarId={active?.id ?? null} active={browserVisible} />
+      <BrowserPane handleRef={browserPaneRef} label="main" activeFamiliarId={active?.id ?? null} active={browserVisible} />
     ) : mode === "github" ? (
       <GitHubView
         onJumpToSession={openFamiliarSession}


### PR DESCRIPTION
## Summary

Bead `cave-masj` (verified-backlog sweep). `workspace.tsx` statically imported `BrowserPane`, making it the last heavy mode-gated surface shipping in the always-loaded boot bundle — everything else already routes through `lazy-surfaces.tsx`. The blocker was its `forwardRef` imperative handle: `next/dynamic`'s wrapper doesn't forward element refs.

**Fix:** the handle now rides a regular `handleRef` prop, which crosses the dynamic boundary losslessly:
- `browser-pane.tsx` drops `forwardRef` and registers `useImperativeHandle(handleRef, ...)` directly (single registration — the existing hooks-test pin still holds)
- `lazy-surfaces.tsx` gains a `timed("browser")` dynamic export, so the chunk's fetch+parse shows up as a `surface-load:browser` perf mark like the other surfaces
- `workspace.tsx` imports the component from lazy-surfaces (type import of `BrowserPaneHandle` stays direct) and passes `handleRef={browserPaneRef}`

Both mounts are mode-conditional (`mode === "browser"` and the companion split-tile), so the chunk genuinely loads on first browser open rather than at boot.

## Test plan

- [x] New pins: `handleRef` registration, `forwardRef` gone, code-split export in lazy-surfaces, workspace has no static component import
- [x] Browser test files + full `pnpm test:app` (569 files) green; `pnpm typecheck` clean
- [x] `pnpm build` green, `bundle-budget: within budget`

🤖 Generated with [Claude Code](https://claude.com/claude-code)