### PR TITLE
fix(capabilities): cancel superseded loads so a slow refresh can't win (cave-yg1x)

### DIFF
--- a/src/components/capabilities-view.test.ts
+++ b/src/components/capabilities-view.test.ts
@@ -47,4 +47,14 @@ assert.match(source, /filename === AUTOMATION_PREVIEW_FILE_NAME/, "preview gate 
 assert.match(source, /json\.path \?\? previewPath/, "preview state should preserve the server-resolved markdown file path");
 assert.match(source, /Markdown preview/, "capability file previews should be explicitly labelled as markdown previews");
 
+// cave-yg1x: the (slow, daemon-fanning) capabilities load is cancellable — a
+// newer refresh aborts the prior one and a superseded/aborted response is dropped
+// before any setState, so an out-of-order resolution can't leave a stale map, and
+// unmount during a refresh doesn't setState on a dead component.
+assert.match(source, /const loadCtlRef = useRef<AbortController \| null>\(null\)/, "load holds an abort controller");
+assert.match(source, /loadCtlRef\.current\?\.abort\(\);\s*\n\s*const ctl = new AbortController\(\)/, "each load aborts the prior one");
+assert.match(source, /fetch\(url, \{ cache: "no-store", signal: ctl\.signal \}\)/, "the load fetch is wired to the abort signal");
+assert.match(source, /if \(ctl\.signal\.aborted\) return;/, "a superseded load response is dropped before setState");
+assert.match(source, /void load\(false\);\s*\n\s*return \(\) => loadCtlRef\.current\?\.abort\(\)/, "the in-flight load aborts on unmount");
+
 console.log("capabilities-view.test.ts: ok");

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -224,13 +224,23 @@ export function CapabilitiesViewSurface({
     error: null,
   });
 
+  // A refresh (?refresh=1) fans out to the daemon + a disk skill scan — slow and
+  // variable — so two loads can resolve out of order. Without cancellation the
+  // LAST-to-resolve wins the setState (which may be the OLDER request), leaving a
+  // stale map + stale "Scanned N ago". Abort the prior load on each new one, drop
+  // a superseded/aborted response before any setState, and abort on unmount.
+  const loadCtlRef = useRef<AbortController | null>(null);
   const load = useCallback(async (refresh = false) => {
+    loadCtlRef.current?.abort();
+    const ctl = new AbortController();
+    loadCtlRef.current = ctl;
     setRefreshing(refresh);
     if (!refresh) setLoaded(false);
     try {
       const url = refresh ? "/api/capabilities?refresh=1" : "/api/capabilities";
-      const res = await fetch(url, { cache: "no-store" });
+      const res = await fetch(url, { cache: "no-store", signal: ctl.signal });
       const json = (await res.json()) as CapabilitiesResponse;
+      if (ctl.signal.aborted) return;
       if (!json.ok) {
         setError(json.error ?? "Couldn't reach the Coven daemon.");
         setItems([]);
@@ -243,18 +253,22 @@ export function CapabilitiesViewSurface({
         setScannedAt(json.scanned_at ?? null);
       }
     } catch (err) {
+      if (ctl.signal.aborted) return; // superseded by a newer load — ignore
       setError(err instanceof Error ? err.message : "fetch failed");
       setItems([]);
       setCovenSkills([]);
       setScannedAt(null);
     } finally {
-      setLoaded(true);
-      setRefreshing(false);
+      if (!ctl.signal.aborted) {
+        setLoaded(true);
+        setRefreshing(false);
+      }
     }
   }, []);
 
   useEffect(() => {
     void load(false);
+    return () => loadCtlRef.current?.abort();
   }, [load]);
 
   // "/" jumps to the search (GitHub-style) while this surface is shown, unless


### PR DESCRIPTION
## What

`load()` fetched `/api/capabilities` with **no cancellation of any kind** — no AbortController, no `cancelled` flag, no request token. A refresh (`?refresh=1`) fans out to the daemon plus a disk skill scan (slow, variable), so two loads (e.g. the mount load still in flight when the user hits ⌘R) race and the **last-to-resolve wins** the `setState` — which can be the **older** request, leaving a stale map + stale "Scanned N ago". And navigating away mid-refresh fired `setState` on an **unmounted** component (the mount effect returned no cleanup).

## Fix

Give `load()` an `AbortController`: abort the prior on each new call, wire the fetch to the signal, drop a superseded/aborted response before any `setState` (including the `finally`'s loaded/refreshing flips), and abort in the mount-effect cleanup. Mirrors the abort pattern used across the other data surfaces.

Found by the Capabilities-surface audit — pure data-flow (no layout, safe next to the responsive pass). Pinned in `capabilities-view.test.ts`.

## Verification

`typecheck` · **568** app test files · `build` within budget.

> The audit's a11y follow-up (no `useAnnouncer` for refresh/copy) is filed as cave-vmj8. Most dimensions verified clean: memoization correct, no keystroke refetch, preview modal is a proper dialog, no tablist anti-pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)