### PR TITLE
fix(shell): title-bar controls never sit under the traffic lights

### DIFF
--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -246,13 +246,26 @@ assert.doesNotMatch(
   );
   assert.match(
     shell,
-    /invoke\("set_traffic_lights_visible", \{ visible: trafficLightsVisible \}\)/,
+    /invoke\("set_traffic_lights_visible", \{ visible \}\)/,
     "the shell drives the native buttons through the app command",
+  );
+  // Title-bar fit contract: the 78px inset is released only AFTER the native
+  // hide is confirmed — marking "hidden" optimistically slid the nav toggle +
+  // history chevrons under still-visible lights when the command failed.
+  assert.match(
+    shell,
+    /applyNative\(false\)\s*\.then\(\(\) => \{\s*if \(!cancelled\) root\.dataset\.trafficLights = "hidden";/,
+    "the root attribute flips to hidden only once the native hide resolves",
   );
   assert.match(
     shell,
-    /root\.dataset\.trafficLights = trafficLightsVisible \? "visible" : "hidden";/,
-    "the root attribute mirrors the native state for CSS",
+    /\.catch\(\(\) => \{[\s\S]{0,220}?if \(!cancelled\) root\.dataset\.trafficLights = "visible";/,
+    "a failed native hide keeps the inset reserved for the still-visible lights",
+  );
+  assert.match(
+    shell,
+    /window\.addEventListener\("focus", onFocus\)/,
+    "focus re-asserts the hidden state after AppKit re-shows the buttons",
   );
   assert.match(
     css,

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -343,28 +343,55 @@ function ShellInner({
   // the panel fully closed (not even hover-peeked) they'd hover over page
   // content, so they follow the panel — hidden with it, back the moment it
   // opens or peeks. The root attribute lets globals.css release the 78px
-  // title-bar inset in the same breath; the native call is an app command
+  // title-bar inset; the native call is an app command
   // (set_traffic_lights_visible in lib.rs), so it needs no ACL entry. Mobile
   // layouts keep their drawer chrome and never hide the lights.
+  //
+  // Fit contract (title-bar overlap bug): the inset is released ONLY after
+  // the native hide is confirmed. Showing is marked optimistically (worst
+  // case: a roomy bar), but marking "hidden" before the buttons actually
+  // vanish — pre-update shell without the command, an AppKit hiccup — slid
+  // the nav toggle + history chevrons underneath still-visible lights.
   const trafficLightsVisible = navOpen || navPeeking || isMobile;
   useEffect(() => {
     const root = document.documentElement;
     // Only the macOS desktop Tauri shell overlays the title bar (the effect
     // above sets this marker); everywhere else there are no lights to manage.
     if (!("tauriTitlebar" in root.dataset)) return;
-    root.dataset.trafficLights = trafficLightsVisible ? "visible" : "hidden";
-    void import("@tauri-apps/api/core")
-      .then(({ invoke }) => invoke("set_traffic_lights_visible", { visible: trafficLightsVisible }))
-      .catch(() => {
-        // Pre-update shell without the command — the attribute above still
-        // frees the inset; the native buttons just stay put.
-      });
+    let cancelled = false;
+    const applyNative = (visible: boolean) =>
+      import("@tauri-apps/api/core").then(({ invoke }) =>
+        invoke("set_traffic_lights_visible", { visible }),
+      );
+    if (trafficLightsVisible) {
+      root.dataset.trafficLights = "visible";
+      void applyNative(true).catch(() => {});
+    } else {
+      void applyNative(false)
+        .then(() => {
+          if (!cancelled) root.dataset.trafficLights = "hidden";
+        })
+        .catch(() => {
+          // Pre-update shell without the command — the buttons stay put, so
+          // the bar must keep the 78px inset reserved for them.
+          if (!cancelled) root.dataset.trafficLights = "visible";
+        });
+    }
+    // macOS re-shows the standard buttons on its own after some window
+    // transitions (fullscreen round-trips, space changes). Re-assert the
+    // intended state whenever the window regains focus so the bar and the
+    // buttons can't drift apart mid-session.
+    const onFocus = () => {
+      if (trafficLightsVisible) return;
+      void applyNative(false).catch(() => {});
+    };
+    window.addEventListener("focus", onFocus);
     return () => {
+      cancelled = true;
+      window.removeEventListener("focus", onFocus);
       // If the shell ever unmounts mid-hide, leave the window usable.
       delete root.dataset.trafficLights;
-      void import("@tauri-apps/api/core")
-        .then(({ invoke }) => invoke("set_traffic_lights_visible", { visible: true }))
-        .catch(() => {});
+      void applyNative(true).catch(() => {});
     };
   }, [trafficLightsVisible]);
 


### PR DESCRIPTION
Fixes the title-bar fit where the nav toggle + back/forward chevrons rendered underneath the macOS traffic lights (screenshot-reported; bead `cave-i7wf`).

**Root cause.** The Dia-style lights effect set `data-traffic-lights="hidden"` — which releases the 78px title-bar inset in globals.css — at the same moment it *requested* the native hide via `set_traffic_lights_visible`. If the hide didn't actually land (pre-update shell binary without the command, or AppKit re-showing the standard buttons after fullscreen/space transitions), the controls slid left into the still-visible close/minimize/zoom buttons.

**Fix (confirm-then-release):**
- the inset is released only **after** the native hide resolves
- a failed hide keeps `data-traffic-lights="visible"` — worst case is a roomy bar, never an overlap
- window `focus` re-asserts the hidden state, healing AppKit's spontaneous re-shows mid-session
- showing remains optimistic (reserving room early is always safe)

`shell-edge-rails.test.ts` now pins the confirm-then-release contract (hidden only in the resolve path, visible in the catch path, focus listener present).

**Verified:** typecheck · test:app (591) · targeted shell tests (edge-rails, drawer smoke, nav-rail coupling, mobile smoke, left-panels fit).