### PR TITLE
chore(release): stamp v0.0.163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.163] - 2026-07-09
+
+> 📱 **Hand off THIS chat to your phone** — the QR pairing carries the current conversation across and finally confirms it took. The Work Queue rides the Tasks page as a tab, the familiar switcher reads as a clean dropdown with a prominent Summon button, multi-file turns collapse into one "Review all" entry, and the chat header slims down for narrow panels. Plus a readable transcript over custom backdrops, mid-save file-switch no longer bleeds content, and Grimoire graph nodes are keyboard-traversable.
+
+Patch release on top of v0.0.162.
+
+### Features
+- **Mobile: Continue on phone hands off the current chat** (#2827, cave-i74f). The QR code carries THIS conversation to the phone, and pairing now reports success instead of leaving you guessing.
+- **Tasks: the Work Queue rides the Tasks page as a tab** (#2830, cave-oa1z) — queue and task views live together instead of split across surfaces.
+- **Familiars: the switcher reads as a clean dropdown with a prominent Summon button** (#2825, cave-6p5l).
+- **Chat: multi-file turns get one "Review all" entry into the Changes tab** (#2823, cave-qva4) instead of a row per file.
+- **Chat: slim header + narrow-panel-aware sidebar rows** (#2831, cave-bmv0) — the header trims down and sidebar rows adapt when the panel is narrow.
+- **Inbox: toast vibe pass** (#2828, cave-18nk) — glass surface, kind-tinted chip, and pill actions.
+
+### Fixes
+- **Chat: readable transcript over a custom backdrop** (#2829, cave-5oeu) — a frosted reading column plus quiet-text lift keeps the transcript legible over any wallpaper.
+- **Grimoire: shell/nav batch** (#2820, cave-quct, cave-eg6f, cave-v1j0) — the graph reaches mobile layouts, the rail supports keyboard nav, and memory groups by source root.
+- **Grimoire: quick wins** (#2822) — preference-aware journal dates, eviction announce, an editor skeleton, tappable chips, and search screen-reader counts.
+- **Code: mid-save file switch no longer paints the saved file's content over the file you moved to** (#2824, cave-uv0t).
+
+### Accessibility
+- **Grimoire: keyboard traversal for graph nodes** (#2821, cave-2cx8) — Tab cycles nodes, Enter opens.
+
 ## [0.0.162] - 2026-07-09
 
 > 🖼️ **Your wallpapers, straight from the camera roll** — the backdrop picker now takes HEIC photos directly, no conversion detour. Plus the side-panel footer stays put on chat pages, familiar switching can't flash another familiar's sessions, Grimoire's graph reaches narrow screens, and daily narratives drop their stowaway next-paths block.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.162",
+  "version": "0.0.163",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.162"
+version = "0.0.163"
 dependencies = [
  "log",
  "once_cell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.162"
+version = "0.0.163"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.162</string>
+	<string>0.0.163</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.162</string>
+	<string>0.0.163</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.162</string>
+	<string>0.0.163</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.162</string>
+	<string>0.0.163</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.162",
+  "version": "0.0.163",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.163** across all six version locations + CHANGELOG.

Patch release on top of v0.0.162 — rolls up 11 merged PRs since the last tag:

**Features:** #2827 (Continue on phone hands off THIS chat), #2830 (Work Queue as Tasks tab), #2825 (familiar switcher dropdown + Summon), #2823 (multi-file → one Review-all), #2831 (slim chat header), #2828 (inbox toast vibe).
**Fixes:** #2829 (frosted reading column over backdrops), #2820 (grimoire shell/nav — mobile graph, rail kbd nav, memory by root), #2822 (grimoire quick wins), #2824 (mid-save file-switch bleed).
**a11y:** #2821 (grimoire graph node keyboard traversal).

Version files: package.json, src-tauri/Cargo.toml, src-tauri/Cargo.lock (app pkg), src-tauri/tauri.conf.json, src-tauri/Info.ios.plist, src-tauri/gen/apple/app_iOS/Info.plist. No dependency drift in Cargo.lock (only the app entry moved).

Tag `v0.0.163` follows once this merges.