### PR TITLE
feat(board+chat): task loop closes — live session status on card chips, one-click Mark done from a settled chat (cave-32ks)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -245,6 +245,7 @@ export const SUITES = {
     "src/components/workspace-familiars-landing.test.ts",
     "src/components/board-kanban-keyboard.test.ts",
     "src/components/board-inspector-a11y.test.ts",
+    "src/lib/session-status.test.ts",
     "src/components/board-grouping.test.ts",
     "src/components/board-project-picker.test.ts",
     "src/components/board-ux-polish.test.ts",

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -29,6 +29,7 @@ import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format
 import { openExternalUrl } from "@/lib/open-external";
 import { attachmentIcon, fileToAttachment, hasDraggedFiles } from "@/lib/chat-attachments";
 import type { CardPatch } from "@/lib/board-card-ops";
+import { sessionStatusTone, sessionStatusWord } from "@/lib/session-status";
 
 const DEFAULT_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
@@ -1273,7 +1274,15 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
                   </span>
                   <span className="board-drawer-chat-body">
                     <span className="board-drawer-chat-title">{session.title || "(untitled)"}</span>
-                    <span className="board-drawer-chat-desc">Open conversation</span>
+                    {/* cave-32ks: live session state — dot + word — so the
+                        drawer answers "is the familiar on it?" at a glance. */}
+                    <span className="board-drawer-chat-desc">
+                      <span
+                        className={`board-drawer-chat-status-dot board-drawer-chat-status-dot--${sessionStatusTone(session.status)}`}
+                        aria-hidden
+                      />
+                      {sessionStatusWord(session.status)} · open conversation
+                    </span>
                   </span>
                   <Icon name="ph:arrow-square-out" width={12} className="board-drawer-chat-trail" />
                 </button>

--- a/src/components/board-kanban.tsx
+++ b/src/components/board-kanban.tsx
@@ -17,6 +17,7 @@ import { useResolvedFamiliars, type ResolvedFamiliar } from "@/lib/familiar-reso
 import { useAnnouncer } from "@/components/ui/live-region";
 import { Popover } from "@/components/ui/popover";
 import { type WipLimits, wipState } from "@/lib/board-wip";
+import { sessionStatusTone, sessionStatusWord } from "@/lib/session-status";
 
 const COLUMNS: { id: CardStatus; label: string; hint: string }[] = [
   { id: "backlog",  label: "Backlog",  hint: "Ideas and work not ready to dispatch." },
@@ -797,12 +798,15 @@ function KanbanCard({ card, familiarById, sessionById, todayMs, isDragging, isSe
       {hasChips && (
         <div className="board-kanban-card-chips">
           {session && (
+            // cave-32ks: the chip carries the linked session's LIVE state
+            // (status-dot + word) so "is my familiar on it?" reads from the
+            // board without opening the chat.
             <span
-              className="board-kanban-card-chip board-kanban-card-chip--chat"
-              title={`Linked chat: ${session.title || "(untitled)"}`}
+              className={`board-kanban-card-chip board-kanban-card-chip--chat board-kanban-card-chip--chat-${sessionStatusTone(session.status)}`}
+              title={`Linked chat (${sessionStatusWord(session.status)}): ${session.title || "(untitled)"}`}
             >
-              <Icon name="ph:chat-circle-dots" width={9} />
-              Chat
+              <span className="board-kanban-card-chip-dot" aria-hidden />
+              Chat · {sessionStatusWord(session.status)}
             </span>
           )}
           {schedule && (

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1696,6 +1696,7 @@ function LinkedContextRow({
   sessionId,
   onLinkedContextChange,
   handoff,
+  sessionSettled = false,
 }: {
   linkedContext: ChatLinkedContext | null;
   onOpenTask?: (cardId: string) => void;
@@ -1704,8 +1705,14 @@ function LinkedContextRow({
   /** Recent turns + familiar/project for the picker's "New task from this chat"
    *  handoff (cave-px7). Absent → the picker only links existing tasks. */
   handoff?: ChatHandoffContext | null;
+  /** True once the latest assistant turn settled cleanly — gates the
+   *  one-click "Mark done" on linked tasks (cave-32ks phase 3): finished
+   *  familiar work is the moment the card can flip without leaving chat. */
+  sessionSettled?: boolean;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [markingId, setMarkingId] = useState<string | null>(null);
+  const { announce } = useAnnouncer();
   const task = linkedContext?.task ?? null;
   const tasks = linkedContext?.tasks ?? (task ? [task] : []);
   const github = linkedContext?.github ?? [];
@@ -1713,6 +1720,39 @@ function LinkedContextRow({
   if (!task && github.length === 0 && !canLink) return null;
 
   const linkedIds = new Set(tasks.map((t) => t.id));
+
+  // cave-32ks phase 3: flip the card through its lifecycle machine —
+  // "completed" derives status "done" server-side, and lifecycleReason is the
+  // card's audit note for where the flip came from.
+  const markDone = async (t: (typeof tasks)[number]) => {
+    setMarkingId(t.id);
+    try {
+      const res = await fetch(`/api/board/${encodeURIComponent(t.id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          lifecycle: "completed",
+          lifecycleReason: sessionId
+            ? `Marked done from chat (session ${sessionId})`
+            : "Marked done from chat",
+        }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json.ok === false) throw new Error(String(json.error ?? res.status));
+      const done = (x: NonNullable<ChatLinkedContext["task"]>) =>
+        x.id === t.id ? { ...x, status: "done" as const, lifecycle: "completed" as const } : x;
+      onLinkedContextChange?.((prev) =>
+        prev
+          ? { ...prev, task: prev.task ? done(prev.task) : prev.task, tasks: prev.tasks?.map(done) ?? prev.tasks }
+          : prev,
+      );
+      announce(`Task "${t.title}" marked done.`);
+    } catch {
+      announce(`Couldn't mark "${t.title}" done — check your connection.`, "assertive");
+    } finally {
+      setMarkingId(null);
+    }
+  };
 
   const onAssigned = (card: Card) => {
     const linked = {
@@ -1738,7 +1778,22 @@ function LinkedContextRow({
   return (
     <div className="cave-chat-linked-context">
       {tasks.map((t) => (
-        <TaskChip key={t.id} task={t} onOpenTask={onOpenTask} />
+        <span key={t.id} className="inline-flex min-w-0 items-center gap-1">
+          <TaskChip task={t} onOpenTask={onOpenTask} />
+          {sessionSettled && t.status !== "done" && onLinkedContextChange ? (
+            <button
+              type="button"
+              onClick={() => void markDone(t)}
+              disabled={markingId === t.id}
+              title={`Mark task done: ${t.title}`}
+              aria-label={`Mark task done: ${t.title}`}
+              className="cave-chat-linked-chip cave-chat-linked-chip--mark-done focus-ring inline-flex items-center gap-1 border border-[color-mix(in_oklch,var(--color-success)_32%,transparent)] bg-[color-mix(in_oklch,var(--color-success)_9%,transparent)] text-[var(--color-success)] transition-colors hover:bg-[color-mix(in_oklch,var(--color-success)_18%,transparent)] disabled:opacity-60"
+            >
+              <Icon name="ph:check-bold" width={10} className="shrink-0" />
+              {markingId === t.id ? "Marking…" : "Mark done"}
+            </button>
+          ) : null}
+        </span>
       ))}
       {canLink ? (
         <span className="relative inline-flex">
@@ -4677,6 +4732,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           sessionId={sessionId}
           onLinkedContextChange={setLinkedContext}
           handoff={{ turns, familiarId: familiar.id ?? null, projectId: projectIdDraft }}
+          sessionSettled={!activePendingTurn && Boolean(lastSettledAssistantTurn) && !lastSettledAssistantTurn?.error}
         />
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />

--- a/src/lib/session-status.test.ts
+++ b/src/lib/session-status.test.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+// cave-32ks — capture → task → done. Phase 1 (send a card to a familiar) was
+// verified already shipped (tile/stack/inspector "Start chat" + the
+// /api/board/[id]/chat backlink route); these pins hold the two NEW deltas:
+// live session status on the card chips (phase 2) and one-click "Mark done"
+// from a settled chat (phase 3).
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { sessionStatusTone, sessionStatusWord } from "./session-status.ts";
+
+// ── Pure mapping ──────────────────────────────────────────────────────────────
+assert.equal(sessionStatusTone("running"), "running");
+assert.equal(sessionStatusTone("starting"), "running");
+assert.equal(sessionStatusTone("completed"), "done");
+assert.equal(sessionStatusTone("failed"), "failed");
+assert.equal(sessionStatusTone("killed"), "failed");
+assert.equal(sessionStatusTone("orphaned"), "failed");
+assert.equal(sessionStatusTone("idle"), "idle");
+assert.equal(sessionStatusTone("something-new"), "idle", "unknown daemon states read as idle, never a lie");
+assert.equal(sessionStatusTone(null), "idle");
+assert.equal(sessionStatusWord("RUNNING"), "running", "case-insensitive");
+
+// ── Phase 2 pins: the board's chips carry live status ─────────────────────────
+const kanban = await readFile(new URL("../components/board-kanban.tsx", import.meta.url), "utf8");
+const inspector = await readFile(new URL("../components/board-inspector.tsx", import.meta.url), "utf8");
+const boardCss = await readFile(new URL("../styles/board.css", import.meta.url), "utf8");
+
+assert.match(
+  kanban,
+  /board-kanban-card-chip--chat-\$\{sessionStatusTone\(session\.status\)\}/,
+  "kanban chat chip is toned by the linked session's live status",
+);
+assert.match(kanban, /Chat · \{sessionStatusWord\(session\.status\)\}/, "kanban chip pairs the dot with the word");
+assert.match(
+  inspector,
+  /board-drawer-chat-status-dot--\$\{sessionStatusTone\(session\.status\)\}/,
+  "inspector chat card shows the status dot",
+);
+assert.match(
+  inspector,
+  /\{sessionStatusWord\(session\.status\)\} · open conversation/,
+  "inspector desc pairs the dot with the word",
+);
+for (const tone of ["done", "failed", "idle"]) {
+  assert.match(boardCss, new RegExp(`board-kanban-card-chip--chat-${tone}`), `kanban tone css: ${tone}`);
+}
+assert.match(boardCss, /board-drawer-chat-status-dot--running/, "inspector dot tones exist");
+
+// ── Phase 3 pins: settled chat offers one-click Mark done ─────────────────────
+const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+
+assert.match(
+  chatView,
+  /sessionSettled && t\.status !== "done" && onLinkedContextChange \? \(/,
+  "Mark done shows only for a settled session on a not-yet-done task",
+);
+assert.match(
+  chatView,
+  /lifecycle: "completed",\s*lifecycleReason: sessionId/,
+  "the flip goes through the card lifecycle machine with an audit reason (status derives server-side)",
+);
+assert.match(
+  chatView,
+  /sessionSettled=\{!activePendingTurn && Boolean\(lastSettledAssistantTurn\) && !lastSettledAssistantTurn\?\.error\}/,
+  "settled = no in-flight turn, a clean last assistant turn",
+);
+assert.match(
+  chatView,
+  /announce\(`Task "\$\{t\.title\}" marked done\.`\)/,
+  "success is voiced for AT",
+);
+assert.match(
+  chatView,
+  /Couldn't mark "\$\{t\.title\}" done/,
+  "failure is voiced too — no silent no-op buttons",
+);
+
+console.log("session-status.test.ts: ok");

--- a/src/lib/session-status.ts
+++ b/src/lib/session-status.ts
@@ -1,0 +1,24 @@
+// cave-32ks phase 2: one mapping from a daemon SessionRow.status string to
+// the status-dot + word pattern (design language §3), shared by the card
+// chips on the board (kanban tile + inspector drawer). Familiar-level
+// presence lives in presence.ts; this is the per-session cut of the same
+// vocabulary. Pure so it pins/tests without a DOM.
+
+export type SessionStatusTone = "running" | "done" | "failed" | "idle";
+
+const RUNNING = new Set(["running", "starting", "working"]);
+const DONE = new Set(["completed", "complete", "done"]);
+const FAILED = new Set(["failed", "error", "killed", "orphaned"]);
+
+export function sessionStatusTone(status: string | null | undefined): SessionStatusTone {
+  const s = (status ?? "").toLowerCase();
+  if (RUNNING.has(s)) return "running";
+  if (DONE.has(s)) return "done";
+  if (FAILED.has(s)) return "failed";
+  return "idle";
+}
+
+/** The word the dot pairs with — always lowercase, one word. */
+export function sessionStatusWord(status: string | null | undefined): string {
+  return sessionStatusTone(status);
+}

--- a/src/styles/board.css
+++ b/src/styles/board.css
@@ -381,6 +381,12 @@
 .board-kanban-card-chip--more { color:var(--text-muted); background:transparent; border-color:transparent; padding:1px 2px; }
 .board-kanban-card-chip--chat { color:var(--accent-presence); background:color-mix(in oklch,var(--accent-presence) 12%,transparent); border-color:color-mix(in oklch,var(--accent-presence) 35%,var(--border-hairline)); }
 .board-kanban-card-chip--chat svg { color:var(--accent-presence); }
+/* cave-32ks: the chat chip carries the linked session's live status — dot +
+   word, toned per state. Running keeps the accent; done/failed/idle re-tint. */
+.board-kanban-card-chip-dot { width:5px; height:5px; border-radius:999px; background:currentColor; flex-shrink:0; }
+.board-kanban-card-chip--chat-done { color:var(--color-success); background:color-mix(in oklch,var(--color-success) 10%,transparent); border-color:color-mix(in oklch,var(--color-success) 32%,var(--border-hairline)); }
+.board-kanban-card-chip--chat-failed { color:var(--color-danger); background:color-mix(in oklch,var(--color-danger) 10%,transparent); border-color:color-mix(in oklch,var(--color-danger) 32%,var(--border-hairline)); }
+.board-kanban-card-chip--chat-idle { color:var(--text-secondary); background:var(--bg-elevated); border-color:var(--border-hairline); }
 .board-kanban-card-chip--schedule { color:var(--text-secondary); background:var(--bg-elevated); border-color:var(--border-hairline); }
 .board-kanban-card-chip--schedule svg { color:var(--text-muted); }
 .board-kanban-card-chip--due-soon { color:var(--color-warning); background:color-mix(in oklch,var(--color-warning) 12%,transparent); border-color:color-mix(in oklch,var(--color-warning) 32%,var(--border-hairline)); }
@@ -485,7 +491,12 @@
 .board-drawer-chat-icon--empty { background:var(--bg-elevated); color:var(--text-muted); }
 .board-drawer-chat-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:1px; }
 .board-drawer-chat-title { font-size:12px; font-weight:500; color:var(--text-primary); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-.board-drawer-chat-desc { font-size:10.5px; color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.board-drawer-chat-desc { font-size:10.5px; color:var(--text-muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; display:inline-flex; align-items:center; gap:5px; }
+/* cave-32ks: live session status dot in the drawer's chat card. */
+.board-drawer-chat-status-dot { width:5px; height:5px; border-radius:999px; flex-shrink:0; background:var(--text-muted); }
+.board-drawer-chat-status-dot--running { background:var(--accent-presence); }
+.board-drawer-chat-status-dot--done { background:var(--color-success); }
+.board-drawer-chat-status-dot--failed { background:var(--color-danger); }
 .board-drawer-chat-trail { color:var(--text-muted); flex-shrink:0; }
 .board-drawer-chat-card--linked:hover .board-drawer-chat-trail { color:var(--text-primary); }
 .board-drawer-chat-cta { display:inline-flex; align-items:center; gap:5px; min-height:28px; padding:0 10px; border-radius:var(--radius-control); border:1px solid color-mix(in oklch,var(--accent-presence) 50%,transparent); background:color-mix(in oklch,var(--accent-presence) 18%,transparent); color:var(--text-primary); font-size:11.5px; font-weight:500; cursor:pointer; flex-shrink:0; transition:background .12s,border-color .12s; }


### PR DESCRIPTION
## Golden path 2 — capture → task → done (docs/golden-paths.md §2, bead `cave-32ks`)

**Story:** an idea captured mid-conversation should become a tracked task a familiar actually works — and "done" shouldn't require the user to remember the card exists.

### Code-wins finding first
The doc's phase 1 ("board card overflow gains Send to familiar") turned out to be **already shipped**: the kanban tile, mobile card stack, and inspector drawer all carry a "Start chat" action, and `POST /api/board/[id]/chat` seeds the daemon session from the card and writes the `sessionId` backlink. Recorded on the bead; this PR lands the two real deltas.

### Phase 2 — the card shows whether the familiar is on it
New pure lib `src/lib/session-status.ts` maps daemon session statuses to the design language's status-dot + word pattern (`running` / `done` / `failed` / `idle`; unknown states read `idle`, never a lie). The kanban chat chip re-tints per tone and reads "Chat · running"; the inspector's chat card gains the dot + word in its description. Both use the session rows the components already receive — no new fetches.

### Phase 3 — done work flips the card from chat
When the chat's latest assistant turn has settled cleanly (no in-flight turn, no error), each linked not-yet-done task chip gains a one-click **Mark done**. The flip goes through the card's existing lifecycle machine — `lifecycle: "completed"` (status derives server-side) with `lifecycleReason` naming the session as the audit note. Success and failure are both announced for assistive tech, and the linked-context chips update in place.

### Verification
- `pnpm typecheck` clean, `pnpm test:app` **574 files green** (both read from raw output) including the new `session-status.test.ts` (wired into `run-tests`) pinning the pure mapping, both chip wirings, the settled-gate, and the lifecycle payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)