### PR TITLE
a11y(toasts): urgency-aware politeness, pausable auto-hide, one titled dismiss (cave-bj68)

### DIFF
--- a/src/components/daily-summary-notifications.test.ts
+++ b/src/components/daily-summary-notifications.test.ts
@@ -105,4 +105,14 @@ assert.match(bell, /<RelativeTime iso=\{iso\} fallback="—" \/>/, "timestamps r
 assert.match(bell, /addEventListener\("pointerdown", onDown\)/, "outside-close listens to pointerdown (mouse + pen + touch)");
 assert.doesNotMatch(bell, /addEventListener\("mousedown", onDown\)/, "the mouse-only closer stays gone");
 
+// ── Toast urgency + pausable auto-hide + single dismiss (cave-bj68) ─────────
+assert.match(toast, /const urgent = t\.kind === "response-needed"/, "reply requests announce assertively, everything else politely");
+assert.match(toast, /role=\{urgent \? "alert" : "status"\}/, "the live-region role follows urgency");
+assert.match(toast, /\.filter\(\(t\) => !pausedIds\.has\(t\.id\)\)/, "hover/focus pauses the 8s auto-hide (WCAG 2.2.1)");
+assert.match(toast, /onMouseEnter=\{\(\) => setPaused\(t\.id, true\)\}/, "hover pauses");
+assert.match(toast, /e\.currentTarget\.contains\(e\.relatedTarget as Node \| null\)/, "focus-within keeps the pause until focus leaves the toast");
+assert.match(toast, /aria-label=\{`Dismiss: \$\{t\.title\}`\}/, "the dismiss control names its toast");
+assert.doesNotMatch(toast, />\s*Dismiss\s*<\/button>/, "the duplicate text Dismiss button stays gone");
+assert.match(toast, /kind: item\.kind,/, "toastFromItem carries the inbox kind for urgency");
+
 console.log("daily-summary-notifications.test.ts: ok");

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { InboxItem, InboxMedia, LinkRef } from "@/lib/cave-inbox";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon, type IconName } from "@/lib/icon";
@@ -15,6 +15,8 @@ export type Toast = {
   link?: LinkRef | null;
   iconName?: IconName;
   media?: InboxMedia | null;
+  /** Inbox kind — drives announcement urgency (response-needed → assertive). */
+  kind?: InboxItem["kind"];
 };
 
 type Props = {
@@ -27,24 +29,47 @@ type Props = {
 const AUTO_DISMISS_MS = 8_000;
 
 export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) {
+  // Hover or focus anywhere inside a toast pauses its auto-hide (WCAG 2.2.1) —
+  // content stopped vanishing mid-read. Unpausing re-arms the full window,
+  // the generous simple option (no per-toast remaining-time bookkeeping).
+  const [pausedIds, setPausedIds] = useState<ReadonlySet<string>>(new Set());
+  const setPaused = (id: string, paused: boolean) =>
+    setPausedIds((prev) => {
+      if (prev.has(id) === paused) return prev;
+      const next = new Set(prev);
+      if (paused) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+
   useEffect(() => {
     if (toasts.length === 0) return;
-    const timers = toasts.map((t) =>
-      setTimeout(() => onDismiss(t.id), AUTO_DISMISS_MS),
-    );
+    const timers = toasts
+      .filter((t) => !pausedIds.has(t.id))
+      .map((t) => setTimeout(() => onDismiss(t.id), AUTO_DISMISS_MS));
     return () => timers.forEach(clearTimeout);
-  }, [toasts, onDismiss]);
+  }, [toasts, pausedIds, onDismiss]);
 
   if (toasts.length === 0) return null;
 
   return (
     <div className="pointer-events-none fixed top-4 right-4 z-50 flex w-80 flex-col gap-2">
-      {toasts.map((t) => (
+      {toasts.map((t) => {
+        // A reply request is time-critical for the user — announce it
+        // assertively; everything else stays polite.
+        const urgent = t.kind === "response-needed";
+        return (
         <div
           key={t.id}
-          role="status"
-          aria-live="polite"
+          role={urgent ? "alert" : "status"}
+          aria-live={urgent ? "assertive" : "polite"}
           aria-atomic="true"
+          onMouseEnter={() => setPaused(t.id, true)}
+          onMouseLeave={() => setPaused(t.id, false)}
+          onFocus={() => setPaused(t.id, true)}
+          onBlur={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setPaused(t.id, false);
+          }}
           className="pointer-events-auto rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] p-3 shadow-2xl"
           style={{ animation: "ui-modal-enter var(--duration-base) var(--ease-decelerate)" }}
         >
@@ -56,7 +81,7 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
             <button
               onClick={() => onDismiss(t.id)}
               className="focus-ring grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-              aria-label="Dismiss"
+              aria-label={`Dismiss: ${t.title}`}
             >
               <Icon name="ph:x-bold" aria-hidden />
             </button>
@@ -72,12 +97,6 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
             <p className="mb-2 line-clamp-3 text-[11px] text-[var(--text-secondary)]">{t.body}</p>
           ) : null}
           <div className="flex gap-1.5">
-            <button
-              onClick={() => onDismiss(t.id)}
-              className="focus-ring rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-            >
-              Dismiss
-            </button>
             <SnoozeMenu onSnooze={(untilIso) => onSnooze(t, untilIso)} />
             {onOpen ? (
               <button
@@ -89,7 +108,8 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
             ) : null}
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -112,5 +132,6 @@ export function toastFromItem(item: InboxItem): Toast {
     link: item.link,
     iconName: toastIconForItem(item),
     media: item.media,
+    kind: item.kind,
   };
 }

--- a/src/components/labels-and-live-regions.test.ts
+++ b/src/components/labels-and-live-regions.test.ts
@@ -51,7 +51,9 @@ function read(file: string) {
 // 5. inbox-toast.tsx root has aria-live + aria-atomic.
 {
   const src = read("inbox-toast.tsx");
-  assert.match(src, /aria-live="polite"/, "inbox-toast has aria-live=polite");
+  // (cave-bj68) politeness follows urgency: reply requests are assertive
+  // alerts, everything else stays a polite status.
+  assert.match(src, /aria-live=\{urgent \? "assertive" : "polite"\}/, "inbox-toast politeness follows urgency");
   assert.match(src, /aria-atomic="true"/, "inbox-toast has aria-atomic=true");
 }
 


### PR DESCRIPTION
## Summary

Bead `cave-bj68` (source-verified), three toast-stack fixes:

**Urgency-blind politeness.** Every toast was `role=status aria-live=polite` regardless of kind, so a reply request — the one notification that's time-critical — got the same lazy announcement as a daily summary. `toastFromItem` now carries the inbox kind, and `response-needed` toasts land as assertive `role=alert`; everything else stays polite.

**Un-pausable 8-second auto-hide (WCAG 2.2.1).** Toasts vanished mid-read with no way to hold them. Hovering or focusing anywhere inside a toast now pauses its timer (focus-within via relatedTarget check); unpausing re-arms the full 8s window — deliberately simple over per-toast remaining-time bookkeeping. The underlying inbox item always persists; this only governs the popup.

**Duplicate dismiss + generic label.** The X icon and a text "Dismiss" button both called `onDismiss`; the text button is gone, and the X is now labelled "Dismiss: \<toast title\>" so AT users know which of several stacked toasts they're closing.

The bead's own verification notes (icon is kind-varied not color-only; images carry alt) needed no change.

## Test plan

- [x] Pins: urgency mapping, role-follows-urgency, paused-filter + hover/focus handlers, titled dismiss, text-button stays-gone, kind carried
- [x] The always-polite pin in `labels-and-live-regions.test.ts` updated to the urgency-aware form
- [x] Full `pnpm test:app` (568 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)