### PR TITLE
fix(bell): announce failed notification mutations instead of silently no-oping (cave-qhz3)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -213,6 +213,7 @@ export const SUITES = {
     "src/components/chat-view-canvas-artifact.test.ts",
     "src/components/chat-response-metadata.test.ts",
     "src/components/daily-summary-notifications.test.ts",
+    "src/components/notification-bell-mutations.test.ts",
     "src/components/surface-error-states.test.ts",
     "src/components/surface-loading-states.test.ts",
     "src/components/chat-header-row.test.ts",

--- a/src/components/notification-bell-mutations.test.ts
+++ b/src/components/notification-bell-mutations.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// Notification bell mutations must not silently no-op on network failure
+// (cave-qhz3): every fetch is fire-and-forget with SSE reconcile as the only
+// feedback, so a failed request needs res.ok verification and an assertive
+// announcement — and clear-all must not abandon the fan-out on one rejection.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./notification-bell.tsx", import.meta.url), "utf8");
+
+assert.match(
+  src,
+  /const \{ announce \} = useAnnouncer\(\)/,
+  "bell announces mutation failures via the shared live region",
+);
+
+assert.match(
+  src,
+  /const mutate = useCallback\(\s*\n\s*async \(run: \(\) => Promise<Response>, failureMessage: string\): Promise<boolean> => \{[\s\S]*?if \(!res\.ok\) throw new Error\(String\(res\.status\)\);[\s\S]*?announce\(failureMessage, "assertive"\);/,
+  "all bell mutations route through one guard that checks res.ok and announces failures assertively",
+);
+
+// Each mutation goes through the guard — no bare fire-and-forget fetch remains.
+for (const [name, message] of [
+  ["toggleMute", "Mute change failed"],
+  ["setSound", "Sound change failed"],
+  ["dismiss", "Dismiss failed"],
+  ["snooze", "Snooze failed"],
+]) {
+  assert.match(
+    src,
+    new RegExp(`const ${name} = useCallback\\([\\s\\S]*?await mutate\\([\\s\\S]*?${message}`),
+    `${name} routes through the failure-announcing guard`,
+  );
+}
+
+// Prefs mutations only refresh prefs after a confirmed success.
+assert.match(
+  src,
+  /const ok = await mutate\([\s\S]{0,400}?if \(ok\) onPrefsChanged\(\);/,
+  "prefs refresh only fires after the server accepted the change",
+);
+
+// Clear-all: one failed dismiss must not reject the whole fan-out.
+assert.match(
+  src,
+  /Promise\.allSettled\(\s*\n\s*dismissableIds\.map/,
+  "clear-all uses allSettled so one failure doesn't abandon the rest",
+);
+assert.match(
+  src,
+  /could not be dismissed — check your connection\./,
+  "clear-all reports how many dismissals failed",
+);
+assert.doesNotMatch(
+  src,
+  /await Promise\.all\(\s*\n\s*dismissableIds/,
+  "the all-or-nothing Promise.all fan-out must not return",
+);
+
+console.log("notification-bell-mutations.test.ts: ok");

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -8,6 +8,7 @@ import type { Familiar } from "@/lib/types";
 import type { InboxPrefs, SoundMode } from "@/lib/cave-inbox-prefs";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 type Props = {
   items: InboxItem[];
@@ -37,6 +38,25 @@ export function NotificationBell({
   const [settingsOpen, setSettingsOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const { announce } = useAnnouncer();
+
+  // Every bell mutation is a fire-and-forget fetch whose UI feedback arrives
+  // via the inbox SSE reconcile — so a network failure or 5xx used to be a
+  // silent no-op (the click did nothing and the rejection was unhandled).
+  // Route them through one guard that verifies res.ok and announces failures.
+  const mutate = useCallback(
+    async (run: () => Promise<Response>, failureMessage: string): Promise<boolean> => {
+      try {
+        const res = await run();
+        if (!res.ok) throw new Error(String(res.status));
+        return true;
+      } catch {
+        announce(failureMessage, "assertive");
+        return false;
+      }
+    },
+    [announce],
+  );
 
   // Trap focus while the popover is open: Escape closes, Tab cycles inside,
   // and closing restores focus to whatever opened it (the bell trigger for
@@ -51,26 +71,34 @@ export function NotificationBell({
 
   const toggleMute = useCallback(
     async (familiarId: string) => {
-      await fetch("/api/inbox/prefs", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ toggleMuteFor: familiarId }),
-      });
-      onPrefsChanged();
+      const ok = await mutate(
+        () =>
+          fetch("/api/inbox/prefs", {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ toggleMuteFor: familiarId }),
+          }),
+        "Mute change failed — check your connection.",
+      );
+      if (ok) onPrefsChanged();
     },
-    [onPrefsChanged],
+    [mutate, onPrefsChanged],
   );
 
   const setSound = useCallback(
     async (mode: SoundMode, name?: string) => {
-      await fetch("/api/inbox/prefs", {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ sound: { mode, name } }),
-      });
-      onPrefsChanged();
+      const ok = await mutate(
+        () =>
+          fetch("/api/inbox/prefs", {
+            method: "PATCH",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ sound: { mode, name } }),
+          }),
+        "Sound change failed — check your connection.",
+      );
+      if (ok) onPrefsChanged();
     },
-    [onPrefsChanged],
+    [mutate, onPrefsChanged],
   );
 
   // Items shown in the dropdown: most-recent fired + the loudest pending alerts
@@ -106,9 +134,15 @@ export function NotificationBell({
     return () => window.removeEventListener("mousedown", onDown);
   }, [open]);
 
-  const dismiss = useCallback(async (id: string) => {
-    await fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
-  }, []);
+  const dismiss = useCallback(
+    async (id: string) => {
+      await mutate(
+        () => fetch(`/api/inbox/${id}/dismiss`, { method: "POST" }),
+        "Dismiss failed — check your connection.",
+      );
+    },
+    [mutate],
+  );
 
   // Fired notifications are the dismissible stack the badge counts; response-
   // needed bridges aren't dismissed here (they need a reply, not a clear).
@@ -119,19 +153,37 @@ export function NotificationBell({
 
   const dismissAll = useCallback(async () => {
     // Fan out the existing per-item dismiss; the inbox SSE reconciles the list
-    // and badge (same path the single ✕ uses).
-    await Promise.all(
-      dismissableIds.map((id) => fetch(`/api/inbox/${id}/dismiss`, { method: "POST" })),
+    // and badge (same path the single ✕ uses). allSettled so one failure
+    // doesn't abandon the rest of the stack; report the stragglers once.
+    const results = await Promise.allSettled(
+      dismissableIds.map(async (id) => {
+        const res = await fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
+        if (!res.ok) throw new Error(String(res.status));
+      }),
     );
-  }, [dismissableIds]);
+    const failed = results.filter((r) => r.status === "rejected").length;
+    if (failed > 0) {
+      announce(
+        `${failed} of ${results.length} notifications could not be dismissed — check your connection.`,
+        "assertive",
+      );
+    }
+  }, [dismissableIds, announce]);
 
-  const snooze = useCallback(async (id: string) => {
-    await fetch(`/api/inbox/${id}/snooze`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ minutes: 10 }),
-    });
-  }, []);
+  const snooze = useCallback(
+    async (id: string) => {
+      await mutate(
+        () =>
+          fetch(`/api/inbox/${id}/snooze`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ minutes: 10 }),
+          }),
+        "Snooze failed — check your connection.",
+      );
+    },
+    [mutate],
+  );
 
   return (
     <div ref={wrapRef} className="notification-bell relative">


### PR DESCRIPTION
## Problem (cave-qhz3, from the notification-bell audit)
`toggleMute`, `setSound`, `dismiss`, `dismissAll`, and `snooze` were fire-and-forget fetches — no `res.ok` check, no catch, invoked as `void` promises. Offline or on a 5xx: the click did nothing visible (the SSE reconcile never arrives because the server never got the request), the rejection was unhandled, and `dismissAll` abandoned its whole fan-out on the first rejection (`Promise.all`).

## Fix
- One `mutate` guard: verifies `res.ok`, announces failures **assertively** via the shared live region (`useAnnouncer`), returns success.
- Prefs mutations only call `onPrefsChanged()` after confirmed success.
- Clear-all uses `Promise.allSettled` and reports how many dismissals failed.

## Verification
- New `notification-bell-mutations.test.ts` (wired into test:app via scripts/run-tests.mjs): guard shape, per-mutation routing, success-gated prefs refresh, allSettled + regression guard on the old Promise.all.
- `pnpm test:app` — 572 files pass · check-tests-wired green · `pnpm typecheck` clean

Closes cave-qhz3 (beads).