### PR TITLE
feat(composer): runtime chip on Home + instant roster refresh after runtime switches (cave-v25g)

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2395,13 +2395,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       );
       void (async () => {
         try {
-          await fetch("/api/config", {
+          const res = await fetch("/api/config", {
             method: "PATCH",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({
               familiars: { [familiar.id]: { harness: runtime, model: nextModel } },
             }),
           });
+          // The roster's familiar.harness feeds the empty-state identity line
+          // (and anything else reading the familiars list) — refresh it now
+          // rather than waiting out the next natural reload.
+          if (res.ok) window.dispatchEvent(new Event("cave:familiars-refresh"));
         } finally {
           await refreshModelState();
         }

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -11,7 +11,36 @@ import { readFileSync } from "node:fs";
 const chip = readFileSync(new URL("./composer-runtime-chip.tsx", import.meta.url), "utf8");
 const logo = readFileSync(new URL("./runtime-logo.tsx", import.meta.url), "utf8");
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const homeComposer = readFileSync(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const homeModelState = readFileSync(new URL("./home/use-home-model-state.ts", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const css = readFileSync(new URL("../styles/composer-runtime-chip.css", import.meta.url), "utf8");
+
+// ── Parity: the home composer carries the same chip (cave-v25g) ─────────────
+assert.match(
+  homeComposer,
+  /<ComposerRuntimeChip\s*\n\s*runtime=\{selectedRuntime\}\s*\n\s*modelValue=\{selectedModelId\}\s*\n\s*modelOptions=\{runtimeModelOptions\}\s*\n\s*onPickRuntime=\{handleSelectRuntime\}\s*\n\s*onPickModel=\{handleSelectModel\}/,
+  "the home composer renders the same runtime chip from its own model state",
+);
+
+// ── Runtime switches refresh the familiar roster immediately (cave-v25g) ────
+// The roster's familiar.harness feeds the chat empty-state identity line;
+// without this it lags a switch until the next natural reload.
+assert.match(
+  workspace,
+  /window\.addEventListener\("cave:familiars-refresh", onFamiliarsRefresh\)/,
+  "workspace reloads the familiar roster on cave:familiars-refresh",
+);
+assert.match(
+  chatView,
+  /if \(res\.ok\) window\.dispatchEvent\(new Event\("cave:familiars-refresh"\)\);/,
+  "a chat runtime switch fires the roster refresh (only on a successful PATCH)",
+);
+assert.match(
+  homeModelState,
+  /if \(json\.ok\) \{\s*\n[\s\S]{0,200}?window\.dispatchEvent\(new Event\("cave:familiars-refresh"\)\);/,
+  "a home runtime switch fires the roster refresh (only on a successful PATCH)",
+);
 
 // ── The chip is always in the composer control row, wired to live state ─────
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -43,6 +43,7 @@ import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
 import { ProjectPicker } from "@/components/project-picker";
 import { ComposerOptionsMenu, type ComposerOptionSection } from "@/components/composer-options-menu";
+import { ComposerRuntimeChip } from "@/components/composer-runtime-chip";
 import { LOCAL_HOST_ID } from "@/lib/chat-hosts";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { catalogForRuntime } from "@/lib/runtime-models";
@@ -906,6 +907,16 @@ export function HomeComposer({
                     onChange: (v: string) => setResponseSpeed(v as CommandResponseSpeed),
                   } satisfies ComposerOptionSection,
                 ]}
+              />
+              {/* Always-visible runtime mark + model, one click to switch —
+                  parity with the chat composer's chip (cave-yq5l). */}
+              <ComposerRuntimeChip
+                runtime={selectedRuntime}
+                modelValue={selectedModelId}
+                modelOptions={runtimeModelOptions}
+                onPickRuntime={handleSelectRuntime}
+                onPickModel={handleSelectModel}
+                disabled={sending}
               />
 
               <div

--- a/src/components/home/use-home-model-state.ts
+++ b/src/components/home/use-home-model-state.ts
@@ -108,7 +108,12 @@ export function useHomeModelState(selectedFamiliarId: string) {
             }),
           });
           const json = (await res.json().catch(() => ({ ok: false }))) as { ok?: boolean };
-          if (json.ok) refetchModelState();
+          if (json.ok) {
+            // Roster consumers (chat empty-state identity line, selectors)
+            // read familiar.harness — let them catch up immediately.
+            window.dispatchEvent(new Event("cave:familiars-refresh"));
+            refetchModelState();
+          }
         } catch {
           refetchModelState();
         }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -781,6 +781,15 @@ export function Workspace() {
     loadFamiliars();
     loadSessions();
   }, [loadFamiliars, loadSessions]);
+  // Composers rebind a familiar's runtime through /api/config (the runtime
+  // chip). Surfaces reading the roster's familiar.harness (e.g. the chat
+  // empty-state identity line) shouldn't wait for the next natural reload —
+  // the switch paths fire this event so the roster catches up immediately.
+  useEffect(() => {
+    const onFamiliarsRefresh = () => void loadFamiliars();
+    window.addEventListener("cave:familiars-refresh", onFamiliarsRefresh);
+    return () => window.removeEventListener("cave:familiars-refresh", onFamiliarsRefresh);
+  }, [loadFamiliars]);
   usePausablePoll(() => void loadSessions(), 4000, {
     pauseWhileInputActive: true,
   });


### PR DESCRIPTION
## What

Two follow-ups to the chat composer's runtime chip (#2711):

1. **Home parity** — the home composer now carries the same always-visible chip (runtime logo + effective model, one-click Runtime/Model switching). Pure wiring: `useHomeModelState` already exposed `selectRuntime`/`selectModel`, and the Options menu already derived `selectedRuntime`/`runtimeModelOptions`; the chip component shipped with self-contained CSS for exactly this.
2. **No more stale roster after a switch** — both switch paths (chat's `handleSelectRuntime`, home's `useHomeModelState`) fire a new `cave:familiars-refresh` event after a successful `/api/config` PATCH, and workspace reloads the familiar roster on it. The chat empty-state identity line ("codex · openai/gpt-5.5") now flips together with the chip instead of lagging until the next natural reload — closing the known-lag note from #2711.

## Tests / verification

- Pins added to `composer-runtime-chip.test.ts`: home wiring parity, the workspace listener, both dispatch sites (success-gated).
- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` — 571 test files pass.
- Live Playwright sweep (7/7): home chip visible with "Codex · GPT-5.5", popover opens, switch flips the chip to Claude Code, the familiars route is refetched after the switch, and the chat empty-state meta line reads "codex" before / "claude" after a chip switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)