### PR TITLE
feat(chat): always-on runtime chip in the composer — logo + model, one-click switching (cave-yq5l)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -201,6 +201,7 @@ export const SUITES = {
     "src/components/message-bubble-jump-to-line.test.ts",
     "src/components/message-bubble-file-links.test.ts",
     "src/components/chat-view-polish.test.ts",
+    "src/components/composer-runtime-chip.test.ts",
     "src/components/chat-empty-state.test.ts",
     "src/components/user-chat-avatar.test.ts",
     "src/components/user-profile-invariants.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -68,7 +68,7 @@ import {
   type PromptOption,
 } from "@/lib/slash-prompt";
 import { PromptSnippetsModal, promptIconName } from "@/components/prompt-snippets-modal";
-import { catalogForRuntime } from "@/lib/runtime-models";
+import { catalogForRuntime, defaultModelForRuntime } from "@/lib/runtime-models";
 import { clearChatDebugState, publishChatDebugState } from "@/lib/chat-debug-store";
 import { Popover, PopoverBody, PopoverItem, PopoverLabel, PopoverSeparator } from "@/components/ui/popover";
 import { VoiceCallOverlay } from "./voice-call-overlay";
@@ -124,6 +124,7 @@ import { isSyntheticLocalModel, type ChatModelState } from "@/lib/chat-model-sta
 import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
 import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
+import { ComposerRuntimeChip } from "@/components/composer-runtime-chip";
 import { resolveActivePath, buildSiblingIndex, childLeaf } from "@/lib/conversation-tree";
 import { appendCollapsingNewlines } from "@/lib/stream-text";
 import { stripStepMarkers } from "@/lib/workflow-step-progress";
@@ -2378,6 +2379,35 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       })();
     },
     [familiar.id, sessionId, refreshModelState],
+  );
+  // Switch the runtime from the composer chip. Familiar-level, like the home
+  // composer's selectRuntime (/api/config is the only channel that rebinds a
+  // harness) — and it applies from the next send, because the send route
+  // re-resolves the familiar's binding from current config on every turn.
+  const handleSelectRuntime = useCallback(
+    (runtime: string) => {
+      const nextModel = defaultModelForRuntime(runtime);
+      // Optimistic: the chip flips immediately; the refetch reconciles.
+      setModelState((current) =>
+        current
+          ? { ...current, harness: runtime, effectiveModel: nextModel, source: "familiar-default", reason: "Selected from the chat composer." }
+          : current,
+      );
+      void (async () => {
+        try {
+          await fetch("/api/config", {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              familiars: { [familiar.id]: { harness: runtime, model: nextModel } },
+            }),
+          });
+        } finally {
+          await refreshModelState();
+        }
+      })();
+    },
+    [familiar.id, refreshModelState],
   );
   const pinFrameRef = useRef<number | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
@@ -5338,6 +5368,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                         onChange: (v: string) => setResponseSpeed(v as ComposerResponseSpeed),
                       } satisfies ComposerOptionSection,
                     ]}
