### PR TITLE
fix(grimoire): editor batch — dirty-tab dot + close confirm, next-paths stripped from journal (cave-vv2h, cave-onp8)

### DIFF
--- a/src/app/api/journal/route.test.ts
+++ b/src/app/api/journal/route.test.ts
@@ -31,6 +31,21 @@ assert.match(
 );
 assert.match(source, /conflict: true/, "the 409 body flags the conflict so the UI can reload");
 
+// ── next-paths never persists as journal content (cave-onp8) ─────────────────
+// A compliant familiar echoes the <coven:next-paths> chat directive back; the
+// journal has no chip row, so the block must be stripped at the persistence
+// boundary no matter which client wrote it.
+assert.match(
+  source,
+  /import \{ extractNextPaths \} from "@\/lib\/next-paths";/,
+  "the route uses the canonical next-paths extractor",
+);
+assert.match(
+  source,
+  /typeof body\.reflection === "string" \? extractNextPaths\(body\.reflection\)\.visible : ""/,
+  "POST strips the next-paths directive block before storing the reflection",
+);
+
 // ── generatedAt is preserved on manual saves, only stamped on generation ─────
 // The route used to stamp generatedAt: new Date() on EVERY save, so a hand-edit
 // read as a fresh generation ("· 2m ago"). Only the generate flow sends a

