### PR TITLE
a11y(automations): status-shaped run icons; detail-form labels actually associated (cave-dgli)

### DIFF
--- a/src/components/automations-detail-inputs.test.ts
+++ b/src/components/automations-detail-inputs.test.ts
@@ -16,10 +16,10 @@ assert.match(
   "Automation detail should compose distinct inputs back into the prompt payload",
 );
 
-assert.match(source, /<FieldLabel>Goals<\/FieldLabel>/, "Automation detail should show a Goals input");
+assert.match(source, /<FieldLabel htmlFor=\{`cron-goals-\$\{auto\.id\}`\}>Goals<\/FieldLabel>/, "Automation detail should show a Goals input");
 assert.match(
   source,
-  /<FieldLabel>Deliverables<\/FieldLabel>/,
+  /<FieldLabel htmlFor=\{`cron-deliverables-\$\{auto\.id\}`\}>Deliverables<\/FieldLabel>/,
   "Automation detail should show a Deliverables input",
 );
 
@@ -97,3 +97,19 @@ assert.match(
   /function linkLabel/,
   "Should derive a sensible label per link kind",
 );
+// ── Field a11y (cave-dgli) ───────────────────────────────────────────────────
+// Detail-form labels are programmatically associated (FieldLabel htmlFor +
+// input id), bare schedule controls carry aria-labels, and the run-status
+// signal is a status-shaped icon (not a color-only dot).
+assert.match(source, /function FieldLabel\(\{ htmlFor, children \}/, "FieldLabel supports htmlFor association");
+for (const f of ["name", "tags", "goals", "deliverables", "model"]) {
+  assert.match(source, new RegExp(String.raw`htmlFor=\{\x60cron-${f}-\$\{auto\.id\}\x60\}`), `the ${f} field label points at its control`);
+  assert.match(source, new RegExp(String.raw`id=\{\x60cron-${f}-\$\{auto\.id\}\x60\}`), `the ${f} control carries its id`);
+}
+assert.match(source, /aria-label="Schedule time"/, "the schedule time input is named");
+assert.match(source, /aria-label="Raw RRULE"/, "the raw RRULE textarea is named");
+assert.match(source, /runStatusIcon\(r\.status\)/, "run rows encode status by icon shape, not color alone");
+{
+  const cwd = await readFile(new URL("./cwd-picker-field.tsx", import.meta.url), "utf8");
+  assert.match(cwd, /aria-label="Working directories, one per line"/, "the cwd textarea is named");
+}

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -49,7 +49,7 @@ import {
   type AutomationEntry,
 } from "@/lib/automations/automation-entry";
 import { listInput, commaInput, parseListInput } from "@/lib/automations/list-input";
-import { runStatusColor } from "@/lib/automations/run-status";
+import { runStatusColor, runStatusIcon } from "@/lib/automations/run-status";
 
 // AutomationsView — Schedules surface, redesigned June 2026
 // Clean list layout matching the sleek/professional reference design:
@@ -131,9 +131,9 @@ function relTime(iso: string | undefined | null): string {
 }
 
 
-function FieldLabel({ children }: { children: ReactNode }) {
+function FieldLabel({ htmlFor, children }: { htmlFor?: string; children: ReactNode }) {
   return (
-    <label className="mb-1 block text-[10px] font-semibold uppercase tracking-widest"
+    <label htmlFor={htmlFor} className="mb-1 block text-[10px] font-semibold uppercase tracking-widest"
       style={{ color: "var(--text-muted)" }}>
       {children}
     </label>
@@ -830,8 +830,9 @@ function CodexDetailPanel({
 
         <CronDetailSection title="Identity" description="Name and labels used to recognize this cron in Schedules.">
           <div>
-            <FieldLabel>Name</FieldLabel>
+            <FieldLabel htmlFor={`cron-name-${auto.id}`}>Name</FieldLabel>
             <input
+              id={`cron-name-${auto.id}`}
               value={name}
               onChange={(event) => setName(event.target.value)}
               className={automationInputClass}
@@ -840,8 +841,9 @@ function CodexDetailPanel({
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <FieldLabel>Tags</FieldLabel>
+              <FieldLabel htmlFor={`cron-tags-${auto.id}`}>Tags</FieldLabel>
               <input
+                id={`cron-tags-${auto.id}`}
                 value={tagsText}
                 onChange={(event) => setTagsText(event.target.value)}
                 className={automationInputClass}
@@ -857,8 +859,9 @@ function CodexDetailPanel({
 
         <CronDetailSection title="Instructions" description="What the cron should do and what output it should leave behind.">
           <div>
-            <FieldLabel>Goals</FieldLabel>
+            <FieldLabel htmlFor={`cron-goals-${auto.id}`}>Goals</FieldLabel>
             <textarea
+              id={`cron-goals-${auto.id}`}
               value={goals}
               onChange={(event) => setGoals(event.target.value)}
               rows={5}
@@ -867,8 +870,9 @@ function CodexDetailPanel({
             />
           </div>
           <div>
-            <FieldLabel>Deliverables</FieldLabel>
+            <FieldLabel htmlFor={`cron-deliverables-${auto.id}`}>Deliverables</FieldLabel>
             <textarea
+              id={`cron-deliverables-${auto.id}`}
               value={deliverables}
               onChange={(event) => setDeliverables(event.target.value)}
               rows={4}
@@ -904,6 +908,7 @@ function CodexDetailPanel({
 
           {scheduleMode === "raw" ? (
             <textarea
+              aria-label="Raw RRULE"
               value={rawRrule}
               onChange={(event) => setRawRrule(event.target.value)}
               rows={3}
@@ -938,6 +943,7 @@ function CodexDetailPanel({
               )}
               <input
                 type="time"
+                aria-label="Schedule time"
                 value={scheduleTime}
                 onChange={(event) => setScheduleTime(event.target.value)}
                 className={automationInputClass}
@@ -953,8 +959,9 @@ function CodexDetailPanel({
         <CronDetailSection title="Runtime" description="Where the cron runs and which model settings it should use.">
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
-              <FieldLabel>Model</FieldLabel>
+              <FieldLabel htmlFor={`cron-model-${auto.id}`}>Model</FieldLabel>
               <input
+                id={`cron-model-${auto.id}`}
                 value={model}
                 onChange={(event) => setModel(event.target.value)}
                 className={automationInputClass}
@@ -1023,7 +1030,12 @@ function CodexDetailPanel({
                     aria-label={`${r.status} run ${relTime(r.startedAt)}${r.summary ? ` — ${r.summary}` : ""}, ${openRunId === r.id ? "hide" : "show"} log`}
                     className="w-full justify-start rounded-[var(--radius-control)] px-2 py-1 text-left text-[12px] hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]"
                   >
-                    <span aria-hidden className="h-2 w-2 shrink-0 rounded-full" style={{ background: runStatusColor(r.status) }} />
+                    {/* Shape + color (WCAG 1.4.1): the icon form carries the
+                        status for color-blind users; AT reads it from the
+                        button's aria-label. */}
+                    <span aria-hidden className="shrink-0" style={{ color: runStatusColor(r.status), lineHeight: 0 }}>
+                      <Icon name={runStatusIcon(r.status)} width={12} />
+                    </span>
                     <span style={{ color: "var(--text-secondary)" }} title={r.startedAt ? formatTimestamp(r.startedAt, readDateTimePrefs()) : undefined}>{relTime(r.startedAt)}</span>
                     {r.summary && <span className="truncate" style={{ color: "var(--text-muted)" }}>{r.summary}</span>}
                     <span aria-hidden className="ml-auto shrink-0" style={{ color: "var(--text-muted)", lineHeight: 0 }}>

--- a/src/components/cwd-picker-field.tsx
+++ b/src/components/cwd-picker-field.tsx
@@ -64,6 +64,7 @@ export function CwdPickerField({
   return (
     <>
       <textarea
+        aria-label="Working directories, one per line"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         rows={3}

--- a/src/lib/automations/run-status.ts
+++ b/src/lib/automations/run-status.ts
@@ -26,3 +26,24 @@ export function runStatusColor(
       return "var(--text-muted)";
   }
 }
+
+/**
+ * Shared run-status → icon mapping (cave-dgli): the colored dot alone encoded
+ * status by color only (WCAG 1.4.1) — a distinct SHAPE per status carries the
+ * outcome for color-blind users, with `runStatusColor` still tinting it. All
+ * names are already in the curated icon subset.
+ */
+export function runStatusIcon(status: AutomationRunStatus | string): "ph:x-circle-fill" | "ph:check-circle-fill" | "ph:clock-countdown" | "ph:play-fill" | "ph:circle-fill" {
+  switch (status) {
+    case "failed":
+      return "ph:x-circle-fill";
+    case "running":
+      return "ph:play-fill";
+    case "queued":
+      return "ph:clock-countdown";
+    case "succeeded":
+      return "ph:check-circle-fill";
+    default:
+      return "ph:circle-fill";
+  }
+}


### PR DESCRIPTION
## Summary

Bead `cave-dgli` (Automations audit sweep, source-verified — scope grew during implementation: the whole detail form had unassociated labels, not just the time input).

**Run status was color-only for sighted users (WCAG 1.4.1).** Each run row's outcome was a 2px colored dot (`aria-hidden`); AT users got the status from the button's aria-label, but color-blind users got color alone. A new shared `runStatusIcon` (next to `runStatusColor` in `lib/automations/run-status.ts`) gives each status a distinct shape — x-circle / check-circle / clock / play — tinted by the existing color mapping. All icon names verified present in the curated subset (no bundle regen needed).

**No label in the detail form was programmatically associated (WCAG 1.3.1/4.1.2).** `FieldLabel` rendered a bare `<label>` — no `htmlFor`, not wrapping — so screen readers announced every input as unnamed. `FieldLabel` gains `htmlFor`, and Name/Tags/Goals/Deliverables/Model are wired with `auto.id`-scoped ids. The bare schedule controls get direct names (Schedule time input, Raw RRULE textarea), and `CwdPickerField`'s textarea is named. Skill/Reasoning/Environment were already accessible through `StandardSelect`'s label prop — left alone.

## Test plan

- [x] Pins in `automations-detail-inputs.test.ts`: FieldLabel htmlFor support, all five label↔control pairs, both bare-control names, icon-shape status, cwd textarea name (two existing label pins updated for the htmlFor form)
- [x] Full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)