### PR TITLE
feat(home): "Needs you" morning-triage strip — one glance, one source, today's report link (cave-925w)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -178,6 +178,7 @@ export const SUITES = {
     "src/components/home-chat-handoff.test.ts",
     "src/components/home-composer.test.ts",
     "src/components/home-digest-carousel.test.ts",
+    "src/components/home-needs-you.test.ts",
     "src/components/home-feed.test.ts",
     "src/components/home-composer-centering.test.ts",
     "src/components/home-composer-hide-archived.test.ts",

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -37,6 +37,7 @@ import { useAttachmentStaging } from "@/lib/use-attachment-staging";
 import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
 import { canonicalize } from "@/lib/slash-commands";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
+import type { InboxItem } from "@/lib/cave-inbox";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { useProjects } from "@/lib/use-projects";
@@ -49,6 +50,7 @@ import { useKeySymbols } from "@/lib/platform-keys";
 import { catalogForRuntime } from "@/lib/runtime-models";
 import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeDigestCarousel } from "@/components/home/home-digest-carousel";
+import { HomeNeedsYou } from "@/components/home/home-needs-you";
 import { HomeSuggestions } from "@/components/home/home-suggestions";
 import { HomeSelect, type HomeSelectGroup } from "@/components/home/home-select";
 import { HomeSlashMenu } from "@/components/home/home-slash-menu";
@@ -107,6 +109,13 @@ type Props = {
   onSlash?: (command: string, args: string) => void;
   /** Resume a recent chat from the Continue column's session cards. */
   onOpenSession?: (sessionId: string, familiarId: string | null) => void;
+  /** "Needs you" attention tier (fired + response-needed) — the SAME
+   *  groupInboxFeed slice the Schedules nav badge counts (cave-925w). */
+  needsYou: InboxItem[];
+  /** Open one needs-you item's target — same handler the bell popover uses. */
+  onOpenInboxItem: (item: InboxItem) => void;
+  /** Jump to the Schedules surface for the full feed. */
+  onOpenSchedules: () => void;
 };
 
 // Persist the in-progress prompt so a page reload doesn't eat what you were
