### PR TITLE
design(typography): adopt Coven canon — EB Garamond + Inter + JetBrains Mono

### DIFF
--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -66,7 +66,7 @@ color.
 - Radii: `--radius-control: 8px` · `--radius-card: 12px` ·
   `--radius-panel: 16px` · and the signature **999px pill** (§3).
 - Spacing: 4px grid (`--space-1` … `--space-10`).
-- Type: Geist Sans + JetBrains Mono; ladder `--text-2xs` (10px) →
+- Type: EB Garamond (display/hero) + Inter (body/UI) + JetBrains Mono (code/labels) — Coven canon per OpenCoven DESIGN.md §4. Geist stays in the selectable catalog but is no longer the shipped default. Ladder: `--text-2xs` (10px) →
   `--text-display` (28px); eyebrow tracking `0.08em` + uppercase for tiny
   labels.
 - Motion: `--duration-fast: 120ms` / `base: 180ms` / `slow: 260ms` with the

--- a/docs/typography-demo.html
+++ b/docs/typography-demo.html
@@ -1,140 +1,152 @@
 <!doctype html>
-<!--
-  Reading typography demo — open this file directly in a browser.
-
-  WHAT: a live, interactive demo of the reading-typography controls
-  (Settings → Appearance → Typography), shipped in v0.0.77. Use the control
-  bar to change each setting and watch it apply to the two prose surfaces.
-
-  HOW IT STAYS HONEST: it <link>s the REAL stylesheets from this repo
-  (../src/styles/cave-chat.css for the shared .cave-md surface, and
-  ../src/styles/library.css for the library overrides), so it never drifts
-  from production CSS. Keep it at docs/ (the relative paths assume it sits
-  one level above src/). The :root block below only supplies the handful of
-  theme color vars that normally come from globals.css — it sets no
-  typography values, so what you see is the real cascade.
-
-  The control bar mirrors src/lib/reading-*.ts: each control writes a
-  CSS var (or the data-reading-dropcap attribute) onto <html>, exactly as
-  applyReading*() does at runtime.
-
-  SCOPE NOTES:
-    • Drop cap is library-only by design (it targets
-      .library-preview-md.cave-md p:first-of-type::first-letter).
-    • The full library reader (.library-reader-body) is a separate,
-      intentionally-independent experience (Lora serif + its own A−/A+
-      size control); it does not follow these controls and isn't shown here.
--->
 <html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>CovenCave — Reading typography demo</title>
-<link rel="stylesheet" href="../src/styles/cave-chat.css">
-<link rel="stylesheet" href="../src/styles/library.css">
-<style>
-  /* Theme color vars normally provided by globals.css. No typography here. */
-  :root {
-    --foreground: #1b1726; --muted-foreground: #5d566f;
-    --text-primary: var(--foreground); --text-secondary: var(--muted-foreground);
-    --text-muted: #8a82a0; --bg-base: #faf8ff; --background: #faf8ff;
-    --border: #e3dcf0; --border-hairline: var(--border); --accent-presence: #6F62A8;
-  }
-  html, body { margin: 0; background: var(--background); }
-  .controls {
-    position: sticky; top: 0; z-index: 9; display: flex; flex-wrap: wrap; gap: 12px;
-    padding: 12px 44px; background: #fff; border-bottom: 1px solid var(--border);
-    font: 13px/1.2 system-ui, sans-serif; color: var(--text-secondary);
-  }
-  .controls label { display: flex; gap: 5px; align-items: center; }
-  .controls select { font: inherit; padding: 2px 4px; }
-  .controls button { font: inherit; padding: 3px 10px; cursor: pointer; }
-  .stage { padding: 32px 44px 64px; }
-  .surface-label {
-    font: 600 12px/1 system-ui, sans-serif; color: var(--accent-presence);
-    margin: 0 0 8px; text-transform: uppercase; letter-spacing: .08em;
-  }
-  .surface + .surface { margin-top: 40px; }
-</style>
-</head>
-<body>
-<div class="controls" id="controls"></div>
-<div class="stage">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OpenCoven Typography — Coven Canon</title>
+    <style>
+      /* Coven canonical fonts. Free / open-source on Google Fonts.
+         DESIGN.md §4: EB Garamond (display) · Inter (sans/UI) · JetBrains Mono (mono/code). */
+      @import url("https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&family=Inter:wght@100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap");
 
-  <section class="surface">
-    <p class="surface-label">Library reader — .library-preview-md.cave-md</p>
-    <div class="library-preview library-preview--full-canvas">
-      <article class="library-preview-md cave-md demo-prose"></article>
-    </div>
-  </section>
+      :root {
+        --oc-serif: "EB Garamond", "Iowan Old Style", Georgia, "Times New Roman", serif;
+        --oc-sans:  Inter, "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+        --oc-mono:  "JetBrains Mono", "SF Mono", SFMono-Regular, ui-monospace, Menlo, monospace;
+        --oc-bg: #0F0A14;
+        --oc-fg: #E8E4F5;
+        --oc-fg-2: #C5BDED;
+        --oc-fg-3: #7A6DAA;
+        --oc-violet: #9A8ECD;
+        --oc-violet-bright: #D4B5FF;
+        --oc-rule: rgba(154, 142, 205, 0.18);
+      }
 
-  <section class="surface">
-    <p class="surface-label">General reading surface — .cave-md (chat / memory)</p>
-    <article class="cave-md demo-prose"></article>
-  </section>
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; background: var(--oc-bg); color: var(--oc-fg); }
+      body { font-family: var(--oc-sans); font-size: 16px; line-height: 1.55; }
+      main { max-width: 760px; margin: 0 auto; padding: 88px 32px 128px; }
 
-</div>
+      /* — Display / brand — */
+      .display, h1, h2, h3 {
+        font-family: var(--oc-serif);
+        letter-spacing: -0.005em;
+        font-weight: 500;
+      }
+      h1 { font-size: clamp(48px, 6vw, 88px); line-height: 1.02; margin: 0 0 8px; color: var(--oc-violet); }
+      .kicker {
+        font-family: var(--oc-serif); font-style: italic; font-weight: 400;
+        font-size: 22px; line-height: 1.3; color: var(--oc-fg-2);
+        margin: 0 0 48px;
+      }
+      h2 { font-size: 36px; line-height: 1.1; margin: 64px 0 12px; color: var(--oc-fg); font-weight: 600; }
+      h3 { font-size: 22px; line-height: 1.2; margin: 32px 0 6px; color: var(--oc-fg); font-weight: 600; }
 
-<template id="prose">
-  <h1>The Cartographer's Confession</h1>
-  <p>Magnificently, and almost incomprehensibly, the old cartographer had spent
-  his entire life convinced that the territory could be flattened onto paper
-  without consequence. He believed, with an antidisestablishmentarian
-  stubbornness, that representation and reality were interchangeable — that a
-  sufficiently detailed map would eventually become indistinguishable from the
-  world it described.</p>
-  <p>But longitude is a liar and latitude keeps no promises. Each projection
-  distorts something — area, angle, distance, direction — and the cartographer,
-  who had internalized this mathematically unavoidable compromise, nonetheless
-  refused to acknowledge it aloud.</p>
-  <blockquote>All maps are arguments about what matters. The cartographer simply
-  forgot he was arguing.</blockquote>
-  <h2>What the margins recorded</h2>
-  <ul>
-    <li>Coastlines that rearranged themselves between surveys.</li>
-    <li>A peninsula that appeared only after particularly long, sleepless nights.</li>
-  </ul>
-  <p>This final paragraph should make every control plainly legible: leading,
-  tracking, alignment, weight, measure width, discretionary hyphenation of
-  <em>extraordinarily</em> long words, and — in the library reader alone — the
-  decorative drop capital that opens the very first paragraph above.</p>
-</template>
+      /* — UI / body — */
+      p { margin: 0 0 16px; max-width: 62ch; color: var(--oc-fg); }
+      p.lead { font-size: 18px; line-height: 1.6; color: var(--oc-fg-2); }
+      .eyebrow {
+        font-family: var(--oc-mono);
+        font-size: 12px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.16em;
+        color: var(--oc-violet);
+        margin: 0 0 12px;
+      }
 
