### PR TITLE
chore(chat): drop the unreachable 3-column pill breakpoint (cave-98bs)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8790,18 +8790,18 @@ a.mobile-handoff__link:hover {
 /* ── Chat next-path suggestion chips ─────────────────────────────────────────
    Clickable next-step chips under an assistant reply (parsed from the
    <coven:next-paths> block); clicking sends the suggestion as the next turn.
-   Rows stay UNIFORM — 1, 2, or 3 chips per row, keyed off the row's chip
-   count (data-count): 2 and 4 chips pair into two columns (4 = 2×2, never a
-   3+1 orphan), and only an exactly-3 row spreads to three columns. */
+   Rows stay UNIFORM, keyed off the row's chip count (data-count): 2 and 4
+   chips pair into two columns (4 = 2×2, never a 3+1 orphan); any other count
+   (legacy 3-chip transcripts predating the 2-or-4 directive) stacks
+   full-width. A three-column rule for exactly-3 rows can't work here: the
+   chatturn container is capped by the 46rem reading column (~672px inner),
+   below any breakpoint where three ~7-word chips fit. */
 .cave-next-paths {
   display: grid; grid-template-columns: 1fr; gap: 6px; margin-top: 10px; width: 100%;
 }
 @container chatturn (min-width: 540px) {
   .cave-next-paths[data-count="2"],
   .cave-next-paths[data-count="4"] { grid-template-columns: repeat(2, 1fr); }
-}
-@container chatturn (min-width: 760px) {
-  .cave-next-paths[data-count="3"] { grid-template-columns: repeat(3, 1fr); }
 }
 .cave-next-path {
   display: inline-flex; align-items: center; width: 100%; max-width: 100%;

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -1114,9 +1114,10 @@ assert.match(
   "the first follow-up is marked as the recommended next step",
 );
 
-// Suggestion pills lay out in UNIFORM rows — 1, 2, or 3 per row, keyed off the
-// chip count: 2 and 4 chips pair into two columns (4 = 2×2, never a 3+1 orphan
-// wrap) and only an exactly-3 row spreads to three columns (cave-wrso).
+// Suggestion pills lay out in UNIFORM rows keyed off the chip count: 2 and 4
+// chips pair into two columns (4 = 2×2, never a 3+1 orphan wrap); every other
+// count — legacy 3-chip transcripts included — stacks full-width (cave-wrso,
+// cave-98bs).
 assert.match(
   source,
   /className="cave-next-paths" data-count=\{nextPaths\.length\}/,
@@ -1127,10 +1128,9 @@ assert.match(
   /\.cave-next-paths\[data-count="2"\],\s*\n\s*\.cave-next-paths\[data-count="4"\] \{ grid-template-columns: repeat\(2, 1fr\); \}/,
   "2 and 4 chips pair into two columns (4 renders 2×2)",
 );
-assert.match(
-  globalsSrc,
-  /\.cave-next-paths\[data-count="3"\] \{ grid-template-columns: repeat\(3, 1fr\); \}/,
-  "only an exactly-3 row spreads to three columns",
+assert.ok(
+  !/\.cave-next-paths\[data-count="3"\]/.test(globalsSrc),
+  "no exactly-3 column rule: the chatturn container (46rem reading column, ~672px inner) can never reach a width where three chips fit, so legacy 3-chip rows stack (cave-98bs)",
 );
 assert.ok(
   !/\.cave-next-paths \{ grid-template-columns: repeat\(/.test(globalsSrc),


### PR DESCRIPTION
## Summary
Removes dead CSS found while verifying #2672: the `.cave-next-paths[data-count="3"]` three-column rule sat behind `@container chatturn (min-width: 760px)`, but the `chatturn` container (`.cave-linear-turn-body`) lives inside the 46rem (736px) reading column and measures ~672px inner — the breakpoint can never fire. Measured live at a 1440px viewport: legacy 3-chip rows always render as a full-width 1×3 stack.

- Rule deleted; comment now records *why* 3 stacks (so it isn't "re-fixed" later).
- Pin in `chat-view-polish.test.ts` flipped from asserting the rule exists to asserting it stays gone.
- No behavior change: 3-chip rows are extinct going forward (2-or-4 directive #2642 + render cap #2672), and existing ones already stacked.

## Verification
- `node src/components/chat-view-polish.test.ts` exits 0 in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)