### PR TITLE
chore(release): stamp v0.0.167

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.0.167] - 2026-07-09
+
+> 🪄 **Polish + hardening pass** — the marketplace's prompt-pack "Try it" becomes an unmissable bordered pill with a hand-off arrow instead of near-invisible ghost text, and the desktop title-bar controls stop hiding under the macOS traffic lights. Under the hood: a ReDoS-prone path regex is replaced with a plain `trimEnd`, and the runtime-sync tooling gets spec-correct prerelease semver plus CI-triggering bot PRs.
+
+Patch release on top of v0.0.166.
+
+### Improvements
+- **Marketplace: "Try it" is finally visible** (#2857) — the prompt-pack hand-off is now a bordered secondary pill with an arrow instead of ghost text that blended into the card.
+- **Shell: title-bar controls never sit under the traffic lights** (#2856, cave-i7wf) — window controls reflow clear of the macOS traffic-light cluster.
+
+### Fixes
+- **Security: no more ReDoS-prone path regex** (#2845, CodeQL #99) — `next-paths.ts` uses `trimEnd` instead of a catastrophically-backtracking regex.
+- **Runtimes: review follow-ups** (#2858) — spec-correct prerelease semver handling and CI-triggering bot PRs in the runtime-sync workflow.
+- **Runtimes: drop a no-op identity newline replacement** in `sync-runtimes.mjs` (#2844).
+
+
 ## [0.0.166] - 2026-07-09
 
 > 📓 **Journal moves into the Grimoire** — daily reflections are now a tab beside Docs and Graph, so the whole knowledge surface lives in one room. Plus registry-driven runtime adapter scaffolds and an analytics contract-compliance pass.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.0.166"
+version = "0.0.167"
 dependencies = [
  "log",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.0.166"
+version = "0.0.167"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/gen/apple/app_iOS/Info.plist
+++ b/src-tauri/gen/apple/app_iOS/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -28,7 +28,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>0.0.166</string>
+	<string>0.0.167</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.0.166",
+  "version": "0.0.167",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps **v0.0.167** across all 6 version files + CHANGELOG.

Rolls up 5 merged PRs on top of v0.0.166:
- #2857 marketplace "Try it" visible pill
- #2856 title-bar controls clear of macOS traffic lights (cave-i7wf)
- #2845 security: trimEnd instead of ReDoS-prone regex (CodeQL #99)
- #2858 runtime review follow-ups (spec-correct prerelease semver, CI-triggering bot PRs)
- #2844 sync-runtimes: remove no-op identity newline replacement

Supersedes #2859 (which only covered #2856/#2857 — this includes the 3 additional merges that landed after).