### PR TITLE
perf(automations): stable in-flight run poll — no interval churn, no N+1 fan-out (cave-1e6k)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -186,3 +186,14 @@ assert.match(source, /togglePauseAutomation: toggleCodex/, "cron pause/resume re
 assert.match(source, /const req = \+\+runLogReqRef\.current;/, "each log fetch takes a request token");
 assert.match(source, /if \(req !== runLogReqRef\.current\) return;/, "stale log responses are dropped");
 assert.match(source, /runLogReqRef\.current \+= 1;\s*\n\s*setOpenRunId\(null\);/, "closing the log invalidates the in-flight fetch");
+
+// ── In-flight run-poll stability (cave-1e6k) ─────────────────────────────────
+// The poll effect depends on a derived boolean, not the runs array — an
+// unchanged 2.5s tick must not tear down and recreate the interval. The runs
+// write is content-guarded for the same reason, and the poll no longer fans
+// out one request per automation: refreshRuns' own response maintains the
+// selected automation's last-run badge.
+assert.match(source, /const hasRunningRun = automationRuns\.some\(\(r\) => r\.status === "running"\)/, "poll gate is a derived boolean");
+assert.match(source, /\}, \[selectedCodex\?\.id, hasRunningRun, refreshRuns\]\);/, "the poll effect does not depend on the runs array identity");
+assert.match(source, /setAutomationRuns\(\(prev\) => \(arrayContentEqual\(prev, runs\) \? prev : runs\)\)/, "unchanged run polls keep the array identity");
+assert.doesNotMatch(source, /void refreshRuns\(id\);\s*\n\s*void refreshLastRuns\(\);/, "the hot poll loop no longer fans out per-automation requests");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1835,7 +1835,26 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
       const json = await res.json().catch(() => null);
       // Drop a stale runs response: a later selection (or poll) superseded it.
       if (reqId !== runsReqRef.current || !mountedRef.current) return;
-      if (json?.ok && Array.isArray(json.runs)) setAutomationRuns(json.runs);
+      if (json?.ok && Array.isArray(json.runs)) {
+        // Content-guard: an unchanged poll keeps the array identity, so the
+        // in-flight poll effect below stops tearing down its interval every
+        // 2.5s tick (cave-1e6k).
+        const runs = json.runs as AutomationRunRecord[];
+        setAutomationRuns((prev) => (arrayContentEqual(prev, runs) ? prev : runs));
+        // This response already carries the newest run — update the row badge
+        // map here instead of re-fetching the same endpoint via the
+        // every-automation fan-out.
+        const newest = runs[0];
+        if (newest) {
+          setLastRunById((prev) => {
+            const current = prev.get(id);
+            if (current && JSON.stringify(current) === JSON.stringify(newest)) return prev;
+            const next = new Map(prev);
+            next.set(id, newest);
+            return next;
+          });
+        }
+      }
     } catch {
       /* ignore */
     }
@@ -1904,17 +1923,20 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   }, [selectedCodex?.id, refreshRuns]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // While a run is in flight, poll so its status + log fill in without a manual refresh.
+  // Depends on a derived boolean (not the runs array) so the interval survives
+  // poll ticks; refreshRuns also maintains this automation's last-run badge,
+  // so the every-automation refreshLastRuns fan-out stays out of the hot loop
+  // (cave-1e6k).
+  const hasRunningRun = automationRuns.some((r) => r.status === "running");
   useEffect(() => {
-    if (!selectedCodex?.id) return;
-    if (!automationRuns.some((r) => r.status === "running")) return;
+    if (!selectedCodex?.id || !hasRunningRun) return;
     const id = selectedCodex.id;
     const t = setInterval(() => {
       if (document.hidden) return; // don't poll a backgrounded tab
       void refreshRuns(id);
-      void refreshLastRuns();
     }, 2500);
     return () => clearInterval(t);
-  }, [selectedCodex?.id, automationRuns, refreshRuns, refreshLastRuns]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [selectedCodex?.id, hasRunningRun, refreshRuns]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Refresh last-run map whenever the automation list changes
   useEffect(() => {


### PR DESCRIPTION
## Summary

Bead `cave-1e6k` (Schedules audit follow-up, source-verified). While an automation run was in flight, the 2.5s status poll wasted work two ways:

**Interval churn.** The poll effect depended on the whole `automationRuns` array, and `refreshRuns` stored a fresh array reference on every tick — so the effect tore down and recreated its `setInterval` every 2.5 seconds. The runs write is now content-guarded (`arrayContentEqual` keeps the previous identity when nothing changed, the same guard `load()` uses for items/autos), and the effect depends on a derived `hasRunningRun` boolean, so the interval only re-arms when running-ness actually flips.

**N+1 fan-out on the same endpoint.** Each tick also called `refreshLastRuns()`, firing one `/api/codex-automations/{id}/runs` request *per automation* — and the selected automation's newest run was already present in the response `refreshRuns` had just fetched from the identical endpoint. `refreshRuns` now maintains the last-run badge map from its own response (identity-guarded); the full fan-out survives only where it belongs, on roster changes.

Net effect: one request per poll tick and one long-lived interval, regardless of roster size.

## Test plan

- [x] Pins: boolean poll gate, no runs-array dep, content-guarded write, no per-automation fan-out in the hot loop
- [x] Automations tests + full `pnpm test:app` (571 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)