### PR TITLE
feat(chat): multi-file turns get one "Review all" entry into the Changes tab (cave-qva4)

### DIFF
--- a/docs/golden-paths.md
+++ b/docs/golden-paths.md
@@ -110,32 +110,31 @@ every element of the answer is one click from acting on it.
 **Story:** As a developer, I want to hand my familiar a change, review the
 diff, and keep the result — without leaving the app for git plumbing.
 
-**The path today:** chat binds a project (`chat-projects.ts`,
-`activeProjectRoot`; per-familiar project grants in the Studio); the code
-rail browses and edits files (`rail-files-panel.tsx`,
-`rail-file-preview.tsx` → `POST /api/project-file`); a unified diff renderer
-exists (`gh-diff-view.tsx`) but is GitHub-review-scoped. **There is no
-working-tree diff view, no review gate, and no commit affordance** — a
-familiar's edits sit in the working directory until the user opens a
-terminal.
+**The path today** (corrected 2026-07-09 — the original assessment here was
+written against a stale snapshot and understated the codebase): chat binds a
+project (`chat-projects.ts`, `activeProjectRoot`; per-familiar grants in the
+Studio); the code rail's **Changes** tab renders the working-tree diff per
+project root (`session-changes-panel.tsx` over `GET /api/changes`,
+double-allowlisted to registered project roots + daemon session roots);
+per-file **revert** with auto-checkpoint, patch-based **checkpoints**, a
+signed **Commit** action (`git add -A` + feature-branch-on-default +
+`git commit -S`) and **Create PR** all live on the same route; chat edit
+cards carry per-file Review/Undo wired through `cave:open-file-diff` /
+`cave:changes-refresh`.
 
-**Where it breaks:** review-and-keep exits the app exactly at the moment of
-highest trust-sensitivity.
+**Where it broke** (the remaining sliver): a turn that edited *several*
+files offered only per-card Review buttons — no single aggregate entry into
+the review at the turn level.
 
-**Enablement plan** (bead `cave-qva4`):
-1. The code rail gains a **Changes** tab: read-only working-tree diff per
-   project root via a new `GET /api/project/changes` (`git status` +
-   `git diff`, allowlisted to registered project roots), rendered with the
-   existing `gh-diff-view` hunks.
-2. A **Checkpoint** action commits the working tree on that root
-   (`git add -A` + signed commit with a generated message) through a server
-   route with the same root allowlisting. No push — publishing stays a
-   deliberate, external act.
-3. Chat linking: when a familiar's turn edited files, the turn footer offers
-   "N files changed — review", opening the Changes tab.
+**Enablement** (bead `cave-qva4`, delivered): phases 1–2 of the original
+plan pre-existed as `/api/changes`, richer than specced (commit *and* PR —
+note the existing Create PR affordance does push, deliberately, on click).
+Phase 3 shipped as an aggregate chip: a settled turn whose edit cards
+touched more than one distinct file renders "N files changed · Review all",
+opening the Changes tab through the cards' existing event contract.
 
-**Done means:** delegate → review the actual diff → checkpoint, all in-app;
-nothing is auto-pushed anywhere.
+**Done means:** delegate → review the actual diff → checkpoint/commit, all
+in-app; nothing is pushed without a deliberate click.
 
 ## 5 · Take Cave with you
 

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -185,6 +185,23 @@ assert.match(
   /const isEditCard = \(t: ToolEvent\) =>\s*toolInputAsDiff\(t\.name, t\.input\) != null;/,
   "any structured file mutation diff stays visible inline, even when the tool input only has a relative path",
 );
