### PR TITLE
chore(release): stamp v0.0.166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.166] - 2026-07-09
+
+> 📓 **Journal moves into the Grimoire** — daily reflections are now a tab beside Docs and Graph, so the whole knowledge surface lives in one room. Plus registry-driven runtime adapter scaffolds and an analytics contract-compliance pass.
+
+Patch release on top of v0.0.165.
+
+### Features
+- **Grimoire: Journal is now a tab** (#2854). The Docs/Graph switcher grows a third tab — Docs · Journal · Graph — rendering the full daily-reflection surface (day rail, generate, edit/delete with undo) in place. The Journal nav item opens it directly instead of routing to Settings; per-familiar journals still live in Settings → Familiars → Journal.
+
+### Improvements
+- **Runtimes: adapter scaffolds come straight from the registry** (#2853, cave-laxg).
+- **Analytics: contract compliance shown beside confidence, with one-click enable for self-reporting** (#2852, cave-ydv5).
+
+
 ## [0.0.165] - 2026-07-09
 
 > 🏛️ **Rooms for every vocation** — the Cave becomes role-aware: a registry-driven Role Surface system gives Familiars specialized workspaces (a Research Desk, a Comms operations center, an Archive) instead of generic tabs. Plus the Coven adopts its canonical typography, an "ultimate Enhance" streaming rewrite across every composer, and a full prompt-template + marketplace-pack workflow.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.165"
+version = "0.0.166"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.165"
+version = "0.0.166"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.165</string>
+	<string>0.0.166</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.165</string>
+	<string>0.0.166</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.165</string>
+	<string>0.0.166</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.165</string>
+	<string>0.0.166</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.0.166 (all seven version locations + CHANGELOG), cut via `scripts/stamp-release.mjs`.

Patch release on top of v0.0.165 — 3 commits:
- **Grimoire: Journal is now a tab** — Docs · Journal · Graph (#2854)
- Runtimes: adapter scaffolds come straight from the registry (#2853, cave-laxg)
- Analytics: contract compliance beside confidence + one-click self-report enable (#2852, cave-ydv5)

After merge: tag `v0.0.166` on the squash commit → release.yml builds + publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)