### PR TITLE
refactor(composer): shared inline slash-menus hook — phase 5 of the composer consolidation (cave-9kir)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -279,6 +279,7 @@ export const SUITES = {
     "src/lib/use-composer-draft.test.ts",
     "src/lib/use-composer-history.test.ts",
     "src/lib/use-attachment-staging.test.ts",
+    "src/lib/use-inline-slash-menus.test.ts",
     "src/lib/prompt-enhancer.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -12,6 +12,8 @@ const globalsSrc = readFileSync(new URL("../app/globals.css", import.meta.url), 
 const attachmentsLib = readFileSync(new URL("../lib/chat-attachments.ts", import.meta.url), "utf8");
 // The staging state machine (cap, drag overlay, paste) lives in the shared hook.
 const attachStagingHook = readFileSync(new URL("../lib/use-attachment-staging.ts", import.meta.url), "utf8");
+// The inline slash menus (options, dismiss, keyboard branches) live in theirs.
+const menusHookSource = readFileSync(new URL("../lib/use-inline-slash-menus.ts", import.meta.url), "utf8");
 
 assert.doesNotMatch(
   globalsSrc,
@@ -623,32 +625,40 @@ assert.doesNotMatch(
 );
 
 // — CHAT-D2-01: slash menu keyboard contract ("↵ run · Tab complete · esc cancel") —
+// The menu branches live in the shared use-inline-slash-menus hook; chat's
+// onComposerKey delegates to its dispatcher. Semantics pin the hook, ordering
+// pins chat's handler.
 const composerKey = source.match(/const onComposerKey = [\s\S]*?\n  \};/)?.[0] ?? "";
-const slashBranch = composerKey.match(/if \(slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0\) \{[\s\S]*?\n    \}/)?.[0] ?? "";
+const slashBranch = menusHookSource.match(/if \(slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0\) \{[\s\S]*?\n      \}/)?.[0] ?? "";
 
 assert.match(
   slashBranch,
-  /if \(e\.key === "Enter" && !e\.shiftKey\) \{[\s\S]*slashSuggestions\[slashIdx\][\s\S]*intentFromSlash\(cmd\.name\)/,
+  /if \(e\.key === "Enter" && !e\.shiftKey\) \{[\s\S]*slashSuggestions\[slashIdx\][\s\S]*onRunCommand\(cmd\)/,
   "Slash-menu Enter must run the highlighted suggestion, not send the partially typed text",
 );
 assert.match(
+  source,
+  /onRunCommand: \(cmd\) => \{\s*\n\s*intentFromSlash\(cmd\.name\);\s*\n\s*\}/,
+  "chat routes a run command through intentFromSlash (home submits the typed text instead)",
+);
+assert.match(
   slashBranch,
-  /cmd\.argPlaceholder && canonicalize\(input\.trim\(\)\) !== cmd\.name[\s\S]*setInput\(cmd\.name \+ " "\)/,
+  /cmd\.argPlaceholder && canonicalize\(text\.trim\(\)\) !== cmd\.name[\s\S]*setText\(cmd\.name \+ " "\)/,
   "Slash-menu Enter autocompletes argument-taking commands (like Tab) instead of running them bare",
 );
 assert.match(
-  slashBranch,
-  /if \(e\.key === "Escape"\) \{[\s\S]*setSlashDismissed\(true\)/,
-  "Esc with the slash menu open must dismiss the menu",
+  menusHookSource,
+  /if \(e\.key === "Escape" && menuOpen\) \{[\s\S]{0,400}setSlashDismissed\(true\);[\s\S]{0,40}return true;/,
+  "Esc with any inline menu open must dismiss the menu",
 );
 assert.ok(
-  composerKey.includes("setSlashDismissed(true)") &&
-    composerKey.indexOf("setSlashDismissed(true)") < composerKey.indexOf("cancelSend()"),
-  "Esc precedence: dismiss the slash menu before the busy-cancel branch can kill the stream",
+  composerKey.includes("handleMenuKey(e)") &&
+    composerKey.indexOf("handleMenuKey(e)") < composerKey.indexOf("cancelSend()"),
+  "Esc precedence: the menu dispatcher (which consumes Esc while open) runs before the busy-cancel branch can kill the stream",
 );
 assert.match(
-  source,
-  /setSlashIdx\(0\);\s*\n\s*setSlashDismissed\(false\);/,
+  menusHookSource,
+  /setSlashIdx\(0\);\s*\n\s*setSlashDismissed\(false\);\s*\n\s*\}, \[text\]\);/,
   "Editing the input must re-arm dismissed slash suggestions",
 );
 assert.match(
@@ -1020,17 +1030,20 @@ assert.match(
   /if \(mentionOpen\) \{[\s\S]*?setMentionDismissed\(true\)/,
   "Esc with the mention picker open must dismiss the picker",
 );
+// The slash branches live behind the shared hook's dispatcher, so the #402
+// ordering contract anchors on the dispatch call: mention branch → menu
+// dispatcher (consumes Esc while any menu is open) → busy-cancel.
 assert.ok(
   mentionComposerKey.indexOf("if (mentionOpen) {") <
-    mentionComposerKey.indexOf("if (slashSuggestions.length > 0 || skillCommandRows.length > 0) {"),
-  "The mention branch must run before the slash branch in onComposerKey",
+    mentionComposerKey.indexOf("handleMenuKey(e)"),
+  "The mention branch must run before the slash-menu dispatcher in onComposerKey",
 );
 assert.ok(
   mentionComposerKey.indexOf("setMentionDismissed(true)") <
-    mentionComposerKey.indexOf("setSlashDismissed(true)") &&
-    mentionComposerKey.indexOf("setSlashDismissed(true)") <
+    mentionComposerKey.indexOf("handleMenuKey(e)") &&
+    mentionComposerKey.indexOf("handleMenuKey(e)") <
       mentionComposerKey.indexOf("cancelSend()"),
-  "Esc precedence: mention dismiss before slash dismiss before busy-cancel",
+  "Esc precedence: mention dismiss before slash dismiss (inside the dispatcher) before busy-cancel",
 );
 assert.match(
   mentionComposerKey,
@@ -1202,10 +1215,12 @@ assert.match(source, /setInput\(""\);\s*\n\s*\/\/[\s\S]*?clearDraft\(\);/, "send
 // (2) send() resets the enhance strip so it doesn't linger over an empty
 //     composer and let Revert repopulate the already-sent message.
 assert.match(source, /clearDraft\(\);[\s\S]{0,400}?setEnhanceStatus\("idle"\);\s*\n\s*setEnhanceOriginal\(null\);/, "send resets the enhance (Prompt improved / Revert) state");
-// (1) the /model, /skill and /prompt inline pickers each dismiss on Escape
+// (1) the slash, /model, /skill and /prompt pickers all dismiss on Escape
 //     (their footers advertise "esc cancel"); previously Esc fell through and
-//     cancelled a live stream. Together with the slash-menu branch that's 4.
-{
-  const escDismiss = source.match(/if \(e\.key === "Escape"\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setSlashDismissed\(true\);\s*\n\s*return;\s*\n\s*\}/g);
-  assert.ok(escDismiss && escDismiss.length >= 4, "the slash, model, skill and prompt pickers all dismiss on Escape (setSlashDismissed)");
-}
+//     cancelled a live stream. The shared hook guards ONE Escape branch on
+//     menuOpen — the union of all four pickers — so none can leak Esc through.
+assert.match(
+  menusHookSource,
+  /if \(e\.key === "Escape" && menuOpen\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*setSlashDismissed\(true\);\s*\n\s*return true;\s*\n\s*\}/,
+  "the slash, model, skill and prompt pickers all dismiss on Escape (setSlashDismissed behind menuOpen)",
+);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -11,7 +11,7 @@ import { segmentTurn } from "@/lib/turn-segments";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { createLiveGenerationRegistry, type LiveGenerationSnapshot } from "@/lib/live-chat-generations";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
-import { canonicalize, formatHelp, matchSlash, type SlashCommand } from "@/lib/slash-commands";
+import { canonicalize, formatHelp } from "@/lib/slash-commands";
 import { Icon, type IconName } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -53,23 +53,19 @@ import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/co
 import { ThinkingIndicator } from "@/components/ui/thinking-indicator";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { DebugPane } from "@/components/debug-pane";
-import { modelSlashOptions, resolveModelArg, formatModelList } from "@/lib/slash-model";
+import { resolveModelArg, formatModelList } from "@/lib/slash-model";
 import {
-  skillSlashOptions,
   resolveSkillInvocation,
   formatSkillList,
   buildSkillPrompt,
-  skillCommandMatches,
   type SkillOption,
 } from "@/lib/slash-skill";
 import {
-  promptSlashOptions,
   resolvePromptArg,
   formatPromptList,
   promptInsertion,
   type PromptOption,
 } from "@/lib/slash-prompt";
-import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
 import { PromptSnippetsModal, promptIconName } from "@/components/prompt-snippets-modal";
 import { catalogForRuntime } from "@/lib/runtime-models";
 import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
@@ -126,6 +122,7 @@ import { findMatchingTurnIds } from "@/lib/transcript-find";
 import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-state";
 import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
+import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
 import { resolveActivePath, buildSiblingIndex, childLeaf } from "@/lib/conversation-tree";
 import { appendCollapsingNewlines } from "@/lib/stream-text";
 import { stripStepMarkers } from "@/lib/workflow-step-progress";
@@ -2707,60 +2704,45 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       ? Math.max(0, window.innerHeight - vv.height - vv.offsetTop)
       : 0;
 
-  // Slash suggestions
-  const slashMatches: SlashCommand[] = useMemo(() => {
-    const firstWord = input.trimStart().split(/\s/)[0] ?? "";
-    if (!firstWord.startsWith("/") || input.trimStart().includes(" ")) return [];
-    return matchSlash(firstWord);
-  }, [input]);
-  const [slashIdx, setSlashIdx] = useState(0);
-  // Esc hides the menu for the current input; any edit brings it back.
-  const [slashDismissed, setSlashDismissed] = useState(false);
-  const slashSuggestions: SlashCommand[] = slashDismissed ? [] : slashMatches;
-  // Skills for the inline `/skill` / `/skills` picker — fetched once from the
-  // local skill scan (Coven skills + ~/.claude/skills).
-  const [skills, setSkills] = useState<SkillOption[]>([]);
-  useEffect(() => {
-    let alive = true;
-    fetch("/api/skills/local", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j) => {
-        if (alive && j?.ok && Array.isArray(j.skills)) setSkills(j.skills as SkillOption[]);
-      })
-      .catch(() => {
-        /* offline → no inline skill picker (the command menu still works) */
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
-  // Prompt templates for the `/prompt` / `/prompts` picker and the Prompt
-  // snippets modal. Seeded with the built-ins so the picker works instantly
-  // (and offline); the fetch layers in ~/.coven/prompts files and installed
-  // marketplace prompt packs.
-  const [prompts, setPrompts] = useState<PromptOption[]>(BUILTIN_PROMPTS);
-  const [promptSnippetsOpen, setPromptSnippetsOpen] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    fetch("/api/prompts", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j) => {
-        if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
-      })
-      .catch(() => {
-        /* offline → built-in templates only */
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
-  // While typing "/model <partial>", the menu shows model options instead of
-  // commands (an inline picker). null ⇒ not in /model arg position.
+  // Inline slash menus (/command listbox + Skills group, /model, /skill,
+  // /prompt pickers) — shared hook (use-inline-slash-menus). What a pick DOES
+  // stays chat's: model picks append a system line + clear, skill picks send
+  // in-thread (invokeSkillOption), prompts insert-for-editing, and Enter on a
+  // command runs the highlighted suggestion's intent — never the partially
+  // typed text, and never recorded in ↑ history (send() owns that push).
   const modelHarness = modelState?.harness ?? familiar.harness ?? "claude";
-  const modelOptions = useMemo(
-    () => (slashDismissed ? null : modelSlashOptions(input, modelHarness)),
-    [input, modelHarness, slashDismissed],
-  );
+  const {
+    skills,
+    prompts,
+    slashSuggestions,
+    skillCommandRows,
+    modelOptions,
+    skillOptions,
+    promptOptions,
+    modelMenuActive,
+    skillMenuActive,
+    promptMenuActive,
+    menuOpen,
+    slashIdx,
+    setSlashIdx,
+    slashListboxId,
+    handleKeyDown: handleMenuKey,
+  } = useInlineSlashMenus({
+    text: input,
+    setText: setInput,
+    modelHarness,
+    onPickModel: (id) => {
+      handleSelectModel(id);
+      appendSystem(`Model set to ${id}.`);
+      setInput("");
+    },
+    onPickSkill: (s) => invokeSkillOption(s),
+    onInsertPrompt: (p) => insertPrompt(p),
+    onRunCommand: (cmd) => {
+      intentFromSlash(cmd.name);
+    },
+  });
+  const [promptSnippetsOpen, setPromptSnippetsOpen] = useState(false);
   // Stable model menu for the composer chip (independent of the /model
   // autocomplete above, which is null outside `/model <arg>` position).
   const composerModelOptions = useMemo(
@@ -2771,36 +2753,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
       ? modelState.effectiveModel
       : composerModelOptions[0]?.id ?? "";
-  const modelMenuActive = (modelOptions?.length ?? 0) > 0;
-  // Inline `/skill` / `/skills` picker — null ⇒ not in a skill-picker position.
-  const skillOptions = useMemo(
-    () => (slashDismissed ? null : skillSlashOptions(input, skills)),
-    [input, skills, slashDismissed],
-  );
-  const skillMenuActive = (skillOptions?.length ?? 0) > 0;
-  // Inline `/prompt` / `/prompts` picker — null ⇒ not in a prompt-picker position.
-  const promptOptions = useMemo(
-    () => (slashDismissed ? null : promptSlashOptions(input, prompts)),
-    [input, prompts, slashDismissed],
-  );
-  const promptMenuActive = (promptOptions?.length ?? 0) > 0;
-  // Skills surfaced directly in the command menu — typing `/revi` finds the
-  // code-review skill without the /skill prefix. Same first-token-only rule as
-  // slashMatches so arg positions never double-render.
-  const skillCommandRows: SkillOption[] = useMemo(() => {
-    if (slashDismissed) return [];
-    const t = input.trimStart();
-    const firstWord = t.split(/\s/)[0] ?? "";
-    if (!firstWord.startsWith("/") || t.includes(" ")) return [];
-    return skillCommandMatches(firstWord, skills);
-  }, [input, skills, slashDismissed]);
-  // The slash-command, /model, /skill and /prompt pickers are mutually
-  // exclusive inline listboxes sharing one listbox id, so the composer's
-  // combobox ARIA tracks whichever is open.
-  const menuOpen = modelMenuActive || skillMenuActive || promptMenuActive || slashSuggestions.length > 0 || skillCommandRows.length > 0;
-  // Stable per-mount listbox id — the home composer mounts its own slash menu,
-  // so ids must be unique across simultaneously mounted composers.
-  const slashListboxId = useId();
 
   // @-file mentions (CHAT-D1-04). Typing `@` opens a workspace-file picker
   // for the selected predetermined project. The file index is fetched once
@@ -2963,9 +2915,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return { groupedTurns: grouped, turnIndexMap };
   }, [activePath]);
 
+  // The slash-menu index/dismissal resets live in useInlineSlashMenus; the
+  // @-mention picker re-arms here (same any-edit-brings-it-back contract).
   useEffect(() => {
-    setSlashIdx(0);
-    setSlashDismissed(false);
     setMentionIdx(0);
     setMentionDismissed(false);
   }, [input]);
@@ -4388,150 +4340,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
     }
-    if (modelMenuActive && modelOptions) {
-      const opts = modelOptions;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.min(i + 1, opts.length - 1));
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const m = opts[slashIdx];
-        if (m) setInput(`/model ${m.id}`);
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        const m = opts[slashIdx];
-        if (m) {
-          handleSelectModel(m.id);
-          appendSystem(`Model set to ${m.id}.`);
-          setInput("");
-        }
-        return;
-      }
-      // Esc dismisses the picker (its footer advertises "esc cancel"); without
-      // this, Esc fell through to the busy branch and cancelled a live stream.
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setSlashDismissed(true);
-        return;
-      }
-    }
-    if (skillMenuActive && skillOptions) {
-      const opts = skillOptions;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.min(i + 1, opts.length - 1));
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const s = opts[slashIdx];
-        if (s) setInput(`/skill ${s.id}`);
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        const s = opts[slashIdx];
-        if (s) invokeSkillOption(s);
-        return;
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setSlashDismissed(true);
-        return;
-      }
-    }
-    if (promptMenuActive && promptOptions) {
-      const opts = promptOptions;
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.min(i + 1, opts.length - 1));
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const p = opts[slashIdx];
-        if (p) setInput(`/prompt ${p.id}`);
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        const p = opts[slashIdx];
-        if (p) insertPrompt(p);
-        return;
-      }
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setSlashDismissed(true);
-        return;
-      }
-    }
-    if (slashSuggestions.length > 0 || skillCommandRows.length > 0) {
-      // One roving index across commands, then the Skills group beneath them.
-      const total = slashSuggestions.length + skillCommandRows.length;
-      const skillAt = (i: number): SkillOption | undefined =>
-        skillCommandRows[i - slashSuggestions.length];
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.min(i + 1, total - 1));
-        return;
-      }
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSlashIdx((i) => Math.max(i - 1, 0));
-        return;
-      }
-      if (e.key === "Tab") {
-        e.preventDefault();
-        const cmd = slashSuggestions[slashIdx];
-        const s = skillAt(slashIdx);
-        if (cmd) setInput(cmd.name + (cmd.argPlaceholder ? " " : ""));
-        else if (s) setInput(`/skill ${s.id} `);
-        return;
-      }
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        const cmd = slashSuggestions[slashIdx];
-        const s = skillAt(slashIdx);
-        // If the highlighted command takes an argument and the input isn't
-        // the exact command yet, autocomplete first (like Tab) so the user
-        // can fill in args; otherwise run the highlighted suggestion — not
-        // the partially typed text. Mirrors home-composer.
-        if (cmd && cmd.argPlaceholder && canonicalize(input.trim()) !== cmd.name) {
-          setInput(cmd.name + " ");
-        } else if (cmd) {
-          intentFromSlash(cmd.name);
-        } else if (s) {
-          invokeSkillOption(s);
-        }
-        return;
-      }
-      // Esc precedence: an open slash menu consumes Esc (dismiss) before
-      // the busy branch below gets a chance to cancel the stream.
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setSlashDismissed(true);
-        return;
-      }
-    }
+    // The inline slash menus (Esc-dismiss, ↑↓/Tab/Enter across all four
+    // pickers) — shared hook. Ordering is load-bearing: the @-mention branch
+    // above consumes Esc first (#402), and the busy-cancel branch below only
+    // sees Esc once no menu is open, so a dismissed menu never costs a
+    // live stream.
+    if (handleMenuKey(e)) return;
     // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer
     if (handleArrowKey(e, input, setInput)) return;
     // `isComposing` is true for the Enter that confirms an IME candidate

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -5,6 +5,7 @@ import { readFile } from "node:fs/promises";
 const source = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
 const draftHook = await readFile(new URL("../lib/use-composer-draft.ts", import.meta.url), "utf8");
 const attachHook = await readFile(new URL("../lib/use-attachment-staging.ts", import.meta.url), "utf8");
