### PR TITLE
fix(marketplace): abort superseded config loads + track saving fields as a Set (cave-4kl7)

### DIFF
--- a/src/components/marketplace/marketplace-configure.tsx
+++ b/src/components/marketplace/marketplace-configure.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -34,17 +34,37 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
   const [fields, setFields] = useState<FieldStatus[]>([]);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [loaded, setLoaded] = useState(false);
-  const [busyKey, setBusyKey] = useState<string | null>(null);
+  // A Set (not a scalar) of the fields currently saving — concurrent saves of
+  // two fields must each keep their own spinner rather than one clearing the
+  // other (mirrors the parent's busyIds).
+  const [busyKeys, setBusyKeys] = useState<Set<string>>(new Set());
+  const setKeyBusy = useCallback((key: string, busy: boolean) => {
+    setBusyKeys((prev) => {
+      const next = new Set(prev);
+      if (busy) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+  }, []);
   type ValidationResult = { state: "idle" | "testing" | "valid" | "invalid"; message?: string };
   const [results, setResults] = useState<Record<string, ValidationResult>>({});
   const [error, setError] = useState<string | null>(null);
   const { announce } = useAnnouncer();
 
+  // Abort a prior in-flight config load before a new one (or on unmount). The
+  // dialog stays mounted between opens, so without this a slow load resolving
+  // after a close/reopen — or after a Save-triggered reload — clobbers the
+  // freshly-seeded fields with the previous plugin's data.
+  const loadCtlRef = useRef<AbortController | null>(null);
   const load = useCallback(async (seedDefaults = false) => {
+    loadCtlRef.current?.abort();
+    const ctl = new AbortController();
+    loadCtlRef.current = ctl;
     setLoaded(false);
     try {
-      const res = await fetch(`/api/marketplace/config?id=${encodeURIComponent(pluginId)}`, { cache: "no-store" });
+      const res = await fetch(`/api/marketplace/config?id=${encodeURIComponent(pluginId)}`, { cache: "no-store", signal: ctl.signal });
       const json = (await res.json()) as { ok?: boolean; fields?: FieldStatus[]; error?: string };
+      if (ctl.signal.aborted) return;
       if (!json.ok) throw new Error(json.error ?? `config http ${res.status}`);
       const nextFields = json.fields ?? [];
       setFields(nextFields);
@@ -58,12 +78,14 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
       }
       setError(null);
     } catch (err) {
+      if (ctl.signal.aborted) return; // superseded by a newer load — ignore
       setFields([]);
       setError(err instanceof Error ? err.message : "config unavailable");
     } finally {
-      setLoaded(true);
+      if (!ctl.signal.aborted) setLoaded(true);
     }
   }, [pluginId]);
+  useEffect(() => () => loadCtlRef.current?.abort(), []);
 
   useEffect(() => {
     if (open) {
@@ -104,7 +126,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
   const save = useCallback(async (field: FieldStatus) => {
     const draft = (drafts[field.key] ?? "").trim();
     if (!draft) return;
-    setBusyKey(field.key);
+    setKeyBusy(field.key, true);
     setError(null);
     try {
       const sensitiveBody = draft.startsWith("op://")
@@ -133,9 +155,9 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
       setError(msg);
       announce(msg, "assertive");
     } finally {
-      setBusyKey(null);
+      setKeyBusy(field.key, false);
     }
-  }, [drafts, pluginId, load, onChanged, validate, announce]);
+  }, [drafts, pluginId, load, onChanged, validate, announce, setKeyBusy]);
 
   return (
     <Modal
@@ -187,7 +209,7 @@ export function MarketplaceConfigure({ pluginId, displayName, open, onClose, onC
                 <Button
                   variant="primary"
                   size="sm"
-                  loading={busyKey === f.key}
+                  loading={busyKeys.has(f.key)}
                   onClick={() => void save(f)}
                 >
                   Save

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -9,6 +9,7 @@ const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url)
 const marketplaceView = await readFile(new URL("./marketplace-view.tsx", import.meta.url), "utf8");
 const marketplaceCard = await readFile(new URL("./marketplace/marketplace-card.tsx", import.meta.url), "utf8");
 const marketplaceDetail = await readFile(new URL("./marketplace/marketplace-detail.tsx", import.meta.url), "utf8");
+const marketplaceConfigure = await readFile(new URL("./marketplace/marketplace-configure.tsx", import.meta.url), "utf8");
 const css = await readFile(new URL("../app/globals.css", import.meta.url), "utf8");
 const rolesRoute = await readFile(new URL("../app/api/roles/route.ts", import.meta.url), "utf8");
 const workspaceMode = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
@@ -309,5 +310,16 @@ assert.match(
   /const remove = useCallback\(async[\s\S]*?markBusy\(id, true\);[\s\S]*?setError\(null\);/,
   "remove() clears the error banner on a fresh uninstall attempt",
 );
+
+// cave-4kl7: the configure modal aborts a superseded config load (the dialog
+// stays mounted between opens, so a late load must not clobber freshly-seeded
+// fields), and tracks in-flight saves as a Set so concurrent field saves keep
+// their own spinner rather than one clearing the other.
+assert.match(marketplaceConfigure, /const loadCtlRef = useRef<AbortController \| null>\(null\)/, "config load has an abort controller");
+assert.match(marketplaceConfigure, /loadCtlRef\.current\?\.abort\(\);[\s\S]*?new AbortController\(\)/, "each load aborts the prior one");
+assert.match(marketplaceConfigure, /if \(ctl\.signal\.aborted\) return/, "a superseded load response is dropped");
+assert.match(marketplaceConfigure, /useEffect\(\(\) => \(\) => loadCtlRef\.current\?\.abort\(\), \[\]\)/, "the in-flight load aborts on unmount");
+assert.match(marketplaceConfigure, /const \[busyKeys, setBusyKeys\] = useState<Set<string>>/, "saving fields are tracked as a Set, not a scalar");
+assert.match(marketplaceConfigure, /loading=\{busyKeys\.has\(f\.key\)\}/, "each field's spinner keys off its own membership in the busy Set");
 
 console.log("roles-tools-navigation.test.ts OK");


### PR DESCRIPTION
## What

Two data-flow fixes in the configure modal (which stays mounted between opens), from the Marketplace-surface audit (worst finding shipped in #2744):

- **`load()` had no abort guard** — a slow `/api/marketplace/config` response resolving after a close/reopen (or after a Save-triggered reload) clobbered the freshly-seeded fields with the prior plugin's data. Add an AbortController-per-call (abort the prior + on unmount) and drop superseded responses, mirroring the parent's `loadCtl` pattern.
- **`busyKey` was a scalar** — saving field A then B before A resolved moved the spinner off A and the first `finally` cleared both. Track in-flight saves as a `Set<string>` (like the parent's `busyIds`) so each field keeps its own spinner.

Pure data-flow — no layout (safe next to the responsive pass). Pinned in `roles-tools-navigation.test.ts`.

## Verification

`typecheck` · **572** app test files · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)