### PR TITLE
feat(chat+board): inline fix actions for harness/runtime failures (cave-noox)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -599,6 +599,8 @@ export const SUITES = {
     "src/lib/server/message-feedback-store.test.ts",
     "src/components/detail-split-host.test.ts",
     "src/lib/server/chat-stop-registry.test.ts",
+    "src/lib/harness-failure.test.ts",
+    "src/components/harness-fix-actions.test.ts",
   ],
   api: [
     "scripts/dependency-policy.test.mjs",

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -24,6 +24,8 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { StandardSelect } from "@/components/ui/select";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { HarnessFixActions } from "@/components/harness-fix-actions";
+import { parseHarnessFailure } from "@/lib/harness-failure";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
 import { openExternalUrl } from "@/lib/open-external";
@@ -78,6 +80,9 @@ type Props = {
    *  daemon offline → 502). Without this the failure only appears as a
    *  small banner at the top of the board, hidden behind the open drawer. */
   chatLinkError?: string | null;
+  /** Harness-failure recovery: rebind the card's familiar to this adapter and
+   *  re-run the task-chat start (provided only when chatLinkError is this card's). */
+  onUseHarnessFix?: (harnessId: string) => void | Promise<void>;
 };
 
 function TimeoutBadge({ runningSince, timeoutMs }: { runningSince?: string; timeoutMs?: number }) {
@@ -1046,7 +1051,7 @@ function DebugSection({ card }: { card: Card }) {
   );
 }
 
