### PR TITLE
fix(marketplace): clear the install/uninstall error banner on a fresh attempt (cave-owvm)

### DIFF
--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -329,6 +329,8 @@ export function MarketplaceViewSurface({
   const add = useCallback(async (id: string) => {
     markBusy(id, true);
     setInstalled(id, true);
+    setError(null); // a fresh attempt clears any prior failure banner (it's only
+                    // set on error and was otherwise never cleared without a reload)
     try {
       const res = await fetch("/api/marketplace/install", {
         method: "POST",
@@ -351,6 +353,7 @@ export function MarketplaceViewSurface({
   const remove = useCallback(async (id: string) => {
     markBusy(id, true);
     setInstalled(id, false);
+    setError(null); // clear any prior failure banner on a fresh attempt
     try {
       const res = await fetch("/api/marketplace/uninstall", {
         method: "POST",

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -296,4 +296,18 @@ assert.match(marketplaceView, /announce\("Removed from your setup", "polite"\)/,
 // with the section.)
 assert.match(marketplaceView, /announce\(msg, "assertive"\)/, "a failed hub action is announced assertively");
 
+// cave-owvm: install/uninstall clear any prior error banner on a fresh attempt —
+// `error` was only ever set on failure and otherwise never cleared without a
+// reload, so a stale "install failed" alert used to persist across Browse.
+assert.match(
+  marketplaceView,
+  /const add = useCallback\(async[\s\S]*?markBusy\(id, true\);[\s\S]*?setError\(null\);/,
+  "add() clears the error banner on a fresh install attempt",
+);
+assert.match(
+  marketplaceView,
+  /const remove = useCallback\(async[\s\S]*?markBusy\(id, true\);[\s\S]*?setError\(null\);/,
+  "remove() clears the error banner on a fresh uninstall attempt",
+);
+
 console.log("roles-tools-navigation.test.ts OK");


### PR DESCRIPTION
## What

`add()` and `remove()` set `error` on failure but **nothing cleared it on a later success** — the only `setError(null)` lived in `load()`, and neither handler reloads. So a failed install (offline / daemon down) left a red `role="alert"` banner that **persisted across the whole Browse panel** even after the user successfully added/removed another plugin or fixed connectivity and re-added — a stale, now-false error until the catalog happened to reload.

## Fix

Clear the error on the **optimistic path** of both handlers (right after `markBusy(id, true)`), so a fresh attempt always drops the previous failure.

Found by the Marketplace-surface audit — pure data-flow (no layout, safe next to the responsive pass). Pinned in `roles-tools-navigation.test.ts`.

## Verification

`typecheck` · **572** app test files · `build` within budget.

> The audit's other (LOW) findings — config-modal abort guard + scalar `busyKey` — are filed as cave-4kl7. Most marketplace dimensions were verified clean (busyIds Set, abort guards, reconcile, memoization, announcements, dialog focus-traps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)