### PR TITLE
feat(marketplace): add "Explain code" starter prompt to Essentials pack

### DIFF
--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -5313,6 +5313,13 @@
       "trust": "official-local",
       "prompts": [
         {
+          "id": "explain-code",
+          "name": "Explain code",
+          "description": "Walk through unfamiliar code — what it does, how, and why.",
+          "icon": "ph:magnifying-glass-bold",
+          "body": "Explain {{file or code}}. Start with what it does at a high level, then walk the key pieces and how they fit together, and call out anything surprising, risky, or non-obvious. Assume I'm new to this code."
+        },
+        {
           "id": "debug-this",
           "name": "Debug this",
           "description": "Reproduce, isolate, and fix a bug with evidence before the patch.",

--- a/marketplace/plugins/prompt-pack-essentials/plugin.json
+++ b/marketplace/plugins/prompt-pack-essentials/plugin.json
@@ -35,6 +35,7 @@
     }
   },
   "prompts": [
+    "explain-code",
     "debug-this",
     "write-tests",
     "refactor-safely",

--- a/marketplace/plugins/prompt-pack-essentials/prompts/explain-code.md
+++ b/marketplace/plugins/prompt-pack-essentials/prompts/explain-code.md
@@ -1,0 +1,7 @@
+---
+name: Explain code
+description: Walk through unfamiliar code — what it does, how, and why.
+icon: ph:magnifying-glass-bold
+---
+
+Explain {{file or code}}. Start with what it does at a high level, then walk the key pieces and how they fit together, and call out anything surprising, risky, or non-obvious. Assume I'm new to this code.


### PR DESCRIPTION
## What

Adds an **Explain code** prompt as the first entry in the `prompt-pack-essentials` pack.

## Why

The Essentials starter set skewed toward the code-change tail-end — debug / write-tests / refactor / PR description / release notes — with no understanding-first opener. "What does this code do?" is one of the most common everyday chat starters and it was missing.

## Changes

- **`marketplace/catalog.json`** (source of truth) — new prompt entry, placed first in the pack's `prompts[]`
- **`marketplace/plugins/prompt-pack-essentials/plugin.json`** — regenerated; `prompts` now leads with `explain-code`
- **`marketplace/plugins/prompt-pack-essentials/prompts/explain-code.md`** — new template

Derived files were regenerated via `scripts/sync-marketplace.py`, not hand-edited.

## The prompt

- **id** `explain-code`, **name** Explain code
- **icon** `ph:magnifying-glass-bold` — distinct from the pack's reused glyphs, already in the `ICON_NAMES` whitelist (no bundle change)
- **placeholder** `{{file or code}}` — consistent autofill affordance
- **body:** *"Explain {{file or code}}. Start with what it does at a high level, then walk the key pieces and how they fit together, and call out anything surprising, risky, or non-obvious. Assume I'm new to this code."*

## Verification

- `sync-marketplace.py --check` clean (346 files, 118 plugins)
- `marketplace-catalog.test.ts` and `icon-subset.test.ts` pass (verified prior turn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)