+// Golden path 4 (cave-qva4): a multi-file turn gets ONE aggregate entry into
+// the working-tree review, riding the per-card cave:open-file-diff contract.
+assert.match(
+  turnRow,
+  /const editedFiles = Array\.from\(\s*\n\s*new Set\(\s*\n\s*editCards\s*\n\s*\.map\(\(t\) => toolTargetFile\(t\.name, t\.input\)\)/,
+  "the aggregate counts DISTINCT edited files (the same file edited twice is one change)",
+);
+assert.match(
+  turnRow,
+  /\{editedFiles\.length > 1 \? \([\s\S]{0,400}?\{editedFiles\.length\} files changed/,
+  "turns that edited more than one distinct file render the 'N files changed' chip (single-file turns keep just the card's own Review)",
+);
+assert.match(
+  turnRow,
+  /aria-label=\{`Review all \$\{editedFiles\.length\} changed files in the Changes tab`\}[\s\S]{0,300}?cave:open-file-diff/,
+  "Review all opens the Changes tab through the cards' existing event contract",
+);
 assert.match(
   turnRow,
   /otherTools\.length \? <ToolGroup tools=\{otherTools\}/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5843,10 +5843,43 @@ function TurnRowImpl({
                     toolInputAsDiff(t.name, t.input) != null;
                   const editCards = turn.tools.filter(isEditCard);
                   const otherTools = turn.tools.filter((t) => !isEditCard(t));
+                  // Golden path 4 (cave-qva4): a multi-file turn gets ONE
+                  // aggregate entry into the working-tree review — the
+                  // per-card Review buttons remain, but "which of these five
+                  // cards do I click" shouldn't be the first question. The
+                  // chip rides the cards' existing cave:open-file-diff
+                  // contract (the Changes panel suffix-matches the path and
+                  // shows every changed file once open).
+                  const editedFiles = Array.from(
+                    new Set(
+                      editCards
+                        .map((t) => toolTargetFile(t.name, t.input))
+                        .filter((p): p is string => Boolean(p)),
+                    ),
+                  );
                   return (
                     <>
                       {editCards.length ? (
                         <div className="cave-edit-cards mt-3 space-y-2">
+                          {editedFiles.length > 1 ? (
+                            <div className="cave-turn-changes flex items-center justify-between gap-3 rounded-md border border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--bg-raised)_78%,transparent)] px-3 py-1.5">
+                              <span className="text-[11px] font-medium text-[var(--text-secondary)]">
+                                {editedFiles.length} files changed
+                              </span>
+                              <button
+                                type="button"
+                                className="focus-ring rounded border border-[var(--border-strong)] px-2 py-0.5 text-[10px] text-[var(--text-secondary)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                                aria-label={`Review all ${editedFiles.length} changed files in the Changes tab`}
+                                onClick={() =>
+                                  window.dispatchEvent(
+                                    new CustomEvent("cave:open-file-diff", { detail: { path: editedFiles[0] } }),
+                                  )
+                                }
+                              >
+                                Review all
+                              </button>
+                            </div>
+                          ) : null}
                           {editCards.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
                         </div>
                       ) : null}


### PR DESCRIPTION
## What

Golden path 4 ("delegate a coding change — review the diff, accept, commit in-app") close-out — with a verification twist.

**Most of the bead's plan already existed.** Phases 1–2 (Changes tab with working-tree diff; signed commit action) shipped long before the golden-paths doc: `session-changes-panel.tsx` over `GET /api/changes` (double-allowlisted to registered project roots + daemon session roots), per-file revert with auto-checkpoint, patch-based checkpoints, `action:"commit"` (`git add -A` + feature-branch-on-default + `git commit -S`), and even `action:"create-pr"`. The doc's "there is no working-tree diff view, no review gate, and no commit affordance" was written against a stale snapshot — **§4 is corrected** to describe reality (including noting that Create PR exceeds the doc's "no push" stance, deliberately, on click).

**The genuinely missing sliver — phase 3 — ships here:** a settled turn whose edit cards touched more than one **distinct** file (same file edited twice counts once) renders a quiet "N files changed · **Review all**" chip above the cards. It dispatches the cards' existing `cave:open-file-diff` event with the first edited path — the Changes panel suffix-matches and shows every changed file once open — so no new API, no new event, no new panel state. Single-file turns keep just the card's own Review button.

## Verification

- `pnpm typecheck` clean; `node scripts/run-tests.mjs app` — 576 test files pass.
- New pins in `chat-view-polish.test.ts`: distinct-file counting, the `> 1` gate (single-file turns don't get the chip), and the reuse of the cards' event contract.
- The event → Changes-tab wiring the chip rides is already pinned end-to-end (`comux-view-changes.test.ts`, `workspace-rail-wiring.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)