### PR TITLE
perf(sidebar): guard the recent-activity poll with arrayContentEqual + a sequence id (cave-lb4e)

### DIFF
--- a/src/components/recent-activity-rollup.test.ts
+++ b/src/components/recent-activity-rollup.test.ts
@@ -36,4 +36,13 @@ assert.match(
   "the sessions poll pauses during active input composition",
 );
 
+// The poll is guarded like every other polled surface: a monotonic reqId drops
+// a superseded overlapping load, and arrayContentEqual keeps the previous
+// reference when an idle tick rebuilds an identical list (no needless re-render
+// of this always-mounted sidebar rollup).
+assert.match(source, /const loadReqRef = useRef\(0\)/, "the rollup poll tracks a request id");
+assert.match(source, /const reqId = \+\+loadReqRef\.current;/, "each load bumps the request id");
+assert.match(source, /if \(reqId !== loadReqRef\.current\) return;/, "a superseded load drops its writes");
+assert.match(source, /setSessions\(\(prev\) => \(arrayContentEqual\(prev, next\) \? prev : next\)\)/, "an unchanged poll keeps the previous sessions reference");
+
 console.log("recent-activity-rollup.test.ts: ok");

--- a/src/components/recent-activity-rollup.tsx
+++ b/src/components/recent-activity-rollup.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon } from "@/lib/icon";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
+import { arrayContentEqual } from "@/lib/array-content-equal";
 import { relativeTime } from "@/lib/relative-time";
 import { formatTimestamp, readDateTimePrefs, useDateTimePrefs } from "@/lib/datetime-format";
 import { modelIcon } from "@/lib/model-label";
@@ -68,15 +69,25 @@ export function RecentActivityRollup({ activeSessionId, onOpenSession }: Props) 
     });
   };
 
+  // This rollup is mounted in the sidebar for the whole app lifetime and polls
+  // the heavy /api/sessions/list every 15s. Guard the poll the way every other
+  // polled surface does: a monotonic reqId drops a superseded overlapping load
+  // (mount vs poll vs visibility-return), and arrayContentEqual keeps the
+  // previous reference when an idle tick rebuilds an identical list so the row
+  // list doesn't re-render for nothing.
+  const loadReqRef = useRef(0);
   const load = useCallback(async () => {
+    const reqId = ++loadReqRef.current;
     try {
       const res = await fetch("/api/sessions/list", { cache: "no-store" });
       const json = await res.json();
+      if (reqId !== loadReqRef.current) return; // superseded by a newer load
       const rows: SessionRow[] = Array.isArray(json?.sessions) ? json.sessions : [];
-      setSessions(rows.filter((s) => !s.archived_at).slice(0, MAX_ROWS));
+      const next = rows.filter((s) => !s.archived_at).slice(0, MAX_ROWS);
+      setSessions((prev) => (arrayContentEqual(prev, next) ? prev : next));
       setLoaded(true);
     } catch {
-      setLoaded(true);
+      if (reqId === loadReqRef.current) setLoaded(true);
     }
   }, []);
   useEffect(() => {


### PR DESCRIPTION
## What

`recent-activity-rollup` is mounted in the sidebar for the **whole app lifetime** and polls the heavy `/api/sessions/list` every 15s — but it was the **only** polled surface whose `load()` called `setSessions` without the `arrayContentEqual` reference-stability guard the rest of the codebase standardizes on (board / automations / session-changes / workspace). So every idle tick rebuilt a fresh array and re-rendered the 8-row list for nothing, and overlapping loads (mount vs poll vs visibility-return) had no sequence guard.

## Fix

- **`loadReqRef`** monotonic id → a superseded overlapping load drops its writes.
- **`arrayContentEqual`** → keep the previous `sessions` reference when an unchanged tick rebuilds an identical list.

Verified `arrayContentEqual` is a **structural value compare** (`JSON.stringify` per element), so it's a real guard on freshly-parsed rows, not a no-op. Source-pinned in `recent-activity-rollup.test.ts`.

Minor/consistency fix found by a proactive audit — brings the last polled surface in line with the convention.

## Verification

`typecheck` · `recent-activity-rollup` + `sidebar-minimal` green · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)