### PR TITLE
chore(release): stamp v0.0.165

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.165] - 2026-07-09
+
+> 🏛️ **Rooms for every vocation** — the Cave becomes role-aware: a registry-driven Role Surface system gives Familiars specialized workspaces (a Research Desk, a Comms operations center, an Archive) instead of generic tabs. Plus the Coven adopts its canonical typography, an "ultimate Enhance" streaming rewrite across every composer, and a full prompt-template + marketplace-pack workflow.
+
+A feature release on top of v0.0.164.
+
+### Features
+- **Role Surface system — registry-driven rooms for Familiar vocations** (#2849, cave-htyp). A role-aware Cave with no role-specific branching in the shell: register a surface and it becomes a first-class room. Ships three — Research Desk (researcher), Comms Operations (messenger), The Archive (indexer) — with per-Familiar × per-surface state. See `docs/role-surfaces.md`.
+- **Typography: adopt the Coven canon** — EB Garamond display, Inter body, JetBrains Mono (#2850).
+- **Composer: ultimate Enhance** — model-backed streaming rewrite, race-safe, with an intent menu, across all three composers (#2842, cave-b6c2).
+- **Prompts: template power** — placeholder Tab flow, favorites/recents/tags, save/edit/delete (#2847, cave-jg6k).
+- **Marketplace: browsable prompt packs** — real previews, one-click Try it, prompt-pack shipping + docs (#2848, cave-1f9h).
+- **Runtimes: sync accepted runtimes from the coven-runtimes registry** (#2841) — one command (or an automated PR) brings a newly-accepted runtime into Cave.
+- **Chat: project group headers gain an activity meta line + explicit project colors** (#2846).
+- **Cron: a prompt bar + analytics UX polish**, alongside a static Coven font preview (#2843).
+
+
 ## [0.0.164] - 2026-07-09
 
 > 🚦 **Chrome that knows when to leave** — the macOS traffic lights hide with the side panel and glide back when it opens, Dia-style. iOS gets real split layouts on wide windows and a decluttered chat header, cron details fit every screen, and releases now stamp themselves with one command.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.164",
+  "version": "0.0.165",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.164"
+version = "0.0.165"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.164"
+version = "0.0.165"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.164</string>
+	<string>0.0.165</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.164</string>
+	<string>0.0.165</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.164</string>
+	<string>0.0.165</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.164</string>
+	<string>0.0.165</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.164",
+  "version": "0.0.165",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.165 (all seven version locations + CHANGELOG), cut via `scripts/stamp-release.mjs`.

A feature release on top of v0.0.164 — 8 commits:
- **Role Surface system** — registry-driven vocation rooms (#2849, cave-htyp)
- Typography: Coven canon — EB Garamond + Inter + JetBrains Mono (#2850)
- Composer: ultimate Enhance streaming rewrite, all three composers (#2842, cave-b6c2)
- Prompts: template power — placeholders, favorites/recents/tags, CRUD (#2847, cave-jg6k)
- Marketplace: browsable prompt packs (#2848, cave-1f9h)
- Runtimes: sync from the coven-runtimes registry (#2841)
- Chat: project group header meta + colors (#2846)
- Font preview + cron prompt bar & analytics polish (#2843)

After merge: tag `v0.0.165` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)