### PR TITLE
fix(chat-overlays): intent-based follow release for quick-chat + group chat (cave-o8si)

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -137,9 +137,12 @@ test("Group Chat is a tab inside the Chat surface, not a standalone page", () =>
 });
 
 test("Group chat is a world-class chat surface (a11y + resilience)", () => {
-  // Smart autoscroll: never yank a reader who scrolled up; offer a jump pill.
-  assert.match(view, /stickToBottomRef/, "tracks whether the transcript is pinned to the bottom");
-  assert.match(view, /onTranscriptScroll/, "recomputes stickiness on scroll");
+  // Smart autoscroll (cave-o8si): intent-based release via the shared hook —
+  // scrolling up detaches, only the true bottom re-attaches. No position
+  // threshold (the old `< 48` re-stick yanked readers hovering near bottom).
+  assert.match(view, /useStickToBottom\(scrollRef, \{/, "follow behavior comes from the shared intent-release hook");
+  assert.match(view, /stuckRef: stickToBottomRef/, "tracks whether the transcript is pinned to the bottom");
+  assert.doesNotMatch(view, /clientHeight < 48/, "the position-threshold re-stick stays gone");
   assert.match(view, /jumpToLatest/, "offers a jump-to-latest affordance");
   // Transcript is an accessible log region.
   assert.match(view, /role="log"/, "transcript is exposed as a log region");

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -25,6 +25,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Popover } from "@/components/ui/popover";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { useStickToBottom } from "@/lib/use-stick-to-bottom";
 import { MessageBubble } from "@/components/message-bubble";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -93,7 +94,6 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // scrolled up to review history, new streaming content must NOT yank them
   // back down — instead we surface a "jump to latest" pill.
   const [showJump, setShowJump] = useState(false);
-  const stickToBottomRef = useRef(true);
   const dtPrefs = useDateTimePrefs();
   const confirm = useConfirm();
   const { announce } = useAnnouncer();
@@ -101,6 +101,15 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   const addBtnRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Intent-based follow (cave-o8si): scrolling up releases the stick, and only
+  // returning to the true bottom re-attaches — the old 48px position threshold
+  // re-stuck a reader pausing near the bottom, so the next streamed token
+  // yanked them back down.
+  const { stuckRef: stickToBottomRef, schedulePin, stick } = useStickToBottom(scrollRef, {
+    onStickChange: (stuck) => {
+      if (stuck) setShowJump(false);
+    },
+  });
   const composerRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   // Caret to restore after we programmatically rewrite the draft (mention insert).
@@ -210,40 +219,25 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
   // Streaming replies grow the transcript constantly; force-scrolling on every
   // update would fight a reader who scrolled up to re-read an earlier answer.
   useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
     if (stickToBottomRef.current) {
-      el.scrollTop = el.scrollHeight;
+      schedulePin();
       setShowJump(false);
     } else {
       // Something new landed while scrolled up — offer a jump affordance.
       setShowJump(true);
     }
-  }, [transcript]);
+  }, [transcript, schedulePin, stickToBottomRef]);
 
   // When the active group changes, snap to the bottom of its transcript.
   useEffect(() => {
-    stickToBottomRef.current = true;
+    stick();
     setShowJump(false);
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [activeId]);
-
-  const onTranscriptScroll = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    // 48px slop so a near-bottom position still counts as "stuck to bottom".
-    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
-    stickToBottomRef.current = atBottom;
-    if (atBottom) setShowJump(false);
-  }, []);
+  }, [activeId, stick]);
 
   const jumpToLatest = useCallback(() => {
-    const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-    stickToBottomRef.current = true;
+    stick();
     setShowJump(false);
-  }, []);
+  }, [stick]);
 
   // --- restore caret after a programmatic draft rewrite (mention insert) ---
   useEffect(() => {
@@ -847,7 +841,6 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             <div className="relative min-h-0 flex-1">
             <div
               ref={scrollRef}
-              onScroll={onTranscriptScroll}
               role="log"
               aria-label="Coven transcript"
               aria-live="off"

--- a/src/components/quick-chat-controls.test.ts
+++ b/src/components/quick-chat-controls.test.ts
@@ -73,23 +73,36 @@ assert.match(
 );
 
 // ── Thread auto-scroll must not fight the user ────────────────────────────────
-// Follow-along only sticks while the user is at the bottom; scrolling up to
-// reread during a streaming reply stays put, and a new turn re-engages it.
+// (cave-o8si) Follow-along uses the shared intent-release hook: scrolling up
+// detaches, only returning to the true bottom re-attaches, and pins are
+// rAF-coalesced. The old `< 48px` position re-stick — which yanked a reader
+// pausing near the bottom — stays gone.
 assert.match(
   source,
-  /stickRef\.current = el\.scrollHeight - el\.scrollTop - el\.clientHeight < 48/,
-  "the thread tracks whether the user is near the bottom",
+  /const \{ schedulePin, stick \} = useStickToBottom\(scrollRef\)/,
+  "the thread follows via the shared intent-release hook",
+);
+assert.doesNotMatch(
+  source,
+  /clientHeight < 48/,
+  "the position-threshold re-stick stays gone",
 );
 assert.match(
   source,
-  /if \(el && stickRef\.current\) el\.scrollTop = el\.scrollHeight/,
-  "streamed tokens only auto-scroll while the user is following along",
+  /schedulePin\(\);\s*\}, \[messages\.length, lastText, schedulePin\]\)/,
+  "streamed tokens pin through the coalesced scheduler",
 );
 assert.match(
   source,
-  /stickRef\.current = true;\s*\}, \[messages\.length\]\)/,
+  /stick\(\);\s*\}, \[messages\.length, stick\]\)/,
   "a new turn re-engages follow-along scrolling",
 );
