### PR TITLE
feat(marketplace): browsable prompt packs — real previews, Try it, prompt-pack-shipping, docs (cave-1f9h)

### DIFF
--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -81,6 +81,10 @@ The Marketplace surface lives as a **Marketplace** tab on the Roles page. Beyond
 
 All package-id → filesystem-path lookups go through the path-injection-safe `resolveCatalogName` in `src/app/api/marketplace/config/catalog-config.ts` — any new route that reads a manifest by id must reuse it.
 
+## Prompt packs
+
+Packs whose capability is `prompts` ship reusable composer templates. The detail pane previews each template (icon, description, body snippet, tags) via `GET /api/marketplace/pack-prompts?id=<pack>` — which works pre-install — and offers a **Try it** that hands the body to the Home composer. See [`prompt-packs.md`](prompt-packs.md) for the file format, the `{{placeholder|default}}` grammar and Tab flow, precedence rules, and how to author a pack.
+
 ## Deferred / future work
 
 Captured for later (not yet built):

--- a/docs/prompt-packs.md
+++ b/docs/prompt-packs.md
@@ -1,0 +1,117 @@
+# Prompt packs & templates
+
+Prompt **templates** are reusable starter prompts you drop into a composer and
+edit before sending. They come from three places, merged by id (later wins):
+
+1. **Built-ins** — `src/lib/prompt-defaults.ts`, always present, even offline.
+2. **Marketplace prompt packs** — `marketplace/plugins/<pack>/prompts/*.md`,
+   resolved at scan time once the pack is tracked-installed (install is
+   track-only; the files ship in the repo).
+3. **Your own templates** — `~/.coven/prompts/*.md`, saved from the app.
+
+Merge precedence is **user > pack > built-in**, so you can retune a shipped
+template by saving one under the same id without forking it.
+
+## File format
+
+One template per `.md` file. YAML frontmatter + a body that is dropped into the
+composer verbatim:
+
+```markdown
+---
+name: Launch release notes
+description: Turn merges into benefit-led, user-facing launch notes.
+icon: ph:megaphone-bold
+tags:
+  - release
+  - writing
+---
+
+Write launch release notes for {{product|the app}} covering the changes since
+{{last release|the last tag}}. Group items by user-facing area…
+```
+
+- **Filename is the id.** `release-notes-launch.md` → id `release-notes-launch`.
+  Ids must be unique across every pack and the built-ins (the merge is by id).
+- `name` (falls back to the id), `description`, `icon` (a Phosphor name from the
+  curated set — invalid names fall back to a default glyph), and `tags` are all
+  optional. Tags power the picker's filter chips and match the `/prompt` search.
+- A file with frontmatter but **no body** is skipped — there is nothing to
+  insert.
+
+## Placeholders & the Tab flow
+
+Wrap the parts to fill in as placeholders:
+
+- `{{name}}` — a plain placeholder.
+- `{{name|default}}` — a placeholder with a default value.
+
+When you insert a template, the **first** placeholder is selected so typing
+replaces it. **Tab** jumps to the next placeholder (wrapping), **Shift+Tab**
+reverses, and **Tab on a selected `{{name|default}}`** accepts the default text
+then jumps onward. Tab only does this while the draft still has placeholders —
+once they're all filled, Tab returns to its normal focus-move behavior. Any
+placeholder you don't replace stays literal, so a half-filled template is never
+destructive.
+
+## Authoring a pack
+
+Packs are generated from the seed catalog — never hand-edit the generated files
+under `marketplace/plugins/`.
+
+1. Add a plugin entry to `marketplace/catalog.json` with a `prompts` array. Each
+   entry is `{ id, name, description?, icon?, tags?, body }`:
+
+   ```json
+   {
+     "name": "prompt-pack-shipping",
+     "displayName": "Prompt Pack: Shipping",
+     "version": "0.1.0",
+     "description": "Release, review, and team-ritual prompts…",
+     "category": "Productivity",
+     "capabilities": ["prompts"],
+     "trust": "official-local",
+     "prompts": [
+       {
+         "id": "standup-update",
+         "name": "Standup update",
+         "description": "A tight daily standup: done, next, blockers.",
+         "icon": "ph:chat-centered-text",
+         "tags": ["team", "meeting"],
+         "body": "Write my standup for {{team|the team}}. Blockers: {{blockers|none}}."
+       }
+     ]
+   }
+   ```
+
+   Pick ids that don't collide with the built-ins or another pack. A pack whose
+   only capability is `prompts` is classified as a **prompt pack** (`kind:
+   "prompt"`) automatically.
+
+2. Regenerate:
+
+   ```bash
+   python3 scripts/sync-marketplace.py
+   ```
+
+   This writes `marketplace/plugins/<pack>/prompts/<id>.md` and refreshes
+   `marketplace/marketplace.json`. `serializePromptTemplate`
+   (`src/lib/server/prompt-file.ts`) emits the exact same shape when a user
+   saves a template from the app, so packs and user files round-trip identically
+   through `scanPromptsDir`.
+
+## How packs surface in Cave
+
+- **Detail previews.** The marketplace detail pane lists each template as a card
+  — icon, name, description, a two-line body snippet, and tag pills — fetched
+  from `GET /api/marketplace/pack-prompts?id=<pack>`. That route works
+  **pre-install** (read-only; the id only selects a catalog entry via the shared
+  `resolveCatalogName`, and the path is built from the entry's own name).
+- **Try it.** Each preview card has a ghost **Try it** that writes the template
+  body into the Home composer draft and navigates Home, where the placeholder
+  Tab flow picks up immediately — no install required.
+- **After install.** Tracked-installed packs are merged by `/api/prompts`, so
+  their templates appear in every composer's `/prompt` picker and the **Prompt
+  snippets** manager alongside the built-ins and your own saved templates.
+
+See also [`marketplace.md`](marketplace.md) for the broader catalog/sync model.

--- a/marketplace/catalog.json
+++ b/marketplace/catalog.json
@@ -5355,6 +5355,84 @@
           "body": "Draft release notes from the merges since {{last release}}. Group by user-facing area, lead each item with the benefit, and keep internal-only changes in a short footnote section."
         }
       ]
