### PR TITLE
fix(settings): On/Off switches match the shared button shape (cave-9yll)

### DIFF
--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -319,4 +319,13 @@ assert.match(source, /connectionError && <span role="alert"/, "the daemon save e
   }
 }
 
+// (cave-9yll, user-requested) The On/Off switches match the shared button
+// shape — every other Settings control is a --radius-control rectangle
+// (.ui-btn), not a pill.
+assert.ok(
+  (source.match(/settings-mobile-switch rounded-\[var\(--radius-control\)\]/g) ?? []).length === 2,
+  "both On/Off switches (News headlines, Mobile mode) use the shared control radius",
+);
+assert.doesNotMatch(source, /settings-mobile-switch rounded-full/, "the pill shape stays gone");
+
 console.log("settings-shell-polish.test.ts OK");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -399,7 +399,7 @@ function HomeNewsToggle() {
         role="switch"
         aria-checked={newsEnabled}
         onClick={() => writeHomeNewsEnabled(!newsEnabled)}
-        className={`settings-mobile-switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+        className={`settings-mobile-switch rounded-[var(--radius-control)] border px-3 py-1.5 text-[12px] transition-colors ${
           newsEnabled
             ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
             : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
@@ -1847,7 +1847,7 @@ function MobileModeToggle() {
           aria-checked={mobileModeEnabled}
           onClick={() => void onMobileModeChange(!mobileModeEnabled)}
           disabled={busy}
-          className={`settings-mobile-switch rounded-full border px-3 py-1.5 text-[12px] transition-colors ${
+          className={`settings-mobile-switch rounded-[var(--radius-control)] border px-3 py-1.5 text-[12px] transition-colors ${
             mobileModeEnabled
               ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-contrast)]"
               : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"


### PR DESCRIPTION
## Summary

User-requested (bead `cave-9yll`): the Settings → General → **News headlines** On/Off button rendered as a `rounded-full` pill, while every other Settings control uses the shared Button's `--radius-control` rectangle (`.ui-btn`, 8px). Its twin — the Mobile-mode On/Off, built from the identical `settings-mobile-switch` pattern — had the same pill, so both are aligned in one pass to avoid creating a new inconsistency between the two switches.

One class change per site: `rounded-full` → `rounded-[var(--radius-control)]`. Switch semantics (`role=switch`/`aria-checked`), sizing, and the accent on/off styling are untouched.

**Verified in the running app** (prod build + Playwright): the switch computes `border-radius: 8px` — exactly the `.ui-btn` token — and the screenshot shows the reshaped button in place on the General section.

## Test plan

- [x] Pins: both switch sites use the control radius; `rounded-full` stays gone; existing touch-target + className pins still hold
- [x] Full `pnpm test:app` (572 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)