### PR TITLE
perf(journal): day reads no longer block on the memory-inventory scan (cave-tgx9)

### DIFF
--- a/src/app/api/journal/route.ts
+++ b/src/app/api/journal/route.ts
@@ -19,12 +19,19 @@ export const runtime = "nodejs";
  * Personal Journal — one reflective entry per day.
  *
  *   GET    /api/journal                       → { ok, days: JournalSummary[] }
- *   GET    /api/journal?date=YYYY-MM-DD        → { ok, ...JournalRecord, stats, context }
+ *   GET    /api/journal?date=YYYY-MM-DD        → { ok, ...JournalRecord }
+ *   GET    /api/journal?date=YYYY-MM-DD&stats=1 → { ok, date, stats, context }
  *   POST   /api/journal  body { date, reflection, reflectedBy } → { ok, ...JournalRecord }
  *   DELETE /api/journal?date=YYYY-MM-DD        → { ok, date, deleted }
  *
  * `date` is the only user-controlled input and is gated on a strict
  * `YYYY-MM-DD` real-day guard before any fs access.
+ *
+ * Stats ride their own request: they need the full memory-file inventory
+ * (a stat of ~1900 files warm, a multi-second head-read scan cold), which
+ * used to block EVERY day read — including Grimoire's and iOS's, which
+ * never look at the stats block. The entry response is now a single file
+ * read; the journal surface fetches ?stats=1 after the entry paints.
  */
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
@@ -34,7 +41,13 @@ export async function GET(req: Request) {
     if (!isValidNoteDate(date)) {
       return NextResponse.json({ ok: false, error: "invalid date" }, { status: 400 });
     }
-    const [rawRecord, memoryEntries] = await Promise.all([readJournalEntry(date), listMemoryFileEntries()]);
+    if (searchParams.has("stats")) {
+      const memoryEntries = await listMemoryFileEntries();
+      const stats = buildJournalMemoryStats(memoryEntries, familiarId);
+      const context = buildJournalMemoryContext(date, familiarId, stats);
+      return NextResponse.json({ ok: true, date, stats, context });
+    }
+    const rawRecord = await readJournalEntry(date);
     const record = familiarId && rawRecord.exists && rawRecord.entry.reflectedBy !== familiarId
       ? {
           date,
@@ -43,9 +56,7 @@ export async function GET(req: Request) {
           modified: null,
         }
       : rawRecord;
-    const stats = buildJournalMemoryStats(memoryEntries, familiarId);
-    const context = buildJournalMemoryContext(date, familiarId, stats);
-    return NextResponse.json({ ok: true, ...record, stats, context });
+    return NextResponse.json({ ok: true, ...record });
   }
   const allDays = await listJournalEntries();
   const days = familiarId ? allDays.filter((day) => day.reflectedBy === familiarId) : allDays;

--- a/src/components/journal/journal-entries.test.ts
+++ b/src/components/journal/journal-entries.test.ts
@@ -51,7 +51,46 @@ assert.match(entries, /const selectedFamiliarId = activeFamiliarId \?\? familiar
 assert.match(entries, /await fetch\(`\/api\/journal`, \{ cache: "no-store" \}\)/, "JournalEntries fetches the full journal day list");
 assert.match(entries, /if \(!familiarInScope\(scope, d\.reflectedBy\)\) return false/, "JournalEntries filters the day list by the familiar multiselect scope");
 // The day detail scopes its memory stats to the single active familiar (null at 0/≥ 2).
-assert.match(entries, /const detailQuery = activeFamiliarId\s*\?\s*`date=\$\{encodeURIComponent\(slug\)\}&familiar=\$\{encodeURIComponent\(activeFamiliarId\)\}`\s*:\s*`date=\$\{encodeURIComponent\(slug\)\}`/, "JournalEntries scopes day detail stats to the active familiar");
+assert.match(entries, /const dayQuery = useCallback\(\(slug: string\) => \(\s*activeFamiliarId\s*\?\s*`date=\$\{encodeURIComponent\(slug\)\}&familiar=\$\{encodeURIComponent\(activeFamiliarId\)\}`\s*:\s*`date=\$\{encodeURIComponent\(slug\)\}`/, "JournalEntries scopes day detail stats to the active familiar");
+
+// ── Perf: the entry paints without waiting for the memory inventory (cave-tgx9)
+// The stats block needs a full memory-file inventory walk server-side (~1900
+// stats warm, a multi-second head-read scan cold). It used to ride the SAME
+// response as the entry, blocking every day selection — and Grimoire's/iOS's
+// day reads, which never use stats, paid for it too.
+const journalRoute = read("../../app/api/journal/route.ts");
+assert.doesNotMatch(
+  journalRoute,
+  /Promise\.all\(\[readJournalEntry[\s\S]*?listMemoryFileEntries/,
+  "Journal day GET must not block the entry read on the memory-inventory scan",
+);
+assert.match(
+  journalRoute,
+  /if \(searchParams\.has\("stats"\)\) \{[\s\S]*?listMemoryFileEntries\(\)[\s\S]*?buildJournalMemoryStats[\s\S]*?buildJournalMemoryContext/,
+  "Journal route serves the inventory-derived stats block on its own ?stats=1 branch",
+);
+assert.match(
+  entries,
+  /fetch\(`\/api\/journal\?\$\{dayQuery\(slug\)\}&stats=1`/,
+  "JournalEntries fetches the stats block on a separate non-blocking request",
+);
+assert.match(
+  entries,
+  /setDay\(\{ \.\.\.\(json as Omit<JournalDay, "stats" \| "context">\), stats: null, context: null \}\)/,
+  "JournalEntries paints the entry immediately with stats pending",
+);
+assert.match(
+  entries,
+  /prev && prev\.date === slug \? \{ \.\.\.prev, \.\.\.block \} : prev/,
+  "Late stats only merge into the same day they were requested for",
+);
+// If the user hits Generate before the stats fetch lands, the context is
+// fetched inline — generation must always carry the memory-scope note.
+assert.match(
+  entries,
+  /const context = day\.context \?\? \(await fetchDayStats\(day\.date\)\)\?\.context \?\? ""/,
+  "Generate falls back to an inline context fetch when stats have not arrived",
+);
 assert.match(entries, /day\.stats\.covenOrigin[\s\S]*?coven files/, "Journal stats include Coven-origin memory files");
 assert.match(entries, /day\.stats\.externalRuntimes[\s\S]*?external runtime files/, "Journal stats include external runtime memory files");
 assert.match(entries, /day\.stats\.runtimeMemory[\s\S]*?runtime files/, "Journal stats include runtime memory files");

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -28,8 +28,9 @@ type JournalDay = {
   exists: boolean;
   entry: { reflectedBy: string | null; generatedAt: string | null; reflection: string };
   modified: string | null;
-  stats: JournalStats;
-  context: string;
+  /** Inventory-derived block; null until the non-blocking ?stats=1 fetch lands. */
+  stats: JournalStats | null;
+  context: string | null;
 };
 
 type NoticeAction = { label: string; mode: string };
@@ -332,23 +333,43 @@ export function JournalEntries({
     }
   }, []);
 
+  // Scope the day's memory stats to the single active familiar; with 0 or
+  // ≥ 2 selected (activeFamiliarId null) the record + stats are unscoped.
+  const dayQuery = useCallback((slug: string) => (
+    activeFamiliarId
+      ? `date=${encodeURIComponent(slug)}&familiar=${encodeURIComponent(activeFamiliarId)}`
+      : `date=${encodeURIComponent(slug)}`
+  ), [activeFamiliarId]);
+
+  const fetchDayStats = useCallback(async (slug: string): Promise<{ stats: JournalStats; context: string } | null> => {
+    try {
+      const res = await fetch(`/api/journal?${dayQuery(slug)}&stats=1`, { cache: "no-store" });
+      const json = await res.json().catch(() => ({}));
+      return json.ok ? { stats: json.stats as JournalStats, context: String(json.context ?? "") } : null;
+    } catch {
+      return null;
+    }
+  }, [dayQuery]);
+
   const loadDay = useCallback(async (slug: string) => {
     const reqId = ++loadDayReqRef.current;
     try {
-      // Scope the day's memory stats to the single active familiar; with 0 or
-      // ≥ 2 selected (activeFamiliarId null) the record + stats are unscoped.
-      const detailQuery = activeFamiliarId
-        ? `date=${encodeURIComponent(slug)}&familiar=${encodeURIComponent(activeFamiliarId)}`
-        : `date=${encodeURIComponent(slug)}`;
-      const res = await fetch(`/api/journal?${detailQuery}`, { cache: "no-store" });
+      const res = await fetch(`/api/journal?${dayQuery(slug)}`, { cache: "no-store" });
       const json = await res.json().catch(() => ({}));
       // Drop a stale response: a newer loadDay (different day) superseded it.
       if (reqId !== loadDayReqRef.current || !mountedRef.current) return;
-      if (json.ok) setDay(json as JournalDay);
+      if (json.ok) setDay({ ...(json as Omit<JournalDay, "stats" | "context">), stats: null, context: null });
     } catch {
       if (reqId === loadDayReqRef.current && mountedRef.current) setDay(null);
+      return;
     }
-  }, [activeFamiliarId]);
+    // The stats block rides a separate request AFTER the entry paints — it
+    // walks the whole memory inventory server-side (seconds when cold), and
+    // used to block every day selection.
+    const block = await fetchDayStats(slug);
+    if (!block || reqId !== loadDayReqRef.current || !mountedRef.current) return;
+    setDay((prev) => (prev && prev.date === slug ? { ...prev, ...block } : prev));
+  }, [dayQuery, fetchDayStats]);
 
   useEffect(() => {
     void loadDays();
@@ -387,7 +408,11 @@ export function JournalEntries({
     if (outOfScopeBy) return; // never overwrite another familiar's entry from a scoped surface
     setError(null);
     setGenerating(true);
-    const result = await generateReflection({ familiarId, context: day.context });
+    // Context normally arrives with the non-blocking stats fetch; if the user
+    // beats it (or it failed), fetch it inline — generation needs the scope note.
+    const context = day.context ?? (await fetchDayStats(day.date))?.context ?? "";
+    if (!mountedRef.current) return;
+    const result = await generateReflection({ familiarId, context });
     if (!mountedRef.current) return;
     if (result.error || !result.text) {
       setGenerating(false);
@@ -405,7 +430,7 @@ export function JournalEntries({
     await loadDays();
     // The reflection appearing is the only visual confirmation — say it too.
     announce("Reflection generated.");
-  }, [selectedFamiliarId, day, loadDay, loadDays, outOfScopeBy, announce]);
+  }, [selectedFamiliarId, day, loadDay, loadDays, outOfScopeBy, announce, fetchDayStats]);
 
   function startEdit() {
     if (!day) return;
@@ -605,9 +630,9 @@ export function JournalEntries({
               ) : null}
             </div>
             <div className="journal-entry__stats">
-              <div className="journal-entry__stat"><b>{day.stats.covenOrigin}</b><span>coven files</span></div>
-              <div className="journal-entry__stat"><b>{day.stats.externalRuntimes}</b><span>external runtime files</span></div>
-              <div className="journal-entry__stat"><b>{day.stats.runtimeMemory}</b><span>runtime files</span></div>
+              <div className="journal-entry__stat"><b>{day.stats ? day.stats.covenOrigin : "–"}</b><span>coven files</span></div>
+              <div className="journal-entry__stat"><b>{day.stats ? day.stats.externalRuntimes : "–"}</b><span>external runtime files</span></div>
+              <div className="journal-entry__stat"><b>{day.stats ? day.stats.runtimeMemory : "–"}</b><span>runtime files</span></div>
             </div>
             <div className="journal-entry__head">
               <h4 className="journal-entry__sec journal-entry__sec-heading">Reflection</h4>

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -65,14 +65,21 @@ export function greeting(date: Date): string {
   return "Good night";
 }
 
+// Intl.DateTimeFormat construction is the expensive part of these labels
+// (fresh locale-data resolution per call), and day rails call them per row
+// per render — share one instance per shape instead.
+const longDateFormat = new Intl.DateTimeFormat([], {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
+const weekdayFormat = new Intl.DateTimeFormat([], { weekday: "long" });
+const monthDayFormat = new Intl.DateTimeFormat([], { month: "short", day: "numeric" });
+
 /** Long human label, e.g. "Thursday, June 18, 2026". */
 export function longDateLabel(date: Date): string {
-  return new Intl.DateTimeFormat([], {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  }).format(date);
+  return longDateFormat.format(date);
 }
 
 /** "Today" / "Yesterday" / weekday for dates inside the last week, else short date. */
@@ -83,9 +90,9 @@ export function relativeDayLabel(date: Date, now = new Date()): string {
   if (days === 0) return "Today";
   if (days === 1) return "Yesterday";
   if (days > 1 && days < 7) {
-    return new Intl.DateTimeFormat([], { weekday: "long" }).format(date);
+    return weekdayFormat.format(date);
   }
-  return new Intl.DateTimeFormat([], { month: "short", day: "numeric" }).format(date);
+  return monthDayFormat.format(date);
 }
 
 // The compact "3h ago" / "2d ago" / short-date phrase now lives in the shared


### PR DESCRIPTION
## Summary

Bead `cave-tgx9` (source-verified): `GET /api/journal?date=…` awaited the full memory-file inventory in the blocking response for **every day selection** — a directory walk + stat of ~1,900 files warm, and a multi-second head-read scan cold — only to feed the three-number stats block. Grimoire's journal reads and the iOS day fetch paid the same cost without ever reading the stats.

**Route.** The plain day GET is now a single journal-file read. The inventory-derived `stats` + `context` moved to a `?stats=1` branch on the same route (no api-contracts change).

**Surface.** `loadDay` paints the entry immediately (`stats: null` renders "–" placeholders) and fetches `?stats=1` non-blocking; the late block merges only into the same day it was requested for (guarded by the existing request token + a `prev.date === slug` check). If the user hits Generate before the stats land, the handler fetches the context inline — generation always carries the memory-scope note.

**Riders from the bead, verified:**
- `Intl.DateTimeFormat` instances in `daily-report`'s day labels hoisted to module scope — the day rail constructed one per row per render. Memoizing labels into `filteredDays` was deliberately skipped: it freezes "Today"/"Yesterday" past midnight (the #2310 foot-gun).
- `FamiliarStudioJournalTab` lazy-wrapping: **no action** — `settings-shell` is only imported by `app/settings/page.tsx`, so the tab rides the `/settings` route chunk, not the boot bundle.

## Measured (real inventory, 1,890 files, prod build)

| Request | Before | After |
| --- | --- | --- |
| Day entry GET (warm) | blocked on scan (~0.5s+) | **41–77ms** |
| Stats (cold / warm) | inline in every day read | 1.7s / 0.5s on its own request |

## Test plan

- [x] Pins: route must not `Promise.all` the entry read with the scan; `?stats=1` branch; non-blocking client fetch; entry-paints-with-null-stats; same-day merge guard; generate inline-context fallback
- [x] Full `pnpm test:app` (570 files) green; `pnpm typecheck` clean
- [x] Live probe of both branches on the built worktree (numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)