### PR TITLE
a11y(inbox): urgency-aware toasts that wait for you; audible snooze menus and dashboard actions (cave-bj68, cave-1y0d)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -475,6 +475,7 @@ export const SUITES = {
     "src/components/chat-switching.test.ts",
     "src/components/chat-view-first-class.test.ts",
     "src/components/labels-and-live-regions.test.ts",
+    "src/components/inbox-notifications-a11y.test.ts",
     "src/components/workspace-inspector-mount.test.ts",
     "src/middleware.test.ts",
     "src/lib/font-settings.test.ts",

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -8,6 +8,7 @@ import type { InboxItem } from "@/lib/cave-inbox";
 import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/lib/daily-report";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { nextItemsAfterAction } from "@/lib/dashboard-model";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 type Action = "done" | "dismiss" | "snooze";
 
@@ -31,6 +32,9 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
   useMinuteTick();    // keep the per-item "Nm ago" labels current; the parent
                       // cockpit re-fetches the list itself every 30s.
+  // Row removal is the only visual feedback on done/dismiss/snooze — announce
+  // successes so AT users aren't left guessing (errors already role=alert).
+  const { announce } = useAnnouncer();
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
   const [snoozeOpenId, setSnoozeOpenId] = useState<string | null>(null);
@@ -62,6 +66,12 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
       : { method: "POST" };
   }
 
