### PR TITLE
style(chrome): slim the title bar to the traffic-light height (cave-p78p)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4847,7 +4847,9 @@ button:active > .edge-rail-chip {
   align-items: center;
   flex-wrap: nowrap;
   flex: 0 0 auto;
-  min-height: 40px;
+  /* Slim band (cave-p78p): hugs the 28px controls — and on the desktop shell,
+     the macOS traffic lights (~18px center) sit dead-center of the 36px bar. */
+  min-height: 34px;
   gap: 8px;
   padding-inline: 12px;
   /* Seamless title bar: the strip shares the app canvas — no band color, no
@@ -4871,7 +4873,7 @@ button:active > .edge-rail-chip {
 
 .shell-top .menu-bar {
   width: 100%;
-  min-height: 44px;
+  min-height: 34px;
   padding-inline: 0;
   border-bottom: 0;
   background: transparent;
@@ -4896,9 +4898,10 @@ button:active > .edge-rail-chip {
    ──────────────────────────────────────────────── */
 @media (min-width: 1024px) {
   :root[data-tauri-titlebar] .shell-top {
-    /* ~78px clears the three traffic lights + their left inset. */
+    /* ~78px clears the three traffic lights + their left inset; 36px centers
+       the bar's 28px controls on the lights (overlay default: ~18px center). */
     padding-left: 78px;
-    min-height: 46px;
+    min-height: 36px;
   }
 
   :root[data-tauri-titlebar] .shell-titlebar-drag-lane {

--- a/src/components/menu-bar-icon-size.test.ts
+++ b/src/components/menu-bar-icon-size.test.ts
@@ -27,4 +27,5 @@ assert.match(css, /\.menu-bar__search \{[\s\S]*?border:\s*1px solid var\(--borde
 assert.match(css, /\.shell-top-history \{/, "history Back/Forward pair has its grouping styles");
 assert.match(css, /\.menu-bar__task-label \{\s*\n\s*display:\s*none/, "task labels are CSS-demoted — the bar shows icons only");
 assert.match(css, /\.menu-bar__task-label--live \{\s*\n\s*display:\s*inline/, "…except live enrich progress, which is information, not chrome");
+assert.match(css, /:root\[data-tauri-titlebar\] \.shell-top \{[\s\S]{0,300}?min-height: 36px/, "the desktop bar is 36px — 28px controls center on the macOS traffic lights (~18px center)");
 console.log("menu-bar-icon-size.test.ts passed");

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -104,8 +104,8 @@ assert.doesNotMatch(
 // icon buttons matching the other controls in the row.
 assert.match(
   css,
-  /\.shell-top\s*\{[\s\S]*?display:\s*flex;[\s\S]*?align-items:\s*center;[\s\S]*?min-height:\s*44px;[\s\S]*?border-bottom:\s*1px solid var\(--border-hairline\);/,
-  "the top bar row owns the shared band background and centers its controls",
+  /\.shell-top\s*\{[\s\S]{0,600}?display:\s*flex;[\s\S]{0,200}?align-items:\s*center;[\s\S]{0,300}?min-height:\s*34px;[\s\S]{0,400}?border-bottom:\s*0;/,
+  "the top bar row is the slim seamless band (34px, borderless) and centers its controls",
 );
 assert.match(
   css,


### PR DESCRIPTION
## Summary

Per Val's direction, the title bar shrinks to hug the macOS traffic lights. The seamless band still ran 40px web / 46px desktop — and the inner `.shell-top .menu-bar` was silently forcing 44px regardless. Now:

- **34px web** / **36px desktop shell** — the 28px controls center at ~18px, matching the overlay traffic lights' default center, so the lights and controls read as one row.
- The inner menu-bar min-height drops to 34px (it no longer overrides the band).
- The mobile `.top-bar` keeps its touch-friendly height.

## Verification

Measured live on the built app: exactly `{webHeight: 34, tauriHeight: 36}`; screenshot reviewed with the desktop variant on — traffic-light inset clear, search pill and icons dead-centered. A stale `44px + border-bottom` pin in `shell-edge-rails.test.ts` (which had survived #2714's seamless change only through regex looseness across blocks) is re-anchored to the real invariant: 34px, borderless. The 36px desktop height is pinned in `menu-bar-icon-size.test.ts`.

`tsc` clean · **570 test files** green · build within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)