### PR TITLE
fix(workspace): sequence-guard loadSessions so switching familiar can't show the previous one's sessions (cave-jibj)

### DIFF
--- a/src/components/surface-loading-states.test.ts
+++ b/src/components/surface-loading-states.test.ts
@@ -38,15 +38,23 @@ assert.match(
   /const \[sessionsLoaded, setSessionsLoaded\] = useState\(false\)/,
   "Workspace flips sessionsLoaded after the first /api/sessions/list fetch settles",
 );
+// The session list is scoped to the active familiar and reloads on every scope
+// change, so loadSessions is sequence-guarded by a monotonic request id: a stale
+// in-flight load must not paint the previous familiar's sessions (cave-jibj).
 assert.match(
   workspace,
-  /const loadSessionsInFlightRef = useRef<Promise<void> \| null>\(null\)/,
-  "Workspace deduplicates overlapping session-list refreshes",
+  /const loadSessionsReqRef = useRef\(0\)/,
+  "Workspace sequence-guards session-list loads with a request id",
 );
 assert.match(
   workspace,
-  /if \(loadSessionsInFlightRef\.current\) return loadSessionsInFlightRef\.current;/,
-  "Workspace reuses an in-flight session-list request instead of stacking pollers",
+  /const reqId = \+\+loadSessionsReqRef\.current;/,
+  "each session-list load bumps the request id",
+);
+assert.match(
+  workspace,
+  /if \(!isCurrent\(\)\) return; \/\/ superseded/,
+  "a superseded (scope-changed) session-list load drops its writes",
 );
 assert.doesNotMatch(
   workspace,

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -281,7 +281,11 @@ export function Workspace() {
   // false until the first /api/sessions/list fetch settles — lets the chat
   // list show a skeleton instead of flashing its empty state on boot.
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
-  const loadSessionsInFlightRef = useRef<Promise<void> | null>(null);
+  // Monotonic sequence guard for loadSessions (see its definition): the list is
+  // scoped to the active familiar, and loadSessions re-fires on every scope
+  // change, so a stale in-flight load must not paint the previous familiar's
+  // sessions.
+  const loadSessionsReqRef = useRef(0);
   const [daemonRunning, setDaemonRunning] = useState<boolean>(false);
   const { pushBanner, dismissBanner } = useShellBanners();
   const [responseNeeded, setResponseNeeded] = useState<Set<string>>(new Set());
@@ -730,9 +734,19 @@ export function Workspace() {
   }, [selectFamiliarScope]);
 
   const loadSessions = useCallback(() => {
-    if (loadSessionsInFlightRef.current) return loadSessionsInFlightRef.current;
+    // Sequence guard. loadSessions runs from mount, the 4s poll, the
+    // familiars-refresh event, and — because `activeId` is a dep — re-fires
+    // whenever the active-familiar SCOPE changes. It scopes the fetch to that
+    // familiar's granted projects, so a load started under scope A that resolves
+    // *after* the user switches to scope B would paint A's sessions under B
+    // until the next poll healed it. A monotonic reqId (replacing the old
+    // in-flight-promise dedup, which additionally *skipped* the new-scope load
+    // while A was still in flight) drops every superseded load's writes, so only
+    // the newest scope ever reaches state.
+    const reqId = ++loadSessionsReqRef.current;
+    const isCurrent = () => reqId === loadSessionsReqRef.current;
 
-    const request = (async () => {
+    return (async () => {
       let baseSessionsApplied = false;
       const githubTasksPromise = fetch("/api/github/tasks", { cache: "no-store" })
         .then((res) => (res.ok ? res.json() : null))
@@ -744,6 +758,7 @@ export function Workspace() {
         const scope = activeId ? `?familiarId=${encodeURIComponent(activeId)}` : "";
         const sessionsResult = await fetch(`/api/sessions/list${scope}`, { cache: "no-store" });
         const json = await sessionsResult.json();
+        if (!isCurrent()) return; // superseded by a newer load / scope change
         if (!json.ok) return;
 
         const baseSessions = (json.sessions ?? []) as SessionRow[];
@@ -755,7 +770,7 @@ export function Workspace() {
         baseSessionsApplied = true;
 
         const githubTasksJson = await githubTasksPromise;
-        if (githubTasksJson) {
+        if (githubTasksJson && isCurrent()) {
           setGithubAssignedCount(Array.isArray(githubTasksJson.tasks) ? githubTasksJson.tasks.length : 0);
           setSessions((currentSessions) => {
             const enriched = attachGitHubTaskContext(
@@ -768,13 +783,9 @@ export function Workspace() {
       } catch {
         /* transient */
       } finally {
-        if (!baseSessionsApplied) setSessionsLoaded(true);
-        loadSessionsInFlightRef.current = null;
+        if (!baseSessionsApplied && isCurrent()) setSessionsLoaded(true);
       }
     })();
-
-    loadSessionsInFlightRef.current = request;
-    return request;
   }, [activeId]);
 
   useEffect(() => {


### PR DESCRIPTION
## What

The session list is scoped to the active familiar (`?familiarId=…`), and `loadSessions` re-fires whenever the scope changes (`activeId` is a dep). It deduped concurrent loads by returning an in-flight promise — but switching familiar **while a load was in flight** had two bugs: (1) the new-scope load was *skipped* (handed the old promise, never fetched), and (2) the old-scope load applied its result unconditionally. So the chat list / rails / badges showed the **previous familiar's** sessions for up to 4s until the next poll healed it.

## Fix

Replaced the in-flight-promise dedup with a monotonic **`loadSessionsReqRef`**: each call bumps it, and every `setState` is gated on the load still being the newest — so a scope change issues a fresh fetch and the stale one drops all its writes. Same guard the rest of the codebase uses (`refreshRuns`, board, schedules, recent-activity). `sameSessionList` reference-stability and the render-base-before-GitHub-enrich ordering are preserved.

Found by the `workspace.tsx` audit. Source-pinned in `surface-loading-states.test.ts` (the old in-flight-ref pins were repointed at the new guard).

## Verification

`typecheck` · 8 workspace test suites green (surface-loading-states, workspace-familiars-landing, workspace-sidebar-wiring, workspace-rail, nav-rail-coupling, chat-sidebar-wiring, workspace-rail-wiring, inbox-calendar-familiar-scope) · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)