### PR TITLE
fix(projects): enforce one project per root in the store (cave-729h)

### DIFF
--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -35,6 +35,13 @@ try {
   assert.equal(created.root, "/tmp/test");
   assert.equal((await loadProjects()).length, 1);
 
+  // cave-729h: one project per root. A second create at the same root (even the
+  // trailing-slash variant) returns the existing project and writes no duplicate.
+  const dup = await createProject({ name: "Dup", root: "/tmp/test/" });
+  assert.equal(dup.id, created.id, "creating at an existing root returns the existing project");
+  assert.equal(dup.name, "Test", "the existing project comes back unchanged, not renamed");
+  assert.equal((await loadProjects()).length, 1, "no duplicate root is persisted on disk");
+
   const patched = await patchProject(created.id, { name: "New", root: "/tmp/test/" });
   assert.equal(patched?.name, "New");
   assert.equal(patched?.root, "/tmp/test");
@@ -62,6 +69,20 @@ try {
   const allSlashProject = await createProject({ name: "All slash", root: "/all-slash" });
   const rootOnly = await patchProject(allSlashProject.id, { root: "////" });
   assert.equal(rootOnly?.root, "/");
+
+  // cave-729h: a root change that would collide with a *different* project is
+  // dropped (keeps the one-per-root invariant), but the patch's other fields apply.
+  const collideSrc = await createProject({ name: "Collide", root: "/tmp/collide-src" });
+  const collided = await patchProject(collideSrc.id, { name: "Renamed", root: "/tmp/test" });
+  assert.equal(collided?.root, "/tmp/collide-src", "a root change colliding with another project is dropped");
+  assert.equal(collided?.name, "Renamed", "non-colliding fields of the same patch still apply");
+  assert.equal(
+    (await loadProjects()).filter((entry) => entry.root === "/tmp/test").length,
+    1,
+    "only one project ever owns /tmp/test",
+  );
+  // Restore the store to the three projects the rest of the suite expects.
+  await deleteProject(collideSrc.id);
 
   const projects = await loadProjects();
   assert.equal(projectForRoot("/tmp/test/", projects)?.id, created.id);

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -83,11 +83,19 @@ export function createProject(input: {
 }): Promise<CaveProject> {
   return withWriteMutex(async () => {
     const projects = await loadProjects();
+    const root = normalizeRoot(input.root);
+    // One project per root. Creating at an already-registered root would persist
+    // a duplicate on disk that the UI hides via dedupeProjectsByRoot but the
+    // server (projectById / trustedProjectCwd) can still resolve to — a
+    // client/server divergence. Return the existing project idempotently instead
+    // ("this folder is already a project → here it is").
+    const existing = projects.find((entry) => normalizeRoot(entry.root) === root);
+    if (existing) return existing;
     const now = new Date().toISOString();
     const project: CaveProject = {
       id: nanoid(),
       name: input.name.trim(),
-      root: normalizeRoot(input.root),
+      root,
       color: input.color,
       createdAt: now,
       updatedAt: now,
@@ -108,10 +116,22 @@ export function patchProject(
     const idx = projects.findIndex((project) => project.id === id);
     if (idx < 0) return null;
     const current = projects[idx];
+    // A root change that would collide with a *different* project is dropped —
+    // it keeps the one-project-per-root invariant that createProject enforces, so
+    // a rename-onto-another-root can't fork the on-disk store into two entries
+    // for one path. Name/color still apply.
+    let nextRoot = current.root;
+    if (patch.root !== undefined) {
+      const candidate = normalizeRoot(patch.root);
+      const collides = projects.some(
+        (entry) => entry.id !== id && normalizeRoot(entry.root) === candidate,
+      );
+      if (!collides) nextRoot = candidate;
+    }
     const updated: CaveProject = {
       ...current,
       name: patch.name !== undefined ? patch.name.trim() : current.name,
-      root: patch.root !== undefined ? normalizeRoot(patch.root) : current.root,
+      root: nextRoot,
       updatedAt: new Date().toISOString(),
     };
     if (patch.color !== undefined) {


### PR DESCRIPTION
## What

createProject appended unconditionally — no check for an existing project with the same normalized root — so registering an already-registered folder (or same path with/without trailing slash) persisted TWO entries for one root. UI hid one via dedupeProjectsByRoot, but both lived on disk → server (projectById/trustedProjectCwd) could resolve the hidden duplicate = client/server divergence; delete let the dup resurface. patchProject had the same gap on root change.

## Fix (store-level, under write mutex)
- createProject returns the existing project idempotently when the normalized root already exists. No dup written; caller lands on the right project. No route/client changes.
- patchProject drops a root change that would collide with a different project (name/color still apply).

Found by the Projects-hub audit. Pinned behaviorally in cave-projects.test.ts.

## Verification
typecheck, 571 app tests, build within budget. Other audit findings: cave-psp8.

Generated with Claude Code