+  function actionAnnouncement(action: Action, subject: string, minutes: number): string {
+    if (action === "done") return `Marked done: ${subject}`;
+    if (action === "dismiss") return `Dismissed: ${subject}`;
+    return `Snoozed for ${minutes >= 60 ? `${Math.round(minutes / 60)}h` : `${minutes}m`}: ${subject}`;
+  }
+
   async function act(item: InboxItem, action: Action, minutes = 60) {
     const prev = items;
     setItems(nextItemsAfterAction(items, item.id)); // optimistic remove
@@ -69,6 +79,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     try {
       const res = await fetch(`/api/inbox/${item.id}/${action}`, requestInit(action, minutes));
       if (!res.ok) throw new Error(String(res.status));
+      announce(actionAnnouncement(action, item.title, minutes), "polite");
     } catch {
       setItems(prev); // revert
       setError("Couldn't update that item — try again.");
@@ -88,6 +99,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
         ids.map((id) => fetch(`/api/inbox/${id}/${action}`, requestInit(action, minutes)).then((r) => r.ok)),
       );
       if (results.some((ok) => !ok)) throw new Error("partial");
+      announce(actionAnnouncement(action, `${ids.length} item${ids.length === 1 ? "" : "s"}`, minutes), "polite");
     } catch {
       setItems(prev); // revert the whole batch
       setError("Couldn't update some items — try again.");
@@ -200,7 +212,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
               <button
                 type="button"
                 className="dash-act dash-act--ghost"
-                aria-label="Dismiss"
+                aria-label={`Dismiss: ${item.title}`}
                 onClick={() => act(item, "dismiss")}
               >
                 <Icon name="ph:x" aria-hidden />

--- a/src/components/inbox-notifications-a11y.test.ts
+++ b/src/components/inbox-notifications-a11y.test.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+// Source pins for the inbox-notification a11y pass (cave-bj68 + cave-1y0d):
+// urgency-aware toast politeness, pausable auto-hide, one contextual dismiss,
+// real menu semantics on the shared SnoozeMenu, and audible dashboard actions.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const toast = readFileSync(new URL("./inbox-toast.tsx", import.meta.url), "utf8");
+const snooze = readFileSync(new URL("./snooze-menu.tsx", import.meta.url), "utf8");
+const actionInbox = readFileSync(new URL("./dashboard/action-inbox.tsx", import.meta.url), "utf8");
+
+// ── Toast stack (cave-bj68) ──────────────────────────────────────────────────
+assert.match(
+  toast,
+  /urgent: item\.kind === "response-needed"/,
+  "response-needed items (a familiar blocked on the user) are the urgent kind",
+);
+assert.match(
+  toast,
+  /\.filter\(\(t\) => !pausedIds\.has\(t\.id\)\)\s*\n\s*\.map\(\(t\) => setTimeout\(\(\) => onDismiss\(t\.id\), AUTO_DISMISS_MS\)\)/,
+  "auto-hide timers skip paused toasts (WCAG 2.2.1 — hover/focus holds the popup open)",
+);
+assert.match(
+  toast,
+  /onMouseEnter=\{\(\) => pause\(t\.id\)\}[\s\S]{0,200}?onFocusCapture=\{\(\) => pause\(t\.id\)\}/,
+  "both pointer hover and keyboard focus pause the auto-hide",
+);
+assert.match(
+  toast,
+  /if \(!e\.currentTarget\.contains\(e\.relatedTarget as Node \| null\)\) resume\(t\.id\);/,
+  "blur only resumes the timer when focus actually left the toast (focus-within semantics)",
+);
+// One dismiss affordance, carrying the toast's title for AT context.
+assert.match(
+  toast,
+  /aria-label=\{`Dismiss notification: \$\{t\.title\}`\}/,
+  "the dismiss button names what it dismisses",
+);
+assert.equal(
+  (toast.match(/onDismiss\(t\.id\)/g) ?? []).length,
+  2, // the timer + the single button — the redundant header X is gone
+  "exactly one user-facing dismiss control per toast (plus the auto-hide timer)",
+);
+
+// ── Shared SnoozeMenu (cave-1y0d) ────────────────────────────────────────────
+assert.match(
+  snooze,
+  /useFocusTrap\(open, menuRef, \{ onEscape: \(\) => setOpen\(false\) \}\)/,
+  "the shared snooze menu traps focus like every other popover (Escape closes, focus returns)",
+);
+assert.match(
+  snooze,
+  /aria-haspopup="menu"\s*\n\s*aria-expanded=\{open\}/,
+  "the trigger advertises the popup and its state",
+);
+assert.match(snooze, /role="menu"\s*\n\s*aria-label="Snooze until"/, "the options render as a labelled menu");
+assert.match(snooze, /role="menuitem"/, "options are menu items");
+
+// ── Dashboard ActionInbox (cave-1y0d) ────────────────────────────────────────
+assert.match(
+  actionInbox,
+  /const \{ announce \} = useAnnouncer\(\);/,
+  "the dashboard inbox wires the shared live-region announcer",
+);
+assert.match(
+  actionInbox,
+  /announce\(actionAnnouncement\(action, item\.title, minutes\), "polite"\);/,
+  "single done/dismiss/snooze successes are announced (row removal is otherwise silent to AT)",
+);
+assert.match(
+  actionInbox,
+  /announce\(actionAnnouncement\(action, `\$\{ids\.length\} item/,
+  "bulk actions announce their count",
+);
+assert.match(
+  actionInbox,
+  /aria-label=\{`Dismiss: \$\{item\.title\}`\}/,
+  "the icon-only dismiss carries the item title",
+);
+
+console.log("inbox-notifications-a11y.test.ts: ok");

--- a/src/components/inbox-toast.tsx
+++ b/src/components/inbox-toast.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { InboxItem, InboxMedia, LinkRef } from "@/lib/cave-inbox";
 import { SnoozeMenu } from "@/components/snooze-menu";
 import { Icon, type IconName } from "@/lib/icon";
@@ -15,6 +15,9 @@ export type Toast = {
   link?: LinkRef | null;
   iconName?: IconName;
   media?: InboxMedia | null;
+  /** Interrupt AT speech (role=alert/assertive) — a familiar is blocked on
+   *  the user. Routine reminders/digests stay polite. */
+  urgent?: boolean;
 };
 
 type Props = {
@@ -27,13 +30,35 @@ type Props = {
 const AUTO_DISMISS_MS = 8_000;
 
 export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) {
+  // Auto-hide pauses while the pointer or keyboard focus is inside a toast
+  // (WCAG 2.2.1) — the underlying inbox item persists either way, but the
+  // popup must not vanish mid-read or mid-interaction. Leaving restarts a
+  // full window (generous by design).
+  const [pausedIds, setPausedIds] = useState<ReadonlySet<string>>(new Set());
+  const pause = (id: string) =>
+    setPausedIds((prev) => (prev.has(id) ? prev : new Set(prev).add(id)));
+  const resume = (id: string) =>
+    setPausedIds((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  useEffect(() => {
+    // Prune ids whose toasts already left so the set can't grow unbounded.
+    setPausedIds((prev) => {
+      const live = new Set(toasts.map((t) => t.id));
+      const next = new Set([...prev].filter((id) => live.has(id)));
+      return next.size === prev.size ? prev : next;
+    });
+  }, [toasts]);
   useEffect(() => {
     if (toasts.length === 0) return;
-    const timers = toasts.map((t) =>
-      setTimeout(() => onDismiss(t.id), AUTO_DISMISS_MS),
-    );
+    const timers = toasts
+      .filter((t) => !pausedIds.has(t.id))
+      .map((t) => setTimeout(() => onDismiss(t.id), AUTO_DISMISS_MS));
     return () => timers.forEach(clearTimeout);
-  }, [toasts, onDismiss]);
+  }, [toasts, pausedIds, onDismiss]);
 
   if (toasts.length === 0) return null;
 
@@ -42,24 +67,23 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
       {toasts.map((t) => (
         <div
           key={t.id}
-          role="status"
-          aria-live="polite"
+          role={t.urgent ? "alert" : "status"}
+          aria-live={t.urgent ? "assertive" : "polite"}
           aria-atomic="true"
           className="pointer-events-auto rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] p-3 shadow-2xl"
           style={{ animation: "ui-modal-enter var(--duration-base) var(--ease-decelerate)" }}
+          onMouseEnter={() => pause(t.id)}
+          onMouseLeave={() => resume(t.id)}
+          onFocusCapture={() => pause(t.id)}
+          onBlurCapture={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node | null)) resume(t.id);
+          }}
         >
           <div className="mb-1 flex items-start gap-2">
             <span className="mt-0.5 shrink-0 text-[var(--color-warning)]" aria-hidden>
               <Icon name={t.iconName ?? "ph:alarm-fill"} />
             </span>
             <span className="flex-1 text-sm font-medium text-[var(--text-primary)]">{t.title}</span>
-            <button
-              onClick={() => onDismiss(t.id)}
-              className="focus-ring grid h-5 w-5 place-items-center rounded text-[var(--text-muted)] hover:text-[var(--text-primary)]"
-              aria-label="Dismiss"
-            >
-              <Icon name="ph:x-bold" aria-hidden />
-            </button>
           </div>
           {t.media?.imageUrl ? (
             <img
@@ -74,6 +98,7 @@ export function InboxToastStack({ toasts, onDismiss, onSnooze, onOpen }: Props) 
           <div className="flex gap-1.5">
             <button
               onClick={() => onDismiss(t.id)}
+              aria-label={`Dismiss notification: ${t.title}`}
               className="focus-ring rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
             >
               Dismiss
@@ -112,5 +137,8 @@ export function toastFromItem(item: InboxItem): Toast {
     link: item.link,
     iconName: toastIconForItem(item),
     media: item.media,
+    // A familiar blocked on the user interrupts; reminders/digests wait
+    // their turn in the AT speech queue.
+    urgent: item.kind === "response-needed",
   };
 }

--- a/src/components/labels-and-live-regions.test.ts
+++ b/src/components/labels-and-live-regions.test.ts
@@ -48,10 +48,21 @@ function read(file: string) {
   assert.match(threadBlock, /role="log"/, "chat thread has role=log (implicit aria-live=polite)");
 }
 
-// 5. inbox-toast.tsx root has aria-live + aria-atomic.
+// 5. inbox-toast.tsx root has aria-live + aria-atomic. Politeness is
+// urgency-aware (cave-bj68): a familiar blocked on the user interrupts,
+// routine reminders/digests stay polite.
 {
   const src = read("inbox-toast.tsx");
-  assert.match(src, /aria-live="polite"/, "inbox-toast has aria-live=polite");
+  assert.match(
+    src,
+    /aria-live=\{t\.urgent \? "assertive" : "polite"\}/,
+    "inbox-toast politeness follows urgency (assertive only when a response is needed)",
+  );
+  assert.match(
+    src,
+    /role=\{t\.urgent \? "alert" : "status"\}/,
+    "inbox-toast role matches its politeness",
+  );
   assert.match(src, /aria-atomic="true"/, "inbox-toast has aria-atomic=true");
 }
 

--- a/src/components/snooze-menu.tsx
+++ b/src/components/snooze-menu.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
 type Props = {
   onSnooze: (untilIso: string) => void;
@@ -27,6 +28,11 @@ const OPTIONS: Option[] = [
 export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  // Same keyboard contract as the rest of the app's popovers (and the
+  // dashboard ActionInbox's snooze menu): first option focused on open,
+  // Tab/Shift+Tab cycle, Escape closes and returns focus to the trigger.
+  useFocusTrap(open, menuRef, { onEscape: () => setOpen(false) });
 
   useEffect(() => {
     if (!open) return;
@@ -39,24 +45,37 @@ export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
 
   const btnCls =
     size === "xs"
-      ? "rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
-      : "rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]";
+      ? "focus-ring rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
+      : "focus-ring rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]";
 
   return (
     <div ref={wrapRef} className={`relative ${className ?? ""}`}>
-      <button onClick={() => setOpen((v) => !v)} className={btnCls}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={btnCls}
+      >
         Snooze ▾
       </button>
       {open ? (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-32 overflow-hidden rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] shadow-xl">
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Snooze until"
+          className="absolute bottom-full left-0 z-50 mb-1 w-32 overflow-hidden rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] shadow-xl"
+        >
           {OPTIONS.map((o) => (
             <button
               key={o.label}
+              type="button"
+              role="menuitem"
               onClick={() => {
                 setOpen(false);
                 onSnooze(o.resolve());
               }}
-              className="block w-full px-2 py-1 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+              className="focus-ring block w-full px-2 py-1 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
             >
               {o.label}
             </button>


### PR DESCRIPTION
Two P2 beads from today's Inbox data-plane audit, both source-verified before filing.

## Toast stack (`cave-bj68`)

- **Urgency-aware politeness** — `response-needed` items (a familiar blocked on the user) now render `role=alert` / `aria-live=assertive`; reminders and digests stay `polite`. Previously everything was polite, so time-critical toasts waited in the AT speech queue behind whatever else was talking.
- **Pausable auto-hide (WCAG 2.2.1)** — the 8s timer pauses on pointer hover and while keyboard focus is anywhere inside the toast (focus-within via relatedTarget check), resuming with a full window on leave. The inbox item always persisted underneath; the fix is that the popup can no longer vanish mid-read or mid-interaction.
- **One dismiss, with context** — the redundant header X (identical action to the labelled Dismiss button) is gone, and the remaining button reads "Dismiss notification: <title>".

## Snooze menus + dashboard actions (`cave-1y0d`)

- The **shared `SnoozeMenu`** (used by the toast stack and inspector) had zero menu semantics — bare divs. It now has the app's standard popover contract: `useFocusTrap` (first option focused, Tab cycles, Escape closes and returns focus), `aria-haspopup`/`aria-expanded` on the trigger, labelled `role=menu` with `menuitem` options, focus rings.
- **Audit correction recorded:** the agent claim that ActionInbox's local snooze menu lacked a focus trap was false — it already has trap + roles + backdrop and was left alone. Only the shared component was bare.
- **ActionInbox announces successes** — done/dismiss/snooze (single and bulk) now announce through the shared live region ("Marked done: X", "Snoozed for 1h: 3 items"); row removal was previously the only feedback, which is silent to AT. Errors already announced via `role=alert`. The icon-only dismiss now carries the item title.

## Verification

- `pnpm typecheck` clean; full `node scripts/run-tests.mjs app` — 569 files pass; `check:tests-wired` green.
- Pins: `labels-and-live-regions.test.ts` politeness pin updated to the urgency-conditional form; new `inbox-notifications-a11y.test.ts` pins the timer-pause filter, focus-within resume, single-dismiss invariant, menu semantics, and both announce sites.
- Not manually driven: toast firing requires live SSE reminder events — the changes there are markup/ARIA + timer-filter logic, held by the pins above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)