### PR TITLE
chore(dashboard): drop the dead zones-era model surface (cave-pbk4)

### DIFF
--- a/src/lib/dashboard-model.test.ts
+++ b/src/lib/dashboard-model.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { buildDashboardModel, dashboardLayout } from "./dashboard-model.ts";
+import { buildDashboardModel } from "./dashboard-model.ts";
 import { nextItemsAfterAction } from "./dashboard-model.ts";
 
 const ISO = "2026-06-20T09:00:00.000Z";
@@ -36,7 +36,6 @@ function summary(slug) {
   const model = buildDashboardModel([summary("2026-06-19")], now);
   assert.equal(model.caughtUp, true, "no open items => caught up");
   assert.equal(model.needsAttention.length, 0);
-  assert.deepEqual(dashboardLayout(model), ["caughtUpStrip", "metrics", "todaySummary", "familiarUpdates", "launcher", "recentReports"]);
 }
 
 // busy when a response is pending today
@@ -47,7 +46,6 @@ function summary(slug) {
   );
   assert.equal(model.caughtUp, false, "open item => busy");
   assert.equal(model.needsAttention.length, 1);
-  assert.deepEqual(dashboardLayout(model), ["actionInbox", "metrics", "todaySummary", "launcher", "recentReports"]);
 }
 
 // needsAttention is capped at 8
