### PR TITLE
chore(release): stamp v0.0.158

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.158] - 2026-07-08
+
+> 🗂️ **Nothing hides the folder browser** — the project directory picker escapes its host's stacking context and always renders on top. Stale polls stop clobbering fresh state on schedules and the board, the sidenav familiar switcher settles into its final chrome, and the inbox goes quieter over SSE.
+
+Patch release on top of v0.0.157.
+
+### Fixes
+- **Projects: the directory-picker modal portals to `<body>`** (#2773, cave-lj6j). A transformed/backdrop-filtered host (the home composer card) trapped the fixed scrim in its stacking context, letting composer chrome paint over the open folder browser. It now renders above everything from every mount.
+- **Schedules: sequence-guarded loads** — a stale poll can no longer revert a just-toggled or just-saved cron (#2771, cave-1303). **Board: same guard** for stale poll/focus GETs vs fresher optimistic moves (#2766, cave-vdvy).
+- **Chat: the sidebar's familiar switcher is restored** — the chat page's only familiar control (#2768, cave-l3ay); **runtime + host chips share the round icon buttons' pill radius** (#2769).
+
+### Features
+- **Sidenav: the familiar switcher is a full-width multiselector wearing the New-chat chrome** (#2761), aligned edge-to-edge with New chat, caret on the right edge (#2772).
+
+### Performance
+- **Inbox: SSE stays quiet when nothing changed** — content-equal updates drop, reconnect snapshots keep array identity, and ActionInbox follows the cockpit repoll (#2762, #2770, cave-bzch).
+
+### Internal
+- CI: the release workflow's Intel leg retries its network-dependent steps (#2767, cave-1hha).
+
 ## [0.0.157] - 2026-07-08
 
 > 🔔 **Heard, not just seen** — inbox triage speaks to assistive tech: one snooze menu with real menu semantics everywhere, actions that announce what they did, urgency-aware toasts, and capabilities that narrate their refreshes. Plus the familiar switcher in every page's sidenav and split tiles that fit every screen.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.157",
+  "version": "0.0.158",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.157"
+version = "0.0.158"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.157"
+version = "0.0.158"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.157</string>
+	<string>0.0.158</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.157</string>
+	<string>0.0.158</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.157</string>
+	<string>0.0.158</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.157</string>
+	<string>0.0.158</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.157",
+  "version": "0.0.158",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.157 — 10 commits: the **directory-picker portal fix** (#2773, cave-lj6j), stale-poll sequence guards on schedules (#2771) + board (#2766), the sidenav familiar-switcher arc (#2761/#2772/#2768) with the chip-radius follow-up (#2769), quieter inbox SSE (#2762/#2770), and Intel-leg release retries (#2767).

Local gate: `cargo check --locked` + typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.158` → release.yml builds → `node scripts/verify-release-updater.mjs`.

Bead: cave-1gzp

🤖 Generated with [Claude Code](https://claude.com/claude-code)