### PR TITLE
fix(ios): chat header sheds the Commands and Share toolbar buttons (sim review)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -158,20 +158,9 @@ struct ChatView: View {
                     return n > 0 ? "Linked tasks, \(n)" : "Linked tasks"
                 }())
             }
-            ToolbarItem(placement: .topBarTrailing) {
-                Button { showCommands = true } label: {
-                    Image(systemName: "command")
-                }
-                .accessibilityLabel("Commands")
-            }
-            ToolbarItem(placement: .topBarTrailing) {
-                ShareLink(item: ThreadMarkdownExport(title: thread.title,
-                                                     markdown: app.exportMarkdown(thread)),
-                          preview: SharePreview(thread.title)) {
-                    Image(systemName: "square.and.arrow.up")
-                }
-                .accessibilityLabel("Export as Markdown")
-            }
+            // The header stays lean (sim review, cave feedback): Commands lives
+            // in the composer's + menu (same sheet), and Markdown export stays
+            // on the thread list's flows — neither earns a toolbar slot here.
         }
         .sheet(isPresented: $showCommands) {
             CommandsSheet { command in prefill(command) }

--- a/scripts/ios-export-markdown.test.mjs
+++ b/scripts/ios-export-markdown.test.mjs
@@ -19,12 +19,11 @@ assert.match(exportFile, /struct ThreadMarkdownExport: Transferable/, "a Transfe
 assert.match(exportFile, /DataRepresentation\(exportedContentType: \.plainText\)/, "should export as data");
 assert.match(exportFile, /\.suggestedFileName \{ export in "\\\(export\.fileBaseName\)\.md" \}/, "should suggest a .md filename");
 
-// ChatView wires a share button to the export.
-assert.match(
-  chat,
-  /ShareLink\(item: ThreadMarkdownExport\(title: thread\.title,\s*markdown: app\.exportMarkdown\(thread\)\)/,
-  "ChatView should offer a ShareLink for the Markdown export",
-);
-assert.match(chat, /\.accessibilityLabel\("Export as Markdown"\)/, "the export button should be labelled");
+// The chat header stays lean (sim review feedback): no toolbar ShareLink or
+// Commands button — Commands lives in the composer's + menu, and Markdown
+// export stays on the thread-list flows.
+assert.doesNotMatch(chat, /ShareLink\(/, "the chat header's ShareLink stays removed");
+assert.doesNotMatch(chat, /accessibilityLabel\("Commands"\)/, "the toolbar Commands button stays removed");
+assert.match(chat, /FloatingAction\(id: "commands", systemImage: "command", label: "Commands"\)/, "Commands stays reachable via the composer + menu");
 
 console.log("ios-export-markdown.test.mjs: ok");


### PR DESCRIPTION
Live simulator review feedback: the chat session's top bar carried a ⌘ **Commands** button and a markdown-export **ShareLink**. Both removed — the header keeps just the agent pill and linked-tasks affordances.

- **Commands stays reachable** through the composer's + menu (the same `CommandsSheet`; the menu entry is now pinned as the surviving path).
- **Markdown export stays** on the thread-list flows (`ThreadMarkdownExport` untouched).
- `ios-export-markdown.test.mjs` retargeted: asserts both removals + the surviving + menu entry.

Validation: mobile suite 75 files green; sim rebuild from this branch verified visually (before/after in session).

Bead: cave-hx2v

🤖 Generated with [Claude Code](https://claude.com/claude-code)