### PR TITLE
feat(calendar): redesign the agenda as a scannable timeline + cron cadence chips

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -254,6 +254,7 @@ export const SUITES = {
     "src/components/board-link-browser.test.ts",
     "src/components/new-card-modal.test.ts",
     "src/components/calendar-view-polish.test.ts",
+    "src/components/calendar-agenda-redesign.test.ts",
     "src/lib/calendar-layout.test.ts",
     "src/lib/canvas-layout.test.ts",
     "src/lib/canvas-artifacts.test.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7561,6 +7561,299 @@ a.mobile-handoff__link:hover {
   }
 }
 
+/* ── Calendar agenda (timeline) ──────────────────────────────────────────────
+   The agenda reads as one vertical thread per day: a date badge, then rows laid
+   out on a [time · spine · body · cue] grid with a connecting rail behind the
+   dots. Semantic tokens only, so it tracks every theme. */
+.cal-agenda-group {
+  padding-bottom: 14px;
+}
+.cal-agenda-group + .cal-agenda-group {
+  padding-top: 6px;
+}
+
+/* Sticky day header — the date context stays put as the list scrolls. */
+.cal-agenda-dayhead {
+  position: sticky;
+  top: -12px;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 4px 10px;
+  background: linear-gradient(
+    to bottom,
+    var(--bg-base) 62%,
+    color-mix(in oklch, var(--bg-base) 40%, transparent)
+  );
+}
+.cal-agenda-datebadge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  border-radius: 11px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  line-height: 1;
+}
+.cal-agenda-dow {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.cal-agenda-dnum {
+  font-size: 17px;
+  font-weight: 650;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  margin-top: 1px;
+}
+.cal-agenda-group.is-today .cal-agenda-datebadge {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 16%, var(--bg-raised));
+}
+.cal-agenda-group.is-today .cal-agenda-dow,
+.cal-agenda-group.is-today .cal-agenda-dnum {
+  color: var(--accent-presence);
+}
+.cal-agenda-daylabel {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.cal-agenda-daylabel-main {
+  font-size: 13px;
+  font-weight: 650;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.cal-agenda-group.is-today .cal-agenda-daylabel-main {
+  color: var(--accent-presence);
+}
+.cal-agenda-daylabel-sub {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-top: 1px;
+}
+.cal-agenda-count {
+  flex-shrink: 0;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-hairline);
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+}
+
+.cal-agenda-list {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Row: fixed clock column, a spine that draws the connecting rail, the body,
+   and an optional right-hand relative cue. */
+.cal-agenda-row {
+  display: grid;
+  grid-template-columns: 62px 22px 1fr auto;
+  align-items: center;
+  column-gap: 8px;
+  width: 100%;
+  padding: 5px 8px;
+  border-radius: 9px;
+  text-align: left;
+  transition: background-color 120ms ease;
+}
+.cal-agenda-row:hover {
+  background: var(--bg-raised);
+}
+.cal-agenda-time {
+  justify-self: end;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.cal-agenda-time.is-next {
+  color: var(--accent-presence);
+  font-weight: 600;
+}
+.cal-agenda-time.is-overdue {
+  color: var(--color-warning);
+}
+.cal-agenda-time.is-due {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in oklch, var(--color-warning) 88%, var(--text-muted));
+}
+
+/* Spine: the connecting rail is a pseudo-element that runs the row's full
+   height; the dot sits on top so consecutive rows read as one thread. */
+.cal-agenda-spine {
+  position: relative;
+  justify-self: center;
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.cal-agenda-spine::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1.5px;
+  background: color-mix(in oklch, var(--text-muted) 30%, transparent);
+}
+.cal-agenda-group.is-today .cal-agenda-spine::before {
+  background: color-mix(in oklch, var(--accent-presence) 32%, transparent);
+}
+.cal-agenda-list > .cal-agenda-row:first-child .cal-agenda-spine::before {
+  top: 50%;
+}
+.cal-agenda-list > .cal-agenda-row:last-child .cal-agenda-spine::before {
+  bottom: 50%;
+}
+.cal-agenda-dot {
+  position: relative;
+  z-index: 1;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  outline: 3px solid var(--bg-base);
+}
+.cal-agenda-row:hover .cal-agenda-dot {
+  outline-color: var(--bg-raised);
+}
+.cal-agenda-dot-check {
+  position: relative;
+  z-index: 1;
+  font-size: 13px;
+  color: var(--text-muted);
+  background: var(--bg-base);
+  border-radius: 999px;
+}
+.cal-agenda-row:hover .cal-agenda-dot-check {
+  background: var(--bg-raised);
+}
+.cal-agenda-dot--task {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  color: var(--color-warning);
+  background: color-mix(in oklch, var(--color-warning) 16%, var(--bg-base));
+}
+
+.cal-agenda-body {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.cal-agenda-platform {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.cal-agenda-title {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.cal-agenda-row.is-done .cal-agenda-title {
+  color: var(--text-muted);
+}
+
+/* Right-hand cues. */
+.cal-agenda-rel {
+  justify-self: end;
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.cal-agenda-rel.is-next {
+  color: var(--accent-presence);
+  font-weight: 600;
+}
+.cal-agenda-rel.is-overdue {
+  color: var(--color-warning);
+}
+.cal-agenda-next {
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  height: 17px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--accent-presence);
+  color: var(--accent-presence-foreground);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.cal-agenda-tag {
+  justify-self: end;
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  padding: 0 6px;
+  border-radius: 5px;
+  border: 1px solid color-mix(in oklch, var(--color-warning) 35%, transparent);
+  background: color-mix(in oklch, var(--color-warning) 12%, transparent);
+  color: color-mix(in oklch, var(--color-warning) 90%, var(--text-secondary));
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+/* Next-up row: a quiet accent wash + edge so the soonest item is obvious. */
+.cal-agenda-row.is-next {
+  background: color-mix(in oklch, var(--accent-presence) 9%, transparent);
+  box-shadow: inset 2px 0 0 var(--accent-presence);
+}
+.cal-agenda-row.is-next:hover {
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+}
+.cal-agenda-row.is-done {
+  opacity: 0.6;
+}
+.cal-agenda-row.is-overdue .cal-agenda-dot {
+  animation: cal-agenda-pulse 2.4s ease-in-out infinite;
+}
+@keyframes cal-agenda-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cal-agenda-row.is-overdue .cal-agenda-dot { animation: none; }
+}
+
 /* Chat mobile command center refinements. These classes are intentionally
    plain CSS hooks around Tailwind-heavy components so phone-specific layout
    can be adjusted without threading conditional class strings through every

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7854,6 +7854,29 @@ a.mobile-handoff__link:hover {
   .cal-agenda-row.is-overdue .cal-agenda-dot { animation: none; }
 }
 
+/* Cron (Codex automation) schedule cue — a quiet clock pill so the cadence reads
+   as a scheduled thing, matching the agenda's timeline language. */
+.cron-schedule-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.cron-schedule-chip__icon {
+  color: var(--text-muted);
+}
+.automation-list-row:hover .cron-schedule-chip,
+.automation-list-row[aria-current="true"] .cron-schedule-chip {
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, var(--border-hairline));
+}
+
 /* Chat mobile command center refinements. These classes are intentionally
    plain CSS hooks around Tailwind-heavy components so phone-specific layout
    can be adjusted without threading conditional class strings through every

--- a/src/components/automations-view.tsx
+++ b/src/components/automations-view.tsx
@@ -1243,8 +1243,9 @@ function AutomationScheduleRow({
             Run {relTime(lastRun.startedAt)}
           </span>
         )}
-        <span className="shrink-0 text-[12px] tabular-nums" style={{ color: "var(--text-muted)" }}>
-          {auto.scheduleHuman}
+        <span className="cron-schedule-chip shrink-0" title={`Runs ${auto.scheduleHuman}`}>
+          <Icon name="ph:clock" width={11} aria-hidden className="cron-schedule-chip__icon" />
+          <span className="tabular-nums">{auto.scheduleHuman}</span>
         </span>
       </button>
       {actions && (

--- a/src/components/calendar-agenda-redesign.test.ts
+++ b/src/components/calendar-agenda-redesign.test.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const view = readFileSync(new URL("./calendar-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+
+// ── Agenda "timeline" redesign ───────────────────────────────────────────────
+// The agenda reads as one vertical thread per day: a date badge header, rows on
+// a [time · spine · body · cue] grid, relative "what's next" cues, a highlighted
+// next-up item, and task deadlines tinted distinctly from reminders.
+
+// Relative-time helper drives the "in 2h / 40m ago / now" cue.
+assert.match(view, /function relTimeShort\(target: Date, now: Date\): string \| null/, "a compact relative-time helper exists");
+assert.match(view, /return mins > 0 \? `in \$\{abs\}m` : `\$\{abs\}m ago`/, "relTimeShort renders minute-scale in/ago");
+assert.match(view, /if \(abs < 60 \* 12\)/, "relTimeShort caps at a ~12h window (else null)");
+
+// The single soonest pending item is computed and threaded as isNext.
+assert.match(view, /const nextId = useMemo\(\(\) => \{/, "AgendaView computes the next-up item id");
+assert.match(view, /it\.status === "done" \|\| it\.status === "dismissed"/, "next-up skips done/dismissed items");
+assert.match(view, /isNext=\{item\.id === nextId\}/, "the next-up item is flagged on its row");
+
+// The row renders the timeline grid pieces + keeps the AT-only familiar name.
+assert.match(view, /className="cal-agenda-time/, "the row has a fixed clock column");
+assert.match(view, /className="cal-agenda-spine"/, "the row has a spine column for the connecting rail");
+assert.match(view, /\{familiarName && <span className="sr-only">, \{familiarName\}<\/span>\}/, "the agenda row keeps the AT-only familiar name");
+assert.match(view, /isNext \? <span className="cal-agenda-next">Next<\/span> : null/, "a next-up row shows a Next tag");
+
+// Day-group headers carry a date badge (weekday over day-number) + count pill.
+assert.match(view, /className="cal-agenda-datebadge"/, "each day group has a date badge");
+assert.match(view, /className="cal-agenda-dow">\{WEEKDAYS\[date\.getDay\(\)\]\}/, "the badge shows the weekday");
+assert.match(view, /className="cal-agenda-dnum">\{date\.getDate\(\)\}/, "the badge shows the day number");
+assert.match(view, /className={`cal-agenda-group\$\{isToday \? " is-today" : ""\}`}/, "today's group is marked for accent treatment");
+
+// Board deadlines render in the same timeline grid but tinted "task", so a due
+// date is never mistaken for a scheduled reminder.
+assert.match(view, /function AgendaDeadlineRow\(/, "deadlines get a dedicated agenda row");
+assert.match(view, /<AgendaDeadlineRow key=\{d\.id\} deadline=\{d\} onOpen=\{onOpenDeadline\}/, "the agenda list uses AgendaDeadlineRow");
+assert.match(view, /className="cal-agenda-tag">Task/, "a deadline row is tagged Task");
+
+// The styles exist and are token-driven (theme-safe).
+assert.match(css, /\.cal-agenda-row \{[\s\S]*?grid-template-columns: 62px 22px 1fr auto/, "the agenda row is a fixed timeline grid");
+assert.match(css, /\.cal-agenda-spine::before \{[\s\S]*?background: color-mix\(in oklch, var\(--text-muted\)/, "the spine draws a connecting rail");
+assert.match(css, /\.cal-agenda-row\.is-next \{[\s\S]*?box-shadow: inset 2px 0 0 var\(--accent-presence\)/, "the next-up row gets an accent edge");
+assert.match(css, /\.cal-agenda-dayhead \{[\s\S]*?position: sticky/, "day headers stick as the list scrolls");
+// Overdue pulse honours reduced motion.
+assert.match(css, /@media \(prefers-reduced-motion: reduce\) \{\s*\.cal-agenda-row\.is-overdue \.cal-agenda-dot \{ animation: none; \}/, "the overdue pulse is disabled under reduced motion");
+
+console.log("calendar-agenda-redesign.test.ts: ok");

--- a/src/components/calendar-view.tsx
+++ b/src/components/calendar-view.tsx
@@ -138,6 +138,22 @@ function agendaDayLabel(date: Date, now: Date = new Date()): string {
   return relDayWord(date, now) ?? fmtDateHeading(date);
 }
 
+// Compact "time until / since" for agenda rows — the affordance that answers
+// "what's next" at a glance ("now", "in 25m", "in 3h", "40m ago"). Only
+// meaningful inside a ~12h window; beyond that the day header already carries
+// the date, so we return null and the row shows just its clock time.
+function relTimeShort(target: Date, now: Date): string | null {
+  const mins = Math.round((target.getTime() - now.getTime()) / 60_000);
+  const abs = Math.abs(mins);
+  if (abs < 1) return "now";
+  if (abs < 60) return mins > 0 ? `in ${abs}m` : `${abs}m ago`;
+  if (abs < 60 * 12) {
+    const hrs = Math.round(abs / 60);
+    return mins > 0 ? `in ${hrs}h` : `${hrs}h ago`;
+  }
+  return null;
+}
+
 // A hydration-safe, live-ticking "now". Null on the server / first client
 // render (so today-highlights and the now-line aren't painted into SSR markup,
 // which would mismatch the client clock), then resolves on mount and re-ticks
@@ -240,37 +256,96 @@ function platformIcon(item: InboxItem): IconName {
 
 // ─── Item chip (shared across views) ──────────────────────────────────────────
 
+// A single agenda row, laid out as a timeline entry: a fixed left clock column,
+// a spine dot threaded by the day's vertical rail, the title, and a right-hand
+// "in 2h" relative cue. `isNext` marks the soonest upcoming item so the agenda
+// answers "what's next" without the user hunting for it.
 function ItemChip({
   item,
   onClick,
+  isNext = false,
+  now = null,
 }: {
   item: InboxItem;
   onClick?: () => void;
+  isNext?: boolean;
+  now?: Date | null;
 }) {
   const done = item.status === "done";
+  const overdue = isOverdueReminder(item);
   const accent = useFamiliarAccent(item.familiarId);
   const familiarName = useFamiliarName(item.familiarId);
+  const iso = item.fireAt ?? item.firedAt ?? null;
+  const rel = iso && now && !done ? relTimeShort(new Date(iso), now) : null;
   return (
     <button
       onClick={onClick}
       title={familiarName ? `${item.title} — ${familiarName}` : item.title}
-      style={accent ? { borderLeftColor: accent, borderLeftWidth: 3 } : undefined}
-      className={`focus-ring group flex w-full items-center gap-1.5 rounded-md border border-[var(--border-hairline)] px-2 py-2.5 text-left text-[13px] transition-colors md:py-1 md:text-[11px] ${done ? "bg-[var(--bg-base)] opacity-60 hover:bg-[var(--bg-raised)]" : "bg-[var(--bg-raised)] hover:bg-[var(--bg-elevated)]"}`}
+      className={`cal-agenda-row focus-ring group${done ? " is-done" : ""}${isNext ? " is-next" : ""}${overdue ? " is-overdue" : ""}`}
     >
-      {done
-        ? <Icon name="ph:check-circle" className="shrink-0 text-[var(--text-muted)] text-[12px]" />
-        : <span role="img" aria-label={urgencyLabel(item)} title={urgencyLabel(item)} className={`h-1.5 w-1.5 shrink-0 rounded-full ${urgencyColor(item)}`} />}
-      <Icon
-        name={platformIcon(item)}
-        className="shrink-0 text-[var(--text-muted)] text-[12px]"
-      />
-      <span className={`flex-1 truncate text-[var(--text-primary)] ${done ? "line-through" : ""}`}>{item.title}</span>
-      {familiarName && <span className="sr-only">, {familiarName}</span>}
-      {(item.fireAt ?? item.firedAt) && (
-        <span className="shrink-0 text-[var(--text-muted)]">
-          {fmtTime((item.fireAt ?? item.firedAt)!)}
+      <span className={`cal-agenda-time${overdue ? " is-overdue" : ""}${isNext ? " is-next" : ""}`}>
+        {iso ? fmtTime(iso) : "—"}
+      </span>
+      <span className="cal-agenda-spine" aria-hidden>
+        {done ? (
+          <Icon name="ph:check-circle" className="cal-agenda-dot-check" />
+        ) : (
+          <span
+            role="img"
+            aria-label={urgencyLabel(item)}
+            title={urgencyLabel(item)}
+            className={`cal-agenda-dot ${urgencyColor(item)}`}
+            style={accent ? { boxShadow: `0 0 0 2.5px color-mix(in oklch, ${accent} 60%, transparent)` } : undefined}
+          />
+        )}
+      </span>
+      <span className="cal-agenda-body">
+        <Icon name={platformIcon(item)} className="cal-agenda-platform" aria-hidden />
+        <span className={`cal-agenda-title${done ? " line-through" : ""}`}>{item.title}</span>
+        {familiarName && <span className="sr-only">, {familiarName}</span>}
+      </span>
+      {isNext ? <span className="cal-agenda-next">Next</span> : null}
+      {rel ? <span className={`cal-agenda-rel${overdue ? " is-overdue" : ""}${isNext ? " is-next" : ""}`}>{rel}</span> : null}
+    </button>
+  );
+}
+
+// A board task's due date, rendered in the same timeline grid as reminders so
+// the agenda reads as one thread — but tinted "task" (warning) and tagged, so a
+// deadline is never mistaken for a scheduled reminder.
+function AgendaDeadlineRow({
+  deadline,
+  onOpen,
+}: {
+  deadline: CalendarDeadline;
+  onOpen?: (id: string) => void;
+}) {
+  const done = deadline.status === "done";
+  const accent = useFamiliarAccent(deadline.familiarId);
+  const familiarName = useFamiliarName(deadline.familiarId);
+  return (
+    <button
+      type="button"
+      data-calendar-deadline="true"
+      onClick={(e) => { e.stopPropagation(); onOpen?.(deadline.id); }}
+      title={`${deadline.title} — task deadline${familiarName ? ` — ${familiarName}` : ""}`}
+      aria-label={`${deadline.title}, task deadline${done ? ", done" : ""}${familiarName ? `, ${familiarName}` : ""}`}
+      className={`cal-agenda-row cal-agenda-row--task focus-ring group${done ? " is-done" : ""}`}
+    >
+      <span className="cal-agenda-time is-due">Due</span>
+      <span className="cal-agenda-spine" aria-hidden>
+        <span
+          className="cal-agenda-dot cal-agenda-dot--task"
+          style={accent ? { boxShadow: `0 0 0 2.5px color-mix(in oklch, ${accent} 60%, transparent)` } : undefined}
+        >
+          <Icon name="ph:clock-countdown" width={9} aria-hidden />
         </span>
-      )}
+      </span>
+      <span className="cal-agenda-body">
+        <span className={`cal-agenda-title${done ? " line-through opacity-70" : ""}`}>{deadline.title}</span>
+        {familiarName && <span className="sr-only">, {familiarName}</span>}
+      </span>
+      <span className="cal-agenda-tag">Task</span>
     </button>
   );
 }
@@ -356,6 +431,21 @@ function AgendaView({
         : a.date.getTime() - b.date.getTime());
   }, [items, deadlines, anchor, showPast]);
 
+  // The single soonest still-pending item — highlighted as "Next" so the agenda
+  // answers "what's up next" without the user scanning for it.
+  const nextId = useMemo(() => {
+    if (!now) return null;
+    const t = now.getTime();
+    let best: { id: string; ms: number } | null = null;
+    for (const it of items) {
+      if (it.status === "done" || it.status === "dismissed") continue;
+      const d = itemDate(it);
+      if (!d || d.getTime() < t) continue;
+      if (!best || d.getTime() < best.ms) best = { id: it.id, ms: d.getTime() };
+    }
+    return best?.id ?? null;
+  }, [items, now]);
+
   if (groups.length === 0) {
     return (
       <div className="flex min-h-[220px] flex-1 flex-col items-center justify-center gap-3 px-4 py-12 text-center text-sm text-[var(--text-muted)]">
@@ -386,9 +476,9 @@ function AgendaView({
   }
 
   return (
-    <div className="flex flex-col gap-6 overflow-y-auto px-3 py-4 sm:px-6">
+    <div className="cal-agenda-scroll flex flex-col overflow-y-auto px-3 py-3 sm:px-5">
       {showPast ? (
-        <div className="-mb-2 flex justify-end">
+        <div className="mb-1 flex justify-end">
           <Button
             variant="ghost"
             size="xs"
@@ -401,25 +491,28 @@ function AgendaView({
       ) : null}
       {groups.map(({ date, items: groupItems, deadlines: groupDeadlines }) => {
         const total = groupItems.length + groupDeadlines.length;
+        const isToday = !!now && isSameDay(date, now);
+        const relWord = now ? relDayWord(date, now) : null;
         return (
-        <div key={date.toISOString()}>
-          <div className="mb-2 flex items-center gap-2 rounded-md border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-base)_86%,var(--foreground)_14%)] px-3 py-1.5">
-            <span
-              className={`text-[12px] font-bold uppercase tracking-wider ${
-                now && isSameDay(date, now)
-                  ? "text-[var(--accent-presence)]"
-                  : "text-[var(--text-primary)]"
-              }`}
-            >
-              {now ? agendaDayLabel(date, now) : fmtDateHeading(date)}
+        <div key={date.toISOString()} className={`cal-agenda-group${isToday ? " is-today" : ""}`}>
+          <div className="cal-agenda-dayhead">
+            <span className="cal-agenda-datebadge" aria-hidden>
+              <span className="cal-agenda-dow">{WEEKDAYS[date.getDay()]}</span>
+              <span className="cal-agenda-dnum">{date.getDate()}</span>
             </span>
-            <span className="ml-auto font-mono text-[11px] text-[var(--text-secondary)] opacity-80">
-              {total} item{total !== 1 ? "s" : ""}
+            <span className="cal-agenda-daylabel">
+              <span className="cal-agenda-daylabel-main">
+                {now ? agendaDayLabel(date, now) : fmtDateHeading(date)}
+              </span>
+              {relWord ? (
+                <span className="cal-agenda-daylabel-sub">{MONTHS[date.getMonth()]} {date.getDate()}, {date.getFullYear()}</span>
+              ) : null}
             </span>
+            <span className="cal-agenda-count" title={`${total} item${total !== 1 ? "s" : ""}`}>{total}</span>
           </div>
-          <div className="flex flex-col gap-1">
+          <div className="cal-agenda-list">
             {groupDeadlines.map((d) => (
-              <DeadlineChip key={d.id} deadline={d} onOpen={onOpenDeadline} />
+              <AgendaDeadlineRow key={d.id} deadline={d} onOpen={onOpenDeadline} />
             ))}
             {[...groupItems]
               // Order by the same key the day bucket uses (itemDate: fireAt ??
@@ -430,6 +523,8 @@ function AgendaView({
                 <ItemChip
                   key={item.id}
                   item={item}
+                  isNext={item.id === nextId}
+                  now={now}
                   onClick={() => onOpenItem?.(item)}
                 />
               ))}


### PR DESCRIPTION
Audited the calendar surface (agenda / day / week / month) and its crons list, then rebuilt the **agenda** — the weakest of the four — and carried its visual language to the crons cadence.

## Agenda → a proper timeline

The agenda was a flat list: uniform gray day bands, rows of `dot · icon · title` with the time crammed on the right, no sense of "what's next," and board deadlines that looked identical to reminders.

- **Date-badge day headers** (weekday over day-number), **sticky**, with the relative label ("Today"/"Tomorrow") + full date and a count pill. Today's badge/label/spine pick up the presence accent.
- **Timeline rows** on a `[clock · spine · body · cue]` grid, with a connecting rail threaded behind the dots so each day reads as one thread.
- **Relative cue** on the right ("in 2h", "40m ago", "now") answers *what's next* at a glance; the single soonest pending item is highlighted with an accent wash + edge + a **Next** tag.
- **Deadlines** render in the same grid but tinted *task* (a "Due" label, a countdown dot, a "Task" tag) so a due date is never mistaken for a reminder.
- Familiar accent rides a ring on the dot; overdue dots pulse (reduced-motion safe). All colours are semantic tokens → tracks every theme.

## Crons → cadence chips

The Codex automation rows showed their schedule ("Daily at 01:00") as plain trailing text. Wrapped it in a quiet **clock chip** matching the agenda's language; the chip warms to the accent on hover/selection. Pure presentation.

## Audit notes

Day / Week / Month grids were reviewed and are already solid (live now-line, event blocks, the Due deadline strip) — left unchanged. Existing agenda invariants (showPast/Hide-past, the `itemDate`-key sort copy, the AT-only familiar name) are preserved.

## Verification

Screenshots confirmed the agenda before/after. `typecheck` · `check:tests-wired` · new `calendar-agenda-redesign.test.ts` (wired) + calendar/automations suites green · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)