### PR TITLE
a11y(journal): delete no longer announces twice — UndoToast already speaks it (cave-6rhk)

### DIFF
--- a/src/components/journal/journal-entries.test.ts
+++ b/src/components/journal/journal-entries.test.ts
@@ -161,7 +161,14 @@ assert.match(css, /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.journal-ne
 assert.match(entries, /const \{ announce \} = useAnnouncer\(\)/, "the surface uses the shared announcer");
 assert.match(entries, /announce\("Reflection generated\."\)/, "generate success is announced");
 assert.match(entries, /announce\("Journal entry saved\."\)/, "save success is announced");
-assert.match(entries, /announce\(`Deleting the entry for [\s\S]{0,80}undo available\.`\)/, "delete scheduling is announced");
+// Delete deliberately does NOT announce(): UndoToast is itself role=status
+// (ui/undo-toast.tsx) and speaks the scheduled deletion — a second announce
+// made AT hear every delete twice (cave-6rhk).
+assert.doesNotMatch(
+  entries,
+  /announce\(`Deleting the entry/,
+  "delete must not announce — UndoToast's live region already speaks it (double-announce, cave-6rhk)",
+);
 assert.match(entries, /aria-busy=\{generating\}/, "the generate button reports busy state");
 assert.match(entries, /unavailable — select today to generate/, "the disabled reason reaches the accessible name (not just title=)");
 assert.match(entries, /<h3 className="journal-entry__sec-heading">What happened/, "the day section is a real heading");

--- a/src/components/journal/journal-entries.tsx
+++ b/src/components/journal/journal-entries.tsx
@@ -506,7 +506,9 @@ export function JournalEntries({
     const date = day.date;
     cancelEdit();
     setError(null);
-    announce(`Deleting the entry for ${longDateLabel(parseDateSlug(date) ?? new Date())} — undo available.`);
+    // No announce() here: UndoToast is itself a live region (role=status,
+    // ui/undo-toast.tsx) and speaks the scheduled deletion + undo affordance —
+    // announcing too made AT hear every delete twice (cave-6rhk).
     scheduleDelete(date, `entry for ${longDateLabel(parseDateSlug(date) ?? new Date())}`, async () => {
       try {
         const res = await fetch(`/api/journal?date=${encodeURIComponent(date)}`, { method: "DELETE" });


### PR DESCRIPTION
The remediation promised in the #2780 review: the delete flow's `announce()` duplicated `UndoToast`'s own live region (`role=status aria-live`, ui/undo-toast.tsx:58), so AT heard every journal delete twice. Dropped the call; its pin flips to a `doesNotMatch` carrying the rationale so it can't quietly come back. Generate/save announces are untouched — nothing else speaks on those paths.

Verification: typecheck clean, full app suite 573 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)