### PR TITLE
feat(settings): summon chip rides the familiar roster · picker wraps · project filter + capped decisions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6605,16 +6605,21 @@ a.mobile-handoff__link:hover {
   text-transform: uppercase;
   color: var(--text-muted);
 }
-/* Horizontal avatar-chip picker — scrollable on overflow so it scales to a
-   large roster without stealing a left rail from the detail pane. */
+/* Avatar-chip picker — WRAPS so every familiar stays visible (the old
+   horizontal scroll silently clipped the roster's tail); the Summon
+   invitation chip rides the end of the flow. */
+.familiar-studio-inline__picker-row {
+  display: flex;
+  align-items: flex-start;
+  min-width: 0;
+}
 .familiar-studio-inline__picker {
   display: flex;
+  flex-wrap: wrap;
   align-items: stretch;
   gap: var(--space-2);
-  overflow-x: auto;
-  padding-bottom: 2px;
-  scrollbar-width: thin;
-  scroll-snap-type: x proximity;
+  min-width: 0;
+  flex: 1 1 auto;
 }
 .familiar-studio-inline__chip {
   display: flex;
@@ -6645,6 +6650,30 @@ a.mobile-handoff__link:hover {
   color: var(--text-primary);
 }
 .familiar-studio-inline__chip:focus-visible { outline: none; box-shadow: 0 0 0 2px var(--ring-focus); }
+/* Summon — the dashed invitation chip (design language: dashed = invitation).
+   It matches the roster chips' shape so the create action reads as "the next
+   member of this row", quiet until hovered. */
+.familiar-studio-inline__chip--summon {
+  border-style: dashed;
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+  background: transparent;
+  color: var(--text-secondary);
+}
+.familiar-studio-inline__chip--summon:hover {
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent);
+  color: var(--text-primary);
+}
+.familiar-studio-inline__summon-glyph {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
 .familiar-studio-inline__chip-text { display: flex; flex-direction: column; gap: 0; min-width: 0; text-align: left; }
 .familiar-studio-inline__chip-name {
   font-size: var(--text-sm); font-weight: 550; color: var(--text-primary);

--- a/src/components/familiar-studio-inline.tsx
+++ b/src/components/familiar-studio-inline.tsx
@@ -22,6 +22,10 @@ type Props = {
   familiars: Familiar[];
   /** Resolved roster (cave overrides applied) — drives the master list + tab bodies. */
   resolved: ResolvedFamiliar[];
+  /** Opens the summoning circle. Renders as a dashed invitation chip riding the
+   *  end of the familiar picker — the create action lives with the roster it
+   *  extends instead of floating above the panel. */
+  onSummon?: () => void;
 };
 
 const TABS: Array<{ id: FamiliarStudioTab; label: string; icon: IconName }> = [
@@ -50,7 +54,7 @@ const TABS: Array<{ id: FamiliarStudioTab; label: string; icon: IconName }> = [
  * tab-body components as the drawer. The Settings provider instance is isolated
  * from the Workspace one, so selecting here never auto-opens the drawer there.
  */
-export function FamiliarStudioInlinePanel({ familiars, resolved }: Props) {
+export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon }: Props) {
   const { activeFamiliarId, activeTab, setActiveTab, openFamiliarStudio } = useFamiliarStudio();
   const daemonSync = useDaemonSyncStatus();
 
@@ -99,34 +103,55 @@ export function FamiliarStudioInlinePanel({ familiars, resolved }: Props) {
         <span className="familiar-studio-inline__selector-label" id="settings-familiar-picker-label">
           Familiar
         </span>
-        <div
-          className="familiar-studio-inline__picker"
-          role="radiogroup"
-          aria-label="Choose familiar to edit"
-          aria-labelledby="settings-familiar-picker-label"
-        >
-          {resolved.map((f) => {
-            const active = f.id === familiar?.id;
-            return (
+        <div className="familiar-studio-inline__picker-row">
+          <div
+            className="familiar-studio-inline__picker"
+            role="radiogroup"
+            aria-label="Choose familiar to edit"
+            aria-labelledby="settings-familiar-picker-label"
+          >
+            {resolved.map((f) => {
+              const active = f.id === familiar?.id;
+              return (
+                <button
+                  key={f.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => openFamiliarStudio(f.id, activeTab)}
+                  className="familiar-studio-inline__chip"
+                  data-active={active ? "true" : undefined}
+                  style={{ ["--chip-accent"]: f.color } as CSSProperties}
+                  title={f.role ? `${f.display_name} — ${f.role}` : f.display_name}
+                >
+                  <FamiliarAvatar familiar={f} size="md" />
+                  <span className="familiar-studio-inline__chip-text">
+                    <span className="familiar-studio-inline__chip-name">{f.display_name}</span>
+                    {f.role ? <span className="familiar-studio-inline__chip-role">{f.role}</span> : null}
+                  </span>
+                </button>
+              );
+            })}
+            {/* Summon rides the roster it extends — a dashed invitation chip
+                (outside the radiogroup semantics: it creates, not selects). */}
+            {onSummon ? (
               <button
-                key={f.id}
                 type="button"
-                role="radio"
-                aria-checked={active}
-                onClick={() => openFamiliarStudio(f.id, activeTab)}
-                className="familiar-studio-inline__chip"
-                data-active={active ? "true" : undefined}
-                style={{ ["--chip-accent"]: f.color } as CSSProperties}
-                title={f.role ? `${f.display_name} — ${f.role}` : f.display_name}
+                onClick={onSummon}
+                className="familiar-studio-inline__chip familiar-studio-inline__chip--summon"
+                title="Summon a new familiar"
+                aria-label="Summon a new familiar"
               >
-                <FamiliarAvatar familiar={f} size="md" />
+                <span className="familiar-studio-inline__summon-glyph" aria-hidden>
+                  <Icon name="ph:magic-wand-fill" width={14} />
+                </span>
                 <span className="familiar-studio-inline__chip-text">
-                  <span className="familiar-studio-inline__chip-name">{f.display_name}</span>
-                  {f.role ? <span className="familiar-studio-inline__chip-role">{f.role}</span> : null}
+                  <span className="familiar-studio-inline__chip-name">Summon</span>
+                  <span className="familiar-studio-inline__chip-role">New familiar</span>
                 </span>
               </button>
-            );
-          })}
+            ) : null}
+          </div>
         </div>
       </div>
 

--- a/src/components/familiar-studio-projects-tab.tsx
+++ b/src/components/familiar-studio-projects-tab.tsx
@@ -195,6 +195,25 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
     [projects, granted, familiar.id],
   );
 
+  // Grant-list filter — rosters run to dozens of projects, so the list is
+  // searchable by name or path once it's big enough to need it.
+  const [projectQuery, setProjectQuery] = useState("");
+  const q = projectQuery.trim().toLowerCase();
+  const visibleProjects = useMemo(
+    () =>
+      q
+        ? projects.filter(
+            (p) => p.name.toLowerCase().includes(q) || (p.root ?? "").toLowerCase().includes(q),
+          )
+        : projects,
+    [projects, q],
+  );
+
+  // Decision history is an audit log — it grows unbounded, so it renders a
+  // recent window with the rest one click away.
+  const AUDIT_PREVIEW = 6;
+  const [showAllAudit, setShowAllAudit] = useState(false);
+
   // Everything below is scoped to THIS familiar — the protocol relocated from a
   // cross-familiar console into each familiar's own tab.
   const famProposals = useMemo(
@@ -255,7 +274,37 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
           label="Project access"
           description={`${grantedCount} of ${projects.length} granted`}
         >
-          {projects.map((project) => {
+          {projects.length > 6 ? (
+            <div className="border-b border-[var(--border-hairline)] px-4 py-2">
+              <label className="flex items-center gap-2">
+                <Icon name="ph:magnifying-glass" width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                <input
+                  type="search"
+                  value={projectQuery}
+                  onChange={(e) => setProjectQuery(e.target.value)}
+                  placeholder="Filter projects…"
+                  aria-label="Filter projects by name or path"
+                  className="w-full bg-transparent text-[12px] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+                />
+                {projectQuery ? (
+                  <button
+                    type="button"
+                    aria-label="Clear project filter"
+                    onClick={() => setProjectQuery("")}
+                    className="focus-ring shrink-0 rounded p-0.5 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                  >
+                    <Icon name="ph:x-bold" width={10} aria-hidden />
+                  </button>
+                ) : null}
+              </label>
+            </div>
+          ) : null}
+          {q && visibleProjects.length === 0 ? (
+            <p className="px-4 py-3 text-[12px] text-[var(--text-muted)]">
+              No projects match “{projectQuery.trim()}”.
+            </p>
+          ) : null}
+          {visibleProjects.map((project) => {
             const key = grantKey(familiar.id, project.id);
             const on = granted.has(key);
             const busy = pending.has(key);
@@ -379,7 +428,7 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
       {/* ── Recent access decisions for this familiar ── */}
       {famAudit.length > 0 && (
         <SettingsGroup label={`Recent decisions (${famAudit.length})`}>
-          {famAudit.map((e) => {
+          {(showAllAudit ? famAudit : famAudit.slice(0, AUDIT_PREVIEW)).map((e) => {
             const meta = auditDecisionMeta(e.decision);
             return (
               <div key={e.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5">
@@ -401,6 +450,16 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
               </div>
             );
           })}
+          {famAudit.length > AUDIT_PREVIEW ? (
+            <button
+              type="button"
+              onClick={() => setShowAllAudit((v) => !v)}
+              aria-expanded={showAllAudit}
+              className="focus-ring w-full border-t border-[var(--border-hairline)] px-4 py-2 text-left text-[11px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            >
+              {showAllAudit ? "Show recent only" : `Show all ${famAudit.length} decisions`}
+            </button>
+          ) : null}
         </SettingsGroup>
       )}
     </div>

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -924,20 +924,12 @@ function FamiliarsSection({
 
   return (
     <>
-      <div className="mb-3 flex justify-end">
-        <Button
-          variant="secondary"
-          size="sm"
-          className="settings-touch-action"
-          onClick={() => setCreateOpen(true)}
-          leadingIcon="ph:magic-wand-fill"
-        >
-          Summon familiar
-        </Button>
-      </div>
+      {/* Summon lives inside the panel's familiar picker (dashed invitation
+          chip at the roster's end) — no floating action above the card. */}
       <FamiliarStudioInlinePanel
         familiars={rawFamiliars}
         resolved={familiars}
+        onSummon={() => setCreateOpen(true)}
       />
       {createDialog}
     </>


### PR DESCRIPTION
Three Settings → Familiars refinements, screenshot-verified live:

## Summon familiar — integrated
The floating top-right button is replaced by a **dashed invitation chip** (wand glyph in an accent halo, "Summon / New familiar") riding the end of the familiar picker — per the design language, dashed = invitation, and the create action now lives with the roster it extends. The empty-roster state keeps its prominent button; `FamiliarSummoningCircle` wiring is unchanged (new optional `onSummon` prop on `FamiliarStudioInlinePanel`).

## Familiar selection — fixed
The picker was a horizontal scroll strip that silently clipped the roster's tail (with 8 familiars, one was fully hidden and another half-cut). It now **wraps**, so every familiar is visible and selectable at once.

## Project selection + decision history — enhanced
- The grant list (runs to dozens of projects) leads with a **"Filter projects…"** search matching names and paths — rendered only when >6 projects, with a clear button and a no-matches state.
- **Recent decisions** renders a window of 6 with a "Show all N decisions" expander instead of dumping the unbounded audit log. Access requests and request history are untouched.

## Verification
Six settings-surface test files pass on this branch (`settings-familiars-section`, `familiar-studio-projects-tab`, `familiar-summoning-circle`, `settings-search`, `settings-overview`, `labels-and-live-regions`); clean `tsc`; before/after screenshots reviewed on the live dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)