### PR TITLE
fix(quick-chat): thread fills the window height — drop the dropdown-era 46vh cap (cave-8f9h)

### DIFF
--- a/src/components/tray-quick-chat.test.ts
+++ b/src/components/tray-quick-chat.test.ts
@@ -75,6 +75,11 @@ assert.match(
   /\.tray-quick-chat__pane\[hidden\] \{\s*\n\s*display: none;/,
   "the pane's display:flex must not defeat the hidden attribute",
 );
+assert.match(
+  glassCss,
+  /\.tray-quick-chat__pane \.quick-chat-thread \{[^}]*max-height: none;/,
+  "the thread fills the window height — globals' 46vh dropdown-era cap must stay overridden",
+);
 
 // ── Closing the quick chat ───────────────────────────────────────────────────
 assert.match(component, /aria-label="Close quick chat"/, "the header exposes a window close button");

--- a/src/styles/quick-chat-glass.css
+++ b/src/styles/quick-chat-glass.css
@@ -141,6 +141,15 @@ html[data-glass] .quick-tab--active {
   min-height: 0;
 }
 
+/* The thread fills whatever height the window has — globals' 46vh cap
+   belongs to the retired dropdown overlay, and inside a full window it left
+   a dead gap under the composer instead of pinning it to the bottom. */
+.tray-quick-chat__pane .quick-chat-thread {
+  flex: 1;
+  min-height: 0;
+  max-height: none;
+}
+
 /* The display:flex above would otherwise beat the `hidden` attribute —
    background tabs must stay mounted (streams keep flowing) but invisible. */
 .tray-quick-chat__pane[hidden] {


### PR DESCRIPTION
User-reported: the quick chat doesn't fill its container — a dead gap sits under the composer.

`globals.css`'s `.quick-chat-thread` still carries `max-height: 46vh` from the retired in-app dropdown overlay, so in the full tray window (and any tall browser view) the thread stops growing and the composer floats mid-window. The tray pane now scopes an override (`flex: 1; min-height: 0; max-height: none`) — the globals class is untouched for any future popover consumer.

Verified in the running app at 390×520 (tray size) and 900×1000: composer bottom flush with the frame bottom (1px border gap), thread height 332px → 801px. Regression-pinned in `tray-quick-chat.test.ts`.

`pnpm typecheck` ✓ · `test:app` 571 files ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)