### PR TITLE
feat(chat): file links only render when the click can actually open them

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4,7 +4,8 @@ import { createContext, forwardRef, Fragment, memo, useCallback, useContext, use
 import { createPortal } from "react-dom";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
 import { RichText } from "@/components/rich-text";
-import { MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
+import { FileLinkResolverContext, MessageBubble, SyntaxBlock, type MessageBubbleSegment } from "@/components/message-bubble";
+import { resolveFileRefTarget, type FileRef } from "@/lib/file-ref";
 import { ChatArtifactViewer } from "@/components/chat-artifact-viewer";
 import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib/canvas-artifacts";
 import { segmentTurn } from "@/lib/turn-segments";
@@ -2870,6 +2871,42 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     };
   }, [mentionToken, mentionRoot, mentionIndex, familiar.id]);
 
+  // Transcript file-ref links: prose refs (`src/foo.ts:42`) only render as
+  // clickable when they resolve to a real file under the session's project
+  // root — a rendered link is a promise the click opens it in the code rail,
+  // so no root or an unindexed path keeps the ref as plain text. The index is
+  // fetched once per root (same /api/project/files the @-mention picker uses;
+  // the API's short-lived cache absorbs re-opens).
+  const transcriptFileRoot = session?.project_root ?? projectRoot ?? null;
+  const [fileRefIndex, setFileRefIndex] = useState<{ root: string; files: Set<string> } | null>(null);
+  useEffect(() => {
+    if (!transcriptFileRoot || fileRefIndex?.root === transcriptFileRoot) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const params = new URLSearchParams({ root: transcriptFileRoot, familiarId: familiar.id });
+        const res = await fetch(`/api/project/files?${params.toString()}`, { cache: "no-store" });
+        const json = await res.json() as { ok?: boolean; repo?: boolean; files?: string[] };
+        if (cancelled) return;
+        setFileRefIndex({
+          root: transcriptFileRoot,
+          files: new Set(json.ok === true && json.repo === true && Array.isArray(json.files) ? json.files : []),
+        });
+      } catch {
+        if (!cancelled) setFileRefIndex({ root: transcriptFileRoot, files: new Set<string>() });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [transcriptFileRoot, fileRefIndex, familiar.id]);
+  const fileLinkResolver = useCallback(
+    (ref: FileRef) =>
+      fileRefIndex?.root === transcriptFileRoot &&
+      resolveFileRefTarget(ref, transcriptFileRoot, fileRefIndex.files) != null,
+    [fileRefIndex, transcriptFileRoot],
+  );
+
   // Insert the picked path inline, replacing the `@query` token (Claude Code
   // convention: `@src/foo.ts`), and record it for the send body.
   const selectMention = (relPath: string) => {
@@ -4796,6 +4833,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
       <ToolProjectRootContext.Provider value={session?.project_root ?? projectRoot ?? null}>
+      <FileLinkResolverContext.Provider value={fileLinkResolver}>
       <div ref={scrollRef} tabIndex={0} className="cave-chat-transcript relative min-h-0 flex-1 overflow-y-auto">
         <div
           ref={threadRef}
@@ -5014,6 +5052,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           </button>
         )}
       </div>
