### PR TITLE
fix(chat): autohide journal-run chats — origin:journal + truncated-title legacy fallback (cave-buih)

### DIFF
--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -4,6 +4,7 @@ import {
   chatProjectName,
   deriveChatProjectGroups,
   filterVisibleChatSessions,
+  isGeneratedChatSession,
 } from "./chat-projects.ts";
 import type { SessionRow } from "./types.ts";
 
@@ -292,5 +293,30 @@ console.log("chat-projects.test.ts: ok");
     }),
     { projectId: "p2", project: roster[1] },
     "a brand-new task chat opens scoped to the task's project, not the first project",
+  );
+}
+
+// ── Journal-narrative noise stays out of the chat lists (cave-buih) ─────────
+{
+  const base = { id: "j", project_root: "", status: "completed", updated_at: "2026-07-08T00:00:00Z", familiarId: "nova" };
+  assert.equal(
+    isGeneratedChatSession({ ...base, title: "anything", origin: "journal" }),
+    true,
+    "origin:journal rows are generated runs",
+  );
+  assert.equal(
+    isGeneratedChatSession({ ...base, title: "Write a short narrative of my day (Jul 8) in the cave, as my familiar reporting back to me." }),
+    true,
+    "legacy untagged narratives hide by their exact machine-prompt title prefix",
+  );
+  assert.equal(
+    isGeneratedChatSession({ ...base, title: "Write a short, first-person reflective journal entry about my…" }),
+    true,
+    "legacy reflection runs hide — including the ~60-char truncated titles the store actually keeps",
+  );
+  assert.equal(
+    isGeneratedChatSession({ ...base, title: "Write a short story for my blog" }),
+    false,
+    "human chats that merely start with Write… stay visible",
   );
 }

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -124,12 +124,25 @@ function projectNameWithParent(projectRoot: string): string {
 // heartbeat automations — not because someone opened a chat. They stay
 // reachable from their origination surfaces (Canvas, Schedules, Work Queue);
 // listing them here is just noise between real conversations.
-const CHAT_HIDDEN_ORIGINS: ReadonlySet<string> = new Set(["cron", "heartbeat", "canvas"]);
+const CHAT_HIDDEN_ORIGINS: ReadonlySet<string> = new Set(["cron", "heartbeat", "canvas", "journal"]);
+
+/** Legacy fallback for journal runs created before origin:"journal" existed:
+ *  their titles are the exact machine prompts (daily-narrative.ts and
+ *  journal-generate.ts), so prefix matches are safe — no human titles a chat
+ *  this way. */
+const LEGACY_JOURNAL_PROMPT_PREFIXES = [
+  "Write a short narrative of my day (",
+  // Stored titles truncate around 60 chars ("…about my…"), so match the
+  // opener, comfortably clear of the cut and still unmistakably machine text.
+  "Write a short, first-person reflective journal entry",
+] as const;
 
 /** True when the row is a generated run rather than a user-facing chat. */
 export function isGeneratedChatSession(session: SessionRow): boolean {
   if (session.generated) return true;
-  return session.origin != null && CHAT_HIDDEN_ORIGINS.has(session.origin);
+  if (session.origin != null && CHAT_HIDDEN_ORIGINS.has(session.origin)) return true;
+  const title = session.title ?? "";
+  return LEGACY_JOURNAL_PROMPT_PREFIXES.some((prefix) => title.startsWith(prefix));
 }
 
 export function filterVisibleChatSessions(

--- a/src/lib/daily-narrative.ts
+++ b/src/lib/daily-narrative.ts
@@ -114,6 +114,9 @@ export async function generateDailyNarrative(opts: {
   signal?: AbortSignal;
 }): Promise<DailyNarrativeResult> {
   const { text, error } = await streamFamiliarText({
+    // Journal narrative runs are generated, not conversations — tagging the
+    // origin keeps them out of the chat lists (cave-buih).
+    origin: "journal",
     familiarId: opts.familiarId,
     prompt: buildDailyNarrativePrompt(opts.report, opts.stats, opts.dayLabel),
     signal: opts.signal,

--- a/src/lib/familiar-stream.ts
+++ b/src/lib/familiar-stream.ts
@@ -1,3 +1,4 @@
+import type { SessionOrigin } from "./types";
 // Client helper: stream a one-shot prompt to a familiar through the chat bridge
 // (`/api/chat/send`, SSE) and return the concatenated assistant text. This is the
 // sanctioned client-side LLM path — the same bridge evals, workflow-generate, and
@@ -18,6 +19,9 @@ export async function streamFamiliarText(opts: {
   responseSpeed?: string;
   modelOverride?: string;
   modelOverrideScope?: "next-message" | "session";
+  /** Session provenance — set by generator surfaces (e.g. "journal") so the
+   *  chat lists can hide the run; user-facing chats leave it unset. */
+  origin?: SessionOrigin;
   signal?: AbortSignal;
   /** Called with the accumulated assistant text after each streamed chunk,
    *  so callers can render the reply incrementally as it arrives. */
@@ -40,6 +44,9 @@ export async function streamFamiliarText(opts: {
         ...(opts.responseSpeed ? { responseSpeed: opts.responseSpeed } : {}),
         ...(opts.modelOverride ? { modelOverride: opts.modelOverride } : {}),
         ...(opts.modelOverrideScope ? { modelOverrideScope: opts.modelOverrideScope } : {}),
+        // Provenance for generated runs (journal narratives, …) so the chat
+        // lists can keep them out of the conversation rail (#2719 model).
+        ...(opts.origin ? { origin: opts.origin } : {}),
       }),
       signal: opts.signal,
     });

--- a/src/lib/journal-generate.ts
+++ b/src/lib/journal-generate.ts
@@ -34,7 +34,9 @@ export async function generateReflection(opts: {
     res = await fetch("/api/chat/send", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ familiarId: opts.familiarId, prompt: buildReflectionPrompt(opts.context) }),
+      // origin:"journal" keeps these generated runs out of the chat lists
+      // (cave-buih, same provenance model as canvas-generate).
+      body: JSON.stringify({ familiarId: opts.familiarId, prompt: buildReflectionPrompt(opts.context), origin: "journal" }),
       signal: opts.signal,
     });
   } catch (err) {

--- a/src/lib/session-origin.ts
+++ b/src/lib/session-origin.ts
@@ -9,6 +9,7 @@ export const SESSION_ORIGINS: readonly SessionOrigin[] = [
   "heartbeat",
   "call",
   "canvas",
+  "journal",
 ] as const;
 
 export const ORIGIN_LABEL: Record<SessionOrigin, string> = {
@@ -19,6 +20,7 @@ export const ORIGIN_LABEL: Record<SessionOrigin, string> = {
   heartbeat: "heartbeat",
   call: "call",
   canvas: "canvas",
+  journal: "journal",
 };
 
 export const ORIGIN_ICON: Record<SessionOrigin, IconName> = {
@@ -29,6 +31,7 @@ export const ORIGIN_ICON: Record<SessionOrigin, IconName> = {
   heartbeat: "ph:heartbeat",
   call: "ph:magic-wand-fill",
   canvas: "ph:paint-brush",
+  journal: "ph:book-open",
 };
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -97,7 +97,8 @@ export type SessionOrigin =
   | "cron"
   | "heartbeat"
   | "call"
-  | "canvas";
+  | "canvas"
+  | "journal";
 
 export type SessionInitiator = {
   kind: "human" | "familiar" | "system" | "unknown";


### PR DESCRIPTION
## Summary

Per Val: the journal-writing runs flooding the chat page are pure noise. Two generators ride the normal client chat path — `daily-narrative.ts` (via `streamFamiliarText`) and `journal-generate.ts` (direct `chat/send` POST) — so their runs create real local conversations that #2719's `generated` flag never catches (it only marks daemon-only rows). On this machine: **93 narrative runs out of 499 sessions** were burying the real conversations.

The fix mirrors #2719's canvas provenance model:

- `SessionOrigin` gains `"journal"` (+ label/icon maps); `streamFamiliarText` gains an `origin` option forwarded to `chat/send`; both journal generators tag their runs.
- `CHAT_HIDDEN_ORIGINS` adds `"journal"` — every list behind `filterVisibleChatSessions` (chat rail, empty-state recents) hides them.
- **Legacy fallback** for the dozens of existing untagged runs: `isGeneratedChatSession` matches the exact machine-prompt openers — including the **~60-char truncated titles the store actually keeps**. (The first attempt matched the full prompt and missed rows cut at "…about my…" — caught by live-driving the built app, which is also how the second generator variant was discovered at all.)

## Verification

Live against real data: with the sessions list genuinely loaded (guarded on timestamped rows, not sleeps), both variants count **0** while real conversations remain. Pins cover the origin tag, both legacy prefixes at truncated lengths, and that a human "Write a short story for my blog" chat stays visible.

`tsc` clean · **571 test files** green · build within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)