### PR TITLE
fix(browser): closing the active tab fully activates the replacement; quick-open dialog gets tabIndex (cave-5hnh)

### DIFF
--- a/src/components/browser-pane-hooks.test.ts
+++ b/src/components/browser-pane-hooks.test.ts
@@ -86,4 +86,27 @@ assert.doesNotMatch(source, /forwardRef/, "BrowserPane no longer uses forwardRef
   assert.match(workspace, /handleRef=\{browserPaneRef\}/, "workspace passes the handle through the handleRef prop");
 }
 
+// ── Closing the active tab fully activates the replacement (cave-5hnh) ──────
+// Setting activeTabId alone left the address bar, loading flag, and history
+// pointing at the closed tab; removeTab must route through switchTab (which
+// syncs all three) and drop the closed tab's history entry.
+{
+  const removeTabBody = extractFunctionBody("removeTab");
+  assert.match(
+    removeTabBody,
+    /if \(activeTabId === id\) switchTab\(/,
+    "removeTab activates the replacement tab through switchTab, not bare setActiveTabId",
+  );
+  assert.doesNotMatch(
+    removeTabBody,
+    /setActiveTabId\(/,
+    "removeTab must not set the active id directly — switchTab owns activation sync",
+  );
+  assert.match(
+    removeTabBody,
+    /delete historyRef\.current\[id\]/,
+    "removeTab drops the closed tab's navigation history",
+  );
+}
+
 console.log("browser-pane-hooks.test.ts: ok");

--- a/src/components/browser-pane.tsx
+++ b/src/components/browser-pane.tsx
@@ -564,7 +564,11 @@ export function BrowserPane({ label = "default", activeFamiliarId = null, active
     const next = tabs.filter((t) => t.id !== id);
     setTabs(next);
     savePinnedTabs(next);
-    if (activeTabId === id) setActiveTabId(next[0]?.id ?? "home");
+    delete historyRef.current[id];
+    // Closing the ACTIVE tab must fully activate the replacement: setting the
+    // id alone left the address bar, loading state, and history pointing at
+    // the closed tab until the user manually switched (cave-5hnh).
+    if (activeTabId === id) switchTab(next[0]?.id ?? "home");
   };
 
   // ── Per-tab navigation ────────────────────────────────────────────

--- a/src/components/browser-quick-open.test.ts
+++ b/src/components/browser-quick-open.test.ts
@@ -12,5 +12,12 @@ assert.match(source, /role="option"/, "items have role=option");
 assert.match(source, /aria-controls=/, "input has aria-controls");
 assert.match(source, /aria-activedescendant=/, "input uses aria-activedescendant");
 assert.match(source, /aria-selected=/, "active item announced via aria-selected");
+// Dialog convention (use-focus-trap.ts): the trapped container must be
+// programmatically focusable.
+assert.match(
+  source,
+  /role="dialog"[\s\S]{0,120}tabIndex=\{-1\}/,
+  "dialog container carries tabIndex={-1} so the focus trap can seat focus",
+);
 
 console.log("browser-quick-open.test.ts OK");

--- a/src/components/browser-quick-open.tsx
+++ b/src/components/browser-quick-open.tsx
@@ -110,6 +110,7 @@ export function BrowserQuickOpen({ tabs, activeId, onSelect, onClose }: Props) {
         role="dialog"
         aria-modal="true"
         aria-label="Jump to tab"
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
         className="w-[420px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl"
       >


### PR DESCRIPTION
Closes bead `cave-5hnh` (from today's source-verified browser-pane audit).

## Bug 1 — stale state after closing the active tab

`removeTab` only called `setActiveTabId(next[0]?.id ?? "home")`; unlike `switchTab` it never synced `addressBar`, `loading`, or `historyRef` — so after closing the active tab the address bar showed the dead tab's URL and back/forward state was wrong until a manual tab switch. Now activation routes through `switchTab` and the closed tab's history entry is deleted.

## Bug 2 — quick-open dialog can't take programmatic focus

The ⌘K jump-to-tab dialog had `role=dialog` + `aria-modal` + `useFocusTrap` but no `tabIndex={-1}` on the container (repo convention: use-focus-trap.ts:18-21). Added.

## Validation

- New pins: `browser-pane-hooks.test.ts` (removeTab routes through switchTab, no bare setActiveTabId, history dropped) and `browser-quick-open.test.ts` (dialog tabIndex)
- All 5 browser test files pass; `pnpm typecheck` clean