### PR TITLE
feat(code): Review button in the Changes panel starts a commit-review session (cave-nqoy)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -66,6 +66,7 @@ export const SUITES = {
     "src/lib/gh-diff.test.ts",
     "src/lib/gh-review-html.test.ts",
     "src/lib/chat-projects.test.ts",
+    "src/lib/changes-review.test.ts",
     "src/lib/chat-hosts.test.ts",
     "src/lib/chat-recency.test.ts",
     "src/lib/chat-open-tasks.test.ts",

--- a/src/components/session-changes-panel.test.ts
+++ b/src/components/session-changes-panel.test.ts
@@ -109,4 +109,35 @@ assert.match(
   "focus matching aligns on / boundaries — bare string suffixes cross-match sibling files",
 );
 
+// ── Commit review action (cave-nqoy) ─────────────────────────────────────────
+// The toolbar's Review button starts a NEW chat session whose opening prompt
+// reviews the working-tree changes like a commit review, routed through the
+// cave:agents-new-chat bridge (Workspace opens the chat from the Code surface;
+// ChatSurface handles it when the panel lives in chat).
+assert.match(
+  src,
+  /import \{ buildChangesReviewPrompt \} from "@\/lib\/changes-review"/,
+  "the review prompt comes from the pure changes-review helper",
+);
+assert.match(
+  src,
+  /new CustomEvent\("cave:agents-new-chat", \{\s*\n\s*detail: \{\s*\n\s*projectRoot: root,\s*\n\s*initialPrompt: buildChangesReviewPrompt\(\{ repoRoot: root, files \}\),/,
+  "Review dispatches a new-chat event carrying the project root and the review prompt",
+);
+assert.match(
+  src,
+  /const root = repoRoot \?\? projectRoot;/,
+  "the review targets the resolved git root, falling back to the project root",
+);
+assert.match(
+  src,
+  /leadingIcon="ph:git-diff"[\s\S]{0,240}?onClick=\{startReviewSession\}\s*\n\s*disabled=\{!canCommit\}[\s\S]{0,200}?aria-label="Review changes in a new session"/,
+  "the Review button is labeled for AT and disabled when there is nothing to review",
+);
+assert.match(
+  src,
+  /announce\("Review session started on the working-tree changes\."\)/,
+  "starting a review announces the outcome",
+);
+
 console.log("session-changes-panel.test.ts: cave-4op footer + icon-button control primitives ok");

--- a/src/components/session-changes-panel.tsx
+++ b/src/components/session-changes-panel.tsx
@@ -11,6 +11,7 @@ import { IconButton } from "@/components/ui/icon-button";
 import { useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { openExternalUrl } from "@/lib/open-external";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { buildChangesReviewPrompt } from "@/lib/changes-review";
 
 /**
  * "Changes" right-panel tab (CHAT-D8-01): a per-session review surface for the
@@ -782,6 +783,23 @@ export function SessionChangesInner({
 
   const canCommit = loaded && !notARepo && !error && files.length > 0;
 
+  // Commit review — start a NEW chat session whose opening prompt reviews the
+  // working-tree changes. Dispatched through the cave:agents-new-chat bridge:
+  // the Workspace opens the chat when this panel lives on a non-chat surface
+  // (the Code view), and ChatSurface handles it directly when already in chat.
+  const startReviewSession = useCallback(() => {
+    const root = repoRoot ?? projectRoot;
+    window.dispatchEvent(
+      new CustomEvent("cave:agents-new-chat", {
+        detail: {
+          projectRoot: root,
+          initialPrompt: buildChangesReviewPrompt({ repoRoot: root, files }),
+        },
+      }),
+    );
+    announce("Review session started on the working-tree changes.");
+  }, [repoRoot, projectRoot, files, announce]);
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Header: honest scope copy + refresh */}
@@ -811,6 +829,18 @@ export function SessionChangesInner({
             </p>
           </div>
           <span className="flex shrink-0 items-center gap-1">
+            <Button
+              size="xs"
+              variant="secondary"
+              leadingIcon="ph:git-diff"
+              className="shrink-0"
+              onClick={startReviewSession}
+              disabled={!canCommit}
+              title="Start a new session that reviews these changes like a commit review"
+              aria-label="Review changes in a new session"
+            >
+              Review
+            </Button>
             <IconButton
               icon="ph:archive"
               size="sm"

--- a/src/lib/changes-review.test.ts
+++ b/src/lib/changes-review.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { buildChangesReviewPrompt, REVIEW_FILE_LIST_CAP } from "./changes-review.ts";
+
+const files = [
+  { path: "src/a.ts", status: "modified", insertions: 12, deletions: 3 },
+  { path: "src/b.ts", status: "added", insertions: 40, deletions: 0 },
+  { path: "docs/x.md", status: "deleted", insertions: 0, deletions: 18 },
+  { path: "src/new-name.ts", status: "renamed", renamedFrom: "src/old-name.ts" },
+  { path: "notes.txt", status: "untracked" },
+];
+
+const prompt = buildChangesReviewPrompt({ repoRoot: "/repo/root", files });
+
+// Anchors: repo root, count, and every file with its status.
+assert.match(prompt, /uncommitted changes in \/repo\/root/, "prompt names the repo root");
+assert.match(prompt, /Changed files \(5\):/, "prompt carries the file count");
+assert.match(prompt, /- src\/a\.ts — modified \(\+12\/−3\)/, "modified file lists ± counts");
+assert.match(prompt, /- src\/new-name\.ts — renamed \(from src\/old-name\.ts\)/, "renames name their origin");
+assert.match(prompt, /- notes\.txt — untracked/, "untracked files are listed");
+
+// The agent must read real patches, not judge from the inventory.
+assert.match(prompt, /git diff/, "prompt instructs reading the actual diff");
+assert.match(prompt, /git diff --staged/, "staged changes are covered");
+assert.match(prompt, /untracked files must be read directly/, "untracked handling is spelled out");
+
+// Review structure: verdict first, then bugs/security/tests/nits.
+assert.match(
+  prompt,
+  /1\. \*\*Verdict\*\*[\s\S]*2\. \*\*Bugs & correctness risks\*\*[\s\S]*3\. \*\*Security & data-loss concerns\*\*[\s\S]*4\. \*\*Test gaps\*\*[\s\S]*5\. \*\*Nits\*\*/,
+  "review sections arrive in verdict-first order",
+);
+
+// Cap: a huge working tree lists the first N files and says how many were cut.
+const many = Array.from({ length: REVIEW_FILE_LIST_CAP + 25 }, (_, i) => ({
+  path: `src/f${i}.ts`,
+  status: "modified",
+}));
+const capped = buildChangesReviewPrompt({ repoRoot: "/r", files: many });
+assert.match(capped, new RegExp(`Changed files \\(${REVIEW_FILE_LIST_CAP + 25}\\):`), "count reflects ALL files");
+assert.match(capped, /…and 25 more \(run git status for the full list\)\./, "omitted files are counted honestly");
+assert.ok(!capped.includes(`src/f${REVIEW_FILE_LIST_CAP}.ts`), "files past the cap are not listed");
+assert.ok(capped.includes(`src/f${REVIEW_FILE_LIST_CAP - 1}.ts`), "files inside the cap are listed");
+
+console.log("changes-review.test.ts: ok");

--- a/src/lib/changes-review.ts
+++ b/src/lib/changes-review.ts
@@ -1,0 +1,61 @@
+/**
+ * Commit-review prompt for the Changes panel's "Review" action (pure, no I/O).
+ *
+ * The button starts a NEW chat session whose opening prompt asks the familiar
+ * to review the uncommitted working-tree changes. The prompt carries the
+ * changed-file inventory (path · status · ±counts) so the review is anchored,
+ * and instructs the agent to read the full patches itself with git — the
+ * session runs with the project root as its working directory.
+ */
+
+export type ReviewFileStatus = "modified" | "added" | "deleted" | "renamed" | "untracked";
+
+export type ReviewChangedFile = {
+  path: string;
+  status: ReviewFileStatus;
+  renamedFrom?: string;
+  insertions?: number;
+  deletions?: number;
+};
+
+function fileLine(f: ReviewChangedFile): string {
+  const counts =
+    typeof f.insertions === "number" || typeof f.deletions === "number"
+      ? ` (+${f.insertions ?? 0}/−${f.deletions ?? 0})`
+      : "";
+  const renamed = f.status === "renamed" && f.renamedFrom ? ` (from ${f.renamedFrom})` : "";
+  return `- ${f.path} — ${f.status}${renamed}${counts}`;
+}
+
+/** Cap the inventory so a huge working tree can't blow up the opening prompt. */
+export const REVIEW_FILE_LIST_CAP = 100;
+
+export function buildChangesReviewPrompt({
+  repoRoot,
+  files,
+}: {
+  repoRoot: string;
+  files: ReviewChangedFile[];
+}): string {
+  const listed = files.slice(0, REVIEW_FILE_LIST_CAP);
+  const omitted = files.length - listed.length;
+  const inventory = listed.map(fileLine).join("\n");
+  const omittedNote = omitted > 0 ? `\n…and ${omitted} more (run git status for the full list).` : "";
+  return [
+    `Review the uncommitted changes in ${repoRoot} as if you were reviewing a commit before it lands.`,
+    "",
+    `Changed files (${files.length}):`,
+    inventory + omittedNote,
+    "",
+    "Read the actual patches first — run `git status` and `git diff` (plus `git diff --staged` if anything is staged) rather than judging from the file list alone; untracked files must be read directly since they have no diff.",
+    "",
+    "Then report, in order:",
+    "1. **Verdict** — ship it, ship with nits, or needs work.",
+    "2. **Bugs & correctness risks** — anything that breaks behavior, misses an edge case, or contradicts nearby code. Cite file:line.",
+    "3. **Security & data-loss concerns** — injection, path traversal, secrets, destructive operations without guards.",
+    "4. **Test gaps** — behavior these changes add or alter that no test covers.",
+    "5. **Nits** — only ones worth a comment; skip style that a formatter owns.",
+    "",
+    "Be specific and cite evidence from the diff. If the changes look unrelated to each other, say so — flagging an overloaded commit is part of the review.",
+  ].join("\n");
+}

--- a/tests/code-rail.spec.ts
+++ b/tests/code-rail.spec.ts
@@ -245,4 +245,47 @@ test.describe("code rail beside chat", () => {
     await expect(rail.locator(".workspace-rail__terminal")).toBeVisible({ timeout: 15_000 });
     await expect(rail.locator(".workspace-rail__soon")).toHaveCount(0);
   });
+
+  test("(g) Changes tab Review button starts a new session carrying the commit-review prompt", async ({ page }) => {
+    const filesRef = { count: 2 };
+    await routeChanges(page, filesRef);
+
+    // Capture the auto-sent opening prompt of the review session. The button
+    // dispatches cave:agents-new-chat; ChatSurface opens a NEW chat whose
+    // initialPrompt auto-sends through /api/chat/send — the honest end of the
+    // wire. Reply with a minimal SSE stream so the chat settles.
+    const sends: Array<{ prompt?: string }> = [];
+    await page.route("**/api/chat/send", (route) => {
+      sends.push(JSON.parse(route.request().postData() ?? "{}"));
+      route.fulfill({
+        contentType: "text/event-stream",
+        body: 'data: {"type":"done"}\n\n',
+      });
+    });
+
+    await base(page, [REPO_SESSION]);
+    await openSession(page, "Refactor auth flow");
+
+    await page.locator(".workspace-rail-reopen").click({ timeout: 30_000 });
+    const rail = page.locator(".workspace-rail");
+    await expect(rail).toBeVisible({ timeout: 15_000 });
+
+    await rail.getByRole("button", { name: "Changes" }).click();
+    const review = rail.getByRole("button", { name: "Review changes in a new session" });
+    await expect(review).toBeVisible({ timeout: 15_000 });
+    await expect(review).toBeEnabled();
+
+    await review.click();
+
+    // The new session fires exactly one opening send with the review prompt,
+    // anchored to the repo root and the changed-file inventory.
+    await expect
+      .poll(() => sends.length, { timeout: 15_000 })
+      .toBeGreaterThan(0);
+    const prompt = sends[0]?.prompt ?? "";
+    expect(prompt).toContain("Review the uncommitted changes in /repo/alpha");
+    expect(prompt).toContain("Changed files (2):");
+    expect(prompt).toContain("src/file-0.ts");
+    expect(prompt).toContain("git diff");
+  });
 });


### PR DESCRIPTION
## Objective (operator autopilot)
In the code editor view, add a commit-review action button that starts a new session reviewing the code changes.

## What landed
- **Review button** in the Changes panel toolbar (`SessionChangesInner` — hosted by the chat code rail, the Code surface embed, and the right panel). One click starts a **new chat session** whose opening prompt performs a commit review of the uncommitted working-tree changes.
- **`buildChangesReviewPrompt`** (pure helper, unit-tested): anchors to the resolved repo root + changed-file inventory (status, ±counts, renames; capped at 100 files with an honest omission note); instructs the agent to read real patches (`git status`/`git diff`/`--staged`, untracked read directly); asks for a verdict-first report — bugs & correctness, security & data loss, test gaps, nits.
- Routed through the existing `cave:agents-new-chat` bridge (ChatSurface handles it in chat; the Workspace bridge covers non-chat hosts). Disabled when there is nothing to review; start announced via the live region.

## Verification
- **New e2e** in `code-rail.spec.ts`: opens the repo session's rail → Changes tab → clicks Review → asserts the new session's auto-sent `/api/chat/send` body carries the review prompt (repo root + file inventory + git-diff instruction). Passing locally.
- New `changes-review.test.ts` unit suite (inventory format, cap behavior, section order) wired into test:app; 5 structural pins in `session-changes-panel.test.ts`.
- `pnpm test:app` — 571 files pass · `pnpm typecheck` clean · check-tests-wired green

Closes cave-nqoy (beads).