### PR TITLE
feat(projects): five hub updates — task quick-add, honest git chip, Recent sort, meta titles, grants clarity (cave-ihox)

### DIFF
--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -83,6 +83,24 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   // never surprisingly hidden). It only narrows the list; it never reorders it,
   // so the alphabetical order stays stable.
   const [statusFilter, setStatusFilter] = useState<"all" | "active">("all");
+  // List order: alphabetical (stable, scannable) or most-recently-active first
+  // (find what you were just working on). Persisted per machine.
+  const [sortMode, setSortMode] = useState<"az" | "recent">(() => {
+    if (typeof window === "undefined") return "az";
+    try {
+      return window.localStorage.getItem("cave:projects:sort") === "recent" ? "recent" : "az";
+    } catch {
+      return "az";
+    }
+  });
+  const changeSortMode = (mode: "az" | "recent") => {
+    setSortMode(mode);
+    try {
+      window.localStorage.setItem("cave:projects:sort", mode);
+    } catch {
+      /* private mode — sort stays session-only */
+    }
+  };
   const searchRef = useRef<HTMLInputElement>(null);
   const rootInputRef = useRef<HTMLInputElement>(null);
   const [nameDraft, setNameDraft] = useState("");
@@ -225,20 +243,29 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
     return byRoot;
   }, [sessions, projectOverrides, order, deletePending]);
 
-  // Keep projects stable and scannable: alphabetical by project name/root.
-  // Session rows inside the detail pane keep their own manual/recency ordering.
-  const sortedProjects = useMemo(() => {
-    return sortProjectsAlphabetically(projects);
-  }, [projects]);
-
-  // Resolve the selection each render: the stored id when it still exists,
-  // otherwise the most recently active project (then the first). Deleting the
-  // selected project or a familiar-scope change re-runs this automatically.
   const lastActiveByRootKey = useMemo(() => {
     const map = new Map<string, number>();
     for (const [root, list] of chatsByRoot) map.set(root, lastActiveMs(list));
     return map;
   }, [chatsByRoot]);
+
+  // List order per the sort toggle: alphabetical (stable, scannable) or by
+  // last session activity, newest first (alphabetical tiebreak so idle
+  // projects don't shuffle). Session rows inside the detail pane keep their
+  // own manual/recency ordering either way.
+  const sortedProjects = useMemo(() => {
+    const az = sortProjectsAlphabetically(projects);
+    if (sortMode === "az") return az;
+    return [...az].sort(
+      (a, b) =>
+        (lastActiveByRootKey.get(normalizeProjectRoot(b.root)) ?? 0) -
+        (lastActiveByRootKey.get(normalizeProjectRoot(a.root)) ?? 0),
+    );
+  }, [projects, sortMode, lastActiveByRootKey]);
+
+  // Resolve the selection each render: the stored id when it still exists,
+  // otherwise the most recently active project (then the first). Deleting the
+  // selected project or a familiar-scope change re-runs this automatically.
   const selectedProjectId = useMemo(
     () =>
       resolveSelectedProjectId(
@@ -493,6 +520,34 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
                     }`}
                   >
                     {opt.value === "active" ? `Active ${activeCount}` : opt.label}
+                  </Button>
+                ))}
+              </div>
+            ) : null}
+            {projects.length > 1 ? (
+              <div
+                role="group"
+                aria-label="Sort projects"
+                className="flex shrink-0 items-center rounded-[var(--radius-control)] border border-[var(--border-hairline)] p-0.5"
+              >
+                {([
+                  { value: "az", label: "A–Z", help: "Alphabetical" },
+                  { value: "recent", label: "Recent", help: "Most recently active first" },
+                ] as const).map((opt) => (
+                  <Button
+                    key={opt.value}
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => changeSortMode(opt.value)}
+                    aria-pressed={sortMode === opt.value}
+                    title={opt.help}
+                    className={`h-7 rounded-[var(--radius-control)] px-2 text-[11px] font-medium ${
+                      sortMode === opt.value
+                        ? "bg-[var(--bg-hover)] text-[var(--text-primary)]"
+                        : "text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                    }`}
+                  >
+                    {opt.label}
                   </Button>
                 ))}
               </div>