--- a/src/app/api/journal/route.ts
+++ b/src/app/api/journal/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { isValidNoteDate } from "@/lib/daily-note";
+import { extractNextPaths } from "@/lib/next-paths";
 import {
   buildJournalMemoryContext,
   buildJournalMemoryStats,
@@ -80,7 +81,12 @@ export async function POST(req: Request) {
   if (!isValidNoteDate(date)) {
     return NextResponse.json({ ok: false, error: "invalid date" }, { status: 400 });
   }
-  const reflection = typeof body.reflection === "string" ? body.reflection : "";
+  // Persistence-layer guard (mirrors /api/inbox/daily-summary): the
+  // <coven:next-paths> chat directive must never be stored as journal content,
+  // regardless of which client wrote it. extractNextPaths is a no-op when no
+  // block is present, so normal autosave round-trips stay byte-identical.
+  const reflection =
+    typeof body.reflection === "string" ? extractNextPaths(body.reflection).visible : "";
   const reflectedBy = typeof body.reflectedBy === "string" && body.reflectedBy ? body.reflectedBy : null;
   const expectedModified = typeof body.expectedModified === "string" ? body.expectedModified : null;
 

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -138,7 +138,7 @@ assert.match(view, /"cave:grimoire:active-tab"/, "the active tab persists too");
 assert.match(view, /export const MAX_OPEN_TABS = 8/, "open-tab count is capped");
 assert.match(view, /role="tablist"[\s\S]*?aria-label="Open documents"/, "tab strip is an accessible tablist");
 assert.match(view, /role="tab"[\s\S]*?aria-selected=\{active\}/, "tabs expose selection state");
-assert.match(view, /aria-label=\{`Close \$\{tabTitle\(tab\)\}`\}/, "each tab has a labelled close button");
+assert.match(view, /aria-label=\{`Close \$\{tabTitle\(tab\)\}/, "each tab has a labelled close button");
 // (cave-mglw) full tabs pattern: one roving tab stop (←/→ between tabs) and
 // tab ↔ tabpanel wiring. The strip stays hand-rolled because the shared
 // ui/tabs primitive has no per-tab close button.
@@ -227,5 +227,16 @@ assert.match(view, /modifiedRef\.current = json\.modified \?\? null;/, "the base
 assert.match(view, /expectedModified: modifiedRef\.current,/, "the autosave sends the mtime baseline");
 assert.match(view, /if \(res\.status === 409\)/, "a journal write conflict is surfaced, not silently overwritten");
 assert.match(view, /modifiedRef\.current = json\.modified \?\? modifiedRef\.current;/, "the baseline advances after a successful save so autosave can't self-conflict");
+
+// ── Dirty tabs: unsaved dot + confirm on close (cave-vv2h) ───────────────────
+// Each editor reports dirty transitions up via onDirtyChange; the tab strip
+// shows a dot and closing a dirty tab confirms instead of silently dropping
+// unsaved edits (autosave mitigates, but conflict-paused docs stay dirty).
+assert.match(view, /const \[dirtyTabs, setDirtyTabs\] = useState<Record<string, boolean>>\(\{\}\)/, "per-tab dirty flags are lifted into GrimoireView");
+assert.match(view, /onDirtyChange=\{\(dirty\) => setTabDirty\(key, dirty\)\}/, "editors report dirty state keyed by tab");
+assert.match(view, /\{dirtyTabs\[key\] \? \(\s*<span\s*\n?\s*title="Unsaved changes"/, "dirty tabs show an unsaved-changes dot");
+assert.match(view, /aria-label=\{`Close \$\{tabTitle\(tab\)\}\$\{dirtyTabs\[key\] \? " \(unsaved changes\)" : ""\}`\}/, "the close button's label says when edits are unsaved");
+assert.match(view, /if \(dirtyTabs\[key\]\) \{\s*\n\s*const ok = await confirm\(/, "closing a dirty tab confirms first");
+assert.match(view, /onClick=\{\(\) => void requestCloseTab\(key, tabTitle\(tab\)\)\}/, "the tab strip close goes through the confirm path");
 
 console.log("grimoire-view.test: ok");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -284,11 +284,14 @@ function KnowledgeMdEditor({
   entry,
   onSaved,
   onCancel,
+  onDirtyChange,
 }: {
   /** null → creating a new entry. */
   entry: KnowledgeEntry | null;
   onSaved: (entry: KnowledgeEntry) => void;
   onCancel?: () => void;
+  /** Forwarded to the editor (unsaved-edits indicator on the host tab). */
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   const initial = useMemo(
     () =>
@@ -326,6 +329,7 @@ function KnowledgeMdEditor({
       sourceLabel="Knowledge vault"
       onSave={save}
       onCancel={onCancel}
+      onDirtyChange={onDirtyChange}
       // A new entry materializes on its first (manual) save, which re-keys and
       // remounts this editor; only autosave once it exists so typing isn't
       // interrupted mid-keystroke by that remount.
@@ -334,7 +338,16 @@ function KnowledgeMdEditor({
   );
 }
 
-function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void }) {
+function JournalMdEditor({
+  date,
+  onSaved,
+  onDirtyChange,
+}: {
+  date: string;
+  onSaved?: () => void;
+  /** Forwarded to the editor (unsaved-edits indicator on the host tab). */
+  onDirtyChange?: (dirty: boolean) => void;
+}) {
   const dateTimePrefs = useDateTimePrefs();
   const [state, setState] = useState<{ reflection: string; reflectedBy: string | null } | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -417,6 +430,7 @@ function JournalMdEditor({ date, onSaved }: { date: string; onSaved?: () => void
       showHeader={false}
       sourceLabel={`Journal · ${journalDayLabel(date, dateTimePrefs)}`}
       onSave={save}
+      onDirtyChange={onDirtyChange}
       autoSave
     />
   );
@@ -765,6 +779,19 @@ export function GrimoireView() {
   });
 
   /** Open (or focus) a document tab. */
+  // (grimoire-audit cave-vv2h) Per-tab unsaved-edits flags, reported by each
+  // editor via onDirtyChange — they drive the tab dot and the close confirm.
+  const [dirtyTabs, setDirtyTabs] = useState<Record<string, boolean>>({});
+  const setTabDirty = useCallback((key: string, dirty: boolean) => {
+    setDirtyTabs((prev) => {
+      if (!!prev[key] === dirty) return prev;
+      const next = { ...prev };
+      if (dirty) next[key] = true;
+      else delete next[key];
+      return next;
+    });
+  }, []);
+
   const openDoc = useCallback((sel: GrimoireSelection) => {
     setTabState((prev) => {
       const key = selectionKey(sel);
@@ -784,6 +811,12 @@ export function GrimoireView() {
   }, []);
 
   const closeTab = useCallback((key: string) => {
+    setDirtyTabs((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
     setTabState((prev) => {
       const index = prev.openTabs.findIndex((t) => selectionKey(t) === key);
       if (index < 0) return prev;
@@ -795,6 +828,23 @@ export function GrimoireView() {
       return { openTabs: tabs, selection };
     });
   }, []);
+
+  /** Close from the tab strip: a tab with unsaved edits confirms first. */
+  const requestCloseTab = useCallback(
+    async (key: string, title: string) => {
+      if (dirtyTabs[key]) {
+        const ok = await confirm({
+          title: `Close ${title}?`,
+          body: "It has unsaved changes that will be lost.",
+          confirmLabel: "Close tab",
+          danger: true,
+        });
+        if (!ok) return;
+      }
+      closeTab(key);
+    },
+    [dirtyTabs, confirm, closeTab],
+  );
 
   /** Swap one tab for another in place (e.g. a saved draft gaining its id). */
   const replaceTab = useCallback((fromKey: string, next: GrimoireSelection) => {
@@ -1079,11 +1129,18 @@ export function GrimoireView() {
           path={tab.path}
           sourceLabel={compactPath(tab.path)}
           onCancel={() => closeTab(key)}
+          onDirtyChange={(dirty) => setTabDirty(key, dirty)}
         />
       );
     }
     if (tab.kind === "journal") {
-      return <JournalMdEditor date={tab.date} onSaved={() => void load()} />;
+      return (
+        <JournalMdEditor
+          date={tab.date}
+          onSaved={() => void load()}
+          onDirtyChange={(dirty) => setTabDirty(key, dirty)}
+        />
+      );
     }
     const entry =
       tab.kind === "knowledge" ? (knowledge ?? []).find((e) => e.id === tab.id) ?? null : null;
@@ -1095,6 +1152,7 @@ export function GrimoireView() {
           void load();
         }}
         onCancel={() => closeTab(key)}
+        onDirtyChange={(dirty) => setTabDirty(key, dirty)}
       />
     );
   };
@@ -1140,10 +1198,17 @@ export function GrimoireView() {
                 >
                   {tabTitle(tab)}
                 </button>
+                {dirtyTabs[key] ? (
+                  <span
+                    title="Unsaved changes"
+                    aria-hidden
+                    className="h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--accent-presence)]"
+                  />
+                ) : null}
                 <button
                   type="button"
-                  aria-label={`Close ${tabTitle(tab)}`}
-                  onClick={() => closeTab(key)}
+                  aria-label={`Close ${tabTitle(tab)}${dirtyTabs[key] ? " (unsaved changes)" : ""}`}
+                  onClick={() => void requestCloseTab(key, tabTitle(tab))}
                   className="focus-ring-inset shrink-0 px-1.5 py-1 text-[var(--text-muted)] hover:text-[var(--text-primary)]"
                 >
                   <Icon name="ph:x" width={9} aria-hidden />

--- a/src/components/md-editor/md-editor.test.ts
+++ b/src/components/md-editor/md-editor.test.ts
@@ -140,6 +140,14 @@ assert.match(sharedTheme, /export const caveCodeMirrorTheme/, "shared theme expo
 const codeEditor = await readFile(new URL("../code-editor.tsx", import.meta.url), "utf8");
 assert.match(codeEditor, /from "@\/components\/code-editor-theme"/, "code-editor consumes the shared theme");
 
+// ── onDirtyChange: hosts can observe unsaved-edits transitions (cave-vv2h) ───
+// The shell reports dirty flips through a ref so an unstable callback identity
+// never re-fires the effect; MemoryMdEditor forwards it to the inner editor.
+assert.match(shell, /onDirtyChange\?: \(dirty: boolean\) => void/, "MdEditor exposes an onDirtyChange prop");
+assert.match(shell, /const onDirtyChangeRef = useRef\(onDirtyChange\)/, "dirty reporting rides a ref, not the callback identity");
+assert.match(shell, /useEffect\(\(\) => \{\s*\n\s*onDirtyChangeRef\.current\?\.\(dirty\);\s*\n\s*\}, \[dirty\]\)/, "dirty transitions fire only when dirty actually flips");
+assert.match(memory, /onDirtyChange=\{onDirtyChange\}/, "MemoryMdEditor forwards onDirtyChange to the shell");
+
 console.log("md-editor.test: ok");
 
 // ── (grimoire-audit cave-say6) editor lazy-load skeleton ─────────────────────

--- a/src/components/md-editor/md-editor.tsx
+++ b/src/components/md-editor/md-editor.tsx
@@ -91,6 +91,9 @@ export type MdEditorProps = {
   onCancel?: () => void;
   /** Observe every raw-document change (e.g. to mirror into caller state). */
   onChange?: (raw: string) => void;
+  /** Observe dirty-state transitions (unsaved edits vs baseline) — e.g. to
+   *  surface an unsaved dot on the host's tab. */
+  onDirtyChange?: (dirty: boolean) => void;
   /**
    * Persist edits automatically a short while after typing stops, in addition
    * to the explicit Save button. Only safe for **idempotent** surfaces whose
@@ -109,6 +112,7 @@ export function MdEditor({
   onSave,
   onCancel,
   onChange,
+  onDirtyChange,
   autoSave = false,
 }: MdEditorProps) {
   const [raw, setRaw] = useState(value);
@@ -136,6 +140,14 @@ export function MdEditor({
   const doc = useMemo(() => parseMdDocument(raw), [raw]);
   const stats = useMemo(() => computeMdDocStats(doc.body), [doc.body]);
   const dirty = raw !== baseline;
+
+  // Report dirty transitions through a ref so an unstable callback identity
+  // never re-fires the effect.
+  const onDirtyChangeRef = useRef(onDirtyChange);
+  onDirtyChangeRef.current = onDirtyChange;
+  useEffect(() => {
+    onDirtyChangeRef.current?.(dirty);
+  }, [dirty]);
 
   const applyHeader = useCallback(
     (header: { title?: string | null; tags?: string[] }) => {

--- a/src/components/md-editor/memory-md-editor.tsx
+++ b/src/components/md-editor/memory-md-editor.tsx
@@ -35,12 +35,15 @@ export function MemoryMdEditor({
   sourceLabel,
   onCancel,
   onSaved,
+  onDirtyChange,
 }: {
   path: string;
   sourceLabel?: string;
   onCancel?: () => void;
   /** Called after each successful save with the saved text. */
   onSaved?: (text: string) => void;
+  /** Forwarded to the inner editor (unsaved-edits indicator). */
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
   // Bumping the token re-fetches (and re-mounts) the editor with disk state.
   const [refreshToken, setRefreshToken] = useState(0);
@@ -194,6 +197,7 @@ export function MemoryMdEditor({
           sourceLabel={sourceLabel}
           onSave={save}
           onCancel={onCancel}
+          onDirtyChange={onDirtyChange}
           onChange={(raw) => {
             draftRef.current = raw;
           }}

--- a/src/lib/journal-generate.test.ts
+++ b/src/lib/journal-generate.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { buildReflectionPrompt } from "./journal-generate.ts";
 
 {
@@ -7,6 +8,24 @@ import { buildReflectionPrompt } from "./journal-generate.ts";
   assert.match(p, /first-person/i, "asks for a first-person reflection");
   assert.match(p, /2026-06-20: 2 responses/, "embeds the provided context");
   assert.match(p, /Reply to Sage/, "embeds the item titles");
+}
+
+// ── next-paths stripped from generated reflections (cave-onp8) ───────────────
+// /api/chat/send appends the next-paths directive to every prompt and a
+// compliant familiar echoes the block back; the journal has no chip row, so
+// generateReflection must strip it (terminated or truncated) before returning.
+{
+  const source = await readFile(new URL("./journal-generate.ts", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /import \{ extractNextPaths \} from "@\/lib\/next-paths";/,
+    "uses the canonical (streaming-safe) next-paths extractor",
+  );
+  assert.match(
+    source,
+    /const trimmed = extractNextPaths\(text\)\.visible\.trim\(\);/,
+    "the directive block is stripped from the reflection text",
+  );
 }
 
 console.log("journal-generate.test.ts: ok");

--- a/src/lib/journal-generate.ts
+++ b/src/lib/journal-generate.ts
@@ -4,6 +4,7 @@
 // but returns the assistant's plain text (no artifact extraction).
 
 import { parseSseFrame } from "@/lib/canvas-generate";
+import { extractNextPaths } from "@/lib/next-paths";
 
 /** Wrap the day's activity context into a request for a short first-person reflection. */
 export function buildReflectionPrompt(context: string): string {
@@ -77,7 +78,11 @@ export async function generateReflection(opts: {
     }
   }
 
-  const trimmed = text.trim();
+  // /api/chat/send appends the <coven:next-paths> suggestions directive to
+  // every prompt, and a compliant familiar echoes the block back. The journal
+  // has no chip row — strip it (terminated or truncated) so it never lands in
+  // the stored reflection.
+  const trimmed = extractNextPaths(text).visible.trim();
   if (!trimmed && !error) error = "The familiar didn't return a reflection. Try again.";
   return { text: trimmed, error };
 }


### PR DESCRIPTION
Batch C of the grimoire UI/UX audit (umbrella cave-x4wf; batches A #2822 and B #2820 already merged).

## cave-vv2h — unsaved edits are visible and protected
- `MdEditor` gains `onDirtyChange`, reported through a ref-driven effect so it fires only on actual dirty transitions.
- `MemoryMdEditor`, `KnowledgeMdEditor`, and `JournalMdEditor` forward it up.
- `GrimoireView` lifts per-tab dirty flags: dirty tabs show an accent dot (`--accent-presence`), the close button's `aria-label` says "(unsaved changes)", and closing a dirty tab confirms via the shared `useConfirm` dialog instead of silently dropping edits (autosave mitigates, but conflict-paused docs stay dirty).

## cave-onp8 — the `<coven:next-paths>` directive never lands in journal content
- `generateReflection` strips the block (terminated or truncated) with the canonical streaming-safe `extractNextPaths` before returning.
- `POST /api/journal` strips it again at the persistence boundary, so any client writing a reflection gets the same guarantee (mirrors `/api/inbox/daily-summary`). Existing stored blocks self-clean on next autosave.

## Validation
- Contract tests extended: `grimoire-view.test.ts`, `md-editor.test.ts`, `journal route.test.ts`, `journal-generate.test.ts` — all green.
- `tsc --noEmit` clean; rebased onto current `main` (resolved overlap with batch A's `useDateTimePrefs`).

Continues orphaned session d1d23cce (died mid-batch 00:52).