### PR TITLE
fix(projects): directory-picker modal portals to <body> — host stacking contexts buried it (cave-lj6j)

### DIFF
--- a/src/components/directory-picker-modal.tsx
+++ b/src/components/directory-picker-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { Button } from "@/components/ui/button";
 
@@ -80,7 +81,13 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
       ? "~" + cwd.slice(home.length)
       : cwd ?? "…";
 
-  return (
+  // Portal to <body>: this modal mounts inside arbitrary hosts (the home
+  // composer card, the projects form), and a transformed/backdrop-filtered
+  // ancestor there becomes the containing block for position:fixed — trapping
+  // the scrim in that ancestor's stacking context, where sibling composer
+  // chrome paints on top of the "open" modal. Rendering from <body> restores
+  // true-viewport fixed positioning regardless of the host's styling.
+  return createPortal(
     <div
       className="fixed inset-0 z-[200] flex items-center justify-center bg-black/50 p-4"
       role="dialog"
@@ -176,6 +183,7 @@ export function DirectoryPickerModal({ open, onClose, onSelect }: DirectoryPicke
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/directory-picker.test.ts
+++ b/src/components/directory-picker.test.ts
@@ -45,3 +45,16 @@ test("the modal navigates via the fs-browse API with up/select controls", () => 
     "modal controls should use radius tokens instead of hard-coded radii",
   );
 });
+
+// cave-lj6j: the modal mounts inside arbitrary hosts (home composer card,
+// projects form). A transformed/backdrop-filtered ancestor becomes the
+// containing block for position:fixed, trapping the z-[200] scrim in that
+// ancestor's stacking context — composer chrome painted OVER the open modal.
+// Portaling to <body> restores true-viewport fixed positioning.
+test("the modal portals to <body> so host stacking contexts can't bury it", () => {
+  const src = read("./directory-picker-modal.tsx");
+  assert.match(src, /import \{ createPortal \} from "react-dom"/, "imports createPortal");
+  assert.match(src, /return createPortal\(\s*<div\s*\n?\s*className="fixed inset-0 z-\[200\]/, "the fixed scrim renders through a portal");
+  assert.match(src, /document\.body,\s*\n\s*\);/, "the portal targets document.body");
+  assert.match(src, /if \(!open\) return null;[\s\S]*createPortal/, "closed modal renders nothing (portal only touches document.body when open)");
+});


### PR DESCRIPTION
## Problem

Screenshot report: opening the folder browser from the home composer's project picker rendered it **behind** the composer's own chrome — Chat/Task tabs, chips, and placeholder text painted over the open modal.

The modal is `fixed inset-0 z-[200]`, but it rendered **inline** inside its host. The home composer's card carries a transform/backdrop-filter, which makes it the containing block for `position: fixed` — so the scrim was trapped inside the composer's stacking context and z-index competed only with its siblings. Same failure class the repo has hit twice before (mode-fade fixed-containing-block; GitHub surface's fixed card → portal).

## Fix

`createPortal(..., document.body)` around the modal JSX. True-viewport fixed positioning for every mount (home composer's picker, the projects form). The cave-psp8 focus trap is untouched, and the `if (!open) return null` guard still means the portal only touches `document.body` when open.

## Validation

- Live probe (worktree server + Playwright): scrim parents to `<body>`; `elementFromPoint` at the dialog center resolves **inside** the modal; screenshot shows the browser cleanly above the scrim
- New pins in `directory-picker.test.ts` (portal import, scrim-through-portal, body target, closed-renders-nothing)
- `pnpm typecheck` + full app suite: 570 test files pass

Bead: cave-lj6j

🤖 Generated with [Claude Code](https://claude.com/claude-code)