### PR TITLE
fix(journal): stop silent write loss + false generation stamps between Grimoire and generate (cave-9f2e)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -267,6 +267,7 @@ export const SUITES = {
     "src/lib/slash-prompt.test.ts",
     "src/lib/cave-canvas.test.ts",
     "src/components/journal/journal-entries.test.ts",
+    "src/app/api/journal/route.test.ts",
     "src/lib/journal.test.ts",
     "src/lib/journal-memory-stats.test.ts",
     "src/lib/journal-generate.test.ts",

--- a/src/app/api/journal/route.test.ts
+++ b/src/app/api/journal/route.test.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+
+// ── Optimistic-concurrency guard (cave-9f2e) ─────────────────────────────────
+// The journal is one file per date and two surfaces write it (Grimoire autosave
+// + the generate/edit flow). Without a conflict check the second writer silently
+// drops the first. POST accepts an opt-in `expectedModified` baseline and 409s
+// when the file changed underneath, mirroring the memory-file convention.
+assert.match(
+  source,
+  /const expectedModified = typeof body\.expectedModified === "string" \? body\.expectedModified : null;/,
+  "POST reads an opt-in expectedModified baseline",
+);
+assert.match(
+  source,
+  /const current = await readJournalEntry\(date\);/,
+  "POST reads the current entry once to drive the guard + generatedAt preservation",
+);
+assert.match(
+  source,
+  /if \(expectedModified !== null && current\.exists && current\.modified !== expectedModified\)/,
+  "POST 409s only when a baseline was sent and the entry changed on disk",
+);
+assert.match(
+  source,
+  /\{ status: 409 \}/,
+  "a journal write conflict returns 409 (not a silent overwrite)",
+);
+assert.match(source, /conflict: true/, "the 409 body flags the conflict so the UI can reload");
+
+// ── generatedAt is preserved on manual saves, only stamped on generation ─────
+// The route used to stamp generatedAt: new Date() on EVERY save, so a hand-edit
+// read as a fresh generation ("· 2m ago"). Only the generate flow sends a
+// generatedAt now; manual saves preserve the existing stamp (or null when new).
+assert.doesNotMatch(
+  source,
+  /generatedAt: new Date\(\)\.toISOString\(\)/,
+  "the route must not restamp generatedAt to now on every save",
+);
+assert.match(
+  source,
+  /typeof body\.generatedAt === "string"\s*\n?\s*\? body\.generatedAt\s*\n?\s*: current\.exists\s*\n?\s*\? current\.entry\.generatedAt\s*\n?\s*: null/,
+  "generatedAt uses the body's value (generation) else preserves the on-disk stamp else null",
+);
+
+console.log("journal route.test.ts: ok");

--- a/src/app/api/journal/route.ts
+++ b/src/app/api/journal/route.ts
@@ -64,7 +64,13 @@ export async function GET(req: Request) {
 }
 
 export async function POST(req: Request) {
-  let body: { date?: unknown; reflection?: unknown; reflectedBy?: unknown };
+  let body: {
+    date?: unknown;
+    reflection?: unknown;
+    reflectedBy?: unknown;
+    generatedAt?: unknown;
+    expectedModified?: unknown;
+  };
   try {
     body = await req.json();
   } catch {
@@ -76,11 +82,43 @@ export async function POST(req: Request) {
   }
   const reflection = typeof body.reflection === "string" ? body.reflection : "";
   const reflectedBy = typeof body.reflectedBy === "string" && body.reflectedBy ? body.reflectedBy : null;
-  const record = await writeJournalEntry(date, {
-    reflectedBy,
-    generatedAt: new Date().toISOString(),
-    reflection,
-  });
+  const expectedModified = typeof body.expectedModified === "string" ? body.expectedModified : null;
+
+  // Read the current entry once — it drives both the conflict guard and the
+  // generatedAt-preservation below.
+  const current = await readJournalEntry(date);
+
+  // Optimistic-concurrency guard (opt-in via expectedModified, mirroring the
+  // memory-file 409). The store is one file per date and two surfaces write it
+  // — Grimoire's debounced autosave and the generate/edit flow — so an
+  // unconditional write silently drops whichever landed first (a generation can
+  // vanish under an autosave mid-flight, and vice versa). If the entry changed
+  // on disk since the caller loaded it, refuse and hand back the current record
+  // so the UI can reload instead of clobbering.
+  if (expectedModified !== null && current.exists && current.modified !== expectedModified) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "This entry changed since you loaded it — reload before saving.",
+        conflict: true,
+        ...current,
+      },
+      { status: 409 },
+    );
+  }
+
+  // `generatedAt` marks an actual generation, so only the generate flow sends
+  // one. A manual save must preserve the existing stamp (or leave it null for a
+  // brand-new entry) rather than restamp `now` — otherwise every hand-edit reads
+  // as a fresh generation in the entry meta ("· 2m ago").
+  const generatedAt =
+    typeof body.generatedAt === "string"
+      ? body.generatedAt
+      : current.exists
+        ? current.entry.generatedAt
+        : null;
+
+  const record = await writeJournalEntry(date, { reflectedBy, generatedAt, reflection });
   return NextResponse.json({ ok: true, ...record });
 }
 

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -142,4 +142,15 @@ assert.match(
 assert.match(view, /scanning=\{scanning\}/, "the graph view knows a scan is in flight");
 assert.match(view, /scanError=\{scan \? null : scanError\}/, "a failed scan is only surfaced when there is no scan to show");
 
+// ── Journal autosave conflict guard (cave-9f2e) ──────────────────────────────
+// The Grimoire journal editor sends the mtime it loaded as an optimistic-
+// concurrency baseline so its debounced autosave can't silently clobber a
+// concurrent generation/edit; it refreshes that baseline from each successful
+// save (so it never self-conflicts) and surfaces a 409 instead of overwriting.
+assert.match(view, /const modifiedRef = useRef<string \| null>\(null\)/, "the journal editor tracks the loaded mtime baseline");
+assert.match(view, /modifiedRef\.current = json\.modified \?\? null;/, "the baseline is captured on load");
+assert.match(view, /expectedModified: modifiedRef\.current,/, "the autosave sends the mtime baseline");
+assert.match(view, /if \(res\.status === 409\)/, "a journal write conflict is surfaced, not silently overwritten");
+assert.match(view, /modifiedRef\.current = json\.modified \?\? modifiedRef\.current;/, "the baseline advances after a successful save so autosave can't self-conflict");
+
 console.log("grimoire-view.test: ok");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -331,21 +331,30 @@ function KnowledgeMdEditor({
 function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void }) {
   const [state, setState] = useState<{ reflection: string; reflectedBy: string | null } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // The `modified` (mtime) this editor last loaded/saved, sent as the
+  // optimistic-concurrency baseline so an autosave can't silently clobber a
+  // concurrent generation/edit of the same date. Refreshed from every
+  // successful save's response so our own saves never self-conflict.
+  const modifiedRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setState(null);
     setError(null);
+    modifiedRef.current = null;
     void (async () => {
       try {
         const res = await fetch(`/api/journal?date=${encodeURIComponent(date)}`, { cache: "no-store" });
         const json = await res.json();
         if (cancelled) return;
         if (!json.ok) setError(json.error ?? "Failed to load journal entry");
-        else setState({
-          reflection: json.entry?.reflection ?? "",
-          reflectedBy: json.entry?.reflectedBy ?? null,
-        });
+        else {
+          modifiedRef.current = json.modified ?? null;
+          setState({
+            reflection: json.entry?.reflection ?? "",
+            reflectedBy: json.entry?.reflectedBy ?? null,
+          });
+        }
       } catch (err) {
         if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load journal entry");
       }
@@ -360,10 +369,21 @@ function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void
         const res = await fetch("/api/journal", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ date, reflection: raw, reflectedBy: state?.reflectedBy ?? null }),
+          body: JSON.stringify({
+            date,
+            reflection: raw,
+            reflectedBy: state?.reflectedBy ?? null,
+            expectedModified: modifiedRef.current,
+          }),
         });
         const json = await res.json();
+        if (res.status === 409) {
+          return { ok: false, error: json.error ?? "This entry changed elsewhere — reload before saving." };
+        }
         if (!json.ok) return { ok: false, error: json.error ?? "Save failed" };
+        // Advance the baseline so the next autosave compares against what we
+        // just wrote, not the now-stale load-time mtime.
+        modifiedRef.current = json.modified ?? modifiedRef.current;
         onSaved?.();
         return { ok: true };
       } catch (err) {

--- a/src/components/journal/journal-entries.test.ts
+++ b/src/components/journal/journal-entries.test.ts
@@ -170,4 +170,22 @@ assert.match(entries, /aria-live="polite" aria-atomic="true"/, "the notice toast
 assert.match(css, /\.journal-day:focus-visible \{\n  outline: var\(--ring-width, 2px\) solid var\(--ring-focus\)/, "day-rail rows have a visible focus ring");
 assert.match(css, /\.journal-entry__action:focus-visible \{\n  outline: var\(--ring-width, 2px\) solid var\(--ring-focus\)/, "entry actions have a distinct focus ring");
 
+// ── Journal write conflict + generatedAt (cave-9f2e) ─────────────────────────
+// generate is the only real generation → it stamps generatedAt and sends the
+// day's mtime baseline so it can't clobber a concurrent edit; a conflict is
+// surfaced rather than silently overwriting.
+assert.match(
+  entries,
+  /generate = useCallback[\s\S]*?generatedAt: new Date\(\)\.toISOString\(\)[\s\S]*?expectedModified: day\.modified/,
+  "generate stamps generatedAt and sends the mtime baseline",
+);
+assert.match(entries, /saveRes && saveRes\.status === 409/, "generate surfaces a write conflict instead of overwriting");
+// saveEdit is a manual edit → no generatedAt (server preserves it), but it still
+// sends the baseline so it can't overwrite a concurrent change.
+assert.match(
+  entries,
+  /reflectedBy: familiarId, expectedModified: day\.modified \}\)/,
+  "saveEdit sends the mtime baseline and no generatedAt (preserved server-side)",
+);
+
 console.log("journal-entries.test.ts: ok");

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -419,13 +419,25 @@ export function JournalEntries({
       setError(result.error ?? "No reflection was returned.");
       return;
     }
-    await fetch("/api/journal", {
+    // A real generation stamps generatedAt (only the generate flow does); the
+    // expectedModified baseline refuses to clobber a concurrent edit that landed
+    // since this day was loaded (the store is one entry per date).
+    const saveRes = await fetch("/api/journal", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ date: day.date, reflection: result.text, reflectedBy: familiarId }),
-    }).catch(() => undefined);
+      body: JSON.stringify({
+        date: day.date,
+        reflection: result.text,
+        reflectedBy: familiarId,
+        generatedAt: new Date().toISOString(),
+        expectedModified: day.modified,
+      }),
+    }).catch(() => null);
     if (!mountedRef.current) return;
     setGenerating(false);
