### PR TITLE
chore(release): stamp v0.0.157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.157] - 2026-07-08
+
+> 🔔 **Heard, not just seen** — inbox triage speaks to assistive tech: one snooze menu with real menu semantics everywhere, actions that announce what they did, urgency-aware toasts, and capabilities that narrate their refreshes. Plus the familiar switcher in every page's sidenav and split tiles that fit every screen.
+
+Patch release on top of v0.0.156.
+
+### Features
+- **Shell: the familiar switcher lives in the sidenav header on every page** (#2750, cave-vtk9).
+
+### Fixes
+- **Inbox: prefs writes are serialized** — concurrent PATCHes can no longer drop each other's changes (#2758, cave-g6ew).
+- **Shell: split tiles fit every screen** — pixel floor, even remounts, container-keyed grids (#2743, cave-hivd).
+
+### Accessibility
+- **One SnoozeMenu, real menu semantics** (#2760, cave-1y0d). The shared snooze menu (inbox toast, inspector, calendar, dashboard) declares `aria-haspopup`/`aria-expanded`, renders a named `role=menu` with `menuitem` options, traps focus with Escape-to-trigger, and the dashboard's hand-rolled copy is gone. Inbox actions announce their outcomes — item titles for single actions, counts for bulk — and the icon-only dismiss names its item.
+- **Toasts: urgency-aware politeness, pausable auto-hide, one titled dismiss** (#2757, cave-bj68).
+- **Capabilities: refresh lifecycle and copy outcomes are announced** (#2755, cave-vmj8).
+
 ## [0.0.156] - 2026-07-08
 
 > 🎛️ **A palette worthy of the slash** — the chat composer's slash view becomes a sectioned palette: Commands and Skills headers, icon-led rows with inline descriptions, and a roomy elevated panel. The shell picks up a familiar dropdown atop the chat sidebar with a Codex-style title bar.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.156",
+  "version": "0.0.157",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.156"
+version = "0.0.157"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.156"
+version = "0.0.157"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.156</string>
+	<string>0.0.157</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.156</string>
+	<string>0.0.157</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.156</string>
+	<string>0.0.157</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.156</string>
+	<string>0.0.157</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.156",
+  "version": "0.0.157",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.156 — an a11y-forward set of 6 commits: the **consolidated SnoozeMenu with real menu semantics + audible inbox actions** (#2760, cave-1y0d), urgency-aware toasts (#2757), capabilities announcements (#2755), the sidenav familiar switcher (#2750), serialized inbox prefs writes (#2758), and split tiles that fit every screen (#2743).

Local gate: `cargo check --locked` + typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.157` → release.yml builds → `node scripts/verify-release-updater.mjs`.

Bead: cave-67yi

🤖 Generated with [Claude Code](https://claude.com/claude-code)