### PR TITLE
fix(chat): runtime + host chips share the round icon buttons' pill radius

### DIFF
--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -108,4 +108,12 @@ assert.match(logo, /fill="currentColor"[\s\S]{0,80}?aria-hidden/, "brand SVGs in
 assert.match(css, /\.cave-runtime-chip__logo \{[\s\S]*?color: var\(--accent-presence\);/, "the runtime mark uses the presence accent token");
 assert.doesNotMatch(css, /#[0-9a-fA-F]{3,8}\b/, "chip styles stay on semantic tokens — no hardcoded hex");
 
+// ── Standardized radius ──────────────────────────────────────────────────────
+// The chip sits between fully round icon buttons (attach/voice/options/send
+// are rounded-full circles), so it must be a pill — the squarer
+// --radius-control made it read as a different control family.
+assert.match(css, /\.cave-composer-runtime-chip \{[\s\S]*?border-radius: 999px;/, "the runtime chip is a pill, matching the round composer icon buttons");
+const hostCss = readFileSync(new URL("../styles/composer-host-chip.css", import.meta.url), "utf8");
+assert.match(hostCss, /\.cave-composer-host-chip \{[\s\S]*?border-radius: 999px;/, "the host chip matches the same pill radius");
+
 console.log("composer-runtime-chip.test.ts: ok");

--- a/src/styles/composer-host-chip.css
+++ b/src/styles/composer-host-chip.css
@@ -18,9 +18,9 @@
   line-height: 1;
   cursor: pointer;
   border: 1px solid var(--border-hairline);
-  /* Shape matches the composer's control family (.cave-composer-select and
-     the icon buttons) — the shared control radius, not a pill. */
-  border-radius: var(--radius-control);
+  /* Pill radius — matches the runtime chip and the fully round icon buttons
+     it sits between in the composer control row (see composer-runtime-chip.css). */
+  border-radius: 999px;
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
 }

--- a/src/styles/composer-runtime-chip.css
+++ b/src/styles/composer-runtime-chip.css
@@ -18,9 +18,11 @@
   line-height: 1;
   cursor: pointer;
   border: 1px solid var(--border-hairline);
-  /* Shape matches the composer's control family (.cave-composer-select and
-     the icon buttons) — the shared control radius, not a pill. */
-  border-radius: var(--radius-control);
+  /* Pill radius — the chip sits in the composer's control row between fully
+     round icon buttons (attach / voice / options / send are rounded-full
+     circles), so it shares their curvature instead of the squarer
+     --radius-control that made it read as a different control family. */
+  border-radius: 999px;
   background: color-mix(in oklch, var(--bg-surface) 50%, transparent);
   color: var(--text-secondary);
 }


### PR DESCRIPTION
## Problem
The chat composer control row mixes fully round icon buttons (attach / voice / options / send — `rounded-full` circles) with a squarer `--radius-control` on the runtime chip (GPT-5.5 ⌄) and its sibling host chip — the chip reads as a different control family in the same row (operator screenshot).

## Fix
`border-radius: 999px` on `.cave-composer-runtime-chip` and `.cave-composer-host-chip`; comments updated; 2 regression pins added so the mixed-radius row cannot return.

## Verification
- Live Playwright: computed chip radius `999px`; control-row screenshot confirms matching curvature
- `composer-runtime-chip.test.ts` green · `pnpm test:app` — 570 files pass