### PR TITLE
a11y(dashboard): drag announcements speak panel titles + positions (cave-0k5b)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -159,4 +159,21 @@ assert.match(heatmap, /role: "img"/, "heatmap can expose an accessible summary")
 assert.match(cockpit, /ariaLabel=\{`Board status:/, "board donut passes a data summary to AT");
 assert.match(cockpit, /ariaLabel=\{`Confidence factors by familiar:/, "confidence heatmap passes a data summary to AT");
 
+// ── Drag a11y (cave-0k5b): titles, not ids ───────────────────────────────────
+// dnd-kit's default announcements read the raw widget ids; the cockpit supplies
+// its own with human panel titles + 1-based positions, and each grip names its
+// panel instead of a generic "Drag to rearrange".
+assert.match(cockpit, /const dragAnnouncements: Announcements = \{/, "cockpit defines custom drag announcements");
+assert.match(cockpit, /accessibility=\{\{ announcements: dragAnnouncements \}\}/, "DndContext receives the custom announcements");
+assert.match(cockpit, /moved to position \$\{pos\.index\} of \$\{pos\.count\}/, "drops announce the panel's new position");
+assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each grip names its panel");
+// The titles map must cover every layout id, or announcements degrade to ids.
+{
+  const layoutIds = cockpit.match(/DEFAULT_LAYOUT: Layout = \{\s*main: \[([^\]]*)\],\s*rail: \[([^\]]*)\]/s);
+  const ids = `${layoutIds[1]},${layoutIds[2]}`.match(/"([^"]+)"/g).map((q) => q.slice(1, -1));
+  for (const id of ids) {
+    assert.match(cockpit, new RegExp(`^  ${id}: "`, "m"), `PANEL_TITLES covers "${id}"`);
+  }
+}
+
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/dashboard/dashboard-cockpit.tsx
+++ b/src/components/dashboard/dashboard-cockpit.tsx
@@ -38,7 +38,7 @@ import { TodaySummary } from "@/components/dashboard/today-summary";
 import { RecentReports } from "@/components/dashboard/recent-reports";
 import {
   DndContext, PointerSensor, KeyboardSensor, useSensor, useSensors, closestCenter,
-  type DragEndEvent,
+  type Announcements, type DragEndEvent,
 } from "@dnd-kit/core";
 import {
   SortableContext, useSortable, arrayMove, sortableKeyboardCoordinates, verticalListSortingStrategy,
@@ -75,6 +75,24 @@ const DEFAULT_LAYOUT: Layout = {
   main: ["usage", "signals", "needs", "board", "today"],
   rail: ["confidence", "agents", "load", "space", "github", "agenda"],
 };
+
+// Human titles for drag-and-drop announcements + grip labels (mirrors each
+// widget's <Panel title>). dnd-kit's defaults read the raw ids, which are
+// semantic but terse — screen readers should hear the visible panel names.
+const PANEL_TITLES: Record<string, string> = {
+  usage: "Activity over time",
+  signals: "Signals",
+  needs: "Needs attention",
+  board: "Board",
+  today: "Today summary",
+  confidence: "Performance matrix",
+  agents: "Familiars",
+  load: "Familiar load",
+  space: "Space usage",
+  github: "GitHub",
+  agenda: "Up next",
+};
+const panelTitle = (id: unknown): string => PANEL_TITLES[String(id)] ?? String(id);
 
 /** Merge a saved order with the defaults: keep known ids in saved order, append
  *  any new defaults, drop anything unknown (survives version changes). */
@@ -392,6 +410,39 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
     }
   };
 
