### PR TITLE
feat(shell): traffic lights follow the side panel, Dia-style (cave-9ja2)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -80,6 +80,7 @@ name = "app"
 version = "0.0.163"
 dependencies = [
  "log",
+ "objc2",
  "once_cell",
  "parking_lot",
  "portable-pty",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,3 +60,6 @@ tauri-plugin-process = "2"
 # the crate compiles everywhere and the call sites are cfg(target_os) gated).
 [target.'cfg(target_os = "macos")'.dependencies]
 window-vibrancy = "0.6"
+# Raw msg_send access to NSWindow's standard buttons (traffic-light
+# show/hide follows the side panel); already in the tree via tauri/wry.
+objc2 = "0.6"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -669,6 +669,41 @@ fn windows_system32_binary(binary: &str) -> std::path::PathBuf {
     system_root.join("System32").join(binary)
 }
 
+/// Show or hide the macOS traffic lights (close/minimize/zoom) on the
+/// invoking window. The main window's title bar is an Overlay (see the main
+/// window builder), so the buttons float over web content — when the app's
+/// side panel is closed the shell asks for them to disappear, Dia-style, and
+/// brings them back the moment the panel (or its hover-peek) opens. AppKit
+/// must be touched on the main thread; a no-op elsewhere.
+#[cfg(desktop)]
+#[tauri::command]
+fn set_traffic_lights_visible(window: tauri::WebviewWindow, visible: bool) {
+    #[cfg(target_os = "macos")]
+    {
+        let win = window.clone();
+        let _ = window.run_on_main_thread(move || {
+            let Ok(ns_ptr) = win.ns_window() else { return };
+            unsafe {
+                use objc2::msg_send;
+                use objc2::runtime::AnyObject;
+                let ns_window = ns_ptr as *mut AnyObject;
+                // NSWindowButton: close = 0, miniaturize = 1, zoom = 2.
+                for kind in 0u64..=2u64 {
+                    let button: *mut AnyObject =
+                        msg_send![&*ns_window, standardWindowButton: kind];
+                    if !button.is_null() {
+                        let _: () = msg_send![&*button, setHidden: !visible];
+                    }
+                }
+            }
+        });
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (window, visible);
+    }
+}
+
 /// Open an http(s) URL in the system default browser.
 #[cfg(desktop)]
 #[tauri::command]
@@ -975,6 +1010,7 @@ pub fn run() {
             shell_open,
             shell_open_path,
             shell_pick_directory,
+            set_traffic_lights_visible,
         ])
         .manage(SidecarState(Mutex::new(None)))
         .setup(|app| {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5003,6 +5003,13 @@ button:active > .edge-rail-chip {
     min-height: 36px;
   }
 
+  /* Dia-style: with the side panel closed the shell hides the traffic lights
+     (set_traffic_lights_visible in lib.rs, driven by shell.tsx), so the bar
+     releases the room reserved for them and slides back to the window edge. */
+  :root[data-tauri-titlebar][data-traffic-lights="hidden"] .shell-top {
+    padding-left: 12px;
+  }
+
   :root[data-tauri-titlebar] .shell-titlebar-drag-lane {
     position: absolute;
     inset: 0;

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -235,4 +235,45 @@ assert.doesNotMatch(
   "Shell no longer wires the retired in-panel collapse event",
 );
 
+
+// ── Dia-style traffic lights follow the side panel (cave-9ja2) ──────────────
+{
+  const librs = readFileSync(new URL("../../src-tauri/src/lib.rs", import.meta.url), "utf8");
+  assert.match(
+    shell,
+    /const trafficLightsVisible = navOpen \|\| navPeeking \|\| isMobile;/,
+    "lights show whenever the panel is open, hover-peeked, or the layout is mobile",
+  );
+  assert.match(
+    shell,
+    /invoke\("set_traffic_lights_visible", \{ visible: trafficLightsVisible \}\)/,
+    "the shell drives the native buttons through the app command",
+  );
+  assert.match(
+    shell,
+    /root\.dataset\.trafficLights = trafficLightsVisible \? "visible" : "hidden";/,
+    "the root attribute mirrors the native state for CSS",
+  );
+  assert.match(
+    css,
+    /:root\[data-tauri-titlebar\]\[data-traffic-lights="hidden"\] \.shell-top \{[\s\S]*?padding-left: 12px;/,
+    "hiding the lights releases the 78px title-bar inset",
+  );
+  assert.match(
+    librs,
+    /fn set_traffic_lights_visible\(window: tauri::WebviewWindow, visible: bool\)/,
+    "the Rust command exists",
+  );
+  assert.match(
+    librs,
+    /standardWindowButton: kind/,
+    "the command toggles NSWindow's standard buttons",
+  );
+  assert.match(
+    librs,
+    /shell_pick_directory,\s*set_traffic_lights_visible,/,
+    "the command is registered with the invoke handler",
+  );
+}
+
 console.log("shell-edge-rails.test.ts OK");

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -338,6 +338,36 @@ function ShellInner({
     if (navOpen || isMobile) setNavPeeking(false);
   }, [navOpen, isMobile]);
 
+  // Dia-style traffic lights: on the macOS desktop shell the native
+  // close/minimize/zoom buttons float over the side panel's top edge. With
+  // the panel fully closed (not even hover-peeked) they'd hover over page
+  // content, so they follow the panel — hidden with it, back the moment it
+  // opens or peeks. The root attribute lets globals.css release the 78px
+  // title-bar inset in the same breath; the native call is an app command
+  // (set_traffic_lights_visible in lib.rs), so it needs no ACL entry. Mobile
+  // layouts keep their drawer chrome and never hide the lights.
+  const trafficLightsVisible = navOpen || navPeeking || isMobile;
+  useEffect(() => {
+    const root = document.documentElement;
+    // Only the macOS desktop Tauri shell overlays the title bar (the effect
+    // above sets this marker); everywhere else there are no lights to manage.
+    if (!("tauriTitlebar" in root.dataset)) return;
+    root.dataset.trafficLights = trafficLightsVisible ? "visible" : "hidden";
+    void import("@tauri-apps/api/core")
+      .then(({ invoke }) => invoke("set_traffic_lights_visible", { visible: trafficLightsVisible }))
+      .catch(() => {
+        // Pre-update shell without the command — the attribute above still
+        // frees the inset; the native buttons just stay put.
+      });
+    return () => {
+      // If the shell ever unmounts mid-hide, leave the window usable.
+      delete root.dataset.trafficLights;
+      void import("@tauri-apps/api/core")
+        .then(({ invoke }) => invoke("set_traffic_lights_visible", { visible: true }))
+        .catch(() => {});
+    };
+  }, [trafficLightsVisible]);
+
   // Track the detail panel's REAL left/right viewport gaps (side panels +
   // separators + edge rails — everything between the detail box and the
   // viewport edges) so child surfaces (e.g. the Home composer) can visually


### PR DESCRIPTION
## What

User request: when the side panel is closed, hide the macOS traffic lights; show them when it opens — like Dia.

- **Rust**: new `set_traffic_lights_visible` app command — NSWindow `standardWindowButton` × 3, `setHidden` on the main thread (objc2 `msg_send`, dep already in the tree via tauri/wry — Cargo.lock +1 line). No-op off macOS; app commands need no ACL entry from the loopback webview (pty_*/browser_*/shell_open already prove the path).
- **Shell**: lights follow the panel — visible when `navOpen`, when the collapsed rail is hover-peeked (they ride in with the overlay panel, matching Dia), or on mobile layouts; hidden otherwise. Gated on the existing `data-tauri-titlebar` marker so browser/Windows/Linux never run it. Cleanup restores them if the shell unmounts.
- **CSS**: `:root[data-traffic-lights="hidden"]` releases the 78px title-bar inset back to 12px so the top bar sits flush to the window edge while the lights are gone.

Bead: cave-9ja2

## Verification

- `cargo check` clean (validates the objc2 call sites)
- `tsc --noEmit` clean
- `shell-edge-rails.test.ts` ok (new pins: visibility rule, invoke, CSS release, command registration)
- Full suite: ✓ 581 test file(s) passed [app]
- Native behavior verifiable only in the desktop shell — ships with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)