### PR TITLE
feat(chat): project group headers gain activity meta line + explicit project colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -999,7 +999,8 @@ tr[role="checkbox"]:focus-visible {
   color: var(--text-muted);
 }
 
-/* Project group header — sticky so context stays while scrolling long lists */
+/* Project group header — sticky so context stays while scrolling long lists.
+   Two lines: bold name over a muted activity meta ("2 running · 12m"). */
 .cnav__group-head {
   position: sticky;
   top: 0;
@@ -1007,8 +1008,8 @@ tr[role="checkbox"]:focus-visible {
   display: flex;
   align-items: center;
   width: 100%;
-  height: 32px;
-  padding: 0 6px 0 8px;
+  min-height: 40px;
+  padding: 4px 6px 4px 8px;
   background: color-mix(in oklch, var(--bg-raised) 96%, var(--foreground) 4%);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
@@ -1040,33 +1041,31 @@ tr[role="checkbox"]:focus-visible {
   flex-shrink: 0;
   color: var(--text-muted);
 }
-.cnav__group-name {
+.cnav__group-text {
+  display: flex;
+  flex-direction: column;
   flex: 1;
+  min-width: 0;
+}
+.cnav__group-name {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: 12.5px;
   font-weight: 600;
+  line-height: 1.25;
   color: var(--text-primary);
 }
-.cnav__count {
-  flex-shrink: 0;
-  min-width: 20px;
-  height: 18px;
-  padding: 0 6px;
-  display: grid;
-  place-items: center;
-  border-radius: 999px;
-  background: color-mix(in oklch, var(--foreground) 8%, transparent);
-  font-size: 10.5px;
-  font-weight: 600;
+.cnav__group-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+  line-height: 1.3;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
-}
-/* Count hides to make room for hover actions on the group header */
-.cnav__group-head:hover .cnav__count {
-  display: none;
 }
 
 /* Reveal-on-hover icon buttons (group +new / register; thread pin / delete) */

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -116,7 +116,7 @@ assert.match(
 );
 assert.match(
   workspaceSidebar,
-  /cnav__thread-proj[\s\S]*?<ProjectAvatar name=\{project\.name\} root=\{project\.root\} size="sm"/,
+  /cnav__thread-proj[\s\S]*?<ProjectAvatar name=\{project\.name\} root=\{project\.root\} color=\{project\.color\} size="sm"/,
   "ThreadRow renders the shared ProjectAvatar tile with an accessible project name",
 );
 assert.match(

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -18,9 +18,15 @@ assert.match(workspaceSidebar, /relativeTime\(iso, Date\.now\(\), "bare"\)/, 'ro
 assert.ok((workspaceSidebar.match(/<ThreadRow/g) ?? []).length >= 2, "both view branches should render ThreadRow");
 assert.match(workspaceSidebar, /const sessionProjectById = useMemo\(\(\) => \{[\s\S]*?for \(const group of groups\)/, "recent-row project lookup derives from override-aware groups");
 assert.match(workspaceSidebar, /indent="flat"\s*\n\s*project=\{sessionProjectById\.get\(session\.id\) \?\? null\}/, "recent rows pass project identity");
-assert.match(workspaceSidebar, /cnav__thread-proj[\s\S]*?<ProjectAvatar name=\{project\.name\} root=\{project\.root\} size="sm"/, "renders ProjectAvatar tile in flat rows");
+assert.match(workspaceSidebar, /cnav__thread-proj[\s\S]*?<ProjectAvatar name=\{project\.name\} root=\{project\.root\} color=\{project\.color\} size="sm"/, "renders ProjectAvatar tile in flat rows with the explicit project color");
 assert.match(workspaceSidebar, /<span className="sr-only">\{project\.name\}<\/span>/, "project name is announced for AT");
 assert.doesNotMatch(workspaceSidebar, /cnav__footer|cnav__user-plan/, "should not render user plan footer");
+// Project group headers: two-line label (bold name over activity meta) with the
+// user-set project color on the avatar; the meta line subsumes the count badge.
+assert.match(workspaceSidebar, /function groupMeta\(group: ChatProjectGroup\): string \{[\s\S]*?running > 0[\s\S]*?"chat" : "chats"/, "group meta reports running count or chat count");
+assert.match(workspaceSidebar, /<ProjectAvatar name=\{label\} root=\{group\.projectRoot\} color=\{group\.projectColor\} size="sm" className="cnav__folder" \/>/, "group header avatar uses the explicit project color");
+assert.match(workspaceSidebar, /<span className="cnav__group-text">[\s\S]*?cnav__group-name[\s\S]*?<span className="cnav__group-meta">\{groupMeta\(group\)\}<\/span>/, "group header stacks name over the activity meta line");
+assert.doesNotMatch(workspaceSidebar, /cnav__count/, "the count badge is retired — the meta line carries the count");
 // New features from code-sidebar
 assert.match(workspaceSidebar, /cave:code-select-project/, "should broadcast code-select-project on project expand");
 // One-row quick actions: New chat + the Scheduled/Plugins icon chips share a

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -87,6 +87,19 @@ function folderIcon(group: ChatProjectGroup, expanded: boolean): IconName {
   return "ph:folder-simple-dashed";
 }
 
+// Activity meta line under the folder name: "2 running · 12m" while sessions
+// run, else "6 chats · 3h". Subsumes the old count badge, so the header keeps
+// a single right-aligned slot for the hover actions.
+function groupMeta(group: ChatProjectGroup): string {
+  const running = group.sessions.filter((s) => s.status === "running").length;
+  const count =
+    running > 0
+      ? `${running} running`
+      : `${group.sessions.length} ${group.sessions.length === 1 ? "chat" : "chats"}`;
+  const age = group.updatedAt ? bareTime(group.updatedAt) : null;
+  return age ? `${count} · ${age}` : count;
+}
+
 // Returns a context-aware leading icon for threads whose title suggests a PR
 // or branch operation (from code-sidebar). Returns null for ordinary threads.
 function threadLeadingIcon(title: string): IconName | null {
@@ -105,7 +118,7 @@ type ThreadRowProps = {
   indent: "folder" | "flat";
   /** Shown in the time-bucketed Recent view, where rows from every project
    *  interleave — the folder view already says this via the group header. */
-  project?: { root: string; name: string } | null;
+  project?: { root: string; name: string; color: string | null } | null;
   /** PR/branch glyph from threadLeadingIcon — shown instead of the status dot when truthy. */
   glyph?: IconName | null;
   onOpen: () => void;
@@ -146,7 +159,7 @@ function ThreadRow({
         )}
         {project ? (
           <span className="cnav__thread-proj" title={project.name}>
-            <ProjectAvatar name={project.name} root={project.root} size="sm" />
+            <ProjectAvatar name={project.name} root={project.root} color={project.color} size="sm" />
             <span className="sr-only">{project.name}</span>
           </span>
         ) : null}
@@ -252,12 +265,12 @@ export function WorkspaceSidebar({
   // override-aware grouping the folder view renders — a chat dragged into
   // another folder shows that folder's tile, not its recorded cwd's.
   const sessionProjectById = useMemo(() => {
-    const byId = new Map<string, { root: string; name: string }>();
+    const byId = new Map<string, { root: string; name: string; color: string | null }>();
     for (const group of groups) {
       if (!group.projectRoot) continue;
       const name = folderLabel(group);
       for (const session of group.sessions) {
-        byId.set(session.id, { root: group.projectRoot, name });
+        byId.set(session.id, { root: group.projectRoot, name, color: group.projectColor });
       }
     }
     return byId;
@@ -595,14 +608,16 @@ export function WorkspaceSidebar({
                       >
                         <Icon name="ph:caret-down" width={10} className="cnav__chev" aria-hidden />
                         {group.projectId ? (
-                          <ProjectAvatar name={label} root={group.projectRoot} size="sm" className="cnav__folder" />
+                          <ProjectAvatar name={label} root={group.projectRoot} color={group.projectColor} size="sm" className="cnav__folder" />
                         ) : (
                           <Icon name={folderIcon(group, expanded)} width={14} className="cnav__folder" aria-hidden />
                         )}
-                        <span className="cnav__group-name" title={group.projectRoot ?? "Threads with no project"}>
-                          {label}
+                        <span className="cnav__group-text">
+                          <span className="cnav__group-name" title={group.projectRoot ?? "Threads with no project"}>
+                            {label}
+                          </span>
+                          <span className="cnav__group-meta">{groupMeta(group)}</span>
                         </span>
-                        <span className="cnav__count">{group.sessions.length}</span>
                       </button>
                       {unregistered ? (
                         <button

--- a/src/lib/chat-projects.test.ts
+++ b/src/lib/chat-projects.test.ts
@@ -127,6 +127,20 @@ assert.deepEqual(
   assert.ok(visible.some((s) => s.id === "beta"), "ordinary chat sessions still show");
 }
 
+// Groups carry the registered project's explicit color for avatar rendering.
+{
+  const colored = deriveChatProjectGroups(
+    [session("tinted", "/work/alpha", "2026-06-06T00:00:00.000Z", "cody")],
+    [{ id: "alpha", name: "Alpha", root: "/work/alpha", color: "oklch(0.74 0.12 250)", createdAt: "", updatedAt: "" }],
+  );
+  assert.equal(colored[0]?.projectColor, "oklch(0.74 0.12 250)", "group exposes the project color");
+  const uncolored = deriveChatProjectGroups(
+    [session("plain", "/somewhere/else", "2026-06-06T00:00:00.000Z", "cody")],
+    [],
+  );
+  assert.equal(uncolored[0]?.projectColor, null, "unregistered roots have no explicit color");
+}
+
 console.log("chat-projects.test.ts: ok");
 
 // ── resolveChatProjectSelection ───────────────────────────────────────────────

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -11,6 +11,8 @@ export type ChatProjectGroup = {
   projectId: string | null;
   projectRoot: string | null;
   projectName: string | null;
+  /** Explicit user-set project color, when the root maps to a registered project. */
+  projectColor: string | null;
   sessions: SessionRow[];
   defaultFamiliarId: string | null;
   updatedAt: string | null;
@@ -194,6 +196,7 @@ export function deriveChatProjectGroups(
         projectId: project?.id ?? null,
         projectRoot,
         projectName: project?.name ?? inferredProjectName,
+        projectColor: project?.color ?? null,
         sessions: sorted,
         defaultFamiliarId: latest?.familiarId ?? null,
         updatedAt: latest ? sessionTimestamp(latest) : null,


### PR DESCRIPTION
Ports the user-approved project-rail UX improvements to the surface that actually renders.

## Context
`feat/chat-project-rail` (interrupted session, resumed here) modernized `chat-project-sidebar.tsx` — but chat mode stopped mounting that component when #2265 introduced `hideThreadRail`, so none of its work reached the screen. Browser verification (the step the interrupted session died on) surfaced this; the improvements are ported to the live cnav sidebar instead. The superseded branch is archived and deleted.

## Changes
- **Two-line project group heads** (`workspace-sidebar.tsx`): bold name over a muted activity meta line — `2 running · 12m` while sessions run, else `11 chats · 1h`. The meta line subsumes the count badge (retired, with its hide-on-hover CSS).
- **Explicit project colors** (`chat-projects.ts`): `ChatProjectGroup.projectColor` now carries the user-set color; both cnav avatar call sites (group head + recent-row project tile) pass it through so an explicit color wins over the derived tint.
- Contract tests updated/extended in `workspace-sidebar-wiring.test.ts` + `chat-sidebar-wiring.test.ts`; `chat-projects.test.ts` locks the color derivation.

## Verification
- Playwright vs. prod build on real session data: 14 groups render 40px two-line heads with correct meta ("11 chats · 1h", singular "1 chat · 3d"), avatars carry tile colors, zero count badges remain, hover still reveals the + action, unregistered roots keep the dashed folder.
- `pnpm test:app` (581 files) + `pnpm typecheck` green.