### PR TITLE
fix(terminal): paired iOS terminal connects — pty-ws host gate honors verified access tokens (cave-iz1j)

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -92,16 +92,17 @@ function sameOrigin(value, expectedOrigin) {
     const url = new URL(value);
     if (url.origin === expectedOrigin) return true;
     const expected = new URL(expectedOrigin);
+    if (url.host === expected.host) return true;
     return url.protocol === expected.protocol && url.port === expected.port && isLoopbackHost(url.host) && isLoopbackHost(expected.host);
   } catch {
     return false;
   }
 }
-function isAllowedUpgradeSource(req) {
+function isAllowedUpgradeSource(req, tokenAuthenticated = false) {
   const host = req.headers.host;
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
   const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
-  if (!tailnetTrusted && !isLoopbackHost(host)) return false;
+  if (!tailnetTrusted && !tokenAuthenticated && !isLoopbackHost(host)) return false;
   return sameOrigin(req.headers.origin, `http://${host}`);
 }
 function isAuthorized(req, query) {
@@ -317,12 +318,13 @@ server.on("upgrade", (req, socket, head) => {
     });
     return;
   }
-  if (!isAllowedUpgradeSource(req)) {
+  const tokenAuthenticated = ACCESS_TOKEN ? isAuthorized(req, query) : false;
+  if (!isAllowedUpgradeSource(req, tokenAuthenticated)) {
     socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     socket.destroy();
     return;
   }
-  if (ACCESS_TOKEN && !isAuthorized(req, query)) {
+  if (ACCESS_TOKEN && !tokenAuthenticated) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;

--- a/server.ts
+++ b/server.ts
@@ -149,6 +149,13 @@ function sameOrigin(value: string | undefined, expectedOrigin: string): boolean 
     if (url.origin === expectedOrigin) return true;
 
     const expected = new URL(expectedOrigin);
+    // Scheme-agnostic host match: `tailscale serve` terminates TLS upstream,
+    // so a browser page served over https://<host>.ts.net opens its terminal
+    // socket with Origin https://… while the expectation string here is built
+    // as http://<Host>. The host (incl. port) equality is the actual
+    // cross-site defence — a hostile page cannot declare this host as its
+    // Origin — so the scheme difference must not 403 the upgrade.
+    if (url.host === expected.host) return true;
     return (
       url.protocol === expected.protocol &&
       url.port === expected.port &&
@@ -160,22 +167,28 @@ function sameOrigin(value: string | undefined, expectedOrigin: string): boolean 
   }
 }
 
-function isAllowedUpgradeSource(req: IncomingMessage): boolean {
+function isAllowedUpgradeSource(req: IncomingMessage, tokenAuthenticated = false): boolean {
   const host = req.headers.host;
   // The peer must always be loopback: `tailscale serve` terminates TLS and
   // forwards to 127.0.0.1, so a legitimate tailnet client still arrives over
   // loopback. A non-loopback peer is a direct LAN/WAN connection — never trust.
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
-  // Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1, set only by
-  // `pnpm mobile:tailscale:app`): `tailscale serve` forwards the request's
-  // `<host>.ts.net` Host — NOT 127.0.0.1 — so the loopback host gate would
-  // otherwise 403 the iOS terminal over the tailnet. Trusting the host here is
-  // safe because tailnet membership is the ingress boundary in this mode, and
-  // the sameOrigin gate below still blocks cross-site browser upgrades (a native
-  // WebSocket sends no Origin). This mirrors the REST trust gate in proxy.ts.
-  // By default (no flag) WebSocket upgrades remain loopback-host only.
+  // Two ways a non-loopback Host is legitimate — both arrive via `tailscale
+  // serve`, which forwards the request's `<host>.ts.net` Host, NOT 127.0.0.1:
+  //   1. Tokenless native-app mode (COVEN_CAVE_TAILNET_TRUST=1, set only by
+  //      `pnpm mobile:tailscale:app`): tailnet membership is the ingress
+  //      boundary, so the host gate is relaxed globally.
+  //   2. A token-authenticated upgrade (paired iOS app / handoff browser
+  //      holding a signed access token): the credential proves the caller,
+  //      exactly like proxy.ts's isAllowedApiHost(mobileAccessAuthenticated)
+  //      relaxation on REST. Without this, a paired phone's terminal 403s at
+  //      the host gate while every REST call works (the "terminal tab never
+  //      connects" bug) — the Bearer header was never even consulted.
+  // The sameOrigin gate below still blocks cross-site browser upgrades (a
+  // native WebSocket sends no Origin). By default (no flag, no credential)
+  // WebSocket upgrades remain loopback-host only.
   const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
-  if (!tailnetTrusted && !isLoopbackHost(host)) return false;
+  if (!tailnetTrusted && !tokenAuthenticated && !isLoopbackHost(host)) return false;
   return sameOrigin(req.headers.origin, `http://${host}`);
 }
 
@@ -463,7 +476,14 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  if (!isAllowedUpgradeSource(req)) {
+  // Verify credentials before the host gate: a valid signed access token
+  // (paired iOS terminal / handoff browser over `tailscale serve`, which
+  // forwards the `<host>.ts.net` Host) legitimately arrives with a
+  // non-loopback Host and must pass the source gate on the strength of its
+  // token — mirroring proxy.ts's isAllowedApiHost relaxation on REST.
+  const tokenAuthenticated = ACCESS_TOKEN ? isAuthorized(req, query) : false;
+
+  if (!isAllowedUpgradeSource(req, tokenAuthenticated)) {
     socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     socket.destroy();
     return;
@@ -475,7 +495,7 @@ server.on("upgrade", (req, socket, head) => {
   // connections are the local app itself. #714 dropped this and 401'd every
   // local terminal (reintroducing the v0.0.72 "Terminal connection failed"
   // regression that server-pty-ws.test.ts warns about).
-  if (ACCESS_TOKEN && !isAuthorized(req, query)) {
+  if (ACCESS_TOKEN && !tokenAuthenticated) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
     socket.destroy();
     return;

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -16,7 +16,36 @@ assert.match(src, /if \(!ACCESS_TOKEN\) return false/, "PTY WebSocket auth fails
 // no token (the local desktop app / dev server) the loopback host+origin gate is
 // the protection — guarding the 401 on ACCESS_TOKEN keeps credential-less local
 // connections working. #714 dropped this guard and 401'd every local terminal.
-assert.match(src, /if \(ACCESS_TOKEN && !isAuthorized\(req, query\)\)/, "PTY upgrade only 401s on missing credentials when a token is configured (credential-less loopback is the local app)");
+assert.match(src, /if \(ACCESS_TOKEN && !tokenAuthenticated\)/, "PTY upgrade only 401s on missing credentials when a token is configured (credential-less loopback is the local app)");
+// Credentials are verified BEFORE the source gate: a paired device over
+// `tailscale serve` arrives with a non-loopback `<host>.ts.net` Host, so a
+// valid signed token must relax the host gate (mirrors proxy.ts's
+// isAllowedApiHost(mobileAccessAuthenticated) on REST). Without this the
+// paired iOS terminal 403s at the host gate while REST works — the "terminal
+// tab never connects" bug (cave-iz1j).
+assert.match(
+  src,
+  /const tokenAuthenticated = ACCESS_TOKEN \? isAuthorized\(req, query\) : false;/,
+  "PTY upgrade verifies the access token before the source gate",
+);
+assert.match(
+  src,
+  /isAllowedUpgradeSource\(req, tokenAuthenticated\)/,
+  "token-authenticated upgrades pass the non-loopback host gate (paired iOS terminal over tailscale serve)",
+);
+assert.match(
+  src,
+  /if \(!tailnetTrusted && !tokenAuthenticated && !isLoopbackHost\(host\)\) return false;/,
+  "host gate relaxes for tailnet-trust mode OR a verified token — never for anonymous non-loopback hosts",
+);
+// Serve terminates TLS, so a legit handoff browser page is https://<host>.ts.net
+// while the expectation string is built as http://<Host> — host equality (the
+// real cross-site defence) must satisfy the origin gate regardless of scheme.
+assert.match(
+  src,
+  /if \(url\.host === expected\.host\) return true;/,
+  "origin gate accepts a scheme-agnostic same-host Origin (Serve-terminated TLS)",
+);
 assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients");
 // Paired devices hold SIGNED tokens (v1.<expiresAt>.<nonce>.<sig> — see
 // src/lib/mobile-access-token.ts), not the raw secret: the QR/deep-link


### PR DESCRIPTION
## Problem

The iOS app's **Developer → Terminal** tab never connects on a paired device, while every other surface of the app works.

**Root cause:** `tailscale serve` forwards the request's `<host>.ts.net` Host header (not `127.0.0.1`). The `/api/pty-ws` WebSocket upgrade gate (`isAllowedUpgradeSource`) rejected any non-loopback Host with 403 **before the Authorization header was ever consulted** — unless `COVEN_CAVE_TAILNET_TRUST=1` (only set by `pnpm mobile:tailscale:app`). REST calls work because `proxy.ts` relaxes its host gate for `mobileAccessAuthenticated`; the WS upgrade had no equivalent, so a paired phone's terminal 403'd forever.

## Fix (server.ts, mirrored into built server.mjs)

- Verify the access token **before** the source gate; a verified token (raw secret or `v1.` signed token) relaxes the loopback-**host** requirement, exactly like REST's `isAllowedApiHost(mobileAccessAuthenticated || tailnetTrusted)`. The loopback **peer-address** requirement is untouched — Serve always forwards from 127.0.0.1.
- `sameOrigin`: accept a scheme-agnostic same-host Origin. Serve terminates TLS, so a handoff browser page is `https://<host>.ts.net` while the expectation string is built as `http://<Host>`; host equality is the actual cross-site defence. This also unbreaks the **mobile-web** bottom terminal over Serve.
- New pins in `src/server-pty-ws.test.ts` for both behaviors.

## Verification (live against `server.ts` with `COVEN_CAVE_ACCESS_TOKEN` set)

| scenario | before | after |
|---|---|---|
| ts.net Host + Bearer signed token (paired iOS terminal) | **403** | **101 upgrade** |
| ts.net Host + https same-host Origin + token (handoff browser) | **403** | **101 upgrade** |
| loopback, no creds (token configured) | 401 | 401 |
| ts.net Host, evil Origin, no token | 403 | 403 |
| evil Origin + auth **cookie** (CSRF WS hijack) | 403 | 403 |
| loopback + Bearer | 101 | 101 |

Suites: `test:api` 127 ✓ · `test:mobile` 74 ✓ · `test:app` 572 ✓
iOS app: `xcodebuild` (sim) builds clean after `xcodegen generate`; CovenCaveTests 10/10 ✓

Bead: cave-iz1j
