### PR TITLE
fix(runtimes): review follow-ups — spec-correct prerelease semver, CI-triggering bot PRs

### DIFF
--- a/.github/workflows/sync-runtimes.yml
+++ b/.github/workflows/sync-runtimes.yml
@@ -8,6 +8,14 @@
 #   - weekly schedule — safety net for missed dispatches.
 #
 # The PR is never auto-merged: required CI gates it and a human clicks merge.
+#
+# Setup (one-time): the bot branch/PR must be pushed with SYNC_RUNTIMES_TOKEN —
+# a fine-grained PAT for this repo with "Contents: read & write" and
+# "Pull requests: read & write". Events created with the workflow's own
+# GITHUB_TOKEN never trigger other workflows (GitHub's recursion guard), so a
+# PR pushed with it would sit with zero required checks and could never merge.
+# The job fails loudly when the secret is missing rather than opening an
+# ungated PR.
 
 name: Sync runtimes registry
 
@@ -19,8 +27,7 @@ on:
     - cron: "17 6 * * 1" # Mondays 06:17 UTC
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: sync-runtimes
@@ -64,10 +71,20 @@ jobs:
           node --experimental-strip-types src/lib/harness-adapters.test.ts
           node --experimental-strip-types src/lib/runtime-models.test.ts
 
+      - name: Require the bot token
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          SYNC_TOKEN: ${{ secrets.SYNC_RUNTIMES_TOKEN }}
+        run: |
+          if [ -z "$SYNC_TOKEN" ]; then
+            echo "::error::SYNC_RUNTIMES_TOKEN is not set. A PR pushed with GITHUB_TOKEN would trigger no required checks (GitHub skips workflows for events created by the workflow token) and could never merge. Create a fine-grained PAT (Contents + Pull requests: read & write on this repo) and add it as the SYNC_RUNTIMES_TOKEN secret."
+            exit 1
+          fi
+
       - name: Create or refresh the sync PR
         if: steps.diff.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SYNC_RUNTIMES_TOKEN }}
         run: |
           set -euo pipefail
           BRANCH=bot/sync-runtimes
@@ -88,6 +105,9 @@ jobs:
           '
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Push with the PAT (not the checkout-persisted GITHUB_TOKEN) so the
+          # push event triggers the required CI workflows on the PR.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout -B "$BRANCH"
           git add src/lib/runtime-registry.gen.ts
           git commit -m "chore(runtimes): sync accepted registry from coven-runtimes"

--- a/scripts/sync-runtimes.mjs
+++ b/scripts/sync-runtimes.mjs
@@ -33,7 +33,11 @@ const OUTPUT_PATH = path.join(scriptDir, "..", "src", "lib", "runtime-registry.g
 
 const ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 
-/** Compare two `major.minor.patch[-pre]` strings; release > prerelease. */
+/** Compare two `major.minor.patch[-pre]` strings; release > prerelease.
+ *  Prerelease precedence follows semver §11.4: dot-separated identifiers
+ *  compare numerically when both are all-digits (so rc.10 > rc.9), lexically
+ *  otherwise; numeric identifiers rank below alphanumeric; fewer identifiers
+ *  lose the tie. */
 export function compareSemver(a, b) {
   const parse = (v) => {
     const [core, ...pre] = String(v).split("-");
@@ -49,7 +53,20 @@ export function compareSemver(a, b) {
   if (pa.pre === pb.pre) return 0;
   if (!pa.pre) return 1; // release beats prerelease
   if (!pb.pre) return -1;
-  return pa.pre < pb.pre ? -1 : 1;
+  const idsA = pa.pre.split(".");
+  const idsB = pb.pre.split(".");
+  const NUM_RE = /^\d+$/;
+  for (let i = 0; i < Math.min(idsA.length, idsB.length); i++) {
+    const ia = idsA[i];
+    const ib = idsB[i];
+    if (ia === ib) continue;
+    const na = NUM_RE.test(ia);
+    const nb = NUM_RE.test(ib);
+    if (na && nb) return Number(ia) - Number(ib);
+    if (na !== nb) return na ? -1 : 1; // numeric < alphanumeric
+    return ia < ib ? -1 : 1;
+  }
+  return idsA.length - idsB.length;
 }
 
 /**

--- a/scripts/sync-runtimes.test.mjs
+++ b/scripts/sync-runtimes.test.mjs
@@ -18,6 +18,13 @@ assert.ok(compareSemver("1.2.0", "1.1.9") > 0, "minor bump wins");
 assert.ok(compareSemver("0.10.0", "0.9.1") > 0, "numeric (not lexical) compare");
 assert.ok(compareSemver("1.0.0", "1.0.0-rc.1") > 0, "release beats prerelease");
 assert.equal(compareSemver("2.0.0", "2.0.0"), 0, "equal versions compare equal");
+// Semver §11.4 prerelease precedence (review finding: plain string compare
+// ranked rc.10 below rc.9).
+assert.ok(compareSemver("1.0.0-rc.10", "1.0.0-rc.9") > 0, "numeric prerelease identifiers compare numerically");
+assert.ok(compareSemver("1.0.0-beta.11", "1.0.0-beta.2") > 0, "beta.11 > beta.2");
+assert.ok(compareSemver("1.0.0-alpha", "1.0.0-alpha.1") < 0, "fewer identifiers lose the tie");
+assert.ok(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.beta") < 0, "numeric identifiers rank below alphanumeric");
+assert.ok(compareSemver("1.0.0-beta", "1.0.0-alpha") > 0, "alphanumeric identifiers compare lexically");
 
 // ── latest non-yanked pick ───────────────────────────────────────────────────
 {


### PR DESCRIPTION
Fixes both findings from the code review of #2841/#2853:

1. **`compareSemver` prerelease ordering (semver §11.4).** Plain string compare ranked `rc.10` below `rc.9`, so the sync could silently generate the module from an *older* adapter document once a runtime accumulated double-digit prereleases. Now: numeric identifiers compare numerically, numeric ranks below alphanumeric, fewer identifiers lose the tie. New test assertions pin `rc.10>rc.9`, `beta.11>beta.2`, `alpha<alpha.1`, `alpha.1<alpha.beta`.

2. **Bot PRs never triggered CI.** The sync workflow pushed `bot/sync-runtimes` + created the PR with `GITHUB_TOKEN`, and GitHub deliberately skips workflow runs for events created by the workflow token — so the "required CI gates it" assumption was false (the PR would sit with checks stuck as *Expected*, unmergeable). The push (remote re-pointed to an `x-access-token` URL) and `gh pr` calls now use a **`SYNC_RUNTIMES_TOKEN`** fine-grained PAT; a guard step fails loudly with setup instructions when the secret is missing instead of opening an ungated PR; job permissions drop to `contents: read`.

⚠️ **Setup after merge:** create a fine-grained PAT on this repo with **Contents: R/W + Pull requests: R/W** and `gh secret set SYNC_RUNTIMES_TOKEN --repo OpenCoven/coven-cave`.

Validation: sync test suite green (incl. new §11.4 cases); `node scripts/sync-runtimes.mjs --check` confirms the committed module is unchanged by the comparator fix; workflow YAML lints.