+{
+  const hook = readFileSync(new URL("../lib/use-stick-to-bottom.ts", import.meta.url), "utf8");
+  assert.match(hook, /e\.deltaY < 0 && stuckRef\.current && scrollable\(\)/, "wheel-up releases the stick");
+  assert.match(hook, /clientHeight <= 4\) setStuck\(true\)/, "only the true bottom re-sticks");
+  assert.match(hook, /cancelAnimationFrame\(pinFrameRef\.current\);[\s\S]{0,400}pinFrameRef\.current = null;/, "the rAF guard nulls on cancel (StrictMode wedge)");
+}
 
 // ── Copy affordance resets ────────────────────────────────────────────────────
 assert.match(

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -15,6 +15,7 @@ import { IconButton } from "@/components/ui/icon-button";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { copyText } from "@/lib/clipboard";
 import type { QuickChatMessage } from "@/lib/use-quick-chat";
+import { useStickToBottom } from "@/lib/use-stick-to-bottom";
 
 export type QuickChatSelectOption<T extends string> = StandardSelectOption<T>;
 
@@ -410,27 +411,23 @@ export function QuickChatThread({
   onRegenerate?: () => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  // Follow the stream only while the user is already at the bottom — pinning
-  // scrollTop on every token would fight scrolling up to reread earlier turns.
-  const stickRef = useRef(true);
+  // Follow the stream with intent-based release (cave-o8si): scrolling up
+  // detaches, returning to the true bottom re-attaches. The old 48px position
+  // threshold re-stuck a reader pausing near the bottom, so the next streamed
+  // token yanked them back down.
+  const { schedulePin, stick } = useStickToBottom(scrollRef);
   const lastText = messages.length > 0 ? messages[messages.length - 1].text : "";
 
-  const onScroll = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    stickRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
-  }, []);
-
-  // A new turn (sending / a reply starting) re-engages follow-along.
+  // A new turn (sending / a reply starting) re-engages follow-along; on mount
+  // this doubles as the initial snap to the latest turn.
   useEffect(() => {
-    stickRef.current = true;
-  }, [messages.length]);
+    stick();
+  }, [messages.length, stick]);
 
   // Keep the newest turn in view as it streams.
   useEffect(() => {
-    const el = scrollRef.current;
-    if (el && stickRef.current) el.scrollTop = el.scrollHeight;
-  }, [messages.length, lastText]);
+    schedulePin();
+  }, [messages.length, lastText, schedulePin]);
 
   const lastAssistantId = (() => {
     for (let i = messages.length - 1; i >= 0; i--) {
@@ -440,7 +437,7 @@ export function QuickChatThread({
   })();
 
   return (
-    <div ref={scrollRef} onScroll={onScroll} className="quick-chat-thread" aria-live="polite">
+    <div ref={scrollRef} className="quick-chat-thread" aria-live="polite">
       {messages.length === 0 ? (
         <div className="quick-chat-empty">
           <span className="quick-chat-empty__glyph" aria-hidden>

--- a/src/lib/use-stick-to-bottom.ts
+++ b/src/lib/use-stick-to-bottom.ts
@@ -1,0 +1,141 @@
+"use client";
+
+import { useCallback, useEffect, useRef, type RefObject } from "react";
+
+/**
+ * Stick-to-bottom follow behavior for small streaming transcripts (quick-chat
+ * tray, group chat), ported from the main chat's intent-release pattern
+ * (CHAT-D10-01 / PR #2659, cave-o8si):
+ *
+ * - While stuck, pins are INSTANT and rAF-coalesced — never a queued smooth
+ *   scroll per streamed chunk, which also satisfies prefers-reduced-motion.
+ * - Only USER intent releases the stick: wheel-up, a downward touch drag,
+ *   PageUp/Home/ArrowUp, or an upward scrollbar drag. The old position
+ *   threshold (`gap < 48` on every scroll event) is gone — it re-stuck a
+ *   reader who paused just above the bottom, so the next streamed token
+ *   yanked them back down.
+ * - Re-stick happens only at the true bottom (≤4px). While stuck that check
+ *   is a no-op, so the pin's own scroll events can never count as intent.
+ *
+ * The caller keeps ownership of *when* to pin (call `schedulePin()` from its
+ * data effects) and of programmatic re-engagement (`stick()` on send / jump /
+ * conversation switch). The main chat keeps its own inline copy — it carries
+ * extra machinery (FAB wiring, ResizeObserver re-pins for long markdown
+ * transcripts) and heavy test pins; these overlays re-pin on every data
+ * mutation and cap at ~46vh, where late-layout drift hasn't been an issue.
+ */
+export function useStickToBottom(
+  scrollRef: RefObject<HTMLElement | null>,
+  opts?: {
+    /** Observe stick/release flips (e.g. to show a "jump to latest" pill). */
+    onStickChange?: (stuck: boolean) => void;
+  },
+): { stuckRef: RefObject<boolean>; schedulePin: () => void; stick: () => void } {
+  const stuckRef = useRef(true);
+  const pinFrameRef = useRef<number | null>(null);
+  const onStickChangeRef = useRef(opts?.onStickChange);
+  onStickChangeRef.current = opts?.onStickChange;
+
+  const setStuck = useCallback((next: boolean) => {
+    if (stuckRef.current === next) return;
+    stuckRef.current = next;
+    onStickChangeRef.current?.(next);
+  }, []);
+
+  const schedulePin = useCallback(() => {
+    if (!stuckRef.current) return;
+    if (pinFrameRef.current !== null) return;
+    pinFrameRef.current = requestAnimationFrame(() => {
+      pinFrameRef.current = null;
+      const el = scrollRef.current;
+      if (!el || !stuckRef.current) return;
+      el.scrollTop = el.scrollHeight;
+    });
+  }, [scrollRef]);
+
+  const stick = useCallback(() => {
+    setStuck(true);
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [scrollRef, setStuck]);
+
+  useEffect(() => () => {
+    if (pinFrameRef.current !== null) {
+      cancelAnimationFrame(pinFrameRef.current);
+      // MUST null: StrictMode/Suspense re-run effects while refs persist —
+      // a cancelled-but-not-nulled id wedges the coalescing guard and the
+      // pin never runs again for this component instance (the rAF-wedge bug
+      // fixed in the main chat, PR #2659).
+      pinFrameRef.current = null;
+    }
+  }, []);
+
+  // Release on intent + re-stick at the true bottom. Programmatic pins emit
+  // scroll events but never wheel/touch/key/scrollbar-grab events, so they
+  // are structurally excluded from intent detection.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    let lastTouchY: number | null = null;
+    // A transcript that doesn't overflow can't be scrolled away from the
+    // bottom — releasing there would strand the surface with no scroll event
+    // to ever re-stick it.
+    const scrollable = () => el.scrollHeight - el.clientHeight > 1;
+    const onWheel = (e: WheelEvent) => {
+      if (e.deltaY < 0 && stuckRef.current && scrollable()) setStuck(false);
+    };
+    const onTouchStart = (e: TouchEvent) => {
+      lastTouchY = e.touches[0]?.clientY ?? null;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      const y = e.touches[0]?.clientY;
+      if (y === undefined) return;
+      // Finger moving down the screen drags content down = scrolling up.
+      if (lastTouchY !== null && y > lastTouchY && stuckRef.current && scrollable()) {
+        setStuck(false);
+      }
+      lastTouchY = y;
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.key === "PageUp" || e.key === "Home" || e.key === "ArrowUp") && stuckRef.current) {
+        setStuck(false);
+      }
+    };
+    // Scrollbar drags emit no wheel/touch/key events. A grab lands on the
+    // scroller itself with its X past the content box (the gutter, LTR); only
+    // an actual upward move during the grab releases.
+    let scrollbarGrab = false;
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.target === el && e.offsetX >= el.clientWidth) scrollbarGrab = true;
+    };
+    const onMouseUp = () => {
+      scrollbarGrab = false;
+    };
+    const onScroll = () => {
+      if (stuckRef.current) {
+        if (scrollbarGrab && el.scrollHeight - el.scrollTop - el.clientHeight > 4) setStuck(false);
+        return;
+      }
+      // Released: re-stick only when the user returns to the true bottom.
+      if (el.scrollHeight - el.scrollTop - el.clientHeight <= 4) setStuck(true);
+    };
+    el.addEventListener("wheel", onWheel, { passive: true });
+    el.addEventListener("touchstart", onTouchStart, { passive: true });
+    el.addEventListener("touchmove", onTouchMove, { passive: true });
+    el.addEventListener("keydown", onKeyDown);
+    el.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mouseup", onMouseUp);
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("keydown", onKeyDown);
+      el.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("mouseup", onMouseUp);
+      el.removeEventListener("scroll", onScroll);
+    };
+  }, [scrollRef, setStuck]);
+
+  return { stuckRef, schedulePin, stick };
+}


