### PR TITLE
fix(calendar): month gridcells keep a single tab stop — nested buttons leave the tab order (cave-sth7)

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -65,6 +65,12 @@ assert.match(view, /role="rowgroup"[\s\S]{0,220}\{weeks\.map\(\(week, wi\) => \(
 assert.match(view, /role="gridcell"\s*\n\s*data-month-cell="true"\s*\n\s*tabIndex=\{-1\}[\s\S]*?onKeyDown=\{\(e\) => \{[\s\S]*?Enter[\s\S]*?onCell/, "month day cells are roving gridcells, keyboard-operable");
 assert.match(view, /itemSelector: '\[data-month-cell="true"\]',\s*\n\s*columns: 7,/, "month cells rove 2-D over a 7-column grid");
 assert.match(view, /if \(anchorIndex >= 0\) setActiveIndex\(anchorIndex\)/, "the grid's tab stop follows the anchor day");
+// (cave-sth7) Nested widgets stay OUT of the tab order — 42 tabbable date
+// buttons (plus overflow buttons) defeated the single roving tab stop. The
+// date button's open-day action moves to Shift+Enter on the cell.
+assert.match(view, /<button\n\s*type="button"\n\s*tabIndex=\{-1\}\n\s*onClick=\{\(e\) => \{ e\.stopPropagation\(\); onDayClick\?\.\(day\); \}\}/, "the date-number button is tab-skipped");
+assert.match(view, /if \(e\.key === "Enter" && e\.shiftKey\) \{\s*\n\s*e\.preventDefault\(\);\s*\n\s*onDayClick\?\.\(day\);/, "Shift+Enter on the cell opens the day (keyboard path for the date button)");
+assert.ok((view.match(/tabIndex=\{-1\}\n\s*onClick=\{\(e\) => \{\n\s*e\.stopPropagation\(\);\n\s*onDayClick\?\.\(day\);/g) ?? []).length >= 2, "both month overflow buttons are tab-skipped");
 // (cave-zqsj) The selected/anchor day was colour-or-nothing; it now carries
 // aria-selected + a ", selected" label token (mirroring the mini-month), and
 // the week header names today instead of a bg tint alone.

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1178,20 +1178,31 @@ function MonthView({
                   aria-label={`${canAdd ? `Add a reminder on ${fmtDateHeading(day)}` : fmtDateHeading(day)}${itemsSuffix}${isAnchor ? ", selected" : ""}`}
                   onClick={onCell}
                   onKeyDown={(e) => {
+                    // Shift+Enter opens the day — the keyboard path for what
+                    // the (tab-skipped) date-number button does on click.
+                    if (e.key === "Enter" && e.shiftKey) {
+                      e.preventDefault();
+                      onDayClick?.(day);
+                      return;
+                    }
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault();
                       onCell();
                     }
                   }}
-                  title={canAdd ? "Click to add a reminder — click the date to open the day" : undefined}
+                  title={canAdd ? "Click to add a reminder — click the date (or Shift+Enter) to open the day" : undefined}
                   className={`group relative focus-ring-inset flex cursor-pointer flex-col overflow-hidden p-1.5 transition-colors ${
                     isCurrentMonth
                       ? "bg-[var(--bg-panel)] hover:bg-[var(--bg-raised)]"
                       : "bg-[var(--bg-base)] hover:bg-[var(--bg-panel)]"
                   } ${isToday ? "ring-1 ring-inset ring-[var(--accent-presence)]" : ""}`}
                 >
+                  {/* Out of the tab order (cave-sth7): 42 of these defeated
+                      the grid's single roving tab stop. Mouse click still
+                      works; keyboard uses Shift+Enter on the cell. */}
                   <button
                     type="button"
+                    tabIndex={-1}
                     onClick={(e) => { e.stopPropagation(); onDayClick?.(day); }}
                     aria-label={`Open ${fmtDateHeading(day)}`}
                     className={`focus-ring mb-1 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-medium ${
@@ -1210,6 +1221,7 @@ function MonthView({
                     ))}
                     {dayDeadlines.length > 2 && (
                       <button
+                        tabIndex={-1}
                         onClick={(e) => {
                           e.stopPropagation();
                           onDayClick?.(day);
@@ -1245,6 +1257,7 @@ function MonthView({
                     })}
                     {dayItems.length > 3 && (
                       <button
+                        tabIndex={-1}
                         onClick={(e) => {
                           e.stopPropagation();
                           onDayClick?.(day);


### PR DESCRIPTION
## Summary

Bead `cave-sth7` — a follow-up on my own #2670 month-grid conversion, and a fair catch: the ARIA grid got one roving tab stop, but every gridcell still contained a natively tabbable date-number button (42 per month) plus tabbable "+N due"/"+N more" overflow buttons. Tab traversal of the page crawled through dozens of stops the roving model was supposed to collapse into one.

**Fix, per the WAI-ARIA grid pattern (nested widgets `tabIndex={-1}`):**
- The date-number button and both overflow buttons leave the tab order — still fully mouse-clickable.
- Their function (open the day) gains an explicit keyboard path on the cell: **Shift+Enter → open day**, alongside the existing Enter/Space → add-or-navigate. The cell's hover title documents it.
- Item and deadline chips deliberately stay tabbable: they're the only keyboard route to a *specific* item from month view, and they only exist on days with content — a handful of stops, not 42-per-month.

## Test plan

- [x] New pins beside the cave-zqsj grid pins: date button tab-skipped, Shift+Enter branch, both overflow buttons tab-skipped
- [x] All calendar test files + full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)