### PR TITLE
chore(release): stamp v0.0.155

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.155] - 2026-07-08
+
+> 🔍 **Review means the one you picked** — a chat edit card's Review no longer keeps snapping the Changes panel back to its own file while an agent is mid-edit; whichever diff you expand stays expanded. Plus a roomier reading measure and a friendlier crons detail panel.
+
+Patch release on top of v0.0.154.
+
+### Fixes
+- **Chat: Review jump-to-diff applies exactly once** (#2742, cave-bvbw). The Changes panel's focus effect re-asserted the original Review target on every 5-second poll while an agent was editing, clobbering whichever diff you had manually selected. Each Review click now consumes its focus once (still retrying until a just-edited file appears in the list), and path matching aligns on `/` boundaries so look-alike filenames can't cross-match.
+
+### Features
+- **Crons: sleek beginner-friendly detail panel**, expandable to full page width (#2740, cave-4p6k).
+- **Chat: the shared reading/composer measure widens one step** (46rem → 52rem) for roomier transcripts (#2739, cave-cy8o).
+
 ## [0.0.154] - 2026-07-08
 
 > ⚗️ **One family of controls** — the composer's runtime chip lands everywhere (logo + model, one-click switching, now on Home too) and every icon button rounds up to match it. The daemon's control-plane catalog gets a proxy route, the projects hub takes five upgrades, and an a11y sweep makes bells, schedules, calendars, and pickers honest to assistive tech.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.154",
+  "version": "0.0.155",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.154"
+version = "0.0.155"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.154"
+version = "0.0.155"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.154</string>
+	<string>0.0.155</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.154</string>
+	<string>0.0.155</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.154</string>
+	<string>0.0.155</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.154</string>
+	<string>0.0.155</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.154",
+  "version": "0.0.155",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.154. Bumps all six version locations and adds the v0.0.155 CHANGELOG entry for the 3 commits since v0.0.154 — the **chat Review jump-to-diff clobber fix** (#2742, cave-bvbw), the wider shared reading/composer measure (#2739), and the crons detail panel (#2740).

Local gate: `cargo check --locked` ✓ (compiles `app v0.0.155`) · typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.155` on the squash commit → release.yml builds → verification via `node scripts/verify-release-updater.mjs`.

Bead: cave-61kr

🤖 Generated with [Claude Code](https://claude.com/claude-code)