-export function BoardInspector({ card, familiars, sessions, projects, onClose, onPatch, onMoveStatus, onDelete, onCardReplaced, onJumpToSession, onOpenTaskChat, onOpenUrl, chatLinking = false, chatLinkError }: Props) {
+export function BoardInspector({ card, familiars, sessions, projects, onClose, onPatch, onMoveStatus, onDelete, onCardReplaced, onJumpToSession, onOpenTaskChat, onOpenUrl, chatLinking = false, chatLinkError, onUseHarnessFix }: Props) {
   const dtPrefs = useDateTimePrefs();
   const [closing, setClosing] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
@@ -1310,6 +1315,18 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
                       ? chatLinkError
                       : "Start a conversation with this card's familiar."}
                   </span>
+                  {(() => {
+                    const failure =
+                      chatLinkError && onUseHarnessFix ? parseHarnessFailure(chatLinkError) : null;
+                    return failure ? (
+                      <HarnessFixActions
+                        failure={failure}
+                        busy={chatLinking}
+                        onUseHarness={onUseHarnessFix}
+                        className="mt-1"
+                      />
+                    ) : null;
+                  })()}
                 </span>
                 <button
                   type="button"

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -32,6 +32,9 @@ import { BoardInspector } from "@/components/board-inspector";
 import { useIsMobile } from "@/lib/use-viewport";
 import { chatProjectById } from "@/lib/chat-projects";
 import { useProjects } from "@/lib/use-projects";
+import { HarnessFixActions } from "@/components/harness-fix-actions";
+import { parseHarnessFailure } from "@/lib/harness-failure";
+import { defaultModelForRuntime } from "@/lib/runtime-models";
 
 type ViewMode = "kanban" | "table" | "gantt";
 
@@ -112,6 +115,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
   const [modalDefaultStatus, setModalDefaultStatus] = useState<CardStatus>("backlog");
   const [chatLinkingId, setChatLinkingId] = useState<string | null>(null);
   const [chatLinkError, setChatLinkError] = useState<string | null>(null);
+  // The card whose chat start failed — the harness fix row needs it to know
+  // which familiar to rebind and which task chat to re-run.
+  const [chatLinkErrorCardId, setChatLinkErrorCardId] = useState<string | null>(null);
   const { projects } = useProjects();
 
   // "Clear done" flow: an inline confirm gate, and a transient undo banner that
@@ -626,6 +632,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     const fallbackFamiliarId = card?.familiarId ?? activeFamiliarId ?? familiars[0]?.id ?? null;
     setChatLinkingId(id);
     setChatLinkError(null);
+    setChatLinkErrorCardId(null);
     try {
       const res = await fetch(`/api/board/${id}/chat`, {
         method: "POST",
@@ -643,6 +650,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
       onJumpToSession?.(json.sessionId, json.familiarId);
     } catch (err) {
       setChatLinkError(err instanceof Error ? err.message : "failed to open task chat");
+      setChatLinkErrorCardId(id);
     } finally {
       setChatLinkingId(null);
     }
@@ -661,6 +669,35 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
     }
     await startTaskChat(id);
   };
+
+  // Recovery for a harness/runtime failure while starting a task chat: rebind
+  // the card's familiar to the chosen adapter via /api/config, then re-run the
+  // same task-chat start.
+  const useHarnessForTaskChat = async (runtime: string) => {
+    const id = chatLinkErrorCardId;
+    if (!id || chatLinkingId !== null) return;
+    const card = cards.find((candidate) => candidate.id === id);
+    const familiarId = card?.familiarId ?? activeFamiliarId ?? familiars[0]?.id ?? null;
+    if (!familiarId) return;
+    try {
+      const res = await fetch("/api/config", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          familiars: { [familiarId]: { harness: runtime, model: defaultModelForRuntime(runtime) } },
+        }),
+      });
+      if (!res.ok) {
+        setChatLinkError(`Could not switch harness (${res.status}).`);
+        return;
+      }
+      window.dispatchEvent(new Event("cave:familiars-refresh"));
+      await onOpenTaskChat(id);
+    } catch {
+      setChatLinkError("Could not switch harness.");
+    }
+  };
+  const chatLinkFailure = chatLinkError ? parseHarnessFailure(chatLinkError) : null;
 
   return (
     <section className="board-shell">
@@ -859,10 +896,17 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
       {chatLinkError && (
         <div
           role="alert"
-          className="flex items-center gap-1.5 border-b border-[color-mix(in_oklch,var(--color-warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_12%,var(--bg-base))] px-5 py-1.5 text-xs text-[var(--color-warning)]"
+          className="flex flex-wrap items-center gap-1.5 border-b border-[color-mix(in_oklch,var(--color-warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--color-warning)_12%,var(--bg-base))] px-5 py-1.5 text-xs text-[var(--color-warning)]"
         >
           <Icon name="ph:warning-circle" width={13} className="shrink-0" aria-hidden />
-          <span className="min-w-0 truncate">{chatLinkError}</span>
+          <span className="min-w-0 flex-1 truncate">{chatLinkError}</span>
+          {chatLinkFailure && chatLinkErrorCardId ? (
+            <HarnessFixActions
+              failure={chatLinkFailure}
+              busy={chatLinkingId !== null}
+              onUseHarness={useHarnessForTaskChat}
+            />
+          ) : null}
         </div>
       )}
       {clearedBanner && (
@@ -1122,6 +1166,9 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           onOpenUrl={onOpenUrl}
           chatLinking={chatLinkingId === selectedCard.id}
           chatLinkError={chatLinkingId === null && !selectedCard.sessionId ? chatLinkError : null}
+          onUseHarnessFix={
+            chatLinkErrorCardId === selectedCard.id ? useHarnessForTaskChat : undefined
+          }
         />
       )}
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -16,6 +16,8 @@ import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/ch
 import { canonicalize, formatHelp } from "@/lib/slash-commands";
 import { Icon, type IconName } from "@/lib/icon";
 import { useCopy } from "@/lib/use-copy";
+import { parseHarnessFailure } from "@/lib/harness-failure";
+import { HarnessFixActions } from "@/components/harness-fix-actions";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useKeySymbols } from "@/lib/platform-keys";
 import { useVisualViewport } from "@/lib/use-viewport";
