### PR TITLE
fix(chat): Review jump-to-diff applies once — stale focus stopped clobbering the selected diff (cave-bvbw)

### DIFF
--- a/src/components/comux-view-changes.test.ts
+++ b/src/components/comux-view-changes.test.ts
@@ -19,10 +19,12 @@ assert.match(
 // matching file's diff (repo-relative or suffix match) when a transcript edit
 // tool is clicked.
 assert.match(changes, /focusPath\?: string \| null;/, "SessionChangesInner takes a focusPath prop");
+// cave-bvbw moved the raw endsWith pair to a /-boundary suffix helper so
+// sibling files with a common string suffix can't cross-match.
 assert.match(
   changes,
-  /focusPath\.endsWith\(f\.path\) \|\| f\.path\.endsWith\(focusPath\)/,
-  "focusPath matches repo-relative or absolute paths by suffix",
+  /suffixMatch\(focusPath, f\.path\) \|\| suffixMatch\(f\.path, focusPath\)/,
+  "focusPath matches repo-relative or absolute paths by /-boundary suffix",
 );
 
 // comux imports it and renders it for the SELECTED project (not the active

--- a/src/components/session-changes-panel.test.ts
+++ b/src/components/session-changes-panel.test.ts
@@ -88,4 +88,25 @@ assert.match(
   "Refresh stays a raw button to keep its inner-glyph spin",
 );
 
+// cave-bvbw: the jump-to-diff focus must apply each nonce exactly once. The
+// effect is (deliberately) keyed on filesSig so a late-appearing file still
+// gets focused — but filesSig churns on every 5s poll while an agent edits,
+// and an unguarded effect re-expanded the stale focus target on every refresh,
+// snapping the panel away from the diff the user had manually selected.
+assert.match(
+  src,
+  /appliedFocusNonceRef\.current === focusNonce\) return;/,
+  "a consumed focus nonce must not re-assert itself on poll refreshes",
+);
+assert.match(
+  src,
+  /if \(!match\) return;\s*\n\s*appliedFocusNonceRef\.current = focusNonce;/,
+  "the nonce is consumed only once a match lands (retry stays alive for late-appearing files)",
+);
+assert.match(
+  src,
+  /long === short \|\| long\.endsWith\(`\/\$\{short\}`\)/,
+  "focus matching aligns on / boundaries — bare string suffixes cross-match sibling files",
+);
+
 console.log("session-changes-panel.test.ts: cave-4op footer + icon-button control primitives ok");

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -580,14 +580,24 @@ export function SessionChangesInner({
 
   // Jump-to-diff: when a transcript edit tool is clicked, expand that file's
   // diff. The changes list is repo-relative while focusPath may be absolute (or
-  // vice versa), so match on exact path or suffix. Keyed on focusNonce + the
-  // file list so it retries once the just-edited file appears in the diff list.
+  // vice versa), so match on exact path or a /-boundary suffix (a bare string
+  // suffix would let `utils/foo.ts` match a sibling `s/foo.ts`). Keyed on
+  // focusNonce + the file list so it retries once the just-edited file appears
+  // in the diff list — but each nonce applies exactly ONCE: filesSig churns on
+  // every 5s poll while an agent is editing (+/- counts change), and without
+  // the consumed guard the stale focus re-expanded its file on every refresh,
+  // snapping the panel away from whichever diff the user had selected.
+  const appliedFocusNonceRef = useRef<number | undefined>(undefined);
   useEffect(() => {
-    if (!focusPath) return;
+    if (!focusPath || focusNonce === undefined) return;
+    if (appliedFocusNonceRef.current === focusNonce) return;
+    const suffixMatch = (long: string, short: string) =>
+      long === short || long.endsWith(`/${short}`);
     const match = files.find(
-      (f) => f.path === focusPath || focusPath.endsWith(f.path) || f.path.endsWith(focusPath),
+      (f) => suffixMatch(focusPath, f.path) || suffixMatch(f.path, focusPath),
     );
     if (!match) return;
+    appliedFocusNonceRef.current = focusNonce;
     setExpandedPath(match.path);
     if (!diffs[match.path]) void fetchDiff(match.path);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Problem

Report: the chat edit cards' **Review** buttons "only show one of the options, not the one selected" — the Changes panel keeps displaying one file's diff no matter which file you pick.

Root cause: the panel's jump-to-diff effect is deliberately keyed on `filesSig` so a just-edited file gets focused once it appears in the changes list — but `filesSig` embeds per-file +/- counts and the panel polls `/api/changes` every 5s. While an agent is actively editing, every poll refresh changed `filesSig`, re-ran the effect, and re-expanded the **stale** Review target — snapping the panel away from whichever diff the user had manually expanded.

## Fix

- Each focus nonce applies **exactly once**: consumed on first successful match, so poll refreshes can't re-assert it. The retry-until-match behavior for late-appearing files is preserved (the nonce isn't consumed until a match lands).
- Suffix matching now aligns on `/` boundaries (`long === short || long.endsWith("/" + short)`) — a bare string suffix let `utils/foo.ts` cross-match a sibling `s/foo.ts`.

Pinned in `session-changes-panel.test.ts` (consumed-nonce guard, retry-alive ordering, boundary matching).

## Validation

Panel pins + typecheck green; full app suite running (posted before merge).

Bead: cave-bvbw

🤖 Generated with [Claude Code](https://claude.com/claude-code)