### PR TITLE
fix(projects): abort board-card loads + expand ~ in roots (cave-psp8)

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -441,4 +441,9 @@ assert.match(
 );
 assert.match(projectsView, /onSelect=\{\(\) => setMenuView\("root"\)\}[\s\S]{0,40}?Back/, "the picker has a Back affordance");
 
+// (cave-psp8) Board-card loads abort the in-flight request per refetch —
+// mount + every window refocus fired overlapping fetches that could land out
+// of order (stale cards) or setState after unmount.
+assert.match(projectsView, /boardAbortRef\.current\?\.abort\(\);/, "each board-cards load aborts the in-flight one");
+assert.match(projectsView, /fetch\("\/api\/board", \{ cache: "no-store", signal: controller\.signal \}\)/, "the board-cards fetch carries an abort signal");
 console.log("projects-view.test.ts: ok");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -193,10 +193,18 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   // refetch on window refocus (throttled) — never per selection switch. The
   // Tasks section filters client-side by projectId/cwd.
   const [boardCards, setBoardCards] = useState<Card[]>([]);
+  // Abort the in-flight load per refetch (mount + every refocus): overlapping
+  // loads could land out of order and show stale board cards, and an unmount
+  // mid-flight leaked the setState (cave-psp8; mirrors useProjects.load).
+  const boardAbortRef = useRef<AbortController | null>(null);
   const loadBoardCards = async () => {
+    boardAbortRef.current?.abort();
+    const controller = new AbortController();
+    boardAbortRef.current = controller;
     try {
-      const res = await fetch("/api/board", { cache: "no-store" });
+      const res = await fetch("/api/board", { cache: "no-store", signal: controller.signal });
       const json = await res.json();
+      if (controller.signal.aborted) return;
       if (json?.ok && Array.isArray(json.cards)) setBoardCards(json.cards as Card[]);
     } catch {
       /* transient — the Tasks section keeps the last known cards */
@@ -204,6 +212,7 @@ export function ProjectsView({ sessions = [], familiars = [], onNewChat, onSessi
   };
   useEffect(() => {
     void loadBoardCards();
+    return () => boardAbortRef.current?.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   useRefreshOnFocus(loadBoardCards);

--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -66,6 +66,25 @@ try {
   });
   assert.equal(slashHeavy.root, "C:/tmp/slash-heavy");
 
+  // (cave-psp8) A manually-typed ~/path expands to the absolute home path —
+  // stored literally it never matched the daemon's absolute project_root, so
+  // Sessions/Git/Tasks stayed empty and the project looked dead.
+  const tilde = await createProject({ name: "Tilde", root: "~/code/my-app" });
+  assert.equal(
+    tilde.root,
+    path.join(os.homedir(), "code/my-app").replace(/\\/g, "/"),
+    "leading ~/ expands to the home directory",
+  );
+  const bareTilde = await createProject({ name: "Home", root: "~" });
+  assert.equal(
+    bareTilde.root,
+    os.homedir().replace(/\\/g, "/"),
+    "a bare ~ expands to the home directory",
+  );
+  // Remove the tilde fixtures so the exact-list assertions below stay true.
+  await deleteProject(tilde.id);
+  await deleteProject(bareTilde.id);
+
   const allSlashProject = await createProject({ name: "All slash", root: "/all-slash" });
   const rootOnly = await patchProject(allSlashProject.id, { root: "////" });
   assert.equal(rootOnly?.root, "/");

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -24,7 +24,15 @@ function projectsFilePath(): string {
 }
 
 function normalizeRoot(root: string): string {
-  const normalized = root.trim().replace(/\\/g, "/");
+  let trimmed = root.trim();
+  // Expand a leading ~ — a manually-typed ~/code/app was stored literally and
+  // never matched the daemon's absolute project_root, so Sessions/Git/Tasks
+  // stayed empty and the project looked dead (cave-psp8).
+  if (trimmed === "~") trimmed = homedir();
+  else if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
+    trimmed = path.join(homedir(), trimmed.slice(2));
+  }
+  const normalized = trimmed.replace(/\\/g, "/");
   let endIndex = normalized.length;
   while (endIndex > 0 && normalized[endIndex - 1] === "/") endIndex--;
   return normalized.slice(0, endIndex) || "/";


### PR DESCRIPTION
## Summary

Bead `cave-psp8` (Projects-hub audit follow-ups). **Rebased after #2733 landed the directory-picker focus trap** — that slice of this bead was implemented concurrently by another session and is now dropped from this PR (their version, with `onEscape` folded into the trap, is the better one). What remains here is the non-overlapping scope:

**Board-card load races (F2).** `loadBoardCards` fires on mount and on every window refocus with no cancellation or ordering guard — overlapping loads could land out of order and show stale cards, and an unmount mid-flight leaked the setState. Now an abort-per-refetch ref, mirroring `useProjects.load`'s existing pattern in the same file.

**Tilde roots looked like dead projects (F4).** `normalizeRoot` stored a manually-typed `~/code/app` literally; it never matched the daemon's absolute `project_root`, so the project's Sessions/Git/Tasks stayed permanently empty. Leading `~/` (and bare `~`) now expand to the home directory server-side, covered by behavioral round-trip tests in `cave-projects.test.ts` (fixtures cleaned so the exact-list assertions stay exact).

**Verified NOT a defect (F3).** The bead asked to confirm `use-undo-delete` commits on unmount — it does (`use-undo-delete.ts:24-33`), so deferred bulk session-deletes are already durable across surface switches.

## Test plan

- [x] Behavioral tilde tests + abort/signal pins
- [x] Full `pnpm test:app` green post-rebase; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)