### PR TITLE
style(sidenav): switcher trigger aligns edge-to-edge with New chat · caret rides the right edge

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5582,6 +5582,37 @@ button:active > .edge-rail-chip {
   line-height: 1;
 }
 
+/* Dropdown affordance on labeled triggers — space-between layout: avatar +
+   name lead, the caret hugs the right edge. */
+.familiar-switcher__trigger-caret {
+  margin-left: auto;
+  flex-shrink: 0;
+  color: var(--text-muted);
+}
+
+/* Row checkbox — the multiselect zone. Clicking it toggles the familiar in
+   the scope (menu stays open); a plain row click still solo-switches. */
+.familiar-switcher__checkbox {
+  display: grid;
+  place-items: center;
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  border: 1px solid var(--border-strong);
+  color: var(--accent-foreground);
+  background: transparent;
+  transition: background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+.familiar-switcher__checkbox.is-checked {
+  background: var(--accent-presence);
+  border-color: var(--accent-presence);
+}
+.familiar-switcher__option:hover .familiar-switcher__checkbox {
+  border-color: var(--accent-presence);
+}
+
 /* Avatar image fills the trigger square edge-to-edge. FamiliarAvatar renders a
    fixed 16px img, which sits centered in the 28px button and leaves a dark gap;
    stretch it to the button's inner box instead. The glyph fallback is a vector

--- a/src/styles/sidebar-minimal.css
+++ b/src/styles/sidebar-minimal.css
@@ -63,13 +63,15 @@
   border-color: transparent;
 }
 
-/* Header familiar switcher (cave-vtk9) — the scope selector on every page. */
+/* Header familiar switcher (cave-vtk9) — the scope selector on every page.
+   Zero horizontal padding so the trigger's edges line up exactly with the
+   New-chat CTA below it (.sidebar-actions is also flush). */
 .sidebar-familiar-switch {
   display: flex;
   align-items: center;
   min-width: 0;
   flex-shrink: 0;
-  padding: 2px 4px 2px 7px;
+  padding: 0;
 }
 .sidebar-familiar-switch .familiar-quickswitch {
   min-width: 0;


### PR DESCRIPTION
Three follow-ups to the sidenav multiselector (#2761), all CSS:

- **Width match:** the switch wrapper's asymmetric `2px 4px 2px 7px` padding inset the trigger relative to the flush `.sidebar-actions` container. Zeroed — the switcher and the New chat CTA now share exact edges (verified live: both 171px wide, identical left x).
- **Space-between:** the trigger caret takes `margin-left: auto`, so avatar + name lead and the caret hugs the right edge (10px inset, mirroring the label's left inset) — it reads as a real select.
- **Checkbox styling restored:** the multiselect rows' 14px accent-filled checkbox (and the caret rule above) were lost when #2761 was rebuilt onto #2750's sidenav relocation — the menu was rendering bare check glyphs. Both rules land in the switcher's globals.css section.

Pin tests pass on the branch: familiar-switcher, familiar-quick-switch, menu-bar-icon-size, sidebar-minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)