### PR TITLE
fix(marketplace): make prompt-pack "Try it" button more visible

### DIFF
--- a/src/components/marketplace/marketplace-detail.test.ts
+++ b/src/components/marketplace/marketplace-detail.test.ts
@@ -49,8 +49,15 @@ assert.match(
 );
 assert.match(
   source,
-  /onClick=\{\(\) => onTry\(p\.body\)\}>Try it/,
+  /onClick=\{\(\) => onTry\(p\.body\)\}\s*>\s*Try it/,
   "each preview card exposes a Try it action bound to its body",
+);
+// Visibility (user feedback): the Try it action is a bordered secondary button
+// with a directional icon — not the near-invisible ghost it started as.
+assert.match(
+  source,
+  /variant="secondary"[\s\S]{0,120}?trailingIcon="ph:arrow-right-bold"[\s\S]{0,160}?Try it/,
+  "Try it is a visible secondary button with a hand-off arrow (not a ghost)",
 );
 assert.match(
   source,

--- a/src/components/marketplace/marketplace-detail.tsx
+++ b/src/components/marketplace/marketplace-detail.tsx
@@ -376,7 +376,15 @@ function PackPromptPreviews({
               </div>
             ) : null}
           </div>
-          <Button variant="ghost" size="sm" onClick={() => onTry(p.body)}>Try it</Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            trailingIcon="ph:arrow-right-bold"
+            className="self-center shrink-0"
+            onClick={() => onTry(p.body)}
+          >
+            Try it
+          </Button>
         </li>
       ))}
     </ul>


### PR DESCRIPTION
## What

Follow-up polish on the marketplace prompt-pack previews (PR #2848): the **Try it** action was too subtle.

## Change

It was a `ghost` (text-only) button that blended into the card. Now it's a **bordered `secondary` pill with a trailing arrow (→)**, vertically centered in the card — clearly the card's affordance. Kept it `secondary` rather than `primary`/accent because the design language reserves accent for presence, not repeated per-card CTAs.

Single-line diff in `marketplace-detail.tsx`; the source pin in `marketplace-detail.test.ts` updated to assert the visible variant + arrow.

## Verification

- `pnpm typecheck` + `marketplace-detail.test.ts` green.
- Screenshot-verified: every template card in the Shipping pack detail now shows a clear "Try it →" pill (vs the old ghost text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)