### PR TITLE
fix(automations): stale-response guard on the run-log fetch (cave-s1i6)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -179,3 +179,10 @@ assert.match(source, /This fires the reminder immediately\./, "reminder run-now 
 assert.doesNotMatch(source, /const toggleFlowActive = useCallback|saveFlow\(setFlowActive|setFlows\(/, "Flow pause/poll mutations are absent");
 assert.match(source, /runAutomation: runCodexNow/, "cron run-now remains wired");
 assert.match(source, /togglePauseAutomation: toggleCodex/, "cron pause/resume remains wired");
+
+// ── Run-log stale-response guard (cave-s1i6) ─────────────────────────────────
+// Rapid run switches must not render run A's log under run B's header: only
+// the latest request may write state, and closing invalidates in-flight reads.
+assert.match(source, /const req = \+\+runLogReqRef\.current;/, "each log fetch takes a request token");
+assert.match(source, /if \(req !== runLogReqRef\.current\) return;/, "stale log responses are dropped");
+assert.match(source, /runLogReqRef\.current \+= 1;\s*\n\s*setOpenRunId\(null\);/, "closing the log invalidates the in-flight fetch");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -677,19 +677,31 @@ function CodexDetailPanel({
   const [openRunId, setOpenRunId] = useState<string | null>(null);
   const [runLog, setRunLog] = useState<string>("");
   const [runLogLoading, setRunLogLoading] = useState(false);
+  // Rapid run switches: only the latest log request may write state, or a
+  // slow earlier response renders the WRONG log under the newer run's header
+  // (same stale-response guard as runsReqRef for the runs list).
+  const runLogReqRef = useRef(0);
   const toggleRunLog = async (runId: string) => {
-    if (openRunId === runId) { setOpenRunId(null); return; }
+    if (openRunId === runId) {
+      // Closing also invalidates any in-flight fetch for this run's log.
+      runLogReqRef.current += 1;
+      setOpenRunId(null);
+      return;
+    }
+    const req = ++runLogReqRef.current;
     setOpenRunId(runId);
     setRunLog("");
     setRunLogLoading(true);
     try {
       const res = await fetch(`/api/codex-automations/${encodeURIComponent(auto.id)}/runs/${encodeURIComponent(runId)}/log`, { cache: "no-store" });
       const json = await res.json().catch(() => null);
+      if (req !== runLogReqRef.current) return;
       setRunLog(json?.ok ? (json.truncated ? "…(truncated)…\n" : "") + (json.log ?? "") : (json?.error ?? "no log"));
     } catch {
+      if (req !== runLogReqRef.current) return;
       setRunLog("failed to load log");
     } finally {
-      setRunLogLoading(false);
+      if (req === runLogReqRef.current) setRunLogLoading(false);
     }
   };
   const [name, setName] = useState(auto.name);


### PR DESCRIPTION
## Summary

Bead `cave-s1i6` (Automations audit sweep, source-verified). `toggleRunLog` (automations-view.tsx) set `openRunId` and fetched `/api/codex-automations/<id>/runs/<runId>/log` with no stale-response guard: clicking run A's log then quickly run B's meant a slow A response could land after B's and render **A's log under B's header**. Closing the log panel also left the in-flight fetch free to repopulate `runLog`/`runLogLoading` afterwards.

Fix: a request-token ref — the exact pattern this file's `runsReqRef` already uses for the runs list. Every fetch takes `++runLogReqRef.current`; responses (success, error, and the loading-flag reset) are dropped unless the token still matches; closing the panel bumps the token to invalidate in-flight reads.

## Test plan

- [x] Pins in `automations-view.test.ts`: token per fetch, stale drop, close-invalidates
- [x] Full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)