### PR TITLE
chore(release): stamp v0.0.160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.160] - 2026-07-08
+
+> 📖 **Responses worth reading** — the chat's Expand view becomes a real reading surface, tables read as rows instead of spreadsheets, inline code stops shouting, and mermaid diagrams finally wear the theme — on a drawing canvas, inline and fullscreen. Plus a backdrop vibe for Home + Chat and journal-run chats that tidy themselves away.
+
+Feature release on top of v0.0.159.
+
+### Features
+- **Chat: modern reading polish** (#2801, cave-po4f). The Expand reader gets a centered 72ch book measure on a larger reading scale; inline code chips go quiet-neutral; tables move to row separators with sticky headers, zebra + hover tints, and a roomier expanded lightbox; mermaid diagrams render token-native across all 19 themes on a dot-grid drawing canvas, with a glassy zoom/pan toolbar fullscreen; user bubbles and thinking blocks soften.
+- **Appearance: backdrop vibe** — an image behind Home + Chat with the accent derived from it (#2799, cave-bq7s).
+
+### Fixes
+- **Chat: journal-run chats auto-hide** — `origin:journal` provenance with a truncated-title legacy fallback (#2798, cave-buih).
+- **Journal: delete announces once** — UndoToast already speaks it (#2800, cave-6rhk).
+
 ## [0.0.159] - 2026-07-08
 
 > 🪟 **Frosted glass and a Copilot in the cave** — overlay chrome goes translucent with real backdrop depth, GitHub Copilot CLI joins as a first-class runtime, the Changes panel reviews your diff in one click, and mornings start with a "Needs you" triage strip.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.159"
+version = "0.0.160"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.159"
+version = "0.0.160"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.159</string>
+	<string>0.0.160</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.159</string>
+	<string>0.0.160</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.159</string>
+	<string>0.0.160</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.159</string>
+	<string>0.0.160</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.159",
+  "version": "0.0.160",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Feature release on top of v0.0.159 — headlined by the **chat reading polish** (#2801, cave-po4f): reader measure, quiet inline chips, row tables with sticky headers, token-native mermaid on a drawing canvas (inline + fullscreen viewer); plus the backdrop vibe (#2799), journal-run chat autohide (#2798), and the journal delete double-announce fix (#2800).

Local gate: `cargo check --locked` + typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.160` → release.yml builds → `node scripts/verify-release-updater.mjs`.

Bead: cave-oztv

🤖 Generated with [Claude Code](https://claude.com/claude-code)