### PR TITLE
a11y(flow): open a graph node from the keyboard, not just double-click (cave-6pp8)

### DIFF
--- a/src/components/flow/flow-canvas.test.ts
+++ b/src/components/flow/flow-canvas.test.ts
@@ -116,4 +116,15 @@ assert.match(rmBlock, /\.react-flow__controls-button/, "reduced-motion zeros the
 assert.match(rmBlock, /\.react-flow__viewport[\s\S]*?transition: none !important/, "reduced-motion zeros the viewport pan/zoom transition (beats React Flow's inline transition)");
 assert.match(styles, /@media \(prefers-reduced-motion: reduce\) \{ \.flow-run-step-spin \{ animation: none; \} \}/, "the existing run-step spinner guard stays");
 
+// ── Keyboard path to open a node (cave-6pp8, WCAG 2.1.1) ──────────────────────
+// Double-click is mouse-only; a keyboard user must be able to open the focused
+// node with Enter/Space. Keyed off the focused node's data-id, skips stickies,
+// announces the open (the NDV doesn't announce itself).
+assert.match(canvas, /const handleCanvasKeyDown = useCallback\(/, "canvas has a keyboard handler for opening nodes");
+assert.match(canvas, /event\.key !== "Enter" && event\.key !== " "/, "Enter or Space triggers the open");
+assert.match(canvas, /closest\?\.\(".react-flow__node"\)[\s\S]*?getAttribute\("data-id"\)/, "the open targets the focused React Flow node by data-id");
+assert.match(canvas, /catalogNode\(source\.type\)\?\.sticky === true\) return/, "sticky notes are skipped (they edit inline)");
+assert.match(canvas, /onOpenNode\(nodeId\);\s*\n\s*announce\(/, "opening a node via keyboard announces it");
+assert.match(canvas, /onKeyDown=\{handleCanvasKeyDown\}/, "the handler is wired on the canvas wrapper");
+
 console.log("flow-canvas.test.ts OK");

--- a/src/components/flow/flow-canvas.tsx
+++ b/src/components/flow/flow-canvas.tsx
@@ -19,9 +19,10 @@ import {
   type NodeTypes,
   type OnConnectStartParams,
 } from "@xyflow/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { catalogNode } from "@/lib/flow/flow-catalog";
 import type { FlowDoc, FlowLayoutOrientation, FlowPosition } from "@/lib/flow/flow-doc";
 import {
@@ -225,6 +226,8 @@ if (syncedViewKey !== viewKey) {
     onMoveNodes(Object.fromEntries(nodesRef.current.map((node) => [node.id, node.position])));
   }, [onMoveNodes]);
 
+  const { announce } = useAnnouncer();
+
   const handleNodeClick: NodeMouseHandler<Node<FlowNodeData>> = useCallback(
     (_event, node) => onSelectNode(node.id),
     [onSelectNode],
@@ -238,6 +241,28 @@ if (syncedViewKey !== viewKey) {
       onOpenNode(node.id);
     },
     [onOpenNode],
+  );
+
+  // Keyboard path to open a node (WCAG 2.1.1): double-click is mouse-only, so a
+  // keyboard user could Tab to a focusable React Flow node and select it but
+  // never open it. Enter/Space on the focused node opens its detail view,
+  // mirroring double-click (stickies edit inline, so they're skipped). Keyed off
+  // the focused node's `data-id` rather than selection, so it works the instant
+  // focus lands. The NDV doesn't announce itself, so announce the open here.
+  const handleCanvasKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key !== "Enter" && event.key !== " ") return;
+      const target = event.target as HTMLElement | null;
+      const nodeEl = target?.closest?.(".react-flow__node") as HTMLElement | null;
+      const nodeId = nodeEl?.getAttribute("data-id");
+      if (!nodeId) return; // focus is on the toolbar / pane / an input, not a node
+      const source = doc.nodes.find((entry) => entry.id === nodeId);
+      if (!source || catalogNode(source.type)?.sticky === true) return;
+      event.preventDefault(); // Space would page-scroll / toggle selection
+      onOpenNode(nodeId);
+      announce(`Opened ${source.name} settings`);
+    },
+    [doc.nodes, onOpenNode, announce],
   );
 
   const handleConnect = useCallback(
@@ -314,7 +339,7 @@ if (syncedViewKey !== viewKey) {
   }, [onRequestAdd, screenToFlowPosition]);
 
   return (
-    <div className="flow-canvas" aria-label={`${doc.name} canvas`} onDoubleClick={handlePaneDoubleClick}>
+    <div className="flow-canvas" aria-label={`${doc.name} canvas`} onDoubleClick={handlePaneDoubleClick} onKeyDown={handleCanvasKeyDown}>
       <div className="flow-canvas-toolbar">
         <Button
           variant="secondary"


### PR DESCRIPTION
## What

flow-canvas wired select (click) and open-detail (double-click) but no keyboard path — a keyboard user could Tab to a focusable React Flow node and select it, yet never open it (WCAG 2.1.1).

## Fix

Canvas-level onKeyDown: Enter/Space on the focused node opens its detail view, mirroring double-click. Keyed off the focused node data-id, skips stickies, preventDefaults so Space does not page-scroll. The node detail view does not announce itself, so the open is announced via useAnnouncer.

Pinned in flow-canvas.test.ts.

## Verification
typecheck, 569 app tests, build within budget.

Generated with Claude Code