### PR TITLE
fix(grimoire): make Graph mode reachable on narrow/mobile (cave-quct)

### DIFF
--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -136,11 +136,27 @@ assert.match(view, /aria-label="Grimoire view"/, "the Docs|Graph switch is a lab
 assert.match(view, /aria-pressed=\{!showGraph\}[\s\S]{0,1000}aria-pressed=\{showGraph\}/, "the segmented control exposes pressed state");
 assert.match(
   view,
-  /showGraph \? \([\s\S]{0,320}<GrimoireGraphView[\s\S]{0,400}onOpen=\{\(ref\) => \{[\s\S]{0,80}openDoc\(ref\)/,
+  /showGraph \? \([\s\S]{0,1200}<GrimoireGraphView[\s\S]{0,400}onOpen=\{\(ref\) => \{[\s\S]{0,80}openDoc\(ref\)/,
   "the graph replaces the detail pane and opens the clicked doc",
 );
 assert.match(view, /scanning=\{scanning\}/, "the graph view knows a scan is in flight");
 assert.match(view, /scanError=\{scan \? null : scanError\}/, "a failed scan is only surfaced when there is no scan to show");
+
+// ── Graph reachable on narrow / mobile (cave-quct) ───────────────────────────
+// On a narrow container the rail and main pane both go full-width, so the rail
+// must hide when the graph is up (not only when a doc is selected) or the graph
+// is pushed off-screen; and the graph gets a narrow-only back affordance since
+// the rail is then hidden.
+assert.match(
+  view,
+  /selection \|\| showGraph \? "hidden @min-\[880px\]\/grimoire:flex" : ""/,
+  "the rail hides on narrow when a doc is open OR the graph is up",
+);
+assert.match(
+  view,
+  /onClick=\{\(\) => setShowGraph\(false\)\}[\s\S]{0,120}aria-label="Back to document list"/,
+  "the graph view offers a back-to-documents affordance (rail is hidden on narrow)",
+);
 
 // ── Journal autosave conflict guard (cave-9f2e) ──────────────────────────────
 // The Grimoire journal editor sends the mtime it loaded as an optimistic-

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -1119,7 +1119,11 @@ export function GrimoireView() {
       <div className="flex min-h-0 flex-1 gap-3 p-3">
       <aside
         className={`flex h-full min-h-0 w-full flex-col rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 @min-[880px]/grimoire:w-[300px] @min-[880px]/grimoire:shrink-0 ${
-          selection ? "hidden @min-[880px]/grimoire:flex" : ""
+          // On a narrow container the rail and the main pane both go full-width,
+          // so only one may show. Hide the rail when a doc is open OR the graph
+          // is up — otherwise the rail wins the width and the graph is pushed
+          // off-screen (Graph mode was dead on phones). Wide keeps both.
+          selection || showGraph ? "hidden @min-[880px]/grimoire:flex" : ""
         }`}
       >
         {/* Title + surface verbs moved to the compact band above; the rail
@@ -1248,16 +1252,34 @@ export function GrimoireView() {
         }`}
       >
         {showGraph ? (
-          <GrimoireGraphView
-            graph={graph}
-            meta={scan?.meta ?? null}
-            scanning={scanning}
-            scanError={scan ? null : scanError}
-            onOpen={(ref) => {
-              openDoc(ref);
-              setShowGraph(false);
-            }}
-          />
+          <div className="flex h-full min-h-0 flex-col">
+            {/* Narrow-only: the rail is hidden while the graph is up (see the
+                aside condition above), so give an explicit way back to the list
+                — mirrors the document view's back header. */}
+            <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-1.5 @min-[880px]/grimoire:hidden">
+              <button
+                type="button"
+                onClick={() => setShowGraph(false)}
+                aria-label="Back to document list"
+                className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+              >
+                <Icon name="ph:arrow-left" width={13} aria-hidden />
+              </button>
+              <span className="text-[11px] text-[var(--text-secondary)]">Documents</span>
+            </div>
+            <div className="min-h-0 flex-1">
+              <GrimoireGraphView
+                graph={graph}
+                meta={scan?.meta ?? null}
+                scanning={scanning}
+                scanError={scan ? null : scanError}
+                onOpen={(ref) => {
+                  openDoc(ref);
+                  setShowGraph(false);
+                }}
+              />
+            </div>
+          </div>
         ) : selection ? (
           <div className="flex h-full min-h-0 flex-col">
             <div


### PR DESCRIPTION
## What

On a narrow container (<880px) the Grimoire rail and the main pane both go full-width, so only one may show. The rail hid only when a doc was **selected** — not when the **graph** was toggled — so opening Graph with no selection left the rail full-width and pushed the graph **off-screen**. Graph mode was effectively dead on phones (P1 blocker; repro `/tmp/grimoire-audit/13-phone-graph.png`).

## Fix

- Include `showGraph` in the rail's hide condition, so the graph gets the full width on narrow.
- Give the graph a narrow-only **"← Documents"** back affordance (the rail is hidden there), mirroring the document view's back header.
- Wide (≥880px) keeps both panes, unchanged.

## Verification

Driven at a **430px** viewport with Graph active: **rail hidden**, graph pane **full-width**, **back button present** (the graph then loads its data). `typecheck` · `grimoire-view.test.ts` (pins updated + new cave-quct assertions) · `build` within budget.

First of the `grimoire-audit` batch (umbrella cave-x4wf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)