### PR TITLE
feat(crons): sleek beginner-friendly detail panel, expandable to full page width (cave-4p6k)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -51,7 +51,7 @@ assert.match(
 // a long undifferentiated form. Key facts are summarized first, editing is
 // grouped into named zones, and primary/destructive actions are separated.
 assert.match(codexDetailPanel, />\s*Cron details\s*</, "cron detail panel uses Cron-specific title copy");
-assert.match(codexDetailPanel, /className="[^"]*cron-detail-summary-grid/, "cron detail panel renders an at-a-glance summary grid");
+assert.match(codexDetailPanel, /cron-detail-summary-grid/, "cron detail panel renders an at-a-glance summary grid");
 assert.match(codexDetailPanel, /<CronDetailSection title="Identity"/, "cron detail groups identity fields");
 assert.match(codexDetailPanel, /<CronDetailSection title="Instructions"/, "cron detail groups prompt fields");
 assert.match(codexDetailPanel, /<CronDetailSection title="Schedule"/, "cron detail groups schedule fields");
@@ -61,8 +61,71 @@ assert.match(codexDetailPanel, /Save changes[\s\S]*Run now[\s\S]*Delete/, "cron 
 assert.match(codexDetailPanel, /leadingIcon="ph:floppy-disk-bold"/, "save action uses a recognizable icon");
 assert.match(codexDetailPanel, /variant="danger-ghost"[\s\S]*Delete/, "delete remains visually separated as a destructive action");
 assert.match(source, /const detailOpen = Boolean\(selectedItem \|\| selectedCodex\)/, "Schedules tracks whether a detail panel is open");
-assert.match(source, /detailOpen \? "hidden md:flex" : "flex"/, "Schedules hides the list on narrow screens while a detail panel is open");
+assert.match(source, /detailOpen \? \(cronDetailExpanded \? "hidden" : "hidden md:flex"\) : "flex"/, "Schedules hides the list on narrow screens while a detail panel is open, and entirely while the cron detail is expanded");
 assert.match(source, /w-full[\s\S]*md:w-\[380px\][\s\S]*md:max-w-\[42vw\]/, "detail panel becomes full-width on narrow screens and a side rail on desktop");
+
+// Cron detail expansion (cave-4p6k): the rail can grow into the full page
+// width — toggle in the panel header, side-rail classes swap for flex-1, the
+// summary tiles go 4-up and the sections reflow into a two-column canvas.
+assert.match(
+  source,
+  /const cronDetailExpanded = detailExpanded && Boolean\(selectedCodex\)/,
+  "expansion only applies while a cron (not a reminder) detail is open",
+);
+assert.match(
+  source,
+  /cronDetailExpanded\s*\n?\s*\? "w-full min-w-0 flex-1 overflow-hidden"/,
+  "the expanded detail wrapper fills the full page width",
+);
+assert.match(
+  codexDetailPanel,
+  /aria-label=\{expanded \? "Collapse to side panel" : "Expand to full width"\}/,
+  "the header toggle names both directions for AT",
+);
+assert.match(
+  codexDetailPanel,
+  /aria-pressed=\{expanded\}/,
+  "the expand control is a proper toggle",
+);
+assert.match(
+  codexDetailPanel,
+  /leadingIcon=\{expanded \? "ph:arrows-in-simple" : "ph:arrows-out-simple"\}/,
+  "the expand control's icon mirrors its direction",
+);
+assert.match(
+  codexDetailPanel,
+  /cron-detail-summary-grid grid grid-cols-2 gap-2\$\{expanded \? " lg:grid-cols-4" : ""\}/,
+  "summary tiles go 4-up on the expanded canvas",
+);
+assert.match(
+  codexDetailPanel,
+  /expanded \? "grid items-start gap-5 lg:grid-cols-2" : "space-y-5"/,
+  "sections reflow into a two-column grid when expanded",
+);
+assert.match(
+  source,
+  /onClose=\{\(\) => \{ setSelectedCodex\(null\); setDetailExpanded\(false\); \}\}/,
+  "closing the cron detail also resets the expansion so the next open starts as a rail",
+);
+
+// Beginner-friendly schedule copy: presets read as plain cadences, the
+// raw-RRULE escape hatch is labeled Advanced, and the cryptic RRULE string
+// only surfaces in Advanced mode or when the schedule is invalid.
+assert.match(
+  source,
+  /const SCHEDULE_MODE_LABEL[\s\S]{0,160}weekly: "Weekly",\s*\n\s*daily: "Daily",\s*\n\s*raw: "Advanced",/,
+  "schedule modes carry beginner-facing labels (raw reads as Advanced)",
+);
+assert.match(
+  codexDetailPanel,
+  /scheduleMode !== "raw" && !invalidSchedule \?[\s\S]{0,320}?Runs every day at[\s\S]{0,220}?Runs weekly on/,
+  "preset modes echo the cadence in plain language instead of an RRULE",
+);
+assert.match(
+  codexDetailPanel,
+  /\{nextRrule \|\| "RRULE required"\}/,
+  "the RRULE line still renders for Advanced mode and invalid schedules",
+);
 
 // List rows + detail-panel close buttons show a visible keyboard focus ring.
 assert.ok(source.includes("focus-ring-inset automation-list-row"), "list rows have a focus ring");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -141,9 +141,9 @@ function FieldLabel({ htmlFor, children }: { htmlFor?: string; children: ReactNo
   );
 }
 
-function CronDetailSection({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
+function CronDetailSection({ title, description, className, children }: { title: string; description?: string; className?: string; children: ReactNode }) {
   return (
-    <section className="space-y-3 rounded-[var(--radius-control)] border p-3"
+    <section className={`space-y-3 rounded-[var(--radius-control)] border p-3${className ? ` ${className}` : ""}`}
       style={{ borderColor: "var(--border-hairline)", background: "color-mix(in oklch, var(--bg-base) 72%, transparent)" }}>
       <div>
         <h3 className="text-[12px] font-semibold" style={{ color: "var(--text-primary)" }}>{title}</h3>
@@ -153,6 +153,14 @@ function CronDetailSection({ title, description, children }: { title: string; de
     </section>
   );
 }
+
+// Beginner-facing names for the schedule cadence modes: the presets read as
+// plain cadences, and the raw-RRULE escape hatch is labeled for what it is.
+const SCHEDULE_MODE_LABEL: Record<"weekly" | "daily" | "raw", string> = {
+  weekly: "Weekly",
+  daily: "Daily",
+  raw: "Advanced",
+};
 
 function CronSummaryTile({ label, value, tone = "default" }: { label: string; value: ReactNode; tone?: "default" | "active" | "paused" | "danger" }) {
   const valueColor =
@@ -665,6 +673,8 @@ function ReminderTaskList({
 function CodexDetailPanel({
   auto,
   busy,
+  expanded,
+  onToggleExpanded,
   onClose,
   onToggle,
   onSave,
@@ -674,6 +684,10 @@ function CodexDetailPanel({
 }: {
   auto: CodexAutomation;
   busy: boolean;
+  /** Full-page-width mode: the rail grows to fill the surface and the form
+   *  reflows into a two-column canvas (list hidden until collapsed). */
+  expanded: boolean;
+  onToggleExpanded: () => void;
   onClose: () => void;
   onToggle: (auto: CodexAutomation) => void;
   onSave: (auto: CodexAutomation, patch: CodexAutomationPatch) => void;
@@ -839,6 +853,16 @@ function CodexDetailPanel({
             <Button
               variant="ghost"
               size="xs"
+              onClick={onToggleExpanded}
+              aria-pressed={expanded}
+              aria-label={expanded ? "Collapse to side panel" : "Expand to full width"}
+              title={expanded ? "Collapse to side panel" : "Expand to full width"}
+              className="hidden rounded-[var(--radius-control)] text-[var(--text-muted)] hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)] md:inline-flex"
+              leadingIcon={expanded ? "ph:arrows-in-simple" : "ph:arrows-out-simple"}
+            />
+            <Button
+              variant="ghost"
+              size="xs"
               onClick={onClose}
               aria-label="Close"
               className="rounded-[var(--radius-control)] text-[var(--text-muted)] hover:bg-[color-mix(in_oklch,var(--foreground)_6%,transparent)]"
@@ -848,14 +872,16 @@ function CodexDetailPanel({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-5 py-5 space-y-5">
-        <div className="cron-detail-summary-grid grid grid-cols-2 gap-2">
+      <div className={`flex-1 overflow-y-auto py-5 ${expanded ? "px-6 md:px-8" : "px-5"}`}>
+        <div className={`space-y-5${expanded ? " mx-auto w-full max-w-6xl" : ""}`}>
+        <div className={`cron-detail-summary-grid grid grid-cols-2 gap-2${expanded ? " lg:grid-cols-4" : ""}`}>
           <CronSummaryTile label="Schedule" value={auto.scheduleHuman || nextRrule || "Not scheduled"} tone={invalidSchedule ? "danger" : "default"} />
           <CronSummaryTile label="Status" value={isActive ? "Active" : "Paused"} tone={isActive ? "active" : "paused"} />
           <CronSummaryTile label="Model" value={model.trim() || "Default"} />
           <CronSummaryTile label="Last run" value={latestRunLabel} tone={latestRun?.status === "failed" ? "danger" : "default"} />
         </div>
 
+        <div className={expanded ? "grid items-start gap-5 lg:grid-cols-2" : "space-y-5"}>
         <CronDetailSection title="Identity" description="Name and labels used to recognize this cron in Schedules.">
           <div>
             <FieldLabel htmlFor={`cron-name-${auto.id}`}>Name</FieldLabel>
@@ -923,13 +949,13 @@ function CodexDetailPanel({
                 size="xs"
                 onClick={() => setScheduleMode(mode)}
                 aria-pressed={scheduleMode === mode}
-                className="rounded-[var(--radius-control)] px-2 py-1 text-[11px] capitalize"
+                className="rounded-[var(--radius-control)] px-2 py-1 text-[11px]"
                 style={{
                   background: scheduleMode === mode ? "rgba(255,255,255,0.08)" : "transparent",
                   color: scheduleMode === mode ? "var(--text-primary)" : "var(--text-muted)",
                 }}
               >
-                {mode}
+                {SCHEDULE_MODE_LABEL[mode]}
               </Button>
             ))}
           </div>
@@ -979,9 +1005,20 @@ function CodexDetailPanel({
               />
             </div>
           )}
-          <p className="mt-2 break-all font-mono text-[10px]" style={{ color: invalidSchedule ? "oklch(0.7 0.16 35)" : "var(--text-muted)" }}>
-            {nextRrule || "RRULE required"}
-          </p>
+          {/* Plain-language echo of the chosen cadence for preset modes; the
+              cryptic RRULE line only surfaces in Advanced mode or when the
+              schedule is invalid — beginners never have to read iCalendar. */}
+          {scheduleMode !== "raw" && !invalidSchedule ? (
+            <p className="mt-2 text-[11px]" style={{ color: "var(--text-muted)" }}>
+              {scheduleMode === "daily"
+                ? `Runs every day at ${scheduleTime}`
+                : `Runs weekly on ${scheduleDays.map((d) => RRULE_DAY_LABEL[d]).join(", ")} at ${scheduleTime}`}
+            </p>
+          ) : (
+            <p className="mt-2 break-all font-mono text-[10px]" style={{ color: invalidSchedule ? "oklch(0.7 0.16 35)" : "var(--text-muted)" }}>
+              {nextRrule || "RRULE required"}
+            </p>
+          )}
         </CronDetailSection>
 
         <CronDetailSection title="Runtime" description="Where the cron runs and which model settings it should use.">
@@ -1045,7 +1082,7 @@ function CodexDetailPanel({
         </CronDetailSection>
 
         {runs.length > 0 && (
-          <CronDetailSection title="Recent runs" description="Open a run to inspect its log without leaving this cron.">
+          <CronDetailSection title="Recent runs" description="Open a run to inspect its log without leaving this cron." className={expanded ? "lg:col-span-2" : undefined}>
             <ul className="mt-1 space-y-1">
               {runs.slice(0, 10).map((r) => (
                 <li key={r.id}>
@@ -1084,10 +1121,13 @@ function CodexDetailPanel({
             </ul>
           </CronDetailSection>
         )}
+        </div>
+        </div>
       </div>
 
-      <div className="cron-detail-actions border-t px-5 py-4 space-y-3"
+      <div className="cron-detail-actions border-t px-5 py-4"
         style={{ borderColor: "var(--border-hairline)" }}>
+        <div className={`space-y-3${expanded ? " mx-auto w-full max-w-xl" : ""}`}>
         {saveBlockedReason ? (
           <p className="text-[11px]" style={{ color: "oklch(0.7 0.16 35)" }} role="alert">
             {saveBlockedReason}
@@ -1133,6 +1173,7 @@ function CodexDetailPanel({
           >
             Delete
           </Button>
+        </div>
         </div>
       </div>
     </div>
@@ -2307,6 +2348,12 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   const selectedReminderId = selectedItem?.id ?? null;
   const selectedAutomationId = selectedCodex?.id ?? null;
   const detailOpen = Boolean(selectedItem || selectedCodex);
+  // The cron detail can grow from its side rail into the full page width —
+  // the compact rail stays the default; expanding gives the form room to
+  // breathe (summary tiles go 4-up, sections flow into two columns) and
+  // hides the list until collapsed again. Reminder details keep the rail.
+  const [detailExpanded, setDetailExpanded] = useState(false);
+  const cronDetailExpanded = detailExpanded && Boolean(selectedCodex);
 
   // At-a-glance operational summary for the header: how many automations are
   // live vs paused. Crons fire server-side, so they don't contribute a next-fire
@@ -2338,7 +2385,7 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
     >
     <section className="flex h-full" style={{ background: "var(--bg-base)" }}>
       {/* ── Main list ──────────────────────────────────────────────────────── */}
-      <div className={`${detailOpen ? "hidden md:flex" : "flex"} flex-1 min-w-0 flex-col`}>
+      <div className={`${detailOpen ? (cronDetailExpanded ? "hidden" : "hidden md:flex") : "flex"} flex-1 min-w-0 flex-col`}>
         {/* Compact header: title, tabs, live summary, filter, and actions in
             ONE slim topmost band — mirrors the GitHub surface's
             gh-compact-header so operational surfaces share the same
@@ -2471,7 +2518,14 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
 
       {/* ── Detail panel ───────────────────────────────────────────────────── */}
       {detailOpen && (
-        <div className="w-full min-w-0 shrink-0 overflow-hidden md:w-[380px] md:max-w-[42vw]" style={{ borderLeft: "1px solid var(--border-hairline)" }}>
+        <div
+          className={
+            cronDetailExpanded
+              ? "w-full min-w-0 flex-1 overflow-hidden"
+              : "w-full min-w-0 shrink-0 overflow-hidden md:w-[380px] md:max-w-[42vw]"
+          }
+          style={{ borderLeft: "1px solid var(--border-hairline)" }}
+        >
           {selectedItem && (
             <DetailPanel
               item={selectedItem}
@@ -2490,7 +2544,9 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
             <CodexDetailPanel
               auto={selectedCodex}
               busy={busyId === selectedCodex.id}
-              onClose={() => setSelectedCodex(null)}
+              expanded={cronDetailExpanded}
+              onToggleExpanded={() => setDetailExpanded((v) => !v)}
+              onClose={() => { setSelectedCodex(null); setDetailExpanded(false); }}
               onToggle={toggleCodex}
               onSave={saveCodex}
               onDelete={deleteCodex}


### PR DESCRIPTION
## Objective (operator autopilot)
Make the Cron details panel sleek, intuitive, minimalist, beginner-friendly — and expandable to full page width.

## What changed
- **Expand to full width**: a header toggle (`⤢` / `⤡`, `aria-pressed`, both directions AT-labeled) grows the 380px side rail into the full page — the list hides, summary tiles go 4-up, sections reflow into a two-column canvas (Recent runs spans both) inside a centered `max-w-6xl` container, and the action rail centers beneath. Collapse or close returns to the rail; closing resets the expansion. Reminder details keep the rail.
- **Beginner-friendly schedule**: cadence chips read **Weekly / Daily / Advanced** (was lowercase `raw`), and preset modes echo the cadence in plain language ("Runs weekly on Mon, Tue, Wed, Thu, Fri at 09:00"). The cryptic RRULE string only surfaces in Advanced mode or when the schedule is invalid — beginners never read iCalendar.
- All existing structure preserved: summary grid, named sections, action order, field ids, focus trap, `aria-label="Raw RRULE"`, and the mobile full-width / desktop rail classes.

## Verification
- **Live Playwright drive** (prod build, mocked cron fixture): collapsed rail → expanded full-width canvas → re-collapsed → Advanced mode. Screenshots confirmed all four states render correctly, expansion fills the viewport and round-trips cleanly.
- 12 updated/new pins in `automations-view.test.ts`; `automations-detail-inputs` + `schedules-tabs` untouched and green
- `pnpm test:app` — 572 files pass · `pnpm typecheck` clean · `pnpm build` clean (bundle within budget)

Closes cave-4p6k (beads).