### PR TITLE
refactor(analytics): contract compliance beside confidence + one-click enable for self-reporting

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11209,30 +11209,49 @@ a.dr-row:hover .dr-row__open { color: var(--accent-presence); transform: transla
   /* Reflow by the panel's own width, not the viewport — the analytics surface also
      renders in the narrow inspector sidepanel, where a fixed 5-column grid crushed
      each cell and broke labels mid-word. auto-fit collapses empty tracks so the
-     items still stretch edge-to-edge on the wide full-page view. */
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 8px;
+     items still stretch edge-to-edge on the wide full-page view. A 140px floor
+     keeps the two-word property names ("Bounded Authority", "Persistent
+     Memory") on one or two clean lines instead of ragged three-line wraps. */
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 10px;
+  align-items: stretch;
 }
 .fa-contract-item {
   display: flex;
-  align-items: center;
-  gap: 7px;
+  /* Top-align the badge with the label's first line — with centered
+     alignment, two-line labels floated the icon into the seam between lines. */
+  align-items: flex-start;
+  gap: 8px;
   min-width: 0;
-  padding: 9px;
+  padding: 9px 11px;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
+  /* Filled tile, matching the score-tile language of the neighboring panels
+     (.fa-thread-score) instead of a hollow outline. */
+  background: var(--bg-base);
   color: var(--text-secondary);
   font-size: 12px;
+}
+.fa-contract-item svg {
+  flex: 0 0 auto;
+  /* Optically center the 1em glyph against the first text line (1.35lh). */
+  margin-top: 1.5px;
 }
 .fa-contract-item span {
   min-width: 0;
   /* Wrap at word boundaries; only break a single over-long word as a last resort
      (avoids the "Name / d / Identit / y" character shredding in tight columns). */
   overflow-wrap: break-word;
-  line-height: 1.3;
+  line-height: 1.35;
 }
 .fa-contract-item.is-pass svg { color: var(--color-success); }
 .fa-contract-item.is-fail svg { color: var(--color-danger); }
+/* Failing properties tint their hairline so the needs-review items pop before
+   the icon color resolves at a glance. */
+.fa-contract-item.is-fail {
+  border-color: color-mix(in oklch, var(--color-danger) 38%, var(--border-hairline));
+  color: var(--text-primary);
+}
 
 /* Pane-width responsiveness — the analytics view also renders in the narrow
    inspector tab, where viewport media queries never fire. */

--- a/src/components/familiar-analytics-view.tsx
+++ b/src/components/familiar-analytics-view.tsx
@@ -7,6 +7,7 @@ import {
   type FamiliarAnalyticsData,
   type FamiliarAnalyticsModel,
 } from "@/components/familiar-analytics-data";
+import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PulseBars } from "@/components/ui/pulse-bars";
 import { RelativeTime } from "@/components/ui/relative-time";
@@ -17,6 +18,7 @@ import { ThreadSignalsSection } from "@/components/thread-signals-section";
 import { escalateBlockers, type SelfHealRequest } from "@/lib/familiar-heal-requests";
 import type { ConfidenceScore } from "@/lib/familiar-confidence";
 import type { ContractReport } from "@/lib/familiar-contract";
+import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import { deriveAnalyticsInsight } from "@/lib/familiar-analytics-insight";
 import { formatTimeToFirstReply, timeToFirstReplyMs } from "@/lib/first-run-stamps";
@@ -169,15 +171,98 @@ function trendColor(averageConfidence: number): string {
   return "var(--color-danger)";
 }
 
