### PR TITLE
feat(home): Chat/Task tabs above the composer card · project chip width fit · wordless News lane

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -53,12 +53,13 @@ assert.match(
 );
 
 // ───────── Command-bar hierarchy ─────────
-// Chat-composer footer: utility cluster (attach · voice · Options) plus the
-// home-only destination pills and agent picker left; enhance · send right.
+// The Chat/Task destination tabs sit ABOVE the input card; the footer keeps
+// the utility cluster (attach · voice · Options) and agent picker left,
+// enhance · send right.
 assert.match(
   source,
-  /cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?className="hc-dest-pills"[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
-  "home composer utility cluster has attach + voice + Options + Chat/Task destination + warning-circle access chip",
+  /className="hc-dest-pills hc-dest-pills--above"[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"[\s\S]*?cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
+  "destination tabs precede the card; the utility cluster keeps attach + voice + Options + warning-circle access chip",
 );
 assert.match(
   source,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -412,8 +412,20 @@ assert.match(
 // ── Destination pills are an accessible single-select radiogroup ─────────────
 assert.match(
   source,
-  /className="hc-dest-pills"\s+role="radiogroup"\s+aria-label="Send to"\s+ref=\{destGroupRef\}\s+onKeyDown=\{handleDestKeyDown\}/,
+  /className="hc-dest-pills hc-dest-pills--above"\s+role="radiogroup"\s+aria-label="Send to"\s+ref=\{destGroupRef\}\s+onKeyDown=\{handleDestKeyDown\}/,
   "Destination pills form a labelled radiogroup with keyboard navigation",
+);
+// The Chat/Task tabs live ABOVE the input card (mode choice, not an input
+// control) — they render before the card and never inside the footer rows.
+assert.match(
+  source,
+  /hc-dest-pills hc-dest-pills--above[\s\S]*?className=\{`home-composer-card cave-composer-panel/,
+  "Destination tabs render above the composer card, outside the input area",
+);
+assert.doesNotMatch(
+  source,
+  /cave-composer-utility-row[\s\S]*?hc-dest-pills/,
+  "The composer footer no longer hosts the destination pills",
 );
 assert.match(
   source,
@@ -428,8 +440,8 @@ assert.match(
 
 // ── Single-row toolbar replaces mode strip + run rail ───────────────────────
 // The top mode strip and the separate run rail were removed. The footer is the
-// chat composer's: attach/voice/Options + Chat-Task pills + agent chip on the
-// left, enhance + send on the right.
+// chat composer's: attach/voice/Options + agent chip on the left (Chat/Task
+// moved above the card), enhance + send on the right.
 assert.doesNotMatch(
   source,
   /className="hc-mode-strip"/,
@@ -442,8 +454,8 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?hc-dest-pills[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?cave-composer-submit-row[\s\S]*?ph:sparkle[\s\S]*?aria-label="Send"/,
-  "The footer has attach/voice/Options + Chat/Task destination + access chip left; enhance + send right",
+  /cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?cave-composer-submit-row[\s\S]*?ph:sparkle[\s\S]*?aria-label="Send"/,
+  "The footer has attach/voice/Options + access chip left; enhance + send right",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -739,6 +739,33 @@ export function HomeComposer({
           />
         ) : null}
 
+        {/* Destination tabs — Chat vs Task is a mode choice, not an input
+            control, so it sits above the card as its own tab row instead of
+            crowding the composer footer. */}
+        <div
+          className="hc-dest-pills hc-dest-pills--above"
+          role="radiogroup"
+          aria-label="Send to"
+          ref={destGroupRef}
+          onKeyDown={handleDestKeyDown}
+        >
+          {DESTINATIONS.map((d) => (
+            <button
+              key={d.id}
+              type="button"
+              className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
+              role="radio"
+              aria-checked={destination === d.id}
+              tabIndex={destination === d.id ? 0 : -1}
+              onClick={() => setDestination(d.id)}
+              disabled={sending}
+            >
+              <Icon name={d.icon} width={14} aria-hidden />
+              <span className="hc-dest-label">{d.label}</span>
+            </button>
+          ))}
+        </div>
+
         <div
           className={`home-composer-card cave-composer-panel${dropActive ? " is-drop-active" : ""}`}
           {...dropHandlers}
@@ -837,8 +864,8 @@ export function HomeComposer({
         ) : null}
 
         {/* Controls — chat-composer footer: utility cluster (attach · voice ·
-            Options) plus the home-only destination pills and agent picker on
-            the left; enhance · send hug the right. */}
+            Options) plus the home-only agent picker on the left; enhance ·
+            send hug the right. (Chat/Task moved above the card.) */}
         <div className="cave-composer-controls">
           <input
             ref={fileInputRef}
@@ -921,30 +948,6 @@ export function HomeComposer({
                 onPickModel={handleSelectModel}
                 disabled={sending}
               />
-
-              <div
-                className="hc-dest-pills"
-                role="radiogroup"
-                aria-label="Send to"
-                ref={destGroupRef}
-                onKeyDown={handleDestKeyDown}
-              >
-                {DESTINATIONS.map((d) => (
-                  <button
-                    key={d.id}
-                    type="button"
-                    className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-                    role="radio"
-                    aria-checked={destination === d.id}
-                    tabIndex={destination === d.id ? 0 : -1}
-                    onClick={() => setDestination(d.id)}
-                    disabled={sending}
-                  >
-                    <Icon name={d.icon} width={14} aria-hidden />
-                    <span className="hc-dest-label">{d.label}</span>
-                  </button>
-                ))}
-              </div>
 
               <HomeSelect
                 icon="ph:warning-circle"

--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -36,9 +36,10 @@ assert.doesNotMatch(view, /aria-label="Close news carousel"/, "the inline X clos
 assert.doesNotMatch(view, /home-digest__media-close/, "no close-button markup remains");
 assert.match(
   view,
-  /className="home-digest__media-chrome"[\s\S]*className="home-digest__media-label"[\s\S]*News[\s\S]*home-digest__track home-digest__track--media/,
-  "news row chrome still labels the media lane outside the moving track",
+  /className="home-digest__media-chrome"[\s\S]*className="home-digest__media-label"[\s\S]*ph:newspaper[\s\S]*home-digest__track home-digest__track--media/,
+  "news row chrome still marks the media lane (icon-only) outside the moving track",
 );
+assert.doesNotMatch(view, />News</, "the visible 'News' word is removed from the media lane chrome");
 
 // ── Media cards support an image thumbnail (with icon fallback on error) ───────
 assert.match(view, /home-digest__thumb/, "media card renders an image thumbnail when available");

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -89,9 +89,10 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
       {mediaCards.length > 0 && newsEnabled ? (
         <div className="home-digest__media">
           <div className="home-digest__media-chrome">
-            <span className="home-digest__media-label">
+            {/* Icon-only lane marker — the track below carries the accessible
+                "Media headlines" name, so the chrome stays wordless. */}
+            <span className="home-digest__media-label" aria-hidden="true">
               <Icon name="ph:newspaper" width={12} aria-hidden />
-              <span>News</span>
             </span>
           </div>
           <div className="home-digest__track home-digest__track--media" aria-label="Media headlines">

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -420,10 +420,13 @@
   color: var(--text-secondary);
 }
 
+/* The picker's caret is INLINE (unlike the familiar chip's absolute
+ * .hc-select-caret), so no phantom right padding — the chip hugs its
+ * avatar + name + caret and only ever truncates on long names. */
 .home-composer-card .cave-project-picker__trigger.hc-project-selector {
   min-height: 30px;
   max-width: 178px;
-  padding: 3px 22px 3px 6px;
+  padding: 3px 8px 3px 6px;
   border-color: color-mix(in oklch, var(--accent-presence) 25%, transparent);
   border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-base));
@@ -441,7 +444,7 @@
   flex-shrink: 0;
 }
 
-/* Destination pills — a segmented toggle in the composer footer. */
+/* Destination pills — a segmented toggle for Chat vs Task. */
 .hc-dest-pills {
   display: inline-flex;
   gap: 2px;
@@ -451,6 +454,13 @@
   border-radius: var(--radius-control);
   background: var(--bg-base);
   border: 1px solid var(--border-hairline);
+}
+
+/* Above-card placement: the mode tabs lead the input, outside its chrome. */
+.hc-dest-pills--above {
+  position: relative;
+  z-index: 1;
+  margin-bottom: 8px;
 }
 
 .hc-dest-pill {


### PR DESCRIPTION
Three home-surface UI fixes from one session.

## 1. Chat/Task tabs move outside the input area

The destination radiogroup was crowding the composer footer between the Options menu and the agent picker. It's a mode choice, not an input control — it now renders as its own tab row above the input card (`.hc-dest-pills--above`, 8px gap). Radiogroup semantics, arrow/Home/End roving tab stop, and the phone-width (`@container ≤620px`) touch-target rules all move with it. The footer keeps attach / voice / Options / runtime chip (#2718) / agent picker on the left, enhance / send on the right.

## 2. Project selector width fit

The home chip override carried `padding: 3px 22px 3px 6px` — the 22px reserved space for the absolutely-positioned `.hc-select-caret` that only the **familiar** chip renders; ProjectPicker's caret is inline. Every project chip dragged ~14px of dead space. Right padding is now 8px: the chip hugs avatar + name + caret (measured live: "Cast Codes" 119px) and still truncates long names at the 178px cap.

## 3. "News" word removed from the media lane

The home digest's media row keeps the newspaper icon as an icon-only lane marker; the visible "News" text is gone. The marker is `aria-hidden` (decorative) — the track's `aria-label="Media headlines"` already names the lane for AT. The Settings → General opt-out is untouched.

## Verification

- Playwright against the live dev server on `/?mode=home`: tabs bounding box ends above the card top (8px gap, outside the card), project chip width 119px hugging content — screenshots reviewed.
- Applied onto current main (post-#2718 runtime chip, post-#2720 IME guard) with a clean 3-way merge; 15 test files pass in this branch including `composer-runtime-chip.test.ts`, the three updated pin files (`home-composer.test.ts` now pins tabs-above-card and asserts the footer no longer hosts the pills), and the digest/density/a11y sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)