--- a/src/components/projects/detail-sections.tsx
+++ b/src/components/projects/detail-sections.tsx
@@ -31,8 +31,21 @@ export function GitSection({
    *  authoritative /api/changes response lands. */
   sessionBranch: string | null;
 }) {
+  const { announce } = useAnnouncer();
   const changes = useChangesSummary(projectRoot, true);
   const branch = changes.branch ?? sessionBranch;
+  const [copiedBranch, setCopiedBranch] = useState(false);
+  const copyBranch = async () => {
+    if (!branch) return;
+    try {
+      await navigator.clipboard.writeText(branch);
+      setCopiedBranch(true);
+      window.setTimeout(() => setCopiedBranch(false), 1600);
+      announce("Branch name copied.");
+    } catch {
+      // Clipboard blocked (insecure context / permissions) — no-op.
+    }
+  };
 
   return (
     <section className="projects-detail-section" aria-label="Git status">
@@ -44,20 +57,28 @@ export function GitSection({
       ) : (
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-[11px] text-[var(--text-muted)]">
           {branch ? (
-            <span className="inline-flex max-w-[16rem] items-center gap-1 truncate font-mono" title={`Branch: ${branch}`}>
-              <Icon name="ph:git-branch-bold" width={11} aria-hidden />
+            <button
+              type="button"
+              onClick={() => void copyBranch()}
+              className="focus-ring inline-flex max-w-[16rem] items-center gap-1 truncate rounded-[var(--radius-control)] px-1 py-0.5 font-mono hover:text-[var(--text-secondary)]"
+              title={copiedBranch ? "Copied" : `Copy branch name: ${branch}`}
+              aria-label={`Copy branch name ${branch}`}
+            >
+              <Icon name={copiedBranch ? "ph:check" : "ph:git-branch-bold"} width={11} aria-hidden />
               <span className="truncate">{branch}</span>
-            </span>
+            </button>
           ) : null}
           {!changes.loaded ? (
             <span>Checking working tree…</span>
           ) : changes.count > 0 ? (
+            // A dirty tree is a normal state, not activity — plain chip, no
+            // pulse, with the "uncommitted, working tree" framing spelled out.
             <span
-              className="projects-session-chip projects-session-chip--running"
-              title={`${changes.count} uncommitted ${changes.count === 1 ? "file" : "files"}`}
+              className="projects-session-chip"
+              title={`${changes.count} ${changes.count === 1 ? "file" : "files"} with uncommitted changes in the working tree`}
             >
               <Icon name="ph:git-diff" width={10} aria-hidden />
-              {changes.count} changed {changes.count === 1 ? "file" : "files"}
+              {changes.count} uncommitted
             </span>
           ) : (
             <span className="inline-flex items-center gap-1">
@@ -101,7 +122,46 @@ export function TasksSection({
   cards: Card[];
   onOpenBoard?: () => void;
 }) {
-  const projectCards = useMemo(() => cardsForProject(cards, project), [cards, project]);
+  const { announce } = useAnnouncer();
+  // Quick-add: a task lands on the board without leaving the hub. The server
+  // derives cwd from projectId (never client-supplied); the created card is
+  // appended locally so it shows instantly, and cave:board:reload nudges the
+  // shell's board fetch for everyone else.
+  const [taskDraft, setTaskDraft] = useState("");
+  const [creatingTask, setCreatingTask] = useState(false);
+  const [createdCards, setCreatedCards] = useState<Card[]>([]);
+  useEffect(() => {
+    setCreatedCards([]);
+    setTaskDraft("");
+  }, [project.id]);
+  const createTask = async () => {
+    const title = taskDraft.trim();
+    if (!title || creatingTask) return;
+    setCreatingTask(true);
+    try {
+      const res = await fetch("/api/board", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title, projectId: project.id }),
+      });
+      const json = await res.json();
+      if (!json?.ok || !json.card) throw new Error(json?.error ?? "create failed");
+      setCreatedCards((prev) => [json.card as Card, ...prev]);
+      setTaskDraft("");
+      announce(`Task added to ${project.name}.`);
+      window.dispatchEvent(new Event("cave:board:reload"));
+    } catch {
+      announce("Couldn't add the task.", "assertive");
+    } finally {
+      setCreatingTask(false);
+    }
+  };
+
+  const mergedCards = useMemo(() => {
+    const seen = new Set(cards.map((c) => c.id));
+    return [...createdCards.filter((c) => !seen.has(c.id)), ...cards];
+  }, [cards, createdCards]);
+  const projectCards = useMemo(() => cardsForProject(mergedCards, project), [mergedCards, project]);
   const open = useMemo(() => projectCards.filter((c) => c.status !== "done"), [projectCards]);
   const doneCount = projectCards.length - open.length;
   const runningCount = open.filter((c) => c.status === "running").length;
@@ -133,8 +193,8 @@ export function TasksSection({
       {open.length === 0 ? (
         <div className="projects-detail-empty">
           {doneCount > 0
-            ? `All ${doneCount} task${doneCount === 1 ? "" : "s"} done — add the next one on the board.`
-            : "No tasks for this project yet."}
+            ? `All ${doneCount} task${doneCount === 1 ? "" : "s"} done — add the next one below.`
+            : "No tasks for this project yet — add one below."}
         </div>
       ) : (
         <>
@@ -164,6 +224,39 @@ export function TasksSection({
           ) : null}
         </>
       )}
+      <form
+        className="mt-1.5 flex items-center gap-1.5"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void createTask();
+        }}
+      >
+        <input
+          value={taskDraft}
+          onChange={(event) => setTaskDraft(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape" && taskDraft) {
+              event.stopPropagation();
+              setTaskDraft("");
+            }
+          }}
+          placeholder="Add a task…"
+          aria-label={`Add a task to ${project.name}`}
+          disabled={creatingTask}
+          className="focus-ring h-7 min-w-0 flex-1 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-transparent px-2 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
+        />
+        <Button
+          type="submit"
+          variant="ghost"
+          size="xs"
+          disabled={creatingTask || !taskDraft.trim()}
+          leadingIcon="ph:plus"
+          aria-label={`Add task to ${project.name}`}
+          className="h-7 shrink-0 rounded-[var(--radius-control)] px-2 text-[11px] font-medium text-[var(--text-muted)] enabled:hover:text-[var(--text-secondary)]"
+        >
+          {creatingTask ? "Adding…" : "Add"}
+        </Button>
+      </form>
     </section>
   );
 }
