### PR TITLE
fix(grimoire): quick wins — pref-aware journal dates, eviction announce, editor skeleton, tappable chips, search SR counts

### DIFF
--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -96,6 +96,27 @@ assert.match(
 );
 assert.match(view, /Show more \(\{group\.entries\.length - limit\} remaining\)/, "each group pages independently");
 
+// ── (grimoire-audit Batch A quick wins) ──────────────────────────────────────
+// cave-0rx0: journal dates honor the user's datetime prefs everywhere (rail
+// rows, tab labels, editor footer, delete confirm) instead of raw ISO.
+assert.match(view, /function journalDayLabel\(date: string, prefs: DateTimePrefs\)/, "there is a shared journal date label helper");
+assert.match(view, /new Date\(`\$\{date\}T00:00:00`\)/, "date-only strings anchor to local midnight (no UTC day shift)");
+assert.match(view, /title=\{journalDayLabel\(day\.date, dateTimePrefs\)\}/, "rail journal rows format through prefs");
+assert.match(view, /return journalDayLabel\(sel\.date, dateTimePrefs\)/, "journal tab labels format through prefs");
+assert.match(view, /Journal · \$\{journalDayLabel\(date, dateTimePrefs\)\}/, "the editor footer source label formats through prefs");
+assert.match(view, /journalDayLabel\(selection\.date, readDateTimePrefs\(\)\)/, "the delete confirm formats through prefs");
+// cave-ezxb: the over-cap tab eviction announces instead of silently closing.
+assert.match(view, /evictedRef\.current = tabs\[evictIndex\] \?\? null/, "openDoc records what it evicted");
+assert.match(view, /announce\(`Closed \$\{tabTitle\(evictedRef\.current\)\} — \$\{MAX_OPEN_TABS\}-tab limit reached`/, "evictions are announced post-commit");
+// cave-gsvf: search results are announced to screen readers (debounced).
+assert.match(view, /No documents match/, "an empty result set announces");
+assert.match(view, /knowledge, \$\{visibleMemory\.length\} memory, \$\{visibleJournal\.length\} journal/, "match counts announce per section");
+// cave-bkpj: unresolved wiki-link chips are actionable on touch — tapping
+// shows a visible hint (and announces it) instead of a hover-only title.
+assert.match(view, /const \[unresolvedHint, setUnresolvedHint\] = useState<string \| null>/, "unresolved chips have a tap-visible hint");
+assert.match(view, /has no matching doc yet — create a knowledge entry/, "the hint says how to resolve the link");
+assert.match(view, /aria-expanded=\{unresolvedHint === display\}/, "the unresolved chip exposes its hint state");
+
 // ── Delete/trash actions (cave-kv3) ──────────────────────────────────────────
 
 assert.match(view, /useConfirm\(\)/, "destructive actions confirm through the shared dialog");
@@ -146,7 +167,7 @@ assert.match(
   "the doc index maps memory entries by fullPath (the same path openDoc navigates to)",
 );
 assert.match(view, /onClick=\{\(\) => onOpen\(ref\)\}/, "a resolved chip navigates to its doc");
-assert.match(view, /title="No matching Grimoire doc"[\s\S]{0,160}border-dashed/, "an unresolved link renders dashed + inert with a hint");
+assert.match(view, /title="No matching Grimoire doc"[\s\S]{0,600}border-dashed/, "an unresolved link renders dashed with a hint (tap shows why — cave-bkpj)");
 assert.match(view, /<GrimoireDocLinks\b[\s\S]{0,280}onOpen=\{openDoc\}/, "the chip row is wired to openDoc for the active doc");
 
 // ── Backlinks: incoming mentions from the doc graph (cave-hand) ──────────────

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -24,6 +24,12 @@ import { MdEditor, type MdEditorSaveResult } from "@/components/md-editor/md-edi
 import { MemoryMdEditor } from "@/components/md-editor/memory-md-editor";
 import { parseMdDocument, serializeMdDocument, type MdDocument } from "@/lib/md-frontmatter";
 import { relativeTime } from "@/lib/relative-time";
+import {
+  formatDate,
+  readDateTimePrefs,
+  useDateTimePrefs,
+  type DateTimePrefs,
+} from "@/lib/datetime-format";
 import { GRIMOIRE_HASH_PREFIX } from "@/lib/grimoire-link";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { useAnnouncer } from "@/components/ui/live-region";
@@ -329,6 +335,7 @@ function KnowledgeMdEditor({
 }
 
 function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void }) {
+  const dateTimePrefs = useDateTimePrefs();
   const [state, setState] = useState<{ reflection: string; reflectedBy: string | null } | null>(null);
   const [error, setError] = useState<string | null>(null);
   // The `modified` (mtime) this editor last loaded/saved, sent as the
@@ -408,7 +415,7 @@ function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void
       key={date}
       value={state.reflection}
       showHeader={false}
-      sourceLabel={`Journal · ${date}`}
+      sourceLabel={`Journal · ${journalDayLabel(date, dateTimePrefs)}`}
       onSave={save}
       autoSave
     />
@@ -416,6 +423,17 @@ function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void
 }
 
 // ── Navigator row ────────────────────────────────────────────────────────────
