### PR TITLE
fix(board): derive a card's cwd server-side from its project, never the client body (cave-pw83)

### DIFF
--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import {
   deleteCard,
+  loadBoard,
   updateCard,
   type CardLifecycle,
   type CardPriority,
@@ -10,6 +11,7 @@ import type { CardStep } from "@/lib/cave-board-types";
 import type { CardGitHubLink } from "@/lib/cave-board-types";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import type { CardOps } from "@/lib/board-card-ops";
+import { trustedProjectCwd } from "@/lib/cave-projects";
 
 export const dynamic = "force-dynamic";
 
@@ -46,6 +48,25 @@ export async function PATCH(
     body = await req.json();
   } catch {
     return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  // Keep a card's cwd consistent with its project, server-side (cave-pw83):
+  //  - assigning a project (projectId set) → derive cwd from it, ignoring the body's;
+  //  - changing cwd alone → re-derive from the card's CURRENT project if it has one,
+  //    so a client can't point a project-assigned card at a contradictory cwd.
+  // Clearing the project (projectId === null) leaves the client cwd (no project to
+  // anchor to). Neither path lets a mismatched body.cwd through.
+  if (body.projectId) {
+    const resolved = await trustedProjectCwd(body.projectId);
+    if (!resolved.ok) {
+      return NextResponse.json({ ok: false, error: "assigned project not found" }, { status: 409 });
+    }
+    body = { ...body, cwd: resolved.root };
+  } else if (body.cwd !== undefined && body.projectId === undefined) {
+    const current = (await loadBoard()).cards.find((entry) => entry.id === id);
+    if (current?.projectId) {
+      const resolved = await trustedProjectCwd(current.projectId);
+      if (resolved.ok) body = { ...body, cwd: resolved.root };
+    }
   }
   const card = await updateCard(id, body);
   if (!card) {

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/cave-board";
 import type { CardGitHubLink } from "@/lib/cave-board-types";
 import type { ChatAttachment } from "@/lib/chat-attachments";
+import { trustedProjectCwd } from "@/lib/cave-projects";
 
 export const dynamic = "force-dynamic";
 
@@ -42,6 +43,16 @@ export async function POST(req: Request) {
   if (!body.title || !body.title.trim()) {
     return NextResponse.json({ ok: false, error: "title required" }, { status: 400 });
   }
+  // A card assigned to a project derives its cwd from that project server-side —
+  // never from the client body, which could contradict the project (cave-pw83).
+  let cwd = body.cwd ?? null;
+  if (body.projectId) {
+    const resolved = await trustedProjectCwd(body.projectId);
+    if (!resolved.ok) {
+      return NextResponse.json({ ok: false, error: "assigned project not found" }, { status: 409 });
+    }
+    cwd = resolved.root;
+  }
   const card = await createCard({
     title: body.title,
     notes: body.notes,
@@ -49,7 +60,7 @@ export async function POST(req: Request) {
     priority: body.priority,
     familiarId: body.familiarId,
     sessionId: body.sessionId,
-    cwd: body.cwd,
+    cwd,
     projectId: body.projectId,
     links: body.links,
     github: body.github,

--- a/src/lib/board-search.test.ts
+++ b/src/lib/board-search.test.ts
@@ -73,6 +73,21 @@ assert.match(boardApi, /links\?: string\[\]/, "Create API should accept task lin
 assert.match(boardApi, /cwd\?: string \| null/, "Create API should accept task cwd");
 assert.match(boardApi, /projectId\?: string \| null/, "Create API should accept task projectId");
 
+// cave-pw83: a card's cwd is derived server-side from its assigned project, never
+// trusted from the client body (a mismatched cwd would poison board search/display).
+const projectsLib = await readFile(new URL("./cave-projects.ts", import.meta.url), "utf8");
+assert.match(projectsLib, /export async function trustedProjectCwd/, "cave-projects exposes a server-trusted cwd resolver");
+assert.match(boardApi, /trustedProjectCwd\(body\.projectId\)/, "Create API resolves the assigned project's cwd server-side");
+assert.match(boardApi, /cwd = resolved\.root/, "Create API stores the server-resolved project root as cwd, not the client's");
+
+const boardIdApi = await readFile(new URL("../app/api/board/[id]/route.ts", import.meta.url), "utf8");
+assert.match(boardIdApi, /trustedProjectCwd\(body\.projectId\)/, "PATCH API derives cwd when a project is (re)assigned");
+assert.match(
+  boardIdApi,
+  /body\.cwd !== undefined && body\.projectId === undefined[\s\S]*?trustedProjectCwd\(current\.projectId\)/,
+  "PATCH API re-derives cwd from the card's current project when cwd changes alone (no client override)",
+);
+
 const boardView = await readFile(new URL("../components/board-view.tsx", import.meta.url), "utf8");
 assert.match(boardView, /board-search-input/, "Tasks header should expose one search input");
 assert.doesNotMatch(boardView, /label="Labels"/, "Tasks header should not show Labels as a separate filter control");

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -156,3 +156,18 @@ export function projectById(
   if (!id) return null;
   return projects.find((project) => project.id === id) ?? null;
 }
+
+/**
+ * The server-trusted working directory for a card assigned to `projectId`: the
+ * project's own root, loaded server-side. A card's `cwd` must never be taken
+ * from a client body alongside a `projectId` — the two could contradict, and a
+ * mismatched cwd then feeds board search (`cwd:` token), display, and the
+ * no-project chat fallback (cave-pw83). Returns `{ ok: false }` when the id
+ * doesn't resolve so the caller can reject with a 409.
+ */
+export async function trustedProjectCwd(
+  projectId: string,
+): Promise<{ ok: true; root: string } | { ok: false }> {
+  const project = projectById(projectId, await loadProjects());
+  return project ? { ok: true, root: project.root } : { ok: false };
+}


### PR DESCRIPTION
## What

`POST /api/board` and `PATCH /api/board/[id]` persisted `body.cwd` **verbatim** even when `body.projectId` was set — so a card could be stored with a `cwd` that contradicts its assigned project. The task-chat route already re-derives the root server-side, but `card.cwd` still feeds board **search** (`cwd:` token), **display**, and the **no-project chat fallback** — a client-controlled inconsistent state was representable.

## Fix

Add `cave-projects.trustedProjectCwd(projectId)` (resolves the project's root server-side, or reports not-found for a 409) and route both handlers through it:

- **POST** — when `projectId` is set, store the resolved root as `cwd` (ignore the body's).
- **PATCH** — same when a project is (re)assigned; and when **`cwd` changes alone**, re-derive from the card's *current* project if it has one, so a client can't repoint a project-assigned card at a contradictory cwd. Clearing the project (`projectId: null`) leaves the client `cwd` (nothing to anchor to).

The UI already sent `{projectId, cwd: project.root}` together, so this only rejects/overrides mismatched or hand-crafted requests.

Pinned in `board-search.test.ts` (helper + both route paths).

## Verification

`typecheck` · **570** app test files · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)