### PR TITLE
perf(inbox): drop content-equal SSE updates; ActionInbox follows the cockpit repoll (cave-bzch)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -176,4 +176,22 @@ assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each g
   }
 }
 
+// ── ActionInbox follows the cockpit's 30s repoll (cave-bzch) ─────────────────
+// The widget froze on its mount-time copy; it now adopts each fresh
+// needsAttention list, with locally-acted ids filtered until the incoming
+// list confirms removal (a racing poll can't resurrect a cleared row).
+{
+  const inbox = readFileSync(new URL("../components/dashboard/action-inbox.tsx", import.meta.url), "utf8");
+  assert.match(inbox, /setItems\(initialItems\.filter\(\(it\) => !actedIdsRef\.current\.has\(it\.id\)\)\)/, "prop updates sync into the widget minus acted ids");
+  assert.match(inbox, /actedIdsRef\.current\.add\(item\.id\)/, "single actions register the acted id");
+  assert.match(inbox, /ids\.forEach\(\(id\) => actedIdsRef\.current\.add\(id\)\)/, "bulk actions register acted ids");
+}
+// The workspace SSE 'updated' branch bails on content-equal echoes, so an
+// optimistic complete/dismiss/snooze doesn't trigger one redundant re-render
+// of every inboxItemsWithEphemeral consumer.
+{
+  const ws = readFileSync(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+  assert.match(ws, /if \(JSON\.stringify\(prev\[idx\]\) === JSON\.stringify\(e\.item\)\) return prev;/, "SSE update echoes keep the array identity");
+}
+
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -31,6 +31,18 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
                       // cockpit re-fetches the list itself every 30s.
   const [items, setItems] = useState<InboxItem[]>(initialItems);
   const [error, setError] = useState<string | null>(null);
+  // The cockpit repolls every 30s and passes a fresh needsAttention list —
+  // adopt it, so items fired/done elsewhere update this widget instead of it
+  // freezing on its mount-time copy (cave-bzch). Locally-acted ids stay
+  // filtered until the incoming list confirms their removal, so a poll that
+  // raced an action can't resurrect a row the user just cleared.
+  const actedIdsRef = useRef(new Set<string>());
+  useEffect(() => {
+    setItems(initialItems.filter((it) => !actedIdsRef.current.has(it.id)));
+    for (const id of Array.from(actedIdsRef.current)) {
+      if (!initialItems.some((it) => it.id === id)) actedIdsRef.current.delete(id);
+    }
+  }, [initialItems]);
   const { announce } = useAnnouncer();
   // Bulk triage: select several items and done/dismiss/snooze them together.
   const [selectMode, setSelectMode] = useState(false);
@@ -61,6 +73,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
 
   async function act(item: InboxItem, action: Action, minutes = 60) {
     const prev = items;
+    actedIdsRef.current.add(item.id);
     setItems(nextItemsAfterAction(items, item.id)); // optimistic remove
     setError(null);
     try {
@@ -70,6 +83,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
       // happened (error feedback already has the role=alert banner).
       announce(`${ACTION_PAST_TENSE[action]} '${item.title}'.`);
     } catch {
+      actedIdsRef.current.delete(item.id);
       setItems(prev); // revert
       setError("Couldn't update that item — try again.");
     }
@@ -80,6 +94,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
     const ids = items.filter((i) => selectedIds.has(i.id)).map((i) => i.id);
     if (ids.length === 0) return;
     const prev = items;
+    ids.forEach((id) => actedIdsRef.current.add(id));
     setItems(items.filter((i) => !selectedIds.has(i.id)));
     exitSelect();
     setError(null);
@@ -90,6 +105,7 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
       if (results.some((ok) => !ok)) throw new Error("partial");
       announce(`${ACTION_PAST_TENSE[action]} ${ids.length} ${ids.length === 1 ? "item" : "items"}.`);
     } catch {
+      ids.forEach((id) => actedIdsRef.current.delete(id));
       setItems(prev); // revert the whole batch
       setError("Couldn't update some items — try again.");
     }

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -881,9 +881,18 @@ export function Workspace() {
         return;
       }
       if (e.type === "updated") {
-        setInboxItems((prev) =>
-          prev.map((it) => (it.id === e.item.id ? e.item : it)),
-        );
+        setInboxItems((prev) => {
+          // The SSE broadcast that follows an optimistic complete/dismiss/
+          // snooze delivers the same content back — bail on identity so every
+          // consumer of inboxItemsWithEphemeral skips one redundant re-render
+          // (cave-bzch).
+          const idx = prev.findIndex((it) => it.id === e.item.id);
+          if (idx === -1) return prev;
+          if (JSON.stringify(prev[idx]) === JSON.stringify(e.item)) return prev;
+          const next = prev.slice();
+          next[idx] = e.item;
+          return next;
+        });
         return;
       }
       if (e.type === "deleted") {


### PR DESCRIPTION
## Summary

Bead `cave-bzch` (inbox audit, both items source-verified):

**Content-equal SSE updates re-rendered everything.** Each optimistic complete/dismiss/snooze is followed by the server's `updated` broadcast carrying identical content — and the handler mapped a new array regardless, so every consumer of `inboxItemsWithEphemeral` re-rendered once per action for nothing. The `updated` branch now compares the incoming item against the current one and keeps the array identity when nothing changed.

**ActionInbox froze on mount.** The dashboard widget copied `initialItems` into state once and never looked at the prop again — while the cockpit repolls every 30s and passes a fresh `needsAttention` list. The widget now adopts each incoming list, guarded by an acted-ids set so a poll response that raced a user action can't resurrect a just-cleared row: single and bulk actions register their ids on optimistic removal, unregister on failure-revert, and the sync effect drops each id once the incoming list confirms the server no longer returns it.

(The bead's not-issues — the 10-min daily-summary GitHub cache, the local-file scheduler tick — were verified during its audit and stand.)

## Test plan

- [x] Pins in `dashboard-page.test.ts`: identity bail on content-equal updates, prop-sync-minus-acted-ids, both action paths registering ids
- [x] Full `pnpm test:app` (568 files) green; `pnpm typecheck` clean (one comment reworded to dodge the no-builtin-roster word ban — "echo" is a familiar name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)