### PR TITLE
feat(ios): wide windows engage the split layouts — no more sparse full-width columns (cave-bgmg)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -14,7 +14,15 @@ struct CovenCaveApp: App {
         let mode = AppearanceMode(rawValue: appearanceRaw) ?? .desktop
         let resolved = mode.resolve(desktop: app.chrome)
         return WindowGroup {
-            RootView()
+            // Wide windows earn the split layouts (cave-bgmg): non-Max iPhones
+            // report a COMPACT horizontal size class in landscape, so every
+            // NavigationSplitView collapses and the lists stretch into one
+            // sparse full-width column. Any window wide enough for two real
+            // columns behaves as regular — the same call Apple makes for Max
+            // phones — which engages the existing balanced splits everywhere.
+            WideSplitEnabler {
+                RootView()
+            }
                 .environment(app)
                 // Propagate the chrome palette to every view, tint app-wide
                 // controls with its accent, and apply the resolved light/dark mode.
@@ -49,6 +57,25 @@ struct CovenCaveApp: App {
                 // the matching tab/sheet. Handled even before connect — the tab is
                 // set so the right surface shows once the desktop is reached.
                 .onOpenURL { app.handleDeepLink($0) }
+        }
+    }
+}
+
+/// Promote the horizontal size class to `.regular` in any window wide enough
+/// for two real columns (cave-bgmg). Non-Max iPhones report `.compact` in
+/// landscape, collapsing every NavigationSplitView into one sparse full-width
+/// column; ≥700pt of width is the same bar Apple's Max phones clear. Narrow
+/// windows keep the inherited class untouched.
+private struct WideSplitEnabler<Content: View>: View {
+    @Environment(\.horizontalSizeClass) private var inherited
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        GeometryReader { geo in
+            content.environment(
+                \.horizontalSizeClass,
+                geo.size.width >= 700 ? .regular : inherited
+            )
         }
     }
 }

--- a/scripts/ios-ipad-split-chats.test.mjs
+++ b/scripts/ios-ipad-split-chats.test.mjs
@@ -53,4 +53,12 @@ assert.match(
 // Balanced style keeps the list visible on iPad.
 assert.match(src, /\.navigationSplitViewStyle\(\.balanced\)/, "should use the balanced split style");
 
+// cave-bgmg: wide-but-compact windows (non-Max iPhone landscape) promote to a
+// regular size class so the splits engage instead of one sparse full-width
+// column; narrow windows keep the inherited class untouched.
+const appRoot = await read("apps/ios/CovenCave/CovenCave/CovenCaveApp.swift");
+assert.match(appRoot, /struct WideSplitEnabler<Content: View>: View/, "the app root defines the wide-window size-class promoter");
+assert.match(appRoot, /geo\.size\.width >= 700 \? \.regular : inherited/, "≥700pt promotes to regular; narrower keeps the inherited class");
+assert.match(appRoot, /WideSplitEnabler \{\s*\n\s*RootView\(\)/, "RootView rides inside the promoter so every tab's split engages");
+
 console.log("ios-ipad-split-chats: OK");


### PR DESCRIPTION
Sim landscape review feedback: rotate a non-Max iPhone and the lists stretch into one sparse full-width column — landscape on those devices reports a **compact** horizontal size class, so every `NavigationSplitView` collapses.

**Fix:** `WideSplitEnabler` at the app root promotes any window **≥700pt** wide to `.regular` (the bar Apple's Max phones already clear), engaging the existing balanced splits on every tab (Chats, Tasks, GitHub, Calendar). Narrower windows pass the **inherited** class through untouched — portrait/phone behaviour is byte-identical (verified in the sim).

Validation: `xcodebuild` BUILD SUCCEEDED (iPhone 16 Pro sim); portrait screenshot unchanged; mobile suite 75 files green; pinned in `ios-ipad-split-chats.test.mjs` (promoter exists, 700pt threshold + inherited fallback, RootView wrapped).

Bead: cave-bgmg

🤖 Generated with [Claude Code](https://claude.com/claude-code)