### PR TITLE
ci: timeout-minutes on every job — hung steps stalled required checks for hours (cave-whm5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   build:
     name: Frontend build
     runs-on: ubuntu-latest
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~3-6min).
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -64,6 +66,8 @@ jobs:
   cargo-check:
     name: Rust check
     runs-on: ubuntu-latest
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~1-5min (cold cargo cache)).
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: src-tauri
@@ -106,6 +110,8 @@ jobs:
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~5-15min; the job this bead exists for).
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -135,6 +141,8 @@ jobs:
   # others. Neutral defaults + per-OS deltas: docs/cross-environment.md.
   conformance:
     name: Cross-environment (${{ matrix.os }})
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~0.5-2min).
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -158,6 +166,8 @@ jobs:
   conformance-required:
     name: Cross-environment required
     runs-on: ubuntu-latest
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (aggregation no-op).
+    timeout-minutes: 5
     needs: conformance
     if: always()
     steps:
@@ -171,6 +181,8 @@ jobs:
 
   sidecar-runtime:
     name: Sidecar runtime (${{ matrix.os }})
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (windows runner is the flaky/slow one).
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -201,6 +213,8 @@ jobs:
   sidecar-runtime-required:
     name: Sidecar runtime required
     runs-on: ubuntu-latest
+    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (aggregation no-op).
+    timeout-minutes: 5
     needs: sidecar-runtime
     if: always()
     steps:


### PR DESCRIPTION
## Summary

Bead `cave-whm5`, closing out a documented standing hazard: no job in `ci.yml` had a `timeout-minutes`, so any hung step held its required check `in_progress` for GitHub's **6-hour** default. This bit in practice — a stuck playwright step held the required E2E check ~24 minutes (and counting) on the home-a11y PR until it was manually cancelled and re-run.

Every job now carries a timeout sized at roughly 3× its observed p95 from today's ~25 green runs:

| Job | Observed | Timeout |
|---|---|---|
| E2E (Playwright) | ~5–15 min | 25 |
| Sidecar runtime (matrix) | ~1.5–2.5 min, windows flaky-slow | 20 |
| Frontend build | ~3–6 min | 15 |
| Rust check | ~1–5 min (cold cargo cache) | 15 |
| Cross-environment (matrix) | ~0.5–2 min | 15 |
| Both aggregation no-ops | seconds | 5 |

A timed-out run surfaces as a normal failure that `gh run rerun --failed` recovers — instead of a silent multi-hour stall on a required check. YAML validated; the CodeQL analyze jobs live in GitHub's default setup (no workflow file to stamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)