### PR TITLE
ci(release): retry the Intel leg's network-dependent steps (cave-1hha)

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -39,9 +39,11 @@ test("notary rejection stops before stapling and prints the Apple log", () => {
   assert.match(releaseScript, /print_notary_log\(\)/);
   assert.match(releaseScript, /Submission in terminal status: Invalid/);
   assert.match(releaseScript, /Notary submission did not report Accepted/);
-  assert.match(releaseScript, /run_notary_submit\n\n/);
+  // (cave-1hha) the call site is the retry wrapper now — transient submit
+  // failures retry, an Invalid verdict still stops before stapling.
+  assert.match(releaseScript, /notarize_with_retries\n\n/);
   assert(
-    releaseScript.indexOf("run_notary_submit") <
+    releaseScript.indexOf("notarize_with_retries") <
       releaseScript.indexOf('echo "==> Stapling notarization ticket"'),
   );
 });
@@ -147,4 +149,17 @@ test("sidecar bundle prunes foreign native packages before release bundling", ()
       sidecarScript.indexOf('fix_node_pty_spawn_helpers "$PNPM_STAGE/node_modules"'),
     "native package pruning should run before node-pty permission repair",
   );
+});
+
+// ── Transient-failure retries (cave-1hha) ────────────────────────────────────
+// The Intel leg failed 3 of 4 cuts on network-dependent steps: the Next
+// build's Google Fonts fetch, Apple's timestamp service during codesign, and
+// a notary submit. Each retries; an Apple REJECTION (Invalid) never retries.
+test("release.sh retries its network-dependent steps", () => {
+  assert.match(releaseScript, /^retry\(\) \{/m, "a retry helper exists");
+  assert.match(releaseScript, /retry 2 30 env \\/, "the tauri build (font fetch inside) gets one retry");
+  assert.match(releaseScript, /retry 3 15 codesign --force --options runtime --timestamp/, "the envelope seal retries the timestamp service");
+  assert.match(releaseScript, /retry 3 10 codesign --force --options runtime --timestamp/, "inner-binary signs retry the timestamp service");
+  assert.match(releaseScript, /notarize_with_retries/, "notary submission goes through the retry loop");
+  assert.match(releaseScript, /2\) echo "Apple rejected the submission \(Invalid\) — not retrying\." >&2; exit 1 ;;/, "a real Invalid verdict never retries");
 });

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,6 +30,23 @@ require_value() {
   local label="${2:-required value}"
   [ -n "$value" ] || { echo "Missing required value: $label" >&2; exit 1; }
 }
