### PR TITLE
a11y(inbox): one SnoozeMenu with real menu semantics; inbox actions audible (cave-1y0d)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -412,6 +412,7 @@ export const SUITES = {
     "src/components/home-composer-polish.test.ts",
     "src/components/inbox-calendar-familiar-scope.test.ts",
     "src/components/inspector-inbox.test.ts",
+    "src/components/snooze-menu.test.ts",
     "src/components/inspector-pane-polish.test.ts",
     "src/components/inspector-pane-load-guards.test.ts",
     "src/components/inspector-pane-surface.test.ts",

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -1,31 +1,29 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
-import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { KIND_ICON, KIND_LABEL, itemHasTarget, itemHref, relativeTime } from "@/lib/daily-report";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { nextItemsAfterAction } from "@/lib/dashboard-model";
+import { SnoozeMenu, minutesUntilTomorrowMorning, type SnoozeOption } from "@/components/snooze-menu";
+import { useAnnouncer } from "@/components/ui/live-region";
 
 type Action = "done" | "dismiss" | "snooze";
 
 /** Snooze durations offered in the per-row menu. `minutes` resolves at click. */
-const SNOOZE_OPTIONS: { label: string; minutes: () => number }[] = [
+const SNOOZE_OPTIONS: SnoozeOption[] = [
   { label: "1 hour", minutes: () => 60 },
   { label: "3 hours", minutes: () => 180 },
   { label: "Tomorrow morning", minutes: () => minutesUntilTomorrowMorning() },
 ];
 
-/** Whole minutes from now until 9am the next calendar day. */
-function minutesUntilTomorrowMorning(): number {
-  const now = new Date();
-  const target = new Date(now);
-  target.setDate(target.getDate() + 1);
-  target.setHours(9, 0, 0, 0);
-  return Math.max(1, Math.round((target.getTime() - now.getTime()) / 60_000));
-}
+const ACTION_PAST_TENSE: Record<Action, string> = {
+  done: "Marked done",
+  dismiss: "Dismissed",
+  snooze: "Snoozed",
+};
 
 export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   useDateTimePrefs(); // subscribe: re-render when the date/time density pref changes
@@ -33,11 +31,10 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                       // cockpit re-fetches the list itself every 30s.
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
-  const [snoozeOpenId, setSnoozeOpenId] = useState<string | null>(null);
+  const { announce } = useAnnouncer();
   // Bulk triage: select several items and done/dismiss/snooze them together.
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set());
-  const [bulkSnoozeOpen, setBulkSnoozeOpen] = useState(false);
   const toggleSelect = (id: string) =>
     setSelectedIds((prev) => {
       const next = new Set(prev);
@@ -69,6 +66,9 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     try {
       const res = await fetch(`/api/inbox/${item.id}/${action}`, requestInit(action, minutes));
       if (!res.ok) throw new Error(String(res.status));
+      // The row disappears optimistically, which is invisible to AT — say what
+      // happened (error feedback already has the role=alert banner).
+      announce(`${ACTION_PAST_TENSE[action]} '${item.title}'.`);
     } catch {
       setItems(prev); // revert
       setError("Couldn't update that item — try again.");
@@ -88,6 +88,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
         ids.map((id) => fetch(`/api/inbox/${id}/${action}`, requestInit(action, minutes)).then((r) => r.ok)),
       );
       if (results.some((ok) => !ok)) throw new Error("partial");
+      announce(`${ACTION_PAST_TENSE[action]} ${ids.length} ${ids.length === 1 ? "item" : "items"}.`);
     } catch {
       setItems(prev); // revert the whole batch
       setError("Couldn't update some items — try again.");
@@ -126,10 +127,12 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
           </div>
           <div className="dash-inbox__bulkbar-right">
             <SnoozeMenu
-              open={bulkSnoozeOpen}
-              onToggle={() => setBulkSnoozeOpen((v) => !v)}
-              onClose={() => setBulkSnoozeOpen(false)}
-              onPick={(minutes) => { setBulkSnoozeOpen(false); void bulkAct("snooze", minutes); }}
+              className="dash-snooze"
+              triggerClassName="dash-act"
+              menuClassName="dash-snooze__menu"
+              optionClassName="dash-snooze__opt"
+              options={SNOOZE_OPTIONS}
+              onSnooze={(_untilIso, minutes) => void bulkAct("snooze", minutes)}
               disabled={selectedCount === 0}
             />
             <button type="button" className="dash-act dash-act--primary" disabled={selectedCount === 0} onClick={() => void bulkAct("done")}>
@@ -186,13 +189,12 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                 </a>
               ) : null}
               <SnoozeMenu
-                open={snoozeOpenId === item.id}
-                onToggle={() => setSnoozeOpenId(snoozeOpenId === item.id ? null : item.id)}
-                onClose={() => setSnoozeOpenId(null)}
-                onPick={(minutes) => {
-                  setSnoozeOpenId(null);
-                  void act(item, "snooze", minutes);
-                }}
+                className="dash-snooze"
+                triggerClassName="dash-act"
+                menuClassName="dash-snooze__menu"
+                optionClassName="dash-snooze__opt"
+                options={SNOOZE_OPTIONS}
+                onSnooze={(_untilIso, minutes) => void act(item, "snooze", minutes)}
               />
               <button type="button" className="dash-act dash-act--primary" onClick={() => act(item, "done")}>
                 Done
@@ -200,7 +202,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
               <button
                 type="button"
                 className="dash-act dash-act--ghost"
-                aria-label="Dismiss"
+                aria-label={`Dismiss '${item.title}'`}
                 onClick={() => act(item, "dismiss")}
               >
                 <Icon name="ph:x" aria-hidden />
@@ -215,63 +217,6 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   );
 }
 
