### PR TITLE
fix(appearance): selected Reading-text and Date & time options actually look selected (cave-q42g)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2256,6 +2256,21 @@ textarea.required-inputs-control {
   color: var(--text-primary);
 }
 
+/* Settings segmented options (Text size, Reading text, Date & time rows).
+   Same cascade problem + cure as .mode-toggle__option below: these render
+   through Button/ghost, whose unlayered transparent background beats the
+   Tailwind accent utilities the rows pass in — so the selected segment showed
+   no selection (cave-q42g). Unlayered + !important wins the state back;
+   parity with the shared Segmented control (Corner radius). */
+.settings-segment[aria-pressed="true"] {
+  background: var(--accent-presence) !important;
+  color: var(--accent-presence-foreground) !important;
+}
+.settings-segment[aria-pressed="true"]:hover {
+  background: var(--accent-presence) !important;
+  color: var(--accent-presence-foreground) !important;
+}
+
 .mode-toggle__option[aria-pressed="true"] {
   background: color-mix(in oklch, var(--accent-presence) 20%, var(--bg-raised)) !important;
   border-color: color-mix(in oklch, var(--accent-presence) 44%, var(--border-strong)) !important;

--- a/src/components/settings-fonts.test.ts
+++ b/src/components/settings-fonts.test.ts
@@ -37,6 +37,33 @@ assert.match(src, /Code &amp; terminal/, "keeps the code and terminal preview");
 assert.match(shell, /import \{ FontSettings \} from "\.\/settings-fonts"/, "shell imports FontSettings");
 assert.match(shell, /<FontSettings\s*\/>/, "AppearanceSection renders <FontSettings />");
 
+// ── The selected segment must actually LOOK selected (cave-q42g) ─────────────
+// SegmentButton renders through Button variant="ghost"; .ui-btn--ghost is
+// UNLAYERED CSS (background: transparent + its own :hover), and unlayered rules
+// beat Tailwind's layered utilities unconditionally — so the active accent
+// classes never painted and Reading text / Date & time selections were
+// invisible (Corner radius, on the shared Segmented's plain <button>, was
+// fine). The cure is the mode-toggle precedent: a scoped unlayered pressed-
+// state rule that wins the background back.
+assert.match(
+  src,
+  /className=\{`settings-segment \$\{segBtn\(active, extra\)\}`\}/,
+  "SegmentButton carries the settings-segment class the pressed-state CSS keys on",
+);
+{
+  const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+  assert.match(
+    globals,
+    /\.settings-segment\[aria-pressed="true"\] \{\s*\n\s*background: var\(--accent-presence\) !important;\s*\n\s*color: var\(--accent-presence-foreground\) !important;/,
+    "the pressed segment's accent fill is unlayered CSS — Button/ghost's unlayered transparent background beats Tailwind utilities, so utilities alone cannot express the selected state",
+  );
+  assert.match(
+    globals,
+    /\.settings-segment\[aria-pressed="true"\]:hover \{/,
+    "hover on the selected segment keeps the accent fill (ghost's own hover would repaint it)",
+  );
+}
+
 // The component must apply the saved fonts on mount (the boot script that would
 // otherwise do it pre-paint is not mounted), so the rendered font matches the
 // persisted selection after a reload — not just after a user change.

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -137,8 +137,16 @@ function SegmentButton({
   extra?: string;
   children: ReactNode;
 }) {
+  // The `settings-segment` class exists for the pressed-state CSS in
+  // globals.css: .ui-btn--ghost is UNLAYERED (background: transparent + its
+  // own :hover) and unlayered rules beat Tailwind's layered utilities
+  // unconditionally — so the Tailwind accent classes below never painted and
+  // the selected option was indistinguishable (Corner radius, on the shared
+  // Segmented's plain button element, never had this fight). Same cure as
+  // .mode-toggle__option[aria-pressed="true"]: scoped unlayered CSS wins back
+  // the pressed state.
   return (
-    <Button variant="ghost" size="xs" className={segBtn(active, extra)} {...props}>
+    <Button variant="ghost" size="xs" className={`settings-segment ${segBtn(active, extra)}`} {...props}>
       {children}
     </Button>
   );


### PR DESCRIPTION
User report: the current selection is invisible in the Reading text and Date & time appearance groups, unlike Corner radius.

**Root cause (proven, not inferred):** the rows had correct markup all along — `aria-pressed` plus Tailwind accent classes for the active state. But `SegmentButton` renders through `Button variant="ghost"`, and `.ui-btn--ghost` is **unlayered** CSS (`background: transparent` + its own `:hover`). With Tailwind v4, unlayered rules beat `@layer utilities` unconditionally, so the accent background never painted. Corner radius uses the shared `Segmented` control — a plain button element with no competing component CSS — which is why it always showed its selection.

**Fix:** the repo already cures this exact cascade one rule down in globals.css (`.mode-toggle__option[aria-pressed="true"]`). Same treatment: `SegmentButton` gains a `settings-segment` class, and a scoped unlayered rule paints its pressed state with the accent fill (hover included, so ghost's hover can't repaint it). This keeps the shared `Button` primitive — settings-fonts' existing pin forbids hand-rolled buttons — while landing exact visual parity with Segmented/Corner radius across all ten groups (Text size, 6 Reading-text rows, 3 Date & time rows).

**Verification:** typecheck clean; full app suite 572 files pass; new pins hold the class and the unlayered rule with the cascade rationale. Live check: pressed segment computes `rgb(154, 142, 205)` (accent) vs transparent siblings; screenshot confirms every group now matches Corner radius.

No file overlap with open #2792 (it touches settings-shell/theme-color-editor; this touches settings-fonts + globals.css).

🤖 Generated with [Claude Code](https://claude.com/claude-code)