+    if (saveRes && saveRes.status === 409) {
+      setError("This day's entry changed while the reflection was being written — reloaded the latest instead of overwriting it.");
+    }
     await loadDay(day.date);
     await loadDays();
     // The reflection appearing is the only visual confirmation — say it too.
@@ -459,7 +471,10 @@ export function JournalEntries({
       const res = await fetch("/api/journal", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ date: day.date, reflection: draft, reflectedBy: familiarId }),
+        // No generatedAt: a manual edit preserves the entry's existing
+        // generation stamp. expectedModified refuses to overwrite a concurrent
+        // change (409 surfaces via the throw below, keeping the draft intact).
+        body: JSON.stringify({ date: day.date, reflection: draft, reflectedBy: familiarId, expectedModified: day.modified }),
       });
       const json = await res.json().catch(() => ({}));
       if (!res.ok || !json.ok) throw new Error(json.error ?? "Could not save journal entry.");


### PR DESCRIPTION
## What

The journal is **one file per date**, written by two surfaces — Grimoire's debounced **autosave** and the journal **generate/edit** flow — with **no conflict handling**. Whichever `POST /api/journal` landed second silently discarded the other (a generation could vanish under an autosave mid-flight, and vice versa). The route also stamped `generatedAt: new Date()` on **every** save, so a manual hand-edit read as a fresh generation ("· 2m ago") in the entry meta.

Source-verified in `route.ts` POST + `grimoire-view.tsx` + `journal/journal-entries.tsx`. (cave-9f2e)

## Fix

**Route (`POST /api/journal`):**
- **Optimistic-concurrency guard**, opt-in via `expectedModified`, mirroring the memory-file **409**: read the current entry once; if it changed on disk since the caller loaded it, return **409** with the current record instead of clobbering. Backward-compatible — omitting `expectedModified` skips the check.
- **`generatedAt` is preserved** from the on-disk entry on a manual save (or `null` for a new entry); only an explicit `body.generatedAt` (the generate flow) moves it.

**Clients:**
- Grimoire `JournalMdEditor` captures the loaded mtime, sends it as the baseline, **advances it from each successful save** (so autosave never self-conflicts), and surfaces a 409 rather than overwriting.
- `journal-entries` `generate` stamps `generatedAt` + sends the baseline (409 → friendly notice); `saveEdit` sends the baseline and no `generatedAt` (preserved).

## Verification

New **`journal/route.test.ts`** (wired into `run-tests.mjs`) + grimoire-view / journal-entries source pins. `typecheck` · `check:tests-wired` (768) · journal test suites green · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)