+# Retry transient-failure commands (Apple timestamp service, notary submit,
+# the Next build's Google Fonts fetch) — the Intel leg failed 3 of 4 cuts on
+# exactly these network-dependent steps (cave-1hha).
+retry() {
+  local attempts="$1"; shift
+  local delay="$1"; shift
+  local n=1
+  until "$@"; do
+    if [ "$n" -ge "$attempts" ]; then
+      echo "    ! giving up after $attempts attempts: $1" >&2
+      return 1
+    fi
+    echo "    retry $n/$((attempts - 1)) in ${delay}s: $1" >&2
+    sleep "$delay"
+    n=$((n + 1))
+  done
+}
 print_notary_log() {
   local submission_id="$1"
 
@@ -87,23 +104,47 @@ run_notary_submit() {
   set -e
 
   submission_id=$(awk '/^[[:space:]]*id:/ { print $2; exit }' "$output")
+  # Return codes: 0 accepted · 2 Apple REJECTED the submission (never retry) ·
+  # 1 transient/submit failure (the caller retries — cave-1hha).
   if [ "$submit_status" -ne 0 ]; then
     print_notary_log "$submission_id"
     rm -f "$output"
-    exit "$submit_status"
+    return 1
   fi
   if grep -Eq "Submission in terminal status: Invalid|Current status: Invalid|^[[:space:]]*status:[[:space:]]*Invalid" "$output"; then
     print_notary_log "$submission_id"
     rm -f "$output"
-    exit 1
+    return 2
   fi
   if ! grep -Eq "Submission in terminal status: Accepted|Received new status: Accepted|^[[:space:]]*status:[[:space:]]*Accepted" "$output"; then
     echo "Notary submission did not report Accepted; refusing to staple." >&2
     print_notary_log "$submission_id"
     rm -f "$output"
-    exit 1
+    return 1
   fi
   rm -f "$output"
+  return 0
+}
+notarize_with_retries() {
+  local attempt rc
+  for attempt in 1 2 3; do
+    set +e
+    run_notary_submit
+    rc=$?
+    set -e
+    case "$rc" in
+      0) return 0 ;;
+      2) echo "Apple rejected the submission (Invalid) — not retrying." >&2; exit 1 ;;
+      *)
+        if [ "$attempt" -eq 3 ]; then
+          echo "Notary submission failed after 3 attempts." >&2
+          exit 1
+        fi
+        echo "==> Notary submission attempt $attempt failed transiently; retrying in 60s" >&2
+        sleep 60
+        ;;
+    esac
+  done
 }
 cleanup_dmg_artifacts() {
   local mount
@@ -249,7 +290,7 @@ echo "==> Running pnpm tauri build"
 # mismatches between the generated script and the installed create-dmg.
 # Keep App Store Connect credentials out of this subprocess so Tauri does not
 # take its built-in notarization path before this script assembles the DMG.
-env \
+retry 2 30 env \
   -u APPLE_API_KEY \
   -u APPLE_API_KEY_PATH \
   -u APPLE_API_ISSUER \
@@ -294,13 +335,13 @@ NATIVE_COUNT=$(wc -l < "$NATIVE_FILES_TMP" | tr -d ' ')
 echo "    found $NATIVE_COUNT native files"
 while IFS= read -r f; do
   if [ "$f" = "$APP_PATH/Contents/Resources/resources/node/bin/node" ]; then
-    codesign --force --options runtime --timestamp \
+    retry 3 10 codesign --force --options runtime --timestamp \
       --entitlements "$NODE_ENTITLEMENTS" \
       --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
         echo "    ! failed to sign bundled Node with entitlements: $f" >&2
       }
   else
-    codesign --force --options runtime --timestamp \
+    retry 3 10 codesign --force --options runtime --timestamp \
       --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
         echo "    ! failed to sign: $f" >&2
       }
@@ -309,7 +350,7 @@ done < "$NATIVE_FILES_TMP"
 rm "$NATIVE_FILES_TMP"
 
 echo "==> Sealing the .app envelope"
-codesign --force --options runtime --timestamp \
+retry 3 15 codesign --force --options runtime --timestamp \
   --sign "$SIGNING_IDENTITY" "$APP_PATH"
 
 echo "==> Verifying signature"
@@ -333,7 +374,7 @@ codesign --force --timestamp \
   --sign "$SIGNING_IDENTITY" "$DMG_PATH"
 
 echo "==> Submitting DMG for notarization"
-run_notary_submit
+notarize_with_retries
 
 echo "==> Stapling notarization ticket"
 xcrun stapler staple "$DMG_PATH"


### PR DESCRIPTION
## Summary

Bead `cave-1hha` (P1). The macOS Intel release leg failed **3 of 4 cuts today**, each on a different network-dependent step — the Google Fonts fetch inside the Next build (v0.0.151), Apple's timestamp service during codesign (v0.0.152), and a notarization submit (v0.0.156) — and every failure shipped a partial release whose missing `latest.json` 404'd the in-app updater until a manual rerun.

`release.sh` gains a generic `retry` helper applied exactly where the flakes live:

- **`pnpm tauri build`** (the font fetch happens inside): one retry, 30s apart — a genuine build error costs one extra attempt, a font-CDN blip no longer kills the cut
- **Every `codesign --timestamp`**: inner binaries retry 3× (still warn-and-continue on final failure, as today), the envelope seal retries 3× and still hard-fails
- **Notary submission**: `notarize_with_retries` — up to 3 attempts for transient failures with the Apple log printed each time, while a real **Invalid verdict returns a distinct code and never retries** (rejection still stops before stapling, and the Accepted-before-staple gate is untouched)

**Deliberately out of scope:** the bead's "tolerate a missing platform in the updater manifest" idea — publishing a partial `latest.json` is an updater-policy change that deserves its own decision rather than riding a retry PR.

## Test plan

- [x] `bash -n` clean; new pins in `release-macos-signing.test.mjs` (helper, all four retry sites, Invalid-never-retries); the pre-existing rejection-stops-stapling pin updated to the wrapper call — all 10 tests pass
- [x] Full `pnpm test:app` (570 files) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)