### PR DESCRIPTION
## Summary

Bead `cave-o8si` (follow-up from #2659/CHAT-D10-01, adopted from a stranded claim with owner approval). The quick-chat tray and group chat still used the position-threshold stick the main chat retired: every scroll event recomputed `stuck = gap < 48px`, so a reader pausing within 48px of the bottom got silently re-stuck and the next streamed token yanked them to the bottom.

**New shared `src/lib/use-stick-to-bottom.ts`** ports the main chat's intent-release pattern for small transcript surfaces:
- **rAF-coalesced instant pins** — never a queued smooth scroll per chunk; the frame guard nulls on cancel (the StrictMode/Suspense wedge fixed in #2659)
- **Release only on user intent** — wheel-up, downward touch drag, PageUp/Home/ArrowUp, or an upward scrollbar drag (grab detected via gutter hit-test); a non-overflowing transcript never releases (nothing could re-stick it)
- **Re-stick only at the true bottom (≤4px)** — while stuck that check is a no-op, so programmatic pins can't count as intent

**Wiring:** quick-chat's `stickRef`/`onScroll` threshold and group chat's `stickToBottomRef`/`onTranscriptScroll` are replaced by the hook; group chat's jump-to-latest pill clears through `onStickChange`, and send/jump/coven-switch re-engage via `stick()`. The main chat deliberately keeps its inline copy (FAB wiring, ResizeObserver re-pins for long markdown transcripts, heavy test pins) — these overlays re-pin on every data mutation and cap at ~46vh.

## Test plan

- [x] Pins updated: hook usage + threshold-stays-gone guards in both surface tests; hook internals (wheel release, true-bottom re-stick, null-on-cancel) pinned from quick-chat's test
- [x] Quick-chat, tray, group-chat tests + full `pnpm test:app` (569 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)