### PR TITLE
a11y(grimoire): announce deletes + saves; full tabs pattern for the document strip (cave-mglw)

### DIFF
--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -68,6 +68,9 @@ assert.match(view, /Move to trash/, "memory delete is labelled as restorable tra
 assert.match(view, /danger: true/, "the confirm renders its destructive style");
 assert.match(view, /closeTab\(selectionKey\(selection\)\);\s*void load\(\)/, "a successful delete closes the doc's tab and reloads the navigator");
 assert.match(view, /deleteError \? \(\s*<span role="alert"/, "delete failures are announced");
+// (cave-mglw) successful deletes are announced too — the row vanishing was the
+// only confirmation, silent to screen readers.
+assert.match(view, /announce\(\s*\n\s*selection\.kind === "memory"\s*\n\s*\? "Memory file moved to trash"/, "successful deletes announce per document kind");
 
 // ── Tabs: persisted multi-doc editing (cave-90u) ─────────────────────────────
 
@@ -77,6 +80,13 @@ assert.match(view, /export const MAX_OPEN_TABS = 8/, "open-tab count is capped")
 assert.match(view, /role="tablist"[\s\S]*?aria-label="Open documents"/, "tab strip is an accessible tablist");
 assert.match(view, /role="tab"[\s\S]*?aria-selected=\{active\}/, "tabs expose selection state");
 assert.match(view, /aria-label=\{`Close \$\{tabTitle\(tab\)\}`\}/, "each tab has a labelled close button");
+// (cave-mglw) full tabs pattern: one roving tab stop (←/→ between tabs) and
+// tab ↔ tabpanel wiring. The strip stays hand-rolled because the shared
+// ui/tabs primitive has no per-tab close button.
+assert.match(view, /useRovingTabIndex\(\{\s*\n\s*containerRef: tabStripRef,\s*\n\s*itemSelector: '\[role="tab"\]',/, "the tab strip roves focus");
+assert.match(view, /if \(selectedTabIndex >= 0\) setTabStopIndex\(selectedTabIndex\)/, "the tab stop follows the selected tab");
+assert.match(view, /aria-controls=\{`grimoire-tabpanel-\$\{i\}`\}/, "tabs point at their panels");
+assert.match(view, /role="tabpanel"\s*\n\s*id=\{`grimoire-tabpanel-\$\{i\}`\}\s*\n\s*aria-labelledby=\{`grimoire-tab-\$\{i\}`\}/, "panels are labelled by their tabs");
 // The core multi-tab behavior: every open tab's editor stays mounted so
 // unsaved drafts survive switching tabs (inactive tabs are display:none).
 assert.match(view, /key === selectedKey \? "h-full min-h-0" : "hidden"/, "inactive tab editors stay mounted, just hidden");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -26,6 +26,8 @@ import { parseMdDocument, serializeMdDocument, type MdDocument } from "@/lib/md-
 import { relativeTime } from "@/lib/relative-time";
 import { GRIMOIRE_HASH_PREFIX } from "@/lib/grimoire-link";
 import { useConfirm } from "@/components/ui/confirm-dialog";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { useRovingTabIndex } from "@/lib/use-roving-tabindex";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -642,6 +644,7 @@ export function GrimoireView() {
     });
   }, []);
   const confirm = useConfirm();
+  const { announce } = useAnnouncer();
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   // Open tabs + the active one. A #grimoire: deep link wins over the restored
@@ -786,12 +789,20 @@ export function GrimoireView() {
       // A deleted document's tab closes with it.
       closeTab(selectionKey(selection));
       void load();
+      // The row disappearing is the only visual confirmation — say it too.
+      announce(
+        selection.kind === "memory"
+          ? "Memory file moved to trash"
+          : selection.kind === "knowledge"
+            ? "Knowledge entry deleted"
+            : `Journal reflection for ${selection.date} deleted`,
+      );
     } catch (err) {
       setDeleteError(err instanceof Error ? err.message : "Delete failed");
     } finally {
       setDeleting(false);
     }
-  }, [closeTab, confirm, deleting, load, selection]);
+  }, [announce, closeTab, confirm, deleting, load, selection]);
 
   const q = query.trim().toLowerCase();
   const matches = useCallback(
@@ -819,6 +830,20 @@ export function GrimoireView() {
 
   const loading = knowledge === null || memory === null || journal === null;
   const selectedKey = selection ? selectionKey(selection) : null;
+
+  // Roving focus for the open-document tab strip (←/→ between tabs, one tab
+  // stop). The shared ui/tabs primitive has no per-tab close button, so the
+  // strip stays hand-rolled — with the same tablist semantics.
+  const tabStripRef = useRef<HTMLDivElement | null>(null);
+  const { setActiveIndex: setTabStopIndex } = useRovingTabIndex({
+    containerRef: tabStripRef,
+    itemSelector: '[role="tab"]',
+    orientation: "horizontal",
+  });
+  const selectedTabIndex = openTabs.findIndex((t) => selectionKey(t) === selectedKey);
+  useEffect(() => {
+    if (selectedTabIndex >= 0) setTabStopIndex(selectedTabIndex);
+  }, [selectedTabIndex, setTabStopIndex]);
 
   // Index of every loaded doc, used to resolve a doc's outgoing [[wiki-links]].
   const docIndex = useMemo<WikiDocIndex>(
@@ -924,11 +949,12 @@ export function GrimoireView() {
     ) : (
       <div className="flex h-full min-h-0 flex-col">
         <div
+          ref={tabStripRef}
           role="tablist"
           aria-label="Open documents"
           className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-[var(--border-hairline)] px-2 py-1.5"
         >
-          {openTabs.map((tab) => {
+          {openTabs.map((tab, i) => {
             const key = selectionKey(tab);
             const active = key === selectedKey;
             return (
@@ -943,7 +969,9 @@ export function GrimoireView() {
                 <button
                   type="button"
                   role="tab"
+                  id={`grimoire-tab-${i}`}
                   aria-selected={active}
+                  aria-controls={`grimoire-tabpanel-${i}`}
                   title={tabTitle(tab)}
                   onClick={() => setTabState((prev) => ({ ...prev, selection: tab }))}
                   className="focus-ring-inset min-w-0 truncate px-2 py-1"
@@ -963,10 +991,16 @@ export function GrimoireView() {
           })}
         </div>
         <div className="relative min-h-0 flex-1">
-          {openTabs.map((tab) => {
+          {openTabs.map((tab, i) => {
             const key = selectionKey(tab);
             return (
-              <div key={key} className={key === selectedKey ? "h-full min-h-0" : "hidden"}>
+              <div
+                key={key}
+                role="tabpanel"
+                id={`grimoire-tabpanel-${i}`}
+                aria-labelledby={`grimoire-tab-${i}`}
+                className={key === selectedKey ? "h-full min-h-0" : "hidden"}
+              >
                 {renderTabDetail(tab)}
               </div>
             );

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -27,6 +27,9 @@ assert.match(shell, /e\.key\.toLowerCase\(\) === "s"/, "Cmd/Ctrl+S saves from th
 assert.match(shell, /const dirty = raw !== baseline/, "dirty tracks the saved baseline");
 assert.match(shell, /disabled=\{!dirty \|\| saving\}/, "save button disabled when clean/saving");
 assert.match(shell, /role="alert"/, "save errors are announced");
+// (cave-mglw) the "Saved" flash is the only save confirmation — it must be a
+// polite status so screen readers hear saves (incl. debounced autosaves) too.
+assert.match(shell, /savedFlash \? \(\s*\n[\s\S]{0,220}?<span role="status"/, "the Saved flash is a polite live region");
 
 // Untouched docs must round-trip byte-identical: raw is canonical state.
 assert.match(shell, /const \[raw, setRaw\] = useState\(value\)/, "raw document string is the canonical state");

--- a/src/components/md-editor/md-editor.tsx
+++ b/src/components/md-editor/md-editor.tsx
@@ -406,7 +406,9 @@ export function MdEditor({
               {saveError}
             </span>
           ) : savedFlash ? (
-            <span className="inline-flex items-center gap-1 text-[var(--text-secondary)]">
+            // role=status: saves (incl. debounced autosaves) were visual-only —
+            // the flash is the sole confirmation, so SRs should hear it too.
+            <span role="status" className="inline-flex items-center gap-1 text-[var(--text-secondary)]">
               <Icon name="ph:check" width={11} aria-hidden />
               Saved
             </span>


### PR DESCRIPTION
## Summary

Bead `cave-mglw` — inherited from the retired Library surface and re-verified against the post-#2676 Grimoire rebuild (both findings survived it).

**Mutations were silent to screen readers.**
- Successful deletes (memory → trash, knowledge entry, journal reflection) now announce through the shared `useAnnouncer` live region — the row vanishing was the only confirmation. Failures already had `role=alert`.
- The shared `MdEditor`'s "Saved" flash gains `role=status`, making manual saves and debounced autosaves audible everywhere the editor mounts (knowledge, journal, memory) — the same conditional-mount status pattern the memory editor's disk-change banner already uses.

**The document tab strip was tabs-in-name-only.** It had `role=tablist`/`tab`/`aria-selected` but every tab was its own Tab stop, there was no arrow-key navigation, and no tab ↔ panel association. Now: one roving tab stop (←/→ via `useRovingTabIndex`, following the selected tab) and full `id`/`aria-controls`/`aria-labelledby` wiring to `role=tabpanel` panels.

**Deliberate deviation from the bead:** the strip stays hand-rolled rather than migrating to `ui/tabs` — the shared primitive has no per-tab close button, and grimoire's sibling-close markup (close button *next to*, not inside, the `role=tab` button) is the structurally correct shape for closable tabs. Nested-interactive inside a tab is the anti-pattern we'd be introducing.

## Test plan

- [x] New pins: per-kind delete announcements, Saved-flash status region, roving strip + selected-tab stop, tab/panel wiring
- [x] Grimoire + md-editor tests and full `pnpm test:app` (569 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)