### PR TITLE
fix(home): Enter during IME composition no longer sends the half-composed draft (cave-572k)

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -282,6 +282,14 @@ assert.match(
   /if \(handleMenuKey\(e\)\) return;/,
   "the inline menus consume their keys before Enter-submit and history recall",
 );
+// The Enter that confirms an IME candidate (CJK/pinyin/kana) reports
+// isComposing — it must never submit a half-composed prompt (cave-572k;
+// parity with chat-view's send guard).
+assert.match(
+  handleKeyDownBlock,
+  /e\.key === "Enter" && !e\.shiftKey && !e\.nativeEvent\.isComposing/,
+  "Enter during IME composition must not send — the candidate-confirm Enter belongs to the IME",
+);
 
 assert.doesNotMatch(
   handleKeyDownBlock,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -615,8 +615,11 @@ export function HomeComposer({
       // The inline menus (Esc-dismiss, ↑↓/Tab/Enter across all four pickers)
       // take priority over history/submit while one is open — shared hook.
       if (handleMenuKey(e)) return;
-      // plain Enter sends; Shift+Enter inserts newline
-      if (e.key === "Enter" && !e.shiftKey) {
+      // plain Enter sends; Shift+Enter inserts newline. `isComposing` is true
+      // for the Enter that confirms an IME candidate (CJK/pinyin/kana) —
+      // treating it as "send" would fire a half-composed prompt and destroy
+      // the candidate selection, so let the IME keep it (mirrors chat-view).
+      if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
         e.preventDefault();
         void handleSubmit();
         return;


### PR DESCRIPTION
Home's Enter-send branch lacked the `isComposing` guard chat-view has: for CJK/pinyin/kana users, the Enter that confirms an IME candidate submitted the half-composed prompt from the home composer and destroyed the candidate selection. One-line fix mirroring chat's send path (`!e.nativeEvent.isComposing`), with a pin in `home-composer.test.ts` so the parity can't regress.

Flagged during the composer-hooks consolidation (#2673) and deliberately kept out of that behavior-preserving refactor as a behavior change.

Verification: typecheck clean; `home-composer.test.ts` + `home-composer-polish.test.ts` pass with the new pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)