### PR TITLE
fix(daily-report): strip the piggybacked next-paths block from narratives

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -294,6 +294,11 @@ for (const contract of contracts) {
     /NARRATIVE_MAX_STORED_CHARS/,
     "/inbox/daily-summary must bound stored narrative length",
   );
+  assert.match(
+    dailySummarySource,
+    /extractNextPaths\(input\.text\)/,
+    "/inbox/daily-summary must strip the piggybacked next-paths block before storing a narrative",
+  );
 }
 
 // CHAT-D5-02 (amended by cave-id5): cancelling a streaming response is an

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -16,6 +16,7 @@ import { completedCardsForDay, unionMergedPrs } from "@/lib/daily-report-facts";
 import { fetchMergedPrsForDay } from "@/lib/server/github-merged";
 import { loadBoard } from "@/lib/cave-board";
 import type { SessionRow } from "@/lib/types";
+import { extractNextPaths } from "@/lib/next-paths";
 import { isLocalOrigin } from "@/lib/server/local-origin";
 
 export const dynamic = "force-dynamic";
@@ -35,8 +36,12 @@ function sanitizeNarrative(
   if (!input) return null;
   if (typeof input.text !== "string" || typeof input.familiarId !== "string") return null;
   if (typeof input.factsHash !== "string" || !input.factsHash) return null;
+  // The narrative rides the chat pipeline, which appends a `<coven:next-paths>`
+  // suggestions block; the report has no chip row, so never persist the block.
   // eslint-disable-next-line no-control-regex
-  const text = input.text.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "").trim();
+  const text = extractNextPaths(input.text)
+    .visible.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, "")
+    .trim();
   if (!text) return null;
   return {
     text: text.slice(0, NARRATIVE_MAX_STORED_CHARS),

--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -32,5 +32,10 @@ assert.match(page, /Cards completed/, "report should list board cards finished d
 assert.match(page, /Recent sessions/, "pre-Phase-B reports should keep the flat recovered session list");
 assert.match(page, /media\?\.narrative\?\.text/, "report should lead with the familiar-written narrative when present");
 assert.match(page, /Written by/, "narrative should carry a familiar attribution byline");
+assert.match(
+  page,
+  /extractNextPaths\(item\.media\.narrative\.text\)\.visible/,
+  "narrative render should exclude the piggybacked next-paths suggestions block",
+);
 
 console.log("daily-report-page.test.ts: ok");

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -11,6 +11,7 @@ import {
   relativeTime,
   type DailyReportStats,
 } from "@/lib/daily-report";
+import { extractNextPaths } from "@/lib/next-paths";
 
 export const dynamic = "force-dynamic";
 
@@ -415,7 +416,9 @@ export default async function DailyReportPage({ params }: Props) {
             {item.media?.narrative?.text ? (
               <>
                 <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>
-                  {item.media.narrative.text}
+                  {/* Narratives stored before the pipeline stripped the
+                      piggybacked next-paths block are cleaned at render. */}
+                  {extractNextPaths(item.media.narrative.text).visible}
                 </p>
                 <p className="dr-narrative-byline">
                   <Icon name="ph:sparkle" aria-hidden />

--- a/src/app/dashboard-page.test.ts
+++ b/src/app/dashboard-page.test.ts
@@ -201,4 +201,19 @@ assert.match(cockpit, /aria-label=\{`Drag to rearrange: \$\{title\}`\}/, "each g
   );
 }
 
+// The dashboard's inline today-summary renders the stored narrative; legacy
+// narratives may still carry the piggybacked <coven:next-paths> block, so the
+// render must exclude it.
+{
+  const todaySummary = readFileSync(
+    new URL("../components/dashboard/today-summary.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    todaySummary,
+    /extractNextPaths\(summary\.narrative\.text\)\.visible/,
+    "today-summary should exclude the next-paths suggestions block from the narrative",
+  );
+}
+
 console.log("dashboard-page.test.ts: ok");

--- a/src/components/dashboard/today-summary.tsx
+++ b/src/components/dashboard/today-summary.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@/lib/icon";
 import { SectionHead } from "@/components/daily-report-ui";
 import { relativeTime, type RecentReport } from "@/lib/daily-report";
+import { extractNextPaths } from "@/lib/next-paths";
 import type { TodaySummary } from "@/lib/dashboard-model";
 import { ReportCallout } from "./report-callout";
 
@@ -40,7 +41,9 @@ export function TodaySummary({
           {summary.narrative?.text ? (
             <>
               <p className="dr-summary-body" style={{ whiteSpace: "pre-line" }}>
-                {summary.narrative.text}
+                {/* Narratives stored before the pipeline stripped the
+                    piggybacked next-paths block are cleaned at render. */}
+                {extractNextPaths(summary.narrative.text).visible}
               </p>
               <p className="dr-narrative-byline">
                 <Icon name="ph:sparkle" aria-hidden />

--- a/src/lib/daily-narrative.test.ts
+++ b/src/lib/daily-narrative.test.ts
@@ -75,6 +75,20 @@ const now = new Date("2026-06-18T21:15:00.000Z");
   const long = normalizeNarrativeText("x".repeat(NARRATIVE_MAX_CHARS + 500));
   assert.ok(long.length <= NARRATIVE_MAX_CHARS, "narrative should cap at the max length");
   assert.match(long, /…$/, "capped narrative should end with an ellipsis");
+  // The chat pipeline appends a <coven:next-paths> suggestions block to every
+  // reply; the report narrative must exclude it entirely.
+  assert.equal(
+    normalizeNarrativeText(
+      "A steady day of shipping.\n\n<coven:next-paths>\n- Review the open PR\n- Plan tomorrow\n</coven:next-paths>",
+    ),
+    "A steady day of shipping.",
+    "the piggybacked next-paths block should be stripped from the narrative",
+  );
+  assert.equal(
+    normalizeNarrativeText("Partial day.\n<coven:next-paths>\n- Run the te"),
+    "Partial day.",
+    "an unterminated next-paths block should also be stripped",
+  );
 }
 
 console.log("daily-narrative.test.ts: ok");

--- a/src/lib/daily-narrative.ts
+++ b/src/lib/daily-narrative.ts
@@ -9,6 +9,7 @@
 import type { InboxMedia } from "./cave-inbox";
 import type { DailyReportPayload } from "./daily-report-facts.ts";
 import type { DailyReportStats } from "./daily-report.ts";
+import { extractNextPaths } from "./next-paths.ts";
 import { streamFamiliarText } from "./familiar-stream";
 
 /** Don't regenerate for a facts change more often than this. */
@@ -92,9 +93,13 @@ export function shouldRegenerateNarrative({
   return now.getTime() - generatedMs >= minRegenMs;
 }
 
-/** Trim, collapse stray blank runs, and cap the generated narrative. */
+/** Trim, collapse stray blank runs, and cap the generated narrative. The
+ *  transport rides the chat pipeline, which appends a `<coven:next-paths>`
+ *  suggestions block to every reply — a report narrative has no chip row, so
+ *  the block is dropped entirely rather than surfaced. */
 export function normalizeNarrativeText(raw: string): string {
-  const text = raw.replace(/\r/g, "").replace(/\n{3,}/g, "\n\n").trim();
+  const withoutNextPaths = extractNextPaths(raw).visible;
+  const text = withoutNextPaths.replace(/\r/g, "").replace(/\n{3,}/g, "\n\n").trim();
   if (text.length <= NARRATIVE_MAX_CHARS) return text;
   return `${text.slice(0, NARRATIVE_MAX_CHARS - 1).trimEnd()}…`;
 }


### PR DESCRIPTION
Continues idle Copilot session `6aa268fc` — this stream was left uncommitted on the shared checkout after its scroll-list piece merged as #2794.

## Problem
The familiar-written daily narrative rides the chat pipeline, which appends a `<coven:next-paths>` suggestions block to every reply. A report narrative has no chip row, so the block leaked into stored and rendered narrative text as raw markup.

## Fix — stripped at every layer
- **Generation**: `normalizeNarrativeText` drops the block (terminated or unterminated) before trim/cap
- **Persistence**: `/api/inbox/daily-summary` `sanitizeNarrative` never stores it
- **Render**: daily-report page + dashboard today-summary clean legacy narratives stored before the pipeline fix

## Verification
- `daily-narrative.test.ts` (with alias loader) → ok — new strip assertions incl. unterminated block
- `api-contracts.test.ts` → 151 route contracts passed
- `daily-report-page.test.ts`, `dashboard-page.test.ts` → ok