### PR TITLE
feat(dashboard): make recent daily reports list scrollable

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8998,6 +8998,13 @@ a.dr-metric--link:hover .dr-metric__go {
 
 /* Item rows ----------------------------------------------------------------- */
 .dr-list { display: flex; flex-direction: column; gap: 8px; }
+.dr-list--scroll {
+  max-height: 420px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  padding-right: 2px;
+}
 .dr-row {
   display: flex;
   align-items: flex-start;

--- a/src/components/dashboard/recent-reports.tsx
+++ b/src/components/dashboard/recent-reports.tsx
@@ -11,14 +11,12 @@ export function RecentReports({
   now: Date;
   hasFeatured: boolean;
 }) {
-  const VISIBLE = 7;
-  const hiddenCount = Math.max(0, reports.length - VISIBLE);
   return (
     <section className="dr-section" id="recent-reports" aria-label="Recent daily reports">
       <SectionHead icon="ph:newspaper" title="Recent daily reports" count={reports.length} />
       {reports.length > 0 ? (
-        <div className="dr-list">
-          {reports.slice(0, VISIBLE).map((report) => {
+        <div className="dr-list dr-list--scroll">
+          {reports.map((report) => {
             const reportDate = new Date(`${report.slug}T00:00:00`);
             return (
               <a key={report.slug} className="dr-row" href={report.href}>
@@ -45,11 +43,6 @@ export function RecentReports({
               </a>
             );
           })}
-          {hiddenCount > 0 ? (
-            <p className="dr-row__sub" style={{ padding: "8px 4px 0", textAlign: "center" }}>
-              +{hiddenCount} older {hiddenCount === 1 ? "report" : "reports"} not shown
-            </p>
-          ) : null}
         </div>
       ) : (
         <EmptyState icon="ph:newspaper">


### PR DESCRIPTION
Replaces the 7-item cap and the '+N older reports not shown' footer on the dashboard's Recent daily reports section with a scrollable row list.

- recent-reports.tsx: render all reports; drop VISIBLE/hiddenCount truncation
- globals.css: new .dr-list--scroll modifier — max-height 420px, overflow-y auto, contained overscroll, thin scrollbar

Verified with tsc --noEmit (clean); no tests referenced the removed truncation.