### PR TITLE
fix(ios): hide journal/generated runs from the familiar thread lists (cave-48aa)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/Models.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Models.swift
@@ -60,6 +60,11 @@ struct SessionRow: Identifiable, Codable, Hashable {
     var createdAt: String?
     var updatedAt: String?
     var archivedAt: String?
+    /// Provenance from /api/sessions/list — generator surfaces (journal,
+    /// canvas, cron, …) tag their runs so chat lists can hide them.
+    var origin: String?
+    /// Daemon-only runs the server flags as generated (not user chats).
+    var generated: Bool?
 
     enum CodingKeys: String, CodingKey {
         case id, title, harness, model, status
@@ -67,6 +72,18 @@ struct SessionRow: Identifiable, Codable, Hashable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case archivedAt = "archived_at"
+        case origin, generated
+    }
+
+    /// Mirrors the web's isGeneratedChatSession (chat-projects.ts): generated
+    /// runs stay out of thread lists. Legacy journal runs predate the origin
+    /// tag, so their exact machine-prompt titles match too — at the truncated
+    /// lengths the store actually keeps.
+    var isGeneratedRun: Bool {
+        if generated == true { return true }
+        if let origin, ["cron", "heartbeat", "canvas", "journal"].contains(origin) { return true }
+        return title.hasPrefix("Write a short narrative of my day (")
+            || title.hasPrefix("Write a short, first-person reflective journal entry")
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1051,7 +1051,9 @@ final class AppModel {
     func serverOnlySessions(for familiarId: String) -> [SessionRow] {
         let bound = Set(threads.flatMap { $0.sessionIds.values }.filter { !$0.isEmpty })
         return serverSessions
-            .filter { $0.familiarId == familiarId && $0.archivedAt == nil && !bound.contains($0.id) }
+            // Generated runs (journal narratives, canvas, crons) are not
+            // conversations — parity with the web chat lists (cave-48aa).
+            .filter { $0.familiarId == familiarId && $0.archivedAt == nil && !bound.contains($0.id) && !$0.isGeneratedRun }
             .sorted { (caveParseISO($0.updatedAt) ?? .distantPast) > (caveParseISO($1.updatedAt) ?? .distantPast) }
     }
 

--- a/scripts/ios-hide-generated-sessions.test.mjs
+++ b/scripts/ios-hide-generated-sessions.test.mjs
@@ -1,0 +1,61 @@
+// iOS thread lists hide generated runs (cave-48aa) — parity with the web's
+// isGeneratedChatSession (src/lib/chat-projects.ts). Source pins on the Swift
+// files; the two rule sets must not drift apart.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const models = readFileSync(
+  new URL("../apps/ios/CovenCave/CovenCave/Models/Models.swift", import.meta.url),
+  "utf8",
+);
+const appModel = readFileSync(
+  new URL("../apps/ios/CovenCave/CovenCave/State/AppModel.swift", import.meta.url),
+  "utf8",
+);
+const web = readFileSync(new URL("../src/lib/chat-projects.ts", import.meta.url), "utf8");
+
+// The model decodes the provenance /api/sessions/list already serves.
+assert.match(models, /var origin: String\?/, "SessionRow decodes origin");
+assert.match(models, /var generated: Bool\?/, "SessionRow decodes generated");
+assert.match(models, /case origin, generated/, "…and both ride CodingKeys");
+
+// The rule mirrors the web: generated flag, hidden origins, legacy prompts.
+assert.match(models, /var isGeneratedRun: Bool/, "SessionRow exposes isGeneratedRun");
+assert.match(
+  models,
+  /\["cron", "heartbeat", "canvas", "journal"\]\.contains\(origin\)/,
+  "hidden origins match the web's CHAT_HIDDEN_ORIGINS",
+);
+assert.match(
+  models,
+  /hasPrefix\("Write a short narrative of my day \("\)/,
+  "legacy daily-narrative titles hide",
+);
+assert.match(
+  models,
+  /hasPrefix\("Write a short, first-person reflective journal entry"\)/,
+  "legacy reflection titles hide (truncation-safe prefix)",
+);
+
+// The list actually applies it.
+assert.match(
+  appModel,
+  /!\$0\.isGeneratedRun/,
+  "serverOnlySessions filters generated runs out of the thread list",
+);
+
+// Drift guard: the web rule still contains the same origins + prefixes, so a
+// change there should visit this file too.
+for (const origin of ["cron", "heartbeat", "canvas", "journal"]) {
+  assert.ok(web.includes(`"${origin}"`), `web CHAT_HIDDEN_ORIGINS still includes ${origin}`);
+}
+assert.ok(
+  web.includes("Write a short narrative of my day ("),
+  "web keeps the daily-narrative legacy prefix",
+);
+assert.ok(
+  web.includes("Write a short, first-person reflective journal entry"),
+  "web keeps the reflection legacy prefix",
+);
+
+console.log("ios-hide-generated-sessions: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -734,6 +734,7 @@ export const SUITES = {
     "src/lib/mobile-token-refresh.test.ts",
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-chat-restyle.test.mjs",
+    "scripts/ios-hide-generated-sessions.test.mjs",
     "scripts/ios-code-browser-files.test.mjs",
     "scripts/ios-code-viewer.test.mjs",
     "scripts/ios-no-canvas-tab.test.mjs",


### PR DESCRIPTION
## Summary

Parity with the web chat lists (#2798): the native iOS app decoded `SessionRow` without `origin`/`generated` and `serverOnlySessions()` never filtered — journal-narrative runs flooded the Threads list exactly as they did on web (93 of 499 sessions on this machine). `/api/sessions/list` already serves both fields server-side, so this is a model + filter change:

- `SessionRow` decodes `origin` + `generated` and exposes `isGeneratedRun`, mirroring the web's `isGeneratedChatSession`: the generated flag, the hidden origins (`cron`/`heartbeat`/`canvas`/`journal`), and the two legacy machine-prompt title prefixes at truncation-safe lengths.
- `serverOnlySessions()` drops generated runs from the thread list.

## Testing

- New `scripts/ios-hide-generated-sessions.test.mjs` (wired into the mobile suite): pins the model fields, the mirrored rule, the filter application — plus a **drift guard** asserting the web rule still carries the same origins/prefixes so the two implementations can't silently diverge.
- `swiftc -parse` clean on both Swift files · mobile suite green (**75 files**) · `check:tests-wired` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)