### PR TITLE
feat(chat): modern reading polish — reader measure, token-native mermaid, row tables, quiet chips (cave-po4f)

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -255,9 +255,14 @@ assert.match(
 );
 assert.match(
   source,
-  /mermaidPlugin\(\{[\s\S]{0,180}theme: "dark"[\s\S]{0,180}securityLevel: "strict", suppressErrorRendering: true/,
-  "mermaid is initialized with the dark theme, strict security, and syntax-error SVG rendering disabled",
+  /mermaidPlugin\(\{[\s\S]{0,320}theme: "base"[\s\S]{0,320}securityLevel: "strict", suppressErrorRendering: true/,
+  "mermaid initializes on the base theme (the only one honoring themeVariables) with strict security and syntax-error SVG rendering disabled",
 );
+// cave-po4f: theme tokens reach mermaid as canvas-resolved hex (khroma cannot
+// parse oklch/color-mix), and the inline-SVG CSS overrides in cave-chat.css
+// keep diagrams tracking the live theme regardless.
+assert.match(source, /function themeToken\(name: string, fallback: string\): string/, "theme tokens resolve through the canvas hex helper");
+assert.match(source, /darkMode: true,/, "base theme derives shades on the dark ramp");
 assert.match(
   source,
   /function isMermaidCodeBlock[\s\S]{0,360}=== "mermaid"/,

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -544,16 +544,93 @@ async function renderTableBlock(block: TableBlock, renderAsync: RenderAsyncFn): 
 // imported lazily and only when a message actually contains a mermaid fence. The
 // instance is a module singleton so init() (which loads mermaid) runs once.
 let mermaidPluginPromise: Promise<PreviewPlugin | null> | null = null;
+
+/** Resolve a CSS custom property to a HEX color for mermaid's theme
+ *  variables. Mermaid bakes colors into SVG attributes and derives shades via
+ *  khroma, which cannot parse the app's oklch()/color-mix() token values —
+ *  fed those raw it produces broken near-white fills. Painting the token onto
+ *  a 1×1 canvas lets the browser resolve ANY CSS color, then we read back
+ *  plain rgb and emit hex. Falls back when the token is missing/unpaintable. */
+function themeToken(name: string, fallback: string): string {
+  try {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    if (!value) return fallback;
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = 1;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return fallback;
+    // Composite over black first so semi-transparent tokens (the border
+    // scale is color-mix ...% transparent) resolve to their on-dark look
+    // instead of reading back a premultiplied near-white.
+    ctx.fillStyle = "#000";
+    ctx.fillRect(0, 0, 1, 1);
+    ctx.fillStyle = value; // unparseable values leave the previous fillStyle
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    return `#${[r, g, b].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
+  } catch {
+    return fallback;
+  }
+}
+
 async function getMermaidPlugin(): Promise<PreviewPlugin | null> {
   if (!mermaidPluginPromise) {
     mermaidPluginPromise = import("@create-markdown/preview-mermaid")
       .then(async ({ mermaidPlugin }) => {
-        // theme "dark" matches the Cave UI; securityLevel "strict" overrides the
-        // plugin's default "loose" so diagrams from untrusted chat content can't
-        // smuggle scripts/click handlers (postProcess output bypasses our sanitizer).
+        // Base "dark" + the app's live theme tokens, so diagrams stop shipping
+        // stock mermaid purple and read as part of the surface: node fills sit
+        // on the raised layer, strokes on the hairline scale, and the accent
+        // appears only where mermaid marks emphasis. securityLevel "strict"
+        // overrides the plugin's default "loose" so diagrams from untrusted
+        // chat content can't smuggle scripts/click handlers (postProcess
+        // output bypasses our sanitizer).
+        const accent = themeToken("--accent-presence", "#9a8ecd");
+        const raised = themeToken("--bg-raised", "#1c1a24");
+        const panel = themeToken("--bg-panel", "#14121b");
+        const textPrimary = themeToken("--text-primary", "#e6e6f0");
+        const textSecondary = themeToken("--text-secondary", "#a5a1b6");
+        const hairline = themeToken("--border-strong", "#3a3648");
         const plugin = mermaidPlugin({
-          theme: "dark",
-          config: { securityLevel: "strict", suppressErrorRendering: true },
+          // "base" is the only mermaid theme that honors themeVariables;
+          // darkMode below keeps its derived shades on the dark ramp.
+          theme: "base",
+          config: {
+            securityLevel: "strict", suppressErrorRendering: true,
+            fontFamily:
+              'var(--font-inter), ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+            themeVariables: {
+              darkMode: true,
+              background: panel,
+              primaryColor: raised,
+              primaryTextColor: textPrimary,
+              primaryBorderColor: hairline,
+              secondaryColor: panel,
+              secondaryTextColor: textSecondary,
+              secondaryBorderColor: hairline,
+              tertiaryColor: panel,
+              tertiaryTextColor: textSecondary,
+              tertiaryBorderColor: hairline,
+              lineColor: textSecondary,
+              textColor: textPrimary,
+              mainBkg: raised,
+              nodeBorder: hairline,
+              clusterBkg: panel,
+              clusterBorder: hairline,
+              titleColor: textPrimary,
+              edgeLabelBackground: panel,
+              actorBkg: raised,
+              actorBorder: hairline,
+              actorTextColor: textPrimary,
+              activationBkgColor: raised,
+              labelBoxBkgColor: raised,
+              labelBoxBorderColor: hairline,
+              noteBkgColor: panel,
+              noteBorderColor: hairline,
+              noteTextColor: textSecondary,
+              pie1: accent,
+              cScale0: accent,
+            },
+          },
         });
         await plugin.init?.();
         return plugin;
@@ -1402,36 +1479,39 @@ function MarkdownExpandModal({
     >
       <div
         ref={dialogRef}
-        className="relative flex h-[90vh] w-[92vw] max-w-[1100px] flex-col overflow-hidden rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl"
+        className="relative flex h-[92vh] w-[94vw] max-w-[1100px] flex-col overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-panel)] shadow-2xl"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-label={`Expanded ${label}`}
         tabIndex={-1}
       >
-        <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-4 py-2.5">
-          <Icon name="ph:arrows-out-simple" width={13} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-          <span className="flex-1 truncate text-[12px] text-[var(--text-secondary)]">{label}</span>
+        <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-5 py-3">
+          <Icon name="ph:book-open" width={14} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+          <span className="flex-1 truncate text-[13px] font-medium text-[var(--text-secondary)]">{label}</span>
           <button
             type="button"
             onClick={() => void copy()}
-            className="flex h-7 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-2.5 text-[11px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+            className="flex h-7 items-center gap-1.5 rounded-full border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
           >
-            <Icon name="ph:copy" width={11} aria-hidden />
+            <Icon name={copied ? "ph:check" : "ph:copy"} width={11} aria-hidden />
             {copied ? "Copied" : "Copy"}
           </button>
           <button
             type="button"
             onClick={onClose}
-            className="ml-1 flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+            className="ml-1 flex h-7 w-7 items-center justify-center rounded-full text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
             aria-label="Close expanded view"
           >
             <Icon name="ph:x-bold" width={11} aria-hidden />
           </button>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto px-8 py-6">
-          <div className="mx-auto w-full max-w-[820px]">
-            <MarkdownBlock text={text} className="cave-md--expanded" />
+        {/* Reader body: a centered book measure with its own reading scale
+            (.cave-md--reader in cave-chat.css) — the transcript's dense 14px
+            is right in the stream, wrong for a full-screen reading surface. */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-10 sm:px-12">
+          <div className="mx-auto w-full max-w-[72ch]">
+            <MarkdownBlock text={text} className="cave-md--expanded cave-md--reader" />
           </div>
         </div>
       </div>

--- a/src/styles/cave-chat.css
+++ b/src/styles/cave-chat.css
@@ -58,8 +58,24 @@
     "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-.cave-md > * + * { margin-top: 0.7em; }
+.cave-md > * + * { margin-top: 0.8em; }
 .cave-md > *:first-child { margin-top: 0; }
+
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   READER SCALE — the full-screen Expand view. The transcript's 14px density
+   is right in the stream; a dedicated reading surface earns a book measure
+   (72ch cap set by the modal) and a calmer, larger scale.
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+.cave-md--reader {
+  font-size: 15.5px;
+  line-height: var(--cave-reading-leading, 1.75);
+}
+.cave-md--reader > * + * { margin-top: 0.95em; }
+.cave-md--reader h1 { font-size: 1.45em; }
+.cave-md--reader h2 { font-size: 1.22em; }
+.cave-md--reader h3 { font-size: 1.05em; }
+.cave-md--reader table { font-size: 13.5px; }
+.cave-md--reader .cave-code-wrap pre code { font-size: 13px; }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    HEADINGS
@@ -109,16 +125,18 @@
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-   INLINE CODE — soft lavender pill
+   INLINE CODE — quiet neutral chip. Responses are dense with identifiers, and
+   the old accent-lavender pill turned every one into decoration; accent is
+   presence, not punctuation (design language). Neutral chips read as text.
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
 .cave-md :not(pre) > code {
   font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  font-size: 0.8em;
-  padding: 0.18em 0.48em;
+  font-size: 0.82em;
+  padding: 0.14em 0.42em;
   border-radius: 5px;
-  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
-  color: color-mix(in oklch, var(--accent-presence) 85%, var(--text-primary));
-  border: 1px solid color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  background: color-mix(in oklch, var(--foreground) 7%, transparent);
+  color: var(--text-primary);
+  border: 1px solid color-mix(in oklch, var(--foreground) 9%, transparent);
   /* Wrap long inline code gracefully instead of overflowing the bubble.
      break-word keeps short snippets intact but lets oversized tokens break. */
   white-space: normal;
@@ -292,8 +310,8 @@
   max-width: min(96vw, 1280px);
   max-height: 90vh;
   border: 1px solid var(--border-strong);
-  border-radius: 12px;
-  background: var(--bg-raised);
+  border-radius: 16px;
+  background: var(--bg-panel);
   box-shadow: 0 24px 70px color-mix(in oklch, black 45%, transparent);
   overflow: hidden;
 }
@@ -314,9 +332,9 @@
   color: var(--text-muted);
 }
 .cave-table-lightbox__close {
-  padding: 3px 12px;
+  padding: 4px 14px;
   border: 1px solid var(--border-hairline);
-  border-radius: 6px;
+  border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
   font-size: 12px;
@@ -335,10 +353,10 @@
 .cave-table-lightbox__body {
   min-height: 0;
   overflow: auto;
-  padding: 14px 16px;
+  padding: 20px 24px;
 }
 .cave-table-lightbox__body table {
-  font-size: 13px;
+  font-size: 13.5px;
 }
 @media (prefers-reduced-motion: reduce) {
   .cave-table-lightbox { animation: none; }
@@ -352,15 +370,71 @@
   display: flex;
   justify-content: center;
   margin: 8px 0 16px;
-  padding: 12px;
-  background: var(--bg-raised);
+  padding: 20px 16px;
+  /* Diagram canvas: a faint dot grid on the panel layer, the same visual
+     language as node editors — diagrams read as a drawing surface, not a
+     quote box. Dots come from the hairline scale so all 19 themes hold. */
+  background:
+    radial-gradient(color-mix(in oklch, var(--foreground) 7%, transparent) 1px, transparent 1px),
+    color-mix(in oklch, var(--bg-panel) 72%, transparent);
+  background-size: 18px 18px;
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: 12px;
   overflow-x: auto;
 }
 .cave-md .cm-mermaid-diagram svg {
   max-width: 100%;
   height: auto;
+}
+/* Token-theme the diagram itself. Mermaid bakes its palette into an inline
+   <style> per SVG (and initialize()-level theming has proven unreliable
+   through the preview plugin), so the surface's own tokens win here — which
+   also keeps diagrams correct across every theme, live. Scoped to the two
+   places a diagram can live: the transcript card and the fullscreen viewer. */
+.cave-md .cm-mermaid-diagram svg .node rect,
+.cave-md .cm-mermaid-diagram svg .node circle,
+.cave-md .cm-mermaid-diagram svg .node ellipse,
+.cave-md .cm-mermaid-diagram svg .node polygon,
+.cave-md .cm-mermaid-diagram svg .node path,
+.cm-mermaid-viewer__canvas svg .node rect,
+.cm-mermaid-viewer__canvas svg .node circle,
+.cm-mermaid-viewer__canvas svg .node ellipse,
+.cm-mermaid-viewer__canvas svg .node polygon,
+.cm-mermaid-viewer__canvas svg .node path {
+  fill: var(--bg-raised) !important;
+  stroke: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline)) !important;
+}
+.cave-md .cm-mermaid-diagram svg .nodeLabel,
+.cave-md .cm-mermaid-diagram svg .edgeLabel,
+.cave-md .cm-mermaid-diagram svg .label,
+.cm-mermaid-viewer__canvas svg .nodeLabel,
+.cm-mermaid-viewer__canvas svg .edgeLabel,
+.cm-mermaid-viewer__canvas svg .label {
+  color: var(--text-primary) !important;
+  fill: var(--text-primary) !important;
+}
+.cave-md .cm-mermaid-diagram svg .edgePath path,
+.cave-md .cm-mermaid-diagram svg path.flowchart-link,
+.cm-mermaid-viewer__canvas svg .edgePath path,
+.cm-mermaid-viewer__canvas svg path.flowchart-link {
+  stroke: var(--text-muted) !important;
+}
+.cave-md .cm-mermaid-diagram svg .marker,
+.cm-mermaid-viewer__canvas svg .marker {
+  fill: var(--text-muted) !important;
+  stroke: var(--text-muted) !important;
+}
+.cave-md .cm-mermaid-diagram svg .edgeLabel rect,
+.cave-md .cm-mermaid-diagram svg .labelBkg,
+.cm-mermaid-viewer__canvas svg .edgeLabel rect,
+.cm-mermaid-viewer__canvas svg .labelBkg {
+  fill: var(--bg-panel) !important;
+  background-color: var(--bg-panel) !important;
+}
+.cave-md .cm-mermaid-diagram svg .cluster rect,
+.cm-mermaid-viewer__canvas svg .cluster rect {
+  fill: color-mix(in oklch, var(--bg-panel) 60%, transparent) !important;
+  stroke: var(--border-hairline) !important;
 }
 /* Rendered diagrams are click-to-expand into the fullscreen zoom/pan viewer. */
 .cave-md .cm-mermaid-diagram--interactive {
@@ -411,6 +485,13 @@
   overflow: hidden;
   cursor: grab;
   touch-action: none;
+  /* The same dot-grid canvas as the inline frame, so expanding feels like
+     zooming into the drawing surface rather than teleporting to a void. */
+  background-image: radial-gradient(
+    color-mix(in oklch, var(--foreground) 6%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 22px 22px;
 }
 .cm-mermaid-viewer__stage--grabbing {
   cursor: grabbing;
@@ -445,8 +526,10 @@
   gap: 4px;
   padding: 4px;
   border: 1px solid var(--border-hairline);
-  border-radius: 10px;
-  background: color-mix(in oklch, var(--bg-panel) 92%, transparent);
+  border-radius: 999px;
+  background: color-mix(in oklch, var(--bg-panel) 78%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
   box-shadow: 0 6px 24px rgba(0, 0, 0, 0.35);
 }
 .cm-mermaid-viewer__btn {
@@ -457,7 +540,7 @@
   height: 30px;
   padding: 0;
   border: none;
-  border-radius: 7px;
+  border-radius: 999px;
   background: transparent;
   color: var(--text-secondary);
   cursor: pointer;
@@ -509,19 +592,24 @@
   white-space: pre;
 }
 
+/* Tables read as rows, not a spreadsheet grid: the frame + radius live on the
+   scroll wrapper (border-radius can't clip a collapsed table), separators are
+   horizontal-only, and the header pins while the wrapper scrolls. */
+.cave-md .cave-table-scroll {
+  border: 1px solid var(--border-hairline);
+  border-radius: 10px;
+  background: color-mix(in oklch, var(--bg-panel) 40%, transparent);
+}
 .cave-md table {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
   font-size: 12.5px;
-  border-radius: 6px;
-  overflow: hidden;
-  border: 1px solid var(--border-hairline);
 }
 .cave-md th,
 .cave-md td {
-  padding: 0.38em 0.75em;
+  padding: 0.52em 0.9em;
   border-bottom: 1px solid var(--border-hairline);
-  border-right: 1px solid var(--border-hairline);
   text-align: left;
   vertical-align: top;
   /* CHAT-D7-08: undo .cave-md's break-anywhere inside cells — auto table
@@ -530,21 +618,26 @@
   word-break: normal;
   overflow-wrap: normal;
 }
+.cave-md th:first-child,
+.cave-md td:first-child { padding-left: 1.1em; }
 .cave-md th:last-child,
-.cave-md td:last-child { border-right: none; }
+.cave-md td:last-child { padding-right: 1.1em; }
 .cave-md tr:last-child td { border-bottom: none; }
 
 .cave-md th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   font-weight: 600;
-  font-size: 11px;
+  font-size: 10.5px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  background: color-mix(in oklch, var(--accent-presence) 6%, var(--bg-raised));
+  letter-spacing: 0.06em;
+  background: var(--bg-raised);
   color: var(--text-secondary);
 }
-.cave-md tr:nth-child(even) td { background: color-mix(in oklch, var(--foreground) 2%, transparent); }
-.cave-md tr:hover td {
-  background: color-mix(in oklch, var(--foreground) 4%, transparent);
+.cave-md tbody tr:nth-child(even) td { background: color-mix(in oklch, var(--foreground) 2%, transparent); }
+.cave-md tbody tr:hover td {
+  background: color-mix(in oklch, var(--foreground) 5%, transparent);
   transition: background 0.1s;
 }
 
@@ -1776,8 +1869,8 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
   background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
   color: var(--text-primary);
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
-  padding: 10px 13px;
+  border-radius: 14px;
+  padding: 11px 15px;
   /* Full-width user turn: the message fills the chat pane (matching the
      assistant prose) instead of a right-aligned narrow bubble. The left accent
      stripe + border still mark it as the operator's turn; the action row and
@@ -2010,9 +2103,9 @@ button.cave-chat-empty-task:hover:not(:disabled) .cave-chat-empty-task-action {
 .cave-progress-group,
 .cave-tool-group {
   border: 1px solid var(--border-hairline);
-  border-radius: 8px;
+  border-radius: 12px;
   background: color-mix(in oklch, var(--bg-panel) 36%, transparent);
-  padding: 9px 10px;
+  padding: 10px 12px;
 }
 
 .cave-tool-summary {


### PR DESCRIPTION
Chat responses read like a modern product (goal: OpenAI/Anthropic-grade). Screenshot-verified end to end via a mocked rich transcript.

- **Reader modal**: centered 72ch book measure on a 15.5px/1.75 reading scale (`.cave-md--reader`) with its own heading ramp; rounded-2xl panel, pill Copy/close.
- **Inline code**: accent-lavender pills → quiet neutral chips (accent is presence, not punctuation — the dominant noise source in dense responses).
- **Tables**: frame + radius on the scroll wrapper, horizontal-only separators, roomier cells with first/last-column insets, sticky header (pins in the expanded lightbox), zebra + hover. Lightbox: 16px panel, roomier body, pill Close, 13.5px cells.
- **Mermaid, token-native**: two real bugs — khroma can't parse the app's `oklch()`/`color-mix()` tokens (canvas-resolved hex now) and only `theme: "base"` honors `themeVariables`. Decisively, inline-SVG CSS overrides keep fills/strokes/labels/edges tracking all 19 themes live. Inline diagrams sit on a dot-grid drawing canvas; the fullscreen viewer gets the same canvas + a glassy pill toolbar. Verified: node fills probe as the resolved `--bg-raised` token (was mermaid-default `#ECECFF`).
- **Messages**: user bubble 14px radius, reasoning/tool/progress blocks 12px + calmer padding, prose rhythm 0.8em.

Validation: reader modal, table lightbox, and mermaid viewer all driven + screenshotted live; pins updated (`message-bubble-markdown.test.ts`); typecheck + full app suite (571 files) green.

Bead: cave-po4f

🤖 Generated with [Claude Code](https://claude.com/claude-code)