@@ -260,9 +353,14 @@ export function GrantsSection({
   return (
     <section className="projects-detail-section" aria-label={`Familiar access to ${project.name}`}>
       <div className="projects-detail-section__title">
-        <span>Grants</span>
+        <span title="Which familiars may work in this project's folder — click a chip to grant or revoke">
+          Grants
+        </span>
         {granted.size > 0 ? <span className="projects-list-row__count">{granted.size}</span> : null}
       </div>
+      <p className="mb-1.5 text-[10px] text-[var(--text-muted)]">
+        Click a familiar to let it work in this project&apos;s folder — dashed means no access yet.
+      </p>
       {error ? (
         <p role="alert" className="mb-1.5 text-[11px] text-[var(--color-danger)]">
           {error}

--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -469,7 +469,10 @@ export function ProjectDetail({
 
       {/* Status line: state in words + stats chips + branch + recency. */}
       <div className="projects-detail-head__meta">
-        <span className="inline-flex items-center gap-1.5">
+        <span
+          className="inline-flex items-center gap-1.5"
+          title="Project state, derived from its latest sessions"
+        >
           {projectStatus ? (
             <span className={`projects-status-dot ${chatDotClass(projectStatus)}`} aria-hidden />
           ) : null}
@@ -478,6 +481,7 @@ export function ProjectDetail({
         <span
           className="projects-session-count"
           aria-label={`${chats.length} ${chats.length === 1 ? "session" : "sessions"}`}
+          title={`${chats.length} ${chats.length === 1 ? "session" : "sessions"} in this project`}
         >
           <Icon name="ph:chats-circle" width={12} aria-hidden />
           {chats.length}

--- a/src/components/projects/projects-hub.test.ts
+++ b/src/components/projects/projects-hub.test.ts
@@ -117,7 +117,16 @@ assert.match(detail, /<GitSection projectRoot=\{project\.root\} sessionBranch=\{
 // Tasks: one board fetch in the SHELL (not per selection — the detail remounts
 // on every switch), refetched on window refocus, filtered client-side.
 assert.equal((shell.match(/fetch\("\/api\/board"/g) ?? []).length, 1, "the shell fetches the board exactly once per mount");
-assert.doesNotMatch(sections, /fetch\("\/api\/board"/, "the Tasks section never fetches — cards arrive from the shell");
+assert.equal(
+  (sections.match(/fetch\("\/api\/board"/g) ?? []).length,
+  1,
+  "the Tasks section touches /api/board exactly once",
+);
+assert.match(
+  sections,
+  /fetch\("\/api\/board", \{\s*\n\s*method: "POST"/,
+  "…and that one call is the quick-add create (a mutation) — card READS still arrive from the shell",
+);
 assert.match(shell, /useRefreshOnFocus\(loadBoardCards\)/, "board cards refetch on window refocus (throttled)");
 assert.match(
   sections,
@@ -178,5 +187,32 @@ assert.doesNotMatch(boardCss, /projects-table|projects-session-count|projects-se
 for (const dead of ["../../lib/projects/projects-ui-state.ts", "../../lib/projects/use-projects-ui-state.ts"]) {
   assert.equal(existsSync(new URL(dead, import.meta.url)), false, `${dead} stays deleted`);
 }
+
+// ── Hub updates (cave-ihox): quick-add · honest git · sort · titles ─────────
+// Tasks quick-add: optimistic local append + a board-reload nudge for the rest
+// of the app; the created card comes back from the server (cwd derived from
+// projectId server-side, never client-supplied).
+assert.match(sections, /JSON\.stringify\(\{ title, projectId: project\.id \}\)/, "quick-add sends title + projectId only");
+assert.match(sections, /setCreatedCards\(\(prev\) => \[json\.card as Card, \.\.\.prev\]\)/, "the created card appends optimistically");
+assert.match(sections, /window\.dispatchEvent\(new Event\("cave:board:reload"\)\)/, "creation nudges the app-wide board reload");
+assert.match(sections, /aria-label=\{`Add a task to \$\{project\.name\}`\}/, "the quick-add input is named for AT");
+
+// Git: a dirty tree is status, not activity — the chip must not pulse; the
+// branch is click-to-copy.
+assert.doesNotMatch(sections, /projects-session-chip--running"\s*\n?\s*title=\{`\$\{changes\.count\}/, "the changed-files chip does not wear the running pulse");
+assert.match(sections, /uncommitted changes in the working tree/, "the chip says what the count actually is");
+assert.match(sections, /aria-label=\{`Copy branch name \$\{branch\}`\}/, "the branch is a copy button");
+
+// List sort: alphabetical or most-recent-first, persisted per machine.
+assert.match(shell, /"cave:projects:sort"/, "the sort choice persists to localStorage");
+assert.match(shell, /aria-label="Sort projects"/, "the sort toggle is a labelled group");
+assert.match(shell, /lastActiveByRootKey\.get\(normalizeProjectRoot\(b\.root\)\) \?\? 0/, "recent sort orders by last session activity");
+
+// Meta-row comprehension: the status word and session count explain themselves.
+assert.match(detail, /title="Project state, derived from its latest sessions"/, "the status word carries its derivation");
+assert.match(detail, /\} in this project`\}/, "the session count chip is titled");
+
+// Grants explain themselves where the chips are.
+assert.match(sections, /dashed means no access yet/, "the grants section says what a chip click does");
 
 console.log("projects-hub.test.ts: ok");


### PR DESCRIPTION
## Summary

Five updates to the Projects hub, identified from the screenshot review and verified in source before building:

1. **Tasks quick-add** — an inline "Add a task…" input in the Tasks section. Enter POSTs `{title, projectId}` (cwd derives server-side per #2708's hardening); the created card appends optimistically and `cave:board:reload` nudges the app-wide board fetch. Both empty states now point at the input instead of sending users to the board.
2. **Honest Git chip** — the changed-files count drops the `--running` pulse (a dirty tree is *status*, not activity), reads "N uncommitted" with a working-tree explainer title, and the **branch chip becomes click-to-copy** (with announce + check flash).
3. **Recent sort** — an A–Z | Recent segmented toggle by the filter, persisted to `cave:projects:sort`. Recent orders by last session activity (the map the hub already computed for selection-resolution) with an alphabetical tiebreak so idle projects don't shuffle.
4. **Meta-row comprehension** — the status word carries its derivation ("Project state, derived from its latest sessions") and the session-count chip is titled — no more bare `0` next to an icon.
5. **Grants clarity** — a one-line hint under the section title says exactly what a chip click does ("dashed means no access yet"), plus a header title for hover.

## Testing

- **Live-verified via Playwright** on a real dev server: Recent sort visibly reorders the list and persists across the toggle; quick-add created a real board card end-to-end (deleted from the live board afterward); copy-branch button, uncommitted chip, and grants hint all render. Screenshots reviewed.
- Pins: the sections' single `/api/board` call is pinned as the quick-add **POST** (card *reads* still arrive from the shell — the original polling-discipline pin is preserved, made precise), plus new pins for all five behaviors in `projects-hub.test.ts`.
- `tsc` clean · full suite green (**571 test files**) · `pnpm build` within bundle budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)