### PR TITLE
fix(grimoire): mobile graph reachability, rail keyboard nav, memory grouped by source root

### DIFF
--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -57,6 +57,44 @@ assert.match(view, /GRIMOIRE_HASH_PREFIX/, "hash prefix is shared with cross-sur
 assert.match(view, /decodeURIComponent/, "hash ids are URL-decoded");
 assert.match(view, /aria-label="Back to document list"/, "compact widths get a back affordance");
 assert.match(view, /@container\/grimoire/, "layout adapts via container queries");
+// (grimoire-audit cave-quct) Graph mode must own the narrow viewport: the rail
+// hides when the graph is showing, and the graph pane gets its own back row.
+assert.match(
+  view,
+  /selection \|\| showGraph \? "hidden @min-\[880px\]\/grimoire:flex" : ""/,
+  "the rail yields to the graph on narrow widths",
+);
+assert.match(
+  view,
+  /onClick=\{\(\) => setShowGraph\(false\)\}\s*\n\s*aria-label="Back to document list"/,
+  "the graph pane has its own narrow-width back affordance",
+);
+
+// ── (grimoire-audit cave-eg6f) rail keyboard navigation ─────────────────────
+// One roving tab stop across the whole navigator: section headers, memory
+// group toggles, rows, and show-more — reaching Journal never means tabbing
+// through hundreds of memory rows.
+assert.match(
+  view,
+  /useRovingTabIndex\(\{\s*\n\s*containerRef: railListRef,\s*\n\s*itemSelector: "\[data-rail-item\]",\s*\n\s*orientation: "vertical",/,
+  "the rail roves focus vertically",
+);
+assert.match(view, /ref=\{railListRef\}/, "the rail scroll container carries the roving scope");
+const railItemCount = (view.match(/data-rail-item/g) ?? []).length;
+assert.ok(railItemCount >= 4, `NavRow, section headers, group toggles, and show-more are all roving items (found ${railItemCount})`);
+
+// ── (grimoire-audit cave-v1j0) memory grouped by source root ────────────────
+// Runtime roots write thousands of timestamp-named files; grouping by
+// rootLabel with big groups collapsed keeps Knowledge and Journal visible.
+assert.match(view, /"cave:grimoire:memory-groups-collapsed"/, "memory group collapse overrides persist");
+assert.match(view, /const grouped = memoryGroups\.length > 1/, "a lone memory root renders flat (no redundant header)");
+assert.match(view, /defaultCollapsed = grouped && group\.entries\.length > 20/, "big memory groups start collapsed");
+assert.match(
+  view,
+  /grouped && !q && \(collapsedMemoryGroups\[group\.label\] \?\? defaultCollapsed\)/,
+  "an active search expands memory groups so matches stay reachable",
+);
+assert.match(view, /Show more \(\{group\.entries\.length - limit\} remaining\)/, "each group pages independently");
 
 // ── Delete/trash actions (cave-kv3) ──────────────────────────────────────────
 

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -433,6 +433,7 @@ function NavRow({
   return (
     <button
       type="button"
+      data-rail-item
       onClick={onClick}
       aria-current={selected ? "true" : undefined}
       className={`focus-ring-inset w-full rounded-md px-2 py-1.5 text-left transition-colors ${
@@ -455,6 +456,19 @@ function NavRow({
 const RAIL_COLLAPSED_STORAGE_KEY = "cave:grimoire:rail-collapsed";
 
 type RailSectionId = "knowledge" | "memory" | "journal";
+
+const MEMORY_GROUPS_STORAGE_KEY = "cave:grimoire:memory-groups-collapsed";
+
+/** Per-root collapse overrides for the Memory section's source groups. */
+function readCollapsedMemoryGroups(): Record<string, boolean> {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(MEMORY_GROUPS_STORAGE_KEY) ?? "{}");
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
 
 function readCollapsedSections(): Record<RailSectionId, boolean> {
   const none = { knowledge: false, memory: false, journal: false };
@@ -499,6 +513,7 @@ function RailSection({
       <h3>
         <button
           type="button"
+          data-rail-item
           aria-expanded={!collapsed}
           title={description}
           onClick={onToggle}
@@ -861,10 +876,40 @@ export function GrimoireView() {
     () => (memory ?? []).filter((e) => matches(e.relPath, e.fullPath, e.rootLabel, e.familiarId)),
     [memory, matches],
   );
-  // Big memory inventories (1000s of runtime files) would swamp the DOM —
-  // render in pages of 100 with an explicit "show more".
-  const [memoryLimit, setMemoryLimit] = useState(100);
-  const pagedMemory = useMemo(() => visibleMemory.slice(0, memoryLimit), [visibleMemory, memoryLimit]);
+  // Runtime roots write thousands of timestamp-named session files; rendered
+  // flat they drown Knowledge and Journal. Group memory by its source root —
+  // big groups start collapsed, and an active search expands everything so
+  // matches stay reachable.
+  const memoryGroups = useMemo(() => {
+    const order: string[] = [];
+    const byRoot = new Map<string, MemoryEntry[]>();
+    for (const entry of visibleMemory) {
+      let group = byRoot.get(entry.rootLabel);
+      if (!group) {
+        group = [];
+        byRoot.set(entry.rootLabel, group);
+        order.push(entry.rootLabel);
+      }
+      group.push(entry);
+    }
+    return order.map((label) => ({ label, entries: byRoot.get(label)! }));
+  }, [visibleMemory]);
+  const [collapsedMemoryGroups, setCollapsedMemoryGroups] =
+    useState<Record<string, boolean>>(readCollapsedMemoryGroups);
+  const toggleMemoryGroup = useCallback((label: string, defaultCollapsed: boolean) => {
+    setCollapsedMemoryGroups((prev) => {
+      const next = { ...prev, [label]: !(prev[label] ?? defaultCollapsed) };
+      try {
+        window.localStorage.setItem(MEMORY_GROUPS_STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        /* private mode — session-only */
+      }
+      return next;
+    });
+  }, []);
+  // Big groups (1000s of runtime files) would swamp the DOM — render each in
+  // pages of 100 with an explicit "show more".
+  const [memoryGroupLimits, setMemoryGroupLimits] = useState<Record<string, number>>({});
   const visibleJournal = useMemo(
     () => (journal ?? []).filter((d) => matches(d.date, d.preview)),
     [journal, matches],
@@ -886,6 +931,16 @@ export function GrimoireView() {
   useEffect(() => {
     if (selectedTabIndex >= 0) setTabStopIndex(selectedTabIndex);
   }, [selectedTabIndex, setTabStopIndex]);
+
+  // Roving focus for the navigator rail (↑/↓ across section headers, memory
+  // group toggles, and document rows — one tab stop), so reaching Journal
+  // never means tabbing through hundreds of memory rows.
+  const railListRef = useRef<HTMLDivElement | null>(null);
+  useRovingTabIndex({
+    containerRef: railListRef,
+    itemSelector: "[data-rail-item]",
+    orientation: "vertical",
+  });
 
   // Index of every loaded doc, used to resolve a doc's outgoing [[wiki-links]].
   const docIndex = useMemo<WikiDocIndex>(
@@ -1141,7 +1196,7 @@ export function GrimoireView() {
             className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-transparent px-2 py-1.5 text-[12px] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
           />
         </div>
-        <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
+        <div ref={railListRef} className="min-h-0 flex-1 space-y-3 overflow-y-auto p-2">
           {loadError ? (
             <ErrorState compact headline="Couldn't load documents" subtitle={loadError} />
           ) : loading ? (
@@ -1194,27 +1249,68 @@ export function GrimoireView() {
                     {q ? "No matches." : "No memory files found."}
                   </p>
                 ) : (
-                  <>
-                    {pagedMemory.map((entry) => (
-                      <NavRow
-                        key={entry.fullPath}
-                        selected={selectedKey === `memory:${entry.fullPath}`}
-                        title={entry.relPath.split("/").pop() ?? entry.relPath}
-                        subtitle={entry.rootLabel}
-                        meta={entry.modified ? relativeTime(entry.modified) : undefined}
-                        onClick={() => openDoc({ kind: "memory", path: entry.fullPath })}
-                      />
-                    ))}
-                    {visibleMemory.length > memoryLimit ? (
-                      <button
-                        type="button"
-                        onClick={() => setMemoryLimit((n) => n + 200)}
-                        className="focus-ring-inset w-full rounded-md px-2 py-1.5 text-left text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
-                      >
-                        Show more ({visibleMemory.length - memoryLimit} remaining)
-                      </button>
-                    ) : null}
-                  </>
+                  memoryGroups.map((group) => {
+                    // A lone group renders flat — its header would only echo
+                    // the row subtitles. Multiple roots get disclosures, and
+                    // big groups start closed so runtime logs stay tamed.
+                    const grouped = memoryGroups.length > 1;
+                    const defaultCollapsed = grouped && group.entries.length > 20;
+                    const collapsed =
+                      grouped && !q && (collapsedMemoryGroups[group.label] ?? defaultCollapsed);
+                    const limit = memoryGroupLimits[group.label] ?? 100;
+                    const paged = group.entries.slice(0, limit);
+                    return (
+                      <div key={group.label}>
+                        {grouped ? (
+                          <button
+                            type="button"
+                            data-rail-item
+                            aria-expanded={!collapsed}
+                            onClick={() => toggleMemoryGroup(group.label, defaultCollapsed)}
+                            className="focus-ring-inset flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                          >
+                            <Icon name={collapsed ? "ph:caret-right" : "ph:caret-down"} width={9} aria-hidden />
+                            <span className="min-w-0 flex-1 truncate text-left">{group.label}</span>
+                            <span className="shrink-0 font-normal text-[var(--text-muted)]">
+                              {group.entries.length}
+                            </span>
+                          </button>
+                        ) : null}
+                        {collapsed ? null : (
+                          <>
+                            {paged.map((entry) => (
+                              <NavRow
+                                key={entry.fullPath}
+                                selected={selectedKey === `memory:${entry.fullPath}`}
+                                title={entry.relPath.split("/").pop() ?? entry.relPath}
+                                subtitle={
+                                  grouped
+                                    ? entry.relPath.includes("/")
+                                      ? entry.relPath.slice(0, entry.relPath.lastIndexOf("/"))
+                                      : undefined
+                                    : entry.rootLabel
+                                }
+                                meta={entry.modified ? relativeTime(entry.modified) : undefined}
+                                onClick={() => openDoc({ kind: "memory", path: entry.fullPath })}
+                              />
+                            ))}
+                            {group.entries.length > limit ? (
+                              <button
+                                type="button"
+                                data-rail-item
+                                onClick={() =>
+                                  setMemoryGroupLimits((prev) => ({ ...prev, [group.label]: limit + 200 }))
+                                }
+                                className="focus-ring-inset w-full rounded-md px-2 py-1.5 text-left text-[11px] text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-secondary)]"
+                              >
+                                Show more ({group.entries.length - limit} remaining)
+                              </button>
+                            ) : null}
+                          </>
+                        )}
+                      </div>
+                    );
+                  })
                 )}
               </RailSection>
               <RailSection


### PR DESCRIPTION
## Grimoire UI/UX audit — Batch B (shell/navigation)

Part of the `grimoire-audit` bead series.

> Note: the mobile-graph finding (cave-quct) landed independently as #2814 while this PR was open — after rebase this PR carries the remaining two items plus test pins for all three.

### cave-v1j0 — 1889 flat memory rows drowned the rail (P1)
Runtime roots write thousands of timestamp-named session files; rendered flat they buried Knowledge and Journal. Memory now groups by source root (`rootLabel`):
- groups >20 entries start collapsed; overrides persist (`cave:grimoire:memory-groups-collapsed`)
- a lone root renders flat (no redundant header)
- an active search expands all groups so matches stay reachable
- paging (100 + show-more) is per group

Verified live: 1889 rows → 7 disclosures with counts.

### cave-eg6f — rail had no keyboard list navigation (P2)
One roving tab stop across the whole navigator (section headers, group toggles, rows, show-more) via the shared `useRovingTabIndex` — reaching Journal no longer means tabbing through hundreds of memory rows.

### Validation
- `grimoire-view.test.ts` extended with pins for grouping, rail roving, and the narrow-graph behavior (#2814's fix is pinned too)
- targeted + full `pnpm test:app` (580 files) green; `tsc --noEmit` clean
- Live screenshots (prod build, 1600px + 390px): grouped rail, group expand, phone graph + back row