### PR TITLE
fix(inbox): serialize prefs read-modify-write so concurrent PATCHes can't drop a change (cave-g6ew)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -53,6 +53,7 @@ export const SUITES = {
     "src/lib/screen-magnification.test.ts",
     "src/lib/no-builtin-familiar-roster.test.ts",
     "src/lib/cave-projects.test.ts",
+    "src/lib/cave-inbox-prefs.test.ts",
     "src/lib/project-permissions.test.ts",
     "src/lib/permissions-console.test.ts",
     "src/lib/project-status.test.ts",

--- a/src/lib/cave-inbox-prefs.test.ts
+++ b/src/lib/cave-inbox-prefs.test.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./cave-inbox-prefs.ts", import.meta.url), "utf8");
+
+// cave-g6ew: prefs mutations must serialize their read-modify-write. Before this,
+// patchPrefs/toggleMute each did an unlocked load→merge→save, so two concurrent
+// PATCHes (mute toggle from two surfaces, rapid toggles) last-writer-wins and
+// silently dropped a change. A globalThis promise-chain (like withInboxLock)
+// serializes them.
+assert.match(src, /var __inboxPrefsWriteChain: Promise<unknown> \| undefined/, "a hot-reload-safe prefs write chain exists on globalThis");
+assert.match(
+  src,
+  /function withPrefsLock<T>\(fn: \(\) => Promise<T>\): Promise<T> \{[\s\S]*?__inboxPrefsWriteChain[\s\S]*?prev\.then\(fn, fn\)/,
+  "withPrefsLock chains each mutation after the previous",
+);
+
+// The actual load→merge→save is the *unlocked* internal; the exported patchPrefs
+// wraps it in the lock.
+assert.match(src, /async function patchPrefsUnlocked\(/, "the raw read-modify-write is an unlocked internal");
+assert.match(
+  src,
+  /export function patchPrefs\([\s\S]*?return withPrefsLock\(\(\) => patchPrefsUnlocked\(patch\)\)/,
+  "patchPrefs runs its read-modify-write under the lock",
+);
+
+// toggleMute reads the current set AND writes under ONE lock acquisition (else two
+// toggles read the same set and one flip is lost), using the unlocked inner patch
+// to avoid re-entrant deadlock on the single-acquisition chain.
+assert.match(
+  src,
+  /export function toggleMute\([\s\S]*?return withPrefsLock\(async \(\) => \{[\s\S]*?loadPrefs\(\)[\s\S]*?patchPrefsUnlocked\(/,
+  "toggleMute takes the lock once and reads+writes atomically via the unlocked patch",
+);
+
+console.log("cave-inbox-prefs.test.ts: ok");

--- a/src/lib/cave-inbox-prefs.ts
+++ b/src/lib/cave-inbox-prefs.ts
@@ -23,6 +23,24 @@ async function ensureDir() {
   await mkdir(path.dirname(PREFS_PATH), { recursive: true });
 }
 
+// Serialize prefs read-modify-write. Two concurrent PATCHes (e.g. a mute toggle
+// from two surfaces, or rapid toggles outracing the disk write) each did an
+// unlocked load→merge→save, so the last writer silently dropped the other's
+// change. This promise-chain (mirroring withInboxLock in cave-inbox.ts) runs each
+// mutation to completion before the next starts. Attached to globalThis so the
+// chain survives Next.js dev hot-reloads.
+declare global {
+  // eslint-disable-next-line no-var
+  var __inboxPrefsWriteChain: Promise<unknown> | undefined;
+}
+
+function withPrefsLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = globalThis.__inboxPrefsWriteChain ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  globalThis.__inboxPrefsWriteChain = next.catch(() => undefined);
+  return next;
+}
+
 export async function loadPrefs(): Promise<InboxPrefs> {
   try {
     const raw = await readFile(PREFS_PATH, "utf8");
@@ -55,7 +73,10 @@ export async function savePrefs(prefs: InboxPrefs): Promise<void> {
   await writeJsonAtomic(PREFS_PATH, prefs);
 }
 
-export async function patchPrefs(
+// The actual load→merge→save. Must run under withPrefsLock — never call it
+// directly (except from another already-locked mutator, to avoid re-entrant
+// deadlock on the single-acquisition chain).
+async function patchPrefsUnlocked(
   patch: Partial<Omit<InboxPrefs, "version">>,
 ): Promise<InboxPrefs> {
   const current = await loadPrefs();
@@ -72,12 +93,24 @@ export async function patchPrefs(
   return next;
 }
 
-export async function toggleMute(familiarId: string): Promise<InboxPrefs> {
-  const current = await loadPrefs();
-  const muted = new Set(current.mutedFamiliars);
-  if (muted.has(familiarId)) muted.delete(familiarId);
-  else muted.add(familiarId);
-  return patchPrefs({ mutedFamiliars: Array.from(muted) });
+export function patchPrefs(
+  patch: Partial<Omit<InboxPrefs, "version">>,
+): Promise<InboxPrefs> {
+  return withPrefsLock(() => patchPrefsUnlocked(patch));
+}
+
+export function toggleMute(familiarId: string): Promise<InboxPrefs> {
+  // The read of the current muted set and the write MUST be one atomic unit, or
+  // two concurrent toggles both read the same set and one flip is lost. Take the
+  // lock once and use the unlocked patch inside it (calling the exported
+  // patchPrefs here would deadlock on the same single-acquisition chain).
+  return withPrefsLock(async () => {
+    const current = await loadPrefs();
+    const muted = new Set(current.mutedFamiliars);
+    if (muted.has(familiarId)) muted.delete(familiarId);
+    else muted.add(familiarId);
+    return patchPrefsUnlocked({ mutedFamiliars: Array.from(muted) });
+  });
 }
 
 export { PREFS_PATH };


### PR DESCRIPTION
## What

`patchPrefs`/`toggleMute` (`cave-inbox-prefs.ts`) each did an **unlocked** load→merge→save, while every inbox *item* mutation already goes through `withInboxLock`. So two concurrent `/api/inbox/prefs` PATCHes — a mute toggle from two surfaces, or rapid toggles outracing the disk write — were **last-writer-wins and silently dropped one change**.

## Fix

Add a dedicated `withPrefsLock` (a `globalThis` promise-chain mirroring `withInboxLock`, hot-reload-safe). Both mutators run under it; **`toggleMute` takes the lock once** and does its read + write **atomically** via an unlocked inner patch — so two toggles can't both read the same set and lose a flip (and it avoids a re-entrant deadlock).

Found by the Inbox-surface audit. Isolated lib change, no layout. Source-pinned in a new `cave-inbox-prefs.test.ts` (wired into `run-tests.mjs`).

## Verification

`typecheck` · **569** app test files · `build` within budget · `tests-wired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)