### PR TITLE
feat(tasks): the Work Queue rides the Tasks page as a tab (cave-oa1z)

### DIFF
--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@/styles/board.css";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { Familiar, SessionRow } from "@/lib/types";
 import { NewCardModal, type NewCardDraft } from "@/components/new-card-modal";
 import { type WipLimits, readWipLimits, writeWipLimits, setWipLimit } from "@/lib/board-wip";
@@ -25,6 +25,7 @@ import { BoardGantt } from "@/components/board-gantt";
 import { BoardTable, type GroupBy } from "@/components/board-table";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Button } from "@/components/ui/button";
+import { Tabs } from "@/components/ui/tabs";
 import { StandardSelect } from "@/components/ui/select";
 import { Skeleton, SkeletonRows } from "@/components/ui/skeleton";
 import { BoardCardStack } from "@/components/board-card-stack";
@@ -46,6 +47,12 @@ function loadPref<T extends string>(key: string, fallback: T, valid: T[]): T {
 
 type Props = {
   familiars: Familiar[];
+  /** Work-queue merge (cave-oa1z): the queue rides the Tasks page as a tab.
+   *  The slot keeps BoardView ignorant of the queue's data plumbing (the
+   *  Schedules calendar-slot pattern), and `initialTab` lets the legacy
+   *  familiar-work-queue mode deep-link straight onto the tab. */
+  queueSlot?: ReactNode;
+  initialTab?: "tasks" | "queue";
   sessions: SessionRow[];
   activeFamiliarId: string | null;
   /** Multiselect scope (empty = All). When ≥2 are selected the board filters to
@@ -81,8 +88,11 @@ function BoardKanbanSkeleton() {
   );
 }
 
-export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliarIds, onJumpToSession, onOpenUrl }: Props) {
+export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliarIds, onJumpToSession, onOpenUrl, queueSlot, initialTab }: Props) {
   const isMobile = useIsMobile();
+  const [activeTab, setActiveTab] = useState<"tasks" | "queue">(
+    initialTab === "queue" && queueSlot ? "queue" : "tasks",
+  );
   const [cards, setCards] = useState<Card[]>([]);
   // Deferred + undoable task deletion: cards hide immediately, the DELETEs fire
   // only after the undo window, and Undo restores them (mirrors chat/projects).
@@ -704,6 +714,23 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
       {/* Header */}
       <header className="board-header">
         <span className="board-header-title">Tasks</span>
+        {queueSlot ? (
+          <Tabs
+            className="board-header-tabs"
+            variant="segment"
+            size="sm"
+            ariaLabel="Tasks tabs"
+            idPrefix="tasks"
+            value={activeTab}
+            onChange={setActiveTab}
+            items={[
+              { id: "tasks" as const, label: "Tasks" },
+              { id: "queue" as const, label: "Work queue" },
+            ]}
+          />
+        ) : null}
+        {activeTab === "tasks" ? (
+        <>
         <div className="board-search-wrap">
           <Icon name="ph:magnifying-glass" width={13} className="board-search-icon" />
           <label className="sr-only" htmlFor="board-search">Search tasks</label>
@@ -877,8 +904,25 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
             + New task
           </button>
         </div>
+        </>
+        ) : null}
       </header>
 
+      {activeTab === "queue" && queueSlot ? (
+        <div
+          role="tabpanel"
+          id="tasks-panel-queue"
+          aria-labelledby="tasks-tab-queue"
+          className="min-h-0 flex-1 overflow-hidden"
+        >
+          {queueSlot}
+        </div>
+      ) : null}
+
+      {/* The board body stays mounted while the queue tab shows (polls keep
+          state warm for the switch back); display:contents preserves the
+          shell's flex layout when visible. */}
+      <div style={{ display: activeTab === "queue" ? "none" : "contents" }}>
       {error && (
         <div
           role="alert"
@@ -1185,6 +1229,7 @@ export function BoardView({ familiars, sessions, activeFamiliarId, scopeFamiliar
           onDismiss={commitCardDelete}
         />
       ) : null}
+      </div>
     </section>
   );
 }

--- a/src/components/familiar-work-queue-view.tsx
+++ b/src/components/familiar-work-queue-view.tsx
@@ -24,6 +24,9 @@ import {
 import type { PullRequestSummary } from "@/lib/beads-pr-management";
 
 type Props = {
+  /** Rendered inside the Tasks page's Work-queue tab (cave-oa1z): the tab
+   *  band provides the surface name, so the view's own h1 stays out. */
+  embedded?: boolean;
   familiars?: ResolvedFamiliar[];
   onOpenUrl?: (url: string) => void;
 };
@@ -88,7 +91,7 @@ function sameQueue(a: WorkQueue, b: WorkQueue): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
+export function FamiliarWorkQueueView({ familiars = [], onOpenUrl, embedded = false }: Props) {
   const { announce } = useAnnouncer();
   const [queue, setQueue] = useState<WorkQueue | null>(null);
   const [hasLoaded, setHasLoaded] = useState(false);
@@ -228,7 +231,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
     return (
       <div className="fwq" aria-busy>
         <header className="surface-compact-header">
-          <h1 className="surface-compact-title">Work Queue</h1>
+          {embedded ? null : <h1 className="surface-compact-title">Work Queue</h1>}
         </header>
         <div className="fwq-body">
           <SkeletonRows count={6} />
@@ -264,7 +267,7 @@ export function FamiliarWorkQueueView({ familiars = [], onOpenUrl }: Props) {
           Marketplace / Tasks / Grimoire): small title, live summary inline
           (with a truthful "updated Xm ago" readout), Refresh on the right. */}
       <header className="surface-compact-header">
-        <h1 className="surface-compact-title">Work Queue</h1>
+        {embedded ? null : <h1 className="surface-compact-title">Work Queue</h1>}
         <p className="surface-compact-summary">
           {q.total === 0
             ? "No open PRs or ready beads."

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -124,7 +124,6 @@ const FOLDER_MODES: Array<{
   // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
   // mode + page remain reachable programmatically but aren't surfaced here.
   { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Issues and PRs assigned to you", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
-  { id: "familiar-work-queue", label: "Work Queue", iconName: "ph:list-checks-bold", description: "Ready beads and the PR control tower, by familiar", quiet: true },
 ];
 
 // Rows actually rendered in the sidebar — everything except on-demand surfaces

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2180,8 +2180,14 @@ export function Workspace() {
         onOpenTask={(cardId) => onPaletteIntent({ kind: "focus-card", cardId })}
         onOpenUrl={openUrlInAppBrowser}
       />
-    ) : mode === "board" ? (
+    ) : mode === "board" || mode === "familiar-work-queue" ? (
+      // Tasks and the Work Queue are one surface (cave-oa1z, the Schedules
+      // pattern): the legacy familiar-work-queue mode still resolves here but
+      // opens that tab; keying on the mode remounts so deep links land on it.
       <BoardView
+        key={mode}
+        initialTab={mode === "familiar-work-queue" ? "queue" : "tasks"}
+        queueSlot={<FamiliarWorkQueueView familiars={resolvedFamiliars} onOpenUrl={openUrlInAppBrowser} embedded />}
         familiars={familiars}
         sessions={sessions}
         activeFamiliarId={activeId}
@@ -2267,8 +2273,6 @@ export function Workspace() {
         familiars={resolvedFamiliars}
         onOpenChat={(familiarId) => startFamiliarChat(familiarId)}
       />
-    ) : mode === "familiar-work-queue" ? (
-      <FamiliarWorkQueueView familiars={resolvedFamiliars} onOpenUrl={openUrlInAppBrowser} />
     ) : mode === "submissions" ? (
       <OpenCovenSubmissionPage />
     ) : (

--- a/src/lib/beads-work-queue.test.ts
+++ b/src/lib/beads-work-queue.test.ts
@@ -214,4 +214,41 @@ assert.equal(
   assert.deepEqual(clean.attention, [], "no unlinked/stale PRs → empty attention");
 }
 
+
+// ── cave-oa1z: the Work Queue rides the Tasks page as a tab ──────────────────
+// (Schedules pattern: legacy mode deep-links onto the tab; one nav entry.)
+{
+  const { readFileSync } = await import("node:fs");
+  const read = (rel: string) => readFileSync(new URL(rel, import.meta.url), "utf8");
+
+  const workspace = read("../components/workspace.tsx");
+  if (!/mode === "board" \|\| mode === "familiar-work-queue"/.test(workspace)) {
+    throw new Error("workspace must resolve the legacy familiar-work-queue mode onto the merged Tasks surface");
+  }
+  if (!/initialTab=\{mode === "familiar-work-queue" \? "queue" : "tasks"\}/.test(workspace)) {
+    throw new Error("the legacy mode must deep-link onto the queue tab");
+  }
+  if (!/queueSlot=\{<FamiliarWorkQueueView[^>]*embedded/.test(workspace)) {
+    throw new Error("the queue rides the Tasks page as an embedded slot");
+  }
+
+  const board = read("../components/board-view.tsx");
+  if (!/idPrefix="tasks"/.test(board) || !/label: "Work queue"/.test(board)) {
+    throw new Error("BoardView hosts the Tasks | Work queue segment tabs");
+  }
+  if (!/activeTab === "queue" && queueSlot/.test(board)) {
+    throw new Error("the queue tabpanel renders the slot");
+  }
+
+  const sidebar = read("../components/sidebar-minimal.tsx");
+  if (/label: "Work Queue"/.test(sidebar)) {
+    throw new Error("the standalone Work Queue nav row stays retired — Tasks covers it");
+  }
+
+  const fwq = read("../components/familiar-work-queue-view.tsx");
+  if (!/embedded \? null : <h1 className="surface-compact-title">Work Queue<\/h1>/.test(fwq)) {
+    throw new Error("embedded queue suppresses its own h1 (the tab band names the surface)");
+  }
+}
+
 console.log("beads-work-queue.test.ts: ok");


### PR DESCRIPTION
Goal: merge the Work Queue into the Tasks page as a tab. Implemented with the codebase's own precedent — the Schedules surface's calendar+crons merge.

- **BoardView** hosts a `Tasks | Work queue` segment (shared `Tabs`) in its header band; board search/controls gate on the Tasks tab; the queue renders in a tabpanel via a **slot** (BoardView stays ignorant of queue plumbing). The board body stays mounted behind `display:contents` so polls keep state warm across switches.
- **FamiliarWorkQueueView** gains `embedded`: the tab band names the surface, so its own `h1` stays out — freshness signal, degradation banners, and lanes are untouched (the committed e2e spec keys on `.fwq` internals and stays green).
- **Legacy mode compat**: `familiar-work-queue` still resolves (nav events, `/?mode=` deep links) but opens the queue tab (`key={mode}` remount). The standalone sidebar row retires.

## Validation
- Live probe: tab band renders `["Tasks","Work queue"]`; queue tab shows `.fwq` with board controls hidden; dispatching the legacy mode lands selected on **Work queue**; nav has zero Work Queue rows (screenshots in session)
- Wiring pins added to `beads-work-queue.test.ts`; `pnpm typecheck` + full app suite (581 files) green; `sidebar-minimal.test.ts` and both existing queue pin files pass unchanged

Bead: cave-oa1z

🤖 Generated with [Claude Code](https://claude.com/claude-code)