### PR TITLE
feat(chrome): seamless ultra-minimalist title bar (cave-r1f5)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4835,11 +4835,13 @@ button:active > .edge-rail-chip {
   align-items: center;
   flex-wrap: nowrap;
   flex: 0 0 auto;
-  min-height: 44px;
+  min-height: 40px;
   gap: 8px;
   padding-inline: 12px;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border-hairline);
+  /* Seamless title bar: the strip shares the app canvas — no band color, no
+     border seam. Structure below it reads as one continuous surface. */
+  background: var(--bg-base);
+  border-bottom: 0;
   overflow: hidden;
 }
 
@@ -4884,7 +4886,7 @@ button:active > .edge-rail-chip {
   :root[data-tauri-titlebar] .shell-top {
     /* ~78px clears the three traffic lights + their left inset. */
     padding-left: 78px;
-    min-height: 52px;
+    min-height: 46px;
   }
 
   :root[data-tauri-titlebar] .shell-titlebar-drag-lane {
@@ -4941,10 +4943,10 @@ button:active > .edge-rail-chip {
      of the bar rather than towering over it. */
   width: 28px;
   height: 28px;
-  border: 1px solid var(--border-hairline);
+  border: 1px solid transparent;
   border-radius: var(--radius-control);
-  background: var(--bg-base);
-  color: color-mix(in oklch, var(--text-secondary) 86%, var(--text-primary));
+  background: transparent;
+  color: var(--text-muted);
   cursor: pointer;
   transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
 }
@@ -5165,9 +5167,9 @@ button:active > .edge-rail-chip {
   padding: 5px 12px;
   /* min-height (not a fixed height) so the bar grows with scaled-up content
      under screen magnification instead of clipping the search row. */
-  min-height: 38px;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border-hairline);
+  min-height: 36px;
+  background: var(--bg-base);
+  border-bottom: 0;
   font-size: var(--text-sm);
   user-select: none;
   overflow: hidden;
@@ -5203,17 +5205,21 @@ button:active > .edge-rail-chip {
   align-items: center;
   gap: 8px;
   padding: 4px 10px;
-  border: 1px solid var(--border-hairline);
+  /* Ghost at rest — the pill materializes on hover/focus so the title bar
+     stays a quiet strip (ultra-minimal reference look). */
+  border: 1px solid transparent;
   border-radius: var(--radius-control);
-  background: var(--bg-base);
+  background: transparent;
   color: var(--text-muted);
   transition: border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard),
     color var(--duration-fast) var(--ease-standard);
 }
 
 .menu-bar__search:hover,
 .menu-bar__search:focus-within {
-  border-color: var(--border-strong);
+  border-color: var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-raised) 70%, transparent);
   color: var(--text-secondary);
 }
 
@@ -5259,7 +5265,13 @@ button:active > .edge-rail-chip {
   color: var(--text-muted);
   padding: 2px 5px;
   border-radius: 4px;
-  border: 1px solid var(--border-hairline);
+  border: 1px solid transparent;
+  background: transparent;
+}
+
+.menu-bar__search:hover kbd,
+.menu-bar__search:focus-within kbd {
+  border-color: var(--border-hairline);
   background: var(--bg-raised);
 }
 
@@ -5269,6 +5281,16 @@ button:active > .edge-rail-chip {
   flex: 0 0 auto;
   width: 28px;
   max-width: 200px;
+  /* Seamless bar: the switcher joins the quiet chrome — pill materializes on
+     hover/focus like the search and task chips. */
+  border-color: transparent;
+  background: transparent;
+}
+
+.menu-bar__group--chat .familiar-switcher__trigger:hover,
+.menu-bar__group--chat .familiar-switcher__trigger:focus-visible {
+  border-color: var(--border-hairline);
+  background: var(--bg-raised);
 }
 
 .menu-bar__group--chat .familiar-switcher__trigger--labeled {
@@ -5302,16 +5324,30 @@ button:active > .edge-rail-chip {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 9px;
-  border: 1px solid var(--border-hairline);
+  padding: 4px 7px;
+  /* Quiet monochrome chips — no fill or border until hover, dimmed like the
+     rest of the seamless title bar. */
+  border: 1px solid transparent;
   border-radius: var(--radius-control);
-  background: var(--bg-base);
-  color: var(--foreground);
+  background: transparent;
+  color: var(--text-muted);
   font-size: var(--text-base);
   white-space: nowrap;
   cursor: pointer;
   transition: background var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard);
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+/* Ultra-minimal: the bar shows icons only. Labels stay in the DOM for the
+   markup (aria-labels already name every button); the one exception is the
+   enrich label while a run is live — that's progress, not chrome. */
+.menu-bar__task-label {
+  display: none;
+}
+
+.menu-bar__task-label--live {
+  display: inline;
 }
 
 /* One compact standard across the top chrome (var(--icon-sm), 14px): the
@@ -5336,7 +5372,8 @@ button:active > .edge-rail-chip {
 
 .menu-bar__task:hover {
   background: var(--bg-raised);
-  border-color: var(--border-strong);
+  border-color: var(--border-hairline);
+  color: var(--text-primary);
 }
 
 .menu-bar__badge {
@@ -5446,8 +5483,9 @@ button:active > .edge-rail-chip {
   gap: 12px;
   padding: 0 14px;
   height: 40px;
-  background: var(--bg-panel);
-  border-bottom: 1px solid var(--border-hairline);
+  /* Seamless like the desktop .shell-top — no band, no border seam. */
+  background: var(--bg-base);
+  border-bottom: 0;
   font-size: var(--text-sm);
   user-select: none;
 }