+
+// ── Journal date labels ──────────────────────────────────────────────────────
+
+/** "2026-07-08" → "Jul 8" / "8 Jul" per the user's datetime prefs (+ year when
+ *  it isn't the current one). Date-only ISO strings parse as UTC midnight —
+ *  anchor to local midnight so the label never shifts a day. */
+function journalDayLabel(date: string, prefs: DateTimePrefs): string {
+  const d = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(d.getTime())) return date;
+  return formatDate(d, prefs, { year: d.getFullYear() !== new Date().getFullYear() });
+}
 
 function NavRow({
   selected,
@@ -556,6 +574,11 @@ function GrimoireDocLinks({
   // useMemoryFile is a hook, so it's always called; a null path is a no-op.
   const memoryPath = selection.kind === "memory" ? selection.path : null;
   const memFile = useMemoryFile(memoryPath, { reveal: true });
+  const { announce } = useAnnouncer();
+  // (grimoire-audit cave-bkpj) Unresolved chips explained themselves via
+  // title= only — inert on touch. Tapping one now shows (and announces) why.
+  const [unresolvedHint, setUnresolvedHint] = useState<string | null>(null);
+  useEffect(() => setUnresolvedHint(null), [selection]);
 
   const [journalMd, setJournalMd] = useState<string | null>(null);
   useEffect(() => {
@@ -639,16 +662,29 @@ function GrimoireDocLinks({
                 {display}
               </button>
             ) : (
-              <span
+              <button
                 key={i}
+                type="button"
                 title="No matching Grimoire doc"
-                className="rounded-full border border-dashed border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)]"
+                aria-expanded={unresolvedHint === display}
+                onClick={() => {
+                  const hint = `“${display}” has no matching doc yet — create a knowledge entry with that title to link it.`;
+                  setUnresolvedHint((prev) => (prev === display ? null : display));
+                  if (unresolvedHint !== display) announce(hint, "polite");
+                }}
+                className="focus-ring rounded-full border border-dashed border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)] transition-colors hover:text-[var(--text-secondary)]"
               >
                 {display}
-              </span>
+              </button>
             );
           })}
         </div>
+      ) : null}
+      {unresolvedHint ? (
+        <p className="text-[11px] text-[var(--text-muted)]" role="status">
+          “{unresolvedHint}” has no matching doc yet — create a knowledge entry with that title to
+          link it.
+        </p>
       ) : null}
       {backlinks.length > 0 ? (
         <div className="flex flex-wrap items-center gap-1.5">
@@ -702,6 +738,9 @@ export function GrimoireView() {
   }, []);
   const confirm = useConfirm();
   const { announce } = useAnnouncer();
+  const dateTimePrefs = useDateTimePrefs();
+  // Selection evicted by an over-cap openDoc, announced post-commit.
+  const evictedRef = useRef<GrimoireSelection | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   // Open tabs + the active one. A #grimoire: deep link wins over the restored
@@ -737,6 +776,7 @@ export function GrimoireView() {
         // Evict the oldest non-active tab to stay within the mount budget.
         const activeKey = prev.selection ? selectionKey(prev.selection) : null;
         const evictIndex = tabs.findIndex((t) => selectionKey(t) !== activeKey);
+        evictedRef.current = tabs[evictIndex] ?? null;
         tabs = tabs.filter((_, i) => i !== evictIndex);
       }
       return { openTabs: tabs, selection: sel };
@@ -817,7 +857,7 @@ export function GrimoireView() {
         ? "Move this memory file to the trash?"
         : selection.kind === "knowledge"
           ? "Delete this knowledge entry?"
-          : `Delete the journal reflection for ${selection.date}?`;
+          : `Delete the journal reflection for ${journalDayLabel(selection.date, readDateTimePrefs())}?`;
     const body =
       selection.kind === "memory"
         ? "The file moves to the Cave's memory trash and can be restored from there."
@@ -915,6 +955,23 @@ export function GrimoireView() {
     [journal, matches],
   );
 
+  // (grimoire-audit cave-gsvf) The only search feedback was the visual section
+  // counters — announce result counts to screen readers, debounced past the
+  // keystroke burst.
+  useEffect(() => {
+    if (!q) return;
+    const t = window.setTimeout(() => {
+      const total = visibleKnowledge.length + visibleMemory.length + visibleJournal.length;
+      announce(
+        total === 0
+          ? "No documents match"
+          : `${total} ${total === 1 ? "match" : "matches"} — ${visibleKnowledge.length} knowledge, ${visibleMemory.length} memory, ${visibleJournal.length} journal`,
+        "polite",
+      );
+    }, 400);
+    return () => window.clearTimeout(t);
+  }, [q, visibleKnowledge.length, visibleMemory.length, visibleJournal.length, announce]);
+
   const loading = knowledge === null || memory === null || journal === null;
   const selectedKey = selection ? selectionKey(selection) : null;
 
@@ -998,10 +1055,18 @@ export function GrimoireView() {
         return (knowledge ?? []).find((e) => e.id === sel.id)?.title ?? sel.id;
       }
       if (sel.kind === "memory") return sel.path.split("/").pop() ?? sel.path;
-      return sel.date;
+      return journalDayLabel(sel.date, dateTimePrefs);
     },
-    [knowledge],
+    [knowledge, dateTimePrefs],
   );
+
+  // (grimoire-audit cave-ezxb) The over-cap eviction in openDoc was silent — a
+  // doc you had open just vanished. Announce it after the commit lands.
+  useEffect(() => {
+    if (!evictedRef.current) return;
+    announce(`Closed ${tabTitle(evictedRef.current)} — ${MAX_OPEN_TABS}-tab limit reached`, "polite");
+    evictedRef.current = null;
+  }, [openTabs, announce, tabTitle]);
 
   /** Detail editor for one tab. Every open tab stays mounted (hidden when
    *  inactive) so unsaved drafts survive switching tabs. */
@@ -1331,7 +1396,7 @@ export function GrimoireView() {
                     <NavRow
                       key={day.date}
                       selected={selectedKey === `journal:${day.date}`}
-                      title={day.date}
+                      title={journalDayLabel(day.date, dateTimePrefs)}
                       subtitle={day.preview}
                       onClick={() => openDoc({ kind: "journal", date: day.date })}
                     />

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -141,3 +141,11 @@ const codeEditor = await readFile(new URL("../code-editor.tsx", import.meta.url)
 assert.match(codeEditor, /from "@\/components\/code-editor-theme"/, "code-editor consumes the shared theme");
 
 console.log("md-editor.test: ok");
+
+// ── (grimoire-audit cave-say6) editor lazy-load skeleton ─────────────────────
+// The visual editor chunk used to flash a bare "Loading editor…" line while
+// Milkdown loaded — it now renders skeleton text lines like the other panes.
+assert.match(shell, /loading: \(\) => \(\s*\n\s*\/\/ Skeleton lines/, "the dynamic import has a skeleton fallback");
+assert.match(shell, /<Skeleton key=\{i\} variant="text" width=\{w\} \/>/, "the fallback uses the shared Skeleton primitive");
+assert.match(shell, /aria-label="Loading editor" aria-busy="true"/, "the fallback is announced as busy");
+assert.ok(!shell.includes("Loading editor…"), "the bare text flash is gone");

--- a/src/components/md-editor/md-editor.tsx
+++ b/src/components/md-editor/md-editor.tsx
@@ -22,6 +22,7 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
 
 /** Trailing debounce before an autosave fires once typing pauses. */
 const AUTOSAVE_DEBOUNCE_MS = 1200;
@@ -38,8 +39,11 @@ import { diffLines, mergeThreeWay, type LineDiffOp } from "@/lib/line-diff";
 const MdEditorVisual = dynamic(() => import("./md-editor-visual"), {
   ssr: false,
   loading: () => (
-    <div className="grid h-full place-items-center text-[11px] text-[var(--text-muted)]">
-      Loading editor…
+    // Skeleton lines instead of a bare text flash while the editor chunk loads.
+    <div className="space-y-2.5 p-4" aria-label="Loading editor" aria-busy="true">
+      {["92%", "85%", "97%", "70%"].map((w, i) => (
+        <Skeleton key={i} variant="text" width={w} />
+      ))}
     </div>
   ),
 });

--- a/tests/grimoire-autosave.spec.ts
+++ b/tests/grimoire-autosave.spec.ts
@@ -121,7 +121,10 @@ async function typeInEditor(page: Page, text: string) {
 test.describe("grimoire autosave (desktop)", () => {
   test("journal reflections autosave after the debounce — no Save click", async ({ page }) => {
     await gotoGrimoire(page);
-    await page.getByRole("button", { name: /2026-07-01/ }).click();
+    // The rail formats journal dates through datetime prefs ("Jul 1" /
+    // "1 Jul", + year when not current) — match the row by its preview text,
+    // which is stable across pref and clock-year changes.
+    await page.getByRole("button", { name: /Shipped the grimoire\./ }).click();
 
     const posted = page.waitForRequest(
       (req) => req.method() === "POST" && req.url().includes("/api/journal"),


### PR DESCRIPTION
## Grimoire UI/UX audit — Batch A (quick wins)

Part of the `grimoire-audit` bead series (follows #2820).

- **cave-0rx0** — journal dates honor datetime prefs (`formatDate`) in the rail, tab labels, editor footer, and delete confirm; date-only ISO anchors to local midnight (no UTC day shift)
- **cave-ezxb** — the 8-tab over-cap eviction announces which doc it closed (was silent data loss from the tab strip)
- **cave-say6** — visual editor lazy-load renders skeleton lines instead of a bare 'Loading editor…' flash (benefits every MdEditor host)
- **cave-bkpj** — unresolved wiki-link chips: tap shows a visible + announced hint (title-tooltip was pointer-only)
- **cave-gsvf** — rail search announces debounced per-section result counts to SRs (content search half of this bead is filed separately)

### Validation
- New pins in `grimoire-view.test.ts` + `md-editor.test.ts`; targeted + full `pnpm test:app` (581 files) green; `tsc --noEmit` clean