### PR TITLE
fix(palette): Enter opens the top local match — Ask-Salem becomes the fallback row (cave-42r5)

### DIFF
--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -62,6 +62,15 @@ assert.match(
   "Command palette includes a Salem AI answer row",
 );
 
+// (cave-42r5) Ask-Salem trails the local matches: Enter on a typed query opens
+// the best local hit; the AI row is the fallback (rows[0] only when nothing
+// matches locally).
+assert.match(
+  source,
+  /return \[\.\.\.localRows, \.\.\.salemRows\];/,
+  "local matches come before the Ask-Salem fallback row",
+);
+
 assert.match(
   source,
   /fetch\("\/api\/salem"[\s\S]*body: JSON\.stringify\(\{[\s\S]*message:\s*query\.trim\(\)[\s\S]*context:/,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -615,7 +615,12 @@ export function CommandPalette({
       ? [{ id: "salem-answer", kind: "salem-answer", query: query.trim() }]
       : [];
 
-    return [...salemRows, ...localRows];
+    // Ask-Salem is the FALLBACK row, not the default (cave-42r5): Enter on a
+    // typed query must open the best local match (sessions, familiars, cards,
+    // surfaces), not fire a network AI call. With zero local matches the
+    // Salem row is still rows[0], so unmatched queries keep their one-Enter
+    // AI path.
+    return [...localRows, ...salemRows];
   }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, contentHits, query, activeFamiliarId, projects]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Bead `cave-42r5` (source-verified). The command palette prepended the Ask-Salem AI row for every non-slash query, and every keystroke resets `activeIdx` to 0 — so the launcher's core gesture (type a few characters, press Enter, open the best hit) instead fired a network AI request through `/api/salem` and left the palette open. Sessions, familiars, cards, and surfaces were never Enter-reachable without arrowing past the AI row first.

**Fix: one line of composition order** — `[...localRows, ...salemRows]`. Enter now opens the top local match (the standard VS Code/Linear/Raycast contract), while queries with **zero** local matches still put Ask-Salem at `rows[0]`, preserving the one-Enter AI path exactly where it's wanted. The row remains reachable by arrowing down whenever local matches exist.

## Test plan

- [x] New ordering pin in `command-palette.test.ts`; existing salem-row pins unchanged
- [x] All three palette test files + full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)