### PR TITLE
a11y(projects): trap focus in the directory-picker modal (cave-psp8, picker slice)

### DIFF
--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Button } from "@/components/ui/button";
 
 type DirEntry = { name: string; path: string };
@@ -65,16 +66,12 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
     }
   }, [open, load]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
   const dialogRef = useRef<HTMLDivElement | null>(null);
+  // This is a true modal (aria-modal, covers the page). Trap focus inside it,
+  // close on Escape, and restore focus to the trigger on close — the hook does
+  // all three, replacing the old window-level Escape listener (which left focus
+  // free to Tab out to the page behind the scrim).
+  useFocusTrap(open, dialogRef, { onEscape: onClose });
   if (!open) return null;
 
   // Display the current path with $HOME collapsed to `~`.
@@ -93,7 +90,8 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
     >
       <div
         ref={dialogRef}
-        className="flex max-h-[80vh] w-[520px] max-w-full flex-col overflow-hidden rounded-[var(--radius-panel)] border border-[var(--border-hairline)] shadow-xl"
+        tabIndex={-1}
+        className="flex max-h-[80vh] w-[520px] max-w-full flex-col overflow-hidden rounded-[var(--radius-panel)] border border-[var(--border-hairline)] shadow-xl focus:outline-none"
         style={{ background: "var(--bg-panel)" }}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/components/directory-picker.test.ts
+++ b/src/components/directory-picker.test.ts
@@ -35,6 +35,10 @@ test("the modal navigates via the fs-browse API with up/select controls", () => 
   assert.match(src, /Select this folder/, "can select the current folder");
   assert.match(src, /import \{ Button \}/, "modal actions use the shared Button primitive");
   assert.doesNotMatch(src, /<button\b/, "modal should not hand-roll button controls");
+  // cave-psp8: a true modal must trap focus + restore it on close, not just listen
+  // for Escape at the window (which let Tab escape to the page behind the scrim).
+  assert.match(src, /useFocusTrap\(open, dialogRef, \{ onEscape: onClose \}\)/, "modal traps focus, closes on Escape, and returns focus on close");
+  assert.doesNotMatch(src, /addEventListener\("keydown"/, "the hand-rolled window Escape listener is gone (useFocusTrap owns it)");
   assert.doesNotMatch(
     src,
     /rounded-md|rounded-lg|rounded(?=\s|")/,


### PR DESCRIPTION
## What

`DirectoryPickerModal` was `aria-modal` and covered the page, but only listened for **Escape at the window** — Tab could walk out of the dialog to the page behind the scrim, and closing didn't restore focus to the Browse button that opened it.

## Fix

Adopt the shared `useFocusTrap(open, dialogRef, { onEscape: onClose })`: it contains Tab within the panel, closes on Escape, and **returns focus to the trigger** on close. Retire the hand-rolled window keydown listener it replaces; the panel gets `tabIndex={-1}` as the hook's focus-fallback.

## Scope

Just this isolated file. The rest of **cave-psp8** (`loadBoardCards` abort guard, `~`-path expansion, deferred-delete durability) is **deferred to avoid collisions** — `projects-view.tsx` is being edited by cave-ihox and `cave-projects.ts` by the in-flight cave-729h.

Pinned in `directory-picker.test.ts`.

## Verification

`typecheck` · **572** app test files · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)