### PR TITLE
fix(settings): pin typography controls to one standard 28px height

### DIFF
--- a/src/components/settings-fonts.test.ts
+++ b/src/components/settings-fonts.test.ts
@@ -31,6 +31,24 @@ assert.match(
   /label="Typography pair"[\s\S]*?style=\{\{ width: "min\(100%, 300px\)", maxWidth: "100%" \}\}/,
   "typography pair selector uses a responsive width that fits curated pair labels",
 );
+// Row controls share one standard 28px height: the select trigger pins h-7
+// explicitly and the segmented wrappers pin the same h-7.
+assert.doesNotMatch(src, /gh-select/, "settings does not borrow the board view's 26px control chrome");
+assert.match(
+  src,
+  /const segWrap =\s*\n?\s*"flex h-7 /,
+  "segmented control wrappers pin the standard settings control height",
+);
+assert.match(
+  src,
+  /const selectTrigger =\s*\n?\s*"h-7 /,
+  "select triggers pin the standard settings control height",
+);
+assert.match(
+  src,
+  /className=\{selectTrigger\}/,
+  "typography pair selector uses the shared standard-height trigger styling",
+);
 assert.match(src, /Interface/, "keeps the interface preview");
 assert.match(src, /Code &amp; terminal/, "keeps the code and terminal preview");
 

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -115,14 +115,26 @@ const PREVIEW: Record<FontSlot, string> = {
   mono: "const x = 42; // 0123",
 };
 
+// Every row control in Settings shares one standard height (h-7 = 28px):
+// segmented groups reach it via 22px xs buttons + 2px wrapper padding + 1px
+// border, and select triggers pin it explicitly via `selectTrigger`.
+
 // Shared segmented-control styling, hoisted so each option group stays terse.
 const segWrap =
-  "flex w-fit shrink-0 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5";
+  "flex h-7 w-fit shrink-0 items-center rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] p-0.5";
+
+// Shared select-trigger styling — same chrome and height as the segmented
+// groups so a row with a dropdown lines up with a row of segment buttons. The
+// border uses the strong token so the selection control reads clearly.
+const selectTrigger =
+  "h-7 shrink-0 cursor-pointer rounded-[var(--radius-control)] border border-[var(--border-strong)] bg-[var(--bg-base)] px-2.5 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
 
 function segBtn(active: boolean, extra = ""): string {
+  // The selected option gets a visible border on top of the accent fill (the
+  // .ui-btn base already carries a 1px transparent border, so no layout shift).
   return `focus-ring ${extra} rounded-[var(--radius-control)] px-2.5 py-1.5 text-[11px] font-medium transition-colors ${
     active
-      ? "bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+      ? "border-[color-mix(in_oklch,var(--accent-presence)_65%,var(--accent-presence-foreground))] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
       : "text-[var(--text-secondary)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
   }`;
 }
@@ -320,7 +332,7 @@ export function FontSettings() {
         <ReadingRow label="Typography pair" hint="Approved interface + code pairing.">
           <StandardSelect
             label="Typography pair"
-            className="gh-select"
+            className={selectTrigger}
             style={{ width: "min(100%, 300px)", maxWidth: "100%" }}
             value={pairId}
             onChange={selectPair}


### PR DESCRIPTION
Continues idle Copilot session `25ed6348` ("fix the height of the typography pair selector button in the settings … and standardize the heights of all such buttons comprehensively") — its work was left uncommitted on the shared checkout.

## What
- **Typography pair select** drops the board view's `.gh-select` chrome (26px) for a settings-native `selectTrigger` pinned at `h-7` (28px) with the strong border token.
- **Segmented wrappers** (`segWrap`) pin the same `h-7` so every row control in the Fonts card shares one height.
- **Selected segments** get a visible border over the accent fill; the `.ui-btn` base already carries a transparent border, so no layout shift.

## Verification
- `node --experimental-strip-types src/components/settings-fonts.test.ts` → OK (new assertions: shared h-7 heights, `gh-select` banished, shared trigger styling in use).

Scoped to `settings-fonts.tsx` + its test only — the other dirty files on the primary checkout belong to other live sessions and were not touched.