### PR TITLE
perf(inbox): SSE echo/reconnect guards; dashboard inbox hears the cockpit refetch (cave-bzch)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -365,6 +365,7 @@ export const SUITES = {
     "src/lib/automations/list-input.test.ts",
     "src/lib/automations/run-status.test.ts",
     "src/lib/inbox-feed.test.ts",
+    "src/lib/inbox-hygiene.test.ts",
     "src/lib/daily-summary-notifications.test.ts",
     "src/components/daily-summary-notifications.test.ts",
     "src/app/daily-report-page.test.ts",

--- a/src/components/dashboard/action-inbox.tsx
+++ b/src/components/dashboard/action-inbox.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import { Icon, type IconName } from "@/lib/icon";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -30,6 +31,14 @@ export function ActionInbox({ initialItems }: { initialItems: InboxItem[] }) {
   useMinuteTick();    // keep the per-item "Nm ago" labels current; the parent
                       // cockpit re-fetches the list itself every 30s.
   const [items, setItems] = useState<InboxItem[]>(initialItems);
+  // The cockpit re-fetches its model every 30s and re-renders us with fresh
+  // initialItems — but useState reads the prop once, so items fired, done or
+  // dismissed elsewhere stayed in this widget until remount (cave-bzch).
+  // Reconcile on prop change; the content-equal guard keeps the reference
+  // (and any in-flight optimistic removal) stable when nothing moved.
+  useEffect(() => {
+    setItems((prev) => (arrayContentEqual(prev, initialItems) ? prev : initialItems));
+  }, [initialItems]);
   const [error, setError] = useState<string | null>(null);
   const { announce } = useAnnouncer();
   // Bulk triage: select several items and done/dismiss/snooze them together.

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -869,7 +869,9 @@ export function Workspace() {
         | { type: "updated"; item: InboxItem }
         | { type: "deleted"; id: string };
       if (e.type === "snapshot") {
-        setInboxItems(e.items);
+        // Reconnect snapshots usually carry what we already have — keep the
+        // reference so inboxItemsWithEphemeral consumers don't re-render.
+        setInboxItems((prev) => (arrayContentEqual(prev, e.items) ? prev : e.items));
         return;
       }
       if (e.type === "created") {
@@ -881,9 +883,14 @@ export function Workspace() {
         return;
       }
       if (e.type === "updated") {
-        setInboxItems((prev) =>
-          prev.map((it) => (it.id === e.item.id ? e.item : it)),
-        );
+        setInboxItems((prev) => {
+          // Server echoes of our own optimistic writes (dismiss/done/snooze
+          // set state locally, then the broadcast arrives) can be
+          // content-identical — bail before minting a new array reference.
+          const existing = prev.find((it) => it.id === e.item.id);
+          if (existing && JSON.stringify(existing) === JSON.stringify(e.item)) return prev;
+          return prev.map((it) => (it.id === e.item.id ? e.item : it));
+        });
         return;
       }
       if (e.type === "deleted") {

--- a/src/lib/inbox-hygiene.test.ts
+++ b/src/lib/inbox-hygiene.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+// Source pins for the inbox state-hygiene pass (cave-bzch): SSE echo and
+// reconnect guards in workspace, and the dashboard widget actually hearing
+// the cockpit's refetches. (The prefs write lock the same audit found is
+// covered by cave-inbox-prefs.test.ts.)
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const workspace = readFileSync(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+const actionInbox = readFileSync(new URL("../components/dashboard/action-inbox.tsx", import.meta.url), "utf8");
+
+// ── SSE guards in workspace ──────────────────────────────────────────────────
+assert.match(
+  workspace,
+  /setInboxItems\(\(prev\) => \(arrayContentEqual\(prev, e\.items\) \? prev : e\.items\)\);/,
+  "reconnect snapshots keep the previous reference when content-identical",
+);
+assert.match(
+  workspace,
+  /const existing = prev\.find\(\(it\) => it\.id === e\.item\.id\);\s*\n\s*if \(existing && JSON\.stringify\(existing\) === JSON\.stringify\(e\.item\)\) return prev;/,
+  "content-identical update echoes (our own optimistic writes bounced back) don't mint a new array",
+);
+
+// ── ActionInbox hears the cockpit refetch ────────────────────────────────────
+assert.match(
+  actionInbox,
+  /useEffect\(\(\) => \{\s*\n\s*setItems\(\(prev\) => \(arrayContentEqual\(prev, initialItems\) \? prev : initialItems\)\);\s*\n\s*\}, \[initialItems\]\);/,
+  "the widget reconciles with fresh initialItems (useState read the prop exactly once before) — content-guarded so in-flight optimistic removals survive no-op re-renders",
+);
+
+console.log("inbox-hygiene.test.ts: ok");


### PR DESCRIPTION
The surviving piece of the inbox data-plane audit (cave-bzch), rebuilt on latest main after #2757/#2760 landed the a11y beads and the prefs lock (cave-g6ew) via a sibling session.

- **SSE reconnect snapshots** keep the previous `inboxItems` reference when content-identical (`arrayContentEqual`) — a reconnect used to re-render every `inboxItemsWithEphemeral` consumer with an identical list.
- **Content-identical `updated` echoes** (our own optimistic dismiss/done/snooze writes bounced back by the broadcast) bail before minting a new array.
- **ActionInbox actually hears the cockpit's 30s refetch** — `useState(initialItems)` read the prop exactly once, so items fired/done/dismissed elsewhere stayed in the dashboard widget until remount. The audit bead guessed "subscribe to SSE"; the real mechanism was the ignored prop, and the fix is a content-guarded reconcile effect that also preserves in-flight optimistic removals.

Pinned in `inbox-hygiene.test.ts` (wired into the app suite). Verification: typecheck clean, 571 suite files pass, `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)