### PR TITLE
feat(daemon): proxy the daemon control-plane capability catalog

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -616,6 +616,7 @@ export const SUITES = {
     "src/app/api/app/latest-release/route.test.ts",
     "src/app/api/opencoven-tools/status/route.test.ts",
     "src/app/api/daemon/status/route.test.ts",
+    "src/app/api/daemon/capabilities/route.test.ts",
     "src/app/api/travel/client/route.test.ts",
     "src/app/api/travel/offline-work-queue.test.ts",
     "src/lib/executor-status.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -42,6 +42,7 @@ const contracts: RouteContract[] = [
   { route: "/config", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/coven-memory", methods: ["GET"], kind: "json" },
   { route: "/coven/exec", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/daemon/capabilities", methods: ["GET"], kind: "json" },
   { route: "/daemon/start", methods: ["POST"], kind: "json" },
   { route: "/daemon/status", methods: ["GET"], kind: "json" },
   { route: "/escalations/[id]", methods: ["PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/daemon/capabilities/route.test.ts
+++ b/src/app/api/daemon/capabilities/route.test.ts
@@ -1,0 +1,56 @@
+// @ts-nocheck
+// Cave consumes the daemon's control-plane capability catalog (served at the
+// exact /api/v1/capabilities path) for feature negotiation. It must:
+//  - read that exact daemon path,
+//  - validate the catalog shape so an unrelated aggregate payload isn't passed
+//    through as capabilities,
+//  - distinguish a genuinely offline daemon from one that is up but too old to
+//    expose the catalog.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /callDaemon<DaemonCapabilityCatalog>\(\{\s*path: "\/api\/v1\/capabilities"/,
+  "control-plane capabilities route should fetch the daemon's exact /api/v1/capabilities path",
+);
+
+assert.match(
+  source,
+  /Array\.isArray\(\(data as DaemonCapabilityCatalog\)\.capabilities\)/,
+  "the catalog shape must be validated before it is trusted (harness-aggregate payloads have no `capabilities` array)",
+);
+
+assert.match(
+  source,
+  /new Set\(\s*capabilities[\s\S]*\.flatMap\(\(c\) => c\.actions/,
+  "action ids should be flattened and de-duped across capabilities",
+);
+
+assert.match(
+  source,
+  /\.filter\(\(c\) => c\.status === "available"\)/,
+  "only available capabilities should contribute routable control actions",
+);
+
+assert.match(
+  source,
+  /ECONNREFUSED|ETIMEDOUT|ENOENT/,
+  "connection-level failures should be classified as the daemon being offline",
+);
+
+assert.match(
+  source,
+  /running: false[\s\S]*error: "daemon offline"/,
+  "an offline daemon should report running:false with a daemon-offline error",
+);
+
+assert.match(
+  source,
+  /running: true,\s*capabilities: \[\],[\s\S]*does not expose a control-plane capability catalog/,
+  "a reachable daemon without the catalog should report running:true (not an outage)",
+);
+
+console.log("daemon capabilities route.test.ts: ok");

--- a/src/app/api/daemon/capabilities/route.ts
+++ b/src/app/api/daemon/capabilities/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import { callDaemon, extractDaemonError, type DaemonResponse } from "@/lib/coven-daemon";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+// The daemon's control-plane capability catalog, served at the exact
+// GET /api/v1/capabilities path (coven `control_plane::capabilities()`).
+//
+// This is deliberately distinct from the harness capability *manifests* at
+// `/api/capabilities` (skills/plugins per adapter). This catalog describes the
+// daemon's own control-plane features and the actions each one can route —
+// i.e. it is the capability-negotiation surface Cave uses to feature-detect
+// what the connected daemon can actually do before offering it in the UI.
+//
+// Field casing mirrors the Rust `#[serde(rename_all = "camelCase")]` output.
+export type DaemonCapabilityStatus = "available" | "planned";
+export type DaemonCapabilityPolicy = "allow" | "requiresApproval";
+
+export type DaemonCapability = {
+  id: string;
+  label: string;
+  adapter: string;
+  status: DaemonCapabilityStatus;
+  policy: DaemonCapabilityPolicy;
+  actions: string[];
+};
+
+export type DaemonCapabilityCatalog = {
+  capabilities: DaemonCapability[];
+};
+
+export type DaemonCapabilitiesResponse = {
+  ok: boolean;
+  // Whether the daemon answered at all (reachable), independent of whether it
+  // serves the control-plane catalog. Lets the UI distinguish "daemon offline"
+  // from "daemon up but too old to expose control-plane capabilities".
+  running: boolean;
+  capabilities: DaemonCapability[];
+  // Flattened, de-duped action ids across every available capability — the set
+  // of control actions Cave may POST to /api/v1/actions on this daemon.
+  actions: string[];
+  fetchedAt: string;
+  error?: string;
+};
+
+function isCatalog(data: unknown): data is DaemonCapabilityCatalog {
+  return Boolean(
+    data &&
+      typeof data === "object" &&
+      Array.isArray((data as DaemonCapabilityCatalog).capabilities),
+  );
+}
+
+// A status of 0 or a connection-level error string means the socket/hub never
+// answered — the daemon is genuinely offline, not merely lacking the catalog.
+function daemonOffline(res: DaemonResponse<unknown>): boolean {
+  return (
+    res.status === 0 ||
+    (res.error != null && /(ENOENT|ECONNREFUSED|ETIMEDOUT|socket|connect)/i.test(res.error))
+  );
+}
+
+export async function GET() {
+  const res = await callDaemon<DaemonCapabilityCatalog>({
+    path: "/api/v1/capabilities",
+    timeoutMs: 1500,
+  });
+  const fetchedAt = new Date().toISOString();
+
+  // Some daemons answer the same exact path with the harness-manifest aggregate
+  // ({ harness_capabilities: [...] }), which carries no `capabilities` array.
+  // Validate the shape so we surface the real catalog or a truthful degradation
+  // rather than passing an unrelated payload through as if it were the catalog.
+  if (res.ok && isCatalog(res.data)) {
+    const capabilities = res.data.capabilities;
+    const actions = [
+      ...new Set(
+        capabilities
+          .filter((c) => c.status === "available")
+          .flatMap((c) => c.actions ?? []),
+      ),
+    ];
+    return NextResponse.json({
+      ok: true,
+      running: true,
+      capabilities,
+      actions,
+      fetchedAt,
+    } satisfies DaemonCapabilitiesResponse);
+  }
+
+  if (daemonOffline(res)) {
+    return NextResponse.json(
+      {
+        ok: false,
+        running: false,
+        capabilities: [],
+        actions: [],
+        fetchedAt,
+        error: "daemon offline",
+      } satisfies DaemonCapabilitiesResponse,
+      { status: 503 },
+    );
+  }
+
+  // Reachable, but no recognizable control-plane catalog — the daemon is
+  // healthy yet predates (or does not expose) this surface. Report it as a
+  // non-error informational state so the UI can hide catalog-gated affordances
+  // without claiming an outage.
+  return NextResponse.json({
+    ok: false,
+    running: true,
+    capabilities: [],
+    actions: [],
+    fetchedAt,
+    error:
+      extractDaemonError(res) ??
+      "daemon does not expose a control-plane capability catalog",
+  } satisfies DaemonCapabilitiesResponse);
+}


### PR DESCRIPTION
## What

Adds `GET /api/daemon/capabilities`, a thin proxy over the coven daemon's `GET /api/v1/capabilities` (`control_plane::capabilities`). It returns a normalized `DaemonCapabilitiesResponse`: the capability list plus a flattened, de-duped set of `actions` across all **available** capabilities — the control actions Cave may POST to `/api/v1/actions`.

This is the capability-negotiation surface Cave uses to feature-detect what a connected daemon can actually do before offering it in the UI. It is deliberately distinct from the harness capability *manifests* at `/api/capabilities` (skills/plugins per adapter).

## Behavior

Three states so the UI can distinguish "offline" from "too old to expose the catalog":

| Situation | Response |
|---|---|
| Socket never answered (ENOENT/ECONNREFUSED/…) | `running:false`, `ok:false`, HTTP 503 |
| Daemon reachable, no recognizable catalog | `running:true`, `ok:false` (informational, not an outage) |
| Catalog present | `running:true`, `ok:true` |

Payload shape is validated (`isCatalog`) so a harness-manifest aggregate answered at the same path isn't passed through as if it were the control-plane catalog. Field casing mirrors the Rust `#[serde(rename_all = "camelCase")]` output.

## Tests

- `src/app/api/daemon/capabilities/route.test.ts` (new) — covers the three states + shape validation.
- Registered in the `/api` contract suite (`api-contracts.test.ts`) and wired into `run-tests.mjs`.

Local: `route.test.ts` ok · `api-contracts.test.ts` 151 contracts pass.

## Notes

- Additive only (new route + two one-line suite registrations). Branch is based on an earlier `main`; changes don't touch existing behavior, but rebase/Update-branch before merge if desired.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)