### PR TITLE
fix(settings): abort/ordering guards on daemon-status + config fetches (cave-dgac)

### DIFF
--- a/src/components/settings-daemon-multihost.test.ts
+++ b/src/components/settings-daemon-multihost.test.ts
@@ -13,7 +13,7 @@ assert.match(
 
 assert.match(
   shell,
-  /fetch\("\/api\/config", \{ cache: "no-store" \}\)/,
+  /fetch\("\/api\/config", \{ cache: "no-store", signal: ctl\.signal \}\)/,
   "Daemon settings should load Cave config before rendering connection controls",
 );
 
@@ -88,5 +88,14 @@ assert.match(
   /keywords: "daemon status running start stop restart hub server executor private network tailscale"/,
   "Settings search should route hub/server/executor queries to the Daemon section",
 );
+
+// ── Fetch guards (cave-dgac) ─────────────────────────────────────────────────
+// Start/Restart/Manual-Offline each trigger a status refresh; without
+// cancellation a slow earlier response can land after a newer one and flash a
+// stale pre-action status. Once-on-mount loads abort on unmount too.
+assert.match(shell, /refreshCtlRef\.current\?\.abort\(\);/, "each daemon-status refresh aborts the in-flight one");
+assert.match(shell, /fetch\("\/api\/daemon\/status", \{ cache: "no-store", signal: ctl\.signal \}\)/, "daemon-status fetches carry an abort signal");
+assert.match(shell, /fetch\("\/api\/config", \{ cache: "no-store", signal: ctl\.signal \}\)/, "the multi-host config load carries an abort signal");
+assert.doesNotMatch(shell, /getItem\("coven-custom-theme"\)/, "the custom-theme key goes through COVEN_CUSTOM_THEME_KEY, never a string literal");
 
 console.log("settings-daemon-multihost.test.ts: ok");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
@@ -414,10 +414,14 @@ function HomeNewsToggle() {
 function WorkspacePathField() {
   const [path, setPath] = useState("");
   useEffect(() => {
-    fetch("/api/daemon/status", { cache: "no-store" })
+    const ctl = new AbortController();
+    fetch("/api/daemon/status", { cache: "no-store", signal: ctl.signal })
       .then((r) => r.json())
-      .then((j: { workspacePath?: string }) => { if (j.workspacePath) setPath(j.workspacePath); })
+      .then((j: { workspacePath?: string }) => {
+        if (!ctl.signal.aborted && j.workspacePath) setPath(j.workspacePath);
+      })
       .catch(() => {});
+    return () => ctl.abort();
   }, []);
   return (
     <input
@@ -457,20 +461,42 @@ function DaemonSection() {
   const [savingTravel, setSavingTravel] = useState(false);
   const [travelError, setTravelError] = useState<string | null>(null);
 
+  // Abort the in-flight status read on each refresh: Start/Restart/Manual-
+  // Offline each trigger one, and without cancellation a slow earlier
+  // response can land after a newer one and flash a stale pre-action status
+  // (same guard FamiliarsSection uses for its loads).
+  const refreshCtlRef = useRef<AbortController | null>(null);
   const refresh = () => {
+    refreshCtlRef.current?.abort();
+    const ctl = new AbortController();
+    refreshCtlRef.current = ctl;
     setLoading(true);
-    fetch("/api/daemon/status", { cache: "no-store" })
+    fetch("/api/daemon/status", { cache: "no-store", signal: ctl.signal })
       .then((r) => r.json())
-      .then((j: DaemonStatus) => { setStatus(j); setLoading(false); })
-      .catch(() => { setStatus({ running: false }); setLoading(false); });
+      .then((j: DaemonStatus) => {
+        if (ctl.signal.aborted) return;
+        setStatus(j); setLoading(false);
+      })
+      .catch(() => {
+        if (ctl.signal.aborted) return;
+        setStatus({ running: false }); setLoading(false);
+      });
   };
 
-  useEffect(refresh, []);
+  useEffect(() => {
+    refresh();
+    return () => refreshCtlRef.current?.abort();
+    // refresh is stable-by-construction (only touches refs/setters); running
+    // this once on mount is the intent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
-    fetch("/api/config", { cache: "no-store" })
+    const ctl = new AbortController();
+    fetch("/api/config", { cache: "no-store", signal: ctl.signal })
       .then((r) => r.json())
       .then((j: { ok?: boolean; config?: { multiHost?: { mode?: MultiHostMode; hubUrl?: string; executorUrls?: string[] } } }) => {
+        if (ctl.signal.aborted) return;
         const multiHost = j.config?.multiHost;
         if (!j.ok || !multiHost) return;
         setMode(multiHost.mode === "hub" ? "hub" : "local");
@@ -478,6 +504,7 @@ function DaemonSection() {
         setExecutorText((multiHost.executorUrls ?? []).join("\n"));
       })
       .catch(() => {});
+    return () => ctl.abort();
   }, []);
 
   const saveConnection = async (nextMode = mode) => {
@@ -1583,7 +1610,7 @@ function AppearanceSection() {
               onSave={() => {
                 setActiveTheme("custom");
                 try {
-                  const raw = localStorage.getItem("coven-custom-theme");
+                  const raw = localStorage.getItem(COVEN_CUSTOM_THEME_KEY);
                   if (raw) setCustomData(JSON.parse(raw) as CustomThemeData);
                 } catch { /* ignore */ }
               }}


### PR DESCRIPTION
## Summary

Bead `cave-dgac` (Settings audit sweep, source-verified). Three fetch-hygiene fixes in `settings-shell.tsx`:

**DaemonSection refresh races.** Start, Restart, and the Manual-Offline toggle each fire a `/api/daemon/status` read with no cancellation or ordering guard — with rapid actions, a slow earlier response could land after a newer one and flash a stale pre-action status. `refresh()` now aborts the in-flight request before starting the next (the exact pattern `FamiliarsSection` already uses), checks `signal.aborted` before every setState, and the mount effect aborts on unmount.

**Once-on-mount loads.** The `/api/config` multi-host load and `WorkspacePathField`'s status read now carry abort signals and bail if aborted — no setState after unmount on slow networks.

**Hardcoded storage key.** `ThemeColorEditor`'s onSave read `localStorage.getItem("coven-custom-theme")` while all four other sites use the imported `COVEN_CUSTOM_THEME_KEY` constant — a silent drift trap if the key ever changes. Now the constant everywhere; a `doesNotMatch` pin keeps string literals out.

## Test plan

- [x] Pins in `settings-daemon-multihost.test.ts`: abort-per-refresh, signals on both fetches, no literal theme key (existing config-load pin updated for the signal)
- [x] Full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)