@@ -505,6 +507,7 @@ function ChatErrorStrip({
   addProjectLabel,
   addingProject,
   onAddProject,
+  onUseHarness,
 }: {
   message: string;
   code?: string;
@@ -520,6 +523,8 @@ function ChatErrorStrip({
   addProjectLabel?: string;
   addingProject?: boolean;
   onAddProject?: () => void;
+  /** Switch the familiar to this harness and retry (harness-failure fix row). */
+  onUseHarness?: (harnessId: string) => void | Promise<void>;
 }) {
   const { copied, copy } = useCopy();
   const erroredTools = (failingTurn?.tools ?? []).filter((t) => t.status === "error");
@@ -546,6 +551,10 @@ function ChatErrorStrip({
     }
     return lines.join("\n");
   }, [message, code, erroredTools, erroredSteps]);
+
+  // Harness/runtime failures get an inline fix row (switch adapter / copy the
+  // quoted `coven adapter …` commands) instead of ending at the message.
+  const harnessFailure = useMemo(() => parseHarnessFailure(detailText), [detailText]);
 
   const btn =
     "focus-ring inline-flex shrink-0 items-center gap-1 rounded-md border border-[color-mix(in_oklch,var(--color-warning)_42%,transparent)] bg-[var(--bg-base)]/35 px-2 py-1 text-[11px] font-medium text-[var(--color-warning)] transition-colors hover:bg-[var(--bg-raised)] disabled:opacity-40";
@@ -602,6 +611,15 @@ function ChatErrorStrip({
           </button>
         </div>
       </div>
+      {harnessFailure ? (
+        <HarnessFixActions
+          failure={harnessFailure}
+          busy={busy}
+          onUseHarness={onUseHarness}
+          buttonClassName={btn}
+          className="px-5 pb-2"
+        />
+      ) : null}
       {hasDetail && open ? (
         <div className="max-h-48 overflow-auto border-t border-[color-mix(in_oklch,var(--color-warning)_22%,transparent)] px-5 py-2">
           {erroredTools.map((t) => (
@@ -3918,6 +3936,36 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     );
   }
 
+  // Recovery for a harness/runtime failure: rebind the familiar to the chosen
+  // adapter via /api/config (the only channel that rebinds a harness — the
+  // send route re-resolves the binding on every turn), then retry the send.
+  const switchingHarnessRef = useRef(false);
+  async function handleUseHarnessFix(runtime: string) {
+    if (busy || switchingHarnessRef.current) return;
+    switchingHarnessRef.current = true;
+    try {
+      const nextModel = defaultModelForRuntime(runtime);
+      const res = await fetch("/api/config", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          familiars: { [familiar.id]: { harness: runtime, model: nextModel } },
+        }),
+      });
+      if (!res.ok) {
+        setError(`Could not switch harness (${res.status}). Try again from the composer's runtime picker.`);
+        return;
+      }
+      window.dispatchEvent(new Event("cave:familiars-refresh"));
+      void refreshModelState();
+      retryLastSend();
+    } catch {
+      setError("Could not switch harness. Try again from the composer's runtime picker.");
+    } finally {
+      switchingHarnessRef.current = false;
+    }
+  }
+
   // Recovery for a 403 project-access failure: register the chat's cwd as a
   // Cave project and grant it to this familiar (both user-initiated writes the
   // server accepts), then retry the send. The daemon re-reads projects/grants
@@ -4996,6 +5044,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           busy={busy}
           onRetry={retryLastSend}
           onOpenDebug={openDebug}
+          onUseHarness={lastFailedSend ? handleUseHarnessFix : undefined}
           addProjectLabel={
             projectAccessRoot ? `Add "${projectNameForRoot(projectAccessRoot)}" as project` : undefined
           }

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -21,6 +21,9 @@ import {
 import { Icon } from "@/lib/icon";
 import { extractNextPaths } from "@/lib/next-paths";
 import { Button } from "@/components/ui/button";
+import { HarnessFixActions } from "@/components/harness-fix-actions";
+import { parseHarnessFailure } from "@/lib/harness-failure";
+import { defaultModelForRuntime } from "@/lib/runtime-models";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Popover } from "@/components/ui/popover";
 import { useConfirm } from "@/components/ui/confirm-dialog";
@@ -594,6 +597,32 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
     [busy, byId, updateReply, streamOne, announce, operatorDisplayName],
   );
 
+  // Recovery for a harness/runtime failure on one reply: rebind that familiar
+  // to the chosen adapter via /api/config, then re-run just their reply.
+  const useHarnessForReply = useCallback(
+    async (reply: GroupReply, runtime: string) => {
+      if (busy) return;
+      try {
+        const res = await fetch("/api/config", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            familiars: { [reply.familiarId]: { harness: runtime, model: defaultModelForRuntime(runtime) } },
+          }),
+        });
+        if (!res.ok) {
+          announce(`Could not switch harness (${res.status}).`, "assertive");
+          return;
+        }
+        window.dispatchEvent(new Event("cave:familiars-refresh"));
+        await retryReply(reply);
+      } catch {
+        announce("Could not switch harness.", "assertive");
+      }
+    },
+    [busy, retryReply, announce],
+  );
+
   // --- @mention autocomplete ----------------------------------------------
   const mentionable = useMemo<MentionableFamiliar[]>(() => {
     if (!activeGroup) return [];
@@ -935,7 +964,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                   showTimestamp={false}
                                 />
                                 {r.status === "error" ? (
-                                  <div className="mt-1.5">
+                                  <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                                     <Button
                                       size="xs"
                                       variant="secondary"
@@ -945,6 +974,16 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
                                     >
                                       Retry
                                     </Button>
+                                    {(() => {
+                                      const failure = parseHarnessFailure(r.error);
+                                      return failure ? (
+                                        <HarnessFixActions
+                                          failure={failure}
+                                          busy={busy}
+                                          onUseHarness={(runtime) => void useHarnessForReply(r, runtime)}
+                                        />
+                                      ) : null;
+                                    })()}
                                   </div>
                                 ) : null}
                                 {r.status === "done" && suggestions.length > 0 ? (

--- a/src/components/harness-fix-actions.test.ts
+++ b/src/components/harness-fix-actions.test.ts
@@ -1,0 +1,148 @@
+// @ts-nocheck
+//
+// Guard: harness/runtime failures render inline fix actions (cave-noox)
+// everywhere the daemon's error prose can otherwise dead-end the user:
+//   - chat view's ChatErrorStrip
+//   - group chat error replies (next to Retry)
+//   - board task-chat errors (top banner + inspector empty-chat card)
+//
+// The shared component (harness-fix-actions.tsx) offers "Use <Adapter>"
+// switch buttons and "Copy fix command" for quoted `coven adapter …` lines;
+// the parse logic itself is unit-tested in src/lib/harness-failure.test.ts.
+// Source-string assertions keep this guard light (home-composer.test.ts style).
+//
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// ── The shared component ─────────────────────────────────────────────────────
+{
+  const source = await readFile(
+    new URL("./harness-fix-actions.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    source,
+    /harnessSwitchTargets/,
+    "HarnessFixActions should derive switch buttons from harnessSwitchTargets",
+  );
+  assert.match(
+    source,
+    /harnessFixCommand/,
+    "HarnessFixActions should surface the quoted fix command via harnessFixCommand",
+  );
+  assert.match(
+    source,
+    /copyText/,
+    "HarnessFixActions should copy via the shared clipboard helper (execCommand fallback)",
+  );
+  assert.match(
+    source,
+    /Use \{target\.label\}/,
+    "switch buttons read 'Use <Adapter>'",
+  );
+}
+
+// ── Chat view: ChatErrorStrip ────────────────────────────────────────────────
+{
+  const source = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /import \{ parseHarnessFailure \} from "@\/lib\/harness-failure"/,
+    "chat-view should parse harness failures from the shared lib",
+  );
+  assert.match(
+    source,
+    /parseHarnessFailure\(detailText\)/,
+    "ChatErrorStrip should parse the full detail text (message + code + tool/step output)",
+  );
+  assert.match(
+    source,
+    /<HarnessFixActions[\s\S]{0,200}onUseHarness=\{onUseHarness\}/,
+    "ChatErrorStrip should render HarnessFixActions wired to onUseHarness",
+  );
+  assert.match(
+    source,
+    /async function handleUseHarnessFix\(runtime: string\)/,
+    "chat-view should define the harness-fix recovery handler",
+  );
+  assert.match(
+    source,
+    /handleUseHarnessFix[\s\S]{0,600}method: "PATCH"[\s\S]{0,300}familiars: \{ \[familiar\.id\]: \{ harness: runtime/,
+    "the fix handler should rebind the familiar via /api/config PATCH",
+  );
+  assert.match(
+    source,
+    /onUseHarness=\{lastFailedSend \? handleUseHarnessFix : undefined\}/,
+    "the strip only offers a switch when there is a failed send to retry",
+  );
+}
+
+// ── Group chat: error replies ────────────────────────────────────────────────
+{
+  const source = await readFile(new URL("./group-chat-view.tsx", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /parseHarnessFailure\(r\.error\)/,
+    "group chat should parse each error reply's text",
+  );
+  assert.match(
+    source,
+    /useHarnessForReply/,
+    "group chat should define a per-reply harness-fix handler",
+  );
+  assert.match(
+    source,
+    /familiars: \{ \[reply\.familiarId\]: \{ harness: runtime/,
+    "the group-chat fix should rebind the failing reply's familiar",
+  );
+  assert.match(
+    source,
+    /await retryReply\(reply\)/,
+    "after rebinding, the group-chat fix should re-run just that reply",
+  );
+}
+
+// ── Board: chat-link error banner + inspector card ───────────────────────────
+{
+  const source = await readFile(new URL("./board-view.tsx", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /chatLinkErrorCardId/,
+    "board should track which card's chat start failed",
+  );
+  assert.match(
+    source,
+    /useHarnessForTaskChat/,
+    "board should define the task-chat harness-fix handler",
+  );
+  assert.match(
+    source,
+    /await onOpenTaskChat\(id\)/,
+    "after rebinding, the board fix should re-run the task-chat start",
+  );
+  assert.match(
+    source,
+    /chatLinkFailure && chatLinkErrorCardId \?[\s\S]{0,200}<HarnessFixActions/,
+    "the top banner should render fix actions for parsed harness failures",
+  );
+  assert.match(
+    source,
+    /onUseHarnessFix=\{[\s\S]{0,120}useHarnessForTaskChat/,
+    "the inspector should receive the fix handler for the failing card",
+  );
+}
+{
+  const source = await readFile(new URL("./board-inspector.tsx", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /chatLinkError && onUseHarnessFix \? parseHarnessFailure\(chatLinkError\) : null/,
+    "the inspector's empty-chat card should parse the chat-link error",
+  );
+  assert.match(
+    source,
+    /<HarnessFixActions[\s\S]{0,200}onUseHarness=\{onUseHarnessFix\}/,
+    "the inspector's empty-chat card should render fix actions",
+  );
+}
+
+console.log("harness-fix-actions.test.ts: ok");

--- a/src/components/harness-fix-actions.tsx
+++ b/src/components/harness-fix-actions.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * Inline fix actions for a parsed harness/runtime failure (cave-noox).
+ *
+ * Every surface that shows a daemon harness error (chat error strip, group
+ * chat error replies, board task-chat errors) renders this row instead of a
+ * dead-end message: one "Use <Adapter>" button per switch target, and a
+ * "Copy fix command" button when the error quotes `coven adapter …` commands.
+ *
+ * Style-neutral on purpose — hosts pass `buttonClassName` so the buttons
+ * inherit the surrounding strip/bubble/banner chrome.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { copyText } from "@/lib/clipboard";
+import {
+  harnessFixCommand,
+  harnessSwitchTargets,
+  type HarnessFailure,
+} from "@/lib/harness-failure";
+
+const DEFAULT_BTN =
+  "focus-ring inline-flex shrink-0 items-center gap-1 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/50 px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] disabled:opacity-40";
+
+export function HarnessFixActions({
+  failure,
+  busy = false,
+  onUseHarness,
+  buttonClassName,
+  className,
+}: {
+  failure: HarnessFailure;
+  /** Disables the buttons while the host is already switching/retrying. */
+  busy?: boolean;
+  /** Switch the failing familiar to this adapter id (host PATCHes config + retries). */
+  onUseHarness?: (harnessId: string) => void | Promise<void>;
+  /** Host-supplied button chrome so the row matches the surrounding surface. */
+  buttonClassName?: string;
+  className?: string;
+}) {
+  const targets = onUseHarness ? harnessSwitchTargets(failure) : [];
+  const command = harnessFixCommand(failure);
+  const [copied, setCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+    },
+    [],
+  );
+
+  if (targets.length === 0 && !command) return null;
+
+  const btn = buttonClassName ?? DEFAULT_BTN;
+
+  return (
+    <span className={`flex flex-wrap items-center gap-1 ${className ?? ""}`}>
+      {targets.map((target) => (
+        <button
+          key={target.id}
+          type="button"
+          className={btn}
+          disabled={busy}
+          onClick={() => void onUseHarness?.(target.id)}
+          title={`Switch this familiar to ${target.label} and retry`}
+        >
+          <Icon name="ph:plugs" width={11} aria-hidden />
+          Use {target.label}
+        </button>
+      ))}
+      {command ? (
+        <button
+          type="button"
+          className={btn}
+          disabled={busy}
+          onClick={() => {
+            void copyText(command).then((ok) => {
+              if (!ok) return;
+              setCopied(true);
+              if (copiedTimer.current) clearTimeout(copiedTimer.current);
+              copiedTimer.current = setTimeout(() => setCopied(false), 1500);
+            });
+          }}
+          title={command}
+        >
+          <Icon name={copied ? "ph:check-bold" : "ph:terminal-window"} width={11} aria-hidden />
+          {copied ? "Copied" : "Copy fix command"}
+        </button>
+      ) : null}
+    </span>
+  );
+}

--- a/src/lib/harness-failure.test.ts
+++ b/src/lib/harness-failure.test.ts
@@ -1,0 +1,108 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  harnessFixCommand,
+  harnessSwitchTargets,
+  parseHarnessFailure,
+} from "./harness-failure.ts";
+
+// ── The canonical daemon message ─────────────────────────────────────────────
+{
+  const text =
+    "unsupported harness `copilot`. Configured harnesses: codex, claude. " +
+    "To use Hermes, run `coven adapter install hermes`, then `coven adapter doctor hermes`. " +
+    "For other external harnesses, create a trusted adapter manifest under COVEN_HOME/adapters " +
+    "or set COVEN_HARNESS_ADAPTER_MANIFEST / COVEN_HARNESS_ADAPTER_DIRS before starting Coven.";
+  const failure = parseHarnessFailure(text);
+  assert.ok(failure, "the canonical unsupported-harness message must be detected");
+  assert.equal(failure.harness, "copilot");
+  assert.equal(failure.harnessLabel, "Copilot");
+  assert.deepEqual(failure.configured, ["codex", "claude"], "configured list parsed and canonicalized");
+  assert.deepEqual(
+    failure.commands,
+    ["coven adapter install hermes", "coven adapter doctor hermes"],
+    "quoted coven adapter commands captured in order",
+  );
+  assert.equal(
+    harnessFixCommand(failure),
+    "coven adapter install hermes && coven adapter doctor hermes",
+    "fix command chains install + doctor",
+  );
+  const targets = harnessSwitchTargets(failure);
+  assert.deepEqual(
+    targets,
+    [
+      { id: "codex", label: "Codex" },
+      { id: "claude", label: "Claude Code" },
+    ],
+    "switch targets are the configured harnesses with catalog labels",
+  );
+}
+
+// ── The board route's wrapped variant still parses (embedded daemon detail) ──
+{
+  const failure = parseHarnessFailure(
+    "This familiar uses the 'copilot' harness, which the daemon doesn't start as a task session. " +
+      "Reassign the card to a familiar with a daemon-supported harness, or use the regular Chat " +
+      "surface (daemon detail: unsupported harness `copilot`. Configured harnesses: codex, claude.).",
+  );
+  assert.ok(failure);
+  assert.equal(failure.harness, "copilot");
+  assert.deepEqual(failure.configured, ["codex", "claude"]);
+}
+
+// ── Alias + "not configured" phrasing canonicalize ───────────────────────────
+{
+  const failure = parseHarnessFailure("harness `claude-code` is not configured on this daemon");
+  assert.ok(failure);
+  assert.equal(failure.harness, "claude", "aliases map to canonical adapter ids");
+  assert.deepEqual(failure.configured, []);
+  const targets = harnessSwitchTargets(failure);
+  assert.ok(targets.length > 0, "without a configured list, other chat adapters are offered");
+  assert.ok(!targets.some((t) => t.id === "claude"), "the failed harness is never offered");
+  assert.ok(targets.length <= 3, "switch targets are capped");
+}
+
+// ── Missing adapter binary reads as a runtime failure ────────────────────────
+{
+  const failure = parseHarnessFailure("Error: spawn codex ENOENT");
+  assert.ok(failure, "a known adapter binary ENOENT is a harness failure");
+  assert.equal(failure.harness, "codex");
+  assert.ok(parseHarnessFailure("/bin/sh: hermes: command not found"));
+  assert.equal(parseHarnessFailure("zsh: command not found: claude")?.harness, "claude");
+}
+
+// ── Non-harness errors stay null (no false positives) ────────────────────────
+{
+  assert.equal(parseHarnessFailure(null), null);
+  assert.equal(parseHarnessFailure(""), null);
+  assert.equal(parseHarnessFailure("project access denied for /tmp/foo"), null);
+  assert.equal(
+    parseHarnessFailure("Error: spawn ffmpeg ENOENT"),
+    null,
+    "an unknown binary's ENOENT is not a harness failure",
+  );
+  assert.equal(
+    parseHarnessFailure("bash: rg: command not found"),
+    null,
+    "a random missing tool is not a harness failure",
+  );
+  assert.equal(
+    parseHarnessFailure("run `coven adapter install hermes` for docs"),
+    null,
+    "a quoted command alone (no failed harness, no configured list) is not a failure",
+  );
+}
+
+// ── Junk in the configured list is dropped, duplicates collapse ──────────────
+{
+  const failure = parseHarnessFailure(
+    "unsupported harness `mystery`. Configured harnesses: codex, codex, weird-thing, claude",
+  );
+  assert.ok(failure);
+  assert.equal(failure.harness, "mystery", "unknown harness ids pass through raw");
+  assert.equal(failure.harnessLabel, "mystery", "unknown ids label as themselves");
+  assert.deepEqual(failure.configured, ["codex", "claude"], "untrusted entries and dupes drop out");
+}
+
+console.log("harness-failure.test.ts: ok");

--- a/src/lib/harness-failure.ts
+++ b/src/lib/harness-failure.ts
@@ -1,0 +1,161 @@
+/**
+ * Harness/runtime failure detection — turns the daemon's raw error prose into
+ * a structured, actionable shape so error surfaces can render inline fixes
+ * instead of a dead-end message.
+ *
+ * The canonical example (from `coven`):
+ *
+ *   unsupported harness `copilot`. Configured harnesses: codex, claude.
+ *   To use Hermes, run `coven adapter install hermes`, then
+ *   `coven adapter doctor hermes`. For other external harnesses, create a
+ *   trusted adapter manifest under COVEN_HOME/adapters or set
+ *   COVEN_HARNESS_ADAPTER_MANIFEST / COVEN_HARNESS_ADAPTER_DIRS before
+ *   starting Coven.
+ *
+ * Pure and React-free so every surface (chat strip, group chat, board) and the
+ * unit test can share it.
+ */
+
+import {
+  COMPATIBILITY_ADAPTERS,
+  canonicalHarnessId,
+  isTrustedChatHarness,
+} from "./harness-adapters.ts";
+
+export type HarnessFailure = {
+  /** Canonical id of the harness that failed, when identifiable. */
+  harness: string | null;
+  /** Display label for the failed harness (adapter catalog, else raw id). */
+  harnessLabel: string | null;
+  /** Canonical ids parsed from a "Configured harnesses: …" list (failed one excluded). */
+  configured: string[];
+  /** Shell commands the error quotes as the fix (e.g. `coven adapter install hermes`). */
+  commands: string[];
+};
+
+export type HarnessSwitchTarget = { id: string; label: string };
+
+function adapterLabel(id: string): string {
+  return COMPATIBILITY_ADAPTERS.find((adapter) => adapter.id === id)?.label ?? id;
+}
+
+// "unsupported harness `copilot`" / "unknown harness copilot" /
+// "unrecognized harness 'copilot'"
+const FAILED_HARNESS_RE =
+  /\b(?:unsupported|unknown|unrecognized|invalid)\s+harness\s+[`'"]?([\w.-]+)[`'"]?/i;
+// "harness `copilot` is not configured" / "harness copilot not installed/available/found/supported"
+const HARNESS_NOT_RE =
+  /\bharness\s+[`'"]?([\w.-]+)[`'"]?\s+(?:is\s+)?not\s+(?:configured|installed|available|supported|found)\b/i;
+// "Configured harnesses: codex, claude." — capture up to the sentence end.
+const CONFIGURED_RE = /\bconfigured\s+harnesses?\s*:\s*([^.\n]+)/i;
+// Backtick-quoted fix commands: only trust the coven adapter verbs.
+const COMMAND_RE = /`(coven\s+adapter\s+[^`]+)`/gi;
+// Missing runtime binary: "spawn claude ENOENT" / "claude: command not found" /
+// "command not found: claude" — only meaningful when the binary maps to a
+// known adapter.
+const SPAWN_ENOENT_RE = /\bspawn\s+([\w.-]+)\s+ENOENT\b/i;
+const NOT_FOUND_A_RE = /(?:^|[\s"'`])([\w.-]+):\s*command not found\b/im;
+const NOT_FOUND_B_RE = /\bcommand not found[:\s]+[`'"]?([\w.-]+)[`'"]?/i;
+
+function knownAdapterId(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const canonical = canonicalHarnessId(raw);
+  return COMPATIBILITY_ADAPTERS.some((adapter) => adapter.id === canonical)
+    ? canonical
+    : null;
+}
+
+/**
+ * Parse a harness/runtime failure out of error text. Returns null when the
+ * text doesn't look like a harness problem (so surfaces render nothing extra).
+ */
+export function parseHarnessFailure(
+  text: string | null | undefined,
+): HarnessFailure | null {
+  if (!text || typeof text !== "string") return null;
+
+  let harness: string | null = null;
+  let matched = false;
+
+  const failed = FAILED_HARNESS_RE.exec(text) ?? HARNESS_NOT_RE.exec(text);
+  if (failed) {
+    matched = true;
+    harness = canonicalHarnessId(failed[1]);
+  }
+
+  // A missing adapter binary is a runtime failure even without the word
+  // "harness" — but only when the binary is a known adapter's (a random
+  // tool's ENOENT is not a harness problem).
+  if (!matched) {
+    const candidates = [
+      SPAWN_ENOENT_RE.exec(text)?.[1],
+      NOT_FOUND_A_RE.exec(text)?.[1],
+      NOT_FOUND_B_RE.exec(text)?.[1],
+    ];
+    for (const binary of candidates) {
+      const known = knownAdapterId(binary);
+      if (known) {
+        matched = true;
+        harness = known;
+        break;
+      }
+    }
+  }
+
+  const configuredMatch = CONFIGURED_RE.exec(text);
+  const configured = configuredMatch
+    ? [
+        ...new Set(
+          configuredMatch[1]
+            .split(/[,;/]|\band\b/i)
+            .map((token) => token.trim().replace(/^[`'"]|[`'"]$/g, ""))
+            .filter(Boolean)
+            .map((token) => canonicalHarnessId(token))
+            .filter(
+              (id) => id !== harness && isTrustedChatHarness(id),
+            ),
+        ),
+      ]
+    : [];
+  if (configured.length > 0) matched = true;
+
+  const commands: string[] = [];
+  for (const match of text.matchAll(COMMAND_RE)) {
+    const command = match[1].replace(/\s+/g, " ").trim();
+    if (!commands.includes(command)) commands.push(command);
+  }
+  if (commands.length > 0 && (harness || configured.length > 0)) matched = true;
+
+  if (!matched || (harness === null && configured.length === 0)) return null;
+
+  return {
+    harness,
+    harnessLabel: harness ? adapterLabel(harness) : null,
+    configured,
+    commands: harness || configured.length > 0 ? commands : [],
+  };
+}
+
+/**
+ * The harnesses a fix UI should offer to switch to: the configured list when
+ * the error names one, otherwise every other chat-supported adapter. Capped so
+ * the button row never crowds the surface.
+ */
+export function harnessSwitchTargets(
+  failure: HarnessFailure,
+  limit = 3,
+): HarnessSwitchTarget[] {
+  const ids =
+    failure.configured.length > 0
+      ? failure.configured
+      : COMPATIBILITY_ADAPTERS.filter(
+          (adapter) => adapter.chatSupported && adapter.id !== failure.harness,
+        ).map((adapter) => adapter.id);
+  return ids.slice(0, limit).map((id) => ({ id, label: adapterLabel(id) }));
+}
+
+/** One copy-pasteable fix command line (install + doctor chained). */
+export function harnessFixCommand(failure: HarnessFailure): string | null {
+  if (failure.commands.length === 0) return null;
+  return failure.commands.join(" && ");
+}


### PR DESCRIPTION
## What

Daemon harness/runtime errors — `unsupported harness \`copilot\`. Configured harnesses: codex, claude. To use Hermes, run \`coven adapter install hermes\`…`, adapter-binary ENOENT/command-not-found — used to dead-end at a message. Every surface that shows one now renders an inline fix row.

## How

- **`src/lib/harness-failure.ts`** — pure, React-free parser: failure text → `{harness, configured, commands}`. Detects unsupported/unknown/not-configured harness phrasing, `Configured harnesses:` lists (canonicalized, untrusted entries dropped), quoted `coven adapter …` commands, and known-adapter binary ENOENT. `harnessSwitchTargets` (capped at 3) + `harnessFixCommand` (install && doctor chained). Unit-tested incl. false-positive guards.
- **`src/components/harness-fix-actions.tsx`** — shared row: **Use \<Adapter\>** per switch target + **Copy fix command** (shared `copyText`). Style-neutral: hosts pass `buttonClassName`.
- **Chat** — `ChatErrorStrip` parses message+code+errored tool/step detail; *Use X* PATCHes `/api/config` (the only channel that rebinds a harness), refreshes model state, retries the failed send. Only offered when a retry exists.
- **Group chat** — fix row next to *Retry* under an error reply; rebinds just that reply's familiar, re-runs just that reply.
- **Board** — chat-link error banner + inspector empty-chat card; rebinds the card's familiar, re-runs the task-chat start (tracked per failing card via `chatLinkErrorCardId`).

## Verification

- `pnpm test:app` — **580 test files pass** (incl. new `harness-failure.test.ts`, `harness-fix-actions.test.ts`, both wired into the suite; `check-tests-wired` green)
- `pnpm exec tsc --noEmit` — clean

## Notes

Resumes dead session `ebbb48be`'s autopilot objective (bead **cave-noox**). Also fixes a latent parser bug from that session: multiple missing-binary patterns are each tried instead of short-circuiting on the first match (`zsh: command not found: claude` now resolves to `claude`).