### PR TITLE
feat(mobile): Continue on phone — the QR hands off THIS chat, and pairing finally says it took (cave-i74f)

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import QRCode from "qrcode";
 import { stripAnsi } from "@/lib/ansi";
+import { readMobileLastSeen } from "@/lib/server/mobile-paired";
 import {
   createMobileInvite,
+  withChatFragment,
   MOBILE_INVITE_TTL_MS,
   nativeAppDiscoveryProof,
   tailnetDiscoveryProof,
@@ -196,7 +198,7 @@ function mobileAccessUnavailableResponse() {
   return NextResponse.json({ ok: false, error }, { status: 503 });
 }
 
-async function ensureNativeAppServe(req: Request) {
+async function ensureNativeAppServe(req: Request, chatId?: string | null) {
   const hostPortRejection = rejectMismatchedHostPort(req);
   if (hostPortRejection) return hostPortRejection;
 
@@ -270,7 +272,12 @@ async function ensureNativeAppServe(req: Request) {
     );
   }
 
-  const qrSvg = await QRCode.toString(discovery.serveUrl, {
+  // "Continue on phone" (cave-i74f): the QR target carries the chat
+  // deep-link fragment so one scan opens THIS conversation. The bare host
+  // (nativeHost/serveUrl) stays clean — the native app pairs on the host,
+  // not the fragment.
+  const qrTarget = withChatFragment(discovery.serveUrl, chatId);
+  const qrSvg = await QRCode.toString(qrTarget, {
     type: "svg",
     margin: 1,
     width: 256,
@@ -281,15 +288,19 @@ async function ensureNativeAppServe(req: Request) {
     ok: true,
     backendUrl: backend,
     serveUrl: discovery.serveUrl,
+    url: qrTarget,
     nativeUrl: discovery.serveUrl,
     nativeHost: discovery.host,
     discoverySource: discovery.source,
+    // Paired signal (cave-i74f): the last token-refresh beat from a paired
+    // device — null until a phone has actually connected.
+    lastSeenAt: await readMobileLastSeen(),
     qrSvg,
     warning: fallbackWarning ?? serveWarning ?? undefined,
   });
 }
 
-async function mobileHandoff(req: Request) {
+async function mobileHandoff(req: Request, chatId?: string | null) {
   const hostPortRejection = rejectMismatchedHostPort(req);
   if (hostPortRejection) return hostPortRejection;
 
@@ -353,7 +364,10 @@ async function mobileHandoff(req: Request) {
     sidecarToken: process.env.COVEN_CAVE_AUTH_TOKEN,
     ttlMs: MOBILE_INVITE_TTL_MS,
   });
-  const qrSvg = await QRCode.toString(invite.url, {
+  // "Continue on phone" (cave-i74f): the QR carries the chat deep-link
+  // fragment so one scan opens THIS conversation, not just the app.
+  const inviteUrl = withChatFragment(invite.url, chatId);
+  const qrSvg = await QRCode.toString(inviteUrl, {
     type: "svg",
     margin: 1,
     width: 256,
@@ -364,9 +378,9 @@ async function mobileHandoff(req: Request) {
     ok: true,
     backendUrl: backend,
     serveUrl: discovery.serveUrl,
-    inviteUrl: invite.url,
-    url: invite.url,
-    appUrl: invite.url,
+    inviteUrl,
+    url: inviteUrl,
+    appUrl: inviteUrl,
     // Native-app pairing: covencave:// deep link with a long-lived token —
     // shown beside the QR so the iOS/iPadOS app pairs without typing.
     appInviteUrl: invite.appInviteUrl,
@@ -374,6 +388,9 @@ async function mobileHandoff(req: Request) {
     discoverySource: discovery.source,
     expiresAt: invite.expiresAt,
     expiresAtIso: invite.expiresAtIso,
+    // Paired signal (cave-i74f): the last token-refresh beat from a paired
+    // device — null until a phone has actually connected.
+    lastSeenAt: await readMobileLastSeen(),
     qrSvg,
     // Non-fatal: the link/QR are usable, but Serve couldn't be (re)started, so
     // the tunnel may need attention if the link doesn't resolve on the phone.
@@ -385,11 +402,14 @@ export async function GET(req: Request) {
   return mobileHandoff(req);
 }
 
+
 export async function POST(req: Request) {
   let action = "start";
+  let chatId: string | null = null;
   try {
-    const body = (await req.json()) as { action?: string };
+    const body = (await req.json()) as { action?: string; chatId?: string };
     action = body.action ?? "start";
+    if (typeof body.chatId === "string") chatId = body.chatId;
   } catch {
     action = "start";
   }
@@ -404,7 +424,7 @@ export async function POST(req: Request) {
   }
 
   if (action === "app-start") {
-    return ensureNativeAppServe(req);
+    return ensureNativeAppServe(req, chatId);
   }
 
   if (action === "app-stop") {
@@ -416,5 +436,5 @@ export async function POST(req: Request) {
     }, { status: reset.ok ? 200 : 500 });
   }
 
-  return mobileHandoff(req);
+  return mobileHandoff(req, chatId);
 }

--- a/src/app/api/mobile-token/refresh/route.ts
+++ b/src/app/api/mobile-token/refresh/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { refreshMobileAccessToken } from "@/lib/mobile-token-refresh";
+import { recordMobileSeen } from "@/lib/server/mobile-paired";
 import { ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_QUERY_PARAM } from "@/proxy-helpers";
 
 export const dynamic = "force-dynamic";
@@ -34,6 +35,9 @@ export async function POST(req: NextRequest) {
   if (!result.ok) {
     return NextResponse.json({ ok: false, error: result.error }, { status: result.status });
   }
+  // Paired-signal beat (cave-i74f): a successful refresh IS the proof a paired
+  // device is alive — record it so the desktop's Settings card can say so.
+  await recordMobileSeen();
   return NextResponse.json({
     ok: true,
     token: result.token,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -797,6 +797,7 @@ function SessionOverflowMenu({
   onProjectChange,
   onAddProject,
   familiar,
+  sessionId,
   voiceActive,
   onOpenVoice,
   onOpenDebug,
@@ -807,6 +808,8 @@ function SessionOverflowMenu({
   /** Opens the shared add-project flow (register + grant) — proactive, not 403-recovery-only. */
   onAddProject?: () => void;
   familiar: Familiar;
+  /** Active conversation id — powers "Continue on phone" (cave-i74f). */
+  sessionId?: string | null;
   voiceActive: boolean;
   onOpenVoice: () => void;
   onOpenDebug: () => void;
@@ -844,6 +847,21 @@ function SessionOverflowMenu({
         ariaLabel="Chat options"
       >
         <PopoverBody>
+          {sessionId ? (
+            <PopoverItem
+              icon="ph:device-mobile"
+              onSelect={() => {
+                close();
+                // Golden path 5: hand off the MOMENT — the pairing modal's QR
+                // carries #chat-<id> so one scan opens this conversation.
+                window.dispatchEvent(
+                  new CustomEvent("cave:continue-on-phone", { detail: { chatId: sessionId } }),
+                );
+              }}
+            >
+              Continue on phone
+            </PopoverItem>
+          ) : null}
           <PopoverItem
             icon="ph:pencil-simple"
             onSelect={() => {
@@ -4768,6 +4786,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onProjectChange={setProjectIdDraft}
                 onAddProject={overflowAddProject.beginAddProject}
                 familiar={familiar}
+                sessionId={sessionId}
                 voiceActive={voiceCallOpen}
                 onOpenVoice={() => setVoiceCallOpen(true)}
                 onOpenDebug={openDebug}

--- a/src/components/mobile-handoff-modal.tsx
+++ b/src/components/mobile-handoff-modal.tsx
@@ -36,6 +36,9 @@ type Props = {
   nativeHost?: string | null;
   mobileModeError?: string | null;
   onMobileModeChange?: (enabled: boolean) => void;
+  /** Continue-on-phone (cave-i74f): when set, the QR carries `#chat-<id>` so
+   *  one scan opens THIS conversation on the phone, not just the app. */
+  chatId?: string | null;
 };
 
 function expiryLabel(expiresAtIso: string) {
@@ -58,6 +61,7 @@ export function MobileHandoffModal({
   nativeHost = null,
   mobileModeError = null,
   onMobileModeChange,
+  chatId = null,
 }: Props) {
   const [handoff, setHandoff] = useState<HandoffReady | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -86,7 +90,7 @@ export function MobileHandoffModal({
       const res = await fetch("/api/mobile-handoff", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ action: "app-start" }),
+        body: JSON.stringify(chatId ? { action: "app-start", chatId } : { action: "app-start" }),
       });
       const json = (await res.json()) as HandoffResponse;
       if (!json.ok) {
@@ -105,7 +109,7 @@ export function MobileHandoffModal({
     } finally {
       setLoading(false);
     }
-  }, [copyHandoffUrl]);
+  }, [chatId, copyHandoffUrl]);
 
   useEffect(() => {
     if (open) void start(autoCopyRequest);
@@ -149,7 +153,7 @@ export function MobileHandoffModal({
     <Modal
       open={open}
       onClose={onClose}
-      breadcrumb={["CovenCave", "Open on phone"]}
+      breadcrumb={["CovenCave", chatId ? "Continue this chat on phone" : "Open on phone"]}
       footerActions={
         <>
           <Button variant="ghost" onClick={resetServe} disabled={loading}>
@@ -192,7 +196,11 @@ export function MobileHandoffModal({
         </div>
 
         <div className="mobile-handoff__body">
-          <p className="mobile-handoff__title">Connect CovenCave on your phone.</p>
+          <p className="mobile-handoff__title">
+            {chatId
+              ? "Scan to continue this conversation on your phone."
+              : "Connect CovenCave on your phone."}
+          </p>
           {handoff ? (
             <>
               {handoff.nativeHost ? (

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -41,8 +41,11 @@ assert.match(modal, /handoff\?\.inviteUrl \|\| handoff\?\.url/, "Modal should pr
 assert.match(modal, /mobile-handoff__link[\s\S]*href=\{handoff\.inviteUrl \|\| handoff\.url\}/, "Modal should display the invite link as a clickable link");
 assert.match(css, /\.mobile-handoff__link/, "Invite link should have stable styling");
 assert.match(modal, /action: "reset"/, "Modal should expose explicit Tailscale Serve reset");
-assert.match(handoffRoute, /inviteUrl: invite\.url/, "API should expose inviteUrl as the canonical invite field");
-assert.match(handoffRoute, /appUrl: invite\.url/, "API should keep appUrl as an inviteUrl alias for compatibility");
+// cave-i74f: the invite may carry a #chat-<id> fragment (Continue on phone),
+// so the canonical field is the fragment-aware inviteUrl.
+assert.match(handoffRoute, /const inviteUrl = withChatFragment\(invite\.url, chatId\);/, "the web invite rides the chat fragment when a handoff targets a conversation");
+assert.match(handoffRoute, /inviteUrl,\n\s*url: inviteUrl,/, "API should expose inviteUrl as the canonical invite field");
+assert.match(handoffRoute, /appUrl: inviteUrl/, "API should keep appUrl as an inviteUrl alias for compatibility");
 assert.match(handoffRoute, /action === "app-start"/, "API should expose a native app mobile-mode start action");
 assert.match(handoffRoute, /action === "app-stop"/, "API should expose a native app mobile-mode stop action");
 assert.match(handoffRoute, /nativeHost/, "API should return the exact host the native iOS app should connect to");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { Icon } from "@/lib/icon";
+import { relativeTime } from "@/lib/relative-time";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { SettingsGroup, settingsGroupId } from "@/components/ui/settings-group";
 import { Button } from "@/components/ui/button";
@@ -1950,6 +1951,9 @@ type MobileHandoffCardState = {
   inviteUrl: string | null;
   appInviteUrl: string | null;
   qrSvg: string | null;
+  /** Last token-refresh beat from a paired device (cave-i74f) — pairing
+   *  success used to be silent on the desktop. */
+  lastSeenAt: number | null;
 };
 
 function MobileModeToggle() {
@@ -1974,6 +1978,7 @@ function MobileModeToggle() {
         inviteUrl?: string | null;
         appInviteUrl?: string | null;
         qrSvg?: string | null;
+        lastSeenAt?: number | null;
         error?: string;
         stderr?: string;
       };
@@ -1988,6 +1993,7 @@ function MobileModeToggle() {
               inviteUrl: json.inviteUrl ?? null,
               appInviteUrl: json.appInviteUrl ?? null,
               qrSvg: json.qrSvg ?? null,
+              lastSeenAt: json.lastSeenAt ?? null,
             }
           : null,
       );
@@ -2051,6 +2057,11 @@ function MobileModeToggle() {
           <div className="min-w-0">
             <p className="text-[13px] font-medium text-[var(--text-primary)]">Mobile mode</p>
             <p className="truncate text-[11px] text-[var(--text-muted)]">{statusLine}</p>
+            {handoff?.lastSeenAt ? (
+              <p className="truncate text-[11px] text-[var(--text-secondary)]">
+                Paired · last seen {relativeTime(new Date(handoff.lastSeenAt).toISOString())}
+              </p>
+            ) : null}
           </div>
         </div>
         <button

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -407,6 +407,8 @@ export function Workspace() {
   const [glyphPickerFor, setGlyphPickerFor] = useState<Familiar | null>(null);
   const [addChooserOpen, setAddChooserOpen] = useState(false);
   const [mobileHandoffOpen, setMobileHandoffOpen] = useState(false);
+  // Continue-on-phone (cave-i74f): the chat id riding the next handoff QR.
+  const [mobileHandoffChatId, setMobileHandoffChatId] = useState<string | null>(null);
   const [mobileModeEnabled, setMobileModeEnabledState] = useState(readMobileModeEnabled);
   const [mobileModeHost, setMobileModeHost] = useState<string | null>(null);
   const [mobileModeError, setMobileModeError] = useState<string | null>(null);
@@ -1491,6 +1493,14 @@ export function Workspace() {
       startFamiliarChat(d?.familiarId ?? null, d?.projectRoot ?? null, d?.initialPrompt ?? null, d?.initialControls ?? null);
     };
     window.addEventListener("cave:agents-new-chat", onAgentsNewChat);
+    // Chat overflow → "Continue on phone": open the pairing modal with the
+    // active conversation's deep link on the QR.
+    const onContinueOnPhone = (event: Event) => {
+      const detail = (event as CustomEvent<{ chatId?: string }>).detail;
+      setMobileHandoffChatId(detail?.chatId ?? null);
+      setMobileHandoffOpen(true);
+    };
+    window.addEventListener("cave:continue-on-phone", onContinueOnPhone as EventListener);
     return () => window.removeEventListener("cave:agents-new-chat", onAgentsNewChat);
   }, [startFamiliarChat]);
 
@@ -2535,7 +2545,11 @@ export function Workspace() {
 
       <MobileHandoffModal
         open={mobileHandoffOpen}
-        onClose={() => setMobileHandoffOpen(false)}
+        chatId={mobileHandoffChatId}
+        onClose={() => {
+          setMobileHandoffOpen(false);
+          setMobileHandoffChatId(null);
+        }}
         mobileModeEnabled={mobileModeEnabled}
         nativeHost={mobileModeHost}
         mobileModeError={mobileModeError}

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   buildInviteUrl,
   createMobileInvite,
+  withChatFragment,
   findServeUrl,
   magicDnsHost,
   magicDnsServeUrl,
@@ -209,6 +210,57 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.equal(tailscaleIpHost({ Self: { TailscaleIPs: "100.101.102.103" } }), null);
   assert.equal(tailscaleIpHost({ TailscaleIPs: { primary: "100.101.102.103" } }), null);
   assert.equal(tailscaleIpHost({ TailscaleIPs: [null, 42, "100.101.102.103"] }), "100.101.102.103");
+}
+
+// ── Continue on phone (cave-i74f): the chat deep-link fragment ───────────────
+{
+  const base = "https://cave.ts.net/?coven_access_token=t";
+  assert.equal(
+    withChatFragment(base, "s-abc123"),
+    `${base}#chat-s-abc123`,
+    "a valid session id rides the invite as a #chat fragment",
+  );
+  assert.equal(withChatFragment(base, null), base, "no chat id → untouched");
+  assert.equal(withChatFragment(base, "   "), base, "blank id → untouched");
+  assert.equal(
+    withChatFragment(base, "../../evil"),
+    base,
+    "ids outside the daemon's shape never reach the URL",
+  );
+  assert.equal(
+    withChatFragment(`${base}#stale`, "s-1"),
+    `${base}#chat-s-1`,
+    "an existing fragment is replaced, not doubled",
+  );
+}
+
+// ── Wiring pins: one action → QR opens THIS conversation + paired signal ─────
+{
+  const { readFileSync } = await import("node:fs");
+  const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8");
+
+  const route = read("../app/api/mobile-handoff/route.ts");
+  assert.match(route, /withChatFragment\(discovery\.serveUrl, chatId\)/, "app-start QR target carries the chat fragment");
+  assert.match(route, /ensureNativeAppServe\(req, chatId\)/, "POST threads chatId into app-start");
+  assert.match(route, /lastSeenAt: await readMobileLastSeen\(\)/, "handoff responses expose the paired-device beat");
+
+  const refresh = read("../app/api/mobile-token/refresh/route.ts");
+  assert.match(refresh, /await recordMobileSeen\(\);/, "a successful token refresh records the paired-device beat");
+
+  const modal = read("../components/mobile-handoff-modal.tsx");
+  assert.match(modal, /chatId \? \{ action: "app-start", chatId \} : \{ action: "app-start" \}/, "the modal forwards its chatId to app-start");
+  assert.match(modal, /Scan to continue this conversation on your phone\./, "chat handoff says what the scan does");
+
+  const chatView = read("../components/chat-view.tsx");
+  assert.match(chatView, /cave:continue-on-phone[\s\S]*detail: \{ chatId: sessionId \}/, "chat overflow dispatches the continue-on-phone event with the session id");
+  assert.match(chatView, />\s*Continue on phone\s*</, "the overflow menu offers Continue on phone");
+
+  const workspace = read("../components/workspace.tsx");
+  assert.match(workspace, /addEventListener\("cave:continue-on-phone"/, "workspace listens for the handoff event");
+  assert.match(workspace, /chatId=\{mobileHandoffChatId\}/, "workspace threads the chat id into the pairing modal");
+
+  const settings = read("../components/settings-shell.tsx");
+  assert.match(settings, /Paired · last seen \{relativeTime\(/, "the Settings card shows the paired-device beat");
 }
 
 console.log("mobile-handoff.test.ts OK");

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -309,6 +309,20 @@ export function buildInviteUrl({
   return url.toString();
 }
 
+/** Golden path 5 (cave-i74f): "Continue on phone" hands off the MOMENT, not
+ *  just the app. Appending `#chat-<id>` to the invite URL rides the existing
+ *  web deep-link (the chat router already resolves the fragment on boot), so
+ *  the scanned QR opens the same conversation — no new API surface. Session
+ *  ids are validated against the shapes the daemon mints; anything else
+ *  returns the URL untouched (a malformed id must never break pairing). */
+export function withChatFragment(url: string, chatId: string | null | undefined): string {
+  if (!chatId) return url;
+  const id = chatId.trim();
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(id)) return url;
+  const base = url.split("#")[0];
+  return `${base}#chat-${id}`;
+}
+
 /** Deep link the native app registers (`covencave://connect`) — tapping it on
  *  the device configures host + credential in one step, no typing. */
 export function buildAppInviteUrl({

--- a/src/lib/server/mobile-paired.ts
+++ b/src/lib/server/mobile-paired.ts
@@ -1,0 +1,40 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { covenHome } from "@/lib/coven-paths";
+import { writeJsonAtomic } from "@/lib/server/atomic-write";
+
+// Paired-phone signal (golden path 5, cave-i74f). Pairing success used to be
+// silent on the desktop: the phone scans, connects, and refreshes its token,
+// but nothing on this side ever said so. The token-refresh route is the one
+// beat every healthy paired device already hits (30-day rolling renewal +
+// the refresh-on-launch), so recording its timestamp gives the Settings card
+// an honest "Paired · last seen <t>" with zero new client traffic.
+
+type MobilePairedState = { lastSeenAt: number };
+
+export function mobilePairedPath(): string {
+  return path.join(covenHome(), "cave-mobile-paired.json");
+}
+
+/** Record that a paired device just authenticated (token refresh succeeded).
+ *  Best-effort: a write failure must never fail the refresh itself. */
+export async function recordMobileSeen(now = Date.now()): Promise<void> {
+  try {
+    await writeJsonAtomic(mobilePairedPath(), { lastSeenAt: now } satisfies MobilePairedState);
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** The last time a paired device authenticated, or null when never/unreadable. */
+export async function readMobileLastSeen(): Promise<number | null> {
+  try {
+    const raw = await readFile(mobilePairedPath(), "utf8");
+    const parsed = JSON.parse(raw) as Partial<MobilePairedState>;
+    return typeof parsed.lastSeenAt === "number" && Number.isFinite(parsed.lastSeenAt)
+      ? parsed.lastSeenAt
+      : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Golden path 5 (docs/golden-paths.md §5), phases 1+2. Phase 3 (iOS in-app QR scan, Swift lane) is filed as cave-gwyw.

## Session hand-off
- Chat overflow gains **Continue on phone** → pairing modal opens titled for the conversation → the QR target carries `#chat-<id>` (both handoff flows), so one scan opens **this** conversation via the existing web deep link. No new API — an additive `chatId` on the existing `app-start` action.
- `withChatFragment` shape-validates ids (unit-tested: valid append, blank/malformed untouched, existing fragment replaced); the native-app host stays fragment-free.

## Paired signal
- A successful `/api/mobile-token/refresh` — the beat every healthy paired device already hits — records `lastSeenAt` (atomic write, best-effort). Handoff responses expose it; the Settings card shows **"Paired · last seen <t>"**. Pairing success is no longer silent on the desktop.

## Validation
- Live (worktree server + Playwright, handoff API mocked): overflow action → chat-titled modal → `app-start` body carries `chatId` → rendered invite link shows `#chat-s-continue` (screenshot in session)
- Unit tests + wiring pins in `src/lib/mobile-handoff.test.ts` and `src/components/mobile-handoff.test.ts`
- `pnpm typecheck` + mobile & app suites: **656 test files green**

Bead: cave-i74f

🤖 Generated with [Claude Code](https://claude.com/claude-code)