### PR TITLE
style(composer): runtime + host chips take the shared control radius, not a pill

### DIFF
--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -17,11 +17,12 @@
   font-family: inherit;
   line-height: 1;
   cursor: pointer;
-  border: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
-  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  /* Shape matches the composer's control family (.cave-composer-select and
+     the icon buttons) — the shared control radius, not a pill. */
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
-  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 .cave-composer-host-chip:disabled { opacity: 0.5; cursor: default; }
 .cave-composer-host-chip svg { flex-shrink: 0; color: var(--accent-presence); }

--- a/src/styles/composer-runtime-chip.css
+++ b/src/styles/composer-runtime-chip.css
@@ -17,11 +17,12 @@
   font-family: inherit;
   line-height: 1;
   cursor: pointer;
-  border: 1px solid color-mix(in oklch, var(--foreground) 10%, transparent);
-  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  /* Shape matches the composer's control family (.cave-composer-select and
+     the icon buttons) — the shared control radius, not a pill. */
+  border-radius: var(--radius-control);
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
-  box-shadow: inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 .cave-composer-runtime-chip:disabled { opacity: 0.5; cursor: default; }
 .cave-composer-runtime-chip:hover:not(:disabled) {


### PR DESCRIPTION
The model-selection runtime chip (`GPT-5.5 ⌄`) and its sibling host chip rendered as 999px pills with an inset shine, while every neighboring composer control — `.cave-composer-select` and the attach/options icon buttons — sits on `var(--radius-control)` with the hairline border. Both chips' own CSS comments claim they mirror `.cave-composer-select`; the radius had drifted.

Both chips now use `border-radius: var(--radius-control)` (so they also track the user's corner-radius setting), `border: 1px solid var(--border-hairline)`, and drop the inset box-shadow. Heights stay 30px, matching the select family.

Verified live: computed radius 8px at rest beside the icon buttons, screenshot reviewed. `composer-runtime-chip`, `chat-view-polish`, and `composer-density` tests pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)