### PR TITLE
fix(chat): readable transcript over a custom backdrop — frosted reading column + quiet-text lift (cave-5oeu)

### DIFF
--- a/src/lib/cave-backdrop.test.ts
+++ b/src/lib/cave-backdrop.test.ts
@@ -111,6 +111,27 @@ assert.match(
 );
 assert.doesNotMatch(css, /#[0-9a-fA-F]{3,8}\b/, "backdrop.css is tokens-only");
 
+// Readability over the image (cave-5oeu): the transcript flattens bubbles to
+// bare text, so the reading column (and the group-chat shell) gets real glass
+// — scrim + blur — and the quiet text lifts one contrast step. Engines
+// without backdrop-filter fall back to a near-opaque fill instead of
+// see-through text.
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.cave-chat-linear \.cave-chat-thread,\s*html\[data-backdrop-on\] \.cave-group-chat-shell \{[^}]*backdrop-filter: blur\(var\(--glass-blur\)\)/,
+  "the chat reading column sits on glass while the image is frontmost",
+);
+assert.match(
+  css,
+  /html\[data-backdrop-on\] \.cave-chat-linear,\s*html\[data-backdrop-on\] \.cave-group-chat-shell \{[^}]*--text-muted: var\(--text-secondary\)/,
+  "quiet transcript text lifts to secondary strength over the image",
+);
+assert.match(
+  css,
+  /@supports not \(\(backdrop-filter: blur\(1px\)\)[\s\S]*?92%, transparent\)/,
+  "no-blur engines get a near-opaque fill instead of see-through text",
+);
+
 // Settings wiring: the Appearance section owns the controls.
 assert.match(settings, /<BackdropSettings \/>/, "Appearance renders the backdrop controls");
 assert.match(backdropSettings, /prepareBackdropImage\(file\)/, "picking an image downscales + derives the seed");

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -54,8 +54,65 @@ html[data-backdrop-on] .cave-chat-linear {
   background: color-mix(in oklch, var(--bg-base) 16%, transparent);
 }
 
+/* ── Readable transcript over the image (cave-5oeu) ──────────────────────────
+   The session transcript deliberately flattens bubbles to bare text on the
+   pane (.cave-chat-linear strips bubble fills/borders), so with a backdrop
+   frontmost the words sit almost directly on the photo — the 16% wash above
+   is a vibe knob, not a readability floor. Give the reading column real
+   glass: a scrimmed, blurred panel behind the thread keeps prose legible at
+   any intensity while the pane margins keep the vivid image. Group chat gets
+   the same treatment on its shell (its rail text sits on the photo too). */
+html[data-backdrop-on] .cave-chat-linear .cave-chat-thread,
+html[data-backdrop-on] .cave-group-chat-shell {
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
+  border-radius: 14px;
+  padding-inline: clamp(14px, 2vw, 22px);
+}
+
+/* The header bar's 74%-raised wash shimmers over a busy photo — blur what's
+   behind it so the title and session actions stay steady. */
+html[data-backdrop-on] .cave-chat-linear-header {
+  backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+  -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
+}
+
+/* One-step contrast lift for the quiet text while the image is on — meta
+   rows, recency, peeks. --text-muted is tuned against solid bg-base; over a
+   photo it drops below comfortable, so it reads at secondary strength. */
+html[data-backdrop-on] .cave-chat-linear,
+html[data-backdrop-on] .cave-group-chat-shell {
+  --text-muted: var(--text-secondary);
+}
+
+/* No backdrop-filter → a see-through fill over a photo is unreadable; go
+   near-opaque instead (same rationale as the app-wide glass fallback). */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  html[data-backdrop-on] .cave-chat-linear .cave-chat-thread,
+  html[data-backdrop-on] .cave-group-chat-shell {
+    background: color-mix(in oklch, var(--bg-base) 92%, transparent);
+  }
+}
+
 @media (prefers-reduced-transparency: reduce) {
   html[data-backdrop] .cave-backdrop-layer {
     display: none;
+  }
+
+  /* The image layer above is hidden here, so the glass column would blur a
+     solid pane — drop it and let the transcript sit on the base surface. */
+  html[data-backdrop-on] .cave-chat-linear .cave-chat-thread,
+  html[data-backdrop-on] .cave-group-chat-shell {
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+
+  html[data-backdrop-on] .cave-chat-linear .cave-chat-thread {
+    padding-inline: 0;
   }
 }


### PR DESCRIPTION
## What

With a custom backdrop image enabled, the sessions-chat transcript was close to unreadable: the linear view deliberately flattens bubbles to bare text on the pane, and the only thing between the words and the photo was a 16% bg-base wash (an intensity/vibe knob, not a readability floor). Muted 11px meta rows disappeared entirely on busy images.

While `html[data-backdrop-on]` (all token-pure, in `backdrop.css`):

- **Frosted reading column** — `.cave-chat-thread` (which also hosts the new-thread landing) and the group-chat shell get real glass: 62% bg-base scrim + `blur(var(--glass-blur)) saturate(var(--glass-saturate))`. Prose stays legible at any intensity; the pane margins keep the vivid image.
- **Header blur** — the 74%-raised header wash shimmered over busy photos; it now blurs what's behind it.
- **Quiet-text lift** — `--text-muted` reads at `--text-secondary` strength inside the transcript; muted is contrast-tuned against solid bg-base, not a photo.
- **Fallbacks** — `@supports not (backdrop-filter…)` goes near-opaque (92%) instead of see-through text; `prefers-reduced-transparency` drops the glass along with the already-hidden image layer.

No change without a backdrop — everything is scoped to `data-backdrop-on` (verified in the baseline shot).

## Verification

Prod build in a worktree, Playwright against mocked session APIs, worst-case synthetic image (bright/dark stripes + discs):

- intensity 100 + transcript: turns, names, timestamps, code block all readable on the glass column
- intensity 100 + new-thread landing: greeting, project chip, suggestion pills readable (was the worst offender)
- intensity 70: same, with more image showing in the margins
- no backdrop: unchanged, no glass panel rendered

`pnpm typecheck` ✓ · `pnpm test:app` ✓ (581 files) · pins added to `cave-backdrop.test.ts`

Bead: cave-5oeu

🤖 Generated with [Claude Code](https://claude.com/claude-code)