### PR TITLE
chore(release): stamp v0.0.154

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.154] - 2026-07-08
+
+> ⚗️ **One family of controls** — the composer's runtime chip lands everywhere (logo + model, one-click switching, now on Home too) and every icon button rounds up to match it. The daemon's control-plane catalog gets a proxy route, the projects hub takes five upgrades, and an a11y sweep makes bells, schedules, calendars, and pickers honest to assistive tech.
+
+Feature release on top of v0.0.153.
+
+### Features
+- **Composer: always-on runtime chip** (#2711, cave-yq5l) — the active runtime's logo + effective model live in the composer, one click to switch either; **on Home too, with instant roster refresh after runtime switches** (#2718, cave-v25g).
+- **Composer: icon buttons match the chip** (#2735, cave-8jp4). Attach/voice/options/stop/send become 30px capsules like the runtime and host chips — one control family at every breakpoint.
+- **Daemon: control-plane capability catalog proxy** (#2695/#2724). `GET /api/daemon/capabilities` normalizes the daemon's catalog with three feature-detectable states (offline / no catalog / ok).
+- **Projects: five hub updates** (#2730, cave-ihox) — task quick-add, honest git chip, Recent sort, meta titles, grants clarity; **one project per root enforced in the store** (#2732, cave-729h).
+- **Home: Chat/Task tabs above the composer card**, project chip width fit, wordless News lane (#2725).
+- **Chat: externally-generated sessions stay out of the chat lists** (#2719, cave-73fr); **file links render only when the click can actually open them** (#2698).
+- **Chrome: seamless ultra-minimalist title bar** (#2714, cave-r1f5).
+
+### Fixes
+- **Quick chat: the thread fills the window height** — the dropdown-era 46vh cap is gone (#2729, cave-8f9h); **intent-based follow release for quick-chat + group chat** (#2696, cave-o8si).
+- **Home/palette: IME composition no longer sends half-composed drafts** (#2720, #2705); **palette Enter opens the top local match** with Ask-Salem as the fallback row (#2706).
+- **GitHub: detail fetches abort on switch, optimistic resolves protected, PAT modal guarded mid-save** (#2726, cave-b8ba); **review familiar backfills once the list loads** (#2723).
+- **Automations: stable in-flight run poll** (no interval churn, no N+1 fan-out — #2716), stale-response guard on the run log (#2702), status-shaped run icons + associated labels (#2703).
+- **Settings: abort/ordering guards on daemon-status + config fetches** (#2701); the undefined `var(--danger)` becomes the real `--color-danger` token (#2700).
+- **Board: a card's cwd derives server-side from its project, never the client body** (#2708, cave-pw83).
+- **Browser: closing the active tab fully activates its replacement** (#2707); **popovers close on focus-out** per their non-modal role (#2712).
+- **UX: confusion-helpers sweep** — jargon defined at decision points, states labeled, verbs made honest (#2699).
+
+### Accessibility
+- **Bell**: trigger names its dialog, chips are real toggles, times stay live, pointer-wide dismiss (#2728); failed notification mutations are announced (#2727).
+- **Schedules**: both detail panels are real dialogs (#2717). **Calendar**: month gridcells keep a single tab stop (#2710) with a committed e2e keyboard model (#2722). **Projects**: the directory picker traps focus (#2733).
+
+### Internal
+- CI: `timeout-minutes` on every job — hung steps no longer stall required checks for the 6-hour default (#2715). Shared inline slash-menus hook (#2697). Committed e2e spec for the runtime-chip switch flow (#2721). Canvas sandbox postMessage invariant pinned (#2704).
+
 ## [0.0.153] - 2026-07-08
 
 > 🕸️ **The grimoire grows a graph** — every doc's [[wiki-links]] and semantic kinships spread across a force-directed canvas you can wander. Chat learns the Codex model catalog, the browser pane finally leaves the boot bundle, and suggestion chips close out their 2-or-4 arc with the dead CSS swept.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.153",
+  "version": "0.0.154",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.153"
+version = "0.0.154"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.153"
+version = "0.0.154"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.153</string>
+	<string>0.0.154</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.153</string>
+	<string>0.0.154</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.153</string>
+	<string>0.0.154</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.153</string>
+	<string>0.0.154</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.153",
+  "version": "0.0.154",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Feature release on top of v0.0.153. Bumps all six version locations (package.json, Cargo.toml, Cargo.lock, tauri.conf.json, both iOS Info.plists) and adds the v0.0.154 CHANGELOG entry for the 37 commits since v0.0.153 — headlined by the **composer runtime-chip arc** (#2711/#2718) and **icon buttons matching it as one 30px-capsule control family** (#2735), plus the daemon control-plane catalog proxy (#2695), five projects-hub upgrades (#2730/#2732/#2733), the seamless title bar (#2714), an a11y sweep (bell/schedules/calendar/pickers), and CI job timeouts (#2715).

Local gate: `cargo check --locked` + typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.154` on the squash commit → release.yml builds the notarized DMG + AppImage + MSI and publishes `latest.json`; final verification via `node scripts/verify-release-updater.mjs`.

Bead: cave-sdym

🤖 Generated with [Claude Code](https://claude.com/claude-code)