### PR TITLE
fix(projects): expand a leading ~ in a project root, server-side (cave-pgvc)

### DIFF
--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -66,6 +66,19 @@ try {
   });
   assert.equal(slashHeavy.root, "C:/tmp/slash-heavy");
 
+  // cave-pgvc: a leading ~ expands to the home dir server-side, so a hand-typed
+  // "~/code/app" is stored absolute and can match the daemon's project_root.
+  const home = os.homedir().replace(/\\/g, "/");
+  const tildeProject = await createProject({ name: "Tilde", root: "~/code/app/" });
+  assert.equal(tildeProject.root, `${home}/code/app`, "leading ~/ expands to $HOME and trims the trailing slash");
+  const bareTilde = await createProject({ name: "Bare tilde", root: "~" });
+  assert.equal(bareTilde.root, home, "a bare ~ expands to $HOME exactly");
+  const notTilde = await createProject({ name: "Mid tilde", root: "/opt/~keep" });
+  assert.equal(notTilde.root, "/opt/~keep", "a ~ that isn't a leading home marker is left untouched");
+  await deleteProject(tildeProject.id);
+  await deleteProject(bareTilde.id);
+  await deleteProject(notTilde.id);
+
   const allSlashProject = await createProject({ name: "All slash", root: "/all-slash" });
   const rootOnly = await patchProject(allSlashProject.id, { root: "////" });
   assert.equal(rootOnly?.root, "/");

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -24,7 +24,16 @@ function projectsFilePath(): string {
 }
 
 function normalizeRoot(root: string): string {
-  const normalized = root.trim().replace(/\\/g, "/");
+  let normalized = root.trim().replace(/\\/g, "/");
+  // Expand a leading ~ to the home directory. A hand-typed "~/code/app" would
+  // otherwise be stored literally and never match the absolute project_root the
+  // daemon reports, so the project's Sessions/Git/Tasks stay empty and it looks
+  // permanently dead. Server-side only (createProject/patchProject) so the CLI
+  // and API agree. `~user` (other users' homes) is left untouched — we don't
+  // guess it. Runs before the trailing-slash trim below.
+  if (normalized === "~" || normalized.startsWith("~/")) {
+    normalized = homedir().replace(/\\/g, "/") + normalized.slice(1);
+  }
   let endIndex = normalized.length;
   while (endIndex > 0 && normalized[endIndex - 1] === "/") endIndex--;
   return normalized.slice(0, endIndex) || "/";


### PR DESCRIPTION
## What

`normalizeRoot` only trimmed + slash-normalized — it never expanded a leading `~`. A user who hand-typed `~/code/app` in the New-project root field got a project whose root was the **literal** `~/code/app`, which never matched the absolute `project_root` the daemon reports — so its Sessions/Git/Tasks stayed empty and the project looked **permanently dead**. (The native picker and in-app browser return absolute paths, so only manual typers hit it.)

## Fix

Expand a leading `~` / `~/` against the already-imported `homedir()` before the trailing-slash trim. **Server-side only** (`createProject`/`patchProject` use `normalizeRoot`) so the CLI and API agree; `~user` is left untouched — we don't guess other users' homes. Runs **before** the one-per-root dedup (cave-729h), so the expanded absolute path is what dedup compares.

Split from the Projects-hub audit's cave-psp8 (its picker slice shipped in #2733; the `loadBoardCards` abort + deferred-delete parts remain deferred while `projects-view.tsx` is under active edit). Pinned in `cave-projects.test.ts` (`~/…`, bare `~`, and a non-leading `~` left alone).

## Verification

`typecheck` · **572** app test files · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)