### PR TITLE
fix(code): don't paint a saved file's content over the file you switched to mid-save (cave-uv0t)

### DIFF
--- a/src/components/comux-view-edit.test.ts
+++ b/src/components/comux-view-edit.test.ts
@@ -10,9 +10,16 @@ const source = await readFile(new URL("./comux-view.tsx", import.meta.url), "utf
 // Save posts the edited content to the write endpoint.
 assert.match(
   source,
-  /fetch\("\/api\/project-file",\s*\{[\s\S]*?method:\s*"POST"[\s\S]*?body:\s*JSON\.stringify\(\{ path: previewPath, content: editValue, familiarId: selectedProjectFamiliarId \}\)/,
+  /fetch\("\/api\/project-file",\s*\{[\s\S]*?method:\s*"POST"[\s\S]*?body:\s*JSON\.stringify\(\{ path: savedPath, content: editValue, familiarId: selectedProjectFamiliarId \}\)/,
   "saveEdit must POST { path, content, familiarId } to /api/project-file",
 );
+
+// A save targets the path captured at start, and its UI result is dropped if the
+// user opened a different file while the POST was in flight (cave-uv0t) —
+// otherwise the saved file's content paints over the newly-opened one.
+assert.match(source, /const savedPath = previewPath;/, "saveEdit captures the path it targets");
+assert.match(source, /const stillCurrent = previewReqRef\.current === savedPath;/, "saveEdit checks the file is still current after the POST");
+assert.match(source, /if \(!stillCurrent\) return;.*the user moved on/, "a save that lands after a file switch leaves the new file's preview alone");
 
 // On success the edit is committed back into the preview and edit mode exits.
 assert.match(

--- a/src/components/comux-view.tsx
+++ b/src/components/comux-view.tsx
@@ -1139,6 +1139,11 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
   const savingRef = useRef(false);
   const saveEdit = useCallback(async () => {
     if (!previewPath || savingRef.current) return;
+    // The file this save targets. If the user opens a different file while the
+    // POST is in flight, the write still lands server-side — but its result must
+    // not paint over the file now on screen (mirrors openFilePreview's
+    // previewReqRef guard); previewReqRef changes the moment another file opens.
+    const savedPath = previewPath;
     savingRef.current = true;
     setSaving(true);
     setSaveError(null);
@@ -1146,21 +1151,25 @@ export function ComuxView({ view, sessions: daemonSessions, onOpenSession, onNew
       const res = await fetch("/api/project-file", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ path: previewPath, content: editValue, familiarId: selectedProjectFamiliarId }),
+        body: JSON.stringify({ path: savedPath, content: editValue, familiarId: selectedProjectFamiliarId }),
       });
       const json = (await res.json()) as { ok: boolean; size?: number; error?: string };
+      const stillCurrent = previewReqRef.current === savedPath;
       if (!res.ok || !json.ok) {
-        setSaveError(json.error ?? `save failed (${res.status})`);
+        if (stillCurrent) setSaveError(json.error ?? `save failed (${res.status})`);
         return;
       }
+      if (!stillCurrent) return; // saved fine, but the user moved on — leave the new file alone
       // Commit the edit into the preview so a cancel/reopen shows saved text.
       setPreview({ kind: "text", content: editValue, size: json.size });
       setEditing(false);
       setJustSaved(true);
       announce("File saved.");
     } catch (err) {
-      setSaveError(String(err));
-      announce(`Couldn't save the file: ${String(err)}`, "assertive");
+      if (previewReqRef.current === savedPath) {
+        setSaveError(String(err));
+        announce(`Couldn't save the file: ${String(err)}`, "assertive");
+      }
     } finally {
       setSaving(false);
       savingRef.current = false;


### PR DESCRIPTION
## What

comux's `openFilePreview` drops a stale file-load response via `previewReqRef`, but `saveEdit` didn't apply the same guard: on success it **unconditionally** `setPreview(editValue)` + `setEditing(false)` + `setJustSaved(true)`. So:

> Save file **A** → open file **B** before the POST returns → A's save resolves → **A's content paints over B's preview** (and a "Saved" flash shows on B).

Narrow (the save-in-flight window), and the write itself lands correctly server-side — only the UI showed the wrong file.

## Fix

Capture `savedPath` at the start and gate the success/UI updates (and the error banner) on `previewReqRef.current === savedPath`, mirroring `openFilePreview`. A save that lands after a file switch stays silent and leaves the new file untouched.

## Verification

`typecheck` · `comux-view-edit` (new guard pins) + `comux-view-changes` + `comux-view-selected-project` + `code-editor` green · `build` within budget. Found by a proactive `comux-view` audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)