@@ -130,6 +139,9 @@ export function HomeComposer({
   onToast,
   onSlash,
   onOpenSession,
+  needsYou,
+  onOpenInboxItem,
+  onOpenSchedules,
 }: Props) {
   const [text, setText] = useState(() => readComposerDraft(HOME_DRAFT_KEY));
   const [destination, setDestination] = useState<Destination>("chat");
@@ -1010,6 +1022,14 @@ export function HomeComposer({
         </div>
         </div>
       </div>
+
+      {/* Morning triage — the "needs you" tier + today's report link, fed by
+          the same grouping the Schedules nav badge counts (cave-925w). */}
+      <HomeNeedsYou
+        items={needsYou}
+        onOpenItem={onOpenInboxItem}
+        onOpenSchedules={onOpenSchedules}
+      />
 
       <HomeSuggestions
         projectName={selectedProject?.name ?? null}

--- a/src/components/home-needs-you.test.ts
+++ b/src/components/home-needs-you.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+// cave-925w — morning triage: Home's "Needs you" strip. Pins the three phases:
+// (1) the strip surfaces the needs-you tier with each row one click from its
+// target, (2) the header links today's /daily-report, (3) the strip and the
+// Schedules nav badge share ONE groupInboxFeed memo so they can never disagree.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const strip = await readFile(new URL("./home/home-needs-you.tsx", import.meta.url), "utf8");
+const composer = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/home-composer.css", import.meta.url), "utf8");
+
+// ── Phase 3: one source of truth ──────────────────────────────────────────────
+assert.match(
+  workspace,
+  /const inboxNeedsYou = useMemo\(\s*\(\) => groupInboxFeed\(inboxItemsWithEphemeral\)\.needsYou,/,
+  "workspace computes the needs-you tier once",
+);
+assert.match(
+  workspace,
+  /const scheduleNeedsCount = inboxNeedsYou\.length;/,
+  "the Schedules nav badge derives from that same memo",
+);
+assert.match(workspace, /needsYou=\{inboxNeedsYou\}/, "Home receives the same group, not a copy");
+
+// ── Rows reuse existing plumbing, no new stores/APIs ──────────────────────────
+assert.match(
+  workspace,
+  /needsYou=\{inboxNeedsYou\}\s*onOpenInboxItem=\{openInspectorInboxItem\}/,
+  "strip rows open items through the same handler the bell popover uses",
+);
+assert.match(
+  workspace,
+  /onOpenSchedules=\{\(\) => setMode\("inbox"\)\}/,
+  "the overflow affordance jumps to the Schedules surface",
+);
+assert.doesNotMatch(strip, /fetch\(/, "the strip fetches nothing — data arrives via props");
+
+// ── Strip behavior ────────────────────────────────────────────────────────────
+assert.match(strip, /const MAX_ROWS = 3/, "at most three rows inline");
+assert.match(strip, /\+\{overflow\} more/, "overflow collapses into a +N more chip");
+assert.match(strip, /onClick=\{onOpenSchedules\}/, "+N more opens Schedules");
+assert.match(strip, /"Waiting on you"/, "response-needed rows say so instead of a timestamp");
+assert.match(strip, /"All clear"/, "an empty tier still answers the question");
+assert.match(strip, /aria-label="Needs you"/, "the strip is a named region for AT");
+assert.match(strip, /useMinuteTick\(\)/, "persistently mounted strip keeps its times honest");
+
+// ── Phase 2: today's report link ──────────────────────────────────────────────
+assert.match(
+  strip,
+  /const reportSlug = mounted \? dateSlug\(new Date\(\)\) : null/,
+  "report date sampled after mount (deterministic SSR, same pattern as the greeting)",
+);
+assert.match(strip, /\/daily-report\/\$\{reportSlug\}/, "header links today's daily report");
+
+// ── Placement + chrome ────────────────────────────────────────────────────────
+assert.ok(
+  composer.indexOf("<HomeNeedsYou") > composer.indexOf("home-composer-card-wrap") &&
+    composer.indexOf("<HomeNeedsYou") < composer.indexOf("<HomeSuggestions"),
+  "strip sits between the composer card and the suggestion pills",
+);
+assert.match(css, /\.home-needs-you \{/, "strip styles live in the home stylesheet");
+assert.match(
+  css,
+  /\.home-needs-you \{ animation-delay: 100ms; \}/,
+  "strip joins the page-load choreography between card and pills",
+);
+assert.match(
+  css,
+  /--color-warning\) 30%, var\(--border-hairline\)/,
+  "attention tint follows the design-language recipe (30% border)",
+);
+
+console.log("home-needs-you.test.ts: ok");

--- a/src/components/home/home-needs-you.tsx
+++ b/src/components/home/home-needs-you.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+/**
+ * HomeNeedsYou — morning triage in one glance (cave-925w). The strip under the
+ * composer surfaces the same "needs you" attention tier the Schedules nav
+ * badge counts (groupInboxFeed: fired items + response-needed bridges), so the
+ * first screen answers "what needs me" without touring bell → Schedules →
+ * daily report. Rows open their item's target through the same handler the
+ * bell popover uses; the header always links today's /daily-report so the
+ * answer stays one click deep even when all is clear.
+ */
+
+import { useEffect, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { RelativeTime } from "@/components/ui/relative-time";
+import { useMinuteTick } from "@/lib/use-minute-tick";
+import type { InboxItem } from "@/lib/cave-inbox";
+import { inboxKindLabel } from "@/lib/inbox-feed";
+import { dateSlug } from "@/lib/daily-report";
+
+/** Rows shown inline; the rest collapse into a "+N more" jump to Schedules. */
+const MAX_ROWS = 3;
+
+// Same kind → glyph mapping the bell popover uses, so an item reads the same
+// wherever it surfaces.
+function kindIcon(kind: InboxItem["kind"]): string {
+  switch (kind) {
+    case "response-needed":
+      return "ph:chat-circle-dots-fill";
+    case "daily-summary":
+      return "ph:newspaper";
+    case "agent":
+      return "ph:magic-wand-fill";
+    default:
+      return "ph:alarm-fill";
+  }
+}
+
+type Props = {
+  /** The "needs you" tier from groupInboxFeed — most-recent first. */
+  items: InboxItem[];
+  /** Open one item's target (session/card) — same handler the bell uses. */
+  onOpenItem: (item: InboxItem) => void;
+  /** See the full feed on the Schedules surface. */
+  onOpenSchedules: () => void;
+};
+
+export function HomeNeedsYou({ items, onOpenItem, onOpenSchedules }: Props) {
+  // The strip is persistently mounted (unlike the bell popover), so tick each
+  // minute: row times stay honest and the report link rolls over at midnight.
+  useMinuteTick();
+  // Sampled after mount so SSR markup stays deterministic — same pattern as
+  // the hero greeting; the minute tick above recomputes it on re-render.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const reportSlug = mounted ? dateSlug(new Date()) : null;
+
+  const shown = items.slice(0, MAX_ROWS);
+  const overflow = items.length - shown.length;
+
+  return (
+    <section className="home-needs-you" aria-label="Needs you">
+      <div className="home-needs-you__header">
+        <span className={`home-needs-you__count${items.length > 0 ? " is-live" : ""}`}>
+          {items.length > 0 ? `Needs you · ${items.length}` : "All clear"}
+        </span>
+        {reportSlug ? (
+          <a className="home-needs-you__report focus-ring" href={`/daily-report/${reportSlug}`}>
+            Today&rsquo;s report →
+          </a>
+        ) : null}
+      </div>
+
+      {shown.length > 0 ? (
+        <ul className="home-needs-you__list">
+          {shown.map((it) => (
+            <li key={it.id}>
+              <button
+                type="button"
+                className="home-needs-you__item focus-ring"
+                onClick={() => onOpenItem(it)}
+                title={it.title}
+              >
+                <Icon name={kindIcon(it.kind)} width={12} aria-hidden />
+                <span className="home-needs-you__item-title">{it.title}</span>
+                <span className="home-needs-you__item-time">
+                  {it.kind === "response-needed" ? (
+                    "Waiting on you"
+                  ) : (
+                    <RelativeTime
+                      iso={it.firedAt ?? it.fireAt ?? it.updatedAt ?? it.createdAt}
+                      fallback="—"
+                    />
+                  )}
+                </span>
+                <span className="sr-only">{inboxKindLabel(it.kind)}</span>
+              </button>
+            </li>
+          ))}
+          {overflow > 0 ? (
+            <li>
+              <button
+                type="button"
+                className="home-needs-you__more focus-ring"
+                onClick={onOpenSchedules}
+              >
+                +{overflow} more
+              </button>
+            </li>
+          ) : null}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/home/home-needs-you.tsx
+++ b/src/components/home/home-needs-you.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { Icon } from "@/lib/icon";
+import { Icon, type IconName } from "@/lib/icon";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -23,7 +23,7 @@ const MAX_ROWS = 3;
 
 // Same kind → glyph mapping the bell popover uses, so an item reads the same
 // wherever it surfaces.
-function kindIcon(kind: InboxItem["kind"]): string {
+function kindIcon(kind: InboxItem["kind"]): IconName {
   switch (kind) {
     case "response-needed":
       return "ph:chat-circle-dots-fill";

--- a/src/components/sidepanel-badges.test.ts
+++ b/src/components/sidepanel-badges.test.ts
@@ -17,7 +17,10 @@ assert.match(sidebar, /badge: \(p\) => badgeText\(p\.githubAssignedCount\)/, "Gi
 assert.match(workspace, /boardOpenCount=\{boardTaskCount\}/, "board count passed to sidebar");
 assert.match(workspace, /scheduleNeedsCount=\{scheduleNeedsCount\}/, "schedules count passed");
 assert.match(workspace, /githubAssignedCount=\{githubAssignedCount\}/, "github count passed");
-assert.match(workspace, /groupInboxFeed\(inboxItemsWithEphemeral\)\.needsYou\.length/, "schedules badge = needs-you group");
+// cave-925w: the badge and Home's "Needs you" strip read ONE memo — the badge
+// is that shared group's length, not a separately computed count.
+assert.match(workspace, /const inboxNeedsYou = useMemo\(\s*\(\) => groupInboxFeed\(inboxItemsWithEphemeral\)\.needsYou,/, "schedules badge = needs-you group (shared memo)");
+assert.match(workspace, /const scheduleNeedsCount = inboxNeedsYou\.length;/, "badge count derives from the shared group");
 
 // Per-familiar rail-tab persistence was dropped with the right companion rail
 // (drag-to-split replaces it) — the workspace no longer stores cave:rail.tab.

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -1945,12 +1945,14 @@ export function Workspace() {
     return [...inboxItems, ...ephemeral];
   }, [inboxItems, responseNeeded, familiars, sessions]);
 
-  // Schedules nav badge: how many inbox items currently need you (fired or
-  // response-needed) - mirrors the Schedules > Inbox tab "needs you" group.
-  const scheduleNeedsCount = useMemo(
-    () => groupInboxFeed(inboxItemsWithEphemeral).needsYou.length,
+  // The "needs you" attention tier (fired or response-needed). ONE memo feeds
+  // both the Schedules nav badge and Home's "Needs you" strip so the two can
+  // never disagree (cave-925w).
+  const inboxNeedsYou = useMemo(
+    () => groupInboxFeed(inboxItemsWithEphemeral).needsYou,
     [inboxItemsWithEphemeral],
   );
+  const scheduleNeedsCount = inboxNeedsYou.length;
 
   // Mood C three-pane Shell:
   //   nav   = always present (mode switcher + command launchers)
@@ -2258,6 +2260,9 @@ export function Workspace() {
         onToast={pushToast}
         onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
+        needsYou={inboxNeedsYou}
+        onOpenInboxItem={openInspectorInboxItem}
+        onOpenSchedules={() => setMode("inbox")}
       />
     );
 

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -897,6 +897,99 @@
   color: var(--text-muted);
 }
 
+/* ── Needs you — morning-triage strip under the composer (cave-925w). The
+   same "needs you" tier the Schedules nav badge counts; a quiet single line
+   when all clear so today's report stays one click away either way. Tint
+   recipe per the design language: solid warning text, 6→12% fill, 30% border. */
+.home-needs-you {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  width: 100%;
+  max-width: 860px;
+}
+
+.home-needs-you__header {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 10px;
+}
+
+.home-needs-you__count {
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--text-muted);
+}
+
+.home-needs-you__count.is-live {
+  color: var(--color-warning);
+  font-weight: 600;
+}
+
+.home-needs-you__report {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-decoration: none;
+  border-radius: 4px;
+  transition: color 120ms ease;
+}
+
+.home-needs-you__report:hover {
+  color: var(--text-primary);
+}
+
+.home-needs-you__list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.home-needs-you__item,
+.home-needs-you__more {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 5px 12px;
+  border: 1px solid color-mix(in oklch, var(--color-warning) 30%, var(--border-hairline));
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--color-warning) 6%, transparent);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.3;
+  cursor: pointer;
+  transition: background-color 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.home-needs-you__item svg {
+  color: var(--color-warning);
+  flex-shrink: 0;
+}
+
+.home-needs-you__item:hover,
+.home-needs-you__more:hover {
+  background: color-mix(in oklch, var(--color-warning) 12%, transparent);
+  color: var(--text-primary);
+}
+
+.home-needs-you__item-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 260px;
+}
+
+.home-needs-you__item-time {
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
 /* ── Suggested prompts ───────────────────────────────────────────────────── */
 .home-suggestions {
   display: flex;
@@ -1121,6 +1214,7 @@
  *   entirely under prefers-reduced-motion. */
 @media (prefers-reduced-motion: no-preference) {
   .home-composer-hero,
+  .home-needs-you,
   .home-suggestions,
   .home-columns {
     animation: home-rise 460ms var(--ease-decelerate) backwards;
@@ -1128,6 +1222,7 @@
   .home-composer-card-wrap {
     animation: home-rise 460ms var(--ease-decelerate) 60ms backwards;
   }
+  .home-needs-you { animation-delay: 100ms; }
   .home-suggestions { animation-delay: 140ms; }
   .home-columns { animation-delay: 220ms; }
 }


### PR DESCRIPTION
## Golden path 3 — morning triage (docs/golden-paths.md §3 via PR #2787, bead `cave-925w`)

**Story:** as a returning user opening Cave with coffee, one glance should tell me what needs me — today that answer is spread across Home, the bell popover, Schedules, and `/daily-report`.

### What changed

- **Phase 1 — the strip.** Home gains a compact `Needs you` strip between the composer card and the suggestion pills, fed by the **existing** `groupInboxFeed` attention tier (fired items + response-needed bridges, ephemeral ones included). Up to three pill rows inline, `+N more` jumps to Schedules. Rows open their item's target via the same `openInspectorInboxItem` handler the bell uses; response-needed rows read "Waiting on you" (mirrors the bell). No new API, no new store, the strip fetches nothing.
- **Phase 2 — today's report.** The strip header always links `/daily-report/<today>` (`dateSlug` sampled after mount for deterministic SSR; the strip's minute tick rolls the date at midnight). When nothing needs you it reads `All clear · Today's report →` — the answer stays one glance, one click.
- **Phase 3 — one source of truth.** One memo (`inboxNeedsYou`) now feeds both the Schedules nav badge and the strip, so the two counts can never disagree. `sidepanel-badges.test.ts` pin updated to the shared-memo shape (intent preserved and strengthened).

### Verification

- `pnpm typecheck` clean; `pnpm test:app` **572 files green**, including the new `home-needs-you.test.ts` (wired into `scripts/run-tests.mjs`).
- Design language: warning-tint recipe (solid text / 6→12% fill / 30% border), 999px pills, semantic tokens only, named region for AT, joins the page-load choreography with reduced-motion fallback.
- No e2e spec asserts on Home markup (checked), so Playwright is unaffected.

### Discovered nearby, deliberately untouched (noted on the bead)

- The bell badge counts `/api/escalations` (`workspace.tsx` — a separate, commented decision); its popover list shows a different set. Follow-up candidate, not relitigated here.
- `automations-view.tsx` still computes an `inboxFeed`/`inboxEmpty` memo for the removed Inbox tab — dead code, left for a cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)