### PR TITLE
chore(release): stamp v0.0.167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ breaking config changes; patch releases stay additive.
 
 ## [0.0.167] - 2026-07-09
 
-> _One-line teaser — edit before merge._
+> 🪄 **Polish pass** — the marketplace's prompt-pack "Try it" becomes an unmissable pill-with-arrow instead of near-invisible ghost text, and the desktop title-bar controls stop hiding under the macOS traffic lights.
 
 Patch release on top of v0.0.166.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.167] - 2026-07-09
+
+> _One-line teaser — edit before merge._
+
+Patch release on top of v0.0.166.
+
+### Changes
+- fix(marketplace): make prompt-pack "Try it" visible — bordered secondary pill with hand-off arrow (#2857)
+- fix(shell): title-bar controls never sit under the traffic lights (cave-i7wf) (#2856)
+
+
 ## [0.0.166] - 2026-07-09
 
 > 📓 **Journal moves into the Grimoire** — daily reflections are now a tab beside Docs and Graph, so the whole knowledge surface lives in one room. Plus registry-driven runtime adapter scaffolds and an analytics contract-compliance pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.166"
+version = "0.0.167"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.166"
+version = "0.0.167"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamped by `scripts/stamp-release.mjs`. Edit the CHANGELOG teaser/grouping before merge.

```
## [0.0.167] - 2026-07-09

> _One-line teaser — edit before merge._

Patch release on top of v0.0.166.

### Changes
- fix(marketplace): make prompt-pack "Try it" visible — bordered secondary pill with hand-off arrow (#2857)
- fix(shell): title-bar controls never sit under the traffic lights (cave-i7wf) (#2856)

```