+const menusHook = await readFile(new URL("../lib/use-inline-slash-menus.ts", import.meta.url), "utf8");
 const homeSelect = await readFile(new URL("./home/home-select.tsx", import.meta.url), "utf8");
 const modelStateHook = await readFile(new URL("./home/use-home-model-state.ts", import.meta.url), "utf8");
 const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
@@ -269,10 +270,17 @@ assert.doesNotMatch(
   "HomeComposer should allow OpenClaw familiars through native chat send",
 );
 
+// The menu branches live in the shared hook (use-inline-slash-menus); the
+// keyboard handler depends on the hook's dispatcher + the current submit.
 assert.match(
   handleKeyDownBlock,
-  /\[[\s\S]*handleSubmit[\s\S]*modelMenuActive[\s\S]*modelOptions[\s\S]*\]/,
-  "HomeComposer Enter-submit keyboard handler should depend on the current submit callback and model menu state",
+  /\[handleMenuKey, handleSubmit, handleArrowKey, text\]/,
+  "HomeComposer Enter-submit keyboard handler should depend on the shared menu dispatcher and the current submit callback",
+);
+assert.match(
+  handleKeyDownBlock,
+  /if \(handleMenuKey\(e\)\) return;/,
+  "the inline menus consume their keys before Enter-submit and history recall",
 );
 
 assert.doesNotMatch(
@@ -358,30 +366,28 @@ for (const [name, src] of [
     /aria-activedescendant=\{\s*menuOpen \? `\$\{slashListboxId\}-opt-\$\{slashIdx\}` : undefined\s*\}/,
     `${name} aria-activedescendant should track the highlighted index and be absent when the menu is closed`,
   );
-  // menuOpen unifies the slash-command and /model listboxes (both share the
-  // listbox id), so the combobox ARIA covers the /model picker too — not just
-  // the slash menu. Both composers must use it. (HomeComposer additionally gates
-  // the slash term on its Escape-dismiss flag: `(!slashDismissed && …)`.)
+  // menuOpen unifies the slash-command, /model, /skill and /prompt listboxes
+  // (all share the listbox id) so the combobox ARIA covers whichever is open.
+  // Its definition lives in the shared hook; each composer must destructure it
+  // from there rather than deriving its own.
   assert.match(
     src,
-    /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\|[\s\S]{0,80}slashSuggestions\.length > 0/,
-    `${name} combobox ARIA must reflect every inline menu (slash, /model, /skill, /prompt)`,
+    /menuOpen,[\s\S]{0,200}?\} = useInlineSlashMenus\(\{/,
+    `${name} combobox ARIA must reflect every inline menu via the shared hook's menuOpen`,
   );
 }
 
-// ── HomeComposer combobox ARIA covers the /model picker, not just slash ──────
-// Both inline listboxes share the listbox id; menuOpen unifies them so the
-// textarea announces the /model picker too (was: slash-only). The slash term is
-// gated on the Escape-dismiss flag so a dismissed menu also drops the combobox
-// ARIA.
+// ── The menuOpen union itself lives in the shared hook ───────────────────────
+// The slash/skills terms fold the Escape-dismiss flag into the lists (emptied
+// while dismissed), so a dismissed menu also drops the combobox ARIA.
 assert.match(
-  source,
-  /const menuOpen =\s*modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\|\s*\(!slashDismissed && \(slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0\)\);/,
-  "HomeComposer combobox ARIA reflects every inline menu (slash, /model, /skill, /prompt, Skills group)",
+  menusHook,
+  /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/,
+  "menuOpen reflects every inline menu (slash, /model, /skill, /prompt, Skills group)",
 );
 
 // ── /skill + /skills inline picker (mirrors /model) ──────────────────────────
-assert.match(source, /skillSlashOptions\(text, skills\)/, "HomeComposer offers inline /skill autocomplete");
+assert.match(menusHook, /skillSlashOptions\(text, skills\)/, "the shared hook offers inline /skill autocomplete");
 assert.match(source, /command === "\/skill" \|\| command === "\/skills"/, "HomeComposer handles the /skill and /skills commands");
 assert.match(
   source,
@@ -452,9 +458,14 @@ assert.match(
 );
 
 assert.match(
-  source,
+  menusHook,
   /modelSlashOptions\(text, modelHarness\)/,
-  "HomeComposer offers inline /model autocomplete",
+  "the shared hook offers inline /model autocomplete",
+);
+assert.match(
+  source,
+  /onPickModel: \(id\) => \{ handleSelectModel\(id\); onToast\(`Model set to \$\{id\}\.`\); setText\(""\); \}/,
+  "a /model pick lands as the home model selection with a toast (chat appends a system line instead)",
 );
 
 assert.match(
@@ -623,29 +634,31 @@ assert.match(
 // (reset on text change) closes them; and the genuinely-silent state changes
 // (enhance success, attachment add — neither raises a toast) announce to the
 // shared live region so screen-reader users aren't left guessing.
+// (The dismiss machinery moved into the shared hook — one flag, reset on text,
+// options nulled while dismissed so every *MenuActive respects it.)
 assert.match(
-  source,
+  menusHook,
   /const \[slashDismissed, setSlashDismissed\] = useState\(false\)/,
   "a slashDismissed flag backs Escape-to-dismiss for the inline menus",
 );
 assert.match(
-  source,
-  /if \(e\.key === "Escape" && menuOpen\) \{[\s\S]{0,120}setSlashDismissed\(true\);[\s\S]{0,40}return;/,
+  menusHook,
+  /if \(e\.key === "Escape" && menuOpen\) \{[\s\S]{0,400}setSlashDismissed\(true\);[\s\S]{0,40}return true;/,
   "Escape closes any open inline menu (the footers advertise Esc cancel)",
 );
 assert.match(
-  source,
-  /setSlashIdx\(0\);\s*setSlashDismissed\(false\);/,
+  menusHook,
+  /setSlashIdx\(0\);\s*setSlashDismissed\(false\);\s*\}, \[text\]\);/,
   "the dismissed flag resets when the text changes so a fresh token re-opens the menu",
 );
 assert.match(
-  source,
-  /const modelMenuActive = !slashDismissed &&/,
+  menusHook,
+  /slashDismissed \? null : modelSlashOptions\(text, modelHarness\)/,
   "the model menu respects the dismissed flag",
 );
 assert.match(
-  source,
-  /const skillMenuActive = !slashDismissed &&/,
+  menusHook,
+  /slashDismissed \? null : skillSlashOptions\(text, skills\)/,
   "the skill menu respects the dismissed flag",
 );
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -12,34 +12,30 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
 } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { Icon, type IconName } from "@/lib/icon";
-import { modelSlashOptions, resolveModelArg } from "@/lib/slash-model";
+import { resolveModelArg } from "@/lib/slash-model";
 import {
-  skillSlashOptions,
   resolveSkillInvocation,
   buildSkillPrompt,
-  skillCommandMatches,
   type SkillOption,
 } from "@/lib/slash-skill";
 import {
-  promptSlashOptions,
   resolvePromptArg,
   promptInsertion,
   type PromptOption,
 } from "@/lib/slash-prompt";
-import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
 import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import { useAutogrowTextarea } from "@/lib/use-autogrow-textarea";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
 import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
-import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
+import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
+import { canonicalize } from "@/lib/slash-commands";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
@@ -140,11 +136,6 @@ export function HomeComposer({
   // Persisted ↑/↓ prompt-history recall — shared hook (use-composer-history);
   // home records slash commands in history too, so pushes stay at call sites.
   const { push: pushHistory, handleArrowKey } = useComposerHistory(HOME_HISTORY_KEY);
-  const [slashIdx, setSlashIdx] = useState(0);
-  // Escape dismisses the inline slash/model/skill menus (they otherwise stay
-  // open purely as a function of the text). Reset whenever the text changes so
-  // typing a fresh command token re-opens them.
-  const [slashDismissed, setSlashDismissed] = useState(false);
   // Time-of-day greeting for the hero eyebrow. Sampled after mount (client
   // clock) so SSR markup stays deterministic — the eyebrow fades in once set.
   const [greeting, setGreeting] = useState<string | null>(null);
@@ -152,9 +143,6 @@ export function HomeComposer({
     setGreeting(greetingForHour(new Date().getHours()));
   }, []);
   const { announce } = useAnnouncer();
-  // Stable per-mount listbox id — the chat composer mounts its own slash menu,
-  // so ids must be unique across simultaneously mounted composers.
-  const slashListboxId = useId();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   // Attachments staged in the composer (cap 10, mirroring the chat composer);
   // handed to the opened chat on submit. Shared hook — home adds the limit
@@ -283,71 +271,40 @@ export function HomeComposer({
     setSelectedProjectId(projects[0]?.id ?? "");
   }, [projects, selectedProjectId]);
 
-  // Mirror the chat composer's matching rule: surface only while the user is
-  // still typing the command token (no whitespace yet).
-  const slashSuggestions: SlashCommand[] = useMemo(() => {
-    const firstWord = text.trimStart().split(/\s/)[0] ?? "";
-    if (!firstWord.startsWith("/") || text.trimStart().includes(" ")) return [];
-    return matchSlash(firstWord);
-  }, [text]);
-
-  // Inline model picker: typing "/model <partial>" shows model options.
+  // Inline slash menus (/command listbox + Skills group, /model, /skill,
+  // /prompt pickers) — shared hook (use-inline-slash-menus). What a pick DOES
+  // stays home's: model picks toast + clear, skill picks start a new chat
+  // (invokeSkill), prompts insert-for-editing, and Enter on a command (or
+  // nothing highlighted) falls through to handleSubmit — home dispatches the
+  // typed text, so slash commands also land in the ↑ history.
   const modelHarness =
     modelState?.harness ?? selectedFamiliar?.harness ?? "claude";
-  const modelOptions = useMemo(() => modelSlashOptions(text, modelHarness), [text, modelHarness]);
-  const modelMenuActive = !slashDismissed && (modelOptions?.length ?? 0) > 0;
-  // Inline skill picker: "/skill <partial>" / "/skills" shows skill options.
-  const [skills, setSkills] = useState<SkillOption[]>([]);
-  useEffect(() => {
-    let alive = true;
-    fetch("/api/skills/local", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j) => {
-        if (alive && j?.ok && Array.isArray(j.skills)) setSkills(j.skills as SkillOption[]);
-      })
-      .catch(() => {
-        /* offline → no inline skill picker */
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
-  const skillOptions = useMemo(() => skillSlashOptions(text, skills), [text, skills]);
-  const skillMenuActive = !slashDismissed && (skillOptions?.length ?? 0) > 0;
-  // Prompt templates for the "/prompt <partial>" / "/prompts" picker. Seeded
-  // with the built-ins so it works instantly (and offline); the fetch layers
-  // in ~/.coven/prompts files and installed marketplace prompt packs.
-  const [prompts, setPrompts] = useState<PromptOption[]>(BUILTIN_PROMPTS);
-  useEffect(() => {
-    let alive = true;
-    fetch("/api/prompts", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j) => {
-        if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
-      })
-      .catch(() => {
-        /* offline → built-in templates only */
-      });
-    return () => {
-      alive = false;
-    };
-  }, []);
-  const promptOptions = useMemo(() => promptSlashOptions(text, prompts), [text, prompts]);
-  const promptMenuActive = !slashDismissed && (promptOptions?.length ?? 0) > 0;
-  // Skills surfaced directly in the command menu — typing `/revi` finds the
-  // code-review skill without the /skill prefix. Same first-token-only rule
-  // as slashSuggestions; mirrors chat-view.
-  const skillCommandRows: SkillOption[] = useMemo(() => {
-    const t = text.trimStart();
-    const firstWord = t.split(/\s/)[0] ?? "";
-    if (!firstWord.startsWith("/") || t.includes(" ")) return [];
-    return skillCommandMatches(firstWord, skills);
-  }, [text, skills]);
-  // The inline listboxes (slash commands, /model, /skill, /prompt) share the
-  // same listbox id, so the textarea's combobox ARIA tracks whichever is open.
-  const menuOpen =
-    modelMenuActive || skillMenuActive || promptMenuActive ||
-    (!slashDismissed && (slashSuggestions.length > 0 || skillCommandRows.length > 0));
+  const {
+    skills,
+    prompts,
+    slashSuggestions,
+    skillCommandRows,
+    modelOptions,
+    skillOptions,
+    promptOptions,
+    modelMenuActive,
+    skillMenuActive,
+    promptMenuActive,
+    menuOpen,
+    slashIdx,
+    setSlashIdx,
+    slashListboxId,
+    handleKeyDown: handleMenuKey,
+  } = useInlineSlashMenus({
+    text,
+    setText,
+    modelHarness,
+    onPickModel: (id) => { handleSelectModel(id); onToast(`Model set to ${id}.`); setText(""); },
+    onPickSkill: (s) => invokeSkill(s),
+    onInsertPrompt: (p) => insertPromptTemplate(p),
+    onRunCommand: () => { void handleSubmit(); },
+    onNoMatchEnter: () => { void handleSubmit(); },
+  });
 
   // Invoke a skill from home = open a new chat that asks the familiar to run
   // it. A skill with an argument-hint autofills `/skill <id> ` for argument
@@ -398,11 +355,6 @@ export function HomeComposer({
     },
     [announce],
   );
-
-  useEffect(() => {
-    setSlashIdx(0);
-    setSlashDismissed(false);
-  }, [text]);
 
   // Persist the draft so a reload restores it; cleared when the input empties
   // (e.g. after a send), so sent prompts don't reappear. Shared hook —
@@ -659,93 +611,9 @@ export function HomeComposer({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      // Escape closes any open inline menu — the menu footers advertise
-      // "Esc cancel", and typing re-opens it (slashDismissed resets on text).
-      if (e.key === "Escape" && menuOpen) {
-        e.preventDefault();
-        setSlashDismissed(true);
-        return;
-      }
-      // Inline model picker takes priority when "/model <partial>" is open.
-      if (modelMenuActive && modelOptions) {
-        const opts = modelOptions;
-        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
-        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
-        if (e.key === "Tab") { e.preventDefault(); const m = opts[slashIdx]; if (m) setText(`/model ${m.id}`); return; }
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          const m = opts[slashIdx];
-          if (m) { handleSelectModel(m.id); onToast(`Model set to ${m.id}.`); setText(""); }
-          return;
-        }
-      }
-      // Inline skill picker ("/skill <partial>" or "/skills").
-      if (skillMenuActive && skillOptions) {
-        const opts = skillOptions;
-        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
-        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
-        if (e.key === "Tab") { e.preventDefault(); const s = opts[slashIdx]; if (s) setText(`/skill ${s.id}`); return; }
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          const s = opts[slashIdx];
-          if (s) invokeSkill(s);
-          return;
-        }
-      }
-      // Inline prompt picker ("/prompt <partial>" or "/prompts") — Enter
-      // INSERTS the template into the composer for editing, never a start.
-      if (promptMenuActive && promptOptions) {
-        const opts = promptOptions;
-        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return; }
-        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return; }
-        if (e.key === "Tab") { e.preventDefault(); const p = opts[slashIdx]; if (p) setText(`/prompt ${p.id}`); return; }
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          const p = opts[slashIdx];
-          if (p) insertPromptTemplate(p);
-          return;
-        }
-      }
-      // Slash menu hotkeys take priority over history/submit when it's open.
-      // One roving index across commands, then the Skills group beneath them.
-      if (!slashDismissed && (slashSuggestions.length > 0 || skillCommandRows.length > 0)) {
-        const total = slashSuggestions.length + skillCommandRows.length;
-        const skillAt = (i: number): SkillOption | undefined =>
-          skillCommandRows[i - slashSuggestions.length];
-        if (e.key === "ArrowDown") {
-          e.preventDefault();
-          setSlashIdx((i) => Math.min(i + 1, total - 1));
-          return;
-        }
-        if (e.key === "ArrowUp") {
-          e.preventDefault();
-          setSlashIdx((i) => Math.max(i - 1, 0));
-          return;
-        }
-        if (e.key === "Tab") {
-          e.preventDefault();
-          const cmd = slashSuggestions[slashIdx];
-          const s = skillAt(slashIdx);
-          if (cmd) setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
-          else if (s) setText(`/skill ${s.id} `);
-          return;
-        }
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          const cmd = slashSuggestions[slashIdx];
-          const s = skillAt(slashIdx);
-          // If the input is an exact command (no args yet), run it directly;
-          // otherwise autocomplete first so the user can fill in args.
-          if (cmd && cmd.argPlaceholder && canonicalize(text.trim()) !== cmd.name) {
-            setText(cmd.name + " ");
-          } else if (s) {
-            invokeSkill(s);
-          } else {
-            void handleSubmit();
-          }
-          return;
-        }
-      }
+      // The inline menus (Esc-dismiss, ↑↓/Tab/Enter across all four pickers)
+      // take priority over history/submit while one is open — shared hook.
+      if (handleMenuKey(e)) return;
       // plain Enter sends; Shift+Enter inserts newline
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
@@ -754,26 +622,7 @@ export function HomeComposer({
       }
       if (handleArrowKey(e, text, setText)) return;
     },
-    [
-      handleSubmit,
-      handleSelectModel,
-      handleArrowKey,
-      modelMenuActive,
-      modelOptions,
-      skillMenuActive,
-      skillOptions,
-      invokeSkill,
-      promptMenuActive,
-      promptOptions,
-      insertPromptTemplate,
-      onToast,
-      menuOpen,
-      slashDismissed,
-      slashIdx,
-      slashSuggestions,
-      skillCommandRows,
-      text,
-    ],
+    [handleMenuKey, handleSubmit, handleArrowKey, text],
   );
 
   return (
@@ -851,7 +700,7 @@ export function HomeComposer({
               if (p) insertPromptTemplate(p);
             }}
           />
-        ) : !slashDismissed && (slashSuggestions.length > 0 || skillCommandRows.length > 0) ? (
+        ) : slashSuggestions.length > 0 || skillCommandRows.length > 0 ? (
           <HomeSlashMenu
             listboxId={slashListboxId}
             ariaLabel="Slash commands"

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -63,13 +63,18 @@ const slashCmds = await readFile(new URL("./slash-commands.ts", import.meta.url)
 assert.match(slashCmds, /name: "\/prompt",[\s\S]*?argPlaceholder: "name"/, "/prompt is registered with an arg placeholder");
 assert.match(slashCmds, /name: "\/prompts"/, "/prompts is registered");
 
+// The picker machinery (option memo, menuOpen union, the /api/prompts fetch,
+// the built-in seed) lives in the shared use-inline-slash-menus hook, consumed
+// by BOTH composers; the insert-not-send contract stays pinned per composer.
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
-assert.match(chatView, /promptSlashOptions\(input, prompts\)/, "chat-view computes the inline /prompt options");
-assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "chat-view menuOpen includes the prompt picker");
+const menusHook = await readFile(new URL("./use-inline-slash-menus.ts", import.meta.url), "utf8");
+assert.match(menusHook, /promptSlashOptions\(text, prompts\)/, "the shared hook computes the inline /prompt options");
+assert.match(menusHook, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "menuOpen includes the prompt picker");
 assert.match(chatView, /command === "\/prompt" \|\| command === "\/prompts"/, "chat-view dispatches /prompt and /prompts");
 assert.match(chatView, /role="listbox" aria-label="Prompts"/, "chat-view renders a Prompts listbox");
-assert.match(chatView, /fetch\("\/api\/prompts"/, "chat-view sources templates from /api/prompts");
-assert.match(chatView, /useState<PromptOption\[\]>\(BUILTIN_PROMPTS\)/, "picker is seeded with the built-ins so it works offline");
+assert.match(menusHook, /fetch\("\/api\/prompts"/, "the shared hook sources templates from /api/prompts");
+assert.match(menusHook, /useState<PromptOption\[\]>\(BUILTIN_PROMPTS\)/, "picker is seeded with the built-ins so it works offline");
+assert.match(chatView, /onInsertPrompt: \(p\) => insertPrompt\(p\)/, "the hook's prompt picks route through chat-view's insert helper");
 // The core contract: picking a prompt INSERTS into the composer — never sends.
 assert.match(chatView, /const insertPrompt = \(p: PromptOption\)/, "chat-view has the shared insert helper");
 assert.doesNotMatch(chatView, /sendRaw\([^)]*promptInsertion/, "prompt insertion is never routed into sendRaw");
@@ -89,10 +94,11 @@ const emptyState = await readFile(new URL("../components/chat-empty-state.tsx", 
 assert.match(emptyState, /onOpenPromptSnippets/, "empty state exposes the snippets entry point");
 
 // ── Home composer parity ─────────────────────────────────────────────────────
+// Parity is structural now: home consumes the same hook (asserted above), so
+// only home's own pick plumbing needs pins.
 const homeComposer = await readFile(new URL("../components/home-composer.tsx", import.meta.url), "utf8");
-assert.match(homeComposer, /promptSlashOptions\(text, prompts\)/, "home computes the inline /prompt options");
-assert.match(homeComposer, /fetch\("\/api\/prompts"/, "home sources templates from /api/prompts");
-assert.match(homeComposer, /useState<PromptOption\[\]>\(BUILTIN_PROMPTS\)/, "home picker is seeded with the built-ins");
+assert.match(homeComposer, /useInlineSlashMenus\(\{/, "home consumes the shared inline-menus hook");
+assert.match(homeComposer, /onInsertPrompt: \(p\) => insertPromptTemplate\(p\)/, "the hook's prompt picks route through home's insert helper");
 assert.match(homeComposer, /command === "\/prompt" \|\| command === "\/prompts"/, "home dispatches /prompt and /prompts");
 assert.match(homeComposer, /const insertPromptTemplate = useCallback/, "home has the template-insert helper");
 assert.doesNotMatch(homeComposer, /onStartChat\([^)]*promptInsertion/, "a template body never starts a chat directly");

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -102,17 +102,22 @@ const slashCmds = await readFile(new URL("./slash-commands.ts", import.meta.url)
 assert.match(slashCmds, /name: "\/skill",[\s\S]*?argPlaceholder: "name"/, "/skill is registered with an arg placeholder");
 assert.match(slashCmds, /name: "\/skills"/, "/skills is registered");
 
+// The inline-menu machinery (option memos, menuOpen union, skills fetch, the
+// Skills command-menu rows) lives in the shared use-inline-slash-menus hook;
+// what a pick DOES (send in-thread vs start-a-chat) stays per composer.
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
-assert.match(chatView, /skillSlashOptions\(input, skills\)/, "chat-view computes the inline /skill options");
-assert.match(chatView, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "chat-view menuOpen includes the skill picker and the Skills group");
+const menusHook = await readFile(new URL("./use-inline-slash-menus.ts", import.meta.url), "utf8");
+assert.match(menusHook, /skillSlashOptions\(text, skills\)/, "the shared hook computes the inline /skill options");
+assert.match(menusHook, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "menuOpen includes the skill picker and the Skills group");
 assert.match(chatView, /command === "\/skill" \|\| command === "\/skills"/, "chat-view dispatches /skill and /skills");
 assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill, skillArgs\)\)/, "typed /skill arguments are forwarded into the invocation");
 assert.match(chatView, /sendRaw\(buildSkillPrompt\(s\)\)/, "picking a skill sends the invocation directive");
 assert.match(chatView, /const invokeSkillOption = \(s: SkillOption\)/, "chat-view shares one skill-invoke helper across picker, menu and clicks");
+assert.match(chatView, /onPickSkill: \(s\) => invokeSkillOption\(s\)/, "the hook's skill picks route through chat-view's invoke helper");
 assert.match(chatView, /s\.argumentHint && input\.trim\(\)\.toLowerCase\(\) !== filled\.toLowerCase\(\)/, "a hinted skill autofills /skill <id> for argument editing instead of sending");
-assert.match(chatView, /skillCommandMatches\(firstWord, skills\)/, "chat-view surfaces skills in the top-level command menu");
+assert.match(menusHook, /skillCommandMatches\(firstWord, skills\)/, "the shared hook surfaces skills in the top-level command menu");
 assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");
-assert.match(chatView, /fetch\("\/api\/skills\/local"/, "chat-view sources skills from the local skill scan");
+assert.match(menusHook, /fetch\("\/api\/skills\/local"/, "the shared hook sources skills from the local skill scan");
 
 // argument-hint flows from SKILL.md frontmatter to the picker metadata.
 const scan = await readFile(new URL("./server/skill-scan.ts", import.meta.url), "utf8");

--- a/src/lib/use-inline-slash-menus.test.ts
+++ b/src/lib/use-inline-slash-menus.test.ts
@@ -1,0 +1,84 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./use-inline-slash-menus.ts", import.meta.url), "utf8");
+
+// ── Signature: pick semantics stay per-composer via callbacks ────────────────
+assert.match(
+  src,
+  /export function useInlineSlashMenus\(opts: \{\s*text: string;\s*setText: \(t: string\) => void;\s*modelHarness: string;\s*onPickModel:[\s\S]*?onPickSkill:[\s\S]*?onInsertPrompt:[\s\S]*?onRunCommand:[\s\S]*?onNoMatchEnter\?:/,
+  "useInlineSlashMenus takes the text pair + pick callbacks — what a pick DOES stays per-composer",
+);
+assert.match(
+  src,
+  /const cbRef = useRef\(opts\);\s*\n\s*cbRef\.current = opts;/,
+  "pick callbacks ride a latest-ref so inline arrows at call sites don't churn handleKeyDown identity",
+);
+
+// ── The keyboard dispatcher never owns Enter-send or Esc-busy-cancel ─────────
+assert.match(
+  src,
+  /handleKeyDown: \(e: KeyboardEvent<HTMLTextAreaElement>\) => boolean;/,
+  "handleKeyDown reports consumption so callers keep their own branch ordering around it",
+);
+assert.doesNotMatch(
+  src,
+  /cancelSend|isComposing|\bsend\(\)|handleSubmit/,
+  "the hook must never own Enter-send or Esc-cancel — chat's pinned ordering is mention → menus → history → IME-guarded send → busy-cancel",
+);
+assert.match(
+  src,
+  /return false;\s*\n\s*\},/,
+  "unconsumed keys report false so history recall and Enter-send still run",
+);
+
+// ── First-token-only matching (menus never open mid-sentence) ────────────────
+assert.match(
+  src,
+  /const firstWord = text\.trimStart\(\)\.split\(\/\\s\/\)\[0\] \?\? "";\s*\n\s*if \(!firstWord\.startsWith\("\/"\) \|\| text\.trimStart\(\)\.includes\(" "\)\) return \[\];/,
+  "slash suggestions surface only while the user is still typing the command token",
+);
+
+// ── Esc-dismiss: one flag, all four pickers, typing re-opens ─────────────────
+assert.match(
+  src,
+  /const slashSuggestions: SlashCommand\[\] = slashDismissed \? \[\] : slashMatches;/,
+  "dismissal empties the command list",
+);
+assert.match(
+  src,
+  /slashDismissed \? null : modelSlashOptions\(text, modelHarness\)/,
+  "dismissal nulls the /model options",
+);
+assert.match(
+  src,
+  /useEffect\(\(\) => \{\s*\n\s*setSlashIdx\(0\);\s*\n\s*setSlashDismissed\(false\);\s*\n\s*\}, \[text\]\);/,
+  "any edit re-arms the menus and resets the roving index",
+);
+
+// ── Roving index runs from the command list into the Skills group ────────────
+assert.match(
+  src,
+  /const total = slashSuggestions\.length \+ skillCommandRows\.length;/,
+  "one roving index spans commands then the Skills group",
+);
+assert.match(
+  src,
+  /const skillAt = \(i: number\): SkillOption \| undefined =>\s*\n\s*skillCommandRows\[i - slashSuggestions\.length\];/,
+  "the Skills group indexes after the command rows",
+);
+
+// ── Enter on a command: autocomplete-then-run ────────────────────────────────
+assert.match(
+  src,
+  /if \(cmd && cmd\.argPlaceholder && canonicalize\(text\.trim\(\)\) !== cmd\.name\) \{\s*\n\s*setText\(cmd\.name \+ " "\);\s*\n\s*\} else if \(cmd\) \{\s*\n\s*cbRef\.current\.onRunCommand\(cmd\);\s*\n\s*\} else if \(s\) \{\s*\n\s*cbRef\.current\.onPickSkill\(s\);\s*\n\s*\} else \{\s*\n\s*cbRef\.current\.onNoMatchEnter\?\.\(\);\s*\n\s*\}/,
+  "Enter autocompletes argument-taking commands, runs exact ones, picks skills, and defers no-match to the caller (home submits; chat consumes)",
+);
+
+// ── Shared listbox id + fetches ──────────────────────────────────────────────
+assert.match(src, /const slashListboxId = useId\(\);/, "the listbox id is per-mount — home and chat composers can be mounted simultaneously");
+assert.match(src, /fetch\("\/api\/skills\/local", \{ cache: "no-store" \}\)/, "skills come from the local skill scan");
+assert.match(src, /fetch\("\/api\/prompts", \{ cache: "no-store" \}\)/, "prompts come from /api/prompts, seeded with the built-ins");
+
+console.log("use-inline-slash-menus.test.ts: ok");

--- a/src/lib/use-inline-slash-menus.ts
+++ b/src/lib/use-inline-slash-menus.ts
@@ -1,0 +1,292 @@
+"use client";
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
+import { modelSlashOptions } from "@/lib/slash-model";
+import type { RuntimeModelOption } from "@/lib/runtime-models";
+import { skillCommandMatches, skillSlashOptions, type SkillOption } from "@/lib/slash-skill";
+import { promptSlashOptions, type PromptOption } from "@/lib/slash-prompt";
+import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
+
+/**
+ * The composer's inline slash menus: the `/command` listbox (with its Skills
+ * group), and the `/model`, `/skill`, `/prompt` argument pickers.
+ *
+ * Why this exists: the chat composer (chat-view.tsx) and the home composer
+ * (home-composer.tsx) each hand-rolled the identical menu machinery — the
+ * first-token-only matching rule, the skills/prompts fetches, the roving
+ * index that runs from the command list into the Skills group, the shared
+ * listbox id behind the textarea's combobox ARIA, Esc-dismiss with
+ * typing-reopens, and the ↑↓/Tab/Enter keyboard branches. One implementation
+ * keeps the two composers' command surface identical.
+ *
+ * What a pick *does* stays per-composer, by design, via callbacks:
+ * - onPickModel: home toasts, chat appends a system line (both then clear);
+ * - onPickSkill: home starts a new chat, chat sends in-thread;
+ * - onInsertPrompt: both insert-for-editing (never send) — but with their own
+ *   caret/announce plumbing;
+ * - onRunCommand: home submits the typed text, chat runs the slash intent;
+ * - onNoMatchEnter: home falls through to submit; chat consumes and does
+ *   nothing.
+ *
+ * `handleKeyDown` returns true when it consumed the event. It must NEVER own
+ * Enter-send or Esc-cancel — chat's pinned ordering is: @-mention branch →
+ * this hook → history recall → IME-guarded Enter-send → Esc busy-cancel.
+ */
+export function useInlineSlashMenus(opts: {
+  text: string;
+  setText: (t: string) => void;
+  modelHarness: string;
+  onPickModel: (id: string) => void;
+  onPickSkill: (s: SkillOption) => void;
+  onInsertPrompt: (p: PromptOption) => void;
+  onRunCommand: (cmd: SlashCommand) => void;
+  onNoMatchEnter?: () => void;
+}): {
+  skills: SkillOption[];
+  prompts: PromptOption[];
+  slashSuggestions: SlashCommand[];
+  skillCommandRows: SkillOption[];
+  modelOptions: RuntimeModelOption[] | null;
+  skillOptions: SkillOption[] | null;
+  promptOptions: PromptOption[] | null;
+  modelMenuActive: boolean;
+  skillMenuActive: boolean;
+  promptMenuActive: boolean;
+  menuOpen: boolean;
+  slashIdx: number;
+  setSlashIdx: (updater: number | ((i: number) => number)) => void;
+  slashListboxId: string;
+  dismiss: () => void;
+  handleKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+} {
+  const { text, setText, modelHarness } = opts;
+  // Latest-ref for the pick callbacks (usePausablePoll pattern) so inline
+  // arrows at the call site don't churn handleKeyDown's identity per render.
+  const cbRef = useRef(opts);
+  cbRef.current = opts;
+
+  const [slashIdx, setSlashIdx] = useState(0);
+  // Esc hides the menus for the current input; any edit brings them back.
+  const [slashDismissed, setSlashDismissed] = useState(false);
+  useEffect(() => {
+    setSlashIdx(0);
+    setSlashDismissed(false);
+  }, [text]);
+
+  // Slash suggestions — surface only while the user is still typing the
+  // command token (no whitespace yet).
+  const slashMatches: SlashCommand[] = useMemo(() => {
+    const firstWord = text.trimStart().split(/\s/)[0] ?? "";
+    if (!firstWord.startsWith("/") || text.trimStart().includes(" ")) return [];
+    return matchSlash(firstWord);
+  }, [text]);
+  const slashSuggestions: SlashCommand[] = slashDismissed ? [] : slashMatches;
+
+  // Skills for the inline `/skill` / `/skills` picker — fetched once from the
+  // local skill scan (Coven skills + ~/.claude/skills).
+  const [skills, setSkills] = useState<SkillOption[]>([]);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/skills/local", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (alive && j?.ok && Array.isArray(j.skills)) setSkills(j.skills as SkillOption[]);
+      })
+      .catch(() => {
+        /* offline → no inline skill picker (the command menu still works) */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  // Prompt templates for the `/prompt` / `/prompts` picker. Seeded with the
+  // built-ins so the picker works instantly (and offline); the fetch layers
+  // in ~/.coven/prompts files and installed marketplace prompt packs.
+  const [prompts, setPrompts] = useState<PromptOption[]>(BUILTIN_PROMPTS);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/prompts", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
+      })
+      .catch(() => {
+        /* offline → built-in templates only */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // While typing "/model <partial>", the menu shows model options instead of
+  // commands (an inline picker). null ⇒ not in /model arg position.
+  const modelOptions = useMemo(
+    () => (slashDismissed ? null : modelSlashOptions(text, modelHarness)),
+    [text, modelHarness, slashDismissed],
+  );
+  const modelMenuActive = (modelOptions?.length ?? 0) > 0;
+  // Inline `/skill` / `/skills` picker — null ⇒ not in a skill-picker position.
+  const skillOptions = useMemo(
+    () => (slashDismissed ? null : skillSlashOptions(text, skills)),
+    [text, skills, slashDismissed],
+  );
+  const skillMenuActive = (skillOptions?.length ?? 0) > 0;
+  // Inline `/prompt` / `/prompts` picker — null ⇒ not in a prompt-picker position.
+  const promptOptions = useMemo(
+    () => (slashDismissed ? null : promptSlashOptions(text, prompts)),
+    [text, prompts, slashDismissed],
+  );
+  const promptMenuActive = (promptOptions?.length ?? 0) > 0;
+  // Skills surfaced directly in the command menu — typing `/revi` finds the
+  // code-review skill without the /skill prefix. Same first-token-only rule as
+  // slashSuggestions so arg positions never double-render.
+  const skillCommandRows: SkillOption[] = useMemo(() => {
+    if (slashDismissed) return [];
+    const t = text.trimStart();
+    const firstWord = t.split(/\s/)[0] ?? "";
+    if (!firstWord.startsWith("/") || t.includes(" ")) return [];
+    return skillCommandMatches(firstWord, skills);
+  }, [text, skills, slashDismissed]);
+
+  // The slash-command, /model, /skill and /prompt pickers are mutually
+  // exclusive inline listboxes sharing one listbox id, so the composer's
+  // combobox ARIA tracks whichever is open. The id is per-mount — the home
+  // and chat composers can be mounted simultaneously.
+  const menuOpen = modelMenuActive || skillMenuActive || promptMenuActive || slashSuggestions.length > 0 || skillCommandRows.length > 0;
+  const slashListboxId = useId();
+
+  const dismiss = useCallback(() => setSlashDismissed(true), []);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
+      // Escape closes whichever menu is open — the menu footers advertise
+      // "esc cancel", and typing re-opens it (slashDismissed resets on text).
+      // Callers order this after any higher-precedence branch (chat: the
+      // @-mention picker) and before Esc-busy-cancel, so a dismissed menu
+      // never costs a live stream.
+      if (e.key === "Escape" && menuOpen) {
+        e.preventDefault();
+        setSlashDismissed(true);
+        return true;
+      }
+      // Inline model picker takes priority when "/model <partial>" is open.
+      if (modelMenuActive && modelOptions) {
+        const opts = modelOptions;
+        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return true; }
+        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return true; }
+        if (e.key === "Tab") { e.preventDefault(); const m = opts[slashIdx]; if (m) setText(`/model ${m.id}`); return true; }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const m = opts[slashIdx];
+          if (m) cbRef.current.onPickModel(m.id);
+          return true;
+        }
+      }
+      // Inline skill picker ("/skill <partial>" or "/skills").
+      if (skillMenuActive && skillOptions) {
+        const opts = skillOptions;
+        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return true; }
+        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return true; }
+        if (e.key === "Tab") { e.preventDefault(); const s = opts[slashIdx]; if (s) setText(`/skill ${s.id}`); return true; }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const s = opts[slashIdx];
+          if (s) cbRef.current.onPickSkill(s);
+          return true;
+        }
+      }
+      // Inline prompt picker ("/prompt <partial>" or "/prompts") — Enter
+      // INSERTS the template into the composer for editing, never a start.
+      if (promptMenuActive && promptOptions) {
+        const opts = promptOptions;
+        if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return true; }
+        if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return true; }
+        if (e.key === "Tab") { e.preventDefault(); const p = opts[slashIdx]; if (p) setText(`/prompt ${p.id}`); return true; }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const p = opts[slashIdx];
+          if (p) cbRef.current.onInsertPrompt(p);
+          return true;
+        }
+      }
+      // Slash-command menu. One roving index across commands, then the Skills
+      // group beneath them.
+      if (slashSuggestions.length > 0 || skillCommandRows.length > 0) {
+        const total = slashSuggestions.length + skillCommandRows.length;
+        const skillAt = (i: number): SkillOption | undefined =>
+          skillCommandRows[i - slashSuggestions.length];
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSlashIdx((i) => Math.min(i + 1, total - 1));
+          return true;
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSlashIdx((i) => Math.max(i - 1, 0));
+          return true;
+        }
+        if (e.key === "Tab") {
+          e.preventDefault();
+          const cmd = slashSuggestions[slashIdx];
+          const s = skillAt(slashIdx);
+          if (cmd) setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
+          else if (s) setText(`/skill ${s.id} `);
+          return true;
+        }
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          const cmd = slashSuggestions[slashIdx];
+          const s = skillAt(slashIdx);
+          // If the highlighted command takes an argument and the input isn't
+          // the exact command yet, autocomplete first (like Tab) so the user
+          // can fill in args; otherwise run the highlighted suggestion.
+          if (cmd && cmd.argPlaceholder && canonicalize(text.trim()) !== cmd.name) {
+            setText(cmd.name + " ");
+          } else if (cmd) {
+            cbRef.current.onRunCommand(cmd);
+          } else if (s) {
+            cbRef.current.onPickSkill(s);
+          } else {
+            cbRef.current.onNoMatchEnter?.();
+          }
+          return true;
+        }
+      }
+      return false;
+    },
+    [
+      menuOpen,
+      modelMenuActive,
+      modelOptions,
+      skillMenuActive,
+      skillOptions,
+      promptMenuActive,
+      promptOptions,
+      slashSuggestions,
+      skillCommandRows,
+      slashIdx,
+      text,
+      setText,
+    ],
+  );
+
+  return {
+    skills,
+    prompts,
+    slashSuggestions,
+    skillCommandRows,
+    modelOptions,
+    skillOptions,
+    promptOptions,
+    modelMenuActive,
+    skillMenuActive,
+    promptMenuActive,
+    menuOpen,
+    slashIdx,
+    setSlashIdx,
+    slashListboxId,
+    dismiss,
+    handleKeyDown,
+  };
+}