+/**
+ * Empty state for the Response confidence panel. When the familiar hasn't
+ * enabled response self-reporting, the notice carries the fix — a one-click
+ * enable that persists `autoSelfReport` to cave-config (the same key the
+ * Studio's Brain tab toggles) instead of sending the user hunting through
+ * Settings.
+ */
+function SelfReportEmptyState({
+  familiar,
+  onSelfReportEnabled,
+}: {
+  familiar: Familiar | null;
+  onSelfReportEnabled?: () => void;
+}) {
+  const { announce } = useAnnouncer();
+  const [enabling, setEnabling] = useState(false);
+  // Truthful optimistic latch: set only after the config write succeeds, so
+  // the notice never claims a state the daemon didn't accept.
+  const [justEnabled, setJustEnabled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const selfReportOn = justEnabled || Boolean(familiar?.autoSelfReport);
+
+  const enable = useCallback(async () => {
+    if (!familiar) return;
+    setEnabling(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/config", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ familiars: { [familiar.id]: { autoSelfReport: true } } }),
+      });
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
+      if (!res.ok || !json?.ok) throw new Error(json?.error ?? res.statusText);
+      setJustEnabled(true);
+      announce("Response self-reporting enabled.");
+      onSelfReportEnabled?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "couldn't save");
+    } finally {
+      setEnabling(false);
+    }
+  }, [announce, familiar, onSelfReportEnabled]);
+
+  if (selfReportOn) {
+    return (
+      <EmptyState
+        compact
+        icon="ph:chart-bar-bold"
+        headline="No response confidence events yet."
+        subtitle={
+          justEnabled
+            ? "Self-reporting enabled — reports are written when a chat closes or is archived."
+            : "Self-reporting is on — reports are written when a chat closes or is archived."
+        }
+      />
+    );
+  }
+
+  return (
+    <EmptyState
+      compact
+      icon="ph:chart-bar-bold"
+      headline={RESPONSE_CONFIDENCE_EMPTY_STATE}
+      subtitle={error ? `Couldn't enable: ${error}` : undefined}
+      actions={
+        familiar ? (
+          <Button size="sm" variant="primary" loading={enabling} onClick={() => void enable()}>
+            Enable self-reporting
+          </Button>
+        ) : undefined
+      }
+    />
+  );
+}
+
 const ResponseConfidenceSection = memo(function ResponseConfidenceSection({
   rollup,
   events,
+  familiar,
+  onSelfReportEnabled,
 }: {
   rollup: ResponseConfidenceRollup;
   events: ResponseConfidenceEvent[];
+  familiar: Familiar | null;
+  onSelfReportEnabled?: () => void;
 }) {
   if (rollup.eventCount === 0) {
-    return <EmptyState compact icon="ph:chart-bar-bold" headline={RESPONSE_CONFIDENCE_EMPTY_STATE} />;
+    return (
+      <SelfReportEmptyState familiar={familiar} onSelfReportEnabled={onSelfReportEnabled} />
+    );
   }
   const trend = buildResponseTrend(events);
 
@@ -572,10 +657,21 @@ export function FamiliarAnalyticsContent({
           wide={model.responseConfidenceRollup.eventCount > 0}
           count={`${model.responseConfidenceRollup.eventCount} ${model.responseConfidenceRollup.eventCount === 1 ? "event" : "events"}`}
         >
-          <ResponseConfidenceSection rollup={model.responseConfidenceRollup} events={model.responseConfidenceEvents} />
+          <ResponseConfidenceSection
+            rollup={model.responseConfidenceRollup}
+            events={model.responseConfidenceEvents}
+            familiar={model.familiar}
+            onSelfReportEnabled={onRefresh}
+          />
         </FaSection>
 
         <ConfidenceBreakdown confidence={model.confidence} />
+
+        {/* Contract compliance pairs with the confidence breakdown — both read
+            on identity health — and sits above the fold instead of dangling
+            under the operational panels. The #fa-contract KPI drill-through
+            keeps working wherever the section lives. */}
+        <ContractCompliance report={model.contractReport} />
 
         <FaSection
           id="fa-heal"
@@ -592,8 +688,6 @@ export function FamiliarAnalyticsContent({
         >
           <ThreadSignalsSection familiarId={model.familiarId} reports={model.threadReports} />
         </FaSection>
-
-        <ContractCompliance report={model.contractReport} />
       </div>
     </>
   );


### PR DESCRIPTION
Tracked by bead `cave-ydv5`.

## Contract compliance — better location + alignment/spacing

**Location.** The section moves from the bottom of the `fa-grid` (dangling under Self-heal / Thread signals) to directly after **Confidence breakdown** — the two panels both read on identity health, and the compact checklist now sits above the fold. The `#fa-contract` KPI drill-through is anchor-based and keeps working.

**Alignment & spacing pass** (`.fa-contract-grid` / `.fa-contract-item`):
- badges top-align with the label's first line (`align-items: flex-start` + optical nudge) — centered icons floated into the seam of two-line labels
- filled `--bg-base` tiles matching the neighboring score-tile language instead of hollow outlines
- column floor widened 120→140px and gap 8→10px so "Bounded Authority" / "Persistent Memory" wrap cleanly
- failing properties tint their hairline danger and lift copy to `--text-primary`, so needs-review items pop at a glance

## Self-reporting notice → actionable

The Response confidence empty state ("No response confidence events yet. **Enable response self-reporting** to build confidence trends.") now carries the fix instead of pointing at Settings:

- **Enable self-reporting** button (primary, loading state) persists `autoSelfReport: true` through `PATCH /api/config` — the exact key the Studio Brain tab toggles
- success announces via the live region, refreshes the analytics model, and the notice truthfully flips to "reports are written when a chat closes or is archived"
- failures render honestly in the subtitle (`Couldn't enable: …`), never faking success
- familiars that already have self-reporting on see the truthful "Self-reporting is on" notice instead of a dead-end suggestion

## Verification

- `pnpm typecheck` ✓
- `pnpm test:app` — 591 files ✓
- targeted: familiar-analytics-view (12), familiar-analytics-navigation, globals.css, composer-zoom-smoke, a11y-audit-fixes ✓
