### PR TITLE
feat(release): stamp-release script + partial updater manifest resilience (cave-ef6f)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,7 +544,13 @@ jobs:
     name: Publish updater manifest (latest.json)
     needs: build
     runs-on: ubuntu-24.04
-    if: success()
+    # cave-ef6f: `if: success()` skipped this job whenever ANY platform leg
+    # flaked (3 of 4 cuts on 2026-07-08), publishing a release with NO
+    # latest.json — the in-app updater then 404s for every install until
+    # someone reruns the failed leg. Run whenever the build ran at all and
+    # publish entries for the platforms that DID produce signed artifacts;
+    # zero platforms stays fatal (see the verify step below).
+    if: ${{ !cancelled() && needs.build.result != 'cancelled' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -577,6 +583,7 @@ jobs:
           set -euo pipefail
           count=$(node -e "const m=require('./latest.json'); process.stdout.write(String(Object.keys(m.platforms||{}).length))")
           echo "latest.json platform count: $count"
+          echo "PLATFORM_COUNT=$count" >> "$GITHUB_ENV"
           if [ "$count" -eq 0 ]; then
             echo "::error::latest.json has 0 platforms — no signed updater artifacts were produced, so in-app auto-update would silently find nothing."
             echo "::error::Ensure the TAURI_SIGNING_PRIVATE_KEY (+ TAURI_SIGNING_PRIVATE_KEY_PASSWORD) repo secrets are set so the build jobs emit signed *.sig artifacts."
@@ -591,3 +598,32 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: latest.json
+
+      # cave-ef6f: an honest release body — when the manifest ships partial,
+      # say so on the release itself (and remove the note when a rerun heals
+      # it to 4/4). Idempotent: the marker line is stripped before deciding.
+      - name: Flag partial updater coverage in the release body
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          rel=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" 2>/dev/null) || {
+            echo "no release object for ${RELEASE_TAG} yet — skipping body note"
+            exit 0
+          }
+          id=$(jq -r .id <<<"$rel")
+          body=$(jq -r '.body // ""' <<<"$rel")
+          cleaned=$(printf '%s' "$body" | sed '/Partial updater coverage/d')
+          if [ "${PLATFORM_COUNT}" -lt 4 ]; then
+            note="> ⚠️ **Partial updater coverage**: latest.json carries ${PLATFORM_COUNT}/4 platforms — auto-update is unavailable on the missing ones until \`gh run rerun --failed\` heals this run."
+            new=$(printf '%s\n\n%s\n' "$cleaned" "$note")
+          else
+            new=$cleaned
+          fi
+          if [ "$new" != "$body" ]; then
+            jq -n --arg body "$new" '{body:$body}' | gh api -X PATCH "repos/${GITHUB_REPOSITORY}/releases/$id" --input - >/dev/null
+            echo "release body updated (${PLATFORM_COUNT}/4 platforms)"
+          else
+            echo "release body already accurate (${PLATFORM_COUNT}/4 platforms)"
+          fi

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -695,6 +695,7 @@ export const SUITES = {
     "src/lib/pty-ws-bridge.test.ts",
     "scripts/release-macos-signing.test.mjs",
     "scripts/generate-latest-json.test.mjs",
+    "scripts/stamp-release.test.mjs",
     "src/app/api/daemon/start/route.test.ts",
     "src/app/api/github/activity/route.test.ts",
     "src/app/api/github/assigned/route.test.ts",

--- a/scripts/stamp-release.mjs
+++ b/scripts/stamp-release.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// cave-ef6f: one-command release stamp.
+//
+//   node scripts/stamp-release.mjs [--level patch|minor|major] [--version X.Y.Z]
+//                                  [--dry-run] [--no-pr]
+//
+// Hand-rolled stamps produced three PR collisions between concurrent sessions
+// on 2026-07-08 alone, and every cut re-derives the same six version
+// locations by hand. This script:
+//   1. REFUSES when another stamp PR is already open (the collision guard);
+//   2. bumps the six version locations (package.json, tauri.conf.json,
+//      Cargo.toml, Cargo.lock's `app` package, both iOS Info.plists);
+//   3. drafts the CHANGELOG section from `git log v<prev>..HEAD` subjects —
+//      a starting point to edit in the PR, not prose to trust blindly;
+//   4. branches, commits SIGNED (-S), pushes, and opens the PR via the REST
+//      API (survives exhausted GraphQL quota).
+//
+// `--dry-run` prints the plan (new version, per-file replacement counts, the
+// changelog draft) and writes nothing. Pure helpers are exported for tests.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+// ── pure helpers (exported for scripts/stamp-release.test.mjs) ───────────────
+
+export function bumpVersion(current, level = "patch") {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(current.trim());
+  if (!m) throw new Error(`unparseable current version: "${current}"`);
+  const [major, minor, patch] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  if (level === "major") return `${major + 1}.0.0`;
+  if (level === "minor") return `${major}.${minor + 1}.0`;
+  if (level === "patch") return `${major}.${minor}.${patch + 1}`;
+  throw new Error(`unknown bump level: "${level}"`);
+}
+
+/** The six stamp locations and how each encodes the version. */
+export const STAMP_FILES = [
+  { file: "package.json", kind: "json-version" },
+  { file: "src-tauri/tauri.conf.json", kind: "json-version" },
+  { file: "src-tauri/Cargo.toml", kind: "toml-version" },
+  { file: "src-tauri/Cargo.lock", kind: "cargo-lock-app" },
+  { file: "src-tauri/Info.ios.plist", kind: "plist-string" },
+  { file: "src-tauri/gen/apple/app_iOS/Info.plist", kind: "plist-string" },
+];
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** Replace the version in one file's content; returns {content, replaced}.
+ *  Every kind is scoped so an unrelated dependency at the same version can
+ *  never be rewritten (the Cargo.lock hazard). */
+export function stampContent(kind, content, oldVersion, newVersion) {
+  const old = escapeRe(oldVersion);
+  let replaced = 0;
+  // The counting wrapper is a replacer FUNCTION, so `$1`-style strings would
+  // be inserted literally — always rebuild from the captured groups.
+  const sub = (re) => {
+    content = content.replace(re, (_, before, after) => {
+      replaced++;
+      return `${before}${newVersion}${after}`;
+    });
+  };
+  switch (kind) {
+    case "json-version":
+      sub(new RegExp(`("version":\\s*")${old}(")`));
+      break;
+    case "toml-version":
+      sub(new RegExp(`(^version = ")${old}(")`, "m"));
+      break;
+    case "cargo-lock-app":
+      sub(new RegExp(`(name = "app"\\nversion = ")${old}(")`));
+      break;
+    case "plist-string":
+      sub(new RegExp(`(<string>)${old}(</string>)`, "g"));
+      break;
+    default:
+      throw new Error(`unknown stamp kind: "${kind}"`);
+  }
+  return { content, replaced };
+}
+
+/** Keep-a-Changelog section drafted from commit subjects since the last tag. */
+export function buildChangelogSection({ version, prevVersion, dateIso, subjects }) {
+  const bullets = subjects
+    .filter((s) => s.trim() && !/^chore\(release\): stamp v/.test(s))
+    .map((s) => `- ${s}`);
+  return [
+    `## [${version}] - ${dateIso}`,
+    "",
+    "> _One-line teaser — edit before merge._",
+    "",
+    `Patch release on top of v${prevVersion}.`,
+    "",
+    "### Changes",
+    ...(bullets.length ? bullets : ["- _No commits since the previous tag?_"]),
+    "",
+  ].join("\n");
+}
+
+export function insertChangelogSection(changelog, section) {
+  const anchor = "## [Unreleased]";
+  const at = changelog.indexOf(anchor);
+  if (at === -1) throw new Error(`CHANGELOG.md has no "${anchor}" anchor`);
+  const after = at + anchor.length;
+  return `${changelog.slice(0, after)}\n\n${section.trimEnd()}\n${changelog.slice(after)}`;
+}
+
+/** The collision guard: any open PR already stamping a release. */
+export function findOpenStampPr(pulls) {
+  return (
+    pulls.find((p) => typeof p?.title === "string" && /^chore\(release\): stamp v/.test(p.title)) ??
+    null
+  );
+}
+
+// ── main ──────────────────────────────────────────────────────────────────────
+
+const run = (cmd, args, opts = {}) =>
+  execFileSync(cmd, args, { cwd: ROOT, encoding: "utf8", ...opts }).trim();
+
+function main() {
+  const argv = process.argv.slice(2);
+  const flag = (name) => argv.includes(name);
+  const value = (name) => {
+    const i = argv.indexOf(name);
+    return i !== -1 ? argv[i + 1] : undefined;
+  };
+  const dryRun = flag("--dry-run");
+  const noPr = flag("--no-pr");
+  const level = value("--level") ?? "patch";
+
+  // Preflight: a dirty tree would fold unrelated edits into the stamp commit
+  // (the exact failure mode that motivated per-session worktrees).
+  const dirty = run("git", ["status", "--porcelain"]);
+  if (dirty && !dryRun) {
+    console.error("✗ working tree is dirty — stamp from a clean checkout:\n" + dirty);
+    process.exit(1);
+  }
+
+  const current = JSON.parse(readFileSync(path.join(ROOT, "package.json"), "utf8")).version;
+  const next = value("--version") ?? bumpVersion(current, level);
+  if (!/^\d+\.\d+\.\d+$/.test(next)) {
+    console.error(`✗ refusing non-semver version "${next}"`);
+    process.exit(1);
+  }
+
+  // Collision guard — three stamp PRs raced on 2026-07-08; never open a second.
+  const repo = "OpenCoven/coven-cave";
+  const pulls = JSON.parse(run("gh", ["api", `repos/${repo}/pulls?state=open&per_page=50`]));
+  const openStamp = findOpenStampPr(pulls);
+  if (openStamp) {
+    console.error(
+      `✗ stamp PR already open: #${openStamp.number} "${openStamp.title}" — land or close it first.`,
+    );
+    process.exit(1);
+  }
+
+  const prevTag = `v${current}`;
+  const subjects = run("git", ["log", `${prevTag}..HEAD`, "--no-merges", "--pretty=%s"])
+    .split("\n")
+    .filter(Boolean);
+  const dateIso = new Date().toISOString().slice(0, 10);
+  const section = buildChangelogSection({ version: next, prevVersion: current, dateIso, subjects });
+
+  console.log(`stamp: v${current} → v${next} (${subjects.length} commits since ${prevTag})`);
+
+  const edits = [];
+  for (const { file, kind } of STAMP_FILES) {
+    const abs = path.join(ROOT, file);
+    const before = readFileSync(abs, "utf8");
+    const { content, replaced } = stampContent(kind, before, current, next);
+    if (replaced === 0) {
+      console.error(`✗ ${file}: found no "${current}" to stamp (${kind}) — aborting, nothing written`);
+      process.exit(1);
+    }
+    edits.push({ abs, file, content, replaced });
+  }
+  const changelogAbs = path.join(ROOT, "CHANGELOG.md");
+  const changelog = insertChangelogSection(readFileSync(changelogAbs, "utf8"), section);
+
+  if (dryRun) {
+    for (const e of edits) console.log(`  would stamp ${e.file} (${e.replaced} occurrence${e.replaced === 1 ? "" : "s"})`);
+    console.log("  would insert CHANGELOG section:\n");
+    console.log(section.replace(/^/gm, "    "));
+    console.log("\n(dry run — nothing written)");
+    return;
+  }
+
+  for (const e of edits) writeFileSync(e.abs, e.content);
+  writeFileSync(changelogAbs, changelog);
+  console.log("✓ six locations stamped + CHANGELOG drafted");
+
+  const branch = `release/stamp-v${next}`;
+  run("git", ["checkout", "-b", branch]);
+  run("git", ["add", "CHANGELOG.md", ...STAMP_FILES.map((f) => f.file)]);
+  // -S: repo rule — every commit lands Verified.
+  run("git", ["commit", "-S", "-m", `chore(release): stamp v${next}\n\nPatch release on top of v${current}. Bumps all six version locations and\ndrafts the v${next} CHANGELOG entry for the ${subjects.length} commits since ${prevTag}.`]);
+  run("git", ["push", "-u", "origin", branch]);
+  console.log(`✓ committed + pushed ${branch}`);
+
+  if (noPr) {
+    console.log("(--no-pr: open the PR yourself when ready)");
+    return;
+  }
+  const pr = JSON.parse(
+    run("gh", [
+      "api",
+      `repos/${repo}/pulls`,
+      "-X",
+      "POST",
+      "-f",
+      `head=${branch}`,
+      "-f",
+      "base=main",
+      "-f",
+      `title=chore(release): stamp v${next}`,
+      "-f",
+      `body=Stamped by \`scripts/stamp-release.mjs\`. Edit the CHANGELOG teaser/grouping before merge.\n\n\`\`\`\n${section}\n\`\`\``,
+    ]),
+  );
+  console.log(`✓ PR opened: ${pr.html_url}`);
+  console.log(`next: merge it, then tag — git tag -s v${next} <squash-sha> && git push origin v${next}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/scripts/stamp-release.test.mjs
+++ b/scripts/stamp-release.test.mjs
@@ -1,0 +1,106 @@
+// @ts-nocheck
+// cave-ef6f — stamp-release script + partial updater manifest resilience.
+// Pure tests exercise the exported stamp helpers; source pins hold the
+// release.yml resilience and the verify script's --allow-partial contract.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  bumpVersion,
+  STAMP_FILES,
+  stampContent,
+  buildChangelogSection,
+  insertChangelogSection,
+  findOpenStampPr,
+} from "./stamp-release.mjs";
+
+// ── bumpVersion ───────────────────────────────────────────────────────────────
+assert.equal(bumpVersion("0.0.159"), "0.0.160");
+assert.equal(bumpVersion("0.0.159", "minor"), "0.1.0");
+assert.equal(bumpVersion("0.4.9", "major"), "1.0.0");
+assert.throws(() => bumpVersion("garbage"), /unparseable/);
+assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
+
+// ── stampContent: each kind scoped so nothing unrelated rewrites ──────────────
+{
+  const { content, replaced } = stampContent(
+    "json-version",
+    `{\n  "name": "coven-cave",\n  "version": "0.0.159",\n  "dep": { "version": "0.0.159" }\n}`,
+    "0.0.159",
+    "0.0.160",
+  );
+  assert.equal(replaced, 1, "json stamps only the first version field");
+  assert.match(content, /"version": "0\.0\.160"/);
+  assert.match(content, /"dep": \{ "version": "0\.0\.159" \}/, "nested same-version field untouched");
+}
+{
+  const lock = `[[package]]\nname = "aho-corasick"\nversion = "0.0.159"\n\n[[package]]\nname = "app"\nversion = "0.0.159"\n`;
+  const { content, replaced } = stampContent("cargo-lock-app", lock, "0.0.159", "0.0.160");
+  assert.equal(replaced, 1, "only the app package block is stamped");
+  assert.match(content, /name = "aho-corasick"\nversion = "0\.0\.159"/, "same-version dependency untouched");
+  assert.match(content, /name = "app"\nversion = "0\.0\.160"/);
+}
+{
+  const plist = `<key>CFBundleShortVersionString</key>\n\t<string>0.0.159</string>\n<key>CFBundleVersion</key>\n\t<string>0.0.159</string>\n<key>Other</key>\n\t<string>1.0</string>`;
+  const { content, replaced } = stampContent("plist-string", plist, "0.0.159", "0.0.160");
+  assert.equal(replaced, 2, "both plist version strings stamp");
+  assert.doesNotMatch(content, /0\.0\.159/);
+  assert.match(content, /<string>1\.0<\/string>/, "unrelated strings untouched");
+}
+{
+  const { replaced } = stampContent("toml-version", `[package]\nname = "app"\nversion = "0.0.159"\n`, "0.0.159", "0.0.160");
+  assert.equal(replaced, 1);
+}
+assert.equal(STAMP_FILES.length, 6, "exactly the six stamp locations");
+assert.throws(() => stampContent("nope", "", "a", "b"), /unknown stamp kind/);
+
+// ── changelog ─────────────────────────────────────────────────────────────────
+{
+  const section = buildChangelogSection({
+    version: "0.0.160",
+    prevVersion: "0.0.159",
+    dateIso: "2026-07-09",
+    subjects: ["feat(a): thing (#1)", "chore(release): stamp v0.0.159 (#2797)", "fix(b): other (#2)"],
+  });
+  assert.match(section, /^## \[0\.0\.160\] - 2026-07-09/, "keep-a-changelog heading");
+  assert.match(section, /- feat\(a\): thing \(#1\)/);
+  assert.doesNotMatch(section, /stamp v0\.0\.159/, "prior stamp commits filtered from the draft");
+  const inserted = insertChangelogSection("# Changelog\n\n## [Unreleased]\n\n## [0.0.159] - 2026-07-08\n", section);
+  assert.ok(
+    inserted.indexOf("## [Unreleased]") < inserted.indexOf("## [0.0.160]") &&
+      inserted.indexOf("## [0.0.160]") < inserted.indexOf("## [0.0.159]"),
+    "new section lands between Unreleased and the previous release",
+  );
+  assert.throws(() => insertChangelogSection("# no anchor here", section), /no "## \[Unreleased\]" anchor/);
+}
+
+// ── collision guard ───────────────────────────────────────────────────────────
+assert.equal(findOpenStampPr([{ title: "feat: x" }]), null);
+assert.equal(findOpenStampPr([{ title: "feat: x" }, { title: "chore(release): stamp v0.0.160", number: 9 }]).number, 9);
+
+// ── release.yml resilience pins ───────────────────────────────────────────────
+const yml = await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+assert.match(
+  yml,
+  /updater-manifest:[\s\S]{0,900}if: \$\{\{ !cancelled\(\) && needs\.build\.result != 'cancelled' \}\}/,
+  "updater-manifest runs even when a build leg failed (a flake must not 404 the updater)",
+);
+assert.match(yml, /PLATFORM_COUNT=\$count.*GITHUB_ENV/, "platform count exported for the body note");
+assert.match(yml, /Flag partial updater coverage in the release body/, "partial coverage is flagged on the release itself");
+assert.match(yml, /sed '\/Partial updater coverage\/d'/, "the body note is idempotent (marker stripped before deciding)");
+assert.match(yml, /latest\.json has 0 platforms/, "zero platforms stays fatal");
+
+// ── verify-release-updater --allow-partial pins ───────────────────────────────
+const verify = await readFile(new URL("./verify-release-updater.mjs", import.meta.url), "utf8");
+assert.match(verify, /allowPartial = process\.argv\.includes\("--allow-partial"\)/, "flag exists");
+assert.match(
+  verify,
+  /\(allowPartial \? warn : fail\)\(`missing platform/,
+  "missing platform downgrades to a warning under --allow-partial",
+);
+assert.match(
+  verify,
+  /if \(!Object\.keys\(plats\)\.length\) fail\(/,
+  "an EMPTY manifest fails even with --allow-partial",
+);
+
+console.log("stamp-release.test.mjs: ok");

--- a/scripts/verify-release-updater.mjs
+++ b/scripts/verify-release-updater.mjs
@@ -15,14 +15,23 @@
 //
 // Pure Node — no minisign CLI: ed25519 over a blake2b512 prehash, per the
 // minisign "ED" (prehashed) / "Ed" (legacy) formats Tauri emits.
+//
+// --allow-partial (cave-ef6f, CI use only): a missing PLATFORM downgrades to
+// a warning — the updater-manifest job now publishes honest partial
+// manifests when a build leg flakes, and CI verification of such a release
+// must judge what shipped, not what didn't. An EMPTY manifest, an invalid
+// signature, or version drift still fail either way.
 import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const TARGETS = ["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"];
+const allowPartial = process.argv.includes("--allow-partial");
 let failures = 0;
+let partialWarnings = 0;
 const fail = (m) => { console.log("  ✗ " + m); failures++; };
+const warn = (m) => { console.log("  ! " + m); partialWarnings++; };
 const ok = (m) => console.log("  ✓ " + m);
 
 // ── minisign verification (pure node) ──────────────────────────────────
@@ -80,7 +89,10 @@ if (manifest) {
   if (!Object.keys(plats).length) fail("platforms{} is EMPTY — no signed artifacts (updater non-functional)");
   for (const t of TARGETS) {
     const p = plats[t];
-    if (!p) { fail(`missing platform "${t}"`); continue; }
+    if (!p) {
+      (allowPartial ? warn : fail)(`missing platform "${t}"${allowPartial ? " (tolerated: --allow-partial)" : ""}`);
+      continue;
+    }
     if (p.url && p.signature) ok(`${t}: url + signature present`);
     else fail(`${t}: missing ${!p.url ? "url" : "signature"}`);
   }
@@ -109,5 +121,6 @@ if (manifest) {
   }
 }
 
-console.log(`\n=== RESULT: ${failures === 0 ? "PASS — updater chain verified end to end" : failures + " FAILURE(S)"} ===`);
+const partialNote = partialWarnings ? ` (${partialWarnings} platform(s) tolerated by --allow-partial)` : "";
+console.log(`\n=== RESULT: ${failures === 0 ? `PASS — updater chain verified end to end${partialNote}` : failures + " FAILURE(S)"} ===`);
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Golden path 8b (docs/golden-paths.md §8), bead **cave-ef6f**. Complements cave-1hha (Intel-leg retries).

## What

**1. `scripts/stamp-release.mjs` — one-command release stamp**
- Bumps the six version locations (package.json, tauri.conf.json, Cargo.toml, Cargo.lock `app` package, both iOS Info.plists) with scoped regexes so a same-version dependency can never be rewritten (the Cargo.lock hazard).
- Drafts the Keep-a-Changelog section from `git log v<prev>..HEAD` subjects — a starting point to edit in the PR, not prose to trust blindly.
- **Collision guard**: refuses when another `chore(release): stamp v*` PR is open (3 stamp collisions observed 2026-07-08). Verified live: the `--dry-run` in this session correctly refused against open #2832.
- Refuses dirty trees, non-semver versions, and zero-replacement stamps. `--dry-run` / `--no-pr` / `--level` / `--version` flags; commits signed (-S); opens the PR via REST.

**2. `release.yml` — partial updater manifest resilience**
- `updater-manifest` now runs on `!cancelled()` instead of `success()`: a single flaked build leg no longer ships a release with NO latest.json (which 404s the in-app updater for every install until someone reruns the leg).
- Partial coverage is flagged in the release body (idempotent — marker stripped before deciding, so a healing rerun removes the note). Zero platforms stays fatal.

**3. `verify-release-updater.mjs --allow-partial`** — CI verification of honest partial manifests downgrades missing platforms to warnings; an EMPTY manifest, invalid signature, or version drift still fail either way.

## Verification
- `node scripts/stamp-release.test.mjs` — pure helper tests + source pins on release.yml/verify contracts; wired into the api suite (check-tests-wired green, 774 files).
- Live `--dry-run` exercised the collision guard against real open stamp PR #2832.
- Fixed a real bug found by the tests: the counting replacer function made `$1`-style replacement strings insert literally; replacements now rebuild from captured groups.