### PR TITLE
feat(home): reference-layout composer card — controls inside, attached footer band (cave-dmdq)

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -53,18 +53,29 @@ assert.match(
 );
 
 // ───────── Command-bar hierarchy ─────────
-// The Chat/Task destination tabs sit ABOVE the input card; the footer keeps
-// the utility cluster (attach · voice · Options) and agent picker left,
-// enhance · send right.
+// Reference layout: the + attach trigger and Chat/Task pills sit bottom-left
+// INSIDE the card; the model runtime chip, voice, enhance, and send hug the
+// right; the darker footer band beneath carries project + agent (left) and
+// the Options menu (right).
 assert.match(
   source,
-  /className="hc-dest-pills hc-dest-pills--above"[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"[\s\S]*?cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?ph:warning-circle[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip/,
-  "destination tabs precede the card; the utility cluster keeps attach + voice + Options + warning-circle access chip",
+  /cave-composer-utility-row[\s\S]*?aria-label="Attach images, videos, or files"[\s\S]*?ph:plus[\s\S]*?hc-dest-pills hc-dest-pills--inline[\s\S]*?role="radiogroup"[\s\S]*?aria-label="Send to"/,
+  "the utility row leads with + attach, then the Chat/Task pill toggle",
 );
 assert.match(
   source,
-  /cave-composer-submit-row[\s\S]*?aria-label="Enhance prompt"[\s\S]*?aria-label="Send"/,
-  "home composer submit cluster has enhance and send",
+  /cave-composer-submit-row[\s\S]*?<ComposerRuntimeChip[\s\S]*?aria-label="Voice input"[\s\S]*?aria-label="Enhance prompt"[\s\S]*?aria-label="Send"/,
+  "the submit cluster runs model chip · voice · enhance · send",
+);
+assert.match(
+  source,
+  /className="hc-footer-band"[\s\S]*?<ProjectPicker[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?<ComposerOptionsMenu/,
+  "the footer band hosts project + agent pickers left and the Options menu right",
+);
+assert.match(
+  source,
+  /className=\{`home-composer-card cave-composer-panel[\s\S]*?className="hc-footer-band"/,
+  "the footer band renders inside the card so the panel chrome clips its corners",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -412,20 +412,20 @@ assert.match(
 // ── Destination pills are an accessible single-select radiogroup ─────────────
 assert.match(
   source,
-  /className="hc-dest-pills hc-dest-pills--above"\s+role="radiogroup"\s+aria-label="Send to"\s+ref=\{destGroupRef\}\s+onKeyDown=\{handleDestKeyDown\}/,
+  /className="hc-dest-pills hc-dest-pills--inline"\s+role="radiogroup"\s+aria-label="Send to"\s+ref=\{destGroupRef\}\s+onKeyDown=\{handleDestKeyDown\}/,
   "Destination pills form a labelled radiogroup with keyboard navigation",
 );
-// The Chat/Task tabs live ABOVE the input card (mode choice, not an input
-// control) — they render before the card and never inside the footer rows.
+// Reference layout: the Chat/Task pills sit INSIDE the card's control row,
+// next to the + attach trigger — not above the card, not in the footer band.
 assert.match(
   source,
-  /hc-dest-pills hc-dest-pills--above[\s\S]*?className=\{`home-composer-card cave-composer-panel/,
-  "Destination tabs render above the composer card, outside the input area",
+  /cave-composer-utility-row[\s\S]*?aria-label="Attach images, videos, or files"[\s\S]*?hc-dest-pills hc-dest-pills--inline/,
+  "Destination pills render inside the utility row, after the attach trigger",
 );
 assert.doesNotMatch(
   source,
-  /cave-composer-utility-row[\s\S]*?hc-dest-pills/,
-  "The composer footer no longer hosts the destination pills",
+  /hc-dest-pills--above/,
+  "The above-card pill placement is retired",
 );
 assert.match(
   source,
@@ -454,8 +454,8 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /cave-composer-utility-row[\s\S]*?ph:paperclip[\s\S]*?ph:microphone[\s\S]*?<ComposerOptionsMenu[\s\S]*?ariaLabel="Choose chat agent"[\s\S]*?hc-access-chip[\s\S]*?cave-composer-submit-row[\s\S]*?ph:sparkle[\s\S]*?aria-label="Send"/,
-  "The footer has attach/voice/Options + access chip left; enhance + send right",
+  /cave-composer-utility-row[\s\S]*?ph:plus[\s\S]*?hc-dest-pills--inline[\s\S]*?cave-composer-submit-row[\s\S]*?<ComposerRuntimeChip[\s\S]*?ph:microphone[\s\S]*?ph:sparkle[\s\S]*?aria-label="Send"[\s\S]*?className="hc-footer-band"[\s\S]*?<ProjectPicker[\s\S]*?hc-access-chip[\s\S]*?<ComposerOptionsMenu/,
+  "Control row: + attach and Chat/Task pills left, model chip · voice · enhance · send right; the footer band beneath carries project + agent + Options",
 );
 
 // ── Model selection moved to the /model slash command ────────────────────────
@@ -545,8 +545,8 @@ assert.match(
 // ── Attachments ─────────────────────────────────────────────────────────────
 assert.match(
   source,
-  /aria-label="Attach images, videos, or files"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:paperclip/,
-  "the paperclip button opens the file picker (chat-composer parity)",
+  /aria-label="Attach images, videos, or files"[\s\S]*?onClick=\{\(\) => fileInputRef\.current\?\.click\(\)\}[\s\S]*?ph:plus/,
+  "the + button opens the file picker (reference layout)",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -739,33 +739,9 @@ export function HomeComposer({
           />
         ) : null}
 
-        {/* Destination tabs — Chat vs Task is a mode choice, not an input
-            control, so it sits above the card as its own tab row instead of
-            crowding the composer footer. */}
-        <div
-          className="hc-dest-pills hc-dest-pills--above"
-          role="radiogroup"
-          aria-label="Send to"
-          ref={destGroupRef}
-          onKeyDown={handleDestKeyDown}
-        >
-          {DESTINATIONS.map((d) => (
-            <button
-              key={d.id}
-              type="button"
-              className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
-              role="radio"
-              aria-checked={destination === d.id}
-              tabIndex={destination === d.id ? 0 : -1}
-              onClick={() => setDestination(d.id)}
-              disabled={sending}
-            >
-              <Icon name={d.icon} width={14} aria-hidden />
-              <span className="hc-dest-label">{d.label}</span>
-            </button>
-          ))}
-        </div>
-
+        {/* Composer card — reference layout: the input leads; the mode pills,
+            attach, model chip, and mic all live INSIDE the card's control row,
+            with a darker attached footer band beneath for context pickers. */}
         <div
           className={`home-composer-card cave-composer-panel${dropActive ? " is-drop-active" : ""}`}
           {...dropHandlers}
@@ -863,9 +839,9 @@ export function HomeComposer({
           </div>
         ) : null}
 
-        {/* Controls — chat-composer footer: utility cluster (attach · voice ·
-            Options) plus the home-only agent picker on the left; enhance ·
-            send hug the right. (Chat/Task moved above the card.) */}
+        {/* Controls — reference layout: `+` attach and the Chat/Task pills sit
+            bottom-left inside the card; the model chip, voice, enhance, and
+            send hug the right. Context pickers move to the footer band. */}
         <div className="cave-composer-controls">
           <input
             ref={fileInputRef}
@@ -886,58 +862,33 @@ export function HomeComposer({
                 disabled={sending || attachments.length >= 10}
                 onClick={() => fileInputRef.current?.click()}
               >
-                <Icon name="ph:paperclip" width={14} aria-hidden />
+                <Icon name="ph:plus" width={15} aria-hidden />
               </button>
-              <button
-                type="button"
-                className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
-                title="Voice input (coming soon)"
-                aria-label="Voice input"
-                disabled
+              <div
+                className="hc-dest-pills hc-dest-pills--inline"
+                role="radiogroup"
+                aria-label="Send to"
+                ref={destGroupRef}
+                onKeyDown={handleDestKeyDown}
               >
-                <Icon name="ph:microphone" width={15} aria-hidden />
-              </button>
-              <ComposerOptionsMenu
-                hostValue={runtimeHost ?? LOCAL_HOST_ID}
-                onHostPick={setRuntimeHost}
-                disabled={sending}
-                indicator={
-                  thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
-                  responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed
-                }
-                sections={[
-                  {
-                    id: "runtime",
-                    label: "Runtime",
-                    value: selectedRuntime,
-                    options: runtimeSectionOptions,
-                    onChange: (id: string) => handleSelectRuntime(id),
-                  } satisfies ComposerOptionSection,
-                  ...(runtimeModelOptions.length > 0
-                    ? [{
-                        id: "model",
-                        label: "Model",
-                        value: selectedModelId,
-                        options: runtimeModelOptions.map((m) => ({ value: m.id, label: m.label })),
-                        onChange: (id: string) => handleSelectModel(id),
-                      } satisfies ComposerOptionSection]
-                    : []),
-                  {
-                    id: "thinking",
-                    label: "Thinking",
-                    value: thinkingEffort,
-                    options: COMMAND_THINKING_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
-                    onChange: (v: string) => setThinkingEffort(v as CommandThinkingEffort),
-                  } satisfies ComposerOptionSection,
-                  {
-                    id: "speed",
-                    label: "Speed",
-                    value: responseSpeed,
-                    options: COMMAND_RESPONSE_SPEED_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
-                    onChange: (v: string) => setResponseSpeed(v as CommandResponseSpeed),
-                  } satisfies ComposerOptionSection,
-                ]}
-              />
+                {DESTINATIONS.map((d) => (
+                  <button
+                    key={d.id}
+                    type="button"
+                    className={`hc-dest-pill${destination === d.id ? " active" : ""}`}
+                    role="radio"
+                    aria-checked={destination === d.id}
+                    tabIndex={destination === d.id ? 0 : -1}
+                    onClick={() => setDestination(d.id)}
+                    disabled={sending}
+                  >
+                    <Icon name={d.icon} width={14} aria-hidden />
+                    <span className="hc-dest-label">{d.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="cave-composer-submit-row">
               {/* Always-visible runtime mark + model, one click to switch —
                   parity with the chat composer's chip (cave-yq5l). */}
               <ComposerRuntimeChip
@@ -948,34 +899,15 @@ export function HomeComposer({
                 onPickModel={handleSelectModel}
                 disabled={sending}
               />
-
-              <HomeSelect
-                icon="ph:warning-circle"
-                value={selectedFamiliarId}
-                onChange={(value) => {
-                  if (value) onSetActiveFamiliar(value);
-                }}
-                groups={familiarSelectGroups}
-                ariaLabel="Choose chat agent"
-                disabled={visibleFamiliars.length === 0 || sending}
-                className="hc-access-chip"
-              />
-              {/* Project selector — picks which project the new chat runs in
-                  (mirrors the chat composer). Its own search popover, so it sits
-                  alongside the familiar select rather than inside the ⚙ menu. */}
-              <ProjectPicker
-                projects={projects}
-                value={selectedProjectId || null}
-                onChange={setSelectedProjectId}
-                allowNoProject
-                familiarId={selectedFamiliarId || null}
-                createProject={createProject}
-                disabled={sending}
-                ariaLabel="Choose project"
-                className="hc-project-selector"
-              />
-            </div>
-            <div className="cave-composer-submit-row">
+              <button
+                type="button"
+                className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
+                title="Voice input (coming soon)"
+                aria-label="Voice input"
+                disabled
+              >
+                <Icon name="ph:microphone" width={15} aria-hidden />
+              </button>
               <button
                 type="button"
                 className="cave-composer-icon-button focus-ring grid h-[30px] w-[30px] place-items-center rounded-full border border-[var(--border-hairline)] hover:bg-[var(--bg-raised)] disabled:opacity-40"
@@ -1002,6 +934,79 @@ export function HomeComposer({
               </button>
             </div>
           </div>
+        </div>
+
+        {/* Footer band — the darker strip attached to the card's underside
+            (reference layout): where the message runs (project) and who runs
+            it (agent) on the left, run settings (Options) on the right. */}
+        <div className="hc-footer-band">
+          <div className="hc-footer-band-left">
+            {/* Project selector — picks which project the new chat runs in
+                (mirrors the chat composer). */}
+            <ProjectPicker
+              projects={projects}
+              value={selectedProjectId || null}
+              onChange={setSelectedProjectId}
+              allowNoProject
+              familiarId={selectedFamiliarId || null}
+              createProject={createProject}
+              disabled={sending}
+              ariaLabel="Choose project"
+              className="hc-project-selector"
+            />
+            <HomeSelect
+              icon="ph:warning-circle"
+              value={selectedFamiliarId}
+              onChange={(value) => {
+                if (value) onSetActiveFamiliar(value);
+              }}
+              groups={familiarSelectGroups}
+              ariaLabel="Choose chat agent"
+              disabled={visibleFamiliars.length === 0 || sending}
+              className="hc-access-chip"
+            />
+          </div>
+          <ComposerOptionsMenu
+            hostValue={runtimeHost ?? LOCAL_HOST_ID}
+            onHostPick={setRuntimeHost}
+            disabled={sending}
+            indicator={
+              thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
+              responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed
+            }
+            sections={[
+              {
+                id: "runtime",
+                label: "Runtime",
+                value: selectedRuntime,
+                options: runtimeSectionOptions,
+                onChange: (id: string) => handleSelectRuntime(id),
+              } satisfies ComposerOptionSection,
+              ...(runtimeModelOptions.length > 0
+                ? [{
+                    id: "model",
+                    label: "Model",
+                    value: selectedModelId,
+                    options: runtimeModelOptions.map((m) => ({ value: m.id, label: m.label })),
+                    onChange: (id: string) => handleSelectModel(id),
+                  } satisfies ComposerOptionSection]
+                : []),
+              {
+                id: "thinking",
+                label: "Thinking",
+                value: thinkingEffort,
+                options: COMMAND_THINKING_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+                onChange: (v: string) => setThinkingEffort(v as CommandThinkingEffort),
+              } satisfies ComposerOptionSection,
+              {
+                id: "speed",
+                label: "Speed",
+                value: responseSpeed,
+                options: COMMAND_RESPONSE_SPEED_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+                onChange: (v: string) => setResponseSpeed(v as CommandResponseSpeed),
+              } satisfies ComposerOptionSection,
+            ]}
+          />
         </div>
         </div>
       </div>

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -218,6 +218,40 @@
   border-color: color-mix(in oklch, var(--accent-presence) 50%, var(--border-strong));
 }
 
+/* ── Footer band ────────────────────────────────────────────────────────────
+ * The darker strip attached to the card's underside (reference layout):
+ * context pickers (project · agent) on the left, run settings on the right.
+ * Last child of the card, so the panel's overflow clips it to the rounded
+ * bottom corners — it reads as part of the card, one tone deeper. */
+.hc-footer-band {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  padding: 6px 10px;
+  border-top: 1px solid var(--border-hairline);
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+}
+
+.hc-footer-band-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+/* Phone width: the band's pickers wrap instead of crushing each other. */
+@container (max-width: 620px) {
+  .hc-footer-band {
+    flex-wrap: wrap;
+  }
+  .hc-footer-band-left {
+    flex-wrap: wrap;
+  }
+}
+
 /* ── Textarea ──────────────────────────────────────────────────────────────
  *   Sizing and chrome come from the shared .cave-composer-input class plus the
  *   same utility classes the chat composer uses; .hc-textarea stays as a
@@ -456,11 +490,11 @@
   border: 1px solid var(--border-hairline);
 }
 
-/* Above-card placement: the mode tabs lead the input, outside its chrome. */
-.hc-dest-pills--above {
+/* Inline placement (reference layout): the pills sit inside the card's
+ * control row next to the + attach button — compact, no outer margin. */
+.hc-dest-pills--inline {
   position: relative;
-  z-index: 1;
-  margin-bottom: 8px;
+  padding: 2px;
 }
 
 .hc-dest-pill {


### PR DESCRIPTION
## Objective (operator autopilot)
Restyle the home composer to match the provided reference: input leads the card; `+` and the mode pill toggle sit bottom-left inside it; model selector + mic on the right; a darker attached footer band beneath for context pickers.

## What changed
- **Control row (in-card)**: round `+` attach trigger → Chat/Task segmented pills (moved down from above the card, radiogroup + roving tabindex intact) on the left; **model runtime chip · voice · enhance · send** on the right.
- **Footer band** (`hc-footer-band`): one-tone-darker strip attached to the card underside (hairline top border, corners clipped by the panel) with the **project picker + agent select** left and the **Options menu** right.
- Attach icon: paperclip → `+` per the reference. All behavior (drop targets, attachments, slash menus, drafts, keyboard nav) untouched — markup moved, logic identical.

## Verification
- **Live Playwright** at 1440px (prod build, demo data): card + footer band render as designed; measured the send button 13px inside the card edge (not clipped).
- Pins updated in `home-composer.test.ts` + `home-composer-polish.test.ts` (inline pills, +-attach, submit-row order, footer-band composition, above-card placement retired); centering/mobile-gaps/hide-archived suites untouched and green.
- `pnpm test:app` — 568 files pass · `pnpm typecheck` clean · `pnpm build` clean

Closes cave-dmdq (beads).