### PR TITLE
feat(harness): GitHub Copilot CLI as a first-class runtime

### DIFF
--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -19,6 +19,7 @@ for (const pkg of [
   "coven-code@latest",
   "@openai\\/codex",
   "@anthropic-ai\\/claude-code",
+  "@github\\/copilot@latest",
   "openclaw@latest",
 ]) {
   assert.match(

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -59,6 +59,13 @@ const INSTALL_TARGETS = {
     binary: "claude",
     timeoutMs: 240_000,
   },
+  copilot: {
+    kind: "npm",
+    label: "Copilot",
+    packageName: "@github/copilot@latest",
+    binary: "copilot",
+    timeoutMs: 240_000,
+  },
   openclaw: {
     kind: "npm",
     label: "OpenClaw",

--- a/src/components/composer-runtime-chip.tsx
+++ b/src/components/composer-runtime-chip.tsx
@@ -28,7 +28,7 @@ export function ComposerRuntimeChip({
   onPickModel,
   disabled,
 }: {
-  /** Active runtime (harness id): codex | claude | hermes | openclaw. */
+  /** Active runtime (harness id): codex | claude | copilot | hermes | openclaw. */
   runtime: string;
   /** Effective model id ("" when the runtime has no curated models). */
   modelValue: string;

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -794,7 +794,7 @@ function StageVessel({
             <p className="text-[11px] text-[var(--text-muted)]">Looking for installed runtimes…</p>
           ) : installedHarnesses.length === 0 ? (
             <p className="text-[11px] text-[var(--color-warning)]">
-              No chat-capable runtime found. Install one (Codex, Claude Code, Hermes…) from Settings, then return to the circle.
+              No chat-capable runtime found. Install one (Codex, Claude Code, Copilot, Hermes…) from Settings, then return to the circle.
             </p>
           ) : (
             <div role="radiogroup" aria-label="Runtime" className="summoning-chiprow">

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -82,6 +82,7 @@ type InstallTarget =
   | "coven-code"
   | "codex"
   | "claude"
+  | "copilot"
   | "openclaw"
   | "hermes";
 
@@ -120,6 +121,7 @@ const INSTALL_TARGET_KIND: Record<InstallTarget, "npm" | "script"> = {
   "coven-code": "npm",
   codex: "npm",
   claude: "npm",
+  copilot: "npm",
   openclaw: "npm",
   hermes: "script",
 };
@@ -163,6 +165,12 @@ const HARNESS_ONE_CLICK: Partial<
     target: "claude",
     command: "npm install -g @anthropic-ai/claude-code",
     afterInstall: "then run `claude doctor` in a terminal to finish setup",
+  },
+  copilot: {
+    target: "copilot",
+    command: "npm install -g @github/copilot",
+    afterInstall:
+      "then run `copilot` in a terminal and sign in with `/login` (or set GH_TOKEN)",
   },
   openclaw: {
     target: "openclaw",

--- a/src/components/runtime-logo.tsx
+++ b/src/components/runtime-logo.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 // The runtime's visual identity: real brand marks for provider-backed
-// runtimes (OpenAI for codex, Anthropic for claude — simple-icons paths,
-// CC0), Phosphor glyphs for the runtime-managed adapters that have no brand
-// (hermes, openclaw). Inline SVGs keep the two brand marks out of the
-// Phosphor icon-subset pipeline; they inherit currentColor like Icon does.
+// runtimes (OpenAI for codex, Anthropic for claude, GitHub Copilot for
+// copilot — simple-icons paths, CC0), Phosphor glyphs for the runtime-managed
+// adapters that have no brand (hermes, openclaw). Inline SVGs keep the brand
+// marks out of the Phosphor icon-subset pipeline; they inherit currentColor
+// like Icon does.
 
 import { Icon, type IconName } from "@/lib/icon";
 
@@ -14,9 +15,13 @@ const OPENAI_PATH =
 const ANTHROPIC_PATH =
   "M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z";
 
+const GITHUB_COPILOT_PATH =
+  "M23.922 16.997C23.061 18.492 18.063 22.02 12 22.02 5.937 22.02.939 18.492.078 16.997A.641.641 0 0 1 0 16.741v-2.869a.883.883 0 0 1 .053-.22c.372-.935 1.347-2.292 2.605-2.656.167-.429.414-1.055.644-1.517a10.098 10.098 0 0 1-.052-1.086c0-1.331.282-2.499 1.132-3.368.397-.406.89-.717 1.474-.952C7.255 2.937 9.248 1.98 11.978 1.98c2.731 0 4.767.957 6.166 2.093.584.235 1.077.546 1.474.952.85.869 1.132 2.037 1.132 3.368 0 .368-.014.733-.052 1.086.23.462.477 1.088.644 1.517 1.258.364 2.233 1.721 2.605 2.656a.841.841 0 0 1 .053.22v2.869a.641.641 0 0 1-.078.256Zm-11.75-5.992h-.344a4.359 4.359 0 0 1-.355.508c-.77.947-1.918 1.492-3.508 1.492-1.725 0-2.989-.359-3.782-1.259a2.137 2.137 0 0 1-.085-.104L4 11.746v6.585c1.435.779 4.514 2.179 8 2.179 3.486 0 6.565-1.4 8-2.179v-6.585l-.098-.104s-.033.045-.085.104c-.793.9-2.057 1.259-3.782 1.259-1.59 0-2.738-.545-3.508-1.492a4.359 4.359 0 0 1-.355-.508Zm2.328 3.25c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm-5 0c.549 0 1 .451 1 1v2c0 .549-.451 1-1 1-.549 0-1-.451-1-1v-2c0-.549.451-1 1-1Zm3.313-6.185c.136 1.057.403 1.913.878 2.497.442.544 1.134.938 2.344.938 1.573 0 2.292-.337 2.657-.751.384-.435.558-1.15.558-2.361 0-1.14-.243-1.847-.705-2.319-.477-.488-1.319-.862-2.824-1.025-1.487-.161-2.192.138-2.533.529-.269.307-.437.808-.438 1.578v.021c0 .265.021.562.063.893Zm-1.626 0c.042-.331.063-.628.063-.894v-.02c-.001-.77-.169-1.271-.438-1.578-.341-.391-1.046-.69-2.533-.529-1.505.163-2.347.537-2.824 1.025-.462.472-.705 1.179-.705 2.319 0 1.211.175 1.926.558 2.361.365.414 1.084.751 2.657.751 1.21 0 1.902-.394 2.344-.938.475-.584.742-1.44.878-2.497Z";
+
 const BRAND_PATHS: Record<string, string> = {
   codex: OPENAI_PATH,
   claude: ANTHROPIC_PATH,
+  copilot: GITHUB_COPILOT_PATH,
 };
 
 /** Phosphor stand-ins for runtimes without a provider brand (matches the
@@ -32,6 +37,8 @@ export function runtimeDisplayName(runtime: string): string {
       return "Codex";
     case "claude":
       return "Claude Code";
+    case "copilot":
+      return "Copilot";
     case "hermes":
       return "Hermes";
     case "openclaw":

--- a/src/components/salem/salem-context.ts
+++ b/src/components/salem/salem-context.ts
@@ -136,7 +136,7 @@ export const SALEM_PRELOAD_CONTEXT: SalemPreloadContext = {
     {
       id: "sessions",
       label: "Sessions",
-      purpose: "Harness sessions across OpenClaw, Codex, Claude Code, Hermes, and future adapters.",
+      purpose: "Harness sessions across OpenClaw, Codex, Claude Code, Copilot, Hermes, and future adapters.",
     },
     {
       id: "tasks",

--- a/src/components/skill-card.tsx
+++ b/src/components/skill-card.tsx
@@ -11,12 +11,12 @@ type IconRule = { pattern: RegExp; icon: IconName };
 
 const NAME_RULES: IconRule[] = [
   { pattern: /xurl|twitter|x.com/i,          icon: "ph:x-logo-bold" },
+  { pattern: /copilot/i,                       icon: "ph:github-logo" },
   { pattern: /github/i,                        icon: "ph:github-logo" },
   { pattern: /git/i,                         icon: "ph:git-branch-bold" },
   { pattern: /codex/i,                         icon: "ph:terminal-window-bold" },
   { pattern: /claude/i,                        icon: "ph:brain-bold" },
   { pattern: /openclaw|opencoven|coven/i,      icon: "ph:paw-print-bold" },
-  { pattern: /copilot/i,                       icon: "ph:git-branch-bold" },
   { pattern: /figma|design/i,                  icon: "ph:pen-nib-bold" },
   { pattern: /linear/i,                        icon: "ph:arrow-clockwise-bold" },
   { pattern: /notion/i,                        icon: "ph:note-bold" },

--- a/src/lib/chat-model-state.ts
+++ b/src/lib/chat-model-state.ts
@@ -47,6 +47,7 @@ const GLOBAL_DEFAULT_MODEL = "openai/gpt-5.5";
 const SYNTHETIC_LOCAL_MODELS = new Set([
   "codex-local",
   "claude-local",
+  "copilot-local",
   "hermes-local",
   "openclaw-local",
 ]);

--- a/src/lib/context-meter.ts
+++ b/src/lib/context-meter.ts
@@ -47,6 +47,10 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "anthropic/claude-sonnet-5": 1_000_000,
   "anthropic/claude-sonnet-4-6": 1_000_000,
   "anthropic/claude-haiku-4-5": 200_000,
+  // GitHub Copilot (copilot runtime) — cross-provider ids resolve through the
+  // bare-name fallback (gpt-5.5, claude-*); the Copilot-only ids live here.
+  "github/auto": 200_000,
+  "github/gemini-3.1-pro": 1_000_000,
   // Nous (hermes runtime) — estimate.
   "nous/hermes-4": 128_000,
 };

--- a/src/lib/harness-adapters.test.ts
+++ b/src/lib/harness-adapters.test.ts
@@ -49,7 +49,7 @@ assert.equal(
 
 assert.deepEqual(
   COMPATIBILITY_ADAPTERS.map((adapter) => adapter.id),
-  ["codex", "claude", "hermes", "openclaw"],
+  ["codex", "claude", "copilot", "hermes", "openclaw"],
 );
 
 assert.deepEqual(openClawAdapterReport(2), {
@@ -148,6 +148,7 @@ const mergedExternal = mergeAdapterReports(
 assert.equal(mergedExternal[0]?.chatSupported, false);
 assert.equal(mergedExternal[0]?.installed, true);
 assert.equal(isTrustedChatHarness("codex"), true);
+assert.equal(isTrustedChatHarness("copilot"), true);
 assert.equal(isTrustedChatHarness("hermes"), true);
 assert.equal(isTrustedChatHarness("openclaw"), true);
 assert.equal(isTrustedChatHarness("attacker-adapter"), false);
@@ -160,6 +161,9 @@ assert.equal(isTrustedOnboardingHarness("attacker-adapter"), false);
 assert.equal(canonicalHarnessId("hermes-agent"), "hermes");
 assert.equal(canonicalHarnessId("Hermes-Agent"), "hermes", "alias match is case-insensitive");
 assert.equal(canonicalHarnessId("claude-code"), "claude");
+assert.equal(canonicalHarnessId("github-copilot"), "copilot");
+assert.equal(canonicalHarnessId("copilot-cli"), "copilot");
+assert.equal(isTrustedChatHarness("github-copilot"), true, "the Copilot package alias must clear the chat trust gate");
 assert.equal(canonicalHarnessId("hermes"), "hermes", "canonical id passes through");
 assert.equal(canonicalHarnessId("HERMES"), "hermes", "id match is case-insensitive");
 assert.equal(canonicalHarnessId("attacker-adapter"), "attacker-adapter", "unknown ids are unchanged (still untrusted)");
@@ -175,7 +179,7 @@ assert.deepEqual(
   adapterSetupState(merged.filter((adapter) => !adapter.installed)),
   {
     ok: false,
-    hint: "Install Codex, Claude Code, Hermes, or connect an OpenClaw agent, then re-check. External adapters can also be added with Coven adapter manifests.",
+    hint: "Install Codex, Claude Code, Copilot, Hermes, or connect an OpenClaw agent, then re-check. External adapters can also be added with Coven adapter manifests.",
   },
 );
 
@@ -213,6 +217,29 @@ assert.deepEqual(JSON.parse(hermesManifest?.contents ?? "{}"), {
   ],
 });
 assert.equal(adapterManifestScaffoldForHarness("codex"), null);
+
+// Copilot runs through a Coven adapter manifest (like Hermes): the prompt is
+// appended after the prefix args, so it lands as the -i/-p flag's value.
+const copilotManifest = adapterManifestScaffoldForHarness("copilot");
+assert.equal(copilotManifest?.filename, "copilot.json");
+assert.deepEqual(JSON.parse(copilotManifest?.contents ?? "{}"), {
+  adapters: [
+    {
+      id: "copilot",
+      label: "Copilot",
+      executable: "copilot",
+      interactive_prompt_prefix_args: ["--interactive"],
+      non_interactive_prompt_prefix_args: [
+        "--allow-all-tools",
+        "--no-color",
+        "--prompt",
+      ],
+      install_hint:
+        "Install GitHub Copilot CLI with `npm install -g @github/copilot`, run `copilot` once and sign in with `/login` (or set GH_TOKEN), and make sure `copilot` is on PATH before using this adapter.",
+      system_prompt_flag: null,
+    },
+  ],
+});
 
 assert.deepEqual(
   runtimeSourceSetupState(

--- a/src/lib/harness-adapters.ts
+++ b/src/lib/harness-adapters.ts
@@ -68,6 +68,16 @@ export const COMPATIBILITY_ADAPTERS: CompatibilityAdapter[] = [
     source: "bundled",
   },
   {
+    id: "copilot",
+    label: "Copilot",
+    binary: "copilot",
+    chatSupported: true,
+    versionArgs: ["--version"],
+    installHint:
+      "Install GitHub Copilot CLI with `npm install -g @github/copilot`, then run `copilot` and sign in with `/login`. Cave creates its Coven adapter manifest.",
+    source: "bundled",
+  },
+  {
     id: "hermes",
     label: "Hermes",
     binary: "hermes",
@@ -111,6 +121,8 @@ const HARNESS_ALIASES: Record<string, string> = {
   "hermes-agent": "hermes",
   "claude-code": "claude",
   "openai-codex": "codex",
+  "github-copilot": "copilot",
+  "copilot-cli": "copilot",
 };
 
 export function canonicalHarnessId(harness: string): string {
@@ -215,7 +227,7 @@ export function mergeAdapterReports(
 
   return [...merged.values()].sort((a, b) => {
     const rank = (id: string) =>
-      id === "codex" ? 0 : id === "claude" ? 1 : id === "hermes" ? 2 : id === "openclaw" ? 3 : 4;
+      id === "codex" ? 0 : id === "claude" ? 1 : id === "copilot" ? 2 : id === "hermes" ? 3 : id === "openclaw" ? 4 : 5;
     return rank(a.id) - rank(b.id) || a.label.localeCompare(b.label);
   });
 }
@@ -230,7 +242,7 @@ export function adapterSetupState(reports: AdapterReport[]): AdapterSetupState {
   }
   return {
     ok: false,
-    hint: "Install Codex, Claude Code, Hermes, or connect an OpenClaw agent, then re-check. External adapters can also be added with Coven adapter manifests.",
+    hint: "Install Codex, Claude Code, Copilot, Hermes, or connect an OpenClaw agent, then re-check. External adapters can also be added with Coven adapter manifests.",
   };
 }
 
@@ -252,6 +264,38 @@ export function runtimeSourceSetupState(
 export function adapterManifestScaffoldForHarness(
   harnessId: string,
 ): AdapterManifestScaffold | null {
+  if (harnessId === "copilot") {
+    return {
+      filename: "copilot.json",
+      contents: `${JSON.stringify(
+        {
+          adapters: [
+            {
+              id: "copilot",
+              label: "Copilot",
+              executable: "copilot",
+              // The prompt is appended after the prefix args, so it lands as
+              // the flag's value: `copilot --interactive <prompt>` /
+              // `copilot … --prompt <prompt>`. Non-interactive runs need
+              // --allow-all-tools (Copilot exits otherwise) and --no-color so
+              // the captured transcript stays ANSI-free.
+              interactive_prompt_prefix_args: ["--interactive"],
+              non_interactive_prompt_prefix_args: [
+                "--allow-all-tools",
+                "--no-color",
+                "--prompt",
+              ],
+              install_hint:
+                "Install GitHub Copilot CLI with `npm install -g @github/copilot`, run `copilot` once and sign in with `/login` (or set GH_TOKEN), and make sure `copilot` is on PATH before using this adapter.",
+              system_prompt_flag: null,
+            },
+          ],
+        },
+        null,
+        2,
+      )}\n`,
+    };
+  }
   if (harnessId !== "hermes") return null;
   return {
     filename: "hermes.json",

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./runtime-models.ts";
 
 // Every bundled chat runtime has a catalog entry.
-for (const runtime of ["codex", "claude", "hermes", "openclaw"]) {
+for (const runtime of ["codex", "claude", "copilot", "hermes", "openclaw"]) {
   const catalog = catalogForRuntime(runtime);
   assert.ok(catalog, `${runtime} should have a catalog entry`);
   assert.equal(catalog.runtime, runtime);
@@ -59,6 +59,25 @@ assert.equal(
   "openai/gpt-5.5",
   "GPT-5.5 must stay first so it remains the codex default",
 );
+
+// Copilot serves multiple providers' models through one GitHub subscription.
+assert.equal(catalogForRuntime("copilot").provider, "github");
+assert.ok(catalogForRuntime("copilot").models.length > 1, "copilot should seed a multi-model menu");
+assert.equal(
+  catalogForRuntime("copilot").models[0].id,
+  "github/auto",
+  "Auto must stay first so Copilot's own default model selection remains the default",
+);
+assert.ok(
+  catalogForRuntime("copilot").models.some((m) => m.id === "github/gpt-5.5"),
+  "copilot catalog should seed GPT-5.5",
+);
+assert.ok(
+  catalogForRuntime("copilot").models.some((m) => m.id === "github/claude-sonnet-5"),
+  "copilot catalog should seed Claude Sonnet 5",
+);
+assert.equal(catalogForRuntime("copilot").allowCustom, true, "copilot accepts unlisted model ids");
+assert.equal(defaultModelForRuntime("copilot"), "github/auto");
 
 // Namespaced model id convention (`provider/model`) holds across the seed.
 for (const catalog of Object.values(RUNTIME_MODEL_CATALOG)) {

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -12,12 +12,12 @@
 // runtime's CLI" branch. That includes Hermes: Cave's Hermes mode means the
 // installed Hermes Agent runtime, not a bundled Nous/Hermes model selection.
 
-export type RuntimeProvider = "openai" | "anthropic" | "nous" | null;
+export type RuntimeProvider = "openai" | "anthropic" | "github" | "nous" | null;
 
 export type RuntimeModelOption = { id: string; label: string };
 
 export type RuntimeModelCatalog = {
-  /** Harness id: codex | claude | hermes | openclaw. */
+  /** Harness id: codex | claude | copilot | hermes | openclaw. */
   runtime: string;
   provider: RuntimeProvider;
   /** Curated seed; empty ⇒ no menu, free-text only. */
@@ -50,6 +50,22 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
       { id: "anthropic/claude-sonnet-5", label: "Claude Sonnet 5" },
       { id: "anthropic/claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
       { id: "anthropic/claude-haiku-4-5", label: "Claude Haiku 4.5" },
+    ],
+    allowCustom: true,
+  },
+  // Copilot serves multiple providers' models through one GitHub subscription;
+  // ids are namespaced under `github/` and forwarded bare to `copilot --model`.
+  // `github/auto` stays first: Copilot's own default is letting it pick.
+  copilot: {
+    runtime: "copilot",
+    provider: "github",
+    models: [
+      { id: "github/auto", label: "Auto (Copilot picks)" },
+      { id: "github/gpt-5.5", label: "GPT-5.5" },
+      { id: "github/claude-opus-4-8", label: "Claude Opus 4.8" },
+      { id: "github/claude-sonnet-5", label: "Claude Sonnet 5" },
+      { id: "github/claude-haiku-4-5", label: "Claude Haiku 4.5" },
+      { id: "github/gemini-3.1-pro", label: "Gemini 3.1 Pro" },
     ],
     allowCustom: true,
   },


### PR DESCRIPTION
## Summary

Comprehensively wires **GitHub Copilot CLI** into Cave as a first-class chat runtime, with the same coverage Codex/Claude Code/Hermes get:

### Harness plumbing
- `copilot` joins `COMPATIBILITY_ADAPTERS` (binary `copilot`, `--version` probe, chat-supported) with aliases `github-copilot`/`copilot-cli` collapsing through `canonicalHarnessId`, so it clears the chat trust gate and onboarding allowlist.
- Coven adapter manifest scaffold (`copilot.json`) written by onboarding setup + familiar creation, mirroring Hermes: `--interactive <prompt>` interactive, `--allow-all-tools --no-color --prompt <prompt>` non-interactive.
- Adapter ordering (codex → claude → copilot → hermes → openclaw) and setup-state hint copy updated.

### Models
- New `github` runtime provider with a curated catalog: **Auto (Copilot picks)** first — Copilot's own default — then GPT-5.5, Claude Opus 4.8, Claude Sonnet 5, Claude Haiku 4.5, Gemini 3.1 Pro; custom ids allowed.
- Context-window entries for the Copilot-only ids (`github/auto`, `github/gemini-3.1-pro`); cross-provider ids resolve through the existing bare-name fallback.
- `copilot-local` joins the synthetic local-model markers.

### Interface
- Runtime chip / summoning circle / model pickers list Copilot automatically via the catalog + `/api/harnesses`.
- GitHub Copilot brand mark (simple-icons, CC0) in `RuntimeLogo`; display name **Copilot**.
- One-click onboarding install target: `npm install -g @github/copilot` (pinned allowlist, npm lane), with sign-in guidance (`/login` or `GH_TOKEN`).
- Skill-card icon rule, summoning-circle empty-state copy, and Salem context awareness.

### Tests
- `harness-adapters.test.ts`: adapter list, aliases, trust gate, manifest scaffold shape, setup-state hint.
- `runtime-models.test.ts`: catalog, default (`github/auto`), curated ids.
- `onboarding/install/route.test.ts`: pinned `@github/copilot@latest` package.

## Verification
- `pnpm test:app` — 572 files ✓
- `pnpm test:api` — 127 files ✓
- `pnpm test:mobile` — 74 files ✓
- `pnpm typecheck` ✓

## Note
The first push of this branch (b9918474) accidentally swallowed an unrelated in-flight familiar-analytics/globals.css change from a concurrent session (the #585 failure mode). The branch was rewritten to scope it to Copilot only; the analytics work was restored to its session's working tree.