+    },
+    {
+      "name": "prompt-pack-shipping",
+      "displayName": "Prompt Pack: Shipping",
+      "version": "0.1.0",
+      "description": "Release, review, and team-ritual prompts — launch notes, detailed PRs, bug repros, standups, retros. Showcases multi-placeholder templates with defaults. Installed templates appear under /prompts and the Prompt snippets picker.",
+      "category": "Productivity",
+      "keywords": [
+        "prompts",
+        "templates",
+        "release",
+        "team",
+        "review"
+      ],
+      "capabilities": [
+        "prompts"
+      ],
+      "sourceRefs": [
+        "https://github.com/OpenCoven/coven-cave"
+      ],
+      "trust": "official-local",
+      "prompts": [
+        {
+          "id": "release-notes-launch",
+          "name": "Launch release notes",
+          "description": "Turn merges into benefit-led, user-facing launch notes.",
+          "icon": "ph:megaphone-bold",
+          "tags": [
+            "release",
+            "writing"
+          ],
+          "body": "Write launch release notes for {{product|the app}} covering the changes since {{last release|the last tag}}. Group items by user-facing area, lead each with the benefit (not the implementation), and keep internal-only changes in a short footnote. Audience: {{audience|end users}}."
+        },
+        {
+          "id": "pr-description-detailed",
+          "name": "Detailed PR description",
+          "description": "A thorough, reviewer-ready PR writeup with verification and risk.",
+          "icon": "ph:note-pencil",
+          "tags": [
+            "git",
+            "review"
+          ],
+          "body": "Draft a detailed pull request description for {{branch|the current branch}}.\n\n## What changed\n{{summary}}\n\n## Why\n{{motivation}}\n\n## How it was verified\n{{verification|tests + manual check}}\n\n## Risk & follow-ups\nCall out anything reviewers should look at closely and anything deliberately left out."
+        },
+        {
+          "id": "bug-repro",
+          "name": "Bug repro report",
+          "description": "Turn a vague bug into a crisp, reproducible report.",
+          "icon": "ph:list-checks-bold",
+          "tags": [
+            "debugging",
+            "quality"
+          ],
+          "body": "Write a reproducible bug report for {{the bug}}.\n\n- Steps to reproduce (numbered, from a clean state)\n- Expected vs actual\n- Environment: {{environment|latest build}}\n- Evidence: logs, screenshots, or a failing test\n- Suspected area: {{suspected area|unknown}}"
+        },
+        {
+          "id": "standup-update",
+          "name": "Standup update",
+          "description": "A tight daily standup: done, next, blockers.",
+          "icon": "ph:chat-centered-text",
+          "tags": [
+            "team",
+            "meeting"
+          ],
+          "body": "Write my standup update for {{team|the team}}.\n\n- Yesterday: {{done}}\n- Today: {{plan}}\n- Blockers: {{blockers|none}}\n\nKeep it to a few lines and lead with anything that needs someone else."
+        },
+        {
+          "id": "retro-notes",
+          "name": "Retro notes",
+          "description": "Structure a retrospective into keep / drop / try actions.",
+          "icon": "ph:book-open",
+          "tags": [
+            "team",
+            "meeting"
+          ],
+          "body": "Summarize the retro for {{sprint or period}} into clear sections:\n\n- What went well (keep)\n- What didn't (drop)\n- What to try next (with an owner each)\n\nSource material: {{notes|the discussion above}}. End with the top 3 action items."
+        }
+      ]
     }
   ]
 }

--- a/marketplace/exports/codex/marketplace.json
+++ b/marketplace/exports/codex/marketplace.json
@@ -1419,6 +1419,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Productivity"
+    },
+    {
+      "name": "prompt-pack-shipping",
+      "source": {
+        "source": "local",
+        "path": "../../plugins/prompt-pack-shipping"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
     }
   ]
 }

--- a/marketplace/marketplace.json
+++ b/marketplace/marketplace.json
@@ -1775,6 +1775,21 @@
       },
       "trust": "official-local",
       "roleAffinity": []
