### PR TITLE
feat(appearance): backdrop vibe — image behind Home + Chat, accent derived from it (cave-bq7s)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -465,6 +465,7 @@ export const SUITES = {
     "src/components/chat-archive-nudge.test.ts",
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",
+    "src/lib/cave-backdrop.test.ts",
     "src/lib/url-safety.test.ts",
     "src/lib/use-focus-trap.test.ts",
     "src/lib/use-prefers-reduced-motion.test.ts",
@@ -816,6 +817,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/cave-backdrop.test.ts",
   "src/lib/wiki-link-parser.test.ts",
   "src/lib/wiki-link-resolve.test.ts",
   "src/lib/grimoire-graph.test.ts",

--- a/src/components/backdrop-settings.tsx
+++ b/src/components/backdrop-settings.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useAnnouncer } from "@/components/ui/live-region";
+import {
+  prepareBackdropImage,
+  readBackdropImage,
+  useBackdropPrefs,
+  writeBackdropImage,
+  writeBackdropPrefs,
+} from "@/lib/cave-backdrop";
+
+/**
+ * Settings → Appearance → Backdrop: pick an image that shows behind Home and
+ * Chat, tune how much of it shows through, and let the app's accent take on
+ * the image's dominant color ("match the vibe"). The heavy lifting lives in
+ * cave-backdrop.ts; this card is pure controls + preview.
+ */
+export function BackdropSettings() {
+  const prefs = useBackdropPrefs();
+  const { announce } = useAnnouncer();
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const urlRef = useRef<string | null>(null);
+
+  // Thumbnail of whatever is stored — follows enable/replace/clear.
+  useEffect(() => {
+    let cancelled = false;
+    void readBackdropImage().then((blob) => {
+      if (cancelled) return;
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+      urlRef.current = blob ? URL.createObjectURL(blob) : null;
+      setPreviewUrl(urlRef.current);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [prefs.enabled, busy]);
+  useEffect(
+    () => () => {
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+    },
+    [],
+  );
+
+  async function pickImage(file: File) {
+    setBusy(true);
+    try {
+      const { blob, accentSeed } = await prepareBackdropImage(file);
+      await writeBackdropImage(blob);
+      writeBackdropPrefs({ enabled: true, accentSeed });
+      announce(
+        accentSeed
+          ? "Backdrop set — accent matched to the image."
+          : "Backdrop set. The image has no dominant color, so the theme accent stays.",
+      );
+    } catch (err) {
+      announce(err instanceof Error ? err.message : "Could not read that image.", "assertive");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function clearBackdrop() {
+    setBusy(true);
+    try {
+      await writeBackdropImage(null);
+      writeBackdropPrefs({ enabled: false, accentSeed: null });
+      announce("Backdrop cleared.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3 px-4 py-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => fileRef.current?.click()}
+          disabled={busy}
+          aria-label={previewUrl ? "Replace backdrop image" : "Choose backdrop image"}
+          className="focus-ring grid h-20 w-32 shrink-0 place-items-center overflow-hidden rounded-[var(--radius-card)] border border-dashed border-[var(--border-strong)] bg-[var(--bg-base)]/40 text-[11px] text-[var(--text-muted)] hover:border-[var(--accent-presence)]/60"
+        >
+          {previewUrl ? (
+            <img src={previewUrl} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <span>{busy ? "Reading…" : "Choose image"}</span>
+          )}
+        </button>
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/png,image/jpeg,image/webp,image/avif"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0] ?? null;
+            if (file) void pickImage(file);
+            e.target.value = "";
+          }}
+        />
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-medium text-[var(--text-primary)]">Backdrop</p>
+          <p className="text-[11px] leading-relaxed text-[var(--text-muted)]">
+            Shows behind Home and Chat. The accent tints to the image’s dominant color, kept
+            readable against your theme.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {previewUrl ? (
+            <Button size="xs" variant="ghost" leadingIcon="ph:x" onClick={() => void clearBackdrop()} disabled={busy}>
+              Clear
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {prefs.enabled ? (
+        <div className="flex flex-col gap-3 border-l border-[var(--border-hairline)] pl-3">
+          <label className="flex items-center gap-3 text-[12px] text-[var(--text-secondary)]">
+            <span className="w-16 shrink-0">Intensity</span>
+            <input
+              type="range"
+              min={10}
+              max={80}
+              value={prefs.intensity}
+              onChange={(e) => writeBackdropPrefs({ intensity: Number(e.target.value) })}
+              className="cave-backdrop-intensity min-w-0 flex-1"
+              aria-label="Backdrop intensity"
+            />
+            <span className="w-8 text-right font-mono text-[11px] text-[var(--text-muted)]">
+              {prefs.intensity}
+            </span>
+          </label>
+          <label className="flex items-center justify-between gap-3 text-[12px] text-[var(--text-secondary)]">
+            <span>Match accent to the image</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={prefs.matchAccent}
+              onClick={() => writeBackdropPrefs({ matchAccent: !prefs.matchAccent })}
+              className={`focus-ring rounded-[var(--radius-control)] border px-3 py-1 text-[12px] transition-colors ${
+                prefs.matchAccent
+                  ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/15 text-[var(--text-primary)]"
+                  : "border-[var(--border-hairline)] text-[var(--text-secondary)]"
+              }`}
+            >
+              {prefs.matchAccent ? "On" : "Off"}
+            </button>
+          </label>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/cave-backdrop-layer.tsx
+++ b/src/components/cave-backdrop-layer.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import "@/styles/backdrop.css";
+import {
+  applyBackdropToDocument,
+  readBackdropImage,
+  useBackdropPrefs,
+} from "@/lib/cave-backdrop";
+
+/**
+ * Mounts once in the workspace: loads the stored backdrop image from
+ * IndexedDB into an object URL, keeps <html>'s backdrop state in sync with
+ * the prefs store, and renders the fixed image layer. `active` says whether
+ * the frontmost surface wants the backdrop (home/chat) — the layer stays
+ * mounted and crossfades via CSS.
+ *
+ * The derived accent is re-fit whenever the theme mode flips (dark ↔ light
+ * changes --bg-base, and the contrast fit depends on it).
+ */
+export function CaveBackdropLayer({ active }: { active: boolean }) {
+  const prefs = useBackdropPrefs();
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const urlRef = useRef<string | null>(null);
+
+  // Load (or clear) the stored image whenever the backdrop is toggled.
+  useEffect(() => {
+    let cancelled = false;
+    if (!prefs.enabled) {
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+      urlRef.current = null;
+      setImageUrl(null);
+      return;
+    }
+    void readBackdropImage().then((blob) => {
+      if (cancelled) return;
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+      urlRef.current = blob ? URL.createObjectURL(blob) : null;
+      setImageUrl(urlRef.current);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [prefs.enabled]);
+
+  // Push prefs + image to <html>; re-fit the accent when the mode flips.
+  useEffect(() => {
+    applyBackdropToDocument(prefs, imageUrl);
+    const observer = new MutationObserver(() => applyBackdropToDocument(prefs, undefined));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-mode", "data-theme"] });
+    return () => observer.disconnect();
+  }, [prefs, imageUrl]);
+
+  // Flag the document while a backdrop surface is frontmost, so the shell's
+  // opaque panes (shell-root/detail, chat roots) go translucent only then.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (prefs.enabled && active) root.dataset.backdropOn = "1";
+    else delete root.dataset.backdropOn;
+    return () => {
+      delete root.dataset.backdropOn;
+    };
+  }, [prefs.enabled, active]);
+
+  // Revoke the object URL when the layer unmounts for good.
+  useEffect(
+    () => () => {
+      if (urlRef.current) URL.revokeObjectURL(urlRef.current);
+    },
+    [],
+  );
+
+  if (!prefs.enabled) return null;
+  return <div className="cave-backdrop-layer" data-on={active ? "true" : "false"} aria-hidden />;
+}

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -47,6 +47,7 @@ import {
 import { readableTextColor } from "@/lib/readable-text-color";
 import { openExternalUrl } from "@/lib/open-external";
 import { copyText } from "@/lib/clipboard";
+import { BackdropSettings } from "@/components/backdrop-settings";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -1683,6 +1684,12 @@ function AppearanceSection() {
       </SettingsGroup>
 
       <FontSettings />
+
+      {/* ── Backdrop ── an image behind Home + Chat with the accent tinted to
+          match it (cave-backdrop.ts owns storage + the vibe derivation). */}
+      <SettingsGroup label="Backdrop">
+        <BackdropSettings />
+      </SettingsGroup>
 
       {/* ── Corner radius ── a minor shape tweak (drives the shared --radius
           tokens), kept last so the primary color/theme and text controls lead. */}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -14,6 +14,7 @@ import { CommandPalette, type PaletteIntent } from "@/components/command-palette
 import { GrimoireView } from "@/components/grimoire-view";
 import type { CalendarDeadline } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
+import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
 import {
   COVEN_CODE_SKIP_KEY,
   shouldAutoOpenOnboarding,
@@ -2311,6 +2312,10 @@ export function Workspace() {
   // openFamiliarStudio(...) trigger (cards, switcher, onboarding) there.
   return (
     <FamiliarStudioProvider redirectToSettings>
+      {/* Backdrop vibe: the user's image behind Home + Chat, painted under
+          the shell; the derived accent applies document-wide from the same
+          store (cave-backdrop.ts). */}
+      <CaveBackdropLayer active={mode === "home" || mode === "chat"} />
       <Shell
         ref={shellRef}
         mobileTabs={mobileTabs}

--- a/src/lib/cave-backdrop.test.ts
+++ b/src/lib/cave-backdrop.test.ts
@@ -1,0 +1,120 @@
+// @ts-nocheck
+// Backdrop vibe (cave-bq7s): unit tests for the pure derivation math, plus
+// source pins for the storage split, the one-var accent cascade, and the
+// layer/settings wiring.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dominantVibrantOklab, fitAccentToBackground } from "./cave-backdrop.ts";
+import { parseThemeColor, contrastRatio } from "./theme-contrast.ts";
+
+// ── dominantVibrantOklab: picks the vibrant hue, ignores neutrals ────────────
+function pixels(colors: Array<[number, number, number]>, repeat = 1): Uint8ClampedArray {
+  const out = new Uint8ClampedArray(colors.length * repeat * 4);
+  let i = 0;
+  for (let r = 0; r < repeat; r++) {
+    for (const [red, green, blue] of colors) {
+      out[i++] = red;
+      out[i++] = green;
+      out[i++] = blue;
+      out[i++] = 255;
+    }
+  }
+  return out;
+}
+
+{
+  // Mostly gray with a strong orange minority — the orange must win.
+  const data = pixels([
+    ...Array.from({ length: 30 }, () => [128, 128, 128]),
+    ...Array.from({ length: 10 }, () => [255, 120, 40]),
+  ]);
+  const seed = dominantVibrantOklab(data);
+  assert.ok(seed, "a vibrant minority against neutral majority still yields a seed");
+  assert.ok(seed.a > 0.05, `orange seed should sit in the +a half (got a=${seed.a.toFixed(3)})`);
+}
+
+{
+  // Pure grayscale → no seed; the theme accent must stay.
+  const data = pixels(Array.from({ length: 40 }, (_, i) => [i * 6, i * 6, i * 6]));
+  assert.equal(dominantVibrantOklab(data), null, "a grayscale image has no vibe seed");
+}
+
+{
+  // Transparent pixels are ignored entirely.
+  const data = pixels([[255, 0, 0]]);
+  data[3] = 0;
+  assert.equal(dominantVibrantOklab(data), null, "fully transparent pixels carry no vibe");
+}
+
+// ── fitAccentToBackground: keeps ≥3:1 against the live background ───────────
+{
+  const seed = { L: 0.3, a: 0.12, b: 0.02 }; // dark red — too dark for a dark bg
+  const css = fitAccentToBackground(seed, "oklch(0.13 0.022 293)");
+  assert.match(css, /^oklch\(/, "fit emits an oklch() color");
+  const rgb = parseThemeColor(css);
+  const bg = parseThemeColor("oklch(0.13 0.022 293)");
+  assert.ok(rgb && bg, "both colors parse");
+  assert.ok(
+    contrastRatio(rgb, bg) >= 3,
+    `derived accent must reach 3:1 on the dark base (got ${contrastRatio(rgb, bg).toFixed(2)})`,
+  );
+}
+
+{
+  const seed = { L: 0.9, a: 0.1, b: 0.05 }; // near-white — too light for a light bg
+  const css = fitAccentToBackground(seed, "oklch(0.97 0.005 293)");
+  const rgb = parseThemeColor(css);
+  const bg = parseThemeColor("oklch(0.97 0.005 293)");
+  assert.ok(
+    contrastRatio(rgb, bg) >= 3,
+    `derived accent must reach 3:1 on the light base (got ${contrastRatio(rgb, bg).toFixed(2)})`,
+  );
+}
+
+// ── source pins ──────────────────────────────────────────────────────────────
+const lib = await readFile(new URL("./cave-backdrop.ts", import.meta.url), "utf8");
+const layer = await readFile(new URL("../components/cave-backdrop-layer.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/backdrop.css", import.meta.url), "utf8");
+const settings = await readFile(new URL("../components/settings-shell.tsx", import.meta.url), "utf8");
+const workspace = await readFile(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+const backdropSettings = await readFile(new URL("../components/backdrop-settings.tsx", import.meta.url), "utf8");
+
+// Storage split: image bytes in IDB, prefs (incl. the seed) in localStorage.
+assert.match(lib, /indexedDB\.open\(DB_NAME, DB_VERSION\)/, "image bytes live in IndexedDB");
+assert.match(lib, /PREFS_KEY = "cave:backdrop:v1"/, "prefs persist under a stable versioned key");
+
+// The vibe rides exactly one custom property, so clearing restores the theme.
+assert.match(
+  lib,
+  /root\.style\.setProperty\("--accent-presence", fitAccentToBackground/,
+  "the derived accent overrides --accent-presence inline (ring/tints cascade)",
+);
+assert.match(
+  lib,
+  /root\.style\.removeProperty\("--accent-presence"\)/,
+  "disabling the match restores the theme accent untouched",
+);
+
+// The layer stays mounted and crossfades; only home/chat lift the opaque panes.
+assert.match(layer, /data-on=\{active \? "true" : "false"\}/, "the layer crossfades via data-on");
+assert.match(layer, /root\.dataset\.backdropOn = "1"/, "the frontmost-surface flag rides <html>");
+assert.match(
+  workspace,
+  /<CaveBackdropLayer active=\{mode === "home" \|\| mode === "chat"\} \/>/,
+  "the workspace scopes the backdrop to Home + Chat",
+);
+assert.match(css, /html\[data-backdrop-on\] \.shell-root,/, "shell panes go translucent only while a backdrop surface is frontmost");
+assert.match(
+  css,
+  /@media \(prefers-reduced-transparency: reduce\)[\s\S]*display: none/,
+  "reduced-transparency users get their solid surfaces back",
+);
+assert.doesNotMatch(css, /#[0-9a-fA-F]{3,8}\b/, "backdrop.css is tokens-only");
+
+// Settings wiring: the Appearance section owns the controls.
+assert.match(settings, /<BackdropSettings \/>/, "Appearance renders the backdrop controls");
+assert.match(backdropSettings, /prepareBackdropImage\(file\)/, "picking an image downscales + derives the seed");
+assert.match(backdropSettings, /accent matched to the image/i, "the pick announces the vibe match to AT");
+assert.match(backdropSettings, /writeBackdropImage\(null\)/, "Clear removes the stored image");
+
+console.log("cave-backdrop.test.ts: ok");

--- a/src/lib/cave-backdrop.ts
+++ b/src/lib/cave-backdrop.ts
@@ -1,0 +1,269 @@
+"use client";
+
+/**
+ * Backdrop store — a user-chosen image behind the Chat and Home surfaces,
+ * with an accent derived from the image so the app tints to match its vibe.
+ *
+ * Storage split: the image bytes live in IndexedDB (far too big for
+ * localStorage); the small prefs INCLUDING the derived accent live in
+ * localStorage under `cave:backdrop:v1`, so the accent can apply pre-paint
+ * while the image itself fades in after the async IDB read.
+ *
+ * The accent override rides one custom property: setting `--accent-presence`
+ * inline on <html> cascades through the existing color-mix chains
+ * (`--ring-focus`, presence dots, tint recipes) — no per-token theme work,
+ * and clearing the override restores the active theme untouched.
+ */
+
+import { useSyncExternalStore } from "react";
+import { contrastRatio, oklabToRgb, parseThemeColor, rgbToOklab } from "@/lib/theme-contrast";
+
+const PREFS_KEY = "cave:backdrop:v1";
+const DB_NAME = "cave-backdrop";
+const DB_VERSION = 1;
+const STORE_NAME = "backdrop";
+const IMAGE_KEY = "image";
+/** Longest edge the stored image is downscaled to — plenty for a blurred
+ *  backdrop, and keeps the IDB record small. */
+const MAX_EDGE = 1920;
+
+export type BackdropAccentSeed = { L: number; a: number; b: number };
+
+export type BackdropPrefs = {
+  enabled: boolean;
+  /** 0–100 — how much of the image shows through the scrim. */
+  intensity: number;
+  /** Tint the app's accent to the image palette. */
+  matchAccent: boolean;
+  /** Dominant vibrant color sampled from the image (OKLab), or null when the
+   *  image is effectively monochrome. Lightness is re-fit against the live
+   *  background at apply time, so one seed serves dark and light modes. */
+  accentSeed: BackdropAccentSeed | null;
+};
+
+const DEFAULT_PREFS: BackdropPrefs = {
+  enabled: false,
+  intensity: 50,
+  matchAccent: true,
+  accentSeed: null,
+};
+
+// ── prefs store (localStorage + useSyncExternalStore) ───────────────────────
+
+let cachedPrefs: BackdropPrefs | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+export function readBackdropPrefs(): BackdropPrefs {
+  if (cachedPrefs) return cachedPrefs;
+  if (typeof window === "undefined") return DEFAULT_PREFS;
+  try {
+    const raw = window.localStorage.getItem(PREFS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<BackdropPrefs>;
+      cachedPrefs = {
+        enabled: parsed.enabled === true,
+        intensity: clamp(Number(parsed.intensity ?? DEFAULT_PREFS.intensity), 0, 100),
+        matchAccent: parsed.matchAccent !== false,
+        accentSeed:
+          parsed.accentSeed && Number.isFinite(parsed.accentSeed.L)
+            ? { L: parsed.accentSeed.L, a: parsed.accentSeed.a, b: parsed.accentSeed.b }
+            : null,
+      };
+      return cachedPrefs;
+    }
+  } catch {
+    /* corrupt — fall through to defaults */
+  }
+  cachedPrefs = { ...DEFAULT_PREFS };
+  return cachedPrefs;
+}
+
+export function writeBackdropPrefs(patch: Partial<BackdropPrefs>): BackdropPrefs {
+  const next = { ...readBackdropPrefs(), ...patch };
+  cachedPrefs = next;
+  try {
+    window.localStorage.setItem(PREFS_KEY, JSON.stringify(next));
+  } catch {
+    /* private mode — the session still works, it just won't persist */
+  }
+  // Prefs (accent, intensity, enablement) take effect immediately everywhere —
+  // including routes that don't mount the layer, like /settings. The image
+  // itself is the layer's job.
+  applyBackdropToDocument(next, undefined);
+  notify();
+  return next;
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+const getServerPrefs = () => DEFAULT_PREFS;
+
+export function useBackdropPrefs(): BackdropPrefs {
+  return useSyncExternalStore(subscribe, readBackdropPrefs, getServerPrefs);
+}
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Number.isFinite(n) ? Math.min(hi, Math.max(lo, n)) : lo;
+}
+
+// ── image record (IndexedDB) ─────────────────────────────────────────────────
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE_NAME)) {
+        req.result.createObjectStore(STORE_NAME);
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("indexedDB open failed"));
+  });
+}
+
+export async function readBackdropImage(): Promise<Blob | null> {
+  if (typeof indexedDB === "undefined") return null;
+  const db = await openDb();
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readonly");
+      const req = tx.objectStore(STORE_NAME).get(IMAGE_KEY);
+      req.onsuccess = () => resolve((req.result as Blob | undefined) ?? null);
+      req.onerror = () => reject(req.error ?? new Error("backdrop read failed"));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function writeBackdropImage(blob: Blob | null): Promise<void> {
+  if (typeof indexedDB === "undefined") return;
+  const db = await openDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_NAME, "readwrite");
+      const store = tx.objectStore(STORE_NAME);
+      if (blob) store.put(blob, IMAGE_KEY);
+      else store.delete(IMAGE_KEY);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error ?? new Error("backdrop write failed"));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+// ── vibe extraction ──────────────────────────────────────────────────────────
+
+/** Downscale the picked file for storage and sample it for the accent seed.
+ *  Returns the stored blob + the dominant vibrant OKLab color (null when the
+ *  image has no meaningfully chromatic pixels — e.g. a grayscale photo). */
+export async function prepareBackdropImage(
+  file: Blob,
+): Promise<{ blob: Blob; accentSeed: BackdropAccentSeed | null }> {
+  const bitmap = await createImageBitmap(file);
+  try {
+    const scale = Math.min(1, MAX_EDGE / Math.max(bitmap.width, bitmap.height));
+    const width = Math.max(1, Math.round(bitmap.width * scale));
+    const height = Math.max(1, Math.round(bitmap.height * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("canvas unavailable");
+    ctx.drawImage(bitmap, 0, 0, width, height);
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error("encode failed"))), "image/jpeg", 0.85);
+    });
+
+    // Sample a small grid for the palette — 48×48 is plenty to find the vibe.
+    const sample = document.createElement("canvas");
+    sample.width = 48;
+    sample.height = 48;
+    const sctx = sample.getContext("2d");
+    if (!sctx) return { blob, accentSeed: null };
+    sctx.drawImage(bitmap, 0, 0, 48, 48);
+    const { data } = sctx.getImageData(0, 0, 48, 48);
+    return { blob, accentSeed: dominantVibrantOklab(data) };
+  } finally {
+    bitmap.close();
+  }
+}
+
+/** Bucket chromatic pixels by hue and return the mean OKLab of the most
+ *  populous bucket — the image's dominant vibrant color. */
+export function dominantVibrantOklab(rgba: Uint8ClampedArray): BackdropAccentSeed | null {
+  const BUCKETS = 24;
+  const sums = Array.from({ length: BUCKETS }, () => ({ n: 0, L: 0, a: 0, b: 0 }));
+  for (let i = 0; i < rgba.length; i += 4) {
+    if (rgba[i + 3] < 128) continue;
+    const lab = rgbToOklab({ r: rgba[i] / 255, g: rgba[i + 1] / 255, b: rgba[i + 2] / 255, alpha: 1 });
+    const chroma = Math.hypot(lab.a, lab.b);
+    // Skip near-neutrals and near-black/white — they carry no vibe.
+    if (chroma < 0.05 || lab.L < 0.15 || lab.L > 0.92) continue;
+    const hue = Math.atan2(lab.b, lab.a);
+    const bucket = Math.floor(((hue + Math.PI) / (2 * Math.PI)) * BUCKETS) % BUCKETS;
+    const cell = sums[bucket];
+    // Weight by chroma so saturated pixels steer their bucket's mean.
+    cell.n += chroma;
+    cell.L += lab.L * chroma;
+    cell.a += lab.a * chroma;
+    cell.b += lab.b * chroma;
+  }
+  let best = sums[0];
+  for (const cell of sums) if (cell.n > best.n) best = cell;
+  if (best.n <= 0) return null;
+  return { L: best.L / best.n, a: best.a / best.n, b: best.b / best.n };
+}
+
+/** Fit the seed's lightness against the live background so the derived accent
+ *  keeps a legible presence (target ≥ 3:1, the app's decorative-accent floor)
+ *  in the CURRENT theme/mode. Hue and chroma stay the image's. */
+export function fitAccentToBackground(seed: BackdropAccentSeed, bgCss: string): string {
+  const bg = parseThemeColor(bgCss);
+  const chroma = Math.min(0.16, Math.hypot(seed.a, seed.b));
+  const hue = Math.atan2(seed.b, seed.a);
+  let L = clamp(seed.L, 0.35, 0.85);
+  if (bg) {
+    const bgIsDark = rgbToOklab(bg).L < 0.5;
+    for (let step = 0; step < 14; step++) {
+      const candidate = oklabToRgb({ L, a: chroma * Math.cos(hue), b: chroma * Math.sin(hue), alpha: 1 });
+      if (contrastRatio(candidate, bg) >= 3) break;
+      L = clamp(L + (bgIsDark ? 0.04 : -0.04), 0.2, 0.92);
+    }
+  }
+  const c = chroma.toFixed(4);
+  const h = ((hue * 180) / Math.PI + 360) % 360;
+  return `oklch(${L.toFixed(4)} ${c} ${h.toFixed(1)})`;
+}
+
+// ── applying to the document ─────────────────────────────────────────────────
+
+/** Applies prefs (and optionally the image object URL) to <html>. Pass
+ *  `imageUrl: undefined` to leave the current image untouched (pref-only
+ *  updates); `null` clears it. */
+export function applyBackdropToDocument(prefs: BackdropPrefs, imageUrl?: string | null): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  const active = prefs.enabled;
+  if (active) root.dataset.backdrop = "1";
+  else delete root.dataset.backdrop;
+  root.style.setProperty("--cave-backdrop-opacity", String(clamp(prefs.intensity, 0, 100) / 100));
+  if (imageUrl !== undefined) {
+    if (imageUrl && active) root.style.setProperty("--cave-backdrop-image", `url("${imageUrl}")`);
+    else root.style.removeProperty("--cave-backdrop-image");
+  }
+  if (active && prefs.matchAccent && prefs.accentSeed) {
+    const bg = getComputedStyle(root).getPropertyValue("--bg-base").trim() || "oklch(0.13 0.022 293)";
+    root.style.setProperty("--accent-presence", fitAccentToBackground(prefs.accentSeed, bg));
+  } else {
+    root.style.removeProperty("--accent-presence");
+  }
+}

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -1,0 +1,61 @@
+/* ── Backdrop vibe ───────────────────────────────────────────────────────────
+   A user-chosen image behind the Chat and Home surfaces. The fixed layer
+   sits under the workspace content; `--cave-backdrop-opacity` (0–1, from the
+   Settings intensity slider) controls how much shows through, and a
+   bg-base-derived scrim keeps text areas readable in every theme. The
+   derived accent rides `--accent-presence` (set inline by cave-backdrop.ts),
+   so the glass tokens and tint recipes above this layer pick up the image's
+   vibe for free. */
+
+html[data-backdrop] .cave-backdrop-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-image: var(--cave-backdrop-image);
+  background-size: cover;
+  background-position: center;
+  opacity: 0;
+  transition: opacity var(--duration-slow, 260ms) ease;
+}
+
+/* Visible only while a backdrop-bearing surface (home/chat) is frontmost —
+   crossfades on mode switches instead of popping. */
+html[data-backdrop] .cave-backdrop-layer[data-on="true"] {
+  opacity: var(--cave-backdrop-opacity, 0.35);
+}
+
+/* Readability floor: bg-base gradient scrim, heavier toward the bottom where
+   composers and transcripts live. Sits inside the layer so the intensity
+   slider scales image and scrim together. */
+html[data-backdrop] .cave-backdrop-layer::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklch, var(--bg-base) 18%, transparent),
+    color-mix(in oklch, var(--bg-base) 42%, transparent)
+  );
+}
+
+/* The big opaque paints over the layer go translucent while a backdrop
+   surface (home/chat) is frontmost — the layer component flips
+   html[data-backdrop-on]. Side panes (nav, list) keep their own solid
+   backgrounds, so the image shows through the content area only. The shared
+   glass tokens (PR 2790) give floating chrome above the image a real blur. */
+html[data-backdrop-on] .shell-root,
+html[data-backdrop-on] .shell-detail {
+  background: transparent;
+}
+
+html[data-backdrop-on] .chat-surface,
+html[data-backdrop-on] .cave-chat-linear {
+  background: color-mix(in oklch, var(--bg-base) 16%, transparent);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  html[data-backdrop] .cave-backdrop-layer {
+    display: none;
+  }
+}


### PR DESCRIPTION
Settings → Appearance → **Backdrop**: choose an image and it paints behind Home and Chat, while the app's **accent takes on the image's dominant color** — focus ring, presence dots, and tint recipes follow through the existing color-mix chains via a single inline `--accent-presence` override.

- **Storage**: image downscaled to ≤1920px and stored in IndexedDB; prefs + derived accent seed in localStorage (accent applies instantly, image fades in from IDB).
- **Vibe derivation**: 48×48 canvas sample → OKLab hue-bucketed chroma-weighted dominant color (reusing `theme-contrast`'s converters) → lightness re-fit against the live `--bg-base` to ≥3:1 (re-fits on theme/mode change). Grayscale images keep the theme accent; Clear restores everything.
- **Scoping**: a fixed layer + `html[data-backdrop-on]` lift the shell/chat panes to translucent only while Home/Chat are frontmost (board etc. stay opaque, verified); bg-base gradient scrim for readability; crossfade on mode switch; `prefers-reduced-transparency` hides the image.
- **Synergy**: the new shared glass tokens (PR 2790) finally have something to blur on base surfaces.

Verified live with a generated sunset (screenshots in session): accent derived to the sunset pink, image glowing through the chat landing with readable content, instant apply from /settings, board unaffected. Unit tests for the derivation + contrast fit (grayscale→null, vibrant-minority wins, 3:1 on dark and light); pins for storage split, one-var cascade, scoping, reduced transparency, tokens-only CSS.

typecheck ✓ · test:app 573 files ✓ · tests-wired ✓ · build + bundle budget ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)