### PR TITLE
a11y(schedules): make the two detail panels real dialogs (cave-qfdv)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -186,3 +186,21 @@ assert.match(source, /togglePauseAutomation: toggleCodex/, "cron pause/resume re
 assert.match(source, /const req = \+\+runLogReqRef\.current;/, "each log fetch takes a request token");
 assert.match(source, /if \(req !== runLogReqRef\.current\) return;/, "stale log responses are dropped");
 assert.match(source, /runLogReqRef\.current \+= 1;\s*\n\s*setOpenRunId\(null\);/, "closing the log invalidates the in-flight fetch");
+
+// ── Detail panels are dialogs (cave-qfdv) ────────────────────────────────────
+// Both the reminder DetailPanel and the cron CodexDetailPanel trap focus, close
+// on Escape, and restore focus to the opening row (useFocusTrap does return-focus).
+// role="dialog" + aria-labelledby name them; aria-modal is deliberately omitted
+// (desktop keeps the list as an interactive sibling; mobile hides it via display:none).
+assert.match(source, /import \{ useFocusTrap \} from "@\/lib\/use-focus-trap"/, "the surface uses the shared focus-trap hook");
+assert.equal(
+  (source.match(/useFocusTrap\(true, panelRef, \{ onEscape: onClose \}\)/g) ?? []).length,
+  2,
+  "both detail panels trap focus and close on Escape",
+);
+assert.equal(
+  (source.match(/role="dialog" aria-labelledby=\{titleId\} tabIndex=\{-1\}/g) ?? []).length,
+  2,
+  "both detail panels are role=dialog, labelled by their title, focusable as a fallback",
+);
+assert.doesNotMatch(source, /aria-modal=/, "aria-modal is omitted — it would be a lie on the desktop split-pane");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import type { Familiar } from "@/lib/types";
 import { arrayContentEqual } from "@/lib/array-content-equal";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
@@ -247,13 +248,22 @@ function DetailPanel({
   const isReminder = item.kind === "reminder";
   const busy = busyId === item.id;
 
+  // The detail panel is a dialog: trap focus, close on Escape, and restore focus
+  // to the row that opened it (useFocusTrap does the return-focus). aria-modal is
+  // deliberately omitted — on desktop the list stays an interactive sibling, and
+  // on mobile it's display:none, so claiming the rest is inert would be a lie.
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  useFocusTrap(true, panelRef, { onEscape: onClose });
+
   return (
-    <div className="flex h-full flex-col"
+    <div ref={panelRef} role="dialog" aria-labelledby={titleId} tabIndex={-1}
+      className="flex h-full flex-col focus:outline-none"
       style={{ background: "var(--bg-raised)", borderLeft: "1px solid var(--border-hairline)" }}>
       {/* Header */}
       <div className="flex items-center justify-between border-b px-5 py-3"
         style={{ borderColor: "var(--border-hairline)" }}>
-        <h2 className="text-[13px] font-semibold" style={{ color: "var(--text-primary)" }}>
+        <h2 id={titleId} className="text-[13px] font-semibold" style={{ color: "var(--text-primary)" }}>
           {isDailySummary ? "Daily summary details" : isReminder ? "Reminder details" : "Activity details"}
         </h2>
         <Button
@@ -672,6 +682,11 @@ function CodexDetailPanel({
   runs: AutomationRunRecord[];
 }) {
   const isActive = auto.status === "ACTIVE";
+  // Dialog semantics for the cron detail panel — trap focus, Escape closes, focus
+  // returns to the opening row. aria-modal omitted (see DetailPanel's note).
+  const panelRef = useRef<HTMLDivElement>(null);
+  const titleId = useId();
+  useFocusTrap(true, panelRef, { onEscape: onClose });
   const parsedSchedule = useMemo(() => parseCodexRrule(auto.rrule), [auto.rrule]);
   const promptParts = splitAutomationPrompt(auto.prompt);
   const [openRunId, setOpenRunId] = useState<string | null>(null);
@@ -795,7 +810,8 @@ function CodexDetailPanel({
     : "No runs yet";
 
   return (
-    <div className="flex h-full flex-col"
+    <div ref={panelRef} role="dialog" aria-labelledby={titleId} tabIndex={-1}
+      className="flex h-full flex-col focus:outline-none"
       style={{ background: "var(--bg-raised)", borderLeft: "1px solid var(--border-hairline)" }}>
       <div className="border-b px-5 py-4"
         style={{ borderColor: "var(--border-hairline)" }}>
@@ -804,7 +820,7 @@ function CodexDetailPanel({
             <p className="text-[10px] font-semibold uppercase tracking-widest" style={{ color: "var(--text-muted)" }}>
               Cron details
             </p>
-            <h2 className="mt-1 truncate text-[15px] font-semibold" style={{ color: "var(--text-primary)" }}>
+            <h2 id={titleId} className="mt-1 truncate text-[15px] font-semibold" style={{ color: "var(--text-primary)" }}>
               {name.trim() || auto.name}
             </h2>
           </div>


### PR DESCRIPTION
## What

From the Schedules-surface audit. The reminder DetailPanel and cron CodexDetailPanel rendered as bare divs — no role, no focus trap, no Escape-to-close, and a plain Close dropped focus to body.

## Fix
Adopt the shared useFocusTrap the sibling calendar surface uses: both panels trap focus, close on Escape, and restore focus to the opening row, with role=dialog + aria-labelledby. aria-modal is deliberately omitted (desktop split-pane keeps the list interactive; mobile hides it via display:none).

Pinned in automations-view.test.ts.

## Verification
typecheck, 571 app tests, build within budget. Audit LOW/perf findings filed as cave-1e6k.

Generated with Claude Code