### PR TITLE
feat(projects): hub round 2 — task deep-links, Reveal in Finder, color row demoted (cave-dn9w)

### DIFF
--- a/src/components/projects/detail-sections.tsx
+++ b/src/components/projects/detail-sections.tsx
@@ -200,17 +200,27 @@ export function TasksSection({
         <>
           <ul className="m-0 flex list-none flex-col gap-0.5 p-0">
             {open.slice(0, TASK_CAP).map((card) => (
-              <li key={card.id} className="flex items-center gap-2 px-1 py-1 text-[12px] text-[var(--text-secondary)]">
-                <span
-                  aria-hidden
-                  className={`h-1.5 w-1.5 shrink-0 rounded-full ${CARD_STATUS_DOT[card.status] ?? "bg-[var(--text-muted)]"}`}
-                />
-                <span className="min-w-0 flex-1 truncate" title={card.title}>
-                  {card.title}
-                </span>
-                <span className="shrink-0 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
-                  {card.status}
-                </span>
+              <li key={card.id} className="m-0 list-none p-0">
+                {/* Deep-link: the board honors #card-<id> (same hash the
+                    notification bell and cockpit drill-throughs use). */}
+                <button
+                  type="button"
+                  onClick={() => {
+                    onOpenBoard?.();
+                    window.location.hash = `card-${card.id}`;
+                  }}
+                  title={`Open "${card.title}" on the board`}
+                  className="focus-ring-inset flex w-full items-center gap-2 rounded-[var(--radius-control)] px-1 py-1 text-left text-[12px] text-[var(--text-secondary)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                >
+                  <span
+                    aria-hidden
+                    className={`h-1.5 w-1.5 shrink-0 rounded-full ${CARD_STATUS_DOT[card.status] ?? "bg-[var(--text-muted)]"}`}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{card.title}</span>
+                  <span className="shrink-0 text-[10px] uppercase tracking-wider text-[var(--text-muted)]">
+                    {card.status}
+                  </span>
+                </button>
               </li>
             ))}
           </ul>

--- a/src/components/projects/project-detail.tsx
+++ b/src/components/projects/project-detail.tsx
@@ -32,6 +32,8 @@ import {
   CHAT_CAP,
   PROJECT_COLOR_SWATCHES,
   chatDotClass,
+  hasDesktopBridge,
+  revealProjectFolder,
   shortRoot,
   type MoveTarget,
 } from "./projects-shared";
@@ -399,6 +401,18 @@ export function ProjectDetail({
             <PopoverItem icon={copiedRoot ? "ph:check" : "ph:copy"} onSelect={() => void copyRoot()}>
               Copy path
             </PopoverItem>
+            {hasDesktopBridge() ? (
+              <PopoverItem
+                icon="ph:folder-open-bold"
+                onSelect={() => {
+                  void revealProjectFolder(project.root).then((ok) =>
+                    announce(ok ? `Opened ${project.name} in the file manager.` : "Couldn't open the folder.", ok ? "polite" : "assertive"),
+                  );
+                }}
+              >
+                Reveal in Finder
+              </PopoverItem>
+            ) : null}
             <PopoverItem
               icon="ph:file-code"
               onSelect={() => {
@@ -413,6 +427,51 @@ export function ProjectDetail({
             >
               Browse files
             </PopoverItem>
+            <PopoverSeparator />
+            {/* Tile color moved out of the always-visible header (cave-dn9w):
+                a rarely-used preference doesn't earn a whole header line. Same
+                swatches + handlers, now a menu row. */}
+            <div className="px-2 py-1.5">
+      {/* Color: auto (root-hash tint) or a preset swatch. */}
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
+                Color
+              </span>
+              <div className="flex items-center gap-1.5" role="group" aria-label={`Tile color for ${project.name}`}>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  onClick={() => void setColor(null)}
+                  disabled={busy === "color"}
+                  aria-pressed={!project.color}
+                  title="Auto — tinted from the project path"
+                  aria-label="Auto color"
+                  className={`h-4 w-4 shrink-0 rounded-full border border-dashed border-[var(--border-strong)] p-0 ${
+                    !project.color ? "ring-2 ring-[var(--accent-presence)] ring-offset-1 ring-offset-[var(--bg-base)]" : ""
+                  }`}
+                  style={{ background: `color-mix(in oklch, ${projectTint(project.root)} 45%, transparent)` }}
+                />
+                {PROJECT_COLOR_SWATCHES.map((swatch) => (
+                  <Button
+                    key={swatch.value}
+                    variant="ghost"
+                    size="xs"
+                    onClick={() => void setColor(swatch.value)}
+                    disabled={busy === "color"}
+                    aria-pressed={project.color === swatch.value}
+                    title={swatch.name}
+                    aria-label={`${swatch.name} color`}
+                    className={`h-4 w-4 shrink-0 rounded-full p-0 ${
+                      project.color === swatch.value
+                        ? "ring-2 ring-[var(--accent-presence)] ring-offset-1 ring-offset-[var(--bg-base)]"
+                        : ""
+                    }`}
+                    style={{ background: swatch.value }}
+                  />
+                ))}
+              </div>
+            </div>
+            </div>
             <PopoverSeparator />
             <PopoverItem icon="ph:trash-bold" danger onSelect={() => setConfirmDelete(true)}>
               Delete project…
@@ -539,45 +598,6 @@ export function ProjectDetail({
         </div>
       ) : null}
 
-      {/* Color: auto (root-hash tint) or a preset swatch. */}
-      <div className="flex min-w-0 items-center gap-2">
-        <span className="shrink-0 text-[10px] font-medium uppercase tracking-wide text-[var(--text-muted)]">
-          Color
-        </span>
-        <div className="flex items-center gap-1.5" role="group" aria-label={`Tile color for ${project.name}`}>
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={() => void setColor(null)}
-            disabled={busy === "color"}
-            aria-pressed={!project.color}
-            title="Auto — tinted from the project path"
-            aria-label="Auto color"
-            className={`h-4 w-4 shrink-0 rounded-full border border-dashed border-[var(--border-strong)] p-0 ${
-              !project.color ? "ring-2 ring-[var(--accent-presence)] ring-offset-1 ring-offset-[var(--bg-base)]" : ""
-            }`}
-            style={{ background: `color-mix(in oklch, ${projectTint(project.root)} 45%, transparent)` }}
-          />
-          {PROJECT_COLOR_SWATCHES.map((swatch) => (
-            <Button
-              key={swatch.value}
-              variant="ghost"
-              size="xs"
-              onClick={() => void setColor(swatch.value)}
-              disabled={busy === "color"}
-              aria-pressed={project.color === swatch.value}
-              title={swatch.name}
-              aria-label={`${swatch.name} color`}
-              className={`h-4 w-4 shrink-0 rounded-full p-0 ${
-                project.color === swatch.value
-                  ? "ring-2 ring-[var(--accent-presence)] ring-offset-1 ring-offset-[var(--bg-base)]"
-                  : ""
-              }`}
-              style={{ background: swatch.value }}
-            />
-          ))}
-        </div>
-      </div>
 
       {/* ── Sessions ─────────────────────────────────────────────────────────── */}
       <section className="projects-detail-section" aria-label={`Sessions in ${project.name}`}>

--- a/src/components/projects/project-list.tsx
+++ b/src/components/projects/project-list.tsx
@@ -11,7 +11,12 @@ import { normalizeProjectRoot } from "@/lib/cave-projects-types";
 import type { SessionRow } from "@/lib/types";
 import { deriveProjectStatus } from "@/lib/project-status";
 
-import { chatDotClass, lastActiveMs } from "./projects-shared";
+import {
+  chatDotClass,
+  hasDesktopBridge,
+  lastActiveMs,
+  revealProjectFolder,
+} from "./projects-shared";
 
 // The hub's master list: one compact row per project. Selecting a row swaps the
 // detail pane; everything heavier (rename, path, sessions, delete) lives there.
@@ -148,6 +153,17 @@ function ProjectListRow({
         >
           Copy path
         </PopoverItem>
+        {hasDesktopBridge() ? (
+          <PopoverItem
+            icon="ph:folder-open-bold"
+            onSelect={() => {
+              setMenu(null);
+              void revealProjectFolder(project.root);
+            }}
+          >
+            Reveal in Finder
+          </PopoverItem>
+        ) : null}
       </ContextMenu>
     </li>
   );

--- a/src/components/projects/projects-hub.test.ts
+++ b/src/components/projects/projects-hub.test.ts
@@ -215,4 +215,13 @@ assert.match(detail, /\} in this project`\}/, "the session count chip is titled"
 // Grants explain themselves where the chips are.
 assert.match(sections, /dashed means no access yet/, "the grants section says what a chip click does");
 
+// ── Hub round 2 (cave-dn9w): deep-links · reveal · demoted color row ─────────
+assert.match(sections, /window\.location\.hash = `card-\$\{card\.id\}`/, "task rows deep-link to their board card");
+assert.match(sections, /onOpenBoard\?\.\(\);\s*\n\s*window\.location\.hash/, "…after switching to the board surface");
+assert.match(shared, /export async function revealProjectFolder/, "the reveal helper lives in projects-shared");
+assert.match(shared, /invoke\("shell_open_path", \{ path: root \}\)/, "…and uses the app's absolute-path-validated command");
+assert.match(detail, /hasDesktopBridge\(\) \?[\s\S]{0,400}Reveal in Finder/, "the detail overflow reveals the folder, desktop only");
+assert.match(list, /hasDesktopBridge\(\) \?[\s\S]{0,500}Reveal in Finder/, "the list row context menu reveals too, desktop only");
+// The color swatches moved INTO the overflow — no always-visible header row.
+assert.match(detail, /PopoverSeparator \/>[\s\S]{0,1400}aria-label=\{`Tile color for \$\{project\.name\}`\}/, "the tile-color swatches live inside the overflow menu");
 console.log("projects-hub.test.ts: ok");

--- a/src/components/projects/projects-shared.ts
+++ b/src/components/projects/projects-shared.ts
@@ -53,3 +53,23 @@ export const PROJECT_COLOR_SWATCHES: { name: string; value: string }[] = [
   { name: "Violet", value: "oklch(0.74 0.12 300)" },
   { name: "Rose", value: "oklch(0.74 0.12 340)" },
 ];
+
+/** True when the desktop shell's native bridge is reachable (Tauri webview). */
+export function hasDesktopBridge(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/** Open the project folder in the OS file manager (Finder/Explorer/xdg-open).
+ *  Desktop shell only — resolves false in a plain browser so callers can hide
+ *  or fall back. Uses the app's `shell_open_path` command (absolute,
+ *  must-exist paths enforced on the Rust side). */
+export async function revealProjectFolder(root: string): Promise<boolean> {
+  if (!hasDesktopBridge()) return false;
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("shell_open_path", { path: root });
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Second identified-and-implemented round on the Projects hub (goal image #2 — the hub's master-detail screenshot). Each candidate verified in source before building: task rows were inert `<li>`s, no reveal-folder action existed anywhere in the app, and the color swatches still occupied an always-visible header line.

1. **Task rows deep-link to their board card** — rows become buttons: switch to the board, then set `#card-<id>` (the same hash the notification bell and cockpit drill-throughs already use).
2. **Reveal in Finder (detail overflow)** — desktop shell only (`hasDesktopBridge` gate), via the existing `shell_open_path` command (absolute, must-exist paths validated Rust-side); announces success/failure.
3. **Reveal in Finder (list-row context menu)** — the same action where users right-click.
4. **Color row demoted into the overflow menu** — identical swatches, handlers, aria group, and announcements, now living between Browse files and Delete; the detail header drops a full line, per the ultra-minimal direction.

## Verification

Live-driven on the built app: the color group is absent from the header flow (probe: 0 before the menu opens, 1 inside it), the selected project's open task renders as a titled deep-link button, and Reveal in Finder correctly hides in a plain browser. Screenshot reviewed with the menu open. Pins for all four behaviors in `projects-hub.test.ts`.

`tsc` clean · **570 test files** green · build within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)