### PR TITLE
style(marketplace): skill-browser rail slims from five labeled groups to three (cave-99k1)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12082,6 +12082,35 @@ details[open] > .cave-edit-card__summary::before {
   flex-wrap: wrap;
   gap: 5px;
 }
+/* Badge toggles ride inside the merged Filter group, set off from the
+   category buttons by a hairline. */
+.skill-browser__rail-group .skill-browser__browse {
+  margin-top: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-hairline);
+}
+/* Rank lives in the leaderboard header now. */
+.skill-browser__leaderboard .skill-browser__modes {
+  margin-top: 8px;
+}
+.skill-browser__rail-group--inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+.skill-browser__rail-group--inline .skill-browser__rail-label {
+  margin: 0;
+}
+.skill-browser__agent-select {
+  min-width: 0;
+  flex: 1;
+  max-width: 220px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  padding: 4px 8px;
+  font-size: 11px;
+}
 .skill-browser__topics {
   gap: 4px;
 }

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -67,9 +67,27 @@ assert.match(src, /function matchesBrowseFilter\(skill: SkillBrowserEntry, filte
 assert.match(src, /function matchesTopic\(skill: SkillBrowserEntry, topicId: string\)/, "topic filters are applied by helper");
 assert.match(src, /matchesBrowseFilter\(s, browse\)/, "visible skills are filtered by browse state");
 assert.match(src, /matchesTopic\(s, topic\)/, "visible skills are filtered by topic state");
-assert.match(src, /className="skill-browser__browse"/, "renders the Browse chip row");
+assert.match(src, /className="skill-browser__browse"/, "renders the badge-toggle chip row");
 assert.match(src, /className="skill-browser__topics"/, "renders the Topics chip row");
-assert.match(src, /className="skill-browser__agents"/, "renders the agent compatibility filter row");
+// cave-99k1 simplification: the rail collapsed from five labeled groups to
+// two. Categories + Browse merged into one Filter group (badge toggles click
+// off back to "all"; zero-count claude/generic categories hide), Rank rides
+// the leaderboard header, and the agent chips became one compact select.
+assert.match(src, /aria-label="Filter skills"/, "one merged Filter group replaces Categories + Browse");
+assert.doesNotMatch(src, /aria-label="Browse skills"/, "the separate Browse group stays deleted");
+assert.match(src, /setBrowse\(active \? "all" : item\.id\)/, "badge toggles deselect back to the full list");
+assert.match(
+  src,
+  /RAIL\.filter\(\(cat\) => cat\.id === "all" \|\| cat\.id === "installed" \|\| counts\[cat\.id\] > 0\)/,
+  "zero-count claude/generic categories stay hidden",
+);
+assert.match(
+  src,
+  /skill-browser__leaderboard-title[\s\S]{0,400}skill-browser__modes/,
+  "Rank lives in the leaderboard header, not its own rail group",
+);
+assert.match(src, /className="skill-browser__agent-select"/, "agents collapse into one compact select");
+assert.match(src, /label="Filter by agent"/, "the agent select stays labeled for AT");
 assert.match(src, /function installCommand\(skill: SkillBrowserEntry\)/, "builds a skills CLI install command");
 assert.match(src, /function useCommand\(skill: SkillBrowserEntry\)/, "builds a skills CLI use command");
 assert.match(src, /function sourceTarget\(skill: SkillBrowserEntry\)/, "derives the skills CLI source from owner/repo or package");

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -10,6 +10,7 @@ import { Icon, type IconName } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { IconButton } from "@/components/ui/icon-button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { StandardSelect } from "@/components/ui/select";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { MarkdownBlock } from "@/components/message-bubble";
 import { copyText } from "@/lib/clipboard";
@@ -623,6 +624,20 @@ export function SkillBrowser({
           <div>
             <p className="skill-browser__leaderboard-kicker">Skills Leaderboard</p>
             <p className="skill-browser__leaderboard-title">{formatCount(skills.reduce((sum, skill) => sum + (skill.installsAllTime ?? 0), 0))} installs tracked</p>
+            <div className="skill-browser__modes" role="group" aria-label="Rank skills">
+              {LEADERBOARD_MODES.map((item) => (
+                <Button
+                  key={item.id}
+                  variant="ghost"
+                  size="xs"
+                  className={`skill-browser__mode${mode === item.id ? " is-active" : ""}`}
+                  aria-pressed={mode === item.id}
+                  onClick={() => setMode(item.id)}
+                >
+                  {item.label}
+                </Button>
+              ))}
+            </div>
           </div>
           <div className="skill-browser__ecosystem">
             <div className="skill-browser__ecosystem-command">
@@ -646,9 +661,14 @@ export function SkillBrowser({
           </div>
         </div>
         <nav className="skill-browser__rail" aria-label="Skill filters">
-        <div className="skill-browser__rail-group" role="group" aria-label="Skill categories">
-          <p className="skill-browser__rail-label">Categories</p>
-          {RAIL.map((cat) => {
+        {/* One Filter group replaces the old Categories + Browse pair, which
+            duplicated All and Installed across two labeled rows and kept
+            zero-count categories (Claude Code 0) on screen. Categories stay
+            exclusive; the two badge toggles (Official / Security audits)
+            compose with them and click off back to everything. */}
+        <div className="skill-browser__rail-group" role="group" aria-label="Filter skills">
+          <p className="skill-browser__rail-label">Filter</p>
+          {RAIL.filter((cat) => cat.id === "all" || cat.id === "installed" || counts[cat.id] > 0).map((cat) => {
             const count = counts[cat.id === "all" ? "all" : cat.id];
             const active = category === cat.id;
             return (
@@ -665,26 +685,23 @@ export function SkillBrowser({
               </Button>
             );
           })}
-        </div>
-        <div className="skill-browser__rail-group" role="group" aria-label="Browse skills">
-          <p className="skill-browser__rail-label">Browse</p>
-          <div className="skill-browser__browse">
-            {BROWSE_FILTERS.map((item) => (
-              <Button
-                key={item.id}
-                variant="ghost"
-                size="xs"
-                className={`skill-browser__browse-btn${browse === item.id ? " is-active" : ""}`}
-                aria-pressed={browse === item.id}
-                onClick={() => {
-                  setBrowse(item.id);
-                  if (item.id === "all") setTopic("all");
-                }}
-              >
-                <Icon name={item.icon} width={13} aria-hidden />
-                <span>{item.label}</span>
-              </Button>
-            ))}
+          <div className="skill-browser__browse" role="group" aria-label="Badge filters">
+            {BROWSE_FILTERS.filter((item) => item.id === "official" || item.id === "audited").map((item) => {
+              const active = browse === item.id;
+              return (
+                <Button
+                  key={item.id}
+                  variant="ghost"
+                  size="xs"
+                  className={`skill-browser__browse-btn${active ? " is-active" : ""}`}
+                  aria-pressed={active}
+                  onClick={() => setBrowse(active ? "all" : item.id)}
+                >
+                  <Icon name={item.icon} width={13} aria-hidden />
+                  <span>{item.label}</span>
+                </Button>
+              );
+            })}
           </div>
         </div>
         <div className="skill-browser__rail-group" role="group" aria-label="Browse by topic">
@@ -714,40 +731,21 @@ export function SkillBrowser({
             ))}
           </div>
         </div>
-        <div className="skill-browser__rail-group" role="group" aria-label="Rank skills">
-          <p className="skill-browser__rail-label">Rank</p>
-          <div className="skill-browser__modes">
-            {LEADERBOARD_MODES.map((item) => (
-              <Button
-                key={item.id}
-                variant="ghost"
-                size="xs"
-                className={`skill-browser__mode${mode === item.id ? " is-active" : ""}`}
-                aria-pressed={mode === item.id}
-                onClick={() => setMode(item.id)}
-              >
-                {item.label}
-              </Button>
-            ))}
-          </div>
-        </div>
+        {/* Rank moved into the leaderboard header (it ranks the leaderboard);
+            the eight agent chips collapse into one compact select. */}
         {agents.length > 1 ? (
-          <div className="skill-browser__rail-group" role="group" aria-label="Filter by agent">
-            <p className="skill-browser__rail-label">Agents</p>
-            <div className="skill-browser__agents">
-              {agents.slice(0, 8).map((name) => (
-                <Button
-                  key={name}
-                  variant="ghost"
-                  size="xs"
-                  className={`skill-browser__agent${agent === name ? " is-active" : ""}`}
-                  aria-pressed={agent === name}
-                  onClick={() => setAgent(name)}
-                >
-                  {name === "all" ? "All agents" : name}
-                </Button>
-              ))}
-            </div>
+          <div className="skill-browser__rail-group skill-browser__rail-group--inline" role="group" aria-label="Filter by agent">
+            <p className="skill-browser__rail-label">Agent</p>
+            <StandardSelect
+              label="Filter by agent"
+              value={agent}
+              onChange={(next) => setAgent(next)}
+              className="skill-browser__agent-select"
+              options={agents.map((name) => ({
+                value: name,
+                label: name === "all" ? "All agents" : name,
+              }))}
+            />
           </div>
         ) : null}
         </nav>


### PR DESCRIPTION
## Problem

Screenshot report: the skills leaderboard's filter rail stacked **five** labeled groups — Categories, Browse, Topics, Rank, Agents — with All + Installed duplicated across the first two, a zero-count "Claude Code 0" category on screen, and eight agent chips burning a full row.

## Simplification (same state model, simpler presentation)

- **Categories + Browse → one Filter group**: categories keep their counts (claude/generic hide when 0); Official / Security audits ride below a hairline as badge toggles that click off back to the full list — they still compose with the category selection.
- **Rank → the leaderboard header** (it ranks the leaderboard; a segmented All Time / Trending / Hot under the title).
- **Agents → one labeled `StandardSelect`** instead of 8 chips.
- Topics unchanged (already hides zero-count entries).

## Validation

- Live probe: rail renders exactly `["Filter","Topics","Agent"]`; screenshot confirms Claude Code 0 hidden, Rank in the header, and the ranked list starting far higher
- Updated + new pins in `skill-browser.test.ts` (merged group, badge-toggle deselect, zero-count hiding, header rank, labeled select)
- `pnpm typecheck` + full app suite: 570 test files pass

Bead: cave-99k1

🤖 Generated with [Claude Code](https://claude.com/claude-code)