-/**
- * Snooze split button + duration menu. Trapping focus inside the open menu
- * (via the shared useFocusTrap) gives it the keyboard behaviour the rest of
- * the app's popovers have: the first option is focused on open, Tab/Shift+Tab
- * cycle the options, Escape closes the menu and returns focus to the trigger.
- */
-function SnoozeMenu({
-  open,
-  onToggle,
-  onClose,
-  onPick,
-  disabled = false,
-}: {
-  open: boolean;
-  onToggle: () => void;
-  onClose: () => void;
-  onPick: (minutes: number) => void;
-  disabled?: boolean;
-}) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  useFocusTrap(open, menuRef, { onEscape: onClose });
-  return (
-    <div className="dash-snooze">
-      <button
-        type="button"
-        className="dash-act"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        disabled={disabled}
-        onClick={onToggle}
-      >
-        Snooze
-        <Icon name="ph:caret-down" aria-hidden />
-      </button>
-      {open ? (
-        <>
-          <button
-            type="button"
-            className="dash-snooze__backdrop"
-            aria-label="Close snooze menu"
-            onClick={onClose}
-          />
-          <div ref={menuRef} className="dash-snooze__menu" role="menu" aria-label="Snooze for">
-            {SNOOZE_OPTIONS.map((opt) => (
-              <button
-                key={opt.label}
-                type="button"
-                role="menuitem"
-                className="dash-snooze__opt"
-                onClick={() => onPick(opt.minutes())}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </>
-      ) : null}
-    </div>
-  );
-}
+// The snooze split button + duration menu lives in the shared
+// @/components/snooze-menu now (this file used to carry its own copy) — one
+// component owns the menu semantics + focus trap for every inbox surface.

--- a/src/components/snooze-menu.test.ts
+++ b/src/components/snooze-menu.test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+// cave-1y0d: the shared SnoozeMenu is a real menu to assistive tech, and it is
+// the ONLY snooze menu — the dashboard's ActionInbox used to hand-roll its own
+// copy, and both drifted (the shared one had zero semantics; the local one had
+// them but nowhere else did). These pins keep the semantics on the shared
+// component and the dashboard on the shared component.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const menu = await readFile(new URL("./snooze-menu.tsx", import.meta.url), "utf8");
+const inbox = await readFile(new URL("./dashboard/action-inbox.tsx", import.meta.url), "utf8");
+const ws = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+// ── Shared component: menu semantics + focus trap ────────────────────────────
+assert.match(menu, /aria-haspopup="menu"/, "trigger declares it opens a menu");
+assert.match(menu, /aria-expanded=\{open\}/, "trigger reflects open state");
+assert.match(menu, /role="menu"/, "popup is a menu");
+assert.match(menu, /aria-label="Snooze for"/, "menu is named");
+assert.match(menu, /role="menuitem"/, "options are menu items");
+assert.match(
+  menu,
+  /useFocusTrap\(open, menuRef, \{ onEscape: \(\) => setOpen\(false\) \}\)/,
+  "the shared focus trap owns keyboard behaviour: focus-first, Tab cycle, Escape closes + returns focus",
+);
+assert.match(
+  menu,
+  /onSnooze: \(untilIso: string, minutes: number\) => void/,
+  "onSnooze carries both currencies: untilIso for timestamp APIs, minutes for duration APIs",
+);
+assert.match(menu, /options\?: SnoozeOption\[\]/, "surfaces can supply their own durations");
+
+// ── Dashboard: consolidated onto the shared component ────────────────────────
+assert.match(
+  inbox,
+  /import \{ SnoozeMenu, minutesUntilTomorrowMorning, type SnoozeOption \} from "@\/components\/snooze-menu"/,
+  "ActionInbox uses the shared SnoozeMenu instead of a local copy",
+);
+assert.doesNotMatch(inbox, /function SnoozeMenu\(/, "the hand-rolled dashboard copy stays deleted");
+assert.doesNotMatch(inbox, /useFocusTrap/, "trap ownership moved into the shared component");
+
+// ── Dashboard: actions are audible (WCAG 4.1.3) ──────────────────────────────
+// done/dismiss/snooze optimistically REMOVE the row — silent to AT without an
+// announcement (errors already had the role=alert banner).
+assert.match(inbox, /useAnnouncer/, "ActionInbox announces action outcomes");
+assert.match(
+  inbox,
+  /announce\(`\$\{ACTION_PAST_TENSE\[action\]\} '\$\{item\.title\}'\.`\)/,
+  "single-item actions announce with the item title",
+);
+assert.match(
+  inbox,
+  /announce\(`\$\{ACTION_PAST_TENSE\[action\]\} \$\{ids\.length\}/,
+  "bulk actions announce the affected count",
+);
+assert.match(
+  inbox,
+  /aria-label=\{`Dismiss '\$\{item\.title\}'`\}/,
+  "the icon-only dismiss button names its item",
+);
+
+// ── Workspace inbox callbacks (calendar et al) announce too ──────────────────
+assert.match(ws, /void fetch\(`\/api\/inbox\/\$\{id\}\/done`, \{ method: "POST" \}\);\s*\n\s*announce\("Marked done\."\);/, "complete announces");
+assert.match(ws, /void fetch\(`\/api\/inbox\/\$\{id\}\/dismiss`, \{ method: "POST" \}\);\s*\n\s*announce\("Dismissed\."\);/, "dismiss announces");
+assert.match(ws, /announce\("Snoozed\."\);/, "snooze announces");
+
+console.log("snooze-menu.test.ts: ok");

--- a/src/components/snooze-menu.tsx
+++ b/src/components/snooze-menu.tsx
@@ -1,32 +1,68 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
-type Props = {
-  onSnooze: (untilIso: string) => void;
-  className?: string;
-  size?: "sm" | "xs";
+// The one snooze split-button + duration menu, shared by the inbox toast, the
+// inspector inbox list, and the dashboard's ActionInbox (which used to carry
+// its own copy). Real menu semantics: the trigger declares aria-haspopup /
+// aria-expanded, the popup is role=menu with menuitem options, and the shared
+// focus trap gives it the app's standard popover keyboard behaviour — first
+// option focused on open, Tab/Shift+Tab cycle, Escape closes and returns
+// focus to the trigger. Outside clicks close it.
+
+export type SnoozeOption = {
+  label: string;
+  /** Whole minutes from "now", resolved at click time so relative options
+   *  (tomorrow morning) stay correct however long the menu sits open. */
+  minutes: () => number;
 };
 
-type Option = { label: string; resolve: () => string };
-
-function tomorrowAt9(): string {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  d.setHours(9, 0, 0, 0);
-  return d.toISOString();
+/** Whole minutes from now until 9am the next calendar day. */
+export function minutesUntilTomorrowMorning(): number {
+  const now = new Date();
+  const target = new Date(now);
+  target.setDate(target.getDate() + 1);
+  target.setHours(9, 0, 0, 0);
+  return Math.max(1, Math.round((target.getTime() - now.getTime()) / 60_000));
 }
 
-const OPTIONS: Option[] = [
-  { label: "5 min", resolve: () => new Date(Date.now() + 5 * 60_000).toISOString() },
-  { label: "30 min", resolve: () => new Date(Date.now() + 30 * 60_000).toISOString() },
-  { label: "1 hour", resolve: () => new Date(Date.now() + 60 * 60_000).toISOString() },
-  { label: "Tomorrow 9am", resolve: tomorrowAt9 },
+const DEFAULT_OPTIONS: SnoozeOption[] = [
+  { label: "5 min", minutes: () => 5 },
+  { label: "30 min", minutes: () => 30 },
+  { label: "1 hour", minutes: () => 60 },
+  { label: "Tomorrow 9am", minutes: () => minutesUntilTomorrowMorning() },
 ];
 
-export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
+type Props = {
+  /** Both currencies of the snooze APIs: `untilIso` for /snooze bodies that
+   *  take a timestamp, `minutes` for the ones that take a duration. */
+  onSnooze: (untilIso: string, minutes: number) => void;
+  options?: SnoozeOption[];
+  disabled?: boolean;
+  className?: string;
+  size?: "sm" | "xs";
+  /** Presentation overrides so surfaces with bespoke button systems (the
+   *  dashboard's dash-act family) can reuse the semantics without restyling. */
+  triggerClassName?: string;
+  menuClassName?: string;
+  optionClassName?: string;
+};
+
+export function SnoozeMenu({
+  onSnooze,
+  options = DEFAULT_OPTIONS,
+  disabled = false,
+  className,
+  size = "sm",
+  triggerClassName,
+  menuClassName,
+  optionClassName,
+}: Props) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(open, menuRef, { onEscape: () => setOpen(false) });
 
   useEffect(() => {
     if (!open) return;
@@ -38,25 +74,49 @@ export function SnoozeMenu({ onSnooze, className, size = "sm" }: Props) {
   }, [open]);
 
   const btnCls =
-    size === "xs"
+    triggerClassName ??
+    (size === "xs"
       ? "rounded border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]"
-      : "rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]";
+      : "rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] hover:bg-[var(--bg-raised)]");
+
+  const pick = (o: SnoozeOption) => {
+    setOpen(false);
+    const minutes = o.minutes();
+    onSnooze(new Date(Date.now() + minutes * 60_000).toISOString(), minutes);
+  };
 
   return (
     <div ref={wrapRef} className={`relative ${className ?? ""}`}>
-      <button onClick={() => setOpen((v) => !v)} className={btnCls}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className={btnCls}
+      >
         Snooze ▾
       </button>
       {open ? (
-        <div className="absolute bottom-full left-0 z-50 mb-1 w-32 overflow-hidden rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] shadow-xl">
-          {OPTIONS.map((o) => (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-label="Snooze for"
+          className={
+            menuClassName ??
+            "absolute bottom-full left-0 z-50 mb-1 w-32 overflow-hidden rounded-md border border-[var(--border-strong)] bg-[var(--bg-raised)] shadow-xl"
+          }
+        >
+          {options.map((o) => (
             <button
               key={o.label}
-              onClick={() => {
-                setOpen(false);
-                onSnooze(o.resolve());
-              }}
-              className="block w-full px-2 py-1 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+              type="button"
+              role="menuitem"
+              onClick={() => pick(o)}
+              className={
+                optionClassName ??
+                "block w-full px-2 py-1 text-left text-[11px] text-[var(--text-primary)] hover:bg-[var(--bg-raised)]"
+              }
             >
               {o.label}
             </button>

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -30,6 +30,7 @@ import { MobileBottomTabs } from "@/components/mobile-bottom-tabs";
 import { Icon } from "@/lib/icon";
 import { FamiliarStudioProvider, openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { RailInspector } from "@/components/inspector-pane";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { SalemChatPanel } from "@/components/salem/salem-widget";
 import { FamiliarsView } from "@/components/familiars-view";
 import {
@@ -1130,15 +1131,20 @@ export function Workspace() {
 
   // Calendar item actions — optimistic local update + fire-and-forget POST;
   // the /api/inbox/stream SSE reconciles authoritative state (same pattern as
-  // dismissToast/snoozeToast).
+  // dismissToast/snoozeToast). The optimistic update is invisible to AT, so
+  // each action announces its outcome (generic on purpose: the callbacks are
+  // [] -deps'd and only carry the id — no stale-closure title lookups).
+  const { announce } = useAnnouncer();
   const completeInboxItem = useCallback((id: string) => {
     setInboxItems((prev) => prev.map((it) => (it.id === id ? { ...it, status: "done" } : it)));
     void fetch(`/api/inbox/${id}/done`, { method: "POST" });
-  }, []);
+    announce("Marked done.");
+  }, [announce]);
   const dismissInboxItem = useCallback((id: string) => {
     setInboxItems((prev) => prev.map((it) => (it.id === id ? { ...it, status: "dismissed" } : it)));
     void fetch(`/api/inbox/${id}/dismiss`, { method: "POST" });
-  }, []);
+    announce("Dismissed.");
+  }, [announce]);
   const snoozeInboxItem = useCallback((id: string, untilIso: string) => {
     setInboxItems((prev) => prev.map((it) => (it.id === id ? { ...it, status: "snoozed", snoozeUntil: untilIso } : it)));
     void fetch(`/api/inbox/${id}/snooze`, {
@@ -1146,7 +1152,8 @@ export function Workspace() {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ untilIso }),
     });
-  }, []);
+    announce("Snoozed.");
+  }, [announce]);
   // Drag-to-reschedule from the calendar: move the item to a new fireAt and make
   // it pending there (clearing any snooze). Optimistic; the SSE stream reconciles.
   const rescheduleInboxItem = useCallback((id: string, fireAtIso: string) => {


### PR DESCRIPTION
## Problem (source-verified in the bead)

1. The **shared** `snooze-menu.tsx` (inbox toast, inspector, calendar) was a bare div dropdown: no `role=menu`/`menuitem`, no `aria-haspopup`/`aria-expanded`, no focus trap, no Escape.
2. The dashboard's ActionInbox hand-rolled its **own** SnoozeMenu copy (with roles + trap) — two implementations drifting apart.
3. ActionInbox's optimistic done/dismiss/snooze removals were **silent to AT** (WCAG 4.1.3) — zero announcements in the file; same gap in `workspace.tsx`'s calendar-facing inbox callbacks.
4. The icon-only dismiss button was labeled just "Dismiss" with no item name.

## Fix

- **One SnoozeMenu**: the shared component now owns the semantics — trigger `aria-haspopup`/`aria-expanded`, `role=menu` named "Snooze for", `menuitem` options, shared `useFocusTrap` (focus-first, Tab cycle, Escape closes + returns focus to trigger), outside-click close. Flexible API: per-surface duration `options`, class overrides for bespoke button systems, and `onSnooze(untilIso, minutes)` so both snooze API currencies (timestamp bodies and duration bodies) are served. Existing consumers' `(untilIso) => …` callbacks are unchanged.
- **Dashboard consolidated**: local copy deleted; per-row + bulk-bar call sites use the shared component with `dash-act`/`dash-snooze__*` styling intact; two pieces of open-menu state removed.
- **Audible actions**: single-item actions announce with the item title, bulk actions announce counts, dismiss names its item, and the workspace inbox callbacks announce (generic on purpose — they're `[]`-deps'd and only carry the id).

## Validation

- New `snooze-menu.test.ts` pin file, wired into the app suite
- Consumer pins (calendar-actions, inspector-inbox, notification-bell-mutations) green unchanged
- `pnpm typecheck` + full app suite: 569 test files pass

Bead: cave-1y0d

🤖 Generated with [Claude Code](https://claude.com/claude-code)