+  // Speak panel titles + positions during drag — dnd-kit's defaults read the
+  // raw widget ids. Positions come from the pre-move layout: with arrayMove
+  // semantics the dragged panel takes over.id's index, so it reads correctly
+  // for the drop announcement too.
+  const positionOf = (id: string): { index: number; count: number } | null => {
+    for (const col of ["main", "rail"] as const) {
+      const idx = layout[col].indexOf(id);
+      if (idx !== -1) return { index: idx + 1, count: layout[col].length };
+    }
+    return null;
+  };
+  const dragAnnouncements: Announcements = {
+    onDragStart({ active }) {
+      const pos = positionOf(String(active.id));
+      return `Picked up ${panelTitle(active.id)}${pos ? `, position ${pos.index} of ${pos.count}` : ""}.`;
+    },
+    onDragOver({ active, over }) {
+      if (!over) return undefined;
+      const pos = positionOf(String(over.id));
+      return pos ? `${panelTitle(active.id)} is over position ${pos.index} of ${pos.count}.` : undefined;
+    },
+    onDragEnd({ active, over }) {
+      if (!over) return `${panelTitle(active.id)} was dropped.`;
+      const pos = positionOf(String(over.id));
+      return pos
+        ? `${panelTitle(active.id)} moved to position ${pos.index} of ${pos.count}.`
+        : `${panelTitle(active.id)} was dropped.`;
+    },
+    onDragCancel({ active }) {
+      return `Dragging ${panelTitle(active.id)} cancelled.`;
+    },
+  };
+
   const isVisible = (id: string) => {
     if (id === "needs") return !model.caughtUp;
     if (id === "signals") return signals.length > 0;
@@ -508,14 +559,14 @@ export function DashboardCockpit({ model }: { model: DashboardModel }) {
       </section>
 
       {/* Secondary panels — drag to rearrange (hover for the grip) */}
-      <DndContext id="dashboard-cockpit" sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+      <DndContext id="dashboard-cockpit" sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd} accessibility={{ announcements: dragAnnouncements }}>
         <div className="cockpit-grid">
           {(["main", "rail"] as const).map((col) => {
             const ids = layout[col].filter(isVisible);
             return (
               <div key={col} className={`cockpit-col cockpit-col--${col}`}>
                 <SortableContext items={ids} strategy={verticalListSortingStrategy}>
-                  {ids.map((id) => <SortableWidget key={id} id={id}>{widget(id)}</SortableWidget>)}
+                  {ids.map((id) => <SortableWidget key={id} id={id} title={panelTitle(id)}>{widget(id)}</SortableWidget>)}
                 </SortableContext>
               </div>
             );
@@ -587,7 +638,7 @@ function Panel({ title, icon, count, hint, href, children }: {
 
 // ─── Sortable widget wrapper ─────────────────────────────────────────────────────
 
-function SortableWidget({ id, children }: { id: string; children: ReactNode }) {
+function SortableWidget({ id, title, children }: { id: string; title: string; children: ReactNode }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
   const reduceMotion = usePrefersReducedMotion();
   const style: CSSProperties = {
@@ -601,7 +652,7 @@ function SortableWidget({ id, children }: { id: string; children: ReactNode }) {
   };
   return (
     <div ref={setNodeRef} style={style} className={`cockpit-sortable${isDragging ? " is-dragging" : ""}`}>
-      <button type="button" className="cockpit-grip" aria-label="Drag to rearrange" {...attributes} {...listeners}>
+      <button type="button" className="cockpit-grip" aria-label={`Drag to rearrange: ${title}`} {...attributes} {...listeners}>
         <Icon name="ph:dots-six-vertical" aria-hidden />
       </button>
       {children}


### PR DESCRIPTION
## Summary

Bead `cave-0k5b` (verified-backlog sweep). The cockpit's `DndContext` had no `accessibility` config: dnd-kit's default announcements read the raw widget ids ("usage", "load", …) and every drag grip carried the same generic "Drag to rearrange" label.

- **`PANEL_TITLES`** maps each layout id to its visible `<Panel title>` — with a pin that iterates `DEFAULT_LAYOUT` and asserts every id has an entry, so announcements can never silently degrade back to ids when a panel is added.
- **Custom `Announcements`** speak human titles plus 1-based positions: "Picked up Activity over time, position 1 of 5", "… is over position 3 of 5", "… moved to position 3 of 5", and a cancel line. Positions come from the pre-move layout — with `arrayMove` semantics the dragged panel takes `over.id`'s index, so the drop line reads correctly.
- **Each grip** is now labelled "Drag to rearrange: \<Title\>", so keyboard users tabbing between grips know which panel they're about to lift.

## Test plan

- [x] New pins in `dashboard-page.test.ts` (announcements object, DndContext wiring, position phrasing, per-panel grip label, full title coverage)
- [x] Full `pnpm test:app` (569 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)