+      </FileLinkResolverContext.Provider>
       </ToolProjectRootContext.Provider>
 
       {reflectError ? (
@@ -6269,6 +6308,11 @@ function EditCardActions({
 }
 
 function ToolBlock({ tool }: { tool: ToolEvent }) {
+  // The file chip's click opens the code rail, which needs a project root —
+  // without one the rail never shows, so the chip renders as plain text
+  // instead of a dead button (the edit card's Review has its own modal
+  // fallback and stays clickable regardless).
+  const railRoot = useContext(ToolProjectRootContext);
   const argSummary = toolArgSummary(tool.name, tool.input);
   // CHAT-D8-02: Edit/Write/MultiEdit/NotebookEdit inputs render as a
   // structured before/after diff instead of the raw JSON payload; null for
@@ -6345,7 +6389,7 @@ function ToolBlock({ tool }: { tool: ToolEvent }) {
         <Icon name={visual.icon} width={12} className="cave-tool-icon shrink-0" aria-hidden />
         <span className="cave-tool-name min-w-0 truncate font-mono">{tool.name}</span>
         {argSummary ? (
-          targetFile ? (
+          targetFile && railRoot ? (
             <button
               type="button"
               onClick={openTargetFile}

--- a/src/components/message-bubble-file-links.test.ts
+++ b/src/components/message-bubble-file-links.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const { FILE_REF_RE } = await import("../lib/file-ref.ts");
+const { FILE_REF_RE, resolveFileRefTarget } = await import("../lib/file-ref.ts");
 
 // ── FILE_REF_RE: matches real file refs, ignores ordinary prose/code ─────────
 const matches = (s) => FILE_REF_RE.exec(s);
@@ -26,9 +26,23 @@ const matches = (s) => FILE_REF_RE.exec(s);
   assert.equal(matches("just some text"), null, "prose");
 }
 
+// ── resolveFileRefTarget: only real project files are openable ───────────────
+{
+  const root = "/repo/app";
+  const files = new Set(["src/foo.ts", "docs/guide.md"]);
+  assert.equal(resolveFileRefTarget({ path: "src/foo.ts" }, root, files), "src/foo.ts", "indexed relative path resolves");
+  assert.equal(resolveFileRefTarget({ path: "./src/foo.ts" }, root, files), "src/foo.ts", "leading ./ is normalized");
+  assert.equal(resolveFileRefTarget({ path: "/repo/app/docs/guide.md" }, root, files), "docs/guide.md", "absolute path under the root resolves to its repo-relative form");
+  assert.equal(resolveFileRefTarget({ path: "src/missing.ts" }, root, files), null, "a path absent from the index never resolves");
+  assert.equal(resolveFileRefTarget({ path: "/elsewhere/foo.ts" }, root, files), null, "an absolute path outside the root never resolves");
+  assert.equal(resolveFileRefTarget({ path: "src/foo.ts" }, null, files), null, "no project root ⇒ nothing resolves");
+  assert.equal(resolveFileRefTarget({ path: "src/foo.ts" }, root, null), null, "no index ⇒ nothing resolves (strict: unverified refs stay plain text)");
+}
+
 // ── wiring ───────────────────────────────────────────────────────────────────
 const bubble = await readFile(new URL("./message-bubble.tsx", import.meta.url), "utf8");
 const comux = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf8");
+const chatView = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const css = await readFile(new URL("../styles/cave-chat.css", import.meta.url), "utf8");
 
 // Linkify only inline code, never fenced-block lines.
@@ -42,9 +56,21 @@ assert.match(
   /dispatchEvent\(new CustomEvent\("cave:open-project-file", \{ detail: \{ path, line \} \}\)\)/,
   "clicking a file ref opens it in the Code workspace",
 );
-// Chat prose enables linkify; the shared MarkdownBlock must NOT.
-assert.match(bubble, /useWireCopyButtons\(html, onOpenUrl, true\)/, "MarkdownContent (chat) enables linkifyPaths");
+// A ref is only linkified when the surface's resolver confirms the click can
+// open it; wiring reconciles (adds AND removes the affordance) so a resolver
+// change never leaves a stale clickable ref.
+assert.match(bubble, /const want = Boolean\(ref && resolve\?\.\(ref\)\)/, "linkify is gated on the resolver approving the ref");
+assert.match(bubble, /_caveFileLinkCleanup = \(\) => \{[\s\S]*?removeEventListener\("click", open\)[\s\S]*?classList\.remove\("cave-file-link"\)/, "wiring keeps a cleanup so a rejected ref is un-linkified in place");
+// Chat prose supplies the resolver via context; the shared MarkdownBlock must NOT.
+assert.match(bubble, /const fileLinkResolver = useContext\(FileLinkResolverContext\)/, "MarkdownContent reads the resolver from FileLinkResolverContext");
 assert.match(bubble, /const containerRef = useWireCopyButtons\(html\);/, "MarkdownBlock keeps linkify off (default)");
+// ChatView provides the resolver over its transcript, backed by the project
+// file index, so links only render for files that exist under the session root.
+assert.match(chatView, /<FileLinkResolverContext\.Provider value=\{fileLinkResolver\}>/, "chat transcript provides the file-link resolver");
+assert.match(chatView, /resolveFileRefTarget\(ref, transcriptFileRoot, fileRefIndex\.files\) != null/, "the chat resolver verifies refs against the fetched project file index");
+// The tool file chip needs the code rail (a project root) to open anything —
+// no root ⇒ plain text, not a dead button.
+assert.match(chatView, /targetFile && railRoot \? \(/, "tool file chips are gated on a project root");
 
 // comux resolves relative refs against the selected project root.
 assert.match(

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -17,7 +17,9 @@
  */
 
 import {
+  createContext,
   useCallback,
+  useContext,
   useEffect,
   useRef,
   useState,
@@ -35,7 +37,7 @@ import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { SHIKI_LANGS, resolveShikiLang, diffContentLang } from "@/lib/code-lang";
-import { parseFileRef } from "@/lib/file-ref";
+import { parseFileRef, type FileRef } from "@/lib/file-ref";
 import { toggleCodeBlockCollapse } from "@/lib/code-block-collapse";
 import { wireMermaidDiagrams } from "./mermaid-viewer";
 
@@ -758,29 +760,54 @@ function wireMarkdownLinks(container: HTMLElement, onOpenUrl?: (url: string) => 
 // Inline file references in prose (e.g. `src/foo.ts` or `lib/bar.py:42`) become
 // clickable, opening the file in the Code workspace. Match logic lives in
 // @/lib/file-ref (pure + unit-tested); only inline code is considered.
-function wireFilePathLinks(container: HTMLElement) {
+//
+// A ref is only linkified when the surface's resolver confirms the click can
+// actually open it (project root known + file present in its index) — a dead
+// affordance is worse than plain text. Reconciles rather than wires-once:
+// when the resolver changes (project switch, index load), refs gain or lose
+// the affordance in place, so a stale link never lingers.
+export type FileLinkResolver = (ref: FileRef) => boolean;
+
+/** Chat provides a resolver over its transcript; everywhere else (group chat,
+ *  quick chat, previews) the default null keeps prose refs as plain text. */
+export const FileLinkResolverContext = createContext<FileLinkResolver | null>(null);
+
+function wireFilePathLinks(container: HTMLElement, resolve: FileLinkResolver | null) {
   for (const code of Array.from(container.querySelectorAll<HTMLElement>("code"))) {
     // Inline code only — never the highlighted lines inside a fenced block.
     if (code.closest("pre") || code.closest(".cave-code-wrap")) continue;
-    const flagged = code as HTMLElement & { _caveFileLink?: boolean };
-    if (flagged._caveFileLink) continue;
+    const flagged = code as HTMLElement & { _caveFileLinkCleanup?: () => void };
     const ref = parseFileRef(code.textContent ?? "");
-    if (!ref) continue;
-    flagged._caveFileLink = true;
-    const { path, line } = ref;
+    const want = Boolean(ref && resolve?.(ref));
+    if (want === Boolean(flagged._caveFileLinkCleanup)) continue;
+    if (!want) {
+      flagged._caveFileLinkCleanup?.();
+      delete flagged._caveFileLinkCleanup;
+      continue;
+    }
+    const { path, line } = ref!;
     code.classList.add("cave-file-link");
     code.setAttribute("role", "button");
     code.setAttribute("tabindex", "0");
     code.title = `Open ${path}${line ? `:${line}` : ""} in the Code workspace`;
     const open = () =>
       window.dispatchEvent(new CustomEvent("cave:open-project-file", { detail: { path, line } }));
-    code.addEventListener("click", open);
-    code.addEventListener("keydown", (e) => {
+    const onKeydown = (e: KeyboardEvent) => {
       if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
         open();
       }
-    });
+    };
+    code.addEventListener("click", open);
+    code.addEventListener("keydown", onKeydown);
+    flagged._caveFileLinkCleanup = () => {
+      code.removeEventListener("click", open);
+      code.removeEventListener("keydown", onKeydown);
+      code.classList.remove("cave-file-link");
+      code.removeAttribute("role");
+      code.removeAttribute("tabindex");
+      code.removeAttribute("title");
+    };
   }
 }
 
@@ -877,10 +904,11 @@ function openTableLightbox(scroll: HTMLElement) {
  * returned ref, otherwise its Copy buttons render but silently do nothing
  * (wireCopyButtons is idempotent per button via the `_wired` flag).
  *
- * `linkifyPaths` opts inline file references in prose into clickable
- * Code-workspace links; only the chat prose path enables it.
+ * `fileLinkResolver` opts inline file references in prose into clickable
+ * Code-workspace links; only chat prose (via FileLinkResolverContext) supplies
+ * one, and only refs the resolver confirms openable get the affordance.
  */
-function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => void, linkifyPaths = false) {
+function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => void, fileLinkResolver: FileLinkResolver | null = null) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     const el = containerRef.current;
@@ -890,7 +918,7 @@ function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => vo
       wireMarkdownLinks(el, onOpenUrl);
       wireMermaidDiagrams(el);
       wireExpandableTables(el);
-      if (linkifyPaths) wireFilePathLinks(el);
+      wireFilePathLinks(el, fileLinkResolver);
     };
     wireAll();
     // Re-wire when nodes are added after the first pass. Components that render
@@ -904,7 +932,7 @@ function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => vo
     const observer = new MutationObserver(() => wireAll());
     observer.observe(el, { childList: true, subtree: true });
     return () => observer.disconnect();
-  }, [html, onOpenUrl, linkifyPaths]);
+  }, [html, onOpenUrl, fileLinkResolver]);
   return containerRef;
 }
 
@@ -915,8 +943,11 @@ function useWireCopyButtons(html: string | null, onOpenUrl?: (url: string) => vo
 
 function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?: boolean; onOpenUrl?: (url: string) => void }) {
   const [html, setHtml] = useState<string | null>(null);
-  // linkifyPaths=true: chat prose file references (`src/foo.ts:42`) open in Code.
-  const containerRef = useWireCopyButtons(html, onOpenUrl, true);
+  // Chat prose file references (`src/foo.ts:42`) open in Code — but only when
+  // the surface's resolver (FileLinkResolverContext) confirms the file exists
+  // under the session's project root. No resolver ⇒ refs stay plain text.
+  const fileLinkResolver = useContext(FileLinkResolverContext);
+  const containerRef = useWireCopyButtons(html, onOpenUrl, fileLinkResolver);
   // Out-of-order guard: mdToHtml is async and during streaming several
   // renders can be in flight at once. Every render takes a monotonically
   // increasing stamp, and a result only commits if it is newer than the

--- a/src/lib/file-ref.ts
+++ b/src/lib/file-ref.ts
@@ -19,3 +19,27 @@ export function parseFileRef(text: string): FileRef | null {
   if (!match) return null;
   return { path: match[1], line: match[2] ? Number(match[2]) : undefined };
 }
+
+/**
+ * Resolve a parsed ref against a project root + its file index (repo-relative
+ * paths, as served by /api/project/files). Returns the repo-relative path when
+ * the ref names a real file the Code rail can open, else null — the caller
+ * only linkifies refs that resolve, so a rendered file link is a promise the
+ * click will actually open the file (no root, wrong repo, or a hallucinated
+ * path ⇒ plain text).
+ */
+export function resolveFileRefTarget(
+  ref: FileRef,
+  root: string | null | undefined,
+  files: ReadonlySet<string> | null | undefined,
+): string | null {
+  if (!root || !files) return null;
+  const clean = ref.path.replace(/^\.\//, "");
+  if (clean.startsWith("/")) {
+    const base = root.replace(/\/$/, "");
+    if (!clean.startsWith(`${base}/`)) return null;
+    const rel = clean.slice(base.length + 1);
+    return files.has(rel) ? rel : null;
+  }
+  return files.has(clean) ? clean : null;
+}


### PR DESCRIPTION
## Problem

A file ref in chat prose (`src/foo.ts:42` in inline code) linkified on shape alone and dispatched `cave:open-project-file` on click. When the session had no project root the code rail never opens — the click did nothing. Surfaces with no listener at all (group chat, quick chat, markdown previews) rendered every ref as a dead button. Same story for the tool row's file chip.

## Fix — a rendered link is a promise the click opens it

- **`resolveFileRefTarget`** (`src/lib/file-ref.ts`, pure + unit-tested): a ref is openable only when a project root is known **and** the path resolves into the project's file index. Handles relative, `./`-prefixed, and absolute-under-root forms; absolute paths outside the root never resolve.
- **ChatView provides a resolver** over its transcript via the new `FileLinkResolverContext`, backed by the project file index fetched once per session root (the same `/api/project/files` the @-mention picker uses; its short-lived server cache absorbs re-opens). The resolver requires the exact root that makes the code rail available, so an approved click always has a rail to open into.
- **`wireFilePathLinks` reconciles instead of wiring once**: refs gain the affordance only when the resolver approves, and lose it in place (listeners, `cave-file-link` class, `role`, `tabindex`, `title`) when it stops approving — a project switch or late index load can't leave a stale clickable ref.
- **No resolver ⇒ plain text**: group chat, quick chat, and preview surfaces render refs as ordinary inline code instead of dead buttons.
- **Tool file chips** (Read/Grep targets) are gated on `ToolProjectRootContext` — no root renders the plain-text span, not a dead button. The edit card's Review button keeps its in-chat modal fallback and stays clickable everywhere.

## Verification

- `message-bubble-file-links.test.ts` updated: 7 new unit cases for `resolveFileRefTarget` + pins for the resolver gate, the un-linkify cleanup, the transcript provider, the index check, and the chip gate.
- 13 chat/message-bubble test files pass in this branch; the same change also passed the full 51-file sweep of everything scanning `chat-view.tsx`/`message-bubble.tsx`, plus a clean `tsc` and a live check of the `/api/project/files` contract (`repo: true`, repo-relative paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)