### PR TITLE
fix(ux): confusion-helpers sweep — jargon defined at decision points, states labeled, verbs made honest (cave-ohht)

### DIFF
--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -294,8 +294,9 @@ function EmptyScheduleState({
           leadingIcon="ph:plus"
           onClick={onAddEntry}
           className="calendar-empty-action"
+          title="Creates a scheduled reminder (an inbox item) — board tasks get due dates on the Tasks surface"
         >
-          Add task or event
+          Add reminder
         </Button>
       ) : null}
     </div>
@@ -375,8 +376,9 @@ function AgendaView({
             leadingIcon="ph:plus"
             onClick={() => onAddEntry({ fireAt: defaultEntryFireAt(anchor) })}
             className="calendar-empty-action"
+            title="Creates a scheduled reminder (an inbox item) — board tasks get due dates on the Tasks surface"
           >
-            Add task or event
+            Add reminder
           </Button>
         ) : null}
       </div>
@@ -560,7 +562,10 @@ function DeadlineStrip({
   return (
     <div className="flex shrink-0 overflow-x-auto border-b border-[var(--border-hairline)] bg-[var(--bg-panel)]">
       <div className="sticky left-0 z-10 flex w-12 shrink-0 items-center justify-end border-r border-[var(--border-hairline)] bg-[var(--bg-panel)] py-1 pr-1.5">
-        <span className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)] leading-tight text-right">
+        <span
+          className="text-[9px] uppercase tracking-wider text-[var(--text-secondary)] leading-tight text-right"
+          title="Task due dates from the Board — separate from your scheduled reminders below"
+        >
           Due
         </span>
       </div>

--- a/src/components/capability-card.tsx
+++ b/src/components/capability-card.tsx
@@ -81,7 +81,9 @@ export function CapabilitiesView({
   if (items.length === 0) {
     return (
       <p className="rounded-lg border border-border px-4 py-6 text-center text-[13px] text-muted-foreground">
-        No runtime capabilities found. Start the daemon or add a local runtime to see its instructions, skills, and plugins.
+        Nothing to show yet — this tab lists what each runtime on your machine can do (its global
+        instructions, installed skills, and plugins). Start the daemon or add a local runtime and it
+        fills in.
       </p>
     );
   }
@@ -178,8 +180,11 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
 
         {manifest.skills.length > 0 ? (
           <div className="px-4 py-3">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-widest text-[var(--text-secondary)]">
-              Automations / skills · {manifest.skills.length}
+            <p
+              className="mb-2 text-[11px] font-medium uppercase tracking-widest text-[var(--text-secondary)]"
+              title="SKILL.md procedures this runtime has installed"
+            >
+              Skills · {manifest.skills.length}
             </p>
             <ul className="space-y-1.5">
               {manifest.skills.map((skill) => (
@@ -196,17 +201,6 @@ function HarnessCapabilityCard({ manifest }: { manifest: HarnessCapabilityManife
             </ul>
           </div>
         ) : null}
-
-        {manifest.skills && manifest.skills.length > 0 && (
-          <div className="px-4 py-2">
-            <p className="text-[11px] text-muted-foreground">
-              Skills · {manifest.skills.length}
-              {" — "}
-              {manifest.skills.slice(0, 3).map((s) => s.name).join(", ")}
-              {manifest.skills.length > 3 ? ` +${manifest.skills.length - 3} more` : ""}
-            </p>
-          </div>
-        )}
 
         {manifest.warnings.length > 0 ? (
           <div className="px-4 py-3">

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1032,7 +1032,7 @@ export function CommandPalette({
                       <span className="flex min-w-0 flex-1 flex-col">
                         <span className="truncate text-[var(--text-primary)]">Ask Salem: {row.query}</span>
                         <span className="truncate text-[10px] text-[var(--text-muted)]">
-                          Context-aware AI answer via salem.opencoven.ai
+                          Salem is the docs familiar — answers from the OpenCoven docs
                         </span>
                       </span>
                       <span className="text-[10px] text-[var(--text-muted)]">ask</span>
@@ -1046,6 +1046,7 @@ export function CommandPalette({
         </ul>
         <div className="flex items-center justify-between border-t border-[var(--border-hairline)] px-4 py-2 text-[10px] text-[var(--text-muted)]">
           <span>{keys.up}{keys.down} navigate · {keys.enter} select · esc close</span>
+          <span className="hidden sm:inline">@familiar scopes results</span>
           <span>{keys.mod}K</span>
         </div>
       </div>

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -117,7 +117,8 @@ export function FamiliarMenuBar({
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
           placeholder="Search or ask Salem..."
-          aria-label="Search anything or ask Salem"
+          aria-label="Search anything or ask Salem, the docs familiar"
+          title="Search everything — or ask Salem, the familiar trained on the OpenCoven docs"
           autoComplete="off"
           spellCheck={false}
         />

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -101,7 +101,7 @@ const NAME_POOL = [
 ] as const;
 
 const STAGES = [
-  { key: "vessel", numeral: "I", title: "The vessel", hint: "Choose where your familiar lives." },
+  { key: "vessel", numeral: "I", title: "The vessel", hint: "Choose where your familiar lives — the machine or agent its mind runs on." },
   { key: "name", numeral: "II", title: "The name", hint: "Every familiar answers to a name." },
   { key: "form", numeral: "III", title: "The form", hint: "Give it a sigil and an aura." },
   { key: "summon", numeral: "IV", title: "The summoning", hint: "Read the incantation, then call." },
@@ -987,7 +987,7 @@ function StageName({
           id="summon-role"
           value={role}
           onChange={(e) => setRole(e.target.value)}
-          placeholder="Familiar"
+          placeholder="e.g. Researcher, Code reviewer"
           className={inputClass}
         />
       </div>

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -563,7 +563,14 @@ function WorkQueueCard({
           </Button>
         ) : null}
         {item.lane === "no-open-PR" && beadId ? (
-          <Button variant="secondary" size="xs" loading={busy} leadingIcon="ph:hand" onClick={onClaim}>
+          <Button
+            variant="secondary"
+            size="xs"
+            loading={busy}
+            leadingIcon="ph:hand"
+            onClick={onClaim}
+            title="Take this work item (bead) — marks it in progress under your name"
+          >
             Claim
           </Button>
         ) : null}
@@ -575,7 +582,11 @@ function WorkQueueCard({
             leadingIcon="ph:check"
             onClick={onClose}
             disabled={closeBlocked}
-            title={closeBlocked ? "Add a handoff note to record verification before closing" : undefined}
+            title={
+              closeBlocked
+                ? "Add a handoff note to record verification before closing"
+                : "Mark this work item (bead) complete — it leaves the queue"
+            }
           >
             Close bead
           </Button>

--- a/src/components/familiars-memory-view.tsx
+++ b/src/components/familiars-memory-view.tsx
@@ -450,9 +450,9 @@ export function FamiliarsMemoryView({ familiars, activeFamiliar, onOpenMemoryFil
               <span className="inline-flex items-baseline gap-1 px-1"><span className="text-[var(--text-muted)]">Familiar memories</span> <span className="font-semibold text-[var(--text-primary)]">{visibleCoven.length}</span></span>
               <span aria-hidden className="text-[var(--border-strong)]">·</span>
               <span className="mr-0.5 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">Sources</span>
-              <SourceFilterChip label="Coven origin" count={fileSourceCounts.covenOrigin} active={sourceFilter === "coven-origin"} onClick={() => setSourceFilter((s) => (s === "coven-origin" ? "all" : "coven-origin"))} />
-              <SourceFilterChip label="External runtimes" count={fileSourceCounts.externalHarnesses} active={sourceFilter === "external-harness"} onClick={() => setSourceFilter((s) => (s === "external-harness" ? "all" : "external-harness"))} />
-              <SourceFilterChip label="Runtime memory" count={fileSourceCounts.runtimeMemory} active={sourceFilter === "runtime"} onClick={() => setSourceFilter((s) => (s === "runtime" ? "all" : "runtime"))} />
+              <SourceFilterChip label="Coven origin" count={fileSourceCounts.covenOrigin} active={sourceFilter === "coven-origin"} onClick={() => setSourceFilter((s) => (s === "coven-origin" ? "all" : "coven-origin"))} help="Files written by this Cave's own familiars and conversations" />
+              <SourceFilterChip label="External runtimes" count={fileSourceCounts.externalHarnesses} active={sourceFilter === "external-harness"} onClick={() => setSourceFilter((s) => (s === "external-harness" ? "all" : "external-harness"))} help="Memory kept by other agent tools on this machine (e.g. Claude Code, Codex)" />
+              <SourceFilterChip label="Runtime memory" count={fileSourceCounts.runtimeMemory} active={sourceFilter === "runtime"} onClick={() => setSourceFilter((s) => (s === "runtime" ? "all" : "runtime"))} help="Working files a runtime writes for itself while it runs" />
               {sourceFilter !== "all" ? (
                 <button
                   type="button"
@@ -886,17 +886,22 @@ function SourceFilterChip({
   count,
   active,
   onClick,
+  help,
 }: {
   label: string;
   count: number;
   active: boolean;
   onClick: () => void;
+  /** One line saying what this source actually is — the three source names
+   *  read as synonyms without it. */
+  help?: string;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-pressed={active}
+      title={help}
       className={`focus-ring inline-flex h-6 items-center gap-1 rounded-md border px-1.5 text-[11px] transition-colors ${
         active
           ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"

--- a/src/components/familiars-view.tsx
+++ b/src/components/familiars-view.tsx
@@ -419,7 +419,7 @@ function FamiliarsEmptyState({
       className="familiars-view__empty mx-auto my-16 max-w-md"
       icon="ph:sparkle"
       headline="The circle awaits"
-      subtitle="No familiars yet — summon your first from a local runtime, a remote host, or an OpenClaw agent."
+      subtitle="No familiars yet — summon your first: it can run on this machine, on a remote host over SSH, or bridge an OpenClaw agent you already keep."
       actions={
         <div className="flex items-center gap-2">
           <Button variant="primary" leadingIcon="ph:magic-wand-fill" onClick={onCreate}>

--- a/src/components/flow/flow-toolbar.tsx
+++ b/src/components/flow/flow-toolbar.tsx
@@ -143,6 +143,7 @@ function FlowToolbarImpl(props: FlowToolbarProps) {
             className="flow-toolbar-execute"
             onClick={props.onExecute}
             disabled={props.executing}
+            title="Run the current draft once, right now — publishing is what arms its trigger"
           >
             {props.executing ? "Running…" : "Execute"}
           </Button>

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -1007,8 +1007,9 @@ export function FlowView() {
                   <div className="flow-canvas-coach" role="note">
                     <p className="flow-canvas-coach-title">Start building</p>
                     <p className="flow-canvas-coach-sub">
-                      Drag from a node&apos;s port to wire the next step, press <kbd>N</kbd> to add a node,
-                      or double-click anywhere on the canvas.
+                      Each node is one step — a trigger, a familiar message, a skill, a delay, a rule —
+                      and the wires pass data between them. Drag from a node&apos;s port to wire the next
+                      step, press <kbd>N</kbd> to add a node, or double-click anywhere on the canvas.
                     </p>
                     <div className="flow-canvas-coach-actions">
                       <Button

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2539,7 +2539,10 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
           )}
 
           {activity?.rateLimit && (
-            <span className="gh-compact-rate">
+            <span
+              className="gh-compact-rate"
+              title="GitHub API requests left this hour — public gets 60/h, a PAT gets 5,000/h"
+            >
               {activity.rateLimit.remaining}/{activity.rateLimit.limit} req left
             </span>
           )}
@@ -2673,7 +2676,7 @@ export function GitHubView({ onJumpToSession, onFocusCard }: Props = {}) {
             <EmptyState
               icon="ph:github-logo"
               headline="Connect your GitHub account"
-              subtitle="Cave uses the public GitHub API (no auth needed) or your own PAT for private repos and reviews."
+              subtitle="Start with just a GitHub username to browse public repos — add a personal access token (PAT) later for private repos and reviews. Both stay on this machine."
               actions={
                 <Button variant="primary" leadingIcon="ph:github-logo" onClick={() => setShowPatModal(true)}>
                   Set up GitHub

--- a/src/components/grimoire-graph-view.tsx
+++ b/src/components/grimoire-graph-view.tsx
@@ -700,8 +700,12 @@ export function GrimoireGraphView({
     onChange: (next: boolean) => void,
     dotToken?: string,
     count?: number,
+    help?: string,
   ) => (
-    <label className="flex cursor-pointer items-center gap-1.5 py-0.5 text-[11px] text-[var(--text-secondary)]">
+    <label
+      title={help}
+      className="flex cursor-pointer items-center gap-1.5 py-0.5 text-[11px] text-[var(--text-secondary)]"
+    >
       <input
         type="checkbox"
         checked={checked}
@@ -781,6 +785,7 @@ export function GrimoireGraphView({
                 (v) => setPrefs((p) => ({ ...p, groups: { ...p.groups, knowledge: v } })),
                 NODE_KIND_TOKEN.knowledge,
                 counts.knowledge,
+                "Curated reference entries from the knowledge vault",
               )}
               {checkboxRow(
                 "Memory",
@@ -788,6 +793,7 @@ export function GrimoireGraphView({
                 (v) => setPrefs((p) => ({ ...p, groups: { ...p.groups, memory: v } })),
                 NODE_KIND_TOKEN.memory,
                 counts.memory,
+                "Files your familiars and runtimes write as they work",
               )}
               {checkboxRow(
                 "Journal",
@@ -795,6 +801,7 @@ export function GrimoireGraphView({
                 (v) => setPrefs((p) => ({ ...p, groups: { ...p.groups, journal: v } })),
                 NODE_KIND_TOKEN.journal,
                 counts.journal,
+                "Daily reflections, one per day",
               )}
               {checkboxRow(
                 "Tags",
@@ -802,22 +809,45 @@ export function GrimoireGraphView({
                 (v) => setPrefs((p) => ({ ...p, groups: { ...p.groups, tag: v } })),
                 NODE_KIND_TOKEN.tag,
                 counts.tag,
+                "Each tag is its own node, connected to the docs that carry it",
               )}
             </div>
             <div>
               <p className="pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
                 Connections
               </p>
-              {checkboxRow("Links", prefs.edgeTypes.link, (v) =>
-                setPrefs((p) => ({ ...p, edgeTypes: { ...p.edgeTypes, link: v } })),
+              {checkboxRow(
+                "Links",
+                prefs.edgeTypes.link,
+                (v) => setPrefs((p) => ({ ...p, edgeTypes: { ...p.edgeTypes, link: v } })),
+                undefined,
+                undefined,
+                "Solid lines — explicit [[wiki-links]] written in a doc",
               )}
-              {checkboxRow("Mentions", prefs.edgeTypes.mention, (v) =>
-                setPrefs((p) => ({ ...p, edgeTypes: { ...p.edgeTypes, mention: v } })),
+              {checkboxRow(
+                "Mentions",
+                prefs.edgeTypes.mention,
+                (v) => setPrefs((p) => ({ ...p, edgeTypes: { ...p.edgeTypes, mention: v } })),
+                undefined,
+                undefined,
+                "Dashed lines — one doc's text mentions another's title, without a link",
               )}
-              {checkboxRow("Tag links", prefs.edgeTypes.tag, (v) =>
-                setPrefs((p) => ({ ...p, edgeTypes: { ...p.edgeTypes, tag: v } })),
+              {checkboxRow(
+                "Tag links",
+                prefs.edgeTypes.tag,
+                (v) => setPrefs((p) => ({ ...p, edgeTypes: { ...p.edgeTypes, tag: v } })),
+                undefined,
+                undefined,
+                "Faint lines — a doc connected to a tag it carries",
               )}
-              {checkboxRow("Orphans", prefs.orphans, (v) => setPrefs((p) => ({ ...p, orphans: v })))}
+              {checkboxRow(
+                "Orphans",
+                prefs.orphans,
+                (v) => setPrefs((p) => ({ ...p, orphans: v })),
+                undefined,
+                undefined,
+                "Docs with no connections at all — hide them to see only the web",
+              )}
             </div>
             <div>
               <p className="pb-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)]">

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -457,6 +457,7 @@ function RailSection({
   ariaLabel,
   icon,
   label,
+  description,
   count,
   collapsed,
   onToggle,
@@ -465,6 +466,9 @@ function RailSection({
   ariaLabel: string;
   icon: IconName;
   label: string;
+  /** One line saying what belongs in this source — the three sources read as
+   *  synonyms to a new user, so each header explains its own. */
+  description: string;
   count: number;
   collapsed: boolean;
   onToggle: () => void;
@@ -476,6 +480,7 @@ function RailSection({
         <button
           type="button"
           aria-expanded={!collapsed}
+          title={description}
           onClick={onToggle}
           className="focus-ring-inset flex w-full items-center gap-1.5 rounded-md px-2 pb-1 pt-0.5 text-[10px] font-semibold uppercase tracking-wide text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
         >
@@ -560,7 +565,24 @@ function GrimoireDocLinks({
     return out;
   }, [markdown, docIndex]);
 
-  if (links.length === 0 && backlinks.length === 0) return null;
+  // A doc with no connections teaches the syntax instead of hiding the strip —
+  // [[wiki-links]] have no visible affordance in the editor, so this hint is
+  // where a user learns they exist. Waits for content to load (null) so it
+  // doesn't flash on every doc open.
+  if (links.length === 0 && backlinks.length === 0) {
+    const loaded =
+      selection.kind === "knowledge" ||
+      (selection.kind === "memory" ? memFile.text !== null : journalMd !== null);
+    if (!loaded || markdown.trim().length === 0) return null;
+    return (
+      <div className="grimoire-doc-links shrink-0 border-t border-[var(--border-hairline)] px-3 py-2">
+        <p className="text-[10px] text-[var(--text-muted)]">
+          Tip: type <code className="rounded bg-[var(--bg-elevated)] px-1">[[a doc&apos;s title]]</code> anywhere in
+          the text to link documents — links show up here and weave the graph.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="grimoire-doc-links shrink-0 space-y-1.5 border-t border-[var(--border-hairline)] px-3 py-2">
@@ -1112,6 +1134,7 @@ export function GrimoireView() {
                 ariaLabel="Knowledge vault"
                 icon="ph:book-open"
                 label="Knowledge"
+                description="Curated reference entries you write and keep — the durable vault"
                 count={visibleKnowledge.length}
                 collapsed={!q && collapsedSections.knowledge}
                 onToggle={() => toggleSection("knowledge")}
@@ -1137,6 +1160,7 @@ export function GrimoireView() {
                 ariaLabel="Memory files"
                 icon="ph:brain"
                 label="Memory"
+                description="Files your familiars and runtimes write as they work — editable in place"
                 count={visibleMemory.length}
                 collapsed={!q && collapsedSections.memory}
                 onToggle={() => toggleSection("memory")}
@@ -1173,6 +1197,7 @@ export function GrimoireView() {
                 ariaLabel="Journal"
                 icon="ph:calendar-blank"
                 label="Journal"
+                description="One reflection per day, written by a familiar or by you"
                 count={visibleJournal.length}
                 collapsed={!q && collapsedSections.journal}
                 onToggle={() => toggleSection("journal")}

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -55,10 +55,10 @@ const SECTIONS: ReadonlyArray<{ id: MarketplaceSection; label: string; icon: Ico
 // One-line hint per section — surfaces as the tab tooltip (the old hero
 // subtitle, demoted so the header stays a single row).
 const SECTION_HINT: Record<MarketplaceSection, string> = {
-  browse: "Browse MCP servers and skills, then add them to give your familiars new capabilities.",
+  browse: "The catalog — add MCP servers, connected APIs, skills, and prompt packs to your Cave.",
   roles: "Personas your familiars wear — each bundles skills, tools, MCP servers, and workflows.",
-  skills: "Reusable SKILL.md procedures your familiars can load while they work.",
-  capabilities: "What each runtime supports — compare tools and features side by side.",
+  skills: "Skills already in your Cave — reusable SKILL.md procedures familiars load while they work.",
+  capabilities: "What each runtime you've installed can do — its instructions, skills, and plugins, side by side.",
 };
 
 const SEARCH_LABEL: Record<Exclude<MarketplaceSection, "capabilities">, string> = {

--- a/src/components/marketplace/marketplace-card.tsx
+++ b/src/components/marketplace/marketplace-card.tsx
@@ -39,6 +39,15 @@ function kindLabel(kind: MarketplacePlugin["kind"]) {
   return "Skill";
 }
 
+// What "Add" actually does differs by kind — the button says so on hover
+// instead of leaving the verb ambiguous.
+function addHelp(kind: MarketplacePlugin["kind"]) {
+  if (kind === "mcp") return "Add this MCP server to your Cave — familiars can call its tools";
+  if (kind === "api") return "Connect this API so your familiars can use it";
+  if (kind === "prompt") return "Add this prompt pack — its templates join the / menu";
+  return "Install this skill — familiars load it while they work";
+}
+
 function setupEffortLabel(plugin: MarketplacePlugin) {
   if (!plugin.available) return { icon: "ph:warning" as const, label: "Unavailable" };
   if (plugin.requiresSetup && !plugin.configured) {
@@ -110,7 +119,14 @@ export const MarketplaceCard = memo(function MarketplaceCard({
             Set up
           </Button>
         ) : state === "added" ? (
-          <Button variant="secondary" size="sm" leadingIcon="ph:check" loading={busy} onClick={() => onRemove(plugin.id)}>
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon="ph:check"
+            loading={busy}
+            onClick={() => onRemove(plugin.id)}
+            title="In your Cave — click to remove it"
+          >
             Added
           </Button>
         ) : state === "unavailable" ? (
@@ -118,7 +134,14 @@ export const MarketplaceCard = memo(function MarketplaceCard({
             Unavailable
           </Button>
         ) : (
-          <Button variant="primary" size="sm" leadingIcon="ph:plus" loading={busy} onClick={() => onAdd(plugin.id)}>
+          <Button
+            variant="primary"
+            size="sm"
+            leadingIcon="ph:plus"
+            loading={busy}
+            onClick={() => onAdd(plugin.id)}
+            title={addHelp(plugin.kind)}
+          >
             Add
           </Button>
         )}

--- a/src/components/opencoven-submission-panel.tsx
+++ b/src/components/opencoven-submission-panel.tsx
@@ -314,7 +314,11 @@ export function OpenCovenSubmissionPanel() {
           </div>
           <p className="mt-1 max-w-3xl text-[12px] text-muted-foreground">
             Submit once to OpenCoven, validate against OpenCoven contracts, publish into the
-            OpenCoven catalog, then route through OpenCoven execution services.
+            OpenCoven catalog, then route through OpenCoven execution services. A{" "}
+            <strong className="font-medium text-[var(--text-secondary)]">harness</strong> is an agent
+            environment (like Claude Code); a{" "}
+            <strong className="font-medium text-[var(--text-secondary)]">runtime</strong> is the
+            execution layer it runs on — harnesses stay disabled until a compatible runtime exists.
           </p>
         </div>
         <div className="flex shrink-0 rounded-[var(--radius-control)] border border-border bg-background p-1" aria-label="Submission type">
@@ -533,10 +537,7 @@ function CatalogDiscovery({ catalog }: { catalog: CatalogEntry[] }) {
                   <dt className="font-medium text-foreground">Version</dt>
                   <dd>{entry.latestCompatibleVersion}</dd>
                 </div>
-                <div>
-                  <dt className="font-medium text-foreground">Validation status</dt>
-                  <dd>{entry.validationStatus}</dd>
-                </div>
+                {/* Validation status renders once, as the header badge. */}
                 <div>
                   <dt className="font-medium text-foreground">Examples / docs</dt>
                   <dd>

--- a/src/components/projects/project-list.tsx
+++ b/src/components/projects/project-list.tsx
@@ -122,7 +122,9 @@ function ProjectListRow({
           {status ? (
             <span
               className={`projects-status-dot ${chatDotClass(status)}${status === "running" ? " animate-pulse" : ""}`}
-              aria-hidden
+              role="img"
+              aria-label={`Latest chat ${status}`}
+              title={`Latest chat in this project: ${status}`}
             />
           ) : null}
         </span>

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -161,7 +161,8 @@ export function TopBar(props: Props) {
           value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
           placeholder="Search or ask Salem..."
-          aria-label="Search anything or ask Salem"
+          aria-label="Search anything or ask Salem, the docs familiar"
+          title="Search everything — or ask Salem, the familiar trained on the OpenCoven docs"
           autoComplete="off"
           spellCheck={false}
         />


### PR DESCRIPTION
## Summary

A five-agent confusion audit across every workspace surface, triaged hard (each finding verified against current source — several were stale or false), then implemented as a copy/tooltip-level sweep: **18 fixes across 18 files**. Theme: define jargon exactly where a user must make a decision, label color-only state, and make action verbs say what they actually do.

**Identity & navigation** — Salem is introduced as the docs familiar in both search bars and the palette row; the palette footer now surfaces `@familiar` scoping.

**Grimoire** — a `[[wiki-link]]` syntax hint teaches the feature on unlinked docs; rail sections explain knowledge vs memory vs journal; graph filter rows double as a legend (solid = link, dashed = unlinked mention, faint = tag; orphans explained).

**Familiars** — the summon empty state defines the three destinations; the role field shows examples ("e.g. Researcher, Code reviewer"); the vessel stage defines its metaphor.

**Honest verbs** — calendar "Add task or event" → "Add reminder" (verified: it opens the reminder modal, never a board task) with a title explaining the reminder/task split; marketplace "Add" explains what adding does per kind, and "Added" warns it removes on click; flow "Execute" clarifies draft-run vs Publish; work-queue Claim/Close define "bead" in passing.

**Labeled state** — projects status dot gains `role=img` + label (was color-only, invisible to AT/touch); GitHub rate chip explains 60 vs 5,000/h; GitHub empty state says username-only is a valid start; calendar "Due" strip says deadlines come from the Board; memory source-filter chips explain their three sources.

**De-confusion by deletion** — submissions panel's duplicated validation-status row removed (badge is authoritative) + harness/runtime defined inline; capability card's double skills section consolidated; marketplace section hints now distinguish the catalog from installed skills.

**Verified false positives (no change)**: work-queue lane names (already humanized by `LANE_TITLES`), journal attribution ("Reflected by" renders), GitHub auth badge titles, icon-button labeling, settings hints — and the audit confirmed a shortcuts sheet already exists (⌘/), so no new primitives were added.

## Testing

- `pnpm exec tsc --noEmit` clean.
- Full suite green: **569 test files pass** — zero copy-pin breaks (labels changed were unpinned; verified before editing).
- Behavior verified in source for every relabel (e.g. calendar `onAddEntry` → `openReminderModal` at workspace.tsx:2179).

🤖 Generated with [Claude Code](https://claude.com/claude-code)