### PR TITLE
fix(a11y): focus-trap the notification popover; keep the selected board card in view across view switches (cave-6fqb)

### DIFF
--- a/src/components/board-gantt.tsx
+++ b/src/components/board-gantt.tsx
@@ -790,6 +790,7 @@ export function BoardGantt({ cards, familiars, projects, selectedCardId, onSelec
                     <button
                       key={row.rowId}
                       type="button"
+                      data-card-id={row.cardId}
                       className={`cg-row${selectedCardId === row.cardId ? " cg-row--sel" : ""}`}
                       onClick={() => {
                         if (suppressClickRef.current) { suppressClickRef.current = false; return; }

--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -225,4 +225,14 @@ assert.match(kanban, /if \(grabbedCardId && !inBoard\)/, "a grab releases when f
 assert.match(kanban, /document\.querySelector<HTMLElement>\(`\[data-card-id="\$\{movedId\}"\]`\)\?\.focus\(\)/, "keyboard drop refocuses the moved card");
 assert.match(gantt, /announce\(`Rescheduled '\$\{row\.label\}':/, "gantt step reschedules announce the committed range");
 
+// ── Selection survives a view-mode switch AND stays visible (P1-6, 2026-07-03
+// heuristic audit): the new view mounts at scroll 0, so BoardView scrolls the
+// still-selected card back into view. Scroll only — no focus steal.
+assert.match(view, /prevViewModeRef\.current !== viewMode/, "view switches are detected against the previous mode, not selection changes");
+assert.match(view, /\[data-card-id="\$\{selectedCardId\}"\]/, "the selected card is located by its data-card-id in the mounted view");
+assert.match(view, /scrollIntoView\(\{ block: "nearest", inline: "nearest" \}\)/, "the selected card scrolls into view without recentering the whole board");
+assert.match(view, /return \(\) => cancelAnimationFrame\(frame\);/, "the scroll rAF is a fresh closure cancelled on cleanup (no persistent ref guard to wedge)");
+assert.doesNotMatch(view, /querySelector<HTMLElement>\(`\[data-card-id="\$\{selectedCardId\}"\]`\)\s*\?\.focus\(\)/, "view switches must not steal focus from the toggle the user clicked");
+assert.match(gantt, /data-card-id=\{row\.cardId\}/, "gantt rows carry data-card-id so the view-switch scroll finds them");
+
 console.log("board-ux-polish.test.ts: ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -289,6 +289,25 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     if (selectedCardId && !cards.some((c) => c.id === selectedCardId)) setSelectedCardId(null);
   }, [cards, selectedCardId]);
 
+  // Selection survives a view-mode switch (state lives here, not in the
+  // views), but the freshly mounted view renders from scroll 0 — the
+  // still-selected card the open inspector describes can sit far off-screen.
+  // After the new view commits, bring it back into view. Scroll only, no
+  // focus steal — the user's focus belongs on the toggle they just clicked.
+  const viewAreaRef = useRef<HTMLDivElement | null>(null);
+  const prevViewModeRef = useRef(viewMode);
+  useEffect(() => {
+    const switched = prevViewModeRef.current !== viewMode;
+    prevViewModeRef.current = viewMode;
+    if (!switched || !selectedCardId) return;
+    const frame = requestAnimationFrame(() => {
+      viewAreaRef.current
+        ?.querySelector<HTMLElement>(`[data-card-id="${selectedCardId}"]`)
+        ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [viewMode, selectedCardId]);
+
   const lifecycleForStatus = (status: CardStatus) => {
     if (status === "running") return "running" as const;
     if (status === "review") return "review" as const;
@@ -881,7 +900,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
       )}
 
       {/* Content */}
-      <div style={{ flex: 1, minHeight: 0, overflow: "hidden", display: "flex", flexDirection: "column" }}>
+      <div ref={viewAreaRef} style={{ flex: 1, minHeight: 0, overflow: "hidden", display: "flex", flexDirection: "column" }}>
         {cardSelect.selectMode && (
           <div className="px-5 pt-3">
             <SelectionToolbar

--- a/src/components/modal-trap-adoption.test.ts
+++ b/src/components/modal-trap-adoption.test.ts
@@ -10,6 +10,7 @@ const FILES = [
   "github-action-popover.tsx",
   "code-quick-open.tsx",
   "new-reminder-modal.tsx",
+  "notification-bell.tsx",
 ];
 
 for (const file of FILES) {

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -7,6 +7,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
 import type { InboxPrefs, SoundMode } from "@/lib/cave-inbox-prefs";
 import { Icon } from "@/lib/icon";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 type Props = {
   items: InboxItem[];
@@ -35,6 +36,12 @@ export function NotificationBell({
   const [open, setOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  // Trap focus while the popover is open: Escape closes, Tab cycles inside,
+  // and closing restores focus to whatever opened it (the bell trigger for
+  // keyboard users). Same pattern as github-action-popover.
+  useFocusTrap(open, popoverRef, { onEscape: () => setOpen(false) });
 
   const familiarName = useCallback(
     (id: string | null | undefined) =>
@@ -151,7 +158,13 @@ export function NotificationBell({
       </button>
 
       {open ? (
-        <div className="notification-bell__popover group/popover absolute right-0 top-full z-50 mt-1 w-[400px] rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl">
+        <div
+          ref={popoverRef}
+          role="dialog"
+          aria-label="Notifications"
+          tabIndex={-1}
+          className="notification-bell__popover group/popover absolute right-0 top-full z-50 mt-1 w-[400px] rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl"
+        >
           <div className="notification-bell__header flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
             <span className="text-[11px] font-medium text-[var(--text-primary)]">
               Notifications
@@ -159,7 +172,7 @@ export function NotificationBell({
             <div className="notification-bell__header-actions flex items-center gap-1.5">
               <button
                 onClick={() => setSettingsOpen((v) => !v)}
-                className="notification-bell__settings-btn touch-always-visible focus-ring grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover/popover:opacity-100"
+                className="notification-bell__settings-btn touch-always-visible focus-ring grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:text-[var(--text-primary)] group-hover/popover:opacity-100 focus-visible:opacity-100"
                 title="Notification settings"
                 aria-label="Notification settings"
               >
@@ -298,7 +311,7 @@ export function NotificationBell({
                         onClick={() => void toggleMute(it.familiarId!)}
                         title={muted ? `Unmute ${fname}` : `Mute ${fname}`}
                         aria-label={muted ? `Unmute ${fname}` : `Mute ${fname}`}
-                        className="notification-bell__mute touch-always-visible focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] group-hover/popover:opacity-100"
+                        className="notification-bell__mute touch-always-visible focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] group-hover/popover:opacity-100 focus-visible:opacity-100"
                       >
                         <Icon
                           name={muted ? "ph:bell-slash-fill" : "ph:bell-slash"}


### PR DESCRIPTION
## Summary

Closes the two still-open P1 findings from Sage's 2026-07-03 heuristic audit (board card `953cfbab`, bead `cave-6fqb`). The audit's other five P1 findings were **verified already shipped** on today's main before any code was written:

| Audit finding | Verdict |
|---|---|
| P1-1 edit-and-resubmit / regenerate | shipped — `onEdit`/`onRegenerate` wired, pinned in chat-view-lifecycle.test.ts |
| P1-2 markdown only after done | shipped — progressive `mdToHtml` w/ 200ms throttle, pinned in message-bubble-markdown.test.ts |
| P1-3 focus restore | expand modal + lightbox shipped; **bell popover was still open → fixed here** |
| P1-4 hover-gated actions | shipped — always in DOM, opacity + `:focus-within` reveal, pinned |
| P1-5 kanban drag announce | shipped — central `moveCardToStatus` announce covers all five move paths |
| P1-6 board selection on view switch | selection/inspector survive; **no scroll-to-card → fixed here** |
| P1-7 chat deep links | shipped — `#chat-<id>` hash sync tagged CHAT-D9-01 in chat-router.tsx |

## Changes

**notification-bell** — the popover adopts the shared `useFocusTrap` (Escape closes, Tab cycles, close restores focus to the trigger; same pattern as `github-action-popover`). It's now a named dialog (`role="dialog"`, `aria-label`, `tabIndex={-1}`), and the hover-revealed settings/mute buttons also reveal on `:focus-visible`. Added to the `modal-trap-adoption.test.ts` sweep.

**board** — after a kanban/table/gantt switch, BoardView scrolls the still-selected card back into view once the new view commits (`block/inline: "nearest"`, scroll only — no focus steal from the toggle). The rAF id is a fresh closure cancelled on cleanup, per the #2659 wedge lesson. Gantt rows gain `data-card-id` so the lookup works in all three desktop views. Pinned in `board-ux-polish.test.ts`.

## Verification

- `pnpm typecheck` clean
- `pnpm test:app` — 567 test files pass, including the two extended pin files

🤖 Generated with [Claude Code](https://claude.com/claude-code)