### PR TITLE
feat(models): enable Claude Fable 5 in the claude runtime catalog

### DIFF
--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -29,8 +29,13 @@ assert.ok(
   "claude catalog should seed Claude Sonnet 5",
 );
 assert.ok(
-  !catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
-  "claude catalog should not offer Claude Fable 5",
+  catalogForRuntime("claude").models.some((m) => m.id === "anthropic/claude-fable-5"),
+  "claude catalog should offer Claude Fable 5 (re-enabled: Coven Code ships full Fable support)",
+);
+assert.equal(
+  catalogForRuntime("claude").models[0].id,
+  "anthropic/claude-opus-4-8",
+  "Opus 4.8 must stay first so it remains the claude default",
 );
 assert.ok(catalogForRuntime("codex").models.length > 1, "codex should seed a multi-model menu, not just the default");
 assert.ok(

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -45,6 +45,7 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
     provider: "anthropic",
     models: [
       { id: "anthropic/claude-opus-4-8", label: "Claude Opus 4.8" },
+      { id: "anthropic/claude-fable-5", label: "Claude Fable 5" },
       { id: "anthropic/claude-opus-4-7", label: "Claude Opus 4.7" },
       { id: "anthropic/claude-sonnet-5", label: "Claude Sonnet 5" },
       { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },

--- a/src/lib/slash-model.test.ts
+++ b/src/lib/slash-model.test.ts
@@ -7,9 +7,9 @@ assert.equal(modelSlashOptions("/mod", "claude"), null, "not /model arg position
 assert.equal(modelSlashOptions("/familiar researcher", "claude"), null, "ignores other commands");
 
 const all = modelSlashOptions("/model ", "claude");
-assert.ok(Array.isArray(all) && all.length === 5, "‘/model ’ lists every claude model");
+assert.ok(Array.isArray(all) && all.length === 6, "‘/model ’ lists every claude model");
 
-assert.equal(modelSlashOptions("/m ", "claude").length, 5, "the /m alias works too");
+assert.equal(modelSlashOptions("/m ", "claude").length, 6, "the /m alias works too");
 
 const opus = modelSlashOptions("/model opus", "claude");
 assert.ok(opus.every((m) => /opus/i.test(m.label)), "filters by partial label");


### PR DESCRIPTION
## Objective (operator autopilot)
Enable Fable 5 support across **Cave**, **coven CLI**, and **Coven Code**.

## Audit result
- **Coven Code**: already ships first-class Fable 5 — model picker default list, `FABLE_MODEL` constant, effort + max-effort capability tiers, 1M-token budget, compaction awareness, Anthropic provider `list_models` entry. **No changes needed.**
- **coven CLI**: model-agnostic — `normalize_model_id` strips the `provider/` namespace and forwards any id to the harness (`claude --model claude-fable-5`); no allow-list anywhere. **No changes needed.**
- **Cave**: the one real gate — `runtime-models.ts` deliberately excluded `anthropic/claude-fable-5` with a test pin (removal history: CHANGELOG #908/#913/#915, when the harness lacked support).

## Change
- Claude catalog now offers **Claude Fable 5** (second, after Opus 4.8 — the default model is unchanged, guarded by a new pin).
- Exclusion pin flips to an inclusion pin; `/model` slash list count updated (5 → 6).
- `model-label` ("Fable 5") and `context-meter` (1M window) already handled the id — no changes.

## Verification
- `runtime-models` / `model-label` / `context-meter` / `slash-model` tests green
- `pnpm test:app` — 570 files pass · `pnpm typecheck` clean