### PR TITLE
perf(inbox): SSE reconnect snapshots keep the array identity when content-identical (cave-bzch)

### DIFF
--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -192,6 +192,13 @@ assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each g
 {
   const ws = readFileSync(new URL("../components/workspace.tsx", import.meta.url), "utf8");
   assert.match(ws, /if \(JSON\.stringify\(prev\[idx\]\) === JSON\.stringify\(e\.item\)\) return prev;/, "SSE update echoes keep the array identity");
+  // Same guard for the reconnect path: a snapshot that matches current state
+  // must not re-render every inboxItemsWithEphemeral consumer.
+  assert.match(
+    ws,
+    /setInboxItems\(\(prev\) => \(arrayContentEqual\(prev, e\.items\) \? prev : e\.items\)\);/,
+    "SSE reconnect snapshots keep the array identity when content-identical",
+  );
 }
 
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -869,7 +869,10 @@ export function Workspace() {
         | { type: "updated"; item: InboxItem }
         | { type: "deleted"; id: string };
       if (e.type === "snapshot") {
-        setInboxItems(e.items);
+        // Reconnect snapshots usually carry what we already have — keep the
+        // reference so inboxItemsWithEphemeral consumers don't re-render
+        // (companion to #2762's content-equal guard on `updated` echoes).
+        setInboxItems((prev) => (arrayContentEqual(prev, e.items) ? prev : e.items));
         return;
       }
       if (e.type === "created") {


### PR DESCRIPTION
The one-liner promised in #2765's closing handoff, now that #2762 has merged: the SSE `snapshot` branch (reconnects) still did an unconditional `setInboxItems(e.items)`, re-rendering every `inboxItemsWithEphemeral` consumer with an identical list. Same `arrayContentEqual` bail #2762 applied to `updated` echoes, pinned alongside its pin in `dashboard-page.test.ts`.

Verification: typecheck clean, full app suite 570 files pass in the worktree.

Closes out the last piece of audit bead cave-bzch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)