+    },
+    {
+      "name": "prompt-pack-shipping",
+      "displayName": "Prompt Pack: Shipping",
+      "category": "Productivity",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prompt-pack-shipping"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "trust": "official-local",
+      "roleAffinity": []
     }
   ]
 }

--- a/marketplace/plugins/prompt-pack-shipping/.codex-plugin/plugin.json
+++ b/marketplace/plugins/prompt-pack-shipping/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "prompt-pack-shipping",
+  "version": "0.1.0",
+  "description": "Release, review, and team-ritual prompts \u2014 launch notes, detailed PRs, bug repros, standups, retros. Showcases multi-placeholder templates with defaults. Installed templates appear under /prompts and the Prompt snippets picker.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prompt Pack: Shipping",
+    "shortDescription": "Release, review, and team-ritual prompts \u2014 launch notes, detailed PRs, bug repros, standups, retros. Showcases multi-placeholder templates with defaults. Installed templates appear under /prompts and the Prompt snippets picker.",
+    "longDescription": "Release, review, and team-ritual prompts \u2014 launch notes, detailed PRs, bug repros, standups, retros. Showcases multi-placeholder templates with defaults. Installed templates appear under /prompts and the Prompt snippets picker.",
+    "developerName": "OpenCoven",
+    "category": "Productivity",
+    "capabilities": [
+      "prompts",
+      "templates",
+      "release",
+      "team",
+      "review"
+    ],
+    "defaultPrompt": "Help me use Prompt Pack: Shipping safely."
+  }
+}

--- a/marketplace/plugins/prompt-pack-shipping/plugin.json
+++ b/marketplace/plugins/prompt-pack-shipping/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "prompt-pack-shipping",
+  "version": "0.1.0",
+  "description": "Release, review, and team-ritual prompts \u2014 launch notes, detailed PRs, bug repros, standups, retros. Showcases multi-placeholder templates with defaults. Installed templates appear under /prompts and the Prompt snippets picker.",
+  "author": {
+    "name": "OpenCoven"
+  },
+  "homepage": "https://opencoven.ai",
+  "repository": "https://github.com/OpenCoven/coven-cave",
+  "license": "GPL-3.0",
+  "keywords": [
+    "prompts",
+    "templates",
+    "release",
+    "team",
+    "review"
+  ],
+  "capabilities": [
+    "prompts"
+  ],
+  "marketplaceId": "opencoven/prompt-pack-shipping",
+  "x-coven": {
+    "displayName": "Prompt Pack: Shipping",
+    "category": "Productivity",
+    "trust": "official-local",
+    "sourceRefs": [
+      "https://github.com/OpenCoven/coven-cave"
+    ],
+    "roleAffinity": [],
+    "compatibility": {
+      "covenCave": true,
+      "covenCode": true,
+      "codex": true,
+      "mcp": false,
+      "rolePatch": false
+    }
+  },
+  "prompts": [
+    "release-notes-launch",
+    "pr-description-detailed",
+    "bug-repro",
+    "standup-update",
+    "retro-notes"
+  ]
+}

--- a/marketplace/plugins/prompt-pack-shipping/prompts/bug-repro.md
+++ b/marketplace/plugins/prompt-pack-shipping/prompts/bug-repro.md
@@ -1,0 +1,16 @@
+---
+name: Bug repro report
+description: Turn a vague bug into a crisp, reproducible report.
+icon: ph:list-checks-bold
+tags:
+  - debugging
+  - quality
+---
+
+Write a reproducible bug report for {{the bug}}.
+
+- Steps to reproduce (numbered, from a clean state)
+- Expected vs actual
+- Environment: {{environment|latest build}}
+- Evidence: logs, screenshots, or a failing test
+- Suspected area: {{suspected area|unknown}}

--- a/marketplace/plugins/prompt-pack-shipping/prompts/pr-description-detailed.md
+++ b/marketplace/plugins/prompt-pack-shipping/prompts/pr-description-detailed.md
@@ -1,0 +1,22 @@
+---
+name: Detailed PR description
+description: A thorough, reviewer-ready PR writeup with verification and risk.
+icon: ph:note-pencil
+tags:
+  - git
+  - review
+---
+
+Draft a detailed pull request description for {{branch|the current branch}}.
+
+## What changed
+{{summary}}
+
+## Why
+{{motivation}}
+
+## How it was verified
+{{verification|tests + manual check}}
+
+## Risk & follow-ups
+Call out anything reviewers should look at closely and anything deliberately left out.

--- a/marketplace/plugins/prompt-pack-shipping/prompts/release-notes-launch.md
+++ b/marketplace/plugins/prompt-pack-shipping/prompts/release-notes-launch.md
@@ -1,0 +1,10 @@
+---
+name: Launch release notes
+description: Turn merges into benefit-led, user-facing launch notes.
+icon: ph:megaphone-bold
+tags:
+  - release
+  - writing
+---
+
+Write launch release notes for {{product|the app}} covering the changes since {{last release|the last tag}}. Group items by user-facing area, lead each with the benefit (not the implementation), and keep internal-only changes in a short footnote. Audience: {{audience|end users}}.

