### PR TITLE
chore(release): stamp v0.0.164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.164] - 2026-07-09
+
+> 🚦 **Chrome that knows when to leave** — the macOS traffic lights hide with the side panel and glide back when it opens, Dia-style. iOS gets real split layouts on wide windows and a decluttered chat header, cron details fit every screen, and releases now stamp themselves with one command.
+
+Patch release on top of v0.0.163.
+
+### Features
+- **Shell: traffic lights follow the side panel, Dia-style** (#2837, cave-9ja2). Closed panel → the native buttons hide and the title bar reclaims their inset; open or hover-peek → they glide back.
+- **iOS: wide windows engage the split layouts** — no more sparse full-width columns (#2838, cave-bgmg).
+- **Marketplace: skills-leaderboard detail** — click-to-copy CLI, minimalist stats, tidy actions (#2834).
+- **Release tooling: one-command stamp script + partial updater-manifest resilience** (#2833, cave-ef6f).
+
+### Fixes
+- **Crons: cron detail fits every screen** — balanced expanded columns, adaptive list rows, honest mobile chrome (#2839).
+- **Grimoire: editor batch** — dirty-tab dot + close confirm, next-paths stripped from journal (#2836, cave-vv2h/cave-onp8).
+- **iOS: chat header sheds the Commands and Share toolbar buttons** (#2835, cave-yey7).
+- **Release tooling: stamp script survives the gitignored-but-tracked generated iOS plist** (`git add -f`; found on this stamp's first real run).
+
+
 ## [0.0.163] - 2026-07-09
 
 > 📱 **Hand off THIS chat to your phone** — the QR pairing carries the current conversation across and finally confirms it took. The Work Queue rides the Tasks page as a tab, the familiar switcher reads as a clean dropdown with a prominent Summon button, multi-file turns collapse into one "Review all" entry, and the chat header slims down for narrow panels. Plus a readable transcript over custom backdrops, mid-save file-switch no longer bleeds content, and Grimoire graph nodes are keyboard-traversable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.163",
+  "version": "0.0.164",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/scripts/stamp-release.mjs
+++ b/scripts/stamp-release.mjs
@@ -195,7 +195,10 @@ function main() {
 
   const branch = `release/stamp-v${next}`;
   run("git", ["checkout", "-b", branch]);
-  run("git", ["add", "CHANGELOG.md", ...STAMP_FILES.map((f) => f.file)]);
+  // -f: src-tauri/gen is gitignored but the generated iOS plist inside it is
+  // TRACKED — a plain `git add` exits 1 with the ignored-paths advice and
+  // killed the first real run of this script mid-stamp.
+  run("git", ["add", "-f", "CHANGELOG.md", ...STAMP_FILES.map((f) => f.file)]);
   // -S: repo rule — every commit lands Verified.
   run("git", ["commit", "-S", "-m", `chore(release): stamp v${next}\n\nPatch release on top of v${current}. Bumps all six version locations and\ndrafts the v${next} CHANGELOG entry for the ${subjects.length} commits since ${prevTag}.`]);
   run("git", ["push", "-u", "origin", branch]);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.163"
+version = "0.0.164"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.163"
+version = "0.0.164"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.163</string>
+	<string>0.0.164</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.163</string>
+	<string>0.0.164</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.163</string>
+	<string>0.0.164</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.163</string>
+	<string>0.0.164</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.163",
+  "version": "0.0.164",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.164 (all seven version locations + CHANGELOG), cut via `scripts/stamp-release.mjs` (#2833) on its first real outing.

Carries 7 commits since v0.0.163: Dia-style traffic lights (#2837), iOS wide-window splits (#2838) + chat-header declutter (#2835), cron detail responsive pass (#2839), grimoire editor batch (#2836), skills-leaderboard detail (#2834), and the stamp tooling itself (#2833).

Rider fix (found by this stamp): `stamp-release.mjs` now uses `git add -f` — the generated iOS plist is tracked inside gitignored `src-tauri/gen`, and the plain `add` exit-1'd on the ignored-paths advice, killing the script mid-stamp.

After merge: tag `v0.0.164` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)