### PR TITLE
fix(settings): var(--danger) is undefined — use the real --color-danger token (cave-rj0z)

### DIFF
--- a/src/components/settings-profile.tsx
+++ b/src/components/settings-profile.tsx
@@ -219,7 +219,7 @@ export function ProfileSection() {
       ) : null}
 
       {error ? (
-        <p className="rounded-xl border border-[var(--danger)] bg-[color-mix(in_oklch,var(--danger)_12%,transparent)] px-4 py-3 text-[12px] text-[var(--danger)]">
+        <p className="rounded-xl border border-[var(--color-danger)] bg-[color-mix(in_oklch,var(--color-danger)_12%,transparent)] px-4 py-3 text-[12px] text-[var(--color-danger)]">
           {error}
         </p>
       ) : null}
@@ -389,12 +389,12 @@ export function ProfileSection() {
                   </Button>
                 </div>
                 {rowIncomplete ? (
-                  <p className="text-[11px] text-[var(--danger)] md:col-span-3">Add both fields to save this link.</p>
+                  <p className="text-[11px] text-[var(--color-danger)] md:col-span-3">Add both fields to save this link.</p>
                 ) : null}
               </div>
             );
           })}
-          {linkHint ? <p className="text-[11px] text-[var(--danger)]">{linkHint}</p> : null}
+          {linkHint ? <p className="text-[11px] text-[var(--color-danger)]">{linkHint}</p> : null}
           <div>
             <Button
               variant="secondary"

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -309,4 +309,14 @@ assert.match(source, /aria-label="Executor addresses, one per line"/, "the execu
 assert.match(source, /focusTarget\.focus\(\{ preventScroll: true \}\)/, "a search/deep-link jump moves focus to the target group");
 assert.match(source, /connectionError && <span role="alert"/, "the daemon save error is a live alert");
 
+// (cave-rj0z) var(--danger) is NOT a defined token — only --color-danger
+// exists. Uses of the phantom variable silently resolved to nothing, so
+// error text/borders rendered unstyled. Keep it out of the settings sources.
+{
+  const profile = readFileSync(new URL("./settings-profile.tsx", import.meta.url), "utf8");
+  for (const [name, src] of [["settings-shell", source], ["settings-profile", profile]]) {
+    assert.doesNotMatch(src, /var\(--danger\)/, `${name} must use var(--color-danger), not the undefined var(--danger)`);
+  }
+}
+
 console.log("settings-shell-polish.test.ts OK");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1829,7 +1829,7 @@ function MobileModeToggle() {
           {busy ? "Updating..." : mobileModeEnabled ? "On" : "Off"}
         </button>
         {host ? <code className="max-w-[220px] truncate text-[11px] text-[var(--text-muted)]">{host}</code> : null}
-        {error ? <span className="max-w-[220px] text-right text-[11px] text-[var(--danger)]">{error}</span> : null}
+        {error ? <span className="max-w-[220px] text-right text-[11px] text-[var(--color-danger)]">{error}</span> : null}
       </div>
     </SettingsRow>
   );


### PR DESCRIPTION
## Summary

Bead `cave-rj0z` (from the Settings/Automations/Canvas audit sweep, source-verified). No stylesheet anywhere defines a `--danger` custom property — the design system's token is `--color-danger` — so four settings sites styled with `var(--danger)` silently resolved to nothing:

- `settings-shell.tsx:1832` — MobileModeToggle's error message rendered in the inherited muted color, visually indistinguishable from normal UI text
- `settings-profile.tsx:222` — the profile error banner lost its border, tinted background, **and** text color in one line
- `settings-profile.tsx:392, :397` — field validation hints rendered unstyled

All swapped to `var(--color-danger)`. A `doesNotMatch` pin in `settings-shell-polish.test.ts` keeps the phantom variable out of both settings sources.

## Test plan

- [x] Repo-wide grep: zero `var(--danger)` remains
- [x] Settings tests + full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)