### PR TITLE
fix(schedules): sequence-guard load() so a stale poll can't revert a just-toggled/saved cron (cave-1303)

### DIFF
--- a/src/components/automations-view.test.ts
+++ b/src/components/automations-view.test.ts
@@ -155,6 +155,13 @@ assert.match(source, /if \(document\.hidden\) return;.*don't poll a backgrounded
 assert.match(source, /const mountedRef = useRef\(true\)/, "tracks mounted state for async guards");
 assert.match(source, /const runsReqRef = useRef\(0\)/, "refreshRuns tracks a request id");
 assert.match(source, /if \(reqId !== runsReqRef\.current \|\| !mountedRef\.current\) return/, "a stale/late runs fetch is dropped");
+// load() is sequence-guarded the same way: it runs from mount, the 15s poll,
+// and after every mutation (toggle/save/delete all await load()), so a stale
+// in-flight poll must not reapply pre-mutation data over a fresher reload.
+assert.match(source, /const loadReqRef = useRef\(0\)/, "load() tracks its own request id");
+assert.match(source, /const reqId = \+\+loadReqRef\.current;/, "each load() bumps the request id");
+assert.match(source, /const live = \(\) => reqId === loadReqRef\.current && mountedRef\.current/, "load() writes only while it's the newest load and still mounted");
+assert.match(source, /if \(!live\(\)\) return;/, "a superseded load() drops its writes");
 
 // ── Per-row quick actions (run-now + pause/resume), always visible ──
 assert.match(source, /const ScheduleActionsContext = createContext/, "row actions are provided via context (no prop threading)");

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1853,19 +1853,29 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
   // runs fetch when a faster, later selection won.
   const mountedRef = useRef(true);
   const runsReqRef = useRef(0);
+  // Sequence guard for load(), mirroring runsReqRef: load() runs from mount, the
+  // 15s poll, AND after every mutation (toggle/save/delete all await load()), so
+  // an in-flight poll can resolve *after* a mutation's reload and reapply its
+  // pre-mutation data — a just-paused cron would flip back to Active for up to
+  // 15s. Dropping a superseded load's writes closes that revert-flash.
+  const loadReqRef = useRef(0);
   useEffect(() => {
     mountedRef.current = true;
     return () => { mountedRef.current = false; };
   }, []);
 
   const load = useCallback(async () => {
+    const reqId = ++loadReqRef.current;
+    // Live only while this is still the newest load AND the view is mounted; a
+    // superseded (or unmounted) load drops all its writes.
+    const live = () => reqId === loadReqRef.current && mountedRef.current;
     try {
       const [inboxRes, codexRes] = await Promise.all([
         fetch("/api/inbox", { cache: "no-store" }),
         fetch("/api/codex-automations", { cache: "no-store" }),
       ]);
       const inboxJson = await inboxRes.json();
-      if (!mountedRef.current) return;
+      if (!live()) return;
       if (!inboxJson.ok) { setError(inboxJson.error ?? "load failed"); return; }
       // Content-equality guards (codebase convention — see board-view/workspace):
       // an unchanged poll keeps the previous references, so derived memos,
@@ -1874,16 +1884,16 @@ export function AutomationsView({ familiars, onOpenSession, onNewReminder, onEdi
       const nextItems = inboxJson.items ?? [];
       setItems((prev) => (arrayContentEqual(prev, nextItems) ? prev : nextItems));
       const codexJson = await codexRes.json();
-      if (!mountedRef.current) return;
+      if (!live()) return;
       if (codexJson.ok) {
         const nextAutos = codexJson.automations ?? [];
         setCodexAutos((prev) => (arrayContentEqual(prev, nextAutos) ? prev : nextAutos));
       }
       setError(null);
     } catch (err) {
-      if (mountedRef.current) setError(err instanceof Error ? err.message : "fetch failed");
+      if (live()) setError(err instanceof Error ? err.message : "fetch failed");
     } finally {
-      if (mountedRef.current) setInitialLoadDone(true);
+      if (live()) setInitialLoadDone(true);
     }
   }, []);
 

--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -9,7 +9,7 @@ const read = (rel) => readFileSync(new URL(rel, import.meta.url), "utf8");
 const inbox = read("./automations-view.tsx");
 assert.match(
   inbox,
-  /initialLoadDone[\s\S]*?finally \{\s*(?:if \(mountedRef\.current\) )?setInitialLoadDone\(true\);/,
+  /initialLoadDone[\s\S]*?finally \{\s*(?:if \((?:mountedRef\.current|live\(\))\) )?setInitialLoadDone\(true\);/,
   "Inbox/automations tracks first-fetch settlement (success or failure)",
 );
 assert.match(


### PR DESCRIPTION
## What

`automations-view.tsx` (Schedules surface) `load()` fetches `/api/inbox` + `/api/codex-automations` and `setItems`/`setCodexAutos`. It runs from **mount**, the **15s `usePausablePoll`**, **and after every mutation** (`toggleCodex`/`saveCodex`/`deleteCodex` all `await load()`).

Unlike `refreshRuns` — which already drops stale responses via a `runsReqRef` monotonic request id (cave-1e6k) — `load()` had only `mountedRef` + `arrayContentEqual`, **no sequence guard**. So an in-flight poll `load()` that resolves *after* a mutation's reload reapplies its **pre-mutation** data:

> Pause a cron → an in-flight stale poll lands → the cron flips back to **Active** for up to 15s until the next poll heals it.

## Fix

Add a `loadReqRef` monotonic counter mirroring `runsReqRef`, and a `live()` helper (`reqId` is still newest **and** still mounted) that gates every `setState` — so a superseded `load()` drops all its writes. Consistent with the file's own `runsReqRef` pattern and the board (#2766) / capabilities (#2754) / marketplace-configure (#2749) guards shipped this session.

Found by a proactive Schedules-surface audit. Source-pinned in `automations-view.test.ts`; the shared `surface-loading-states` pin is widened to accept the `live()` guard.

## Verification

`typecheck` · `automations-view` + `automations-detail-inputs` + `schedules-tabs` + `surface-error-states` + `surface-loading-states` + `inbox-feed-a11y` + `delete-undo-surfaces` + `daily-summary-notifications` all green · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)