### PR TITLE
fix(ui): Popover earns its dialog role; theme-editor reset clears persistence (cave-fu1y)

### DIFF
--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -414,3 +414,15 @@ assert.match(
   /function applyTokenOverride\(key: string, hex: string, mode: Mode\)/,
   "editing a token forks the active theme to a custom theme and re-syncs",
 );
+
+// ── Editor reset clears persistence (cave-fu1y) ──────────────────────────────
+// Resetting from the theme editor only reset React state; the persisted
+// custom theme resurrected on reload. The onReset path now drops the key,
+// matching the Appearance-tab reset. The editor's saved-flash timer also
+// clears on unmount/re-save instead of firing setState on a dead component.
+assert.match(settings, /localStorage\.removeItem\(COVEN_CUSTOM_THEME_KEY\); \} catch [\s\S]{0,80}setActiveTheme\(colorEditorBase\)/, "editor reset drops the persisted custom theme");
+{
+  const editor = await readFile(new URL("./theme-color-editor.tsx", import.meta.url), "utf8");
+  assert.match(editor, /savedTimerRef\.current = setTimeout\(\(\) => setSaved\(false\), 2000\)/, "the saved flash goes through a tracked timer");
+  assert.match(editor, /if \(savedTimerRef\.current\) clearTimeout\(savedTimerRef\.current\);\n  \}, \[\]\)/, "the saved timer clears on unmount");
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -1615,6 +1615,10 @@ function AppearanceSection() {
                 } catch { /* ignore */ }
               }}
               onReset={() => {
+                // Drop the persisted custom theme too — resetting only React
+                // state left the stale swatches in localStorage to resurrect
+                // on reload (cave-fu1y); the Appearance reset already clears.
+                try { localStorage.removeItem(COVEN_CUSTOM_THEME_KEY); } catch { /* ignore */ }
                 setActiveTheme(colorEditorBase);
                 setCustomData(null);
               }}

--- a/src/components/theme-color-editor.tsx
+++ b/src/components/theme-color-editor.tsx
@@ -297,11 +297,18 @@ export function ThemeColorEditor({
   }, []);
   const commitRecent = (hex: string) => setRecents(addRecentColor(hex));
 
