### PR TITLE
fix(chat): composer icon buttons match the runtime/host chip — 30px capsule (cave-8jp4)

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5308,7 +5308,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 <div className="cave-composer-utility-row">
                   <button
                     type="button"
-                    className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
+                    className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
                     title="Attach images, videos, or files"
                     aria-label="Attach images, videos, or files"
                     disabled={busy || attachments.length >= 10}
@@ -5322,7 +5322,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   {sessionId ? (
                     <button
                       type="button"
-                      className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
+                      className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)]"
                       title="Voice"
                       aria-label="Voice"
                       onClick={() => setVoiceCallOpen(true)}
@@ -5385,7 +5385,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 <div className="cave-composer-submit-row">
                   <button
                     type="button"
-                    className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                    className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
                     title="Enhance prompt"
                     aria-label="Enhance prompt"
                     disabled={busy || enhanceStatus === "loading" || !input.trim()}
@@ -5397,7 +5397,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     <button
                       type="button"
                       onClick={cancelSend}
-                      className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md bg-[color-mix(in_oklch,var(--color-danger)_90%,transparent)] text-white transition-colors hover:bg-[var(--color-danger)]"
+                      className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full bg-[color-mix(in_oklch,var(--color-danger)_90%,transparent)] text-white transition-colors hover:bg-[var(--color-danger)]"
                       title="Cancel (esc)"
                       aria-label="Cancel response"
                     >
@@ -5408,7 +5408,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                       type="button"
                       onClick={() => void send()}
                       disabled={!input.trim() && attachments.length === 0}
-                      className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
+                      className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
                       title={`Send message (${keys.enter})`}
                       aria-label="Send message"
                     >

--- a/src/components/composer-options-menu.tsx
+++ b/src/components/composer-options-menu.tsx
@@ -112,7 +112,7 @@ export function ComposerOptionsMenu({
       <button
         ref={anchorRef}
         type="button"
-        className="cave-composer-icon-button composer-options__trigger focus-ring relative grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+        className="cave-composer-icon-button composer-options__trigger focus-ring relative grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
         disabled={disabled}
         aria-haspopup="dialog"
         aria-expanded={open}

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -880,7 +880,7 @@ export function HomeComposer({
             <div className="cave-composer-utility-row">
               <button
                 type="button"
-                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
                 title="Attach images, videos, or files"
                 aria-label="Attach images, videos, or files"
                 disabled={sending || attachments.length >= 10}
@@ -890,7 +890,7 @@ export function HomeComposer({
               </button>
               <button
                 type="button"
-                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
                 title="Voice input (coming soon)"
                 aria-label="Voice input"
                 disabled
@@ -978,7 +978,7 @@ export function HomeComposer({
             <div className="cave-composer-submit-row">
               <button
                 type="button"
-                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
                 title="Enhance prompt"
                 aria-label="Enhance prompt"
                 disabled={sending || enhanceStatus === "loading" || !text.trim()}
@@ -990,7 +990,7 @@ export function HomeComposer({
                 type="button"
                 onClick={() => void handleSubmit()}
                 disabled={(!text.trim() && attachments.length === 0) || sending}
-                className="cave-composer-icon-button focus-ring grid h-7 w-7 place-items-center rounded-md bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
+                className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)] transition-colors hover:bg-[color-mix(in_oklch,var(--accent-presence)_85%,#000)] disabled:opacity-40"
                 title={`Send message (${keys.enter})`}
                 aria-label="Send"
               >

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -4093,7 +4093,9 @@ details[open] > .cave-tool-summary::before {
     height: var(--touch-target);
     min-width: var(--touch-target);
     min-height: var(--touch-target);
-    border-radius: 9px;
+    /* Match the capsule runtime/host chips — the utility row reads as one
+       family of controls at every breakpoint. */
+    border-radius: 999px;
     -webkit-tap-highlight-color: transparent;
   }
 


### PR DESCRIPTION
The composer utility row mixed two control families: 28px / 6px-radius icon buttons (attach, voice, options, stop, send — `h-7 w-7 rounded-md`, 10 sites across chat-view, home-composer, and composer-options-menu) next to the 30px / 999px capsule `ComposerRuntimeChip` / `ComposerHostChip`. Screenshot report: the paperclip + sliders buttons visibly shorter and squarer than the "Claude Opus 4.8" chip.

**Fix:** all icon-button sites → `h-[30px] w-[30px] rounded-full`; the mobile `--touch-target` media-query override's `border-radius: 9px` → `999px` so the match holds at every breakpoint.

**Verified live** (worktree server + Playwright measurement): every rendered button is exactly 30×30 full-radius beside the 30px/999px chip — one control family. Full app suite (572 files) + typecheck green.

Bead: cave-8jp4

🤖 Generated with [Claude Code](https://claude.com/claude-code)