### PR TITLE
a11y(bell): trigger names its dialog, chips are real toggles, times stay live (cave-jm6t)

### DIFF
--- a/src/components/daily-summary-notifications.test.ts
+++ b/src/components/daily-summary-notifications.test.ts
@@ -93,4 +93,16 @@ assert.match(
   "Internal daily report links should navigate in-app instead of opening the browser pane",
 );
 
+// ── Bell a11y/polish (cave-jm6t) ─────────────────────────────────────────────
+// The trigger names its popup + state; sound/mute chips are real toggles;
+// item times stay live while the popover is open (per-row minute tick, zero
+// cost while closed); outside-close covers pen/touch via pointerdown.
+assert.match(bell, /aria-haspopup="dialog"\s*\n\s*aria-expanded=\{open\}/, "the bell trigger exposes its dialog + open state");
+assert.match(bell, /aria-pressed=\{active\}/, "sound chips announce the selected mode");
+assert.match(bell, /aria-pressed=\{muted\}/, "mute chips are real toggles");
+assert.match(bell, /function BellItemTime\(\{ iso, waiting \}[\s\S]{0,120}useMinuteTick\(\)/, "item timestamps tick while mounted");
+assert.match(bell, /<RelativeTime iso=\{iso\} fallback="—" \/>/, "timestamps render through the shared RelativeTime");
+assert.match(bell, /addEventListener\("pointerdown", onDown\)/, "outside-close listens to pointerdown (mouse + pen + touch)");
+assert.doesNotMatch(bell, /addEventListener\("mousedown", onDown\)/, "the mouse-only closer stays gone");
+
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { relativeTime } from "@/lib/relative-time";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { Familiar } from "@/lib/types";
@@ -19,8 +20,16 @@ type Props = {
   onPrefsChanged: () => void;
 };
 
-function relTime(iso: string | null | undefined): string {
-  return iso ? relativeTime(iso) : "—";
+// Live per-row timestamp: ticks each minute so a popover left open doesn't
+// show a stale "2m ago" forever (cave-jm6t). Rows unmount with the popover,
+// so the always-mounted bell trigger pays nothing while closed.
+function BellItemTime({ iso, waiting }: { iso: string | null | undefined; waiting: boolean }) {
+  useMinuteTick();
+  return (
+    <div className="mt-1 text-[10px] text-[var(--text-muted)]">
+      {waiting ? "Waiting on you" : <RelativeTime iso={iso} fallback="—" />}
+    </div>
+  );
 }
 
 export function NotificationBell({
@@ -99,11 +108,11 @@ export function NotificationBell({
   // Close on outside click.
   useEffect(() => {
     if (!open) return;
-    const onDown = (e: MouseEvent) => {
+    const onDown = (e: PointerEvent) => {
       if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
     };
-    window.addEventListener("mousedown", onDown);
-    return () => window.removeEventListener("mousedown", onDown);
+    window.addEventListener("pointerdown", onDown);
+    return () => window.removeEventListener("pointerdown", onDown);
   }, [open]);
 
   const dismiss = useCallback(async (id: string) => {
@@ -137,6 +146,8 @@ export function NotificationBell({
     <div ref={wrapRef} className="notification-bell relative">
       <button
         onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
         className={`notification-bell__trigger focus-ring relative grid h-7 w-7 place-items-center rounded-md border transition-colors ${
           displayBadgeCount > 0
             ? "border-[color-mix(in_oklch,var(--color-warning)_45%,var(--border-strong))] bg-[color-mix(in_oklch,var(--color-warning)_14%,transparent)] text-[var(--color-warning)] hover:bg-[color-mix(in_oklch,var(--color-warning)_22%,transparent)]"
@@ -224,6 +235,7 @@ export function NotificationBell({
                       onClick={() =>
                         setSound(opt.mode, "name" in opt ? opt.name : undefined)
                       }
+                      aria-pressed={active}
                       className={`focus-ring rounded border px-2 py-0.5 text-[10px] transition-colors ${
                         active
                           ? "border-[color-mix(in_oklch,var(--accent-presence)_55%,transparent)] bg-[color-mix(in_oklch,var(--accent-presence)_20%,transparent)] text-[var(--text-primary)]"
@@ -250,6 +262,8 @@ export function NotificationBell({
                       <span className="truncate text-[var(--text-secondary)]" title={f.display_name}>{f.display_name}</span>
                       <button
                         onClick={() => toggleMute(f.id)}
+                        aria-pressed={muted}
+                        aria-label={`${muted ? "Unmute" : "Mute"} ${f.display_name}`}
                         className={`focus-ring rounded border px-1.5 py-0.5 text-[10px] transition-colors ${
                           muted
                             ? "border-[color-mix(in_oklch,var(--color-warning)_45%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_14%,transparent)] text-[var(--color-warning)]"
@@ -300,11 +314,10 @@ export function NotificationBell({
                           {it.body}
                         </div>
                       ) : null}
-                      <div className="mt-1 text-[10px] text-[var(--text-muted)]">
-                        {it.kind === "response-needed"
-                          ? "Waiting on you"
-                          : relTime(it.status === "fired" ? it.firedAt : it.updatedAt)}
-                      </div>
+                      <BellItemTime
+                        iso={it.status === "fired" ? it.firedAt : it.updatedAt}
+                        waiting={it.kind === "response-needed"}
+                      />
                     </div>
                     {it.familiarId ? (
                       <button


### PR DESCRIPTION
## Summary

Bead `cave-jm6t` (source-verified), four fixes to the notification bell:

- **Trigger semantics:** it toggles a `role=dialog` popover but exposed no `aria-haspopup="dialog"` / `aria-expanded` — screen-reader users couldn't tell it opens a panel or whether it's currently open.
- **Real toggles:** sound-mode chips encoded the active mode visually only (border/bg); mute chips relied on their "mute"/"muted" text. Both now carry `aria-pressed`, and mute chips gain an action-first accessible name ("Mute/Unmute <familiar>").
- **Live timestamps:** item times were a static string computed at render, so a popover left open showed "2m ago" forever. A per-row `BellItemTime` ticks each minute and renders through the shared `<RelativeTime>` (semantic `<time>`, pref-aware hover title). Rows unmount with the popover, so the always-mounted bell trigger pays zero re-renders while closed — deliberately not a component-level `useMinuteTick`.
- **Pointer-wide dismiss:** outside-close listened to `mousedown` only; `pointerdown` covers mouse, pen, and touch consistently.

## Test plan

- [x] Pins in `daily-summary-notifications.test.ts`: haspopup+expanded pair, both `aria-pressed` sites, ticking row component, shared RelativeTime, pointerdown (with a mousedown stays-gone guard)
- [x] Full `pnpm test:app` (571 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)