--- a/marketplace/plugins/prompt-pack-shipping/prompts/retro-notes.md
+++ b/marketplace/plugins/prompt-pack-shipping/prompts/retro-notes.md
@@ -1,0 +1,16 @@
+---
+name: Retro notes
+description: Structure a retrospective into keep / drop / try actions.
+icon: ph:book-open
+tags:
+  - team
+  - meeting
+---
+
+Summarize the retro for {{sprint or period}} into clear sections:
+
+- What went well (keep)
+- What didn't (drop)
+- What to try next (with an owner each)
+
+Source material: {{notes|the discussion above}}. End with the top 3 action items.

--- a/marketplace/plugins/prompt-pack-shipping/prompts/standup-update.md
+++ b/marketplace/plugins/prompt-pack-shipping/prompts/standup-update.md
@@ -1,0 +1,16 @@
+---
+name: Standup update
+description: A tight daily standup: done, next, blockers.
+icon: ph:chat-centered-text
+tags:
+  - team
+  - meeting
+---
+
+Write my standup update for {{team|the team}}.
+
+- Yesterday: {{done}}
+- Today: {{plan}}
+- Blockers: {{blockers|none}}
+
+Keep it to a few lines and lead with anything that needs someone else.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -178,6 +178,7 @@ export const SUITES = {
     "src/components/home-composer.test.ts",
     "src/components/composer-enhance.test.ts",
     "src/components/prompt-snippets-modal.test.ts",
+    "src/components/marketplace/marketplace-detail.test.ts",
     "src/components/home-digest-carousel.test.ts",
     "src/components/home-needs-you.test.ts",
     "src/components/home-feed.test.ts",
@@ -633,6 +634,7 @@ export const SUITES = {
     "src/app/api/chat/model-state/route.test.ts",
     "src/app/api/prompt/enhance/route.test.ts",
     "src/app/api/prompts/route.test.ts",
+    "src/app/api/marketplace/pack-prompts-route.test.ts",
     "src/app/api/app/latest-release/route.test.ts",
     "src/app/api/opencoven-tools/status/route.test.ts",
     "src/app/api/daemon/status/route.test.ts",
@@ -836,6 +838,7 @@ const STRIP_TYPES_MJS = new Set([
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
   "src/app/api/prompts/route.test.ts",
+  "src/app/api/marketplace/pack-prompts-route.test.ts",
   "src/lib/cave-backdrop.test.ts",
   "src/lib/wiki-link-parser.test.ts",
   "src/lib/wiki-link-resolve.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -101,6 +101,7 @@ const contracts: RouteContract[] = [
   { route: "/mcp", methods: ["GET"], kind: "json" },
   { route: "/marketplace", methods: ["GET"], kind: "json" },
   { route: "/marketplace/install", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/marketplace/pack-prompts", methods: ["GET"], kind: "json" },
   { route: "/marketplace/uninstall", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/config", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/marketplace/config/validate", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/marketplace/install/route.ts
+++ b/src/app/api/marketplace/install/route.ts
@@ -10,32 +10,12 @@ import { NextResponse } from "next/server";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { installMarketplacePlugin } from "@/lib/cave-config";
-import { sanitizeMarketplacePlugins, type MarketplaceJsonPlugin } from "@/lib/marketplace-catalog";
+import { resolveCatalogName } from "@/lib/server/marketplace-catalog-resolve";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
-
-/**
- * Resolve the user-provided id to the matching catalog entry's OWN name string
- * (sourced from the trusted marketplace.json, not the request). Returns null
- * when the id is not in the catalog. Downstream filesystem paths are built from
- * this file-derived name — the request value only selects from the allowlist,
- * it never constructs a path (avoids js/path-injection).
- */
-async function resolveCatalogName(id: string): Promise<string | null> {
-  try {
-    const raw = JSON.parse(await readFile(path.join(MARKETPLACE_DIR, "marketplace.json"), "utf8"));
-    const plugins = sanitizeMarketplacePlugins(
-      raw && Array.isArray(raw.plugins) ? (raw.plugins as MarketplaceJsonPlugin[]) : [],
-    );
-    const match = plugins.find((p: { name?: string }) => p.name === id);
-    return match && typeof match.name === "string" ? match.name : null;
-  } catch {
-    return null;
-  }
-}
 
 async function pluginVersion(name: string): Promise<string> {
   try {

--- a/src/app/api/marketplace/pack-prompts-route.test.ts
+++ b/src/app/api/marketplace/pack-prompts-route.test.ts
@@ -1,0 +1,73 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { scanPromptsDir } from "../../../lib/server/prompt-scan.ts";
+
+// Marketplace prompt-pack previews (cave-1f9h). The route itself is thin
+// (resolveCatalogName → scanPromptsDir), so these tests exercise the real
+// pack files on disk: every shipped pack parses, the shipping pack is present
+// with multi-placeholder + defaulted bodies, and NO prompt id collides across
+// packs or the built-ins (the merge is by id, so a collision would silently
+// shadow a template).
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../../../..");
+const pluginsDir = path.join(repoRoot, "marketplace", "plugins");
+
+// ── Route source pins ────────────────────────────────────────────────────────
+const routeSrc = await readFile(new URL("./pack-prompts/route.ts", import.meta.url), "utf8");
+assert.match(routeSrc, /export async function GET/, "pack-prompts exposes GET");
+assert.match(routeSrc, /resolveCatalogName\(id\)/, "the id is resolved against the catalog allowlist");
+assert.match(routeSrc, /return NextResponse\.json\(\{ ok: false[\s\S]{0,80}?status: 400/, "an unknown id is a 400");
+assert.match(routeSrc, /scanPromptsDir\(path\.join\(pluginDir\(name\), "prompts"\)/, "scans the resolved pack's prompts dir");
+assert.doesNotMatch(routeSrc, /isLocalOrigin/, "read-only preview needs no local-origin gate");
+
+// ── Every shipped pack's prompts parse ───────────────────────────────────────
+const packNames = (await readdir(pluginsDir, { withFileTypes: true }))
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name);
+
+const idOwners = new Map(); // prompt id → first source that claimed it
+let totalPromptFiles = 0;
+for (const name of packNames) {
+  const scanned = [];
+  await scanPromptsDir(path.join(pluginsDir, name, "prompts"), `pack:${name}`, scanned);
+  for (const p of scanned) {
+    totalPromptFiles += 1;
+    assert.ok(p.body.trim().length > 0, `${name}/${p.id} has a body`);
+    // Collision check across packs.
+    if (idOwners.has(p.id)) {
+      assert.fail(`prompt id "${p.id}" is shared by ${idOwners.get(p.id)} and pack:${name}`);
+    }
+    idOwners.set(p.id, `pack:${name}`);
+  }
+}
+assert.ok(totalPromptFiles > 0, "at least one pack ships prompt templates");
+
+// ── No pack id collides with a built-in ──────────────────────────────────────
+const defaultsSrc = await readFile(new URL("../../../lib/prompt-defaults.ts", import.meta.url), "utf8");
+const builtinIds = [...defaultsSrc.matchAll(/id:\s*"([^"]+)"/g)].map((m) => m[1]);
+assert.ok(builtinIds.length >= 3, "found the built-in ids");
+for (const id of builtinIds) {
+  assert.ok(!idOwners.has(id), `built-in id "${id}" must not collide with pack ${idOwners.get(id)}`);
+}
+
+// ── The shipping pack (this PR) is present and showcases placeholders ─────────
+const shipping = [];
+await scanPromptsDir(path.join(pluginsDir, "prompt-pack-shipping", "prompts"), "pack:prompt-pack-shipping", shipping);
+assert.ok(shipping.length >= 5, "prompt-pack-shipping ships its five templates");
+const byId = Object.fromEntries(shipping.map((p) => [p.id, p]));
+for (const id of ["release-notes-launch", "pr-description-detailed", "bug-repro", "standup-update", "retro-notes"]) {
+  assert.ok(byId[id], `shipping pack includes ${id}`);
+}
+// Distinct from the essentials pack's ids (no release-notes / pr-description clash).
+assert.ok(!byId["release-notes"], "shipping uses release-notes-launch, not release-notes");
+assert.ok(!byId["pr-description"], "shipping uses pr-description-detailed, not pr-description");
+// Multi-placeholder with defaults is the pack's showcase.
+assert.match(byId["standup-update"].body, /\{\{team\|the team\}\}/, "standup shows a defaulted placeholder");
+assert.match(byId["standup-update"].body, /\{\{blockers\|none\}\}/, "standup has a second defaulted placeholder");
+assert.match(byId["release-notes-launch"].body, /\{\{last release\|the last tag\}\}/, "launch notes carry a defaulted token");
+
+console.log("pack-prompts-route.test.ts: ok");

--- a/src/app/api/marketplace/pack-prompts/route.ts
+++ b/src/app/api/marketplace/pack-prompts/route.ts
@@ -1,0 +1,32 @@
+/**
+ * GET /api/marketplace/pack-prompts?id=<pluginId>
+ *
+ * Prompt-pack previews for the marketplace detail pane (cave-1f9h). Resolves
+ * the id against the catalog allowlist (shared resolveCatalogName — the id
+ * only SELECTS an entry, the path is built from the entry's own name), then
+ * scans marketplace/plugins/<name>/prompts and returns each template's full
+ * metadata + body so the client can render real cards and a "Try it".
+ *
+ * Read-only and works pre-install (the pack files ship in the repo; install is
+ * track-only). Not a mutation, so no local-origin gate.
+ */
+
+import { NextResponse } from "next/server";
+import path from "node:path";
+import { pluginDir, resolveCatalogName } from "@/lib/server/marketplace-catalog-resolve";
+import { scanPromptsDir } from "@/lib/server/prompt-scan";
+import type { PromptOption } from "@/lib/slash-prompt";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const id = new URL(req.url).searchParams.get("id") ?? "";
+  const name = await resolveCatalogName(id);
+  if (!name) {
+    return NextResponse.json({ ok: false, error: `unknown plugin "${id}"` }, { status: 400 });
+  }
+  const prompts: PromptOption[] = [];
+  await scanPromptsDir(path.join(pluginDir(name), "prompts"), `pack:${name}`, prompts);
+  return NextResponse.json({ ok: true, prompts });
+}

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -34,7 +34,7 @@ import { useAutogrowTextarea } from "@/lib/use-autogrow-textarea";
 import { handlePlaceholderTab } from "@/lib/prompt-placeholders";
 import { recordPromptRecent } from "@/lib/prompt-prefs";
 import { SaveTemplateModal } from "@/components/save-template-modal";
-import { readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
+import { HOME_DRAFT_KEY, readComposerDraft, useDraftPersistence } from "@/lib/use-composer-draft";
 import { useComposerHistory } from "@/lib/use-composer-history";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
 import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
@@ -120,7 +120,6 @@ type Props = {
 
 // Persist the in-progress prompt so a page reload doesn't eat what you were
 // typing on the home screen (mirrors the chat composer's draft persistence).
-const HOME_DRAFT_KEY = "cave:home-composer-draft:v1";
 const HOME_DRAFT_WRITE_DELAY_MS = 250;
 // Persisted ↑/↓ prompt-history recall stack for the home composer.
 const HOME_HISTORY_KEY = "cave:home-composer-history:v1";

--- a/src/components/marketplace/marketplace-detail.test.ts
+++ b/src/components/marketplace/marketplace-detail.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Marketplace prompt-pack previews + Try-it (cave-1f9h). The detail pane
+// replaces bare template-id chips with real preview cards fetched from
+// /api/marketplace/pack-prompts (works pre-install), and each card's "Try it"
+// hands the body to the Home composer. Source pins — the fetch/render/nav
+// wiring and the fallback that keeps the section from going blank.
+
+const source = await readFile(new URL("./marketplace-detail.tsx", import.meta.url), "utf8");
+
+// ── Previews replace bare ids ────────────────────────────────────────────────
+assert.match(
+  source,
+  /<PackPromptPreviews pluginId=\{plugin\.id\} fallbackIds=\{plugin\.prompts\}/,
+  "the prompt-templates section renders preview cards, not bare id chips",
+);
+assert.match(
+  source,
+  /fetch\(`\/api\/marketplace\/pack-prompts\?id=\$\{encodeURIComponent\(pluginId\)\}`/,
+  "previews are fetched from the pack-prompts route (works pre-install)",
+);
+assert.match(source, /line-clamp-2/, "a two-line body snippet previews the template");
+assert.match(source, /promptIconName\(p\.icon\)/, "card icons are validated against the curated set");
+assert.match(
+  source,
+  /p\.tags\?\.length \?[\s\S]{0,200}?rounded-full/,
+  "tags render as pills on the card",
+);
+
+// ── Fallback keeps the section from going blank ──────────────────────────────
+assert.match(
+  source,
+  /if \(failed \|\| !prompts\?\.length\) \{[\s\S]{0,400}?fallbackIds\.map/,
+  "a failed fetch falls back to the bare catalog ids (never a blank section)",
+);
+
+// ── Try it → Home composer draft + navigate ──────────────────────────────────
+assert.match(
+  source,
+  /writeComposerDraft\(HOME_DRAFT_KEY, body\)/,
+  "Try it writes the template body into the Home composer draft slot",
+);
+assert.match(
+  source,
+  /new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "home" \} \}\)/,
+  "Try it navigates Home so the placeholder Tab flow picks up on arrival",
+);
+assert.match(
+  source,
+  /onClick=\{\(\) => onTry\(p\.body\)\}>Try it/,
+  "each preview card exposes a Try it action bound to its body",
+);
+assert.match(
+  source,
+  /onClose\(\);/,
+  "Try it closes the detail before navigating",
+);
+
+// ── Route reuses the shared catalog resolver ─────────────────────────────────
+const route = await readFile(new URL("../../app/api/marketplace/pack-prompts/route.ts", import.meta.url), "utf8");
+assert.match(route, /resolveCatalogName\(id\)/, "the route resolves the id against the catalog allowlist");
+assert.match(route, /pluginDir\(name\)/, "the scan path is built from the resolved name, not the request id");
+
+// The install route now shares that resolver instead of its own copy.
+const install = await readFile(new URL("../../app/api/marketplace/install/route.ts", import.meta.url), "utf8");
+assert.match(
+  install,
+  /import \{ resolveCatalogName \} from "@\/lib\/server\/marketplace-catalog-resolve"/,
+  "install route reuses the extracted resolver (single allowlist source)",
+);
+assert.doesNotMatch(install, /async function resolveCatalogName/, "install route no longer defines its own resolver copy");
+
+console.log("marketplace-detail.test.ts: ok");

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import type { ReactNode } from "react";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { pluginBadgeState, type MarketplacePlugin } from "@/lib/marketplace-catalog";
 import { openExternalUrl } from "@/lib/open-external";
+import { HOME_DRAFT_KEY, writeComposerDraft } from "@/lib/use-composer-draft";
+import { promptIconName } from "@/components/prompt-snippets-modal";
+import type { PromptOption } from "@/lib/slash-prompt";
+
+type PackPrompt = PromptOption;
 
 const TRUST_LABEL: Record<string, string> = {
   "official-remote": "Official remote",
@@ -118,6 +123,20 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
     }
   }, [plugin.id]);
   useFocusTrap(true, ref, { onEscape: onClose });
+
+  // "Try it" hands the template body to the Home composer: write its draft
+  // slot, close the detail, and navigate Home. Race-free — Home reads the
+  // draft at mount and it is unmounted while the marketplace shows, so there
+  // is no live composer to clobber; Tab-cycling picks up any placeholders on
+  // arrival (cave-1f9h).
+  const handleTryPrompt = useCallback(
+    (body: string) => {
+      writeComposerDraft(HOME_DRAFT_KEY, body);
+      onClose();
+      window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "home" } }));
+    },
+    [onClose],
+  );
   const state = pluginBadgeState(plugin);
   const decisionItems = detailDecisionItems(plugin);
   return (
@@ -190,11 +209,7 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
 
         {plugin.prompts?.length ? (
           <Section title="Prompt templates">
-            <div className="flex flex-wrap gap-1.5">
-              {plugin.prompts.map((p) => (
-                <span key={p} className="rounded-md border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)]">{p}</span>
-              ))}
-            </div>
+            <PackPromptPreviews pluginId={plugin.id} fallbackIds={plugin.prompts} onTry={handleTryPrompt} />
             <p className="mt-1.5 text-[12px] text-[var(--text-muted)]">
               Added templates appear in chat under /prompts and the Prompt snippets picker.
             </p>
@@ -288,6 +303,83 @@ export function MarketplaceDetail({ plugin, busy, onClose, onAdd, onRemove }: Pr
         </div>
       </div>
     </div>
+  );
+}
+
+/** Real previews for a pack's templates (cave-1f9h): fetched from
+ *  /api/marketplace/pack-prompts, which works pre-install. Falls back to the
+ *  bare catalog ids if the fetch fails, so the section never goes blank. */
+function PackPromptPreviews({
+  pluginId,
+  fallbackIds,
+  onTry,
+}: {
+  pluginId: string;
+  fallbackIds: string[];
+  onTry: (body: string) => void;
+}) {
+  const [prompts, setPrompts] = useState<PackPrompt[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    setPrompts(null);
+    setFailed(false);
+    fetch(`/api/marketplace/pack-prompts?id=${encodeURIComponent(pluginId)}`, { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (!alive) return;
+        if (j?.ok && Array.isArray(j.prompts)) setPrompts(j.prompts as PackPrompt[]);
+        else setFailed(true);
+      })
+      .catch(() => {
+        if (alive) setFailed(true);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [pluginId]);
+
+  if (prompts === null && !failed) {
+    return <p className="text-[12px] text-[var(--text-muted)]">Loading previews…</p>;
+  }
+  // Fetch failed → the bare-id chips (previous behavior), never a blank slate.
+  if (failed || !prompts?.length) {
+    return (
+      <div className="flex flex-wrap gap-1.5">
+        {fallbackIds.map((p) => (
+          <span key={p} className="rounded-md border border-[var(--border-hairline)] px-2 py-0.5 text-[11px] text-[var(--text-muted)]">{p}</span>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <ul className="flex flex-col gap-2">
+      {prompts.map((p) => (
+        <li
+          key={p.id}
+          className="flex items-start gap-3 rounded-lg border border-[var(--border-hairline)] p-2.5"
+        >
+          <Icon name={promptIconName(p.icon)} width={16} className="mt-0.5 shrink-0 text-[var(--text-muted)]" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="text-[13px] font-medium text-[var(--text-primary)]">{p.name}</p>
+            {p.description ? (
+              <p className="text-[12px] text-[var(--text-muted)]">{p.description}</p>
+            ) : null}
+            <p className="mt-1 line-clamp-2 text-[11px] leading-4 text-[var(--text-muted)]">{p.body}</p>
+            {p.tags?.length ? (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {p.tags.map((tag) => (
+                  <span key={tag} className="rounded-full border border-[var(--border-hairline)] px-1.5 text-[10px] text-[var(--text-muted)]">{tag}</span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => onTry(p.body)}>Try it</Button>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/lib/marketplace-catalog.test.ts
+++ b/src/lib/marketplace-catalog.test.ts
@@ -278,12 +278,19 @@ for (const plugin of sanitizedProductionCards) {
 }
 for (const [label, source] of [
   ["/api/marketplace", marketplaceRoute],
-  ["/api/marketplace/install", marketplaceInstallRoute],
   ["/api/marketplace/uninstall", marketplaceUninstallRoute],
   ["marketplace catalog-config", marketplaceCatalogConfig],
 ]) {
   assert.match(source, /sanitizeMarketplacePlugins/, `${label} should resolve ids through the familiar-safe marketplace catalog`);
 }
+// The install route delegates id-resolution to the shared, path-injection-safe
+// resolveCatalogName helper (which itself sanitizes the catalog), so it no
+// longer names sanitizeMarketplacePlugins directly (cave-1f9h).
+assert.match(
+  marketplaceInstallRoute,
+  /resolveCatalogName/,
+  "/api/marketplace/install should resolve ids through the shared catalog resolver",
+);
 
 // --- production prompt pack: card derives kind "prompt", template files exist ---
 const packCard = sanitizedProductionCards.find((p) => p.id === "prompt-pack-essentials");

--- a/src/lib/server/marketplace-catalog-resolve.ts
+++ b/src/lib/server/marketplace-catalog-resolve.ts
@@ -1,0 +1,33 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { sanitizeMarketplacePlugins, type MarketplaceJsonPlugin } from "@/lib/marketplace-catalog";
+
+// Shared catalog-id resolver (cave-1f9h). Extracted from the install route so
+// the install and pack-prompts routes agree on the allowlist. A request id
+// only ever SELECTS a catalog entry; the returned name is the entry's OWN
+// trusted string from marketplace.json — filesystem paths are built from that,
+// never from the request (avoids js/path-injection).
+
+const MARKETPLACE_DIR = path.join(process.cwd(), "marketplace");
+
+/** Resolve a user-provided id to the matching catalog entry's own name, or
+ *  null when the id is not in the catalog. */
+export async function resolveCatalogName(id: string): Promise<string | null> {
+  if (!id) return null;
+  try {
+    const raw = JSON.parse(await readFile(path.join(MARKETPLACE_DIR, "marketplace.json"), "utf8"));
+    const plugins = sanitizeMarketplacePlugins(
+      raw && Array.isArray(raw.plugins) ? (raw.plugins as MarketplaceJsonPlugin[]) : [],
+    );
+    const match = plugins.find((p: { name?: string }) => p.name === id);
+    return match && typeof match.name === "string" ? match.name : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Absolute path to an installed/catalog plugin's directory — built from the
+ *  file-derived name only. Callers MUST pass a name from resolveCatalogName. */
+export function pluginDir(name: string): string {
+  return path.join(MARKETPLACE_DIR, "plugins", name);
+}

--- a/src/lib/use-composer-draft.ts
+++ b/src/lib/use-composer-draft.ts
@@ -19,6 +19,10 @@ import { useCallback, useEffect } from "react";
  * otherwise the sent prompt resurrects as an unsent draft on return.
  */
 
+/** Home composer's draft key. Shared so surfaces that hand a prompt off to
+ *  Home (marketplace "Try it") write to the exact slot Home reads at mount. */
+export const HOME_DRAFT_KEY = "cave:home-composer-draft:v1";
+
 export function readComposerDraft(key: string): string {
   if (typeof window === "undefined") return "";
   try {


### PR DESCRIPTION
## What

PR C of the prompt-stack plan (final): makes marketplace prompt packs browsable. The detail pane replaces bare template-id chips with real preview cards and a "Try it" that hands the template to the Home composer — no install required. Ships a second curated pack and authoring docs.

## How

- **Preview API**: new `GET /api/marketplace/pack-prompts?id=<pack>` returns each template's full metadata + body. The catalog resolver is extracted from the install route into `src/lib/server/marketplace-catalog-resolve.ts` so install and previews share one allowlist — the request id only *selects* a catalog entry; the scan path is built from the entry's own trusted name (path-injection-safe). Read-only, works **pre-install** (pack files ship in the repo; install is track-only).
- **Detail previews + Try it** (`marketplace-detail.tsx`): each template renders as a card — icon, name, description, a two-line body snippet, tag pills — with a ghost **Try it**. Try-it writes the body into the Home composer draft (`HOME_DRAFT_KEY`, now exported from `use-composer-draft.ts`), closes the drawer, and navigates Home, where the placeholder Tab flow (PR B) picks up on arrival. Race-free: Home reads the draft at mount and is unmounted while the marketplace shows. A failed fetch falls back to the bare ids so the section never goes blank.
- **Second pack** `prompt-pack-shipping` (authored in `marketplace/catalog.json`, regenerated via `scripts/sync-marketplace.py`): launch release notes, detailed PR description, bug repro, standup, retro — distinct ids from essentials, showcasing multi-`{{name|default}}` placeholders.
- **Docs**: new `docs/prompt-packs.md` (file format, placeholder/default grammar + Tab behavior, precedence + id rules, pack authoring, how previews/Try-it surface), linked from `docs/marketplace.md`.

## Verification

- `pnpm typecheck`, `node scripts/check-tests-wired.mjs`, and `node scripts/run-tests.mjs app api` (718 files) all green.
- New tests: `pack-prompts-route.test.ts` (every shipped pack parses, **no prompt-id collisions** across packs or built-ins, shipping pack present with multi-placeholder/defaulted bodies, route resolves via the shared allowlist); `marketplace-detail.test.ts` (preview fetch, Try-it draft-write + navigate, blank-proof fallback, shared resolver reuse). `api-contracts` + `marketplace-catalog` pins updated for the new route and the extracted resolver.
- Live-verified: the shipping pack's detail pane shows real preview cards, and **Try it** landed the bug-repro template body — placeholders intact — in the Home composer, ready to Tab-cycle. Screenshots captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)