### PR TITLE
chore(release): stamp v0.0.162

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.162] - 2026-07-09
+
+> 🖼️ **Your wallpapers, straight from the camera roll** — the backdrop picker now takes HEIC photos directly, no conversion detour. Plus the side-panel footer stays put on chat pages, familiar switching can't flash another familiar's sessions, Grimoire's graph reaches narrow screens, and daily narratives drop their stowaway next-paths block.
+
+Patch release on top of v0.0.161.
+
+### Fixes
+- **Backdrop: HEIC/HEIF wallpapers work in the picker** (#2815, cave-cjpb). The desktop app decodes iPhone photos natively; where a plain browser can't, the error now says what to do instead of a generic failure.
+- **Shell: the side-panel footer (Dashboard + Settings) stays on chat pages** (#2811).
+- **Workspace: switching familiars can't briefly show the previous familiar's sessions** (#2812, cave-jibj) — session loads are sequence-guarded.
+- **Daily report: narratives no longer carry a piggybacked next-paths block** (#2813).
+- **Grimoire: Graph mode is reachable on narrow/mobile layouts** (#2814, cave-quct).
+
 ## [0.0.161] - 2026-07-09
 
 > 📱 **Threads that stay yours** — the iOS app stops flooding its Threads list with journal-generated runs, matching the web. The task loop closes on the board with live status chips and one-click Mark done, harness failures grow inline fix actions, and Claude Fable 5 joins the Copilot model menu.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.161",
+  "version": "0.0.162",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.161"
+version = "0.0.162"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.161"
+version = "0.0.162"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.161</string>
+	<string>0.0.162</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.161</string>
+	<string>0.0.162</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.161</string>
+	<string>0.0.162</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.161</string>
+	<string>0.0.162</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.161",
+  "version": "0.0.162",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.162 across the six version locations + CHANGELOG.

Patch release on top of v0.0.161:
- **Backdrop: HEIC/HEIF wallpapers work in the picker** (#2815, cave-cjpb)
- Shell: side-panel footer stays on chat pages (#2811)
- Workspace: familiar-switch session sequence guard (#2812, cave-jibj)
- Daily report: next-paths block stripped from narratives (#2813)
- Grimoire: Graph mode reachable on narrow/mobile (#2814, cave-quct)

After merge: tag `v0.0.162` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)