### PR TITLE
chore(dashboard): remove the test-only dashboardLayout() + DashboardZone (cave-pbk4)

### DIFF
--- a/src/lib/dashboard-model.test.ts
+++ b/src/lib/dashboard-model.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { buildDashboardModel, dashboardLayout } from "./dashboard-model.ts";
+import { buildDashboardModel } from "./dashboard-model.ts";
 import { nextItemsAfterAction } from "./dashboard-model.ts";
 
 const ISO = "2026-06-20T09:00:00.000Z";
@@ -36,7 +36,6 @@ function summary(slug) {
   const model = buildDashboardModel([summary("2026-06-19")], now);
   assert.equal(model.caughtUp, true, "no open items => caught up");
   assert.equal(model.needsAttention.length, 0);
-  assert.deepEqual(dashboardLayout(model), ["caughtUpStrip", "metrics", "todaySummary", "familiarUpdates", "launcher", "recentReports"]);
 }
 
 // busy when a response is pending today
@@ -47,7 +46,6 @@ function summary(slug) {
   );
   assert.equal(model.caughtUp, false, "open item => busy");
   assert.equal(model.needsAttention.length, 1);
-  assert.deepEqual(dashboardLayout(model), ["actionInbox", "metrics", "todaySummary", "launcher", "recentReports"]);
 }
 
 // needsAttention is capped at 8

--- a/src/lib/dashboard-model.ts
+++ b/src/lib/dashboard-model.ts
@@ -20,16 +20,6 @@ import {
   type RecentReport,
 } from "./daily-report";
 
-/** Zones the dashboard can render, in display order. Presence varies by state. */
-export type DashboardZone =
-  | "caughtUpStrip"
-  | "actionInbox"
-  | "metrics"
-  | "todaySummary"
-  | "familiarUpdates"
-  | "launcher"
-  | "recentReports";
-
 /** Today's generated daily summary, surfaced inline on the dashboard. */
 export type TodaySummary = {
   title: string;
@@ -107,25 +97,6 @@ export function buildDashboardModel(items: InboxItem[], now: Date): DashboardMod
     featuredReport,
     recentReports: reports.filter((r) => r.slug !== featuredReport?.slug),
   };
-}
-
-/**
- * Ordered zones for the current state on the single unified page.
- *
- * - Busy → lead with the action inbox (triage), then the day at a glance,
- *   today's summary, the launcher, and recent reports.
- * - Caught up → lead with the calm strip, then metrics, today's story,
- *   familiar updates, the launcher, and recent reports.
- *
- * The `metrics` and `todaySummary` zones always render: `metrics` shows live
- * counts before a report exists, and `todaySummary` falls back to a callout
- * linking the latest report when today's hasn't generated yet.
- */
-export function dashboardLayout(model: DashboardModel): DashboardZone[] {
-  if (model.caughtUp) {
-    return ["caughtUpStrip", "metrics", "todaySummary", "familiarUpdates", "launcher", "recentReports"];
-  }
-  return ["actionInbox", "metrics", "todaySummary", "launcher", "recentReports"];
 }
 
 /**


### PR DESCRIPTION
## What

`dashboard-model.ts`'s `dashboardLayout()` and the `DashboardZone` type it returns are referenced **only by `dashboard-model.test.ts`** — the cockpit renders via the newer Layout system, not these zones. Delete the function, the type (used only by that function's signature), and the two test assertions (the surrounding `buildDashboardModel` caughtUp/needsAttention checks stay).

## Scope

Just the unambiguous dead code. The bead's other half — 4 unread `DashboardModel` fields (`metrics`/`metricsLive`/`familiarUpdates`/`todaysReport`) — is **split to cave-inkz**: removing them needs a cross-boundary usage sweep (iOS Swift, API serialization of the model shape) plus unwinding the builder, which a `src/` grep can't fully clear.

## Verification

`typecheck` · **569** app test files · `build` within budget. 32 lines removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)