### PR TITLE
style(chat): widen the shared reading/composer measure one step (46rem → 52rem) (cave-cy8o)

### DIFF
--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -2568,10 +2568,10 @@ details[open] > .cave-tool-summary::before {
   /* Centered reading column (cave-xsq.1): the conversation + composer share one
      comfortable measure and sit in a centered column — the ChatGPT reading
      model — instead of spanning the full pane (reverses the 2026-06-18
-     full-width choice below). ~46rem ≈ a ~72ch line at 14px. The header stays a
+     full-width choice below). ~52rem ≈ a ~81ch line at 14px. The header stays a
      full-bleed bar (its divider spans the pane); only the reading/writing column
      is capped + centered. */
-  --cave-chat-measure: 46rem;
+  --cave-chat-measure: 52rem;
   background:
     linear-gradient(to bottom, color-mix(in oklch, var(--bg-raised) 18%, transparent), transparent 150px),
     var(--bg-base);


### PR DESCRIPTION
## What

Make the chat **input and transcript max-width one step wider**. Both key off the single `--cave-chat-measure` token, so bumping it widens the reading column **and** the composer together, in lockstep.

`46rem` (~72ch) → **`52rem`** (~81ch) — one comfortable step wider on large screens. The header stays full-bleed; the column stays centered.

The "chips never form a 3-wide row" invariant is unaffected — it's enforced by the `data-count` CSS rules (only 2/4 get two columns), not the pixel width, so 3 chips still stack at any measure.

## Verification

`typecheck` · **572** app test files · `build` within budget. Screenshot at 1440px confirms the transcript + composer both render at **832px**, aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)