### PR TITLE
feat(prompts): template power — placeholder Tab flow, favorites/recents/tags, save/edit/delete (cave-jg6k)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -177,6 +177,7 @@ export const SUITES = {
     "src/components/home-chat-handoff.test.ts",
     "src/components/home-composer.test.ts",
     "src/components/composer-enhance.test.ts",
+    "src/components/prompt-snippets-modal.test.ts",
     "src/components/home-digest-carousel.test.ts",
     "src/components/home-needs-you.test.ts",
     "src/components/home-feed.test.ts",
@@ -291,6 +292,8 @@ export const SUITES = {
     "src/lib/use-attachment-staging.test.ts",
     "src/lib/use-inline-slash-menus.test.ts",
     "src/lib/prompt-enhancer.test.ts",
+    "src/lib/prompt-placeholders.test.ts",
+    "src/lib/prompt-prefs.test.ts",
     "src/lib/use-prompt-enhance.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/comux-project-order.test.ts",
@@ -628,6 +631,7 @@ export const SUITES = {
     "src/app/api/familiars/[id]/notes/route.test.ts",
     "src/app/api/chat/model-state/route.test.ts",
     "src/app/api/prompt/enhance/route.test.ts",
+    "src/app/api/prompts/route.test.ts",
     "src/app/api/app/latest-release/route.test.ts",
     "src/app/api/opencoven-tools/status/route.test.ts",
     "src/app/api/daemon/status/route.test.ts",
@@ -830,6 +834,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/app/api/prompts/route.test.ts",
   "src/lib/cave-backdrop.test.ts",
   "src/lib/wiki-link-parser.test.ts",
   "src/lib/wiki-link-resolve.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -131,7 +131,7 @@ const contracts: RouteContract[] = [
   { route: "/prompt/enhance", methods: ["POST"], kind: "json", readsJson: true },
   { route: "/profile/avatar", methods: ["GET", "POST", "DELETE"], kind: "stream", readsJson: true, invalidJson: "guarded" },
   { route: "/profile", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/prompts", methods: ["GET"], kind: "json" },
+  { route: "/prompts", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/roles", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/roles/workflows", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/retro-runs", methods: ["GET"], kind: "json" },

--- a/src/app/api/prompts/route.test.ts
+++ b/src/app/api/prompts/route.test.ts
@@ -1,0 +1,111 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { writeFileAtomic } from "../../../lib/server/atomic-write.ts";
+import {
+  PROMPT_SLUG_RE,
+  promptSlug,
+  serializePromptTemplate,
+} from "../../../lib/server/prompt-file.ts";
+import { scanPromptsDir } from "../../../lib/server/prompt-scan.ts";
+
+// ── promptSlug: derivation + confinement ─────────────────────────────────────
+assert.equal(promptSlug("Release notes"), "release-notes", "spaces become dashes, lowercased");
+assert.equal(promptSlug("  PR / Description!  "), "pr-description", "punctuation collapses to single dashes");
+assert.equal(promptSlug("---"), null, "nothing usable → null");
+assert.equal(promptSlug(""), null, "empty → null");
+assert.equal(promptSlug("a".repeat(200))?.length, 64, "slugs cap at 64 chars");
+
+// The slug regex is the DELETE/POST path confinement — traversal shapes must fail.
+for (const evil of ["../evil", "a/b", "a\\b", "..", ".", "a.md", "-lead", "UPPER", "a b", ""]) {
+  assert.equal(PROMPT_SLUG_RE.test(evil), false, `slug regex rejects ${JSON.stringify(evil)}`);
+}
+assert.equal(PROMPT_SLUG_RE.test("bug-repro-2"), true, "plain slugs pass");
+
+// ── serialize → scan round-trip (the write side mirrors the read side) ───────
+const root = await mkdtemp(path.join(tmpdir(), "prompt-file-"));
+try {
+  const dir = path.join(root, "prompts");
+  await mkdir(dir);
+  const body = "Draft release notes since {{last release|the last tag}}.\n\nGroup by {{area}}.";
+  const md = serializePromptTemplate({
+    name: "Release notes: launch\nedition",
+    description: "Turn merges into\nrelease notes",
+    icon: "ph:book-open",
+    tags: ["release", "writing", "  ", ""],
+    body,
+  });
+  await writeFileAtomic(path.join(dir, "release-notes-launch.md"), md);
+
+  const scanned = [];
+  await scanPromptsDir(dir, "user", scanned);
+  assert.equal(scanned.length, 1, "the serialized file scans back");
+  const p = scanned[0];
+  assert.equal(p.id, "release-notes-launch", "id from the filename");
+  assert.equal(p.name, "Release notes: launch edition", "newlines in the name flatten to spaces");
+  assert.equal(p.description, "Turn merges into release notes", "newlines in the description flatten");
+  assert.equal(p.icon, "ph:book-open", "icon survives");
+  assert.deepEqual(p.tags, ["release", "writing"], "blank tags are dropped, real ones survive");
+  assert.equal(p.body, body, "the body round-trips verbatim (placeholders intact)");
+  assert.equal(p.source, "user", "scanned as a user template");
+
+  // No description/icon/tags → minimal frontmatter, still scannable.
+  await writeFileAtomic(
+    path.join(dir, "bare.md"),
+    serializePromptTemplate({ name: "Bare", body: "Just the body." }),
+  );
+  const again = [];
+  await scanPromptsDir(dir, "user", again);
+  const bare = again.find((t) => t.id === "bare");
+  assert.equal(bare.name, "Bare");
+  assert.equal(bare.description, undefined, "no description key when omitted");
+  assert.equal(bare.tags, undefined, "no tags key when omitted");
+  const bareRaw = await readFile(path.join(dir, "bare.md"), "utf8");
+  assert.doesNotMatch(bareRaw, /description:|icon:|tags:/, "omitted fields are omitted, not empty");
+} finally {
+  await rm(root, { recursive: true, force: true });
+}
+
+// ── Route pins: gates, statuses, confinement ─────────────────────────────────
+const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
+
+assert.match(source, /export async function POST/, "the route grows a POST (save template)");
+assert.match(source, /export async function DELETE/, "the route grows a DELETE (remove template)");
+// Desktop-only: both mutations behind the loopback gate, before any body read.
+assert.match(
+  source,
+  /export async function POST\(req: Request\) \{\s*\n\s*if \(!isLocalOrigin\(req\)\)/,
+  "POST is desktop-only (403 off-loopback) before reading the body",
+);
+assert.match(
+  source,
+  /export async function DELETE\(req: Request\) \{\s*\n\s*if \(!isLocalOrigin\(req\)\)/,
+  "DELETE is desktop-only (403 off-loopback)",
+);
+assert.match(source, /\{ status: 403 \}/, "off-loopback mutations 403");
+assert.match(source, /\{ status: 400 \}/, "bad input 400s");
+assert.match(source, /raw\.overwrite !== true/, "existing files 409 unless overwrite is explicitly true");
+assert.match(source, /\{ status: 409 \}/, "exists-without-overwrite is a 409");
+// Path confinement: the slug regex is the only path component; DELETE never
+// takes a caller path.
+assert.match(
+  source,
+  /if \(!PROMPT_SLUG_RE\.test\(id\)\) \{[\s\S]{0,200}?status: 400/,
+  "DELETE validates the id against the slug regex before touching the filesystem",
+);
+assert.match(
+  source,
+  /unlink\(path\.join\(userPromptsDir\(\), `\$\{id\}\.md`\)\)/,
+  "DELETE joins the validated slug only — never a caller-supplied path",
+);
+assert.match(source, /writeFileAtomic/, "saves are atomic writes");
+assert.match(
+  source,
+  /await scanPromptsDir\(dir, "user", scanned\)/,
+  "POST returns the template as the scanner sees it (round-trip guarantee)",
+);
+assert.doesNotMatch(source, /rmdir|rm\(/, "the route never removes directories");
+
+console.log("prompts route.test.ts: ok");

--- a/src/app/api/prompts/route.test.ts
+++ b/src/app/api/prompts/route.test.ts
@@ -97,8 +97,13 @@ assert.match(
 );
 assert.match(
   source,
-  /unlink\(path\.join\(userPromptsDir\(\), `\$\{id\}\.md`\)\)/,
-  "DELETE joins the validated slug only — never a caller-supplied path",
+  /unlink\(path\.join\(userPromptsDir\(\), `\$\{path\.basename\(id\)\}\.md`\)\)/,
+  "DELETE joins the validated slug through path.basename — never a caller-supplied path",
+);
+assert.match(
+  source,
+  /path\.join\(dir, `\$\{path\.basename\(id\)\}\.md`\)/,
+  "POST routes the slug through path.basename (the recognized path-injection sanitizer)",
 );
 assert.match(source, /writeFileAtomic/, "saves are atomic writes");
 assert.match(

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -100,7 +100,10 @@ export async function POST(req: Request) {
   }
 
   const dir = userPromptsDir();
-  const file = path.join(dir, `${id}.md`);
+  // path.basename is the CodeQL-recognized js/path-injection sanitizer; the
+  // slug regex above already forbids any separator, so this is a no-op on
+  // valid input and defense-in-depth against a future looser id source.
+  const file = path.join(dir, `${path.basename(id)}.md`);
   if (raw.overwrite !== true) {
     try {
       await stat(file);
@@ -152,7 +155,8 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ ok: false, error: "invalid template id" }, { status: 400 });
   }
   try {
-    await unlink(path.join(userPromptsDir(), `${id}.md`));
+    // path.basename is the recognized path-injection sanitizer (see POST).
+    await unlink(path.join(userPromptsDir(), `${path.basename(id)}.md`));
   } catch {
     return NextResponse.json({ ok: false, error: "template not found" }, { status: 404 });
   }

--- a/src/app/api/prompts/route.ts
+++ b/src/app/api/prompts/route.ts
@@ -1,21 +1,31 @@
 /**
- * GET /api/prompts
+ * /api/prompts
  *
- * Prompt templates for the chat composer's /prompt picker and the Prompt
- * snippets modal. Merges three sources by id (user > pack > builtin):
+ * GET — prompt templates for the chat composer's /prompt picker and the
+ * Prompt snippets modal. Merges three sources by id (user > pack > builtin):
  *  1. built-in defaults (src/lib/prompt-defaults.ts)
  *  2. installed marketplace prompt packs (marketplace/plugins/<id>/prompts/) —
  *     install is track-only (cave-config marketplace.installed), so packs are
  *     resolved here at scan time rather than copied on install
  *  3. the user's own ~/.coven/prompts/*.md files
- * Read-only.
+ *
+ * POST — save a user template to ~/.coven/prompts/<slug>.md (cave-jg6k:
+ * save-as-template / edit from the app). DELETE ?id=<slug> removes one.
+ * Both are desktop-only (isLocalOrigin) and id-confined: the slug regex is
+ * the only path component ever accepted — callers can't reach outside the
+ * prompts dir. Pack and builtin templates are never writable here (users
+ * override them by saving under the same id instead — merge order wins).
  */
 
 import { NextResponse } from "next/server";
+import { mkdir, stat, unlink } from "node:fs/promises";
 import path from "node:path";
 import { covenHome } from "@/lib/coven-paths";
 import { loadConfig } from "@/lib/cave-config";
 import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
+import { writeFileAtomic } from "@/lib/server/atomic-write";
+import { isLocalOrigin } from "@/lib/server/local-origin";
+import { PROMPT_SLUG_RE, promptSlug, serializePromptTemplate } from "@/lib/server/prompt-file";
 import { mergePrompts, scanPromptsDir } from "@/lib/server/prompt-scan";
 import type { PromptOption } from "@/lib/slash-prompt";
 
@@ -43,4 +53,108 @@ export async function GET() {
   }
 
   return NextResponse.json({ ok: true, prompts: mergePrompts(BUILTIN_PROMPTS, user, packs) });
+}
+
+function userPromptsDir(): string {
+  return path.join(covenHome(), "prompts");
+}
+
+type SavePromptBody = {
+  name?: unknown;
+  body?: unknown;
+  description?: unknown;
+  icon?: unknown;
+  tags?: unknown;
+  id?: unknown;
+  overwrite?: unknown;
+};
+
+export async function POST(req: Request) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json({ ok: false, error: "desktop only" }, { status: 403 });
+  }
+  let raw: SavePromptBody;
+  try {
+    raw = (await req.json()) as SavePromptBody;
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid JSON body" }, { status: 400 });
+  }
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  const body = typeof raw.body === "string" ? raw.body.trim() : "";
+  if (!name) return NextResponse.json({ ok: false, error: "name is required" }, { status: 400 });
+  if (!body) return NextResponse.json({ ok: false, error: "body is required" }, { status: 400 });
+
+  // Explicit id (edit/duplicate flows) must already be a valid slug; without
+  // one the display name derives it.
+  const id =
+    typeof raw.id === "string" && raw.id
+      ? PROMPT_SLUG_RE.test(raw.id)
+        ? raw.id
+        : null
+      : promptSlug(name);
+  if (!id) {
+    return NextResponse.json(
+      { ok: false, error: "id must be a lowercase alphanumeric-dash slug" },
+      { status: 400 },
+    );
+  }
+
+  const dir = userPromptsDir();
+  const file = path.join(dir, `${id}.md`);
+  if (raw.overwrite !== true) {
+    try {
+      await stat(file);
+      return NextResponse.json(
+        { ok: false, error: `a template named "${id}" already exists`, id },
+        { status: 409 },
+      );
+    } catch {
+      // Absent — clear to create.
+    }
+  }
+
+  await mkdir(dir, { recursive: true });
+  await writeFileAtomic(
+    file,
+    serializePromptTemplate({
+      name,
+      description: typeof raw.description === "string" ? raw.description : undefined,
+      icon: typeof raw.icon === "string" ? raw.icon : undefined,
+      tags: Array.isArray(raw.tags)
+        ? raw.tags.filter((t): t is string => typeof t === "string")
+        : undefined,
+      body,
+    }),
+  );
+
+  // Return the template as the scanner sees it, so callers render exactly
+  // what the next GET will serve (round-trip guarantee).
+  const scanned: PromptOption[] = [];
+  await scanPromptsDir(dir, "user", scanned);
+  const prompt = scanned.find((p) => p.id === id);
+  if (!prompt) {
+    return NextResponse.json(
+      { ok: false, error: "template was written but did not scan back" },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ ok: true, prompt });
+}
+
+export async function DELETE(req: Request) {
+  if (!isLocalOrigin(req)) {
+    return NextResponse.json({ ok: false, error: "desktop only" }, { status: 403 });
+  }
+  const id = new URL(req.url).searchParams.get("id") ?? "";
+  // The slug regex is the confinement: no separators, dots, or traversal can
+  // pass it, so the join below cannot escape the prompts dir.
+  if (!PROMPT_SLUG_RE.test(id)) {
+    return NextResponse.json({ ok: false, error: "invalid template id" }, { status: 400 });
+  }
+  try {
+    await unlink(path.join(userPromptsDir(), `${id}.md`));
+  } catch {
+    return NextResponse.json({ ok: false, error: "template not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
 }

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -116,6 +116,7 @@ import { useProjects } from "@/lib/use-projects";
 import { useAutogrowTextarea } from "@/lib/use-autogrow-textarea";
 import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
 import { recordPromptRecent } from "@/lib/prompt-prefs";
+import { SaveTemplateModal } from "@/components/save-template-modal";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
 import { ProjectPicker, useAddProjectFlow } from "@/components/project-picker";
 import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
@@ -2873,6 +2874,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     },
   });
   const [promptSnippetsOpen, setPromptSnippetsOpen] = useState(false);
+  // Save-as-template (cave-jg6k): snapshots the draft for the modal form.
+  const [saveTemplateSeed, setSaveTemplateSeed] = useState<string | null>(null);
   // Stable model menu for the composer chip (independent of the /model
   // autocomplete above, which is null outside `/model <arg>` position).
   const composerModelOptions = useMemo(
@@ -5456,6 +5459,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     onHostPick={setRuntimeHost}
                     disabled={busy}
                     onOpenPromptSnippets={() => setPromptSnippetsOpen(true)}
+                    onSaveAsTemplate={() => setSaveTemplateSeed(input)}
+                    saveAsTemplateDisabled={!input.trim()}
                     indicator={
                       permissionMode !== DEFAULT_PERMISSION_MODE ||
                       thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
@@ -5553,6 +5558,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           setPromptSnippetsOpen(false);
           insertPrompt(p);
         }}
+      />
+      <SaveTemplateModal
+        open={saveTemplateSeed !== null}
+        onClose={() => setSaveTemplateSeed(null)}
+        initialBody={saveTemplateSeed ?? ""}
       />
       <Modal
         open={debugModalOpen}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -114,6 +114,8 @@ import {
 import type { CaveProject } from "@/lib/cave-projects";
 import { useProjects } from "@/lib/use-projects";
 import { useAutogrowTextarea } from "@/lib/use-autogrow-textarea";
+import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
+import { recordPromptRecent } from "@/lib/prompt-prefs";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
 import { ProjectPicker, useAddProjectFlow } from "@/components/project-picker";
 import { toolArgDetail, toolArgSummary } from "@/lib/tool-arg-summary";
@@ -3542,6 +3544,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // replaces it; otherwise park the caret at the end.
   const insertPrompt = (p: PromptOption) => {
     const ins = promptInsertion(p);
+    recordPromptRecent(p.id);
     setInput(ins.text);
     setSlashIdx(0);
     announce("Prompt inserted — edit and send.");
@@ -4533,6 +4536,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // sees Esc once no menu is open, so a dismissed menu never costs a
     // live stream.
     if (handleMenuKey(e)) return;
+    // Tab cycles {{placeholder}} tokens left in the draft (Shift+Tab
+    // reverses; Tab on a selected {{name|default}} accepts the default).
+    // After the menus — they own Tab-complete while open — and only when a
+    // token exists, so native focus-move survives (a11y).
+    if (handlePlaceholderTab(e, inputRef.current, setInput)) return;
     // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer
     if (handleArrowKey(e, input, setInput)) return;
     // `isComposing` is true for the Enter that confirms an IME candidate

--- a/src/components/composer-options-menu.tsx
+++ b/src/components/composer-options-menu.tsx
@@ -87,6 +87,8 @@ export function ComposerOptionsMenu({
   indicator,
   disabled,
   onOpenPromptSnippets,
+  onSaveAsTemplate,
+  saveAsTemplateDisabled,
 }: {
   hostValue: string;
   onHostPick: (id: string) => void;
@@ -99,6 +101,10 @@ export function ComposerOptionsMenu({
    *  composer's utility row folds its dedicated snippets button in here so the
    *  resting row is just attach · voice · this overflow (cave-xsq.4). */
   onOpenPromptSnippets?: () => void;
+  /** When set, a "Save draft as template…" action follows the snippets one
+   *  (cave-jg6k). Callers disable it while the draft is empty. */
+  onSaveAsTemplate?: () => void;
+  saveAsTemplateDisabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const [connectOpen, setConnectOpen] = useState(false);
@@ -147,6 +153,20 @@ export function ComposerOptionsMenu({
             >
               <Icon name="ph:chat-centered-text" width={14} aria-hidden />
               Prompt snippets…
+            </button>
+          ) : null}
+          {onSaveAsTemplate ? (
+            <button
+              type="button"
+              className="composer-options__action focus-ring disabled:opacity-40"
+              disabled={saveAsTemplateDisabled}
+              onClick={() => {
+                setOpen(false);
+                onSaveAsTemplate();
+              }}
+            >
+              <Icon name="ph:floppy-disk-bold" width={14} aria-hidden />
+              Save draft as template…
             </button>
           ) : null}
           <div className="composer-options__section">

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -33,6 +33,7 @@ import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import { useAutogrowTextarea } from "@/lib/use-autogrow-textarea";
 import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
 import { recordPromptRecent } from "@/lib/prompt-prefs";
+import { SaveTemplateModal } from "@/components/save-template-modal";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
 import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
@@ -144,6 +145,9 @@ export function HomeComposer({
   const [text, setText] = useState(() => readComposerDraft(HOME_DRAFT_KEY));
   const [destination, setDestination] = useState<Destination>("chat");
   const [sending, setSending] = useState(false);
+  // Save-as-template (cave-jg6k): the Options menu action snapshots the draft
+  // into the modal so edits while it is open don't mutate the form seed.
+  const [saveTemplateSeed, setSaveTemplateSeed] = useState<string | null>(null);
   // Persisted ↑/↓ prompt-history recall — shared hook (use-composer-history);
   // home records slash commands in history too, so pushes stay at call sites.
   const { push: pushHistory, handleArrowKey } = useComposerHistory(HOME_HISTORY_KEY);
@@ -911,6 +915,8 @@ export function HomeComposer({
             hostValue={runtimeHost ?? LOCAL_HOST_ID}
             onHostPick={setRuntimeHost}
             disabled={sending}
+            onSaveAsTemplate={() => setSaveTemplateSeed(text)}
+            saveAsTemplateDisabled={!text.trim()}
             indicator={
               thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
               responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed
@@ -973,6 +979,11 @@ export function HomeComposer({
         sessions={sessions}
         familiarNameById={familiarNameById}
         onOpenSession={onOpenSession}
+      />
+      <SaveTemplateModal
+        open={saveTemplateSeed !== null}
+        onClose={() => setSaveTemplateSeed(null)}
+        initialBody={saveTemplateSeed ?? ""}
       />
     </div>
   );

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -31,6 +31,8 @@ import {
 } from "@/lib/slash-prompt";
 import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import { useAutogrowTextarea } from "@/lib/use-autogrow-textarea";
+import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
+import { recordPromptRecent } from "@/lib/prompt-prefs";
 import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
 import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
@@ -311,6 +313,7 @@ export function HomeComposer({
   const insertPromptTemplate = useCallback(
     (p: PromptOption) => {
       const ins = promptInsertion(p);
+      recordPromptRecent(p.id);
       setText(ins.text);
       setSlashIdx(0);
       announce("Prompt inserted — edit and send.");
@@ -569,6 +572,11 @@ export function HomeComposer({
       // The inline menus (Esc-dismiss, ↑↓/Tab/Enter across all four pickers)
       // take priority over history/submit while one is open — shared hook.
       if (handleMenuKey(e)) return;
+      // Tab cycles {{placeholder}} tokens left in the draft (Shift+Tab
+      // reverses; Tab on a selected {{name|default}} accepts the default).
+      // After the menus — they own Tab-complete while open — and only when a
+      // token exists, so native focus-move survives (a11y).
+      if (handlePlaceholderTab(e, textareaRef.current, setText)) return;
       // plain Enter sends; Shift+Enter inserts newline. `isComposing` is true
       // for the Enter that confirms an IME candidate (CJK/pinyin/kana) —
       // treating it as "send" would fire a half-composed prompt and destroy

--- a/src/components/prompt-snippets-modal.test.ts
+++ b/src/components/prompt-snippets-modal.test.ts
@@ -1,0 +1,133 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Prompt snippets picker + manager (cave-jg6k) and the Save-as-template form.
+// The prefs helpers execute in prompt-prefs.test.ts and the API in
+// prompts/route.test.ts — these pins hold the modal's UI contracts: tag
+// chips, favorites, user-only edit/delete, duplicate for shipped rows, and
+// the no-nested-focus-traps rule.
+
+const modal = await readFile(new URL("./prompt-snippets-modal.tsx", import.meta.url), "utf8");
+const saveModal = await readFile(new URL("./save-template-modal.tsx", import.meta.url), "utf8");
+const optionsMenu = await readFile(new URL("./composer-options-menu.tsx", import.meta.url), "utf8");
+const home = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+const chat = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+// ── Ordering + tag chips ─────────────────────────────────────────────────────
+assert.match(
+  modal,
+  /orderPrompts\(prompts, favorites, readPromptRecents\(\)\)/,
+  "rows rank favorites > recents > scan order (shared prefs ranking)",
+);
+assert.match(
+  modal,
+  /role="group" aria-label="Filter by tag"/,
+  "tag chips are a labelled group",
+);
+assert.match(modal, /aria-pressed=\{activeTag === tag\}/, "tag chips expose pressed state");
+assert.match(
+  modal,
+  /rounded-full border border-\[var\(--border-hairline\)\]/,
+  "chips are 999px pills with hairline borders",
+);
+assert.match(
+  modal,
+  /bg-\[var\(--bg-raised\)\] text-\[var\(--text-primary\)\]/,
+  "the selected chip fills with raised-bg — accent stays presence-only",
+);
+assert.doesNotMatch(
+  modal,
+  /--accent/,
+  "no accent in the picker chrome (design-language rule)",
+);
+
+// ── Favorites ────────────────────────────────────────────────────────────────
+assert.match(modal, /togglePromptFavorite\(cur, p\.id\)/, "the bookmark toggles a favorite");
+assert.match(
+  modal,
+  /aria-pressed=\{isFavorite\}/,
+  "the favorite toggle exposes its state",
+);
+assert.match(
+  modal,
+  /isFavorite \? "ph:bookmark-simple-fill" : "ph:bookmark-simple"/,
+  "favorite state swaps the bookmark glyph",
+);
+
+// ── Manage: user-only edit/delete, duplicate elsewhere ───────────────────────
+assert.match(
+  modal,
+  /p\.source === "user" \?[\s\S]*?Edit \$\{p\.name\}[\s\S]*?Delete \$\{p\.name\}/,
+  "edit and delete render for user templates only",
+);
+assert.match(
+  modal,
+  /Duplicate \$\{p\.name\} to my templates/,
+  "builtin/pack rows offer Duplicate to my templates instead",
+);
+assert.match(modal, /originLabel/, "non-user rows carry a muted origin chip");
+assert.match(
+  modal,
+  /const ok = await confirm\(\{[\s\S]*?danger: true/,
+  "delete goes through the shared ConfirmDialog in destructive style",
+);
+assert.match(
+  modal,
+  /fetch\(`\/api\/prompts\?id=\$\{encodeURIComponent\(p\.id\)\}`, \{ method: "DELETE" \}\)/,
+  "delete is id-based only (the server slug regex confines the path)",
+);
+assert.match(modal, /broadcastPromptsRefresh\(\)/, "a delete broadcasts the re-scan event");
+
+// ── No nested focus traps ────────────────────────────────────────────────────
+// Both Modal and ConfirmDialog trap focus on window keydown; stacking them
+// would double-fire Escape. The list modal hides while a child dialog is up.
+assert.match(
+  modal,
+  /const listOpen = open && editing === null && duplicating === null && !confirming;/,
+  "the list modal yields to the save/confirm dialogs instead of stacking traps",
+);
+
+// ── Save-as-template form ────────────────────────────────────────────────────
+assert.match(saveModal, /export const PROMPTS_REFRESH_EVENT = "cave:prompts-refresh"/, "the refresh event name is exported once");
+assert.match(saveModal, /method: "POST"/, "saving POSTs to /api/prompts");
+assert.match(
+  saveModal,
+  /\.\.\.\(editing \? \{ id: editing\.id, overwrite: true \} : \{\}\)/,
+  "edits keep their id and overwrite",
+);
+assert.match(
+  saveModal,
+  /res\.status === 409[\s\S]{0,200}?setOverwriteArmed\(true\)/,
+  "a create-collision 409 arms an explicit Overwrite confirm instead of silently replacing",
+);
+assert.match(saveModal, /broadcastPromptsRefresh\(\);/, "a save broadcasts the re-scan event");
+assert.doesNotMatch(saveModal, /autoFocus/, "no autoFocus inside a focus-trapped Modal (breaks return-focus)");
+assert.match(saveModal, /\{\{name\|default\}\}/, "the form teaches the placeholder + default grammar");
+
+// ── Composer wiring ──────────────────────────────────────────────────────────
+assert.match(optionsMenu, /Save draft as template…/, "the Options menu carries the save action");
+assert.match(
+  optionsMenu,
+  /disabled=\{saveAsTemplateDisabled\}/,
+  "the save action can be disabled (empty draft)",
+);
+for (const [name, src, draft] of [["home-composer", home, "text"], ["chat-view", chat, "input"]]) {
+  assert.match(
+    src,
+    new RegExp(`onSaveAsTemplate=\\{\\(\\) => setSaveTemplateSeed\\(${draft}\\)\\}`),
+    `${name} seeds the save modal with the current draft`,
+  );
+  assert.match(
+    src,
+    new RegExp(`saveAsTemplateDisabled=\\{!${draft}\\.trim\\(\\)\\}`),
+    `${name} disables save-as-template while the draft is empty`,
+  );
+  assert.match(
+    src,
+    /<SaveTemplateModal[\s\S]{0,200}?initialBody=\{saveTemplateSeed \?\? ""\}/,
+    `${name} mounts the save modal`,
+  );
+}
+
+console.log("prompt-snippets-modal.test.ts: ok");

--- a/src/components/prompt-snippets-modal.tsx
+++ b/src/components/prompt-snippets-modal.tsx
@@ -1,8 +1,19 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Modal } from "@/components/ui/modal";
+import { useConfirm } from "@/components/ui/confirm-dialog";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { Icon, ICON_NAMES, type IconName } from "@/lib/icon";
+import {
+  orderPrompts,
+  promptTags,
+  readPromptFavorites,
+  readPromptRecents,
+  togglePromptFavorite,
+} from "@/lib/prompt-prefs";
 import type { PromptOption } from "@/lib/slash-prompt";
+import { SaveTemplateModal, broadcastPromptsRefresh } from "@/components/save-template-modal";
 
 const FALLBACK_ICON: IconName = "ph:chat-centered-text";
 
@@ -14,6 +25,13 @@ export function promptIconName(icon?: string): IconName {
     : FALLBACK_ICON;
 }
 
+/** Muted origin chip for non-user rows ("built-in" / the pack id). */
+function originLabel(source: PromptOption["source"]): string | null {
+  if (source === "builtin") return "built-in";
+  if (source.startsWith("pack:")) return source.slice(5);
+  return null;
+}
+
 type PromptSnippetsModalProps = {
   open: boolean;
   onClose: () => void;
@@ -22,47 +40,206 @@ type PromptSnippetsModalProps = {
   onPick: (prompt: PromptOption) => void;
 };
 
-/** "Prompt snippets" picker — a starter prompt dropped into the composer for
- *  editing, never sent. Dumb component: fetching stays in the caller. */
-export function PromptSnippetsModal({ open, onClose, prompts, onPick }: PromptSnippetsModalProps) {
+/** "Prompt snippets" picker + manager (cave-jg6k). Picking still just inserts;
+ *  rows now carry favorite stars, user templates get edit/delete, and
+ *  builtin/pack templates can be duplicated into ~/.coven/prompts. The list
+ *  itself stays caller-fetched — saves/deletes broadcast cave:prompts-refresh
+ *  and the caller's picker hook re-scans. */
+export function PromptSnippetsModal(props: PromptSnippetsModalProps) {
+  return <PromptSnippetsModalInner key={String(props.open)} {...props} />;
+}
+
+function PromptSnippetsModalInner({ open, onClose, prompts, onPick }: PromptSnippetsModalProps) {
+  const confirm = useConfirm();
+  const { announce } = useAnnouncer();
+  const [favorites, setFavorites] = useState<string[]>(() => readPromptFavorites());
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  // The nested save modal serves both flows: `editing` (user rows' pencil)
+  // and `seed` (builtin/pack rows' duplicate).
+  const [editing, setEditing] = useState<PromptOption | null>(null);
+  const [duplicating, setDuplicating] = useState<PromptOption | null>(null);
+  const [confirming, setConfirming] = useState(false);
+
+  const tags = useMemo(() => promptTags(prompts), [prompts]);
+  const ordered = useMemo(
+    () =>
+      orderPrompts(prompts, favorites, readPromptRecents()).filter(
+        (p) => !activeTag || (p.tags ?? []).includes(activeTag),
+      ),
+    [prompts, favorites, activeTag],
+  );
+
+  const removeTemplate = async (p: PromptOption) => {
+    // The confirm dialog and this modal both trap focus on window keydown —
+    // hide this one while the dialog is up so Escape only addresses one trap.
+    setConfirming(true);
+    const ok = await confirm({
+      title: `Delete "${p.name}"?`,
+      body: "Removes the template file from ~/.coven/prompts. This can't be undone.",
+      confirmLabel: "Delete",
+      danger: true,
+    });
+    setConfirming(false);
+    if (!ok) return;
+    const res = await fetch(`/api/prompts?id=${encodeURIComponent(p.id)}`, { method: "DELETE" });
+    const json = (await res.json().catch(() => ({ ok: false }))) as { ok: boolean; error?: string };
+    if (json.ok) {
+      broadcastPromptsRefresh();
+      announce("Template deleted.", "polite");
+    } else {
+      announce(json.error ?? "Couldn't delete the template.", "assertive");
+    }
+  };
+
+  const tagPill = (selected: boolean) =>
+    `focus-ring rounded-full border border-[var(--border-hairline)] px-2.5 py-0.5 text-[11px] transition-colors ${
+      selected
+        ? "bg-[var(--bg-raised)] text-[var(--text-primary)]"
+        : "text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+    }`;
+
+  const rowAction =
+    "focus-ring grid h-6 w-6 shrink-0 place-items-center rounded-full text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]";
+
+  // The nested save/confirm dialogs replace (not stack on) this modal — two
+  // simultaneous focus traps would both fire on Escape and fight over Tab.
+  const listOpen = open && editing === null && duplicating === null && !confirming;
+
   return (
-    <Modal open={open} onClose={onClose} breadcrumb={["Chat", "Prompt snippets"]}>
+    <>
+    <Modal open={listOpen} onClose={onClose} breadcrumb={["Chat", "Prompt snippets"]}>
       <p className="mb-3 text-sm text-[var(--text-muted)]">
-        Pick a starter prompt to drop into the composer.
+        Pick a starter prompt to drop into the composer — Tab cycles any{" "}
+        <code className="rounded bg-[var(--bg-raised)] px-1">{"{{placeholders}}"}</code> after
+        inserting.
       </p>
-      {prompts.length === 0 ? (
+      {tags.length > 0 ? (
+        <div className="mb-3 flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter by tag">
+          <button
+            type="button"
+            className={tagPill(activeTag === null)}
+            aria-pressed={activeTag === null}
+            onClick={() => setActiveTag(null)}
+          >
+            All
+          </button>
+          {tags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              className={tagPill(activeTag === tag)}
+              aria-pressed={activeTag === tag}
+              onClick={() => setActiveTag((cur) => (cur === tag ? null : tag))}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      {ordered.length === 0 ? (
         <p className="text-sm text-[var(--text-muted)]">
-          No prompt templates found. Add .md files under ~/.coven/prompts or install a prompt
-          pack from the Marketplace.
+          {prompts.length === 0
+            ? "No prompt templates found. Add .md files under ~/.coven/prompts or install a prompt pack from the Marketplace."
+            : "No templates carry this tag."}
         </p>
       ) : (
         <ul className="flex flex-col gap-1" aria-label="Prompt snippets">
-          {prompts.map((p) => (
-            <li key={p.id}>
-              <button
-                type="button"
-                className="focus-ring flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-[var(--bg-raised)]"
-                onClick={() => onPick(p)}
-              >
-                <Icon
-                  name={promptIconName(p.icon)}
-                  width={16}
-                  className="mt-0.5 shrink-0 text-[var(--text-muted)]"
-                  aria-hidden
-                />
-                <span className="min-w-0">
-                  <span className="block text-sm font-medium text-[var(--text-primary)]">
-                    {p.name}
+          {ordered.map((p) => {
+            const isFavorite = favorites.includes(p.id);
+            const origin = originLabel(p.source);
+            return (
+              <li key={p.id} className="group flex items-start gap-1">
+                <button
+                  type="button"
+                  className="focus-ring flex min-w-0 flex-1 items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-[var(--bg-raised)]"
+                  onClick={() => onPick(p)}
+                >
+                  <Icon
+                    name={promptIconName(p.icon)}
+                    width={16}
+                    className="mt-0.5 shrink-0 text-[var(--text-muted)]"
+                    aria-hidden
+                  />
+                  <span className="min-w-0">
+                    <span className="flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                      <span className="truncate">{p.name}</span>
+                      {origin ? (
+                        <span className="shrink-0 rounded-full border border-[var(--border-hairline)] px-1.5 text-[10px] font-normal text-[var(--text-muted)]">
+                          {origin}
+                        </span>
+                      ) : null}
+                    </span>
+                    {p.description ? (
+                      <span className="block text-xs text-[var(--text-muted)]">{p.description}</span>
+                    ) : null}
                   </span>
-                  {p.description ? (
-                    <span className="block text-xs text-[var(--text-muted)]">{p.description}</span>
-                  ) : null}
+                </button>
+                <span className="mt-1.5 flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    className={rowAction}
+                    aria-pressed={isFavorite}
+                    aria-label={isFavorite ? `Unfavorite ${p.name}` : `Favorite ${p.name}`}
+                    title={isFavorite ? "Unfavorite" : "Favorite"}
+                    onClick={() => setFavorites((cur) => togglePromptFavorite(cur, p.id))}
+                  >
+                    <Icon
+                      name={isFavorite ? "ph:bookmark-simple-fill" : "ph:bookmark-simple"}
+                      width={13}
+                      aria-hidden
+                    />
+                  </button>
+                  {p.source === "user" ? (
+                    <>
+                      <button
+                        type="button"
+                        className={rowAction}
+                        aria-label={`Edit ${p.name}`}
+                        title="Edit template"
+                        onClick={() => setEditing(p)}
+                      >
+                        <Icon name="ph:pencil-simple" width={13} aria-hidden />
+                      </button>
+                      <button
+                        type="button"
+                        className={rowAction}
+                        aria-label={`Delete ${p.name}`}
+                        title="Delete template"
+                        onClick={() => void removeTemplate(p)}
+                      >
+                        <Icon name="ph:trash" width={13} aria-hidden />
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      className={rowAction}
+                      aria-label={`Duplicate ${p.name} to my templates`}
+                      title="Duplicate to my templates"
+                      onClick={() => setDuplicating(p)}
+                    >
+                      <Icon name="ph:copy" width={13} aria-hidden />
+                    </button>
+                  )}
                 </span>
-              </button>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ul>
       )}
     </Modal>
+    {/* The edit/duplicate form is a SIBLING, never nested (focus-trap note
+        above) — while it is open, listOpen hides the list; closing it
+        restores the list modal. */}
+    <SaveTemplateModal
+      open={editing !== null || duplicating !== null}
+      onClose={() => {
+        setEditing(null);
+        setDuplicating(null);
+      }}
+      editing={editing}
+      seed={duplicating}
+    />
+    </>
   );
 }

--- a/src/components/save-template-modal.tsx
+++ b/src/components/save-template-modal.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { useAnnouncer } from "@/components/ui/live-region";
+import type { PromptOption } from "@/lib/slash-prompt";
+
+// Save-as-template (cave-jg6k): turn the current draft into a reusable
+// ~/.coven/prompts template, or edit an existing user template in place. One
+// form for both — `editing` prefills and pins the id (overwrite), create mode
+// derives the id from the name server-side. Success broadcasts
+// `cave:prompts-refresh` so every mounted picker re-scans.
+
+export const PROMPTS_REFRESH_EVENT = "cave:prompts-refresh";
+
+export function broadcastPromptsRefresh(): void {
+  window.dispatchEvent(new Event(PROMPTS_REFRESH_EVENT));
+}
+
+type SaveTemplateModalProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Seed for the template body — the composer draft. */
+  initialBody?: string;
+  /** Duplicate mode: prefill every field from a builtin/pack template but
+   *  save as a NEW user template (fresh id from the name). */
+  seed?: PromptOption | null;
+  /** Editing an existing USER template: prefills every field and saves back
+   *  to the same id. */
+  editing?: PromptOption | null;
+  /** Fired after a successful save with the scanned template. */
+  onSaved?: (prompt: PromptOption) => void;
+};
+
+export function SaveTemplateModal({
+  open,
+  onClose,
+  initialBody,
+  seed,
+  editing,
+  onSaved,
+}: SaveTemplateModalProps) {
+  const { announce } = useAnnouncer();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [tags, setTags] = useState("");
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  // A 409 (name collision on create) arms an explicit second confirm — the
+  // button relabels to "Overwrite" rather than silently replacing.
+  const [overwriteArmed, setOverwriteArmed] = useState(false);
+
+  // (Re)seed whenever the modal opens — edits prefill from the template,
+  // creates from the draft.
+  useEffect(() => {
+    if (!open) return;
+    const from = editing ?? seed;
+    setName(from?.name ?? "");
+    setDescription(from?.description ?? "");
+    setTags((from?.tags ?? []).join(", "));
+    setBody(from?.body ?? initialBody ?? "");
+    setError(null);
+    setOverwriteArmed(false);
+  }, [open, editing, seed, initialBody]);
+
+  const save = async () => {
+    if (saving) return;
+    if (!name.trim()) {
+      setError("Give the template a name.");
+      return;
+    }
+    if (!body.trim()) {
+      setError("The template body is empty.");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/prompts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          description: description.trim() || undefined,
+          tags: tags
+            .split(",")
+            .map((t) => t.trim())
+            .filter(Boolean),
+          body,
+          // Edits keep their id and always overwrite; creates only overwrite
+          // after the user confirmed the 409.
+          ...(editing ? { id: editing.id, overwrite: true } : {}),
+          ...(!editing && overwriteArmed ? { overwrite: true } : {}),
+          ...((editing ?? seed)?.icon ? { icon: (editing ?? seed)?.icon } : {}),
+        }),
+      });
+      const json = (await res.json().catch(() => ({ ok: false }))) as {
+        ok: boolean;
+        prompt?: PromptOption;
+        error?: string;
+      };
+      if (res.status === 409) {
+        setOverwriteArmed(true);
+        setError(json.error ?? "A template with this name already exists.");
+        return;
+      }
+      if (!json.ok || !json.prompt) {
+        setError(json.error ?? "Couldn't save the template.");
+        return;
+      }
+      broadcastPromptsRefresh();
+      announce(editing ? "Template updated." : "Template saved.", "polite");
+      onSaved?.(json.prompt);
+      onClose();
+    } catch {
+      setError("Couldn't reach the server.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const inputClass =
+    "focus-ring w-full rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-sunken)] px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)]";
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      breadcrumb={["Prompts", editing ? "Edit template" : "Save as template"]}
+      footerActions={
+        <>
+          <Button variant="secondary" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm" onClick={() => void save()} disabled={saving}>
+            {saving ? "Saving…" : overwriteArmed ? "Overwrite" : editing ? "Save changes" : "Save template"}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-3">
+        {error ? (
+          <p className="text-sm text-[var(--color-warning)]" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <label className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
+          Name
+          <input
+            className={inputClass}
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setOverwriteArmed(false);
+            }}
+            placeholder="Release notes"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
+          Description
+          <input
+            className={inputClass}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="What this template is for (shown in the picker)"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
+          Tags
+          <input
+            className={inputClass}
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="release, writing (comma-separated)"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-[var(--text-muted)]">
+          Template
+          <textarea
+            className={`${inputClass} min-h-32 resize-y font-mono text-[13px] leading-5`}
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            placeholder={"Draft release notes since {{last release|the last tag}}…"}
+          />
+        </label>
+        <p className="text-[11px] text-[var(--text-muted)]">
+          Wrap the parts to fill in as{" "}
+          <code className="rounded bg-[var(--bg-raised)] px-1">{"{{placeholder}}"}</code> or{" "}
+          <code className="rounded bg-[var(--bg-raised)] px-1">{"{{name|default}}"}</code> — Tab
+          cycles through them after inserting.
+        </p>
+      </div>
+    </Modal>
+  );
+}

--- a/src/lib/prompt-placeholders.test.ts
+++ b/src/lib/prompt-placeholders.test.ts
@@ -1,0 +1,172 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  acceptPlaceholderDefault,
+  handlePlaceholderTab,
+  nextPlaceholder,
+  placeholderSpans,
+} from "./prompt-placeholders.ts";
+
+// ── placeholderSpans ─────────────────────────────────────────────────────────
+const text = "Ship {{feature}} to {{env|production}} by {{date}}";
+const spans = placeholderSpans(text);
+assert.equal(spans.length, 3, "all three tokens found");
+assert.deepEqual(
+  spans.map((s) => s.name),
+  ["feature", "env", "date"],
+  "names parse in document order",
+);
+assert.equal(spans[0].def, null, "no-default token carries def: null");
+assert.equal(spans[1].def, "production", "defaulted token carries its default");
+assert.equal(text.slice(spans[1].start, spans[1].end), "{{env|production}}", "span covers the whole token");
+
+assert.deepEqual(placeholderSpans("no tokens here"), [], "plain text has no spans");
+assert.deepEqual(placeholderSpans("{{ }}"), [], "a blank name is not a token");
+assert.equal(placeholderSpans("{{a|}}")[0].def, "", "an empty default is still a default (Tab accepts to empty)");
+assert.equal(placeholderSpans("{{team|the team}}")[0].def, "the team", "defaults may contain spaces");
+
+// ── nextPlaceholder: wrapping in both directions ─────────────────────────────
+assert.equal(nextPlaceholder(text, 0, 1)?.name, "feature", "forward from the top hits the first token");
+assert.equal(nextPlaceholder(text, spans[0].end, 1)?.name, "env", "forward from past a token hits the next");
+assert.equal(nextPlaceholder(text, spans[2].end, 1)?.name, "feature", "forward wraps past the last token");
+assert.equal(nextPlaceholder(text, spans[2].start, -1)?.name, "env", "backward from a token's start hits the previous");
+assert.equal(nextPlaceholder(text, 0, -1)?.name, "date", "backward wraps to the last token");
+assert.equal(nextPlaceholder("no tokens", 0, 1), null, "no tokens → null (callers fall through to native Tab)");
+
+// ── acceptPlaceholderDefault ─────────────────────────────────────────────────
+const accepted = acceptPlaceholderDefault(text, spans[1]);
+assert.equal(
+  accepted.text,
+  "Ship {{feature}} to production by {{date}}",
+  "accepting replaces the token with its default",
+);
+assert.equal(
+  accepted.caret,
+  "Ship {{feature}} to production".length,
+  "the caret lands just past the inserted default",
+);
+const noDefault = acceptPlaceholderDefault(text, spans[0]);
+assert.equal(noDefault.text, text, "a token without a default is left alone");
+
+// ── handlePlaceholderTab (fake textarea) ─────────────────────────────────────
+function fakeTextarea(value, selectionStart = 0, selectionEnd = selectionStart) {
+  return {
+    value,
+    selectionStart,
+    selectionEnd,
+    focused: false,
+    focus() {
+      this.focused = true;
+    },
+    setSelectionRange(start, end) {
+      this.selectionStart = start;
+      this.selectionEnd = end;
+    },
+  };
+}
+function tabEvent(shiftKey = false) {
+  return {
+    key: "Tab",
+    shiftKey,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+  };
+}
+const rafQueue = [];
+globalThis.requestAnimationFrame = (cb) => {
+  rafQueue.push(cb);
+  return rafQueue.length;
+};
+const flushRaf = () => {
+  while (rafQueue.length) rafQueue.shift()();
+};
+
+// Tab falls through when the draft has no tokens (native focus-move survives).
+{
+  const el = fakeTextarea("plain draft");
+  const e = tabEvent();
+  assert.equal(handlePlaceholderTab(e, el, () => {}), false, "no tokens → not consumed");
+  assert.equal(e.defaultPrevented, false, "no tokens → default not prevented");
+}
+// Non-Tab keys are never consumed.
+{
+  const el = fakeTextarea(text);
+  assert.equal(
+    handlePlaceholderTab({ key: "Enter", shiftKey: false, preventDefault() {} }, el, () => {}),
+    false,
+    "only Tab is owned",
+  );
+}
+// Tab selects the first token; Tab again advances; wrapping past the end.
+{
+  const el = fakeTextarea(text, 0);
+  assert.equal(handlePlaceholderTab(tabEvent(), el, () => {}), true);
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{feature}}", "first Tab selects the first token");
+  handlePlaceholderTab(tabEvent(), el, () => {});
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{env|production}}", "second Tab advances");
+  // Tab on the selected defaulted token would ACCEPT (covered below) — park
+  // the caret past it to keep exercising pure navigation.
+  el.setSelectionRange(el.selectionEnd, el.selectionEnd);
+  handlePlaceholderTab(tabEvent(), el, () => {});
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{date}}", "third Tab reaches the last token");
+  handlePlaceholderTab(tabEvent(), el, () => {});
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{feature}}", "Tab wraps back to the first token ({{date}} has no default, so Tab navigates)");
+}
+// Shift+Tab reverses (and wraps backward).
+{
+  const el = fakeTextarea(text, 0);
+  handlePlaceholderTab(tabEvent(true), el, () => {});
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{date}}", "Shift+Tab from the top wraps to the last token");
+  handlePlaceholderTab(tabEvent(true), el, () => {});
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{env|production}}", "Shift+Tab keeps reversing");
+}
+// A caret inside a token selects that token first.
+{
+  const inside = text.indexOf("feature") + 3;
+  const el = fakeTextarea(text, inside);
+  handlePlaceholderTab(tabEvent(), el, () => {});
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{feature}}", "caret inside a token selects it");
+}
+// Tab on a selected defaulted token accepts the default then jumps onward.
+{
+  const span = placeholderSpans(text)[1];
+  const el = fakeTextarea(text, span.start, span.end);
+  let latest = text;
+  const consumed = handlePlaceholderTab(tabEvent(), el, (v) => {
+    latest = v;
+    el.value = v; // simulate the controlled re-render before the rAF fires
+  });
+  assert.equal(consumed, true, "accepting a default consumes Tab");
+  assert.equal(latest, "Ship {{feature}} to production by {{date}}", "the default replaced the token");
+  flushRaf();
+  assert.equal(el.focused, true, "focus returns to the textarea after the re-render");
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{date}}", "after accepting, selection jumps to the next token");
+}
+// Accepting the LAST remaining default parks the caret after the inserted text.
+{
+  const solo = "Deploy {{env|staging}} now";
+  const span = placeholderSpans(solo)[0];
+  const el = fakeTextarea(solo, span.start, span.end);
+  handlePlaceholderTab(tabEvent(), el, (v) => {
+    el.value = v;
+  });
+  flushRaf();
+  const caret = "Deploy staging".length;
+  assert.equal(el.selectionStart, caret, "caret parks after the accepted default");
+  assert.equal(el.selectionEnd, caret, "nothing stays selected when no tokens remain");
+}
+// Shift+Tab on a selected defaulted token navigates (never accepts).
+{
+  const span = placeholderSpans(text)[1];
+  const el = fakeTextarea(text, span.start, span.end);
+  let called = false;
+  handlePlaceholderTab(tabEvent(true), el, () => {
+    called = true;
+  });
+  assert.equal(called, false, "Shift+Tab never accepts a default");
+  assert.equal(el.value.slice(el.selectionStart, el.selectionEnd), "{{feature}}", "Shift+Tab moves backward instead");
+}
+
+console.log("prompt-placeholders.test.ts: ok");

--- a/src/lib/prompt-placeholders.ts
+++ b/src/lib/prompt-placeholders.ts
@@ -1,0 +1,126 @@
+// Template placeholder engine (cave-jg6k): Tab-cycling for {{placeholder}}
+// tokens in the composer. Stateless by design — the spans derive from the live
+// textarea text on every keypress, so there is nothing to sync when the user
+// edits around (or inside) a token; unreplaced tokens simply stay literal.
+//
+// Grammar: `{{name}}` or `{{name|default}}`. Names are free-form (anything but
+// braces or a pipe); the optional default after the first pipe is what Tab
+// accepts when the token is already selected.
+
+export type PlaceholderSpan = {
+  /** Index of the opening `{{`. */
+  start: number;
+  /** Index just past the closing `}}`. */
+  end: number;
+  name: string;
+  /** Text after the first `|`, when present. */
+  def: string | null;
+};
+
+const PLACEHOLDER_RE = /\{\{([^{}|]+)(?:\|([^{}]*))?\}\}/g;
+
+/** Every placeholder token in the text, in document order. */
+export function placeholderSpans(text: string): PlaceholderSpan[] {
+  const spans: PlaceholderSpan[] = [];
+  for (const m of text.matchAll(PLACEHOLDER_RE)) {
+    const name = m[1].trim();
+    if (!name) continue;
+    spans.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      name,
+      def: m[2] !== undefined ? m[2] : null,
+    });
+  }
+  return spans;
+}
+
+/** The next placeholder to visit from `caret`, wrapping. `dir` 1 finds the
+ *  first token starting at/after the caret; -1 the last token ending
+ *  at/before it. Returns null only when the text has no tokens at all. */
+export function nextPlaceholder(
+  text: string,
+  caret: number,
+  dir: 1 | -1 = 1,
+): PlaceholderSpan | null {
+  const spans = placeholderSpans(text);
+  if (!spans.length) return null;
+  if (dir === 1) {
+    return spans.find((s) => s.start >= caret) ?? spans[0];
+  }
+  for (let i = spans.length - 1; i >= 0; i -= 1) {
+    if (spans[i].end <= caret) return spans[i];
+  }
+  return spans[spans.length - 1];
+}
+
+/** Replace a defaulted token with its default text. Returns the new text and
+ *  the caret just past the inserted default. No-op passthrough for tokens
+ *  without a default (callers keep the selection instead). */
+export function acceptPlaceholderDefault(
+  text: string,
+  span: PlaceholderSpan,
+): { text: string; caret: number } {
+  if (span.def === null) return { text, caret: span.end };
+  return {
+    text: text.slice(0, span.start) + span.def + text.slice(span.end),
+    caret: span.start + span.def.length,
+  };
+}
+
+/** Composer keydown helper: owns Tab/Shift+Tab while the draft carries
+ *  placeholder tokens. Returns true when it consumed the event.
+ *
+ *  - Tab jumps to (selects) the next token from the caret, wrapping;
+ *    Shift+Tab reverses.
+ *  - Tab while a *defaulted* token is exactly selected accepts the default,
+ *    then jumps to the next token if one remains.
+ *  - No tokens in the draft → returns false so the native focus-move keeps
+ *    working (a11y: Tab must not be unconditionally trapped).
+ *
+ *  `setText` triggers the React re-render for accepted defaults; the
+ *  selection lands on the next frame (the promptInsertion idiom).
+ */
+export function handlePlaceholderTab(
+  e: { key: string; shiftKey: boolean; preventDefault: () => void },
+  el: HTMLTextAreaElement | null,
+  setText: (value: string) => void,
+): boolean {
+  if (e.key !== "Tab" || !el) return false;
+  const text = el.value;
+  const spans = placeholderSpans(text);
+  if (!spans.length) return false;
+  const dir: 1 | -1 = e.shiftKey ? -1 : 1;
+
+  const selected = spans.find(
+    (s) => s.start === el.selectionStart && s.end === el.selectionEnd,
+  );
+  if (selected && selected.def !== null && dir === 1) {
+    // Accept the default in place, then move on to the next token (if any)
+    // once the re-rendered value is in the DOM.
+    e.preventDefault();
+    const accepted = acceptPlaceholderDefault(text, selected);
+    setText(accepted.text);
+    requestAnimationFrame(() => {
+      el.focus();
+      const next = nextPlaceholder(accepted.text, accepted.caret, 1);
+      if (next) el.setSelectionRange(next.start, next.end);
+      else el.setSelectionRange(accepted.caret, accepted.caret);
+    });
+    return true;
+  }
+
+  // Plain navigation: no text change, select the target token directly.
+  // A caret sitting inside a token selects that token first; otherwise
+  // forward scans from the selection's end so a selected token advances past
+  // itself, and backward scans from its start for the mirror-image reason.
+  e.preventDefault();
+  const from = dir === 1 ? el.selectionEnd : el.selectionStart;
+  const inside =
+    el.selectionStart === el.selectionEnd
+      ? spans.find((s) => s.start < from && from < s.end)
+      : undefined;
+  const target = inside ?? nextPlaceholder(text, from, dir);
+  if (target) el.setSelectionRange(target.start, target.end);
+  return true;
+}

--- a/src/lib/prompt-prefs.test.ts
+++ b/src/lib/prompt-prefs.test.ts
@@ -1,0 +1,85 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  PROMPT_FAVORITES_KEY,
+  PROMPT_RECENTS_KEY,
+  PROMPT_RECENTS_MAX,
+  orderPrompts,
+  promptTags,
+  readPromptFavorites,
+  readPromptRecents,
+  recordPromptRecent,
+  togglePromptFavorite,
+} from "./prompt-prefs.ts";
+
+// Minimal window.localStorage shim (chat-session-prefs test pattern).
+const store = new Map();
+globalThis.window = {
+  localStorage: {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  },
+};
+
+const P = (id, tags = []) => ({ id, name: id, body: id, source: "builtin", tags });
+
+// ── ordering: favorites > recents (MRU) > scan order ─────────────────────────
+const prompts = [P("a"), P("b"), P("c"), P("d")];
+assert.equal(
+  orderPrompts(prompts, [], []),
+  prompts,
+  "no prefs → the same array reference (memo-friendly bail)",
+);
+assert.deepEqual(
+  orderPrompts(prompts, ["c"], ["d", "b"]).map((p) => p.id),
+  ["c", "d", "b", "a"],
+  "favorites lead, then recents in MRU order, then scan order",
+);
+assert.deepEqual(
+  orderPrompts(prompts, ["c", "b"], ["b", "c"]).map((p) => p.id),
+  ["b", "c", "a", "d"],
+  "a template that is both favorite and recent ranks as favorite (scan order within favorites)",
+);
+
+// ── favorites: toggle + persistence ──────────────────────────────────────────
+assert.deepEqual(readPromptFavorites(), [], "empty store reads as no favorites");
+let favs = togglePromptFavorite([], "a");
+assert.deepEqual(favs, ["a"], "toggle on");
+assert.deepEqual(readPromptFavorites(), ["a"], "toggle persists");
+favs = togglePromptFavorite(favs, "a");
+assert.deepEqual(favs, [], "toggle off");
+
+// ── recents: MRU, dedup, cap ─────────────────────────────────────────────────
+recordPromptRecent("x");
+recordPromptRecent("y");
+assert.deepEqual(readPromptRecents(), ["y", "x"], "most recent first");
+recordPromptRecent("x");
+assert.deepEqual(readPromptRecents(), ["x", "y"], "re-inserting moves to front without duplicating");
+for (let i = 0; i < PROMPT_RECENTS_MAX + 3; i += 1) recordPromptRecent(`r${i}`);
+assert.equal(readPromptRecents().length, PROMPT_RECENTS_MAX, "MRU list is capped");
+
+// ── corrupt storage degrades to empty, never throws ──────────────────────────
+store.set(PROMPT_FAVORITES_KEY, "{not json");
+assert.deepEqual(readPromptFavorites(), [], "corrupt JSON reads as empty");
+store.set(PROMPT_RECENTS_KEY, JSON.stringify({ nope: true }));
+assert.deepEqual(readPromptRecents(), [], "non-array JSON reads as empty");
+store.set(PROMPT_RECENTS_KEY, JSON.stringify(["ok", 42, null, "fine"]));
+assert.deepEqual(readPromptRecents(), ["ok", "fine"], "non-string entries are filtered");
+
+// ── SSR guard ────────────────────────────────────────────────────────────────
+const savedWindow = globalThis.window;
+delete globalThis.window;
+assert.deepEqual(readPromptFavorites(), [], "no window → empty, no throw");
+assert.deepEqual(togglePromptFavorite([], "a"), ["a"], "toggle still returns the new array without window");
+globalThis.window = savedWindow;
+
+// ── tags ─────────────────────────────────────────────────────────────────────
+assert.deepEqual(
+  promptTags([P("a", ["writing", "git"]), P("b", ["git", "release"]), P("c")]),
+  ["git", "release", "writing"],
+  "distinct tags, alphabetical",
+);
+assert.deepEqual(promptTags([P("a")]), [], "no tags → empty list");
+
+console.log("prompt-prefs.test.ts: ok");

--- a/src/lib/prompt-prefs.ts
+++ b/src/lib/prompt-prefs.ts
@@ -1,0 +1,98 @@
+import type { PromptOption } from "./slash-prompt.ts";
+
+// Prompt-template preferences (cave-jg6k): favorites and a most-recently-used
+// list, both Cave-local UI state (localStorage, chat-session-prefs pattern —
+// the scanner and the daemon never learn about them). Pure order/toggle
+// helpers so the pickers and the snippets modal share one ranking.
+
+export const PROMPT_FAVORITES_KEY = "cave:prompt-favorites:v1";
+export const PROMPT_RECENTS_KEY = "cave:prompt-recents:v1";
+
+/** MRU cap — recents beyond this fall off the end. */
+export const PROMPT_RECENTS_MAX = 8;
+
+function readStringArray(key: string): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeStringArray(key: string, value: readonly string[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Quota/private-mode failures degrade to session-only prefs.
+  }
+}
+
+/** Read favorite template ids; survives SSR and corrupt values. */
+export function readPromptFavorites(): string[] {
+  return readStringArray(PROMPT_FAVORITES_KEY);
+}
+
+/** Toggle membership; always returns a new array (state-setter friendly)
+ *  and persists as a side effect. */
+export function togglePromptFavorite(favorites: readonly string[], id: string): string[] {
+  const next = favorites.includes(id)
+    ? favorites.filter((f) => f !== id)
+    : [...favorites, id];
+  writeStringArray(PROMPT_FAVORITES_KEY, next);
+  return next;
+}
+
+/** Read the MRU insert list, most recent first. */
+export function readPromptRecents(): string[] {
+  return readStringArray(PROMPT_RECENTS_KEY);
+}
+
+/** Record an insert: move-to-front, dedup, cap. Persists and returns the
+ *  new list. */
+export function recordPromptRecent(id: string): string[] {
+  const next = [id, ...readPromptRecents().filter((r) => r !== id)].slice(
+    0,
+    PROMPT_RECENTS_MAX,
+  );
+  writeStringArray(PROMPT_RECENTS_KEY, next);
+  return next;
+}
+
+/** Ranking shared by the inline picker and the snippets modal:
+ *  favorites first, then recents (MRU order), then scan order. Stable within
+ *  each partition; returns the input array untouched when prefs are empty so
+ *  memoized consumers can bail. */
+export function orderPrompts(
+  prompts: PromptOption[],
+  favorites: readonly string[],
+  recents: readonly string[],
+): PromptOption[] {
+  if (!favorites.length && !recents.length) return prompts;
+  const favSet = new Set(favorites);
+  const recentRank = new Map(recents.map((id, i) => [id, i]));
+  const fav: PromptOption[] = [];
+  const recent: PromptOption[] = [];
+  const rest: PromptOption[] = [];
+  for (const p of prompts) {
+    if (favSet.has(p.id)) fav.push(p);
+    else if (recentRank.has(p.id)) recent.push(p);
+    else rest.push(p);
+  }
+  recent.sort((a, b) => (recentRank.get(a.id) ?? 0) - (recentRank.get(b.id) ?? 0));
+  return [...fav, ...recent, ...rest];
+}
+
+/** Distinct tags across the scanned templates, alphabetical, for filter
+ *  chips. */
+export function promptTags(prompts: PromptOption[]): string[] {
+  const tags = new Set<string>();
+  for (const p of prompts) for (const t of p.tags ?? []) tags.add(t);
+  return [...tags].sort((a, b) => a.localeCompare(b));
+}

--- a/src/lib/server/prompt-file.ts
+++ b/src/lib/server/prompt-file.ts
@@ -12,21 +12,25 @@
 export const PROMPT_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 /** Derive a slug from a display name: lowercase, alphanumeric runs joined by
- *  single dashes, trimmed to 64 chars. Returns null when nothing survives. */
+ *  single dashes, trimmed to 64 chars. Returns null when nothing survives.
+ *  Dash-trimming is a linear scan, not an anchored `-+$` regex — the latter
+ *  is a polynomial-ReDoS shape on all-dash input (flagged by CodeQL). */
 export function promptSlug(name: string): string | null {
-  const slug = name
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64)
-    .replace(/-+$/, "");
+  const joined = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 64);
+  let start = 0;
+  let end = joined.length;
+  while (start < end && joined[start] === "-") start += 1;
+  while (end > start && joined[end - 1] === "-") end -= 1;
+  const slug = joined.slice(start, end);
   return PROMPT_SLUG_RE.test(slug) ? slug : null;
 }
 
-/** Single-line frontmatter scalar: strip newlines (they would break the
- *  block) and the leading/trailing whitespace they leave behind. */
+/** Single-line frontmatter scalar: collapse every whitespace run (newlines
+ *  included) to a single space so the value can't break the YAML block.
+ *  `\s+` is linear — the earlier `\s*\r?\n\s*` overlapped and was a
+ *  polynomial-ReDoS shape. */
 function scalar(value: string): string {
-  return value.replace(/\s*\r?\n\s*/g, " ").trim();
+  return value.replace(/\s+/g, " ").trim();
 }
 
 /** Serialize a template to the .md shape prompt-scan.ts reads. Tags are

--- a/src/lib/server/prompt-file.ts
+++ b/src/lib/server/prompt-file.ts
@@ -1,0 +1,58 @@
+/**
+ * User prompt-template file serializer (cave-jg6k) — the write-side mirror of
+ * prompt-scan.ts, in the exact shape scripts/sync-marketplace.py emits for
+ * packs (frontmatter name/description/icon/tags + body). Round-trip safety is
+ * pinned by the route test: serialize → scanPromptsDir must reproduce the
+ * template.
+ */
+
+/** File-name/id slug. Also the ONLY path component the API ever accepts —
+ *  the regex confines writes and deletes to direct children of
+ *  ~/.coven/prompts (no separators, no dots, no traversal). */
+export const PROMPT_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+/** Derive a slug from a display name: lowercase, alphanumeric runs joined by
+ *  single dashes, trimmed to 64 chars. Returns null when nothing survives. */
+export function promptSlug(name: string): string | null {
+  const slug = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/, "");
+  return PROMPT_SLUG_RE.test(slug) ? slug : null;
+}
+
+/** Single-line frontmatter scalar: strip newlines (they would break the
+ *  block) and the leading/trailing whitespace they leave behind. */
+function scalar(value: string): string {
+  return value.replace(/\s*\r?\n\s*/g, " ").trim();
+}
+
+/** Serialize a template to the .md shape prompt-scan.ts reads. Tags are
+ *  filtered to non-empty single-line strings; the body is dropped in
+ *  verbatim (it may itself contain {{placeholders}}). */
+export function serializePromptTemplate({
+  name,
+  description,
+  icon,
+  tags,
+  body,
+}: {
+  name: string;
+  description?: string;
+  icon?: string;
+  tags?: string[];
+  body: string;
+}): string {
+  const lines = ["---", `name: ${scalar(name)}`];
+  if (description?.trim()) lines.push(`description: ${scalar(description)}`);
+  if (icon?.trim()) lines.push(`icon: ${scalar(icon)}`);
+  const cleanTags = (tags ?? []).map(scalar).filter(Boolean);
+  if (cleanTags.length) {
+    lines.push("tags:");
+    for (const tag of cleanTags) lines.push(`  - ${tag}`);
+  }
+  lines.push("---", "", body.replace(/\r\n/g, "\n").trim(), "");
+  return lines.join("\n");
+}

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -41,6 +41,19 @@ assert.equal(plain.text, "Review the current change.", "insertion carries the bo
 assert.equal(plain.selectStart, undefined, "no placeholder → no selection range");
 const templated = promptInsertion(PROMPTS[1]);
 assert.equal(templated.text.slice(templated.selectStart, templated.selectEnd), "{{what to build}}", "first placeholder is selected");
+// Defaulted tokens ({{name|default}}) use the shared placeholder grammar —
+// the old inline regex missed them (cave-jg6k).
+const defaulted = promptInsertion({ id: "d", name: "D", body: "Ship {{env|production}} today.", source: "user" });
+assert.equal(
+  defaulted.text.slice(defaulted.selectStart, defaulted.selectEnd),
+  "{{env|production}}",
+  "a defaulted first token is selected whole (Tab can then accept the default)",
+);
+
+// Tags participate in the picker filter.
+const TAGGED = [...PROMPTS, { id: "retro", name: "Retro notes", body: "x", source: "user", tags: ["meeting", "team"] }];
+assert.equal(promptSlashOptions("/prompt meeting", TAGGED).length, 1, "a tag matches the /prompt filter");
+assert.equal(promptSlashOptions("/prompt meeting", TAGGED)[0].id, "retro", "the tag match is the tagged template");
 
 // ── formatPromptList ─────────────────────────────────────────────────────────
 const list = formatPromptList(PROMPTS);
@@ -86,7 +99,7 @@ assert.match(chatView, /onOpenPromptSnippets=\{\(\) => setPromptSnippetsOpen\(tr
 
 // ── Prompt snippets modal ────────────────────────────────────────────────────
 const modal = await readFile(new URL("../components/prompt-snippets-modal.tsx", import.meta.url), "utf8");
-assert.match(modal, /Pick a starter prompt to drop into the composer\./, "modal keeps the insert-not-send subtitle");
+assert.match(modal, /Pick a starter prompt to drop into the composer/, "modal keeps the insert-not-send subtitle");
 assert.match(modal, /export function promptIconName/, "icon names from data are validated against the curated set");
 assert.match(modal, /breadcrumb=\{\["Chat", "Prompt snippets"\]\}/, "modal is built on the shared Modal primitive");
 
@@ -102,5 +115,34 @@ assert.match(homeComposer, /onInsertPrompt: \(p\) => insertPromptTemplate\(p\)/,
 assert.match(homeComposer, /command === "\/prompt" \|\| command === "\/prompts"/, "home dispatches /prompt and /prompts");
 assert.match(homeComposer, /const insertPromptTemplate = useCallback/, "home has the template-insert helper");
 assert.doesNotMatch(homeComposer, /onStartChat\([^)]*promptInsertion/, "a template body never starts a chat directly");
+
+// ── Placeholder Tab-cycling wiring (cave-jg6k) ───────────────────────────────
+// Order is load-bearing in both composers: the inline menus own Tab-complete
+// while open, so the placeholder branch sits AFTER handleMenuKey and only
+// consumes Tab when the draft carries a token (native focus-move survives).
+assert.match(
+  homeComposer,
+  /if \(handleMenuKey\(e\)\) return;[\s\S]{0,400}?if \(handlePlaceholderTab\(e, textareaRef\.current, setText\)\) return;/,
+  "home: placeholder Tab runs after the inline menus",
+);
+assert.match(
+  chatView,
+  /if \(handleMenuKey\(e\)\) return;[\s\S]{0,400}?if \(handlePlaceholderTab\(e, inputRef\.current, setInput\)\) return;/,
+  "chat: placeholder Tab runs after the inline menus",
+);
+
+// ── Recents + refresh + ordering (cave-jg6k) ─────────────────────────────────
+assert.match(homeComposer, /recordPromptRecent\(p\.id\);/, "home records an insert as a recent");
+assert.match(chatView, /recordPromptRecent\(p\.id\);/, "chat records an insert as a recent");
+assert.match(
+  menusHook,
+  /window\.addEventListener\("cave:prompts-refresh", load\)/,
+  "the picker hook re-scans on cave:prompts-refresh (save/delete broadcast)",
+);
+assert.match(
+  menusHook,
+  /orderPrompts\(options, readPromptFavorites\(\), readPromptRecents\(\)\)/,
+  "picker options rank favorites > recents > scan order",
+);
 
 console.log("slash-prompt.test.ts: ok");

--- a/src/lib/slash-prompt.ts
+++ b/src/lib/slash-prompt.ts
@@ -6,6 +6,8 @@
 // deliberate difference: picking a prompt INSERTS its body into the composer
 // for editing — it never sends.
 
+import { nextPlaceholder } from "@/lib/prompt-placeholders";
+
 export type PromptOption = {
   id: string;
   name: string;
@@ -35,7 +37,8 @@ function filterPrompts(prompts: PromptOption[], partial: string): PromptOption[]
     (p) =>
       p.id.toLowerCase().includes(q) ||
       p.name.toLowerCase().includes(q) ||
-      (p.description?.toLowerCase().includes(q) ?? false),
+      (p.description?.toLowerCase().includes(q) ?? false) ||
+      (p.tags?.some((tag) => tag.toLowerCase().includes(q)) ?? false),
   );
 }
 
@@ -71,11 +74,13 @@ export type PromptInsertion = {
   selectEnd?: number;
 };
 
-/** The composer insertion for a picked template. Never a send. */
+/** The composer insertion for a picked template. Never a send. Selects the
+ *  first {{placeholder}} (shared engine grammar, incl. {{name|default}}) so
+ *  typing replaces it and Tab cycles onward from there. */
 export function promptInsertion(p: PromptOption): PromptInsertion {
-  const m = p.body.match(/\{\{[^{}]*\}\}/);
-  if (!m || m.index === undefined) return { text: p.body };
-  return { text: p.body, selectStart: m.index, selectEnd: m.index + m[0].length };
+  const first = nextPlaceholder(p.body, 0, 1);
+  if (!first) return { text: p.body };
+  return { text: p.body, selectStart: first.start, selectEnd: first.end };
 }
 
 /** One-line-per-prompt list for the bare `/prompt` / `/prompts` system message. */

--- a/src/lib/slash-prompt.ts
+++ b/src/lib/slash-prompt.ts
@@ -6,7 +6,7 @@
 // deliberate difference: picking a prompt INSERTS its body into the composer
 // for editing — it never sends.
 
-import { nextPlaceholder } from "@/lib/prompt-placeholders";
+import { nextPlaceholder } from "./prompt-placeholders.ts";
 
 export type PromptOption = {
   id: string;

--- a/src/lib/use-inline-slash-menus.ts
+++ b/src/lib/use-inline-slash-menus.ts
@@ -7,6 +7,7 @@ import type { RuntimeModelOption } from "@/lib/runtime-models";
 import { skillCommandMatches, skillSlashOptions, type SkillOption } from "@/lib/slash-skill";
 import { promptSlashOptions, type PromptOption } from "@/lib/slash-prompt";
 import { BUILTIN_PROMPTS } from "@/lib/prompt-defaults";
+import { orderPrompts, readPromptFavorites, readPromptRecents } from "@/lib/prompt-prefs";
 
 /**
  * The composer's inline slash menus: the `/command` listbox (with its Skills
@@ -106,16 +107,23 @@ export function useInlineSlashMenus(opts: {
   const [prompts, setPrompts] = useState<PromptOption[]>(BUILTIN_PROMPTS);
   useEffect(() => {
     let alive = true;
-    fetch("/api/prompts", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((j) => {
-        if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
-      })
-      .catch(() => {
-        /* offline → built-in templates only */
-      });
+    const load = () => {
+      fetch("/api/prompts", { cache: "no-store" })
+        .then((r) => r.json())
+        .then((j) => {
+          if (alive && j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PromptOption[]);
+        })
+        .catch(() => {
+          /* offline → built-in templates only */
+        });
+    };
+    load();
+    // Saving/deleting a user template broadcasts this event so every mounted
+    // picker re-scans without a reload.
+    window.addEventListener("cave:prompts-refresh", load);
     return () => {
       alive = false;
+      window.removeEventListener("cave:prompts-refresh", load);
     };
   }, []);
 
@@ -132,11 +140,15 @@ export function useInlineSlashMenus(opts: {
     [text, skills, slashDismissed],
   );
   const skillMenuActive = (skillOptions?.length ?? 0) > 0;
-  // Inline `/prompt` / `/prompts` picker — null ⇒ not in a prompt-picker position.
-  const promptOptions = useMemo(
-    () => (slashDismissed ? null : promptSlashOptions(text, prompts)),
-    [text, prompts, slashDismissed],
-  );
+  // Inline `/prompt` / `/prompts` picker — null ⇒ not in a prompt-picker
+  // position. Options rank favorites > recent inserts > scan order; the prefs
+  // are re-read per keystroke (tiny localStorage arrays) so an insert reranks
+  // the very next open.
+  const promptOptions = useMemo(() => {
+    if (slashDismissed) return null;
+    const options = promptSlashOptions(text, prompts);
+    return options ? orderPrompts(options, readPromptFavorites(), readPromptRecents()) : null;
+  }, [text, prompts, slashDismissed]);
   const promptMenuActive = (promptOptions?.length ?? 0) > 0;
   // Skills surfaced directly in the command menu — typing `/revi` finds the
   // code-review skill without the /skill prefix. Same first-token-only rule as

--- a/tests/prompt-templates.spec.ts
+++ b/tests/prompt-templates.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+// Template power (cave-jg6k): the composer's /prompt picker inserts a template
+// with its first {{placeholder}} selected, Tab cycles the rest (and accepts a
+// {{name|default}}), and the Options → "Save draft as template…" flow round-
+// trips through /api/prompts with a live re-scan.
+//
+// Daemon-less: familiars + sessions mocked; /api/prompts is a stateful mock so
+// a POST is observably reflected in the next GET (the re-scan the feature
+// depends on).
+
+const FAMILIAR = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Orchestrator",
+  status: "active",
+  icon: "ph:sparkle-fill",
+};
+
+type PromptStore = { prompts: Array<Record<string, unknown>>; posted: Array<Record<string, unknown>> };
+
+async function seed(page: Page): Promise<PromptStore> {
+  const store: PromptStore = {
+    prompts: [
+      {
+        id: "release-notes",
+        name: "Release notes",
+        description: "Turn merges into notes",
+        body: "Draft release notes since {{last release|the last tag}}. Group by {{area}}.",
+        source: "builtin",
+        tags: ["release", "writing"],
+      },
+    ],
+    posted: [],
+  };
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [{ ...FAMILIAR, harness: "claude" }] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [] } }),
+  );
+  await page.route("**/api/board**", (route) => route.fulfill({ json: { ok: true, cards: [] } }));
+  await page.route("**/api/skills/local**", (route) => route.fulfill({ json: { ok: true, skills: [] } }));
+  await page.route("**/api/prompts**", async (route: Route) => {
+    const req = route.request();
+    if (req.method() === "POST") {
+      const body = req.postDataJSON() as Record<string, unknown>;
+      store.posted.push(body);
+      const id = String(body.name).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+      const prompt = {
+        id,
+        name: body.name,
+        description: body.description,
+        body: body.body,
+        source: "user",
+        tags: body.tags,
+      };
+      store.prompts = [...store.prompts.filter((p) => p.id !== id), prompt];
+      return route.fulfill({ json: { ok: true, prompt } });
+    }
+    if (req.method() === "DELETE") {
+      const id = new URL(req.url()).searchParams.get("id");
+      store.prompts = store.prompts.filter((p) => p.id !== id);
+      return route.fulfill({ json: { ok: true } });
+    }
+    return route.fulfill({ json: { ok: true, prompts: store.prompts } });
+  });
+  return store;
+}
+
+async function openHomeDraft(page: Page) {
+  await page.goto("/?mode=home");
+  const draft = page.getByRole("textbox", { name: "Ask anything" });
+  await expect(draft).toBeVisible({ timeout: 45_000 });
+  return draft;
+}
+
+test.describe("prompt templates", () => {
+  test("inserting a template selects the first placeholder; Tab cycles and accepts defaults", async ({ page }) => {
+    await seed(page);
+    const draft = await openHomeDraft(page);
+
+    // Insert via the /prompt picker.
+    await draft.fill("/prompt release");
+    await page.getByRole("option", { name: /Release notes/ }).first().click();
+
+    // The body lands with the first token — the defaulted one — selected.
+    await expect(draft).toHaveValue(/Draft release notes since \{\{last release\|the last tag\}\}\. Group by \{\{area\}\}\./);
+    const firstSel = await draft.evaluate((el: HTMLTextAreaElement) =>
+      el.value.slice(el.selectionStart, el.selectionEnd),
+    );
+    expect(firstSel).toBe("{{last release|the last tag}}");
+
+    // Tab on the selected defaulted token accepts the default, then jumps to
+    // the next placeholder.
+    await draft.press("Tab");
+    await expect(draft).toHaveValue(/Draft release notes since the last tag\. Group by \{\{area\}\}\./);
+    const nextSel = await draft.evaluate((el: HTMLTextAreaElement) =>
+      el.value.slice(el.selectionStart, el.selectionEnd),
+    );
+    expect(nextSel).toBe("{{area}}");
+
+    // Typing replaces the selected token; Tab with no tokens left falls
+    // through to native focus-move (draft unchanged, blur off the textarea).
+    await page.keyboard.type("area");
+    await expect(draft).toHaveValue("Draft release notes since the last tag. Group by area.");
+  });
+
+  test("Save draft as template round-trips and re-scans the picker", async ({ page }) => {
+    const store = await seed(page);
+    const draft = await openHomeDraft(page);
+    await draft.fill("Summarize {{topic}} for {{audience|the team}}.");
+
+    // Options → Save draft as template…
+    await page.getByRole("button", { name: "Composer options" }).click();
+    await page.getByRole("button", { name: "Save draft as template…" }).click();
+
+    // Fill the form and save.
+    const nameField = page.getByRole("textbox", { name: "Name" });
+    await expect(nameField).toBeVisible();
+    await nameField.fill("Standup update");
+    await page.getByRole("button", { name: "Save template" }).click();
+
+    // The POST carried the draft body + name; the modal closed.
+    await expect(() => {
+      expect(store.posted.at(-1)?.name).toBe("Standup update");
+      expect(String(store.posted.at(-1)?.body)).toContain("{{topic}}");
+    }).toPass({ timeout: 10_000 });
+    await expect(nameField).toBeHidden();
+
+    // The refresh event re-scanned: the new template shows in the /prompt picker.
+    await draft.fill("/prompt standup");
+    await expect(page.getByRole("option", { name: /Standup update/ })).toBeVisible({ timeout: 10_000 });
+  });
+});


### PR DESCRIPTION
## What

PR B of the prompt-stack plan: makes prompt templates first-class. Placeholders become a Tab-cycling flow, templates gain favorites/recents/tags in the pickers, and users can save/edit/delete their own templates from the app.

## How

- **Placeholder engine** (`src/lib/prompt-placeholders.ts`): `{{name}}` / `{{name|default}}` grammar, stateless spans derived from the live textarea on every keypress. `handlePlaceholderTab` wires into both composer keydowns **after** the inline menus (they own Tab-complete while open) and only consumes Tab when a token exists — so native focus-move survives for a11y. Tab selects/cycles tokens (Shift+Tab reverses, both wrapping); Tab on a selected defaulted token accepts the default then jumps onward. `promptInsertion` and the `/prompt` filter now use the shared grammar (defaulted first tokens select whole; `p.tags` participate in filtering).
- **Prefs** (`src/lib/prompt-prefs.ts`): localStorage favorites + MRU recents (cap 8), pure `orderPrompts` (favorites > recents > scan order) + `promptTags`. The picker hook ranks options by prefs, records inserts as recents, and re-scans on a `cave:prompts-refresh` window event.
- **Manage**: `/api/prompts` grows **POST** + **DELETE** — desktop-only (`isLocalOrigin`), slug-confined (the `/^[a-z0-9][a-z0-9-]{0,63}$/` regex is the *only* path component, so no traversal), atomic writes, round-trip-verified through `scanPromptsDir`. `serializePromptTemplate` mirrors `scripts/sync-marketplace.py`. New `SaveTemplateModal` (save-as-template / edit / duplicate) and a "Save draft as template…" action in both composers' Options menu (disabled on empty draft). The snippets modal gains tag filter chips, favorite bookmarks, user-row edit/delete (via the shared `ConfirmDialog`), and duplicate-to-my-templates for builtin/pack rows with a muted origin chip.

## Verification

- `pnpm typecheck`, `node scripts/check-tests-wired.mjs` (787 files), and `node scripts/run-tests.mjs app api` (715 files) all green.
- New tests: `prompt-placeholders.test.ts` + `prompt-prefs.test.ts` (executable — spans/wrap/accept-default/Tab fall-through; ordering/MRU/storage guards); `prompts/route.test.ts` (serialize→scan round-trip, slug confinement incl. traversal shapes, 403/400/409); `prompt-snippets-modal.test.ts`; `slash-prompt.test.ts` extended (defaulted-token selection, tag filter, keydown-order pins, recents recording). New daemon-less e2e `tests/prompt-templates.spec.ts` (Tab cycle + default-accept; save round-trip + live re-scan) — 2/2 pass.
- Live screenshots verified the snippets manager (tag chips, favorites, per-source actions) and the edit form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)