### PR TITLE
fix(palette): Enter opens the best local match — Ask-Salem row trails the results (cave-42r5)

### DIFF
--- a/src/components/command-palette-a11y.test.ts
+++ b/src/components/command-palette-a11y.test.ts
@@ -46,4 +46,19 @@ assert.match(
   "palette keyboard handler ignores keydowns while an IME composition is in progress",
 );
 
+// cave-42r5: every keystroke resets activeIdx to 0, so whatever row is first
+// owns the type-then-Enter gesture. Local matches must lead and Ask-Salem must
+// trail — with Salem prepended, Enter always fired an AI network call and the
+// best local hit was never Enter-reachable.
+assert.match(
+  src,
+  /return \[\.\.\.localRows, \.\.\.salemRows\];/,
+  "the Ask-Salem row trails the local matches (Enter opens the best local hit)",
+);
+assert.doesNotMatch(
+  src,
+  /return \[\.\.\.salemRows, \.\.\.localRows\];/,
+  "the Salem-first ordering must not return",
+);
+
 console.log("command-palette-a11y.test.ts: ok");

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -615,7 +615,12 @@ export function CommandPalette({
       ? [{ id: "salem-answer", kind: "salem-answer", query: query.trim() }]
       : [];
 
-    return [...salemRows, ...localRows];
+    // Local matches lead; Ask-Salem is the LAST row. Every keystroke resets
+    // activeIdx to 0, so whatever sits first owns the type-then-Enter gesture —
+    // with Salem prepended, Enter always fired an AI network call and the best
+    // local hit was never Enter-reachable (cave-42r5, direction confirmed by
+    // the operator). Salem stays one ArrowUp away (or arrow past the list).
+    return [...localRows, ...salemRows];
   }, [familiars, familiarById, sessions, cards, covenMemory, fsMemory, contentHits, query, activeFamiliarId, projects]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem (cave-42r5)
The Ask-Salem row was **prepended** for every non-slash query, and every keystroke resets `activeIdx` to 0 — so the launcher's core gesture (type a few chars → Enter → open best hit) always fired an AI network call via `/api/salem` instead. Local matches (sessions, familiars, cards, surfaces) were never Enter-reachable without arrowing past the Salem row first.

## Fix
`return [...localRows, ...salemRows]` — local matches lead, Ask-Salem is pinned last (still arrow-reachable; loading/answer regions unchanged). Ordering direction confirmed by @BunsDev in-session (the AI-first ordering originated in #1031).

## Verification
- 2 new source pins (salem-last + regression guard on the old ordering)
- `pnpm test:app` — 570 files pass · `pnpm typecheck` clean

Closes cave-42r5 (beads).