### PR TITLE
feat(chat): slim header + narrow-panel-aware sidebar rows

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -756,6 +756,11 @@ tr[role="checkbox"]:focus-visible {
   height: 100%;
   min-height: 0;
   background: color-mix(in oklch, var(--bg-raised) 92%, transparent);
+  /* Rows respond to the panel, not the viewport — the sidebar is drag-resizable
+     down to ~200px, where per-row ornaments crowd out the thread title. The
+     matching @container rules live below the thread-row styles they override. */
+  container-type: inline-size;
+  container-name: cnav;
 }
 
 /* Header */
@@ -774,7 +779,7 @@ tr[role="checkbox"]:focus-visible {
   /* Extra right padding so the trailing options (⋯) button isn't jammed against
      the panel edge; the left stays at --cnav-pad to align with the New-chat and
      search fields below. */
-  padding: 12px 15px 6px var(--cnav-pad);
+  padding: 8px 15px 4px var(--cnav-pad);
 }
 .cnav__back {
   display: grid;
@@ -1235,6 +1240,18 @@ tr[role="checkbox"]:focus-visible {
 /* On hover / active-with-actions, the timestamp yields to the row actions */
 .cnav__thread:hover .cnav__time {
   display: none;
+}
+
+/* Narrow panel: the title is the row's reason to exist — reclaim the project
+   tile's slot (its name stays for AT via the sr-only span) and tighten the row
+   gap so a ~200px panel still shows a readable title. */
+@container cnav (max-width: 212px) {
+  .cnav__thread-proj {
+    display: none;
+  }
+  .cnav__thread-main {
+    gap: 6px;
+  }
 }
 
 /* Inline delete confirm */
@@ -8600,12 +8617,12 @@ a.mobile-handoff__link:hover {
 }
 
 .chat-scope-tabs--minimal {
-  min-height: 38px;
+  min-height: 34px;
   background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
 }
 
 .chat-scope-tabs--minimal [role="tab"] {
-  padding-block: 8px;
+  padding-block: 7px;
 }
 
 /* Dynamic viewport units for layout shell + modals — `100vh` on iOS

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -138,4 +138,17 @@ assert.doesNotMatch(
   ".cave-mode-fade must not retain end-state animation styles (containing-block trap, cave-cco)",
 );
 
+// The chat/code sidebar responds to its own panel width, not the viewport —
+// at narrow drag widths the per-row project tile yields its slot to the title.
+assert.match(
+  css,
+  /\.cnav\s*\{[\s\S]*?container-type:\s*inline-size;[\s\S]*?container-name:\s*cnav;/,
+  ".cnav is an inline-size query container",
+);
+assert.match(
+  css,
+  /@container cnav \(max-width: 212px\)\s*\{[\s\S]*?\.cnav__thread-proj\s*\{\s*display:\s*none;/,
+  "narrow cnav panels drop the per-row project tile so titles keep room",
+);
+
 console.log("globals.css.test.ts (mode-fade containing block) OK");

--- a/src/components/chat-view-polish.test.ts
+++ b/src/components/chat-view-polish.test.ts
@@ -553,6 +553,19 @@ assert.match(
   /<LinkedContextRow\b/,
   "ChatView header should render LinkedContextRow for task/GitHub chips",
 );
+// Slim header: the linked-context strip only earns its own header row when
+// there are actual chips; the bare "link a task" affordance rides inline with
+// the session actions so an unlinked session's header stays one row.
+assert.match(
+  source,
+  /const hasLinkedChips =[\s\S]*?Boolean\(linkedContext\?\.task\)/,
+  "ChatView derives hasLinkedChips from the linked context",
+);
+assert.match(
+  source,
+  /\{!hasLinkedChips \? linkedContextRow : null\}[\s\S]*?<\/MetaLine>[\s\S]*?\{hasLinkedChips \? linkedContextRow : null\}/,
+  "The linked-context row renders inline with session actions when chip-less, and as its own header row only with chips",
+);
 
 assert.doesNotMatch(
   turnRow,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -4672,6 +4672,25 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     [], // eslint-disable-line react-hooks/exhaustive-deps
   );
 
+  // Slim header: the linked-context strip only earns its own header row when
+  // there are actual task/GitHub chips to show. A bare "link a task" affordance
+  // rides inline with the session actions instead, so an unlinked session's
+  // header is one row (title + meta), not title + a mostly-empty second band.
+  const hasLinkedChips =
+    Boolean(linkedContext?.task) ||
+    (linkedContext?.tasks?.length ?? 0) > 0 ||
+    (linkedContext?.github?.length ?? 0) > 0;
+  const linkedContextRow = (
+    <LinkedContextRow
+      linkedContext={linkedContext}
+      onOpenTask={onOpenTask}
+      sessionId={sessionId}
+      onLinkedContextChange={setLinkedContext}
+      handoff={{ turns, familiarId: familiar.id ?? null, projectId: projectIdDraft }}
+      sessionSettled={!activePendingTurn && Boolean(lastSettledAssistantTurn) && !lastSettledAssistantTurn?.error}
+    />
+  );
+
   return (
     <section
       className="cave-chat-linear flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]"
@@ -4777,16 +4796,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             {sessionId && familiar.id ? (
               <HeaderReflectButton reflecting={reflecting} onReflect={() => void reflectOnThread()} />
             ) : null}
+            {!hasLinkedChips ? linkedContextRow : null}
           </div>
         </MetaLine>
-        <LinkedContextRow
-          linkedContext={linkedContext}
-          onOpenTask={onOpenTask}
-          sessionId={sessionId}
-          onLinkedContextChange={setLinkedContext}
-          handoff={{ turns, familiarId: familiar.id ?? null, projectId: projectIdDraft }}
-          sessionSettled={!activePendingTurn && Boolean(lastSettledAssistantTurn) && !lastSettledAssistantTurn?.error}
-        />
+        {hasLinkedChips ? linkedContextRow : null}
       </header>
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
       <ToolProjectRootContext.Provider value={session?.project_root ?? projectRoot ?? null}>

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -37,6 +37,10 @@ assert.match(workspaceSidebar, /ph:git-pull-request/, "should support PR glyph o
 assert.match(workspaceSidebar, /scheduledCount/, "should accept scheduledCount prop");
 // Outer CSS classes for e2e compat
 assert.match(workspaceSidebar, /workspace-sidebar chat-sidebar/, "outer div must include both CSS classes for e2e compat");
+// The search placeholder must fit the panel's ~200px minimum width (the old
+// "Search projects or threads…" clipped); the aria-label keeps the full scope.
+assert.match(workspaceSidebar, /placeholder="Search chats…"/, "search placeholder fits the narrow panel");
+assert.match(workspaceSidebar, /aria-label="Search projects and threads"/, "search keeps its descriptive accessible name");
 // chat-view wiring (unchanged — just verify it still exists)
 assert.match(chatView, /setProjectAccessRoot/, "chat-view should capture failing project root on 403");
 assert.match(chatView, /async function handleAddProject/, "chat-view should implement add-project recovery");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -466,7 +466,7 @@ export function WorkspaceSidebar({
               type="search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search projects or threads…"
+              placeholder="Search chats…"
               aria-label="Search projects and threads"
             />
             {query ? (


### PR DESCRIPTION
Optimizes the chat page header and the chat side panel (autopilot objective, bead `cave-bmv0`).

## Header
- **One-row resting header for unlinked sessions (57px → 34px).** The linked-context strip only earns its own header row when there are actual task/GitHub chips. A chip-less session renders the bare "link a task" affordance inline with the session actions cluster (same hover-reveal behavior); sessions with linked tasks keep the dedicated chip row exactly as before.
- Scope-tabs band trimmed 38px → 34px to match the slimmer header.

## Sidebar (`.cnav` — shared Chat + Code navigator)
- **Panel-width-aware rows.** `.cnav` is now an inline-size query container: below 212px the per-row project tile yields its slot to the thread title (project name stays for AT via the existing `sr-only` span) and row gaps tighten — thread titles gain ~26px at the panel's minimum drag width.
- **Search placeholder no longer clips** at narrow widths ("Search projects or threads…" → "Search chats…"); the descriptive `aria-label` is unchanged.
- Header chrome padding tightened (50px → 44px), threads start higher.

## Validation
- Playwright against the prod build: resting chip-less header measures 34px (was 57), hover keeps 34px with the inline `+` linker revealing at opacity 1; linked-task session keeps its chip row (task chip + Mark done + GitHub chip all render); narrow panel hides the project tile and titles widen 74px → 100px at a 183px panel; mobile (390px) identity header unaffected.
- `pnpm test:app` green; new assertions lock the inline-linker gating, the `@container` rule, and the placeholder.
- `tests/chat-task-chip-nav.spec.ts` + `tests/chat-boot-landing.spec.ts` (desktop) pass — one pre-existing flake in the board-inspector dialog wait retries green and is unrelated (chip renders/clicks fine).
