### PR TITLE
feat(models): Claude Fable 5 joins the Copilot model menu (cave-ufvy)

### DIFF
--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -73,6 +73,10 @@ assert.ok(
   "copilot catalog should seed GPT-5.5",
 );
 assert.ok(
+  catalogForRuntime("copilot").models.some((m) => m.id === "github/claude-fable-5"),
+  "copilot catalog should seed Claude Fable 5 (parity with the claude catalog)",
+);
+assert.ok(
   catalogForRuntime("copilot").models.some((m) => m.id === "github/claude-sonnet-5"),
   "copilot catalog should seed Claude Sonnet 5",
 );

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -63,6 +63,7 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
       { id: "github/auto", label: "Auto (Copilot picks)" },
       { id: "github/gpt-5.5", label: "GPT-5.5" },
       { id: "github/claude-opus-4-8", label: "Claude Opus 4.8" },
+      { id: "github/claude-fable-5", label: "Claude Fable 5" },
       { id: "github/claude-sonnet-5", label: "Claude Sonnet 5" },
       { id: "github/claude-haiku-4-5", label: "Claude Haiku 4.5" },
       { id: "github/gemini-3.1-pro", label: "Gemini 3.1 Pro" },


### PR DESCRIPTION
## Summary

The Copilot runtime catalog (`github/` namespace, forwarded bare to `copilot --model`) listed Claude Opus 4.8 / Sonnet 5 / Haiku 4.5 but not **Claude Fable 5**, which the `claude` catalog already carries. Added `github/claude-fable-5` "Claude Fable 5" right after Opus 4.8, mirroring the claude catalog's ordering.

## Testing

Membership pin added in `runtime-models.test.ts` beside the existing seed assertions; full suite green; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)