### PR TITLE
feat(grimoire): Journal becomes a tab inside the Grimoire surface

### DIFF
--- a/src/components/familiar-studio-journal-tab.test.ts
+++ b/src/components/familiar-studio-journal-tab.test.ts
@@ -91,10 +91,12 @@ const pageDrag = read("../lib/page-drag.ts");
 const slash = read("../lib/slash-commands.ts");
 
 // ── Workspace: "journal" is a redirect-only mode (like groupchat) ────────────
+// It now opens the Grimoire surface on its Journal tab; per-familiar journals
+// still live in Settings → Familiars → Journal via FamiliarStudioJournalTab.
 assert.match(
   ws,
-  /if \(next === "journal"\) \{[\s\S]{0,400}?openFamiliarStudioSettingsTab\("journal"\)/,
-  "setMode redirects journal to Settings → Familiars → Journal",
+  /if \(next === "journal"\) \{[\s\S]{0,400}?setGrimoireView\("journal"\);\s*\n\s*setModeRaw\("grimoire"\)/,
+  "setMode routes journal into the Grimoire Journal tab",
 );
 assert.doesNotMatch(ws, /import \{ JournalView \}/, "workspace no longer imports JournalView");
 assert.doesNotMatch(ws, /mode === "journal" \?/, "no journal surface branch remains");

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -11,7 +11,10 @@ const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.
 
 assert.match(modeType, /\| "grimoire"/, "grimoire is a WorkspaceMode");
 assert.match(workspace, /grimoire: "Grimoire"/, "grimoire has a page title (sr-only h1)");
-assert.match(workspace, /mode === "grimoire" \? \(\s*<GrimoireView \/>/, "grimoire mode renders GrimoireView");
+assert.match(workspace, /mode === "grimoire" \? \(\s*<GrimoireView\s+view=\{grimoireView\}/, "grimoire mode renders GrimoireView with the controlled view");
+// Journal is now a tab inside Grimoire: the nav/deep-link `journal` mode opens
+// Grimoire on its Journal tab instead of redirecting to Settings.
+assert.match(workspace, /if \(next === "journal"\) \{[\s\S]{0,400}setGrimoireView\("journal"\);\s*\n\s*setModeRaw\("grimoire"\);/, "the journal mode routes into the Grimoire Journal tab");
 assert.match(sidebar, /\| "grimoire"/, "grimoire is a FolderMode");
 assert.match(sidebar, /id: "grimoire", label: "Grimoire"/, "grimoire has a sidebar row (and ⌘K palette entry via FOLDER_MODES)");
 
@@ -61,12 +64,12 @@ assert.match(view, /@container\/grimoire/, "layout adapts via container queries"
 // hides when the graph is showing, and the graph pane gets its own back row.
 assert.match(
   view,
-  /selection \|\| showGraph \? "hidden @min-\[880px\]\/grimoire:flex" : ""/,
-  "the rail yields to the graph on narrow widths",
+  /selection \|\| view !== "docs" \? "hidden @min-\[880px\]\/grimoire:flex" : ""/,
+  "the rail yields to the graph/journal tabs on narrow widths",
 );
 assert.match(
   view,
-  /onClick=\{\(\) => setShowGraph\(false\)\}\s*\n\s*aria-label="Back to document list"/,
+  /onClick=\{\(\) => setView\("docs"\)\}\s*\n\s*aria-label="Back to document list"/,
   "the graph pane has its own narrow-width back affordance",
 );
 
@@ -191,12 +194,27 @@ assert.match(view, /const localGraph = useMemo\([\s\S]{0,200}buildDocGraph\(/, "
 assert.match(view, /markdown: k\.body/, "the fallback graph reads each knowledge body (already loaded)");
 assert.match(view, /const graph = scan\?\.graph \?\? localGraph/, "the server scan wins, the local graph stands in — never blank");
 assert.match(view, /if \(firstLoadDoneRef\.current\) refreshGraph\(\)/, "saves/deletes rescan the graph (mount already fetched)");
-assert.match(view, /aria-label="Grimoire view"/, "the Docs|Graph switch is a labelled control group");
-assert.match(view, /aria-pressed=\{!showGraph\}[\s\S]{0,1000}aria-pressed=\{showGraph\}/, "the segmented control exposes pressed state");
+assert.match(view, /aria-label="Grimoire view"/, "the Docs|Journal|Graph switch is a labelled control group");
 assert.match(
   view,
-  /showGraph \? \([\s\S]{0,1200}<GrimoireGraphView[\s\S]{0,400}onOpen=\{\(ref\) => \{[\s\S]{0,80}openDoc\(ref\)/,
+  /aria-pressed=\{view === "docs"\}[\s\S]{0,900}aria-pressed=\{view === "journal"\}[\s\S]{0,900}aria-pressed=\{view === "graph"\}/,
+  "the three-way segmented control exposes pressed state for docs, journal, and graph",
+);
+assert.match(
+  view,
+  /view === "graph" \? \([\s\S]{0,1200}<GrimoireGraphView[\s\S]{0,400}onOpen=\{\(ref\) => \{[\s\S]{0,80}openDoc\(ref\)/,
   "the graph replaces the detail pane and opens the clicked doc",
+);
+// Journal tab renders the full daily-reflection surface inside Grimoire (cave).
+assert.match(
+  view,
+  /view === "journal" \? \([\s\S]{0,600}<JournalEntries familiars=\{familiars\} activeFamiliarId=\{activeFamiliarId\}/,
+  "the Journal tab mounts the JournalEntries surface, coven-wide",
+);
+assert.match(
+  view,
+  /import \{ JournalEntries \} from "@\/components\/journal\/journal-entries"/,
+  "grimoire-view imports the shared journal surface",
 );
 assert.match(view, /scanning=\{scanning\}/, "the graph view knows a scan is in flight");
 assert.match(view, /scanError=\{scan \? null : scanError\}/, "a failed scan is only surfaced when there is no scan to show");
@@ -208,12 +226,12 @@ assert.match(view, /scanError=\{scan \? null : scanError\}/, "a failed scan is o
 // the rail is then hidden.
 assert.match(
   view,
-  /selection \|\| showGraph \? "hidden @min-\[880px\]\/grimoire:flex" : ""/,
-  "the rail hides on narrow when a doc is open OR the graph is up",
+  /selection \|\| view !== "docs" \? "hidden @min-\[880px\]\/grimoire:flex" : ""/,
+  "the rail hides on narrow when a doc is open OR a non-docs tab is up",
 );
 assert.match(
   view,
-  /onClick=\{\(\) => setShowGraph\(false\)\}[\s\S]{0,120}aria-label="Back to document list"/,
+  /onClick=\{\(\) => setView\("docs"\)\}[\s\S]{0,120}aria-label="Back to document list"/,
   "the graph view offers a back-to-documents affordance (rail is hidden on narrow)",
 );
 

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -22,6 +22,9 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { Icon, type IconName } from "@/lib/icon";
 import { MdEditor, type MdEditorSaveResult } from "@/components/md-editor/md-editor";
 import { MemoryMdEditor } from "@/components/md-editor/memory-md-editor";
+import { JournalEntries } from "@/components/journal/journal-entries";
+import "@/styles/journal.css";
+import type { Familiar } from "@/lib/types";
 import { parseMdDocument, serializeMdDocument, type MdDocument } from "@/lib/md-frontmatter";
 import { relativeTime } from "@/lib/relative-time";
 import {
@@ -727,13 +730,37 @@ function GrimoireDocLinks({
 
 // ── Surface ──────────────────────────────────────────────────────────────────
 
-export function GrimoireView() {
+export type GrimoireViewKind = "docs" | "graph" | "journal";
+
+export function GrimoireView({
+  view: controlledView,
+  onViewChange,
+  familiars = [],
+  activeFamiliarId = null,
+}: {
+  /** Which tab shows. Controlled by the Workspace so the Journal nav row can
+   *  route straight into the Journal tab; falls back to internal state when the
+   *  view is rendered bare (tests). */
+  view?: GrimoireViewKind;
+  onViewChange?: (view: GrimoireViewKind) => void;
+  /** Roster for the Journal tab (reflection filter + attribution). */
+  familiars?: Familiar[];
+  activeFamiliarId?: string | null;
+} = {}) {
   const [knowledge, setKnowledge] = useState<KnowledgeEntry[] | null>(null);
   const [memory, setMemory] = useState<MemoryEntry[] | null>(null);
   const [journal, setJournal] = useState<JournalSummary[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
-  const [showGraph, setShowGraph] = useState(false);
+  const [internalView, setInternalView] = useState<GrimoireViewKind>("docs");
+  const view = controlledView ?? internalView;
+  const setView = useCallback(
+    (next: GrimoireViewKind) => {
+      onViewChange?.(next);
+      if (controlledView === undefined) setInternalView(next);
+    },
+    [controlledView, onViewChange],
+  );
   const { scan, scanning, scanError, refreshGraph } = useGrimoireGraphScan();
   const [collapsedSections, setCollapsedSections] = useState<Record<RailSectionId, boolean>>(
     readCollapsedSections,
@@ -1266,10 +1293,10 @@ export function GrimoireView() {
           >
             <button
               type="button"
-              aria-pressed={!showGraph}
-              onClick={() => setShowGraph(false)}
+              aria-pressed={view === "docs"}
+              onClick={() => setView("docs")}
               className={`focus-ring inline-flex h-full items-center gap-1 rounded px-2 text-[11px] transition-colors ${
-                !showGraph
+                view === "docs"
                   ? "bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"
                   : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
               }`}
@@ -1279,10 +1306,23 @@ export function GrimoireView() {
             </button>
             <button
               type="button"
-              aria-pressed={showGraph}
-              onClick={() => setShowGraph(true)}
+              aria-pressed={view === "journal"}
+              onClick={() => setView("journal")}
               className={`focus-ring inline-flex h-full items-center gap-1 rounded px-2 text-[11px] transition-colors ${
-                showGraph
+                view === "journal"
+                  ? "bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              <Icon name="ph:calendar-blank" width={11} aria-hidden />
+              Journal
+            </button>
+            <button
+              type="button"
+              aria-pressed={view === "graph"}
+              onClick={() => setView("graph")}
+              className={`focus-ring inline-flex h-full items-center gap-1 rounded px-2 text-[11px] transition-colors ${
+                view === "graph"
                   ? "bg-[var(--accent-presence)]/12 text-[var(--text-primary)]"
                   : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
               }`}
@@ -1308,7 +1348,7 @@ export function GrimoireView() {
           // so only one may show. Hide the rail when a doc is open OR the graph
           // is up — otherwise the rail wins the width and the graph is pushed
           // off-screen (Graph mode was dead on phones). Wide keeps both.
-          selection || showGraph ? "hidden @min-[880px]/grimoire:flex" : ""
+          selection || view !== "docs" ? "hidden @min-[880px]/grimoire:flex" : ""
         }`}
       >
         {/* Title + surface verbs moved to the compact band above; the rail
@@ -1474,10 +1514,18 @@ export function GrimoireView() {
       </aside>
       <main
         className={`h-full min-h-0 min-w-0 flex-1 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/30 ${
-          selection || showGraph ? "" : "hidden @min-[880px]/grimoire:block"
+          selection || view !== "docs" ? "" : "hidden @min-[880px]/grimoire:block"
         }`}
       >
-        {showGraph ? (
+        {view === "journal" ? (
+          // Journal tab — the full daily-reflection surface (day rail, generate,
+          // edit/delete with undo), coven-wide (no familiar scope). Not
+          // `standalone`: it's inside the Workspace, so "Run now" and toast
+          // actions ride the live event bus.
+          <div className="grimoire-journal-tab h-full min-h-0">
+            <JournalEntries familiars={familiars} activeFamiliarId={activeFamiliarId} />
+          </div>
+        ) : view === "graph" ? (
           <div className="flex h-full min-h-0 flex-col">
             {/* Narrow-only: the rail is hidden while the graph is up (see the
                 aside condition above), so give an explicit way back to the list
@@ -1485,7 +1533,7 @@ export function GrimoireView() {
             <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-1.5 @min-[880px]/grimoire:hidden">
               <button
                 type="button"
-                onClick={() => setShowGraph(false)}
+                onClick={() => setView("docs")}
                 aria-label="Back to document list"
                 className="focus-ring inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
               >
@@ -1501,7 +1549,7 @@ export function GrimoireView() {
                 scanError={scan ? null : scanError}
                 onOpen={(ref) => {
                   openDoc(ref);
-                  setShowGraph(false);
+                  setView("docs");
                 }}
               />
             </div>

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -126,7 +126,7 @@ const FOLDER_MODES: Array<{
   // also carries the needs-you badge). Journal and Grimoire join the quiet
   // cluster: same flat list, same reachability (rows, palette, deep links),
   // just muted-until-hover so the conversation-first surfaces read first.
-  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — opens in Settings", quiet: true },
+  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in the Grimoire", quiet: true },
   { id: "grimoire", label: "Grimoire", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
   // Browser is summoned on demand (a clicked link/URL opens it, plus ⌘5 and the
   // ⌘K palette) rather than navigated to daily, so it's kept in the list for

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -12,7 +12,7 @@ import type { WorkspaceMode as WorkspaceModeFromDaemon } from "@/lib/workspace-m
 import { CommandPalette, type PaletteIntent } from "@/components/command-palette";
 // Journal retired as an in-shell surface (redirects to Settings → Familiars),
 // so JournalView is gone; Grimoire is a new in-shell surface from main.
-import { GrimoireView } from "@/components/grimoire-view";
+import { GrimoireView, type GrimoireViewKind } from "@/components/grimoire-view";
 import type { CalendarDeadline } from "@/components/calendar-view";
 import { OnboardingOverlay } from "@/components/onboarding-overlay";
 import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
@@ -314,6 +314,10 @@ export function Workspace() {
   // whose lastNonChatMode below still defaults to "home"). Deep links (?mode=,
   // #chat-…) and cave:navigate-mode override this as before.
   const [mode, setModeRaw] = useState<CaveMode>("chat");
+  // Which tab the Grimoire surface shows. Lifted here so the Journal nav row can
+  // route straight into Grimoire's Journal tab (see the setMode `journal` branch)
+  // and so the choice persists across Grimoire remounts within a session.
+  const [grimoireView, setGrimoireView] = useState<GrimoireViewKind>("docs");
   // Group Chat retired its standalone page — it's now a tab inside the Chat
   // surface. Any request for the legacy `groupchat` mode (nav, deep link,
   // palette, keyboard, drag-to-split) is redirected to chat and opens the Group
@@ -328,11 +332,13 @@ export function Workspace() {
       return;
     }
     if (next === "journal") {
-      // The Journal page retired — it lives in Settings → Familiars → Journal.
-      // Every entry point (sidebar row, ⌘K palette, ?mode= deep link,
-      // cave:navigate-mode, dashboard links) funnels through setMode, so this
-      // one redirect covers them all.
-      openFamiliarStudioSettingsTab("journal");
+      // Journal is now a tab inside the Grimoire surface. Every entry point
+      // (sidebar row, ⌘K palette, ?mode= deep link, cave:navigate-mode,
+      // dashboard links) funnels through setMode, so opening Grimoire on its
+      // Journal tab here covers them all. (Per-familiar journals still live in
+      // Settings → Familiars → Journal.)
+      setGrimoireView("journal");
+      setModeRaw("grimoire");
       return;
     }
     setModeRaw(next);
@@ -2264,7 +2270,12 @@ export function Workspace() {
         }}
       />
     ) : mode === "grimoire" ? (
-      <GrimoireView />
+      <GrimoireView
+        view={grimoireView}
+        onViewChange={setGrimoireView}
+        familiars={familiars}
+        activeFamiliarId={activeId}
+      />
     ) : mode === "inbox" || mode === "calendar" ? (
       // Calendar and crons are one Schedules surface. The "calendar" mode still resolves
       // here (nav button / deep links) but opens that tab; keying on the mode

--- a/tests/mobile/foundations.spec.ts
+++ b/tests/mobile/foundations.spec.ts
@@ -226,11 +226,11 @@ test.describe("mobile foundations", () => {
     test.slow();
     // The in-shell WorkspaceMode set (src/lib/workspace-mode.ts). Keep in sync
     // when a new surface is added — a new mode with a render crash should turn
-    // this red. Two modes are intentionally excluded: "journal" retired as a
-    // standalone surface and now redirects to Settings → Familiars (swept
-    // separately after the loop, asserting the redirect); "grimoire" mounts a
-    // heavy Milkdown editor whose cold compile under next dev makes this fast
-    // canary flaky — it has its own coverage (see cave follow-up).
+    // this red. Two modes are intentionally excluded: "journal" now opens the
+    // Grimoire surface on its Journal tab (swept separately after the loop);
+    // "grimoire" mounts a heavy Milkdown editor whose cold compile under next
+    // dev makes this fast canary flaky — it has its own coverage (see cave
+    // follow-up), and the journal step below exercises the same mount.
     const IN_SHELL_SURFACES = [
       "home", "agents", "chat", "groupchat", "board", "calendar", "inbox",
       "browser", "terminal", "github", "roles", "marketplace",
@@ -261,31 +261,28 @@ test.describe("mobile foundations", () => {
       await expect(page.locator(".shell-frame"), `${surface} must keep the app shell mounted (no crash)`).toBeVisible();
     }
 
-    // Assert no in-shell surface render-crashed BEFORE the journal redirect
-    // below. That step navigates cross-document to /settings, which cancels the
-    // workspace's in-flight chunk/fetch requests; next dev and WebKit surface
-    // those cancellations as benign pageerrors ("Failed to load chunk",
-    // "aborted", "…due to access control checks") that are loading artifacts,
-    // not render crashes. Checking here keeps the canary meaningful without
-    // enumerating every benign message.
+    // Assert no in-shell surface render-crashed while sweeping.
     expect(errors, `render crashes while sweeping surfaces:\n${errors.join("\n")}`).toEqual([]);
 
-    // "journal" is a WorkspaceMode but no longer an in-shell surface: it
-    // hard-redirects to Settings → Familiars (openFamiliarStudioSettingsTab →
-    // window.location.assign("/settings#familiars")). Run it last — its
-    // navigation away from the workspace would strand the sweep otherwise — and
-    // assert the redirect lands on the Settings shell. A render crash there
-    // unmounts to the error boundary, so .settings-shell never appears.
+    // "journal" is now an in-shell surface: it opens the Grimoire surface on its
+    // Journal tab (setGrimoireView("journal") → mode "grimoire"), no longer a
+    // cross-document redirect to Settings. Assert the shell survives and the
+    // Grimoire surface mounts (a render crash there unmounts to the error
+    // boundary, so .grimoire-view never appears).
     current = "journal";
     await page.evaluate(() =>
       window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "journal" } })),
     );
-    // /settings now mounts the Milkdown-backed memory/journal editor, whose
-    // first-hit compile under next dev can run well past 15s — wait generously.
-    await page.waitForURL(/\/settings(\?|#|$)/, { timeout: 45_000 });
+    await page.waitForTimeout(250);
     await expect(
-      page.locator(".settings-shell"),
-      "journal must redirect to the Settings shell without crashing",
+      page.locator(".shell-frame"),
+      "journal must keep the app shell mounted (no crash)",
+    ).toBeVisible();
+    // The Grimoire surface (with its Journal tab) mounts in-shell; its first-hit
+    // compile under next dev can run well past 15s — wait generously.
+    await expect(
+      page.locator(".grimoire-view"),
+      "journal opens the Grimoire surface without crashing",
     ).toBeVisible({ timeout: 45_000 });
   });
 });


### PR DESCRIPTION
## What

User request: group Journal within the Grimoire page as a tab.

Grimoire's existing **Docs / Graph** segmented switcher grows a third tab — **Docs · Journal · Graph**. The Journal tab renders the full daily-reflection surface (`JournalEntries`: day rail, generate reflection, edit/delete with undo), coven-wide (no familiar scope) and non-`standalone`, so "Run now" and toast actions ride the live workspace event bus.

The `journal` nav mode (sidebar row, ⌘K palette, `?mode=`, `#` deep links, `cave:navigate-mode`) now opens Grimoire on its Journal tab instead of redirecting to Settings — every entry point funnels through `setMode`, so one reroute covers them all. Per-familiar journals still live in Settings → Familiars → Journal (`FamiliarStudioJournalTab` unchanged).

## How

- **grimoire-view**: `showGraph` boolean → `view: "docs" | "graph" | "journal"`, controlled by the Workspace with an uncontrolled fallback for bare renders; the rail yields to any non-docs tab on narrow widths.
- **workspace**: lifts `grimoireView` state (persists across Grimoire remounts), reroutes the `journal` branch to `setGrimoireView("journal") + setModeRaw("grimoire")`, and passes `familiars` / `activeFamiliarId` to the surface.
- **sidebar**: the Journal row description now points at the Grimoire tab.

## Verification

- `tsc --noEmit` clean
- Full suite: ✓ 591 test file(s) passed [app] (pins updated in `grimoire-view.test.ts` + `familiar-studio-journal-tab.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)