### PR TITLE
feat(chat): keep externally-generated sessions out of the chat lists (cave-73fr)

### DIFF
--- a/src/lib/canvas-generate.ts
+++ b/src/lib/canvas-generate.ts
@@ -55,6 +55,9 @@ export async function generateArtifactCode(opts: {
         familiarId: opts.familiarId,
         prompt: opts.prompt,
         projectRoot: opts.projectRoot ?? undefined,
+        // Provenance: these sends belong to the Canvas/artifact surface, so
+        // the chat lists can keep them out of the conversation rail.
+        origin: "canvas",
       }),
       signal: opts.signal,
     });

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -54,6 +54,27 @@ assert.deepEqual(
   "specific familiar scope should still show only that familiar's chats",
 );
 
+// Externally-generated sessions stay out of the chat lists: daemon-only runs
+// flagged `generated` (journal narratives, flows, automations, CLI) and
+// generator origins (canvas refines, cron/heartbeat automations). They remain
+// reachable from their origination surfaces; the chat rail is for chats.
+{
+  const noisy = [
+    ...sessions,
+    { ...session("journal-run", "", "2026-06-06T00:00:00.000Z", "nova"), generated: true },
+    { ...session("canvas-refine", "", "2026-06-07T00:00:00.000Z", "nova"), origin: "canvas" },
+    { ...session("cron-sweep", "", "2026-06-08T00:00:00.000Z", "nova"), origin: "cron" },
+    { ...session("heartbeat-tick", "", "2026-06-09T00:00:00.000Z", "nova"), origin: "heartbeat" },
+    { ...session("task-chat", "/work/alpha", "2026-06-10T00:00:00.000Z", "nova"), origin: "board" },
+    { ...session("telegram-ping", "", "2026-06-11T00:00:00.000Z", "nova"), origin: "mention" },
+  ];
+  assert.deepEqual(
+    filterVisibleChatSessions(noisy, null).map((s) => s.id),
+    ["telegram-ping", "task-chat", "scratch", "new-alpha", "beta", "old-alpha"],
+    "generated runs and canvas/cron/heartbeat origins are hidden; board tasks and mentions stay",
+  );
+}
+
 const groups = deriveChatProjectGroups(filterVisibleChatSessions(sessions, null), projects);
 
 assert.deepEqual(

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -120,12 +120,25 @@ function projectNameWithParent(projectRoot: string): string {
   return parts[0] ?? projectRoot;
 }
 
+// Sessions that exist because a generator ran — canvas refines, cron and
+// heartbeat automations — not because someone opened a chat. They stay
+// reachable from their origination surfaces (Canvas, Schedules, Work Queue);
+// listing them here is just noise between real conversations.
+const CHAT_HIDDEN_ORIGINS: ReadonlySet<string> = new Set(["cron", "heartbeat", "canvas"]);
+
+/** True when the row is a generated run rather than a user-facing chat. */
+export function isGeneratedChatSession(session: SessionRow): boolean {
+  if (session.generated) return true;
+  return session.origin != null && CHAT_HIDDEN_ORIGINS.has(session.origin);
+}
+
 export function filterVisibleChatSessions(
   sessions: SessionRow[],
   familiarId: string | null,
 ): SessionRow[] {
   return sessions
     .filter((session) => !DEAD_CHAT_STATUSES.has(session.status))
+    .filter((session) => !isGeneratedChatSession(session))
     .filter((session) => familiarId === null || session.familiarId === familiarId)
     .sort((a, b) => (sessionTimestamp(a) < sessionTimestamp(b) ? 1 : -1));
 }

--- a/src/lib/session-list-merge.test.ts
+++ b/src/lib/session-list-merge.test.ts
@@ -237,4 +237,48 @@ const analyticsRows = localConversationSessionRows(
 );
 assert.equal(analyticsRows[0].origin, "chat", "analytics discussion origin maps to regular chat");
 
+// Provenance: a daemon session with no Cave conversation and only the
+// inferred-"chat" default is a generated run (journal narrative, flow,
+// automation, CLI) — flagged so chat lists can hide it. A conversation-backed
+// row keeps the conversation's recorded origin and is never flagged.
+{
+  const bareState = { sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {} };
+  const daemonRun = (id, title) => ({
+    id,
+    project_root: "/repo",
+    harness: "codex",
+    title,
+    status: "completed",
+    exit_code: 0,
+    archived_at: null,
+    created_at: "2026-06-08T18:00:00.000Z",
+    updated_at: "2026-06-08T18:05:00.000Z",
+  });
+  const rows = mergeSessionRows({
+    daemonSessions: [
+      daemonRun("spawned-run", "Write a short narrative of my day"),
+      daemonRun("cron-run", "[cron] nightly sweep"),
+      daemonRun("canvas-run", "Build a pricing page"),
+    ],
+    localConversations: [
+      {
+        sessionId: "canvas-run",
+        familiarId: "nova",
+        harness: "codex",
+        title: "Build a pricing page",
+        updatedAt: "2026-06-08T18:06:00.000Z",
+        origin: "canvas",
+      },
+    ],
+    state: bareState,
+    includeArchived: false,
+  });
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  assert.equal(byId.get("spawned-run")?.generated, true, "daemon-only inferred-chat run is flagged generated");
+  assert.equal(byId.get("cron-run")?.origin, "cron", "explicit provenance patterns still infer their origin");
+  assert.equal(byId.get("cron-run")?.generated, undefined, "non-default inferred origins carry no generated flag");
+  assert.equal(byId.get("canvas-run")?.origin, "canvas", "a conversation's recorded origin beats title inference");
+  assert.equal(byId.get("canvas-run")?.generated, undefined, "conversation-backed rows are real chats, never flagged");
+}
+
 console.log("session-list-merge.test.ts: ok");

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -128,7 +128,13 @@ export function mergeSessionRows({
         defaultChatTitleForSession(session.id),
       archived_at,
       familiarId: state.sessionFamiliar[session.id] ?? null,
-      origin: inferOrigin(session),
+      // A Cave conversation records real provenance at send time; harness/
+      // title inference is only the fallback for daemon-only sessions.
+      origin: local?.origin ?? inferOrigin(session),
+      // No conversation + nothing better than the inferred-"chat" default =
+      // a run some generator spawned (journal narrative, flow, automation,
+      // CLI), not something a person typed into a chat surface.
+      ...(!local && inferOrigin(session) === "chat" ? { generated: true } : {}),
       initiator:
         session.initiator ??
         initiatorFromSessionKey("", state.sessionFamiliar[session.id] ?? session.harness),

--- a/src/lib/session-origin.ts
+++ b/src/lib/session-origin.ts
@@ -8,6 +8,7 @@ export const SESSION_ORIGINS: readonly SessionOrigin[] = [
   "cron",
   "heartbeat",
   "call",
+  "canvas",
 ] as const;
 
 export const ORIGIN_LABEL: Record<SessionOrigin, string> = {
@@ -17,6 +18,7 @@ export const ORIGIN_LABEL: Record<SessionOrigin, string> = {
   cron: "cron",
   heartbeat: "heartbeat",
   call: "call",
+  canvas: "canvas",
 };
 
 export const ORIGIN_ICON: Record<SessionOrigin, IconName> = {
@@ -26,6 +28,7 @@ export const ORIGIN_ICON: Record<SessionOrigin, IconName> = {
   cron: "ph:alarm-fill",
   heartbeat: "ph:heartbeat",
   call: "ph:magic-wand-fill",
+  canvas: "ph:paint-brush",
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,13 @@ export type SessionRow = {
   updated_at: string;
   familiarId?: string | null;
   origin?: SessionOrigin;
+  /**
+   * True for daemon sessions with no Cave conversation behind them — runs
+   * spawned by generators (journal narratives, flows, automations, CLI runs)
+   * rather than by someone chatting. Chat lists hide these; the sessions stay
+   * reachable from their origination surfaces (Work Queue, Schedules, …).
+   */
+  generated?: boolean;
   initiator?: SessionInitiator;
   git?: SessionGitContext | null;
   pullRequest?: SessionPullRequestContext | null;
@@ -89,7 +96,8 @@ export type SessionOrigin =
   | "board"
   | "cron"
   | "heartbeat"
-  | "call";
+  | "call"
+  | "canvas";
 
 export type SessionInitiator = {
   kind: "human" | "familiar" | "system" | "unknown";


### PR DESCRIPTION
## Summary
Journal narratives, canvas refines, flow/automation runs, and other generator-spawned sessions were interleaved with real conversations in the chat sidebar/list. Per the session goal: those belong at their origination surfaces, not the chat rail.

- `session-list-merge` prefers the Cave conversation's recorded origin over title inference, and flags daemon-only inferred-"chat" rows as `generated: true`.
- Canvas/artifact sends self-declare `origin: "canvas"` (they ride /api/chat/send and persist real conversations).
- `filterVisibleChatSessions` — the single choke point behind the sidebar, chat list, router grouping, empty state, and open-tasks — drops generated rows plus canvas/cron/heartbeat origins. Board tasks and channel mentions keep their rows.
- Deep links and Work Queue still resolve hidden sessions by id — the router reads the unfiltered list (chat-router.tsx:130/328/432).

## Verification
- Unit: session-list-merge + chat-projects tests extended (generated flag, origin fidelity, filter allow/deny sets) — pass; alias-loader tests + tsc clean.
- App: built the branch, served it, drove a mocked sidebar with journal/canvas/cron/board/chat rows — only the three real conversations and the board task render; all noise rows absent (screenshot in session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)