### PR TITLE
fix(board): sequence-guard load() so a stale poll/focus GET can't clobber a fresher optimistic move (cave-vdvy)

### DIFF
--- a/src/components/board-ux-polish.test.ts
+++ b/src/components/board-ux-polish.test.ts
@@ -8,7 +8,7 @@ const styles = await readFile(new URL("../styles/board.css", import.meta.url), "
 
 // ───────── Loading state (no empty-CTA flash on open) ─────────
 assert.match(view, /const \[hasLoaded, setHasLoaded\] = useState\(false\)/, "BoardView must track a hasLoaded flag");
-assert.match(view, /finally\s*\{\s*setHasLoaded\(true\);/, "load() must set hasLoaded in finally");
+assert.match(view, /finally\s*\{\s*if \(!ctl\.signal\.aborted\) setHasLoaded\(true\);/, "load() must set hasLoaded in finally (skipping a superseded/aborted load)");
 assert.match(view, /!hasLoaded && !error \?/, "A loading branch must precede the empty-state branch");
 assert.match(view, /role="status" aria-label="Loading tasks"/, "Loading state must be announced");
 
@@ -170,6 +170,15 @@ assert.match(
   /setCards\(\(prev\) => \(arrayContentEqual\(prev, loaded\) \? prev : loaded\)\)/,
   "the board poll guards setCards with arrayContentEqual",
 );
+
+// 2b. load() is sequence-guarded: five overlapping callers (mount, focus,
+//    reload event, 15s poll, failure-revert paths) mean an older GET can
+//    resolve last and clobber a fresher optimistic move. Abort the prior load
+//    and drop a superseded response so only the latest load touches state.
+assert.match(view, /const loadCtlRef = useRef<AbortController \| null>\(null\)/, "the board load has an abort controller");
+assert.match(view, /loadCtlRef\.current\?\.abort\(\);\s*\n\s*const ctl = new AbortController\(\)/, "each load aborts the prior in-flight one");
+assert.match(view, /if \(ctl\.signal\.aborted\) return; \/\/ superseded/, "a superseded load response is dropped before touching state");
+assert.match(view, /useEffect\(\(\) => \(\) => loadCtlRef\.current\?\.abort\(\), \[\]\)/, "the in-flight load aborts on unmount");
 
 // 3. A second reschedule inside the undo window must not clobber the snapshot —
 //    Undo restores the ORIGINAL dates, not the intermediate position.

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -129,11 +129,26 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   // the board (setCards([])) or flash an error — leave the last-good cards in
   // place. Explicit loads (mount, focus, reload event) stay loud. Callers that
   // pass an event (e.g. useRefreshOnFocus) read as not-quiet, which is correct.
+  //
+  // Sequence guard: load() fires from five overlapping sources (mount, focus
+  // refresh, the reload event, the 15s poll, and the failure-revert paths in
+  // patchCard/deleteCards/handleClearDone). Without this, whichever GET
+  // *resolves* last wins — which may be an *older* request, so a slow poll can
+  // land after an optimistic move (drag/table edit, neither of which pauses the
+  // poll) and clobber it back to the pre-move state until the next tick. Abort
+  // the prior in-flight load before each new one and drop a superseded (aborted)
+  // response, so only the latest load ever touches state (mirrors
+  // capabilities-view / marketplace-configure).
+  const loadCtlRef = useRef<AbortController | null>(null);
   const load = useCallback(async (opts?: { quiet?: boolean }) => {
     const quiet = opts?.quiet === true;
+    loadCtlRef.current?.abort();
+    const ctl = new AbortController();
+    loadCtlRef.current = ctl;
     try {
-      const res = await fetch("/api/board", { cache: "no-store" });
+      const res = await fetch("/api/board", { cache: "no-store", signal: ctl.signal });
       const json = await res.json();
+      if (ctl.signal.aborted) return; // superseded by a newer load — ignore
       if (json.ok) {
         const loaded = json.cards as Card[];
         // Poll ticks rebuild an identical array most of the time; keep the
@@ -147,16 +162,19 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
         setError(json.error ?? "load failed");
       }
     } catch (err) {
+      if (ctl.signal.aborted) return; // aborted mid-flight — leave state to the newer load
       if (!quiet) {
         setCards([]);
         setError(err instanceof Error ? err.message : "load failed");
       }
     } finally {
-      setHasLoaded(true);
+      if (!ctl.signal.aborted) setHasLoaded(true);
     }
   }, []);
 
   useEffect(() => { void load(); }, [load]);
+  // Abort any in-flight load when the board unmounts.
+  useEffect(() => () => loadCtlRef.current?.abort(), []);
 
   // "/" jumps to the task search (GitHub-style) while the board is shown,
   // unless the user is already typing in a field or holding a modifier.


### PR DESCRIPTION
## What

`BoardView.load()` fires from **five overlapping sources** — mount, `useRefreshOnFocus`, the `cave:board:reload` event, the 15s `usePausablePoll`, and the failure-revert paths in `patchCard`/`deleteCards`/`handleClearDone` — with **no request-sequencing guard**. Whichever GET *resolves* last wins, even if it's an *older* request.

The poll pauses during modal/inspector/undo/confirm interactions but **not** during a bare kanban drag or a table inline edit (both go through `patchCard` without opening the inspector). So:

1. A slow quiet poll GET is in flight.
2. User drags a card Running→Done → optimistic + PATCH succeeds → board shows Done.
3. The stale poll GET resolves with pre-drag data → `setCards` snaps the card back to Running for up to 15s until the next tick heals it.

## Fix

`AbortController`-per-load: abort the prior in-flight load before each new one, **drop a superseded (aborted) response before it touches state**, and abort on unmount. Only the latest load ever mutates `cards`/`error`/`hasLoaded`. Mirrors the guard shipped this session for `capabilities-view` (#2754) and `marketplace-configure` (#2749). The `arrayContentEqual` reference-stability guard is untouched.

Found by a proactive board-surface audit. Source-pinned in `board-ux-polish.test.ts`.

## Verification

`typecheck` · all board-reading test suites + `surface-error-states` green · `build` within budget (largest 992 KB / 2400 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)