### PR TITLE
a11y(journal): audible mutations, real headings, visible focus, spoken disabled reason (cave-t1ou)

### DIFF
--- a/src/components/journal/journal-entries.test.ts
+++ b/src/components/journal/journal-entries.test.ts
@@ -118,4 +118,17 @@ assert.match(css, /\.journal-day:active \{ transform:/, "day rows have a tactile
 assert.match(css, /\.journal-entry__action:active:not\(:disabled\) \{ transform: scale/, "entry action icons have a tactile press");
 assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.journal-next__chip,/, "the new interactions respect prefers-reduced-motion");
 
+// ── a11y: audible mutations, real headings, visible focus (cave-t1ou) ────────
+assert.match(entries, /const \{ announce \} = useAnnouncer\(\)/, "the surface uses the shared announcer");
+assert.match(entries, /announce\("Reflection generated\."\)/, "generate success is announced");
+assert.match(entries, /announce\("Journal entry saved\."\)/, "save success is announced");
+assert.match(entries, /announce\(`Deleting the entry for [\s\S]{0,80}undo available\.`\)/, "delete scheduling is announced");
+assert.match(entries, /aria-busy=\{generating\}/, "the generate button reports busy state");
+assert.match(entries, /unavailable — select today to generate/, "the disabled reason reaches the accessible name (not just title=)");
+assert.match(entries, /<h3 className="journal-entry__sec-heading">What happened/, "the day section is a real heading");
+assert.match(entries, /<h4 className="journal-entry__sec journal-entry__sec-heading">Reflection<\/h4>/, "the reflection section is a real heading");
+assert.match(entries, /aria-live="polite" aria-atomic="true"/, "the notice toast announces atomically");
+assert.match(css, /\.journal-day:focus-visible \{\n  outline: var\(--ring-width, 2px\) solid var\(--ring-focus\)/, "day-rail rows have a visible focus ring");
+assert.match(css, /\.journal-entry__action:focus-visible \{\n  outline: var\(--ring-width, 2px\) solid var\(--ring-focus\)/, "entry actions have a distinct focus ring");
+
 console.log("journal-entries.test.ts: ok");

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -7,6 +7,7 @@ import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { MdEditor } from "@/components/md-editor/md-editor";
 import { extractNextPaths } from "@/lib/next-paths";
@@ -256,6 +257,7 @@ export function JournalEntries({
   // Deferred + undoable delete: the day reads as empty immediately, the DELETE
   // fires only after the undo window, and Undo restores the reflection.
   const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<string>();
+  const { announce } = useAnnouncer();
   const [error, setError] = useState<string | null>(null);
   // Transient confirmation toast for one-click "automate" actions on the
   // suggested next steps (Add task / Remind me / Run now).
@@ -401,7 +403,9 @@ export function JournalEntries({
     setGenerating(false);
     await loadDay(day.date);
     await loadDays();
-  }, [selectedFamiliarId, day, loadDay, loadDays, outOfScopeBy]);
+    // The reflection appearing is the only visual confirmation — say it too.
+    announce("Reflection generated.");
+  }, [selectedFamiliarId, day, loadDay, loadDays, outOfScopeBy, announce]);
 
   function startEdit() {
     if (!day) return;
@@ -438,6 +442,7 @@ export function JournalEntries({
       cancelEdit();
       await loadDay(day.date);
       await loadDays();
+      announce("Journal entry saved.");
       // The reload's setState re-renders the detail AFTER this point and steals
       // focus from the Edit button the editing→false effect restored. Re-assert
       // it on the next frame, once that re-render has committed and painted, so
@@ -461,6 +466,7 @@ export function JournalEntries({
     const date = day.date;
     cancelEdit();
     setError(null);
+    announce(`Deleting the entry for ${longDateLabel(parseDateSlug(date) ?? new Date())} — undo available.`);
     scheduleDelete(date, `entry for ${longDateLabel(parseDateSlug(date) ?? new Date())}`, async () => {
       try {
         const res = await fetch(`/api/journal?date=${encodeURIComponent(date)}`, { method: "DELETE" });
@@ -508,12 +514,20 @@ export function JournalEntries({
         <button
           type="button"
           className={`journal-entry-gen${generating ? " is-generating" : ""}`}
+          aria-busy={generating}
           disabled={!canGenerate || generating || selected !== today || Boolean(outOfScopeBy)}
           onClick={generate}
           title={Boolean(outOfScopeBy) ? `Today's entry was written by ${outOfScopeBy}` : selected !== today ? "Select today to generate" : undefined}
         >
           <Icon name="ph:sparkle" aria-hidden />
           {generating ? "Reflecting…" : "Generate today's entry"}
+          {/* The disabled reason lived only in title= (hover-only) — AT and
+              keyboard users get it in the accessible name too (cave-t1ou). */}
+          {!generating && Boolean(outOfScopeBy) ? (
+            <span className="sr-only">, unavailable — today's entry was written by {outOfScopeBy}</span>
+          ) : !generating && selected !== today ? (
+            <span className="sr-only">, unavailable — select today to generate</span>
+          ) : null}
         </button>
         {error ? (
           <div className="journal-list__error" role="alert">
@@ -564,7 +578,7 @@ export function JournalEntries({
         {day ? (
           <>
             <div className="journal-entry__sec journal-entry__sec--nav">
-              <span>What happened · {longDateLabel(parseDateSlug(day.date) ?? now)}</span>
+              <h3 className="journal-entry__sec-heading">What happened · {longDateLabel(parseDateSlug(day.date) ?? now)}</h3>
               {filteredDays.length > 1 ? (
                 <span className="journal-entry__daynav">
                   <button
@@ -596,7 +610,7 @@ export function JournalEntries({
               <div className="journal-entry__stat"><b>{day.stats.runtimeMemory}</b><span>runtime files</span></div>
             </div>
             <div className="journal-entry__head">
-              <div className="journal-entry__sec">Reflection</div>
+              <h4 className="journal-entry__sec journal-entry__sec-heading">Reflection</h4>
               {hasEntry ? (
                 <div className="journal-entry__actions">
                   {editing ? (
@@ -697,6 +711,13 @@ export function JournalEntries({
                       disabled={!canGenerate || generating}
                     >
                       {generating ? "Reflecting…" : "Generate today's entry"}
+          {/* The disabled reason lived only in title= (hover-only) — AT and
+              keyboard users get it in the accessible name too (cave-t1ou). */}
+          {!generating && Boolean(outOfScopeBy) ? (
+            <span className="sr-only">, unavailable — today's entry was written by {outOfScopeBy}</span>
+          ) : !generating && selected !== today ? (
+            <span className="sr-only">, unavailable — select today to generate</span>
+          ) : null}
                     </Button>
                   ) : undefined
                 }
@@ -708,7 +729,7 @@ export function JournalEntries({
         )}
       </section>
       {notice ? (
-        <div className="journal-notice" role="status" aria-live="polite">
+        <div className="journal-notice" role="status" aria-live="polite" aria-atomic="true">
           <Icon name="ph:check-circle" width={16} aria-hidden className="journal-notice__icon" />
           <span className="journal-notice__text">{notice.text}</span>
           {notice.action ? (

--- a/src/styles/journal.css
+++ b/src/styles/journal.css
@@ -134,6 +134,12 @@
     transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .journal-day:hover { border-color: var(--border-strong); transform: translateX(2px); }
+/* Keyboard parity (cave-t1ou): the rail rows and entry actions had no visible
+   focus state — hover styling alone is invisible to keyboard users. */
+.journal-day:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus);
+  outline-offset: 2px;
+}
 .journal-day:active { transform: translateX(2px) scale(0.99); }
 .journal-day.is-selected {
   border-color: var(--accent-presence);
@@ -198,6 +204,10 @@
   cursor: pointer;
   transition: border-color 0.13s ease, color 0.13s ease, background 0.13s ease,
     transform 0.1s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.journal-entry__action:focus-visible {
+  outline: var(--ring-width, 2px) solid var(--ring-focus);
+  outline-offset: 1px;
 }
 .journal-entry__action:hover:not(:disabled),
 .journal-entry__action:focus-visible {
@@ -467,3 +477,13 @@
    detail pane scroll internally instead of growing the settings page. */
 .familiar-studio-journal { display: flex; min-width: 0; }
 .familiar-studio-journal .journal-list { height: min(65vh, 720px); }
+
+/* The section labels are real headings now (cave-t1ou) — inherit the label
+   styling instead of UA heading defaults. */
+.journal-entry__sec-heading {
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+}


### PR DESCRIPTION
## Summary

Bead `cave-t1ou` (journal audit, source-verified), four fixes:

**Silent mutations.** The surface had zero `useAnnouncer` usage — generate success, save, and delete-scheduling all changed the page silently for screen-reader users (errors and notices had live regions; success said nothing). All three announce now; the generate button also reports `aria-busy` while reflecting, and the notice toast gains `aria-atomic` so partial updates don't read as fragments.

**No heading structure.** "What happened · \<date\>" and "Reflection" were a span and a div — the detail pane had no outline for AT navigation (WCAG 1.3.1). Both are real `h3`/`h4` now, with a `font: inherit` reset class so the visual design is pixel-unchanged.

**Invisible keyboard focus.** The day-rail rows had no `:focus-visible` rule at all, and the entry actions' focus state merely reused hover colors — indistinguishable from a pointer hover. Both get the standard `--ring-focus` outline, mirroring the `.journal-next__chip` rule that already existed in the same file.

**Hover-only disabled reason.** The generate button's explanation ("today's entry was written by X" / "select today to generate") lived only in `title=` — an sr-only suffix now carries it into the accessible name for AT and keyboard users.

The bead's remaining small riders (filter result-count feedback, stat label association, skeleton roles) are noted there — diminishing returns for this pass.

## Test plan

- [x] Pins: announcer + all three announcements, aria-busy, sr-only reason, both headings, atomic notice, both focus rules
- [x] Full `pnpm test:app` (570 files) green; `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)