### PR TITLE
chore(release): stamp v0.0.161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.161] - 2026-07-09
+
+> 📱 **Threads that stay yours** — the iOS app stops flooding its Threads list with journal-generated runs, matching the web. The task loop closes on the board with live status chips and one-click Mark done, harness failures grow inline fix actions, and Claude Fable 5 joins the Copilot model menu.
+
+Patch release on top of v0.0.160.
+
+### Fixes
+- **iOS: journal/generated runs stay out of familiar thread lists** (#2806, cave-48aa). The Swift session model now carries `origin`/`generated` and filters with the same rule as the web (#2798) — generated flag, hidden origins including `journal`, and the legacy truncated-title fallback.
+- **Settings: typography controls pin to one standard 28px height** (#2809).
+
+### Features
+- **Board + chat: the task loop closes** — live session status on card chips and one-click Mark done from a settled chat (#2805, cave-32ks).
+- **Chat + board: inline fix actions for harness/runtime failures** (#2807, cave-noox).
+- **Models: Claude Fable 5 joins the Copilot model menu** (#2808, cave-ufvy).
+
 ## [0.0.160] - 2026-07-08
 
 > 📖 **Responses worth reading** — the chat's Expand view becomes a real reading surface, tables read as rows instead of spreadsheets, inline code stops shouting, and mermaid diagrams finally wear the theme — on a drawing canvas, inline and fullscreen. Plus a backdrop vibe for Home + Chat and journal-run chats that tidy themselves away.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.160",
+  "version": "0.0.161",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.160"
+version = "0.0.161"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.160"
+version = "0.0.161"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.160</string>
+	<string>0.0.161</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.160</string>
+	<string>0.0.161</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.160</string>
+	<string>0.0.161</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.160</string>
+	<string>0.0.161</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.160",
+  "version": "0.0.161",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Patch release on top of v0.0.160 — 5 commits: **iOS journal-run hiding** (#2806, cave-48aa — the adopted iOS-arc fix; the tagged commit also feeds the TestFlight build), the board/chat **task-loop close** (#2805), inline fix actions for harness failures (#2807), Claude Fable 5 in the Copilot model menu (#2808), and the settings typography height pin (#2809).

Local gate: `cargo check --locked` + typecheck + test:app + build running (results posted before merge).

After merge: signed tag `v0.0.161` → release.yml builds → `node scripts/verify-release-updater.mjs`.

Bead: cave-680u

🤖 Generated with [Claude Code](https://claude.com/claude-code)