### PR TITLE
feat(chrome): glassmorphic overlay chrome — shared glass tokens for popovers, modals, and the palette (cave-6u0j)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -217,6 +217,7 @@ export const SUITES = {
     "src/components/daily-summary-notifications.test.ts",
     "src/components/notification-bell-mutations.test.ts",
     "src/components/surface-error-states.test.ts",
+    "src/components/glass-overlay-chrome.test.ts",
     "src/components/surface-loading-states.test.ts",
     "src/components/chat-header-row.test.ts",
     "src/components/chat-usage-plan-ui.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,6 +202,19 @@
   /* ---- Surface alphas ---- */
   --backdrop-scrim: oklch(0 0 0 / 60%);
 
+  /* ---- Glass (native-vibrancy translucency for overlay chrome) ----
+     Derived from the theme's own surface tokens via color-mix, so every
+     accent theme and light mode track automatically. Overlay surfaces only —
+     base panes have nothing rendering beneath them to blur, so glass there
+     would cost compositing for no visible depth. Pair the translucent fill
+     with blur(var(--glass-blur)); a see-through fill WITHOUT blur is
+     unreadable, which is why the @supports fallback below restores the
+     opaque tokens wherever backdrop-filter is unavailable. */
+  --glass-blur: 16px;
+  --glass-saturate: 140%;
+  --glass-elevated: color-mix(in oklch, var(--bg-elevated) 74%, transparent);
+  --glass-raised: color-mix(in oklch, var(--bg-raised) 80%, transparent);
+
   /* Foundations PR — disabled state */
   --opacity-disabled: 0.4;
 
@@ -1477,6 +1490,9 @@ tr[role="checkbox"]:focus-visible {
   position: fixed;
   inset: 0;
   background: var(--backdrop-scrim);
+  /* Soft depth cue: the app recedes behind the scrim instead of just dimming. */
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -1503,7 +1519,10 @@ tr[role="checkbox"]:focus-visible {
   width: 100%;
   max-width: 560px;
   max-height: calc(100vh - 2 * var(--space-4));
-  background: var(--bg-raised);
+  /* Glassmorphic sheet — the dimmed app blurs through the dialog body. */
+  background: var(--glass-raised);
+  backdrop-filter: blur(calc(var(--glass-blur) + 2px)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(calc(var(--glass-blur) + 2px)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-card);
   display: flex;
@@ -2716,7 +2735,11 @@ textarea.required-inputs-control {
 }
 .ui-popover {
   position: absolute;
-  background: var(--bg-elevated);
+  /* Glassmorphic overlay: translucent theme surface over blurred content.
+     Opaque fallbacks live in the @supports / reduced-transparency blocks. */
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-control);
   box-shadow: 0 16px 40px oklch(0 0 0 / 45%);
@@ -2729,6 +2752,50 @@ textarea.required-inputs-control {
 @keyframes ui-popover-enter {
   from { opacity: 0; transform: translateY(-2px); }
   to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Glass overlay utility ────────────────────────────────────────────────────
+ * For overlay surfaces that carry their chrome as component classes (command
+ * palette, notification bell popover, …) instead of the ui-popover/ui-modal
+ * primitives: the same translucent-fill + backdrop-blur pairing, from the
+ * same tokens. */
+.glass-overlay {
+  background: var(--glass-elevated);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+/* Glass is only legible while the backdrop actually blurs: with no
+ * backdrop-filter support, a translucent fill over scrolling content is
+ * unreadable soup — restore the opaque theme surfaces. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .ui-popover,
+  .glass-overlay {
+    background: var(--bg-elevated);
+  }
+  .ui-modal {
+    background: var(--bg-raised);
+  }
+}
+
+/* Native accessibility setting wins: users who asked the OS for less
+ * transparency get the opaque surfaces (and their compositor back). */
+@media (prefers-reduced-transparency: reduce) {
+  .ui-popover,
+  .glass-overlay {
+    background: var(--bg-elevated);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .ui-modal {
+    background: var(--bg-raised);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+  .ui-modal-backdrop {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
 }
 
 /* Projects tab: a project's session list slides+fades in when expanded.

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -801,7 +801,7 @@ export function CommandPalette({
         aria-modal="true"
         aria-label="Command palette"
         tabIndex={-1}
-        className="mt-[12vh] w-[640px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl"
+        className="glass-overlay mt-[12vh] w-[640px] max-w-[92vw] overflow-hidden rounded-2xl border border-[var(--border-strong)] shadow-2xl"
         style={{ animation: "ui-modal-enter var(--duration-base) var(--ease-decelerate)" }}
       >
         <input

--- a/src/components/glass-overlay-chrome.test.ts
+++ b/src/components/glass-overlay-chrome.test.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+// Glassmorphic overlay chrome (cave-6u0j): overlay surfaces pair a translucent
+// theme-derived fill with backdrop blur, from shared --glass-* tokens — with
+// opaque fallbacks wherever backdrop-filter is unavailable or the user asked
+// the OS for reduced transparency (a see-through fill WITHOUT blur is
+// unreadable over scrolling content).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const palette = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
+const bell = readFileSync(new URL("./notification-bell.tsx", import.meta.url), "utf8");
+
+// ── Tokens: theme-derived, so every accent theme + light mode track ──────────
+assert.match(css, /--glass-blur: \d+px;/, "glass blur token exists");
+assert.match(css, /--glass-saturate: \d+%;/, "glass saturate token exists");
+assert.match(
+  css,
+  /--glass-elevated: color-mix\(in oklch, var\(--bg-elevated\) \d+%, transparent\);/,
+  "elevated glass derives from the theme's elevated surface",
+);
+assert.match(
+  css,
+  /--glass-raised: color-mix\(in oklch, var\(--bg-raised\) \d+%, transparent\);/,
+  "raised glass derives from the theme's raised surface",
+);
+
+// ── Primitives: popover + modal are glass; the scrim gains a depth blur ──────
+assert.match(
+  css,
+  /\.ui-popover \{[\s\S]{0,400}?background: var\(--glass-elevated\);[\s\S]{0,200}?backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/,
+  "ui-popover pairs the translucent fill with backdrop blur",
+);
+assert.match(
+  css,
+  /\.ui-modal \{[\s\S]{0,500}?background: var\(--glass-raised\);[\s\S]{0,300}?backdrop-filter: blur\(/,
+  "ui-modal is a glass sheet",
+);
+assert.match(
+  css,
+  /\.ui-modal-backdrop \{[\s\S]{0,300}?backdrop-filter: blur\(/,
+  "the modal scrim blurs the app behind it",
+);
+
+// ── Shared utility + fallbacks ────────────────────────────────────────────────
+assert.match(
+  css,
+  /\.glass-overlay \{\s*\n\s*background: var\(--glass-elevated\);\s*\n\s*backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/,
+  "the glass-overlay utility exists for component-class surfaces",
+);
+assert.match(
+  css,
+  /@supports not \(\(backdrop-filter: blur\(1px\)\) or \(-webkit-backdrop-filter: blur\(1px\)\)\) \{[\s\S]{0,400}?background: var\(--bg-elevated\);/,
+  "no-backdrop-filter environments fall back to opaque surfaces",
+);
+assert.match(
+  css,
+  /@media \(prefers-reduced-transparency: reduce\) \{[\s\S]{0,600}?backdrop-filter: none;/,
+  "the OS reduced-transparency setting restores opaque, blur-free chrome",
+);
+
+// Every glass consumer keeps -webkit-backdrop-filter for WebKit (the Tauri
+// webview on macOS is WebKit — the native platform this vibe is for).
+const webkitPairs = css.match(/backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);\s*\n\s*-webkit-backdrop-filter: blur\(var\(--glass-blur\)\) saturate\(var\(--glass-saturate\)\);/g) ?? [];
+assert.ok(webkitPairs.length >= 2, "glass consumers carry the -webkit- prefix pair");
+
+// ── Component-class surfaces ride the shared utility ─────────────────────────
+assert.match(palette, /className="glass-overlay mt-\[12vh\]/, "the command palette dialog is glass");
+assert.doesNotMatch(palette, /mt-\[12vh\][^"]*bg-\[var\(--bg-elevated\)\]/, "the palette's old opaque fill is gone");
+assert.match(bell, /notification-bell__popover glass-overlay/, "the notification bell popover is glass");
+
+console.log("glass-overlay-chrome.test.ts: ok");

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -226,7 +226,7 @@ export function NotificationBell({
           role="dialog"
           aria-label="Notifications"
           tabIndex={-1}
-          className="notification-bell__popover group/popover absolute right-0 top-full z-50 mt-1 w-[400px] rounded-xl border border-[var(--border-strong)] bg-[var(--bg-elevated)] shadow-2xl"
+          className="notification-bell__popover glass-overlay group/popover absolute right-0 top-full z-50 mt-1 w-[400px] rounded-xl border border-[var(--border-strong)] shadow-2xl"
         >
           <div className="notification-bell__header flex items-center justify-between border-b border-[var(--border-hairline)] px-3 py-2">
             <span className="text-[11px] font-medium text-[var(--text-primary)]">


### PR DESCRIPTION
## Objective (operator autopilot)
Enhance the app's opacity for a more native glassmorphic vibe.

## What landed
- **Shared glass tokens**: `--glass-blur` / `--glass-saturate` / `--glass-elevated` / `--glass-raised`, built with `color-mix` over the theme's own surface vars — every accent theme + light mode track automatically.
- **Primitives**: `.ui-popover` (every popover, select, and menu in the app) and `.ui-modal` are now translucent + backdrop-blurred; the modal scrim gains a 6px depth blur so the app recedes behind dialogs instead of just dimming.
- **`.glass-overlay` utility** for component-class surfaces — applied to the command palette dialog and the notification bell popover.
- **Scoped to overlays** — base panes have nothing beneath them to blur; glass there costs compositing for zero visible depth.
- **Honest fallbacks**: `@supports not (backdrop-filter…)` restores opaque surfaces (translucency without blur is unreadable), and `prefers-reduced-transparency: reduce` honors the OS accessibility setting with opaque, blur-free chrome.

## Verification
- **Live Playwright screenshots, dark + light**: home content visibly blurs through the open ⌘K palette; text contrast intact in both modes.
- New wired `glass-overlay-chrome.test.ts`: tokens are theme-derived, primitives pair fill+blur, -webkit- pairs present (the macOS Tauri webview is WebKit), both fallback blocks exist, palette + bell ride the utility.
- `pnpm test:app` — 572 files pass · `pnpm typecheck` clean · `pnpm build` clean

Closes cave-6u0j (beads).