+  // The saved-flash timer must clear on unmount (and on re-save) or it fires
+  // setState on an unmounted editor (cave-fu1y).
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+  }, []);
   const handleSave = () => {
     persistCustomTheme(basePreset, colors, mode);
     setSaved(true);
     onSave?.(colors);
-    setTimeout(() => setSaved(false), 2000);
+    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+    savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
   };
 
   const handleReset = () => {

--- a/src/components/ui/popover.test.ts
+++ b/src/components/ui/popover.test.ts
@@ -71,4 +71,16 @@ assert.ok(
   `popover portal (z ${portalZ}) must stack above the board drawer (z ${drawerZ})`,
 );
 
+// ── Honest dialog semantics (cave-fu1y) ─────────────────────────────────────
+// role=dialog promised AT a dialog while Tab walked the page behind it. The
+// popover now contains Tab (wrap + recapture), moves focus in on open unless
+// a consumer already placed it, and declares aria-modal. Containment lives in
+// Popover's own capture handler — NOT useFocusTrap, whose unconditional
+// return-focus would steal focus from a control the user clicked to dismiss.
+assert.match(src, /aria-modal="true"/, "the popover declares modal semantics");
+assert.match(src, /tabIndex=\{-1\}/, "the popover container can take fallback focus");
+assert.match(src, /if \(e\.key === "Tab"\) \{/, "Tab is contained inside the popover");
+assert.match(src, /if \(!active \|\| !el\.contains\(active\)\) \{/, "escaped focus is recaptured on Tab");
+assert.match(src, /if \(!el \|\| el\.contains\(document\.activeElement\)\) return;/, "open only moves focus in when a consumer hasn't already");
+
 console.log("popover.test.ts: ok");

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -9,6 +9,7 @@ import {
   type CSSProperties,
   type ReactNode,
 } from "react";
+import { FOCUSABLE } from "@/lib/use-focus-trap";
 import { createPortal } from "react-dom";
 import { Icon, type IconName } from "@/lib/icon";
 
@@ -114,6 +115,38 @@ export function Popover({
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
+      // Tab containment (cave-fu1y): role=dialog + aria-modal promise AT that
+      // focus stays inside — wrap at the edges and recapture if focus escaped.
+      // Implemented here (not useFocusTrap) to keep Popover's conditional
+      // return-focus: the shared trap always yanks focus back to the trigger
+      // on close, which would steal it from a control the user just clicked.
+      if (e.key === "Tab") {
+        const el = popoverRef.current;
+        if (!el) return;
+        const focusables = Array.from(el.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+          (f) => !f.hasAttribute("disabled"),
+        );
+        if (focusables.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        const active = document.activeElement as HTMLElement | null;
+        if (!active || !el.contains(active)) {
+          e.preventDefault();
+          (e.shiftKey ? last : first).focus();
+          return;
+        }
+        if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+        return;
+      }
       if (e.key === "Escape") {
         // Consume the Escape so it doesn't bubble to a parent dialog's keydown
         // handler (e.g. the Settings panel, which closes itself on Escape). The
@@ -149,6 +182,18 @@ export function Popover({
     };
   }, [open, onOpenChange, anchorRef, compute]);
 
+  // Move focus into the popover on open — role=dialog without focus entering
+  // it leaves keyboard users tabbing the page behind. Consumers that place
+  // focus themselves (own useFocusTrap, autoFocus) win: child effects run
+  // first, and we bail if focus is already inside.
+  useEffect(() => {
+    if (!open) return;
+    const el = popoverRef.current;
+    if (!el || el.contains(document.activeElement)) return;
+    const first = el.querySelector<HTMLElement>(FOCUSABLE);
+    (first ?? el).focus();
+  }, [open]);
+
   // Return focus to the trigger when the popover closes, so keyboard users aren't
   // stranded (Escape, item-select, or outside-click on empty space all leave focus
   // on document.body once the popover unmounts). If the user moved focus to another
@@ -171,6 +216,8 @@ export function Popover({
         className={["ui-popover", className ?? ""].filter(Boolean).join(" ")}
         style={style}
         role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
         aria-label={ariaLabel}
       >
         {children}


### PR DESCRIPTION
## Summary

Bead `cave-fu1y` (source-verified audit findings), three fixes:

**Popover earns its `role=dialog`.** The shared popover announced a dialog to AT while Tab freely walked the page behind it — no containment, no focus entry, no `aria-modal`. It now: contains Tab (edge wrap + recapture when focus escaped) inside its existing capture-phase key handler; moves focus into the panel on open *unless a consumer already placed it* (child effects run first, so consumer traps/autofocus win); and declares `aria-modal="true"` + `tabIndex={-1}`. **Deliberate design choice:** containment is implemented natively rather than via `useFocusTrap`, because the shared trap's cleanup unconditionally returns focus to the trigger — which would steal focus from whatever control the user clicked to dismiss the popover, regressing the conditional return-focus behavior all 12+ call sites rely on. Light-dismiss (outside click) is unchanged.

**Theme-editor reset now clears persistence.** The editor's reset path reset React state and DOM vars only; the persisted custom theme in localStorage resurrected on the next reload — divergent from the Appearance-tab reset, which clears storage. The `onReset` handler now removes `COVEN_CUSTOM_THEME_KEY` before restoring the base preset (which the persist effect then writes).

**Saved-flash timer leak.** `setTimeout(() => setSaved(false), 2000)` was never cleared — setState after unmount, and rapid re-saves stacked timers so an early flash could truncate a later one. Now a tracked ref, cleared on re-save and unmount.

## Test plan

- [x] Pins in `ui/popover.test.ts` (aria-modal, Tab containment, recapture, consumer-first focus) and `settings-appearance.test.ts` (reset clears the key; tracked timer + unmount cleanup)
- [x] Full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)