### PR TITLE
feat(marketplace): skills-leaderboard detail — click-to-copy CLI, minimalist stats, tidy actions

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12773,26 +12773,24 @@ details[open] > .cave-edit-card__summary::before {
   gap: 8px;
   margin-top: 12px;
 }
+/* Minimalist stat: just the labelled value, no description paragraph. */
 .skill-browser__decision-card {
-  min-height: 92px;
   min-width: 0;
-  border: 1px solid color-mix(in oklch, var(--border-hairline) 86%, transparent);
+  border: 1px solid color-mix(in oklch, var(--border-hairline) 70%, transparent);
   border-radius: 8px;
-  background: color-mix(in oklch, var(--bg-panel) 88%, transparent);
-  padding: 10px;
+  background: color-mix(in oklch, var(--bg-panel) 60%, transparent);
+  padding: 8px 10px;
 }
 .skill-browser__decision-card strong {
   display: block;
-  margin-top: 7px;
-  color: var(--text-primary);
-  font-size: 12px;
-  line-height: 1.25;
-}
-.skill-browser__decision-card p {
   margin-top: 5px;
-  color: var(--text-muted);
-  font-size: 11px;
-  line-height: 1.35;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .skill-browser__decision-label {
   display: inline-flex;
@@ -12814,20 +12812,73 @@ details[open] > .cave-edit-card__summary::before {
   margin-top: 10px;
   min-width: 0;
 }
-.skill-browser__install code {
+/* The install command is a clickable copy affordance: click sweeps a green fill
+   across the line and flips it to "Copied" (auto-resets after ~1.5s). */
+.skill-browser__cli {
+  position: relative;
   flex: 1 1 240px;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  height: 30px;
+  padding: 0 8px;
+  border: 1px solid var(--border-hairline);
+  border-radius: 8px;
+  background: var(--bg-base);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s ease;
+}
+.skill-browser__cli:hover { border-color: var(--border-strong, var(--text-muted)); }
+.skill-browser__cli.is-copied { border-color: color-mix(in oklch, var(--color-success) 55%, transparent); }
+.skill-browser__cli code {
+  position: relative;
+  z-index: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  border: 1px solid var(--border-hairline);
-  border-radius: 8px;
-  background: var(--bg-base);
+  background: transparent;
   color: var(--text-primary);
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 12px;
-  padding: 6px 8px;
 }
+/* Green fill that sweeps left→right on copy. */
+.skill-browser__cli-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0;
+  background: color-mix(in oklch, var(--color-success) 20%, transparent);
+  pointer-events: none;
+}
+.skill-browser__cli.is-copied .skill-browser__cli-fill {
+  width: 100%;
+  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.skill-browser__cli-copied {
+  position: absolute;
+  right: 8px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding-left: 8px;
+  background: linear-gradient(to right, transparent, var(--bg-base) 30%);
+  color: var(--color-success);
+  font-size: 11px;
+  font-weight: 650;
+  opacity: 0;
+  transition: opacity 0.15s ease 0.1s;
+  pointer-events: none;
+}
+.skill-browser__cli.is-copied .skill-browser__cli-copied { opacity: 1; }
+@media (prefers-reduced-motion: reduce) {
+  .skill-browser__cli.is-copied .skill-browser__cli-fill { transition: none; }
+  .skill-browser__cli-copied { transition: none; }
+}
+/* Folder + delete action icons share one glyph size regardless of button kind. */
+.skill-browser__action svg { width: 15px; height: 15px; }
 .skill-browser__install-button,
 .skill-browser__use-button,
 .skill-browser__prompt-button {

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -102,12 +102,20 @@ assert.match(src, /Install state/, "detail decision summary labels install state
 assert.match(src, /Trust signal/, "detail decision summary labels trust signal");
 assert.match(src, /Source/, "detail decision summary labels source");
 assert.match(css, /\.skill-browser__decision \{[\s\S]*?grid-template-columns/, "detail decision summary uses a responsive grid");
-assert.match(css, /\.skill-browser__decision-card \{[\s\S]*?min-height:/, "detail decision cards reserve stable height");
-assert.match(src, /copyText\(installCommand\(selected\)\)/, "detail pane can copy the install command");
-assert.match(src, /function handleInstall\(\)/, "detail pane can install a selected directory skill");
-assert.match(src, /fetch\("\/api\/skills\/directory\/install"/, "install action calls the guarded install route");
-assert.match(src, /body: JSON\.stringify\(\{ id: selected\.id, source: sourceTarget\(selected\), agents: \["claude-code", "codex"\] \}\)/, "install action requests Claude Code and Codex installation");
-assert.match(src, /onChanged\?\.\(\)/, "successful install asks the parent to rescan installed state");
+// Minimalist stat cards: just the labelled value, no description paragraph and
+// no fixed card height.
+assert.doesNotMatch(src, /skill-browser__decision-card"[\s\S]{0,220}<p>/, "decision cards drop the description paragraph");
+assert.doesNotMatch(css, /\.skill-browser__decision-card \{[^}]*min-height:/, "minimalist decision cards no longer reserve a fixed height");
+// The install command line is itself the copy affordance — click sweeps a green
+// progressive fill and flips to "Copied"; the separate Install button/pill and
+// standalone copy icon are gone (keep just Use + Copy prompt).
+assert.match(src, /copyText\(installCommand\(selected\)\)/, "the CLI line copies the install command");
+assert.match(src, /skill-browser__cli\$\{copiedInstall \? " is-copied"/, "the install command is a clickable copy button");
+assert.match(src, /className="skill-browser__cli-fill"/, "the CLI copy renders a progressive fill overlay");
+assert.match(css, /\.skill-browser__cli\.is-copied \.skill-browser__cli-fill \{[\s\S]*?width: 100%;[\s\S]*?transition: width/, "the fill sweeps to 100% on copy");
+assert.doesNotMatch(src, /function handleInstall\(/, "the one-click Install button/pill is removed (copy the CLI or Use instead)");
+assert.doesNotMatch(src, /className="skill-browser__install-button"/, "the Install button markup is gone");
+assert.match(src, /onChanged\?\.\(\)/, "a successful delete asks the parent to rescan installed state");
 assert.match(src, /function handleUseSkill\(\)/, "detail pane can use a selected skill without installing it");
 assert.match(src, /fetch\("\/api\/skills\/directory\/use"/, "use action calls the guarded skills use route");
 assert.match(src, /function requestSkillPrompt\(selectedSkill: SkillBrowserEntry\)/, "use and copy prompt share the guarded prompt request");
@@ -119,7 +127,15 @@ assert.match(src, /className="skill-browser__prompt-button"/, "detail pane rende
 assert.match(src, /leadingIcon="ph:clipboard-text"/, "copy-prompt action uses a clipboard icon");
 assert.match(src, /import \{ Button \}/, "SkillBrowser labelled actions use the shared Button primitive");
 assert.match(src, /import \{ IconButton \}/, "SkillBrowser icon actions use the shared IconButton primitive");
-assert.doesNotMatch(src, /<button\b/, "SkillBrowser should not hand-roll button controls");
+// Labelled/icon actions must use the shared Button/IconButton. The sole
+// exception is the bespoke CLI copy-chip (a code line with a progressive fill
+// overlay the primitive can't express) — accessible via type="button" +
+// aria-label. Assert exactly one raw button and that it's that one.
+{
+  const rawButtons = src.match(/<button\b/g) ?? [];
+  assert.equal(rawButtons.length, 1, "the only hand-rolled button is the bespoke CLI copy-chip; everything else uses the shared Button");
+  assert.match(src, /<button\s+type="button"\s+className=\{`skill-browser__cli/, "the one raw button is the clickable CLI copy line");
+}
 assert.doesNotMatch(
   src,
   /rounded-md|rounded-lg|rounded(?=\s|")|rounded-\[4px\]/,

--- a/src/components/skill-browser.tsx
+++ b/src/components/skill-browser.tsx
@@ -65,7 +65,7 @@ type PreviewState = {
   text: string | null;
   error: string | null;
 };
-type BusyState = "reveal" | "delete" | "install" | "use" | "prompt" | null;
+type BusyState = "reveal" | "delete" | "use" | "prompt" | null;
 
 // The scan tags user skills by agent/root while installed entries get a
 // first-class Installed tab.
@@ -295,19 +295,16 @@ function skillDecisionItems(skill: SkillBrowserEntry) {
       icon: installed ? "ph:check-circle" as const : "ph:arrow-down" as const,
       label: "Install state",
       value: installed ? "Installed" : "Available",
-      detail: installed ? "Ready from your local skill roots." : "Install or use it from the directory.",
     },
     {
       icon: skill.trust?.official ? "ph:seal-check" as const : "ph:shield-warning" as const,
       label: "Trust signal",
       value: trustValue,
-      detail: skill.trust?.source ? `Sourced from ${skill.trust.source}.` : "Review source before installing.",
     },
     {
       icon: local ? "ph:folder-open" as const : "ph:cloud-bold" as const,
       label: "Source",
       value: local ? "Local skill" : "Directory",
-      detail: sourceTarget(skill),
     },
   ];
 }
@@ -504,31 +501,6 @@ export function SkillBrowser({
       setNotice("Install command copied");
     } catch {
       setNotice("Could not copy install command");
-    }
-  }
-
-  async function handleInstall() {
-    if (!selected || selected.local?.installed || selected.installed || busy) return;
-    setBusy("install");
-    setNotice(null);
-    try {
-      const res = await fetch("/api/skills/directory/install", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        cache: "no-store",
-        body: JSON.stringify({ id: selected.id, source: sourceTarget(selected), agents: ["claude-code", "codex"] }),
-      });
-      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; alreadyInstalled?: boolean };
-      if (!res.ok || !json.ok) {
-        setNotice(json.error ? `Install failed: ${json.error}` : "Install failed. Try again.");
-        return;
-      }
-      setNotice(json.alreadyInstalled ? "Skill already installed" : "Skill installed");
-      onChanged?.();
-    } catch (err) {
-      setNotice(err instanceof Error ? `Install failed: ${err.message}` : "Install failed");
-    } finally {
-      setBusy(null);
     }
   }
 
@@ -849,7 +821,7 @@ export function SkillBrowser({
                   <div className="skill-browser__actions">
                     <IconButton
                       icon="ph:folder-open"
-                      size="sm"
+                      size="xs"
                       className="skill-browser__action"
                       onClick={handleReveal}
                       disabled={busy != null}
@@ -875,34 +847,29 @@ export function SkillBrowser({
                 {selectedDecisionItems.map((item) => (
                   <div key={item.label} className="skill-browser__decision-card">
                     <span className="skill-browser__decision-label">
-                      <Icon name={item.icon} width={12} aria-hidden />
+                      <Icon name={item.icon} width={11} aria-hidden />
                       {item.label}
                     </span>
                     <strong>{item.value}</strong>
-                    <p>{item.detail}</p>
                   </div>
                 ))}
               </div>
               <div className="skill-browser__install">
-                <code title={installCommand(selected)}>{installCommand(selected)}</code>
-                <IconButton
-                  icon={copiedInstall ? "ph:check" : "ph:copy"}
-                  size="sm"
-                  className="skill-browser__action"
+                {/* The CLI line is itself the copy affordance: click sweeps a
+                    green fill across and flips to "Copied" (auto-resets). */}
+                <button
+                  type="button"
+                  className={`skill-browser__cli${copiedInstall ? " is-copied" : ""}`}
                   onClick={handleCopyInstall}
-                  title={copiedInstall ? "Copied" : "Copy install command"}
-                  aria-label="Copy install command"
-                />
-                <Button
-                  variant="primary"
-                  size="xs"
-                  leadingIcon={selected.installed || selected.local?.installed ? "ph:check-circle" : "ph:arrow-down"}
-                  className="skill-browser__install-button"
-                  onClick={handleInstall}
-                  disabled={busy != null || selected.installed || selected.local?.installed}
+                  title={copiedInstall ? "Copied!" : "Click to copy the install command"}
+                  aria-label={copiedInstall ? "Install command copied" : `Copy install command: ${installCommand(selected)}`}
                 >
-                  <span>{busy === "install" ? "Installing" : selected.installed || selected.local?.installed ? "Installed" : "Install"}</span>
-                </Button>
+                  <code>{installCommand(selected)}</code>
+                  <span className="skill-browser__cli-fill" aria-hidden />
+                  <span className="skill-browser__cli-copied" aria-hidden>
+                    <Icon name="ph:check-bold" width={12} aria-hidden /> Copied
+                  </span>
+                </button>
                 <Button
                   variant="secondary"
                   size="xs"


### PR DESCRIPTION
Polish pass on the **skills leaderboard** detail pane.

## Changes

- **Click the CLI line to copy** — the install-command line is now the copy affordance itself: clicking it copies and sweeps a **green progressive fill** across, flipping to **"✓ Copied"** (auto-resets, reduced-motion safe). Replaces the separate copy icon-button. Implemented as a semantic `<button type="button">` with an `aria-label` — the one deliberate bespoke control in a Button-primitive file (scoped in the test).
- **Dropped the Install button/pill** — the action row is just **Use + Copy prompt** (copy the CLI or Use instead). Removed the now-dead `handleInstall` + its `BusyState`.
- **Minimalist stat cards** — the labelled value only, no description paragraph and no fixed card height (dropped the unused `detail` field too).
- **Folder icon matches delete icon height** (both 15px glyphs).

## Verification

Driven in a real browser (skills leaderboard → select a skill): green fill sweeps to 100% on click with "✓ Copied", Install pill gone (Use + Copy prompt remain), 3 stat cards with **0** description paragraphs, folder/delete icons both **15px**. `typecheck` · `skill-browser` + `roles-tools-navigation` suites · `build` within budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)