### PR TITLE
fix(calendar): week view falls back to day rendering in narrow split panes (cave-87zv)

### DIFF
--- a/src/components/calendar-actions.test.ts
+++ b/src/components/calendar-actions.test.ts
@@ -170,4 +170,15 @@ assert.ok((view.match(/\{familiarName && <span className="sr-only">, \{familiarN
 assert.match(view, /task deadline\$\{done \? ", done" : ""\}\$\{familiarName \? `, \$\{familiarName\}` : ""\}/, "deadline chips name their familiar");
 assert.match(view, /\$\{done \? ", done" : ""\}\$\{familiarName \? `, \$\{familiarName\}` : ""\}`\}\n\s*title=\{`\$\{familiarName \? `\$\{ev\.item\.title\} — \$\{familiarName\}` : ev\.item\.title\}/, "grid events name their familiar in label + tooltip");
 
+// ── Narrow split panes (cave-87zv) ───────────────────────────────────────────
+// Week view needs ~7 usable columns; below 560px of container width it falls
+// back to the DAY presentation without clobbering the user's stored week
+// choice. Everything presentation-driven (render switch, heading, navigate
+// step, announcements) reads effectiveView; the toggle keeps viewMode.
+assert.match(view, /const effectiveView: ViewMode = viewMode === "week" && narrowPane \? "day" : viewMode/, "week falls back to day rendering in narrow panes");
+assert.match(view, /setNarrowPane\(w > 0 && w < 560\)/, "the fallback keys on container width, not viewport");
+assert.match(view, /\{effectiveView === "week" && \(/, "the render switch reads the effective view");
+assert.match(view, /if \(effectiveView === "week"\) return addDays\(prev, dir \* 7\)/, "navigate steps by the VISIBLE unit");
+assert.match(view, /aria-pressed=\{viewMode === id\}/, "the view toggle still reflects the user's stored choice");
+
 console.log("calendar-actions.test.ts: ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -1543,6 +1543,22 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   const [selectedItem, setSelectedItem] = useState<InboxItem | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
+  // Week view needs ~7 usable columns; inside a narrow split tile (~360px)
+  // they floor at ~40px each. Below 560px of CONTAINER width, week renders
+  // with the day presentation instead — the user's stored week choice is
+  // untouched and returns the moment the pane widens (cave-87zv).
+  const [narrowPane, setNarrowPane] = useState(false);
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? el.clientWidth;
+      setNarrowPane(w > 0 && w < 560);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const effectiveView: ViewMode = viewMode === "week" && narrowPane ? "day" : viewMode;
 
   // Keep the open event detail panel in sync with live updates. `selectedItem`
   // is a snapshot captured at click; without this, an SSE update/delete (or a
@@ -1674,13 +1690,15 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
     return () => window.removeEventListener("keydown", handler);
     // re-bind when viewMode/anchor changes so navigate() and the new-entry
     // shortcut close over the current values.
-  }, [viewMode, anchor, onAddEntry]);
+    // effectiveView folds in narrowPane, so the handlers re-bind when the
+    // week→day fallback engages and navigate() steps by the visible unit.
+  }, [effectiveView, anchor, onAddEntry]);
 
   function navigate(dir: -1 | 1) {
     setAnchor((prev) => {
-      if (viewMode === "day") return addDays(prev, dir);
-      if (viewMode === "week") return addDays(prev, dir * 7);
-      if (viewMode === "month") {
+      if (effectiveView === "day") return addDays(prev, dir);
+      if (effectiveView === "week") return addDays(prev, dir * 7);
+      if (effectiveView === "month") {
         const d = new Date(prev);
         d.setMonth(d.getMonth() + dir);
         return d;
@@ -1691,8 +1709,8 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   }
 
   function headingLabel(): string {
-    if (viewMode === "day") return fmtDateHeading(anchor);
-    if (viewMode === "week") {
+    if (effectiveView === "day") return fmtDateHeading(anchor);
+    if (effectiveView === "week") {
       const ws = startOfWeek(anchor);
       const we = addDays(ws, 6);
       if (ws.getMonth() === we.getMonth()) {
@@ -1700,7 +1718,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
       }
       return `${MONTHS[ws.getMonth()]} ${ws.getDate()} – ${MONTHS[we.getMonth()]} ${we.getDate()}, ${ws.getFullYear()}`;
     }
-    if (viewMode === "month") {
+    if (effectiveView === "month") {
       return `${MONTHS[anchor.getMonth()]} ${anchor.getFullYear()}`;
     }
     return "Upcoming";
@@ -1719,11 +1737,11 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
   const announcedRef = useRef(false);
   useEffect(() => {
     if (!announcedRef.current) { announcedRef.current = true; return; }
-    const label = VIEW_MODES.find((v) => v.id === viewMode)?.label ?? "";
+    const label = VIEW_MODES.find((v) => v.id === effectiveView)?.label ?? "";
     announce(`${label} view, ${headingLabel()}`);
     // headingLabel() reads viewMode + anchor; re-announce whenever either moves.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [viewMode, anchor, announce]);
+  }, [effectiveView, anchor, announce]);
 
   return (
     <FamiliarColorContext.Provider value={accentFor}>
@@ -1830,7 +1848,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
 
       {/* View body */}
       <div className="flex-1 overflow-hidden flex flex-col">
-        {viewMode === "agenda" && (
+        {effectiveView === "agenda" && (
           <AgendaView
             items={scopedItems}
             deadlines={scopedDeadlines}
@@ -1840,7 +1858,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
             onOpenDeadline={onOpenDeadline}
           />
         )}
-        {viewMode === "day" && (
+        {effectiveView === "day" && (
           <DayView
             items={scopedItems}
             deadlines={scopedDeadlines}
@@ -1851,7 +1869,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
             onOpenDeadline={onOpenDeadline}
           />
         )}
-        {viewMode === "week" && (
+        {effectiveView === "week" && (
           <WeekView
             items={scopedItems}
             deadlines={scopedDeadlines}
@@ -1863,7 +1881,7 @@ export function CalendarView({ items, familiars, activeFamiliarId, scopeFamiliar
             onOpenDay={goToDay}
           />
         )}
-        {viewMode === "month" && (
+        {effectiveView === "month" && (
           <MonthView
             items={scopedItems}
             deadlines={scopedDeadlines}


### PR DESCRIPTION
## Summary

Bead `cave-87zv` (split from the cave-hivd split-view fit pass). Inside a ~360px split tile, the week grid floors its 7 day columns at ~40px each — scrollable since the fit pass, but unreadable. Since the calendar's view state is React (not CSS), a container query alone can't switch presentations; this adds the observer the bead asked for:

- A `ResizeObserver` on the calendar container derives `narrowPane` (**container** width < 560px — a narrow split tile triggers it even on a wide window; a full-width calendar on a small window behaves as before).
- `effectiveView` folds the fallback in: `week && narrowPane → day`. Everything presentation-driven reads it — the render switch, `headingLabel` (single-day heading while collapsed), `navigate()` (steps ±1 day while showing a day, not ±7), and the view announcements. The affected effects re-bind on `effectiveView`, so the keyboard nav flips units the moment the pane crosses the threshold.
- **The user's stored choice is never clobbered:** `viewMode` stays "week", the toggle still shows Week pressed, and the full grid returns as soon as the pane widens.

## Test plan

- [x] New pins: the fallback derivation, container-width keying, effective-view render switch, visible-unit navigation, toggle-keeps-user-choice
- [x] All calendar tests (incl. the month-grid e2e-pinned invariants) + full `pnpm test:app` (572 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)