### PR TITLE
fix(backdrop): accept HEIC/HEIF photos in the backdrop picker (cave-cjpb)

### DIFF
--- a/src/components/backdrop-settings.tsx
+++ b/src/components/backdrop-settings.tsx
@@ -57,7 +57,18 @@ export function BackdropSettings() {
           : "Backdrop set. The image has no dominant color, so the theme accent stays.",
       );
     } catch (err) {
-      announce(err instanceof Error ? err.message : "Could not read that image.", "assertive");
+      // createImageBitmap rejects when the engine can't decode the format —
+      // most commonly HEIC photos outside the desktop app. Name the fix
+      // instead of surfacing the engine's opaque decode error.
+      const heicLike = /\.hei[cf]$/i.test(file.name) || /image\/hei[cf]/i.test(file.type);
+      announce(
+        heicLike
+          ? "Couldn't decode that HEIC photo here. It works in the desktop app — elsewhere, convert it to JPEG first."
+          : err instanceof Error && err.message
+            ? err.message
+            : "Could not read that image.",
+        "assertive",
+      );
     } finally {
       setBusy(false);
     }
@@ -93,7 +104,7 @@ export function BackdropSettings() {
         <input
           ref={fileRef}
           type="file"
-          accept="image/png,image/jpeg,image/webp,image/avif"
+          accept="image/png,image/jpeg,image/webp,image/avif,image/heic,image/heif"
           className="hidden"
           onChange={(e) => {
             const file = e.target.files?.[0] ?? null;

--- a/src/lib/cave-backdrop.test.ts
+++ b/src/lib/cave-backdrop.test.ts
@@ -116,5 +116,15 @@ assert.match(settings, /<BackdropSettings \/>/, "Appearance renders the backdrop
 assert.match(backdropSettings, /prepareBackdropImage\(file\)/, "picking an image downscales + derives the seed");
 assert.match(backdropSettings, /accent matched to the image/i, "the pick announces the vibe match to AT");
 assert.match(backdropSettings, /writeBackdropImage\(null\)/, "Clear removes the stored image");
+assert.match(
+  backdropSettings,
+  /accept="image\/png,image\/jpeg,image\/webp,image\/avif,image\/heic,image\/heif"/,
+  "the picker accepts HEIC/HEIF photos (cave-cjpb)",
+);
+assert.match(
+  backdropSettings,
+  /convert it to JPEG first/,
+  "an undecodable HEIC gets an actionable announce, not the engine's decode error",
+);
 
 console.log("cave-backdrop.test.ts: ok");


### PR DESCRIPTION
## What

Most iPhone wallpapers are HEIC, but the backdrop file input filtered them out of the picker entirely (found while setting a user wallpaper — had to `sips -s format jpeg` around it).

- `accept` list gains `image/heic,image/heif`. The desktop app's WebKit webview decodes HEIC natively via `createImageBitmap`, so the existing `prepareBackdropImage` path just works there.
- Where the engine can't decode (plain browsers), the generic "Could not read that image." announce becomes actionable: HEIC works in the desktop app; elsewhere convert to JPEG first.
- Pins added in `cave-backdrop.test.ts` for the accept list and the fallback message.

Bead: cave-cjpb

## Verification

- `tsc --noEmit` clean
- `cave-backdrop.test.ts` ok
- Full suite: ✓ 580 test file(s) passed [app]

🤖 Generated with [Claude Code](https://claude.com/claude-code)