### PR TITLE
a11y(capabilities): announce refresh lifecycle and copy outcomes (cave-vmj8)

### DIFF
--- a/src/components/capabilities-view-polish.test.ts
+++ b/src/components/capabilities-view-polish.test.ts
@@ -196,4 +196,13 @@ assert.match(source, /Show more|Show less/, "clamp exposes a Show more/Show less
 assert.match(source, /<InspectorMetaItem label="Detail" value=\{item\.description\}/, "the Detail metadata field is collapsed into the inline meta row");
 assert.match(source, /<InspectorMetaItem label="Warning" value=\{item\.warningMessage\} tone="warning"/, "Warning metadata stays collapsed but keeps warning tone");
 
+// ── Announcements (cave-vmj8) ────────────────────────────────────────────────
+// Refresh and copy were visual-only — spinner, "Scanned N ago", and the
+// copied-check flash said nothing to screen readers.
+assert.match(source, /const \{ announce \} = useAnnouncer\(\)/, "the surface uses the shared announcer");
+assert.match(source, /if \(refresh\) announce\("Refreshing capabilities…"\)/, "user-triggered refresh announces start (mount load stays quiet)");
+assert.match(source, /announce\(`Capabilities refreshed — \$\{harness\.length \+ skills\.length\} items\.`\)/, "refresh success announces the item count");
+assert.match(source, /announce\(`Capabilities refresh failed: \$\{msg\}`, "assertive"\)/, "refresh failures announce assertively");
+assert.match(source, /announce\(`Copied \$\{key\}\.`\)/, "copy success is announced");
+
 console.log("capabilities-view-polish.test.ts OK");

--- a/src/components/capabilities-view.tsx
+++ b/src/components/capabilities-view.tsx
@@ -11,6 +11,7 @@ import { copyText } from "@/lib/clipboard";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { MarkdownBlock } from "@/components/message-bubble";
 // Hidden for now — the OpenCoven submissions panel (add a new harness/runtime)
@@ -230,41 +231,51 @@ export function CapabilitiesViewSurface({
   // stale map + stale "Scanned N ago". Abort the prior load on each new one, drop
   // a superseded/aborted response before any setState, and abort on unmount.
   const loadCtlRef = useRef<AbortController | null>(null);
+  const { announce } = useAnnouncer();
   const load = useCallback(async (refresh = false) => {
     loadCtlRef.current?.abort();
     const ctl = new AbortController();
     loadCtlRef.current = ctl;
     setRefreshing(refresh);
     if (!refresh) setLoaded(false);
+    // Only user-triggered refreshes announce — the mount load would be noise.
+    if (refresh) announce("Refreshing capabilities…");
     try {
       const url = refresh ? "/api/capabilities?refresh=1" : "/api/capabilities";
       const res = await fetch(url, { cache: "no-store", signal: ctl.signal });
       const json = (await res.json()) as CapabilitiesResponse;
       if (ctl.signal.aborted) return;
       if (!json.ok) {
-        setError(json.error ?? "Couldn't reach the Coven daemon.");
+        const msg = json.error ?? "Couldn't reach the Coven daemon.";
+        setError(msg);
         setItems([]);
         setCovenSkills([]);
         setScannedAt(null);
+        if (refresh) announce(`Capabilities refresh failed: ${msg}`, "assertive");
       } else {
         setError(null);
-        setItems(json.harness_capabilities ?? []);
-        setCovenSkills(json.coven_skills ?? []);
+        const harness = json.harness_capabilities ?? [];
+        const skills = json.coven_skills ?? [];
+        setItems(harness);
+        setCovenSkills(skills);
         setScannedAt(json.scanned_at ?? null);
+        if (refresh) announce(`Capabilities refreshed — ${harness.length + skills.length} items.`);
       }
     } catch (err) {
       if (ctl.signal.aborted) return; // superseded by a newer load — ignore
-      setError(err instanceof Error ? err.message : "fetch failed");
+      const msg = err instanceof Error ? err.message : "fetch failed";
+      setError(msg);
       setItems([]);
       setCovenSkills([]);
       setScannedAt(null);
+      if (refresh) announce(`Capabilities refresh failed: ${msg}`, "assertive");
     } finally {
       if (!ctl.signal.aborted) {
         setLoaded(true);
         setRefreshing(false);
       }
     }
-  }, []);
+  }, [announce]);
 
   useEffect(() => {
     void load(false);
@@ -409,11 +420,13 @@ export function CapabilitiesViewSurface({
     try {
       await copyText(value);
       setCopiedKey(key);
+      announce(`Copied ${key}.`);
       window.setTimeout(() => setCopiedKey(null), 1200);
     } catch {
       setCopiedKey(null);
+      announce("Copy failed.", "assertive");
     }
-  }, []);
+  }, [announce]);
 
   const openLocalPath = useCallback(async (path?: string) => {
     if (!path || !path.startsWith("/")) return;


### PR DESCRIPTION
## Summary

Bead `cave-vmj8` (Capabilities audit). The surface had zero `useAnnouncer` usage while ~20 other surfaces follow the convention — so Refresh/⌘R gave screen-reader users no signal that a scan started, succeeded, changed the list, or failed (the spinner and "Scanned N ago" readout are visual-only), and the copy buttons' check-flash was equally silent.

- **Refresh lifecycle:** user-triggered refreshes announce "Refreshing capabilities…", then success with the combined item count, or the failure message assertively. The mount load deliberately stays quiet — announcing on every surface open would be noise.
- **Copy outcomes:** success announces which detail was copied ("Copied path." etc.); failure announces assertively.
- The bead's low note about the row status dot needs no change: the same row already renders the status as a text pill, so it isn't color-only.

## Test plan

- [x] Pins: announcer usage, refresh start/success-with-count/assertive-failure, copy announcement
- [x] Capabilities tests + full `pnpm test:app` green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)