--- a/src/components/board-enrich-steps.test.ts
+++ b/src/components/board-enrich-steps.test.ts
@@ -39,7 +39,7 @@ assert.match(
 
 assert.match(
   menuBar,
-  /onEnrichTasks \? \([\s\S]*onClick=\{onEnrichTasks\}[\s\S]*disabled=\{enrichingTasks \|\| !activeFamiliarId\}[\s\S]*aria-label=\{enrichingTasks[\s\S]*<span>\{enrichingTasks \? enrichLabel : "Enhance"\}<\/span>[\s\S]*onClick=\{onViewTasks\}/,
+  /onEnrichTasks \? \([\s\S]*onClick=\{onEnrichTasks\}[\s\S]*disabled=\{enrichingTasks \|\| !activeFamiliarId\}[\s\S]*aria-label=\{enrichingTasks[\s\S]*\{enrichingTasks \? enrichLabel : "Enhance"\}[\s\S]*onClick=\{onViewTasks\}/,
   "Desktop menu bar should place Enhance next to Tasks and disable it without a selected familiar",
 );
 

--- a/src/components/familiar-menu-bar.test.ts
+++ b/src/components/familiar-menu-bar.test.ts
@@ -123,8 +123,8 @@ assert.match(
 );
 assert.match(
   source,
-  /<Icon name="ph:calendar-check"[\s\S]{0,120}<span>Schedules<\/span>/,
-  "the Schedules button matches the sidebar's Schedules label + icon",
+  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">Schedules<\/span>/,
+  "the Schedules button matches the sidebar's Schedules label + icon (label CSS-demoted in the seamless bar; aria-label carries the name)",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/familiar-menu-bar.tsx
+++ b/src/components/familiar-menu-bar.tsx
@@ -136,7 +136,7 @@ export function FamiliarMenuBar({
             title="Quick chat (⌘J)"
           >
             <Icon name="ph:chat-circle-dots" width={22} height={22} aria-hidden />
-            <span>Chat</span>
+            <span className="menu-bar__task-label">Chat</span>
           </button>
         ) : null}
         {onEnrichTasks ? (
@@ -149,7 +149,11 @@ export function FamiliarMenuBar({
             title={activeFamiliarId ? ENRICH_TASKS_TITLE : "Select a familiar to enhance tasks"}
           >
             <Icon name="ph:sparkle" width={22} height={22} aria-hidden />
-            <span>{enrichingTasks ? enrichLabel : "Enhance"}</span>
+            {/* Live progress is information, not chrome — it stays visible
+                while a run is in flight; the idle label is icon-only. */}
+            <span className={enrichingTasks ? "menu-bar__task-label menu-bar__task-label--live" : "menu-bar__task-label"}>
+              {enrichingTasks ? enrichLabel : "Enhance"}
+            </span>
           </button>
         ) : null}
         <button
@@ -159,7 +163,7 @@ export function FamiliarMenuBar({
           aria-label={taskCount > 0 ? `View tasks — ${taskCount} open` : "View tasks"}
         >
           <Icon name="ph:kanban" width={22} height={22} aria-hidden />
-          <span>Tasks</span>
+          <span className="menu-bar__task-label">Tasks</span>
           {taskCount > 0 ? <span className="menu-bar__badge">{fmtBadge(taskCount)}</span> : null}
         </button>
         {/* This button lands on the Schedules surface (workspace mode "inbox"
@@ -173,7 +177,7 @@ export function FamiliarMenuBar({
           aria-label={scheduleNeedsCount > 0 ? `View schedules — ${scheduleNeedsCount} need attention` : "View schedules"}
         >
           <Icon name="ph:calendar-check" width={22} height={22} aria-hidden />
-          <span>Schedules</span>
+          <span className="menu-bar__task-label">Schedules</span>
           {scheduleNeedsCount > 0 ? (
             <span className="menu-bar__badge menu-bar__badge--alert">{fmtBadge(scheduleNeedsCount)}</span>
           ) : null}

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -14,4 +14,12 @@ const iconLib = readFileSync(new URL("../lib/icon.tsx", import.meta.url), "utf8"
 assert.match(iconLib, /shellToggle:\s*"var\(--icon-sm\)"/, "sidepanel toggle glyph is var(--icon-sm)");
 // Avatar tiles match the top-bar button/search height so the strip lines up.
 assert.match(css, /\.menu-bar \.familiar-quickswitch__btn\s*\{[\s\S]*?width:\s*28px[\s\S]*?height:\s*28px/, "menu-bar avatar tiles match the button height (28px)");
+// ── Seamless ultra-minimal title bar (cave-r1f5) ─────────────────────────────
+// The top strip shares the app canvas — no band color, no border seam — and
+// its controls are quiet monochrome: ghost search, borderless icon chips.
+assert.match(css, /\.shell-top \{[\s\S]*?background:\s*var\(--bg-base\)[\s\S]*?border-bottom:\s*0/, "shell-top is seamless (canvas background, no border seam)");
+assert.match(css, /\.top-bar \{[\s\S]*?background:\s*var\(--bg-base\)[\s\S]*?border-bottom:\s*0/, "mobile top-bar matches the seamless treatment");
+assert.match(css, /\.menu-bar__search \{[\s\S]*?border:\s*1px solid transparent[\s\S]*?background:\s*transparent/, "search is a ghost at rest (pill materializes on hover/focus)");
+assert.match(css, /\.menu-bar__task-label \{\s*\n\s*display:\s*none/, "task labels are CSS-demoted — the bar shows icons only");
+assert.match(css, /\.menu-bar__task-label--live \{\s*\n\s*display:\s*inline/, "…except live enrich progress, which is information, not chrome");
 console.log("menu-bar-icon-size.test.ts passed");

--- a/src/components/schedules-tabs.test.ts
+++ b/src/components/schedules-tabs.test.ts
@@ -39,8 +39,8 @@ assert.match(
 // no inbox tab and inbox items live in the notification bell instead.
 assert.match(
   menuBar,
-  /<Icon name="ph:calendar-check"[\s\S]{0,120}<span>Schedules<\/span>/,
-  "Desktop menu bar names the surface Schedules with the calendar-check icon",
+  /<Icon name="ph:calendar-check"[\s\S]{0,160}<span className="menu-bar__task-label">Schedules<\/span>/,
+  "Desktop menu bar names the surface Schedules with the calendar-check icon (label CSS-demoted in the seamless bar; aria-label carries the name)",
 );
 assert.doesNotMatch(
   menuBar,


### PR DESCRIPTION
## Summary

The topmost title bar stops being a band. Reference: the ChatGPT macOS titlebar — traffic lights plus a few dimmed monochrome glyphs on a strip that **shares the surface beneath it**: no band color, no border seam, no heavy controls.

- **Seamless**: `.shell-top`, the mobile `.top-bar`, and the standalone `.menu-bar` drop `--bg-panel` + the hairline border for the app canvas (`--bg-base`). Heights slim to 40px web / 46px Tauri — the overlay traffic lights stay framed, and the drag lane + ACL rules are untouched.
- **Ghost search**: the pill and its ⌘K chip are invisible at rest (icon + muted placeholder only) and materialize on hover/focus.
- **Icon-only actions**: Chat / Enhance / Tasks / Schedules demote to dimmed monochrome chips — labels CSS-hidden via a new `.menu-bar__task-label` class (every button already carries an aria-label + title, per the earlier confusion sweep). **Live enrich progress keeps its text** (information, not chrome) and the count badges stay.
- **Quiet triggers**: the sidepanel toggles and the familiar-switcher pill (menu-bar scope only) go borderless until hover.

## Testing

- Full suite green: **570 test files** (three stale label pins updated: `schedules-tabs`, `board-enrich-steps`, `familiar-menu-bar`; the accessible names live in aria-labels, unchanged).
- New regression pins in `menu-bar-icon-size.test.ts`: canvas background + zero border on both bars, ghost search at rest, label demotion + live-progress exception.
- `pnpm build` green, bundle within budget.
- **Verified live** (Playwright on a real dev server): computed `.shell-top` background is byte-identical to the body background with `border-bottom: 0px`; task labels `display:none`; rest + hover screenshots reviewed against the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)