### PR TITLE
style(home): drop the news lane's newspaper chrome marker (cave-e2zx)

### DIFF
--- a/src/components/home-digest-carousel.test.ts
+++ b/src/components/home-digest-carousel.test.ts
@@ -34,10 +34,15 @@ assert.match(view, /mediaCards\.length > 0 && newsEnabled/, "disabling news leav
 assert.doesNotMatch(view, /mediaDismissed|setMediaDismissed/, "the per-mount dismissed state is retired (setting is the one source of truth)");
 assert.doesNotMatch(view, /aria-label="Close news carousel"/, "the inline X close button is removed");
 assert.doesNotMatch(view, /home-digest__media-close/, "no close-button markup remains");
+// cave-e2zx: the lane chrome is gone entirely — no icon marker, no band. The
+// track's aria-label is the lane's only (accessible) name; the reversed drift
+// direction separates it visually from the chats row.
+assert.doesNotMatch(view, /home-digest__media-chrome/, "the icon-only lane chrome stays deleted");
+assert.doesNotMatch(view, /home-digest__media-label/, "no lane-marker markup remains");
 assert.match(
   view,
-  /className="home-digest__media-chrome"[\s\S]*className="home-digest__media-label"[\s\S]*ph:newspaper[\s\S]*home-digest__track home-digest__track--media/,
-  "news row chrome still marks the media lane (icon-only) outside the moving track",
+  /home-digest__track home-digest__track--media" aria-label="Media headlines"/,
+  "the media track still names the lane for AT",
 );
 assert.doesNotMatch(view, />News</, "the visible 'News' word is removed from the media lane chrome");
 
@@ -72,7 +77,7 @@ assert.match(css, /\.home-digest__thumb[\s\S]*?object-fit: cover/, "media thumbn
 assert.match(css, /\.home-digest__thumb[\s\S]*?width: 46px/, "media thumbnail is enlarged for the image-forward row");
 assert.match(css, /\.home-digest__card--media[\s\S]*?padding-left/, "media cards are image-forward (thumbnail hugs the leading edge)");
 assert.match(css, /\.home-digest__media[\s\S]*?position: relative/, "media row anchors the close button");
-assert.match(css, /\.home-digest__media-chrome\s*\{[\s\S]*?display: flex[\s\S]*?justify-content: space-between/, "news row has static chrome outside the marquee track");
+assert.doesNotMatch(css, /home-digest__media-chrome/, "dead lane-chrome CSS is removed with the marker");
 assert.doesNotMatch(css, /home-digest__media-close/, "dead close-button CSS is removed with the inline dismiss");
 
 // ── Settings owns the opt-out: General section renders the switch ─────────────

--- a/src/components/home/home-digest-carousel.tsx
+++ b/src/components/home/home-digest-carousel.tsx
@@ -88,13 +88,9 @@ export function HomeDigestCarousel({ sessions, familiarNameById, onOpenSession }
       ) : null}
       {mediaCards.length > 0 && newsEnabled ? (
         <div className="home-digest__media">
-          <div className="home-digest__media-chrome">
-            {/* Icon-only lane marker — the track below carries the accessible
-                "Media headlines" name, so the chrome stays wordless. */}
-            <span className="home-digest__media-label" aria-hidden="true">
-              <Icon name="ph:newspaper" width={12} aria-hidden />
-            </span>
-          </div>
+          {/* No lane chrome — the track itself carries the accessible
+              "Media headlines" name; the drift direction separates it
+              visually from the chats row. */}
           <div className="home-digest__track home-digest__track--media" aria-label="Media headlines">
             <DigestRow cards={mediaCards} onOpenSession={onOpenSession} />
             <DigestRow cards={mediaCards} onOpenSession={onOpenSession} duplicate />

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -1165,24 +1165,6 @@
   position: relative;
   margin-top: 10px;
 }
-.home-digest__media-chrome {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding-inline: max(24px, 7%);
-  margin-bottom: 6px;
-}
-.home-digest__media-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  color: var(--text-muted);
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
 .home-digest__track--media {
   animation-direction: reverse;
 }


### PR DESCRIPTION
User request: remove the news icon on the home page news section.

The media-headlines lane rendered an icon-only chrome band (`ph:newspaper` in `home-digest__media-chrome`) above the marquee track. The track already names itself for assistive tech (`aria-label="Media headlines"`), and the reversed drift direction separates it visually from the chats row — so the marker was pure chrome. Removed the band, its CSS, and retargeted the pins (chrome stays deleted; the track's AT name is pinned instead). Per-card favicon fallbacks (also a newspaper glyph) are untouched.

Validation: digest pins + typecheck green; full app suite running (posted before merge).

Bead: cave-e2zx

🤖 Generated with [Claude Code](https://claude.com/claude-code)