### PR TITLE
feat(onboarding): first-run golden path — daemon auto-start, circle draft survival, time-to-first-reply funnel (cave-fy1q)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -343,6 +343,8 @@ export const SUITES = {
     "src/lib/familiar-growth-signals.test.ts",
     "src/lib/familiar-growth-route-wiring.test.ts",
     "src/lib/session-pulse.test.ts",
+    "src/lib/first-run-stamps.test.ts",
+    "src/lib/summoning-draft.test.ts",
     "src/components/familiar-growth-view.test.ts",
     "src/lib/familiar-confidence.test.ts",
     "src/lib/familiar-analytics-insight.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -11,6 +11,7 @@ import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib
 import { segmentTurn } from "@/lib/turn-segments";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { createLiveGenerationRegistry, type LiveGenerationSnapshot } from "@/lib/live-chat-generations";
+import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp } from "@/lib/slash-commands";
 import { Icon, type IconName } from "@/lib/icon";
@@ -4311,6 +4312,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           // message from the turn's errored step when the stream gave none.
           setError((prev) => prev ?? "The agent run ended with an error.");
           raiseDebugError({ turnId: assistantId });
+        } else {
+          // cave-fy1q phase 3: first completed reply ever — no-op unless the
+          // first-open anchor exists (fresh installs only).
+          stampFirstReplyOnce();
         }
         void refreshUsagePlan(ev.responseMetadata?.confirmedModel ?? ev.responseMetadata?.model ?? null);
         if (ev.sessionId && ev.sessionId !== currentSessionRef.current) {

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -19,6 +19,7 @@ import type { ConfidenceScore } from "@/lib/familiar-confidence";
 import type { ContractReport } from "@/lib/familiar-contract";
 import { Icon } from "@/lib/icon";
 import { deriveAnalyticsInsight } from "@/lib/familiar-analytics-insight";
+import { formatTimeToFirstReply, timeToFirstReplyMs } from "@/lib/first-run-stamps";
 import { pulseTotal } from "@/lib/session-pulse";
 import {
   RESPONSE_CONFIDENCE_EMPTY_STATE,
@@ -466,6 +467,13 @@ export function FamiliarAnalyticsContent({
     return [...escalated, ...model.healRequests];
   }, [model.familiarId, model.healRequests, threadSignalsAggregate]);
   const pulseSessions = pulseTotal(model.sessionPulse);
+  // cave-fy1q phase 3: surface the first-run funnel while this install has
+  // both stamps. Sampled after mount — localStorage isn't SSR-safe.
+  const [timeToFirstReply, setTimeToFirstReply] = useState<string | null>(null);
+  useEffect(() => {
+    const ms = timeToFirstReplyMs();
+    setTimeToFirstReply(ms === null ? null : formatTimeToFirstReply(ms));
+  }, []);
 
   return (
     <>
@@ -522,6 +530,7 @@ export function FamiliarAnalyticsContent({
           <span className="fa-pulse__meta">
             {pulseSessions} session{pulseSessions === 1 ? "" : "s"} · last active{" "}
             <RelativeTime iso={model.growthReport?.lastActiveAt} fallback="never" />
+            {timeToFirstReply ? <> · first reply {timeToFirstReply} after first open</> : null}
           </span>
         </div>
         <ConfidenceRing confidence={model.confidence} />

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -14,6 +14,7 @@ import { COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { slugifyFamiliarId } from "@/lib/onboarding-familiars";
 import { defaultModelForRuntime } from "@/lib/runtime-models";
 import { setFamiliarOverride } from "@/lib/cave-familiar-overrides";
+import { clearSummoningDraft, readSummoningDraft, saveSummoningDraft } from "@/lib/summoning-draft";
 import { setGlyphOverride } from "@/lib/cave-glyph-overrides";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
@@ -258,42 +259,75 @@ function SummoningRite({
   onStartChat?: (id: string) => void;
   onClose: () => void;
 }) {
-  const [stage, setStage] = useState<StageIndex>(0);
+  // cave-fy1q: unmount still resets state (by design), but a per-window
+  // sessionStorage draft seeds it back so an accidental Escape doesn't
+  // restart the rite. Read once per mount; cleared on a successful summon.
+  const draft = useRef(readSummoningDraft()).current;
+  const draftVessel: VesselKind | null =
+    draft?.vessel === "local" || draft?.vessel === "ssh" || draft?.vessel === "openclaw"
+      ? draft.vessel
+      : null;
+  const [stage, setStage] = useState<StageIndex>((draft?.stage ?? 0) as StageIndex);
   // Stages the user has reached — sigil chips for these are clickable.
-  const [maxVisited, setMaxVisited] = useState<StageIndex>(0);
+  const [maxVisited, setMaxVisited] = useState<StageIndex>((draft?.maxVisited ?? 0) as StageIndex);
   const [error, setError] = useState<string | null>(null);
   const [summoned, setSummoned] = useState<{ id: string; name: string } | null>(null);
 
   // Stage I — the vessel.
-  const [vessel, setVessel] = useState<VesselKind | null>(null);
+  const [vessel, setVessel] = useState<VesselKind | null>(draftVessel);
   const [harnesses, setHarnesses] = useState<HarnessReport[] | null>(null);
   const [harness, setHarness] = useState<string | null>(
-    defaultHarness && COMPATIBILITY_ADAPTERS.some((a) => a.id === defaultHarness)
-      ? defaultHarness
-      : null,
+    draft?.harness && COMPATIBILITY_ADAPTERS.some((a) => a.id === draft.harness)
+      ? draft.harness
+      : defaultHarness && COMPATIBILITY_ADAPTERS.some((a) => a.id === defaultHarness)
+        ? defaultHarness
+        : null,
   );
   const [agents, setAgents] = useState<OpenClawAgent[] | null>(null);
   const [agentsError, setAgentsError] = useState<string | null>(null);
-  const [agentId, setAgentId] = useState<string | null>(null);
-  const [sshHost, setSshHost] = useState("");
-  const [sshCwd, setSshCwd] = useState("");
-  const [sshCommand, setSshCommand] = useState("");
+  const [agentId, setAgentId] = useState<string | null>(draft?.agentId ?? null);
+  const [sshHost, setSshHost] = useState(draft?.sshHost ?? "");
+  const [sshCwd, setSshCwd] = useState(draft?.sshCwd ?? "");
+  const [sshCommand, setSshCommand] = useState(draft?.sshCommand ?? "");
   const [sshCheck, setSshCheck] = useState<SshCheckState>({ state: "idle" });
 
   // Stage II — the name.
-  const [name, setName] = useState("");
-  const [role, setRole] = useState("");
-  const [description, setDescription] = useState("");
-  const [idOverride, setIdOverride] = useState<string | null>(null);
+  const [name, setName] = useState(draft?.name ?? "");
+  const [role, setRole] = useState(draft?.role ?? "");
+  const [description, setDescription] = useState(draft?.description ?? "");
+  const [idOverride, setIdOverride] = useState<string | null>(draft?.idOverride ?? null);
 
-  // Stage III — the form.
-  const [glyph, setGlyph] = useState<string>(DEFAULT_GLYPH);
+  // Stage III — the form. (The portrait is a File — it can't ride the draft.)
+  const [glyph, setGlyph] = useState<string>(draft?.glyph || DEFAULT_GLYPH);
   const [avatarFile, setAvatarFile] = useState<File | null>(null);
-  const [aura, setAura] = useState<string | null>(null);
+  const [aura, setAura] = useState<string | null>(draft?.aura ?? null);
   const fileRef = useRef<HTMLInputElement | null>(null);
 
   // Stage IV — fine-tuning.
-  const [model, setModel] = useState("");
+  const [model, setModel] = useState(draft?.model ?? "");
+
+  // Persist the rite as it evolves; stop once summoned (success owns the
+  // clear — a re-save from the settle re-render would resurrect the draft).
+  useEffect(() => {
+    if (summoned) return;
+    saveSummoningDraft({
+      stage,
+      maxVisited,
+      vessel,
+      harness,
+      agentId,
+      sshHost,
+      sshCwd,
+      sshCommand,
+      name,
+      role,
+      description,
+      idOverride,
+      glyph,
+      aura,
+      model,
+    });
+  }, [summoned, stage, maxVisited, vessel, harness, agentId, sshHost, sshCwd, sshCommand, name, role, description, idOverride, glyph, aura, model]);
 
   // Load installed runtimes like onboarding did; fall back to the static
   // adapter catalog (installed state unknown) if the probe fails, so the
@@ -493,6 +527,7 @@ function SummoningRite({
         }
       }
       if (aura) setFamiliarOverride(newId, { color: aura });
+      clearSummoningDraft();
       setSummoned({ id: newId, name: name.trim() });
       setSubmitting(false);
       onCreated(newId);

--- a/src/components/onboarding-guided-steps.test.ts
+++ b/src/components/onboarding-guided-steps.test.ts
@@ -365,4 +365,34 @@ assert.match(
   "failed installs expose the full installer output tail",
 );
 
+
+// ── cave-fy1q phase 1: the daemon step auto-starts once ─────────────────────
+
+assert.match(
+  source,
+  /const daemonAutoStartRef = useRef\(false\)/,
+  "one-shot latch is a ref (survives re-renders, StrictMode re-runs)",
+);
+assert.match(
+  source,
+  /if \(s\.daemon\.ok\) \{\s*daemonAutoStartRef\.current = true;\s*return;\s*\}/,
+  "a daemon that's already up latches — a later crash never triggers a surprise auto-start",
+);
+assert.match(
+  source,
+  /if \(!s\.covenCli\.ok \|\| !s\.covenHome\.ok \|\| !s\.adapters\.ok\) return;\s*daemonAutoStartRef\.current = true;\s*void startDaemon\(\);/,
+  "auto-start fires only once the wizard has reached the daemon step (all prior infra healthy)",
+);
+assert.match(
+  source,
+  /\{startingDaemon \? "Starting…" : "Start local daemon"\}/,
+  "the manual button remains — it is the retry affordance when auto-start fails",
+);
+
+assert.match(
+  source,
+  /if \(!open \|\| daemonAutoStartRef\.current\) return;/,
+  "auto-start is gated on the overlay being OPEN — hooks run even while it renders null, and a closed wizard must never start the daemon",
+);
+
 console.log("onboarding-guided-steps.test.ts: ok");

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -890,6 +890,30 @@ export function OnboardingOverlay({ open, onDismiss }: Props) {
     }
   };
 
+  // cave-fy1q phase 1: the daemon is the one infra step that can simply
+  // happen. When the OPEN wizard reaches it (CLI, home, and runtime healthy;
+  // daemon not up), attempt ONE auto-start — the primary button stays as the
+  // retry affordance and the failure path is unchanged. Gated on `open`
+  // because hooks run even while the overlay renders null — a veteran
+  // machine with a stopped daemon must never get a surprise background
+  // start on boot. The ref (not state) survives re-renders, and it latches
+  // when the daemon is already up so a later crash mid-wizard never
+  // auto-restarts either.
+  const daemonAutoStartRef = useRef(false);
+  useEffect(() => {
+    if (!open || daemonAutoStartRef.current) return;
+    const s = status?.steps;
+    if (!s) return;
+    if (s.daemon.ok) {
+      daemonAutoStartRef.current = true;
+      return;
+    }
+    if (!s.covenCli.ok || !s.covenHome.ok || !s.adapters.ok) return;
+    daemonAutoStartRef.current = true;
+    void startDaemon();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, status]);
+
   const saveOnboardingConnection = async () => {
     setSavingOnboardingConnection(true);
     setSetupError(null);

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { SidebarMinimal } from "@/components/sidebar-minimal";
+import { stampFirstOpenOnce } from "@/lib/first-run-stamps";
 import { groupInboxFeed } from "@/lib/inbox-feed";
 import { sameSessionList } from "@/lib/session-list-equal";
 import { arrayContentEqual } from "@/lib/array-content-equal";
@@ -840,6 +841,13 @@ export function Workspace() {
   // mute toggle.
   const inboxPrefsRef = useRef(inboxPrefs);
   inboxPrefsRef.current = inboxPrefs;
+
+  // cave-fy1q phase 3: first-run funnel anchor — written once ever, and only
+  // while onboarding is still undismissed (the lib guards both), so
+  // time-to-first-reply measures fresh installs and never re-anchors old ones.
+  useEffect(() => {
+    stampFirstOpenOnce();
+  }, []);
 
   // Subscribe to the inbox SSE stream: drives the inbox list, toasts, and
   // macOS system notifications. EventSource auto-reconnects on its own.

--- a/src/lib/first-run-stamps.test.ts
+++ b/src/lib/first-run-stamps.test.ts
@@ -1,0 +1,112 @@
+// @ts-nocheck
+// cave-fy1q phase 3 — first-run funnel stamps: measurement only. Pure tests
+// exercise the injectable store; source pins hold the three wiring points
+// (workspace anchor, chat-view reply stamp, analytics surfacing).
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  FIRST_OPEN_AT_KEY,
+  FIRST_REPLY_AT_KEY,
+  stampFirstOpenOnce,
+  stampFirstReplyOnce,
+  timeToFirstReplyMs,
+  formatTimeToFirstReply,
+} from "./first-run-stamps.ts";
+
+function fakeStore(seed = {}) {
+  const m = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => void m.set(k, String(v)),
+    map: m,
+  };
+}
+
+// ── stampFirstOpenOnce ────────────────────────────────────────────────────────
+{
+  const s = fakeStore();
+  stampFirstOpenOnce(s, new Date("2026-07-09T10:00:00Z"));
+  assert.equal(s.map.get(FIRST_OPEN_AT_KEY), "2026-07-09T10:00:00.000Z", "stamps a fresh install");
+  stampFirstOpenOnce(s, new Date("2026-07-09T11:00:00Z"));
+  assert.equal(s.map.get(FIRST_OPEN_AT_KEY), "2026-07-09T10:00:00.000Z", "written once, ever");
+}
+{
+  const s = fakeStore({ "cave:onboarding:dismissed": "1" });
+  stampFirstOpenOnce(s, new Date());
+  assert.equal(s.map.has(FIRST_OPEN_AT_KEY), false, "existing installs (onboarding dismissed) never re-anchor");
+}
+
+// ── stampFirstReplyOnce ───────────────────────────────────────────────────────
+{
+  const s = fakeStore();
+  stampFirstReplyOnce(s, new Date("2026-07-09T10:05:00Z"));
+  assert.equal(s.map.has(FIRST_REPLY_AT_KEY), false, "no anchor → no reply stamp (pre-existing installs)");
+  s.setItem(FIRST_OPEN_AT_KEY, "2026-07-09T10:00:00.000Z");
+  stampFirstReplyOnce(s, new Date("2026-07-09T10:05:00Z"));
+  assert.equal(s.map.get(FIRST_REPLY_AT_KEY), "2026-07-09T10:05:00.000Z", "stamps once the anchor exists");
+  stampFirstReplyOnce(s, new Date("2026-07-09T12:00:00Z"));
+  assert.equal(s.map.get(FIRST_REPLY_AT_KEY), "2026-07-09T10:05:00.000Z", "first reply is immutable");
+}
+
+// ── timeToFirstReplyMs ────────────────────────────────────────────────────────
+assert.equal(timeToFirstReplyMs(fakeStore()), null, "no stamps → null");
+assert.equal(
+  timeToFirstReplyMs(fakeStore({ [FIRST_OPEN_AT_KEY]: "2026-07-09T10:00:00.000Z" })),
+  null,
+  "anchor only → null",
+);
+assert.equal(
+  timeToFirstReplyMs(
+    fakeStore({
+      [FIRST_OPEN_AT_KEY]: "2026-07-09T10:00:00.000Z",
+      [FIRST_REPLY_AT_KEY]: "2026-07-09T10:07:30.000Z",
+    }),
+  ),
+  450_000,
+  "delta in ms",
+);
+assert.equal(
+  timeToFirstReplyMs(
+    fakeStore({
+      [FIRST_OPEN_AT_KEY]: "2026-07-09T10:00:00.000Z",
+      [FIRST_REPLY_AT_KEY]: "2026-07-09T09:00:00.000Z",
+    }),
+  ),
+  null,
+  "clock-skewed negative delta → null, never a lie",
+);
+
+// ── formatTimeToFirstReply ────────────────────────────────────────────────────
+assert.equal(formatTimeToFirstReply(42_000), "42s");
+assert.equal(formatTimeToFirstReply(18 * 60_000), "18m");
+assert.equal(formatTimeToFirstReply(3 * 3_600_000 + 20 * 60_000), "3h 20m");
+assert.equal(formatTimeToFirstReply(2 * 86_400_000 + 4 * 3_600_000), "2d 4h");
+assert.equal(formatTimeToFirstReply(24 * 3_600_000), "1d");
+
+// ── Wiring pins ───────────────────────────────────────────────────────────────
+const workspace = await readFile(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+const analytics = await readFile(new URL("../components/familiar-analytics-view.tsx", import.meta.url), "utf8");
+
+assert.match(
+  workspace,
+  /useEffect\(\(\) => \{\s*stampFirstOpenOnce\(\);\s*\}, \[\]\)/,
+  "workspace stamps the first-open anchor once on mount",
+);
+assert.match(
+  chatView,
+  /\} else \{[^}]*stampFirstReplyOnce\(\);/,
+  "chat-view stamps the first reply only on a non-error done",
+);
+assert.match(
+  analytics,
+  /first reply \{timeToFirstReply\} after first open/,
+  "the session-pulse header surfaces time-to-first-reply",
+);
+assert.match(
+  analytics,
+  /timeToFirstReply \? </,
+  "the funnel line hides entirely when the stamps are absent",
+);
+
+console.log("first-run-stamps.test.ts: ok");

--- a/src/lib/first-run-stamps.ts
+++ b/src/lib/first-run-stamps.ts
@@ -1,0 +1,73 @@
+// cave-fy1q phase 3: first-run funnel stamps — measurement only. Two keys,
+// each written once ever: first app open (only stamped while onboarding is
+// still undismissed, so existing installs never fake a fresh funnel) and the
+// first completed familiar reply (only stamped when a first-open exists).
+// Time-to-first-reply is the delta the analytics header surfaces.
+
+export const FIRST_OPEN_AT_KEY = "cave:first-open-at";
+export const FIRST_REPLY_AT_KEY = "cave:first-reply-at";
+const ONBOARDING_DISMISSED_KEY = "cave:onboarding:dismissed";
+
+type StringStore = Pick<Storage, "getItem" | "setItem">;
+
+function defaultStore(): StringStore | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Stamp the first app open — only on a machine still mid-onboarding, so the
+ *  funnel measures fresh installs and never re-anchors an existing one. */
+export function stampFirstOpenOnce(store: StringStore | null = defaultStore(), now = new Date()): void {
+  if (!store) return;
+  try {
+    if (store.getItem(FIRST_OPEN_AT_KEY)) return;
+    if (store.getItem(ONBOARDING_DISMISSED_KEY)) return;
+    store.setItem(FIRST_OPEN_AT_KEY, now.toISOString());
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Stamp the first completed reply — requires a first-open anchor, so
+ *  pre-existing installs (no anchor) never record a meaningless delta. */
+export function stampFirstReplyOnce(store: StringStore | null = defaultStore(), now = new Date()): void {
+  if (!store) return;
+  try {
+    if (store.getItem(FIRST_REPLY_AT_KEY)) return;
+    if (!store.getItem(FIRST_OPEN_AT_KEY)) return;
+    store.setItem(FIRST_REPLY_AT_KEY, now.toISOString());
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Milliseconds from first open to first reply, when both stamps exist. */
+export function timeToFirstReplyMs(store: StringStore | null = defaultStore()): number | null {
+  if (!store) return null;
+  try {
+    const open = store.getItem(FIRST_OPEN_AT_KEY);
+    const reply = store.getItem(FIRST_REPLY_AT_KEY);
+    if (!open || !reply) return null;
+    const ms = Date.parse(reply) - Date.parse(open);
+    return Number.isFinite(ms) && ms >= 0 ? ms : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Compact human form: "42s", "18m", "3h 20m", "2d 4h". */
+export function formatTimeToFirstReply(ms: number): string {
+  const s = Math.max(0, Math.round(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  const remM = m % 60;
+  if (h < 24) return remM > 0 ? `${h}h ${remM}m` : `${h}h`;
+  const d = Math.floor(h / 24);
+  const remH = h % 24;
+  return remH > 0 ? `${d}d ${remH}h` : `${d}d`;
+}

--- a/src/lib/summoning-draft.test.ts
+++ b/src/lib/summoning-draft.test.ts
@@ -1,0 +1,103 @@
+// @ts-nocheck
+// cave-fy1q phase 2 — the summoning circle's per-window draft: Escape closes
+// the rite (unmount resets state by design) but reopening seeds right back.
+// Pure tests exercise coercion/clamping; source pins hold the circle wiring.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  SUMMONING_DRAFT_KEY,
+  readSummoningDraft,
+  saveSummoningDraft,
+  clearSummoningDraft,
+} from "./summoning-draft.ts";
+
+function fakeStore(seed = {}) {
+  const m = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => (m.has(k) ? m.get(k) : null),
+    setItem: (k, v) => void m.set(k, String(v)),
+    removeItem: (k) => void m.delete(k),
+    map: m,
+  };
+}
+
+const full = {
+  stage: 2,
+  maxVisited: 2,
+  vessel: "local",
+  harness: "claude-code",
+  agentId: null,
+  sshHost: "",
+  sshCwd: "",
+  sshCommand: "",
+  name: "Nyx",
+  role: "Researcher",
+  description: "Digs deep.",
+  idOverride: null,
+  glyph: "✶",
+  aura: "#a78bfa",
+  model: "claude-fable-5",
+};
+
+// ── Round trip ────────────────────────────────────────────────────────────────
+{
+  const s = fakeStore();
+  saveSummoningDraft(full, s);
+  assert.deepEqual(readSummoningDraft(s), full, "save → read is lossless");
+  clearSummoningDraft(s);
+  assert.equal(readSummoningDraft(s), null, "clear removes the draft");
+}
+
+// ── Coercion: a stale or hand-edited payload can never seed invalid state ────
+{
+  const s = fakeStore({
+    [SUMMONING_DRAFT_KEY]: JSON.stringify({
+      stage: 9,
+      maxVisited: -3,
+      vessel: 42,
+      name: ["not", "a", "string"],
+      glyph: null,
+    }),
+  });
+  const d = readSummoningDraft(s);
+  assert.equal(d.stage, 3, "stage clamps to the last rite stage");
+  assert.equal(d.maxVisited, 3, "maxVisited never trails the restored stage");
+  assert.equal(d.vessel, null, "non-string vessel drops to null");
+  assert.equal(d.name, "", "non-string text fields drop to empty");
+  assert.equal(d.glyph, "", "null glyph reads as empty (caller falls back to the default)");
+}
+assert.equal(readSummoningDraft(fakeStore({ [SUMMONING_DRAFT_KEY]: "{not json" })), null, "junk JSON → null");
+assert.equal(readSummoningDraft(fakeStore({ [SUMMONING_DRAFT_KEY]: "null" })), null, "JSON null → null");
+assert.equal(readSummoningDraft(fakeStore()), null, "absent → null");
+assert.equal(readSummoningDraft(null), null, "no storage (SSR) → null");
+
+// ── Circle wiring pins ────────────────────────────────────────────────────────
+const circle = await readFile(new URL("../components/familiar-summoning-circle.tsx", import.meta.url), "utf8");
+
+assert.match(
+  circle,
+  /const draft = useRef\(readSummoningDraft\(\)\)\.current/,
+  "the rite reads the draft once per mount",
+);
+assert.match(
+  circle,
+  /Mounted only while open — state resets by unmounting/,
+  "the unmount-reset design stays (the draft seeds it back, not a reset())",
+);
+assert.match(
+  circle,
+  /if \(summoned\) return;\s*saveSummoningDraft\(/,
+  "the save effect stops once summoned so the clear can't be raced",
+);
+assert.match(
+  circle,
+  /clearSummoningDraft\(\);\s*setSummoned\(/,
+  "a successful summon clears the draft",
+);
+assert.match(
+  circle,
+  /useState<string>\(draft\?\.glyph \|\| DEFAULT_GLYPH\)/,
+  "an empty drafted glyph falls back to the default sigil",
+);
+
+console.log("summoning-draft.test.ts: ok");

--- a/src/lib/summoning-draft.ts
+++ b/src/lib/summoning-draft.ts
@@ -1,0 +1,88 @@
+// cave-fy1q phase 2: the summoning circle resets by unmounting (by design —
+// see SummoningCircleOverlay), so an accidental Escape used to restart the
+// whole rite. This per-window sessionStorage draft seeds the rite's state
+// back on reopen; a successful summon clears it. Framework-free and
+// storage-injectable so it tests without a DOM.
+
+export const SUMMONING_DRAFT_KEY = "cave:summoning-draft:v1";
+
+export type SummoningDraft = {
+  stage: number;
+  maxVisited: number;
+  vessel: string | null;
+  harness: string | null;
+  agentId: string | null;
+  sshHost: string;
+  sshCwd: string;
+  sshCommand: string;
+  name: string;
+  role: string;
+  description: string;
+  idOverride: string | null;
+  glyph: string;
+  aura: string | null;
+  model: string;
+};
+
+type StringStore = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function defaultStore(): StringStore | null {
+  try {
+    return typeof window === "undefined" ? null : window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse the stored draft, coercing every field so a stale or hand-edited
+ *  payload can never seed invalid state (stages clamp to 0–3). */
+export function readSummoningDraft(store: StringStore | null = defaultStore()): SummoningDraft | null {
+  if (!store) return null;
+  try {
+    const raw = store.getItem(SUMMONING_DRAFT_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<SummoningDraft> | null;
+    if (!parsed || typeof parsed !== "object") return null;
+    const stageOf = (v: unknown) =>
+      typeof v === "number" && Number.isFinite(v) ? Math.min(3, Math.max(0, Math.trunc(v))) : 0;
+    const str = (v: unknown) => (typeof v === "string" ? v : "");
+    const strOrNull = (v: unknown) => (typeof v === "string" && v ? v : null);
+    return {
+      stage: stageOf(parsed.stage),
+      maxVisited: Math.max(stageOf(parsed.maxVisited), stageOf(parsed.stage)),
+      vessel: strOrNull(parsed.vessel),
+      harness: strOrNull(parsed.harness),
+      agentId: strOrNull(parsed.agentId),
+      sshHost: str(parsed.sshHost),
+      sshCwd: str(parsed.sshCwd),
+      sshCommand: str(parsed.sshCommand),
+      name: str(parsed.name),
+      role: str(parsed.role),
+      description: str(parsed.description),
+      idOverride: strOrNull(parsed.idOverride),
+      glyph: str(parsed.glyph),
+      aura: strOrNull(parsed.aura),
+      model: str(parsed.model),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveSummoningDraft(draft: SummoningDraft, store: StringStore | null = defaultStore()): void {
+  if (!store) return;
+  try {
+    store.setItem(SUMMONING_DRAFT_KEY, JSON.stringify(draft));
+  } catch {
+    /* storage full/blocked — the draft is best-effort */
+  }
+}
+
+export function clearSummoningDraft(store: StringStore | null = defaultStore()): void {
+  if (!store) return;
+  try {
+    store.removeItem(SUMMONING_DRAFT_KEY);
+  } catch {
+    /* best-effort */
+  }
+}


### PR DESCRIPTION
## Golden path 1 — first run → first conversation (docs/golden-paths.md §1, bead `cave-fy1q`)

**Story:** a new user should go from opening the app to a familiar answering them in minutes — today the daemon step is a manual click, an accidental Escape restarts the whole summoning rite, and the funnel isn't measurable.

### Phase 1 — the daemon just starts
When the **open** wizard reaches the daemon step (CLI + home + runtime healthy, daemon down), one auto-attempt fires through the existing `startDaemon` path. The button remains as the retry affordance; the failure/diagnostics path is byte-identical. Two safety latches, both pinned:
- Gated on `open` — hooks run even while the overlay renders `null`, so a veteran machine with a merely-stopped daemon never gets a surprise background start on boot (this exact e2e scenario exists: `tests/onboarding-wizard.spec.ts` "does not relaunch…", which never mounts the wizard).
- A ref latches after one attempt, and latches when the daemon is already up — a later crash mid-wizard never auto-restarts.

### Phase 2 — the rite survives Escape
The circle still resets by unmounting (the design comment stays true) — but a per-window `sessionStorage` draft (new `src/lib/summoning-draft.ts`) seeds every stage back on reopen: stage position, vessel (local/SSH/OpenClaw + fields), name/role/description, glyph/aura, model override. Every field is coerced and stage-clamped on read so a stale payload can never seed invalid state. Cleared on a successful summon; the save effect stops once `summoned` so the settle re-render can't resurrect the draft. The portrait is a `File` and deliberately doesn't ride along.

### Phase 3 — measure the funnel (measurement only)
New `src/lib/first-run-stamps.ts`: `cave:first-open-at` stamps once, **only while onboarding is undismissed** — existing installs never fake a fresh funnel; `cave:first-reply-at` stamps on the first non-error `done` event, **only when the anchor exists**. The familiar-analytics pulse header gains "· first reply 7m after first open" while both stamps exist (sampled after mount; hidden otherwise). Negative clock-skew deltas read as null, never a lie.

### Verification
- `pnpm typecheck` clean and `pnpm test:app` **574 files green** (both read from raw output, not pipe exits) — includes the two new suites `first-run-stamps.test.ts` + `summoning-draft.test.ts` (wired into `run-tests`), extended pins in `onboarding-guided-steps.test.ts` (auto-start gates, open-gate, retry button) and `familiar-summoning-circle.test.ts` still green.
- E2E untouched: the wizard spec's daemon-down scenario asserts the wizard never opens; with the open-gate the closed overlay stays inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)