### PR TITLE
fix(palette): ignore keydowns during IME composition (cave-wka1)

### DIFF
--- a/src/components/command-palette-a11y.test.ts
+++ b/src/components/command-palette-a11y.test.ts
@@ -37,4 +37,13 @@ assert.match(
   "the scroll-into-view effect tracks the active index",
 );
 
+// cave-wka1: the Enter/arrows that drive an IME candidate picker must not fire
+// the active row or move the highlight (ChatView and group-chat have the same
+// composer guard).
+assert.match(
+  src,
+  /const onComposerKey = \(e: React\.KeyboardEvent\) => \{[\s\S]{0,320}?if \(e\.nativeEvent\.isComposing\) return;/,
+  "palette keyboard handler ignores keydowns while an IME composition is in progress",
+);
+
 console.log("command-palette-a11y.test.ts: ok");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -722,6 +722,10 @@ export function CommandPalette({
   };
 
   const onComposerKey = (e: React.KeyboardEvent) => {
+    // The Enter/arrows that drive an IME candidate picker (CJK input) belong
+    // to the IME — confirming a character must not fire the active row or
+    // move the highlight. Mirrors the ChatView / group-chat composer guards.
+    if (e.nativeEvent.isComposing) return;
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setActiveIdx((i) => Math.min(i + 1, rows.length - 1));


### PR DESCRIPTION
## Problem (cave-wka1)
`onComposerKey` in the command palette handled ArrowUp/ArrowDown/Enter without `e.nativeEvent.isComposing` — for CJK/IME users the Enter that confirms a candidate fired the active row (usually the Ask-Salem AI network call, or switched familiar / opened a session), and arrows hijacked IME candidate navigation. ChatView (chat-view.tsx:4525) and group-chat (#2662) already guard this.

## Fix
Early-return from `onComposerKey` while a composition is in progress.

## Verification
- New source pin in `command-palette-a11y.test.ts`; palette test files pass
- `pnpm typecheck` clean

Closes cave-wka1 (beads).