### PR TITLE
fix(chat): restore the chat sidebar's familiar switcher — the chat page's only familiar control (cave-l3ay)

### DIFF
--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -19,12 +19,12 @@ assert.doesNotMatch(source, /computeQuickSwitch/, "the strip's pin/recency selec
 assert.doesNotMatch(globals, /\.familiar-quickswitch__strip \{/, "strip CSS removed");
 assert.match(globals, /\.familiar-quickswitch \{/, "wrapper CSS remains for the top-bar call site");
 
-// ── Desktop home: the SIDENAV header switcher (cave-vtk9) ────────────────────
-// Familiar selection lives in the global sidenav header on every page (per
-// operator direction, superseding #2747's chat-sidebar placement — the two
-// panels are adjacent, so both hosting it doubled the same control).
+// ── Familiar selection: sidenav header everywhere, chat sidebar on chat ──────
+// Chat mode swaps the nav panel for the chat sidebar (SidebarMinimal never
+// renders there), so BOTH hosts are needed: the sidenav header on every other
+// page (cave-vtk9), the chat sidebar header on chat (#2747, cave-l3ay).
 assert.doesNotMatch(menuBar, /FamiliarQuickSwitch|FamiliarSwitcher/, "the menu bar no longer hosts familiar selection");
-assert.doesNotMatch(sidebar, /FamiliarSwitcher/, "the chat sidebar no longer duplicates the sidenav switcher");
+assert.match(sidebar, /<FamiliarSwitcher[\s\S]*?labeled/, "the chat sidebar header hosts the switcher (the chat page's only familiar control)");
 const sidenav = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 assert.match(
   sidenav,

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -27,11 +27,11 @@ assert.match(workspaceSidebar, /cave:code-select-project/, "should broadcast cod
 // single row (no stacked mini-row), and the header hosts the familiar switcher.
 assert.doesNotMatch(workspaceSidebar, /cnav__mini-row/, "the stacked mini-row is retired — quick actions are one row");
 assert.match(workspaceSidebar, /aria-label=\{scheduledCount \? `Scheduled \(\$\{scheduledCount\}\)` : "Scheduled"\}/, "Scheduled shortcut is an icon chip with an accessible name");
-// Familiar scope moved to the SIDENAV header (cave-vtk9, operator direction) —
-// it sits directly beside this panel, so a second switcher here doubled the
-// same global control. The header keeps a plain title + Home + organize.
-assert.doesNotMatch(workspaceSidebar, /FamiliarSwitcher/, "the chat sidebar header no longer duplicates the sidenav familiar switcher");
-assert.match(workspaceSidebar, /<span className="cnav__title">Chats<\/span>/, "the header anchors with a plain Chats title");
+// The chat page's ONLY familiar control: chat mode swaps the nav panel for
+// this sidebar (SidebarMinimal never renders there), so the header hosts the
+// labeled switcher (#2747, restored by cave-l3ay after #2750 briefly removed
+// it as a supposed duplicate). Non-chat pages use the sidenav header switcher.
+assert.match(workspaceSidebar, /<header className="cnav__header">[\s\S]*?<FamiliarSwitcher/, "the chat sidebar header hosts the familiar switcher");
 assert.doesNotMatch(workspaceSidebar, /cnav__eyebrow/, "the old Recent eyebrow stays retired");
 assert.match(workspaceSidebar, /ph:git-pull-request/, "should support PR glyph on thread rows");
 assert.match(workspaceSidebar, /scheduledCount/, "should accept scheduledCount prop");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useMinuteTick } from "@/lib/use-minute-tick";
+import { FamiliarSwitcher } from "@/components/familiar-switcher";
 import { Icon, type IconName } from "@/lib/icon";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { sessionRailTitle } from "@/lib/session-rail-title";
@@ -361,12 +362,23 @@ export function WorkspaceSidebar({
       </button>
 
       <div className="workspace-sidebar__full chat-sidebar__full cnav">
-        {/* Header — one row: title + Home + the organize menu. Familiar scope
-            moved to the SIDENAV header (cave-vtk9, per operator direction),
-            which sits directly beside this panel — a second switcher here
-            (#2747's brief home for it) doubled the same global scope control. */}
+        {/* Header — the labeled familiar switcher (#2747). On the CHAT page
+            this sidebar REPLACES the global sidenav (SidebarMinimal never
+            renders here), so this is the page's only familiar control —
+            cave-l3ay restored it after #2750 removed it as a supposed
+            duplicate. Every other page gets the sidenav header switcher. */}
         <header className="cnav__header">
-          <span className="cnav__title">Chats</span>
+          <div className="cnav__switcher">
+            <FamiliarSwitcher
+              familiars={familiars}
+              activeFamiliarId={activeFamiliarId}
+              sessions={sessions}
+              responseNeeded={responseNeeded}
+              onSelectFamiliar={onSelectFamiliar}
+              placement="bottom-start"
+              labeled
+            />
+          </div>
           <button
             type="button"
             aria-label="Go to Home"


### PR DESCRIPTION
## Summary

#2750 removed #2747's header switcher from the chat sidebar as a supposed duplicate of the new sidenav header switcher. **The premise was wrong**: chat mode swaps the nav panel for the chat sidebar — `SidebarMinimal` (and its switcher) never renders on the chat page — so chat shipped with **no familiar selection control at all**. Caught within the hour by driving the built app for a sidenav demo (probe: `sidebar-minimal` absent on chat; header showed only the "Chats" title).

This restores #2747's labeled `FamiliarSwitcher` in the `cnav__header`, and re-states the **two-host model** in the pins: the sidenav header carries familiar selection on every non-chat page (cave-vtk9), the chat sidebar header carries it on chat.

## Testing

`tsc` clean · full suite green (**570 test files**) · pins updated in `workspace-sidebar-wiring.test.ts` + `familiar-quick-switch.test.ts` to assert both hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)