### PR TITLE
fix(grimoire): hide graph orphans by default so it shows structure, not a dot cloud (cave-jf2v)

### DIFF
--- a/src/components/grimoire-graph-view.test.ts
+++ b/src/components/grimoire-graph-view.test.ts
@@ -38,6 +38,10 @@ assert.match(view, /aria-label="Graph filters"/, "the filter card is a labelled 
 assert.match(view, /groups: \{ knowledge: true, memory: true, journal: true, tag: true \}/, "every group defaults on");
 assert.match(view, /edgeTypes: \{ link: true, mention: true, tag: true \}/, "every edge generator defaults on");
 assert.match(view, /prefs\.orphans \? nodesByKind : nodesByKind\.filter/, "orphans are a toggle, not a silent drop");
+// cave-jf2v: orphans default OFF — a mostly-unlinked corpus (e.g. ~400 nodes /
+// ~30 edges) otherwise renders a structureless dot cloud that buries the
+// relationships the graph exists to show.
+assert.match(view, /orphans: false,/, "orphans are hidden by default (connections-first, not a dot cloud)");
 assert.match(view, /aria-label="Repel force"/, "the repel force is a labelled live slider");
 assert.match(view, /aria-label="Link distance"/, "the link distance is a labelled live slider");
 assert.match(view, /aria-label="Highlight graph nodes"/, "graph search is labelled");

--- a/src/components/grimoire-graph-view.tsx
+++ b/src/components/grimoire-graph-view.tsx
@@ -64,7 +64,12 @@ type GraphPrefs = {
 const DEFAULT_PREFS: GraphPrefs = {
   groups: { knowledge: true, memory: true, journal: true, tag: true },
   edgeTypes: { link: true, mention: true, tag: true },
-  orphans: true,
+  // Orphans (unconnected docs) are hidden by default: a real corpus is mostly
+  // unlinked (e.g. ~400 nodes / ~30 edges), so showing them renders a
+  // structureless dot cloud that buries the actual relationships. The graph is
+  // for *connections* — the "Orphans" toggle lets you bring the loose nodes
+  // back when you want them.
+  orphans: false,
   repel: 1,
   linkDistance: DEFAULT_FORCE_PARAMS.linkDistance,
   panelOpen: true,


### PR DESCRIPTION
## What

A real corpus is mostly unlinked — the audit graph was **~411 nodes / ~32 edges** — so the **Orphans** filter defaulting **on** rendered a structureless dot cloud (`407-desktop-graph.png`) that buried the actual relationships the graph exists to show.

## Fix

Flip `DEFAULT_PREFS.orphans` to **off**: the graph now opens on its connected structure, and the **Orphans** toggle brings the loose nodes back on demand. User control and localStorage persistence are unchanged (anyone who has toggled it keeps their choice).

## Verification

`typecheck` · `grimoire-graph-view.test.ts` (new orphans-default pin) · `build` within budget.

Part of the grimoire-audit batch (umbrella cave-x4wf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)