### PR TITLE
fix(github): backfill the review familiar once the list loads (cave-o7jc)

### DIFF
--- a/src/components/gh-review-actions.test.ts
+++ b/src/components/gh-review-actions.test.ts
@@ -10,4 +10,13 @@ assert.match(source, /label="Familiar to review with"/, "review picker has an ac
 assert.doesNotMatch(source, /<select[\s\S]*>/, "PR review actions no longer uses native <select>");
 assert.match(source, /familiar\.display_name/, "review actions displays familiar names in the picker");
 
+// cave-o7jc: familiars load async, so the useState initializer captures "" on the
+// first render — an effect backfills the first familiar once the list arrives, or
+// the "Review with" button (disabled on !familiarId) stays permanently dead.
+assert.match(
+  source,
+  /useEffect\(\(\) => \{\s*\n\s*if \(!familiarId && familiars\[0\]\) setFamiliarId\(familiars\[0\]\.id\);\s*\n\s*\}, \[familiars, familiarId\]\)/,
+  "the review picker backfills the first familiar once familiars load (not left disabled)",
+);
+
 console.log("gh-review-actions.test.ts OK");

--- a/src/components/gh-review-actions.tsx
+++ b/src/components/gh-review-actions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { StandardSelect } from "@/components/ui/select";
 import { Icon } from "@/lib/icon";
@@ -73,6 +73,15 @@ export function GhReviewActions({ pr, familiars }: { pr: PrInfo; familiars: Fami
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [familiarId, setFamiliarId] = useState<string>(familiars[0]?.id ?? "");
+
+  // `familiars` loads async, so on first mount it's usually [] and the initializer
+  // above captures "". A useState initializer never re-runs, which left the
+  // "Review with" button permanently disabled (disabled on !familiarId) even after
+  // familiars arrived. Backfill the first familiar once the list populates, without
+  // clobbering a selection the user has already made.
+  useEffect(() => {
+    if (!familiarId && familiars[0]) setFamiliarId(familiars[0].id);
+  }, [familiars, familiarId]);
 
   const reset = () => {
     setError(null);


### PR DESCRIPTION
## What

`GhReviewActions` seeded `familiarId` from `familiars[0]?.id ?? ""`, but `familiars` is an **async-loaded prop** — on first mount it's `[]`, so the `useState` initializer captured `""` and (initializers never re-run) it stayed `""` after familiars arrived. The "Review with" button is `disabled` on `!familiarId` and the select shows `value={familiarId}`, so the flagship **"have a familiar review this PR" action was permanently dead on first open** until the user manually picked someone.

## Fix

Add an effect that backfills the first familiar once the list populates, without clobbering a selection the user already made.

```ts
useEffect(() => {
  if (!familiarId && familiars[0]) setFamiliarId(familiars[0].id);
}, [familiars, familiarId]);
```

Found by the GitHub-surface audit. Pinned in `gh-review-actions.test.ts`.

## Verification

`typecheck` · **571** app test files · `build` within budget.

> The audit's other (MED/LOW) findings — abort guards, optimistic-resolve overwrite, poll churn — are filed as cave-b8ba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)