@@ -63,12 +61,11 @@ function summary(slug) {
 // today's report becomes featuredReport and is excluded from recentReports
 {
   const model = buildDashboardModel([summary("2026-06-20"), summary("2026-06-19")], now);
-  assert.equal(model.todaysReport?.slug, "2026-06-20");
   assert.equal(model.featuredReport?.slug, "2026-06-20");
   assert.deepEqual(model.recentReports.map((r) => r.slug), ["2026-06-19"]);
 }
 
-// today's summary is folded in: narrative + frozen metrics from today's report
+// today's summary is folded in from today's report
 {
   const today = item({
     id: "s-2026-06-20",
@@ -82,8 +79,6 @@ function summary(slug) {
   assert.ok(model.todaySummary, "today summary present when today's report exists");
   assert.equal(model.todaySummary.imageUrl, "img.png");
   assert.deepEqual(model.todaySummary.recentSessions, ["alpha", "beta"], "recovers session names from body");
-  assert.equal(model.metricsLive, false, "metrics are frozen when today's report exists");
-  assert.deepEqual(model.metrics, { reminders: 1, responses: 2, familiars: 4, sessions: 3 });
 }
 
 // before today's report exists, metrics fall back to the live snapshot
@@ -93,14 +88,11 @@ function summary(slug) {
     now,
   );
   assert.equal(model.todaySummary, null, "no today summary before a report generates");
-  assert.equal(model.metricsLive, true, "metrics are the live snapshot");
-  assert.equal(model.metrics.reminders, 1, "live snapshot counts today's fired reminder");
 }
 
 // with no today report, latest is featured
 {
   const model = buildDashboardModel([summary("2026-06-19"), summary("2026-06-18")], now);
-  assert.equal(model.todaysReport, null);
   assert.equal(model.featuredReport?.slug, "2026-06-19");
   assert.deepEqual(model.recentReports.map((r) => r.slug), ["2026-06-18"]);
 }

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -1,9 +1,10 @@
 // Pure view-model for the unified /dashboard surface. Composes the existing
-// daily-report helpers and decides, from the live inbox, how to order the
-// single-page layout: triage-first when something needs you, calm-first when
-// caught up. Today's daily summary (metrics, narrative, familiar updates) is
-// folded in here so the dashboard *is* the day's report — the standalone
-// /daily-report/[date] route remains for historical days.
+// daily-report helpers over the live inbox. Today's daily summary (narrative,
+// day-in-review facts) is folded in here so the dashboard *is* the day's
+// report — the standalone /daily-report/[date] route remains for historical
+// days. (The cockpit's panel order lives in its own Layout system; the old
+// zones-based dashboardLayout()/DashboardZone were removed as dead code —
+// cave-pbk4.)
 //
 // Kept free of `node:` imports — `InboxItem` is a type-only import — so the
 // client action-inbox island and the strip-types tests can import it safely.
@@ -13,22 +14,10 @@ import type { DailyReportPayload } from "./daily-report-facts";
 import {
   breakdownForDay,
   dateSlug,
-  liveSnapshot,
   parseRecentSessions,
   recentReports,
-  type DailyReportStats,
   type RecentReport,
 } from "./daily-report";
-
-/** Zones the dashboard can render, in display order. Presence varies by state. */
-export type DashboardZone =
-  | "caughtUpStrip"
-  | "actionInbox"
-  | "metrics"
-  | "todaySummary"
-  | "familiarUpdates"
-  | "launcher"
-  | "recentReports";
 
 /** Today's generated daily summary, surfaced inline on the dashboard. */
 export type TodaySummary = {
@@ -50,15 +39,8 @@ export type DashboardModel = {
   caughtUp: boolean;
   /** Open, actionable items — same set the old "Needs attention" list showed, capped. */
   needsAttention: InboxItem[];
-  /** Day-at-a-glance counts. Frozen (from today's report) when available, else live. */
-  metrics: DailyReportStats;
-  /** True when `metrics` is the live inbox snapshot rather than a frozen report. */
-  metricsLive: boolean;
-  /** Familiar updates fired today (live). */
-  familiarUpdates: InboxItem[];
   /** Today's generated summary narrative, or null before one exists. */
   todaySummary: TodaySummary | null;
-  todaysReport: RecentReport | null;
   featuredReport: RecentReport | null;
   /** Reports other than the featured one (newest first). */
   recentReports: RecentReport[];
@@ -89,43 +71,14 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
       }
     : null;
 
-  // Prefer the frozen counts captured when today's report ran (they include
-  // daemon-backed session counts the client can't see); fall back to the live
-  // snapshot before any report exists.
-  const frozen = todayItem?.media?.stats ?? null;
-  const metrics = frozen ?? liveSnapshot(items, now);
-
   return {
     date: now,
     caughtUp: breakdown.openItems.length === 0,
     needsAttention: breakdown.openItems.slice(0, NEEDS_ATTENTION_CAP),
-    metrics,
-    metricsLive: frozen === null,
-    familiarUpdates: breakdown.familiars,
     todaySummary,
-    todaysReport,
     featuredReport,
     recentReports: reports.filter((r) => r.slug !== featuredReport?.slug),
   };
-}
-
-/**
- * Ordered zones for the current state on the single unified page.
- *
- * - Busy → lead with the action inbox (triage), then the day at a glance,
- *   today's summary, the launcher, and recent reports.
- * - Caught up → lead with the calm strip, then metrics, today's story,
- *   familiar updates, the launcher, and recent reports.
- *
- * The `metrics` and `todaySummary` zones always render: `metrics` shows live
- * counts before a report exists, and `todaySummary` falls back to a callout
- * linking the latest report when today's hasn't generated yet.
- */
-export function dashboardLayout(model: DashboardModel): DashboardZone[] {
-  if (model.caughtUp) {
-    return ["caughtUpStrip", "metrics", "todaySummary", "familiarUpdates", "launcher", "recentReports"];
-  }
-  return ["actionInbox", "metrics", "todaySummary", "launcher", "recentReports"];
 }
 
 /**


### PR DESCRIPTION
## Summary

Bead `cave-pbk4` (verified-backlog sweep, flagged with a re-verify caveat — done here against every consumer). The cockpit's dnd-kit `Layout` system replaced the zones-based dashboard, leaving model code that only tests exercised:

- **`dashboardLayout()` + `DashboardZone`**: deleted — zero production references.
- **`DashboardModel` sheds 4 fields** (`metrics`, `metricsLive`, `familiarUpdates`, `todaysReport`): swept `dashboard/page.tsx` and `dashboard-cockpit.tsx` — the cockpit reads only `date`/`caughtUp`/`needsAttention`/`todaySummary`/`featuredReport`/`recentReports` and computes its KPI vitals directly from the data. `todaysReport` survives as a local inside `buildDashboardModel` (it feeds `featuredReport`); the frozen-vs-live metrics selection and its now-unused `liveSnapshot`/`DailyReportStats` imports go with the fields.
- `dashboard-model.test.ts` trimmed to the surviving surface; the header comment documents where panel ordering lives now.

## Test plan

- [x] Consumer sweep: no production read of any removed symbol
- [x] Full `pnpm test:app` (569 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)