### PR TITLE
chore(release): stamp v0.0.156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.156] - 2026-07-08
+
+> 🎛️ **A palette worthy of the slash** — the chat composer's slash view becomes a sectioned palette: Commands and Skills headers, icon-led rows with inline descriptions, and a roomy elevated panel. The shell picks up a familiar dropdown atop the chat sidebar with a Codex-style title bar.
+
+Patch release on top of v0.0.155.
+
+### Features
+- **Chat: slash menus become a sectioned palette** (#2752, cave-nl9n). Sentence-case Commands/Skills headers, leading icons with medium names and unified muted inline descriptions, inset rounded row highlights, and an elevated rounded panel — across the slash menu, /model, /skill, /prompt, and @-file pickers. Keyboard contract unchanged.
+- **Shell: familiar dropdown heads the chat sidebar** · Codex-style title bar · one-row sidepanel chrome (#2747).
+
+### Fixes
+- **Models: the GPT-5.1 generation retires from the codex model menu** (#2751).
+- **Settings: On/Off switches match the shared button shape** (#2741, cave-9yll).
+- **Calendar: week view falls back to day rendering in narrow split panes** (#2748, cave-87zv).
+
 ## [0.0.155] - 2026-07-08
 
 > 🔍 **Review means the one you picked** — a chat edit card's Review no longer keeps snapping the Changes panel back to its own file while an agent is mid-edit; whichever diff you expand stays expanded. Plus a roomier reading measure and a friendlier crons detail panel.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.155",
+  "version": "0.0.156",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.155"
+version = "0.0.156"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.155"
+version = "0.0.156"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.155</string>
+	<string>0.0.156</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.155</string>
+	<string>0.0.156</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.155</string>
+	<string>0.0.156</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.155</string>
+	<string>0.0.156</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.155",
+  "version": "0.0.156",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Release on top of v0.0.155. Five commits — headlined by the sectioned slash palette (#2752), plus the shell familiar dropdown + title bar (#2747), codex model menu cleanup (#2751), settings switch shapes (#2741), calendar narrow-pane fallback (#2748). Local gate: typecheck ✓ · test:app 568 ✓ · build + budget ✓. After merge: signed tag v0.0.156 → release.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)