### PR TITLE
fix(flow): per-flow guard on loadRuns so switching flows fast can't show the wrong run history (cave-g6au)

### DIFF
--- a/src/components/flow/flow-executions.test.ts
+++ b/src/components/flow/flow-executions.test.ts
@@ -51,6 +51,14 @@ assert.match(styles, /\.flow-exec-custom-input/, "Custom execution data filters 
 assert.match(styles, /\.flow-exec-filter\.is-active/, "Active execution filter should be styled");
 assert.match(styles, /\.flow-exec-mode-production/, "Production execution mode badge should be styled");
 assert.match(styles, /\.flow-exec-custom-data/, "Custom execution data chips should be styled");
+// loadRuns is sequence-guarded: it fires on every selectedId change, so
+// switching flows fast must not let an older flow's runs fetch resolve last and
+// overwrite the selected flow's history.
+assert.match(view, /const runsReqRef = useRef\(0\)/, "loadRuns tracks a request id");
+assert.match(view, /const reqId = \+\+runsReqRef\.current;/, "each loadRuns bumps the request id");
+assert.match(view, /const live = \(\) => reqId === runsReqRef\.current && mountedRef\.current/, "loadRuns writes only while it's the newest runs fetch and still mounted");
+assert.match(view, /if \(!live\(\)\) return;\s*\n\s*const list = result\.ok/, "a superseded loadRuns drops its writes before setRuns");
+
 assert.match(view, /activeRun \? progress\.phases : null/, "Flow view should paint seeded progress before transcript markers arrive");
 assert.match(view, /progress\.markersFound \? progress\.steps : activeRun\.steps/, "Flow view should inspect persisted node data when transcript markers are unavailable");
 assert.match(runSteps, /progress\.phases\[id\] \?\? persisted/, "Run steps should use seeded progress before transcript markers arrive");

--- a/src/components/flow/flow-view.tsx
+++ b/src/components/flow/flow-view.tsx
@@ -134,6 +134,11 @@ export function FlowView() {
   // handle, or splice it into an edge.
   const catalogIntentRef = useRef<CatalogIntent>({ kind: "add", position: { x: 160, y: 160 } });
   const mountedRef = useRef(true);
+  // Sequence guard for loadRuns: it fires on every selectedId change, so
+  // switching flows fast can leave an older flow's runs fetch to resolve last
+  // and overwrite the selected flow's history. A monotonic id drops a
+  // superseded response before it touches state.
+  const runsReqRef = useRef(0);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const doc = draftState?.doc ?? null;
@@ -193,10 +198,14 @@ export function FlowView() {
   }, [dispatchDraft, selectedId]);
 
   const loadRuns = useCallback(async (flowId: string) => {
+    const reqId = ++runsReqRef.current;
+    // Live only while this is still the newest runs fetch AND the view is
+    // mounted; a flow switched away from mid-flight drops all its writes.
+    const live = () => reqId === runsReqRef.current && mountedRef.current;
     setRunsLoading(true);
     try {
       const result = await listFlowRuns(flowId);
-      if (!mountedRef.current) return;
+      if (!live()) return;
       const list = result.ok ? result.runs : [];
       setRuns(list);
       // Resume the live overlay if the newest run is still running and we aren't
@@ -206,7 +215,7 @@ export function FlowView() {
         setActiveRun((current) => current ?? top);
       }
     } finally {
-      if (mountedRef.current) setRunsLoading(false);
+      if (live()) setRunsLoading(false);
     }
   }, []);
 


### PR DESCRIPTION
flow-view.tsx loadRuns(flowId) set runs guarded only by mountedRef — no per-flow sequence guard. It fires on every selectedId change, so selecting flow A then quickly flow B lets loadRuns(A) resolve after loadRuns(B) and overwrite B's runs: flow B's executions panel shows flow A's run history until the next reload. Fix: monotonic runsReqRef + live() gate (reqId still newest AND mounted) guards setRuns/setRunsLoading. Same pattern as automations-view #2771 and familiars daily-notes loadSeq. Pinned in flow-executions.test.ts. Verified: typecheck, 5 flow suites, build within budget. cave-g6au. 🤖 Generated with Claude Code