### PR TITLE
feat(familiars): switcher reads as a clean dropdown with a prominent Summon button (cave-6p5l)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5677,6 +5677,10 @@ button:active > .edge-rail-chip {
 
 /* Row checkbox — the multiselect zone. Clicking it toggles the familiar in
    the scope (menu stays open); a plain row click still solo-switches. */
+/* The checkbox is the multi-select click zone, but rows should read as a clean
+   dropdown by default — the empty box only fades in on hover/focus, when the
+   row is checked, or while a ≥2 multiselect scope is live (data-multi on the
+   list). Its 14px slot is always reserved so rows never shift. */
 .familiar-switcher__checkbox {
   display: grid;
   place-items: center;
@@ -5687,8 +5691,16 @@ button:active > .edge-rail-chip {
   border: 1px solid var(--border-strong);
   color: var(--accent-foreground);
   background: transparent;
+  opacity: 0;
   transition: background var(--duration-fast) var(--ease-standard),
-    border-color var(--duration-fast) var(--ease-standard);
+    border-color var(--duration-fast) var(--ease-standard),
+    opacity var(--duration-fast) var(--ease-standard);
+}
+.familiar-switcher__checkbox.is-checked,
+.familiar-switcher__option:hover .familiar-switcher__checkbox,
+.familiar-switcher__option:focus-visible .familiar-switcher__checkbox,
+.familiar-switcher__list[data-multi] .familiar-switcher__checkbox {
+  opacity: 1;
 }
 .familiar-switcher__checkbox.is-checked {
   background: var(--accent-presence);
@@ -6172,9 +6184,39 @@ button:active > .edge-rail-chip {
 /* Footer actions. */
 .familiar-switcher__foot {
   display: flex;
+  flex-direction: column;
   gap: 4px;
   padding: 6px;
   border-top: 1px solid var(--border-hairline);
+}
+
+/* Summoning is the invitation here — dashed border per the design language,
+   tinted with presence, full width so it cannot be missed. */
+.familiar-switcher__summon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px dashed color-mix(in oklch, var(--accent-presence) 42%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 8%, transparent);
+  color: var(--accent-presence);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard),
+              border-color var(--duration-fast) var(--ease-standard);
+}
+.familiar-switcher__summon:hover {
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 60%, transparent);
+}
+
+.familiar-switcher__foot-row {
+  display: flex;
+  gap: 4px;
 }
 
 .familiar-switcher__foot-btn {

--- a/src/components/familiar-switcher.test.ts
+++ b/src/components/familiar-switcher.test.ts
@@ -99,15 +99,44 @@ assert.match(
 // per-row pin toggle.
 assert.doesNotMatch(source, /togglePin|familiar-switcher__pin|useFamiliarPins/, "the dropdown has no per-row pin toggle (pinning moved to Settings)");
 
-// Footer: create (onboarding), manage (Studio list view), reorder.
+// Footer: a prominent full-width Summon invitation, with manage (Studio list
+// view) and reorder as quieter actions beneath it (cave-6p5l).
 assert.match(
   source,
   /new CustomEvent\("cave:onboarding-open"\)/,
-  "New routes to the onboarding create flow (familiars are daemon-owned)",
+  "Summon routes to the summoning circle (familiars are daemon-owned)",
+);
+assert.match(
+  source,
+  /className="familiar-switcher__summon focus-ring"[\s\S]{0,200}ph:magic-wand-fill[\s\S]{0,100}Summon familiar/,
+  "the footer leads with a full-width Summon familiar button wearing the circle's wand",
 );
 assert.match(source, /openFamiliarStudioListView\(\)/, "Manage opens the Studio list view");
 assert.match(source, /setReordering\(true\)/, "Reorder enables drag mode");
 assert.match(source, /setFamiliarOrder\(arrayMove\(/, "reorder persists the new familiar order");
+
+// Rows read as a clean dropdown: the checkbox zone keeps its slot but only
+// fades in on hover/focus, when checked, or while a multiselect scope is live.
+assert.match(
+  source,
+  /data-multi=\{multiScope \? "true" : undefined\}/,
+  "the list flags a live multiselect scope so CSS can keep all checkboxes visible",
+);
+assert.match(
+  globals,
+  /\.familiar-switcher__checkbox \{[\s\S]*?opacity: 0;/,
+  "checkbox zones rest invisible so rows read as a plain dropdown",
+);
+assert.match(
+  globals,
+  /\.familiar-switcher__checkbox\.is-checked,[\s\S]*?\.familiar-switcher__list\[data-multi\] \.familiar-switcher__checkbox \{[\s\S]*?opacity: 1;/,
+  "checked rows, hovered rows, and a live multiselect reveal the checkbox",
+);
+assert.match(
+  globals,
+  /\.familiar-switcher__summon \{[\s\S]*?width: 100%;[\s\S]*?border: 1px dashed color-mix\(in oklch, var\(--accent-presence\)/,
+  "the Summon button is a full-width dashed invitation tinted with presence",
+);
 
 // Styling hooks exist.
 assert.match(globals, /\.familiar-switcher__trigger \{/, "trigger has dedicated styling");

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -231,7 +231,13 @@ export function FamiliarSwitcher({
               </SortableContext>
             </DndContext>
           ) : (
-            <ul className="familiar-switcher__list" role="listbox" aria-label="Switch familiar" aria-multiselectable="true">
+            <ul
+              className="familiar-switcher__list"
+              role="listbox"
+              aria-label="Switch familiar"
+              aria-multiselectable="true"
+              data-multi={multiScope ? "true" : undefined}
+            >
               <li>
                 <button
                   type="button"
@@ -307,27 +313,31 @@ export function FamiliarSwitcher({
               </button>
             ) : (
               <>
+                {/* Summoning gets top billing — the dashed invitation opens the
+                    summoning circle; roster housekeeping sits quieter below. */}
                 <button
                   type="button"
-                  className="familiar-switcher__foot-btn familiar-switcher__foot-btn--pri"
+                  className="familiar-switcher__summon focus-ring"
                   onClick={() => { fireCreateFamiliar(); setOpen(false); }}
                 >
-                  <Icon name="ph:plus-bold" width={11} aria-hidden /> New
+                  <Icon name="ph:magic-wand-fill" width={13} aria-hidden /> Summon familiar
                 </button>
-                <button
-                  type="button"
-                  className="familiar-switcher__foot-btn"
-                  onClick={() => { openFamiliarStudioListView(); setOpen(false); }}
-                >
-                  <Icon name="ph:list-bullets" width={11} aria-hidden /> Manage
-                </button>
-                <button
-                  type="button"
-                  className="familiar-switcher__foot-btn"
-                  onClick={() => setReordering(true)}
-                >
-                  <Icon name="ph:dots-six-vertical" width={11} aria-hidden /> Reorder
-                </button>
+                <div className="familiar-switcher__foot-row">
+                  <button
+                    type="button"
+                    className="familiar-switcher__foot-btn"
+                    onClick={() => { openFamiliarStudioListView(); setOpen(false); }}
+                  >
+                    <Icon name="ph:list-bullets" width={11} aria-hidden /> Manage
+                  </button>
+                  <button
+                    type="button"
+                    className="familiar-switcher__foot-btn"
+                    onClick={() => setReordering(true)}
+                  >
+                    <Icon name="ph:dots-six-vertical" width={11} aria-hidden /> Reorder
+                  </button>
+                </div>
               </>
             )}
           </div>


### PR DESCRIPTION
## What

User request: the familiar selection component should be a clean dropdown selection with a summon button / a scalable solution.

The side-panel familiar switcher (sidenav header everywhere + chat sidebar) already scaled structurally (scrolling list, search at >6), but read busy and buried its create flow:

- **Rows read as a plain dropdown now** — the multi-select checkbox keeps its 14px slot (no layout shift) but only fades in on hover/focus, when checked, or while a ≥2 multiselect scope is live (`data-multi` on the list keeps every checkbox visible mid-multi-pick).
- **Summon familiar gets top billing** — a full-width dashed invitation button (design language: dashed = invitation, presence tint) wearing the summoning circle's own wand icon leads the footer and opens the summoning circle. Manage and Reorder sit quieter beneath it.

All pinned behaviors preserved: ⌘-click / checkbox-zone multi-select, presence dots, reply badges, per-row gear → Studio, reorder drag mode, `cave:onboarding-open` create event.

Bead: cave-6p5l

## Verification

- `tsc --noEmit` clean
- `familiar-switcher.test.ts` ok (new pins: summon invitation markup+CSS, checkbox rest-invisible/reveal rules, data-multi flag)
- Full suite: ✓ 581 test file(s) passed [app]

🤖 Generated with [Claude Code](https://claude.com/claude-code)