### PR TITLE
fix(ui): popover closes on focus-out per its non-modal dialog role; theme editor reset clears persistence (cave-fu1y)

### DIFF
--- a/src/components/theme-color-editor.test.ts
+++ b/src/components/theme-color-editor.test.ts
@@ -141,3 +141,17 @@ describe("preset seed stability (swatch values are deterministic)", () => {
 // vars the whole app reads — coalesce to one write per frame.
 assert.match(source, /requestAnimationFrame\(\(\) => \{[\s\S]*?applyColorsToDOM\(colors, mode\)/, "the live color apply is throttled to one write per animation frame");
 assert.match(source, /cancelAnimationFrame\(applyFrameRef\.current\)/, "a pending apply frame is cancelled before scheduling the next");
+
+// ── Reset clears persistence; saved-flash timer is owned (cave-fu1y) ────────
+// handleReset previously only reset local state + DOM vars, so a reload
+// resurrected the stale persisted custom theme (the Appearance-tab reset
+// already cleared persistence — the two paths must stay consistent).
+assert.match(
+  source,
+  /const handleReset = \(\) => \{[\s\S]*?localStorage\.removeItem\(COVEN_CUSTOM_THEME_KEY\);[\s\S]*?localStorage\.setItem\(COVEN_THEME_KEY, basePreset\);[\s\S]*?onReset\?\.\(\);/,
+  "reset clears the persisted custom theme and hands boot back to the base preset",
+);
+// The 2s "Saved" flash must not setState after unmount, and re-saving resets it.
+assert.match(source, /savedTimerRef\.current = setTimeout\(\(\) => setSaved\(false\), 2000\)/, "saved-flash timer is kept in a ref");
+assert.match(source, /if \(savedTimerRef\.current\) clearTimeout\(savedTimerRef\.current\);/, "a pending saved-flash timer is cleared before re-arming");
+assert.match(source, /useEffect\(\(\) => \(\) => \{\s*\n\s*if \(savedTimerRef\.current\) clearTimeout\(savedTimerRef\.current\);/, "the saved-flash timer is cleared on unmount");

--- a/src/components/theme-color-editor.tsx
+++ b/src/components/theme-color-editor.tsx
@@ -233,6 +233,12 @@ export function ThemeColorEditor({
     border: swatches.border,
   });
   const [saved, setSaved] = useState(false);
+  // "Saved ✓" flash timer — cleared on re-save and on unmount so it can't
+  // setState after the editor unmounts.
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+  }, []);
 
   // When the base preset or mode changes, re-seed.
   useEffect(() => {
@@ -301,7 +307,8 @@ export function ThemeColorEditor({
     persistCustomTheme(basePreset, colors, mode);
     setSaved(true);
     onSave?.(colors);
-    setTimeout(() => setSaved(false), 2000);
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
   };
 
   const handleReset = () => {
@@ -309,6 +316,14 @@ export function ThemeColorEditor({
     const reset = { bg: s.bg, accent: s.accent, border: s.border };
     setColors(reset);
     applyColorsToDOM(reset, mode);
+    // A reset must outlive the session: clear the persisted custom theme and
+    // hand the boot script back to the base preset, otherwise theme-script
+    // resurrects the stale custom colors on reload. Keeps this path consistent
+    // with the Appearance tab's reset (clearCustomTheme in settings-shell).
+    try {
+      localStorage.removeItem(COVEN_CUSTOM_THEME_KEY);
+      localStorage.setItem(COVEN_THEME_KEY, basePreset);
+    } catch { /* ignore */ }
     setSaved(false);
     onReset?.();
   };

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -71,4 +71,26 @@ assert.ok(
   `popover portal (z ${portalZ}) must stack above the board drawer (z ${drawerZ})`,
 );
 
+// Non-modal dialog focus contract (cave-fu1y): the page behind stays
+// interactive (light dismiss), so instead of a focus trap the popover must
+// close when keyboard focus moves out — an open "dialog" must never float
+// astray while Tab walks the page behind it. The container carries
+// tabIndex={-1} so callers can seat focus on it programmatically.
+assert.match(
+  src,
+  /role="dialog"[\s\S]{0,600}tabIndex=\{-1\}/,
+  "dialog container is programmatically focusable (tabIndex={-1})",
+);
+assert.match(src, /onBlur=\{\(e\) => \{/, "popover watches for focus leaving");
+assert.match(
+  src,
+  /if \(!next\) return;[\s\S]{0,300}onOpenChange\(false\)/,
+  "focus-out closes the popover, but a null relatedTarget (window blur / native pickers) does not",
+);
+assert.match(
+  src,
+  /anchorRef\.current\?\.contains\(next\)/,
+  "focus moving back to the anchor doesn't close the popover",
+);
+
 console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -170,8 +170,22 @@ export function Popover({
         ref={popoverRef}
         className={["ui-popover", className ?? ""].filter(Boolean).join(" ")}
         style={style}
+        // Non-modal dialog: the page behind stays interactive (light dismiss on
+        // outside click/scroll), so no aria-modal and no focus trap — instead
+        // the popover closes when keyboard focus moves out of it, so an open
+        // "dialog" never floats astray while Tab walks the page behind it.
         role="dialog"
         aria-label={ariaLabel}
+        tabIndex={-1}
+        onBlur={(e) => {
+          const next = e.relatedTarget as Node | null;
+          // relatedTarget is null when focus leaves the document (window blur,
+          // native pickers) — don't treat that as Tab-out.
+          if (!next) return;
+          if (popoverRef.current?.contains(next)) return;
+          if (anchorRef.current?.contains(next)) return;
+          onOpenChange(false);
+        }}
       >
         {children}
       </div>


### PR DESCRIPTION
Closes bead `cave-fu1y` (from today's source-verified settings audit).

## 1 — shared Popover had a dialog role with no focus contract

`ui/popover.tsx` announced `role=dialog` (+ aria-label) but had no `aria-modal`, no `tabIndex`, and no focus management — Tab silently walked the page behind the open popover while AT still reported an open dialog.

Design decision: this is a **light-dismiss, non-modal** popover (closes on outside click/scroll; page stays interactive), so a WAI-ARIA focus *trap* would be wrong — and would also regress flows where item-select intentionally moves focus elsewhere. Instead:
- container gets `tabIndex={-1}` (repo dialog convention; callers can seat focus)
- **focus-out closes the popover** — Tab past the last item / Shift+Tab out dismisses it, so the dialog never floats astray behind the user's focus
- `relatedTarget === null` (window blur, native color pickers) and focus returning to the anchor are deliberately ignored
- existing Escape-capture and conditional focus-restore behavior unchanged

## 2 — theme editor Reset didn't survive reload

`handleReset` only reset local state + live DOM vars; `coven-custom-theme` stayed in localStorage so the boot script resurrected the stale colors on reload — diverging from the Appearance tab's reset (which clears persistence). Reset now removes the custom-theme key and points `coven-theme` back at the base preset.

## 3 — 'Saved' flash timer leak

The 2s `setTimeout` was unowned: it could setState after unmount and stack on rapid re-saves. Now ref-owned, cleared on re-arm and unmount.

## Validation

- New pins in `popover.test.ts` (tabIndex, focus-out close, null-relatedTarget guard, anchor exemption) and `theme-color-editor.test.ts` (reset clears persistence, timer ownership)
- popover/select/overflow-menu/context-menu/theme-color-editor (42 asserts)/settings-appearance all pass; `pnpm typecheck` clean