### PR TITLE
fix(models): retire the GPT-5.1 generation from the codex model menu

### DIFF
--- a/src/lib/context-meter.ts
+++ b/src/lib/context-meter.ts
@@ -28,8 +28,13 @@ export const DEFAULT_CONTEXT_WINDOW_TOKENS = 200_000;
  * rather than relying on the fallback.
  */
 export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
-  // OpenAI (codex runtime) — estimate; adjust when authoritative.
+  // OpenAI (codex runtime) — estimate; adjust when authoritative. The retired
+  // GPT-5.1 ids stay listed so the meter keeps working for older sessions and
+  // custom configs that still name them.
   "openai/gpt-5.5": 400_000,
+  "openai/gpt-5.4": 400_000,
+  "openai/gpt-5.4-mini": 400_000,
+  "openai/gpt-5.3-codex-spark": 400_000,
   "openai/gpt-5.1-codex-max": 400_000,
   "openai/gpt-5.1-codex": 400_000,
   "openai/gpt-5.1-codex-mini": 400_000,

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -34,8 +34,20 @@ assert.ok(
 );
 assert.ok(catalogForRuntime("codex").models.length > 1, "codex should seed a multi-model menu, not just the default");
 assert.ok(
-  catalogForRuntime("codex").models.some((m) => m.id === "openai/gpt-5.1-codex"),
-  "codex catalog should seed GPT-5.1 Codex",
+  catalogForRuntime("codex").models.some((m) => m.id === "openai/gpt-5.4"),
+  "codex catalog should seed GPT-5.4",
+);
+assert.ok(
+  catalogForRuntime("codex").models.some((m) => m.id === "openai/gpt-5.4-mini"),
+  "codex catalog should seed GPT-5.4 Mini",
+);
+assert.ok(
+  catalogForRuntime("codex").models.some((m) => m.id === "openai/gpt-5.3-codex-spark"),
+  "codex catalog should seed GPT-5.3 Codex Spark",
+);
+assert.ok(
+  !catalogForRuntime("codex").models.some((m) => m.id.includes("gpt-5.1")),
+  "the retired GPT-5.1 generation must not reappear in the codex menu",
 );
 assert.equal(
   catalogForRuntime("codex").models[0].id,

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -34,10 +34,9 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     provider: "openai",
     models: [
       { id: "openai/gpt-5.5", label: "GPT-5.5" },
-      { id: "openai/gpt-5.1-codex-max", label: "GPT-5.1 Codex Max" },
-      { id: "openai/gpt-5.1-codex", label: "GPT-5.1 Codex" },
-      { id: "openai/gpt-5.1-codex-mini", label: "GPT-5.1 Codex Mini" },
-      { id: "openai/gpt-5.1", label: "GPT-5.1" },
+      { id: "openai/gpt-5.4", label: "GPT-5.4" },
+      { id: "openai/gpt-5.4-mini", label: "GPT-5.4 Mini" },
+      { id: "openai/gpt-5.3-codex-spark", label: "GPT-5.3 Codex Spark" },
     ],
     allowCustom: true,
   },


### PR DESCRIPTION
## Problem
The codex runtime model catalog (`runtime-models.ts`) still seeded the GPT-5.1 generation (Codex Max / Codex / Codex Mini / 5.1) — a generation behind what the live harness selector shows.

## Fix
- Codex menu now offers **GPT-5.5** (first — stays the pinned default), **GPT-5.4**, **GPT-5.4 Mini**, **GPT-5.3 Codex Spark**; `allowCustom` still covers anything unlisted.
- Regression pin: the retired `gpt-5.1` ids must not reappear in the menu.
- `context-meter` gains window entries for the new ids and **keeps** the 5.1 entries (the meter is a lookup, not a menu — older sessions/custom configs may still reference them).

## Verification
- `runtime-models` + `context-meter` unit tests green · `pnpm test:app` — 568 files pass · `pnpm typecheck` clean

Requested by @BunsDev (screenshot of the current-generation selector).