-<script>
-  // Fill both prose surfaces from the shared template.
-  const tpl = document.getElementById("prose").content;
-  document.querySelectorAll(".demo-prose").forEach((el) => el.append(tpl.cloneNode(true)));
+      /* — Mono / code — */
+      code, pre, kbd, .mono {
+        font-family: var(--oc-mono);
+        font-feature-settings: "liga" 1, "calt" 1;
+      }
+      pre { background: rgba(255, 255, 255, 0.03); border: 1px solid var(--oc-rule); border-radius: 6px; padding: 16px; overflow-x: auto; margin: 0 0 24px; font-size: 13px; line-height: 1.55; }
+      code { color: var(--oc-fg-2); }
 
-  // Control bar — mirrors src/lib/reading-*.ts (var name + option→value map).
-  const r = document.documentElement;
-  const CONTROLS = [
-    ["leading",  "--cave-reading-leading",  [["normal","1.7"],["compact","1.45"],["relaxed","2"]]],
-    ["tracking", "--cave-reading-tracking", [["normal","0"],["wide","0.02em"],["wider","0.04em"]]],
-    ["weight",   "--cave-reading-weight",   [["normal","400"],["light","300"],["medium","500"]]],
-    ["width",    "--cave-reading-width",    [["full","none"],["medium","680px"],["narrow","560px"]]],
-    ["align",    "--cave-reading-align",    [["left","left"],["justify","justify"]]],
-    ["hyphens",  "--cave-reading-hyphens",  [["off","manual"],["on","auto"]]],
-    ["drop cap", "data-reading-dropcap",    [["off",""],["on","on"]], true],
-  ];
-  const bar = document.getElementById("controls");
-  for (const [name, prop, opts, isAttr] of CONTROLS) {
-    const sel = document.createElement("select");
-    for (const [text, val] of opts) {
-      const o = document.createElement("option"); o.textContent = text; o.value = val; sel.append(o);
-    }
-    sel.onchange = () => {
-      if (isAttr) sel.value ? r.setAttribute(prop, sel.value) : r.removeAttribute(prop);
-      else r.style.setProperty(prop, sel.value);
-    };
-    const lab = document.createElement("label"); lab.append(name + ": ", sel); bar.append(lab);
-  }
-  const reset = document.createElement("button");
-  reset.textContent = "Reset";
-  reset.onclick = () => {
-    CONTROLS.forEach(([, prop, , isAttr]) => isAttr ? r.removeAttribute(prop) : r.style.removeProperty(prop));
-    bar.querySelectorAll("select").forEach((s) => (s.selectedIndex = 0));
-  };
-  bar.append(reset);
-</script>
-</body>
+      hr { border: 0; border-top: 1px solid var(--oc-rule); margin: 48px 0; }
+
+      .specimen {
+        border: 1px solid var(--oc-rule);
+        border-radius: 8px;
+        padding: 24px;
+        margin: 24px 0;
+        background: rgba(255, 255, 255, 0.015);
+      }
+      .specimen .label { color: var(--oc-fg-3); font-size: 12px; text-transform: uppercase; letter-spacing: 0.14em; font-family: var(--oc-mono); margin: 0 0 12px; }
+      .specimen .sample { margin: 0; }
+      .specimen.serif .sample { font-family: var(--oc-serif); font-size: 34px; line-height: 1.2; letter-spacing: -0.005em; }
+      .specimen.serif .sample em { color: var(--oc-violet); }
+      .specimen.sans .sample { font-family: var(--oc-sans); font-size: 20px; line-height: 1.55; }
+      .specimen.mono .sample { font-family: var(--oc-mono); font-size: 14px; line-height: 1.6; }
+
+      .badge {
+        display: inline-block;
+        padding: 4px 10px;
+        border-radius: 999px;
+        font-family: var(--oc-mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        background: rgba(154, 142, 205, 0.14);
+        color: var(--oc-violet);
+        border: 1px solid var(--oc-rule);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="eyebrow">OpenCoven · DESIGN.md §4</p>
+      <h1>The Coven remembers.</h1>
+      <p class="kicker"><em>A three-face system for the grimoire — one for identity, one for reading, one for inspecting.</em></p>
+
+      <p class="lead">This is Inter. It carries every paragraph, form field, control, table cell, chat bubble, docs page, and inline prose in the Coven. It's the sans you read.</p>
+      <p>Body copy should feel calm and dense enough to hold real information but never austere. Inter's optical adjustments make it work at 11px labels and 20px lead paragraphs alike.</p>
+
+      <hr />
+
+      <h2>Display / brand — EB Garamond</h2>
+      <p>Headlines, hero copy, ceremonial spreads. Never body. Its italics carry the charm — use them for pull-quotes, kickers, and named entities in lore copy.</p>
+
+      <div class="specimen serif">
+        <p class="label">Serif · Display</p>
+        <p class="sample">The <em>coven</em> is not a chatbox. It is a workspace of familiars that remember, coordinate, and belong to you.</p>
+      </div>
+
+      <h2>UI / body — Inter</h2>
+      <p>Everything you read. Body copy, controls, tables, chat, docs prose, forms, chrome. Do not use serif here.</p>
+
+      <div class="specimen sans">
+        <p class="label">Sans · Interface</p>
+        <p class="sample">The quick brown fox jumps over the lazy dog. 0123456789 — @OpenCvn · mind.opencoven.ai</p>
+      </div>
+
+      <h2>Mono / code — JetBrains Mono</h2>
+      <p>Everything you inspect. Code, terminal output, session IDs, hashes, paths, API payloads, event streams, diffs, and every uppercase label / badge.</p>
+
+      <div class="specimen mono">
+        <p class="label">Mono · Terminal</p>
+        <pre class="sample">$ cave run familiar=charm
+[10:04:12] session=2051b5cf-f653 model=claude-opus-4.7
+[10:04:13] ↳ typography canon → EB Garamond · Inter · JetBrains Mono
+[10:04:13] ↳ retired: Fredoka (chrome), Satoshi/Neue Montreal (display)
+✔ sha256: 1e8b3d29…9ce32</pre>
+      </div>
+
+      <hr />
+
+      <h2>Rules</h2>
+      <ul>
+        <li>Serif is <strong>identity only</strong> — headlines, hero, ceremonial. Never body, never labels, never dense UI.</li>
+        <li>Sans is <strong>everything you read</strong> — body, chat, prose, controls, tables, docs, forms.</li>
+        <li>Mono is <strong>everything you inspect</strong> — code, terminal, identifiers, uppercase labels, badges, metadata.</li>
+        <li>Real italics matter — EB Garamond has a distinctive italic. Do not synthesize italics on fonts that don't ship one.</li>
+        <li>No playful fonts. No rounded display. No cursive. No novelty.</li>
+        <li>Weights: 400 body · 500 medium · 600 semi-bold section headers · 700 bold headlines.</li>
+        <li>Line heights: 1.4 sans body · 1.55 serif prose · 1.2 headings.</li>
+      </ul>
+
+      <p style="margin-top: 64px;"><span class="badge">v1.2.0 · 2026-07-09</span></p>
+    </main>
+  </body>
 </html>

--- a/public/scripts/theme-init.js
+++ b/public/scripts/theme-init.js
@@ -42,41 +42,51 @@
       applyGroup(modeGroup);
     }
     // ── Fonts ── apply saved non-default families before paint (no flash).
-    // Inlined from src/lib/font-catalog.ts (SANS_FALLBACK / MONO_FALLBACK) and
-    // src/lib/font-storage.ts (keys + approved pairs + stack shape) — keep in sync.
+    // Inlined from src/lib/font-catalog.ts (SERIF_FALLBACK / SANS_FALLBACK / MONO_FALLBACK)
+    // and src/lib/font-storage.ts (keys + approved pairs + stack shape) — keep in sync.
+    // Coven canonical defaults (DESIGN.md §4): EB Garamond + Inter + JetBrains Mono.
+    var SERIF_FB = "\"Iowan Old Style\", Georgia, \"Times New Roman\", serif";
     var SANS_FB = "ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, sans-serif";
     var MONO_FB = "ui-monospace, \"SF Mono\", Menlo, Consolas, \"Liberation Mono\", monospace";
-    var fontSansId = localStorage.getItem("cave:font:sans") || "geist";
+    var fontSerifId = localStorage.getItem("cave:font:serif") || "eb-garamond";
+    var fontSansId = localStorage.getItem("cave:font:sans") || "inter";
     var fontMonoId = localStorage.getItem("cave:font:mono") || "jetbrains-mono";
     var APPROVED_FONT_PAIRS = {
-      "geist-jetbrains": ["geist", "jetbrains-mono"],
-      "inter-geist-mono": ["inter", "geist-mono"],
-      "manrope-space-mono": ["manrope", "space-mono"],
-      "public-sans-roboto-mono": ["public-sans", "roboto-mono"],
-      "ibm-plex-pair": ["ibm-plex-sans", "ibm-plex-mono"],
-      "source-pair": ["source-sans-3", "source-code-pro"],
-      "dm-sans-fira-code": ["dm-sans", "fira-code"]
+      "coven-canon":       ["eb-garamond",      "inter",          "jetbrains-mono"],
+      "editorial-witch":   ["instrument-serif", "inter",          "jetbrains-mono"],
+      "shapeshifter":      ["fraunces",         "inter",          "jetbrains-mono"],
+      "geist-jetbrains":   ["eb-garamond",      "geist",          "jetbrains-mono"],
+      "ibm-plex-pair":     ["eb-garamond",      "ibm-plex-sans",  "ibm-plex-mono"],
+      "source-pair":       ["eb-garamond",      "source-sans-3",  "source-code-pro"]
     };
     var fontPairId = null;
-    if (/^[a-z0-9-]+$/.test(fontSansId) && /^[a-z0-9-]+$/.test(fontMonoId)) {
+    if (/^[a-z0-9-]+$/.test(fontSerifId) && /^[a-z0-9-]+$/.test(fontSansId) && /^[a-z0-9-]+$/.test(fontMonoId)) {
       for (var pairId in APPROVED_FONT_PAIRS) {
         if (!Object.prototype.hasOwnProperty.call(APPROVED_FONT_PAIRS, pairId)) continue;
         var pair = APPROVED_FONT_PAIRS[pairId];
-        if (pair[0] === fontSansId && pair[1] === fontMonoId) {
+        if (pair[0] === fontSerifId && pair[1] === fontSansId && pair[2] === fontMonoId) {
           fontPairId = pairId;
           break;
         }
       }
     }
     if (!fontPairId) {
-      fontSansId = "geist";
+      fontSerifId = "eb-garamond";
+      fontSansId = "inter";
       fontMonoId = "jetbrains-mono";
       try {
+        localStorage.setItem("cave:font:serif", fontSerifId);
         localStorage.setItem("cave:font:sans", fontSansId);
         localStorage.setItem("cave:font:mono", fontMonoId);
       } catch (e) {}
     }
-    if (fontSansId !== "geist") {
+    // Only override if the user picked something OTHER than the canonical
+    // default — the :root fallback in globals.css already points at the
+    // canonical family, so an override for the default would be a no-op.
+    if (fontSerifId !== "eb-garamond") {
+      try { html.style.setProperty("--font-serif", "var(--font-" + fontSerifId + "), " + SERIF_FB); } catch (e) {}
+    }
+    if (fontSansId !== "inter") {
       try { html.style.setProperty("--font-sans", "var(--font-" + fontSansId + "), " + SANS_FB); } catch (e) {}
     }
     if (fontMonoId !== "jetbrains-mono") {

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -1,6 +1,16 @@
 /**
  * Bundled font declarations — the runtime half of the typography feature.
  *
+ * OpenCoven canonical type system (DESIGN.md §4):
+ *   - Display (serif): EB Garamond
+ *   - UI (sans):       Inter
+ *   - Mono (code):     JetBrains Mono
+ *
+ * These three faces preload so a fresh profile renders the classic Coven
+ * type system immediately. Geist Sans and Geist Mono remain in the
+ * selectable catalog as clean alternatives (still declared here, but
+ * with preload: false).
+ *
  * Every `--font-*` cssVar referenced by FONT_OPTIONS in
  * `src/lib/font-catalog.ts` is declared here as a `next/font/google`
  * instance, and all of their `.variable` classes are concatenated into
@@ -9,10 +19,10 @@
  * output actually renders the chosen family rather than silently falling
  * back.
  *
- * Cost: only the two defaults (Geist / Geist Mono) preload. Everything
- * else is `preload: false`, so @font-face files download lazily and only
- * for the family whose cssVar is actually applied to rendered text — an
- * unselected font in the catalog costs nothing at runtime.
+ * Cost: only the three canonical faces preload. Everything else is
+ * `preload: false`, so @font-face files download lazily and only for the
+ * family whose cssVar is actually applied to rendered text — an unselected
+ * font in the catalog costs nothing at runtime.
  *
  * NOTE: `next/font/google` validates `weight` at build time (static
  * families require an explicit weight; variable families accept the full
@@ -50,25 +60,49 @@ import {
 // next/font/google statically parses these calls at build time, so every
 // argument must be an inline literal — no shared consts, spreads, or vars.
 
-// ── Defaults: preload (a fresh profile renders Geist immediately) ──
-export const geistSans = Geist({ variable: "--font-geist-sans", subsets: ["latin"] });
-export const geistMono = Geist_Mono({ variable: "--font-geist-mono", subsets: ["latin"] });
+// ── Canonical Coven trio: preload (a fresh profile renders EB Garamond +
+//    Inter + JetBrains Mono immediately, matching DESIGN.md §4). ──
+export const ebGaramond = EB_Garamond({
+  variable: "--font-eb-garamond",
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+});
+export const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+});
+export const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin"],
+});
 
-// Brand/display font — not in the selectable catalog, but used by the app
-// chrome, so it must stay applied to <html>.
+// ── Legacy defaults kept in the catalog as alternatives ──
+// Geist / Geist Mono were the previous shipped defaults. They stay in the
+// selectable font catalog so existing users who chose them keep working,
+// but they no longer preload — the canonical trio above does.
+export const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+  preload: false,
+});
+export const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+  preload: false,
+});
+
+// Legacy chrome font. Fredoka was the home-composer headline before v1.2
+// of the OpenCoven type system. It's retired from chrome (the home page
+// now uses --font-eb-garamond) but kept declared for backward-compat
+// with any custom themes that still reference --font-fredoka.
 export const fredoka = Fredoka({
   variable: "--font-fredoka",
   subsets: ["latin"],
   weight: ["300", "400", "500", "600", "700"],
-});
-
-
-// ── Classic Coven serifs (preview candidates, preload: false) ──
-export const ebGaramond = EB_Garamond({
-  variable: "--font-eb-garamond",
-  subsets: ["latin"],
   preload: false,
 });
+
+// ── Additional Coven serifs (preload: false, selectable via catalog) ──
 export const instrumentSerif = Instrument_Serif({
   variable: "--font-instrument-serif",
   subsets: ["latin"],
@@ -83,7 +117,6 @@ export const fraunces = Fraunces({
 });
 
 // ── Sans catalog (preload: false) ──
-const inter = Inter({ variable: "--font-inter", subsets: ["latin"], preload: false });
 const roboto = Roboto({ variable: "--font-roboto", subsets: ["latin"], preload: false });
 const openSans = Open_Sans({ variable: "--font-open-sans", subsets: ["latin"], preload: false });
 const lato = Lato({ variable: "--font-lato", subsets: ["latin"], weight: ["400", "700"], preload: false });
@@ -97,7 +130,6 @@ const figtree = Figtree({ variable: "--font-figtree", subsets: ["latin"], preloa
 const publicSans = Public_Sans({ variable: "--font-public-sans", subsets: ["latin"], preload: false });
 
 // ── Mono catalog (preload: false) ──
-const jetbrainsMono = JetBrains_Mono({ variable: "--font-jetbrains-mono", subsets: ["latin"], preload: false });
 const firaCode = Fira_Code({ variable: "--font-fira-code", subsets: ["latin"], preload: false });
 const sourceCodePro = Source_Code_Pro({ variable: "--font-source-code-pro", subsets: ["latin"], preload: false });
 const ibmPlexMono = IBM_Plex_Mono({ variable: "--font-ibm-plex-mono", subsets: ["latin"], weight: ["400", "500", "600", "700"], preload: false });
@@ -108,10 +140,18 @@ const inconsolata = Inconsolata({ variable: "--font-inconsolata", subsets: ["lat
 /** Every declared font instance — order is irrelevant; the layout just
  *  needs all `.variable` classes on the same element. */
 const ALL_FONTS = [
+  // Canonical trio (preloaded)
+  ebGaramond,
+  inter,
+  jetbrainsMono,
+  // Serif catalog
+  instrumentSerif,
+  fraunces,
+  // Legacy defaults
   geistSans,
   geistMono,
   fredoka,
-  inter,
+  // Sans catalog
   roboto,
   openSans,
   lato,
@@ -123,16 +163,13 @@ const ALL_FONTS = [
   manrope,
   figtree,
   publicSans,
-  jetbrainsMono,
+  // Mono catalog
   firaCode,
   sourceCodePro,
   ibmPlexMono,
   robotoMono,
   spaceMono,
   inconsolata,
-  ebGaramond,
-  instrumentSerif,
-  fraunces,
 ];
 
 /** Space-joined `.variable` classes for the root <html> element. */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -339,7 +339,13 @@
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
   --color-accent-presence: var(--accent-presence);
-  --font-sans: var(--font-geist-sans);
+  /* Coven canonical type system (DESIGN.md §4):
+     --font-serif: EB Garamond   — display / hero / identity moments
+     --font-sans:  Inter          — everything you read (body, chat, UI, prose)
+     --font-mono:  JetBrains Mono — everything you inspect (code, terminal, labels)
+     These map to the preloaded next/font/google instances in src/app/fonts.ts. */
+  --font-serif: var(--font-eb-garamond);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-jetbrains-mono);
 }
 

--- a/src/components/font-boot.test.ts
+++ b/src/components/font-boot.test.ts
@@ -1,20 +1,26 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { SANS_FALLBACK, MONO_FALLBACK } from "../lib/font-catalog.ts";
+import { SERIF_FALLBACK, SANS_FALLBACK, MONO_FALLBACK } from "../lib/font-catalog.ts";
 
 const src = readFileSync(new URL("../../public/scripts/theme-init.js", import.meta.url), "utf8");
 
+// Coven canonical defaults (DESIGN.md §4): EB Garamond + Inter + JetBrains Mono.
+assert.match(src, /cave:font:serif/, "boot reads cave:font:serif");
 assert.match(src, /cave:font:sans/, "boot reads cave:font:sans");
 assert.match(src, /cave:font:mono/, "boot reads cave:font:mono");
-assert.match(src, /"geist"/, "boot skips the sans default");
-assert.match(src, /"jetbrains-mono"/, "boot skips the mono default");
+assert.match(src, /"eb-garamond"/, "boot skips the serif default (Coven canon)");
+assert.match(src, /"inter"/, "boot skips the sans default (Coven canon)");
+assert.match(src, /"jetbrains-mono"/, "boot skips the mono default (Coven canon)");
+assert.match(src, /setProperty\(\s*["']--font-serif["']/, "boot sets --font-serif");
 assert.match(src, /setProperty\(\s*["']--font-sans["']/, "boot sets --font-sans");
 assert.match(src, /setProperty\(\s*["']--font-mono["']/, "boot sets --font-mono");
 assert.match(src, /\^\[a-z0-9-\]\+\$/, "boot validates id is kebab-case");
 assert.match(src, /APPROVED_FONT_PAIRS/, "boot gates saved fonts through approved font pairs");
-assert.match(src, /manrope-space-mono/, "boot includes curated pair ids");
+assert.match(src, /coven-canon/, "boot includes the canonical pair id");
+assert.match(src, /editorial-witch/, "boot includes curated pair ids");
 assert.match(src, /fontPairId/, "boot derives a pair id from saved slot ids");
+assert.ok(src.includes(JSON.stringify(SERIF_FALLBACK)), "inlined serif fallback matches catalog SERIF_FALLBACK");
 assert.ok(src.includes(JSON.stringify(SANS_FALLBACK)), "inlined sans fallback matches catalog SANS_FALLBACK");
 assert.ok(src.includes(JSON.stringify(MONO_FALLBACK)), "inlined mono fallback matches catalog MONO_FALLBACK");
 

--- a/src/components/settings-fonts.test.ts
+++ b/src/components/settings-fonts.test.ts
@@ -49,6 +49,7 @@ assert.match(
   /className=\{selectTrigger\}/,
   "typography pair selector uses the shared standard-height trigger styling",
 );
+assert.match(src, /Display/, "renders a display (serif) preview specimen");
 assert.match(src, /Interface/, "keeps the interface preview");
 assert.match(src, /Code &amp; terminal/, "keeps the code and terminal preview");
 

--- a/src/components/settings-fonts.tsx
+++ b/src/components/settings-fonts.tsx
@@ -111,6 +111,7 @@ const ALIGN_LABEL: Record<ReadingAlign, string> = {
 };
 
 const PREVIEW: Record<FontSlot, string> = {
+  serif: "The coven remembers what the machine forgets.",
   sans: "The quick brown fox jumps over 0123",
   mono: "const x = 42; // 0123",
 };
@@ -343,6 +344,7 @@ export function FontSettings() {
         {/* Live specimen — one inset panel, both samples, no center gutter. */}
         <div className="px-4 py-3">
           <div className="overflow-hidden rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] divide-y divide-[var(--border-hairline)]">
+            <FontSpecimen slot="serif" label="Display" fontId={selectedPair.serifId} />
             <FontSpecimen slot="sans" label="Interface" fontId={selectedPair.sansId} />
             <FontSpecimen slot="mono" label={<>Code &amp; terminal</>} fontId={selectedPair.monoId} />
           </div>

--- a/src/components/theme-script.tsx
+++ b/src/components/theme-script.tsx
@@ -11,20 +11,23 @@
  *  4. Always set BOTH `data-theme` and `data-mode` on <html>.
  *  5. If theme === "custom", apply `cssVars.theme` (mode-agnostic) +
  *     `cssVars[mode]` (mode-specific) from localStorage["coven-custom-theme"].
- *  6. Read localStorage["cave:font:sans"] / localStorage["cave:font:mono"],
- *     accept only approved font pairs, and apply --font-sans / --font-mono CSS
- *     vars for non-default selections.
+ *  6. Read localStorage["cave:font:serif"] / localStorage["cave:font:sans"] /
+ *     localStorage["cave:font:mono"], accept only approved font pairs, and apply
+ *     --font-serif / --font-sans / --font-mono CSS vars for non-default
+ *     selections. Canonical defaults are EB Garamond + Inter + JetBrains Mono
+ *     (DESIGN.md §4).
  *
  * NOTE: The storage key strings ("coven-theme", "coven-mode",
  * "coven-custom-theme") and the legacy rename map are duplicated in
  * /public/scripts/theme-init.js from src/lib/theme-storage.ts.
  * Keep both in sync when adding new keys or renames.
  *
- * NOTE: The font keys ("cave:font:sans", "cave:font:mono"), default ids
- * ("geist", "jetbrains-mono"), approved pairs, and the SANS_FALLBACK /
- * MONO_FALLBACK strings are duplicated in /public/scripts/theme-init.js from
- * src/lib/font-catalog.ts and src/lib/font-storage.ts. Keep in sync when
- * adding new fonts, changing fallback chains, or editing pair choices.
+ * NOTE: The font keys ("cave:font:serif", "cave:font:sans", "cave:font:mono"),
+ * default ids ("eb-garamond", "inter", "jetbrains-mono"), approved pairs, and
+ * the SERIF_FALLBACK / SANS_FALLBACK / MONO_FALLBACK strings are duplicated in
+ * /public/scripts/theme-init.js from src/lib/font-catalog.ts and
+ * src/lib/font-storage.ts. Keep in sync when adding new fonts, changing
+ * fallback chains, or editing pair choices.
  */
 
 /**

--- a/src/lib/font-catalog.ts
+++ b/src/lib/font-catalog.ts
@@ -5,8 +5,13 @@
  * app. Unselected fonts cost nothing at runtime: they're declared with
  * `preload: false` and @font-face only downloads files for families that
  * rendered text actually uses.
+ *
+ * The catalog now has three slots (per OpenCoven DESIGN.md §4):
+ *   - "serif" — display / headline / hero face; identity moments
+ *   - "sans"  — UI / body / prose face; everything you read
+ *   - "mono"  — code / terminal / label face; everything you inspect
  */
-export type FontSlot = "sans" | "mono";
+export type FontSlot = "serif" | "sans" | "mono";
 
 export type FontOption = {
   id: string;
@@ -18,19 +23,26 @@ export type FontOption = {
 export type FontPair = {
   id: string;
   label: string;
+  serifId: string;
   sansId: string;
   monoId: string;
 };
 
+export const SERIF_FALLBACK =
+  '"Iowan Old Style", Georgia, "Times New Roman", serif';
 export const SANS_FALLBACK =
   'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif';
 export const MONO_FALLBACK =
   'ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace';
 
 export const FONT_OPTIONS: FontOption[] = [
-  // ── Sans (UI) ──
-  { id: "geist", label: "Geist", slot: "sans", cssVar: "--font-geist-sans" },
+  // ── Serif (display / hero / identity) ──
+  { id: "eb-garamond", label: "EB Garamond", slot: "serif", cssVar: "--font-eb-garamond" },
+  { id: "instrument-serif", label: "Instrument Serif", slot: "serif", cssVar: "--font-instrument-serif" },
+  { id: "fraunces", label: "Fraunces", slot: "serif", cssVar: "--font-fraunces" },
+  // ── Sans (UI / body) ──
   { id: "inter", label: "Inter", slot: "sans", cssVar: "--font-inter" },
+  { id: "geist", label: "Geist", slot: "sans", cssVar: "--font-geist-sans" },
   { id: "roboto", label: "Roboto", slot: "sans", cssVar: "--font-roboto" },
   { id: "open-sans", label: "Open Sans", slot: "sans", cssVar: "--font-open-sans" },
   { id: "lato", label: "Lato", slot: "sans", cssVar: "--font-lato" },
@@ -43,8 +55,8 @@ export const FONT_OPTIONS: FontOption[] = [
   { id: "figtree", label: "Figtree", slot: "sans", cssVar: "--font-figtree" },
   { id: "public-sans", label: "Public Sans", slot: "sans", cssVar: "--font-public-sans" },
   // ── Mono (code / terminal) ──
-  { id: "geist-mono", label: "Geist Mono", slot: "mono", cssVar: "--font-geist-mono" },
   { id: "jetbrains-mono", label: "JetBrains Mono", slot: "mono", cssVar: "--font-jetbrains-mono" },
+  { id: "geist-mono", label: "Geist Mono", slot: "mono", cssVar: "--font-geist-mono" },
   { id: "fira-code", label: "Fira Code", slot: "mono", cssVar: "--font-fira-code" },
   { id: "source-code-pro", label: "Source Code Pro", slot: "mono", cssVar: "--font-source-code-pro" },
   { id: "ibm-plex-mono", label: "IBM Plex Mono", slot: "mono", cssVar: "--font-ibm-plex-mono" },
@@ -54,59 +66,63 @@ export const FONT_OPTIONS: FontOption[] = [
 ];
 
 export const DEFAULT_FONT_ID: Record<FontSlot, string> = {
-  // Geist Sans: already preloaded by Next.js, renders immediately — clean neutral UI
-  sans: "geist",
-  // JetBrains Mono: canonical mono per OpenCoven DESIGN.md / brand/ui/typography.css
-  // Best-in-class readability for code, terminal output, and dense labels at small sizes
+  // EB Garamond: canonical Coven display face — classical old-style serif,
+  // "grimoire not corporate" — DESIGN.md §4.
+  serif: "eb-garamond",
+  // Inter: canonical Coven UI face — highly legible sans, works at every
+  // size. Replaces Geist as the shipped default (Geist stays selectable).
+  sans: "inter",
+  // JetBrains Mono: canonical mono per OpenCoven DESIGN.md / brand/ui/typography.css.
+  // Best-in-class readability for code, terminal output, and dense labels at small sizes.
   mono: "jetbrains-mono",
 };
 
 export const FONT_PAIRS: FontPair[] = [
   {
+    id: "coven-canon",
+    label: "Coven Canon — EB Garamond · Inter · JetBrains Mono",
+    serifId: "eb-garamond",
+    sansId: "inter",
+    monoId: "jetbrains-mono",
+  },
+  {
+    id: "editorial-witch",
+    label: "Editorial Witch — Instrument Serif · Inter · JetBrains Mono",
+    serifId: "instrument-serif",
+    sansId: "inter",
+    monoId: "jetbrains-mono",
+  },
+  {
+    id: "shapeshifter",
+    label: "Shapeshifter — Fraunces · Inter · JetBrains Mono",
+    serifId: "fraunces",
+    sansId: "inter",
+    monoId: "jetbrains-mono",
+  },
+  {
     id: "geist-jetbrains",
-    label: "Geist + JetBrains Mono",
+    label: "Geist + JetBrains Mono (legacy)",
+    serifId: "eb-garamond",
     sansId: "geist",
     monoId: "jetbrains-mono",
   },
   {
-    id: "inter-geist-mono",
-    label: "Inter + Geist Mono",
-    sansId: "inter",
-    monoId: "geist-mono",
-  },
-  {
-    id: "manrope-space-mono",
-    label: "Manrope + Space Mono",
-    sansId: "manrope",
-    monoId: "space-mono",
-  },
-  {
-    id: "public-sans-roboto-mono",
-    label: "Public Sans + Roboto Mono",
-    sansId: "public-sans",
-    monoId: "roboto-mono",
-  },
-  {
     id: "ibm-plex-pair",
     label: "IBM Plex Sans + IBM Plex Mono",
+    serifId: "eb-garamond",
     sansId: "ibm-plex-sans",
     monoId: "ibm-plex-mono",
   },
   {
     id: "source-pair",
     label: "Source Sans 3 + Source Code Pro",
+    serifId: "eb-garamond",
     sansId: "source-sans-3",
     monoId: "source-code-pro",
   },
-  {
-    id: "dm-sans-fira-code",
-    label: "DM Sans + Fira Code",
-    sansId: "dm-sans",
-    monoId: "fira-code",
-  },
 ];
 
-export const DEFAULT_FONT_PAIR_ID = "geist-jetbrains";
+export const DEFAULT_FONT_PAIR_ID = "coven-canon";
 
 export function fontOptionById(id: string): FontOption | undefined {
   return FONT_OPTIONS.find((o) => o.id === id);
@@ -116,12 +132,16 @@ export function fontPairById(id: string): FontPair | undefined {
   return FONT_PAIRS.find((pair) => pair.id === id);
 }
 
-export function fontPairForFonts(sansId: string, monoId: string): FontPair | undefined {
-  return FONT_PAIRS.find((pair) => pair.sansId === sansId && pair.monoId === monoId);
+export function fontPairForFonts(serifId: string, sansId: string, monoId: string): FontPair | undefined {
+  return FONT_PAIRS.find(
+    (pair) => pair.serifId === serifId && pair.sansId === sansId && pair.monoId === monoId,
+  );
 }
 
 export function slotFallback(slot: FontSlot): string {
-  return slot === "sans" ? SANS_FALLBACK : MONO_FALLBACK;
+  if (slot === "serif") return SERIF_FALLBACK;
+  if (slot === "sans") return SANS_FALLBACK;
+  return MONO_FALLBACK;
 }
 
 export function fontStack(option: FontOption): string {

--- a/src/lib/font-css-vars.test.ts
+++ b/src/lib/font-css-vars.test.ts
@@ -13,13 +13,20 @@ const FILES = [
   "../styles/sidebar-minimal.css",
 ];
 
-// The two intentional references that define the defaults.
-const ALIAS_DEF = /--font-(sans|mono):\s*var\(--font-geist-(sans|mono)\)/;
+// The intentional references that define the canonical Coven defaults
+// (DESIGN.md §4): EB Garamond + Inter + JetBrains Mono. Each --font-* alias
+// in :root maps to exactly one --font-<family> from src/app/fonts.ts.
+const ALIAS_DEF = /--font-(serif|sans|mono):\s*var\(--font-(eb-garamond|inter|jetbrains-mono)\)/;
 
 for (const rel of FILES) {
   const src = readFileSync(new URL(rel, import.meta.url), "utf8");
   src.split("\n").forEach((line, i) => {
     if (ALIAS_DEF.test(line)) return;
+    // Body/UI reads must go through --font-sans (not directly through the
+    // canonical Inter/Geist family variables). Same for mono. Serif is a
+    // NEW slot — the home headline reads --font-eb-garamond directly with a
+    // fallback since that's the identity moment; this test allows it by only
+    // fencing --font-geist-* and --font-inter (not --font-eb-garamond).
     assert.doesNotMatch(
       line,
       /var\(--font-geist-(sans|mono)\)/,
@@ -29,8 +36,13 @@ for (const rel of FILES) {
 }
 
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
-assert.match(globals, /--font-sans:\s*var\(--font-geist-sans\)/, ":root --font-sans default must remain");
+assert.match(globals, /--font-sans:\s*var\(--font-inter\)/, ":root --font-sans default must be Inter (Coven canon)");
 assert.match(globals, /--font-mono:\s*var\(--font-jetbrains-mono\)/, ":root --font-mono default is JetBrains Mono");
+assert.match(
+  globals,
+  /--font-serif:\s*var\(--font-eb-garamond\)/,
+  ":root --font-serif default must be EB Garamond (Coven canon display face)",
+);
 
 // The reading line-spacing control drives the shared .cave-md prose surface via
 // --cave-reading-leading, with a 1.7 fallback so the default is unchanged.

--- a/src/lib/font-settings.test.ts
+++ b/src/lib/font-settings.test.ts
@@ -5,6 +5,7 @@ import {
   FONT_PAIRS,
   DEFAULT_FONT_PAIR_ID,
   DEFAULT_FONT_ID,
+  SERIF_FALLBACK,
   SANS_FALLBACK,
   MONO_FALLBACK,
   fontPairById,
@@ -13,13 +14,15 @@ import {
   fontStack,
 } from "./font-catalog.ts";
 
-// Spec: 15–25 bundled options spanning both slots.
+// Spec: 20–30 bundled options spanning all three slots (serif/sans/mono).
 assert.ok(
-  FONT_OPTIONS.length >= 15 && FONT_OPTIONS.length <= 25,
-  `catalog must bundle 15-25 fonts (got ${FONT_OPTIONS.length})`,
+  FONT_OPTIONS.length >= 20 && FONT_OPTIONS.length <= 30,
+  `catalog must bundle 20-30 fonts (got ${FONT_OPTIONS.length})`,
 );
+const serif = FONT_OPTIONS.filter((o) => o.slot === "serif");
 const sans = FONT_OPTIONS.filter((o) => o.slot === "sans");
 const mono = FONT_OPTIONS.filter((o) => o.slot === "mono");
+assert.ok(serif.length >= 2, "catalog needs at least a couple of serifs (display faces)");
 assert.ok(sans.length >= 8, "catalog needs a real sans selection");
 assert.ok(mono.length >= 5, "catalog needs a real mono selection");
 
@@ -32,42 +35,73 @@ for (const o of FONT_OPTIONS) {
   assert.ok(o.label.length > 0, `label for ${o.id}`);
 }
 
-// Defaults are the Coven-branded pair: Geist Sans for UI, JetBrains Mono for code.
-assert.equal(DEFAULT_FONT_ID.sans, "geist");
+// Coven canon defaults (DESIGN.md §4): EB Garamond + Inter + JetBrains Mono.
+assert.equal(DEFAULT_FONT_ID.serif, "eb-garamond");
+assert.equal(DEFAULT_FONT_ID.sans, "inter");
 assert.equal(DEFAULT_FONT_ID.mono, "jetbrains-mono");
+assert.equal(fontOptionById("eb-garamond")?.cssVar, "--font-eb-garamond");
+assert.equal(fontOptionById("inter")?.cssVar, "--font-inter");
+assert.equal(fontOptionById("jetbrains-mono")?.cssVar, "--font-jetbrains-mono");
 assert.equal(fontOptionById("geist")?.cssVar, "--font-geist-sans");
-assert.equal(fontOptionById("geist-mono")?.cssVar, "--font-geist-mono");
 assert.equal(fontOptionById("nope"), undefined);
 
-// Font choices are curated pairs, not arbitrary sans/mono cross-products.
+// Font choices are curated pairs, not arbitrary serif/sans/mono cross-products.
 assert.ok(FONT_PAIRS.length >= 5, "catalog exposes a useful set of curated font pairs");
 const pairIds = new Set(FONT_PAIRS.map((pair) => pair.id));
 assert.equal(pairIds.size, FONT_PAIRS.length, "font pair ids must be unique");
 for (const pair of FONT_PAIRS) {
   assert.match(pair.id, /^[a-z0-9-]+$/, `pair id ${pair.id} must be kebab-case`);
   assert.ok(pair.label.length > 0, `label for pair ${pair.id}`);
-  assert.equal(fontOptionById(pair.sansId)?.slot, "sans", `${pair.id} sans id must resolve to a sans font`);
-  assert.equal(fontOptionById(pair.monoId)?.slot, "mono", `${pair.id} mono id must resolve to a mono font`);
+  assert.equal(
+    fontOptionById(pair.serifId)?.slot,
+    "serif",
+    `${pair.id} serif id must resolve to a serif font`,
+  );
+  assert.equal(
+    fontOptionById(pair.sansId)?.slot,
+    "sans",
+    `${pair.id} sans id must resolve to a sans font`,
+  );
+  assert.equal(
+    fontOptionById(pair.monoId)?.slot,
+    "mono",
+    `${pair.id} mono id must resolve to a mono font`,
+  );
 }
-assert.equal(DEFAULT_FONT_PAIR_ID, "geist-jetbrains");
+assert.equal(DEFAULT_FONT_PAIR_ID, "coven-canon");
 assert.deepEqual(fontPairById(DEFAULT_FONT_PAIR_ID), {
-  id: "geist-jetbrains",
-  label: "Geist + JetBrains Mono",
+  id: "coven-canon",
+  label: "Coven Canon — EB Garamond · Inter · JetBrains Mono",
+  serifId: DEFAULT_FONT_ID.serif,
   sansId: DEFAULT_FONT_ID.sans,
   monoId: DEFAULT_FONT_ID.mono,
 });
-assert.equal(fontPairForFonts(DEFAULT_FONT_ID.sans, DEFAULT_FONT_ID.mono)?.id, DEFAULT_FONT_PAIR_ID);
-assert.equal(fontPairForFonts("manrope", "space-mono")?.id, "manrope-space-mono");
-assert.equal(fontPairForFonts("manrope", "jetbrains-mono"), undefined, "unapproved mixes are not accepted");
+assert.equal(
+  fontPairForFonts(DEFAULT_FONT_ID.serif, DEFAULT_FONT_ID.sans, DEFAULT_FONT_ID.mono)?.id,
+  DEFAULT_FONT_PAIR_ID,
+);
+assert.equal(
+  fontPairForFonts("instrument-serif", "inter", "jetbrains-mono")?.id,
+  "editorial-witch",
+);
+assert.equal(
+  fontPairForFonts("eb-garamond", "inter", "space-mono"),
+  undefined,
+  "unapproved mixes are not accepted",
+);
 
 // Stacks chain the font var onto the slot fallback.
 assert.equal(
-  fontStack(fontOptionById("geist")),
-  `var(--font-geist-sans), ${SANS_FALLBACK}`,
+  fontStack(fontOptionById("eb-garamond")),
+  `var(--font-eb-garamond), ${SERIF_FALLBACK}`,
 );
 assert.equal(
-  fontStack(fontOptionById("geist-mono")),
-  `var(--font-geist-mono), ${MONO_FALLBACK}`,
+  fontStack(fontOptionById("inter")),
+  `var(--font-inter), ${SANS_FALLBACK}`,
+);
+assert.equal(
+  fontStack(fontOptionById("jetbrains-mono")),
+  `var(--font-jetbrains-mono), ${MONO_FALLBACK}`,
 );
 
 console.log("font-catalog tests passed");

--- a/src/lib/font-storage.test.ts
+++ b/src/lib/font-storage.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { fontStack, fontOptionById, DEFAULT_FONT_ID } from "./font-catalog.ts";
 import {
+  FONT_SERIF_KEY,
   FONT_SANS_KEY,
   FONT_MONO_KEY,
   readFontPref,
@@ -34,17 +35,26 @@ function setupDom() {
   return { store, props };
 }
 
-test("write then read round-trips a valid id", () => {
+test("write then read round-trips a valid sans id", () => {
   setupDom();
-  writeFontPref("sans", "inter");
-  assert.equal(readFontPref("sans"), "inter");
-  assert.equal(globalThis.window.localStorage.getItem(FONT_SANS_KEY), "inter");
+  writeFontPref("sans", "geist");
+  assert.equal(readFontPref("sans"), "geist");
+  assert.equal(globalThis.window.localStorage.getItem(FONT_SANS_KEY), "geist");
+});
+
+test("write then read round-trips a valid serif id", () => {
+  setupDom();
+  writeFontPref("serif", "instrument-serif");
+  assert.equal(readFontPref("serif"), "instrument-serif");
+  assert.equal(globalThis.window.localStorage.getItem(FONT_SERIF_KEY), "instrument-serif");
 });
 
 test("unknown/garbage id reads back as the slot default", () => {
   const { store } = setupDom();
   store.set(FONT_SANS_KEY, "not-a-font");
+  store.set(FONT_SERIF_KEY, "not-a-font");
   assert.equal(readFontPref("sans"), DEFAULT_FONT_ID.sans);
+  assert.equal(readFontPref("serif"), DEFAULT_FONT_ID.serif);
 });
 
 test("a mono id stored under the sans key falls back to default", () => {
@@ -53,22 +63,28 @@ test("a mono id stored under the sans key falls back to default", () => {
   assert.equal(readFontPref("sans"), DEFAULT_FONT_ID.sans);
 });
 
+test("a sans id stored under the serif key falls back to default", () => {
+  const { store } = setupDom();
+  store.set(FONT_SERIF_KEY, "inter");
+  assert.equal(readFontPref("serif"), DEFAULT_FONT_ID.serif);
+});
+
 test("applyFont(non-default) sets the var to the fontStack", () => {
   const { props } = setupDom();
-  applyFont("sans", "inter");
-  assert.equal(props.get("--font-sans"), fontStack(fontOptionById("inter")));
+  applyFont("sans", "geist");
+  assert.equal(props.get("--font-sans"), fontStack(fontOptionById("geist")));
 });
 
 test("applyFont(default) removes the override", () => {
   const { props } = setupDom();
-  applyFont("sans", "inter");
+  applyFont("sans", "geist");
   applyFont("sans", DEFAULT_FONT_ID.sans);
   assert.equal(props.has("--font-sans"), false);
 });
 
 test("mono slot uses the mono key and --font-mono var", () => {
   const { props } = setupDom();
-  // geist-mono is a non-default mono now (default is jetbrains-mono), so it
+  // geist-mono is a non-default mono (default is jetbrains-mono), so it
   // sets the override rather than clearing it.
   writeFontPref("mono", "geist-mono");
   applyFont("mono", "geist-mono");
@@ -76,28 +92,48 @@ test("mono slot uses the mono key and --font-mono var", () => {
   assert.equal(props.get("--font-mono"), fontStack(fontOptionById("geist-mono")));
 });
 
-test("readFontPairPref accepts only curated sans/mono pairs", () => {
-  const { store } = setupDom();
-  store.set(FONT_SANS_KEY, "manrope");
-  store.set(FONT_MONO_KEY, "space-mono");
-  assert.equal(readFontPairPref().id, "manrope-space-mono");
-
-  store.set(FONT_MONO_KEY, "jetbrains-mono");
-  assert.equal(readFontPairPref().id, "geist-jetbrains");
-});
-
-test("writeFontPairPref stores both paired slots together", () => {
-  setupDom();
-  writeFontPairPref("manrope-space-mono");
-  assert.equal(readFontPref("sans"), "manrope");
-  assert.equal(readFontPref("mono"), "space-mono");
-  assert.equal(globalThis.window.localStorage.getItem(FONT_SANS_KEY), "manrope");
-  assert.equal(globalThis.window.localStorage.getItem(FONT_MONO_KEY), "space-mono");
-});
-
-test("applyFontPair applies the curated sans and mono stacks together", () => {
+test("serif slot uses the serif key and --font-serif var", () => {
   const { props } = setupDom();
-  applyFontPair("manrope-space-mono");
-  assert.equal(props.get("--font-sans"), fontStack(fontOptionById("manrope")));
-  assert.equal(props.get("--font-mono"), fontStack(fontOptionById("space-mono")));
+  // fraunces is a non-default serif (default is eb-garamond), so it
+  // sets the override rather than clearing it.
+  writeFontPref("serif", "fraunces");
+  applyFont("serif", "fraunces");
+  assert.equal(readFontPref("serif"), "fraunces");
+  assert.equal(props.get("--font-serif"), fontStack(fontOptionById("fraunces")));
+});
+
+test("readFontPairPref accepts only curated serif/sans/mono pairs", () => {
+  const { store } = setupDom();
+  store.set(FONT_SERIF_KEY, "instrument-serif");
+  store.set(FONT_SANS_KEY, "inter");
+  store.set(FONT_MONO_KEY, "jetbrains-mono");
+  assert.equal(readFontPairPref().id, "editorial-witch");
+
+  // Reset back to canon.
+  store.set(FONT_SERIF_KEY, "eb-garamond");
+  assert.equal(readFontPairPref().id, "coven-canon");
+});
+
+test("writeFontPairPref stores all three paired slots together", () => {
+  setupDom();
+  writeFontPairPref("editorial-witch");
+  assert.equal(readFontPref("serif"), "instrument-serif");
+  assert.equal(readFontPref("sans"), "inter");
+  assert.equal(readFontPref("mono"), "jetbrains-mono");
+  assert.equal(
+    globalThis.window.localStorage.getItem(FONT_SERIF_KEY),
+    "instrument-serif",
+  );
+  assert.equal(globalThis.window.localStorage.getItem(FONT_SANS_KEY), "inter");
+  assert.equal(globalThis.window.localStorage.getItem(FONT_MONO_KEY), "jetbrains-mono");
+});
+
+test("applyFontPair applies the curated serif/sans/mono stacks together", () => {
+  const { props } = setupDom();
+  applyFontPair("editorial-witch");
+  // sans + mono match the coven-canon defaults so applyFont clears their overrides.
+  // Only serif differs from default (instrument-serif vs eb-garamond) so it's set.
+  assert.equal(props.get("--font-serif"), fontStack(fontOptionById("instrument-serif")));
+  assert.equal(props.has("--font-sans"), false, "sans matches default; override should be cleared");
+  assert.equal(props.has("--font-mono"), false, "mono matches default; override should be cleared");
 });

--- a/src/lib/font-storage.ts
+++ b/src/lib/font-storage.ts
@@ -2,8 +2,14 @@
  * Persistence + application for the font picker.
  *
  * Stores a catalog id per slot in localStorage and applies the selection by
- * overriding the canonical --font-sans / --font-mono vars on <html>. The
- * default id removes the override so the :root alias (Geist) takes over.
+ * overriding the canonical --font-serif / --font-sans / --font-mono vars on
+ * <html>. The default id removes the override so the :root alias (per
+ * DEFAULT_FONT_ID) takes over.
+ *
+ * The catalog now has three slots (see font-catalog.ts):
+ *   - "serif" (--font-serif) — canonical: EB Garamond
+ *   - "sans"  (--font-sans)  — canonical: Inter
+ *   - "mono"  (--font-mono)  — canonical: JetBrains Mono
  *
  * NOTE: the no-FOUC boot script in src/components/theme-script.tsx applies the
  * same vars before paint. It cannot import this module (it runs as an inline
@@ -21,15 +27,20 @@ import {
   type FontSlot,
 } from "./font-catalog.ts";
 
+export const FONT_SERIF_KEY = "cave:font:serif";
 export const FONT_SANS_KEY = "cave:font:sans";
 export const FONT_MONO_KEY = "cave:font:mono";
 
 function keyFor(slot: FontSlot): string {
-  return slot === "sans" ? FONT_SANS_KEY : FONT_MONO_KEY;
+  if (slot === "serif") return FONT_SERIF_KEY;
+  if (slot === "sans") return FONT_SANS_KEY;
+  return FONT_MONO_KEY;
 }
 
 function varFor(slot: FontSlot): string {
-  return slot === "sans" ? "--font-sans" : "--font-mono";
+  if (slot === "serif") return "--font-serif";
+  if (slot === "sans") return "--font-sans";
+  return "--font-mono";
 }
 
 /** Stored id for the slot, validated against the catalog. Missing, unknown, or
@@ -59,18 +70,23 @@ export function writeFontPref(slot: FontSlot, id: string): void {
 }
 
 export function readFontPairPref(): FontPair {
-  const pair = fontPairForFonts(readFontPref("sans"), readFontPref("mono"));
+  const pair = fontPairForFonts(
+    readFontPref("serif"),
+    readFontPref("sans"),
+    readFontPref("mono"),
+  );
   return pair ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
 }
 
 export function writeFontPairPref(id: string): void {
   const pair = fontPairById(id) ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
+  writeFontPref("serif", pair.serifId);
   writeFontPref("sans", pair.sansId);
   writeFontPref("mono", pair.monoId);
 }
 
 /** Point the slot's CSS var at the chosen family's stack. The default id (or an
- *  unknown id) removes the override so the :root Geist alias applies. */
+ *  unknown id) removes the override so the :root default alias applies. */
 export function applyFont(slot: FontSlot, id: string): void {
   if (typeof document === "undefined") return;
   const cssVar = varFor(slot);
@@ -85,6 +101,7 @@ export function applyFont(slot: FontSlot, id: string): void {
 
 export function applyFontPair(id: string): void {
   const pair = fontPairById(id) ?? fontPairById(DEFAULT_FONT_PAIR_ID)!;
+  applyFont("serif", pair.serifId);
   applyFont("sans", pair.sansId);
   applyFont("mono", pair.monoId);
 }

--- a/src/styles/home-composer.css
+++ b/src/styles/home-composer.css
@@ -103,13 +103,20 @@
   50% { box-shadow: 0 0 12px color-mix(in oklch, var(--accent-presence) 85%, transparent); }
 }
 
+/* Cave home headline — Classic Coven identity moment.
+   Uses the canonical display face (EB Garamond) per OpenCoven DESIGN.md §4.
+   The serif is intentional: the home surface is where Val + her familiars
+   *arrive* every session, and the type should feel like a coven's field
+   manual, not a Vercel dashboard. */
 .home-composer-headline {
-  font-family: var(--font-fredoka, "Fredoka", system-ui, sans-serif);
+  font-family: var(--font-eb-garamond, "EB Garamond", "Iowan Old Style", Georgia, "Times New Roman", serif);
   font-weight: 500;
-  font-size: clamp(26px, 3.8vw, 44px);
-  line-height: 1.1;
+  font-size: clamp(28px, 4vw, 46px);
+  line-height: 1.15;
   color: color-mix(in oklch, var(--text-primary) 88%, var(--text-muted));
-  letter-spacing: -0.02em;
+  /* EB Garamond's proportions already read tight — near-zero tracking
+     lets the letterforms breathe without the corporate feel of -0.02em. */
+  letter-spacing: -0.005em;
   margin: 0 0 6px;
 }
 


### PR DESCRIPTION
Re-lands a commit that was rejected by branch protection on `main` (GH006 — direct pushes blocked; this is the PR path).

Moves OpenCoven's canonical type system to a three-face grimoire system:
- **Display / brand:** EB Garamond (classical old-style serif)
- **UI / body:** Inter
- **Mono / code:** JetBrains Mono

Retires Fredoka from Cave chrome; home-composer headline reads EB Garamond. Fonts preload wiring updated (EB Garamond/Inter/JetBrains Mono `preload:true`; Geist demoted but still selectable).

Original commit: `94f1b29a` by Val Alexander.