### PR TITLE
fix(shell): keep the side-panel footer (Dashboard + Settings) on chat pages too

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -222,6 +222,7 @@ export const SUITES = {
     "src/components/chat-header-row.test.ts",
     "src/components/chat-usage-plan-ui.test.ts",
     "src/components/sidebar-minimal.test.ts",
+    "src/components/sidebar-footer.test.ts",
     "src/components/sidepanel-badges.test.ts",
     "src/components/sidepanel-badge-dots.test.ts",
     "src/components/sidepanel-nav-peek.test.ts",

--- a/src/components/sidebar-footer.test.ts
+++ b/src/components/sidebar-footer.test.ts
@@ -1,0 +1,33 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const footer = readFileSync(new URL("./sidebar-footer.tsx", import.meta.url), "utf8");
+const minimal = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const chatNav = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+
+// The side-panel footer (Dashboard + Settings + version) is a single shared
+// component so it renders identically in every nav host — and, critically,
+// persists on Chat, whose nav panel swaps SidebarMinimal out for WorkspaceSidebar.
+
+// The shared component owns the whole footer.
+assert.match(footer, /export function SidebarFooter\(\{ onOpenSettings \}/, "SidebarFooter is a shared component taking onOpenSettings");
+assert.match(footer, /href="\/dashboard"/, "footer links to the Dashboard route");
+assert.match(footer, /onClick=\{onOpenSettings\}[\s\S]*?aria-label="Settings"/, "footer Settings button calls onOpenSettings");
+assert.match(footer, /className="sidebar-version"[\s\S]*?v\{APP_VERSION\}/, "footer shows the app version line");
+
+// Both nav hosts render it (so the footer can't drift between them)…
+assert.match(minimal, /import \{ SidebarFooter \} from "@\/components\/sidebar-footer"/, "SidebarMinimal imports the shared footer");
+assert.match(minimal, /<SidebarFooter onOpenSettings=\{onOpenSettings\} \/>/, "SidebarMinimal renders the shared footer");
+assert.match(chatNav, /import \{ SidebarFooter \} from "@\/components\/sidebar-footer"/, "the chat nav imports the shared footer");
+assert.match(chatNav, /<SidebarFooter onOpenSettings=\{onOpenSettings\} \/>/, "the chat nav (WorkspaceSidebar) renders the shared footer so Chat keeps it");
+// …and neither hand-rolls its own copy anymore.
+assert.doesNotMatch(minimal, /className="sidebar-foot"[\s\S]{0,40}href="\/dashboard"/, "SidebarMinimal no longer inlines the footer markup");
+
+// WorkspaceSidebar takes onOpenSettings, and workspace threads it through to the
+// chat nav so the Settings button is wired on Chat too.
+assert.match(chatNav, /onOpenSettings: \(\) => void;/, "WorkspaceSidebar declares an onOpenSettings prop");
+assert.match(workspace, /<WorkspaceSidebar[\s\S]*?onOpenSettings=\{\(\) => \{[\s\S]*?push\("\/settings"\)/, "workspace wires onOpenSettings into the chat nav");
+
+console.log("sidebar-footer.test.ts: ok");

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
+import { APP_VERSION } from "@/lib/app-version";
+
+/**
+ * The left side-panel footer — Dashboard + Settings, then the app-version line.
+ *
+ * Extracted so it renders identically in BOTH nav hosts: the labeled
+ * `SidebarMinimal` (shown on every non-chat surface) and the chat-thread
+ * `WorkspaceSidebar` (shown on Chat, which swaps out SidebarMinimal). Without
+ * this the footer vanished on chat pages — the one surface where the nav panel
+ * is replaced. Styles (`.sidebar-foot*`, `.sidebar-version`) live in
+ * sidebar-minimal.css, which globals.css imports app-wide, so they apply here
+ * regardless of host.
+ */
+export function SidebarFooter({ onOpenSettings }: { onOpenSettings: () => void }) {
+  return (
+    <>
+      {/* Bottom: Dashboard + Settings */}
+      <div className="sidebar-foot">
+        {/* Dashboard is a standalone Next route (/dashboard), not a workspace
+            mode — navigate with a real link rather than onModeChange. */}
+        <a
+          className="sidebar-foot-btn"
+          href="/dashboard"
+          aria-label="Dashboard"
+          title="Dashboard — activity overview and daily reports"
+        >
+          <span className="sidebar-foot-icon-cell" aria-hidden="true">
+            <Icon name="ph:squares-four" width={CAVE_ICON_SIZE.sidePanelNav} height={CAVE_ICON_SIZE.sidePanelNav} className="sidebar-foot-icon" />
+          </span>
+          <span className="sidebar-foot-label">Dashboard</span>
+        </a>
+        <button
+          type="button"
+          className="sidebar-foot-btn"
+          onClick={onOpenSettings}
+          aria-label="Settings"
+          title="Settings"
+        >
+          <span className="sidebar-foot-icon-cell" aria-hidden="true">
+            <Icon name="ph:gear-six" width={CAVE_ICON_SIZE.sidePanelNav} height={CAVE_ICON_SIZE.sidePanelNav} className="sidebar-foot-icon" />
+          </span>
+          <span className="sidebar-foot-label">Settings</span>
+        </button>
+      </div>
+
+      {/* Bottommost: app version — one minimal-height muted line. */}
+      <div className="sidebar-version" title={`CovenCave v${APP_VERSION}`}>
+        v{APP_VERSION}
+      </div>
+    </>
+  );
+}

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -5,6 +5,9 @@ import { readFileSync } from "node:fs";
 const styles = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
 const source = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+// The footer (Dashboard + Settings + version) now lives in a shared component so
+// it persists across every nav host, including Chat's WorkspaceSidebar.
+const footer = readFileSync(new URL("./sidebar-footer.tsx", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -228,6 +231,11 @@ assert.match(
 
 assert.match(
   source,
+  /<SidebarFooter onOpenSettings=\{onOpenSettings\} \/>/,
+  "SidebarMinimal renders the shared footer",
+);
+assert.match(
+  footer,
   /sidebar-foot-icon-cell/,
   "Footer controls should use the fixed footer icon cell",
 );
@@ -385,14 +393,19 @@ assert.match(
 // The app version renders as the bottommost sidebar element — one
 // minimal-height muted line under the footer icon row, hidden in the rail.
 assert.match(
-  source,
+  footer,
   /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
-  "SidebarMinimal should read the version from the shared app-version module",
+  "the shared footer reads the version from the shared app-version module",
+);
+assert.match(
+  footer,
+  /className="sidebar-version"[\s\S]{0,120}?v\{APP_VERSION\}[\s\S]{0,40}?<\/div>/,
+  "the version line is the bottommost element of the shared footer",
 );
 assert.match(
   source,
-  /className="sidebar-version"[\s\S]{0,120}?v\{APP_VERSION\}[\s\S]{0,40}?<\/div>\s*<\/nav>/,
-  "The version line should be the bottommost element of the sidebar nav",
+  /<SidebarFooter onOpenSettings=\{onOpenSettings\} \/>\s*<\/nav>/,
+  "the shared footer is the bottommost element of the sidebar nav",
 );
 assert.match(
   styles,

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/lib/page-drag";
 import { sidebarRowState, type SidebarRowState } from "@/lib/sidebar-nav-state";
 import { RecentActivityRollup } from "@/components/recent-activity-rollup";
-import { APP_VERSION } from "@/lib/app-version";
+import { SidebarFooter } from "@/components/sidebar-footer";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -293,39 +293,10 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
         <RecentActivityRollup activeSessionId={activeSessionId} onOpenSession={onOpenSession} />
       </div>
 
-      {/* Bottom: Dashboard + Settings */}
-      <div className="sidebar-foot">
-        {/* Dashboard is a standalone Next route (/dashboard), not a workspace
-            mode — navigate with a real link rather than onModeChange. */}
-        <a
-          className="sidebar-foot-btn"
-          href="/dashboard"
-          aria-label="Dashboard"
-          title="Dashboard — activity overview and daily reports"
-        >
-          <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:squares-four" width={CAVE_ICON_SIZE.sidePanelNav} height={CAVE_ICON_SIZE.sidePanelNav} className="sidebar-foot-icon" />
-          </span>
-          <span className="sidebar-foot-label">Dashboard</span>
-        </a>
-        <button
-          type="button"
-          className="sidebar-foot-btn"
-          onClick={onOpenSettings}
-          aria-label="Settings"
-          title="Settings"
-        >
-          <span className="sidebar-foot-icon-cell" aria-hidden="true">
-            <Icon name="ph:gear-six" width={CAVE_ICON_SIZE.sidePanelNav} height={CAVE_ICON_SIZE.sidePanelNav} className="sidebar-foot-icon" />
-          </span>
-          <span className="sidebar-foot-label">Settings</span>
-        </button>
-      </div>
-
-      {/* Bottommost: app version — one minimal-height muted line. */}
-      <div className="sidebar-version" title={`CovenCave v${APP_VERSION}`}>
-        v{APP_VERSION}
-      </div>
+      {/* Bottom: Dashboard + Settings, then the version line — shared with the
+          chat-thread nav (WorkspaceSidebar) so the footer is identical and
+          persists on every surface, including Chat. */}
+      <SidebarFooter onOpenSettings={onOpenSettings} />
     </nav>
   );
 }

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -5,6 +5,7 @@ import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { FamiliarSwitcher } from "@/components/familiar-switcher";
 import { Icon, type IconName } from "@/lib/icon";
+import { SidebarFooter } from "@/components/sidebar-footer";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { relativeTime } from "@/lib/relative-time";
@@ -47,6 +48,9 @@ type Props = {
   onDeleteSession: (session: SessionRow) => Promise<void>;
   /** Badge count for the Scheduled shortcut (from code-sidebar). */
   scheduledCount?: number;
+  /** Opens Settings — powers the shared footer so Chat keeps the same
+   *  Dashboard/Settings footer as every other surface. */
+  onOpenSettings: () => void;
 };
 
 const THREADS_PREVIEW = 6;
@@ -198,6 +202,7 @@ export function WorkspaceSidebar({
   onNewChat,
   onDeleteSession,
   scheduledCount,
+  onOpenSettings,
 }: Props) {
   const { projects, createProject, reload } = useProjects({ familiarId: activeFamiliarId });
   const overrides = useProjectOverrides();
@@ -674,6 +679,10 @@ export function WorkspaceSidebar({
           )}
         </nav>
 
+        {/* Shared footer (Dashboard + Settings + version) so Chat keeps the same
+            side-panel footer as every other surface; it sits below the scrolling
+            thread list because .cnav__scroll flexes and this stays put. */}
+        <SidebarFooter onOpenSettings={onOpenSettings} />
       </div>
     </div>
   );

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2103,6 +2103,10 @@ export function Workspace() {
         await loadSessions();
       }}
       scheduledCount={scheduleNeedsCount}
+      onOpenSettings={() => {
+        shellRef.current?.dismissNavMobile();
+        nextRouter.push("/settings");
+      }}
     />
   );
 


### PR DESCRIPTION
## What

Chat swaps the left nav from `SidebarMinimal` to `WorkspaceSidebar` — and only `SidebarMinimal` carried the **Dashboard / Settings / version footer**, so it vanished the moment you opened a chat.

## Fix

Extracted the footer into a shared **`<SidebarFooter>`** component and rendered it in **both** nav hosts, so it's identical and present on every surface. In the chat sidebar it sits below the scrolling thread list (`.cnav__scroll` flexes; the footer stays put) and honours the same rail-collapse label-hiding as elsewhere. `WorkspaceSidebar` gains an `onOpenSettings` prop, wired through `workspace.tsx` to the same `/settings` navigation `SidebarMinimal` uses.

## Verification

Driven in a real browser: the footer now shows at the bottom of the expanded chat sidebar (Dashboard + Settings icons + `v0.0.160`), unchanged on other surfaces, exactly **one footer per page** (no duplication). New `sidebar-footer.test.ts` (wired); `SidebarMinimal`'s footer pins were repointed at the shared component. `typecheck` · `check:tests-wired` (776) · sidebar suites green · `build` within budget.

> Note: the chat sidebar's *fully collapsed* rail remains the deliberate minimal "Chats" reopen affordance (unchanged) — the footer shows whenever the panel is open, matching every other surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)