+                  />
+                  <ComposerRuntimeChip
+                    runtime={modelHarness}
+                    modelValue={composerModelValue}
+                    modelOptions={composerModelOptions}
+                    onPickRuntime={handleSelectRuntime}
+                    onPickModel={handleSelectModel}
+                    disabled={busy}
                   />
                 </div>
                 <div className="cave-composer-submit-row">

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+// Source pins for the composer runtime chip (cave-yq5l): the chat composer
+// always shows the active runtime's mark + effective model, and switching
+// runtimes is one click away. These pin the contracts that make the chip
+// honest: real switching (familiar-level /api/config, the only channel that
+// rebinds a harness), an optimistic flip reconciled by a refetch, and
+// menuitemradio semantics in the popover.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const chip = readFileSync(new URL("./composer-runtime-chip.tsx", import.meta.url), "utf8");
+const logo = readFileSync(new URL("./runtime-logo.tsx", import.meta.url), "utf8");
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/composer-runtime-chip.css", import.meta.url), "utf8");
+
+// ── The chip is always in the composer control row, wired to live state ─────
+assert.match(
+  chatView,
+  /<ComposerRuntimeChip\s*\n\s*runtime=\{modelHarness\}\s*\n\s*modelValue=\{composerModelValue\}\s*\n\s*modelOptions=\{composerModelOptions\}\s*\n\s*onPickRuntime=\{handleSelectRuntime\}\s*\n\s*onPickModel=\{handleSelectModel\}/,
+  "the chat composer renders the runtime chip from the live model state (runtime + effective model)",
+);
+assert.match(
+  chatView,
+  /<ComposerOptionsMenu[\s\S]*?\/>\s*\n\s*<ComposerRuntimeChip/,
+  "the chip sits in the utility row after the Options menu — always visible, session or not",
+);
+
+// ── Runtime switching is real: familiar-level config, optimistic + refetch ──
+assert.match(
+  chatView,
+  /const handleSelectRuntime = useCallback\(\s*\n\s*\(runtime: string\) => \{\s*\n\s*const nextModel = defaultModelForRuntime\(runtime\);/,
+  "a runtime pick lands with the runtime's default model (a bare harness flip would keep a foreign model id)",
+);
+assert.match(
+  chatView,
+  /fetch\("\/api\/config", \{\s*\n\s*method: "PATCH",[\s\S]{0,200}?familiars: \{ \[familiar\.id\]: \{ harness: runtime, model: nextModel \} \}/,
+  "runtime switches persist through /api/config — the same channel the home composer's selectRuntime uses; the send route re-resolves the binding per turn, so the switch applies from the next message",
+);
+const selectRuntimeBlock = chatView.match(/const handleSelectRuntime = useCallback\([\s\S]*?\n  \);/)?.[0] ?? "";
+assert.match(
+  selectRuntimeBlock,
+  /setModelState\(\(current\) =>[\s\S]{0,300}?harness: runtime, effectiveModel: nextModel/,
+  "the chip flips optimistically before the network round-trip",
+);
+assert.match(
+  selectRuntimeBlock,
+  /finally \{\s*\n\s*await refreshModelState\(\);/,
+  "the model-state refetch reconciles the optimistic flip (even when the PATCH fails)",
+);
+
+// ── The chip face: runtime logo + model, one accessible name ─────────────────
+assert.match(
+  chip,
+  /aria-label=\{`Runtime: \$\{runtimeName\}\$\{modelLabel \? ` · Model: \$\{modelLabel\}` : ""\}`\}/,
+  "the chip's accessible name carries both the runtime and the model",
+);
+assert.match(
+  chip,
+  /aria-haspopup="menu"\s*\n\s*aria-expanded=\{open\}/,
+  "the chip is a proper menu trigger (ComposerHostChip conventions)",
+);
+assert.match(
+  chip,
+  /checked=\{catalog\.runtime === runtime\}/,
+  "runtime rows are menuitemradio options with the active runtime checked",
+);
+assert.match(
+  chip,
+  /modelOptions\.length > 0 && \([\s\S]*?<PopoverLabel>Model<\/PopoverLabel>/,
+  "the model group only renders for runtimes with a curated catalog (hermes/openclaw run their own adapters)",
+);
+
+// ── Brand marks: real logos for provider runtimes, glyphs for the rest ──────
+assert.match(logo, /codex: OPENAI_PATH,\s*\n\s*claude: ANTHROPIC_PATH,/, "codex and claude carry their providers' brand marks");
+assert.match(logo, /hermes: "ph:plug-bold",\s*\n\s*openclaw: "ph:paw-print-bold",/, "brand-less runtimes reuse the glyph language skill-card established");
+assert.match(logo, /fill="currentColor"[\s\S]{0,80}?aria-hidden/, "brand SVGs inherit currentColor and stay decorative (the trigger carries the name)");
+
+// ── Tokens only; the mark reads as presence ──────────────────────────────────
+assert.match(css, /\.cave-runtime-chip__logo \{[\s\S]*?color: var\(--accent-presence\);/, "the runtime mark uses the presence accent token");
+assert.doesNotMatch(css, /#[0-9a-fA-F]{3,8}\b/, "chip styles stay on semantic tokens — no hardcoded hex");
+
+console.log("composer-runtime-chip.test.ts: ok");

--- a/src/components/composer-runtime-chip.tsx
+++ b/src/components/composer-runtime-chip.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+// ComposerRuntimeChip — the always-visible "what will answer me" chip in the
+// chat composer: the active runtime's logo + the effective model, clickable
+// to switch either. Runtime picks are familiar-level (the same /api/config
+// contract the home composer's selectRuntime uses) and apply from the next
+// send — the send route re-resolves the binding from current config per turn.
+// Mirrors ComposerHostChip's trigger + Popover conventions.
+
+import { useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  Popover,
+  PopoverBody,
+  PopoverItem,
+  PopoverLabel,
+  PopoverSeparator,
+} from "@/components/ui/popover";
+import { RUNTIME_MODEL_CATALOG, type RuntimeModelOption } from "@/lib/runtime-models";
+import { RuntimeLogo, runtimeDisplayName } from "@/components/runtime-logo";
+import "@/styles/composer-runtime-chip.css";
+
+export function ComposerRuntimeChip({
+  runtime,
+  modelValue,
+  modelOptions,
+  onPickRuntime,
+  onPickModel,
+  disabled,
+}: {
+  /** Active runtime (harness id): codex | claude | hermes | openclaw. */
+  runtime: string;
+  /** Effective model id ("" when the runtime has no curated models). */
+  modelValue: string;
+  /** Curated models for the active runtime (catalogForRuntime). */
+  modelOptions: RuntimeModelOption[];
+  onPickRuntime: (runtime: string) => void;
+  onPickModel: (id: string) => void;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+
+  const runtimeName = runtimeDisplayName(runtime);
+  // The chip shows the model when the runtime has one, else the runtime name
+  // alone — hermes/openclaw run their own adapters without a curated menu.
+  const modelLabel =
+    modelOptions.find((m) => m.id === modelValue)?.label ??
+    (modelValue ? modelValue.split("/").pop() ?? modelValue : null);
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        className="cave-composer-select cave-composer-runtime-chip"
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`Runtime: ${runtimeName}${modelLabel ? ` · Model: ${modelLabel}` : ""}`}
+        title={`Runtime: ${runtimeName}${modelLabel ? ` · Model: ${modelLabel}` : ""}`}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="cave-runtime-chip__logo" aria-hidden>
+          <RuntimeLogo runtime={runtime} size={13} />
+        </span>
+        <span className="cave-composer-select__value">{modelLabel ?? runtimeName}</span>
+        <Icon name="ph:caret-down-bold" width={10} aria-hidden className="cave-composer-select__chevron" />
+      </button>
+      <Popover
+        open={open}
+        onOpenChange={setOpen}
+        anchorRef={anchorRef}
+        placement="top-start"
+        minWidth={230}
+        ariaLabel="Runtime and model"
+      >
+        <PopoverBody role="menu" ariaLabel="Runtime and model">
+          <PopoverLabel>Runtime</PopoverLabel>
+          {Object.values(RUNTIME_MODEL_CATALOG).map((catalog) => (
+            <PopoverItem
+              key={catalog.runtime}
+              leading={
+                <span className="cave-runtime-chip__logo" aria-hidden>
+                  <RuntimeLogo runtime={catalog.runtime} size={13} />
+                </span>
+              }
+              checked={catalog.runtime === runtime}
+              onSelect={() => {
+                if (catalog.runtime !== runtime) onPickRuntime(catalog.runtime);
+                setOpen(false);
+              }}
+            >
+              {runtimeDisplayName(catalog.runtime)}
+            </PopoverItem>
+          ))}
+          {modelOptions.length > 0 && (
+            <>
+              <PopoverSeparator />
+              <PopoverLabel>Model</PopoverLabel>
+              {modelOptions.map((m) => (
+                <PopoverItem
+                  key={m.id}
+                  checked={m.id === modelValue}
+                  title={m.id}
+                  onSelect={() => {
+                    if (m.id !== modelValue) onPickModel(m.id);
+                    setOpen(false);
+                  }}
+                >
+                  {m.label}
+                </PopoverItem>
+              ))}
+            </>
+          )}
+        </PopoverBody>
+      </Popover>
+    </>
+  );
+}

--- a/src/components/runtime-logo.tsx
+++ b/src/components/runtime-logo.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+// The runtime's visual identity: real brand marks for provider-backed
+// runtimes (OpenAI for codex, Anthropic for claude — simple-icons paths,
+// CC0), Phosphor glyphs for the runtime-managed adapters that have no brand
+// (hermes, openclaw). Inline SVGs keep the two brand marks out of the
+// Phosphor icon-subset pipeline; they inherit currentColor like Icon does.
+
+import { Icon, type IconName } from "@/lib/icon";
+
+const OPENAI_PATH =
+  "M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z";
+
+const ANTHROPIC_PATH =
+  "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z";
+
+const BRAND_PATHS: Record<string, string> = {
+  codex: OPENAI_PATH,
+  claude: ANTHROPIC_PATH,
+};
+
+/** Phosphor stand-ins for runtimes without a provider brand (matches the
+ *  glyph language skill-card.tsx already uses for these runtimes). */
+const GLYPH_FALLBACKS: Record<string, IconName> = {
+  hermes: "ph:plug-bold",
+  openclaw: "ph:paw-print-bold",
+};
+
+export function runtimeDisplayName(runtime: string): string {
+  switch (runtime) {
+    case "codex":
+      return "Codex";
+    case "claude":
+      return "Claude Code";
+    case "hermes":
+      return "Hermes";
+    case "openclaw":
+      return "OpenClaw";
+    default:
+      return runtime;
+  }
+}
+
+export function RuntimeLogo({ runtime, size = 13 }: { runtime: string; size?: number }) {
+  const brand = BRAND_PATHS[runtime];
+  if (brand) {
+    return (
+      <svg
+        viewBox="0 0 24 24"
+        width={size}
+        height={size}
+        fill="currentColor"
+        aria-hidden
+        focusable="false"
+      >
+        <path d={brand} />
+      </svg>
+    );
+  }
+  return <Icon name={GLYPH_FALLBACKS[runtime] ?? "ph:robot"} width={size} aria-hidden />;
+}

--- a/src/styles/composer-runtime-chip.css
+++ b/src/styles/composer-runtime-chip.css
@@ -1,0 +1,48 @@
+/* Composer Runtime chip — the always-visible runtime-logo + model pill in the
+   chat composer. Values mirror .cave-composer-host-chip (its sibling), which
+   itself mirrors .cave-composer-select in cave-chat.css; carrying the full
+   styling here keeps the chip portable to the home composer later. */
+
+.cave-composer-runtime-chip {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  max-width: 200px;
+  height: 30px;
+  padding: 0 11px;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1;
+  cursor: pointer;
+  border: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
+  color: var(--text-secondary);
+  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.cave-composer-runtime-chip:disabled { opacity: 0.5; cursor: default; }
+.cave-composer-runtime-chip:hover:not(:disabled) {
+  border-color: color-mix(in oklch, var(--foreground) 18%, transparent);
+  color: var(--text-primary);
+}
+.cave-composer-runtime-chip .cave-composer-select__value {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cave-composer-runtime-chip .cave-composer-select__chevron { color: var(--text-muted); }
+
+/* The runtime mark reads as presence, in the chip and in the popover rows. */
+.cave-runtime-chip__logo {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-presence);
+}


### PR DESCRIPTION
## What

The active runtime was invisible in chat — the harness hid behind the Options menu, and switching runtimes meant leaving for Home or Settings. The chat composer now always carries a pill chip showing **the runtime's logo + the effective model** (e.g. the Anthropic mark · "Claude Opus 4.8"), and clicking it opens a two-group picker:

- **Runtime** — Codex (OpenAI mark), Claude Code (Anthropic mark), Hermes, OpenClaw as `menuitemradio` rows with the active one checked. Picking one PATCHes `/api/config` with the familiar's `harness` + that runtime's default model — the exact channel the home composer's `selectRuntime` uses — and since the send route re-resolves the familiar's binding from current config on every turn (`bindingFor(config, familiarId)`), **the switch applies from the next message even mid-conversation**. The chip flips optimistically and the model-state refetch reconciles.
- **Model** — the current runtime's curated catalog, routed through the existing `handleSelectModel` (session scope when a chat exists, else familiar-default). Hidden for hermes/openclaw, which run their own adapters without a curated menu.

Brand marks are inline SVGs (simple-icons paths, CC0) on `currentColor`, so they stay out of the Phosphor icon-subset pipeline; hermes/openclaw reuse the glyph language `skill-card.tsx` already established. Chip styling mirrors its sibling `ComposerHostChip` (999px pill, tokens only, mark on the presence accent); popover uses the shared `Popover`/`PopoverItem` primitives with `role=menu` + radio semantics.

New files: `composer-runtime-chip.tsx`, `runtime-logo.tsx`, `composer-runtime-chip.css`; wired in `chat-view.tsx` (new `handleSelectRuntime` + chip render after the Options menu — the pinned utility-row order is untouched).

## Tests / verification

- New pinned `composer-runtime-chip.test.ts` (registered in the app suite): live-state wiring, the `/api/config` contract, optimistic-flip + refetch-reconcile, the accessible name carrying "Runtime: X · Model: Y", radio semantics, brand-mark mapping, token discipline.
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` — **571 test files pass**; `check:tests-wired` green.
- Live Playwright sweep (8/8): chip visible on the zero-turn landing with "Codex · GPT-5.5"; popover opens with both groups; active runtime checked; picking Claude Code PATCHes config with `harness: claude` + an `anthropic/*` default model; the chip flips to "Claude Code · Claude Opus 4.8"; the Model group re-lists to the new runtime's catalog.

Known minor lag: the empty-state identity meta line reads the familiar roster (`familiar.harness`), so after a switch it catches up on the next roster refresh rather than instantly — the chip is the live source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)