### PR DESCRIPTION
## What

`use-inline-slash-menus` extracts the last duplicated composer concern from `chat-view.tsx` + `home-composer.tsx` (~230 LOC of near-identical machinery): the `/command` listbox with its Skills group, the `/model`, `/skill`, `/prompt` argument pickers, the `/api/skills/local` + `/api/prompts` fetches (byte-identical), the roving index spanning commands → Skills group, the shared per-mount listbox id behind the textarea's combobox ARIA, and Esc-dismiss with typing-reopens.

**Per-composer pick semantics preserved via callbacks** (the deliberate asymmetries):
- `onPickModel` — home toasts + clears; chat appends a system line + clears
- `onPickSkill` — home starts a new chat (`invokeSkill`); chat sends in-thread (`invokeSkillOption`)
- `onRunCommand` / `onNoMatchEnter` — home submits the typed text (slash commands land in its ↑ history); chat runs the highlighted suggestion's intent and never records it

**Ordering contract kept:** `handleKeyDown(e): boolean` reports consumption and never owns Enter-send or Esc-busy-cancel. Chat's pinned #402 ordering survives as call order: `@`-mention branch → menu dispatcher → history recall → IME-guarded Enter-send → busy-cancel. The hook guards one Escape branch on `menuOpen` (the union of all four pickers), observably identical to the previous per-branch handlers.

The hook standardizes on chat's dismissal form (option memos nulled while dismissed); home's gate-the-actives form was observably identical. All menu JSX and textarea combobox ARIA in both composers compile unchanged — the hook's return names match the old locals.

## Tests

New pinned `use-inline-slash-menus.test.ts` (registered in the app suite) covers the signature, the never-owns-send/cancel invariant, first-token matching, dismissal semantics, the roving index, and autocomplete-then-run. Menu-semantics pins in `home-composer.test.ts`, `slash-skill.test.ts`, `slash-prompt.test.ts`, and `chat-view-polish.test.ts` now read the hook source; each composer keeps wiring pins (destructure site, callback routing, branch ordering, footer copy).

## Verification

- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` — 570 test files pass; `pnpm check:tests-wired` green.
- Live Playwright sweep on both composers (18/18): `/` opens the command menu, `/revi` surfaces the code-review skill row, Esc dismisses + typing re-opens, `/model` `/skill` `/prompt` pickers open with correct listbox labels, Tab completes `/model <id>`, and `aria-activedescendant` tracks ArrowDown.

Completes the cave-vtaz consolidation arc (phases 1-4 in #2673). Enhance remains deliberately unextracted — its two state machines genuinely diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)